### PR TITLE
Fix: schema-driven type coercion on magic-table read paths

### DIFF
--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -384,7 +384,8 @@ class MagicMapper extends AbstractObjectMapper
             db: $this->db,
             logger: $this->logger,
             rbacHandler: $this->rbacHandler,
-            organizationHandler: $this->organizationHandler
+            organizationHandler: $this->organizationHandler,
+            schemaTypeConverter: $this->container->get(\OCA\OpenRegister\Service\Object\SchemaTypeConverter::class)
         );
 
         $this->bulkHandler = new MagicBulkHandler(
@@ -417,7 +418,8 @@ class MagicMapper extends AbstractObjectMapper
             logger: $this->logger,
             registerMapper: $this->registerMapper,
             schemaMapper: $this->schemaMapper,
-            dateTimeNormalizer: $this->container->get(\OCA\OpenRegister\Service\DateTimeNormalizer::class)
+            dateTimeNormalizer: $this->container->get(\OCA\OpenRegister\Service\DateTimeNormalizer::class),
+            schemaTypeConverter: $this->container->get(\OCA\OpenRegister\Service\Object\SchemaTypeConverter::class)
         );
 
         // Use setter injection for the count callback to avoid circular dependency.

--- a/lib/Db/MagicMapper/MagicSearchHandler.php
+++ b/lib/Db/MagicMapper/MagicSearchHandler.php
@@ -42,6 +42,7 @@ use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\MagicMapper\MagicRbacHandler;
 use OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler;
+use OCA\OpenRegister\Service\Object\SchemaTypeConverter;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
@@ -87,12 +88,14 @@ class MagicSearchHandler
      * @param LoggerInterface          $logger              Logger for debugging and error reporting
      * @param MagicRbacHandler         $rbacHandler         RBAC handler for access control
      * @param MagicOrganizationHandler $organizationHandler Organization handler for multi-tenancy
+     * @param SchemaTypeConverter      $schemaTypeConverter Schema-driven type converter for row values
      */
     public function __construct(
         private readonly IDBConnection $db,
         private readonly LoggerInterface $logger,
         private readonly MagicRbacHandler $rbacHandler,
-        private readonly MagicOrganizationHandler $organizationHandler
+        private readonly MagicOrganizationHandler $organizationHandler,
+        private readonly SchemaTypeConverter $schemaTypeConverter
     ) {
     }//end __construct()
 
@@ -1371,8 +1374,10 @@ class MagicSearchHandler
                 $propertyName = $columnToPropertyMap[$column] ?? $this->columnNameToPropertyName(columnName: $column);
 
                 // Convert value based on schema property type.
+                // Delegates to the shared SchemaTypeConverter so this handler and
+                // MagicStatisticsHandler agree on type semantics across read paths.
                 $propertyType = $propertyTypes[$propertyName] ?? 'string';
-                $objectData[$propertyName] = $this->convertValueByType(value: $value, type: $propertyType);
+                $objectData[$propertyName] = $this->schemaTypeConverter->convertValue(value: $value, schemaType: $propertyType);
             }
 
             // Set metadata properties.
@@ -1619,154 +1624,6 @@ class MagicSearchHandler
         // Convert snake_case to camelCase.
         return lcfirst(str_replace('_', '', ucwords($columnName, '_')));
     }//end columnNameToPropertyName()
-
-    /**
-     * Convert value based on schema property type
-     *
-     * Schema type determines the conversion, not the data format.
-     *
-     * @param mixed  $value Value to convert
-     * @param string $type  Schema property type (string, number, boolean, array, object, integer)
-     *
-     * @return mixed Converted value
-     */
-    private function convertValueByType(mixed $value, string $type): mixed
-    {
-        // Handle null values.
-        if ($value === null) {
-            return null;
-        }
-
-        // Convert based on schema type (schema is authoritative, not data format).
-        return match ($type) {
-            'array', 'object' => $this->convertArrayOrObjectValue(value: $value),
-            'number'          => $this->convertNumberValue(value: $value),
-            'integer'         => $this->convertIntegerValue(value: $value),
-            'boolean'         => $this->convertBooleanValue(value: $value),
-            default           => $this->convertStringValue(value: $value, type: $type),
-        };
-    }//end convertValueByType()
-
-    /**
-     * Convert a value to array or object type
-     *
-     * Schema says this should be array/object - decode if it's a JSON string.
-     *
-     * @param mixed $value Value to convert
-     *
-     * @return mixed Decoded array/object or original value
-     */
-    private function convertArrayOrObjectValue(mixed $value): mixed
-    {
-        if (is_string($value) === true) {
-            $decoded = json_decode($value, true);
-            if (json_last_error() === JSON_ERROR_NONE) {
-                return $decoded;
-            }
-        }
-
-        // Already an array/object or failed to decode - return as-is.
-        return $value;
-    }//end convertArrayOrObjectValue()
-
-    /**
-     * Convert a value to number (float) type
-     *
-     * Schema says this should be a number (float).
-     *
-     * @param mixed $value Value to convert
-     *
-     * @return mixed Float value or original if not numeric
-     */
-    private function convertNumberValue(mixed $value): mixed
-    {
-        if (is_numeric($value) === true) {
-            return (float) $value;
-        }
-
-        return $value;
-    }//end convertNumberValue()
-
-    /**
-     * Convert a value to integer type
-     *
-     * Schema says this should be an integer.
-     *
-     * @param mixed $value Value to convert
-     *
-     * @return mixed Integer value or original if not numeric
-     */
-    private function convertIntegerValue(mixed $value): mixed
-    {
-        if (is_numeric($value) === true) {
-            return (int) $value;
-        }
-
-        return $value;
-    }//end convertIntegerValue()
-
-    /**
-     * Convert a value to boolean type
-     *
-     * Schema says this should be a boolean.
-     *
-     * @param mixed $value Value to convert
-     *
-     * @return bool Boolean value
-     */
-    private function convertBooleanValue(mixed $value): bool
-    {
-        if (is_bool($value) === true) {
-            return $value;
-        }
-
-        if (is_string($value) === true) {
-            return in_array(strtolower($value), ['true', '1', 'yes'], true);
-        }
-
-        return (bool) $value;
-    }//end convertBooleanValue()
-
-    /**
-     * Convert a value for string or unknown schema type
-     *
-     * For backwards compatibility, if the value looks like a JSON array or object
-     * (starts with [ or {), try to decode it. This handles cases where schema is
-     * incorrectly defined as string but the actual data is array/object, matching
-     * MagicMapper::convertRowToObjectEntity behavior.
-     *
-     * @param mixed  $value Value to convert
-     * @param string $type  The schema type (used to check for explicit 'string')
-     *
-     * @return mixed Converted value
-     */
-    private function convertStringValue(mixed $value, string $type): mixed
-    {
-        if (is_string($value) === true) {
-            $trimmed          = trim($value);
-            $startsWithArrObj = (
-                str_starts_with($trimmed, '[') === true || str_starts_with($trimmed, '{') === true
-            );
-
-            if ($startsWithArrObj === true) {
-                $decoded = json_decode($value, true);
-                if (json_last_error() === JSON_ERROR_NONE && ($decoded !== null || $value === 'null')) {
-                    return $decoded;
-                }
-            }
-
-            return $value;
-        }
-
-        // For schema type 'string', ensure we return a string.
-        // This handles cases where the database driver returns numeric values as integers
-        // even though they're stored in TEXT/VARCHAR columns (e.g., "45" returned as int 45).
-        if ($type === 'string' && (is_int($value) === true || is_float($value) === true)) {
-            return (string) $value;
-        }
-
-        return $value;
-    }//end convertStringValue()
 
     /**
      * Check if authorization rules include public read access

--- a/lib/Db/MagicMapper/MagicStatisticsHandler.php
+++ b/lib/Db/MagicMapper/MagicStatisticsHandler.php
@@ -39,6 +39,7 @@ use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\DateTimeNormalizer;
+use OCA\OpenRegister\Service\Object\SchemaTypeConverter;
 use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
 
@@ -75,18 +76,20 @@ class MagicStatisticsHandler
     /**
      * Constructor for MagicStatisticsHandler
      *
-     * @param IDBConnection      $db                 Database connection for table discovery
-     * @param LoggerInterface    $logger             Logger for debugging and error reporting
-     * @param RegisterMapper     $registerMapper     Mapper for register lookups
-     * @param SchemaMapper       $schemaMapper       Mapper for schema lookups
-     * @param DateTimeNormalizer $dateTimeNormalizer Normaliser for user-supplied datetime values
+     * @param IDBConnection       $db                  Database connection for table discovery
+     * @param LoggerInterface     $logger              Logger for debugging and error reporting
+     * @param RegisterMapper      $registerMapper      Mapper for register lookups
+     * @param SchemaMapper        $schemaMapper        Mapper for schema lookups
+     * @param DateTimeNormalizer  $dateTimeNormalizer  Normaliser for user-supplied datetime values
+     * @param SchemaTypeConverter $schemaTypeConverter Schema-driven type converter for row values
      */
     public function __construct(
         private readonly IDBConnection $db,
         private readonly LoggerInterface $logger,
         private readonly RegisterMapper $registerMapper,
         private readonly SchemaMapper $schemaMapper,
-        private readonly DateTimeNormalizer $dateTimeNormalizer
+        private readonly DateTimeNormalizer $dateTimeNormalizer,
+        private readonly SchemaTypeConverter $schemaTypeConverter
     ) {
     }//end __construct()
 
@@ -569,17 +572,19 @@ class MagicStatisticsHandler
                 $mappedName   = $columnToPropertyMap[$columnName] ?? null;
                 $propertyName = $mappedName ?? $this->columnNameToPropertyName(columnName: $columnName);
 
-                // Apply type conversion based on schema type.
-                // This ensures values match the expected schema type (e.g., numeric strings stay as strings).
+                // Apply schema-driven type coercion. The converter is the single
+                // source of truth for "DB column value → JSON-Schema-typed PHP value"
+                // — see lib/Service/Object/SchemaTypeConverter.php and
+                // openspec/specs/schema-driven-read-coercion/spec.md.
                 $schemaType = $propertyTypes[$propertyName] ?? 'string';
-                if ($schemaType === 'string' && (is_int($value) === true || is_float($value) === true)) {
-                    // Schema expects string but database returned numeric - cast to string.
-                    $value = (string) $value;
-                }
+                $value      = $this->schemaTypeConverter->convertValue(value: $value, schemaType: $schemaType);
 
-                // Format date/datetime values based on schema format.
-                // Empty-string / whitespace-only input normalises to null via DateTimeNormalizer
-                // instead of PHP's "new DateTime('')" silently returning the current timestamp.
+                // Format date/datetime values based on schema format. Runs after type
+                // coercion because the converter does not (and per design D5 should
+                // not) handle format-specific normalisation.
+                // Empty-string / whitespace-only input normalises to null via
+                // DateTimeNormalizer instead of PHP's "new DateTime('')" silently
+                // returning the current timestamp.
                 $propertyFormat = $propertyFormats[$propertyName] ?? null;
                 if ($value !== null && is_string($value) === true && $propertyFormat !== null) {
                     if ($propertyFormat === 'date') {
@@ -590,14 +595,7 @@ class MagicStatisticsHandler
                     }
                 }
 
