### PR TITLE
fix: resolve SOLR object reconstruction and field configuration issues

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -20,6 +20,7 @@ return [
         ['name' => 'settings#testSolrConnection', 'url' => '/api/settings/solr/test', 'verb' => 'POST'],
         ['name' => 'settings#warmupSolrIndex', 'url' => '/api/settings/solr/warmup', 'verb' => 'POST'],
         ['name' => 'settings#testSchemaMapping', 'url' => '/api/settings/solr/test-schema-mapping', 'verb' => 'POST'],
+        ['name' => 'settings#getSolrFields', 'url' => '/api/solr/fields', 'verb' => 'GET'],
         
         // SOLR Dashboard Management endpoints
         ['name' => 'settings#getSolrDashboardStats', 'url' => '/api/solr/dashboard/stats', 'verb' => 'GET'],

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -610,6 +610,44 @@ class SettingsController extends Controller
 
 
     /**
+     * Get SOLR field configuration and schema information
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @return JSONResponse SOLR field configuration data
+     */
+    public function getSolrFields(): JSONResponse
+    {
+        try {
+            // Use GuzzleSolrService to get field information
+            $guzzleSolrService = $this->container->get(GuzzleSolrService::class);
+            
+            // Check if SOLR is available first
+            if (!$guzzleSolrService->isAvailable()) {
+                return new JSONResponse([
+                    'success' => false,
+                    'message' => 'SOLR is not available or not configured',
+                    'details' => ['error' => 'SOLR service is not enabled or connection failed']
+                ], 503);
+            }
+
+            // Get field configuration from SOLR
+            $fieldsData = $guzzleSolrService->getFieldsConfiguration();
+            
+            return new JSONResponse($fieldsData);
+            
+        } catch (\Exception $e) {
+            return new JSONResponse([
+                'success' => false,
+                'message' => 'Failed to retrieve SOLR field configuration: ' . $e->getMessage(),
+                'details' => ['error' => $e->getMessage()]
+            ], 500);
+        }
+    }//end getSolrFields()
+
+
+    /**
      * Get SOLR settings only
      *
      * @NoAdminRequired

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -42,8 +42,11 @@ export const useSettingsStore = defineStore('settings', {
 		settingUpSolr: false,
 		showTestDialog: false,
 		showSetupDialog: false,
+		showFieldsDialog: false,
+		loadingFields: false,
 		testResults: null,
 		setupResults: null,
+		fieldsInfo: null,
 		
 		// Cache states
 		clearingCache: false,
@@ -844,6 +847,38 @@ export const useSettingsStore = defineStore('settings', {
 		 */
 		retrySetup() {
 			this.setupSolr()
+		},
+
+		/**
+		 * Load SOLR field configuration
+		 */
+		async loadSolrFields() {
+			this.loadingFields = true
+			this.showFieldsDialog = true
+			try {
+				const response = await axios.get(generateUrl('/apps/openregister/api/solr/fields'))
+				this.fieldsInfo = response.data
+				return response.data
+			} catch (error) {
+				console.error('Failed to load SOLR fields:', error)
+				const errorData = {
+					success: false,
+					message: 'Failed to load SOLR fields: ' + error.message,
+					details: { error: error.message }
+				}
+				this.fieldsInfo = errorData
+				throw error
+			} finally {
+				this.loadingFields = false
+			}
+		},
+
+		/**
+		 * Hide fields dialog
+		 */
+		hideFieldsDialog() {
+			this.showFieldsDialog = false
+			this.fieldsInfo = null
 		},
 	},
 })


### PR DESCRIPTION
- Fix duplicate method names in GuzzleSolrService causing fatal PHP errors
- Remove problematic fallback method from SOLR object reconstruction
- Implement strict multi-valued field determination based only on schema array type
- Add comprehensive SOLR field inspection modal to settings UI
- Add getSolrFields API endpoint for debugging field configuration differences
- Improve error handling and make reconstruction fail explicitly when primary method fails
- Add helper methods for robust SOLR field value extraction handling both array and single value responses

This resolves the issue where string properties became arrays on test environment due to different SOLR field configurations between environments.