### PR TITLE
fix: standardize SOLR collection availability checking and frontend display

### DIFF
--- a/src/views/settings/sections/SolrDashboard.vue
+++ b/src/views/settings/sections/SolrDashboard.vue
@@ -62,12 +62,12 @@
 
 					<div class="stat-card">
 						<h4>Active Collection</h4>
-						<p>{{ solrStats.cores?.active_core || 'Unknown' }}</p>
+						<p>{{ solrStats.collection || 'Unknown' }}</p>
 					</div>
 
 					<div class="stat-card">
 						<h4>Tenant ID</h4>
-						<p>{{ solrStats.cores?.tenant_id || 'Unknown' }}</p>
+						<p>{{ solrStats.tenant_id || 'Unknown' }}</p>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## 🐛 Problem

Dashboard showed inconsistent collection information and SOLR endpoints had different availability checking logic:
- **Settings page**: Collection = `openregister_nc_7e944f08` ✅
- **Dashboard page**: Active Collection = `openregister` ❌ (wrong fallback)
- **Warmup endpoint**: Failed with "SOLR is not available" despite working test endpoint

## 🔧 Root Cause

Different parts of codebase used inconsistent SOLR availability checks:
1. `/api/settings/solr/test` used `testConnection()` (comprehensive) ✅
2. `/api/settings/solr/warmup` used `isAvailable()` (simple ping) ❌  
3. `/api/solr/setup` used custom connectivity check ❌
4. Frontend looked for wrong API response fields ❌

## 💡 Solution

### Backend Changes (`GuzzleSolrService.php`)
- **Fixed `getActiveCollectionName()`**: Returns `null` instead of falling back to non-existent base collection
- **Updated 15+ methods**: All now handle `null` collection names gracefully with proper error logging
- **Standardized availability checking**: All methods now use consistent logic

### Frontend Changes (`SolrDashboard.vue`)  
- **Fixed collection display**: Use `solrStats.collection` instead of `solrStats.cores?.active_core`
- **Fixed tenant ID display**: Use `solrStats.tenant_id` instead of `solrStats.cores?.tenant_id`

### Enhanced Error Handling (`SettingsController.php`, `SolrSetup.php`)
- **Better logging**: Detailed error information for debugging setup failures
- **Consistent connectivity checks**: All use same robust testing method

## ✅ Expected Results

- Dashboard shows correct tenant-specific collection (`openregister_nc_7e944f08`)
- All SOLR endpoints behave consistently
- Proper error messages when collections don't exist
- Better debugging information for setup issues

## 🧪 Testing

- [ ] Dashboard displays correct collection name
- [ ] Warmup endpoint works when collection exists  
- [ ] Setup endpoint provides detailed error logs
- [ ] All endpoints handle missing collections gracefully

## �� Files Changed

- `lib/Service/GuzzleSolrService.php` - Core SOLR service logic
- `lib/Controller/SettingsController.php` - Enhanced error logging
- `lib/Setup/SolrSetup.php` - Consistent connectivity checking
- `src/views/settings/sections/SolrDashboard.vue` - Frontend display fixes

## ⚠️ Breaking Changes

`getActiveCollectionName()` now returns `null` when no tenant collection exists instead of falling back to base collection. This is intentional as there is no base collection to fall back to.