### PR TITLE
feat(notificatie-engine): per-rule per-recipient token-bucket rate limiter

### DIFF
--- a/lib/Service/Notification/AnnotationNotificationDispatcher.php
+++ b/lib/Service/Notification/AnnotationNotificationDispatcher.php
@@ -49,7 +49,8 @@ class AnnotationNotificationDispatcher
         private readonly IUserManager $userManager,
         private readonly IMailer $mailer,
         private readonly IActivityManager $activityManager,
-        private readonly IClientService $httpClient
+        private readonly IClientService $httpClient,
+        private readonly ?RateLimiter $rateLimiter=null
     ) {}//end __construct()
 
     /**
@@ -90,26 +91,41 @@ class AnnotationNotificationDispatcher
             $rendered = $this->interpolate($subject, $data, $context);
             $channels = (array) ($spec['channels'] ?? ['nc-notification']);
 
+            $rateLimit = is_array($spec['rateLimit'] ?? null) === true ? $spec['rateLimit'] : null;
+            $ruleId    = (string) $name;
+
             // Webhook is fired once per dispatch, not once per recipient,
             // and includes the recipient list in the payload.
             if (in_array('webhook', $channels, true) === true) {
-                $this->emitWebhook(
-                    spec: $spec,
-                    object: $object,
-                    notificationName: (string) $name,
-                    subject: $rendered,
-                    recipients: $recipients,
-                    context: $context
-                );
+                $allowed = $this->rateLimitAllows(ruleId: $ruleId, recipient: '__webhook__', rateLimit: $rateLimit);
+                if ($allowed === true) {
+                    $this->emitWebhook(
+                        spec: $spec,
+                        object: $object,
+                        notificationName: (string) $name,
+                        subject: $rendered,
+                        recipients: $recipients,
+                        context: $context
+                    );
+                }
             }
 
             // Talk channel is fired once per dispatch (chat message goes
             // to the configured Talk room, recipients aren't @-mentioned).
             if (in_array('talk', $channels, true) === true) {
-                $this->emitTalk(spec: $spec, message: $rendered);
+                $allowed = $this->rateLimitAllows(ruleId: $ruleId, recipient: '__talk__', rateLimit: $rateLimit);
+                if ($allowed === true) {
+                    $this->emitTalk(spec: $spec, message: $rendered);
+                }
             }
 
             foreach ($recipients as $uid) {
+                // Per-recipient rate limit gates every channel for this uid.
+                $allowed = $this->rateLimitAllows(ruleId: $ruleId, recipient: $uid, rateLimit: $rateLimit);
+                if ($allowed === false) {
+                    continue;
+                }
+
                 if (in_array('nc-notification', $channels, true) === true) {
                     $this->emitNotification(
                         uid: $uid,
@@ -119,6 +135,7 @@ class AnnotationNotificationDispatcher
                         parameters: $context
                     );
                 }
+
                 if (in_array('email', $channels, true) === true) {
                     $this->emitEmail(
                         uid: $uid,
@@ -126,6 +143,7 @@ class AnnotationNotificationDispatcher
                         body: $rendered
                     );
                 }
+
                 if (in_array('activity', $channels, true) === true) {
                     $this->emitActivity(
                         uid: $uid,
@@ -136,7 +154,31 @@ class AnnotationNotificationDispatcher
                 }
             }
         }
+
     }//end dispatch()
+
+    /**
+     * Apply the (optional) rate limiter. Returns true when the
+     * dispatch may proceed. A null limiter (test contexts where the
+     * dependency wasn't injected) always allows — keeps existing
+     * tests passing without forcing every test to construct a
+     * RateLimiter.
+     *
+     * @param string                    $ruleId    Rule identifier (notification annotation key).
+     * @param string                    $recipient Recipient identifier.
+     * @param array<string, mixed>|null $rateLimit Per-rule override block.
+     *
+     * @return bool True when the dispatch may proceed.
+     */
+    private function rateLimitAllows(string $ruleId, string $recipient, ?array $rateLimit): bool
+    {
+        if ($this->rateLimiter === null) {
+            return true;
+        }
+
+        return $this->rateLimiter->tryConsume(ruleId: $ruleId, recipient: $recipient, perRuleOverride: $rateLimit);
+
+    }//end rateLimitAllows()
 
     /**
      * POST a JSON payload to the configured webhook URL.

--- a/lib/Service/Notification/RateLimiter.php
+++ b/lib/Service/Notification/RateLimiter.php
@@ -1,0 +1,323 @@
+<?php
+
+/**
+ * OpenRegister Notification RateLimiter
+ *
+ * Token-bucket rate limiter for notification dispatches, keyed on
+ * (rule, recipient). Backed by the distributed cache (APCu in dev,
+ * Redis in cluster). Per-bucket state is a `[tokens, lastRefill]`
+ * tuple; tokens refill at a configurable rate up to the bucket
+ * size. When a token isn't available the dispatch is dropped and
+ * logged at info level — operators who care can grep for it.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Notification
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Notification;
+
+use OCP\IAppConfig;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Per-(rule, recipient) token-bucket rate limiter.
+ *
+ * Defaults: bucket size 10, refill 1 token per 60s. Both can be
+ * overridden globally via app-config and per-rule via the
+ * `rateLimit` block on the notification spec. The whole limiter
+ * can be killed via `notification_rate_limit_enabled = false`.
+ */
+class RateLimiter
+{
+
+    /**
+     * Cache TTL for bucket state (24h). Stale entries get evicted
+     * naturally; we never need to keep history past that.
+     */
+    public const STATE_TTL = 86400;
+
+    public const APP_ID = 'openregister';
+
+    public const CONFIG_ENABLED = 'notification_rate_limit_enabled';
+
+    public const CONFIG_DEFAULT_BUCKET_SIZE = 'notification_rate_limit_default_bucket_size';
+
+    public const CONFIG_DEFAULT_REFILL_SECONDS = 'notification_rate_limit_default_refill_seconds';
+
+    public const DEFAULT_BUCKET_SIZE = 10;
+
+    public const DEFAULT_REFILL_SECONDS = 60;
+
+    /**
+     * Distributed cache used to keep bucket state across requests
+     * and (with Redis) across nodes. Null when no cache backend is
+     * available — in that case the limiter fails open and never
+     * drops dispatches.
+     *
+     * @var ICache|null
+     */
+    private ?ICache $cache = null;
+
+    /**
+     * Time provider — callable returning a unix timestamp in
+     * seconds. Constructor-injectable so tests can advance time
+     * without sleep().
+     *
+     * @var callable():int
+     */
+    private $timeProvider;
+
+    /**
+     * Constructor.
+     *
+     * @param ICacheFactory   $cacheFactory Distributed cache factory.
+     * @param IAppConfig      $appConfig    App-config reader for kill switch + defaults.
+     * @param LoggerInterface $logger       Logger for dropped-dispatch info events.
+     * @param callable|null   $timeProvider Optional time source (defaults to time()).
+     */
+    public function __construct(
+        ICacheFactory $cacheFactory,
+        private readonly IAppConfig $appConfig,
+        private readonly LoggerInterface $logger,
+        ?callable $timeProvider=null
+    ) {
+        try {
+            $this->cache = $cacheFactory->createDistributed('openregister_notification_rate_limit');
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                sprintf('[NotificationRateLimiter] cache backend unavailable: %s', $e->getMessage())
+            );
+            $this->cache = null;
+        }//end try
+
+        $this->timeProvider = ($timeProvider ?? static fn(): int => time());
+
+    }//end __construct()
+
+    /**
+     * Try to consume one token for the given (rule, recipient).
+     *
+     * Returns true when the dispatch may proceed. Returns false when
+     * the bucket is empty — the caller MUST then skip the dispatch.
+     * Logs an info-level entry on drop so operators can grep
+     * "[NotificationRateLimiter] dropped".
+     *
+     * Fails open: when the limiter is disabled, the cache is
+     * unavailable, or a state read fails — return true so a broken
+     * limiter never blocks legitimate notifications.
+     *
+     * @param string                    $ruleId          Stable rule identifier (annotation key).
+     * @param string                    $recipient       Recipient ID (uid, group id, webhook URL hash, etc.).
+     * @param array<string, mixed>|null $perRuleOverride Optional `rateLimit` block from the rule spec.
+     *
+     * @return bool True when the dispatch may proceed.
+     */
+    public function tryConsume(string $ruleId, string $recipient, ?array $perRuleOverride=null): bool
+    {
+        if ($this->isEnabled() === false) {
+            return true;
+        }
+
+        if ($this->cache === null) {
+            return true;
+        }
+
+        if ($ruleId === '' || $recipient === '') {
+            // Defensive: a rule without an id can't be rate-limited
+            // in a stable way. Fail open rather than silently grouping
+            // unrelated rules under the empty-string key.
+            return true;
+        }
+
+        [$bucketSize, $refillSeconds] = $this->resolveLimits(perRuleOverride: $perRuleOverride);
+
+        $key = $this->key(ruleId: $ruleId, recipient: $recipient);
+        $now = ($this->timeProvider)();
+
+        try {
+            $state = $this->cache->get($key);
+        } catch (\Throwable $e) {
+            return true;
+        }//end try
+
+        if (is_string($state) === true) {
+            $decoded = json_decode($state, true);
+            if (is_array($decoded) === true && isset($decoded['tokens'], $decoded['lastRefill']) === true) {
+                $tokens     = (float) $decoded['tokens'];
+                $lastRefill = (int) $decoded['lastRefill'];
+            } else {
+                $tokens     = (float) $bucketSize;
+                $lastRefill = $now;
+            }
+        } else {
+            $tokens     = (float) $bucketSize;
+            $lastRefill = $now;
+        }
+
+        // Refill: one token every $refillSeconds. Cap at bucket size.
+        if ($refillSeconds > 0 && $now > $lastRefill) {
+            $elapsed = ($now - $lastRefill);
+            $earned  = ($elapsed / $refillSeconds);
+            $tokens  = min((float) $bucketSize, ($tokens + $earned));
+        }
+
+        if ($tokens < 1.0) {
+            $this->logger->info(
+                sprintf(
+                    '[NotificationRateLimiter] dropped rule="%s" recipient="%s" bucket=%d refillSeconds=%d',
+                    $ruleId,
+                    $recipient,
+                    $bucketSize,
+                    $refillSeconds
+                )
+            );
+            // Persist the new lastRefill so partial earnings don't
+            // get lost on the next call.
+            $this->persist(key: $key, tokens: $tokens, lastRefill: $now);
+            return false;
+        }
+
+        $tokens -= 1.0;
+        $this->persist(key: $key, tokens: $tokens, lastRefill: $now);
+        return true;
+
+    }//end tryConsume()
+
+    /**
+     * Whether the limiter is enabled. Defaults to ON.
+     *
+     * @return bool True when the limiter should run.
+     */
+    private function isEnabled(): bool
+    {
+        try {
+            $value = $this->appConfig->getValueString(self::APP_ID, self::CONFIG_ENABLED, 'true');
+        } catch (\Throwable $e) {
+            return true;
+        }//end try
+
+        return ($value !== 'false' && $value !== '0');
+
+    }//end isEnabled()
+
+    /**
+     * Resolve effective (bucketSize, refillSeconds).
+     *
+     * Order: per-rule override > app-config default > class default.
+     *
+     * @param array<string, mixed>|null $perRuleOverride Per-rule rateLimit block.
+     *
+     * @return array{0:int,1:int} Tuple of (bucketSize, refillSeconds).
+     */
+    private function resolveLimits(?array $perRuleOverride): array
+    {
+        $bucketSize    = self::DEFAULT_BUCKET_SIZE;
+        $refillSeconds = self::DEFAULT_REFILL_SECONDS;
+
+        try {
+            $configuredBucket = (int) $this->appConfig->getValueInt(
+                self::APP_ID,
+                self::CONFIG_DEFAULT_BUCKET_SIZE,
+                self::DEFAULT_BUCKET_SIZE
+            );
+            if ($configuredBucket > 0) {
+                $bucketSize = $configuredBucket;
+            }
+
+            $configuredRefill = (int) $this->appConfig->getValueInt(
+                self::APP_ID,
+                self::CONFIG_DEFAULT_REFILL_SECONDS,
+                self::DEFAULT_REFILL_SECONDS
+            );
+            if ($configuredRefill > 0) {
+                $refillSeconds = $configuredRefill;
+            }
+        } catch (\Throwable $e) {
+            // Fall through with class defaults.
+        }//end try
+
+        if (is_array($perRuleOverride) === true) {
+            $rb = ($perRuleOverride['bucketSize'] ?? null);
+            if (is_int($rb) === true && $rb > 0) {
+                $bucketSize = $rb;
+            } else if (is_string($rb) === true && ctype_digit($rb) === true && (int) $rb > 0) {
+                $bucketSize = (int) $rb;
+            }
+
+            $rr = ($perRuleOverride['refillSecondsPerToken'] ?? null);
+            if (is_int($rr) === true && $rr > 0) {
+                $refillSeconds = $rr;
+            } else if (is_string($rr) === true && ctype_digit($rr) === true && (int) $rr > 0) {
+                $refillSeconds = (int) $rr;
+            }
+        }
+
+        return [
+            $bucketSize,
+            $refillSeconds,
+        ];
+
+    }//end resolveLimits()
+
+    /**
+     * Build the cache key. Hashes rule + recipient so colons or
+     * special chars in either don't collide with the cache key
+     * separator.
+     *
+     * @param string $ruleId    Rule identifier.
+     * @param string $recipient Recipient identifier.
+     *
+     * @return string Cache key.
+     */
+    private function key(string $ruleId, string $recipient): string
+    {
+        return 'notification:rate:'.sha1($ruleId.'|'.$recipient);
+
+    }//end key()
+
+    /**
+     * Persist bucket state. Best-effort; cache write failures are
+     * swallowed so a transient cache hiccup never throws into the
+     * dispatch path.
+     *
+     * @param string $key        Cache key.
+     * @param float  $tokens     Current token count.
+     * @param int    $lastRefill Last refill timestamp.
+     *
+     * @return void
+     */
+    private function persist(string $key, float $tokens, int $lastRefill): void
+    {
+        if ($this->cache === null) {
+            return;
+        }
+
+        try {
+            $this->cache->set(
+                $key,
+                json_encode(
+                    [
+                        'tokens'     => $tokens,
+                        'lastRefill' => $lastRefill,
+                    ]
+                ),
+                self::STATE_TTL
+            );
+        } catch (\Throwable $e) {
+            // Don't escalate.
+        }//end try
+
+    }//end persist()
+}//end class

