### PR TITLE
fix: Bypass RBAC and multitenancy checks in CLI context

### DIFF
--- a/lib/Db/MultiTenancyTrait.php
+++ b/lib/Db/MultiTenancyTrait.php
@@ -694,7 +694,7 @@ trait MultiTenancyTrait
         $activeOrg = $this->organisationService->getActiveOrganisation();
         if ($activeOrg === null) {
             // CLI context — no active organisation is expected. Allow access.
-            if (\OC::$CLI === true) {
+            if (PHP_SAPI === 'cli') {
                 return true;
             }
 
@@ -724,7 +724,7 @@ trait MultiTenancyTrait
         if ($user === null) {
             // CLI context (occ commands, repair steps, cron jobs) — no user session exists.
             // These are trusted system operations that must always succeed.
-            if (\OC::$CLI === true) {
+            if (PHP_SAPI === 'cli') {
                 return true;
             }
 

--- a/lib/Db/MultiTenancyTrait.php
+++ b/lib/Db/MultiTenancyTrait.php
@@ -693,6 +693,11 @@ trait MultiTenancyTrait
 
         $activeOrg = $this->organisationService->getActiveOrganisation();
         if ($activeOrg === null) {
+            // CLI context — no active organisation is expected. Allow access.
+            if (\OC::$CLI === true) {
+                return true;
+            }
+
             // No active organisation, deny access.
             return false;
         }
@@ -717,6 +722,12 @@ trait MultiTenancyTrait
 
         $user = $this->userSession->getUser();
         if ($user === null) {
+            // CLI context (occ commands, repair steps, cron jobs) — no user session exists.
+            // These are trusted system operations that must always succeed.
+            if (\OC::$CLI === true) {
+                return true;
+            }
+
             return false;
         }
 


### PR DESCRIPTION
## Summary

- Fixes RBAC permission checks that block app configuration imports when running from CLI (`occ` commands, repair steps, cron jobs)
- In CLI context, there is no user session or active organisation, so `hasRbacPermission()` returned `false` for both checks
- Now detects `\OC::$CLI === true` and allows access for these trusted system operations

Fixes #973

## Test plan

- [x] Run `docker exec nextcloud php occ maintenance:repair` with Pipelinq installed — schemas should load without "Access denied" errors
- [x] Run `docker exec nextcloud php occ app:disable pipelinq && docker exec nextcloud php occ app:enable pipelinq` — same result
- [x] Verify web UI RBAC is unaffected (non-CLI context still enforces permissions)
- [x] Run Pipelinq Playwright CI — tests should pass now that schemas load