### PR TITLE
feat(openspec): Add seed-related-items change — spec, design, tasks

### DIFF
--- a/openspec/changes/seed-related-items/design.md
+++ b/openspec/changes/seed-related-items/design.md
@@ -1,0 +1,195 @@
+# Design: seed-related-items
+
+## Context
+
+OpenRegister's `ImportHandler::importSeedData()` (lines 2676-3085 of `lib/Service/Configuration/ImportHandler.php`) creates register objects from the `x-openregister.seedData.objects` section of app configuration JSON files. It supports schema resolution, external configuration references, idempotency checks, and magic mapper table pre-creation. However, after creating an object, the method does nothing with related Nextcloud items.
+
+Three services already exist for managing related items on objects:
+- **TaskService** -- Creates CalDAV VTODOs linked via X-OPENREGISTER-* properties.
+- **NoteService** -- Creates Nextcloud Comments linked via objectType "openregister".
+- **FileService** -- Creates files in the object's folder via IRootFolder.
+
+This change extends the seed data import to call these services after object creation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Support `_relatedItems` in seed data JSON for notes, tasks, and files
+- Strip `_relatedItems` before persisting objects (import-only metadata)
+- Graceful degradation: related item failures don't block import
+- Idempotency: skip related items for objects that already exist
+
+**Non-Goals:**
+- Contact seeding (ContactService not yet implemented)
+- Calendar event or Deck card seeding (services not yet implemented)
+- Validating related item content against external schemas
+- Providing a UI for editing seed data
+
+## Decisions
+
+### DD-01: _relatedItems Key Placement
+
+**Decision**: Place `_relatedItems` at the top level of each seed object (sibling to `title`, `slug`, etc.), not in a separate section of the seed data config.
+
+**Rationale**: Co-locating related items with the object they belong to keeps the JSON readable and makes it clear which items belong to which object. A separate top-level section would require cross-referencing by slug/uuid, adding complexity.
+
+**Format**:
+```json
+{
+  "title": "Vergunningsaanvraag Hoofdstraat 42",
+  "slug": "vergunning-hoofdstraat-42",
+  "status": "in_behandeling",
+  "aanvrager": "Bouwbedrijf De Vries B.V.",
+  "_relatedItems": {
+    "notes": [
+      { "message": "Aanvraag ontvangen en geregistreerd. Wachten op aanvullende documenten." },
+      { "message": "Bouwtekening ontvangen, doorgestuurd naar afdeling Ruimtelijke Ordening." }
+    ],
+    "tasks": [
+      {
+        "summary": "Beoordeel constructietekening",
+        "description": "Controleer de constructietekening op conformiteit met Bouwbesluit 2012.",
+        "status": "needs-action",
+        "priority": 3,
+        "due": "2025-02-15"
+      },
+      {
+        "summary": "Welstandsadvies opvragen",
+        "status": "in-process",
+        "priority": 5
+      }
+    ],
+    "files": [
+      {
+        "name": "aanvraagformulier.txt",
+        "content": "Aanvraag omgevingsvergunning\nLocatie: Hoofdstraat 42\nAanvrager: Bouwbedrijf De Vries B.V.\nDatum: 2025-01-10",
+        "tags": ["aanvraag"]
+      },
+      {
+        "name": "situatieschets.txt",
+        "content": "base64:U2l0dWF0aWVzY2hldHMgdm9vciBIb29mZHN0cmFhdCA0Mg==",
+        "share": true,
+        "tags": ["tekening", "situatie"]
+      }
+    ]
+  }
+}
+```
+
+### DD-02: Service Injection into ImportHandler
+
+**Decision**: Inject `TaskService`, `NoteService`, and `FileService` into ImportHandler via constructor. Use nullable types so ImportHandler remains functional even if a service cannot be resolved (e.g., CalDAV backend missing).
+
+**Rationale**: ImportHandler already has ~15 constructor dependencies. Adding three more follows the existing pattern. Nullable injection ensures backward compatibility -- if any service is unavailable, its related items are simply skipped.
+
+**Constructor additions**:
+```php
+private ?TaskService $taskService = null,
+private ?NoteService $noteService = null,
+private ?FileService $fileService = null,
+```
+
+### DD-03: Processing Order
+
+**Decision**: Process related items in the order: files, notes, tasks. Process all items for one object before moving to the next.
+
+**Rationale**: Files are the most commonly expected related item and the least likely to fail (no external service dependency beyond filesystem). Notes depend on ICommentsManager (always available). Tasks depend on CalDAV (may fail if user has no calendar). Processing in reliability order means the most items get created even if a later type fails.
+
+### DD-04: Stripping _relatedItems
+
+**Decision**: Extract and unset `_relatedItems` from `$objectData` before passing to `ObjectEntity::setObject()`, in the existing foreach loop at line 2820.
+
+**Rationale**: The stripping must happen before `setObject()` to prevent `_relatedItems` from being stored in the database. Extracting it into a local variable preserves the data for processing after the object is saved.
+
+**Code location**: Between line 2820 (`foreach ($objects as $objectData)`) and line 2949 (`$objectSlug = ...`).
+
+### DD-05: ObjectEntity Retrieval for FileService
+
+**Decision**: After creating the seed object, use the returned `$createdObject` (ObjectEntity) directly when calling `FileService::addFile()`. The first parameter of `addFile()` accepts `ObjectEntity | string`.
+
+**Rationale**: The object is already in memory after insert. No additional database lookup needed.
+
+### DD-06: User Context Check
+
+**Decision**: Check `IUserSession::getUser()` once at the start of `importSeedData()`. If null, set a flag that disables task and note creation (both require a user) but allows file creation (FileService falls back to system user for public uploads).
+
+**Rationale**: During `occ` CLI import or app install without web context, there may be no user session. Tasks require a user calendar; notes require a user actor. Files can use a system fallback. A single check avoids repeated null-user exceptions.
+
+### DD-07: Idempotency Scope
+
+**Decision**: Related items are NOT individually checked for idempotency. If the parent object already exists (existing idempotency check), ALL its related items are skipped. If the parent object is new, ALL its related items are created.
+
+**Rationale**: Checking individual notes/tasks/files for duplicates would require querying each service (CalDAV search, comment listing, folder scan), adding significant complexity for a marginal benefit. Seed data import is idempotent at the object level -- if you want to re-seed related items, delete the parent object first.
+
+## Seed Data
+
+This change does not introduce new schemas. It extends the seed data JSON format itself. Example seed data that consuming apps would use:
+
+### Notes Format
+```json
+{
+  "notes": [
+    { "message": "Aanvraag ingediend door aanvrager via het online portaal." },
+    { "message": "Dossier compleet verklaard na ontvangst van alle bijlagen." }
+  ]
+}
+```
+
+### Tasks Format
+```json
+{
+  "tasks": [
+    {
+      "summary": "Inhoudelijke beoordeling aanvraag",
+      "description": "Toets de aanvraag aan het bestemmingsplan en bouwvoorschriften.",
+      "status": "needs-action",
+      "priority": 3,
+      "due": "2025-03-01"
+    },
+    {
+      "summary": "Besluit voorbereiden",
+      "status": "needs-action",
+      "priority": 5,
+      "due": "2025-04-01"
+    }
+  ]
+}
+```
+
+### Files Format
+```json
+{
+  "files": [
+    {
+      "name": "aanvraagformulier.txt",
+      "content": "Voorbeeld aanvraagformulier\nNaam: Test Organisatie\nDatum: 2025-01-15",
+      "tags": ["aanvraag", "formulier"]
+    },
+    {
+      "name": "bijlage-situatieschets.txt",
+      "content": "Situatieschets met toelichting op de voorgenomen werkzaamheden.",
+      "share": true,
+      "tags": ["bijlage"]
+    }
+  ]
+}
+```
+
+## Component Diagram
+
+```
+_register.json
+  x-openregister.seedData.objects[schema][n]
+    -> object data (persisted via ObjectEntityMapper / RoutingMapper)
+    -> _relatedItems.files[]  -> FileService::addFile()
+    -> _relatedItems.notes[]  -> NoteService::createNote()
+    -> _relatedItems.tasks[]  -> TaskService::createTask()
+```
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `lib/Service/Configuration/ImportHandler.php` | Add service injection, extract `_relatedItems`, call services after object insert |
+| `lib/AppInfo/Application.php` | Ensure TaskService, NoteService, FileService are registered (may already be) |
+| No new files | This change modifies existing code only |

