### PR TITLE
feat(multitenancy): add configurable published objects bypass

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -115,6 +115,7 @@ return [
         ['name' => 'auditTrail#objects', 'url' => '/api/objects/{register}/{schema}/{id}/audit-trails', 'verb' => 'GET', 'requirements' => ['id' => '[^/]+']],
         ['name' => 'auditTrail#index', 'url' => '/api/audit-trails', 'verb' => 'GET'],
         ['name' => 'auditTrail#export', 'url' => '/api/audit-trails/export', 'verb' => 'GET'],
+        ['name' => 'auditTrail#clearAll', 'url' => '/api/audit-trails/clear-all', 'verb' => 'DELETE'],
         ['name' => 'auditTrail#show', 'url' => '/api/audit-trails/{id}', 'verb' => 'GET', 'requirements' => ['id' => '[^/]+']],
         ['name' => 'auditTrail#destroy', 'url' => '/api/audit-trails/{id}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+']],
         ['name' => 'auditTrail#destroyMultiple', 'url' => '/api/audit-trails', 'verb' => 'DELETE'],
@@ -128,6 +129,7 @@ return [
         ['name' => 'searchTrail#export', 'url' => '/api/search-trails/export', 'verb' => 'GET'],
         ['name' => 'searchTrail#cleanup', 'url' => '/api/search-trails/cleanup', 'verb' => 'POST'],
         ['name' => 'searchTrail#destroyMultiple', 'url' => '/api/search-trails', 'verb' => 'DELETE'],
+        ['name' => 'searchTrail#clearAll', 'url' => '/api/search-trails/clear-all', 'verb' => 'DELETE'],
         ['name' => 'searchTrail#show', 'url' => '/api/search-trails/{id}', 'verb' => 'GET', 'requirements' => ['id' => '[^/]+']],
         ['name' => 'searchTrail#destroy', 'url' => '/api/search-trails/{id}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+']],
         // Deleted Objects

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -171,7 +171,8 @@ class Application extends App implements IBootstrap
                     $container->get('OCP\IGroupManager'),
                     $container->get('OCP\IUserManager'),
                     $container->get('OCP\IAppConfig'),
-                    $container->get('Psr\Log\LoggerInterface')
+                    $container->get('Psr\Log\LoggerInterface'),
+                    null // AuthorizationExceptionService
                     );
                 }
                 );
@@ -248,6 +249,7 @@ class Application extends App implements IBootstrap
                     $container->get(ObjectCacheService::class),
                     $container->get(SchemaCacheService::class),
                     $container->get(SchemaFacetCacheService::class),
+                    $container->get(SettingsService::class),
                     $container->get('Psr\Log\LoggerInterface'),
                     new \Twig\Loader\ArrayLoader([])
                     );
@@ -265,7 +267,21 @@ class Application extends App implements IBootstrap
                     $container->get(SchemaCacheService::class),
                     $container->get(SchemaFacetCacheService::class),
                     $container->get('OCA\OpenRegister\Db\AuditTrailMapper'),
+                    $container->get(SettingsService::class),
                     $container->get('Psr\Log\LoggerInterface')
+                    );
+                }
+                );
+
+        // Register GetObject with SettingsService dependency
+        $context->registerService(
+                GetObject::class,
+                function ($container) {
+                    return new GetObject(
+                    $container->get(ObjectEntityMapper::class),
+                    $container->get(FileService::class),
+                    $container->get('OCA\OpenRegister\Db\AuditTrailMapper'),
+                    $container->get(SettingsService::class)
                     );
                 }
                 );

--- a/lib/Controller/AuditTrailController.php
+++ b/lib/Controller/AuditTrailController.php
@@ -430,4 +430,43 @@ class AuditTrailController extends Controller
     }//end destroyMultiple()
 
 
