### PR TITLE
feat(reference-existence-validation): admin bypass + validation events

### DIFF
--- a/lib/Event/ReferenceValidatedEvent.php
+++ b/lib/Event/ReferenceValidatedEvent.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * OpenRegister ReferenceValidatedEvent
+ *
+ * Side-channel event dispatched when a `validateReference: true`
+ * property successfully resolves: the referenced UUID was found in the
+ * target schema and the save pipeline accepted the reference. This is
+ * an extensibility hook — listeners can use it for analytics, cache
+ * warming, or downstream notifications without altering the save flow.
+ *
+ * Closes the reference-existence-validation spec requirement:
+ * "Validation events dispatched for notification and extensibility."
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Event
+ * @package  OCA\OpenRegister\Event
+ *
+ * @author  Conduction Development Team <dev@conduction.nl>
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Event;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * Event dispatched when reference existence validation succeeds.
+ */
+class ReferenceValidatedEvent extends Event
+{
+    /**
+     * Constructor.
+     *
+     * @param string      $propertyName     Schema property carrying the
+     *                                      validated reference.
+     * @param string      $referencedUuid   UUID that resolved to a real
+     *                                      object.
+     * @param string      $targetSchemaSlug Slug (or raw `$ref`) of the
+     *                                      target schema.
+     * @param string|null $targetRegister   Register the lookup was
+     *                                      performed in, or null when
+     *                                      no register context applied.
+     */
+    public function __construct(
+        private readonly string $propertyName,
+        private readonly string $referencedUuid,
+        private readonly string $targetSchemaSlug,
+        private readonly ?string $targetRegister=null
+    ) {
+        parent::__construct();
+
+    }//end __construct()
+
+    /**
+     * Schema property name that holds the validated reference.
+     *
+     * @return string Property name as declared on the schema.
+     */
+    public function getPropertyName(): string
+    {
+        return $this->propertyName;
+
+    }//end getPropertyName()
+
+    /**
+     * UUID that successfully resolved during validation.
+     *
+     * @return string The resolved UUID.
+     */
+    public function getReferencedUuid(): string
+    {
+        return $this->referencedUuid;
+
+    }//end getReferencedUuid()
+
+    /**
+     * Slug (or raw `$ref`) of the schema the reference targets.
+     *
+     * @return string Target schema slug or raw `$ref`.
+     */
+    public function getTargetSchemaSlug(): string
+    {
+        return $this->targetSchemaSlug;
+
+    }//end getTargetSchemaSlug()
+
+    /**
+     * Register the reference was searched in.
+     *
+     * @return string|null Register identifier or null when no register
+     *                     context applied to the lookup.
+     */
+    public function getTargetRegister(): ?string
+    {
+        return $this->targetRegister;
+
+    }//end getTargetRegister()
+}//end class

--- a/lib/Event/ReferenceValidationFailedEvent.php
+++ b/lib/Event/ReferenceValidationFailedEvent.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * OpenRegister ReferenceValidationFailedEvent
+ *
+ * Side-channel event dispatched when a `validateReference: true`
+ * property fails to resolve: the referenced UUID was not found in the
+ * target schema and the save pipeline rejected the object. This is an
+ * extensibility hook — listeners can use it for monitoring, alerting,
+ * or telemetry without altering the exception-driven failure flow.
+ *
+ * Dispatched immediately before `ReferenceValidationException` is
+ * thrown, so listeners observe every rejection regardless of whether
+ * the controller layer recovers or surfaces the 422 to the client.
+ *
+ * Closes the reference-existence-validation spec requirement:
+ * "Validation events dispatched for notification and extensibility."
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Event
+ * @package  OCA\OpenRegister\Event
+ *
+ * @author  Conduction Development Team <dev@conduction.nl>
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Event;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * Event dispatched when reference existence validation fails.
+ */
+class ReferenceValidationFailedEvent extends Event
+{
+    /**
+     * Constructor.
+     *
+     * @param string      $propertyName     Schema property carrying the
+     *                                      broken reference.
+     * @param string      $referencedUuid   UUID that did not resolve.
+     * @param string      $targetSchemaSlug Slug (or raw `$ref`) of the
+     *                                      target schema.
+     * @param string|null $targetRegister   Register the lookup was
+     *                                      performed in, or null when
+     *                                      no register context applied.
+     */
+    public function __construct(
+        private readonly string $propertyName,
+        private readonly string $referencedUuid,
+        private readonly string $targetSchemaSlug,
+        private readonly ?string $targetRegister=null
+    ) {
+        parent::__construct();
+
+    }//end __construct()
+
+    /**
+     * Schema property name that holds the broken reference.
+     *
+     * @return string Property name as declared on the schema.
+     */
+    public function getPropertyName(): string
+    {
+        return $this->propertyName;
+
+    }//end getPropertyName()
+
+    /**
+     * UUID that failed to resolve during validation.
+     *
+     * @return string The unresolved UUID.
+     */
+    public function getReferencedUuid(): string
+    {
+        return $this->referencedUuid;
+
+    }//end getReferencedUuid()
+
+    /**
+     * Slug (or raw `$ref`) of the schema the reference targets.
+     *
+     * @return string Target schema slug or raw `$ref`.
+     */
+    public function getTargetSchemaSlug(): string
+    {
+        return $this->targetSchemaSlug;
+
+    }//end getTargetSchemaSlug()
+
+    /**
+     * Register the reference was searched in.
+     *
+     * @return string|null Register identifier or null when no register
+     *                     context applied to the lookup.
+     */
+    public function getTargetRegister(): ?string
+    {
+        return $this->targetRegister;
+
+    }//end getTargetRegister()
+}//end class

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -53,6 +53,8 @@ use OCA\OpenRegister\Db\AuditTrailMapper;
 use OCA\OpenRegister\Service\SettingsService;
 use OCA\OpenRegister\Exception\ReferenceValidationException;
 use OCA\OpenRegister\Exception\ValidationException;
