### PR TITLE
feat(rbac-scopes Phase 3): scope caching + OAS scope generation

### DIFF
--- a/lib/Service/OasService.php
+++ b/lib/Service/OasService.php
@@ -489,10 +489,24 @@ class OasService
     }//end getScopeDescription()
 
     /**
-     * Apply RBAC information to an operation by appending group info to description and adding 403 response
+     * Apply RBAC information to an operation
      *
      * Always includes `admin` since admin users have access to all endpoints.
-     * Merges in any schema-specific groups for this CRUD action.
+     * Merges in any schema-specific groups for this CRUD action and:
+     *  - appends a human-readable `**Required scopes:**` block to the operation
+     *    description (Markdown rendered by Swagger UI / Redoc);
+     *  - adds a 403 response definition pointing at the standard Error schema;
+     *  - emits a per-operation OpenAPI 3.0 `security` requirement enumerating
+     *    the groups as OAuth2 scopes alongside `basicAuth` as fallback. This
+     *    makes the OAS a machine-readable access audit (see the Scope Audit
+     *    requirement in the rbac-scopes spec) and lets generated client SDKs
+     *    request the right scope set.
+     *
+     * The `security` block is OR-semantics across alternatives in the array
+     * (per the OpenAPI 3.0 spec), so a caller can either present a Bearer token
+     * with one of the listed oauth2 scopes OR fall back to Basic auth. The
+     * registered Nextcloud OAuth2 scope vocabulary is populated globally from
+     * the union of every schema's groups in createOas().
      *
      * @param array    $operation The operation array (passed by reference)
      * @param string[] $groups    The schema-specific groups that have access to this operation
@@ -505,6 +519,9 @@ class OasService
         if (in_array('admin', $groups, true) === false) {
             array_unshift($groups, 'admin');
         }
+
+        // Deduplicate while preserving order — admin first, then schema groups.
+        $groups = array_values(array_unique($groups));
 
         // Build scope list as inline code fragments.
         $scopeList = implode(
@@ -527,6 +544,14 @@ class OasService
                     'schema' => ['$ref' => '#/components/schemas/Error'],
                 ],
             ],
+        ];
+
+        // Emit per-operation security requirement: oauth2 with the resolved
+        // scope set, OR basicAuth fallback. Two array entries = OR semantics
+        // in OpenAPI 3.0.
+        $operation['security'] = [
+            ['oauth2' => $groups],
+            ['basicAuth' => []],
         ];
     }//end applyRbacToOperation()
 

--- a/lib/Service/Object/PermissionHandler.php
+++ b/lib/Service/Object/PermissionHandler.php
@@ -88,6 +88,25 @@ class PermissionHandler
     private array $cachedRegisterConfig = [];
 
     /**
+     * Per-request memoisation cache for hasPermission() verdicts.
+     *
+     * Hot list endpoints invoke `hasPermission()` once per row. The schema-level
+     * authorization plus user/group membership is identical across rows, so we
+     * cache the verdict keyed on the inputs that actually influence it:
+     * `(userId|null, schemaId, action, objectOwner|null, objectUuid|null)`.
+     *
+     * Object UUID is part of the key so conditional rules with `match` clauses
+     * still re-evaluate per object — same UUID within a request guarantees same
+     * underlying object data, which is the only safe reuse window.
+     *
+     * Implements the "scope caching for performance" requirement of the
+     * rbac-scopes spec (see openspec/changes/rbac-scopes/specs/rbac-scopes/spec.md).
+     *
+     * @var array<string, bool>
+     */
+    private array $permissionCache = [];
+
+    /**
      * PermissionHandler constructor.
      *
      * @param IUserSession       $userSession        User session for getting current user.
@@ -151,6 +170,113 @@ class PermissionHandler
             return true;
         }
 
+        // Build a per-request cache key. The object UUID (when present) is part
+        // of the key so conditional rules with `match` clauses are still
+        // re-evaluated per object — the cache only deduplicates repeated calls
+        // with the exact same inputs within a request lifecycle.
+        //
+        // SAFETY: when an object is supplied without a UUID (e.g. transient
+        // in-memory entity, draft, or unit-test stub), the cache is bypassed
+        // entirely. Conditional rules read from $object->getObject(), which can
+        // differ between calls for objects that share no stable identity.
+        $cacheKey = $this->buildPermissionCacheKey(
+            schemaId: $schema->getId(),
+            action: $action,
+            userId: $userId,
+            objectOwner: $objectOwner,
+            object: $object
+        );
+        if ($cacheKey !== null && array_key_exists($cacheKey, $this->permissionCache) === true) {
+            return $this->permissionCache[$cacheKey];
+        }
+
+        $verdict = $this->evaluatePermission(
+            schema: $schema,
+            action: $action,
+            userId: $userId,
+            objectOwner: $objectOwner,
+            object: $object
+        );
+
+        if ($cacheKey !== null) {
+            $this->permissionCache[$cacheKey] = $verdict;
+        }
+
+        return $verdict;
+    }//end hasPermission()
+
+    /**
+     * Build a stable cache key for hasPermission().
+     *
+     * Returns null when caching is unsafe:
+     *  - schema has no ID (unsaved entity);
+     *  - an object is supplied without a UUID (transient/in-memory entity whose
+     *    data could differ between calls and whose conditional-rule verdict
+     *    therefore cannot be reused).
+     *
+     * @param int|null          $schemaId    Schema ID.
+     * @param string            $action      CRUD action.
+     * @param string|null       $userId      User ID (null = anonymous).
+     * @param string|null       $objectOwner Object owner (null = no owner check).
+     * @param ObjectEntity|null $object      Object entity (UUID is the cache scope).
+     *
+     * @return string|null Cache key, or null to bypass cache.
+     */
+    private function buildPermissionCacheKey(
+        ?int $schemaId,
+        string $action,
+        ?string $userId,
+        ?string $objectOwner,
+        ?ObjectEntity $object
+    ): ?string {
+        if ($schemaId === null) {
+            return null;
+        }
+
+        $objectUuid = null;
+        if ($object !== null) {
+            $objectUuid = $object->getUuid();
+            if ($objectUuid === null || $objectUuid === '') {
+                // Object supplied but has no stable identity — caching is unsafe.
+                return null;
+            }
+        }
+
+        return sprintf(
+            's%d|a%s|u%s|o%s|i%s',
+            $schemaId,
+            $action,
+            $userId ?? '_',
+            $objectOwner ?? '_',
+            $objectUuid ?? '_'
+        );
+    }//end buildPermissionCacheKey()
+
+    /**
+     * Evaluate the full RBAC rule chain for a permission check.
+     *
+     * This is the uncached implementation of {@see hasPermission()} — extracted
+     * so the public entry point can short-circuit on a per-request memoisation
+     * cache without obscuring the evaluation order.
+     *
+     * @param Schema            $schema      Schema being checked.
+     * @param string            $action      CRUD action.
+     * @param string|null       $userId      User ID, or null to resolve from session.
+     * @param string|null       $objectOwner Object owner UID, for ownership bypass.
+     * @param ObjectEntity|null $object      Object entity for conditional matching.
+     *
+     * @return bool True if the user has permission.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) RBAC permission checks require multiple conditional paths
+     * @SuppressWarnings(PHPMD.NPathComplexity)      User/group/owner permission combinations create many paths
+     */
+    private function evaluatePermission(
+        Schema $schema,
+        string $action,
+        ?string $userId,
+        ?string $objectOwner,
+        ?ObjectEntity $object
+    ): bool {
         // Resolve object context for conditional authorization matching.
         // $activeOrganisation is resolved by ConditionMatcher itself (via OrganisationService);
         // no per-call lookup is needed here anymore.
@@ -237,7 +363,23 @@ class PermissionHandler
         }
 
         return false;
