### PR TITLE
feat(i18n): Wrap bare strings and convert Dutch to English keys

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -283,7 +283,7 @@ return [
         // Note: entityId uses [^/]+ (not .+) to prevent slashes in captured values. Entity IDs are
         // opaque (UUIDs / external IDs) and should never contain path separators. The legacy underscore-
         // prefixed variant below (linkedEntity#reverseLookup on /api/linked/_{type}/{entityId}) coexists
-        // for backwards compatibility with older mail-sidebar clients; deduplicate in a future cleanup.
+        // for backwards compatibility with older mail-sidebar clients; removal tracked in issue #1535.
         ['name' => 'linked_entity#reverseLookup', 'url' => '/api/linked/{type}/{entityId}', 'verb' => 'GET', 'requirements' => ['type' => '[^/]+', 'entityId' => '[^/]+']],
 
         // Objects.

--- a/lib/Controller/TasksController.php
+++ b/lib/Controller/TasksController.php
@@ -103,8 +103,11 @@ class TasksController extends Controller
     {
         try {
             $status   = $this->request->getParam('status');
-            $limit    = min((int) ($this->request->getParam('_limit') ?? $this->request->getParam('limit') ?? 50), 200);
-            $offset   = (int) ($this->request->getParam('_offset') ?? $this->request->getParam('offset') ?? 0);
+            $limit    = min(max((int) ($this->request->getParam('_limit') ?? $this->request->getParam('limit') ?? 50), 1), 200);
+            // Clamp offset symmetrically with limit. Without an upper bound a client can pass
+            // _offset=10000000 and force TaskService to walk N calendars before slicing — the
+            // same DoS surface the limit clamp closes (PR #1273 review).
+            $offset   = min(max((int) ($this->request->getParam('_offset') ?? $this->request->getParam('offset') ?? 0), 0), 10000);
             $assignee = $this->request->getParam('assignee');
 
             $result = $this->taskService->getAllUserTasks(

--- a/lib/Controller/TasksController.php
+++ b/lib/Controller/TasksController.php
@@ -102,8 +102,8 @@ class TasksController extends Controller
     public function allUserTasks(): JSONResponse
     {
         try {
-            $status   = $this->request->getParam('status');
-            $limit    = min(max((int) ($this->request->getParam('_limit') ?? $this->request->getParam('limit') ?? 50), 1), 200);
+            $status = $this->request->getParam('status');
+            $limit  = min(max((int) ($this->request->getParam('_limit') ?? $this->request->getParam('limit') ?? 50), 1), 200);
             // Clamp offset symmetrically with limit. Without an upper bound a client can pass
             // _offset=10000000 and force TaskService to walk N calendars before slicing — the
             // same DoS surface the limit clamp closes (PR #1273 review).

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -5845,7 +5845,8 @@ class MagicMapper extends AbstractObjectMapper
                 // PostgreSQL: use JSONB containment operator.
                 // Note: ::jsonb cast is intentional for polymorphic column support, but defeats any GIN
                 // index on $columnName if it is already jsonb. Acceptable for now; if a GIN index is added
-                // in a future migration for this column, branch the query to omit the cast in the jsonb case.
+                // in a future migration for this column, branch the query to omit the cast in the jsonb
+                // case. Tracked under the cross-tenant scan tightening follow-up — see issue #1534.
                 $sql = "SELECT * FROM {$fullTableName}
                         WHERE (_deleted IS NULL OR _deleted::text = 'null')
                         AND {$columnName} IS NOT NULL

--- a/lib/Service/LinkedEntityService.php
+++ b/lib/Service/LinkedEntityService.php
@@ -29,6 +29,7 @@ use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Db\Organisation;
 use OCA\OpenRegister\Db\OrganisationMapper;
 use OCP\DB\Exception as DbException;
+use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -80,12 +81,25 @@ class LinkedEntityService
     private const MAX_TABLES_TO_SCAN = 50;
 
     /**
+     * App-config key controlling whether scanMagicTables() may bypass RBAC + multitenancy
+     * to support cross-tenant reverse-lookups from the mail sidebar.
+     *
+     * '1' (default): bypass enabled — required for the mail-sidebar feature.
+     * '0':           strict-isolation mode — falls back to standard RBAC-scoped findAll().
+     *
+     * Operators in multi-tenant SaaS deployments should set this to '0' until issue #1534
+     * (per-row access check + caller scoping + audit log) lands.
+     */
+    private const CONFIG_CROSS_TENANT_SCAN = 'linkedEntity.crossTenantScan';
+
+    /**
      * Constructor for LinkedEntityService.
      *
      * @param MagicMapper        $magicMapper        Magic mapper for object operations
      * @param SchemaMapper       $schemaMapper       Schema mapper
      * @param RegisterMapper     $registerMapper     Register mapper
      * @param OrganisationMapper $organisationMapper Organisation mapper
+     * @param IAppConfig         $appConfig          App config for strict-isolation flag
      * @param LoggerInterface    $logger             Logger
      */
     public function __construct(
@@ -93,6 +107,7 @@ class LinkedEntityService
         private readonly SchemaMapper $schemaMapper,
         private readonly RegisterMapper $registerMapper,
         private readonly OrganisationMapper $organisationMapper,
+        private readonly IAppConfig $appConfig,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -291,14 +306,22 @@ class LinkedEntityService
         $results = [];
 
         // Find schemas that declare this linkedType.
-        // WARNING: RBAC and multitenancy are intentionally disabled here, so schema metadata (names,
-        // slugs, linkedType declarations) and matched object UUIDs/names are returned cross-tenant to
-        // any authenticated user calling GET /api/linked/{type}/{entityId}. There is currently NO
-        // per-row access check before results are returned. This is intentional for the mail-sidebar
-        // use-case where cross-tenant linking is required, but constitutes a cross-tenant data exposure
-        // for multi-tenant SaaS deployments. A per-row access check should be added before this
-        // endpoint is used in strict-isolation deployments. See TODO #1273.
-        $allSchemas = $this->schemaMapper->findAll(_rbac: false, _multitenancy: false);
+        // WARNING: when the cross-tenant-scan flag is enabled (default), RBAC and multitenancy are
+        // disabled so schema metadata (names, slugs, linkedType declarations) and matched object
+        // UUIDs/names are returned cross-tenant to any authenticated caller of
+        // GET /api/linked/{type}/{entityId}. There is currently NO per-row access check on the
+        // returned objects — this is intentional for the mail-sidebar use-case (cross-tenant linking
+        // is required there) but constitutes a cross-tenant data exposure for multi-tenant SaaS
+        // deployments. Operators in strict-isolation deployments should disable the flag via:
+        //   occ config:app:set openregister linkedEntity.crossTenantScan --value=0
+        // which falls back to standard RBAC + multitenancy-scoped findAll(). Follow-up tracked in
+        // issue #1534 (per-row access check + caller scoping + audit log).
+        $crossTenantScan = ((string) $this->appConfig->getValueString('openregister', self::CONFIG_CROSS_TENANT_SCAN, '1')) === '1';
+        if ($crossTenantScan === true) {
+            $allSchemas = $this->schemaMapper->findAll(_rbac: false, _multitenancy: false);
+        } else {
+            $allSchemas = $this->schemaMapper->findAll();
+        }
         $scanned    = 0;
 
         foreach ($allSchemas as $schema) {

--- a/lib/Service/LinkedEntityService.php
+++ b/lib/Service/LinkedEntityService.php
@@ -313,7 +313,7 @@ class LinkedEntityService
         // returned objects — this is intentional for the mail-sidebar use-case (cross-tenant linking
         // is required there) but constitutes a cross-tenant data exposure for multi-tenant SaaS
         // deployments. Operators in strict-isolation deployments should disable the flag via:
-        //   occ config:app:set openregister linkedEntity.crossTenantScan --value=0
+        // occ config:app:set openregister linkedEntity.crossTenantScan --value=0
         // which falls back to standard RBAC + multitenancy-scoped findAll(). Follow-up tracked in
         // issue #1534 (per-row access check + caller scoping + audit log).
         $crossTenantScan = ((string) $this->appConfig->getValueString('openregister', self::CONFIG_CROSS_TENANT_SCAN, '1')) === '1';
@@ -322,7 +322,8 @@ class LinkedEntityService
         } else {
             $allSchemas = $this->schemaMapper->findAll();
         }
-        $scanned    = 0;
+
+        $scanned = 0;
 
         foreach ($allSchemas as $schema) {
             if ($scanned >= self::MAX_TABLES_TO_SCAN) {

--- a/src/components/workflow/ApprovalStepList.vue
+++ b/src/components/workflow/ApprovalStepList.vue
@@ -11,6 +11,11 @@ import { generateUrl } from '@nextcloud/router'
 		<div v-if="steps.length === 0">
 			<p>{{ t('openregister', 'No approval steps for this object.') }}</p>
 		</div>
+		<!--
+			Dynamic translation contract (mirrored in l10n/en.json + l10n/nl.json):
+			- step.status enum: pending | approved | rejected | waiting (see ApprovalService.php)
+			- step.role:        free-text from workflow config (best-effort identity fallback).
+		-->
 		<div v-for="step in steps" :key="step.id" class="step-row">
 			<span class="step-order">{{ t('openregister', 'Step') }} {{ step.stepOrder }}</span>
 			<span class="step-role">{{ t('openregister', step.role) }}</span>

--- a/src/views/settings/sections/PermissionMatrix.vue
+++ b/src/views/settings/sections/PermissionMatrix.vue
@@ -37,6 +37,12 @@ import { translate as t } from '@nextcloud/l10n'
 							<th class="name-column">
 								{{ t('openregister', 'Register / Schema') }}
 							</th>
+							<!--
+								Dynamic translation contract: action enum is the hardcoded
+								data() value ['read', 'create', 'update', 'delete', 'manage'] —
+								all five are mirrored in l10n/en.json + l10n/nl.json with
+								Dutch translations.
+							-->
 							<th v-for="action in actions" :key="action" class="action-column">
 								{{ t('openregister', action) }}
 							</th>


### PR DESCRIPTION
## Summary
- Wrap all user-facing strings in `t()` / `$this->l10n->t()` translation calls
- Ensure English is the primary language for all translation keys (per ADR-007)
- Convert any hardcoded Dutch strings to English keys with Dutch in nl.json
- Complete `l10n/en.json` (identity-mapped) and `l10n/nl.json` (Dutch translations)
- Fix `<script setup>` components missing direct `t` import from `@nextcloud/l10n`

## Test plan
- [ ] Verify app loads without JavaScript errors
- [ ] Switch Nextcloud language to Dutch and verify translations display correctly
- [ ] Switch back to English and verify English strings display correctly
- [ ] Spot-check key pages (dashboard, settings, detail views) in both languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)