+use OCP\IAppConfig;
+use OCP\IGroupManager;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -127,6 +129,24 @@ class SaveObject
     private const URL_PATH_IDENTIFIER = 'openregister.objects.show';
 
     /**
+     * App identifier used for `IAppConfig` lookups.
+     *
+     * @var string
+     */
+    private const APP_ID = 'openregister';
+
+    /**
+     * App-config key controlling whether admins bypass reference
+     * existence validation. When the stored value parses to `true`
+     * (default), members of the `admin` group skip the check; when
+     * `false`, admins are validated like any other user. Operators
+     * can flip the flag at runtime via `occ config:app:set`.
+     *
+     * @var string
+     */
+    private const CONFIG_KEY_REFERENCE_VALIDATION_ADMIN_BYPASS = 'reference_validation_admin_bypass';
+
+    /**
      * Twig template engine instance
      *
      * @var Environment
@@ -196,6 +216,8 @@ class SaveObject
      * @param LoggerInterface             $logger               Logger interface for logging operations
      * @param TmloService                 $tmloService          TMLO archival metadata service
      * @param ArrayLoader                 $arrayLoader          Twig array loader for template rendering
+     * @param IGroupManager|null          $groupManager         Group manager for admin-bypass detection
+     * @param IAppConfig|null             $appConfig            App-config reader for the admin-bypass toggle
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList) Nextcloud DI requires constructor injection
      */
@@ -219,6 +241,8 @@ class SaveObject
         private readonly LoggerInterface $logger,
         private readonly TmloService $tmloService,
         ArrayLoader $arrayLoader,
+        private readonly ?IGroupManager $groupManager=null,
+        private readonly ?IAppConfig $appConfig=null,
     ) {
         $this->twig = new Environment($arrayLoader);
     }//end __construct()
@@ -3489,6 +3513,19 @@ class SaveObject
         ?string $register,
         ?array $oldData=null
     ): void {
+        // Operator-controlled admin bypass: when the current user is in
+        // the admin group AND the bypass flag is on (default true), skip
+        // reference existence validation entirely. Mirrors the
+        // `MultiTenancyTrait::isCurrentUserAdmin()` short-circuit so
+        // admins can repair broken cross-references during migrations or
+        // bulk imports without tripping 422s. Operators can flip the
+        // flag off via `occ config:app:set openregister
+        // reference_validation_admin_bypass --value=false` to enforce
+        // validation for every user.
+        if ($this->shouldBypassValidationForAdmin() === true) {
+            return;
+        }
+
         $properties = $schema->getProperties();
         if ($properties === null) {
             return;
@@ -3648,6 +3685,45 @@ class SaveObject
             );
         }//end try
     }//end validateReferenceExists()
+
+    /**
+     * Decide whether the current user should bypass reference validation.
+     *
+     * Returns true when the current session user is in the `admin`
+     * group AND the `reference_validation_admin_bypass` app-config flag
+     * resolves to `true` (the default). The dependencies are optional
+     * to keep older test fixtures working — when either is missing the
+     * method returns false so validation runs as before.
+     *
+     * @return bool True when admin bypass applies.
+     */
+    private function shouldBypassValidationForAdmin(): bool
+    {
+        if ($this->groupManager === null || $this->appConfig === null) {
+            return false;
+        }
+
+        $bypassEnabled = filter_var(
+            $this->appConfig->getValueString(
+                app: self::APP_ID,
+                key: self::CONFIG_KEY_REFERENCE_VALIDATION_ADMIN_BYPASS,
+                default: 'true'
+            ),
+            FILTER_VALIDATE_BOOLEAN
+        );
+
+        if ($bypassEnabled === false) {
+            return false;
+        }
+
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        return $this->groupManager->isAdmin($user->getUID());
+
+    }//end shouldBypassValidationForAdmin()
 
     /**
      * Prepares object data by applying all necessary transformations.

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -50,9 +50,12 @@ use OCA\OpenRegister\Service\TmloService;
 use OCA\OpenRegister\Service\Schemas\SchemaCacheHandler;
 use OCA\OpenRegister\Service\Schemas\FacetCacheHandler;
 use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Event\ReferenceValidatedEvent;
+use OCA\OpenRegister\Event\ReferenceValidationFailedEvent;
 use OCA\OpenRegister\Service\SettingsService;
 use OCA\OpenRegister\Exception\ReferenceValidationException;
 use OCA\OpenRegister\Exception\ValidationException;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
 use OCP\IGroupManager;
 use OCP\IURLGenerator;
@@ -218,6 +221,7 @@ class SaveObject
      * @param ArrayLoader                 $arrayLoader          Twig array loader for template rendering
      * @param IGroupManager|null          $groupManager         Group manager for admin-bypass detection
      * @param IAppConfig|null             $appConfig            App-config reader for the admin-bypass toggle
+     * @param IEventDispatcher|null       $eventDispatcher      Event dispatcher for reference validation events
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList) Nextcloud DI requires constructor injection
      */
@@ -243,6 +247,7 @@ class SaveObject
         ArrayLoader $arrayLoader,
         private readonly ?IGroupManager $groupManager=null,
         private readonly ?IAppConfig $appConfig=null,
+        private readonly ?IEventDispatcher $eventDispatcher=null,
     ) {
         $this->twig = new Environment($arrayLoader);
     }//end __construct()
@@ -3658,6 +3663,17 @@ class SaveObject
                 _multitenancy: false
             );
         } catch (DoesNotExistException $e) {
+            // Side-channel notification for monitoring / extensibility.
+            // Dispatched BEFORE the exception so listeners observe every
+            // failure regardless of whether the controller layer
+            // recovers or surfaces the 422.
+            $this->dispatchReferenceValidationFailedEvent(
+                propertyName: $propertyName,
+                referencedUuid: $uuid,
+                targetSchemaSlug: $targetSchemaSlug,
+                targetRegister: $register
+            );
+
             // Throw a structured exception so API clients can render
             // actionable error UI without parsing the message string —
             // closes the spec's "structured diagnostic information"
@@ -3683,7 +3699,18 @@ class SaveObject
                     'error'    => $e->getMessage(),
                 ]
             );
+            return;
         }//end try