-    }//end hasPermission()
+    }//end evaluatePermission()
+
+    /**
+     * Reset the per-request permission verdict cache.
+     *
+     * Long-running CLI processes (e.g. background jobs that span multiple
+     * requests within a single PHP process) can call this to invalidate the
+     * memoised verdicts without instantiating a new handler.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/rbac-scopes/specs/rbac-scopes/spec.md#requirement-scope-caching-for-performance
+     */
+    public function clearPermissionCache(): void
+    {
+        $this->permissionCache = [];
+    }//end clearPermissionCache()
 
     /**
      * Check permission and throw exception if not granted

--- a/openspec/changes/rbac-scopes/tasks.md
+++ b/openspec/changes/rbac-scopes/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: RBAC Scopes
 
-> **Status (Phase 2):** The core 3-level RBAC implementation (PermissionHandler / MagicRbacHandler / PropertyRbacHandler) is in production and verified by the unify-rbac-condition-matching + row-field-level-security integration tests. This spec extends that foundation with OAS scope generation + caching + audit. 8 of 13 tasks tickably complete after Phase 2 added the scope discovery API; 5 left open.
+> **Status (Phase 3):** The core 3-level RBAC implementation (PermissionHandler / MagicRbacHandler / PropertyRbacHandler) is in production and verified by the unify-rbac-condition-matching + row-field-level-security integration tests. Phase 3 adds request-scoped scope caching in PermissionHandler and per-operation OAS `security` blocks emitting OAuth2 scopes from RBAC. 10 of 13 tasks tickably complete; 3 left open: Role Definitions and Hierarchy, Custom Scope Definitions, OAuth 2.0 Token Scopes Integration.
 
 ## Implemented
 
@@ -30,9 +30,9 @@
 
 - [ ] **Role Definitions and Hierarchy.** Partial — rules reference Nextcloud groups directly (no separate "role" abstraction layer). The spec calls for named roles defined at register level + expandable in lower-level authorization blocks. **Open** — requires a `roles: {roleName: [groupIds]}` map on Register + role-expansion logic in PermissionHandler.
 
-- [ ] **OAS Scope Generation from RBAC Configuration.** Not implemented — `OasService::createOas` includes a top-level `securitySchemes` block (Basic auth) but doesn't translate per-schema RBAC rules into per-endpoint `security: [{ openregister: [scope1, scope2] }]` requirements. **Open** — additive change to `OasService` to walk the schema's authorization config and emit OAuth2-flavour scope strings (e.g. `register.{slug}.schema.{slug}.read`).
+- [x] **OAS Scope Generation from RBAC Configuration.** `OasService::createOas` already populates the `components.securitySchemes.oauth2.flows.authorizationCode.scopes` map from the union of every schema's groups. Phase 3 extends `OasService::applyRbacToOperation()` to also emit per-operation `security: [{ "oauth2": [groups] }, { "basicAuth": [] }]` requirements, which makes the OAS a machine-readable access audit (consumed by Swagger UI, generated SDKs, and reverse proxies). The existing description-rendering and 403 response are preserved. Verified by 5 new unit tests in `tests/Unit/Service/OasServiceTest` (Oauth2 block emission, admin-when-empty, dedup, admin-first ordering, no mutation of unrelated keys).
 
-- [ ] **Scope Caching for Performance.** Not implemented — every `hasPermission` call re-evaluates the full rule chain. For hot paths (list endpoints), a per-request cache keyed on (user, schema, action) would reduce evaluator work. **Open** — request-scoped memoisation.
+- [x] **Scope Caching for Performance.** `PermissionHandler::hasPermission()` now short-circuits on a per-request memoisation cache keyed on `(schemaId, action, userId|null, objectOwner|null, objectUuid|null)`. The first call resolves the user via `IUserManager` + `IGroupManager` and walks the rule chain; subsequent calls within the same request reuse the verdict directly. Caching is bypassed when the schema has no ID, or when an object is supplied without a UUID (transient/in-memory entity whose data could differ between calls). The `_rbac=false` bypass short-circuits before the cache lookup, so RBAC disablement remains free. A `clearPermissionCache()` entry point is provided for long-running CLI processes that span multiple logical requests. Verified by 7 new unit tests in `tests/Unit/Service/Object/PermissionHandlerCacheTest`.
 
 - [ ] **Custom Scope Definitions.** Not implemented — the scope vocabulary is fixed (action × entity-level). No support for app-defined custom scopes. **Open** — design question.
 
@@ -44,6 +44,8 @@ The implemented portions are covered by the existing test suites:
 
 - `tests/Service/RbacOperatorMatchingIntegrationTest` — 4 tests (schema-level RLS via `ConditionMatcher`, closed under unify-rbac-condition-matching).
 - `tests/Service/RowFieldLevelSecurityIntegrationTest` — 7 tests (FLS metadata + filtering, closed under row-field-level-security).
-- `tests/Unit/Service/Object/PermissionHandlerRbacTest` — 20 tests (mocked-user RBAC dispatch, all rule types).
+- `tests/Unit/Service/Object/PermissionHandlerRbacTest` — 30 tests (mocked-user RBAC dispatch, all rule types).
+- `tests/Unit/Service/Object/PermissionHandlerCacheTest` — 7 tests (Phase 3: request-scoped permission verdict cache, conditional-rule per-UUID re-evaluation, RBAC bypass short-circuit, clearPermissionCache invalidation).
+- `tests/Unit/Service/OasServiceTest` — 190 tests including 5 new `applyRbacToOperation` tests for the per-operation OAS `security` block emission (Phase 3).
 - `tests/Unit/Db/MagicMapper/MagicRbacHandlerTest` — 14 tests (SQL-emission RBAC + admin/owner bypass).
-- `tests/Service/RbacScopeDiscoveryIntegrationTest` — 5 tests covering the new scope discovery endpoint end-to-end (envelope shape, non-admin-only-permitted-actions, admin-bypass, register filter, unknown-register filter).
+- `tests/Service/RbacScopeDiscoveryIntegrationTest` — 5 tests covering the scope discovery endpoint end-to-end (envelope shape, non-admin-only-permitted-actions, admin-bypass, register filter, unknown-register filter).

--- a/tests/Unit/Service/OasServiceTest.php
+++ b/tests/Unit/Service/OasServiceTest.php
@@ -2875,4 +2875,108 @@ class OasServiceTest extends TestCase
         $this->assertArrayHasKey('components', $result);
         $this->assertSame('3.1.0', $result['openapi']);
     }
+
+    // ========================================================================
+    // applyRbacToOperation: per-operation `security` block emission
+    //
+    // The rbac-scopes spec (OAS Scope Generation from RBAC Configuration
+    // requirement) mandates that every RBAC-protected operation carries a
+    // machine-readable `security` block enumerating the oauth2 scopes alongside
+    // basicAuth as fallback. These tests pin that contract.
+    // ========================================================================
+
+    public function testApplyRbacToOperationEmitsOauth2SecurityBlock(): void
+    {
+        $operation = [
+            'description' => 'List items',
+            'responses'   => [],
+        ];
+
+        $this->invokePrivateMethod('applyRbacToOperation', [&$operation, ['behandelaars', 'redacteuren']]);
+
+        $this->assertArrayHasKey('security', $operation);
+        $this->assertCount(
+            2,
+            $operation['security'],
+            'security MUST contain two alternatives: oauth2 and basicAuth (OR semantics)'
+        );
+
+        $this->assertArrayHasKey('oauth2', $operation['security'][0]);
+        $oauth2Scopes = $operation['security'][0]['oauth2'];
+        $this->assertContains('admin', $oauth2Scopes, 'admin MUST always be included');
+        $this->assertContains('behandelaars', $oauth2Scopes);
+        $this->assertContains('redacteuren', $oauth2Scopes);
+
+        $this->assertArrayHasKey('basicAuth', $operation['security'][1]);
+        $this->assertSame([], $operation['security'][1]['basicAuth']);
+    }
+
+    public function testApplyRbacToOperationSecurityIncludesAdminWhenGroupsEmpty(): void
+    {
+        $operation = [
+            'description' => 'Get item',
+            'responses'   => [],
+        ];
+
+        $this->invokePrivateMethod('applyRbacToOperation', [&$operation, []]);
+
+        $this->assertSame(['admin'], $operation['security'][0]['oauth2']);
+        $this->assertSame([], $operation['security'][1]['basicAuth']);
+    }
+
+    public function testApplyRbacToOperationSecurityDeduplicatesAdmin(): void
+    {
+        $operation = [
+            'description' => 'Update item',
+            'responses'   => [],
+        ];
+
+        $this->invokePrivateMethod('applyRbacToOperation', [&$operation, ['admin', 'admin', 'redacteuren']]);
+
+        $oauth2Scopes  = $operation['security'][0]['oauth2'];
+        $adminCount    = count(array_filter($oauth2Scopes, static fn(string $g): bool => $g === 'admin'));
+
+        $this->assertSame(1, $adminCount, 'admin MUST appear exactly once in the oauth2 scope list');
+        $this->assertContains('redacteuren', $oauth2Scopes);
+    }
+
+    public function testApplyRbacToOperationSecurityAdminFirst(): void
+    {
+        $operation = [
+            'description' => 'Delete item',
+            'responses'   => [],
+        ];
+
+        $this->invokePrivateMethod('applyRbacToOperation', [&$operation, ['behandelaars']]);
+
+        $this->assertSame(
+            'admin',
+            $operation['security'][0]['oauth2'][0],
+            'admin MUST be first in the oauth2 scope list (consistent with description rendering)'
+        );
+        $this->assertSame('behandelaars', $operation['security'][0]['oauth2'][1]);
+    }
+
+    public function testApplyRbacToOperationDoesNotMutateUnrelatedKeys(): void
+    {
+        $operation = [
+            'description' => 'Get item',
+            'responses'   => ['200' => ['description' => 'OK']],
+            'parameters'  => [['name' => 'id', 'in' => 'path']],
+            'tags'        => ['Items'],
+        ];
+
+        $this->invokePrivateMethod('applyRbacToOperation', [&$operation, ['viewers']]);
+
+        // Existing 200 response is preserved.
+        $this->assertArrayHasKey('200', $operation['responses']);
+        $this->assertArrayHasKey('403', $operation['responses']);
+
+        // parameters and tags untouched.
+        $this->assertSame([['name' => 'id', 'in' => 'path']], $operation['parameters']);
+        $this->assertSame(['Items'], $operation['tags']);
+
+        // security freshly added.
+        $this->assertArrayHasKey('security', $operation);
+    }
 }

--- a/tests/Unit/Service/Object/PermissionHandlerCacheTest.php
+++ b/tests/Unit/Service/Object/PermissionHandlerCacheTest.php
@@ -1,0 +1,466 @@
+<?php
+
+/**
+ * PermissionHandler request-scoped cache tests.
+ *
+ * Verifies that hasPermission() memoises verdicts within a single request so
+ * hot list endpoints don't re-walk the rule chain N times for N rows.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/changes/rbac-scopes/specs/rbac-scopes/spec.md#requirement-scope-caching-for-performance
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Object;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Service\ConditionMatcher;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @coversDefaultClass \OCA\OpenRegister\Service\Object\PermissionHandler
+ */
+class PermissionHandlerCacheTest extends TestCase
+{
+
+    private PermissionHandler $handler;
+
+    private IUserSession&MockObject $userSession;
+
+    private IUserManager&MockObject $userManager;
+
+    private IGroupManager&MockObject $groupManager;
+
+    private SchemaMapper&MockObject $schemaMapper;
+
+    private MagicMapper&MockObject $objectEntityMapper;
+
+    private ConditionMatcher&MockObject $conditionMatcher;
+
+    private LoggerInterface&MockObject $logger;
+
+    private ContainerInterface&MockObject $container;
+
+    private RegisterMapper&MockObject $registerMapper;
+
+
+    /**
+     * Wire up a fresh PermissionHandler with mocked collaborators.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->userSession        = $this->createMock(IUserSession::class);
+        $this->userManager        = $this->createMock(IUserManager::class);
+        $this->groupManager       = $this->createMock(IGroupManager::class);
+        $this->schemaMapper       = $this->createMock(SchemaMapper::class);
+        $this->objectEntityMapper = $this->createMock(MagicMapper::class);
+        $this->conditionMatcher   = $this->createMock(ConditionMatcher::class);
+        $this->logger             = $this->createMock(LoggerInterface::class);
+        $this->container          = $this->createMock(ContainerInterface::class);
+        $this->registerMapper     = $this->createMock(RegisterMapper::class);
+
+        $this->handler = new PermissionHandler(
+            $this->userSession,
+            $this->userManager,
+            $this->groupManager,
+            $this->schemaMapper,
+            $this->objectEntityMapper,
+            $this->conditionMatcher,
+            $this->logger,
+            $this->container
+        );
+    }//end setUp()
+
+
+    /**
+     * Helper: stage a logged-in user with the given groups.
+     *
+     * @param string        $uid    The user UID.
+     * @param array<string> $groups The groups the user belongs to.
+     *
+     * @return IUser&MockObject
+     */
+    private function mockUser(string $uid, array $groups): IUser&MockObject
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $user->method('getDisplayName')->willReturn($uid);
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->userManager->method('get')->willReturn($user);
+        $this->groupManager->method('getUserGroupIds')->willReturn($groups);
+        return $user;
+    }//end mockUser()
+
+
+    /**
+     * Helper: build a Schema with the given id and authorization block.
+     *
+     * @param int        $id            Schema ID.
+     * @param array|null $authorization Authorization block, or null.
+     *
+     * @return Schema
+     */
+    private function createSchema(int $id, ?array $authorization): Schema
+    {
+        $schema = new Schema();
+        $schema->setId($id);
+        $schema->setAuthorization($authorization);
+        $schema->setTitle('Test Schema '.$id);
+        return $schema;
+    }//end createSchema()
+
+
+    /**
+     * Helper: build a Register with the given id (no authorization needed for cache tests).
+     *
+     * @param int $id Register ID.
+     *
+     * @return Register
+     */
+    private function createRegister(int $id): Register
+    {
+        $register = new Register();
+        $register->setId($id);
+        $register->setAuthorization(null);
+        $register->setConfiguration([]);
+        return $register;
+    }//end createRegister()
+
+
+    /**
+     * Helper: glue the schema's parent-register lookup to the mocked mappers.
+     *
+     * @param Register $register Register to resolve as the schema's parent.
+     *
+     * @return void
+     */
+    private function setupRegisterForSchema(Register $register): void
+    {
+        $this->container->method('get')
+            ->willReturnCallback(
+                function (string $class) use ($register) {
+                    if ($class === RegisterMapper::class) {
+                        return $this->registerMapper;
+                    }
+                    throw new \RuntimeException('Unknown class: '.$class);
+                }
+            );
+        $this->registerMapper->method('getFirstRegisterWithSchema')->willReturn($register->getId());
+        $this->registerMapper->method('find')->willReturn($register);
+    }//end setupRegisterForSchema()
+
+
+    /**
+     * Helper: build an ObjectEntity with stable UUID + payload.
+     *
+     * @param string $uuid Object UUID.
+     * @param array  $data Object payload.
+     *
+     * @return ObjectEntity
+     */
+    private function createObjectEntity(string $uuid, array $data): ObjectEntity
+    {
+        $object = new ObjectEntity();
+        $object->setUuid($uuid);
+        $object->setObject($data);
+        return $object;
+    }//end createObjectEntity()
+
+
+    /**
+     * Repeated calls with identical inputs must reuse the cached verdict.
+     *
+     * The hot path on list endpoints is N calls to hasPermission() with the same
+     * (schema, action, userId, objectOwner). The user's group memberships should
+     * be resolved once via IGroupManager and reused for every subsequent call.
+     *
+     * @return void
+     */
+    public function testRepeatedHasPermissionCallsHitCacheAndAvoidGroupLookup(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('jan');
+        $user->method('getDisplayName')->willReturn('jan');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->userManager->method('get')->willReturn($user);
+
+        // The whole point of caching: getUserGroupIds is called exactly ONCE
+        // even though hasPermission is invoked many times.
+        $this->groupManager->expects($this->once())
+            ->method('getUserGroupIds')
+            ->willReturn(['behandelaars']);
+
+        $schema = $this->createSchema(1, ['read' => ['behandelaars']]);
+        $this->setupRegisterForSchema($this->createRegister(10));
+
+        for ($i = 0; $i < 5; $i++) {
+            $this->assertTrue(
+                $this->handler->hasPermission(schema: $schema, action: 'read', userId: 'jan'),
+                'Repeated identical hasPermission() calls must return the cached verdict'
+            );
+        }
+    }//end testRepeatedHasPermissionCallsHitCacheAndAvoidGroupLookup()
+
+
+    /**
+     * Different actions on the same schema must not collide in the cache.
+     *
+     * @return void
+     */
+    public function testDifferentActionsAreCachedSeparately(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('jan');
+        $user->method('getDisplayName')->willReturn('jan');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->userManager->method('get')->willReturn($user);
+
+        // Two distinct cache keys (action=read vs action=delete) -> two group lookups.
+        $this->groupManager->expects($this->exactly(2))
+            ->method('getUserGroupIds')
+            ->willReturn(['behandelaars']);
+
+        $schema = $this->createSchema(1, [
+            'read'   => ['behandelaars'],
+            'delete' => ['admin'],
+        ]);
+        $this->setupRegisterForSchema($this->createRegister(10));
+
+        $this->assertTrue($this->handler->hasPermission(schema: $schema, action: 'read', userId: 'jan'));
+        $this->assertFalse($this->handler->hasPermission(schema: $schema, action: 'delete', userId: 'jan'));
+
+        // Re-running both does NOT trigger more group lookups — verdicts are cached.
+        $this->assertTrue($this->handler->hasPermission(schema: $schema, action: 'read', userId: 'jan'));
+        $this->assertFalse($this->handler->hasPermission(schema: $schema, action: 'delete', userId: 'jan'));
+    }//end testDifferentActionsAreCachedSeparately()
+
+
+    /**
+     * Different users must not share cache entries.
+     *
+     * @return void
+     */
+    public function testDifferentUsersAreCachedSeparately(): void
+    {
+        $jan  = $this->createMock(IUser::class);
+        $jan->method('getUID')->willReturn('jan');
+        $jan->method('getDisplayName')->willReturn('jan');
+        $piet = $this->createMock(IUser::class);
+        $piet->method('getUID')->willReturn('piet');
+        $piet->method('getDisplayName')->willReturn('piet');
+
+        $this->userManager->method('get')
+            ->willReturnCallback(
+                function (string $uid) use ($jan, $piet) {
+                    return $uid === 'jan' ? $jan : $piet;
+                }
+            );
+
+        $this->groupManager->expects($this->exactly(2))
+            ->method('getUserGroupIds')
+            ->willReturnCallback(
+                function ($user) {
+                    return $user->getUID() === 'jan' ? ['behandelaars'] : ['kcc-team'];
+                }
+            );
+
+        $schema = $this->createSchema(1, ['read' => ['behandelaars']]);
+        $this->setupRegisterForSchema($this->createRegister(10));
+
+        $this->assertTrue($this->handler->hasPermission(schema: $schema, action: 'read', userId: 'jan'));
+        $this->assertFalse($this->handler->hasPermission(schema: $schema, action: 'read', userId: 'piet'));
+
+        // Repeat — both verdicts cached, no extra group lookups.
+        $this->assertTrue($this->handler->hasPermission(schema: $schema, action: 'read', userId: 'jan'));
+        $this->assertFalse($this->handler->hasPermission(schema: $schema, action: 'read', userId: 'piet'));
+    }//end testDifferentUsersAreCachedSeparately()
+
+
+    /**
+     * Conditional rules with `match` clauses must still re-evaluate per object.
+     *
+     * Two different ObjectEntities with different UUIDs must produce two separate
+     * delegations to ConditionMatcher — caching by UUID is the only safe reuse
+     * window for object-dependent verdicts.
+     *
+     * @return void
+     */
+    public function testConditionalRulesEvaluatePerObjectUuid(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $schema = $this->createSchema(1, [
+            'read' => [
+                ['group' => 'public', 'match' => ['publishDate' => ['$lte' => '$now']]],
+            ],
+        ]);
+        $this->setupRegisterForSchema($this->createRegister(10));
+
+        // Two distinct objects -> two distinct cache keys -> two delegation calls.
+        $this->conditionMatcher->expects($this->exactly(2))
+            ->method('objectMatchesConditions')
+            ->willReturnOnConsecutiveCalls(true, false);
+
+        $objectA = $this->createObjectEntity('uuid-a', ['publishDate' => '2025-01-01']);
+        $objectB = $this->createObjectEntity('uuid-b', ['publishDate' => '2099-01-01']);
+
+        $this->assertTrue(
+            $this->handler->hasPermission(
+                schema: $schema,
+                action: 'read',
+                userId: null,
+                objectOwner: null,
+                _rbac: true,
+                object: $objectA
+            )
+        );
+        $this->assertFalse(
+            $this->handler->hasPermission(
+                schema: $schema,
+                action: 'read',
+                userId: null,
+                objectOwner: null,
+                _rbac: true,
+                object: $objectB
+            )
+        );
+
+        // Re-running on the same UUIDs must hit the cache — no further delegations.
+        $this->assertTrue(
+            $this->handler->hasPermission(
+                schema: $schema,
+                action: 'read',
+                userId: null,
+                objectOwner: null,
+                _rbac: true,
+                object: $objectA
+            )
+        );
+        $this->assertFalse(
+            $this->handler->hasPermission(
+                schema: $schema,
+                action: 'read',
+                userId: null,
+                objectOwner: null,
+                _rbac: true,
+                object: $objectB
+            )
+        );
+    }//end testConditionalRulesEvaluatePerObjectUuid()
+
+
+    /**
+     * Object owner is part of the cache key — different owners must not collide.
+     *
+     * @return void
+     */
+    public function testObjectOwnerIsPartOfCacheKey(): void
+    {
+        $this->mockUser('jan', ['behandelaars']);
+
+        $schema = $this->createSchema(1, ['update' => ['admin']]);
+        $this->setupRegisterForSchema($this->createRegister(10));
+
+        // Owner = 'jan' -> ownership bypass -> true.
+        $this->assertTrue(
+            $this->handler->hasPermission(
+                schema: $schema,
+                action: 'update',
+                userId: 'jan',
+                objectOwner: 'jan'
+            )
+        );
+
+        // Owner = someone else, jan is not admin and not in update authorization -> false.
+        $this->assertFalse(
+            $this->handler->hasPermission(
+                schema: $schema,
+                action: 'update',
+                userId: 'jan',
+                objectOwner: 'piet'
+            )
+        );
+    }//end testObjectOwnerIsPartOfCacheKey()
+
+
+    /**
+     * clearPermissionCache() must invalidate previously memoised verdicts.
+     *
+     * @return void
+     */
+    public function testClearPermissionCacheInvalidatesEntries(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('jan');
+        $user->method('getDisplayName')->willReturn('jan');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->userManager->method('get')->willReturn($user);
+
+        // After clearing, the second call resolves groups from scratch.
+        $this->groupManager->expects($this->exactly(2))
+            ->method('getUserGroupIds')
+            ->willReturn(['behandelaars']);
+
+        $schema = $this->createSchema(1, ['read' => ['behandelaars']]);
+        $this->setupRegisterForSchema($this->createRegister(10));
+
+        $this->assertTrue($this->handler->hasPermission(schema: $schema, action: 'read', userId: 'jan'));
+        $this->assertTrue($this->handler->hasPermission(schema: $schema, action: 'read', userId: 'jan'));
+
+        $this->handler->clearPermissionCache();
+
+        $this->assertTrue($this->handler->hasPermission(schema: $schema, action: 'read', userId: 'jan'));
+    }//end testClearPermissionCacheInvalidatesEntries()
+
+
+    /**
+     * RBAC bypass (_rbac=false) must short-circuit before the cache so it
+     * always returns true regardless of cache contents.
+     *
+     * @return void
+     */
+    public function testRbacBypassShortCircuitsBeforeCache(): void
+    {
+        // No userSession/userManager mocks needed — they must NOT be called.
+        $this->userSession->expects($this->never())->method('getUser');
+        $this->groupManager->expects($this->never())->method('getUserGroupIds');
+
+        $schema = $this->createSchema(1, ['read' => ['admin']]);
+
+        for ($i = 0; $i < 3; $i++) {
+            $this->assertTrue(
+                $this->handler->hasPermission(
+                    schema: $schema,
+                    action: 'read',
+                    userId: 'jan',
+                    objectOwner: null,
+                    _rbac: false
+                )
+            );
+        }
+    }//end testRbacBypassShortCircuitsBeforeCache()
+}//end class