--- a/openspec/changes/notificatie-engine/tasks.md
+++ b/openspec/changes/notificatie-engine/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: Notificatie Engine
 
-> **Status:** This spec overlaps with `notifications-v2` (closed). The foundational notification rule engine is shipped; advanced delivery features (batching, digest, preferences, VNG API, history table, grouping, rate limiting, NL/EN i18n) are not. 5 of 14 tasks are tickably complete from the v2 implementation; the rest are explicit follow-ups.
+> **Status:** This spec overlaps with `notifications-v2` (closed). The foundational notification rule engine is shipped; advanced delivery features (batching/digest, preferences UI, VNG API, history table, grouping, read/unread, NL/EN i18n, org-pinning) are not. 6 of 14 tasks are tickably complete; 8 left open.
 
 ## Implemented (via notifications-v2)
 
@@ -32,7 +32,7 @@
 
 - [ ] **Read/unread tracking MUST be maintained per user per notification.** Nextcloud's INotificationManager handles this for the `nc-notification` channel — read/unread state is tracked in `oc_notifications`. Other channels (email, activity, webhook, talk) don't have a per-user-per-notification read state because they're fire-and-forget. **Open** — depends on whether read/unread for non-in-app channels is meaningful.
 
-- [ ] **Notification rate limiting MUST prevent abuse and system overload.** Not implemented — there's no per-recipient or per-rule rate limit. A misconfigured threshold rule that fires every second would happily flood the dispatcher. **Open** — rate-limit token bucket per (rule, recipient).
+- [x] **Notification rate limiting MUST prevent abuse and system overload.** `RateLimiter` (`lib/Service/Notification/RateLimiter.php`) implements a token-bucket rate limit per (rule, recipient) pair, backed by the distributed cache. Default bucket size 10, refill 1 token/60s; per-rule overrides via `rateLimit: {bucketSize, refillSecondsPerToken}` on the notification spec; operator overrides via app-config keys `notification_rate_limit_default_bucket_size` and `notification_rate_limit_default_refill_seconds`; kill switch `notification_rate_limit_enabled = false`. Drops are logged at info level. Wired into `AnnotationNotificationDispatcher` per recipient (and once per dispatch for one-shot webhook/talk channels). Verified by `tests/Unit/Service/Notification/RateLimiterTest` (8 tests covering bucket-drain, refill, per-(rule,recipient) isolation, kill switch, app-config defaults, fail-open paths, info-not-warning logging).
 
 ## Test coverage
 