+
+        // Lookup succeeded — emit a success event so listeners can hook
+        // into accepted references (analytics, cache warming, etc.)
+        // without changing the save flow.
+        $this->dispatchReferenceValidatedEvent(
+            propertyName: $propertyName,
+            referencedUuid: $uuid,
+            targetSchemaSlug: $targetSchemaSlug,
+            targetRegister: $register
+        );
     }//end validateReferenceExists()
 
     /**
@@ -3724,6 +3751,102 @@ class SaveObject
         return $this->groupManager->isAdmin($user->getUID());
 
     }//end shouldBypassValidationForAdmin()
+
+    /**
+     * Dispatch a `ReferenceValidatedEvent` if a dispatcher is wired.
+     *
+     * Encapsulates the null-check so call-sites stay readable. Failures
+     * inside listeners are caught and logged so a misbehaving listener
+     * cannot block a save.
+     *
+     * @param string      $propertyName     Schema property name.
+     * @param string      $referencedUuid   UUID that resolved.
+     * @param string      $targetSchemaSlug Target schema slug.
+     * @param string|null $targetRegister   Register the lookup ran in.
+     *
+     * @return void
+     */
+    private function dispatchReferenceValidatedEvent(
+        string $propertyName,
+        string $referencedUuid,
+        string $targetSchemaSlug,
+        ?string $targetRegister
+    ): void {
+        if ($this->eventDispatcher === null) {
+            return;
+        }
+
+        try {
+            $this->eventDispatcher->dispatchTyped(
+                new ReferenceValidatedEvent(
+                    propertyName: $propertyName,
+                    referencedUuid: $referencedUuid,
+                    targetSchemaSlug: $targetSchemaSlug,
+                    targetRegister: $targetRegister
+                )
+            );
+        } catch (Exception $e) {
+            $this->logger->warning(
+                message: '[SaveObject] ReferenceValidatedEvent dispatch failed',
+                context: [
+                    'file'     => __FILE__,
+                    'line'     => __LINE__,
+                    'property' => $propertyName,
+                    'uuid'     => $referencedUuid,
+                    'error'    => $e->getMessage(),
+                ]
+            );
+        }//end try
+
+    }//end dispatchReferenceValidatedEvent()
+
+    /**
+     * Dispatch a `ReferenceValidationFailedEvent` if a dispatcher is wired.
+     *
+     * Encapsulates the null-check so call-sites stay readable. Failures
+     * inside listeners are caught and logged so a misbehaving listener
+     * cannot mask the underlying validation failure.
+     *
+     * @param string      $propertyName     Schema property name.
+     * @param string      $referencedUuid   UUID that did not resolve.
+     * @param string      $targetSchemaSlug Target schema slug.
+     * @param string|null $targetRegister   Register the lookup ran in.
+     *
+     * @return void
+     */
+    private function dispatchReferenceValidationFailedEvent(
+        string $propertyName,
+        string $referencedUuid,
+        string $targetSchemaSlug,
+        ?string $targetRegister
+    ): void {
+        if ($this->eventDispatcher === null) {
+            return;
+        }
+
+        try {
+            $this->eventDispatcher->dispatchTyped(
+                new ReferenceValidationFailedEvent(
+                    propertyName: $propertyName,
+                    referencedUuid: $referencedUuid,
+                    targetSchemaSlug: $targetSchemaSlug,
+                    targetRegister: $targetRegister
+                )
+            );
+        } catch (Exception $e) {
+            $this->logger->warning(
+                message: '[SaveObject] ReferenceValidationFailedEvent dispatch failed',
+                context: [
+                    'file'     => __FILE__,
+                    'line'     => __LINE__,
+                    'property' => $propertyName,
+                    'uuid'     => $referencedUuid,
+                    'error'    => $e->getMessage(),
+                ]
+            );
+        }//end try
+
+    }//end dispatchReferenceValidationFailedEvent()
 
     /**
      * Prepares object data by applying all necessary transformations.

--- a/openspec/changes/reference-existence-validation/tasks.md
+++ b/openspec/changes/reference-existence-validation/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: reference-existence-validation Specification
 
-> **Status (Phase 3):** 7 of 16 tasks tickably complete. Phase 3 wired the operator-controlled admin bypass (`reference_validation_admin_bypass` app-config flag, default `true`) into `SaveObject::validateReferences()`. 9 open: soft-deleted refs, batch optimisation, circular detection, external URL refs, request-scoped cache, GraphQL mutations, async validation, validation events, schema-configurable strictness levels.
+> **Status (Phase 3):** 8 of 16 tasks tickably complete. Phase 3 wired the operator-controlled admin bypass (`reference_validation_admin_bypass` app-config flag, default `true`) and the side-channel validation event family (`ReferenceValidatedEvent` / `ReferenceValidationFailedEvent`) into `SaveObject::validateReferences()`. 8 open: soft-deleted refs, batch optimisation, circular detection, external URL refs, request-scoped cache, GraphQL mutations, async validation, schema-configurable strictness levels.
 
 ## Implemented
 
@@ -22,7 +22,7 @@
 - [x] Admin users able to bypass reference validation. `SaveObject::shouldBypassValidationForAdmin()` short-circuits `validateReferences()` when the current session user is in the `admin` group AND the `reference_validation_admin_bypass` app-config flag (default `true`) is on. Operators can flip the flag off via `occ config:app:set openregister reference_validation_admin_bypass --value=false` to enforce validation for every user. The optional `IGroupManager` + `IAppConfig` constructor parameters keep older test fixtures working — when either dependency is absent the method returns `false` and validation runs as before. **Verified** by `tests/Unit/Service/Object/SaveObjectReferenceValidationTest` (4 tests covering: admin bypasses with default-on flag; admin does NOT bypass when flag disabled; non-admin never bypasses; missing optional dependencies fall back to running validation).
 - [ ] Reference validation works in GraphQL mutations. **Open** — GraphQL mutation handler doesn't currently route through the same `SaveObject::saveObject` path; needs alignment.
 - [ ] Async validation supported for large batch operations. **Open** — depends on batch optimisation + a way to surface async errors.
-- [ ] Validation events dispatched for notification and extensibility. **Open** — would add `ReferenceValidatedEvent` / `ReferenceValidationFailedEvent` to the event family.
+- [x] Validation events dispatched for notification and extensibility. Added `lib/Event/ReferenceValidatedEvent.php` and `lib/Event/ReferenceValidationFailedEvent.php` siblings (both `OCP\EventDispatcher\Event` subclasses, both expose typed `propertyName` / `referencedUuid` / `targetSchemaSlug` / `targetRegister` fields). Dispatched from `SaveObject::validateReferenceExists()` via the optional `IEventDispatcher` dependency: `ReferenceValidatedEvent` fires on every successful UUID lookup; `ReferenceValidationFailedEvent` fires immediately BEFORE the `ReferenceValidationException` is thrown, so listeners observe every rejection regardless of whether the controller layer recovers or surfaces the 422. Listener exceptions are caught and logged as warnings — a misbehaving listener cannot block a save or mask the underlying validation failure. **Verified** by `tests/Unit/Service/Object/SaveObjectReferenceValidationTest` (3 tests: failure event carries the typed fields; success event carries the typed fields; no-op when `IEventDispatcher` is absent) plus `tests/Unit/Event/ReferenceValidationEventsTest` (7 tests covering both event classes' field shape, default-null target register, and that the two events are sibling types so listeners can subscribe independently).
 - [ ] Schema-configurable validation strictness levels. **Open** — currently it's binary (`validateReference: true` or absent). Strictness levels (`warn` / `error` / `block`) are a separate UX feature.
 
 ## Test coverage
@@ -34,8 +34,16 @@
   - null reference accepted (optional)
   - empty-string reference accepted (defence in depth)
   - update with unchanged reference skips validation
-- [x] `tests/Unit/Service/Object/SaveObjectReferenceValidationTest` — 4 tests against the SaveObject admin-bypass hook:
+- [x] `tests/Unit/Event/ReferenceValidationEventsTest` — 7 tests against the event classes themselves:
+  - both events extend `OCP\EventDispatcher\Event`
+  - both events expose every typed field on the constructor
+  - both events default `targetRegister` to `null` when omitted
+  - the two events are sibling types so listeners can subscribe independently
+- [x] `tests/Unit/Service/Object/SaveObjectReferenceValidationTest` — 7 tests against the SaveObject extension hooks:
   - admin user bypasses validation when the bypass flag defaults to on
   - admin user does NOT bypass when the bypass flag is disabled
   - non-admin user never bypasses even with the flag on
   - bypass disabled when optional `IGroupManager` / `IAppConfig` are absent
+  - `ReferenceValidationFailedEvent` dispatched (with typed fields populated) immediately before the `ReferenceValidationException` is thrown
+  - `ReferenceValidatedEvent` dispatched (with typed fields populated) on every successful lookup
+  - no events dispatched when `IEventDispatcher` is absent

--- a/openspec/changes/reference-existence-validation/tasks.md
+++ b/openspec/changes/reference-existence-validation/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: reference-existence-validation Specification
 
-> **Status (Phase 2):** Core (6 of 16) implemented in `SaveObject::validateReferences()` and verified by `tests/Service/ReferenceExistenceValidationIntegrationTest` (now 6 tests). Phase 2 added structured diagnostic information by introducing `ReferenceValidationException` (subclass of `ValidationException`) with typed fields. The remaining 10 are extensions — batch optimisation, circular detection, GraphQL/async/events/strictness — left open as separate work.
+> **Status (Phase 3):** 7 of 16 tasks tickably complete. Phase 3 wired the operator-controlled admin bypass (`reference_validation_admin_bypass` app-config flag, default `true`) into `SaveObject::validateReferences()`. 9 open: soft-deleted refs, batch optimisation, circular detection, external URL refs, request-scoped cache, GraphQL mutations, async validation, validation events, schema-configurable strictness levels.
 
 ## Implemented
 
@@ -19,7 +19,7 @@
 - [ ] Circular reference chains detected during validation. **Open** — would need a per-save visited-set to detect cycles like A→B→A.
 - [ ] External URL references support configurable validation. Today only `#/components/schemas/{slug}` refs are validated; HTTP/HTTPS refs aren't. **Open** — design question whether to fetch + verify external URLs at save time (latency) or accept them.
 - [ ] Validation results cached within a request scope. **Open** — see batch optimisation above.
-- [ ] Admin users able to bypass reference validation. **Open** — would mirror `MultiTenancyTrait::isCurrentUserAdmin()` short-circuit.
+- [x] Admin users able to bypass reference validation. `SaveObject::shouldBypassValidationForAdmin()` short-circuits `validateReferences()` when the current session user is in the `admin` group AND the `reference_validation_admin_bypass` app-config flag (default `true`) is on. Operators can flip the flag off via `occ config:app:set openregister reference_validation_admin_bypass --value=false` to enforce validation for every user. The optional `IGroupManager` + `IAppConfig` constructor parameters keep older test fixtures working — when either dependency is absent the method returns `false` and validation runs as before. **Verified** by `tests/Unit/Service/Object/SaveObjectReferenceValidationTest` (4 tests covering: admin bypasses with default-on flag; admin does NOT bypass when flag disabled; non-admin never bypasses; missing optional dependencies fall back to running validation).
 - [ ] Reference validation works in GraphQL mutations. **Open** — GraphQL mutation handler doesn't currently route through the same `SaveObject::saveObject` path; needs alignment.
 - [ ] Async validation supported for large batch operations. **Open** — depends on batch optimisation + a way to surface async errors.
 - [ ] Validation events dispatched for notification and extensibility. **Open** — would add `ReferenceValidatedEvent` / `ReferenceValidationFailedEvent` to the event family.
@@ -34,3 +34,8 @@
   - null reference accepted (optional)
   - empty-string reference accepted (defence in depth)
   - update with unchanged reference skips validation
+- [x] `tests/Unit/Service/Object/SaveObjectReferenceValidationTest` — 4 tests against the SaveObject admin-bypass hook:
+  - admin user bypasses validation when the bypass flag defaults to on
+  - admin user does NOT bypass when the bypass flag is disabled
+  - non-admin user never bypasses even with the flag on
+  - bypass disabled when optional `IGroupManager` / `IAppConfig` are absent

--- a/tests/Unit/Event/ReferenceValidationEventsTest.php
+++ b/tests/Unit/Event/ReferenceValidationEventsTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Event;
+
+use OCA\OpenRegister\Event\ReferenceValidatedEvent;
+use OCA\OpenRegister\Event\ReferenceValidationFailedEvent;
+use OCP\EventDispatcher\Event;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the reference-validation event family.
+ *
+ * Pure value-object tests — no DI, no service wiring. Confirms each
+ * event is a Symfony/NC `Event` subclass and exposes the typed fields
+ * declared by the spec ("Validation events dispatched for notification
+ * and extensibility").
+ */
+class ReferenceValidationEventsTest extends TestCase
+{
+    public function testValidatedEventExtendsEvent(): void
+    {
+        $event = new ReferenceValidatedEvent(
+            propertyName: 'organisation',
+            referencedUuid: 'uuid-1',
+            targetSchemaSlug: 'organisations'
+        );
+        $this->assertInstanceOf(Event::class, $event);
+    }
+
+    public function testValidatedEventExposesAllFields(): void
+    {
+        $event = new ReferenceValidatedEvent(
+            propertyName: 'organisation',
+            referencedUuid: 'uuid-1',
+            targetSchemaSlug: 'organisations',
+            targetRegister: '42'
+        );
+
+        $this->assertSame('organisation', $event->getPropertyName());
+        $this->assertSame('uuid-1', $event->getReferencedUuid());
+        $this->assertSame('organisations', $event->getTargetSchemaSlug());
+        $this->assertSame('42', $event->getTargetRegister());
+    }
+
+    public function testValidatedEventDefaultsTargetRegisterToNull(): void
+    {
+        $event = new ReferenceValidatedEvent(
+            propertyName: 'organisation',
+            referencedUuid: 'uuid-1',
+            targetSchemaSlug: 'organisations'
+        );
+
+        $this->assertNull($event->getTargetRegister());
+    }
+
+    public function testFailedEventExtendsEvent(): void
+    {
+        $event = new ReferenceValidationFailedEvent(
+            propertyName: 'organisation',
+            referencedUuid: 'missing-uuid',
+            targetSchemaSlug: 'organisations'
+        );
+        $this->assertInstanceOf(Event::class, $event);
+    }
+
+    public function testFailedEventExposesAllFields(): void
+    {
+        $event = new ReferenceValidationFailedEvent(
+            propertyName: 'organisation',
+            referencedUuid: 'missing-uuid',
+            targetSchemaSlug: 'organisations',
+            targetRegister: '42'
+        );
+
+        $this->assertSame('organisation', $event->getPropertyName());
+        $this->assertSame('missing-uuid', $event->getReferencedUuid());
+        $this->assertSame('organisations', $event->getTargetSchemaSlug());
+        $this->assertSame('42', $event->getTargetRegister());
+    }
+
+    public function testFailedEventDefaultsTargetRegisterToNull(): void
+    {
+        $event = new ReferenceValidationFailedEvent(
+            propertyName: 'organisation',
+            referencedUuid: 'missing-uuid',
+            targetSchemaSlug: 'organisations'
+        );
+
+        $this->assertNull($event->getTargetRegister());
+    }
+
+    public function testValidatedAndFailedEventsAreDistinctTypes(): void
+    {
+        $valid = new ReferenceValidatedEvent(
+            propertyName: 'organisation',
+            referencedUuid: 'uuid-1',
+            targetSchemaSlug: 'organisations'
+        );
+        $failed = new ReferenceValidationFailedEvent(
+            propertyName: 'organisation',
+            referencedUuid: 'uuid-1',
+            targetSchemaSlug: 'organisations'
+        );
+
+        // Listeners must be able to subscribe to one without catching
+        // the other — these are siblings, not parent/child.
+        $this->assertNotInstanceOf(ReferenceValidatedEvent::class, $failed);
+        $this->assertNotInstanceOf(ReferenceValidationFailedEvent::class, $valid);
+    }
+}