--- a/openspec/changes/seed-related-items/proposal.md
+++ b/openspec/changes/seed-related-items/proposal.md
@@ -1,0 +1,53 @@
+# Seed Related Items
+
+## Problem
+
+OpenRegister's `ImportHandler::importSeedData()` currently creates flat register objects only. It does not create related Nextcloud items (notes, tasks, files, contacts) that would be linked to those objects via OpenRegister's relation system. This means that after app install, seed objects exist but lack the realistic context (attached documents, task lists, notes, contact links) that users and testers expect to see.
+
+ADR-016 mandates that every app ships realistic seed data, and explicitly calls out related items as a gap: "OpenRegister's ImportHandler currently loads seed objects as standalone records. It does not support seeding related items (files, notes, tasks, contacts) that are linked to objects through OpenRegister's relation system."
+
+## Context
+
+- **Existing services**: TaskService (CalDAV VTODO), NoteService (ICommentsManager), FileService (IRootFolder). ContactService is planned in the `nextcloud-entity-relations` change but not yet implemented.
+- **Current seed format**: `x-openregister.seedData.objects` in `_register.json` contains arrays of object data per schema slug.
+- **Consuming apps**: Pipelinq, Procest, Docudesk, ZaakAfhandelApp all need realistic seed data for testing and demos.
+- **ImportHandler location**: `lib/Service/Configuration/ImportHandler.php`, method `importSeedData()` (lines 2676-3085).
+
+## Proposed Solution
+
+Extend the `seedData` JSON format to support a `_relatedItems` key on each seed object. After creating the object, ImportHandler iterates over `_relatedItems` and calls the appropriate service (TaskService, NoteService, FileService) to create linked items. The `_relatedItems` key is stripped before saving the object data.
+
+Example format:
+```json
+{
+  "title": "Omgevingsvergunning Kerkstraat 12",
+  "slug": "omgevingsvergunning-kerkstraat-12",
+  "status": "in_behandeling",
+  "_relatedItems": {
+    "notes": [
+      { "message": "Aanvraag ontvangen via e-formulier op 2025-01-15." }
+    ],
+    "tasks": [
+      { "summary": "Beoordeel bouwtekening", "status": "needs-action", "priority": 5 }
+    ],
+    "files": [
+      { "name": "bouwtekening-v1.pdf", "content": "base64:...", "tags": ["bouwtekening"] }
+    ]
+  }
+}
+```
+
+## Scope
+
+### In scope
+- Extend seedData JSON schema with `_relatedItems` support for notes, tasks, and files
+- Modify `ImportHandler::importSeedData()` to process `_relatedItems` after object creation
+- Strip `_relatedItems` from object data before persisting
+- Idempotency: skip related items if the seed object already existed
+- Error handling: log and continue if a related item fails (non-fatal)
+
+### Out of scope
+- ContactService (not yet implemented; blocked on `nextcloud-entity-relations` change)
+- CalendarEventService and DeckCardService (same blocker)
+- Actual seed data content for consuming apps (each app adds its own seed data separately)
+- Setup wizards or UI for managing seed data

