### PR TITLE
fix: Detect and sync missing columns even when schema version is unchanged

### DIFF
--- a/lib/Db/MagicMapper/MagicTableHandler.php
+++ b/lib/Db/MagicMapper/MagicTableHandler.php
@@ -139,12 +139,12 @@ class MagicTableHandler
                             'missingColumns' => array_keys($missingColumns),
                         ]
                     );
-                }
+                }//end if
 
                 // Schema changed or columns missing, update table.
                 $result = $this->syncTableForRegisterSchema(register: $register, schema: $schema);
                 return $result['success'] ?? true;
-            }
+            }//end if
 
             // Create new table or recreate if forced.
             if (($tableExists === true) && ($force === true)) {

--- a/lib/Db/MagicMapper/MagicTableHandler.php
+++ b/lib/Db/MagicMapper/MagicTableHandler.php
@@ -111,19 +111,37 @@ class MagicTableHandler
             if (($tableExists === true) && ($force === false)) {
                 // Table exists and not forcing update - check if schema changed.
                 if ($this->magicMapper->hasRegisterSchemaChanged(register: $register, schema: $schema) === false) {
-                    $this->logger->debug(
-                        message: '[MagicTableHandler] Table exists and schema unchanged, skipping',
+                    // Sanity check: verify all schema columns exist in the table.
+                    // The version hash can be stale if it was stored without a full sync.
+                    $requiredColumns = $this->magicMapper->buildTableColumnsFromSchema(schema: $schema);
+                    $currentColumns  = $this->magicMapper->getExistingTableColumns(tableName: $tableName);
+                    $missingColumns  = array_diff_key($requiredColumns, array_flip($currentColumns));
+
+                    if (empty($missingColumns) === true) {
+                        $this->logger->debug(
+                            message: '[MagicTableHandler] Table exists and schema unchanged, skipping',
+                            context: [
+                                'file'      => __FILE__,
+                                'line'      => __LINE__,
+                                'tableName' => $tableName,
+                                'cacheKey'  => $cacheKey,
+                            ]
+                        );
+                        return true;
+                    }
+
+                    $this->logger->warning(
+                        message: '[MagicTableHandler] Schema version unchanged but columns missing, forcing sync',
                         context: [
-                            'file'      => __FILE__,
-                            'line'      => __LINE__,
-                            'tableName' => $tableName,
-                            'cacheKey'  => $cacheKey,
+                            'file'           => __FILE__,
+                            'line'           => __LINE__,
+                            'tableName'      => $tableName,
+                            'missingColumns' => array_keys($missingColumns),
                         ]
                     );
-                    return true;
                 }
 
-                // Schema changed, update table.
+                // Schema changed or columns missing, update table.
                 $result = $this->syncTableForRegisterSchema(register: $register, schema: $schema);
                 return $result['success'] ?? true;
             }


### PR DESCRIPTION
## Summary
- `ensureTableForRegisterSchema` previously skipped sync when the stored schema version hash matched
- If columns were added to a schema after the version was stored (without a full sync), the table would permanently miss those columns
- Now performs a fast sanity check: compares required columns from `buildTableColumnsFromSchema` against actual table columns from `getExistingTableColumns`
- If any columns are missing, forces a sync regardless of the version hash

## Root cause
The Procest case schema (204) had `workflowTemplate` and `workflowVersion` properties added after the magic table was created. The version hash was stored as "current" without the columns being created, so subsequent `ensureTable` calls saw no change and skipped sync.

## Test plan
- [x] Verify Tags sidebar tab works on Procest case objects (PATCH with `{tags: [...]}` no longer 500s)
- [x] Verify sync adds missing columns automatically on next table access
- [x] Verify existing tables with all columns present are not unnecessarily synced

Closes #974