### PR TITLE
fix: resolve $now in raw SQL RBAC conditions, unblocking date-based access

### DIFF
--- a/lib/Db/MagicMapper/MagicRbacHandler.php
+++ b/lib/Db/MagicMapper/MagicRbacHandler.php
@@ -1261,8 +1261,15 @@ class MagicRbacHandler
             return null;
         }
 
-        $sqlOperator = $comparisonMap[$operator];
-        $quotedValue = $this->quoteValue(value: $operand);
+        $sqlOperator     = $comparisonMap[$operator];
+        $resolvedOperand = $this->resolveDynamicValue(value: $operand);
+
+        // If dynamic variable resolved to null, this condition cannot be met.
+        if ($operand !== $resolvedOperand && $resolvedOperand === null) {
+            return null;
+        }
+
+        $quotedValue = $this->quoteValue(value: $resolvedOperand);
         return "{$columnName} {$sqlOperator} {$quotedValue}";
     }//end buildComparisonOperatorConditionSql()
 


### PR DESCRIPTION
## Problem

Schema-level RBAC `match` conditions using `$now` (e.g. to gate public access on a `publicatiedatum` field) blocked **all** objects instead of only those without a publication date in the past.

```json
"authorization": {
    "read": [
        { "group": "public", "match": { "publicatiedatum": { "$lte": "$now" } } }
    ]
}