-                // Decode JSON values if they're JSON strings.
                 $objectData[$propertyName] = $value;
-                if (is_string($value) === true && $this->isJsonString(string: $value) === true) {
-                    $decodedValue = json_decode($value, true);
-                    if ($decodedValue !== null) {
-                        $objectData[$propertyName] = $decodedValue;
-                    }
-                }
             }//end foreach
 
             // Set metadata fields on ObjectEntity.
@@ -744,20 +742,4 @@ class MagicStatisticsHandler
         // Convert snake_case to camelCase.
         return lcfirst(str_replace('_', '', ucwords($columnName, '_')));
     }//end columnNameToPropertyName()
-
-    /**
-     * Check if a string is valid JSON
-     *
-     * @param string $string The string to check
-     *
-     * @return bool True if the string is valid JSON
-     */
-    private function isJsonString(string $string): bool
-    {
-        // Decode JSON to check for errors via json_last_error().
-        // Note: We only care about json_last_error(), not the decoded value.
-        $decoded = json_decode($string);
-        unset($decoded);
-        return json_last_error() === JSON_ERROR_NONE;
-    }//end isJsonString()
 }//end class

--- a/lib/Service/Object/SchemaTypeConverter.php
+++ b/lib/Service/Object/SchemaTypeConverter.php
@@ -1,0 +1,220 @@
+<?php
+
+/**
+ * Schema-Driven Type Converter
+ *
+ * Coerces a database column value to the runtime PHP type declared by the
+ * JSON Schema for the corresponding object property. Single source of truth
+ * for type coercion across the magic-table read paths.
+ *
+ * Contract spec: openspec/specs/schema-driven-read-coercion/spec.md
+ *
+ * @category  Service
+ * @package   OCA\OpenRegister\Service\Object
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://www.OpenRegister.app
+ *
+ * @since 2.x.x  Extracted from MagicSearchHandler::convertValueByType so both
+ *               magic-mapper read paths (statistics + search) share one
+ *               converter. Fixes the read-side type drift where booleans came
+ *               back as int 0/1 and string properties were silently
+ *               JSON-decoded when their values looked like JSON literals.
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Object;
+
+/**
+ * Stateless converter that maps a database column value onto the runtime PHP
+ * type declared by the JSON Schema for the corresponding property.
+ *
+ * Used by both `MagicStatisticsHandler::convertRowToObjectEntity` (single
+ * GET, list GET, UNION search across schemas, cross-table find) and
+ * `MagicSearchHandler::convertRowToObjectEntity` (search) so the runtime
+ * type returned to API consumers always matches the schema declaration.
+ *
+ * The converter is intentionally narrow: a single public entry point taking a
+ * raw value and the schema-declared type. Format-specific normalisation
+ * (e.g. `format: date`) stays in the calling handler — see design D5.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Match expression unavoidable for typed dispatch
+ */
+class SchemaTypeConverter
+{
+    /**
+     * Convert a database column value to the type declared in the JSON Schema.
+     *
+     * Dispatch table:
+     *
+     *   $schemaType         | result
+     *   --------------------|----------------------------------------------------
+     *   'array' / 'object'  | JSON-decode if string-shaped, else pass through
+     *   'number'            | (float) when is_numeric, else pass through
+     *   'integer'           | (int) when is_numeric, else pass through
+     *   'boolean'           | true for {true, '1', 1, 'true', 'yes'} (case-insensitive
+     *                       | for strings), false for everything else; passes native bools
+     *   default (string + ??) | pass strings through; cast int/float to (string);
+     *                          | only decode when value starts with '[' or '{' AND parses
+     *
+     * `null` always returns `null` regardless of `$schemaType`.
+     *
+     * @param mixed  $value      The raw column value as returned by the DB driver.
+     * @param string $schemaType The declared JSON-Schema property type.
+     *
+     * @return mixed The schema-typed PHP value.
+     */
+    public function convertValue(mixed $value, string $schemaType): mixed
+    {
+        // Null is preserved across all schema types - see spec scenario "Null integer column".
+        if ($value === null) {
+            return null;
+        }
+
+        return match ($schemaType) {
+            'array', 'object' => $this->convertArrayOrObject(value: $value),
+            'number'          => $this->convertNumber(value: $value),
+            'integer'         => $this->convertInteger(value: $value),
+            'boolean'         => $this->convertBoolean(value: $value),
+            default           => $this->convertString(value: $value, schemaType: $schemaType),
+        };
+    }//end convertValue()
+
+    /**
+     * Convert a value to the `string` schema type (and the unknown-type fallback).
+     *
+     * Strings are passed through. Numeric scalars are cast via `(string)`. Strings
+     * that look like JSON arrays/objects (start with `[` or `{` and parse) are
+     * decoded for backward compatibility with schemas that historically declared
+     * `type: string` but stored array/object data; the same compatibility window
+     * the previous `MagicSearchHandler::convertStringValue` provided.
+     *
+     * Crucially, scalar JSON literals (`"123"`, `"true"`, `"null"`, `'"foo"'`)
+     * are NOT decoded — that was the regression in `MagicStatisticsHandler` this
+     * change fixes.
+     *
+     * @param mixed  $value      The value to convert.
+     * @param string $schemaType The declared schema type (kept for symmetry; unused).
+     *
+     * @return mixed Converted value.
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    private function convertString(mixed $value, string $schemaType): mixed
+    {
+        if (is_string($value) === true) {
+            $trimmed          = trim($value);
+            $startsWithArrObj = (
+                str_starts_with($trimmed, '[') === true
+                || str_starts_with($trimmed, '{') === true
+            );
+
+            if ($startsWithArrObj === true) {
+                $decoded = json_decode($value, true);
+                if (json_last_error() === JSON_ERROR_NONE && ($decoded !== null || $value === 'null')) {
+                    return $decoded;
+                }
+            }
+
+            return $value;
+        }
+
+        // Schema expects string but database returned numeric - cast to string.
+        if (is_int($value) === true || is_float($value) === true) {
+            return (string) $value;
+        }
+
+        return $value;
+    }//end convertString()
+
+    /**
+     * Convert a value to the `boolean` schema type.
+     *
+     * Native bools pass through. Strings `'true'`, `'1'`, `'yes'` are truthy
+     * (case-insensitive); every other string is falsy. Anything else falls back
+     * to PHP's `(bool)` cast, so int `0` becomes `false`, int `1` becomes `true`,
+     * `0.0` becomes `false`, and so on.
+     *
+     * Mirrors `MagicSearchHandler::convertBooleanValue` exactly. Per design D7,
+     * the HTML-form literal `'on'` is intentionally NOT accepted — form
+     * normalisation belongs in the controller layer.
+     *
+     * @param mixed $value The value to convert.
+     *
+     * @return bool Coerced boolean.
+     */
+    private function convertBoolean(mixed $value): bool
+    {
+        if (is_bool($value) === true) {
+            return $value;
+        }
+
+        if (is_string($value) === true) {
+            return in_array(strtolower($value), ['true', '1', 'yes'], true);
+        }
+
+        return (bool) $value;
+    }//end convertBoolean()
+
+    /**
+     * Convert a value to the `integer` schema type.
+     *
+     * `is_numeric` inputs cast to `(int)`. Non-numeric inputs pass through
+     * unchanged so the JSON-Schema validator can flag them at a higher layer.
+     *
+     * @param mixed $value The value to convert.
+     *
+     * @return mixed Integer value or original on non-numeric input.
+     */
+    private function convertInteger(mixed $value): mixed
+    {
+        if (is_numeric($value) === true) {
+            return (int) $value;
+        }
+
+        return $value;
+    }//end convertInteger()
+
+    /**
+     * Convert a value to the `number` schema type.
+     *
+     * `is_numeric` inputs cast to `(float)`. Non-numeric inputs pass through
+     * unchanged for downstream validation.
+     *
+     * @param mixed $value The value to convert.
+     *
+     * @return mixed Float value or original on non-numeric input.
+     */
+    private function convertNumber(mixed $value): mixed
+    {
+        if (is_numeric($value) === true) {
+            return (float) $value;
+        }
+
+        return $value;
+    }//end convertNumber()
+
+    /**
+     * Convert a value to the `array` or `object` schema type.
+     *
+     * Strings are JSON-decoded. Already-array values pass through. Strings that
+     * fail to parse return unchanged so the JSON-Schema validator can flag them.
+     *
+     * @param mixed $value The value to convert.
+     *
+     * @return mixed Decoded array, original array, or original string.
+     */
+    private function convertArrayOrObject(mixed $value): mixed
+    {
+        if (is_string($value) === true) {
+            $decoded = json_decode($value, true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                return $decoded;
+            }
+        }
+
+        return $value;
+    }//end convertArrayOrObject()
+}//end class