--- a/openspec/changes/seed-related-items/spec.md
+++ b/openspec/changes/seed-related-items/spec.md
@@ -1,0 +1,130 @@
+# Spec: seed-related-items
+
+## Overview
+
+Extend OpenRegister's seed data import to support creating related Nextcloud items (notes, tasks, files) alongside seed objects. This enables apps to ship fully realistic seed data where objects come pre-loaded with attached documents, task checklists, and notes -- making the app immediately testable and demo-ready after install.
+
+## Requirements
+
+### REQ-01: _relatedItems JSON Schema
+
+The `seedData.objects[schemaSlug][n]` object MAY contain a `_relatedItems` key. This key is an object with optional sub-keys:
+
+- `notes` -- array of note definitions
+- `tasks` -- array of task definitions
+- `files` -- array of file definitions
+
+Each sub-key is optional. If `_relatedItems` is absent or empty, the object is imported as before (no behavior change).
+
+### REQ-02: Strip _relatedItems Before Persisting
+
+The `_relatedItems` key MUST be removed from the object data before it is stored in the database. It is metadata for the import process only; it MUST NOT appear in the persisted object JSON.
+
+### REQ-03: Process Related Items After Object Creation
+
+Related items MUST be created after the seed object is successfully inserted. The created object's UUID, register ID, and schema ID are required to link the related items. If object creation fails, related items MUST be skipped for that object.
+
+### REQ-04: Note Seeding
+
+Each note definition MUST contain:
+- `message` (string, required) -- The note text content.
+
+The system MUST call `NoteService::createNote(objectUuid, message)` for each note. Notes are created as the system user (the user context active during import, typically `admin`).
+
+**Scenario:**
+```
+GIVEN a seed object with _relatedItems.notes containing 2 entries
+WHEN the seed object is created successfully
+THEN 2 notes are created via NoteService linked to the object's UUID
+AND each note has the specified message content
+```
+
+### REQ-05: Task Seeding
+
+Each task definition MUST contain:
+- `summary` (string, required) -- The task title.
+
+Each task definition MAY contain:
+- `description` (string) -- Task description text.
+- `status` (string) -- One of: `needs-action`, `in-process`, `completed`, `cancelled`. Defaults to `needs-action`.
+- `priority` (integer, 1-9) -- CalDAV priority. Defaults to 0 (undefined).
+- `due` (string, ISO 8601 date) -- Due date.
+
+The system MUST call `TaskService::createTask(registerId, schemaId, objectUuid, objectTitle, data)` for each task.
+
+**Scenario:**
+```
+GIVEN a seed object with _relatedItems.tasks containing 1 entry with summary "Review document"
+WHEN the seed object is created successfully
+THEN 1 VTODO is created in the user's calendar
+AND the VTODO has X-OPENREGISTER-OBJECT set to the object's UUID
+AND the VTODO SUMMARY is "Review document"
+```
+
+### REQ-06: File Seeding
+
+Each file definition MUST contain:
+- `name` (string, required) -- The file name including extension.
+- `content` (string, required) -- The file content. If prefixed with `base64:`, the remainder is base64-decoded. Otherwise treated as plain text.
+
+Each file definition MAY contain:
+- `tags` (array of strings) -- Tags to attach to the file.
+- `share` (boolean) -- Whether to create a public share link. Defaults to `false`.
+
+The system MUST call `FileService::addFile(objectEntity, fileName, content, share, tags)` for each file.
+
+**Scenario:**
+```
+GIVEN a seed object with _relatedItems.files containing 1 entry named "rapport.pdf"
+WHEN the seed object is created successfully
+THEN a file named "rapport.pdf" is created in the object's folder
+AND the file is linked to the object via OpenRegister's file system
+```
+
+### REQ-07: Idempotency for Related Items
+
+If a seed object already exists (detected by the existing idempotency check on slug/uuid), related items MUST be skipped. The system MUST NOT create duplicate notes, tasks, or files on re-import.
+
+**Scenario:**
+```
+GIVEN a seed object with slug "case-001" already exists in the register
+AND the seed data defines _relatedItems with 2 notes
+WHEN importSeedData runs again
+THEN the object is skipped (existing behavior)
+AND no new notes are created
+```
+
+### REQ-08: Error Isolation
+
+If creating a related item fails (e.g., CalDAV unavailable, file quota exceeded), the error MUST be logged at WARNING level and the import MUST continue with the next related item. A failed related item MUST NOT prevent other related items or other seed objects from being imported.
+
+**Scenario:**
+```
+GIVEN a seed object with _relatedItems containing 1 note and 1 task
+AND TaskService throws an exception (no calendar available)
+WHEN the seed object is imported
+THEN the note is created successfully
+AND a warning is logged for the failed task
+AND import continues with the next seed object
+```
+
+### REQ-09: User Context for Related Items
+
+Related items are created under the user context active during the import process. For app install, this is typically the admin user. The import MUST verify that a user session exists before attempting to create tasks (which require a user calendar). If no user session is available, task and note creation MUST be skipped with a warning log.
+
+**Scenario:**
+```
+GIVEN importSeedData runs without an active user session
+AND a seed object has _relatedItems with tasks
+WHEN the object is created
+THEN task creation is skipped
+AND a warning is logged: "Skipping related items - no user session"
+```
+
+### REQ-10: Logging
+
+The system MUST log:
+- INFO: Start of related items processing for an object (count per type).
+- DEBUG: Each successfully created related item (type + identifier).
+- WARNING: Each failed related item (type + error message).
+- INFO: Summary at end of seed data import (total related items created per type).