### PR DESCRIPTION
## Summary

Two additive Phase 3 deliveries against `openspec/changes/rbac-scopes/`:

- **Request-scoped permission verdict cache** in `PermissionHandler::hasPermission()`. Hot list endpoints invoke `hasPermission()` once per row; the schema-level authorization, register cascade, and user/group memberships are identical across rows, so we cache the verdict keyed on `(schemaId, action, userId|null, objectOwner|null, objectUuid|null)`. Object UUID is part of the key so conditional `match` rules still re-evaluate per object — same UUID within a request guarantees same payload, which is the only safe reuse window. Caching is bypassed when the schema has no ID or when an object is supplied without a UUID. `_rbac=false` short-circuits before the cache lookup. A `clearPermissionCache()` entry point is provided for long-running CLI processes.

- **Per-operation OAS `security` blocks emitted from RBAC** in `OasService::applyRbacToOperation()`. Each RBAC-protected operation now carries `security: [{ "oauth2": [admin, ...groups] }, { "basicAuth": [] }]` (OR semantics in OpenAPI 3.0). The existing `**Required scopes:**` description block and 403 response definition are preserved. This makes the generated OAS a machine-readable access audit consumed by Swagger UI, generated SDKs, and reverse proxies.

Both changes are additive — no existing endpoint, response, or authorization rule has changed semantics.

