### PR TITLE
fix(Organisation): remove duplicate property declarations

### DIFF
--- a/lib/Db/Organisation.php
+++ b/lib/Db/Organisation.php
@@ -292,55 +292,6 @@ class Organisation extends Entity implements JsonSerializable
     public ?int $userCount = null;
 
     /**
-     * Linked mail entity IDs for this organisation.
-     *
-     * @var array|null Linked mail entity IDs
-     */
-    protected ?array $mail = null;
-
-    /**
-     * Linked contact entity IDs for this organisation.
-     *
-     * @var array|null Linked contact entity IDs
-     */
-    protected ?array $contacts = null;
-
-    /**
-     * Linked note entity IDs for this organisation.
-     *
-     * @var array|null Linked note entity IDs
-     */
-    protected ?array $notes = null;
-
-    /**
-     * Linked todo entity IDs for this organisation.
-     *
-     * @var array|null Linked todo entity IDs
-     */
-    protected ?array $todos = null;
-
-    /**
-     * Linked calendar event entity IDs for this organisation.
-     *
-     * @var array|null Linked calendar entity IDs
-     */
-    protected ?array $calendar = null;
-
-    /**
-     * Linked Talk conversation IDs for this organisation.
-     *
-     * @var array|null Linked Talk entity IDs
-     */
-    protected ?array $talk = null;
-
-    /**
-     * Linked Deck card IDs for this organisation.
-     *
-     * @var array|null Linked Deck entity IDs
-     */
-    protected ?array $deck = null;
-
-    /**
      * Organisation constructor
      *
      * Sets up the entity type mappings for proper database handling.


### PR DESCRIPTION
## Summary

`lib/Db/Organisation.php` declared seven integration-link properties twice. PHP fatals on the first redeclaration, blocking **every API call that touches the Organisation entity** with HTTP 500 and no body — affecting every consumer (decidesk, opencatalogi, pipelinq, procest, mydash, …).

```
PHP Fatal error: Cannot redeclare OCA\OpenRegister\Db\Organisation::$mail
at /var/www/html/custom_apps/openregister/lib/Db/Organisation.php#320
```

## Root cause

Two property blocks declared the same names:

| Line range | Style |
|---|---|
| 287-306 | short docblocks (`/** @var array\|null Linked mail app data */`) |
| 315-362 | longer docblocks (`/** Linked mail entity IDs for this organisation. */`) |

Likely a copy-paste leftover from a rename-then-restore merge. Both blocks declared `protected ?array $X = null` for the same seven names: `mail`, `contacts`, `notes`, `todos`, `calendar`, `talk`, `deck`. Deleting the second block restores the file.

## Test plan

- [x] `apache2ctl graceful` (clears OPcache)
- [x] `curl -u admin:admin '/apps/openregister/api/objects?register=decidesk&schema=decision&_limit=1'` returns HTTP 200 with `{"results":[],"total":0,...}` instead of HTTP 500
- [ ] CI green (PHPCS/PHPMD/PHPStan/Psalm)
- [ ] Reviewer to confirm no other call sites depend on the duplicate-block docblocks

## Discovered while

Validating the [decidesk JSON manifest pilot](https://github.com/ConductionNL/decidesk/pull/138) — the 500s on every openregister API call were the first thing that broke when running decidesk against a freshly-imported register.