--- a/tests/Unit/Service/Object/SaveObjectReferenceValidationTest.php
+++ b/tests/Unit/Service/Object/SaveObjectReferenceValidationTest.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 /**
  * SaveObject reference-validation extension behaviour.
  *
- * Covers the spec item added in the
+ * Covers two spec items added in the
  * `reference-existence-validation` change:
- *   Admin users can bypass reference validation when the
- *   `reference_validation_admin_bypass` app-config flag is on.
+ *   1. Admin users can bypass reference validation when the
+ *      `reference_validation_admin_bypass` app-config flag is on.
+ *   2. The save pipeline emits `ReferenceValidatedEvent` /
+ *      `ReferenceValidationFailedEvent` so listeners can hook into
+ *      validation outcomes.
  *
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object
@@ -24,6 +27,8 @@ use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Event\ReferenceValidatedEvent;
+use OCA\OpenRegister\Event\ReferenceValidationFailedEvent;
 use OCA\OpenRegister\Exception\ReferenceValidationException;
 use OCA\OpenRegister\Service\Object\CacheHandler;
 use OCA\OpenRegister\Service\Object\SaveObject;
@@ -31,6 +36,7 @@ use OCA\OpenRegister\Service\OrganisationService;
 use OCA\OpenRegister\Service\PropertyRbacHandler;
 use OCA\OpenRegister\Service\SettingsService;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
 use OCP\IGroupManager;
 use OCP\IURLGenerator;
@@ -42,20 +48,21 @@ use ReflectionMethod;
 use Twig\Loader\ArrayLoader;
 
 /**
- * Unit tests for the admin-bypass behaviour added to SaveObject's
- * reference-existence validation pipeline.
+ * Unit tests for the admin-bypass + event dispatch behaviour added to
+ * SaveObject's reference-existence validation pipeline.
  */
 class SaveObjectReferenceValidationTest extends TestCase
 {
     /**
      * Build a SaveObject under test with all dependencies mocked. Lets
-     * each test override the user, group manager, and app-config to
-     * assert the new behaviours in isolation.
+     * each test override the user, group manager, app-config and event
+     * dispatcher to assert the new behaviours in isolation.
      */
     private function buildHandler(
         IUserSession $userSession,
         ?IGroupManager $groupManager,
         ?IAppConfig $appConfig,
+        ?IEventDispatcher $eventDispatcher,
         ?MagicMapper $unifiedObjectMapper = null,
         ?SchemaMapper $schemaMapper = null
     ): SaveObject {
@@ -81,6 +88,7 @@ class SaveObjectReferenceValidationTest extends TestCase
             arrayLoader: new ArrayLoader(),
             groupManager: $groupManager,
             appConfig: $appConfig,
+            eventDispatcher: $eventDispatcher,
         );
     }
 
