### PR TITLE
Fix JSON field type handling in Schema and Register entities

### DIFF
--- a/lib/Db/Register.php
+++ b/lib/Db/Register.php
@@ -66,7 +66,7 @@ use OCP\AppFramework\Db\Entity;
  * @method DateTime|null getDeleted()
  * @method void setDeleted(?DateTime $deleted)
  * @method array|null getConfiguration()
- * @method void setConfiguration(?array $configuration)
+ * @method void setConfiguration(array|string|null $configuration)
  *
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @SuppressWarnings(PHPMD.TooManyFields)
@@ -653,18 +653,58 @@ class Register extends Entity implements JsonSerializable
      */
     public function getConfiguration(): array
     {
-        return ($this->configuration ?? []);
+        if ($this->configuration === null) {
+            return [];
+        }
+
+        // If it's already an array, return it directly.
+        if (is_array($this->configuration) === true) {
+            return $this->configuration;
+        }
+
+        // If it's a JSON string, decode it.
+        if (is_string($this->configuration) === true) {
+            $decoded = json_decode($this->configuration, true);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        // If we get here, something is wrong - return empty array.
+        return [];
     }//end getConfiguration()
 
     /**
      * Set configuration settings.
      *
-     * @param array|null $configuration Configuration settings.
+     * **TYPE SAFETY**: Handle both array and JSON string inputs for database hydration.
+     * The database stores configuration as JSON strings, but we want to work with arrays in PHP.
+     *
+     * @param array|string|null $configuration Configuration settings (array or JSON string).
      *
      * @return void
      */
-    public function setConfiguration(?array $configuration): void
+    public function setConfiguration(array|string|null $configuration): void
     {
+        // **TYPE SAFETY**: Handle JSON string from database.
+        if (is_string($configuration) === true) {
+            try {
+                $decoded = json_decode($configuration, true);
+                if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                    $this->configuration = $decoded;
+                } else {
+                    // Invalid JSON, set to null.
+                    $this->configuration = null;
+                }
+            } catch (Exception $e) {
+                // If decoding fails, set to null.
+                $this->configuration = null;
+            }
+
+            $this->markFieldUpdated('configuration');
+            return;
+        }
+
         $this->configuration = $configuration;
         $this->markFieldUpdated('configuration');
     }//end setConfiguration()

--- a/lib/Db/Schema.php
+++ b/lib/Db/Schema.php
@@ -53,7 +53,7 @@ use OCA\OpenRegister\Service\Schemas\PropertyValidatorHandler;
  * @method string|null getSummary()
  * @method void setSummary(?string $summary)
  * @method array|null getRequired()
- * @method void setRequired(?array $required)
+ * @method void setRequired(array|string|null $required)
  * @method array|null getProperties()
  * @method void setProperties(?array $properties)
  * @method array|null getArchive()
@@ -410,7 +410,25 @@ class Schema extends Entity implements JsonSerializable
      */
     public function getRequired(): array
     {
-        return ($this->required ?? []);
+        if ($this->required === null) {
+            return [];
+        }
+
+        // If it's already an array, return it directly.
+        if (is_array($this->required) === true) {
+            return $this->required;
+        }
+
+        // If it's a JSON string, decode it.
+        if (is_string($this->required) === true) {
+            $decoded = json_decode($this->required, true);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        // If we get here, something is wrong - return empty array.
+        return [];
     }//end getRequired()
 
     /**
@@ -419,12 +437,34 @@ class Schema extends Entity implements JsonSerializable
      * Always ensures required is an array, never NULL.
      * This prevents database errors during schema validation.
      *
-     * @param array|null $required The required field names
+     * **TYPE SAFETY**: Handle both array and JSON string inputs for database hydration.
+     * The database stores required as JSON strings, but we want to work with arrays in PHP.
+     *
+     * @param array|string|null $required The required field names (array or JSON string)
      *
      * @return void
      */
-    public function setRequired(?array $required): void
+    public function setRequired(array|string|null $required): void
     {
+        // **DATABASE COMPATIBILITY**: Handle JSON string from database.
+        if (is_string($required) === true) {
+            try {
+                $decoded = json_decode($required, true);
+                if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                    $this->required = $decoded;
+                } else {
+                    // Invalid JSON, set to empty array.
+                    $this->required = [];
+                }
+            } catch (Exception $e) {
+                // If decoding fails, set to empty array.
+                $this->required = [];
+            }
+
+            $this->markFieldUpdated('required');
+            return;
+        }
+
         // Always ensure required is an array, never NULL.
         // This is critical for schema validation to work correctly.
         $this->required = ($required ?? []);


### PR DESCRIPTION
Handle JSON strings from database in setRequired/getRequired and
setConfiguration/getConfiguration methods. When reading JSON fields
from database, they come as strings but setters expected arrays.

Updated docblocks to match getFacets()/setFacets() style.

Fixes configuration import errors.