--- a/openspec/changes/seed-related-items/tasks.md
+++ b/openspec/changes/seed-related-items/tasks.md
@@ -1,0 +1,61 @@
+# Tasks: seed-related-items
+
+## 1. ImportHandler -- Inject Related Item Services
+
+- [ ] 1.1 Add constructor parameters to `lib/Service/Configuration/ImportHandler.php` for `?TaskService $taskService = null`, `?NoteService $noteService = null`, and `?FileService $fileService = null`. Add corresponding `use` statements for `OCA\OpenRegister\Service\TaskService`, `OCA\OpenRegister\Service\NoteService`, and `OCA\OpenRegister\Service\FileService`. Store as private nullable properties. This follows the existing pattern of nullable service injection already used in ImportHandler (e.g., `$magicMapper`, `$routingMapper`).
+
+## 2. ImportHandler -- Strip and Extract _relatedItems
+
+- [ ] 2.1 In the `importSeedData()` method, inside the `foreach ($objects as $objectData)` loop (line 2820), add extraction of `_relatedItems` BEFORE the existing object processing logic. Extract `$relatedItems = $objectData['_relatedItems'] ?? null;` then `unset($objectData['_relatedItems']);`. This MUST happen before the `$objectSlug` extraction (line 2949) and before `ObjectEntity::setObject($objectData)` (line 3037) to ensure `_relatedItems` is never persisted to the database.
+
+## 3. ImportHandler -- User Context Check
+
+- [ ] 3.1 At the start of `importSeedData()`, after the null/empty check for seedData (line 2686), add a user context check. Get `$user = $this->userSession->getUser()` (IUserSession is already injected into ImportHandler). Store as `$hasUserContext = ($user !== null)`. Log a DEBUG message indicating whether user context is available. This flag is used later to skip task and note creation when no user is logged in.
+
+## 4. ImportHandler -- Process Related Items After Object Creation
+
+- [ ] 4.1 After the successful object insert block (after line 3051 `$result['objects'][] = $createdObject->getId()`), add a call to a new private method `processRelatedItems(ObjectEntity $object, ?array $relatedItems, int $registerId, int $schemaId, string $objectTitle, bool $hasUserContext, array &$result): void`. Pass the `$createdObject`, `$relatedItems`, `$targetRegId`, `$objectSchema->getId()`, `$objectData['title'] ?? $objectSlug`, `$hasUserContext`, and `$result`. Skip the call if `$relatedItems` is null or empty.
+
+## 5. ImportHandler -- Implement processRelatedItems Method
+
+- [ ] 5.1 Create private method `processRelatedItems()` in ImportHandler. Log an INFO message at the start with the count of each related item type (files, notes, tasks). Initialize counters: `$filesCreated = 0`, `$notesCreated = 0`, `$tasksCreated = 0`.
+
+- [ ] 5.2 **Files processing block**: If `$relatedItems['files']` is set and `$this->fileService !== null`, iterate over each file definition. For each: extract `name` (required, skip if missing), `content` (required, skip if missing), `tags` (default `[]`), `share` (default `false`). If `content` starts with `base64:`, decode the remainder via `base64_decode()`. Call `$this->fileService->addFile($object, $name, $content, $share, $tags)`. Wrap in try/catch; on failure log WARNING with file name and error message, continue to next file. Increment `$filesCreated` on success.
+
+- [ ] 5.3 **Notes processing block**: If `$relatedItems['notes']` is set and `$this->noteService !== null` and `$hasUserContext === true`, iterate over each note definition. For each: extract `message` (required, skip if missing). Call `$this->noteService->createNote($object->getUuid(), $message)`. Wrap in try/catch; on failure log WARNING with object UUID and error message, continue. Increment `$notesCreated` on success. If `$hasUserContext` is false, log a single WARNING: "Skipping note creation for seed object -- no user session available".
+
+- [ ] 5.4 **Tasks processing block**: If `$relatedItems['tasks']` is set and `$this->taskService !== null` and `$hasUserContext === true`, iterate over each task definition. For each: extract `summary` (required, skip if missing). Build `$taskData` array with keys: `summary`, `description` (default `''`), `status` (default `needs-action`), `priority` (default `0`), `due` (default `null`). Call `$this->taskService->createTask($registerId, $schemaId, $object->getUuid(), $objectTitle, $taskData)`. Wrap in try/catch; on failure log WARNING with task summary and error message, continue. Increment `$tasksCreated` on success. If `$hasUserContext` is false, log a single WARNING: "Skipping task creation for seed object -- no user session available".
+
+- [ ] 5.5 Log a DEBUG message at the end of `processRelatedItems()` with the counts: files created, notes created, tasks created, and the object UUID.
+
+## 6. ImportHandler -- Summary Counters
+
+- [ ] 6.1 Add summary counters at the `importSeedData()` method level: `$totalFilesCreated = 0`, `$totalNotesCreated = 0`, `$totalTasksCreated = 0`. Have `processRelatedItems()` update these via the `$result` array (add keys `relatedFiles`, `relatedNotes`, `relatedTasks`). In the final INFO log (line 3076-3084), include total related items created per type alongside the existing object count.
+
+## 7. Application Registration
+
+- [ ] 7.1 Verify that `lib/AppInfo/Application.php` registers `TaskService`, `NoteService`, and `FileService` in the DI container. These services are likely already registered since they are used by controllers. If any is missing, add the registration. Confirm ImportHandler can resolve them via constructor injection.
+
+## 8. Unit Tests
+
+- [ ] 8.1 Create `tests/Unit/Service/Configuration/ImportHandlerSeedRelatedItemsTest.php`. Test that `_relatedItems` is stripped from object data before persistence. Mock `ObjectEntityMapper::insert()` and verify the `ObjectEntity::getObject()` result does not contain `_relatedItems`.
+
+- [ ] 8.2 Test that `processRelatedItems()` calls `NoteService::createNote()` for each note entry. Use a mock NoteService, verify it receives the correct objectUuid and message for each note defined in `_relatedItems.notes`.
+
+- [ ] 8.3 Test that `processRelatedItems()` calls `TaskService::createTask()` for each task entry with correct parameters (registerId, schemaId, objectUuid, objectTitle, task data array).
+
+- [ ] 8.4 Test that `processRelatedItems()` calls `FileService::addFile()` for each file entry, including base64 decoding when content starts with `base64:`.
+
+- [ ] 8.5 Test error isolation: mock `TaskService::createTask()` to throw an exception. Verify that note and file creation still proceed, and a warning is logged.
+
+- [ ] 8.6 Test idempotency: when an object already exists (idempotency check returns existing object), verify that `processRelatedItems()` is NOT called.
+
+- [ ] 8.7 Test no-user-context: when `IUserSession::getUser()` returns null, verify tasks and notes are skipped but files are still created.
+
+## 9. Verification
+
+- [ ] 9.1 Install OpenRegister on a clean Nextcloud instance. Create a test `_register.json` with a schema and seed objects that include `_relatedItems` with notes, tasks, and files. Import via `importFromApp()`. Verify: objects are created, notes appear via `/api/objects/{r}/{s}/{id}/notes`, tasks appear via `/api/objects/{r}/{s}/{id}/tasks`, files appear via `/api/objects/{r}/{s}/{id}/files`.
+
+- [ ] 9.2 Re-import the same configuration. Verify no duplicate objects or related items are created.
+
+- [ ] 9.3 Verify that persisted object JSON does not contain `_relatedItems` key (query database or GET object via API).


### PR DESCRIPTION
## Summary

- Defines how OpenRegister's ImportHandler will seed related items (notes, tasks, files) alongside register objects during app install
- 10 requirements with GIVEN/WHEN/THEN scenarios
- 7 design decisions with JSON schema examples
- 17 implementation tasks referencing ImportHandler line numbers

## Context

ADR-016 mandates seed data for all apps. Currently, seed data only creates flat register objects. This change enables seeding related Nextcloud items (notes via NoteService, tasks via TaskService, files via FileService) as part of the `_relatedItems` property on each seed object.

Scoped to existing services — contacts/calendar deferred to `nextcloud-entity-relations` change.

## Files

- `openspec/changes/seed-related-items/proposal.md`
- `openspec/changes/seed-related-items/spec.md`
- `openspec/changes/seed-related-items/design.md`
- `openspec/changes/seed-related-items/tasks.md`