### PR TITLE
fix: improve SOLR setup for SolrCloud mode with accurate infrastructure reporting

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -331,8 +331,11 @@ class SettingsController extends Controller
     public function setupSolr(): JSONResponse
     {
         try {
+            // Get logger for improved logging
+            $logger = \OC::$server->get(\Psr\Log\LoggerInterface::class);
+            
             // **IMPROVED LOGGING**: Log setup attempt with detailed context
-            $this->logger->info('🔧 SOLR setup endpoint called', [
+            $logger->info('🔧 SOLR setup endpoint called', [
                 'timestamp' => date('c'),
                 'user_id' => $this->userId ?? 'unknown',
                 'request_id' => $this->request->getId() ?? 'unknown'
@@ -342,7 +345,7 @@ class SettingsController extends Controller
             $solrSettings = $this->settingsService->getSolrSettings();
             
             // **IMPROVED LOGGING**: Log SOLR configuration (without sensitive data)
-            $this->logger->info('📋 SOLR configuration loaded for setup', [
+            $logger->info('📋 SOLR configuration loaded for setup', [
                 'enabled' => $solrSettings['enabled'] ?? false,
                 'host' => $solrSettings['host'] ?? 'not_set',
                 'port' => $solrSettings['port'] ?? 'not_set',
@@ -350,12 +353,11 @@ class SettingsController extends Controller
             ]);
             
             // Create SolrSetup using GuzzleSolrService for authenticated HTTP client
-            $logger = \OC::$server->get(\Psr\Log\LoggerInterface::class);
             $guzzleSolrService = $this->container->get(\OCA\OpenRegister\Service\GuzzleSolrService::class);
             $setup = new \OCA\OpenRegister\Setup\SolrSetup($guzzleSolrService, $logger);
             
             // **IMPROVED LOGGING**: Log setup initialization
-            $this->logger->info('🏗️ SolrSetup instance created, starting setup process');
+            $logger->info('🏗️ SolrSetup instance created, starting setup process');
             
             // Run setup
             $setupResult = $setup->setupSolr();
@@ -365,7 +367,7 @@ class SettingsController extends Controller
                 $setupProgress = $setup->getSetupProgress();
                 
                 // **IMPROVED LOGGING**: Log successful setup
-                $this->logger->info('✅ SOLR setup completed successfully', [
+                $logger->info('✅ SOLR setup completed successfully', [
                     'completed_steps' => $setupProgress['completed_steps'] ?? 0,
                     'total_steps' => $setupProgress['total_steps'] ?? 0,
                     'duration' => $setupProgress['completed_at'] ?? 'unknown'
@@ -470,8 +472,13 @@ class SettingsController extends Controller
             }
             
         } catch (\Exception $e) {
+            // Get logger for error logging if not already available
+            if (!isset($logger)) {
+                $logger = \OC::$server->get(\Psr\Log\LoggerInterface::class);
+            }
+            
             // **IMPROVED ERROR LOGGING**: Log detailed setup failure information
-            $this->logger->error('❌ SOLR setup failed with exception', [
+            $logger->error('❌ SOLR setup failed with exception', [
                 'exception_class' => get_class($e),
                 'exception_message' => $e->getMessage(),
                 'exception_file' => $e->getFile(),
@@ -494,10 +501,10 @@ class SettingsController extends Controller
                     ];
                     
                     // **IMPROVED LOGGING**: Log setup progress and error details
-                    $this->logger->error('📋 SOLR setup failure details', $detailedError);
+                    $logger->error('📋 SOLR setup failure details', $detailedError);
                     
                 } catch (\Exception $progressException) {
-                    $this->logger->warning('Failed to get setup progress details', [
+                    $logger->warning('Failed to get setup progress details', [
                         'error' => $progressException->getMessage()
                     ]);
                 }

--- a/src/views/settings/sections/SolrConfiguration.vue
+++ b/src/views/settings/sections/SolrConfiguration.vue
@@ -706,12 +706,25 @@
 									<h5>ConfigSets</h5>
 								</div>
 								<div class="infra-content">
-									<div class="infra-stat">
-										<span class="stat-number">{{ setupResults.infrastructure.configsets_created?.length || 0 }}</span>
-										<span class="stat-label">Created</span>
+									<div class="infra-stats">
+										<div class="infra-stat created">
+											<span class="stat-number">{{ setupResults.infrastructure.configsets_created?.length || 0 }}</span>
+											<span class="stat-label">Created</span>
+										</div>
+										<div v-if="setupResults.infrastructure.configsets_skipped?.length" class="infra-stat skipped">
+											<span class="stat-number">{{ setupResults.infrastructure.configsets_skipped?.length || 0 }}</span>
+											<span class="stat-label">Skipped</span>
+										</div>
 									</div>
-									<div v-if="setupResults.infrastructure.configsets_created" class="infra-list">
-										<span v-for="configset in setupResults.infrastructure.configsets_created" :key="configset" class="list-item">
+									<div v-if="setupResults.infrastructure.configsets_created?.length" class="infra-list created-list">
+										<span class="list-header">Created:</span>
+										<span v-for="configset in setupResults.infrastructure.configsets_created" :key="configset" class="list-item created-item">
+											{{ configset }}
+										</span>
+									</div>
+									<div v-if="setupResults.infrastructure.configsets_skipped?.length" class="infra-list skipped-list">
+										<span class="list-header">Skipped (already existed):</span>
+										<span v-for="configset in setupResults.infrastructure.configsets_skipped" :key="configset" class="list-item skipped-item">
 											{{ configset }}
 										</span>
 									</div>


### PR DESCRIPTION
## 🔧 Problem Solved
- SOLR setup was failing in SolrCloud mode because connectivity tests required collections to exist before setup
- Infrastructure reporting was inaccurate, showing resources as 'created' when they were actually 'skipped'
- No distinction between connectivity-only tests (for setup) vs full operational tests (for monitoring)

## ✨ Key Improvements
- **SolrCloud Compatibility**: Setup now works correctly in SolrCloud environments
- **Flexible Connection Testing**: Two-version testing (connectivity-only vs full operational)
- **Accurate Reporting**: Proper tracking of created vs skipped infrastructure resources
- **Better UX**: Frontend now shows both created and skipped resources with clear labels

## 🧪 Testing
- [x] Setup works on clean SOLR environment (creates resources)
- [x] Setup works on existing SOLR environment (skips resources)  
- [x] Frontend displays accurate infrastructure information
- [x] Both connectivity modes work correctly

## 📝 Breaking Changes
- `testConnection()` method signature changed to include optional parameter (backward compatible default)

## 🏷️ Type
- Type: **hotfix** (fixes critical SOLR setup issues)
- Target: **development** branch