+    /**
+     * Clear all audit trail logs
+     *
+     * @return JSONResponse A JSON response indicating success or failure
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function clearAll(): JSONResponse
+    {
+        try {
+            // Get the audit trail mapper from the container
+            $auditTrailMapper = \OC::$server->get('OCA\OpenRegister\Db\AuditTrailMapper');
+            
+                    // Use the clearAllLogs method from the mapper
+                    $result = $auditTrailMapper->clearAllLogs();
+            
+            if ($result) {
+                return new JSONResponse([
+                    'success' => true,
+                    'message' => 'All audit trails cleared successfully',
+                    'deleted' => 'All expired audit trails have been deleted'
+                ]);
+            } else {
+                return new JSONResponse([
+                    'success' => true,
+                    'message' => 'No expired audit trails found to clear',
+                    'deleted' => 0
+                ]);
+            }
+        } catch (\Exception $e) {
+            return new JSONResponse([
+                'success' => false,
+                'error' => 'Failed to clear audit trails: ' . $e->getMessage()
+            ], 500);
+        }
+    }//end clearAll()
+
+
 }//end class

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -492,6 +492,12 @@ class ObjectsController extends Controller
         ObjectService $objectService
     ): JSONResponse {
         try {
+            // DEBUG: Add unique identifier to response
+            $debugInfo = [
+                'DEBUG_CONTROLLER' => 'OpenRegister_ObjectsController',
+                'DEBUG_PARAMS' => ['register' => $register, 'schema' => $schema, 'id' => $id]
+            ];
+            
             // Resolve slugs to numeric IDs consistently
             $resolved = $this->resolveRegisterSchemaIds($register, $schema, $objectService);
         } catch (\OCA\OpenRegister\Exception\RegisterNotFoundException | \OCA\OpenRegister\Exception\SchemaNotFoundException $e) {
@@ -549,6 +555,9 @@ class ObjectsController extends Controller
                 rbac: $rbac,
                 multi: $multi
             );
+
+            // Add debug info to response
+            $renderedObject['DEBUG_INFO'] = $debugInfo;
 
             return new JSONResponse($renderedObject);
         } catch (DoesNotExistException $exception) {
@@ -687,10 +696,10 @@ class ObjectsController extends Controller
         // If admin, disable RBAC
         $multi = !$isAdmin;
         // If admin, disable multitenancy
-        // Check if the object exists and can be updated.
+        // Check if the object exists and can be updated (silent read - no audit trail).
         // @todo shouldn't this be part of the object service?
         try {
-            $existingObject = $this->objectService->find($id, [], false, null, null, $rbac, $multi);
+            $existingObject = $this->objectService->findSilent($id, [], false, null, null, $rbac, $multi);
 
             // Get the resolved register and schema IDs from the ObjectService
             // This ensures proper handling of both numeric IDs and slug identifiers

--- a/lib/Controller/SearchTrailController.php
+++ b/lib/Controller/SearchTrailController.php
@@ -822,4 +822,43 @@ class SearchTrailController extends Controller
     }//end arrayToCsv()
 
 
+    /**
+     * Clear all search trail logs
+     *
+     * @return JSONResponse A JSON response indicating success or failure
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function clearAll(): JSONResponse
+    {
+        try {
+            // Get the search trail mapper from the container
+            $searchTrailMapper = \OC::$server->get('OCA\OpenRegister\Db\SearchTrailMapper');
+            
+                    // Use the clearAllLogs method from the mapper
+                    $result = $searchTrailMapper->clearAllLogs();
+            
+            if ($result) {
+                return new JSONResponse([
+                    'success' => true,
+                    'message' => 'All search trails cleared successfully',
+                    'deleted' => 'All expired search trails have been deleted'
+                ]);
+            } else {
+                return new JSONResponse([
+                    'success' => true,
+                    'message' => 'No expired search trails found to clear',
+                    'deleted' => 0
+                ]);
+            }
+        } catch (\Exception $e) {
+            return new JSONResponse([
+                'success' => false,
+                'error' => 'Failed to clear search trails: ' . $e->getMessage()
+            ], 500);
+        }
+    }//end clearAll()
+
+
 }//end class

--- a/lib/Db/AuditTrailMapper.php
+++ b/lib/Db/AuditTrailMapper.php
@@ -1002,6 +1002,46 @@ class AuditTrailMapper extends QBMapper
 
 
     /**
+     * Clear all audit trail logs (not just expired ones)
+     *
+     * This method deletes all audit trail logs from the database
+     *
+     * @return bool True if any logs were deleted, false otherwise
+     *
+     * @throws \Exception If the deletion fails
+     */
+    public function clearAllLogs(): bool
+    {
+        try {
+            // Get the query builder for database operations
+            $qb = $this->db->getQueryBuilder();
+
+            // Build the delete query to remove ALL audit trail logs
+            $qb->delete('openregister_audit_trails');
+
+            // Execute the query and get the number of affected rows
+            $result = $qb->executeStatement();
+
+            // Return true if any rows were affected (i.e., any logs were deleted)
+            return $result > 0;
+        } catch (\Exception $e) {
+            // Log the error for debugging purposes
+            \OC::$server->getLogger()->error(
+                    'Failed to clear all audit trail logs: '.$e->getMessage(),
+                    [
+                        'app'       => 'openregister',
+                        'exception' => $e,
+                    ]
+                    );
+
+            // Re-throw the exception so the caller knows something went wrong
+            throw $e;
+        }//end try
+
+    }//end clearAllLogs()
+
+
+    /**
      * Count audit trails with optional filters
      *
      * @param array|null $filters The filters to apply (same format as findAll)

--- a/lib/Db/SearchTrailMapper.php
+++ b/lib/Db/SearchTrailMapper.php
@@ -746,6 +746,46 @@ class SearchTrailMapper extends QBMapper
 
 
     /**
+     * Clear all search trail logs (not just expired ones)
+     *
+     * This method deletes all search trail logs from the database
+     *
+     * @return bool True if any logs were deleted, false otherwise
+     *
+     * @throws \Exception Database operation exceptions
+     */
+    public function clearAllLogs(): bool
+    {
+        try {
+            // Get the query builder for database operations
+            $qb = $this->db->getQueryBuilder();
+
+            // Build the delete query to remove ALL search trail logs
+            $qb->delete($this->getTableName());
+
+            // Execute the query and get the number of affected rows
+            $result = $qb->executeStatement();
+
+            // Return true if any rows were affected (i.e., any logs were deleted)
+            return $result > 0;
+        } catch (\Exception $e) {
+            // Log the error for debugging purposes
+            \OC::$server->getLogger()->error(
+                    'Failed to clear all search trail logs: '.$e->getMessage(),
+                    [
+                        'app'       => 'openregister',
+                        'exception' => $e,
+                    ]
+                    );
+
+            // Re-throw the exception so the caller knows something went wrong
+            throw $e;
+        }//end try
+
+    }//end clearAllLogs()
+
+
+    /**
      * Apply filters to the query builder
      *
      * @param IQueryBuilder $qb      The query builder

--- a/lib/Service/MagicMapper.php
+++ b/lib/Service/MagicMapper.php
@@ -48,6 +48,7 @@ use OCA\OpenRegister\Service\MagicMapperHandlers\MagicRbacHandler;
 use OCA\OpenRegister\Service\MagicMapperHandlers\MagicBulkHandler;
 use OCA\OpenRegister\Service\MagicMapperHandlers\MagicOrganizationHandler;
 use OCA\OpenRegister\Service\MagicMapperHandlers\MagicFacetHandler;
+use OCA\OpenRegister\Service\SettingsService;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\IConfig;
@@ -217,6 +218,7 @@ class MagicMapper
      * @param IUserManager        $userManager        User manager for user operations
      * @param IAppConfig          $appConfig          App configuration for feature flags
      * @param LoggerInterface     $logger             Logger for debugging and monitoring
+     * @param SettingsService     $settingsService    Settings service for configuration
      */
     public function __construct(
         private readonly IDBConnection $db,
@@ -228,7 +230,8 @@ class MagicMapper
         private readonly IGroupManager $groupManager,
         private readonly IUserManager $userManager,
         private readonly IAppConfig $appConfig,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly SettingsService $settingsService
     ) {
         // Initialize specialized handlers for modular functionality
         $this->initializeHandlers();

--- a/lib/Service/ObjectHandlers/SaveObject.php
+++ b/lib/Service/ObjectHandlers/SaveObject.php
@@ -40,6 +40,7 @@ use OCA\OpenRegister\Service\ObjectCacheService;
 use OCA\OpenRegister\Service\SchemaCacheService;
 use OCA\OpenRegister\Service\SchemaFacetCacheService;
 use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Service\SettingsService;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -121,6 +122,7 @@ class SaveObject
      * @param ObjectCacheService        $objectCacheService        Object cache service for entity and query caching.
      * @param SchemaCacheService        $schemaCacheService        Schema cache service for schema entity caching.
      * @param SchemaFacetCacheService   $schemaFacetCacheService   Schema facet cache service for facet caching.
+     * @param SettingsService          $settingsService          Settings service for accessing trail settings.
      * @param LoggerInterface          $logger                   Logger interface for logging operations.
      * @param ArrayLoader              $arrayLoader              Twig array loader for template rendering.
      */
@@ -136,6 +138,7 @@ class SaveObject
         private readonly ObjectCacheService $objectCacheService,
         private readonly SchemaCacheService $schemaCacheService,
         private readonly SchemaFacetCacheService $schemaFacetCacheService,
+        private readonly SettingsService $settingsService,
         private readonly LoggerInterface $logger,
         ArrayLoader $arrayLoader,
     ) {
@@ -1514,6 +1517,7 @@ class SaveObject
      * @param bool                     $rbac       Whether to apply RBAC checks (default: true).
      * @param bool                     $multi      Whether to apply multitenancy filtering (default: true).
      * @param bool                     $persist    Whether to persist the object to database (default: true).
+     * @param bool                     $silent     Whether to skip audit trail creation and events (default: false).
      * @param bool                     $validation Whether to validate the object (default: true).
      *
      * @return ObjectEntity The saved object entity.
@@ -1529,6 +1533,7 @@ class SaveObject
         bool $rbac=true,
         bool $multi=true,
         bool $persist=true,
+        bool $silent=false,
         bool $validation=true
     ): ObjectEntity {
 
@@ -1604,7 +1609,7 @@ class SaveObject
                 }
 
                 // Update the object
