### PR TITLE
fix(facets): support date_histogram for object fields with JSON Schema date format

### DIFF
--- a/lib/Db/MagicMapper/MagicFacetHandler.php
+++ b/lib/Db/MagicMapper/MagicFacetHandler.php
@@ -471,6 +471,23 @@ class MagicFacetHandler
                         schema: $schemaForLabels
                     );
                 }
+            } else if ($type === 'date_histogram') {
+                $interval = $config['interval'] ?? 'month';
+
+                // Find which tables have this column.
+                $tablesWithColumn = [];
+                foreach ($tableConfigs as $tc) {
+                    if ($this->columnExists(tableName: $tc['tableName'], columnName: $columnName) === true) {
+                        $tablesWithColumn[] = $tc;
+                    }
+                }
+
+                $facets[$field] = $this->getDateHistogramFacetUnion(
+                    tableConfigs: $tablesWithColumn,
+                    field: $columnName,
+                    interval: $interval,
+                    baseQuery: $baseQuery
+                );
             }//end if
 
             // Add schema property title if available.

--- a/lib/Db/SchemaMapper.php
+++ b/lib/Db/SchemaMapper.php
@@ -1461,10 +1461,15 @@ class SchemaMapper extends QBMapper
      */
     private function determineFacetTypeFromProperty(array $property): string
     {
-        $propertyType = $property['type'] ?? 'string';
+        $propertyType   = $property['type'] ?? 'string';
+        $propertyFormat = $property['format'] ?? '';
 
         // Date/datetime properties use date_histogram.
-        if (in_array($propertyType, ['date', 'datetime', 'date-time']) === true) {
+        // Checks both 'type' (e.g. type: date) and 'format' (e.g. type: string, format: date)
+        // because JSON Schema represents dates as type: "string" with format: "date".
+        if (in_array($propertyType, ['date', 'datetime', 'date-time']) === true
+            || in_array($propertyFormat, ['date', 'date-time', 'datetime']) === true
+        ) {
             return 'date_histogram';
         }
 

--- a/tests/Unit/Db/MagicFacetHandlerTest.php
+++ b/tests/Unit/Db/MagicFacetHandlerTest.php
@@ -192,4 +192,53 @@ class MagicFacetHandlerTest extends TestCase
             $this->invokeBuildDateKeyExpr($handler, 't.publicatiedatum', 'quarter')
         );
     }//end testQualifiedFieldInQuarterConcatOnMariadb()
+
+    // -------------------------------------------------------------------------
+    // determineFacetTypeFromProperty()
+    // -------------------------------------------------------------------------
+    private function invokeDetermineFacetTypeFromProperty(MagicFacetHandler $handler, array $property): string
+    {
+        $method = new ReflectionMethod(MagicFacetHandler::class, 'determineFacetTypeFromProperty');
+        $method->setAccessible(true);
+        return $method->invoke($handler, $property);
+    }//end invokeDetermineFacetTypeFromProperty()
+
+    public function testStringWithDateFormatReturnDateHistogram(): void
+    {
+        // Regression: before the fix this returned 'terms' because only the
+        // 'type' field was checked, not 'format'.
+        $handler = $this->buildHandler($this->createMock(MariaDBPlatform::class));
+        $this->assertSame(
+            'date_histogram',
+            $this->invokeDetermineFacetTypeFromProperty($handler, ['type' => 'string', 'format' => 'date'])
+        );
+    }//end testStringWithDateFormatReturnDateHistogram()
+
+    public function testStringWithDateTimeFormatReturnsDateHistogram(): void
+    {
+        $handler = $this->buildHandler($this->createMock(MariaDBPlatform::class));
+        $this->assertSame(
+            'date_histogram',
+            $this->invokeDetermineFacetTypeFromProperty($handler, ['type' => 'string', 'format' => 'date-time'])
+        );
+    }//end testStringWithDateTimeFormatReturnsDateHistogram()
+
+    public function testPlainStringDefaultsToTerms(): void
+    {
+        $handler = $this->buildHandler($this->createMock(MariaDBPlatform::class));
+        $this->assertSame(
+            'terms',
+            $this->invokeDetermineFacetTypeFromProperty($handler, ['type' => 'string'])
+        );
+    }//end testPlainStringDefaultsToTerms()
+
+    public function testExplicitFacetableTypeOverrideIsRespected(): void
+    {
+        $handler  = $this->buildHandler($this->createMock(MariaDBPlatform::class));
+        $property = ['type' => 'string', 'facetable' => ['type' => 'date_histogram']];
+        $this->assertSame(
+            'date_histogram',
+            $this->invokeDetermineFacetTypeFromProperty($handler, $property)
+        );
+    }//end testExplicitFacetableTypeOverrideIsRespected()
 }//end class


### PR DESCRIPTION
Before this fix, `determineFacetTypeFromProperty()` only checked the `type` field of a schema property to decide the facet type. Properties defined as `{type: "string", format: "date"}` (the standard JSON Schema pattern for date fields) were therefore classified as `terms` facets instead of `date_histogram`. This meant date fields marked as `facetable: true` would produce meaningless bucket counts grouped by raw date strings rather than a proper histogram. The fix adds a check on `format` before falling back to the default, so any property with `format: date`, `date-time`, or `datetime` correctly returns `date_histogram`. The separate `buildDateKeyExpr()` fix ensures the resulting SQL is correct on both PostgreSQL (`TO_CHAR`) and MariaDB (`DATE_FORMAT`).