@@ -161,7 +169,7 @@ class SaveObjectReferenceValidationTest extends TestCase
     }
 
     // ====================================================================
-    // Admin bypass — Open spec item:
+    // 1. Admin bypass — Open spec item:
     //    "Admin users able to bypass reference validation."
     // ====================================================================
 
@@ -175,6 +183,7 @@ class SaveObjectReferenceValidationTest extends TestCase
             userSession: $this->makeAdminSession(),
             groupManager: $this->makeAdminGroupManager(true),
             appConfig: $this->makeAppConfig('true'),
+            eventDispatcher: $this->createMock(IEventDispatcher::class),
             unifiedObjectMapper: $unifiedMapper,
         );
 
@@ -203,6 +212,7 @@ class SaveObjectReferenceValidationTest extends TestCase
             userSession: $this->makeAdminSession(),
             groupManager: $this->makeAdminGroupManager(true),
             appConfig: $this->makeAppConfig('false'),
+            eventDispatcher: $this->createMock(IEventDispatcher::class),
             unifiedObjectMapper: $unifiedMapper,
             schemaMapper: $this->makeSchemaMapperResolvingTarget(),
         );
@@ -231,6 +241,7 @@ class SaveObjectReferenceValidationTest extends TestCase
             userSession: $this->makeNonAdminSession(),
             groupManager: $this->makeAdminGroupManager(false),
             appConfig: $this->makeAppConfig('true'),
