### PR TITLE
Implements unified organisation management UI

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -912,10 +912,6 @@
    TAB COMPONENTS
    ======================================== */
 
-.tabContainer {
-  margin-top: 20px;
-}
-
 /* Bootstrap Vue Tab Styling */
 :deep(.nav-tabs) {
   border-bottom: 1px solid var(--color-border);

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:2461d537-5ec2-4063-9129-ef7fe1daf1cd",
+  "serialNumber": "urn:uuid:88e07eda-b70d-4f82-a615-e3a7dcc15c34",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-03-17T13:20:17Z",
+    "timestamp": "2026-03-17T13:44:15Z",
     "tools": [
       {
         "name": "composer",
@@ -100,11 +100,11 @@
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "01afd82d6dbb24d2c4b981dae06bdd2c2ab8b92d"
+          "value": "5bc3c696c5ff4d5bdc255375d8dc48be6fd1e404"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "01afd82d6dbb24d2c4b981dae06bdd2c2ab8b92d"
+          "value": "5bc3c696c5ff4d5bdc255375d8dc48be6fd1e404"
         },
         {
           "name": "cdx:composer:package:type",

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:c908ba31-9366-472f-a189-0a53fc58b498",
+  "serialNumber": "urn:uuid:157c4cd4-b789-4708-ac99-b271d889b88b",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-03-17T08:51:19Z",
+    "timestamp": "2026-03-17T09:45:37Z",
     "tools": [
       {
         "name": "composer",
@@ -82,10 +82,10 @@
       }
     ],
     "component": {
-      "bom-ref": "conductionnl/openregister-dev-feature/nextcloud-vue-package-usage",
+      "bom-ref": "conductionnl/openregister-dev-feature/REGISTERS-478/organisaties-page",
       "type": "application",
       "name": "openregister",
-      "version": "dev-feature/nextcloud-vue-package-usage",
+      "version": "dev-feature/REGISTERS-478/organisaties-page",
       "group": "conductionnl",
       "description": "Quickly build data registers based on schema.json",
       "author": "Conduction b.v.",
@@ -96,15 +96,15 @@
           }
         }
       ],
-      "purl": "pkg:composer/conductionnl/openregister@dev-feature/nextcloud-vue-package-usage",
+      "purl": "pkg:composer/conductionnl/openregister@dev-feature/REGISTERS-478/organisaties-page",
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "6d27b839d57a55a0d83feacac4a014b1ce9b0b26"
+          "value": "f686467503027ae99786cec221e644ac96296076"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "6d27b839d57a55a0d83feacac4a014b1ce9b0b26"
+          "value": "f686467503027ae99786cec221e644ac96296076"
         },
         {
           "name": "cdx:composer:package:type",
@@ -55483,7 +55483,7 @@
       "ref": "webonyx/graphql-php-15.31.0.0"
     },
     {
-      "ref": "conductionnl/openregister-dev-feature/nextcloud-vue-package-usage",
+      "ref": "conductionnl/openregister-dev-feature/REGISTERS-478/organisaties-page",
       "dependsOn": [
         "adbario/php-dot-notation-3.3.0.0",
         "elasticsearch/elasticsearch-8.15.0.0",

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:b657e937-e1b1-410c-8fa2-eaa9924bc137",
+  "serialNumber": "urn:uuid:97f0575c-5e7e-4a00-bf51-6709af9f748d",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-03-17T10:26:37Z",
+    "timestamp": "2026-03-17T10:36:35Z",
     "tools": [
       {
         "name": "composer",
@@ -100,11 +100,11 @@
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "46d69895162908a5b0094114781e797f66f3115b"
+          "value": "a1d76e56be942d9fa9f2552187e688f5c5e65dbe"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "46d69895162908a5b0094114781e797f66f3115b"
+          "value": "a1d76e56be942d9fa9f2552187e688f5c5e65dbe"
         },
         {
           "name": "cdx:composer:package:type",

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:bafa2212-d8cd-4f52-ad27-e2b6e32f324c",
+  "serialNumber": "urn:uuid:3c7a92f0-762c-4a0f-9402-c58ab7bbf3dd",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-03-19T14:47:51Z",
+    "timestamp": "2026-03-19T15:04:20Z",
     "tools": [
       {
         "name": "composer",
@@ -100,11 +100,11 @@
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "01cfc449d4379723c4094f5cacb0850d3500b11d"
+          "value": "e705f495770e59597e859c070944ad94b542661a"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "01cfc449d4379723c4094f5cacb0850d3500b11d"
+          "value": "e705f495770e59597e859c070944ad94b542661a"
         },
         {
           "name": "cdx:composer:package:type",

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,14 +2,14 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:fb70cbb1-d7ab-4453-939b-8d624fcbf6f4",
+  "serialNumber": "urn:uuid:c85db106-104f-46e8-8be1-b33af37adf6e",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-03-17T13:56:54Z",
+    "timestamp": "2026-03-19T14:21:17Z",
     "tools": [
       {
         "name": "composer",
-        "version": "2.9.3"
+        "version": "2.9.5"
       },
       {
         "vendor": "cyclonedx",
@@ -100,11 +100,11 @@
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "ecdc0423f04894252c5f8dc3226d3aa7978688cf"
+          "value": "b9e9676bd691460bb9ae5f97a84eecea1a6150be"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "ecdc0423f04894252c5f8dc3226d3aa7978688cf"
+          "value": "b9e9676bd691460bb9ae5f97a84eecea1a6150be"
         },
         {
           "name": "cdx:composer:package:type",

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:c85db106-104f-46e8-8be1-b33af37adf6e",
+  "serialNumber": "urn:uuid:bafa2212-d8cd-4f52-ad27-e2b6e32f324c",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-03-19T14:21:17Z",
+    "timestamp": "2026-03-19T14:47:51Z",
     "tools": [
       {
         "name": "composer",
@@ -100,11 +100,11 @@
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "b9e9676bd691460bb9ae5f97a84eecea1a6150be"
+          "value": "01cfc449d4379723c4094f5cacb0850d3500b11d"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "b9e9676bd691460bb9ae5f97a84eecea1a6150be"
+          "value": "01cfc449d4379723c4094f5cacb0850d3500b11d"
         },
         {
           "name": "cdx:composer:package:type",

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:97f0575c-5e7e-4a00-bf51-6709af9f748d",
+  "serialNumber": "urn:uuid:2461d537-5ec2-4063-9129-ef7fe1daf1cd",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-03-17T10:36:35Z",
+    "timestamp": "2026-03-17T13:20:17Z",
     "tools": [
       {
         "name": "composer",
@@ -100,11 +100,11 @@
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "a1d76e56be942d9fa9f2552187e688f5c5e65dbe"
+          "value": "01afd82d6dbb24d2c4b981dae06bdd2c2ab8b92d"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "a1d76e56be942d9fa9f2552187e688f5c5e65dbe"
+          "value": "01afd82d6dbb24d2c4b981dae06bdd2c2ab8b92d"
         },
         {
           "name": "cdx:composer:package:type",

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:88e07eda-b70d-4f82-a615-e3a7dcc15c34",
+  "serialNumber": "urn:uuid:fb70cbb1-d7ab-4453-939b-8d624fcbf6f4",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-03-17T13:44:15Z",
+    "timestamp": "2026-03-17T13:56:54Z",
     "tools": [
       {
         "name": "composer",
@@ -100,11 +100,11 @@
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "5bc3c696c5ff4d5bdc255375d8dc48be6fd1e404"
+          "value": "ecdc0423f04894252c5f8dc3226d3aa7978688cf"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "5bc3c696c5ff4d5bdc255375d8dc48be6fd1e404"
+          "value": "ecdc0423f04894252c5f8dc3226d3aa7978688cf"
         },
         {
           "name": "cdx:composer:package:type",

--- a/src/components/cards/OrganisationCard.vue
+++ b/src/components/cards/OrganisationCard.vue
@@ -1,0 +1,228 @@
+<script setup>
+import { organisationStore, navigationStore } from '../../store/store.js'
+</script>
+
+<template>
+	<div class="orgCard"
+		:class="{ 'orgCard--active': isActive }">
+		<div class="cardHeader">
+			<h2>
+				<OfficeBuilding :size="20" />
+				{{ item.name }}
+				<span v-if="item.isDefault" class="defaultBadge">Standaard</span>
+				<span v-if="isActive" class="activeBadge">Actief</span>
+			</h2>
+			<NcActions :primary="true" menu-name="Actions">
+				<template #icon>
+					<DotsHorizontal :size="20" />
+				</template>
+				<NcActionButton close-after-click
+					@click="$emit('view', item)">
+					<template #icon>
+						<Eye :size="20" />
+					</template>
+					Bekijken
+				</NcActionButton>
+				<NcActionButton v-if="!isActive"
+					close-after-click
+					@click="$emit('set-active', item.uuid)">
+					<template #icon>
+						<Check :size="20" />
+					</template>
+					Instellen als Actief
+				</NcActionButton>
+				<NcActionButton v-if="canEdit"
+					close-after-click
+					@click="$emit('edit', item)">
+					<template #icon>
+						<Pencil :size="20" />
+					</template>
+					Bewerken
+				</NcActionButton>
+				<NcActionButton v-if="item.website"
+					close-after-click
+					@click="$emit('go-to', item)">
+					<template #icon>
+						<OpenInNew :size="20" />
+					</template>
+					Ga naar organisatie
+				</NcActionButton>
+				<NcActionButton
+					close-after-click
+					@click="$emit('add-user', item)">
+					<template #icon>
+						<AccountMultiplePlus :size="20" />
+					</template>
+					Add User
+				</NcActionButton>
+				<NcActionButton v-if="canDelete"
+					close-after-click
+					@click="organisationStore.setOrganisationItem(item); navigationStore.setModal('deleteOrganisation')">
+					<template #icon>
+						<TrashCanOutline :size="20" />
+					</template>
+					Verwijderen
+				</NcActionButton>
+			</NcActions>
+		</div>
+
+		<div class="organisationInfo">
+			<p v-if="item.description" class="description">
+				{{ item.description }}
+			</p>
+			<div class="organisationStats">
+				<div class="stat">
+					<span class="statLabel">Leden:</span>
+					<span class="statValue">{{ item.users?.length || 0 }}</span>
+				</div>
+				<div class="stat">
+					<span class="statLabel">Eigenaar:</span>
+					<span class="statValue">{{ item.owner || 'System' }}</span>
+				</div>
+				<div v-if="item.created" class="stat">
+					<span class="statLabel">Aangemaakt:</span>
+					<span class="statValue">{{ formatDate(item.created) }}</span>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcActions, NcActionButton } from '@nextcloud/vue'
+import OfficeBuilding from 'vue-material-design-icons/OfficeBuilding.vue'
+import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
+import TrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
+import AccountMultiplePlus from 'vue-material-design-icons/AccountMultiplePlus.vue'
+import Eye from 'vue-material-design-icons/Eye.vue'
+import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
+import Check from 'vue-material-design-icons/Check.vue'
+
+export default {
+	name: 'OrganisationCard',
+	components: {
+		NcActions,
+		NcActionButton,
+		OfficeBuilding,
+		DotsHorizontal,
+		Pencil,
+		TrashCanOutline,
+		AccountMultiplePlus,
+		Eye,
+		OpenInNew,
+		Check,
+	},
+	props: {
+		item: {
+			type: Object,
+			required: true,
+		},
+		isActive: {
+			type: Boolean,
+			default: false,
+		},
+		canEdit: {
+			type: Boolean,
+			default: false,
+		},
+		canDelete: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	emits: ['view', 'set-active', 'edit', 'go-to', 'add-user'],
+	methods: {
+		formatDate(dateString) {
+			return new Date(dateString).toLocaleDateString({
+				day: '2-digit',
+				month: '2-digit',
+				year: 'numeric',
+			}) + ', ' + new Date(dateString).toLocaleTimeString({
+				hour: '2-digit',
+				minute: '2-digit',
+			})
+		},
+	},
+}
+</script>
+
+<style scoped lang="scss">
+.orgCard {
+	padding: 16px;
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius-large);
+	background: var(--color-main-background);
+	height: 100%;
+}
+
+.orgCard--active {
+	border: 2px solid var(--color-success) !important;
+	background: var(--color-success-light) !important;
+}
+
+.cardHeader {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-start;
+
+	h2 {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		font-size: 16px;
+		margin: 0;
+		flex-wrap: wrap;
+	}
+}
+
+.defaultBadge, .activeBadge {
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 12px;
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+}
+
+.defaultBadge {
+	background: var(--color-warning);
+	color: var(--color-primary-text);
+}
+
+.activeBadge {
+	background: var(--color-success);
+	color: white;
+}
+
+.organisationInfo {
+	padding: 12px 0 0;
+}
+
+.description {
+	color: var(--color-text-lighter);
+	margin-bottom: 12px;
+	font-style: italic;
+}
+
+.organisationStats {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.stat {
+	display: flex;
+	justify-content: space-between;
+}
+
+.statLabel {
+	color: var(--color-text-lighter);
+	font-size: 12px;
+}
+
+.statValue {
+	font-weight: 600;
+	font-size: 12px;
+}
+</style>

--- a/src/components/cards/OrganisationCard.vue
+++ b/src/components/cards/OrganisationCard.vue
@@ -1,7 +1,3 @@
-<script setup>
-import { organisationStore, navigationStore } from '../../store/store.js'
-</script>
-
 <template>
 	<div class="orgCard"
 		:class="{ 'orgCard--active': isActive }">
@@ -12,58 +8,11 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 				<span v-if="item.isDefault" class="defaultBadge">Standaard</span>
 				<span v-if="isActive" class="activeBadge">Actief</span>
 			</h2>
-			<NcActions :primary="true" menu-name="Actions">
-				<template #icon>
-					<DotsHorizontal :size="20" />
-				</template>
-				<NcActionButton close-after-click
-					@click="$emit('view', item)">
-					<template #icon>
-						<Eye :size="20" />
-					</template>
-					Bekijken
-				</NcActionButton>
-				<NcActionButton v-if="!isActive"
-					close-after-click
-					@click="$emit('set-active', item.uuid)">
-					<template #icon>
-						<Check :size="20" />
-					</template>
-					Instellen als Actief
-				</NcActionButton>
-				<NcActionButton v-if="canEdit"
-					close-after-click
-					@click="$emit('edit', item)">
-					<template #icon>
-						<Pencil :size="20" />
-					</template>
-					Bewerken
-				</NcActionButton>
-				<NcActionButton v-if="item.website"
-					close-after-click
-					@click="$emit('go-to', item)">
-					<template #icon>
-						<OpenInNew :size="20" />
-					</template>
-					Ga naar organisatie
-				</NcActionButton>
-				<NcActionButton
-					close-after-click
-					@click="$emit('add-user', item)">
-					<template #icon>
-						<AccountMultiplePlus :size="20" />
-					</template>
-					Add User
-				</NcActionButton>
-				<NcActionButton v-if="canDelete"
-					close-after-click
-					@click="organisationStore.setOrganisationItem(item); navigationStore.setModal('deleteOrganisation')">
-					<template #icon>
-						<TrashCanOutline :size="20" />
-					</template>
-					Verwijderen
-				</NcActionButton>
-			</NcActions>
+			<CnRowActions
+				:actions="actions"
+				:row="item"
+				:primary="true"
+				menu-name="Actions" />
 		</div>
 
 		<div class="organisationInfo">
@@ -89,29 +38,14 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 </template>
 
 <script>
-import { NcActions, NcActionButton } from '@nextcloud/vue'
+import { CnRowActions } from '@conduction/nextcloud-vue'
 import OfficeBuilding from 'vue-material-design-icons/OfficeBuilding.vue'
-import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
-import Pencil from 'vue-material-design-icons/Pencil.vue'
-import TrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
-import AccountMultiplePlus from 'vue-material-design-icons/AccountMultiplePlus.vue'
-import Eye from 'vue-material-design-icons/Eye.vue'
-import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
-import Check from 'vue-material-design-icons/Check.vue'
 
 export default {
 	name: 'OrganisationCard',
 	components: {
-		NcActions,
-		NcActionButton,
+		CnRowActions,
 		OfficeBuilding,
-		DotsHorizontal,
-		Pencil,
-		TrashCanOutline,
-		AccountMultiplePlus,
-		Eye,
-		OpenInNew,
-		Check,
 	},
 	props: {
 		item: {
@@ -122,16 +56,11 @@ export default {
 			type: Boolean,
 			default: false,
 		},
-		canEdit: {
-			type: Boolean,
-			default: false,
-		},
-		canDelete: {
-			type: Boolean,
-			default: false,
+		actions: {
+			type: Array,
+			default: () => [],
 		},
 	},
-	emits: ['view', 'set-active', 'edit', 'go-to', 'add-user'],
 	methods: {
 		formatDate(dateString) {
 			return new Date(dateString).toLocaleDateString({

--- a/src/components/cards/OrganisationCard.vue
+++ b/src/components/cards/OrganisationCard.vue
@@ -154,6 +154,9 @@ export default {
 	border-radius: var(--border-radius-large);
 	background: var(--color-main-background);
 	height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
 }
 
 .orgCard--active {

--- a/src/modals/organisation/EditOrganisation.vue
+++ b/src/modals/organisation/EditOrganisation.vue
@@ -3,415 +3,363 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 </script>
 
 <template>
-	<NcDialog :name="organisationStore.organisationItem?.uuid && !createAnother ? 'Edit Organisation' : 'Create Organisation'"
-		size="large"
-		:can-close="true"
-		@update:open="handleDialogOpen">
-		<NcNoteCard v-if="success" type="success">
-			<p>Organisation successfully {{ organisationStore.organisationItem?.uuid && !createAnother ? 'updated' : 'created' }}</p>
-		</NcNoteCard>
-		<NcNoteCard v-if="error" type="error">
-			<p>{{ error }}</p>
-		</NcNoteCard>
-		<div v-if="createAnother || !success">
-			<!-- Tabs -->
-			<div class="tabContainer">
-				<BTabs v-model="activeTab" content-class="mt-3" justified>
-					<BTab active>
-						<template #title>
-							<Cog :size="16" />
-							<span>Settings</span>
-						</template>
-						<div class="form-editor">
-							<NcTextField
-								:disabled="loading"
-								label="Name *"
-								:value.sync="organisationItem.name"
-								:error="!organisationItem.name.trim()"
-								placeholder="Enter organisation name" />
+	<Fragment>
+		<CnTabbedFormDialog
+			ref="dialog"
+			:tabs="dialogTabs"
+			:item="organisationStore.organisationItem?.uuid ? organisationStore.organisationItem : null"
+			entity-name="Organisation"
+			:show-create-another="true"
+			:disable-save="!organisationItem.name.trim()"
+			@confirm="saveOrganisation"
+			@close="closeModal"
+			@reset="resetForm">
+			<!-- Settings Tab -->
+			<template #tab-settings="{ loading: dialogLoading }">
+				<NcTextField
+					:disabled="dialogLoading"
+					label="Name *"
+					:value.sync="organisationItem.name"
+					:error="!organisationItem.name.trim()"
+					placeholder="Enter organisation name" />
 
-							<NcTextField
-								:disabled="loading"
-								label="Slug"
-								:value.sync="organisationItem.slug"
-								placeholder="Optional URL-friendly identifier" />
+				<NcTextField
+					:disabled="dialogLoading"
+					label="Slug"
+					:value.sync="organisationItem.slug"
+					placeholder="Optional URL-friendly identifier" />
 
-							<NcTextArea
-								:disabled="loading"
-								label="Description"
-								:value.sync="organisationItem.description"
-								placeholder="Enter organisation description (optional)"
-								:rows="4" />
+				<NcTextArea
+					:disabled="dialogLoading"
+					label="Description"
+					:value.sync="organisationItem.description"
+					placeholder="Enter organisation description (optional)"
+					:rows="4" />
 
-							<div class="groups-select-container">
-								<label class="groups-label">Nextcloud Groups</label>
-								<NcSelect
-									v-model="selectedGroups"
-									:disabled="loading || loadingGroups"
-									:options="availableGroups"
-									label="name"
-									track-by="id"
-									:multiple="true"
-									:label-outside="true"
-									:filterable="false"
-									placeholder="Search groups..."
-									@search-change="searchGroups"
-									@input="updateGroups">
-									<template #option="{ name }">
-										<div class="group-option">
-											<span class="group-name">{{ name }}</span>
-										</div>
-									</template>
-									<template #no-options>
-										<span v-if="loadingGroups">Loading groups...</span>
-										<span v-else>No groups found. Try a different search.</span>
-									</template>
-								</NcSelect>
-								<p class="field-hint">
-									Only members of selected groups can access this organisation
-								</p>
+				<div class="groups-select-container">
+					<label class="groups-label">Nextcloud Groups</label>
+					<NcSelect
+						v-model="selectedGroups"
+						:disabled="dialogLoading || loadingGroups"
+						:options="availableGroups"
+						label="name"
+						track-by="id"
+						:multiple="true"
+						:label-outside="true"
+						:filterable="false"
+						placeholder="Search groups..."
+						@search-change="searchGroups"
+						@input="updateGroups">
+						<template #option="{ name }">
+							<div class="group-option">
+								<span class="group-name">{{ name }}</span>
 							</div>
-
-							<NcCheckboxRadioSwitch
-								:disabled="loading"
-								:checked.sync="organisationItem.active">
-								Active
-							</NcCheckboxRadioSwitch>
-
-							<NcNoteCard v-if="!organisationItem.active" type="warning">
-								<p>Inactive organisations cannot be used</p>
-							</NcNoteCard>
-						</div>
-					</BTab>
-
-					<BTab>
-						<template #title>
-							<Database :size="16" />
-							<span>Quota</span>
 						</template>
-						<div class="form-editor">
-							<NcTextField
-								:disabled="loading"
-								label="Storage Quota (MB)"
-								type="number"
-								placeholder="0 = unlimited"
-								:value="storageQuotaMB"
-								@update:value="updateStorageQuota" />
-
-							<NcTextField
-								:disabled="loading"
-								label="Bandwidth Quota (MB/month)"
-								type="number"
-								placeholder="0 = unlimited"
-								:value="bandwidthQuotaMB"
-								@update:value="updateBandwidthQuota" />
-
-							<NcTextField
-								:disabled="loading"
-								label="API Request Quota (requests/day)"
-								type="number"
-								placeholder="0 = unlimited"
-								:value="organisationItem.quota?.requests || 0"
-								@update:value="updateRequestQuota" />
-
-							<NcTextField
-								:disabled="loading"
-								label="User Quota"
-								type="number"
-								placeholder="0 = unlimited"
-								:value="organisationItem.quota?.users || 0"
-								@update:value="updateUserQuota" />
-
-							<NcTextField
-								:disabled="loading"
-								label="Group Quota"
-								type="number"
-								placeholder="0 = unlimited"
-								:value="organisationItem.quota?.groups || 0"
-								@update:value="updateGroupQuota" />
-						</div>
-					</BTab>
-
-					<BTab :disabled="!organisationItem.uuid">
-						<template #title>
-							<AccountMultiple :size="16" />
-							<span>Users</span>
+						<template #no-options>
+							<span v-if="loadingGroups">Loading groups...</span>
+							<span v-else>No groups found. Try a different search.</span>
 						</template>
-						<div class="users-section">
-							<div class="users-header">
+					</NcSelect>
+					<p class="field-hint">
+						Only members of selected groups can access this organisation
+					</p>
+				</div>
+
+				<NcCheckboxRadioSwitch
+					:disabled="dialogLoading"
+					:checked.sync="organisationItem.active">
+					Active
+				</NcCheckboxRadioSwitch>
+
+				<NcNoteCard v-if="!organisationItem.active" type="warning">
+					<p>Inactive organisations cannot be used</p>
+				</NcNoteCard>
+			</template>
+
+			<!-- Quota Tab -->
+			<template #tab-quota="{ loading: dialogLoading }">
+				<NcTextField
+					:disabled="dialogLoading"
+					label="Storage Quota (MB)"
+					type="number"
+					placeholder="0 = unlimited"
+					:value="storageQuotaMB"
+					@update:value="updateStorageQuota" />
+
+				<NcTextField
+					:disabled="dialogLoading"
+					label="Bandwidth Quota (MB/month)"
+					type="number"
+					placeholder="0 = unlimited"
+					:value="bandwidthQuotaMB"
+					@update:value="updateBandwidthQuota" />
+
+				<NcTextField
+					:disabled="dialogLoading"
+					label="API Request Quota (requests/day)"
+					type="number"
+					placeholder="0 = unlimited"
+					:value="organisationItem.quota?.requests || 0"
+					@update:value="updateRequestQuota" />
+
+				<NcTextField
+					:disabled="dialogLoading"
+					label="User Quota"
+					type="number"
+					placeholder="0 = unlimited"
+					:value="organisationItem.quota?.users || 0"
+					@update:value="updateUserQuota" />
+
+				<NcTextField
+					:disabled="dialogLoading"
+					label="Group Quota"
+					type="number"
+					placeholder="0 = unlimited"
+					:value="organisationItem.quota?.groups || 0"
+					@update:value="updateGroupQuota" />
+			</template>
+
+			<!-- Users Tab -->
+			<template #tab-users="{ loading: dialogLoading }">
+				<div class="users-section">
+					<div class="users-header">
+						<NcButton
+							v-if="organisationItem.uuid"
+							type="primary"
+							:disabled="dialogLoading"
+							@click="showAddUserDialog = true">
+							<template #icon>
+								<AccountPlus :size="20" />
+							</template>
+							Add User
+						</NcButton>
+					</div>
+
+					<div v-if="loadingUsers" class="loading-users">
+						<NcLoadingIcon :size="20" />
+						<span>Loading users...</span>
+					</div>
+
+					<div v-else-if="organisationUsers.length > 0" class="users-list">
+						<h3>Members ({{ organisationUsers.length }})</h3>
+						<div class="user-items">
+							<div v-for="userId in organisationUsers" :key="userId" class="user-item">
+								<div class="user-info">
+									<AccountCircle :size="20" class="user-icon" />
+									<span class="user-id">{{ userId }}</span>
+									<span v-if="userId === organisationItem.owner" class="owner-badge">Owner</span>
+								</div>
 								<NcButton
-									v-if="organisationItem.uuid"
-									type="primary"
-									:disabled="loading"
-									@click="showAddUserDialog = true">
+									v-if="userId !== organisationItem.owner"
+									type="tertiary"
+									:disabled="dialogLoading || removingUser === userId"
+									@click="removeUser(userId)">
 									<template #icon>
-										<AccountPlus :size="20" />
+										<NcLoadingIcon v-if="removingUser === userId" :size="16" />
+										<AccountMinus v-else :size="16" />
 									</template>
-									Add User
+									Remove
 								</NcButton>
 							</div>
-
-							<div v-if="loadingUsers" class="loading-users">
-								<NcLoadingIcon :size="20" />
-								<span>Loading users...</span>
-							</div>
-
-							<div v-else-if="organisationUsers.length > 0" class="users-list">
-								<h3>Members ({{ organisationUsers.length }})</h3>
-								<div class="user-items">
-									<div v-for="userId in organisationUsers" :key="userId" class="user-item">
-										<div class="user-info">
-											<AccountCircle :size="20" class="user-icon" />
-											<span class="user-id">{{ userId }}</span>
-											<span v-if="userId === organisationItem.owner" class="owner-badge">Owner</span>
-										</div>
-										<NcButton
-											v-if="userId !== organisationItem.owner"
-											type="tertiary"
-											:disabled="loading || removingUser === userId"
-											@click="removeUser(userId)">
-											<template #icon>
-												<NcLoadingIcon v-if="removingUser === userId" :size="16" />
-												<AccountMinus v-else :size="16" />
-											</template>
-											Remove
-										</NcButton>
-									</div>
-								</div>
-							</div>
-
-							<div v-else class="no-users">
-								<p>No users in this organisation.</p>
-							</div>
-
-							<NcNoteCard v-if="!organisationItem.uuid" type="warning">
-								<p>Save the organisation first to manage users.</p>
-							</NcNoteCard>
 						</div>
+					</div>
+
+					<div v-else class="no-users">
+						<p>No users in this organisation.</p>
+					</div>
+
+					<NcNoteCard v-if="!organisationItem.uuid" type="warning">
+						<p>Save the organisation first to manage users.</p>
+					</NcNoteCard>
+				</div>
+			</template>
+
+			<!-- Security Tab -->
+			<template #tab-security>
+				<div v-if="loadingGroups" class="loading-groups">
+					<NcLoadingIcon :size="20" />
+					<span>Loading user groups...</span>
+				</div>
+
+				<BTabs v-else content-class="mt-3" pills>
+					<!-- Registers -->
+					<BTab title="Registers">
+						<RbacTable
+							entity-type="register"
+							:authorization="organisationItem.authorization || {}"
+							:available-groups="availableGroups"
+							:organisation-groups="organisationItem.groups || []"
+							@update="updateEntityPermission" />
 					</BTab>
 
-					<BTab>
-						<template #title>
-							<Shield :size="16" />
-							<span>Security</span>
-						</template>
-						<div class="security-section">
-							<div v-if="loadingGroups" class="loading-groups">
-								<NcLoadingIcon :size="20" />
-								<span>Loading user groups...</span>
-							</div>
+					<!-- Schemas -->
+					<BTab title="Schemas">
+						<RbacTable
+							entity-type="schema"
+							:authorization="organisationItem.authorization || {}"
+							:available-groups="availableGroups"
+							:organisation-groups="organisationItem.groups || []"
+							@update="updateEntityPermission" />
+					</BTab>
 
-							<div v-else class="rbac-container">
-								<BTabs content-class="mt-3" pills>
-									<!-- Registers -->
-									<BTab title="Registers">
-										<RbacTable
-											entity-type="register"
-											:authorization="organisationItem.authorization || {}"
-											:available-groups="availableGroups"
-											:organisation-groups="organisationItem.groups || []"
-											@update="updateEntityPermission" />
-									</BTab>
+					<!-- Objects -->
+					<BTab title="Objects">
+						<RbacTable
+							entity-type="object"
+							:authorization="organisationItem.authorization || {}"
+							:available-groups="availableGroups"
+							:organisation-groups="organisationItem.groups || []"
+							@update="updateEntityPermission" />
+					</BTab>
 
-									<!-- Schemas -->
-									<BTab title="Schemas">
-										<RbacTable
-											entity-type="schema"
-											:authorization="organisationItem.authorization || {}"
-											:available-groups="availableGroups"
-											:organisation-groups="organisationItem.groups || []"
-											@update="updateEntityPermission" />
-									</BTab>
+					<!-- Views -->
+					<BTab title="Views">
+						<RbacTable
+							entity-type="view"
+							:authorization="organisationItem.authorization || {}"
+							:available-groups="availableGroups"
+							:organisation-groups="organisationItem.groups || []"
+							@update="updateEntityPermission" />
+					</BTab>
 
-									<!-- Objects -->
-									<BTab title="Objects">
-										<RbacTable
-											entity-type="object"
-											:authorization="organisationItem.authorization || {}"
-											:available-groups="availableGroups"
-											:organisation-groups="organisationItem.groups || []"
-											@update="updateEntityPermission" />
-									</BTab>
+					<!-- Agents -->
+					<BTab title="Agents">
+						<RbacTable
+							entity-type="agent"
+							:authorization="organisationItem.authorization || {}"
+							:available-groups="availableGroups"
+							:organisation-groups="organisationItem.groups || []"
+							@update="updateEntityPermission" />
+					</BTab>
 
-									<!-- Views -->
-									<BTab title="Views">
-										<RbacTable
-											entity-type="view"
-											:authorization="organisationItem.authorization || {}"
-											:available-groups="availableGroups"
-											:organisation-groups="organisationItem.groups || []"
-											@update="updateEntityPermission" />
-									</BTab>
+					<!-- Configurations -->
+					<BTab title="Configurations">
+						<RbacTable
+							entity-type="configuration"
+							:authorization="organisationItem.authorization || {}"
+							:available-groups="availableGroups"
+							:organisation-groups="organisationItem.groups || []"
+							@update="updateEntityPermission" />
+					</BTab>
 
-									<!-- Agents -->
-									<BTab title="Agents">
-										<RbacTable
-											entity-type="agent"
-											:authorization="organisationItem.authorization || {}"
-											:available-groups="availableGroups"
-											:organisation-groups="organisationItem.groups || []"
-											@update="updateEntityPermission" />
-									</BTab>
+					<!-- Applications -->
+					<BTab title="Applications">
+						<RbacTable
+							entity-type="application"
+							:authorization="organisationItem.authorization || {}"
+							:available-groups="availableGroups"
+							:organisation-groups="organisationItem.groups || []"
+							@update="updateEntityPermission" />
+					</BTab>
 
-									<!-- Configurations -->
-									<BTab title="Configurations">
-										<RbacTable
-											entity-type="configuration"
-											:authorization="organisationItem.authorization || {}"
-											:available-groups="availableGroups"
-											:organisation-groups="organisationItem.groups || []"
-											@update="updateEntityPermission" />
-									</BTab>
+					<!-- Special Rights -->
+					<BTab title="Special Rights">
+						<div class="special-rights-container">
+							<p class="rbac-description">
+								Grant additional permissions beyond standard CRUD operations
+							</p>
 
-									<!-- Applications -->
-									<BTab title="Applications">
-										<RbacTable
-											entity-type="application"
-											:authorization="organisationItem.authorization || {}"
-											:available-groups="availableGroups"
-											:organisation-groups="organisationItem.groups || []"
-											@update="updateEntityPermission" />
-									</BTab>
-
-									<!-- Special Rights -->
-									<BTab title="Special Rights">
-										<div class="special-rights-container">
-											<p class="rbac-description">
-												Grant additional permissions beyond standard CRUD operations
-											</p>
-
-											<table class="rbac-table special-rights-table">
-												<thead>
-													<tr>
-														<th>Right</th>
-														<th>Description</th>
-														<th>Groups</th>
-													</tr>
-												</thead>
-												<tbody>
-													<tr>
-														<td class="right-name">
-															<span class="right-badge">object_publish</span>
-														</td>
-														<td class="right-description">
-															Publish objects to make them publicly available
-														</td>
-														<td class="right-groups">
-															<NcSelect
-																v-model="selectedSpecialRights.object_publish"
-																:options="filteredAvailableGroups"
-																label="name"
-																track-by="id"
-																:multiple="true"
-																placeholder="Select groups..."
-																@input="updateSpecialRight('object_publish', $event)" />
-														</td>
-													</tr>
-													<tr>
-														<td class="right-name">
-															<span class="right-badge">agent_use</span>
-														</td>
-														<td class="right-description">
-															Use AI agents for processing and analysis
-														</td>
-														<td class="right-groups">
-															<NcSelect
-																v-model="selectedSpecialRights.agent_use"
-																:options="filteredAvailableGroups"
-																label="name"
-																track-by="id"
-																:multiple="true"
-																placeholder="Select groups..."
-																@input="updateSpecialRight('agent_use', $event)" />
-														</td>
-													</tr>
-													<tr>
-														<td class="right-name">
-															<span class="right-badge">dashboard_view</span>
-														</td>
-														<td class="right-description">
-															Access organisation dashboard and analytics
-														</td>
-														<td class="right-groups">
-															<NcSelect
-																v-model="selectedSpecialRights.dashboard_view"
-																:options="filteredAvailableGroups"
-																label="name"
-																track-by="id"
-																:multiple="true"
-																placeholder="Select groups..."
-																@input="updateSpecialRight('dashboard_view', $event)" />
-														</td>
-													</tr>
-													<tr>
-														<td class="right-name">
-															<span class="right-badge">llm_use</span>
-														</td>
-														<td class="right-description">
-															Use Large Language Model features
-														</td>
-														<td class="right-groups">
-															<NcSelect
-																v-model="selectedSpecialRights.llm_use"
-																:options="filteredAvailableGroups"
-																label="name"
-																track-by="id"
-																:multiple="true"
-																placeholder="Select groups..."
-																@input="updateSpecialRight('llm_use', $event)" />
-														</td>
-													</tr>
-												</tbody>
-											</table>
-										</div>
-									</BTab>
-								</BTabs>
-							</div>
+							<table class="rbac-table special-rights-table">
+								<thead>
+									<tr>
+										<th>Right</th>
+										<th>Description</th>
+										<th>Groups</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td class="right-name">
+											<span class="right-badge">object_publish</span>
+										</td>
+										<td class="right-description">
+											Publish objects to make them publicly available
+										</td>
+										<td class="right-groups">
+											<NcSelect
+												v-model="selectedSpecialRights.object_publish"
+												:options="filteredAvailableGroups"
+												label="name"
+												track-by="id"
+												:multiple="true"
+												placeholder="Select groups..."
+												@input="updateSpecialRight('object_publish', $event)" />
+										</td>
+									</tr>
+									<tr>
+										<td class="right-name">
+											<span class="right-badge">agent_use</span>
+										</td>
+										<td class="right-description">
+											Use AI agents for processing and analysis
+										</td>
+										<td class="right-groups">
+											<NcSelect
+												v-model="selectedSpecialRights.agent_use"
+												:options="filteredAvailableGroups"
+												label="name"
+												track-by="id"
+												:multiple="true"
+												placeholder="Select groups..."
+												@input="updateSpecialRight('agent_use', $event)" />
+										</td>
+									</tr>
+									<tr>
+										<td class="right-name">
+											<span class="right-badge">dashboard_view</span>
+										</td>
+										<td class="right-description">
+											Access organisation dashboard and analytics
+										</td>
+										<td class="right-groups">
+											<NcSelect
+												v-model="selectedSpecialRights.dashboard_view"
+												:options="filteredAvailableGroups"
+												label="name"
+												track-by="id"
+												:multiple="true"
+												placeholder="Select groups..."
+												@input="updateSpecialRight('dashboard_view', $event)" />
+										</td>
+									</tr>
+									<tr>
+										<td class="right-name">
+											<span class="right-badge">llm_use</span>
+										</td>
+										<td class="right-description">
+											Use Large Language Model features
+										</td>
+										<td class="right-groups">
+											<NcSelect
+												v-model="selectedSpecialRights.llm_use"
+												:options="filteredAvailableGroups"
+												label="name"
+												track-by="id"
+												:multiple="true"
+												placeholder="Select groups..."
+												@input="updateSpecialRight('llm_use', $event)" />
+										</td>
+									</tr>
+								</tbody>
+							</table>
 						</div>
 					</BTab>
 				</BTabs>
-			</div>
-		</div>
+			</template>
+		</CnTabbedFormDialog>
 
-		<template #actions>
-			<NcCheckboxRadioSwitch
-				v-if="!organisationStore.organisationItem?.uuid"
-				class="create-another-checkbox"
-				:disabled="loading"
-				:checked.sync="createAnother">
-				Create another
-			</NcCheckboxRadioSwitch>
-			<NcButton @click="closeModal">
-				<template #icon>
-					<Cancel :size="20" />
-				</template>
-				{{ success ? 'Close' : 'Cancel' }}
-			</NcButton>
-			<NcButton v-if="createAnother || !success"
-				:disabled="loading || !organisationItem.name.trim()"
-				type="primary"
-				@click="saveOrganisation()">
-				<template #icon>
-					<NcLoadingIcon v-if="loading" :size="20" />
-					<ContentSaveOutline v-if="!loading && organisationStore.organisationItem?.uuid" :size="20" />
-					<Plus v-if="!loading && !organisationStore.organisationItem?.uuid" :size="20" />
-				</template>
-				{{ organisationStore.organisationItem?.uuid && !createAnother ? 'Save' : 'Create' }}
-			</NcButton>
-		</template>
 		<RemoveUserDialog
 			:show="showRemoveUserDialog"
 			:user-id="userToRemove"
 			:removing="removingUser !== null"
 			@cancel="cancelRemoveUser"
 			@confirm="confirmRemoveUser" />
-	</NcDialog>
+	</Fragment>
 </template>
 
 <script>
 import {
 	NcButton,
-	NcDialog,
 	NcTextField,
 	NcTextArea,
 	NcSelect,
@@ -419,12 +367,10 @@ import {
 	NcNoteCard,
 	NcCheckboxRadioSwitch,
 } from '@nextcloud/vue'
+import { CnTabbedFormDialog } from '@conduction/nextcloud-vue'
 import { BTabs, BTab } from 'bootstrap-vue'
 import { showSuccess, showError } from '@nextcloud/dialogs'
 
-import ContentSaveOutline from 'vue-material-design-icons/ContentSaveOutline.vue'
-import Cancel from 'vue-material-design-icons/Cancel.vue'
-import Plus from 'vue-material-design-icons/Plus.vue'
 import AccountCircle from 'vue-material-design-icons/AccountCircle.vue'
 import AccountMinus from 'vue-material-design-icons/AccountMinus.vue'
 import AccountPlus from 'vue-material-design-icons/AccountPlus.vue'
@@ -439,7 +385,7 @@ import RbacTable from '../../components/RbacTable.vue'
 export default {
 	name: 'EditOrganisation',
 	components: {
-		NcDialog,
+		CnTabbedFormDialog,
 		NcTextField,
 		NcTextArea,
 		NcSelect,
@@ -452,20 +398,12 @@ export default {
 		RemoveUserDialog,
 		RbacTable,
 		// Icons
-		ContentSaveOutline,
-		Cancel,
-		Plus,
 		AccountCircle,
 		AccountMinus,
 		AccountPlus,
-		Cog,
-		Database,
-		AccountMultiple,
-		Shield,
 	},
 	data() {
 		return {
-			activeTab: 0,
 			organisationItem: {
 				name: '',
 				slug: '',
@@ -496,14 +434,22 @@ export default {
 			showRemoveUserDialog: false,
 			showAddUserDialog: false,
 			userToRemove: null,
-			createAnother: false,
-			success: false,
-			loading: false,
-			error: false,
-			closeModalTimeout: null,
 		}
 	},
 	computed: {
+		/**
+		 * Tab definitions for CnTabbedFormDialog
+		 *
+		 * @return {Array} Tab configuration
+		 */
+		dialogTabs() {
+			return [
+				{ id: 'settings', title: 'Settings', icon: Cog },
+				{ id: 'quota', title: 'Quota', icon: Database },
+				{ id: 'users', title: 'Users', icon: AccountMultiple, disabled: !this.organisationItem.uuid },
+				{ id: 'security', title: 'Security', icon: Shield },
+			]
+		},
 		storageQuotaMB() {
 			if (!this.organisationItem.quota?.storage) return 0
 			return Math.round(this.organisationItem.quota.storage / (1024 * 1024))
@@ -536,7 +482,6 @@ export default {
 				// Only reinitialize if the UUID changed (different organisation) or went from null to something
 				if (newVal && (!oldVal || newVal.uuid !== oldVal?.uuid)) {
 					this.initializeOrganisationItem()
-					// Users are already included in the organisation object, no need to fetch separately
 				}
 			},
 			deep: true,
@@ -575,7 +520,6 @@ export default {
 					this.initializeOrganisationItem()
 				}).catch(error => {
 					console.error('Error loading Nextcloud groups:', error)
-					this.error = 'Failed to load Nextcloud groups'
 					this.loadingGroups = false
 				})
 			}
@@ -688,6 +632,29 @@ export default {
 		},
 
 		/**
+		 * Reset form data for "create another" mode
+		 *
+		 * @return {void}
+		 */
+		resetForm() {
+			this.organisationItem = {
+				name: '',
+				slug: '',
+				description: '',
+				active: true,
+				quota: {
+					storage: 0,
+					bandwidth: 0,
+					requests: 0,
+					users: 0,
+					groups: 0,
+				},
+				groups: [],
+			}
+			this.selectedGroups = []
+		},
+
+		/**
 		 * Show confirmation dialog before removing a user
 		 *
 		 * @param {string} userId - User ID to remove
@@ -719,7 +686,6 @@ export default {
 			if (!this.organisationItem.uuid || !this.userToRemove) return
 
 			this.removingUser = this.userToRemove
-			this.error = null
 
 			try {
 				const response = await fetch(
@@ -750,26 +716,15 @@ export default {
 					showSuccess(this.$t('openregister', 'User removed successfully'))
 				} else {
 					const errorData = await response.json()
-					this.error = errorData.error || 'Failed to remove user from organisation'
-					showError(this.error)
+					const errorMsg = errorData.error || 'Failed to remove user from organisation'
+					showError(errorMsg)
 				}
 			} catch (error) {
 				console.error('Error removing user:', error)
-				this.error = 'Failed to remove user from organisation'
-				showError(this.error)
+				showError('Failed to remove user from organisation')
 			} finally {
 				this.removingUser = null
 			}
-		},
-
-		/**
-		 * Get current user
-		 *
-		 * @return {string}
-		 */
-		getCurrentUser() {
-			// Implementation would depend on how you get current user
-			return 'current-user' // Placeholder
 		},
 
 		/**
@@ -785,25 +740,13 @@ export default {
 		},
 
 		/**
-		 * Remove a group from selection
-		 *
-		 * @param {object} groupToRemove - Group to remove
-		 * @return {void}
-		 */
-		removeGroup(groupToRemove) {
-			this.selectedGroups = this.selectedGroups.filter(g => g.id !== groupToRemove.id)
-			// Store only the group IDs, not the full objects
-			this.organisationItem.groups = this.selectedGroups.map(group => group.id)
-		},
-
-		/**
 		 * Update storage quota (converts MB to bytes)
 		 *
 		 * @param {number} value - Quota in MB
 		 * @return {void}
 		 */
 		updateStorageQuota(value) {
-		// Convert MB to bytes (0 = unlimited)
+			// Convert MB to bytes (0 = unlimited)
 			const mbValue = value ? parseInt(value) : 0
 			if (!this.organisationItem.quota) {
 				this.organisationItem.quota = { storage: 0, bandwidth: 0, requests: 0, users: 0, groups: 0 }
@@ -818,7 +761,7 @@ export default {
 		 * @return {void}
 		 */
 		updateBandwidthQuota(value) {
-		// Convert MB to bytes (0 = unlimited)
+			// Convert MB to bytes (0 = unlimited)
 			const mbValue = value ? parseInt(value) : 0
 			if (!this.organisationItem.quota) {
 				this.organisationItem.quota = { storage: 0, bandwidth: 0, requests: 0, users: 0, groups: 0 }
@@ -833,7 +776,7 @@ export default {
 		 * @return {void}
 		 */
 		updateRequestQuota(value) {
-		// 0 = unlimited
+			// 0 = unlimited
 			if (!this.organisationItem.quota) {
 				this.organisationItem.quota = { storage: 0, bandwidth: 0, requests: 0, users: 0, groups: 0 }
 			}
@@ -847,7 +790,7 @@ export default {
 		 * @return {void}
 		 */
 		updateUserQuota(value) {
-		// 0 = unlimited
+			// 0 = unlimited
 			if (!this.organisationItem.quota) {
 				this.organisationItem.quota = { storage: 0, bandwidth: 0, requests: 0, users: 0, groups: 0 }
 			}
@@ -861,7 +804,7 @@ export default {
 		 * @return {void}
 		 */
 		updateGroupQuota(value) {
-		// 0 = unlimited
+			// 0 = unlimited
 			if (!this.organisationItem.quota) {
 				this.organisationItem.quota = { storage: 0, bandwidth: 0, requests: 0, users: 0, groups: 0 }
 			}
@@ -874,14 +817,9 @@ export default {
 		 * @return {void}
 		 */
 		closeModal() {
-			this.success = false
-			this.error = null
-			this.createAnother = false
 			this.selectedGroups = []
-			this.activeTab = 0
 			navigationStore.setModal(false)
 			navigationStore.setDialog(false)
-			clearTimeout(this.closeModalTimeout)
 		},
 
 		/**
@@ -890,13 +828,9 @@ export default {
 		 * @return {Promise<void>}
 		 */
 		async saveOrganisation() {
-			this.loading = true
-			this.error = null
-
 			// Validate required fields
 			if (!this.organisationItem.name.trim()) {
-				this.error = 'Organisation name is required'
-				this.loading = false
+				this.$refs.dialog.setResult({ error: 'Organisation name is required' })
 				return
 			}
 
@@ -914,59 +848,14 @@ export default {
 						await organisationStore.getActiveOrganisation()
 					}
 
-					if (this.createAnother) {
-						// Clear the form after successful creation
-						setTimeout(() => {
-							this.organisationItem = {
-								name: '',
-								slug: '',
-								description: '',
-								active: true,
-								quota: {
-									storage: null,
-									bandwidth: null,
-									requests: null,
-								},
-								groups: [],
-							}
-							this.selectedGroups = []
-							this.activeTab = 0
-						}, 500)
-
-						this.success = true
-						this.error = false
-
-						// Clear success message after 2s
-						setTimeout(() => {
-							this.success = null
-						}, 2000)
-					} else {
-						this.success = true
-						this.error = false
-
-						this.closeModalTimeout = setTimeout(this.closeModal, 2000)
-					}
+					this.$refs.dialog.setResult({ success: true })
 				}
 
 			} catch (error) {
 				console.error('Error saving organisation:', error)
-				this.success = false
-				this.error = error.message || 'An error occurred while saving the organisation'
-			} finally {
-				this.loading = false
-			}
-		},
-
-		/**
-		 * Handle dialog open/close event
-		 *
-		 * @param {boolean} isOpen - Whether the dialog is open
-		 * @return {void}
-		 */
-		handleDialogOpen(isOpen) {
-			// Only close the modal if the dialog is being closed (isOpen = false)
-			if (!isOpen) {
-				this.closeModal()
+				this.$refs.dialog.setResult({
+					error: error.message || 'An error occurred while saving the organisation',
+				})
 			}
 		},
 
@@ -1059,29 +948,7 @@ export default {
 </script>
 
 <style scoped>
-/* EditOrganisation-specific styles */
-.tabContainer {
-	margin-top: 20px;
-}
-
-/* Tab title styling with icons */
-.tabContainer :deep(.nav-link) {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	justify-content: center;
-}
-
-.form-editor {
-	display: flex;
-	flex-direction: column;
-	gap: 16px;
-	padding: 16px 0;
-}
-
-.create-another-checkbox {
-	margin-right: auto;
-}
+/* Organisation-specific styles (tab shell handled by CnTabbedFormDialog) */
 
 .groups-select-container {
 	display: flex;
@@ -1111,13 +978,6 @@ export default {
 	font-weight: 500;
 }
 
-.security-section {
-	display: flex;
-	flex-direction: column;
-	gap: 16px;
-	padding: 16px 0;
-}
-
 .loading-groups {
 	display: flex;
 	align-items: center;
@@ -1126,62 +986,11 @@ export default {
 	padding: 16px;
 }
 
-.groups-list {
-	display: flex;
-	flex-direction: column;
-	gap: 12px;
-}
-
-.groups-list h3 {
-	margin: 0;
-	font-size: 16px;
-	font-weight: 500;
-	color: var(--color-main-text);
-}
-
-.group-items {
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
-}
-
-.group-item {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: 8px 12px;
-	background-color: var(--color-background-hover);
-	border-radius: var(--border-radius);
-}
-
-.group-badge {
-	display: inline-flex;
-	align-items: center;
-	padding: 4px 12px;
-	background-color: var(--color-primary-element-light);
-	color: var(--color-primary-element-text);
-	border-radius: 16px;
-	font-size: 13px;
-	font-weight: 500;
-}
-
-.no-groups {
-	padding: 16px;
-	text-align: center;
-	color: var(--color-text-lighter);
-	font-style: italic;
-}
-
-.no-groups p {
-	margin: 0;
-}
-
 /* Users section styles */
 .users-section {
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
-	padding: 16px 0;
 }
 
 .users-header {
@@ -1265,26 +1074,6 @@ export default {
 }
 
 /* RBAC Security Tab Styling */
-.rbac-container {
-	display: flex;
-	flex-direction: column;
-	gap: 16px;
-	padding: 16px 0;
-}
-
-.rbac-section {
-	display: flex;
-	flex-direction: column;
-	gap: 12px;
-}
-
-.rbac-section h3 {
-	margin: 0;
-	font-size: 18px;
-	font-weight: 600;
-	color: var(--color-main-text);
-}
-
 .rbac-description {
 	font-size: 14px;
 	color: var(--color-text-lighter);

--- a/src/modals/organisation/JoinOrganisation.vue
+++ b/src/modals/organisation/JoinOrganisation.vue
@@ -3,177 +3,129 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 </script>
 
 <template>
-	<NcDialog
-		name="Add User to Organisation"
-		size="normal"
-		:can-close="true"
-		@update:open="handleDialogClose">
-		<NcNoteCard v-if="success" type="success">
-			<p>Successfully added user to organisation: {{ joinedOrganisationName }}</p>
-		</NcNoteCard>
-		<NcNoteCard v-if="error" type="error">
-			<p>{{ error }}</p>
-		</NcNoteCard>
-
-		<div v-if="!success">
-			<div class="selection-section">
-				<!-- Organisation Selection -->
-				<div class="field-group">
-					<label for="organisation-select">Organisation</label>
-					<NcSelect
-						v-model="selectedOrganisation"
-						input-id="organisation-select"
-						input-label="Organisation"
-						:disabled="loading"
-						:loading="searchLoading"
-						:options="organisationOptions"
-						:filterable="true"
-						:filter-by="filterOrganisation"
-						placeholder="Type to search for organisations"
-						label-outside
-						@search="handleOrganisationSearch">
-						<template #option="{ name, description, users, isDefault }">
-							<div class="organisation-option">
-								<div class="organisation-header">
-									<span class="organisation-name">{{ name }}</span>
-									<span v-if="isDefault" class="badge badge-default">Default</span>
-								</div>
-								<p v-if="description" class="organisation-description">
-									{{ description }}
-								</p>
-								<span class="organisation-meta">{{ (users?.length || 0) }} members</span>
-							</div>
-						</template>
-						<template #selected-option="{ name }">
-							<span>{{ name }}</span>
-						</template>
-					</NcSelect>
+	<CnFormDialog
+		ref="formDialog"
+		:fields="fields"
+		dialog-title="Add User to Organisation"
+		confirm-label="Add User"
+		@confirm="onConfirm"
+		@close="onClose">
+		<!-- Organisation option: name, badge, description, member count -->
+		<template #field-organisation-option="{ name, description, users, isDefault }">
+			<div class="organisation-option">
+				<div class="organisation-header">
+					<span class="organisation-name">{{ name }}</span>
+					<span v-if="isDefault" class="badge badge-default">Default</span>
 				</div>
-
-				<!-- User Selection -->
-				<div class="field-group">
-					<label for="user-select">User</label>
-					<NcSelect
-						v-model="selectedUser"
-						input-id="user-select"
-						input-label="User"
-						:disabled="loading"
-						:loading="loadingUsers"
-						:options="userOptions"
-						:filterable="true"
-						placeholder="Type to search for users"
-						label-outside
-						@search="handleUserSearch">
-						<template #option="{ id, displayName }">
-							<div class="user-option">
-								<span class="user-name">{{ displayName }}</span>
-								<span class="user-id">{{ id }}</span>
-							</div>
-						</template>
-						<template #selected-option="{ displayName }">
-							<span>{{ displayName }}</span>
-						</template>
-					</NcSelect>
-					<p class="helper-text">
-						Defaults to current user. Select a different user if needed.
-					</p>
-				</div>
-
-				<div class="info-help">
-					<NcNoteCard type="info">
-						<p>Select an organisation and user to add them as a member. Search for organisations by name.</p>
-					</NcNoteCard>
-				</div>
+				<p v-if="description" class="organisation-description">
+					{{ description }}
+				</p>
+				<span class="organisation-meta">{{ (users?.length || 0) }} members</span>
 			</div>
-		</div>
-
-		<template #actions>
-			<NcButton @click="closeModal">
-				<template #icon>
-					<Cancel :size="20" />
-				</template>
-				{{ success ? 'Close' : 'Cancel' }}
-			</NcButton>
-			<NcButton
-				v-if="!success"
-				type="primary"
-				:disabled="!selectedOrganisation || joining"
-				@click="joinSelectedOrganisation">
-				<template #icon>
-					<NcLoadingIcon v-if="joining" :size="20" />
-					<AccountPlus v-else :size="20" />
-				</template>
-				Add User
-			</NcButton>
 		</template>
-	</NcDialog>
+		<template #field-organisation-selected-option="{ name }">
+			<span>{{ name }}</span>
+		</template>
+
+		<!-- User option: display name + id -->
+		<template #field-user-option="{ id, displayName }">
+			<div class="user-option">
+				<span class="user-name">{{ displayName }}</span>
+				<span class="user-id">{{ id }}</span>
+			</div>
+		</template>
+		<template #field-user-selected-option="{ displayName }">
+			<span>{{ displayName }}</span>
+		</template>
+
+		<!-- Info note below the form -->
+		<template #after-fields>
+			<NcNoteCard type="info">
+				<p>Select an organisation and user to add them as a member. Search for organisations by name.</p>
+			</NcNoteCard>
+		</template>
+	</CnFormDialog>
 </template>
 
 <script>
-import {
-	NcButton,
-	NcDialog,
-	NcSelect,
-	NcLoadingIcon,
-	NcNoteCard,
-} from '@nextcloud/vue'
-
-import AccountPlus from 'vue-material-design-icons/AccountPlus.vue'
-import Cancel from 'vue-material-design-icons/Cancel.vue'
+import { NcNoteCard } from '@nextcloud/vue'
+import { CnFormDialog } from '@conduction/nextcloud-vue'
 
 export default {
 	name: 'JoinOrganisation',
 	components: {
-		NcDialog,
-		NcSelect,
-		NcButton,
-		NcLoadingIcon,
+		CnFormDialog,
 		NcNoteCard,
-		// Icons
-		AccountPlus,
-		Cancel,
 	},
 	data() {
 		return {
-			selectedOrganisation: null,
-			selectedUser: null,
-			organisationOptions: [],
-			userOptions: [],
-			searchLoading: false,
-			loadingUsers: false,
-			success: false,
-			loading: false,
-			joining: false,
-			error: false,
-			joinedOrganisationName: '',
-			searchTimeout: null,
-			userSearchTimeout: null,
-			closeModalTimeout: null,
+			fields: [
+				{
+					key: 'organisation',
+					widget: 'select',
+					label: 'Organisation',
+					required: true,
+					description: 'Type to search for organisations',
+					enum: async (query) => {
+						const results = await organisationStore.searchOrganisations(query, 20, 0)
+						return results.map(org => ({
+							label: org.name,
+							id: org.uuid || org.id,
+							uuid: org.uuid || org.id,
+							name: org.name,
+							description: org.description,
+							users: org.users || [],
+							isDefault: org.isDefault,
+						}))
+					},
+					debounce: 500,
+				},
+				{
+					key: 'user',
+					widget: 'select',
+					label: 'User',
+					required: true,
+					description: 'Defaults to current user. Select a different user if needed.',
+					enum: this.fetchUsers,
+					debounce: 500,
+				},
+			],
 		}
 	},
 	async mounted() {
-		// Set default user to current user
-		this.setDefaultUser()
+		// Pre-select current user
+		const currentUser = this.getCurrentUser()
+		if (currentUser) {
+			this.$refs.formDialog.updateField('user', currentUser)
+		}
 
-		// Load initial organisations list
-		await this.loadInitialOrganisations()
-
-		// Load initial users list
-		await this.loadInitialUsers()
-
-		// If organisation is pre-selected (passed via transferData), set it
+		// If organisation is pre-selected (passed via transferData), load and select it
 		const transferData = navigationStore.getTransferData()
 		if (transferData?.organisationUuid) {
-			this.loadPreselectedOrganisation(transferData.organisationUuid)
-			// Clear transfer data after using it
 			navigationStore.clearTransferData()
+			try {
+				const organisation = await organisationStore.getOrganisation(transferData.organisationUuid)
+				if (organisation) {
+					this.$refs.formDialog.updateField('organisation', {
+						label: organisation.name,
+						id: organisation.uuid,
+						uuid: organisation.uuid,
+						name: organisation.name,
+						description: organisation.description,
+						users: organisation.users || [],
+						isDefault: organisation.isDefault,
+					})
+				}
+			} catch (error) {
+				console.error('Error loading preselected organisation:', error)
+			}
 		}
 	},
 	methods: {
 		/**
 		 * Get the current user information from Nextcloud
 		 *
-		 * @return {object|null} Current user object
+		 * @return {object|null} Current user object with label for NcSelect
 		 */
 		getCurrentUser() {
 			if (window.OC && window.OC.getCurrentUser) {
@@ -181,364 +133,67 @@ export default {
 				return {
 					id: user.uid,
 					displayName: user.displayName || user.uid,
+					label: user.displayName || user.uid,
 				}
 			}
 			return null
 		},
-		/**
-		 * Set default user to current user
-		 */
-		setDefaultUser() {
-			const currentUser = this.getCurrentUser()
-			if (currentUser) {
-				// Add label property for vue-select
-				const userOption = {
-					...currentUser,
-					label: currentUser.displayName,
-				}
-				this.selectedUser = userOption
-				this.userOptions = [userOption]
-			}
-		},
-		/**
-		 * Load initial list of organisations (first 20)
-		 */
-		async loadInitialOrganisations() {
-			try {
-				this.searchLoading = true
-				// Load first 20 organisations (empty query returns all, paginated)
-				const results = await organisationStore.searchOrganisations('', 20, 0)
-
-				// Transform results to NcSelect format with all necessary fields
-				this.organisationOptions = results.map(org => ({
-					id: org.uuid || org.id,
-					uuid: org.uuid || org.id,
-					name: org.name,
-					label: org.name,
-					description: org.description,
-					users: org.users || [],
-					isDefault: org.isDefault,
-				}))
-			} catch (error) {
-				console.error('Error loading initial organisations:', error)
-				this.organisationOptions = []
-			} finally {
-				this.searchLoading = false
-			}
-		},
-		/**
-		 * Load a preselected organisation
-		 * @param {string} uuid - The UUID of the organisation to load
-		 */
-		async loadPreselectedOrganisation(uuid) {
-			try {
-				// Find the organisation in already loaded options
-				let orgOption = this.organisationOptions.find(org => org.uuid === uuid || org.id === uuid)
-
-				// If not found in options, fetch it
-				if (!orgOption) {
-					const organisation = await organisationStore.getOrganisation(uuid)
-
-					if (organisation) {
-						orgOption = {
-							id: organisation.uuid,
-							uuid: organisation.uuid,
-							name: organisation.name,
-							label: organisation.name,
-							description: organisation.description,
-							users: organisation.users || [],
-							isDefault: organisation.isDefault,
-						}
-						// Add to options if not already there
-						if (!this.organisationOptions.some(o => o.uuid === orgOption.uuid)) {
-							this.organisationOptions.unshift(orgOption)
-						}
-					}
-				}
-
-				// Select the organisation
-				if (orgOption) {
-					this.selectedOrganisation = orgOption
-				}
-			} catch (error) {
-				console.error('Error loading preselected organisation:', error)
-			}
-		},
-		/**
-		 * Handle organisation search with pagination
-		 * @param {string} query - The query to search for
-		 */
-		async handleOrganisationSearch(query) {
-			// Clear previous timeout
-			if (this.searchTimeout) {
-				clearTimeout(this.searchTimeout)
-			}
-
-			// If empty query, reload initial list
-			if (!query || query.trim().length === 0) {
-				await this.loadInitialOrganisations()
-				return
-			}
-
-			// Debounce search
-			this.searchTimeout = setTimeout(async () => {
-				if (query.trim().length < 2) {
-					return
-				}
-
-				this.searchLoading = true
-				this.error = null
-
-				try {
-					// Search with limit of 20 results
-					const results = await organisationStore.searchOrganisations(query.trim(), 20, 0)
-
-					// Transform results to NcSelect format with all necessary fields
-					this.organisationOptions = results.map(org => ({
-						id: org.uuid || org.id,
-						uuid: org.uuid || org.id,
-						name: org.name,
-						label: org.name,
-						description: org.description,
-						users: org.users || [],
-						isDefault: org.isDefault,
-					}))
-				} catch (error) {
-					console.error('Error searching organisations:', error)
-					this.error = 'Failed to search organisations: ' + error.message
-					this.organisationOptions = []
-				} finally {
-					this.searchLoading = false
-				}
-			}, 500)
-		},
-		/**
-		 * Load initial list of users (first 20)
-		 */
-		async loadInitialUsers() {
-			this.loadingUsers = true
-
-			try {
-				// Get list of users from Nextcloud API with pagination
-				// Limit to first 20 users for performance
-				const response = await fetch(
-					'/ocs/v2.php/cloud/users?limit=20&offset=0',
-					{
-						headers: {
-							'OCS-APIRequest': 'true',
-							Accept: 'application/json',
-						},
+		async fetchUsers(query) {
+			const response = await fetch(
+				`/ocs/v2.php/cloud/users?search=${encodeURIComponent(query)}&limit=20`,
+				{
+					headers: {
+						'OCS-APIRequest': 'true',
+						Accept: 'application/json',
 					},
-				)
-
-				if (!response.ok) {
-					throw new Error('Failed to load users')
-				}
-
-				const data = await response.json()
-				const users = data?.ocs?.data?.users || []
-
-				// Transform to NcSelect format with label property
-				this.userOptions = users.map(userId => ({
-					id: userId,
-					displayName: userId,
-					label: userId, // Required by vue-select
-				}))
-
-				// Ensure current user is in the list and selected
-				const currentUser = this.getCurrentUser()
-				if (currentUser) {
-					const currentUserOption = {
-						...currentUser,
-						label: currentUser.displayName,
-					}
-
-					if (!this.userOptions.some(u => u.id === currentUser.id)) {
-						this.userOptions.unshift(currentUserOption)
-					}
-
-					// Keep current user as selected
-					this.selectedUser = currentUserOption
-				}
-			} catch (error) {
-				console.error('Error loading initial users:', error)
-				this.setDefaultUser() // Fallback to current user only
-			} finally {
-				this.loadingUsers = false
-			}
-		},
-		/**
-		 * Handle user search with pagination
-		 * @param {string} query - The query to search for
-		 */
-		async handleUserSearch(query) {
-			// Clear previous timeout
-			if (this.userSearchTimeout) {
-				clearTimeout(this.userSearchTimeout)
-			}
-
-			// If query is empty, reload initial users
-			if (!query || query.trim().length === 0) {
-				await this.loadInitialUsers()
-				return
-			}
-
-			// Debounce search
-			this.userSearchTimeout = setTimeout(async () => {
-				if (query.trim().length < 2) {
-					return
-				}
-
-				this.loadingUsers = true
-
-				try {
-					// Search for users via Nextcloud API with limit
-					const response = await fetch(
-						`/ocs/v2.php/cloud/users?search=${encodeURIComponent(query.trim())}&limit=20`,
-						{
-							headers: {
-								'OCS-APIRequest': 'true',
-								Accept: 'application/json',
-							},
-						},
-					)
-
-					if (!response.ok) {
-						throw new Error('Failed to search users')
-					}
-
-					const data = await response.json()
-					const users = data?.ocs?.data?.users || []
-
-					// Transform to NcSelect format with label property
-					this.userOptions = users.map(userId => ({
-						id: userId,
-						displayName: userId,
-						label: userId, // Required by vue-select
-					}))
-
-					// Always include current user in options
-					const currentUser = this.getCurrentUser()
-					if (currentUser && !this.userOptions.some(u => u.id === currentUser.id)) {
-						this.userOptions.unshift({
-							...currentUser,
-							label: currentUser.displayName,
-						})
-					}
-				} catch (error) {
-					console.error('Error searching users:', error)
-					// Don't clear existing options on error
-				} finally {
-					this.loadingUsers = false
-				}
-			}, 500)
-		},
-		/**
-		 * Filter organisation for local filtering
-		 * @param {object} option - The organisation option to filter
-		 * @param {string} label - The label of the organisation option
-		 * @param {string} search - The search query
-		 */
-		filterOrganisation(option, label, search) {
-			return (
-				option.name?.toLowerCase().includes(search.toLowerCase())
-				|| option.description?.toLowerCase().includes(search.toLowerCase())
+				},
 			)
+			if (!response.ok) {
+				throw new Error('Failed to search users')
+			}
+			const data = await response.json()
+			const users = (data?.ocs?.data?.users || []).map(userId => ({
+				id: userId,
+				displayName: userId,
+				label: userId,
+			}))
+
+			// Ensure current user is always in the list
+			const currentUser = this.getCurrentUser()
+			if (currentUser && !users.some(u => u.id === currentUser.id)) {
+				users.unshift(currentUser)
+			}
+
+			return users
 		},
 		/**
-		 * Join the selected organisation
+		 * Handle form confirmation — join the organisation
+		 *
+		 * @param {object} formData Form data with organisation and user objects
 		 */
-		async joinSelectedOrganisation() {
-			if (!this.selectedOrganisation) {
-				this.error = 'Please select an organisation'
-				return
-			}
-
-			if (!this.selectedUser) {
-				this.error = 'Please select a user'
-				return
-			}
-
-			this.joining = true
-			this.error = null
-
+		async onConfirm(formData) {
 			try {
-				// Get userId - use selected user or default to current user
-				const userId = this.selectedUser?.id || null
-
-				// Check if the SELECTED USER (not logged-in user) is already a member
-				// We can't easily check this client-side, so we'll rely on the backend to validate
-				// and return an appropriate error message
-
-				await organisationStore.joinOrganisation(this.selectedOrganisation.uuid, userId)
-
-				this.success = true
-				this.joinedOrganisationName = this.selectedOrganisation.name
-
-				this.closeModalTimeout = setTimeout(this.closeModal, 3000)
+				const userId = formData.user?.id || null
+				await organisationStore.joinOrganisation(formData.organisation.uuid, userId)
+				this.$refs.formDialog.setResult({ success: true })
 			} catch (error) {
 				console.error('Error joining organisation:', error)
-				this.error = error.message || 'Failed to add user to organisation'
-			} finally {
-				this.joining = false
+				this.$refs.formDialog.setResult({
+					error: error.message || 'Failed to add user to organisation',
+				})
 			}
 		},
 		/**
-		 * Close the modal
+		 * Handle dialog close
 		 */
-		closeModal() {
-			this.success = false
-			this.error = null
-			this.selectedOrganisation = null
-			this.organisationOptions = []
-			this.joinedOrganisationName = ''
-			this.joining = false
-			this.setDefaultUser() // Reset to current user
+		onClose() {
 			navigationStore.setModal(false)
-			clearTimeout(this.closeModalTimeout)
-			clearTimeout(this.searchTimeout)
-			clearTimeout(this.userSearchTimeout)
-		},
-		/**
-		 * Handle dialog close event
-		 */
-		handleDialogClose() {
-			this.closeModal()
 		},
 	},
 }
 </script>
 
 <style scoped>
-/* JoinOrganisation-specific styles */
-.selection-section {
-	display: flex;
-	flex-direction: column;
-	gap: 20px;
-}
-
-.field-group {
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
-}
-
-.field-group label {
-	font-weight: 600;
-	color: var(--color-text-dark);
-	font-size: 14px;
-}
-
-.helper-text {
-	font-size: 12px;
-	color: var(--color-text-lighter);
-	margin: 4px 0 0 0;
-}
-
-.info-help {
-	margin-top: 8px;
-}
-
 /* Organisation option styling */
 .organisation-option {
 	display: flex;
@@ -600,11 +255,5 @@ export default {
 .user-id {
 	font-size: 12px;
 	color: var(--color-text-lighter);
-}
-
-@media screen and (max-width: 768px) {
-	.selection-section {
-		gap: 16px;
-	}
 }
 </style>

--- a/src/views/organisation/OrganisationsIndex.vue
+++ b/src/views/organisation/OrganisationsIndex.vue
@@ -4,326 +4,172 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 
 <template>
 	<NcAppContent>
-		<div class="viewContainer">
-			<!-- Header -->
-			<div class="viewHeader">
-				<h1 class="viewHeaderTitleIndented">
-					Organisaties
-				</h1>
-				<p>Beheer uw organisaties en wissel tussen hen</p>
-			</div>
-
-			<!-- Active Organisation Status -->
-			<div v-if="organisationStore.userStats.active" class="activeOrgBanner">
-				<div class="activeOrgInfo">
-					<span class="activeOrgLabel">Actieve Organisatie:</span>
-					<span class="activeOrgName">{{ organisationStore.userStats.active.name }}</span>
-					<span v-if="organisationStore.userStats.active.isDefault" class="defaultBadge">
-						Standaard
-					</span>
+		<CnIndexPage
+			ref="indexPage"
+			title="Organisaties"
+			description="Beheer uw organisaties en wissel tussen hen"
+			:show-title="true"
+			:objects="organisationStore.userStats.list"
+			:columns="tableColumns"
+			:pagination="paginationData"
+			:view-mode="organisationStore.viewMode"
+			:selectable="true"
+			:selected-ids="selectedOrganisations"
+			:show-edit-action="false"
+			:show-copy-action="false"
+			:show-delete-action="false"
+			:show-mass-import="false"
+			:show-mass-export="false"
+			:show-mass-copy="false"
+			:show-mass-delete="false"
+			show-view-toggle
+			add-label="Organisatie Aanmaken"
+			row-key="uuid"
+			empty-text="Geen organisaties gevonden"
+			:row-class="getRowClass"
+			:refreshing="isRefreshing"
+			@add="createOrganisation"
+			@refresh="handleRefresh"
+			@page-changed="onPageChanged"
+			@page-size-changed="onPageSizeChanged"
+			@view-mode-change="organisationStore.setViewMode($event)"
+			@select="selectedOrganisations = $event">
+			<!-- Active Organisation Banner (below title, above actions bar) -->
+			<template #below-header>
+				<div v-if="organisationStore.userStats.active" class="activeOrgBanner">
+					<div class="activeOrgInfo">
+						<span class="activeOrgLabel">Actieve Organisatie:</span>
+						<span class="activeOrgName">{{ organisationStore.userStats.active.name }}</span>
+						<span v-if="organisationStore.userStats.active.isDefault" class="defaultBadge">
+							Standaard
+						</span>
+					</div>
+					<NcButton v-if="organisationStore.userStats.total > 1"
+						type="secondary"
+						@click="showOrganisationSwitcher = true">
+						<template #icon>
+							<SwapHorizontal :size="20" />
+						</template>
+						Wissel Organisatie
+					</NcButton>
 				</div>
-				<NcButton v-if="organisationStore.userStats.total > 1"
+			</template>
+
+			<!-- Inline button next to actions menu -->
+			<template #header-actions>
+				<NcButton
 					type="secondary"
-					@click="showOrganisationSwitcher = true">
+					@click="navigationStore.setModal('joinOrganisation')">
 					<template #icon>
-						<SwapHorizontal :size="20" />
+						<AccountPlus :size="20" />
 					</template>
-					Wissel Organisatie
+					Add User to Organisation
 				</NcButton>
-			</div>
+			</template>
 
-			<!-- Actions Bar -->
-			<div class="viewActionsBar">
-				<div class="viewInfo">
-					<span class="viewTotalCount">
-						Toont {{ paginatedOrganisations.length }} van {{ organisationStore.userStats.total }} organisaties
-					</span>
-					<span v-if="selectedOrganisations.length > 0" class="viewIndicator">
-						({{ selectedOrganisations.length }} geselecteerd)
-					</span>
+			<!-- Custom card template -->
+			<template #card="{ object }">
+				<OrganisationCard
+					:item="object"
+					:is-active="isActiveOrganisation(object)"
+					:can-edit="canEditOrganisation(object)"
+					:can-delete="canDeleteOrganisation(object)"
+					@view="viewOrganisation"
+					@set-active="setActiveOrganisation"
+					@edit="editOrganisation"
+					@go-to="goToOrganisation"
+					@add-user="openJoinModal" />
+			</template>
+
+			<!-- Custom column: name with badges -->
+			<template #column-name="{ row }">
+				<div class="titleContent">
+					<strong>{{ row.name }}</strong>
+					<div class="badges">
+						<span v-if="row.isDefault" class="defaultBadge">Standaard</span>
+						<span v-if="isActiveOrganisation(row)" class="activeBadge">Actief</span>
+					</div>
+					<span v-if="row.description" class="textDescription textEllipsis">{{ row.description }}</span>
 				</div>
-				<div class="viewActions">
-					<div class="viewModeSwitchContainer">
-						<NcCheckboxRadioSwitch
-							v-model="organisationStore.viewMode"
-							v-tooltip="'See organisations as cards'"
-							:button-variant="true"
-							value="cards"
-							name="view_mode_radio"
-							type="radio"
-							button-variant-grouped="horizontal">
-							Kaarten
-						</NcCheckboxRadioSwitch>
-						<NcCheckboxRadioSwitch
-							v-model="organisationStore.viewMode"
-							v-tooltip="'See organisations as a table'"
-							:button-variant="true"
-							value="table"
-							name="view_mode_radio"
-							type="radio"
-							button-variant-grouped="horizontal">
-							Tabel
-						</NcCheckboxRadioSwitch>
-					</div>
+			</template>
 
-					<NcActions
-						:force-name="true"
-						:inline="3"
-						menu-name="Actions">
-						<NcActionButton
-							:primary="true"
-							close-after-click
-							@click="createOrganisation">
-							<template #icon>
-								<Plus :size="20" />
-							</template>
-							Organisatie Aanmaken
-						</NcActionButton>
-						<NcActionButton
-							close-after-click
-							@click="navigationStore.setModal('joinOrganisation')">
-							<template #icon>
-								<AccountPlus :size="20" />
-							</template>
-							Add User to Organisation
-						</NcActionButton>
-						<NcActionButton
-							close-after-click
-							@click="organisationStore.refreshOrganisationList()">
-							<template #icon>
-								<Refresh :size="20" />
-							</template>
-							Vernieuwen
-						</NcActionButton>
-					</NcActions>
-				</div>
-			</div>
+			<!-- Custom column: members -->
+			<template #column-members="{ row }">
+				{{ row.users?.length || 0 }}
+			</template>
 
-			<!-- Empty State -->
-			<NcEmptyContent v-if="!organisationStore.userStats.total"
-				:name="'Geen organisaties gevonden'"
-				:description="'U bent nog geen lid van organisaties.'">
-				<template #icon>
-					<OfficeBuilding :size="64" />
-				</template>
-			</NcEmptyContent>
+			<!-- Custom column: status -->
+			<template #column-status="{ row }">
+				<span v-if="isActiveOrganisation(row)" class="statusActive">Actief</span>
+				<span v-else class="statusInactive">Inactief</span>
+			</template>
 
-			<!-- Content -->
-			<div v-else>
-				<template v-if="organisationStore.viewMode === 'cards'">
-					<div class="cardGrid">
-						<div v-for="organisation in paginatedOrganisations"
-							:key="organisation.uuid"
-							class="card"
-							:class="{ 'active-org-card': isActiveOrganisation(organisation) }">
-							<div class="cardHeader">
-								<h2>
-									<OfficeBuilding :size="20" />
-									{{ organisation.name }}
-									<span v-if="organisation.isDefault" class="defaultBadge">Standaard</span>
-									<span v-if="isActiveOrganisation(organisation)" class="activeBadge">Actief</span>
-								</h2>
-								<NcActions :primary="true" menu-name="Actions">
-									<template #icon>
-										<DotsHorizontal :size="20" />
-									</template>
-									<NcActionButton close-after-click
-										@click="viewOrganisation(organisation)">
-										<template #icon>
-											<Eye :size="20" />
-										</template>
-										Bekijken
-									</NcActionButton>
-									<NcActionButton v-if="!isActiveOrganisation(organisation)"
-										close-after-click
-										@click="setActiveOrganisation(organisation.uuid)">
-										<template #icon>
-											<Check :size="20" />
-										</template>
-										Instellen als Actief
-									</NcActionButton>
-									<NcActionButton v-if="canEditOrganisation(organisation)"
-										close-after-click
-										@click="editOrganisation(organisation)">
-										<template #icon>
-											<Pencil :size="20" />
-										</template>
-										Bewerken
-									</NcActionButton>
-									<NcActionButton v-if="organisation.website"
-										close-after-click
-										@click="goToOrganisation(organisation)">
-										<template #icon>
-											<OpenInNew :size="20" />
-										</template>
-										Ga naar organisatie
-									</NcActionButton>
-									<NcActionButton
-										close-after-click
-										@click="openJoinModal(organisation)">
-										<template #icon>
-											<AccountMultiplePlus :size="20" />
-										</template>
-										Add User
-									</NcActionButton>
-									<NcActionButton v-if="canDeleteOrganisation(organisation)"
-										close-after-click
-										@click="organisationStore.setOrganisationItem(organisation); navigationStore.setModal('deleteOrganisation')">
-										<template #icon>
-											<TrashCanOutline :size="20" />
-										</template>
-										Verwijderen
-									</NcActionButton>
-								</NcActions>
-							</div>
+			<!-- Custom column: created -->
+			<template #column-created="{ row }">
+				{{ row.created ? formatDate(row.created) : '-' }}
+			</template>
 
-							<div class="organisationInfo">
-								<p v-if="organisation.description" class="description">
-									{{ organisation.description }}
-								</p>
-								<div class="organisationStats">
-									<div class="stat">
-										<span class="statLabel">Leden:</span>
-										<span class="statValue">{{ organisation.users?.length || 0 }}</span>
-									</div>
-									<div class="stat">
-										<span class="statLabel">Eigenaar:</span>
-										<span class="statValue">{{ organisation.owner || 'System' }}</span>
-									</div>
-									<div v-if="organisation.created" class="stat">
-										<span class="statLabel">Aangemaakt:</span>
-										<span class="statValue">{{ formatDate(organisation.created) }}</span>
-									</div>
-								</div>
-							</div>
-						</div>
-					</div>
-				</template>
-				<template v-else>
-					<div class="viewTableContainer">
-						<table class="viewTable">
-							<thead>
-								<tr>
-									<th class="tableColumnCheckbox">
-										<NcCheckboxRadioSwitch
-											:checked="allSelected"
-											:indeterminate="someSelected"
-											@update:checked="toggleSelectAll" />
-									</th>
-									<th>Naam</th>
-									<th>Leden</th>
-									<th>Eigenaar</th>
-									<th>Status</th>
-									<th>Aangemaakt</th>
-									<th>Bijgewerkt</th>
-									<th class="tableColumnActions">
-										Acties
-									</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr v-for="organisation in paginatedOrganisations"
-									:key="organisation.uuid"
-									class="viewTableRow"
-									:class="{
-										viewTableRowSelected: selectedOrganisations.includes(organisation.uuid),
-										'active-org-row': isActiveOrganisation(organisation)
-									}">
-									<td class="tableColumnCheckbox">
-										<NcCheckboxRadioSwitch
-											:checked="selectedOrganisations.includes(organisation.uuid)"
-											@update:checked="(checked) => toggleOrganisationSelection(organisation.uuid, checked)" />
-									</td>
-									<td class="tableColumnTitle">
-										<div class="titleContent">
-											<strong>{{ organisation.name }}</strong>
-											<div class="badges">
-												<span v-if="organisation.isDefault" class="defaultBadge">Standaard</span>
-												<span v-if="isActiveOrganisation(organisation)" class="activeBadge">Actief</span>
-											</div>
-											<span v-if="organisation.description" class="textDescription textEllipsis">{{ organisation.description }}</span>
-										</div>
-									</td>
-									<td>{{ organisation.users?.length || 0 }}</td>
-									<td>{{ organisation.owner || 'System' }}</td>
-									<td>
-										<span v-if="isActiveOrganisation(organisation)" class="statusActive">Actief</span>
-										<span v-else class="statusInactive">Inactief</span>
-									</td>
-									<td>{{ organisation.created ? formatDate(organisation.created) : '-' }}</td>
-									<td>{{ organisation.updated ? formatDate(organisation.updated) : '-' }}</td>
-									<td class="tableColumnActions">
-										<NcActions :primary="false">
-											<template #icon>
-												<DotsHorizontal :size="20" />
-											</template>
-											<NcActionButton close-after-click
-												@click="viewOrganisation(organisation)">
-												<template #icon>
-													<Eye :size="20" />
-												</template>
-												Bekijken
-											</NcActionButton>
-											<NcActionButton v-if="!isActiveOrganisation(organisation)"
-												close-after-click
-												@click="setActiveOrganisation(organisation.uuid)">
-												<template #icon>
-													<Check :size="20" />
-												</template>
-												Instellen als Actief
-											</NcActionButton>
-											<NcActionButton v-if="canEditOrganisation(organisation)"
-												close-after-click
-												@click="editOrganisation(organisation)">
-												<template #icon>
-													<Pencil :size="20" />
-												</template>
-												Bewerken
-											</NcActionButton>
-											<NcActionButton v-if="organisation.website"
-												close-after-click
-												@click="goToOrganisation(organisation)">
-												<template #icon>
-													<OpenInNew :size="20" />
-												</template>
-												Ga naar organisatie
-											</NcActionButton>
-											<NcActionButton
-												close-after-click
-												@click="openJoinModal(organisation)">
-												<template #icon>
-													<AccountMultiplePlus :size="20" />
-												</template>
-												Add User
-											</NcActionButton>
-											<NcActionButton v-if="canDeleteOrganisation(organisation)"
-												close-after-click
-												@click="organisationStore.setOrganisationItem(organisation); navigationStore.setModal('deleteOrganisation')">
-												<template #icon>
-													<TrashCanOutline :size="20" />
-												</template>
-												Verwijderen
-											</NcActionButton>
-										</NcActions>
-									</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
-				</template>
-			</div>
+			<!-- Custom column: updated -->
+			<template #column-updated="{ row }">
+				{{ row.updated ? formatDate(row.updated) : '-' }}
+			</template>
 
-			<!-- Pagination -->
-			<PaginationComponent
-				v-if="organisationStore.userStats.total > 0"
-				:current-page="organisationStore.pagination.page || 1"
-				:total-pages="Math.ceil(organisationStore.userStats.total / (organisationStore.pagination.limit || 20))"
-				:total-items="organisationStore.userStats.total"
-				:current-page-size="organisationStore.pagination.limit || 20"
-				:min-items-to-show="10"
-				@page-changed="onPageChanged"
-				@page-size-changed="onPageSizeChanged" />
-		</div>
+			<!-- Custom row actions -->
+			<template #row-actions="{ row }">
+				<NcActions :primary="false">
+					<template #icon>
+						<DotsHorizontal :size="20" />
+					</template>
+					<NcActionButton close-after-click
+						@click="viewOrganisation(row)">
+						<template #icon>
+							<Eye :size="20" />
+						</template>
+						Bekijken
+					</NcActionButton>
+					<NcActionButton v-if="!isActiveOrganisation(row)"
+						close-after-click
+						@click="setActiveOrganisation(row.uuid)">
+						<template #icon>
+							<Check :size="20" />
+						</template>
+						Instellen als Actief
+					</NcActionButton>
+					<NcActionButton v-if="canEditOrganisation(row)"
+						close-after-click
+						@click="editOrganisation(row)">
+						<template #icon>
+							<Pencil :size="20" />
+						</template>
+						Bewerken
+					</NcActionButton>
+					<NcActionButton v-if="row.website"
+						close-after-click
+						@click="goToOrganisation(row)">
+						<template #icon>
+							<OpenInNew :size="20" />
+						</template>
+						Ga naar organisatie
+					</NcActionButton>
+					<NcActionButton
+						close-after-click
+						@click="openJoinModal(row)">
+						<template #icon>
+							<AccountMultiplePlus :size="20" />
+						</template>
+						Add User
+					</NcActionButton>
+					<NcActionButton v-if="canDeleteOrganisation(row)"
+						close-after-click
+						@click="organisationStore.setOrganisationItem(row); navigationStore.setModal('deleteOrganisation')">
+						<template #icon>
+							<TrashCanOutline :size="20" />
+						</template>
+						Verwijderen
+					</NcActionButton>
+				</NcActions>
+			</template>
+		</CnIndexPage>
 
 		<!-- Organisation Switcher Modal -->
 		<NcModal v-if="showOrganisationSwitcher"
@@ -347,77 +193,74 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 				</div>
 			</div>
 		</NcModal>
-
-		<!-- Organisation Management Modal -->
 	</NcAppContent>
 </template>
 
 <script>
-import { NcAppContent, NcEmptyContent, NcActions, NcActionButton, NcCheckboxRadioSwitch, NcButton, NcModal } from '@nextcloud/vue'
-import OfficeBuilding from 'vue-material-design-icons/OfficeBuilding.vue'
+import { NcAppContent, NcActions, NcActionButton, NcButton, NcModal } from '@nextcloud/vue'
+import { CnIndexPage } from '@conduction/nextcloud-vue'
 import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
 import Pencil from 'vue-material-design-icons/Pencil.vue'
 import TrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
-import Refresh from 'vue-material-design-icons/Refresh.vue'
 import AccountPlus from 'vue-material-design-icons/AccountPlus.vue'
 import AccountMultiplePlus from 'vue-material-design-icons/AccountMultiplePlus.vue'
 import SwapHorizontal from 'vue-material-design-icons/SwapHorizontal.vue'
-import Plus from 'vue-material-design-icons/Plus.vue'
 import Eye from 'vue-material-design-icons/Eye.vue'
 import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
-
-import PaginationComponent from '../../components/PaginationComponent.vue'
-import { reloadAppData } from '../../services/AppInitializationService.js'
 import Check from 'vue-material-design-icons/Check.vue'
+
+import OrganisationCard from '../../components/cards/OrganisationCard.vue'
+import { reloadAppData } from '../../services/AppInitializationService.js'
 
 export default {
 	name: 'OrganisationsIndex',
 	components: {
-		NcCheckboxRadioSwitch,
 		NcAppContent,
-		NcEmptyContent,
+		CnIndexPage,
 		NcActions,
 		NcActionButton,
 		NcButton,
 		NcModal,
-		OfficeBuilding,
+		OrganisationCard,
 		DotsHorizontal,
 		Pencil,
 		TrashCanOutline,
-		Refresh,
 		AccountPlus,
 		AccountMultiplePlus,
 		SwapHorizontal,
-		Plus,
 		Eye,
 		OpenInNew,
 		Check,
-		PaginationComponent,
 	},
 	data() {
 		return {
 			selectedOrganisations: [],
 			showOrganisationSwitcher: false,
+			isRefreshing: false,
 		}
 	},
 	computed: {
-		allSelected() {
-			return organisationStore.userStats.list.length > 0 && organisationStore.userStats.list.every(org => this.selectedOrganisations.includes(org.uuid))
+		tableColumns() {
+			return [
+				{ key: 'name', label: 'Naam', sortable: true },
+				{ key: 'members', label: 'Leden' },
+				{ key: 'owner', label: 'Eigenaar' },
+				{ key: 'status', label: 'Status' },
+				{ key: 'created', label: 'Aangemaakt', sortable: true },
+				{ key: 'updated', label: 'Bijgewerkt', sortable: true },
+			]
 		},
-		someSelected() {
-			return this.selectedOrganisations.length > 0 && !this.allSelected
-		},
-		paginatedOrganisations() {
-			const start = ((organisationStore.pagination.page || 1) - 1) * (organisationStore.pagination.limit || 20)
-			const end = start + (organisationStore.pagination.limit || 20)
-			return organisationStore.userStats.list.slice(start, end)
+		paginationData() {
+			const page = organisationStore.pagination.page || 1
+			const limit = organisationStore.pagination.limit || 20
+			const total = organisationStore.userStats.total || 0
+			const pages = Math.ceil(total / limit)
+			return { page, pages, total, limit }
 		},
 	},
 	async mounted() {
 		try {
-			// Load Nextcloud groups into store first (needed for edit modal)
 			await organisationStore.loadNextcloudGroups()
-			// Then load organisations
 			await organisationStore.refreshOrganisationList()
 			await organisationStore.getActiveOrganisation()
 		} catch (error) {
@@ -425,40 +268,31 @@ export default {
 		}
 	},
 	methods: {
+		getRowClass(row) {
+			return this.isActiveOrganisation(row) ? 'active-org-row' : ''
+		},
 		isActiveOrganisation(organisation) {
 			return organisationStore.userStats.active
 				   && organisationStore.userStats.active.uuid === organisation.uuid
 		},
 		getCurrentUser() {
-			// Get current user from global OC object (Nextcloud's way)
 			return window.OC?.getCurrentUser?.()?.uid || 'unknown'
 		},
 		canEditOrganisation(organisation) {
-			// Only the owner can edit the organisation (or system for default org)
 			return organisation.owner === 'system'
 				   || organisation.owner === this.getCurrentUser()
 		},
-		canLeaveOrganisation(organisation) {
-			// Can't leave if it's your only organisation or if you're the owner
-			return organisationStore.userStats.total > 1
-				   && !organisation.isDefault
-				   && organisation.owner !== this.getCurrentUser()
-		},
 		canDeleteOrganisation(organisation) {
-			// Only owners can delete, and can't delete default organisation
 			return !organisation.isDefault
 				   && organisation.owner === this.getCurrentUser()
 		},
 		async setActiveOrganisation(uuid) {
 			try {
 				await organisationStore.setActiveOrganisationById(uuid)
-				this.showSuccessMessage('Active organisation changed successfully')
-
-				// Reload all hot-loaded data for the new organisation context
 				console.info('[OrganisationsIndex] Reloading application data after organisation switch...')
 				await reloadAppData()
 			} catch (error) {
-				this.showErrorMessage('Failed to change active organisation: ' + error.message)
+				console.error('Failed to change active organisation:', error.message)
 			}
 		},
 		async switchToOrganisation(organisation) {
@@ -466,33 +300,15 @@ export default {
 				await this.setActiveOrganisation(organisation.uuid)
 				this.showOrganisationSwitcher = false
 			} catch (error) {
-				this.showErrorMessage('Failed to switch organisation: ' + error.message)
+				console.error('Failed to switch organisation:', error.message)
 			}
 		},
-		async leaveOrganisation(organisation) {
-			if (!confirm(`Are you sure you want to leave '${organisation.name}'?`)) {
-				return
-			}
-
+		async handleRefresh() {
+			this.isRefreshing = true
 			try {
-				await organisationStore.leaveOrganisation(organisation.uuid)
-				this.showSuccessMessage('Left organisation successfully')
-			} catch (error) {
-				this.showErrorMessage('Failed to leave organisation: ' + error.message)
-			}
-		},
-		toggleSelectAll(checked) {
-			if (checked) {
-				this.selectedOrganisations = organisationStore.userStats.list.map(org => org.uuid)
-			} else {
-				this.selectedOrganisations = []
-			}
-		},
-		toggleOrganisationSelection(orgUuid, checked) {
-			if (checked) {
-				this.selectedOrganisations.push(orgUuid)
-			} else {
-				this.selectedOrganisations = this.selectedOrganisations.filter(uuid => uuid !== orgUuid)
+				await organisationStore.refreshOrganisationList()
+			} finally {
+				this.isRefreshing = false
 			}
 		},
 		onPageChanged(page) {
@@ -511,7 +327,6 @@ export default {
 				minute: '2-digit',
 			})
 		},
-		// Organisation Modal Methods
 		createOrganisation() {
 			organisationStore.setOrganisationItem(null)
 			navigationStore.setModal('editOrganisation')
@@ -521,20 +336,11 @@ export default {
 			navigationStore.setModal('editOrganisation')
 		},
 		openJoinModal(organisation) {
-			// Set the transfer data with the organisation UUID
 			navigationStore.setTransferData({
 				organisationUuid: organisation.uuid,
 			})
-			// Open the join organisation modal
 			navigationStore.setModal('joinOrganisation')
 		},
-		openManageRolesModal(organisation) {
-			// Set the organisation item in store
-			organisationStore.setOrganisationItem(organisation)
-			// Open the manage organisation roles modal
-			navigationStore.setModal('manageOrganisationRoles')
-		},
-		// Organisation Action Methods
 		viewOrganisation(organisation) {
 			const publicationUrl = `https://www.softwarecatalogus.nl/publicatie/${organisation.id}`
 			window.open(publicationUrl, '_blank')
@@ -542,20 +348,11 @@ export default {
 		goToOrganisation(organisation) {
 			if (organisation.website) {
 				let websiteUrl = organisation.website
-				// Add https:// if no protocol is specified
 				if (!websiteUrl.startsWith('http://') && !websiteUrl.startsWith('https://')) {
 					websiteUrl = 'https://' + websiteUrl
 				}
 				window.open(websiteUrl, '_blank')
 			}
-		},
-		showSuccessMessage(message) {
-			// Implementation would depend on your notification system
-			// TODO: Integrate with Nextcloud notification system
-		},
-		showErrorMessage(message) {
-			// Implementation would depend on your notification system
-			// TODO: Integrate with Nextcloud notification system
 		},
 	},
 }
@@ -567,11 +364,11 @@ export default {
 	background: var(--color-primary-light);
 	border: 1px solid var(--color-primary-element-light);
 	border-radius: 8px;
-	padding: 16px;
-	margin-bottom: 20px;
+	padding: 12px 16px;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
+	gap: 12px;
 }
 
 .activeOrgInfo {
@@ -609,46 +406,14 @@ export default {
 	color: white;
 }
 
-/* Cards styling */
-.active-org-card {
-	border: 2px solid var(--color-success) !important;
-	background: var(--color-success-light) !important;
-}
-
-.organisationInfo {
-	padding: 16px 0;
-}
-
-.description {
-	color: var(--color-text-lighter);
-	margin-bottom: 12px;
-	font-style: italic;
-}
-
-.organisationStats {
-	display: flex;
-	flex-direction: column;
-	gap: 4px;
-}
-
-.stat {
-	display: flex;
-	justify-content: space-between;
-}
-
-.statLabel {
-	color: var(--color-text-lighter);
-	font-size: 12px;
-}
-
-.statValue {
-	font-weight: 600;
-	font-size: 12px;
-}
-
 /* Table styling */
 .active-org-row {
 	background: var(--color-success-light) !important;
+}
+
+.titleContent {
+	display: flex;
+	flex-direction: column;
 }
 
 .badges {

--- a/src/views/organisation/OrganisationsIndex.vue
+++ b/src/views/organisation/OrganisationsIndex.vue
@@ -27,6 +27,7 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 			row-key="uuid"
 			empty-text="Geen organisaties gevonden"
 			:row-class="getRowClass"
+			:actions="rowActions"
 			:refreshing="isRefreshing"
 			@add="createOrganisation"
 			@refresh="handleRefresh"
@@ -72,13 +73,7 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 				<OrganisationCard
 					:item="object"
 					:is-active="isActiveOrganisation(object)"
-					:can-edit="canEditOrganisation(object)"
-					:can-delete="canDeleteOrganisation(object)"
-					@view="viewOrganisation"
-					@set-active="setActiveOrganisation"
-					@edit="editOrganisation"
-					@go-to="goToOrganisation"
-					@add-user="openJoinModal" />
+					:actions="rowActions" />
 			</template>
 
 			<!-- Custom column: name with badges -->
@@ -113,62 +108,6 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 			<template #column-updated="{ row }">
 				{{ row.updated ? formatDate(row.updated) : '-' }}
 			</template>
-
-			<!-- Custom row actions -->
-			<template #row-actions="{ row }">
-				<NcActions :primary="false">
-					<template #icon>
-						<DotsHorizontal :size="20" />
-					</template>
-					<NcActionButton close-after-click
-						@click="viewOrganisation(row)">
-						<template #icon>
-							<Eye :size="20" />
-						</template>
-						Bekijken
-					</NcActionButton>
-					<NcActionButton v-if="!isActiveOrganisation(row)"
-						close-after-click
-						@click="setActiveOrganisation(row.uuid)">
-						<template #icon>
-							<Check :size="20" />
-						</template>
-						Instellen als Actief
-					</NcActionButton>
-					<NcActionButton v-if="canEditOrganisation(row)"
-						close-after-click
-						@click="editOrganisation(row)">
-						<template #icon>
-							<Pencil :size="20" />
-						</template>
-						Bewerken
-					</NcActionButton>
-					<NcActionButton v-if="row.website"
-						close-after-click
-						@click="goToOrganisation(row)">
-						<template #icon>
-							<OpenInNew :size="20" />
-						</template>
-						Ga naar organisatie
-					</NcActionButton>
-					<NcActionButton
-						close-after-click
-						@click="openJoinModal(row)">
-						<template #icon>
-							<AccountMultiplePlus :size="20" />
-						</template>
-						Add User
-					</NcActionButton>
-					<NcActionButton v-if="canDeleteOrganisation(row)"
-						close-after-click
-						@click="organisationStore.setOrganisationItem(row); navigationStore.setModal('deleteOrganisation')">
-						<template #icon>
-							<TrashCanOutline :size="20" />
-						</template>
-						Verwijderen
-					</NcActionButton>
-				</NcActions>
-			</template>
 		</CnIndexPage>
 
 		<!-- Organisation Switcher Modal -->
@@ -197,9 +136,8 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 </template>
 
 <script>
-import { NcAppContent, NcActions, NcActionButton, NcButton, NcModal } from '@nextcloud/vue'
+import { NcAppContent, NcButton, NcModal } from '@nextcloud/vue'
 import { CnIndexPage } from '@conduction/nextcloud-vue'
-import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
 import Pencil from 'vue-material-design-icons/Pencil.vue'
 import TrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import AccountPlus from 'vue-material-design-icons/AccountPlus.vue'
@@ -217,20 +155,11 @@ export default {
 	components: {
 		NcAppContent,
 		CnIndexPage,
-		NcActions,
-		NcActionButton,
 		NcButton,
 		NcModal,
 		OrganisationCard,
-		DotsHorizontal,
-		Pencil,
-		TrashCanOutline,
 		AccountPlus,
-		AccountMultiplePlus,
 		SwapHorizontal,
-		Eye,
-		OpenInNew,
-		Check,
 	},
 	data() {
 		return {
@@ -248,6 +177,49 @@ export default {
 				{ key: 'status', label: 'Status' },
 				{ key: 'created', label: 'Aangemaakt', sortable: true },
 				{ key: 'updated', label: 'Bijgewerkt', sortable: true },
+			]
+		},
+		rowActions() {
+			return [
+				{
+					label: 'Bekijken',
+					icon: Eye,
+					disabled: true,
+					handler: (row) => this.viewOrganisation(row),
+				},
+				{
+					label: 'Instellen als Actief',
+					icon: Check,
+					disabled: (row) => this.isActiveOrganisation(row),
+					handler: (row) => this.setActiveOrganisation(row.uuid),
+				},
+				{
+					label: 'Bewerken',
+					icon: Pencil,
+					disabled: (row) => !this.canEditOrganisation(row),
+					handler: (row) => this.editOrganisation(row),
+				},
+				{
+					label: 'Ga naar organisatie',
+					icon: OpenInNew,
+					disabled: (row) => !row.website,
+					handler: (row) => this.goToOrganisation(row),
+				},
+				{
+					label: 'Add User',
+					icon: AccountMultiplePlus,
+					handler: (row) => this.openJoinModal(row),
+				},
+				{
+					label: 'Verwijderen',
+					icon: TrashCanOutline,
+					destructive: true,
+					disabled: (row) => !this.canDeleteOrganisation(row),
+					handler: (row) => {
+						organisationStore.setOrganisationItem(row)
+						navigationStore.setModal('deleteOrganisation')
+					},
+				},
 			]
 		},
 		paginationData() {

--- a/src/views/organisation/OrganisationsIndex.vue
+++ b/src/views/organisation/OrganisationsIndex.vue
@@ -22,6 +22,7 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 			:show-mass-export="false"
 			:show-mass-copy="false"
 			:show-mass-delete="false"
+			mass-action-name-field="name"
 			show-view-toggle
 			add-label="Organisatie Aanmaken"
 			row-key="uuid"
@@ -29,6 +30,7 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 			:row-class="getRowClass"
 			:actions="rowActions"
 			:refreshing="isRefreshing"
+			@delete="handleDelete"
 			@add="createOrganisation"
 			@refresh="handleRefresh"
 			@page-changed="onPageChanged"
@@ -214,11 +216,7 @@ export default {
 					label: 'Verwijderen',
 					icon: TrashCanOutline,
 					destructive: true,
-					disabled: (row) => !this.canDeleteOrganisation(row),
-					handler: (row) => {
-						organisationStore.setOrganisationItem(row)
-						navigationStore.setModal('deleteOrganisation')
-					},
+					handler: (row) => this.$refs.indexPage.openDeleteDialog(row),
 				},
 			]
 		},
@@ -254,9 +252,22 @@ export default {
 			return organisation.owner === 'system'
 				   || organisation.owner === this.getCurrentUser()
 		},
-		canDeleteOrganisation(organisation) {
-			return !organisation.isDefault
-				   && organisation.owner === this.getCurrentUser()
+		async handleDelete(id) {
+			const organisation = organisationStore.userStats.list.find(
+				(org) => String(org.id) === String(id),
+			)
+			if (!organisation) {
+				this.$refs.indexPage.setSingleDeleteResult({ error: 'Organisation not found' })
+				return
+			}
+			try {
+				const { response } = await organisationStore.deleteOrganisation(organisation)
+				this.$refs.indexPage.setSingleDeleteResult({ success: response.ok })
+			} catch (error) {
+				this.$refs.indexPage.setSingleDeleteResult({
+					error: error.message || 'An error occurred while deleting the organisation',
+				})
+			}
 		},
 		async setActiveOrganisation(uuid) {
 			try {


### PR DESCRIPTION
Refactors organisation management pages for a consistent and improved user experience.

- Integrates the `CnIndexPage` component to standardize the organisation listing view, providing both card and table layouts.
- Replaces the custom organisation dialog with the `CnTabbedFormDialog` for a consistent experience when creating or editing organisations.
- Introduces a dedicated `OrganisationCard` component to display details in the card view mode.
- Removes obsolete styling for tab containers, as styling is now handled by the new Nextcloud Vue components.

Requires https://github.com/ConductionNL/nextcloud-vue/pull/15, https://github.com/ConductionNL/nextcloud-vue/pull/20