### PR TITLE
Refactors application management views

### DIFF
--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:fb70cbb1-d7ab-4453-939b-8d624fcbf6f4",
+  "serialNumber": "urn:uuid:f25e16e5-1fcc-49c6-9a3f-600d8e7da1da",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-03-17T13:56:54Z",
+    "timestamp": "2026-03-17T14:49:11Z",
     "tools": [
       {
         "name": "composer",
@@ -82,10 +82,10 @@
       }
     ],
     "component": {
-      "bom-ref": "conductionnl/openregister-dev-feature/REGISTERS-478/organisaties-page",
+      "bom-ref": "conductionnl/openregister-dev-feature/REGISTERS-479/Applicaties-page",
       "type": "application",
       "name": "openregister",
-      "version": "dev-feature/REGISTERS-478/organisaties-page",
+      "version": "dev-feature/REGISTERS-479/Applicaties-page",
       "group": "conductionnl",
       "description": "Quickly build data registers based on schema.json",
       "author": "Conduction b.v.",
@@ -96,15 +96,15 @@
           }
         }
       ],
-      "purl": "pkg:composer/conductionnl/openregister@dev-feature/REGISTERS-478/organisaties-page",
+      "purl": "pkg:composer/conductionnl/openregister@dev-feature/REGISTERS-479/Applicaties-page",
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "ecdc0423f04894252c5f8dc3226d3aa7978688cf"
+          "value": "b64f5436b4023376bbb8eff5d47e65044e662ab3"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "ecdc0423f04894252c5f8dc3226d3aa7978688cf"
+          "value": "b64f5436b4023376bbb8eff5d47e65044e662ab3"
         },
         {
           "name": "cdx:composer:package:type",
@@ -55484,7 +55484,7 @@
       "ref": "webonyx/graphql-php-15.31.1.0"
     },
     {
-      "ref": "conductionnl/openregister-dev-feature/REGISTERS-478/organisaties-page",
+      "ref": "conductionnl/openregister-dev-feature/REGISTERS-479/Applicaties-page",
       "dependsOn": [
         "adbario/php-dot-notation-3.3.0.0",
         "elasticsearch/elasticsearch-8.19.0.0",

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:cadeae51-63b3-41e2-973b-12a1e65f0878",
+  "serialNumber": "urn:uuid:8e14ff88-8ceb-4cee-b981-778d5c299829",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-03-19T15:23:31Z",
+    "timestamp": "2026-03-20T08:03:19Z",
     "tools": [
       {
         "name": "composer",
@@ -82,10 +82,10 @@
       }
     ],
     "component": {
-      "bom-ref": "conductionnl/openregister-dev-feature/nextcloud-vue-package-usage",
+      "bom-ref": "conductionnl/openregister-dev-feature/REGISTERS-479/Applicaties-page",
       "type": "application",
       "name": "openregister",
-      "version": "dev-feature/nextcloud-vue-package-usage",
+      "version": "dev-feature/REGISTERS-479/Applicaties-page",
       "group": "conductionnl",
       "description": "Quickly build data registers based on schema.json",
       "author": "Conduction b.v.",
@@ -96,15 +96,15 @@
           }
         }
       ],
