### PR TITLE
hotfix: improve SOLR object reconstruction and fix serialization

### DIFF
--- a/lib/Service/GuzzleSolrService.php
+++ b/lib/Service/GuzzleSolrService.php
@@ -1098,7 +1098,7 @@ class GuzzleSolrService
             'self_files' => $this->flattenFilesForSolr($object->getFiles()),
             
             // **COMPLETE OBJECT STORAGE**: Store entire object as JSON for exact reconstruction
-            'self_object' => json_encode($objectData ?: [])
+            'self_object' => json_encode($objectData->jsonSerialize() ?: [])
         ];
         
         // **SCHEMA-AWARE FIELD MAPPING**: Map object data based on schema properties


### PR DESCRIPTION
This hotfix improves SOLR object reconstruction and fixes a critical serialization issue.

## Changes
- Add hydrateObject method to ObjectEntity for better object hydration from SOLR data  
- Refactor reconstructObjectFromSolrDocument to use new hydration approach
- **FIX: Proper object data serialization by calling jsonSerialize() before JSON encoding**
- Improve consistency and predictability of SOLR search results

## Impact
- Better object reconstruction from SOLR documents
- Fixed serialization issues that could cause data corruption
- More predictable search results
- Improved data consistency

## Commits
- Initial SOLR reconstruction improvements
- Critical serialization fix for object data storage