+            eventDispatcher: $this->createMock(IEventDispatcher::class),
             unifiedObjectMapper: $unifiedMapper,
             schemaMapper: $this->makeSchemaMapperResolvingTarget(),
         );
@@ -262,6 +273,7 @@ class SaveObjectReferenceValidationTest extends TestCase
             userSession: $this->makeAdminSession(),
             groupManager: null,
             appConfig: null,
+            eventDispatcher: null,
             unifiedObjectMapper: $unifiedMapper,
             schemaMapper: $this->makeSchemaMapperResolvingTarget(),
         );
@@ -277,5 +289,125 @@ class SaveObjectReferenceValidationTest extends TestCase
                 'oldData' => null,
             ]
         );
+    }
+
+    // ====================================================================
+    // 2. Validation events — Open spec item:
+    //    "Validation events dispatched for notification and extensibility."
+    // ====================================================================
+
+    public function testReferenceValidationFailedEventDispatchedOnMissingTarget(): void
+    {
+        $unifiedMapper = $this->createMock(MagicMapper::class);
+        $unifiedMapper->method('find')->willThrowException(new DoesNotExistException('not found'));
+
+        $eventDispatcher = $this->createMock(IEventDispatcher::class);
+        $captured = null;
+        $eventDispatcher->expects($this->once())
+            ->method('dispatchTyped')
+            ->willReturnCallback(function ($event) use (&$captured): void {
+                $captured = $event;
+            });
+
+        $handler = $this->buildHandler(
+            userSession: $this->makeNonAdminSession(),
+            groupManager: $this->makeAdminGroupManager(false),
+            appConfig: $this->makeAppConfig('true'),
+            eventDispatcher: $eventDispatcher,
+            unifiedObjectMapper: $unifiedMapper,
+            schemaMapper: $this->makeSchemaMapperResolvingTarget(),
+        );
+
+        try {
+            $this->invoke(
+                $handler,
+                'validateReferences',
+                [
+                    'schema' => $this->buildSchemaWithReference(),
+                    'data' => ['organisation' => 'missing-uuid'],
+                    'register' => '1',
+                    'oldData' => null,
+                ]
+            );
+            $this->fail('Expected ReferenceValidationException');
+        } catch (ReferenceValidationException $e) {
+            // expected
+        }
+
+        $this->assertInstanceOf(ReferenceValidationFailedEvent::class, $captured);
+        $this->assertSame('organisation', $captured->getPropertyName());
+        $this->assertSame('missing-uuid', $captured->getReferencedUuid());
+        $this->assertSame('organisations', $captured->getTargetSchemaSlug());
+        $this->assertSame('1', $captured->getTargetRegister());
+    }
+
+    public function testReferenceValidatedEventDispatchedOnSuccessfulLookup(): void
+    {
+        // Mapper find succeeds (returns silently) → success event must fire.
+        $unifiedMapper = $this->createMock(MagicMapper::class);
+        $unifiedMapper->expects($this->once())->method('find');
+
+        $eventDispatcher = $this->createMock(IEventDispatcher::class);
+        $captured = null;
+        $eventDispatcher->expects($this->once())
+            ->method('dispatchTyped')
+            ->willReturnCallback(function ($event) use (&$captured): void {
+                $captured = $event;
+            });
+
+        $handler = $this->buildHandler(
+            userSession: $this->makeNonAdminSession(),
+            groupManager: $this->makeAdminGroupManager(false),
+            appConfig: $this->makeAppConfig('true'),
+            eventDispatcher: $eventDispatcher,
+            unifiedObjectMapper: $unifiedMapper,
+            schemaMapper: $this->makeSchemaMapperResolvingTarget(),
+        );
+
+        $this->invoke(
+            $handler,
+            'validateReferences',
+            [
+                'schema' => $this->buildSchemaWithReference(),
+                'data' => ['organisation' => 'existing-uuid'],
+                'register' => '1',
+                'oldData' => null,
+            ]
+        );
+
+        $this->assertInstanceOf(ReferenceValidatedEvent::class, $captured);
+        $this->assertSame('organisation', $captured->getPropertyName());
+        $this->assertSame('existing-uuid', $captured->getReferencedUuid());
+        $this->assertSame('organisations', $captured->getTargetSchemaSlug());
+        $this->assertSame('1', $captured->getTargetRegister());
+    }
+
+    public function testNoEventsDispatchedWhenDispatcherMissing(): void
+    {
+        // No exception, no fatals, no dispatch calls — graceful no-op.
+        $unifiedMapper = $this->createMock(MagicMapper::class);
+        $unifiedMapper->method('find'); // succeeds
+
+        $handler = $this->buildHandler(
+            userSession: $this->makeNonAdminSession(),
+            groupManager: $this->makeAdminGroupManager(false),
+            appConfig: $this->makeAppConfig('true'),
+            eventDispatcher: null,
+            unifiedObjectMapper: $unifiedMapper,
+            schemaMapper: $this->makeSchemaMapperResolvingTarget(),
+        );
+
+        $this->invoke(
+            $handler,
+            'validateReferences',
+            [
+                'schema' => $this->buildSchemaWithReference(),
+                'data' => ['organisation' => 'existing-uuid'],
+                'register' => '1',
+                'oldData' => null,
+            ]
+        );
+
+        $this->assertTrue(true, 'No-op when event dispatcher absent');
     }
 }

