### PR TITLE
feat: add ObjectServiceMapperAdapter

### DIFF
--- a/lib/Service/ObjectServiceMapperAdapter.php
+++ b/lib/Service/ObjectServiceMapperAdapter.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Exception\ValidationException;
+
+/**
+ * Adapter that exposes a mapper-like API over ObjectService.
+ *
+ * Allows external apps (e.g. OpenConnector) to interact with OpenRegister
+ * objects through a familiar mapper contract without depending on ObjectService
+ * internals. Register and schema context are injected once at construction time.
+ */
+class ObjectServiceMapperAdapter
+{
+    public function __construct(
+        private readonly ObjectService $objectService,
+        private readonly int|string|null $register = null,
+        private readonly int|string|null $schema = null
+    ) {
+    }
+
+    public function find(int|string $identifier, ?array $extend = null): ?ObjectEntity
+    {
+        return $this->objectService->find(
+            id: $identifier,
+            _extend: $extend ?? [],
+            register: $this->register,
+            schema: $this->schema
+        );
+    }
+
+    public function findByUuid(int|string $identifier): ?ObjectEntity
+    {
+        return $this->find(identifier: $identifier);
+    }
+
+    public function findAll(
+        array $config = [],
+        ?array $filters = null,
+        ?array $ids = null,
+        ?int $limit = null,
+        ?int $offset = null,
+        ?array $sort = null,
+        ?array $extend = null,
+        ?string $search = null
+    ): array {
+        if ($filters !== null) {
+            $config['filters'] = $filters;
+        }
+
+        if ($ids !== null) {
+            $config['ids'] = $ids;
+        }
+
+        if ($limit !== null) {
+            $config['limit'] = $limit;
+        }
+
+        if ($offset !== null) {
+            $config['offset'] = $offset;
+        }
+
+        if ($sort !== null) {
+            $config['sort'] = $sort;
+        }
+
+        if ($extend !== null) {
+            $config['extend'] = $extend;
+        }
+
+        if ($search !== null) {
+            $config['search'] = $search;
+        }
+
+        $config['filters'] ??= [];
+
+        if ($this->register !== null && !isset($config['filters']['register'])) {
+            $config['filters']['register'] = $this->register;
+        }
+
+        if ($this->schema !== null && !isset($config['filters']['schema'])) {
+            $config['filters']['schema'] = $this->schema;
+        }
+
+        return $this->objectService->findAll(config: $config);
+    }
+
+    public function createFromArray(array $object): ObjectEntity
+    {
+        return $this->objectService->saveObject(
+            object: $object,
+            register: $this->register,
+            schema: $this->schema
+        );
+    }
+
+    public function updateFromArray(
+        int|string $id,
+        array $object,
+        bool $validate = true,
+        bool $patch = false
+    ): ObjectEntity {
+        if ($patch === true) {
+            return $this->objectService->patchObject((string) $id, $object);
+        }
+
+        return $this->objectService->updateObject((string) $id, $object);
+    }
+
+    public function update(ObjectEntity $object): ObjectEntity
+    {
+        return $this->objectService->saveObject(
+            object: $object,
+            register: $this->register,
+            schema: $this->schema
+        );
+    }
+
+    public function delete(array $criteria): bool
+    {
+        $id = $criteria['id'] ?? null;
+        if ($id === null) {
+            throw new ValidationException('No id given to delete');
+        }
+
+        return $this->objectService->deleteObject((string) $id);
+    }
+
+    public function getSchema(): ?int
+    {
+        return $this->schema !== null ? (int) $this->schema : null;
+    }
+
+    public function getRegister(): ?int
+    {
+        return $this->register !== null ? (int) $this->register : null;
+    }
+
+    public function getValidateHandler(): mixed
+    {
+        return $this->objectService->getValidateHandler();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ObjectServiceMapperAdapter` — a mapper-like adapter over `ObjectService`
- Allows external apps (e.g. OpenConnector) to interact with OpenRegister objects through a familiar mapper contract without depending on `ObjectService` internals
- Register and schema context are injected once at construction time

## Motivation

OpenConnector needs a way to call into OpenRegister using a mapper-like API. This adapter lives in OpenRegister so any external app can use it — not just OpenConnector.

## Changes

- **Added**: `lib/Service/ObjectServiceMapperAdapter.php`
  - Methods: `find`, `findByUuid`, `findAll`, `createFromArray`, `updateFromArray`, `update`, `delete`, `getSchema`, `getRegister`, `getValidateHandler`

## Related

Coordinated with [openconnector#722](https://github.com/ConductionNL/openconnector/pull/722) which updates the type hint references in `EndpointService`.

## Test plan

- [ ] Verify `ObjectServiceMapperAdapter` can be instantiated via DI with register/schema context
- [ ] Confirm OpenConnector `EndpointService` resolves the adapter correctly after both PRs are merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)