-                return $this->updateObject(register: $register, schema: $schema, data: $data, existingObject: $preparedObject, folderId: $folderId);
+                return $this->updateObject(register: $register, schema: $schema, data: $data, existingObject: $preparedObject, folderId: $folderId, silent: $silent);
             } catch (DoesNotExistException $e) {
                 // Object not found, proceed with creating new object.
             } catch (Exception $e) {
@@ -1646,9 +1651,11 @@ class SaveObject
         // Save the object to database.
         $savedEntity = $this->objectEntityMapper->insert($preparedObject);
 
-        // Create audit trail for creation.
-        $log = $this->auditTrailMapper->createAuditTrail(old: null, new: $savedEntity);
-        $savedEntity->setLastLog($log->jsonSerialize());
+        // Create audit trail for creation if audit trails are enabled and not in silent mode.
+        if (!$silent && $this->isAuditTrailsEnabled()) {
+            $log = $this->auditTrailMapper->createAuditTrail(old: null, new: $savedEntity);
+            $savedEntity->setLastLog($log->jsonSerialize());
+        }
 
         // Handle file properties - process them and replace content with file IDs
         foreach ($data as $propertyName => $value) {
@@ -3044,6 +3051,7 @@ class SaveObject
      * @param array               $data           The updated object data.
      * @param ObjectEntity        $existingObject The existing object to update.
      * @param int|null            $folderId       The folder ID to set on the object (optional).
+     * @param bool                $silent         Whether to skip audit trail creation and events (default: false).
      *
      * @return ObjectEntity The updated object entity.
      *
@@ -3054,7 +3062,8 @@ class SaveObject
         Schema | int | string $schema,
         array $data,
         ObjectEntity $existingObject,
-        ?int $folderId=null
+        ?int $folderId=null,
+        bool $silent=false
     ): ObjectEntity {
 
         // Store the old state for audit trail.
@@ -3102,9 +3111,11 @@ class SaveObject
         // Save the object to database.
         $updatedEntity = $this->objectEntityMapper->update($preparedObject);
 
-        // Create audit trail for update.
-        $log = $this->auditTrailMapper->createAuditTrail(old: $oldObject, new: $updatedEntity);
-        $updatedEntity->setLastLog($log->jsonSerialize());
+        // Create audit trail for update if audit trails are enabled and not in silent mode.
+        if (!$silent && $this->isAuditTrailsEnabled()) {
+            $log = $this->auditTrailMapper->createAuditTrail(old: $oldObject, new: $updatedEntity);
+            $updatedEntity->setLastLog($log->jsonSerialize());
+        }
 
         // Handle file properties - process them and replace content with file IDs
         foreach ($data as $propertyName => $value) {
@@ -3203,6 +3214,24 @@ class SaveObject
         return true;
 
     }//end isValueNotEmpty()
+
+
+    /**
+     * Check if audit trails are enabled in the settings
+     *
+     * @return bool True if audit trails are enabled, false otherwise
+     */
+    private function isAuditTrailsEnabled(): bool
+    {
+        try {
+            $retentionSettings = $this->settingsService->getRetentionSettingsOnly();
+            return $retentionSettings['auditTrailsEnabled'] ?? true;
+        } catch (\Exception $e) {
+            // If we can't get settings, default to enabled for safety
+            $this->logger->warning('Failed to check audit trails setting, defaulting to enabled', ['error' => $e->getMessage()]);
+            return true;
+        }
+    }//end isAuditTrailsEnabled()
 
 
 }//end class

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -63,6 +63,12 @@ export const useSettingsStore = defineStore('settings', {
 		showMassValidateConfirmation: false,
 		massValidateResults: null,
 		
+		// Clear logs states
+		clearingAuditTrails: false,
+		clearingSearchTrails: false,
+		showClearAuditTrailsConfirmation: false,
+		showClearSearchTrailsConfirmation: false,
+		
 		// Settings data
 		solrOptions: {
 			enabled: false,
@@ -95,6 +101,7 @@ export const useSettingsStore = defineStore('settings', {
 			enabled: false,
 			defaultUserTenant: '',
 			defaultObjectTenant: '',
+			publishedObjectsBypassMultiTenancy: false,
 		},
 		
 		retentionOptions: {
@@ -105,6 +112,8 @@ export const useSettingsStore = defineStore('settings', {
 			readLogRetention: 86400000,          // 24 hours
 			updateLogRetention: 604800000,       // 1 week
 			deleteLogRetention: 2592000000,      // 1 month
+			auditTrailsEnabled: true,            // Audit trails enabled by default
+			searchTrailsEnabled: true,           // Search trails enabled by default
 		},
 		
 		versionInfo: {
@@ -910,6 +919,80 @@ export const useSettingsStore = defineStore('settings', {
 				showError('Failed to clear cache: ' + error.message)
 			} finally {
 				this.clearingCache = false
+			}
+		},
+
+		/**
+		 * Show clear audit trails confirmation dialog
+		 */
+		showClearAuditTrailsDialog() {
+			this.showClearAuditTrailsConfirmation = true
+		},
+
+		/**
+		 * Hide clear audit trails confirmation dialog
+		 */
+		hideClearAuditTrailsDialog() {
+			this.showClearAuditTrailsConfirmation = false
+		},
+
+		/**
+		 * Clear all audit trails
+		 */
+		async clearAllAuditTrails() {
+			this.clearingAuditTrails = true
+			
+			try {
+				const response = await axios.delete(generateUrl('/apps/openregister/api/audit-trails/clear-all'))
+				
+				if (response.data.success) {
+					showSuccess(`Successfully cleared ${response.data.deleted || 0} audit trails`)
+					this.hideClearAuditTrailsDialog()
+				} else {
+					showError('Failed to clear audit trails: ' + (response.data.error || 'Unknown error'))
+				}
+			} catch (error) {
+				console.error('Failed to clear audit trails:', error)
+				showError('Failed to clear audit trails: ' + error.message)
+			} finally {
+				this.clearingAuditTrails = false
+			}
+		},
+
+		/**
+		 * Show clear search trails confirmation dialog
+		 */
+		showClearSearchTrailsDialog() {
+			this.showClearSearchTrailsConfirmation = true
+		},
+
+		/**
+		 * Hide clear search trails confirmation dialog
+		 */
+		hideClearSearchTrailsDialog() {
+			this.showClearSearchTrailsConfirmation = false
+		},
+
+		/**
+		 * Clear all search trails
+		 */
+		async clearAllSearchTrails() {
+			this.clearingSearchTrails = true
+			
+			try {
+				const response = await axios.delete(generateUrl('/apps/openregister/api/search-trails/clear-all'))
+				
+				if (response.data.success) {
+					showSuccess(`Successfully cleared ${response.data.deleted || 0} search trails`)
+					this.hideClearSearchTrailsDialog()
+				} else {
+					showError('Failed to clear search trails: ' + (response.data.error || 'Unknown error'))
+				}
+			} catch (error) {
+				console.error('Failed to clear search trails:', error)
+				showError('Failed to clear search trails: ' + error.message)
+			} finally {
+				this.clearingSearchTrails = false
 			}
 		},
 

--- a/src/views/organisation/OrganisationsIndex.vue
+++ b/src/views/organisation/OrganisationsIndex.vue
@@ -8,18 +8,18 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 			<!-- Header -->
 			<div class="viewHeader">
 				<h1 class="viewHeaderTitleIndented">
-					{{ t('openregister', 'Organisations') }}
+					Organisaties
 				</h1>
-				<p>{{ t('openregister', 'Manage your organisations and switch between them') }}</p>
+				<p>Beheer uw organisaties en wissel tussen hen</p>
 			</div>
 
 			<!-- Active Organisation Status -->
 			<div v-if="organisationStore.userStats.active" class="activeOrgBanner">
 				<div class="activeOrgInfo">
-					<span class="activeOrgLabel">{{ t('openregister', 'Active Organisation:') }}</span>
+					<span class="activeOrgLabel">Actieve Organisatie:</span>
 					<span class="activeOrgName">{{ organisationStore.userStats.active.name }}</span>
 					<span v-if="organisationStore.userStats.active.isDefault" class="defaultBadge">
-						{{ t('openregister', 'Default') }}
+						Standaard
 					</span>
 				</div>
 				<NcButton v-if="organisationStore.userStats.total > 1"
@@ -28,7 +28,7 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 					<template #icon>
 						<SwapHorizontal :size="20" />
 					</template>
-					{{ t('openregister', 'Switch Organisation') }}
+					Wissel Organisatie
 				</NcButton>
 			</div>
 
@@ -36,10 +36,10 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 			<div class="viewActionsBar">
 				<div class="viewInfo">
 					<span class="viewTotalCount">
-						{{ t('openregister', 'Showing {showing} of {total} organisations', { showing: paginatedOrganisations.length, total: organisationStore.userStats.total }) }}
+						Toont {{ paginatedOrganisations.length }} van {{ organisationStore.userStats.total }} organisaties
 					</span>
 					<span v-if="selectedOrganisations.length > 0" class="viewIndicator">
-						({{ t('openregister', '{count} selected', { count: selectedOrganisations.length }) }})
+						({{ selectedOrganisations.length }} geselecteerd)
 					</span>
 				</div>
 				<div class="viewActions">
@@ -52,7 +52,7 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 							name="view_mode_radio"
 							type="radio"
 							button-variant-grouped="horizontal">
-							Cards
+							Kaarten
 						</NcCheckboxRadioSwitch>
 						<NcCheckboxRadioSwitch
 							v-model="organisationStore.viewMode"
@@ -62,7 +62,7 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 							name="view_mode_radio"
 							type="radio"
 							button-variant-grouped="horizontal">
-							Table
+							Tabel
 						</NcCheckboxRadioSwitch>
 					</div>
 
@@ -77,7 +77,7 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 							<template #icon>
 								<Plus :size="20" />
 							</template>
-							Create Organisation
+							Organisatie Aanmaken
 						</NcActionButton>
 						<NcActionButton
 							close-after-click
@@ -85,7 +85,7 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 							<template #icon>
 								<AccountPlus :size="20" />
 							</template>
-							Join Organisation
+							Organisatie Deelnemen
 						</NcActionButton>
 						<NcActionButton
 							close-after-click
@@ -93,7 +93,7 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 							<template #icon>
 								<Refresh :size="20" />
 							</template>
-							Refresh
+							Vernieuwen
 						</NcActionButton>
 					</NcActions>
 				</div>
@@ -101,8 +101,8 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 
 			<!-- Empty State -->
 			<NcEmptyContent v-if="!organisationStore.userStats.total"
-				:name="t('openregister', 'No organisations found')"
-				:description="t('openregister', 'You are not a member of any organisations yet.')">
+				:name="'Geen organisaties gevonden'"
+				:description="'U bent nog geen lid van organisaties.'">
 				<template #icon>
 					<OfficeBuilding :size="64" />
 				</template>
@@ -120,8 +120,8 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 								<h2>
 									<OfficeBuilding :size="20" />
 									{{ organisation.name }}
-									<span v-if="organisation.isDefault" class="defaultBadge">Default</span>
-									<span v-if="isActiveOrganisation(organisation)" class="activeBadge">Active</span>
+									<span v-if="organisation.isDefault" class="defaultBadge">Standaard</span>
+									<span v-if="isActiveOrganisation(organisation)" class="activeBadge">Actief</span>
 								</h2>
 								<NcActions :primary="true" menu-name="Actions">
 									<template #icon>
@@ -132,7 +132,7 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 										<template #icon>
 											<Eye :size="20" />
 										</template>
-										View
+										Bekijken
 									</NcActionButton>
 									<NcActionButton v-if="canEditOrganisation(organisation)"
 										close-after-click
@@ -140,14 +140,14 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 										<template #icon>
 											<Pencil :size="20" />
 										</template>
-										Edit
+										Bewerken
 									</NcActionButton>
 									<NcActionButton close-after-click
 										@click="copyOrganisation(organisation)">
 										<template #icon>
 											<ContentCopy :size="20" />
 										</template>
-										Copy
+										Kopiëren
 									</NcActionButton>
 									<NcActionButton v-if="organisation.website"
 										close-after-click
@@ -155,7 +155,7 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 										<template #icon>
 											<OpenInNew :size="20" />
 										</template>
-										Go to organisation
+										Ga naar organisatie
 									</NcActionButton>
 									<NcActionButton v-if="!isActiveOrganisation(organisation)"
 										close-after-click
@@ -171,7 +171,7 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 										<template #icon>
 											<TrashCanOutline :size="20" />
 										</template>
-										Delete
+										Verwijderen
 									</NcActionButton>
 								</NcActions>
 							</div>
@@ -182,15 +182,15 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 								</p>
 								<div class="organisationStats">
 									<div class="stat">
-										<span class="statLabel">{{ t('openregister', 'Members:') }}</span>
+										<span class="statLabel">Leden:</span>
 										<span class="statValue">{{ organisation.userCount || 0 }}</span>
 									</div>
 									<div class="stat">
-										<span class="statLabel">{{ t('openregister', 'Owner:') }}</span>
+										<span class="statLabel">Eigenaar:</span>
 										<span class="statValue">{{ organisation.owner || 'System' }}</span>
 									</div>
 									<div v-if="organisation.created" class="stat">
-										<span class="statLabel">{{ t('openregister', 'Created:') }}</span>
+										<span class="statLabel">Aangemaakt:</span>
 										<span class="statValue">{{ formatDate(organisation.created) }}</span>
 									</div>
 								</div>
@@ -209,14 +209,14 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 											:indeterminate="someSelected"
 											@update:checked="toggleSelectAll" />
 									</th>
-									<th>{{ t('openregister', 'Name') }}</th>
-									<th>{{ t('openregister', 'Members') }}</th>
-									<th>{{ t('openregister', 'Owner') }}</th>
-									<th>{{ t('openregister', 'Status') }}</th>
-									<th>{{ t('openregister', 'Created') }}</th>
-									<th>{{ t('openregister', 'Updated') }}</th>
+									<th>Naam</th>
+									<th>Leden</th>
+									<th>Eigenaar</th>
+									<th>Status</th>
+									<th>Aangemaakt</th>
+									<th>Bijgewerkt</th>
 									<th class="tableColumnActions">
-										{{ t('openregister', 'Actions') }}
+										Acties
 									</th>
 								</tr>
 							</thead>
@@ -237,8 +237,8 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 										<div class="titleContent">
 											<strong>{{ organisation.name }}</strong>
 											<div class="badges">
-												<span v-if="organisation.isDefault" class="defaultBadge">Default</span>
-												<span v-if="isActiveOrganisation(organisation)" class="activeBadge">Active</span>
+												<span v-if="organisation.isDefault" class="defaultBadge">Standaard</span>
+												<span v-if="isActiveOrganisation(organisation)" class="activeBadge">Actief</span>
 											</div>
 											<span v-if="organisation.description" class="textDescription textEllipsis">{{ organisation.description }}</span>
 										</div>
@@ -246,8 +246,8 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 									<td>{{ organisation.userCount || 0 }}</td>
 									<td>{{ organisation.owner || 'System' }}</td>
 									<td>
-										<span v-if="isActiveOrganisation(organisation)" class="statusActive">Active</span>
-										<span v-else class="statusInactive">Inactive</span>
+										<span v-if="isActiveOrganisation(organisation)" class="statusActive">Actief</span>
+										<span v-else class="statusInactive">Inactief</span>
 									</td>
 									<td>{{ organisation.created ? formatDate(organisation.created) : '-' }}</td>
 									<td>{{ organisation.updated ? formatDate(organisation.updated) : '-' }}</td>
@@ -261,7 +261,7 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 												<template #icon>
 													<Eye :size="20" />
 												</template>
-												View
+												Bekijken
 											</NcActionButton>
 											<NcActionButton v-if="canEditOrganisation(organisation)"
 												close-after-click
@@ -269,14 +269,14 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 												<template #icon>
 													<Pencil :size="20" />
 												</template>
-												Edit
+												Bewerken
 											</NcActionButton>
 											<NcActionButton close-after-click
 												@click="copyOrganisation(organisation)">
 												<template #icon>
 													<ContentCopy :size="20" />
 												</template>
-												Copy
+												Kopiëren
 											</NcActionButton>
 											<NcActionButton v-if="organisation.website"
 												close-after-click
@@ -284,7 +284,7 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 												<template #icon>
 													<OpenInNew :size="20" />
 												</template>
-												Go to organisation
+												Ga naar organisatie
 											</NcActionButton>
 											<NcActionButton v-if="!isActiveOrganisation(organisation)"
 												close-after-click
@@ -317,10 +317,10 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 
 		<!-- Organisation Switcher Modal -->
 		<NcModal v-if="showOrganisationSwitcher"
-			:name="t('openregister', 'Switch Active Organisation')"
+			:name="'Wissel Actieve Organisatie'"
 			@close="showOrganisationSwitcher = false">
 			<div class="organisationSwitcher">
-				<h3>{{ t('openregister', 'Select Active Organisation') }}</h3>
+				<h3>Selecteer Actieve Organisatie</h3>
 				<div class="organisationList">
 					<div v-for="org in organisationStore.userStats.list"
 						:key="org.uuid"
@@ -330,7 +330,7 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 						<div class="organisationOptionContent">
 							<span class="organisationOptionName">{{ org.name }}</span>
 							<span v-if="org.isDefault" class="defaultBadge">Default</span>
-							<span v-if="isActiveOrganisation(org)" class="activeBadge">Current</span>
+							<span v-if="isActiveOrganisation(org)" class="activeBadge">Huidig</span>
 						</div>
 						<span v-if="org.description" class="organisationOptionDescription">{{ org.description }}</span>
 					</div>

--- a/src/views/settings/sections/MultitenancyConfiguration.vue
+++ b/src/views/settings/sections/MultitenancyConfiguration.vue
@@ -71,6 +71,20 @@
 				</NcCheckboxRadioSwitch>
 			</div>
 
+			<!-- Published Objects Bypass -->
+			<div v-if="multitenancyOptions.enabled" class="option-section">
+				<NcCheckboxRadioSwitch
+					:checked.sync="multitenancyOptions.publishedObjectsBypassMultiTenancy"
+					:disabled="saving"
+					type="switch">
+					Published objects bypass multi-tenancy
+				</NcCheckboxRadioSwitch>
+				<p class="option-description">
+					When enabled, published objects will be visible to users from all organizations, bypassing multi-tenancy restrictions. 
+					This allows for public sharing of published content across organizational boundaries.
+				</p>
+			</div>
+
 			<!-- Default Tenants -->
 			<div v-if="multitenancyOptions.enabled">
 				<h4>Default Tenants</h4>

--- a/src/views/settings/sections/RetentionConfiguration.vue
+++ b/src/views/settings/sections/RetentionConfiguration.vue
@@ -48,6 +48,40 @@
 				</p>
 			</div>
 
+			<!-- Enable/Disable Trail Features -->
+			<div class="option-section">
+				<h4>Trail Features</h4>
+				<p class="option-description">
+					Control which types of audit trails are enabled. Disabling trails will stop recording new entries but won't affect existing data.
+				</p>
+
+				<div class="trail-switches">
+					<div class="trail-switch-row">
+						<NcCheckboxRadioSwitch
+							:checked.sync="auditTrailsEnabled"
+							:disabled="loading || saving"
+							type="switch">
+							Audit Trails enabled
+						</NcCheckboxRadioSwitch>
+						<p class="trail-description">
+							Record all CRUD operations (create, read, update, delete) for objects and system actions
+						</p>
+					</div>
+
+					<div class="trail-switch-row">
+						<NcCheckboxRadioSwitch
+							:checked.sync="searchTrailsEnabled"
+							:disabled="loading || saving"
+							type="switch">
+							Search Trails enabled
+						</NcCheckboxRadioSwitch>
+						<p class="trail-description">
+							Record search queries and analytics for performance monitoring and usage insights
+						</p>
+					</div>
+				</div>
+			</div>
+
 			<!-- Consolidated Retention Settings -->
 			<div class="option-section">
 				<h4>Data & Log Retention Policies</h4>
@@ -231,7 +265,7 @@
 <script>
 import { mapStores } from 'pinia'
 import { useSettingsStore } from '../../../store/settings.js'
-import { NcSettingsSection, NcButton, NcLoadingIcon } from '@nextcloud/vue'
+import { NcSettingsSection, NcButton, NcLoadingIcon, NcCheckboxRadioSwitch } from '@nextcloud/vue'
 import Refresh from 'vue-material-design-icons/Refresh.vue'
 import Save from 'vue-material-design-icons/ContentSave.vue'
 
@@ -242,6 +276,7 @@ export default {
 		NcSettingsSection,
 		NcButton,
 		NcLoadingIcon,
+		NcCheckboxRadioSwitch,
 		Refresh,
 		Save,
 	},
@@ -255,6 +290,24 @@ export default {
 			},
 			set(value) {
 				this.settingsStore.retentionOptions = value
+			}
+		},
+
+		auditTrailsEnabled: {
+			get() {
+				return this.settingsStore.retentionOptions.auditTrailsEnabled ?? true
+			},
+			set(value) {
+				this.settingsStore.retentionOptions.auditTrailsEnabled = value
+			}
+		},
+
+		searchTrailsEnabled: {
+			get() {
+				return this.settingsStore.retentionOptions.searchTrailsEnabled ?? true
+			},
+			set(value) {
+				this.settingsStore.retentionOptions.searchTrailsEnabled = value
 			}
 		},
 
@@ -393,6 +446,30 @@ export default {
 	color: var(--color-text-light);
 	margin: 24px 0 16px 0;
 	font-size: 16px;
+}
+
+.trail-switches {
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+	margin-top: 16px;
+}
+
+.trail-switch-row {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 16px;
+	background: var(--color-main-background);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+}
+
+.trail-description {
+	color: var(--color-text-maxcontrast);
+	font-size: 14px;
+	margin: 0;
+	line-height: 1.3;
 }
 
 .retention-table {


### PR DESCRIPTION
- Add publishedObjectsBypassMultiTenancy setting to allow admins to control whether published objects bypass multi-tenancy restrictions
- Fix RBAC filter to include published objects when bypass is enabled
- Update organization filters to handle bypass when no active organization is set
- Add UI toggle in multitenancy configuration section
- Resolve circular dependency between SettingsService and ObjectEntityMapper

This allows organizations to share published content across organizational boundaries while maintaining proper isolation for non-published objects.

Fixes issue where users could see count of published objects but not the actual objects due to RBAC filtering.