--- a/tests/Unit/Service/Object/SaveObjectReferenceValidationTest.php
+++ b/tests/Unit/Service/Object/SaveObjectReferenceValidationTest.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SaveObject reference-validation extension behaviour.
+ *
+ * Covers the spec item added in the
+ * `reference-existence-validation` change:
+ *   Admin users can bypass reference validation when the
+ *   `reference_validation_admin_bypass` app-config flag is on.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ * @author   OpenRegister Team
+ * @license  AGPL-3.0-or-later
+ * @link     https://github.com/OpenRegister/OpenRegister
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Object;
+
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Exception\ReferenceValidationException;
+use OCA\OpenRegister\Service\Object\CacheHandler;
+use OCA\OpenRegister\Service\Object\SaveObject;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCA\OpenRegister\Service\PropertyRbacHandler;
+use OCA\OpenRegister\Service\SettingsService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IAppConfig;
+use OCP\IGroupManager;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+use Twig\Loader\ArrayLoader;
+
+/**
+ * Unit tests for the admin-bypass behaviour added to SaveObject's
+ * reference-existence validation pipeline.
+ */
+class SaveObjectReferenceValidationTest extends TestCase
+{
+    /**
+     * Build a SaveObject under test with all dependencies mocked. Lets
+     * each test override the user, group manager, and app-config to
+     * assert the new behaviours in isolation.
+     */
+    private function buildHandler(
+        IUserSession $userSession,
+        ?IGroupManager $groupManager,
+        ?IAppConfig $appConfig,
+        ?MagicMapper $unifiedObjectMapper = null,
+        ?SchemaMapper $schemaMapper = null
+    ): SaveObject {
+        return new SaveObject(
+            objectEntityMapper: $this->createMock(MagicMapper::class),
+            unifiedObjectMapper: $unifiedObjectMapper ?? $this->createMock(MagicMapper::class),
+            metaHydrationHandler: $this->createMock(\OCA\OpenRegister\Service\Object\SaveObject\MetadataHydrationHandler::class),
+            filePropertyHandler: $this->createMock(\OCA\OpenRegister\Service\Object\SaveObject\FilePropertyHandler::class),
+            linkedEntityHandler: $this->createMock(\OCA\OpenRegister\Service\Object\SaveObject\LinkedEntityPropertyHandler::class),
+            userSession: $userSession,
+            auditTrailMapper: $this->createMock(AuditTrailMapper::class),
+            schemaMapper: $schemaMapper ?? $this->createMock(SchemaMapper::class),
+            registerMapper: $this->createMock(RegisterMapper::class),
+            urlGenerator: $this->createMock(IURLGenerator::class),
+            organisationService: $this->createMock(OrganisationService::class),
+            cacheHandler: $this->createMock(CacheHandler::class),
+            settingsService: $this->createMock(SettingsService::class),
+            propertyRbacHandler: $this->createMock(PropertyRbacHandler::class),
+            computedFieldHandler: $this->createMock(\OCA\OpenRegister\Service\Object\SaveObject\ComputedFieldHandler::class),
+            translationHandler: $this->createMock(\OCA\OpenRegister\Service\Object\TranslationHandler::class),
+            logger: $this->createMock(LoggerInterface::class),
+            tmloService: $this->createMock(\OCA\OpenRegister\Service\TmloService::class),
+            arrayLoader: new ArrayLoader(),
+            groupManager: $groupManager,
+            appConfig: $appConfig,
+        );
+    }
+
+    private function invoke(SaveObject $handler, string $methodName, array $args): mixed
+    {
+        $reflection = new ReflectionMethod(SaveObject::class, $methodName);
+        $reflection->setAccessible(true);
+        return $reflection->invokeArgs($handler, array_values($args));
+    }
+
+    private function buildSchemaWithReference(): Schema
+    {
+        $schema = $this->getMockBuilder(Schema::class)
+            ->onlyMethods(['getProperties'])
+            ->getMock();
+        $schema->setId(1);
+        $schema->setSlug('referrer');
+        $schema->method('getProperties')->willReturn([
+            'organisation' => [
+                'type' => 'string',
+                '$ref' => '#/components/schemas/organisations',
+                'validateReference' => true,
+            ],
+        ]);
+        return $schema;
+    }
+
+    /**
+     * Build a SchemaMapper mock whose findAll() returns a target
+     * schema named `organisations` so resolveSchemaReference() can
+     * walk `#/components/schemas/organisations` to a real ID.
+     */
+    private function makeSchemaMapperResolvingTarget(): SchemaMapper
+    {
+        $target = $this->getMockBuilder(Schema::class)
+            ->onlyMethods([])
+            ->getMock();
+        $target->setId(2);
+        $target->setSlug('organisations');
+
+        $schemaMapper = $this->createMock(SchemaMapper::class);
+        $schemaMapper->method('findAll')->willReturn([$target]);
+        return $schemaMapper;
+    }
+
+    private function makeAppConfig(string $bypassValue = 'true'): IAppConfig
+    {
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueString')
+            ->with('openregister', 'reference_validation_admin_bypass', 'true')
+            ->willReturn($bypassValue);
+        return $appConfig;
+    }
+
+    private function makeAdminSession(string $uid = 'admin-user'): IUserSession
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn($user);
+        return $session;
+    }
+
+    private function makeNonAdminSession(string $uid = 'plain-user'): IUserSession
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn($user);
+        return $session;
+    }
+
+    private function makeAdminGroupManager(bool $isAdmin): IGroupManager
+    {
+        $groupManager = $this->createMock(IGroupManager::class);
+        $groupManager->method('isAdmin')->willReturn($isAdmin);
+        return $groupManager;
+    }
+
+    // ====================================================================
+    // Admin bypass — Open spec item:
+    //    "Admin users able to bypass reference validation."
+    // ====================================================================
+
+    public function testAdminUserBypassesReferenceValidationWhenFlagDefaultOn(): void
+    {
+        // unifiedObjectMapper->find() must NOT be called when admin bypass kicks in.
+        $unifiedMapper = $this->createMock(MagicMapper::class);
+        $unifiedMapper->expects($this->never())->method('find');
+
+        $handler = $this->buildHandler(
+            userSession: $this->makeAdminSession(),
+            groupManager: $this->makeAdminGroupManager(true),
+            appConfig: $this->makeAppConfig('true'),
+            unifiedObjectMapper: $unifiedMapper,
+        );
+
+        $this->invoke(
+            $handler,
+            'validateReferences',
+            [
+                'schema' => $this->buildSchemaWithReference(),
+                'data' => ['organisation' => 'never-checked-uuid'],
+                'register' => '1',
+                'oldData' => null,
+            ]
+        );
+    }
+
+    public function testAdminUserDoesNotBypassWhenFlagDisabled(): void
+    {
+        // With bypass off, the mapper IS called and the missing object
+        // surfaces as a ReferenceValidationException.
+        $unifiedMapper = $this->createMock(MagicMapper::class);
+        $unifiedMapper->expects($this->once())
+            ->method('find')
+            ->willThrowException(new DoesNotExistException('not found'));
+
+        $handler = $this->buildHandler(
+            userSession: $this->makeAdminSession(),
+            groupManager: $this->makeAdminGroupManager(true),
+            appConfig: $this->makeAppConfig('false'),
+            unifiedObjectMapper: $unifiedMapper,
+            schemaMapper: $this->makeSchemaMapperResolvingTarget(),
+        );
+
+        $this->expectException(ReferenceValidationException::class);
+        $this->invoke(
+            $handler,
+            'validateReferences',
+            [
+                'schema' => $this->buildSchemaWithReference(),
+                'data' => ['organisation' => 'missing-uuid'],
+                'register' => null,
+                'oldData' => null,
+            ]
+        );
+    }
+
+    public function testNonAdminUserNeverBypassesEvenWhenFlagOn(): void
+    {
+        $unifiedMapper = $this->createMock(MagicMapper::class);
+        $unifiedMapper->expects($this->once())
+            ->method('find')
+            ->willThrowException(new DoesNotExistException('not found'));
+
+        $handler = $this->buildHandler(
+            userSession: $this->makeNonAdminSession(),
+            groupManager: $this->makeAdminGroupManager(false),
+            appConfig: $this->makeAppConfig('true'),
+            unifiedObjectMapper: $unifiedMapper,
+            schemaMapper: $this->makeSchemaMapperResolvingTarget(),
+        );
+
+        $this->expectException(ReferenceValidationException::class);
+        $this->invoke(
+            $handler,
+            'validateReferences',
+            [
+                'schema' => $this->buildSchemaWithReference(),
+                'data' => ['organisation' => 'missing-uuid'],
+                'register' => null,
+                'oldData' => null,
+            ]
+        );
+    }
+
+    public function testBypassDisabledWhenGroupManagerMissing(): void
+    {
+        // Optional dependencies absent — validation must still run as
+        // before (back-compat with older test fixtures that don't pass
+        // groupManager / appConfig).
+        $unifiedMapper = $this->createMock(MagicMapper::class);
+        $unifiedMapper->expects($this->once())
+            ->method('find')
+            ->willThrowException(new DoesNotExistException('not found'));
+
+        $handler = $this->buildHandler(
+            userSession: $this->makeAdminSession(),
+            groupManager: null,
+            appConfig: null,
+            unifiedObjectMapper: $unifiedMapper,
+            schemaMapper: $this->makeSchemaMapperResolvingTarget(),
+        );
+
+        $this->expectException(ReferenceValidationException::class);
+        $this->invoke(
+            $handler,
+            'validateReferences',
+            [
+                'schema' => $this->buildSchemaWithReference(),
+                'data' => ['organisation' => 'missing-uuid'],
+                'register' => null,
+                'oldData' => null,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Picks up two open items from the `reference-existence-validation` OpenSpec change. Tickable progress: 6 → 8 of 16. Spec NOT archived; 8 items still open.

- **Admin bypass (commit 1)** — `SaveObject::validateReferences()` short-circuits when the current session user is in the `admin` group AND the new `reference_validation_admin_bypass` app-config flag (default `true`) is on. Operators can disable it via `occ config:app:set openregister reference_validation_admin_bypass --value=false` to enforce validation for every user. The new `IGroupManager` + `IAppConfig` constructor parameters are optional so existing test fixtures keep working.
- **Validation events (commit 2)** — adds `ReferenceValidatedEvent` and `ReferenceValidationFailedEvent` to the event family (both extend `OCP\EventDispatcher\Event`, both expose typed `propertyName` / `referencedUuid` / `targetSchemaSlug` / `targetRegister` fields). Success event fires on every successful UUID lookup; failure event fires immediately before the `ReferenceValidationException` is thrown. Listener exceptions are caught and logged as warnings.

## Test plan

- [x] `tests/Unit/Service/Object/SaveObjectReferenceValidationTest` — 7 unit tests (4 admin-bypass paths + 3 event-dispatch paths)
- [x] `tests/Unit/Event/ReferenceValidationEventsTest` — 7 unit tests for the event classes themselves
- [x] All 14 new tests pass under `composer test:unit` in the dev container
- [x] All 607 pre-existing SaveObject unit tests still pass (constructor params added at the end with nullable defaults)
- [x] PHPCS clean on every touched file (`composer phpcs`)
- [ ] Integration tests skipped — Docker NC env shared with parallel agents