### PR TITLE
feat(data-import-export): downloadable per-schema import template

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -395,6 +395,12 @@ return [
         // Registers
         ['name' => 'registers#export', 'url' => '/api/registers/{id}/export', 'verb' => 'GET', 'requirements' => ['id' => '[^/]+']],
         ['name' => 'registers#import', 'url' => '/api/registers/{id}/import', 'verb' => 'POST', 'requirements' => ['id' => '[^/]+']],
+        [
+            'name'         => 'registers#importTemplate',
+            'url'          => '/api/registers/{id}/schemas/{schema}/import-template',
+            'verb'         => 'GET',
+            'requirements' => ['id' => '[^/]+', 'schema' => '[^/]+'],
+        ],
         ['name' => 'registers#publishToGitHub', 'url' => '/api/registers/{id}/publish/github', 'verb' => 'POST', 'requirements' => ['id' => '[^/]+']],
         ['name' => 'registers#publish', 'url' => '/api/registers/{id}/publish', 'verb' => 'POST', 'requirements' => ['id' => '[^/]+']],
         ['name' => 'registers#depublish', 'url' => '/api/registers/{id}/depublish', 'verb' => 'POST', 'requirements' => ['id' => '[^/]+']],

--- a/lib/Controller/RegistersController.php
+++ b/lib/Controller/RegistersController.php
@@ -797,6 +797,77 @@ class RegistersController extends Controller
     }//end export()
 
     /**
+     * Download an empty import template for a schema
+     *
+     * Returns a spreadsheet (XLSX by default, CSV when `format=csv` is supplied)
+     * containing only the schema's header row, so users can fill it in and
+     * upload it via the existing import endpoint. The resulting file uses the
+     * same column layout that `ExportService::exportToExcel()` would emit, so a
+     * round-trip export/import keeps headers stable.
+     *
+     * @param int|string $id     The register slug or numeric id
+     * @param int|string $schema The schema slug or numeric id
+     *
+     * @return DataDownloadResponse|JSONResponse Spreadsheet on success, JSON error otherwise
+     *
+     * @NoAdminRequired
+     *
+     * @NoCSRFRequired
+     */
+    public function importTemplate(int|string $id, int|string $schema): JSONResponse|DataDownloadResponse
+    {
+        try {
+            $format = strtolower((string) $this->request->getParam(key: 'format', default: 'xlsx'));
+            if (in_array($format, ['xlsx', 'csv'], true) === false) {
+                return new JSONResponse(
+                    data: ['error' => 'Unsupported template format: '.$format.'. Supported formats: xlsx, csv.'],
+                    statusCode: 400
+                );
+            }
+
+            // RBAC is enforced inside both find() calls (default _rbac=true).
+            $register     = $this->registerMapper->find($id);
+            $schemaEntity = $this->schemaMapper->find($schema);
+
+            $schemaSlug  = $schemaEntity->getSlug() ?? 'schema';
+            $currentUser = $this->userSession->getUser();
+
+            if ($format === 'csv') {
+                $content  = $this->exportService->buildTemplateCsv(
+                    register: $register,
+                    schema: $schemaEntity,
+                    currentUser: $currentUser
+                );
+                $filename = sprintf('%s_template.csv', $schemaSlug);
+                return new DataDownloadResponse($content, $filename, 'text/csv');
+            }
+
+            $spreadsheet = $this->exportService->buildTemplateSpreadsheet(
+                register: $register,
+                schema: $schemaEntity,
+                currentUser: $currentUser
+            );
+            $writer      = new Xlsx($spreadsheet);
+            ob_start();
+            $writer->save('php://output');
+            $content  = ob_get_clean();
+            $filename = sprintf('%s_template.xlsx', $schemaSlug);
+            $mime     = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+            return new DataDownloadResponse($content, $filename, $mime);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(
+                data: ['error' => 'Register or schema not found: '.$e->getMessage()],
+                statusCode: 404
+            );
+        } catch (Exception $e) {
+            return new JSONResponse(
+                data: ['error' => 'Failed to generate import template: '.$e->getMessage()],
+                statusCode: 400
+            );
+        }//end try
+    }//end importTemplate()
+
+    /**
      * Publish register OAS specification to GitHub
      *
      * Exports the register as OpenAPI Specification and publishes it to a GitHub repository.

--- a/lib/Service/ExportService.php
+++ b/lib/Service/ExportService.php
@@ -239,6 +239,72 @@ class ExportService
     }//end exportToCsv()
 
     /**
+     * Build an empty import template spreadsheet for a schema
+     *
+     * Generates a spreadsheet that contains only the header row derived from the
+     * schema's properties (the same headers `exportToExcel` would emit), with no
+     * data rows. The returned spreadsheet can be written to either XLSX or CSV.
+     *
+     * @param Register|null $register    Optional register context (used for translation column expansion)
+     * @param Schema        $schema      Schema whose property keys become the header row
+     * @param IUser|null    $currentUser Current user (drives admin metadata column inclusion)
+     *
+     * @return Spreadsheet Spreadsheet with a single sheet containing only header cells
+     */
+    public function buildTemplateSpreadsheet(
+        ?Register $register,
+        Schema $schema,
+        ?IUser $currentUser=null
+    ): Spreadsheet {
+        // Capture register context so getHeaders can emit per-language
+        // `field_lang` columns for translatable properties.
+        $this->contextRegister = $register;
+
+        $spreadsheet = new Spreadsheet();
+        $spreadsheet->removeSheetByIndex(0);
+        $sheet = $spreadsheet->createSheet();
+        $sheet->setTitle($schema->getSlug() ?? 'data');
+
+        $headers = $this->getHeaders(schema: $schema, currentUser: $currentUser);
+        foreach ($headers as $col => $header) {
+            $sheet->setCellValue(coordinate: $col.'1', value: $header);
+        }
+
+        return $spreadsheet;
+    }//end buildTemplateSpreadsheet()
+
+    /**
+     * Render an empty CSV import template for a schema
+     *
+     * Emits a UTF-8 BOM-prefixed CSV string containing only the header row
+     * derived from the schema's properties. Mirrors the BOM convention used
+     * by the export pipeline so Excel opens the file with the correct encoding.
+     *
+     * @param Register|null $register    Optional register context
+     * @param Schema        $schema      Schema whose property keys become the header row
+     * @param IUser|null    $currentUser Current user (drives admin metadata column inclusion)
+     *
+     * @return string CSV content with a UTF-8 BOM prefix and a single header row
+     */
+    public function buildTemplateCsv(
+        ?Register $register,
+        Schema $schema,
+        ?IUser $currentUser=null
+    ): string {
+        $spreadsheet = $this->buildTemplateSpreadsheet(
+            register: $register,
+            schema: $schema,
+            currentUser: $currentUser
+        );
+        $writer      = new Csv($spreadsheet);
+        $writer->setUseBOM(true);
+
+        ob_start();
+        $writer->save('php://output');
+        return ob_get_clean();
+    }//end buildTemplateCsv()
+
+    /**
      * Populate a worksheet with data
      *
      * Uses a two-pass approach for optimal UUID-to-name resolution:

--- a/openspec/changes/data-import-export/tasks.md
+++ b/openspec/changes/data-import-export/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: Data Import and Export
 
-> **Status (Phase 2):** OpenRegister already ships a full Excel + CSV import/export pipeline (`ImportService` + `ExportService`) plus a configuration-level JSON portability path (`ConfigurationService::importFromJson` / `exportConfig`). Phase 2 is a documentation-vs-implementation sync — every Excel/CSV/JSON requirement has shipped code with file:line evidence. The XML / ODS formats, structured rollback, downloadable templates, and full streaming progress endpoint remain genuinely open. **8 of 12 tasks tickably complete.**
+> **Status (Phase 2):** OpenRegister already ships a full Excel + CSV import/export pipeline (`ImportService` + `ExportService`) plus a configuration-level JSON portability path (`ConfigurationService::importFromJson` / `exportConfig`). Phase 2 is a documentation-vs-implementation sync — every Excel/CSV/JSON requirement has shipped code with file:line evidence. Downloadable per-schema import templates ship via `RegistersController::importTemplate`. The XML / ODS formats, structured rollback, downloadable error files, and full streaming progress endpoint remain genuinely open. **9 of 12 tasks tickably complete.**
 
 ## Implemented
 
@@ -20,6 +20,8 @@
 
 - [x] **Configuration import/export MUST support full register portability.** [`ConfigurationService::exportConfig`](../../../lib/Service/ConfigurationService.php) emits a full JSON bundle (registers + schemas + optional objects); `ConfigurationService::importFromJson` is the inverse. The Configuration `ImportHandler` / `ExportHandler` ([`lib/Service/Configuration/`](../../../lib/Service/Configuration/)) handle GitHub / GitLab repository-backed register portability.
 
+- [x] **Import templates MUST be downloadable per schema.** [`RegistersController::importTemplate`](../../../lib/Controller/RegistersController.php) serves `GET /api/registers/{id}/schemas/{schema}/import-template?format={xlsx|csv}` and returns an empty spreadsheet whose header row is built by [`ExportService::buildTemplateSpreadsheet`](../../../lib/Service/ExportService.php) / [`buildTemplateCsv`](../../../lib/Service/ExportService.php) — so the file mirrors the export column layout (RBAC-aware, translation-aware, admin-metadata-aware) and round-trips through the existing import endpoint without header drift. CSV output is UTF-8 BOM prefixed for Excel compatibility; filename pattern is `{schema-slug}_template.{ext}`. RBAC is enforced by the underlying `RegisterMapper::find` / `SchemaMapper::find` calls (default `_rbac=true`).
+
 ## Open
 
 - [ ] **Import MUST provide detailed error reporting with downloadable error files.** Partial — `ImportService` returns a per-row error summary in the import result envelope, but a downloadable "errors.csv" artefact is not generated. **Open** — additive feature gated on a UX decision about format (CSV row-by-row vs JSON envelope).
@@ -27,8 +29,6 @@
 - [ ] **Import MUST support progress tracking for large datasets.** Partial — the chunked-batch architecture documented in the `ImportService` class docblock provides progress hooks (the import is processed in chunks with summary aggregation), but a streaming `Server-Sent Events` progress endpoint surface is not exposed. The frontend currently polls the import job status. **Open** — depends on the realtime-updates SSE work to ship first.
 
 - [ ] **Import MUST support rollback on critical failure.** Not implemented — partial imports leave persisted rows in place. A real implementation would need a transaction span across all chunked batches plus a compensation pass to undo materialised relation rows; both are non-trivial against the multi-table magic-mapper layout. **Open** — design phase.
-
-- [ ] **Import templates MUST be downloadable per schema.** Not implemented — there is no "download a blank XLSX with the schema's columns pre-headered" endpoint. **Open** — small additive controller method; could borrow `ExportService::getHeaders` and emit an empty spreadsheet.
 
 ## Test coverage
 

--- a/tests/Unit/Controller/RegistersControllerTest.php
+++ b/tests/Unit/Controller/RegistersControllerTest.php
@@ -22,6 +22,7 @@ use OCA\OpenRegister\Service\RegisterService;
 use OCA\OpenRegister\Service\UploadService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\DB\Exception as DBException;
 use OCP\IRequest;
@@ -93,7 +94,8 @@ class RegistersControllerTest extends TestCase
             $this->githubService,
             $this->appManager,
             $this->oasService,
-            $this->createMock(\Psr\Container\ContainerInterface::class)
+            $this->createMock(\Psr\Container\ContainerInterface::class),
+            $this->createMock(\OCP\IGroupManager::class)
         );
     }
 
@@ -1823,6 +1825,106 @@ class RegistersControllerTest extends TestCase
         $result = $this->controller->export(1);
 
         // json_encode returns false for INF, triggering the exception catch
+        $this->assertInstanceOf(JSONResponse::class, $result);
+        $this->assertSame(400, $result->getStatus());
+    }
+
+    public function testImportTemplateReturnsXlsxByDefault(): void
+    {
+        $register = $this->createRealRegister(1, 'Test');
+        $register->setSlug('test-register');
+        $schema = $this->createRealSchema(5, 'Meldingen');
+        $schema->setSlug('meldingen');
+
+        $this->request->method('getParam')->willReturnMap([
+            ['format', 'xlsx', 'xlsx'],
+        ]);
+        $this->registerMapper->method('find')->with(1)->willReturn($register);
+        $this->schemaMapper->method('find')->with(5)->willReturn($schema);
+
+        $spreadsheet = new \PhpOffice\PhpSpreadsheet\Spreadsheet();
+        $this->exportService
+            ->expects($this->once())
+            ->method('buildTemplateSpreadsheet')
+            ->willReturn($spreadsheet);
+
+        $result = $this->controller->importTemplate(1, 5);
+
+        $this->assertInstanceOf(DataDownloadResponse::class, $result);
+        // DataDownloadResponse exposes the filename via getHeaders()['Content-Disposition'].
+        $headers = $result->getHeaders();
+        $this->assertArrayHasKey('Content-Disposition', $headers);
+        $this->assertStringContainsString('meldingen_template.xlsx', $headers['Content-Disposition']);
+    }
+
+    public function testImportTemplateReturnsCsvWhenRequested(): void
+    {
+        $register = $this->createRealRegister(1, 'Test');
+        $schema = $this->createRealSchema(5, 'Meldingen');
+        $schema->setSlug('meldingen');
+
+        $this->request->method('getParam')->willReturnMap([
+            ['format', 'xlsx', 'csv'],
+        ]);
+        $this->registerMapper->method('find')->willReturn($register);
+        $this->schemaMapper->method('find')->willReturn($schema);
+
+        $this->exportService
+            ->expects($this->once())
+            ->method('buildTemplateCsv')
+            ->willReturn("\xEF\xBB\xBFid,titel\n");
+
+        $result = $this->controller->importTemplate(1, 5);
+
+        $this->assertInstanceOf(DataDownloadResponse::class, $result);
+        $headers = $result->getHeaders();
+        $this->assertStringContainsString('meldingen_template.csv', $headers['Content-Disposition']);
+    }
+
+    public function testImportTemplateReturns400OnUnsupportedFormat(): void
+    {
+        $this->request->method('getParam')->willReturnMap([
+            ['format', 'xlsx', 'pdf'],
+        ]);
+
+        $result = $this->controller->importTemplate(1, 5);
+
+        $this->assertInstanceOf(JSONResponse::class, $result);
+        $this->assertSame(400, $result->getStatus());
+        $this->assertStringContainsString('Unsupported template format', $result->getData()['error']);
+    }
+
+    public function testImportTemplateReturns404WhenRegisterNotFound(): void
+    {
+        $this->request->method('getParam')->willReturnMap([
+            ['format', 'xlsx', 'xlsx'],
+        ]);
+        $this->registerMapper->method('find')
+            ->willThrowException(new DoesNotExistException('Register not found'));
+
+        $result = $this->controller->importTemplate(999, 5);
+
+        $this->assertInstanceOf(JSONResponse::class, $result);
+        $this->assertSame(404, $result->getStatus());
+    }
+
+    public function testImportTemplateReturns400OnGenericException(): void
+    {
+        $register = $this->createRealRegister(1, 'Test');
+        $schema = $this->createRealSchema(5, 'Meldingen');
+
+        $this->request->method('getParam')->willReturnMap([
+            ['format', 'xlsx', 'xlsx'],
+        ]);
+        $this->registerMapper->method('find')->willReturn($register);
+        $this->schemaMapper->method('find')->willReturn($schema);
+
+        $this->exportService
+            ->method('buildTemplateSpreadsheet')
+            ->willThrowException(new Exception('Boom'));
+
+        $result = $this->controller->importTemplate(1, 5);
+
         $this->assertInstanceOf(JSONResponse::class, $result);
         $this->assertSame(400, $result->getStatus());
     }


### PR DESCRIPTION
## Summary

Closes one of the 4 remaining open items on the `data-import-export` OpenSpec change: **Import templates MUST be downloadable per schema**.

- New endpoint: `GET /api/registers/{id}/schemas/{schema}/import-template?format={xlsx|csv}`
- Returns an empty spreadsheet with the schema's columns pre-headered using the same `getHeaders` logic the existing exports rely on, so a round-trip through the import endpoint keeps headers stable.
- New `ExportService::buildTemplateSpreadsheet` / `buildTemplateCsv` helpers — RBAC-aware, translation-aware (`field_lang` columns expanded), admin-metadata-aware (`@self.*` columns only for admins).
- CSV output is UTF-8 BOM-prefixed (matches the existing CSV export convention).
- Filename pattern: `{schema-slug}_template.{ext}`.
- RBAC enforced via the default `_rbac=true` on `RegisterMapper::find` / `SchemaMapper::find`.

## Test plan

- [x] 5 new unit tests on `RegistersControllerTest`: xlsx default, csv branch, unsupported format -> 400, register-not-found -> 404, generic exception -> 400.
- [x] Backfilled the missing 18th constructor argument (`IGroupManager`) on the test's `setUp` so all 92 RegistersController unit tests run green again (they had been broken since the `IGroupManager` injection landed).
- [x] PHPCS clean on every touched production file (no new violations).
- [ ] Manual verification: download a CSV template and re-upload it via the existing import endpoint to confirm headers round-trip.

## Spec status

`openspec/changes/data-import-export/tasks.md` updated: this item moves to `Implemented`, status banner now reads **9 of 12 tasks tickably complete**. Three items remain genuinely open and are out of scope for this PR:

- Import MUST provide detailed error reporting with downloadable error files.
- Import MUST support progress tracking (SSE) for large datasets.
- Import MUST support rollback on critical failure.

The spec change is intentionally **not archived** — those three items still need to ship.