@@ -43,3 +43,4 @@ The implemented portions are covered by the `notifications-v2` test suite:
 - `tests/Unit/Service/Notification/NotificationsAnnotationInstallerTest` — 8 tests covering webhook auto-create.
 - `tests/Unit/BackgroundJob/ScheduledNotificationJobTest` — 8 tests covering scheduled trigger evaluation.
 - `tests/Unit/Listener/AggregationThresholdListenerTest` — 5 tests covering threshold transition logic.
+- `tests/Unit/Service/Notification/RateLimiterTest` — 8 tests covering token-bucket drain/refill, per-(rule, recipient) isolation, kill switch, app-config defaults, fail-open behaviour on cache failure / empty inputs, and info-level (not warning) drop logging.

--- a/tests/Unit/Service/Notification/RateLimiterTest.php
+++ b/tests/Unit/Service/Notification/RateLimiterTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Service\Notification;
+
+use OCA\OpenRegister\Service\Notification\RateLimiter;
+use OCP\IAppConfig;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Verifies the token-bucket rate limiter behaviour. Time is mocked
+ * so the tests are deterministic — no sleep(), no timing flakes.
+ */
+class RateLimiterTest extends TestCase
+{
+    private IAppConfig&MockObject $appConfig;
+    private LoggerInterface&MockObject $logger;
+    private ICacheFactory&MockObject $cacheFactory;
+    private InMemoryCache $cache;
+    private int $now = 1000000;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->appConfig    = $this->createMock(IAppConfig::class);
+        $this->logger       = $this->createMock(LoggerInterface::class);
+        $this->cache        = new InMemoryCache();
+        $this->cacheFactory = $this->createMock(ICacheFactory::class);
+        $this->cacheFactory->method('createDistributed')->willReturn($this->cache);
+    }
+
+    public function testAllowsUpToBucketSizeThenDrops(): void
+    {
+        $this->appConfigDefaults();
+        $limiter = $this->makeLimiter();
+
+        // Bucket size is 10 (default). Override per-rule down to 3
+        // so the test doesn't have to spam 11 calls.
+        $override = ['bucketSize' => 3, 'refillSecondsPerToken' => 60];
+
+        $this->assertTrue($limiter->tryConsume('rule-a', 'alice', $override));
+        $this->assertTrue($limiter->tryConsume('rule-a', 'alice', $override));
+        $this->assertTrue($limiter->tryConsume('rule-a', 'alice', $override));
+        $this->assertFalse($limiter->tryConsume('rule-a', 'alice', $override));
+    }
+
+    public function testRefillsOneTokenAfterRefillInterval(): void
+    {
+        $this->appConfigDefaults();
+        $limiter = $this->makeLimiter();
+        $override = ['bucketSize' => 2, 'refillSecondsPerToken' => 60];
+
+        // Drain the bucket.
+        $this->assertTrue($limiter->tryConsume('rule-b', 'bob', $override));
+        $this->assertTrue($limiter->tryConsume('rule-b', 'bob', $override));
+        $this->assertFalse($limiter->tryConsume('rule-b', 'bob', $override));
+
+        // Advance time by exactly one refill interval — one token returns.
+        $this->now += 60;
+        $this->assertTrue($limiter->tryConsume('rule-b', 'bob', $override));
+        $this->assertFalse($limiter->tryConsume('rule-b', 'bob', $override));
+    }
+
+    public function testIsolatesPerRuleAndPerRecipient(): void
+    {
+        $this->appConfigDefaults();
+        $limiter = $this->makeLimiter();
+        $override = ['bucketSize' => 1, 'refillSecondsPerToken' => 3600];
+
+        // Drain alice's bucket on rule-a.
+        $this->assertTrue($limiter->tryConsume('rule-a', 'alice', $override));
+        $this->assertFalse($limiter->tryConsume('rule-a', 'alice', $override));
+
+        // Bob on the same rule still has a full bucket.
+        $this->assertTrue($limiter->tryConsume('rule-a', 'bob', $override));
+        // Alice on a different rule still has a full bucket.
+        $this->assertTrue($limiter->tryConsume('rule-b', 'alice', $override));
+    }
+
+    public function testKillSwitchAlwaysAllows(): void
+    {
+        $this->appConfig->method('getValueString')->willReturn('false');
+        $this->appConfig->method('getValueInt')->willReturnArgument(2);
+
+        $limiter = $this->makeLimiter();
+        // Even with bucket size 1, the kill switch should let every
+        // call through.
+        $override = ['bucketSize' => 1, 'refillSecondsPerToken' => 3600];
+        for ($i = 0; $i < 5; $i++) {
+            $this->assertTrue($limiter->tryConsume('rule-a', 'alice', $override));
+        }
+    }
+
+    public function testAppConfigDefaultsApply(): void
+    {
+        $this->appConfig->method('getValueString')
+            ->with('openregister', 'notification_rate_limit_enabled', 'true')
+            ->willReturn('true');
+        $this->appConfig->method('getValueInt')
+            ->willReturnCallback(static function (string $app, string $key, int $default): int {
+                if ($key === 'notification_rate_limit_default_bucket_size') {
+                    return 2;
+                }
+                if ($key === 'notification_rate_limit_default_refill_seconds') {
+                    return 30;
+                }
+                return $default;
+            });
+
+        $limiter = $this->makeLimiter();
+        // No per-rule override -> uses the operator's defaults: bucket=2.
+        $this->assertTrue($limiter->tryConsume('rule-c', 'carol'));
+        $this->assertTrue($limiter->tryConsume('rule-c', 'carol'));
+        $this->assertFalse($limiter->tryConsume('rule-c', 'carol'));
+
+        // Refill interval is 30s, so one token returns after 30s.
+        $this->now += 30;
+        $this->assertTrue($limiter->tryConsume('rule-c', 'carol'));
+    }
+
+    public function testEmptyRuleOrRecipientFailsOpen(): void
+    {
+        $this->appConfigDefaults();
+        $limiter = $this->makeLimiter();
+        $override = ['bucketSize' => 1, 'refillSecondsPerToken' => 3600];
+
+        // Spam without ever consuming a token from any real bucket.
+        for ($i = 0; $i < 5; $i++) {
+            $this->assertTrue($limiter->tryConsume('', 'alice', $override));
+            $this->assertTrue($limiter->tryConsume('rule', '', $override));
+        }
+    }
+
+    public function testCacheReadFailureFailsOpen(): void
+    {
+        $this->appConfigDefaults();
+        $cache = $this->createMock(ICache::class);
+        $cache->method('get')->willThrowException(new \RuntimeException('redis down'));
+        $cacheFactory = $this->createMock(ICacheFactory::class);
+        $cacheFactory->method('createDistributed')->willReturn($cache);
+
+        $limiter = new RateLimiter(
+            $cacheFactory,
+            $this->appConfig,
+            $this->logger,
+            fn (): int => $this->now
+        );
+
+        // Bucket size 1, but each call fails open because cache is broken.
+        $override = ['bucketSize' => 1, 'refillSecondsPerToken' => 3600];
+        $this->assertTrue($limiter->tryConsume('rule', 'alice', $override));
+        $this->assertTrue($limiter->tryConsume('rule', 'alice', $override));
+    }
+
+    public function testDropEmitsInfoNotWarning(): void
+    {
+        $this->appConfigDefaults();
+        $this->logger->expects($this->never())->method('warning');
+        $this->logger->expects($this->atLeastOnce())->method('info');
+
+        $limiter = $this->makeLimiter();
+        $override = ['bucketSize' => 1, 'refillSecondsPerToken' => 3600];
+        $limiter->tryConsume('rule', 'alice', $override);
+        $limiter->tryConsume('rule', 'alice', $override); // dropped
+    }
+
+    private function appConfigDefaults(): void
+    {
+        $this->appConfig->method('getValueString')
+            ->willReturnCallback(static fn (string $app, string $key, string $default): string => $default);
+        $this->appConfig->method('getValueInt')
+            ->willReturnCallback(static fn (string $app, string $key, int $default): int => $default);
+    }
+
+    private function makeLimiter(): RateLimiter
+    {
+        return new RateLimiter(
+            $this->cacheFactory,
+            $this->appConfig,
+            $this->logger,
+            fn (): int => $this->now
+        );
+    }
+}
+
+/**
+ * Minimal in-memory ICache for tests. Implements only the methods
+ * the RateLimiter touches (get/set/hasKey/remove/clear) — others
+ * throw so a test using them surfaces the gap.
+ */
+class InMemoryCache implements ICache
+{
+    /** @var array<string, mixed> */
+    public array $store = [];
+
+    public function get($key)
+    {
+        return $this->store[$key] ?? null;
+    }
+
+    public function set($key, $value, $ttl = 0): bool
+    {
+        $this->store[$key] = $value;
+        return true;
+    }
+
+    public function hasKey($key): bool
+    {
+        return array_key_exists($key, $this->store);
+    }
+
+    public function remove($key): bool
+    {
+        unset($this->store[$key]);
+        return true;
+    }
+
+    public function clear($prefix = ''): bool
+    {
+        $this->store = [];
+        return true;
+    }
+
+    public static function isAvailable(): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary

Implements one of the open items in the `notificatie-engine` OpenSpec change:

> **Notification rate limiting MUST prevent abuse and system overload.**

A misconfigured threshold rule that fires every second would happily flood the dispatcher today — there was no per-recipient or per-rule rate limit. This PR adds a token-bucket guard between the dispatcher and every channel emit.

## What ships

- **`lib/Service/Notification/RateLimiter.php`** — token-bucket service.
  - Backed by the distributed cache (APCu in dev, Redis in cluster) — same pattern as `AggregationCache`.
  - Per-bucket state is `[tokens, lastRefill]` with a 24h TTL, keyed on `sha1(ruleId | recipient)`.
  - Defaults: bucket size 10, refill 1 token / 60s.
  - Operator overrides via app-config: `notification_rate_limit_default_bucket_size`, `notification_rate_limit_default_refill_seconds`.
  - Per-rule override via `rateLimit: {bucketSize, refillSecondsPerToken}` on the notification spec.
  - Kill switch: `notification_rate_limit_enabled = false`.
  - **Fails open** on every degenerate path (disabled, cache unavailable, cache read failure, empty rule/recipient) — a broken limiter never blocks legitimate notifications.
  - Drops logged at **info** (not warning) so operators who care can grep without drowning normal channel deliveries.
  - Constructor-injectable time provider so unit tests aren't flaky.

- **`AnnotationNotificationDispatcher`** — wired the limiter in:
  - Per-recipient `nc-notification` / `email` / `activity` emits gated by `tryConsume(rule, uid, rateLimit)`.
  - One-shot `webhook` and `talk` channels each consume against synthetic recipients (`__webhook__`, `__talk__`) so a flooding rule can't hammer a webhook URL even if the recipient list rotates.
  - The dependency is constructor-default-null so existing tests that build the dispatcher without a limiter keep passing.

- **`tests/Unit/Service/Notification/RateLimiterTest`** — 8 tests:
  - Allow up to bucket size, then drop.
  - Refill exactly one token after the refill interval.
  - Per-(rule, recipient) isolation (drained alice/rule-a doesn't drain bob/rule-a or alice/rule-b).
  - Kill switch always allows.
  - App-config defaults apply when no per-rule override.
  - Empty rule or recipient fails open.
  - Cache read failure fails open.
  - Drops emit `info`, never `warning`.

- **Spec**: `openspec/changes/notificatie-engine/tasks.md` updated — the rate-limiting box ticked, status banner moved to "6 of 14 tasks tickably complete; 8 left open".

## Test plan

- [x] `phpunit tests/Unit/Service/Notification/RateLimiterTest.php` — 8 tests, 35 assertions, all pass.
- [x] Full notification suite (`tests/Unit/Service/Notification/`) — 47 tests / 99 assertions, all pass with the dispatcher wiring.
- [x] PHPCS clean on `RateLimiter.php`; my edits to `AnnotationNotificationDispatcher.php` introduce no new violations relative to the file's pre-existing baseline (in fact net-2-better).
- [x] App still loads in NC (`occ app:list` shows `openregister: 0.2.13-unstable.80`) — DI autowiring of the new dispatcher param works.

## What stays open in `notificatie-engine`

8 items:
1. Batching / digest delivery
2. User-managed notification preferences UI
3. VNG Notificaties API channel adapter
4. Explicit organisation-pinning on rules
5. `oc_openregister_notification_history` table + query API
6. NL/EN i18n on subject templates (gated on `register-i18n`)
7. Notification grouping (debounce/coalesce)
8. Read/unread tracking for non-in-app channels