-      "purl": "pkg:composer/conductionnl/openregister@dev-feature/nextcloud-vue-package-usage",
+      "purl": "pkg:composer/conductionnl/openregister@dev-feature/REGISTERS-479/Applicaties-page",
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "e47a59d78ad7687e37dcfb2399e6db261adc88e0"
+          "value": "22d9c000be2649482b64d1546420da4086e57aef"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "e47a59d78ad7687e37dcfb2399e6db261adc88e0"
+          "value": "22d9c000be2649482b64d1546420da4086e57aef"
         },
         {
           "name": "cdx:composer:package:type",
@@ -55484,7 +55484,7 @@
       "ref": "webonyx/graphql-php-15.31.1.0"
     },
     {
-      "ref": "conductionnl/openregister-dev-feature/nextcloud-vue-package-usage",
+      "ref": "conductionnl/openregister-dev-feature/REGISTERS-479/Applicaties-page",
       "dependsOn": [
         "adbario/php-dot-notation-3.3.0.0",
         "elasticsearch/elasticsearch-8.19.0.0",

--- a/src/components/cards/ApplicationCard.vue
+++ b/src/components/cards/ApplicationCard.vue
@@ -1,0 +1,173 @@
+<script setup>
+import { applicationStore, navigationStore } from '../../store/store.js'
+</script>
+
+<template>
+	<div class="applicationCard">
+		<div class="cardHeader">
+			<h2 v-tooltip.bottom="item.description">
+				<ApplicationOutline :size="20" />
+				{{ item.name }}
+				<span v-if="item.active !== undefined"
+					:class="item.active ? 'statusBadge--active' : 'statusBadge--inactive'">
+					{{ item.active ? 'Active' : 'Inactive' }}
+				</span>
+			</h2>
+			<NcActions :primary="true" menu-name="Actions">
+				<template #icon>
+					<DotsHorizontal :size="20" />
+				</template>
+				<NcActionButton close-after-click
+					@click="applicationStore.setApplicationItem(item); navigationStore.setModal('editApplication')">
+					<template #icon>
+						<Pencil :size="20" />
+					</template>
+					Edit
+				</NcActionButton>
+				<NcActionButton close-after-click
+					@click="applicationStore.setApplicationItem(item); navigationStore.setDialog('deleteApplication')">
+					<template #icon>
+						<TrashCanOutline :size="20" />
+					</template>
+					Delete
+				</NcActionButton>
+			</NcActions>
+		</div>
+
+		<div class="applicationInfo">
+			<p v-if="item.description" class="description">
+				{{ item.description }}
+			</p>
+			<div class="applicationStats">
+				<div v-if="item.version" class="stat">
+					<span class="statLabel">{{ t('openregister', 'Version') }}:</span>
+					<span class="statValue">{{ item.version }}</span>
+				</div>
+				<div v-if="item.configurations" class="stat">
+					<span class="statLabel">{{ t('openregister', 'Configurations') }}:</span>
+					<span class="statValue">{{ item.configurations.length }}</span>
+				</div>
+				<div v-if="item.registers" class="stat">
+					<span class="statLabel">{{ t('openregister', 'Registers') }}:</span>
+					<span class="statValue">{{ item.registers.length }}</span>
+				</div>
+				<div v-if="item.schemas" class="stat">
+					<span class="statLabel">{{ t('openregister', 'Schemas') }}:</span>
+					<span class="statValue">{{ item.schemas.length }}</span>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcActions, NcActionButton } from '@nextcloud/vue'
+import ApplicationOutline from 'vue-material-design-icons/ApplicationOutline.vue'
+import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
+import TrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
+
+export default {
+	name: 'ApplicationCard',
+	components: {
+		NcActions,
+		NcActionButton,
+		ApplicationOutline,
+		DotsHorizontal,
+		Pencil,
+		TrashCanOutline,
+	},
+	props: {
+		item: {
+			type: Object,
+			required: true,
+		},
+	},
+}
+</script>
+
+<style scoped lang="scss">
+.applicationCard {
+	padding: 16px;
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius-large);
+	background: var(--color-main-background);
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+}
+
+.cardHeader {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-start;
+
+	h2 {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		font-size: 16px;
+		margin: 0;
+		flex-wrap: wrap;
+	}
+}
+
+.statusBadge--active,
+.statusBadge--inactive {
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 12px;
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+}
+
+.statusBadge--active {
+	background: var(--color-success);
+	color: white;
+}
+
+.statusBadge--inactive {
+	background: var(--color-text-lighter);
+	color: white;
+}
+
+.applicationInfo {
+	padding: 12px 0 0;
+}
+
+.description {
+	color: var(--color-text-lighter);
+	margin-bottom: 12px;
+	font-style: italic;
+	word-wrap: break-word;
+	overflow-wrap: break-word;
+	display: -webkit-box;
+	-webkit-line-clamp: 3;
+	line-clamp: 3;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.applicationStats {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.stat {
+	display: flex;
+	justify-content: space-between;
+}
+
+.statLabel {
+	color: var(--color-text-lighter);
+	font-size: 12px;
+}
+
+.statValue {
+	font-weight: 600;
+	font-size: 12px;
+}
+</style>

--- a/src/modals/application/EditApplication.vue
+++ b/src/modals/application/EditApplication.vue
@@ -3,187 +3,133 @@ import { applicationStore, organisationStore, navigationStore } from '../../stor
 </script>
 
 <template>
-	<NcDialog :name="applicationStore.applicationItem?.uuid ? 'Edit Application' : 'Create Application'"
-		:open="true"
-		size="large"
-		:can-close="true"
-		@update:open="handleDialogOpen">
-		<NcNoteCard v-if="success" type="success">
-			<p>Application successfully {{ applicationStore.applicationItem?.uuid ? 'updated' : 'created' }}</p>
-		</NcNoteCard>
-		<NcNoteCard v-if="error" type="error">
-			<p>{{ error }}</p>
-		</NcNoteCard>
-		<div v-if="!success">
-			<!-- Tabs -->
-			<div class="tabContainer">
-				<BTabs v-model="activeTab" content-class="mt-3" justified>
-					<BTab active>
-						<template #title>
-							<Cog :size="16" />
-							<span>Settings</span>
-						</template>
-						<div class="form-editor">
-							<NcTextField
-								:disabled="loading"
-								label="Name *"
-								:value.sync="applicationItem.name"
-								:error="!applicationItem.name.trim()"
-								placeholder="Enter application name" />
+	<CnTabbedFormDialog
+		ref="dialog"
+		:tabs="dialogTabs"
+		:item="applicationStore.applicationItem?.uuid ? applicationStore.applicationItem : null"
+		entity-name="Application"
+		:show-create-another="true"
+		:disable-save="!applicationItem.name.trim()"
+		@confirm="saveApplication"
+		@close="closeModal"
+		@reset="resetForm">
+		<!-- Settings Tab -->
+		<template #tab-settings="{ loading: dialogLoading }">
+			<NcTextField
+				:disabled="dialogLoading"
+				label="Name *"
+				:value.sync="applicationItem.name"
+				:error="!applicationItem.name.trim()"
+				placeholder="Enter application name" />
 
-							<NcTextArea
-								:disabled="loading"
-								label="Description"
-								:value.sync="applicationItem.description"
-								placeholder="Enter application description (optional)"
-								:rows="4" />
+			<NcTextArea
+				:disabled="dialogLoading"
+				label="Description"
+				:value.sync="applicationItem.description"
+				placeholder="Enter application description (optional)"
+				:rows="4" />
 
-							<!-- Organisation is automatically set to active organisation by backend -->
+			<!-- Organisation is automatically set to active organisation by backend -->
 
-							<div class="groups-select-container">
-								<label class="groups-label">Nextcloud Groups</label>
-								<NcSelect
-									v-model="selectedGroups"
-									:disabled="loading || loadingGroups"
-									:options="availableGroups"
-									label="name"
-									track-by="id"
-									:multiple="true"
-									:label-outside="true"
-									:filterable="false"
-									placeholder="Search groups..."
-									@search-change="searchGroups"
-									@input="updateGroups">
-									<template #option="{ name }">
-										<div class="group-option">
-											<span class="group-name">{{ name }}</span>
-										</div>
-									</template>
-									<template #no-options>
-										<span v-if="loadingGroups">Loading groups...</span>
-										<span v-else>No groups found. Try a different search.</span>
-									</template>
-								</NcSelect>
-								<p class="field-hint">
-									Only members of selected groups can access this application
-								</p>
-							</div>
+			<div class="groups-select-container">
+				<label class="groups-label">Nextcloud Groups</label>
+				<NcSelect
+					v-model="selectedGroups"
+					:disabled="dialogLoading || loadingGroups"
+					:options="availableGroups"
+					label="name"
+					track-by="id"
+					:multiple="true"
+					:label-outside="true"
+					:filterable="false"
+					placeholder="Search groups..."
+					@search-change="searchGroups"
+					@input="updateGroups">
+					<template #option="{ name }">
+						<div class="group-option">
+							<span class="group-name">{{ name }}</span>
 						</div>
-					</BTab>
-
-					<BTab>
-						<template #title>
-							<Database :size="16" />
-							<span>Quota</span>
-						</template>
-						<div class="form-editor">
-							<NcTextField
-								:disabled="loading"
-								label="Storage Quota (MB)"
-								type="number"
-								placeholder="0 = unlimited"
-								:value="storageQuotaMB"
-								@update:value="updateStorageQuota" />
-
-							<NcTextField
-								:disabled="loading"
-								label="Bandwidth Quota (MB/month)"
-								type="number"
-								placeholder="0 = unlimited"
-								:value="bandwidthQuotaMB"
-								@update:value="updateBandwidthQuota" />
-
-							<NcTextField
-								:disabled="loading"
-								label="API Request Quota (requests/day)"
-								type="number"
-								placeholder="0 = unlimited"
-								:value="applicationItem.quota?.requests || 0"
-								@update:value="updateRequestQuota" />
-
-							<NcTextField
-								:disabled="loading"
-								label="User Quota"
-								type="number"
-								placeholder="0 = unlimited (not applicable for applications)"
-								:value="applicationItem.quota?.users || 0"
-								@update:value="updateUserQuota" />
-
-							<NcTextField
-								:disabled="loading"
-								label="Group Quota"
-								type="number"
-								placeholder="0 = unlimited"
-								:value="applicationItem.quota?.groups || 0"
-								@update:value="updateGroupQuota" />
-						</div>
-					</BTab>
-
-					<BTab>
-						<template #title>
-							<Shield :size="16" />
-							<span>Security</span>
-						</template>
-						<div class="security-section">
-							<div class="rbac-container">
-								<div class="rbac-section">
-									<p class="rbac-description">
-										Configure CRUD permissions for this application.
-										Empty permissions = open access for all application groups.
-										The 'admin' group always has full access.
-									</p>
-
-									<RbacTable
-										entity-type="application"
-										:authorization="applicationItem.authorization"
-										:available-groups="availableGroups"
-										:organisation-groups="applicationItem.groups || []"
-										@update="updateApplicationPermission" />
-								</div>
-							</div>
-						</div>
-					</BTab>
-				</BTabs>
+					</template>
+					<template #no-options>
+						<span v-if="loadingGroups">Loading groups...</span>
+						<span v-else>No groups found. Try a different search.</span>
+					</template>
+				</NcSelect>
+				<p class="field-hint">
+					Only members of selected groups can access this application
+				</p>
 			</div>
-		</div>
-
-		<template #actions>
-			<NcButton @click="closeModal">
-				<template #icon>
-					<Cancel :size="20" />
-				</template>
-				{{ success ? 'Close' : 'Cancel' }}
-			</NcButton>
-			<NcButton v-if="!success"
-				:disabled="loading || !applicationItem.name.trim()"
-				type="primary"
-				@click="saveApplication()">
-				<template #icon>
-					<NcLoadingIcon v-if="loading" :size="20" />
-					<ContentSaveOutline v-if="!loading && applicationStore.applicationItem?.uuid" :size="20" />
-					<Plus v-if="!loading && !applicationStore.applicationItem?.uuid" :size="20" />
-				</template>
-				{{ applicationStore.applicationItem?.uuid ? 'Save' : 'Create' }}
-			</NcButton>
 		</template>
-	</NcDialog>
+
+		<!-- Quota Tab -->
+		<template #tab-quota="{ loading: dialogLoading }">
+			<NcTextField
+				:disabled="dialogLoading"
+				label="Storage Quota (MB)"
+				type="number"
+				placeholder="0 = unlimited"
+				:value="storageQuotaMB"
+				@update:value="updateStorageQuota" />
+
+			<NcTextField
+				:disabled="dialogLoading"
+				label="Bandwidth Quota (MB/month)"
+				type="number"
+				placeholder="0 = unlimited"
+				:value="bandwidthQuotaMB"
+				@update:value="updateBandwidthQuota" />
+
+			<NcTextField
+				:disabled="dialogLoading"
+				label="API Request Quota (requests/day)"
+				type="number"
+				placeholder="0 = unlimited"
+				:value="applicationItem.quota?.requests || 0"
+				@update:value="updateRequestQuota" />
+
+			<NcTextField
+				:disabled="dialogLoading"
+				label="User Quota"
+				type="number"
+				placeholder="0 = unlimited (not applicable for applications)"
+				:value="applicationItem.quota?.users || 0"
+				@update:value="updateUserQuota" />
+
+			<NcTextField
+				:disabled="dialogLoading"
+				label="Group Quota"
+				type="number"
+				placeholder="0 = unlimited"
+				:value="applicationItem.quota?.groups || 0"
+				@update:value="updateGroupQuota" />
+		</template>
+
+		<!-- Security Tab -->
+		<template #tab-security>
+			<p class="rbac-description">
+				Configure CRUD permissions for this application.
+				Empty permissions = open access for all application groups.
+				The 'admin' group always has full access.
+			</p>
+
+			<RbacTable
+				entity-type="application"
+				:authorization="applicationItem.authorization"
+				:available-groups="availableGroups"
+				:organisation-groups="applicationItem.groups || []"
+				@update="updateApplicationPermission" />
+		</template>
+	</CnTabbedFormDialog>
 </template>
 
 <script>
 import {
-	NcButton,
-	NcDialog,
 	NcTextField,
 	NcTextArea,
 	NcSelect,
-	NcLoadingIcon,
-	NcNoteCard,
 } from '@nextcloud/vue'
-import { BTabs, BTab } from 'bootstrap-vue'
+import { CnTabbedFormDialog } from '@conduction/nextcloud-vue'
 
-import ContentSaveOutline from 'vue-material-design-icons/ContentSaveOutline.vue'
-import Cancel from 'vue-material-design-icons/Cancel.vue'
-import Plus from 'vue-material-design-icons/Plus.vue'
 import Cog from 'vue-material-design-icons/Cog.vue'
 import Database from 'vue-material-design-icons/Database.vue'
 import Shield from 'vue-material-design-icons/Shield.vue'
@@ -193,27 +139,14 @@ import RbacTable from '../../components/RbacTable.vue'
 export default {
 	name: 'EditApplication',
 	components: {
-		NcDialog,
+		CnTabbedFormDialog,
 		NcTextField,
 		NcTextArea,
 		NcSelect,
-		NcButton,
-		NcLoadingIcon,
-		NcNoteCard,
-		BTabs,
-		BTab,
 		RbacTable,
-		// Icons
-		ContentSaveOutline,
-		Cancel,
-		Plus,
-		Cog,
-		Database,
-		Shield,
 	},
 	data() {
 		return {
-			activeTab: 0,
 			applicationItem: {
 				name: '',
 				description: '',
@@ -237,13 +170,21 @@ export default {
 			availableGroups: [],
 			loadingGroups: false,
 			groupSearchDebounce: null,
-			success: false,
-			loading: false,
-			error: false,
-			closeModalTimeout: null,
 		}
 	},
 	computed: {
+		/**
+		 * Tab definitions for CnTabbedFormDialog
+		 *
+		 * @return {Array} Tab configuration
+		 */
+		dialogTabs() {
+			return [
+				{ id: 'settings', title: 'Settings', icon: Cog },
+				{ id: 'quota', title: 'Quota', icon: Database },
+				{ id: 'security', title: 'Security', icon: Shield },
+			]
+		},
 		storageQuotaMB() {
 			if (!this.applicationItem.quota?.storage) return 0
 			return Math.round(this.applicationItem.quota.storage / (1024 * 1024))
@@ -253,7 +194,7 @@ export default {
 			return Math.round(this.applicationItem.quota.bandwidth / (1024 * 1024))
 		},
 		filteredAvailableGroups() {
-		// Filter available groups to only show groups assigned to the application
+			// Filter available groups to only show groups assigned to the application
 			if (!this.applicationItem.groups || this.applicationItem.groups.length === 0) {
 				return this.availableGroups
 			}
@@ -300,7 +241,7 @@ export default {
 					this.initializeApplicationItem()
 				}).catch(error => {
 					console.error('Error loading Nextcloud groups:', error)
-					this.error = 'Failed to load Nextcloud groups'
+					this.$refs.dialog.setResult({ error: 'Failed to load Nextcloud groups' })
 					this.loadingGroups = false
 				})
 			}
@@ -403,6 +344,33 @@ export default {
 		},
 
 		/**
+		 * Reset form data for "create another" mode
+		 *
+		 * @return {void}
+		 */
+		resetForm() {
+			this.applicationItem = {
+				name: '',
+				description: '',
+				quota: {
+					storage: 0,
+					bandwidth: 0,
+					requests: 0,
+					users: 0,
+					groups: 0,
+				},
+				groups: [],
+				authorization: {
+					create: [],
+					read: [],
+					update: [],
+					delete: [],
+				},
+			}
+			this.selectedGroups = []
+		},
+
+		/**
 		 * Update groups selection
 		 *
 		 * @param {Array} groups - Selected groups
@@ -410,18 +378,6 @@ export default {
 		 */
 		updateGroups(groups) {
 			this.selectedGroups = groups || []
-			// Store only the group IDs, not the full objects
-			this.applicationItem.groups = this.selectedGroups.map(group => group.id)
-		},
-
-		/**
-		 * Remove a group from selection
-		 *
-		 * @param {object} groupToRemove - Group to remove
-		 * @return {void}
-		 */
-		removeGroup(groupToRemove) {
-			this.selectedGroups = this.selectedGroups.filter(g => g.id !== groupToRemove.id)
 			// Store only the group IDs, not the full objects
 			this.applicationItem.groups = this.selectedGroups.map(group => group.id)
 		},
@@ -454,11 +410,11 @@ export default {
 			// Update the permission
 			const groupIndex = this.applicationItem.authorization[action].indexOf(groupId)
 			if (hasPermission && groupIndex === -1) {
-			// Add the group
+				// Add the group
 				this.applicationItem.authorization[action].push(groupId)
 				console.info(`Added ${groupId} to ${action}:`, this.applicationItem.authorization[action])
 			} else if (!hasPermission && groupIndex !== -1) {
-			// Remove the group
+				// Remove the group
 				this.applicationItem.authorization[action].splice(groupIndex, 1)
 				console.info(`Removed ${groupId} from ${action}:`, this.applicationItem.authorization[action])
 			}
@@ -474,7 +430,7 @@ export default {
 		 * @return {void}
 		 */
 		updateStorageQuota(value) {
-		// Convert MB to bytes (0 = unlimited)
+			// Convert MB to bytes (0 = unlimited)
 			const mbValue = value ? parseInt(value) : 0
 			if (!this.applicationItem.quota) {
 				this.applicationItem.quota = { storage: 0, bandwidth: 0, requests: 0, users: 0, groups: 0 }
@@ -489,7 +445,7 @@ export default {
 		 * @return {void}
 		 */
 		updateBandwidthQuota(value) {
-		// Convert MB to bytes (0 = unlimited)
+			// Convert MB to bytes (0 = unlimited)
 			const mbValue = value ? parseInt(value) : 0
 			if (!this.applicationItem.quota) {
 				this.applicationItem.quota = { storage: 0, bandwidth: 0, requests: 0, users: 0, groups: 0 }
@@ -518,7 +474,7 @@ export default {
 		 * @return {void}
 		 */
 		updateUserQuota(value) {
-		// 0 = unlimited (not applicable for applications, but kept for consistency)
+			// 0 = unlimited (not applicable for applications, but kept for consistency)
 			if (!this.applicationItem.quota) {
 				this.applicationItem.quota = { storage: 0, bandwidth: 0, requests: 0, users: 0, groups: 0 }
 			}
@@ -532,7 +488,7 @@ export default {
 		 * @return {void}
 		 */
 		updateGroupQuota(value) {
-		// 0 = unlimited
+			// 0 = unlimited
 			if (!this.applicationItem.quota) {
 				this.applicationItem.quota = { storage: 0, bandwidth: 0, requests: 0, users: 0, groups: 0 }
 			}
@@ -545,13 +501,9 @@ export default {
 		 * @return {void}
 		 */
 		closeModal() {
-			this.success = false
-			this.error = null
 			this.selectedGroups = []
-			this.activeTab = 0
 			navigationStore.setModal(false)
 			navigationStore.setDialog(false)
-			clearTimeout(this.closeModalTimeout)
 		},
 
 		/**
@@ -560,13 +512,9 @@ export default {
 		 * @return {Promise<void>}
 		 */
 		async saveApplication() {
-			this.loading = true
-			this.error = null
-
 			// Validate required fields
 			if (!this.applicationItem.name.trim()) {
-				this.error = 'Application name is required'
-				this.loading = false
+				this.$refs.dialog.setResult({ error: 'Application name is required' })
 				return
 			}
 
@@ -575,31 +523,15 @@ export default {
 					...this.applicationItem,
 				})
 
-				this.success = response.ok
-				this.error = false
-
 				if (response.ok) {
-					this.closeModalTimeout = setTimeout(this.closeModal, 2000)
+					this.$refs.dialog.setResult({ success: true })
 				}
 
 			} catch (error) {
-				this.success = false
-				this.error = error.message || 'An error occurred while saving the application'
-			} finally {
-				this.loading = false
-			}
-		},
-
-		/**
-		 * Handle dialog open/close event
-		 *
-		 * @param {boolean} isOpen - Whether the dialog is open
-		 * @return {void}
-		 */
-		handleDialogOpen(isOpen) {
-			// Only close the modal if the dialog is being closed (isOpen = false)
-			if (!isOpen) {
-				this.closeModal()
+				console.error('Error saving application:', error)
+				this.$refs.dialog.setResult({
+					error: error.message || 'An error occurred while saving the application',
+				})
 			}
 		},
 	},
@@ -607,41 +539,7 @@ export default {
 </script>
 
 <style scoped>
-/* EditApplication-specific styles */
-.tabContainer {
-	margin-top: 20px;
-}
-
-/* Tab title styling with icons */
-.tabContainer :deep(.nav-link) {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	justify-content: center;
-}
-
-.form-editor {
-	display: flex;
-	flex-direction: column;
-	gap: 16px;
-	padding: 16px 0;
-}
-
-.option-content {
-	display: flex;
-	flex-direction: column;
-	gap: 4px;
-}
-
-.option-title {
-	font-weight: 500;
-	color: var(--color-main-text);
-}
-
-.option-description {
-	font-size: 12px;
-	color: var(--color-text-lighter);
-}
+/* Application-specific styles (tab shell handled by CnTabbedFormDialog) */
 
 .groups-select-container {
 	display: flex;
@@ -671,87 +569,9 @@ export default {
 	font-weight: 500;
 }
 
-.security-section {
-	display: flex;
-	flex-direction: column;
-	gap: 16px;
-	padding: 16px 0;
-}
-
-.rbac-container {
-	display: flex;
-	flex-direction: column;
-	gap: 16px;
-	padding: 0;
-}
-
-.rbac-section {
-	display: flex;
-	flex-direction: column;
-	gap: 12px;
-}
-
 .rbac-description {
 	font-size: 14px;
 	color: var(--color-text-lighter);
 	margin: 0 0 16px 0;
-}
-
-.loading-groups {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	color: var(--color-text-lighter);
-	padding: 16px;
-}
-
-.groups-list {
-	display: flex;
-	flex-direction: column;
-	gap: 12px;
-}
-
-.groups-list h3 {
-	margin: 0;
-	font-size: 16px;
-	font-weight: 500;
-	color: var(--color-main-text);
-}
-
-.group-items {
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
-}
-
-.group-item {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: 8px 12px;
-	background-color: var(--color-background-hover);
-	border-radius: var(--border-radius);
-}
-
-.group-badge {
-	display: inline-flex;
-	align-items: center;
-	padding: 4px 12px;
-	background-color: var(--color-primary-element-light);
-	color: var(--color-primary-element-text);
-	border-radius: 16px;
-	font-size: 13px;
-	font-weight: 500;
-}
-
-.no-groups {
-	padding: 16px;
-	text-align: center;
-	color: var(--color-text-lighter);
-	font-style: italic;
-}
-
-.no-groups p {
-	margin: 0;
 }
 </style>

--- a/src/views/application/ApplicationsIndex.vue
+++ b/src/views/application/ApplicationsIndex.vue
@@ -4,360 +4,179 @@ import { applicationStore, navigationStore } from '../../store/store.js'
 
 <template>
 	<NcAppContent>
-		<div class="viewContainer">
-			<!-- Header -->
-			<div class="viewHeader">
-				<h1 class="viewHeaderTitleIndented">
-					{{ t('openregister', 'Applications') }}
-				</h1>
-				<p>{{ t('openregister', 'Manage your applications and modules') }}</p>
-			</div>
+		<CnIndexPage
+			ref="indexPage"
+			title="Applications"
+			description="Manage your applications and modules"
+			:show-title="true"
+			:objects="applicationStore.applicationList"
+			:columns="tableColumns"
+			:pagination="paginationData"
+			:view-mode="viewMode"
+			:selectable="true"
+			:selected-ids="selectedApplications"
+			:show-edit-action="false"
+			:show-copy-action="false"
+			:show-delete-action="false"
+			:show-mass-import="false"
+			:show-mass-export="false"
+			:show-mass-copy="false"
+			:show-mass-delete="false"
+			show-view-toggle
+			add-label="Add Application"
+			empty-text="No applications found"
+			:refreshing="isRefreshing"
+			@add="createApplication"
+			@refresh="handleRefresh"
+			@page-changed="onPageChanged"
+			@page-size-changed="onPageSizeChanged"
+			@view-mode-change="viewMode = $event"
+			@select="selectedApplications = $event">
+			<!-- Custom card template -->
+			<template #card="{ object }">
+				<ApplicationCard :item="object" />
+			</template>
 
-			<!-- Actions Bar -->
-			<div class="viewActionsBar">
-				<div class="viewInfo">
-					<span class="viewTotalCount">
-						{{ t('openregister', 'Showing {showing} of {total} applications', { showing: paginatedApplications.length, total: applicationStore.applicationList.length }) }}
-					</span>
-					<span v-if="selectedApplications.length > 0" class="viewIndicator">
-						({{ t('openregister', '{count} selected', { count: selectedApplications.length }) }})
-					</span>
+			<!-- Custom column: name with description -->
+			<template #column-name="{ row }">
+				<div class="titleContent">
+					<strong>{{ row.name }}</strong>
+					<span v-if="row.description" class="textDescription textEllipsis">{{ row.description }}</span>
 				</div>
-				<div class="viewActions">
-					<div class="viewModeSwitchContainer">
-						<NcCheckboxRadioSwitch
-							v-model="viewMode"
-							v-tooltip="'See applications as cards'"
-							:button-variant="true"
-							value="cards"
-							name="view_mode_radio"
-							type="radio"
-							button-variant-grouped="horizontal">
-							Cards
-						</NcCheckboxRadioSwitch>
-						<NcCheckboxRadioSwitch
-							v-model="viewMode"
-							v-tooltip="'See applications as a table'"
-							:button-variant="true"
-							value="table"
-							name="view_mode_radio"
-							type="radio"
-							button-variant-grouped="horizontal">
-							Table
-						</NcCheckboxRadioSwitch>
-					</div>
+			</template>
 
-					<NcActions
-						:force-name="true"
-						:inline="2"
-						menu-name="Actions">
-						<NcActionButton
-							:primary="true"
-							close-after-click
-							@click="applicationStore.setApplicationItem(null); navigationStore.setModal('editApplication')">
-							<template #icon>
-								<Plus :size="20" />
-							</template>
-							Add Application
-						</NcActionButton>
-						<NcActionButton
-							close-after-click
-							@click="applicationStore.refreshApplicationList()">
-							<template #icon>
-								<Refresh :size="20" />
-							</template>
-							Refresh
-						</NcActionButton>
-					</NcActions>
-				</div>
-			</div>
+			<!-- Custom column: status -->
+			<template #column-status="{ row }">
+				<span :class="row.active ? 'status-active' : 'status-inactive'">
+					{{ row.active ? 'Active' : 'Inactive' }}
+				</span>
+			</template>
 
-			<!-- Loading, Error, and Empty States -->
-			<NcEmptyContent v-if="applicationStore.loading || applicationStore.error || !applicationStore.applicationList.length"
-				:name="emptyContentName"
-				:description="emptyContentDescription">
-				<template #icon>
-					<NcLoadingIcon v-if="applicationStore.loading" :size="64" />
-					<ApplicationOutline v-else :size="64" />
-				</template>
-			</NcEmptyContent>
+			<!-- Custom column: configurations -->
+			<template #column-configurations="{ row }">
+				{{ row.configurations?.length || 0 }}
+			</template>
 
-			<!-- Content -->
-			<div v-else>
-				<template v-if="viewMode === 'cards'">
-					<div class="cardGrid">
-						<div v-for="application in paginatedApplications" :key="application.id" class="card">
-							<div class="cardHeader">
-								<h2 v-tooltip.bottom="application.description">
-									<ApplicationOutline :size="20" />
-									{{ application.name }}
-								</h2>
-								<NcActions :primary="true" menu-name="Actions">
-									<template #icon>
-										<DotsHorizontal :size="20" />
-									</template>
-									<NcActionButton close-after-click @click="applicationStore.setApplicationItem(application); navigationStore.setModal('editApplication')">
-										<template #icon>
-											<Pencil :size="20" />
-										</template>
-										Edit
-									</NcActionButton>
-									<NcActionButton close-after-click @click="applicationStore.setApplicationItem(application); navigationStore.setDialog('deleteApplication')">
-										<template #icon>
-											<TrashCanOutline :size="20" />
-										</template>
-										Delete
-									</NcActionButton>
-								</NcActions>
-							</div>
-							<!-- Application Details -->
-							<div class="applicationDetails">
-								<p v-if="application.description" class="applicationDescription">
-									{{ application.description }}
-								</p>
-								<div class="applicationInfo">
-									<div v-if="application.version" class="applicationInfoItem">
-										<strong>{{ t('openregister', 'Version') }}:</strong>
-										<span>{{ application.version }}</span>
-									</div>
-									<div v-if="application.active !== undefined" class="applicationInfoItem">
-										<strong>{{ t('openregister', 'Status') }}:</strong>
-										<span :class="application.active ? 'status-active' : 'status-inactive'">
-											{{ application.active ? 'Active' : 'Inactive' }}
-										</span>
-									</div>
-									<div v-if="application.configurations" class="applicationInfoItem">
-										<strong>{{ t('openregister', 'Configurations') }}:</strong>
-										<span>{{ application.configurations.length }}</span>
-									</div>
-									<div v-if="application.registers" class="applicationInfoItem">
-										<strong>{{ t('openregister', 'Registers') }}:</strong>
-										<span>{{ application.registers.length }}</span>
-									</div>
-									<div v-if="application.schemas" class="applicationInfoItem">
-										<strong>{{ t('openregister', 'Schemas') }}:</strong>
-										<span>{{ application.schemas.length }}</span>
-									</div>
-								</div>
-							</div>
-						</div>
-					</div>
-				</template>
-				<template v-else>
-					<div class="viewTableContainer">
-						<table class="viewTable">
-							<thead>
-								<tr>
-									<th class="tableColumnCheckbox">
-										<NcCheckboxRadioSwitch
-											:checked="allSelected"
-											:indeterminate="someSelected"
-											@update:checked="toggleSelectAll" />
-									</th>
-									<th>{{ t('openregister', 'Name') }}</th>
-									<th>{{ t('openregister', 'Version') }}</th>
-									<th>{{ t('openregister', 'Status') }}</th>
-									<th>{{ t('openregister', 'Configurations') }}</th>
-									<th>{{ t('openregister', 'Registers') }}</th>
-									<th>{{ t('openregister', 'Schemas') }}</th>
-									<th>{{ t('openregister', 'Created') }}</th>
-									<th class="tableColumnActions">
-										{{ t('openregister', 'Actions') }}
-									</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr v-for="application in paginatedApplications"
-									:key="application.id"
-									class="viewTableRow"
-									:class="{ viewTableRowSelected: selectedApplications.includes(application.id) }">
-									<td class="tableColumnCheckbox">
-										<NcCheckboxRadioSwitch
-											:checked="selectedApplications.includes(application.id)"
-											@update:checked="(checked) => toggleApplicationSelection(application.id, checked)" />
-									</td>
-									<td class="tableColumnTitle">
-										<div class="titleContent">
-											<strong>{{ application.name }}</strong>
-											<span v-if="application.description" class="textDescription textEllipsis">{{ application.description }}</span>
-										</div>
-									</td>
-									<td>{{ application.version || '-' }}</td>
-									<td>
-										<span :class="application.active ? 'status-active' : 'status-inactive'">
-											{{ application.active ? 'Active' : 'Inactive' }}
-										</span>
-									</td>
-									<td>{{ application.configurations?.length || 0 }}</td>
-									<td>{{ application.registers?.length || 0 }}</td>
-									<td>{{ application.schemas?.length || 0 }}</td>
-									<td>{{ application.created ? new Date(application.created).toLocaleDateString() : '-' }}</td>
-									<td class="tableColumnActions">
-										<NcActions :primary="false">
-											<template #icon>
-												<DotsHorizontal :size="20" />
-											</template>
-											<NcActionButton close-after-click @click="applicationStore.setApplicationItem(application); navigationStore.setModal('editApplication')">
-												<template #icon>
-													<Pencil :size="20" />
-												</template>
-												Edit
-											</NcActionButton>
-											<NcActionButton close-after-click @click="applicationStore.setApplicationItem(application); navigationStore.setDialog('deleteApplication')">
-												<template #icon>
-													<TrashCanOutline :size="20" />
-												</template>
-												Delete
-											</NcActionButton>
-										</NcActions>
-									</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
-				</template>
-			</div>
+			<!-- Custom column: registers -->
+			<template #column-registers="{ row }">
+				{{ row.registers?.length || 0 }}
+			</template>
 
-			<!-- Pagination -->
-			<PaginationComponent
-				v-if="applicationStore.applicationList.length > 0"
-				:current-page="pagination.page || 1"
-				:total-pages="Math.ceil(applicationStore.applicationList.length / (pagination.limit || 20))"
-				:total-items="applicationStore.applicationList.length"
-				:current-page-size="pagination.limit || 20"
-				:min-items-to-show="10"
-				@page-changed="onPageChanged"
-				@page-size-changed="onPageSizeChanged" />
-		</div>
+			<!-- Custom column: schemas -->
+			<template #column-schemas="{ row }">
+				{{ row.schemas?.length || 0 }}
+			</template>
+
+			<!-- Custom column: created -->
+			<template #column-created="{ row }">
+				{{ row.created ? new Date(row.created).toLocaleDateString() : '-' }}
+			</template>
+
+			<!-- Custom row actions -->
+			<template #row-actions="{ row }">
+				<NcActions :primary="false">
+					<template #icon>
+						<DotsHorizontal :size="20" />
+					</template>
+					<NcActionButton close-after-click
+						@click="applicationStore.setApplicationItem(row); navigationStore.setModal('editApplication')">
+						<template #icon>
+							<Pencil :size="20" />
+						</template>
+						Edit
+					</NcActionButton>
+					<NcActionButton close-after-click
+						@click="applicationStore.setApplicationItem(row); navigationStore.setDialog('deleteApplication')">
+						<template #icon>
+							<TrashCanOutline :size="20" />
+						</template>
+						Delete
+					</NcActionButton>
+				</NcActions>
+			</template>
+		</CnIndexPage>
 	</NcAppContent>
 </template>
 
 <script>
-import { NcAppContent, NcEmptyContent, NcLoadingIcon, NcActions, NcActionButton, NcCheckboxRadioSwitch } from '@nextcloud/vue'
-import ApplicationOutline from 'vue-material-design-icons/ApplicationOutline.vue'
+import { NcAppContent, NcActions, NcActionButton } from '@nextcloud/vue'
+import { CnIndexPage } from '@conduction/nextcloud-vue'
 import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
 import Pencil from 'vue-material-design-icons/Pencil.vue'
 import TrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
-import Refresh from 'vue-material-design-icons/Refresh.vue'
-import Plus from 'vue-material-design-icons/Plus.vue'
 
-import PaginationComponent from '../../components/PaginationComponent.vue'
+import ApplicationCard from '../../components/cards/ApplicationCard.vue'
 
 export default {
 	name: 'ApplicationsIndex',
 	components: {
 		NcAppContent,
-		NcEmptyContent,
-		NcLoadingIcon,
+		CnIndexPage,
 		NcActions,
 		NcActionButton,
-		NcCheckboxRadioSwitch,
-		ApplicationOutline,
+		ApplicationCard,
 		DotsHorizontal,
 		Pencil,
 		TrashCanOutline,
-		Refresh,
-		Plus,
-		PaginationComponent,
 	},
 	data() {
 		return {
 			viewMode: 'cards',
 			selectedApplications: [],
-			pagination: {
-				page: 1,
-				limit: 20,
-			},
+			isRefreshing: false,
 		}
 	},
 	computed: {
-		paginatedApplications() {
-			const start = ((this.pagination.page || 1) - 1) * (this.pagination.limit || 20)
-			const end = start + (this.pagination.limit || 20)
-			return applicationStore.applicationList.slice(start, end)
+		tableColumns() {
+			return [
+				{ key: 'name', label: t('openregister', 'Name'), sortable: true },
+				{ key: 'version', label: t('openregister', 'Version') },
+				{ key: 'status', label: t('openregister', 'Status') },
+				{ key: 'configurations', label: t('openregister', 'Configurations') },
+				{ key: 'registers', label: t('openregister', 'Registers') },
+				{ key: 'schemas', label: t('openregister', 'Schemas') },
+				{ key: 'created', label: t('openregister', 'Created'), sortable: true },
+			]
 		},
-		allSelected() {
-			return applicationStore.applicationList.length > 0 && applicationStore.applicationList.every(application => this.selectedApplications.includes(application.id))
-		},
-		someSelected() {
-			return this.selectedApplications.length > 0 && !this.allSelected
-		},
-		emptyContentName() {
-			if (applicationStore.loading) {
-				return t('openregister', 'Loading applications...')
-			} else if (applicationStore.error) {
-				return applicationStore.error
-			} else if (!applicationStore.applicationList.length) {
-				return t('openregister', 'No applications found')
-			}
-			return ''
-		},
-		emptyContentDescription() {
-			if (applicationStore.loading) {
-				return t('openregister', 'Please wait while we fetch your applications.')
-			} else if (applicationStore.error) {
-				return t('openregister', 'Please try again later.')
-			} else if (!applicationStore.applicationList.length) {
-				return t('openregister', 'No applications are available.')
-			}
-			return ''
+		paginationData() {
+			const page = applicationStore.pagination.page || 1
+			const limit = applicationStore.pagination.limit || 20
+			const total = applicationStore.applicationList.length
+			const pages = Math.ceil(total / limit)
+			return { page, pages, total, limit }
 		},
 	},
 	async mounted() {
-		// Load Nextcloud groups into store first (needed for edit modal)
 		await applicationStore.loadNextcloudGroups()
-		// Use soft reload (no loading spinner) since data is hot-loaded at app startup
 		applicationStore.refreshApplicationList(null, true)
 	},
 	methods: {
-		toggleSelectAll(checked) {
-			if (checked) {
-				this.selectedApplications = applicationStore.applicationList.map(application => application.id)
-			} else {
-				this.selectedApplications = []
-			}
+		createApplication() {
+			applicationStore.setApplicationItem(null)
+			navigationStore.setModal('editApplication')
 		},
-		toggleApplicationSelection(applicationId, checked) {
-			if (checked) {
-				this.selectedApplications.push(applicationId)
-			} else {
-				this.selectedApplications = this.selectedApplications.filter(id => id !== applicationId)
+		async handleRefresh() {
+			this.isRefreshing = true
+			try {
+				await applicationStore.refreshApplicationList()
+			} finally {
+				this.isRefreshing = false
 			}
 		},
 		onPageChanged(page) {
-			this.pagination.page = page
+			applicationStore.setPagination(page, applicationStore.pagination.limit)
 		},
 		onPageSizeChanged(pageSize) {
-			this.pagination.page = 1
-			this.pagination.limit = pageSize
+			applicationStore.setPagination(1, pageSize)
 		},
 	},
 }
 </script>
 
 <style scoped>
-.applicationDetails {
-	margin-top: 1rem;
-}
-
-.applicationDescription {
-	color: var(--color-text-lighter);
-	margin-bottom: 1rem;
-}
-
-.applicationInfo {
+.titleContent {
 	display: flex;
 	flex-direction: column;
-	gap: 0.5rem;
-}
-
-.applicationInfoItem {
-	display: flex;
-	gap: 0.5rem;
-}
-
-.applicationInfoItem strong {
-	min-width: 120px;
 }
 
 .status-active {


### PR DESCRIPTION
Generalizes the user interface for application management by adopting reusable Nextcloud Vue components.

*   **Applications Index Page (`ApplicationsIndex.vue`):** Migrates to `CnIndexPage` for a standardized list view, handling data display, pagination, view mode toggling (cards/table), and common actions. This significantly reduces boilerplate and improves consistency.
*   **Application Card Component (`ApplicationCard.vue`):** Introduces a new dedicated component to display individual application details, utilized within the `CnIndexPage`'s card view.
*   **Edit Application Modal (`EditApplication.vue`):** Refactors to use `CnTabbedFormDialog`, standardizing the creation and editing modal forms with built-in tab navigation, loading states, and success/error feedback.

These changes streamline development, enhance UI consistency, and leverage established Nextcloud Vue patterns.

Based off of https://github.com/ConductionNL/openregister/pull/931
requires https://github.com/ConductionNL/nextcloud-vue/pull/15