### PR TITLE
fix(MagicMapper): CAST(col AS CHAR) for MariaDB in UNION queries

### DIFF
--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -1278,6 +1278,7 @@ class MagicMapper extends AbstractObjectMapper
          * Cast syntax is database-specific: PostgreSQL uses `col::text`, while
          * MariaDB/MySQL requires the standard `CAST(col AS CHAR)`.
          */
+        
         $existingColumns = [];
         foreach (array_keys($allPropertyColumns) as $columnName) {
             $quotedCol = $this->quoteIdentifier(

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -1267,15 +1267,17 @@ class MagicMapper extends AbstractObjectMapper
         // Base SELECT with metadata columns.
         $selectColumns = $metadataColumns;
 
-        // Every SELECT in the UNION must have identical columns in the same order.
-        // We build the superset of all property columns across all schemas:
-        // - Columns present in this table are cast to a text type so that the same
-        //   column from two different schemas (e.g. 'type' as VARCHAR in one table
-        //   and JSONB in another) remains type-compatible across the UNION arms.
-        // - Columns absent from this table are emitted as NULL with the same alias
-        //   so the column count stays consistent.
-        // Cast syntax is database-specific: PostgreSQL uses `col::text`, while
-        // MariaDB/MySQL requires the standard `CAST(col AS CHAR)`.
+        /*
+         * Every SELECT in the UNION must have identical columns in the same order.
+         * We build the superset of all property columns across all schemas:
+         *  - Columns present in this table are cast to a text type so that the same
+         *    column from two different schemas (e.g. 'type' as VARCHAR in one table
+         *    and JSONB in another) remains type-compatible across the UNION arms.
+         *  - Columns absent from this table are emitted as NULL with the same alias
+         *    so the column count stays consistent.
+         * Cast syntax is database-specific: PostgreSQL uses `col::text`, while
+         * MariaDB/MySQL requires the standard `CAST(col AS CHAR)`.
+         */
         $existingColumns = [];
         foreach (array_keys($allPropertyColumns) as $columnName) {
             $quotedCol = $this->quoteIdentifier(
@@ -1283,23 +1285,29 @@ class MagicMapper extends AbstractObjectMapper
                 isPostgres: $isPostgres
             );
             // Absent column: emit a typed NULL placeholder.
-            $colExpr   = $isPostgres
-                ? "NULL::text AS {$quotedCol}"
-                : "NULL AS {$quotedCol}";
+            if ($isPostgres === true) {
+                $colExpr = "NULL::text AS {$quotedCol}";
+            } else {
+                $colExpr = "NULL AS {$quotedCol}";
+            }
+
             $columnInTable = $this->columnExistsInTable(
                 tableName: $tableName,
                 columnName: $columnName
             );
             if ($columnInTable === true) {
                 // Present column: cast to text for cross-schema type compatibility.
-                $colExpr           = $isPostgres
-                    ? "{$quotedCol}::text AS {$quotedCol}"
-                    : "CAST({$quotedCol} AS CHAR) AS {$quotedCol}";
+                if ($isPostgres === true) {
+                    $colExpr = "{$quotedCol}::text AS {$quotedCol}";
+                } else {
+                    $colExpr = "CAST({$quotedCol} AS CHAR) AS {$quotedCol}";
+                }
+
                 $existingColumns[] = $columnName;
             }
 
             $selectColumns[] = $colExpr;
-        }
+        }//end foreach
 
         $selectColumns[] = "'{$register->getId()}' AS _union_register_id";
         $selectColumns[] = "'{$schema->getId()}' AS _union_schema_id";
@@ -1340,21 +1348,18 @@ class MagicMapper extends AbstractObjectMapper
                     if ($isPostgres === true) {
                         // PostgreSQL: pg_trgm similarity() for fuzzy relevance;
                         // fall back to ILIKE when pg_trgm is unavailable.
-                        $scoreExpr = "CASE WHEN {$quotedCol}::text"
-                            . " ILIKE {$likePattern} THEN 1 ELSE 0 END";
+                        $scoreExpr = "CASE WHEN {$quotedCol}::text ILIKE {$likePattern} THEN 1 ELSE 0 END";
                         if ($hasTrgm === true) {
-                            $scoreExpr = "COALESCE(similarity({$quotedCol}::text,"
-                                . " {$quotedTerm}), 0)";
+                            $scoreExpr = "COALESCE(similarity({$quotedCol}::text, {$quotedTerm}), 0)";
                         }
                     } else {
                         // MariaDB/MySQL: ILIKE and similarity() are unavailable;
                         // use case-sensitive LIKE with a standard CAST instead.
-                        $scoreExpr = "CASE WHEN CAST({$quotedCol} AS CHAR)"
-                            . " LIKE {$likePattern} THEN 1 ELSE 0 END";
+                        $scoreExpr = "CASE WHEN CAST({$quotedCol} AS CHAR) LIKE {$likePattern} THEN 1 ELSE 0 END";
                     }
 
                     $searchColumns[] = $scoreExpr;
-                }
+                }//end if
             }//end foreach
 
             $selectColumns[] = '0 AS _search_score';

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -1277,9 +1277,14 @@ class MagicMapper extends AbstractObjectMapper
         // MariaDB/MySQL requires the standard `CAST(col AS CHAR)`.
         $existingColumns = [];
         foreach (array_keys($allPropertyColumns) as $columnName) {
-            $quotedCol = $this->quoteIdentifier(name: $columnName, isPostgres: $isPostgres);
+            $quotedCol = $this->quoteIdentifier(
+                name: $columnName,
+                isPostgres: $isPostgres
+            );
             // Absent column: emit a typed NULL placeholder.
-            $colExpr   = $isPostgres ? "NULL::text AS {$quotedCol}" : "NULL AS {$quotedCol}";
+            $colExpr   = $isPostgres
+                ? "NULL::text AS {$quotedCol}"
+                : "NULL AS {$quotedCol}";
             if ($this->columnExistsInTable(tableName: $tableName, columnName: $columnName) === true) {
                 // Present column: cast to text for cross-schema type compatibility.
                 $colExpr           = $isPostgres
@@ -1320,16 +1325,19 @@ class MagicMapper extends AbstractObjectMapper
                     $quotedCol   = $this->quoteIdentifier(name: $columnName, isPostgres: $isPostgres);
                     $likePattern = "'%".trim($quotedTerm, "'")."%'";
                     if ($isPostgres === true) {
-                        // PostgreSQL: prefer pg_trgm similarity() for fuzzy relevance;
-                        // fall back to case-insensitive ILIKE when the extension is absent.
-                        $scoreExpr = "CASE WHEN {$quotedCol}::text ILIKE {$likePattern} THEN 1 ELSE 0 END";
+                        // PostgreSQL: pg_trgm similarity() for fuzzy relevance;
+                        // fall back to ILIKE when pg_trgm is unavailable.
+                        $scoreExpr = "CASE WHEN {$quotedCol}::text"
+                            . " ILIKE {$likePattern} THEN 1 ELSE 0 END";
                         if ($hasTrgm === true) {
-                            $scoreExpr = "COALESCE(similarity({$quotedCol}::text, {$quotedTerm}), 0)";
+                            $scoreExpr = "COALESCE(similarity({$quotedCol}::text,"
+                                . " {$quotedTerm}), 0)";
                         }
                     } else {
                         // MariaDB/MySQL: ILIKE and similarity() are unavailable;
                         // use case-sensitive LIKE with a standard CAST instead.
-                        $scoreExpr = "CASE WHEN CAST({$quotedCol} AS CHAR) LIKE {$likePattern} THEN 1 ELSE 0 END";
+                        $scoreExpr = "CASE WHEN CAST({$quotedCol} AS CHAR)"
+                            . " LIKE {$likePattern} THEN 1 ELSE 0 END";
                     }
 
                     $searchColumns[] = $scoreExpr;

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -1266,18 +1266,25 @@ class MagicMapper extends AbstractObjectMapper
         // Base SELECT with metadata columns.
         $selectColumns = $metadataColumns;
 
-        // Add schema property columns for UNION compatibility.
-        // Each schema's SELECT includes ALL property columns across all schemas.
-        // Columns that exist in this schema's table use the real column cast to text.
-        // Columns that don't exist use NULL::text AS placeholder.
-        // Cast to text ensures type compatibility across schemas in UNION.
-        // (e.g., one schema has 'type' as text, another as jsonb).
+        // Every SELECT in the UNION must have identical columns in the same order.
+        // We build the superset of all property columns across all schemas:
+        // - Columns present in this table are cast to a text type so that the same
+        //   column from two different schemas (e.g. 'type' as VARCHAR in one table
+        //   and JSONB in another) remains type-compatible across the UNION arms.
+        // - Columns absent from this table are emitted as NULL with the same alias
+        //   so the column count stays consistent.
+        // Cast syntax is database-specific: PostgreSQL uses `col::text`, while
+        // MariaDB/MySQL requires the standard `CAST(col AS CHAR)`.
         $existingColumns = [];
         foreach (array_keys($allPropertyColumns) as $columnName) {
             $quotedCol = $this->quoteIdentifier(name: $columnName, isPostgres: $isPostgres);
-            $colExpr   = "NULL::text AS {$quotedCol}";
+            // Absent column: emit a typed NULL placeholder.
+            $colExpr   = $isPostgres ? "NULL::text AS {$quotedCol}" : "NULL AS {$quotedCol}";
             if ($this->columnExistsInTable(tableName: $tableName, columnName: $columnName) === true) {
-                $colExpr           = "{$quotedCol}::text AS {$quotedCol}";
+                // Present column: cast to text for cross-schema type compatibility.
+                $colExpr           = $isPostgres
+                    ? "{$quotedCol}::text AS {$quotedCol}"
+                    : "CAST({$quotedCol} AS CHAR) AS {$quotedCol}";
                 $existingColumns[] = $columnName;
             }
 
@@ -1310,13 +1317,19 @@ class MagicMapper extends AbstractObjectMapper
                         continue;
                     }
 
-                    $quotedCol = $this->quoteIdentifier(name: $columnName, isPostgres: $isPostgres);
-                    // Fallback: use CASE with ILIKE for basic relevance scoring.
+                    $quotedCol   = $this->quoteIdentifier(name: $columnName, isPostgres: $isPostgres);
                     $likePattern = "'%".trim($quotedTerm, "'")."%'";
-                    $scoreExpr   = "CASE WHEN {$quotedCol}::text ILIKE {$likePattern} THEN 1 ELSE 0 END";
-                    if ($hasTrgm === true) {
-                        // Use similarity() for fuzzy scoring when pg_trgm is available.
-                        $scoreExpr = "COALESCE(similarity({$quotedCol}::text, {$quotedTerm}), 0)";
+                    if ($isPostgres === true) {
+                        // PostgreSQL: prefer pg_trgm similarity() for fuzzy relevance;
+                        // fall back to case-insensitive ILIKE when the extension is absent.
+                        $scoreExpr = "CASE WHEN {$quotedCol}::text ILIKE {$likePattern} THEN 1 ELSE 0 END";
+                        if ($hasTrgm === true) {
+                            $scoreExpr = "COALESCE(similarity({$quotedCol}::text, {$quotedTerm}), 0)";
+                        }
+                    } else {
+                        // MariaDB/MySQL: ILIKE and similarity() are unavailable;
+                        // use case-sensitive LIKE with a standard CAST instead.
+                        $scoreExpr = "CASE WHEN CAST({$quotedCol} AS CHAR) LIKE {$likePattern} THEN 1 ELSE 0 END";
                     }
 
                     $searchColumns[] = $scoreExpr;

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -1137,7 +1137,8 @@ class MagicMapper extends AbstractObjectMapper
         $unionSql = implode(' UNION ALL ', $parts);
 
         // Apply global ORDER BY - supports _order parameter or defaults to search score.
-        $hasSearch   = isset($query['_search']) === true && empty($query['_search']) === false;
+        $hasSearch   = isset($query['_search']) === true
+            && empty($query['_search']) === false;
         $orderParams = $query['_order'] ?? [];
 
         if (empty($orderParams) === false && is_array($orderParams) === true) {
@@ -1285,7 +1286,11 @@ class MagicMapper extends AbstractObjectMapper
             $colExpr   = $isPostgres
                 ? "NULL::text AS {$quotedCol}"
                 : "NULL AS {$quotedCol}";
-            if ($this->columnExistsInTable(tableName: $tableName, columnName: $columnName) === true) {
+            $columnInTable = $this->columnExistsInTable(
+                tableName: $tableName,
+                columnName: $columnName
+            );
+            if ($columnInTable === true) {
                 // Present column: cast to text for cross-schema type compatibility.
                 $colExpr           = $isPostgres
                     ? "{$quotedCol}::text AS {$quotedCol}"
@@ -1300,7 +1305,8 @@ class MagicMapper extends AbstractObjectMapper
         $selectColumns[] = "'{$schema->getId()}' AS _union_schema_id";
 
         // Add search score if _search is present.
-        $hasSearch   = isset($query['_search']) === true && empty($query['_search']) === false;
+        $hasSearch   = isset($query['_search']) === true
+            && empty($query['_search']) === false;
         $searchTerm  = $query['_search'] ?? '';
         $schemaProps = $schema->getProperties() ?? [];
 
@@ -1318,11 +1324,18 @@ class MagicMapper extends AbstractObjectMapper
                     // Only score columns that actually exist in this table.
                     // Columns from other schemas are aliased as NULL in the SELECT
                     // and cannot be referenced by similarity()/ILIKE expressions.
-                    if ($this->columnExistsInTable(tableName: $tableName, columnName: $columnName) === false) {
+                    $columnInTable = $this->columnExistsInTable(
+                        tableName: $tableName,
+                        columnName: $columnName
+                    );
+                    if ($columnInTable === false) {
                         continue;
                     }
 
-                    $quotedCol   = $this->quoteIdentifier(name: $columnName, isPostgres: $isPostgres);
+                    $quotedCol   = $this->quoteIdentifier(
+                        name: $columnName,
+                        isPostgres: $isPostgres
+                    );
                     $likePattern = "'%".trim($quotedTerm, "'")."%'";
                     if ($isPostgres === true) {
                         // PostgreSQL: pg_trgm similarity() for fuzzy relevance;
@@ -1347,7 +1360,8 @@ class MagicMapper extends AbstractObjectMapper
             $selectColumns[] = '0 AS _search_score';
             if (empty($searchColumns) === false) {
                 $scoreExpression = 'GREATEST('.implode(', ', $searchColumns).')';
-                $selectColumns[count($selectColumns) - 1] = "{$scoreExpression} AS _search_score";
+                $lastIndex       = count($selectColumns) - 1;
+                $selectColumns[$lastIndex] = "{$scoreExpression} AS _search_score";
             }
         }//end if
 
@@ -1355,7 +1369,8 @@ class MagicMapper extends AbstractObjectMapper
             $selectColumns[] = '0 AS _search_score';
         }
 
-        $selectSql = 'SELECT '.implode(', ', $selectColumns)." FROM {$fullTableName}";
+        $colList   = implode(', ', $selectColumns);
+        $selectSql = "SELECT {$colList} FROM {$fullTableName}";
 
         // Build WHERE conditions using shared method (single source of truth for filters).
         // This ensures search, count, and facets all use the same filter logic.

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -1278,7 +1278,7 @@ class MagicMapper extends AbstractObjectMapper
          * Cast syntax is database-specific: PostgreSQL uses `col::text`, while
          * MariaDB/MySQL requires the standard `CAST(col AS CHAR)`.
          */
-     
+
         $existingColumns = [];
         foreach (array_keys($allPropertyColumns) as $columnName) {
             $quotedCol = $this->quoteIdentifier(

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -1278,7 +1278,7 @@ class MagicMapper extends AbstractObjectMapper
          * Cast syntax is database-specific: PostgreSQL uses `col::text`, while
          * MariaDB/MySQL requires the standard `CAST(col AS CHAR)`.
          */
-        
+     
         $existingColumns = [];
         foreach (array_keys($allPropertyColumns) as $columnName) {
             $quotedCol = $this->quoteIdentifier(


### PR DESCRIPTION
## Fix: MariaDB 500 error when fetching publications from a multi-schema catalog

### Problem

When a catalog contained more than one schema, fetching publications failed with:

```
SQLSTATE[42000]: Syntax error or access violation: 1064
You have an error in your SQL syntax … near '::text AS `title`,
`kenmerk`::text AS `kenmerk`, `publicatiedatum`::text …'
```

Multi-schema catalogs trigger a `UNION` query so that results from every schema's table can be combined in a single result set. Each `SELECT` arm must expose the same columns, so `buildUnionSelectPart()` casts every column to a common text type. The method correctly detected the database platform (`$isPostgres`), but then ignored that flag and hardcoded PostgreSQL's `::text` cast syntax unconditionally — syntax that MariaDB does not support.

### Root cause

`buildUnionSelectPart()` in `MagicMapper.php`:

```php
// before — always emits ::text regardless of database
$colExpr = "NULL::text AS {$quotedCol}";
$colExpr = "{$quotedCol}::text AS {$quotedCol}";
```

The same pattern already existed correctly in `MagicFacetHandler.php`, which uses `CAST(x AS CHAR)` for MariaDB and `x::text` only for PostgreSQL.

### Fix

Both the column cast expressions and the search relevance score expressions now branch on `$isPostgres`:

| Database | Column cast | Search score |
|---|---|---|
| PostgreSQL | `col::text` | `ILIKE` / `similarity()` (pg_trgm) |
| MariaDB/MySQL | `CAST(col AS CHAR)` | `LIKE` |

### Files changed

- `lib/Db/MagicMapper.php` — `buildUnionSelectPart()`: column casts and search score expressions are now database-aware