## Spec status

10 of 13 rbac-scopes tasks ticked after this PR. 3 remain open:

- **Role Definitions and Hierarchy** — needs `roles: {roleName: [groupIds]}` map on Register + role-expansion logic in PermissionHandler. Bigger refactor than this PR scope.
- **Custom Scope Definitions** — open design question (is this app-defined scope vocabulary? operator-defined? does it require a new model entity?).
- **OAuth 2.0 Token Scopes Integration** — gated on the broader auth-system spec; depends on Nextcloud's own oauth2 flow.

## Test plan

- [x] `tests/Unit/Service/Object/PermissionHandlerCacheTest` — 7 new tests (repeated hits avoid IGroupManager lookup, separate keys for action and user, conditional rules still evaluate per UUID, owner is part of the key, `clearPermissionCache` invalidates entries, `_rbac=false` short-circuits before cache).
- [x] `tests/Unit/Service/Object/PermissionHandlerRbacTest` — 30 pre-existing tests still pass (no regression).
- [x] `tests/Unit/Service/OasServiceTest` — 5 new `applyRbacToOperation` security-block tests + 185 pre-existing tests still pass (190 total).
- [x] PHPCS clean on every file touched (`lib/Service/Object/PermissionHandler.php`, `lib/Service/OasService.php`).
- [ ] CI runs the integration suite (Docker NC env was shared with parallel agents during this session, so integration tests were skipped per the worktree contract).

## Files changed

- `lib/Service/Object/PermissionHandler.php` — add `$permissionCache`, extract `evaluatePermission()`, add `buildPermissionCacheKey()`, add `clearPermissionCache()`.
- `lib/Service/OasService.php` — extend `applyRbacToOperation()` to emit `$operation['security']` (oauth2 + basicAuth alternatives).
- `tests/Unit/Service/Object/PermissionHandlerCacheTest.php` — new test class (7 tests).
- `tests/Unit/Service/OasServiceTest.php` — 5 new tests appended.
- `openspec/changes/rbac-scopes/tasks.md` — tick the two boxes, update status banner sentence, refresh test-coverage list.