### PR TITLE
fix: guard against null return from find() in PATCH path of updateFromArray

### DIFF
--- a/lib/Service/ObjectServiceMapperAdapter.php
+++ b/lib/Service/ObjectServiceMapperAdapter.php
@@ -179,7 +179,12 @@ class ObjectServiceMapperAdapter
                 register: $this->register,
                 schema: $this->schema
             );
-            $object   = array_merge($existing->getObject(), $object);
+            if ($existing === null) {
+                throw new ValidationException(
+                    message: sprintf('Object "%s" not found or not accessible', $id)
+                );
+            }
+            $object = array_merge($existing->getObject(), $object);
         }
 
         return $this->objectService->saveObject(


### PR DESCRIPTION
## Summary

`objectService->find()` returns `?ObjectEntity` (nullable). In `updateFromArray()`, when `$patch === true`, the result was dereferenced unconditionally via `$existing->getObject()`. If the target object does not exist — unknown ID, wrong register/schema scope, or RBAC denial — `find()` returns `null` and the call produces a fatal `TypeError`, surfacing as an unhandled 500.

The fix adds an explicit null check immediately after `find()` and throws `ValidationException` with a clear message. Using a uniform message for both "not found" and "not accessible" also prevents ID enumeration through differing error signatures.

Reported in code review by @WilcoLouwerse.

## Test plan

- [ ] PATCH an object with a valid ID in the correct register/schema scope — verify normal update behaviour is unchanged
- [ ] PATCH an object with an ID that does not exist — verify a `ValidationException` is thrown (no unhandled 500)
- [ ] PATCH an object with an ID that exists but in a different register/schema scope — verify a `ValidationException` is thrown rather than a fatal TypeError
- [ ] Run existing unit and integration tests for `ObjectServiceMapperAdapter` and confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)