### PR TITLE
fix: Conditional @conduction/nextcloud-vue alias with npm fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 	],
 	"dependencies": {
 		"@codemirror/lang-json": "^6.0.1",
+		"@conduction/nextcloud-vue": "^0.1.0-beta.3",
 		"@fortawesome/fontawesome-svg-core": "^6.5.2",
 		"@fortawesome/free-solid-svg-icons": "^6.5.2",
 		"@nextcloud/axios": "^2.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const fs = require('fs')
 const webpackConfig = require('@nextcloud/webpack-vue-config')
 
 const buildMode = process.env.NODE_ENV
@@ -35,10 +36,19 @@ webpackConfig.resolve.extensions = [
 	'.json',
 	...(webpackConfig.resolve.extensions || []),
 ]
+// Use local source when available (monorepo dev), otherwise fall back to npm package
+const localLib = path.resolve(__dirname, '../nextcloud-vue/src')
+const useLocalLib = fs.existsSync(localLib)
+
 webpackConfig.resolve.alias = {
 	...(webpackConfig.resolve.alias || {}),
 	'@': path.resolve(__dirname, 'src'),
-	'@conduction/nextcloud-vue': path.resolve(__dirname, '../nextcloud-vue/src'),
+	...(useLocalLib ? { '@conduction/nextcloud-vue': localLib } : {}),
+	// Deduplicate shared packages so the aliased library source uses
+	// the same instances as the app (prevents dual-Pinia / dual-Vue bugs).
+	'vue$': path.resolve(__dirname, 'node_modules/vue'),
+	'pinia$': path.resolve(__dirname, 'node_modules/pinia'),
+	'@nextcloud/vue$': path.resolve(__dirname, 'node_modules/@nextcloud/vue'),
 }
 
 const appId = 'openregister'


### PR DESCRIPTION
## Summary
- Add `@conduction/nextcloud-vue` as npm dependency (was missing entirely)
- Make webpack alias conditional: uses local `../nextcloud-vue/src` when available (monorepo dev), falls back to npm package on CI
- Add vue/pinia/@nextcloud/vue deduplication aliases to prevent dual-instance bugs

Matches the pattern already used by procest, pipelinq, larpingapp, and mydash.