### PR TITLE
Refactors Entities page with CnIndexPage

### DIFF
--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:187ab954-60a0-4ea8-bd37-8ecd8ae82503",
+  "serialNumber": "urn:uuid:2ea5bb26-6d13-4bef-a197-dc4166f15869",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-03-18T11:09:41Z",
+    "timestamp": "2026-03-18T11:56:44Z",
     "tools": [
       {
         "name": "composer",
@@ -82,10 +82,10 @@
       }
     ],
     "component": {
-      "bom-ref": "conductionnl/openregister-dev-feature/REGISTERS-480/data-sources-page",
+      "bom-ref": "conductionnl/openregister-dev-feature/REGISTERS-481/entities-page",
       "type": "application",
       "name": "openregister",
-      "version": "dev-feature/REGISTERS-480/data-sources-page",
+      "version": "dev-feature/REGISTERS-481/entities-page",
       "group": "conductionnl",
       "description": "Quickly build data registers based on schema.json",
       "author": "Conduction b.v.",
@@ -96,15 +96,15 @@
           }
         }
       ],
-      "purl": "pkg:composer/conductionnl/openregister@dev-feature/REGISTERS-480/data-sources-page",
+      "purl": "pkg:composer/conductionnl/openregister@dev-feature/REGISTERS-481/entities-page",
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "bfcc6fbb4e6de35bb01de7755a03828ec0f231b5"
+          "value": "036430b648ef929a58ff599165fdd4a2f43d8237"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "bfcc6fbb4e6de35bb01de7755a03828ec0f231b5"
+          "value": "036430b648ef929a58ff599165fdd4a2f43d8237"
         },
         {
           "name": "cdx:composer:package:type",
@@ -55484,7 +55484,7 @@
       "ref": "webonyx/graphql-php-15.31.1.0"
     },
     {
-      "ref": "conductionnl/openregister-dev-feature/REGISTERS-480/data-sources-page",
+      "ref": "conductionnl/openregister-dev-feature/REGISTERS-481/entities-page",
       "dependsOn": [
         "adbario/php-dot-notation-3.3.0.0",
         "elasticsearch/elasticsearch-8.19.0.0",

--- a/src/views/entities/EntitiesIndex.vue
+++ b/src/views/entities/EntitiesIndex.vue
@@ -1,223 +1,82 @@
 <template>
 	<NcAppContent :show-details="sidebarOpen" @update:showDetails="toggleSidebar">
-		<div class="viewContainer">
-			<!-- Header -->
-			<div class="viewHeader">
-				<div class="viewHeaderTitle">
-					<h1 class="viewHeaderTitleIndented">
-						{{ t('openregister', 'Entities') }}
-					</h1>
-					<NcButton
-						type="tertiary"
-						:aria-label="t('openregister', 'Toggle search sidebar')"
-						@click="toggleSidebar">
-						<template #icon>
-							<FilterVariant :size="20" />
-						</template>
-						{{ sidebarOpen ? t('openregister', 'Hide Filters') : t('openregister', 'Show Filters') }}
-					</NcButton>
+		<CnIndexPage
+			ref="indexPage"
+			title="Entities"
+			description="Manage and view detected entities from files and objects"
+			:show-title="true"
+			:show-add="false"
+			:objects="entitiesList"
+			:columns="tableColumns"
+			:pagination="paginationData"
+			:view-mode="viewMode"
+			:selectable="false"
+			:show-edit-action="false"
+			:show-copy-action="false"
+			:show-delete-action="false"
+			:show-form-dialog="false"
+			:show-mass-import="false"
+			:show-mass-export="false"
+			:show-mass-copy="false"
+			:show-mass-delete="false"
+			show-view-toggle
+			:actions="customActions"
+			:loading="loading"
+			:refreshing="isRefreshing"
+			empty-text="No entities found"
+			@row-click="viewEntity"
+			@refresh="handleRefresh"
+			@page-changed="onPageChanged"
+			@page-size-changed="onPageSizeChanged"
+			@view-mode-change="viewMode = $event">
+			<!-- Custom card template -->
+			<template #card="{ object }">
+				<CnCard
+					:title="object.value"
+					:labels="mapEntityLabels(object)"
+					:stats="mapEntityStats(object)">
+					<template #icon>
+						<AccountOutline :size="20" />
+					</template>
+				</CnCard>
+			</template>
+
+			<!-- Custom column: value with icon -->
+			<template #column-value="{ row }">
+				<div class="entityValueCell">
+					<AccountOutline :size="20" class="entityIcon" />
+					<strong>{{ row.value }}</strong>
 				</div>
-				<p>
-					{{ t('openregister', 'Manage and view detected entities from files and objects') }}
-				</p>
-			</div>
+			</template>
 
-			<!-- Actions Bar -->
-			<div class="viewActionsBar">
-				<div class="viewInfo">
-					<span v-if="entitiesList.length" class="viewTotalCount">
-						{{ t('openregister', 'Showing {showing} of {total} entities', {
-							showing: paginatedEntities.length,
-							total: totalEntities
-						}) }}
-					</span>
-					<span v-if="selectedEntities.length > 0" class="viewIndicator">
-						({{ t('openregister', '{count} selected', { count: selectedEntities.length }) }})
-					</span>
-				</div>
-				<div class="viewActions">
-					<div class="viewModeSwitchContainer">
-						<NcCheckboxRadioSwitch
-							v-model="viewMode"
-							v-tooltip="'See entities as cards'"
-							:button-variant="true"
-							value="cards"
-							name="view_mode_radio"
-							type="radio"
-							button-variant-grouped="horizontal">
-							Cards
-						</NcCheckboxRadioSwitch>
-						<NcCheckboxRadioSwitch
-							v-model="viewMode"
-							v-tooltip="'See entities as a table'"
-							:button-variant="true"
-							value="table"
-							name="view_mode_radio"
-							type="radio"
-							button-variant-grouped="horizontal">
-							Table
-						</NcCheckboxRadioSwitch>
-					</div>
+			<!-- Custom column: type badge -->
+			<template #column-type="{ row }">
+				<span class="badge badgeType">{{ row.type }}</span>
+			</template>
 
-					<NcActions
-						:force-name="true"
-						:inline="1"
-						menu-name="Actions">
-						<NcActionButton
-							close-after-click
-							@click="refreshEntities">
-							<template #icon>
-								<Refresh :size="20" />
-							</template>
-							{{ t('openregister', 'Refresh') }}
-						</NcActionButton>
-					</NcActions>
-				</div>
-			</div>
+			<!-- Custom column: category badge -->
+			<template #column-category="{ row }">
+				<span class="badge badgeCategory">{{ row.category }}</span>
+			</template>
 
-			<!-- Loading State -->
-			<NcLoadingIcon v-if="loading" :size="64" />
+			<!-- Custom column: detected at -->
+			<template #column-detectedAt="{ row }">
+				{{ formatDate(row.detectedAt) }}
+			</template>
 
-			<!-- Empty State -->
-			<NcEmptyContent
-				v-else-if="!entitiesList.length"
-				:name="t('openregister', 'No entities found')"
-				:description="t('openregister', 'No entities have been detected yet')">
-				<template #icon>
-					<AccountOutline :size="64" />
-				</template>
-			</NcEmptyContent>
-
-			<!-- Content -->
-			<div v-else>
-				<!-- Cards View -->
-				<template v-if="viewMode === 'cards'">
-					<div class="cardGrid">
-						<div v-for="entity in paginatedEntities"
-							:key="entity.id"
-							class="card"
-							@click="viewEntity(entity)">
-							<div class="cardHeader">
-								<h2>
-									<AccountOutline :size="20" />
-									{{ entity.value }}
-									<span class="badge badge-type">{{ entity.type }}</span>
-								</h2>
-								<NcActions :primary="true" menu-name="Actions">
-									<template #icon>
-										<DotsHorizontal :size="20" />
-									</template>
-									<NcActionButton
-										close-after-click
-										@click.stop="viewEntity(entity)">
-										<template #icon>
-											<EyeOutline :size="20" />
-										</template>
-										View Details
-									</NcActionButton>
-								</NcActions>
-							</div>
-
-							<!-- Entity Info -->
-							<table class="statisticsTable entityStats">
-								<tbody>
-									<tr>
-										<td><strong>{{ t('openregister', 'Category') }}</strong></td>
-										<td><span class="badge badge-category">{{ entity.category }}</span></td>
-									</tr>
-									<tr>
-										<td><strong>{{ t('openregister', 'Detected At') }}</strong></td>
-										<td>{{ formatDate(entity.detectedAt) }}</td>
-									</tr>
-									<tr>
-										<td><strong>{{ t('openregister', 'Relations') }}</strong></td>
-										<td>{{ entity.relationCount || 0 }}</td>
-									</tr>
-								</tbody>
-							</table>
-						</div>
-					</div>
-				</template>
-
-				<!-- Table View -->
-				<template v-else>
-					<div class="viewTableContainer">
-						<table class="viewTable">
-							<thead>
-								<tr>
-									<th class="tableColumnCheckbox">
-										<NcCheckboxRadioSwitch
-											:checked="allSelected"
-											:indeterminate="someSelected"
-											@update:checked="toggleSelectAll" />
-									</th>
-									<th>{{ t('openregister', 'Value') }}</th>
-									<th>{{ t('openregister', 'Type') }}</th>
-									<th>{{ t('openregister', 'Category') }}</th>
-									<th>{{ t('openregister', 'Detected At') }}</th>
-									<th>{{ t('openregister', 'Relations') }}</th>
-									<th class="tableColumnActions">
-										{{ t('openregister', 'Actions') }}
-									</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr v-for="entity in paginatedEntities"
-									:key="entity.id"
-									class="viewTableRow"
-									:class="{ viewTableRowSelected: selectedEntities.includes(entity.id) }">
-									<td class="tableColumnCheckbox">
-										<NcCheckboxRadioSwitch
-											:checked="selectedEntities.includes(entity.id)"
-											@update:checked="(checked) => toggleEntitySelection(entity.id, checked)" />
-									</td>
-									<td class="tableColumnTitle">
-										<div class="entity-value-cell">
-											<AccountOutline :size="20" class="entity-icon" />
-											<strong>{{ entity.value }}</strong>
-										</div>
-									</td>
-									<td>
-										<span class="badge badge-type">{{ entity.type }}</span>
-									</td>
-									<td>
-										<span class="badge badge-category">{{ entity.category }}</span>
-									</td>
-									<td>{{ formatDate(entity.detectedAt) }}</td>
-									<td>{{ entity.relationCount || 0 }}</td>
-									<td class="tableColumnActions">
-										<NcActions :primary="false">
-											<template #icon>
-												<DotsHorizontal :size="20" />
-											</template>
-											<NcActionButton
-												close-after-click
-												@click="viewEntity(entity)">
-												<template #icon>
-													<EyeOutline :size="20" />
-												</template>
-												View Details
-											</NcActionButton>
-										</NcActions>
-									</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
-				</template>
-			</div>
-
-			<!-- Pagination -->
-			<PaginationComponent
-				v-if="entitiesList.length > 0"
-				:current-page="currentPage"
-				:total-pages="totalPages"
-				:total-items="totalEntities"
-				:current-page-size="limit"
-				:min-items-to-show="10"
-				@page-changed="onPageChanged"
-				@page-size-changed="onPageSizeChanged" />
-		</div>
+			<!-- Filter toggle in header actions -->
+			<template #header-actions>
+				<NcButton
+					type="tertiary"
+					:aria-label="t('openregister', 'Toggle search sidebar')"
+					@click="toggleSidebar">
+					<template #icon>
+						<FilterVariant :size="20" />
+					</template>
+					{{ sidebarOpen ? t('openregister', 'Hide Filters') : t('openregister', 'Show Filters') }}
+				</NcButton>
+			</template>
+		</CnIndexPage>
 
 		<!-- Search Sidebar -->
 		<template #details>
@@ -238,106 +97,68 @@ import { generateUrl } from '@nextcloud/router'
 import { showError } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
 
-import {
-	NcAppContent,
-	NcActions,
-	NcActionButton,
-	NcButton,
-	NcLoadingIcon,
-	NcEmptyContent,
-	NcCheckboxRadioSwitch,
-} from '@nextcloud/vue'
+import { NcAppContent, NcButton } from '@nextcloud/vue'
+import { CnIndexPage, CnCard } from '@conduction/nextcloud-vue'
 
 import AccountOutline from 'vue-material-design-icons/AccountOutline.vue'
-import Refresh from 'vue-material-design-icons/Refresh.vue'
+import Eye from 'vue-material-design-icons/Eye.vue'
 import FilterVariant from 'vue-material-design-icons/FilterVariant.vue'
-import EyeOutline from 'vue-material-design-icons/EyeOutline.vue'
-import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
 
 import EntitiesSidebar from '../../components/EntitiesSidebar.vue'
-import PaginationComponent from '../../components/PaginationComponent.vue'
 
-/**
- * Main view for managing entities
- *
- * @package
- * @category View
- * @author Ruben Linde <ruben@conduction.nl>
- * @copyright 2024 Conduction B.V.
- * @license EUPL-1.2
- * @version 1.0.0
- * @link https://github.com/ConductionNL/openregister
- */
 export default {
 	name: 'EntitiesIndex',
 	components: {
 		NcAppContent,
-		NcActions,
-		NcActionButton,
 		NcButton,
-		NcLoadingIcon,
-		NcEmptyContent,
-		NcCheckboxRadioSwitch,
+		CnIndexPage,
+		CnCard,
 		AccountOutline,
-		Refresh,
 		FilterVariant,
-		EyeOutline,
-		DotsHorizontal,
 		EntitiesSidebar,
-		PaginationComponent,
 	},
 	data() {
 		return {
 			entitiesList: [],
 			loading: false,
+			isRefreshing: false,
 			totalEntities: 0,
-			limit: 20,
-			currentPage: 1,
+			viewMode: 'table',
 			sidebarOpen: false,
 			searchQuery: '',
 			typeFilter: null,
 			categoryFilter: null,
-			viewMode: 'table',
-			selectedEntities: [],
+			pagination: {
+				page: 1,
+				limit: 20,
+			},
 		}
 	},
 	computed: {
-		/**
-		 * Get total number of pages
-		 *
-		 * @return {number} Total pages
-		 */
-		totalPages() {
-			return Math.ceil(this.totalEntities / this.limit)
+		tableColumns() {
+			return [
+				{ key: 'value', label: t('openregister', 'Value'), sortable: true },
+				{ key: 'type', label: t('openregister', 'Type') },
+				{ key: 'category', label: t('openregister', 'Category') },
+				{ key: 'detectedAt', label: t('openregister', 'Detected At'), sortable: true },
+				{ key: 'relationCount', label: t('openregister', 'Relations') },
+			]
 		},
-
-		/**
-		 * Get paginated entities for current page
-		 *
-		 * @return {Array} Paginated entities
-		 */
-		paginatedEntities() {
-			const start = (this.currentPage - 1) * this.limit
-			const end = start + this.limit
-			return this.entitiesList.slice(start, end)
+		paginationData() {
+			const page = this.pagination.page
+			const limit = this.pagination.limit
+			const total = this.totalEntities
+			const pages = Math.ceil(total / limit)
+			return { page, pages, total, limit }
 		},
-
-		/**
-		 * Check if all entities are selected
-		 *
-		 * @return {boolean} True if all selected
-		 */
-		allSelected() {
-			return this.entitiesList.length > 0 && this.entitiesList.every(entity => this.selectedEntities.includes(entity.id))
-		},
-
-		/**
-		 * Check if some entities are selected
-		 *
-		 * @return {boolean} True if some selected
-		 */
-		someSelected() {
-			return this.selectedEntities.length > 0 && !this.allSelected
+		customActions() {
+			return [
+				{
+					label: 'View',
+					icon: Eye,
+					handler: (row) => this.viewEntity(row),
+				},
+			]
 		},
 	},
 	mounted() {
@@ -346,62 +167,34 @@ export default {
 	methods: {
 		t,
 
-		/**
-		 * Toggle sidebar visibility
-		 *
-		 * @return {void}
-		 */
 		toggleSidebar() {
 			this.sidebarOpen = !this.sidebarOpen
 		},
 
-		/**
-		 * Handle search query update
-		 *
-		 * @param {string} query - Search query
-		 * @return {void}
-		 */
 		handleSearchUpdate(query) {
 			this.searchQuery = query
-			this.currentPage = 1
+			this.pagination.page = 1
 			this.loadEntities()
 		},
 
-		/**
-		 * Handle type filter update
-		 *
-		 * @param {string|null} type - Type filter
-		 * @return {void}
-		 */
 		handleTypeUpdate(type) {
 			this.typeFilter = type
-			this.currentPage = 1
+			this.pagination.page = 1
 			this.loadEntities()
 		},
 
-		/**
-		 * Handle category filter update
-		 *
-		 * @param {string|null} category - Category filter
-		 * @return {void}
-		 */
 		handleCategoryUpdate(category) {
 			this.categoryFilter = category
-			this.currentPage = 1
+			this.pagination.page = 1
 			this.loadEntities()
 		},
 
-		/**
-		 * Load entities from the API
-		 *
-		 * @return {Promise<void>}
-		 */
 		async loadEntities() {
 			this.loading = true
 			try {
 				const params = {
-					limit: this.limit,
-					offset: (this.currentPage - 1) * this.limit,
+					limit: this.pagination.limit,
+					offset: (this.pagination.page - 1) * this.pagination.limit,
 				}
 
 				if (this.searchQuery) {
@@ -433,230 +226,68 @@ export default {
 			}
 		},
 
-		/**
-		 * Refresh the entities list
-		 *
-		 * @return {void}
-		 */
-		refreshEntities() {
-			this.loadEntities()
+		async handleRefresh() {
+			this.isRefreshing = true
+			try {
+				await this.loadEntities()
+			} finally {
+				this.isRefreshing = false
+			}
 		},
 
-		/**
-		 * Handle page change event
-		 *
-		 * @param {number} page - New page number
-		 * @return {void}
-		 */
 		onPageChanged(page) {
-			this.currentPage = page
+			this.pagination.page = page
 			this.loadEntities()
 		},
 
-		/**
-		 * Handle page size change event
-		 *
-		 * @param {number} pageSize - New page size
-		 * @return {void}
-		 */
 		onPageSizeChanged(pageSize) {
-			this.limit = pageSize
-			this.currentPage = 1
+			this.pagination.page = 1
+			this.pagination.limit = pageSize
 			this.loadEntities()
 		},
 
-		/**
-		 * Toggle select all entities
-		 *
-		 * @param {boolean} checked - Whether to select all
-		 * @return {void}
-		 */
-		toggleSelectAll(checked) {
-			if (checked) {
-				this.selectedEntities = this.entitiesList.map(entity => entity.id)
-			} else {
-				this.selectedEntities = []
-			}
-		},
-
-		/**
-		 * Toggle entity selection
-		 *
-		 * @param {number} entityId - Entity ID
-		 * @param {boolean} checked - Whether entity is selected
-		 * @return {void}
-		 */
-		toggleEntitySelection(entityId, checked) {
-			if (checked) {
-				this.selectedEntities.push(entityId)
-			} else {
-				this.selectedEntities = this.selectedEntities.filter(id => id !== entityId)
-			}
-		},
-
-		/**
-		 * View entity details
-		 *
-		 * @param {object} entity - Entity object
-		 * @return {void}
-		 */
 		viewEntity(entity) {
 			this.$router.push({ name: 'entityDetails', params: { id: entity.id } })
 		},
 
-		/**
-		 * Format date for display
-		 *
-		 * @param {string} date - Date string
-		 * @return {string} Formatted date
-		 */
 		formatDate(date) {
 			if (!date) return '-'
 			return new Date(date).toLocaleString()
+		},
+
+		mapEntityLabels(entity) {
+			const labels = []
+			if (entity.type) {
+				labels.push({ text: entity.type, color: 'primary' })
+			}
+			if (entity.category) {
+				labels.push({ text: entity.category, color: 'info' })
+			}
+			return labels
+		},
+
+		mapEntityStats(entity) {
+			return [
+				{ label: t('openregister', 'Detected At'), value: this.formatDate(entity.detectedAt) },
+				{ label: t('openregister', 'Relations'), value: String(entity.relationCount || 0) },
+			]
 		},
 	},
 }
 </script>
 
-<style scoped lang="scss">
-.viewContainer {
-	padding: 20px;
-	max-width: 100%;
-}
-
-.viewHeader {
-	margin-bottom: 20px;
-}
-
-.viewHeaderTitle {
-	display: flex;
-	align-items: center;
-	gap: 16px;
-	margin-bottom: 8px;
-}
-
-.viewHeaderTitleIndented {
-	margin: 0;
-	font-size: 28px;
-	font-weight: 600;
-}
-
-.viewHeader p {
-	color: var(--color-text-maxcontrast);
-	margin: 0;
-}
-
-.viewActionsBar {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	margin-bottom: 20px;
-	padding: 12px;
-	background: var(--color-background-hover);
-	border-radius: var(--border-radius-large);
-}
-
-.viewInfo {
-	display: flex;
-	gap: 12px;
-	align-items: center;
-}
-
-.viewTotalCount {
-	font-weight: 600;
-}
-
-.viewIndicator {
-	color: var(--color-text-maxcontrast);
-}
-
-.viewActions {
-	display: flex;
-	gap: 8px;
-}
-
-/* Cards Grid */
-.cardGrid {
-	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-	gap: 20px;
-	margin-bottom: 20px;
-}
-
-.card {
-	background: var(--color-main-background);
-	border: 1px solid var(--color-border);
-	border-radius: var(--border-radius-large);
-	overflow: hidden;
-	transition: box-shadow 0.2s ease;
-	cursor: pointer;
-}
-
-.card:hover {
-	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-}
-
-.cardHeader {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	padding: 16px;
-	border-bottom: 1px solid var(--color-border);
-}
-
-.cardHeader h2 {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	margin: 0;
-	font-size: 16px;
-	font-weight: 600;
-	flex-wrap: wrap;
-}
-
-/* Entity Stats Table */
-.entityStats {
-	width: 100%;
-	border-collapse: collapse;
-}
-
-.entityStats tbody tr {
-	border-bottom: 1px solid var(--color-border);
-}
-
-.entityStats tbody tr:last-child {
-	border-bottom: none;
-}
-
-.entityStats td {
-	padding: 12px 16px;
-}
-
-.entityStats td:first-child {
-	width: 40%;
-	color: var(--color-text-maxcontrast);
-}
-
-/* Table View */
-.viewTableContainer {
-	background: var(--color-main-background);
-	border-radius: var(--border-radius-large);
-	overflow: hidden;
-	margin-bottom: 20px;
-}
-
-.entity-value-cell {
+<style scoped>
+.entityValueCell {
 	display: flex;
 	align-items: center;
 	gap: 8px;
 }
 
-.entity-icon {
+.entityIcon {
 	color: var(--color-primary-element);
 	flex-shrink: 0;
 }
 
-/* Badges */
 .badge {
 	display: inline-block;
 	padding: 4px 8px;
@@ -666,26 +297,13 @@ export default {
 	text-transform: uppercase;
 }
 
-.badge-type {
+.badgeType {
 	background: var(--color-primary-light);
 	color: var(--color-primary-element);
 }
 
-.badge-category {
+.badgeCategory {
 	background: var(--color-background-dark);
 	color: var(--color-text-maxcontrast);
-}
-
-/* Column sizes for table view */
-.tableColumnCheckbox {
-	width: 50px;
-}
-
-.tableColumnTitle {
-	min-width: 200px;
-}
-
-.tableColumnActions {
-	width: 50px;
 }
 </style>


### PR DESCRIPTION
Rewrites the Entities index page to utilize the `CnIndexPage` component for a more streamlined and standardized user interface.

This refactoring significantly simplifies the template and associated component logic by:
- Replacing extensive custom layout, pagination, loading states, and view mode toggles with the encapsulated functionality of `CnIndexPage`.
- Leveraging `CnIndexPage`'s slots for custom card and table column rendering, providing specific displays for entity values, types, categories, and detection times.
- Operating in a read-only mode, disabling direct edit, copy, or delete actions within the index page.

Based off of: https://github.com/ConductionNL/openregister/pull/934
Requires: https://github.com/ConductionNL/nextcloud-vue/pull/17