### PR TITLE
fix: Add missing hooks property to Schema entity

### DIFF
--- a/lib/Db/Schema.php
+++ b/lib/Db/Schema.php
@@ -82,6 +82,8 @@ use OCA\OpenRegister\Service\Schemas\PropertyValidatorHandler;
  * @method void setDeleted(?DateTime $deleted)
  * @method array|null getConfiguration()
  * @method void setConfiguration(?array $configuration)
+ * @method array|null getHooks()
+ * @method void setHooks(?array $hooks)
  *
  * @SuppressWarnings(PHPMD.ExcessiveClassLength)
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
@@ -364,6 +366,13 @@ class Schema extends Entity implements JsonSerializable
     protected ?DateTime $depublished = null;
 
     /**
+     * Hooks configuration for the schema
+     *
+     * @var array|null Hooks configuration
+     */
+    protected ?array $hooks = null;
+
+    /**
      * Constructor for the Schema class
      *
      * Sets up field types for all properties
@@ -401,6 +410,7 @@ class Schema extends Entity implements JsonSerializable
         $this->addType(fieldName: 'groups', type: 'json');
         $this->addType(fieldName: 'published', type: 'datetime');
         $this->addType(fieldName: 'depublished', type: 'datetime');
+        $this->addType(fieldName: 'hooks', type: 'json');
     }//end __construct()
 
     /**
@@ -1236,6 +1246,7 @@ class Schema extends Entity implements JsonSerializable
             'oneOf'          => $this->oneOf,
             'anyOf'          => $this->anyOf,
             'facets'         => $this->facets,
+            'hooks'          => $this->hooks,
         ];
     }//end jsonSerialize()
 

--- a/tests/Unit/Service/BulkMetadataHandlingTest.php
+++ b/tests/Unit/Service/BulkMetadataHandlingTest.php
@@ -4,7 +4,7 @@
  *
  * This test class verifies that both individual and bulk object save operations
  * correctly set owner and organization metadata when not provided in the object data.
- * 
+ *
  * Test Coverage:
  * - Owner metadata setting in bulk operations
  * - Organization metadata setting using optimized OrganisationService
@@ -113,18 +113,18 @@ class BulkMetadataHandlingTest extends TestCase
     private MockObject $mockUser;
 
     /**
-     * Mock register entity
+     * Register entity for testing
      *
-     * @var MockObject|Register
+     * @var Register
      */
-    private MockObject $mockRegister;
+    private Register $mockRegister;
 
     /**
-     * Mock schema entity
+     * Schema entity for testing
      *
-     * @var MockObject|Schema
+     * @var Schema
      */
-    private MockObject $mockSchema;
+    private Schema $mockSchema;
 
 
     /**
@@ -145,17 +145,18 @@ class BulkMetadataHandlingTest extends TestCase
         $this->mockUserSession = $this->createMock(IUserSession::class);
         $this->mockOrganisationService = $this->createMock(OrganisationService::class);
 
-        // Create mock entities.
+        // Create mock user (interface, keep as mock).
         $this->mockUser = $this->createMock(IUser::class);
-        $this->mockRegister = $this->createMock(Register::class);
-        $this->mockSchema = $this->createMock(Schema::class);
 
-        // Configure basic mock entity behavior.
-        $this->mockRegister->method('getId')->willReturn(1);
-        $this->mockSchema->method('getId')->willReturn(1);
-        $this->mockSchema->method('getProperties')->willReturn([]);
-        $this->mockSchema->method('getConfiguration')->willReturn([]);
-        $this->mockSchema->method('getHardValidation')->willReturn(false);
+        // Create real entity instances instead of mocks (Entity __call does not support mocking).
+        $this->mockRegister = new Register();
+        $this->mockRegister->setId(1);
+
+        $this->mockSchema = new Schema();
+        $this->mockSchema->setId(1);
+        $this->mockSchema->setProperties([]);
+        $this->mockSchema->setConfiguration([]);
+        $this->mockSchema->setHardValidation(false);
 
         // Create the SaveObjects handler with mocked dependencies.
         $this->saveObjectsHandler = new SaveObjects(


### PR DESCRIPTION
## Summary
- Adds the missing `hooks` property to `Schema.php` entity class — the DB column existed but the entity lacked the matching PHP property, causing `Entity::fromRow()` to throw on every schema load
- Updates `BulkMetadataHandlingTest` to use real entities instead of mocks

## Context
This was the root cause of **all 500 errors** on the SWC API test suite (0% → 100% pass rate after fix). Every OpenRegister endpoint that loads a schema was broken.

## Test plan
- [x] Full SWC Newman test suite: 424/424 assertions passing
- [x] Schema API endpoints return 200 instead of 500