--- a/openspec/changes/fix-magic-table-type-coercion/.openspec.yaml
+++ b/openspec/changes/fix-magic-table-type-coercion/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/fix-magic-table-type-coercion/design.md
+++ b/openspec/changes/fix-magic-table-type-coercion/design.md
@@ -1,0 +1,170 @@
+## Context
+
+OpenRegister stores objects in per-register/schema "magic tables" with normalized columns whose SQL types are derived from the JSON Schema (`MagicMapper::buildTableColumnsFromSchema`). On read, two parallel converters reconstruct an `ObjectEntity` from a row:
+
+| Path | Where | Type-coercion quality |
+| --- | --- | --- |
+| Single-object find / UNION / cross-table | `MagicMapper::convertRowToObjectEntity` (public) → delegates to `MagicStatisticsHandler::convertRowToObjectEntity` | **incomplete** |
+| Search results | `MagicSearchHandler::convertRowToObjectEntity` (private) → `convertValueByType` | **complete and correct** |
+
+The "complete" converter in `MagicSearchHandler` dispatches on the schema's declared type and handles all six cases (`string`, `boolean`, `integer`, `number`, `array`, `object`). The "incomplete" converter in `MagicStatisticsHandler` has two specific defects:
+
+1. **String-cast undone.** Line ~575 casts numeric DB values to string when the schema says `string`. Lines ~593–600 then run `is_string($value) && isJsonString($value) → json_decode`, which decodes any value that happens to be valid JSON — including scalar JSON like `"123"` (literal int), `"true"` (literal bool), `"null"` (literal null), `'"foo"'` (escaped string). The decode runs on every property regardless of schema type and routinely undoes the preceding cast.
+
+2. **Coverage gap.** Only `string` is coerced. `boolean` properties are passed through as whatever the DB driver returned. On MariaDB, `BOOLEAN` is a TINYINT(1) alias and the driver returns PHP `int 0`/`1`. On PostgreSQL it would return native `bool` — so this defect is MariaDB-specific at the driver level but ought to be platform-independent in our code.
+
+The path from row to API consumer:
+
+```
+DB row                                           consumer
+   ├─ getObject(uuid)                             OpenRegister API  →  frontend / OpenConnector
+   ├─ getObjects(query) ─ search ──── good        ╲
+   └─ getObjects(query) ─ list/scope ─ ✗ broken    ╲ silent type drift
+                                                    ╲
+                                              ↓
+                              "0" appears as int 0 instead of bool
+                              "123" appears as int instead of string
+                              JSON literal in a string field gets decoded
+```
+
+OpenConnector and the OpenRegister frontend both call the API and inherit whatever type drift OpenRegister produces — fixing the source fixes both consumers.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A single, schema-driven converter that produces correctly-typed values for all six JSON Schema primitive types (`string`, `boolean`, `integer`, `number`, `array`, `object`).
+- Both magic-table read paths (`MagicStatisticsHandler` for single/UNION, `MagicSearchHandler` for search) delegate to the same converter — no duplication, no future drift.
+- The fix lands without DB migrations, without API-contract changes, and without forcing any consumer-side change.
+- Behaviour is platform-independent — applies the same coercion regardless of whether the underlying DB is MariaDB or PostgreSQL, even though the bug is largely MariaDB-driver-induced.
+
+**Non-Goals:**
+- Write-side coercion in `SaveObject` / `SaveObjects` / `MagicBulkHandler`. Validation today is reject-only via `ValidateObject`; coerce-on-write is a deliberate semantic shift and belongs in the integer-bounds change.
+- Requiring `minimum`/`maximum` on JSON Schema `integer` properties (deferred to `require-integer-bounds`).
+- Migrating existing `INTEGER` columns to `BIGINT`. Out of scope.
+- Schema editor UI changes (no JSON-Schema definition is changing).
+- Changes to `openconnector` or `nextcloud-vue` consumer code. Both inherit the fix transparently.
+
+## Decisions
+
+### D1 — New shared utility class, not a trait
+
+**Decision:** create `lib/Service/Object/SchemaTypeConverter.php` as a stateless service class with a single public method `convertValue(mixed $value, string $schemaType): mixed` and private per-type helpers. Inject it into `MagicStatisticsHandler` and `MagicSearchHandler` via the existing constructor DI pattern.
+
+**Why a service class over a trait or static utility:**
+- ADR-008 prescribes the Controller → Service → Mapper layering. A read-side type converter is service-layer concern (transformation logic), not mapper concern (CRUD). Hosting it in `lib/Service/Object/` keeps that boundary clean.
+- A class allows future extension (e.g. a `convertValueWithFormat` overload that respects `format: date` / `date-time`) without breaking the call sites.
+- Stateless service classes are idiomatic in this codebase (`DateTimeNormalizer`, `ContactMatchingService`, etc.).
+
+**Rejected alternative — trait shared between the two handlers:** Traits make it harder to mock for unit tests and confuse `__call`-based DI in some edge cases. They also obscure the layer boundary.
+
+**Rejected alternative — `static` utility methods:** Statelessness is a property, not a structural constraint. A regular service injected via DI is just as cheap and gives us mockability for free.
+
+### D2 — `convertValue($value, $schemaType)` signature, not `convertRow($row, $schema)`
+
+**Decision:** the converter takes a single value and the schema type string. The handlers iterate the row and call `convertValue` per property.
+
+**Why per-value:** the handlers already iterate the row to handle metadata-prefix splitting and column-name → property-name remapping (see `MagicStatisticsHandler::convertRowToObjectEntity` lines ~515–601). Forcing the iteration into the converter would either duplicate that logic or pull metadata-handling into the converter — the wrong direction.
+
+**Per-value also makes unit-testing trivial:** one input, one schema-type string, one expected output. No row-construction setup.
+
+### D3 — Mirror `MagicSearchHandler`'s existing dispatch
+
+**Decision:** the converter's dispatch matches the proven `convertValueByType` already in `MagicSearchHandler` (lines ~1633–1648):
+
+```php
+return match ($schemaType) {
+    'array', 'object'        => $this->convertArrayOrObject($value),
+    'number'                 => $this->convertNumber($value),
+    'integer'                => $this->convertInteger($value),
+    'boolean'                => $this->convertBoolean($value),
+    default /* string + ?? */ => $this->convertString($value, $schemaType),
+};
+```
+
+**Why mirror, not redesign:**
+- The search-side converter has been in production and is known to handle the cases correctly. Mirroring its semantics minimizes the risk of introducing new edge-case regressions.
+- The migration is a refactor toward shared code, not a behavioural change for the search path.
+
+**Note on `string` semantics:** the existing `convertStringValue` (line ~1743) preserves the historical behaviour of decoding strings that look like JSON arrays/objects — `[…]` or `{…}` only — for backward compatibility with schemas that had `type: string` but stored array/object data. This historical quirk is **preserved as-is** in the new converter to avoid regressing that compatibility window. Plain numeric strings, boolean-literal strings, and quoted strings are NOT decoded.
+
+### D4 — Drop the unconditional `is_string($value) && isJsonString($value)` block
+
+**Decision:** the JSON-decode pass at `MagicStatisticsHandler` lines ~593–600 is removed. The converter's `array`/`object` branch already handles JSON-string columns correctly by decoding; scalars are no longer eaten.
+
+**Why this matters:** the bug isn't subtle. With the current code:
+- `string` property + DB value `'true'` → `json_decode('true', true)` → `true` (bool) → returned as bool.
+- `string` property + DB value `'null'` → `json_decode('null', true)` → `null` → property silently dropped.
+- `string` property + DB value `'"foo"'` (escaped string) → `json_decode('"foo"', true)` → `'foo'` → quotes stripped.
+- `string` property + DB value `'[]'` (literal text) → decoded to empty array.
+
+Removing the unconditional decode and pushing the decode behind the schema-type gate is what makes `string` actually mean string.
+
+### D5 — Format handling stays in the handler, not the converter
+
+**Decision:** `MagicStatisticsHandler` already applies date/datetime formatting via `DateTimeNormalizer` after the type cast (lines ~580–591). That logic stays where it is. The new converter does NOT take a `format` parameter today.
+
+**Why:** date formatting requires `DateTimeNormalizer` injection and is already correct. Pulling it into the converter would expand scope and require coupling the converter to `DateTimeNormalizer`. If we later want a single-call "convert by type and format" entry point, `convertValue` can grow a third parameter without breaking existing callers.
+
+### D6 — Boolean coercion accepts the same forms as the search-path converter
+
+**Decision:** `convertBoolean($value)` (mirroring the existing `MagicSearchHandler::convertBooleanValue`):
+- `is_bool($value)` → return as-is.
+- `is_string($value)` → `true` if `strtolower($value) ∈ {'true', '1', 'yes'}`, else `false`.
+- otherwise → `(bool) $value` (so int `0` becomes `false`, int `1` becomes `true`, `0.0` becomes `false`).
+
+**Why this set:** matches the search-path semantics exactly. If we wanted stricter behaviour (e.g. reject `'yes'`), it'd be a behavioural change relative to the proven path and should be a separate decision.
+
+### D7 — Boolean converter does NOT accept the HTML-form literal `'on'`
+
+**Decision:** the truthy string set is `{'true', '1', 'yes'}` only — `'on'` is NOT included.
+
+**Why:** HTML form payloads (where checkboxes serialize as `name=on`) should be normalized in the controller layer, before the data ever reaches a magic-table column. Accepting `'on'` at the read converter would paper over a layering violation upstream rather than fix it at the source. Mirroring the search-path converter exactly is also the cleaner story for "single source of truth" — there is no behavioural divergence between the two read paths.
+
+**Confirmed by team review.**
+
+**Rejected alternative — accept `'on'` for HTML-form compatibility:** the bug it would prevent only exists when something is bypassing the controller normalization. If we observe such a bug in practice, the fix is to find the bypass and route it through the normalizer, not to silently absorb form-shaped values inside the data layer.
+
+### D8 — Inline converters in `MagicSearchHandler` are deleted, not kept as deprecation wrappers
+
+**Decision:** the existing private methods on `MagicSearchHandler` (`convertValueByType`, `convertStringValue`, `convertBooleanValue`, `convertNumberValue`, `convertIntegerValue`, `convertArrayOrObjectValue`) are deleted in the same PR that introduces `SchemaTypeConverter`. They are NOT kept as one-line wrappers for a release cycle.
+
+**Why delete immediately:**
+- All six methods are `private` to `MagicSearchHandler`. There are no external consumers — a grep of `lib/` and `tests/` is part of task 4.4.
+- Conduction's project guideline ("no half-finished implementations") favours a clean rip-out over deprecation shims when there's no backwards-compat risk.
+- A single source of truth from day one is the goal of this change. Wrappers re-introduce the surface area the change exists to remove.
+- If something *does* reference one of the private methods despite the grep (reflection, dynamic dispatch), PHP fails loudly with `Error: Call to undefined method` — caught by CI before merge, not silently masked.
+
+**Confirmed by team review.**
+
+**Rejected alternative — keep as thin one-line wrappers for one release cycle:** would buy a deprecation window for downstream code that doesn't exist (the methods are private). Adds technical debt with no real upside.
+
+## Risks / Trade-offs
+
+- **[Consumer relied on int 0/1 for boolean]** → grep `apps-extra/` for `=== 1` / `=== 0` near suspected boolean fields; document any hits in tasks. Expected: zero hits in Conduction code.
+- **[Consumer relied on string-typed property silently being decoded as JSON]** → same grep approach; this is rarer because the silent-decode behaviour was clearly buggy. If we find any, decide per-call site whether to update consumer or escalate.
+- **[Tests for search path break because behaviour changes]** → search path's behaviour does NOT change (we mirror it). If a test breaks it's revealing a different latent issue. Mitigate by running the full magic-mapper test suite before merging.
+- **[Performance regression — extra method call per property]** → conversion was already happening for `string`; adding similar one-line dispatches for the other types is `O(properties)` per row, identical complexity to today. No DB roundtrips added.
+- **[Scope creep — someone wants to add format / locale / collation handling]** → out of scope. The converter's surface stays minimal; format handling stays in handlers.
+- **[Mockability — handlers now depend on a new service]** → standard DI injection, idiomatic for this codebase. Existing tests for the handlers will need to construct the new dependency or mock it; mitigated by keeping the converter pure (no DB access, no I/O) so a real instance is cheap.
+
+## Migration Plan
+
+This is read-side code only. No DB migration, no schema migration, no API change.
+
+**Deployment:**
+1. Land the converter + handler refactor + tests in a single PR.
+2. CI runs `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan, PHPUnit) — see ADR-009. All must pass.
+3. Manual verification on staging:
+   - Create a register/schema with one property of each primitive type plus an `array` and an `object`.
+   - Insert objects with values that exercise both the bug paths (numeric data in a string field, `0`/`1` in a boolean field, JSON literals in string fields).
+   - Hit `GET /api/objects/<uuid>` and `GET /api/objects` (list with no search) — verify types in the response.
+   - Hit `GET /api/search?q=…` — verify search path still returns the same shapes.
+4. Roll out via the normal release cadence — no feature flag required because the change is observable but always-correct.
+
+**Rollback:** revert the PR. The shared converter file is new (deleted on revert); the handler refactors are net-zero behavioural for already-correct types and only restore the bug for the broken types. No data is changed.
+
+**Out-of-band note for OpenConnector reviewers:** call this fix out in the next OpenConnector release notes. Sync flows that previously received `0`/`1` for booleans will now receive native `bool`. Mapping templates that explicitly checked `=== 1` need to be updated. Conduction-internal mappings have been audited — no such checks found.
+
+## Seed Data
+
+N/A. Per ADR-016, seed data is required only when a change introduces or modifies OpenRegister schemas. This change is a read-path bug fix — no schemas, registers, or seed objects are added or modified.

--- a/openspec/changes/fix-magic-table-type-coercion/plan.json
+++ b/openspec/changes/fix-magic-table-type-coercion/plan.json
@@ -1,0 +1,63 @@
+{
+  "change": "fix-magic-table-type-coercion",
+  "project": "openregister",
+  "repo": "ConductionNL/openregister",
+  "created": "2026-04-30",
+  "tracking_issue": 1366,
+  "tracking_issue_url": "https://github.com/ConductionNL/openregister/issues/1366",
+  "specs": [
+    "schema-driven-read-coercion"
+  ],
+  "tasks": [
+    { "id": "1.1", "section": "Pre-implementation audit", "status": "done", "title": "Grep apps-extra for code depending on boolean=0/1", "result": "0 hits in consumer code" },
+    { "id": "1.2", "section": "Pre-implementation audit", "status": "done", "title": "Grep apps-extra for code depending on string-as-decoded-JSON", "result": "0 hits in consumer code" },
+    { "id": "1.3", "section": "Pre-implementation audit", "status": "done", "title": "Confirm proposal capability list matches files", "result": "specs/ contains only schema-driven-read-coercion as listed" },
+
+    { "id": "2.1", "section": "Implement the shared converter", "status": "pending", "title": "Create lib/Service/Object/SchemaTypeConverter.php with convertValue()" },
+    { "id": "2.2", "section": "Implement the shared converter", "status": "pending", "title": "Implement convertString() with array/object compat decode" },
+    { "id": "2.3", "section": "Implement the shared converter", "status": "pending", "title": "Implement convertBoolean() (true/1/yes literals)" },
+    { "id": "2.4", "section": "Implement the shared converter", "status": "pending", "title": "Implement convertInteger() (numeric → int)" },
+    { "id": "2.5", "section": "Implement the shared converter", "status": "pending", "title": "Implement convertNumber() (numeric → float)" },
+    { "id": "2.6", "section": "Implement the shared converter", "status": "pending", "title": "Implement convertArrayOrObject() (JSON-string → array)" },
+    { "id": "2.7", "section": "Implement the shared converter", "status": "pending", "title": "Wire dispatch in convertValue with match{} and null short-circuit" },
+    { "id": "2.8", "section": "Implement the shared converter", "status": "pending", "title": "Add PHPDoc and PHPMD annotations" },
+
+    { "id": "3.1", "section": "Refactor MagicStatisticsHandler", "status": "pending", "title": "Inject SchemaTypeConverter via constructor" },
+    { "id": "3.2", "section": "Refactor MagicStatisticsHandler", "status": "pending", "title": "Replace partial coercion + JSON-decode with converter call" },
+    { "id": "3.3", "section": "Refactor MagicStatisticsHandler", "status": "pending", "title": "Keep DateTimeNormalizer block after converter call" },
+    { "id": "3.4", "section": "Refactor MagicStatisticsHandler", "status": "pending", "title": "Delete now-unused isJsonString helper" },
+
+    { "id": "4.1", "section": "Refactor MagicSearchHandler", "status": "pending", "title": "Inject SchemaTypeConverter via constructor" },
+    { "id": "4.2", "section": "Refactor MagicSearchHandler", "status": "pending", "title": "Replace convertValueByType call with converter call" },
+    { "id": "4.3", "section": "Refactor MagicSearchHandler", "status": "pending", "title": "Delete inline convert*Value private methods" },
+    { "id": "4.4", "section": "Refactor MagicSearchHandler", "status": "pending", "title": "Retarget any other callers of the deleted methods" },
+
+    { "id": "5.1", "section": "Unit tests", "status": "pending", "title": "Create SchemaTypeConverterTest.php" },
+    { "id": "5.2", "section": "Unit tests", "status": "pending", "title": "String coverage tests (8 cases)" },
+    { "id": "5.3", "section": "Unit tests", "status": "pending", "title": "Boolean coverage tests (12 cases)" },
+    { "id": "5.4", "section": "Unit tests", "status": "pending", "title": "Integer coverage tests (5 cases)" },
+    { "id": "5.5", "section": "Unit tests", "status": "pending", "title": "Number coverage tests (4 cases)" },
+    { "id": "5.6", "section": "Unit tests", "status": "pending", "title": "Array/object coverage tests (5 cases)" },
+    { "id": "5.7", "section": "Unit tests", "status": "pending", "title": "Unknown-type fallback tests" },
+    { "id": "5.8", "section": "Unit tests", "status": "pending", "title": "Run PHPUnit and verify green" },
+
+    { "id": "6.1", "section": "Handler-level integration tests", "status": "pending", "title": "MagicStatisticsHandlerTest delegation assertion" },
+    { "id": "6.2", "section": "Handler-level integration tests", "status": "pending", "title": "MagicSearchHandlerTest delegation assertion" },
+    { "id": "6.3", "section": "Handler-level integration tests", "status": "pending", "title": "Date-format ordering regression test" },
+
+    { "id": "7.1", "section": "Quality gates and verification", "status": "pending", "title": "composer check:strict passes" },
+    { "id": "7.2", "section": "Quality gates and verification", "status": "pending", "title": "Full magic-mapper PHPUnit suite passes" },
+    { "id": "7.3", "section": "Quality gates and verification", "status": "pending", "title": "Manual API verification (GET single + list)" },
+    { "id": "7.4", "section": "Quality gates and verification", "status": "pending", "title": "Manual API verification (POST + PUT response bodies)" },
+    { "id": "7.5", "section": "Quality gates and verification", "status": "pending", "title": "Manual search-path regression verification" },
+    { "id": "7.6", "section": "Quality gates and verification", "status": "pending", "title": "OpenConnector downstream spot-check" },
+
+    { "id": "8.1", "section": "Documentation and rollout", "status": "pending", "title": "Update docs/ if API-types section documented the bug" },
+    { "id": "8.2", "section": "Documentation and rollout", "status": "pending", "title": "Release-notes entry" },
+    { "id": "8.3", "section": "Documentation and rollout", "status": "pending", "title": "OpenConnector release-notes mention" },
+
+    { "id": "9.1", "section": "PR and archive", "status": "pending", "title": "Open PR against development" },
+    { "id": "9.2", "section": "PR and archive", "status": "pending", "title": "Run /opsx:verify" },
+    { "id": "9.3", "section": "PR and archive", "status": "pending", "title": "Archive change after merge" }
+  ]
+}

--- a/openspec/changes/fix-magic-table-type-coercion/proposal.md
+++ b/openspec/changes/fix-magic-table-type-coercion/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+OpenRegister's API returns object-property values whose runtime types do not match the JSON Schema's declared property type. A property typed as `string` whose stored data is numeric comes back as a PHP `int`; a property typed as `boolean` comes back as `int 0`/`1`. Consumers (the OpenRegister frontend, OpenConnector sync mappings, downstream apps via the typed API) defensively cast to recover, or — more often — silently propagate the wrong type and break further downstream.
+
+The schema is meant to be authoritative: a typed contract between producer and consumer. Today the magic-table read path violates that contract on every row.
+
+## What Changes
+
+- **Fix the over-eager JSON-decode** in `MagicStatisticsHandler::convertRowToObjectEntity`: the existing `is_string($value) && isJsonString($value)` block at lines ~593–600 decodes any string that happens to be valid JSON — including scalar JSON like `"123"`, `"true"`, `"null"`. This undoes the partial string-cast on the preceding lines and corrupts string properties whose values look like JSON literals.
+
+- **Cover all schema types, not only `string`.** Today only `string` properties are coerced (lines ~575–578). `boolean`, `integer`, `number`, `array`, and `object` properties are returned as whatever the database driver produced — which on MariaDB means `boolean` → `int 0`/`1` and (in some drivers/configurations) numeric strings → `int`.
+
+- **Unify the converter.** A schema-driven converter already exists for the search read path (`MagicSearchHandler::convertValueByType`) and handles all six types correctly. Extract that logic into a shared utility (`lib/Service/Object/SchemaTypeConverter.php`) and have both `MagicStatisticsHandler::convertRowToObjectEntity` (the public single-object/UNION path) and `MagicSearchHandler::convertRowToObjectEntity` (the search path) delegate to it. Single source of truth — no future drift between the two read paths.
+
+- **Restrict JSON-decode to `array`/`object` schema types.** The decode is meant for columns that store nested structures as JSON text; gating it on the schema type instead of on `is_string($value)` prevents scalar-JSON corruption.
+
+This change is **read-only**: write-side coercion is intentionally **out of scope** and will be tackled together with the integer-bounds-required design in the follow-up change `require-integer-bounds`.
+
+## Capabilities
+
+### New Capabilities
+- `schema-driven-read-coercion`: When the magic-table read path produces an `ObjectEntity` from a row, every property's runtime PHP type matches its schema-declared type. Single converter is the source of truth across all read paths.
+
+### Modified Capabilities
+<!-- None — no existing spec covers row-to-object type coercion. -->
+
+## Impact
+
+**Code (OpenRegister):**
+- `lib/Db/MagicMapper/MagicStatisticsHandler.php` — replace the partial coercion + over-eager JSON-decode with a delegated call to the shared converter.
+- `lib/Db/MagicMapper/MagicSearchHandler.php` — replace the inline `convertValueByType` / `convertStringValue` / `convertNumberValue` / `convertIntegerValue` / `convertBooleanValue` / `convertArrayOrObjectValue` methods with a delegated call to the shared converter.
+- `lib/Service/Object/SchemaTypeConverter.php` — **new** utility class. Single public method `convertValue(mixed $value, string $schemaType): mixed` plus type-specific helpers; no instance state, easy to unit-test.
+
+**Tests (OpenRegister):**
+- `tests/Unit/Service/Object/SchemaTypeConverterTest.php` — **new**. Cover each of the six schema types with normal cases plus the regression suite: `string` + `123` (int), `string` + `"true"` (must stay literal `'true'`), `string` + `"null"` (must stay literal `'null'`), `string` + `'"foo"'` (no quote-stripping), `boolean` + `0`/`1` (becomes `false`/`true`), `boolean` + `"true"`/`"yes"`/`"1"` (also `true`), `integer` + numeric string, `number` + int, `array` + JSON string, `object` + JSON string, all-types + `null`.
+- Integration check that both `MagicStatisticsHandler` and `MagicSearchHandler` delegate (mock the shared converter or assert observable behaviour through `convertRowToObjectEntity`).
+
+**Downstream apps (no code changes required):**
+- **OpenConnector** — register-backed sync flows will start receiving correctly-typed values from OpenRegister's API. Any defensive `(string)` / `(bool)` casts in OC become no-ops; no regressions expected. Out of scope here; mention in the rollout note.
+- **Frontend (`@conduction/nextcloud-vue`, openregister UI)** — `CnDataTable`, form widgets, and any explicit type checks that previously had to handle `0`/`1` for booleans no longer need to. Out of scope; downstream cleanup can be a follow-up if desired.
+
+**Backwards compatibility:**
+- Consumers that **depend on** the broken behaviour (e.g. JS `value === 1` for "true") will break. We expect zero such cases in Conduction code; a grep across `apps-extra/` is part of the verification.
+- No DB migration. No magic-table schema change. No API contract change at the spec level — this brings the runtime in line with the spec.
+
+**Endpoint coverage:**
+
+`MagicMapper::insertObjectEntity` (line 5066–5086) and `MagicMapper::updateObjectEntity` re-fetch the saved row via `findInRegisterSchemaTable` after writing — explicitly so the response body carries DB-generated metadata. That re-fetch goes through `convertRowToObjectEntity` → `MagicStatisticsHandler`, which means **POST and PUT response bodies are produced by the same path this change unifies**. After the fix, every endpoint that returns an `ObjectEntity` (single GET, list GET, search GET, POST create, PUT update) is schema-typed consistently.
+
+| Endpoint | Reads `ObjectEntity` via | Affected by fix |
+| --- | --- | :-: |
+| `GET /api/objects/<uuid>` | `MagicStatisticsHandler::convertRowToObjectEntity` | ✓ |
+| `GET /api/objects` (list) | `MagicStatisticsHandler::convertRowToObjectEntity` | ✓ |
+| `GET /api/search` | `MagicSearchHandler::convertRowToObjectEntity` | ✓ (refactored to share converter) |
+| `POST /api/objects` | re-fetch via `MagicStatisticsHandler::convertRowToObjectEntity` | ✓ |
+| `PUT /api/objects/<uuid>` | re-fetch via `MagicStatisticsHandler::convertRowToObjectEntity` | ✓ |
+
+**Out of scope (deferred to follow-up changes):**
+- Write-side coercion in `SaveObject` / `SaveObjects` / `MagicBulkHandler`.
+- Requiring `minimum`/`maximum` on JSON Schema integer properties (`require-integer-bounds`).
+- `number` precision/scale defaults.
+- Schema editor UI changes.
+- Migration of existing magic-table `INTEGER` columns to `BIGINT`.

--- a/openspec/changes/fix-magic-table-type-coercion/specs/schema-driven-read-coercion/spec.md
+++ b/openspec/changes/fix-magic-table-type-coercion/specs/schema-driven-read-coercion/spec.md
@@ -1,0 +1,157 @@
+## ADDED Requirements
+
+### Requirement: Single shared schema-type converter on read
+
+The system SHALL provide a single `SchemaTypeConverter` service in `lib/Service/Object/` whose `convertValue(mixed $value, string $schemaType): mixed` method is the only place that converts a database column value to a JSON-Schema-typed PHP value.
+
+Both magic-table read paths — `MagicStatisticsHandler::convertRowToObjectEntity` (single-object find, UNION search across schemas, cross-table lookup) and `MagicSearchHandler::convertRowToObjectEntity` (search) — MUST delegate every per-property conversion to this service. Inline per-type converters (`convertValueByType`, `convertStringValue`, `convertBooleanValue`, `convertNumberValue`, `convertIntegerValue`, `convertArrayOrObjectValue`) MUST NOT remain on either handler after this change lands.
+
+#### Scenario: Single source of truth for read coercion
+
+- **WHEN** a developer searches the codebase for type-conversion logic that runs against a magic-table row
+- **THEN** the only implementation found is `SchemaTypeConverter::convertValue` and its private helpers
+- **AND** both handlers reference the converter via constructor-injected service
+
+#### Scenario: Both read paths produce identical output for identical input
+
+- **WHEN** the same `(value, schemaType)` pair is passed to both `MagicStatisticsHandler` and `MagicSearchHandler` row converters
+- **THEN** the resulting property value on the `ObjectEntity` is identical in both PHP type and content
+
+### Requirement: `string` properties always return PHP `string`
+
+When the schema declares a property as `type: string`, the converter SHALL return a PHP `string` for any non-null value. Numeric, boolean, and other scalar inputs MUST be cast via `(string) $value`. Inputs that are already strings MUST be returned unchanged unless they begin with `[` or `{` and parse as valid JSON, in which case they MAY be decoded for backward compatibility with schemas that historically stored array/object data under a `string` type.
+
+#### Scenario: Numeric DB value coerces to string
+
+- **WHEN** the schema property is `{ "type": "string" }` and the row contains the integer `45`
+- **THEN** the returned property value is the string `"45"`
+
+#### Scenario: Boolean-literal JSON is not decoded
+
+- **WHEN** the schema property is `{ "type": "string" }` and the row contains the string `"true"`
+- **THEN** the returned property value is the string `"true"` (not the boolean `true`)
+
+#### Scenario: Null-literal JSON is not decoded
+
+- **WHEN** the schema property is `{ "type": "string" }` and the row contains the string `"null"`
+- **THEN** the returned property value is the string `"null"` (not PHP `null`, and the property is not silently dropped)
+
+#### Scenario: Quoted-string JSON is not unwrapped
+
+- **WHEN** the schema property is `{ "type": "string" }` and the row contains the string `'"foo"'` (six characters including the literal quotes)
+- **THEN** the returned property value is the string `'"foo"'` with quotes intact
+
+#### Scenario: Array-shaped string is decoded for backward compatibility
+
+- **WHEN** the schema property is `{ "type": "string" }` and the row contains the string `'[1,2,3]'`
+- **THEN** the returned property value is the array `[1, 2, 3]` (preserves historical behavior for schemas with mismatched type declarations)
+
+### Requirement: `boolean` properties always return PHP `bool`
+
+When the schema declares a property as `type: boolean`, the converter SHALL return a PHP `bool` for any non-null value. The conversion SHALL accept:
+
+- native `bool` (returned unchanged),
+- the strings `"true"`, `"1"`, `"yes"` (case-insensitive) → `true`; any other string → `false`,
+- any other type → `(bool) $value` (so int `0` → `false`, int `1` → `true`).
+
+#### Scenario: MariaDB TINYINT(1) result coerces to bool
+
+- **WHEN** the schema property is `{ "type": "boolean" }` and the row contains the integer `1` (as returned by mysqlnd from a TINYINT(1) column)
+- **THEN** the returned property value is PHP `true`
+
+#### Scenario: MariaDB false coerces to bool
+
+- **WHEN** the schema property is `{ "type": "boolean" }` and the row contains the integer `0`
+- **THEN** the returned property value is PHP `false`
+
+#### Scenario: PostgreSQL native bool passes through
+
+- **WHEN** the schema property is `{ "type": "boolean" }` and the row contains the PHP boolean `true` (as returned by the PostgreSQL driver from a `BOOLEAN` column)
+- **THEN** the returned property value is PHP `true`
+
+#### Scenario: String "yes" coerces to bool
+
+- **WHEN** the schema property is `{ "type": "boolean" }` and the row contains the string `"yes"`
+- **THEN** the returned property value is PHP `true`
+
+### Requirement: `integer` properties return PHP `int` for numeric input
+
+When the schema declares a property as `type: integer`, the converter SHALL return a PHP `int` for any value that PHP's `is_numeric()` accepts. Non-numeric values are returned unchanged so that a downstream JSON-Schema validator can reject them.
+
+#### Scenario: Numeric string coerces to int
+
+- **WHEN** the schema property is `{ "type": "integer" }` and the row contains the string `"42"`
+- **THEN** the returned property value is the integer `42`
+
+#### Scenario: Already-integer passes through
+
+- **WHEN** the schema property is `{ "type": "integer" }` and the row contains the integer `42`
+- **THEN** the returned property value is the integer `42`
+
+### Requirement: `number` properties return PHP `float` for numeric input
+
+When the schema declares a property as `type: number`, the converter SHALL return a PHP `float` for any value that PHP's `is_numeric()` accepts.
+
+#### Scenario: Integer DB value coerces to float
+
+- **WHEN** the schema property is `{ "type": "number" }` and the row contains the integer `7`
+- **THEN** the returned property value is the float `7.0`
+
+#### Scenario: Decimal string coerces to float
+
+- **WHEN** the schema property is `{ "type": "number" }` and the row contains the string `"3.14"`
+- **THEN** the returned property value is the float `3.14`
+
+### Requirement: `array` and `object` properties are JSON-decoded only under their schema type
+
+When the schema declares a property as `type: array` or `type: object`, the converter SHALL JSON-decode any string-shaped value and return the resulting PHP array. Values that are already arrays MUST be returned unchanged. Strings that fail to decode MUST be returned as the original string so the JSON-Schema validator can flag them.
+
+JSON decoding MUST NOT run for any other schema type. The converter MUST NOT contain a fall-through "if value is JSON, decode it" path.
+
+#### Scenario: JSON-string array column is decoded
+
+- **WHEN** the schema property is `{ "type": "array" }` and the row contains the string `'[1,2,3]'`
+- **THEN** the returned property value is the PHP array `[1, 2, 3]`
+
+#### Scenario: Already-array column passes through
+
+- **WHEN** the schema property is `{ "type": "object" }` and the row already holds the PHP array `['key' => 'value']` (e.g. from a JSON column the driver pre-decoded)
+- **THEN** the returned property value is the PHP array `['key' => 'value']` unchanged
+
+#### Scenario: Numeric-looking value under string type is not decoded
+
+- **WHEN** the schema property is `{ "type": "string" }` and the row contains the string `"123"`
+- **THEN** the returned property value is the string `"123"` and is NOT passed through `json_decode`
+
+### Requirement: `null` is preserved across all schema types
+
+When the row value is `null`, the converter SHALL return `null` regardless of the schema type. No coercion runs on a `null` input.
+
+#### Scenario: Null integer column
+
+- **WHEN** the schema property is `{ "type": "integer" }` and the row contains `null` (nullable column with no value)
+- **THEN** the returned property value is `null`
+
+#### Scenario: Null boolean column
+
+- **WHEN** the schema property is `{ "type": "boolean" }` and the row contains `null`
+- **THEN** the returned property value is `null` (NOT `false`)
+
+### Requirement: Unknown schema types fall through unchanged
+
+When the schema declares a property with an unrecognized `type` (e.g. a typo, a custom type, or an empty string), the converter SHALL apply the same backward-compatible handling as the `string` branch — pass strings through and only attempt JSON decoding if the value begins with `[` or `{`.
+
+#### Scenario: Unknown type passes the value through
+
+- **WHEN** the schema property has `{ "type": "mystery" }` and the row contains the string `"hello"`
+- **THEN** the returned property value is the string `"hello"`
+
+### Requirement: Read-side format handling stays in the handler
+
+Format-specific normalization (e.g. `format: date`, `format: date-time`) SHALL NOT be the converter's responsibility. The handler that calls the converter MUST continue to apply its existing format normalization (via `DateTimeNormalizer`) after the converter has produced the schema-typed value.
+
+#### Scenario: Date-formatted string column
+
+- **WHEN** the schema property is `{ "type": "string", "format": "date" }` and the row contains the string `"2026-04-30T10:00:00+02:00"`
+- **THEN** the converter returns the string unchanged
+- **AND** the handler applies `DateTimeNormalizer::normalize` and produces `"2026-04-30"` on the resulting `ObjectEntity`

--- a/openspec/changes/fix-magic-table-type-coercion/tasks.md
+++ b/openspec/changes/fix-magic-table-type-coercion/tasks.md
@@ -1,0 +1,68 @@
+## 1. Pre-implementation audit
+
+- [x] 1.1 Grep `apps-extra/` for code that depends on a boolean property arriving as int `0`/`1` (patterns: `=== 0`, `=== 1`, `=== '0'`, `=== '1'` near suspected boolean fields). Document any hits in this task list and flag for follow-up; expected zero hits in Conduction code.
+- [x] 1.2 Grep `apps-extra/` for code that depends on a `string`-typed property silently being JSON-decoded (e.g. `if (is_array($obj['someStringField']))` patterns). Document any hits.
+- [x] 1.3 Confirm the spec list in `proposal.md` matches the actual file shape: only `specs/schema-driven-read-coercion/spec.md` is created, no other specs touched.
+
+## 2. Implement the shared converter
+
+- [x] 2.1 Create `lib/Service/Object/SchemaTypeConverter.php` with public `convertValue(mixed $value, string $schemaType): mixed`.
+- [x] 2.2 Implement private `convertString(mixed $value, string $schemaType): mixed` — passes strings through; only decodes strings starting with `[` or `{` when they are valid JSON (preserving the historical compatibility window from `MagicSearchHandler::convertStringValue`); casts `int` and `float` inputs to string.
+- [x] 2.3 Implement private `convertBoolean(mixed $value): bool` — returns native bools unchanged; treats strings `"true"` / `"1"` / `"yes"` (case-insensitive) as `true`, every other string as `false`; falls back to `(bool) $value` for everything else.
+- [x] 2.4 Implement private `convertInteger(mixed $value): mixed` — returns `(int) $value` when `is_numeric($value)`, otherwise returns the value unchanged for downstream validation.
+- [x] 2.5 Implement private `convertNumber(mixed $value): mixed` — returns `(float) $value` when `is_numeric($value)`, otherwise unchanged.
+- [x] 2.6 Implement private `convertArrayOrObject(mixed $value): mixed` — JSON-decodes string-shaped values; passes already-array values through; returns the original string when JSON decoding fails.
+- [x] 2.7 Wire the dispatch in `convertValue` using a `match` on `$schemaType` that mirrors the table in design D3, with `null` short-circuited at the top.
+- [x] 2.8 Add PHPDoc on the class and every method; include the `@SuppressWarnings(PHPMD.CyclomaticComplexity)` annotation on the dispatch method only if PHPMD flags it.
+
+## 3. Refactor `MagicStatisticsHandler`
+
+- [x] 3.1 Inject `SchemaTypeConverter` via the constructor (follow existing DI pattern; `services.xml` registration if applicable).
+- [x] 3.2 In `convertRowToObjectEntity` (around lines 575–600), replace the `if ($schemaType === 'string' && (is_int($value) || is_float($value)))` block and the subsequent `is_string && isJsonString` decode block with a single call to `$this->schemaTypeConverter->convertValue($value, $schemaType)`.
+- [x] 3.3 Keep the pre-existing format-handling block (`DateTimeNormalizer` for `format: date` / `date-time`) AFTER the converter call. The converter does not take a `format` argument.
+- [x] 3.4 Delete the now-unused `isJsonString` private helper (line ~755) if no other call sites remain after the refactor; verify with grep.
+
+## 4. Refactor `MagicSearchHandler`
+
+- [x] 4.1 Inject `SchemaTypeConverter` via the constructor.
+- [x] 4.2 In `convertRowToObjectEntity` (line ~1337), replace the `convertValueByType` call at line ~1375 with `$this->schemaTypeConverter->convertValue($value, $propertyType)`.
+- [x] 4.3 Delete `convertValueByType`, `convertStringValue`, `convertNumberValue`, `convertIntegerValue`, `convertBooleanValue`, `convertArrayOrObjectValue` from `MagicSearchHandler` — they are private and the converter is now the source of truth.
+- [x] 4.4 Search for any other callers of the deleted methods within `MagicSearchHandler.php` and the broader `lib/Db/MagicMapper/`; if found, retarget them to the converter.
+
+## 5. Unit tests
+
+- [x] 5.1 Create `tests/Unit/Service/Object/SchemaTypeConverterTest.php` with one test method per spec scenario.
+- [x] 5.2 String coverage: `'45' (string)`, `45 (int)`, `4.5 (float)`, `'true' (string)`, `'null' (string)`, `'"foo"' (escaped)`, `'[1,2,3]'`, `'{"k":"v"}'`. Verify each produces the spec'd output.
+- [x] 5.3 Boolean coverage: `0`, `1`, `'0'`, `'1'`, `true`, `false`, `'true'`, `'TRUE'`, `'yes'`, `'no'`, `'random string'`, `null`.
+- [x] 5.4 Integer coverage: `'42'`, `42`, `'42.5'`, `'not a number'`, `null`.
+- [x] 5.5 Number coverage: `7`, `'3.14'`, `'not a number'`, `null`.
+- [x] 5.6 Array/object coverage: `'[1,2,3]'`, `'{"a":1}'`, `[1,2,3]` (already-array), `'not json'`, `null`.
+- [x] 5.7 Unknown-type coverage: `'mystery'` schema type with `'hello'` string returns `'hello'`; with `'[1]'` returns `[1]` (matches the string fallback).
+- [x] 5.8 Verify all tests pass: `docker exec nextcloud php /var/www/html/custom_apps/openregister/vendor/bin/phpunit tests/Unit/Service/Object/SchemaTypeConverterTest.php`.
+
+## 6. Handler-level integration tests
+
+- [x] 6.1 Update or extend tests for `MagicStatisticsHandler::convertRowToObjectEntity` (add file at `tests/Unit/Db/MagicMapper/MagicStatisticsHandlerTest.php` if not present): mock the converter and assert it's invoked once per non-metadata column, with the column value and the property's schema type.
+- [x] 6.2 Update or extend tests for `MagicSearchHandler::convertRowToObjectEntity`: same mock-based assertion.
+- [x] 6.3 Add a regression test for the date-format path: `format: date` property + raw string column → handler returns the formatted result, confirming the converter→DateTimeNormalizer ordering still holds.
+
+## 7. Quality gates and verification
+
+- [x] 7.1 Run `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan, PHPUnit) — all must pass per ADR-009. Fix any pre-existing issues in touched files per project rules.
+- [x] 7.2 Run the full magic-mapper test suite to confirm no regressions in adjacent code: `docker exec nextcloud php /var/www/html/custom_apps/openregister/vendor/bin/phpunit tests/Unit/Db/MagicMapper/`.
+- [ ] 7.3 Manual API verification on a register/schema with one property of each primitive type: insert objects exercising the bug paths (numeric data in a string field, `0`/`1` in a boolean field, JSON-literal strings); call `GET /api/objects/<uuid>` and `GET /api/objects` (list); assert types in the JSON response.
+- [ ] 7.4 Manual POST/PUT verification on the same register/schema: send a `POST /api/objects` and a `PUT /api/objects/<uuid>` and assert the **response body** carries schema-typed values (booleans as `true`/`false`, strings as strings) — the response is built from a re-fetch via `MagicMapper::findInRegisterSchemaTable` so it goes through the unified converter.
+- [ ] 7.5 Manual search verification on the same register/schema: call `GET /api/search?q=…` and assert the same shapes appear in the search response (no regression on the path that was already correct).
+- [ ] 7.6 Spot-check downstream: pull the same schema's data through OpenConnector's source proxy (one register-backed flow) — confirm booleans now arrive as `true`/`false` and strings stay strings.
+
+## 8. Documentation and rollout
+
+- [x] 8.1 Update `docs/` if there's an "API response types" or "data types" section that documented the buggy behaviour.
+- [ ] 8.2 Add a release-notes entry mentioning the type-coercion fix and the consumer-impact note (booleans now arrive as PHP bool, not int).
+- [ ] 8.3 Mention the OpenConnector knock-on effect in the OC release notes for the next OC release.
+
+## 9. PR and archive
+
+- [ ] 9.1 Open the PR against `development` (per Conduction default).
+- [ ] 9.2 Run `/opsx:verify` to check this change against its artifacts.
+- [ ] 9.3 After merge: run `/opsx:archive fix-magic-table-type-coercion` to move the change into `openspec/changes/archive/` and merge `schema-driven-read-coercion` requirements into the long-lived spec.

--- a/openspec/specs/schema-driven-read-coercion/spec.md
+++ b/openspec/specs/schema-driven-read-coercion/spec.md
@@ -1,0 +1,15 @@
+---
+status: in-progress
+---
+
+# Schema-Driven Read Coercion
+
+## Purpose
+Defines how OpenRegister coerces database column values to JSON-Schema-typed PHP values when reconstructing an `ObjectEntity` from a magic-table row. Establishes a single canonical converter (`SchemaTypeConverter`) that all read paths delegate to, eliminating the class of bugs where the schema declares one type but the API returns another — `boolean` properties arriving as `int 0`/`1` from MariaDB, or `string` properties whose values look like JSON literals being silently decoded back into the original primitive.
+
+**OpenSpec changes**
+- `fix-magic-table-type-coercion` (active) — introduces the `SchemaTypeConverter` service, refactors both `MagicStatisticsHandler::convertRowToObjectEntity` and `MagicSearchHandler::convertRowToObjectEntity` to delegate to it, and pins the contract with unit + integration tests.
+
+## Requirements
+
+_Requirements for this capability are introduced by the active change above and will be merged here on archive._

--- a/tests/Unit/Db/MagicSearchHandlerTest.php
+++ b/tests/Unit/Db/MagicSearchHandlerTest.php
@@ -8,6 +8,7 @@ use OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler;
 use OCA\OpenRegister\Db\MagicMapper\MagicRbacHandler;
 use OCA\OpenRegister\Db\MagicMapper\MagicSearchHandler;
 use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Service\Object\SchemaTypeConverter;
 use OCP\IDBConnection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -44,16 +45,17 @@ class MagicSearchHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->db                  = $this->createMock(IDBConnection::class);
-        $this->logger              = $this->createMock(LoggerInterface::class);
-        $this->rbacHandler         = $this->createMock(MagicRbacHandler::class);
+        $this->db          = $this->createMock(IDBConnection::class);
+        $this->logger      = $this->createMock(LoggerInterface::class);
+        $this->rbacHandler = $this->createMock(MagicRbacHandler::class);
         $this->organizationHandler = $this->createMock(MagicOrganizationHandler::class);
 
         $this->handler = new MagicSearchHandler(
             db: $this->db,
             logger: $this->logger,
             rbacHandler: $this->rbacHandler,
-            organizationHandler: $this->organizationHandler
+            organizationHandler: $this->organizationHandler,
+            schemaTypeConverter: new SchemaTypeConverter()
         );
     }//end setUp()
 
@@ -90,7 +92,6 @@ class MagicSearchHandlerTest extends TestCase
     // -------------------------------------------------------------------------
     // [gte] / [lte] — the original bug report
     // -------------------------------------------------------------------------
-
     public function testGteProducesGreaterThanOrEqualCondition(): void
     {
         $conditions = $this->invokeMethod(
@@ -131,7 +132,6 @@ class MagicSearchHandlerTest extends TestCase
     // -------------------------------------------------------------------------
     // [gt] / [lt]
     // -------------------------------------------------------------------------
-
     public function testGtProducesStrictGreaterThanCondition(): void
     {
         $conditions = $this->invokeMethod(
@@ -159,7 +159,6 @@ class MagicSearchHandlerTest extends TestCase
     // -------------------------------------------------------------------------
     // [in] as an operator key
     // -------------------------------------------------------------------------
-
     public function testInOperatorKeyProducesInClause(): void
     {
         $conditions = $this->invokeMethod(
@@ -187,7 +186,6 @@ class MagicSearchHandlerTest extends TestCase
     // -------------------------------------------------------------------------
     // Plain array values (backward compatibility — must still produce IN clause)
     // -------------------------------------------------------------------------
-
     public function testPlainArrayValueStillProducesInClause(): void
     {
         $conditions = $this->invokeMethod(
@@ -203,7 +201,6 @@ class MagicSearchHandlerTest extends TestCase
     // -------------------------------------------------------------------------
     // Simple scalar equality (unchanged behaviour)
     // -------------------------------------------------------------------------
-
     public function testScalarValueProducesEqualityCondition(): void
     {
         $conditions = $this->invokeMethod(
@@ -219,7 +216,6 @@ class MagicSearchHandlerTest extends TestCase
     // -------------------------------------------------------------------------
     // Unknown property must still produce the 1=0 guard condition
     // -------------------------------------------------------------------------
-
     public function testUnknownPropertyProducesImpossibleCondition(): void
     {
         $conditions = $this->invokeMethod(
@@ -231,5 +227,4 @@ class MagicSearchHandlerTest extends TestCase
         $this->assertCount(1, $conditions);
         $this->assertSame('1=0', $conditions[0]);
     }//end testUnknownPropertyProducesImpossibleCondition()
-
 }//end class

--- a/tests/Unit/Db/MagicStatisticsHandlerTest.php
+++ b/tests/Unit/Db/MagicStatisticsHandlerTest.php
@@ -10,6 +10,7 @@ use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\DateTimeNormalizer;
+use OCA\OpenRegister\Service\Object\SchemaTypeConverter;
 use OCP\IDBConnection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -39,8 +40,8 @@ class MagicStatisticsHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->db             = $this->createMock(IDBConnection::class);
-        $this->logger         = $this->createMock(LoggerInterface::class);
+        $this->db     = $this->createMock(IDBConnection::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
         $this->registerMapper = $this->createMock(RegisterMapper::class);
         $this->schemaMapper   = $this->createMock(SchemaMapper::class);
 
@@ -49,7 +50,8 @@ class MagicStatisticsHandlerTest extends TestCase
             logger: $this->logger,
             registerMapper: $this->registerMapper,
             schemaMapper: $this->schemaMapper,
-            dateTimeNormalizer: new DateTimeNormalizer($this->logger)
+            dateTimeNormalizer: new DateTimeNormalizer($this->logger),
+            schemaTypeConverter: new SchemaTypeConverter()
         );
     }//end setUp()
 
@@ -59,7 +61,7 @@ class MagicStatisticsHandlerTest extends TestCase
      * Entity::getId() is final on the framework base class, so mocking it
      * fails; using the concrete class keeps the test focused on the handler.
      */
-    private function makeRegister(int $id = 1): Register
+    private function makeRegister(int $id=1): Register
     {
         $register = new Register();
         $register->setId($id);
@@ -69,7 +71,7 @@ class MagicStatisticsHandlerTest extends TestCase
     /**
      * Build a real Schema with the given properties map and a fixed id.
      */
-    private function makeSchema(array $properties, int $id = 1): Schema
+    private function makeSchema(array $properties, int $id=1): Schema
     {
         $schema = new Schema();
         $schema->setId($id);
@@ -201,5 +203,4 @@ class MagicStatisticsHandlerTest extends TestCase
             'Whitespace-only stored date-time value must render as null'
         );
     }//end testWhitespaceOnlyDateTimePropertyRendersAsNull()
-
 }//end class

--- a/tests/Unit/Service/Object/SchemaTypeConverterTest.php
+++ b/tests/Unit/Service/Object/SchemaTypeConverterTest.php
@@ -1,0 +1,256 @@
+<?php
+
+/**
+ * SchemaTypeConverter Unit Test
+ *
+ * Pins the contract defined in
+ * openspec/specs/schema-driven-read-coercion/spec.md.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Object;
+
+use OCA\OpenRegister\Service\Object\SchemaTypeConverter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for SchemaTypeConverter.
+ *
+ * Each test method maps to a scenario in the schema-driven-read-coercion spec.
+ */
+class SchemaTypeConverterTest extends TestCase
+{
+
+    private SchemaTypeConverter $converter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->converter = new SchemaTypeConverter();
+    }//end setUp()
+
+    /*
+        ====================================================================
+     * String
+     * ==================================================================== */
+
+    /**
+     * @dataProvider stringCoercionProvider
+     */
+    public function testStringCoercion(mixed $input, mixed $expected, string $message): void
+    {
+        $this->assertSame($expected, $this->converter->convertValue($input, 'string'), $message);
+    }//end testStringCoercion()
+
+    public static function stringCoercionProvider(): array
+    {
+        return [
+            'numeric string passes through'           => ['45', '45', "string '45' must stay '45'"],
+            'integer DB value coerces to string'      => [45, '45', 'int 45 must coerce to string "45"'],
+            'float DB value coerces to string'        => [4.5, '4.5', 'float 4.5 must coerce to string "4.5"'],
+            'boolean-literal "true" stays string'     => ['true', 'true', '"true" must NOT decode to bool'],
+            'boolean-literal "false" stays string'    => ['false', 'false', '"false" must NOT decode to bool'],
+            'null-literal "null" stays string'        => ['null', 'null', '"null" must NOT decode to PHP null'],
+            'numeric-shaped string stays string'      => ['123', '123', '"123" must NOT decode to int (regression of MagicStatisticsHandler bug)'],
+            'quoted-string JSON keeps its quotes'     => ['"foo"', '"foo"', 'escaped string must not be unwrapped'],
+            'array-shaped string DECODED for compat'  => ['[1,2,3]', [1, 2, 3], 'array-shaped string under string type decodes for legacy compat'],
+            'object-shaped string DECODED for compat' => ['{"k":"v"}', ['k' => 'v'], 'object-shaped string under string type decodes for legacy compat'],
+            'plain text passes through'               => ['hello', 'hello', 'plain text stays plain text'],
+        ];
+    }//end stringCoercionProvider()
+
+    /*
+        ====================================================================
+     * Boolean
+     * ==================================================================== */
+
+    /**
+     * @dataProvider booleanCoercionProvider
+     */
+    public function testBooleanCoercion(mixed $input, bool $expected, string $message): void
+    {
+        $this->assertSame($expected, $this->converter->convertValue($input, 'boolean'), $message);
+    }//end testBooleanCoercion()
+
+    public static function booleanCoercionProvider(): array
+    {
+        return [
+            'native true passes through'           => [true, true, 'PostgreSQL native true returns true'],
+            'native false passes through'          => [false, false, 'PostgreSQL native false returns false'],
+            'MariaDB int 1 coerces to true'        => [1, true, 'MariaDB TINYINT(1) value 1 must become true'],
+            'MariaDB int 0 coerces to false'       => [0, false, 'MariaDB TINYINT(1) value 0 must become false'],
+            'string "1" coerces to true'           => ['1', true, 'string "1" is truthy literal'],
+            'string "0" coerces to false'          => ['0', false, 'string "0" is not in the truthy set'],
+            'string "true" coerces to true'        => ['true', true, 'string "true" is truthy literal'],
+            'string "TRUE" (upper) is truthy'      => ['TRUE', true, 'truthy match is case-insensitive'],
+            'string "yes" coerces to true'         => ['yes', true, 'string "yes" is truthy literal'],
+            'string "no" coerces to false'         => ['no', false, 'string "no" is not truthy'],
+            'random string coerces to false'       => ['random string', false, 'unknown string is falsy'],
+            'empty string coerces to false'        => ['', false, 'empty string is not in truthy set'],
+            'string "on" is FALSE (per design D7)' => ['on', false, "HTML form 'on' is intentionally NOT truthy — see design D7"],
+            'float 0.0 coerces to false'           => [0.0, false, '0.0 is falsy via (bool) cast'],
+            'float 1.5 coerces to true'            => [1.5, true, '1.5 is truthy via (bool) cast'],
+        ];
+    }//end booleanCoercionProvider()
+
+    /*
+        ====================================================================
+     * Integer
+     * ==================================================================== */
+
+    /**
+     * @dataProvider integerCoercionProvider
+     */
+    public function testIntegerCoercion(mixed $input, mixed $expected, string $message): void
+    {
+        $this->assertSame($expected, $this->converter->convertValue($input, 'integer'), $message);
+    }//end testIntegerCoercion()
+
+    public static function integerCoercionProvider(): array
+    {
+        return [
+            'numeric string coerces to int' => ['42', 42, 'string "42" must become int 42'],
+            'integer passes through'        => [42, 42, 'int 42 stays 42'],
+            'float string truncates to int' => ['42.7', 42, 'is_numeric "42.7" truncates via (int) cast'],
+            'non-numeric stays unchanged'   => ['not a number', 'not a number', 'non-numeric input passes through for downstream validation'],
+        ];
+    }//end integerCoercionProvider()
+
+    /*
+        ====================================================================
+     * Number
+     * ==================================================================== */
+
+    /**
+     * @dataProvider numberCoercionProvider
+     */
+    public function testNumberCoercion(mixed $input, mixed $expected, string $message): void
+    {
+        $this->assertSame($expected, $this->converter->convertValue($input, 'number'), $message);
+    }//end testNumberCoercion()
+
+    public static function numberCoercionProvider(): array
+    {
+        return [
+            'integer DB value coerces to float' => [7, 7.0, 'int 7 must become float 7.0'],
+            'decimal string coerces to float'   => ['3.14', 3.14, 'string "3.14" must become float 3.14'],
+            'integer string coerces to float'   => ['7', 7.0, 'string "7" must become float 7.0'],
+            'non-numeric stays unchanged'       => ['not a number', 'not a number', 'non-numeric input passes through for downstream validation'],
+        ];
+    }//end numberCoercionProvider()
+
+    /*
+        ====================================================================
+     * Array / Object
+     * ==================================================================== */
+
+    /**
+     * @dataProvider arrayCoercionProvider
+     */
+    public function testArrayCoercion(mixed $input, mixed $expected, string $message): void
+    {
+        $this->assertSame($expected, $this->converter->convertValue($input, 'array'), $message);
+    }//end testArrayCoercion()
+
+    /**
+     * @dataProvider arrayCoercionProvider
+     */
+    public function testObjectCoercion(mixed $input, mixed $expected, string $message): void
+    {
+        // Object schema type behaves identically to array per design and existing helper.
+        $this->assertSame($expected, $this->converter->convertValue($input, 'object'), $message);
+    }//end testObjectCoercion()
+
+    public static function arrayCoercionProvider(): array
+    {
+        return [
+            'JSON-string array decodes'                 => ['[1,2,3]', [1, 2, 3], 'JSON-string array column decodes'],
+            'JSON-string object decodes'                => ['{"a":1}', ['a' => 1], 'JSON-string object column decodes'],
+            'already-array passes through'              => [['k' => 'v'], ['k' => 'v'], 'pre-decoded array passes through'],
+            'already-list passes through'               => [[1, 2, 3], [1, 2, 3], 'pre-decoded list passes through'],
+            'invalid JSON returns string for validator' => ['not json', 'not json', 'failing decode returns original string'],
+        ];
+    }//end arrayCoercionProvider()
+
+    /*
+        ====================================================================
+     * Null
+     * ==================================================================== */
+
+    /**
+     * @dataProvider nullPreservationProvider
+     */
+    public function testNullPreserved(string $schemaType): void
+    {
+        $this->assertNull(
+            $this->converter->convertValue(null, $schemaType),
+            "null must be preserved for schema type '$schemaType'"
+        );
+    }//end testNullPreserved()
+
+    public static function nullPreservationProvider(): array
+    {
+        return [
+            'string'  => ['string'],
+            'boolean' => ['boolean'],
+            'integer' => ['integer'],
+            'number'  => ['number'],
+            'array'   => ['array'],
+            'object'  => ['object'],
+            'mystery' => ['mystery'],
+        ];
+    }//end nullPreservationProvider()
+
+    /*
+        ====================================================================
+     * Unknown schema type — falls through with string semantics
+     * ==================================================================== */
+
+    public function testUnknownSchemaTypePassesPlainStringThrough(): void
+    {
+        $this->assertSame(
+            'hello',
+            $this->converter->convertValue('hello', 'mystery'),
+            'unknown type defaults to string semantics: passes plain text through'
+        );
+    }//end testUnknownSchemaTypePassesPlainStringThrough()
+
+    public function testUnknownSchemaTypeDecodesArrayShapedStringForCompat(): void
+    {
+        $this->assertSame(
+            [1],
+            $this->converter->convertValue('[1]', 'mystery'),
+            "unknown type defaults to string semantics: decodes array-shaped strings for backward compat"
+        );
+    }//end testUnknownSchemaTypeDecodesArrayShapedStringForCompat()
+
+    public function testUnknownSchemaTypeCastsNumericInputToString(): void
+    {
+        $this->assertSame(
+            '7',
+            $this->converter->convertValue(7, 'mystery'),
+            'unknown type defaults to string semantics: int → string'
+        );
+    }//end testUnknownSchemaTypeCastsNumericInputToString()
+
+    /*
+        ====================================================================
+     * Empty schema type — same fallback as unknown
+     * ==================================================================== */
+
+    public function testEmptySchemaTypeUsesStringFallback(): void
+    {
+        $this->assertSame('hello', $this->converter->convertValue('hello', ''));
+        $this->assertSame('5', $this->converter->convertValue(5, ''));
+    }//end testEmptySchemaTypeUsesStringFallback()
+}//end class


### PR DESCRIPTION
## Summary

Fixes the read-side type drift where API responses for OpenRegister and OpenConnector returned object-property values whose runtime PHP type didn't match the JSON-Schema-declared property type:

- A `boolean`-typed property came back as `int 0`/`1` (MariaDB TINYINT(1) → mysqlnd).
- A `string`-typed property whose value looked like a JSON literal (`"123"`, `"true"`, `"null"`, `'"foo"'`) was silently re-decoded back into the original primitive — string-cast undone by an over-eager `is_string && isJsonString` decode block in `MagicStatisticsHandler::convertRowToObjectEntity`.

Both magic-table read paths now delegate to a single shared converter.

Closes #1366.

## Endpoint coverage

Every endpoint that reconstructs an `ObjectEntity` from a magic-table row goes through the unified converter:

| Endpoint | Reads `ObjectEntity` via | Affected |
| --- | --- | :-: |
| `GET /api/objects/<uuid>` | `MagicStatisticsHandler::convertRowToObjectEntity` | ✓ |
| `GET /api/objects` (list) | `MagicStatisticsHandler::convertRowToObjectEntity` | ✓ |
| `GET /api/search` | `MagicSearchHandler::convertRowToObjectEntity` | ✓ (refactored to share converter) |
| `POST /api/objects` | re-fetch via `MagicStatisticsHandler` | ✓ |
| `PUT /api/objects/<uuid>` | re-fetch via `MagicStatisticsHandler` | ✓ |

POST/PUT responses build their bodies by re-fetching through `findInRegisterSchemaTable` (see comment in `MagicMapper::insertObjectEntity`: "CRITICAL FIX: Re-fetch the inserted object from database to get complete metadata"). That re-fetch goes through the same converter, so create/update responses are now type-consistent with reads.

## What changed

- **New** `lib/Service/Object/SchemaTypeConverter.php` — stateless service with a single public `convertValue(value, schemaType)`. Zero deps, auto-wired.
- `lib/Db/MagicMapper/MagicStatisticsHandler.php` — replaces the partial coercion + over-eager JSON-decode block with one converter call. `DateTimeNormalizer` format handling stays where it is (per design D5). Unused `isJsonString` helper removed.
- `lib/Db/MagicMapper/MagicSearchHandler.php` — replaces the inline `convertValueByType` call with a delegated converter call. Six private converter methods deleted (single source of truth from day one — per design D8).
- `lib/Db/MagicMapper.php` — handler instantiation updated to inject the converter via the app container.
- **New** `tests/Unit/Service/Object/SchemaTypeConverterTest.php` — 55 cases across 8 test methods covering every JSON-Schema primitive type and the regression suite.
- `tests/Unit/Db/MagicStatisticsHandlerTest.php` and `tests/Unit/Db/MagicSearchHandlerTest.php` — constructors updated for the new dependency.

## Out of scope (deferred to follow-up changes)

- Write-side coercion in `SaveObject` / `SaveObjects` / `MagicBulkHandler`.
- Requiring `minimum`/`maximum` on JSON Schema integer properties (`require-integer-bounds`).
- Schema editor UI changes.
- BIGINT migration of existing INTEGER columns.

## Spec / design artifacts

Full OpenSpec change under `openspec/changes/fix-magic-table-type-coercion/`:
- `proposal.md` — Why + What + Capabilities + Endpoint coverage matrix
- `design.md` — 8 decisions (incl. D7: reject `'on'`, D8: delete inline methods immediately) + risks + migration plan
- `specs/schema-driven-read-coercion/spec.md` — 9 ADDED requirements with WHEN/THEN scenarios
- `tasks.md` — implementation checklist (33/42 done before opening this PR; remaining are manual verification + release notes + archive)
- `plan.json` — tracking issue #1366

Long-lived spec stub: `openspec/specs/schema-driven-read-coercion/spec.md`.

## Test plan

- [x] `php -l` clean on all touched files.
- [x] PHPCS clean on `lib/` files (sniff scope per `phpcs.xml`).
- [x] PHPMD clean on touched `lib/` files (pre-existing complexity warnings on `applyObjectFilters` / `buildObjectFilterConditionsSql` are out of scope — methods I didn't touch).
- [x] `SchemaTypeConverterTest` — 55/55 unit tests pass.
- [x] Existing `MagicStatisticsHandlerTest` + `MagicSearchHandlerTest` — 14/14 pass with the new converter wired in.
- [x] Magic-mapper test suite (excluding the pre-existing-broken `tests/Unit/Service/MagicMapperTest.php` that fails with `ConditionMatcher` constructor mismatch unrelated to this PR) — 49/49 pass.
- [ ] Manual API verification: register/schema with one property of each primitive type; insert objects exercising the bug paths (numeric data in a string field, `0`/`1` in a boolean field, JSON-literal strings); call `GET /api/objects/<uuid>`, `GET /api/objects`, `POST /api/objects`, `PUT /api/objects/<uuid>`, `GET /api/search?q=…` and assert types in the JSON response.
- [ ] OpenConnector downstream spot-check: pull the same schema's data through OC's source proxy — confirm booleans now arrive as `true`/`false`.
- [ ] Release-notes entry.

## Heads-up for OpenConnector reviewers

Sync flows that previously received `0`/`1` for booleans will now receive native `bool`. Mapping templates that explicitly checked `=== 1` would break — Conduction-internal mappings have been audited (zero hits).

## Pre-existing issues NOT fixed by this PR

- `tests/Unit/Service/MagicMapperTest.php:224` — constructor missing `$conditionMatcher` arg, all 29 tests in that file fail. Stack trace lands at line 365 of `MagicMapper.php` (`MagicRbacHandler` instantiation), which I did not modify. Last touched by commit `44894ed42`. Worth a small follow-up fix.