### PR TITLE
docs(openspec batch D): proposal Why/What sections + verification

### DIFF
--- a/openspec/changes/api-test-coverage/proposal.md
+++ b/openspec/changes/api-test-coverage/proposal.md
@@ -1,5 +1,21 @@
 # API Integration Test Coverage to 100%
 
+## Why
+
+OpenRegister exposes ~455 API routes across 85 controllers, but only ~71 (≈18.9%) are exercised by Newman/Postman collections today. Tender requirements (DON, MDTO, e-Depot consumers) demand demonstrable API stability, and downstream apps (opencatalogi, softwarecatalog, docudesk) regress silently when controller behaviour drifts. Without server-side coverage measured by PCOV during integration runs, regressions in error paths, auth matrices, and pagination land in production undetected. This change brings the integration suite to full route coverage and ties it to the CI quality gate.
+
+## What Changes
+
+- New Newman collections per API resource group covering full CRUD lifecycles (success + error paths, all HTTP error codes 400/401/403/404/409/422/500).
+- Coverage of the 12 Settings sub-controllers (~90 routes) which currently have zero integration tests.
+- GraphQL, MCP, webhook delivery/lifecycle, multi-tenancy isolation, and search/faceting/vector tests added.
+- Authentication matrix tests (admin, regular user, public, no-auth) per route.
+- Pagination, sorting, filtering tests on every list endpoint.
+- File operations (upload, download, extraction, search, anonymization) and concurrency/race tests added.
+- CI pipeline: PCOV-instrumented Newman runs producing server-side coverage reports; coverage gate added.
+- Idempotent test data setup/teardown so suite is rerunnable; modular collection structure aligned with API domains.
+- New composer scripts to run API coverage locally.
+
 ## Problem
 Achieve 100% API route coverage with Newman integration tests and measure server-side code coverage from those tests using PCOV. Every API route defined in `appinfo/routes.php` SHALL have at least one Newman test covering the success path and one covering the error path.
 

--- a/openspec/changes/edepot-transfer/proposal.md
+++ b/openspec/changes/edepot-transfer/proposal.md
@@ -1,5 +1,21 @@
 # Proposal: edepot-transfer
 
+## Why
+
+Dutch government bodies are legally obliged under Archiefwet 1995 (Article 12) to transfer permanent records to a regional or national archive — typically an e-Depot. Tender intelligence shows 273 tenders with 547 requirements explicitly demanding e-Depot/MDTO/TMLO support across NL local government (Berkelland, Hilversum, Winterswijk, Zeist, Omgevingsdienst). Without an SIP-based transfer pipeline, OpenRegister cannot be the system-of-record for permanent records, and Conduction loses qualifying eligibility on those tenders. This change delivers MDTO-compliant SIP packaging, durable format conversion, and configurable e-Depot connectors — closing a regulatory and commercial gap.
+
+## What Changes
+
+- New `EdepotTransferService` orchestrating object selection, SIP build, transport, and status tracking.
+- MDTO XML generator mapping OpenRegister object metadata to MDTO fields with configurable mapping; TMLO fallback for legacy regional profiles (e.g. TMLO-Achterhoek).
+- SIP package builder producing OAIS-compliant Submission Information Packages (objects + files + metadata XML).
+- Durable format conversion before packaging: PDF/A-1b/PDF/A-2b for documents, ODF for spreadsheets, TIFF for images (Docudesk integration).
+- Pluggable transports: REST API (Preservica-style), SFTP, and OpenConnector — extensible interface for additional e-Depot vendors.
+- Pre-transfer metadata-completeness validation that blocks transfer with field-level errors when required MDTO/TMLO fields are missing.
+- Per-object transfer status (pending/submitted/accepted/rejected) surfaced in the object detail view; failed transfers retried without duplication.
+- Bulk selection by schema, register, or retention category.
+- Settings controller for configuring the e-Depot endpoint, credentials, and metadata mapping per installation.
+
 ## Summary
 
 Implement the ability to transfer OpenRegister objects and their associated files to e-Depot (regional digital archive) systems, with full MDTO/TMLO metadata compliance and durable format conversion (PDF/A, ODF). This enables Dutch government organisations to meet their legal obligation to transfer permanent records to a regional or national archive.

--- a/openspec/changes/geo-metadata-kaart/proposal.md
+++ b/openspec/changes/geo-metadata-kaart/proposal.md
@@ -1,5 +1,24 @@
 # Geo Metadata en Kaart
 
+## Why
+
+Dutch government registers are inherently geospatial — addresses, parcels, plan boundaries, monuments, traffic decisions, environmental permits — and tender requirements consistently demand BAG/BGT/BRT integration, RD New (EPSG:28992) coordinate handling, and PDOK-based map visualisation. OpenRegister currently treats geometry fields as opaque JSON: no validation, no spatial query, no map view, no INSPIRE compliance. This blocks ecosystem apps (opencatalogi catalogue maps, zaakafhandelapp location-based zaken, docudesk geo-tagged documents) and disqualifies Conduction from a large slice of municipal/provincial tenders. This change makes geospatial a first-class capability across schema definition, storage, query, and UI.
+
+## What Changes
+
+- Schema property types extended to support GeoJSON geometry (Point, Polygon, MultiPolygon, LineString) with CRS metadata.
+- MagicMapper indexes geometry columns and accepts spatial query parameters (bbox, within, intersects, distance).
+- Map visualization Vue component with PDOK (BRT, Luchtfoto) tile layers, marker clustering, and layer control.
+- Geocoding via PDOK Locatieserver and reverse geocoding helpers exposed through the API.
+- BAG and BGT base-registration lookup integration; resolved IDs stored alongside free-form addresses.
+- WFS and GeoJSON export endpoints for downstream GIS tooling.
+- INSPIRE metadata fields on schemas for compliant European geo-data sharing.
+- Coordinate transformation between WGS84/EPSG:4326 and RD New/EPSG:28992 (proj4js).
+- Geo-fencing event triggers (object moved into/out of polygon → workflow events).
+- Geo-filtering integrated into search/facet API and Solr/Elasticsearch spatial backends.
+- Map drawing/editing UI for in-place geometry capture.
+- NL Design System map styling tokens (no hardcoded colours).
+
 ## Problem
 Enable OpenRegister to store, validate, query, and visualize geospatial data attached to register objects. Objects MUST support GeoJSON geometry types (Point, Polygon, MultiPolygon, LineString), coordinate reference system negotiation (WGS84/EPSG:4326 and RD New/EPSG:28992), and references to Dutch base registrations (BAG, BGT, BRT).
 

--- a/openspec/changes/unit-test-coverage/proposal.md
+++ b/openspec/changes/unit-test-coverage/proposal.md
@@ -1,5 +1,24 @@
 # Unit Test Coverage
 
+## Why
+
+OpenRegister is the foundation for every Conduction app — opencatalogi, docudesk, softwarecatalog, zaakafhandelapp, mydash, larpingapp, procest, pipelinq — meaning every undetected regression in `lib/` cascades into the entire product line. The codebase has ~708 PHP source files with only ~422 unit tests today, leaving the largest classes (MagicMapper, ObjectService, organisation/multi-tenancy paths, webhook delivery, format converters) under-covered on error branches and edge cases. ADR-008 already mandates a 75% coverage gate but it is not enforced in CI, so coverage drifts. This change writes the missing tests, locks in the gate, and standardises how unit tests are written across the codebase.
+
+## What Changes
+
+- Coverage gate enforcement: 75% line + method coverage minimum in `composer check:strict`; build fails below threshold.
+- Standardise on PHPUnit `TestCase` with comprehensive mocking; ban Entity mocks (use real instances per `__call` quirk).
+- Branch coverage for ~175 service classes including all error paths and edge cases.
+- Coverage for ~46 root + 12 Settings controllers across CRUD and error handling.
+- Coverage for ~65 Db entities and mapper handlers (full field coverage).
+- Coverage for ~39 Event classes via DataProvider grouping.
+- Coverage for BackgroundJob, Command, Cron, Listener, Exception, Format classes.
+- Targeted suites for OrganisationService multi-tenancy, WebhookService delivery/retry, Import/Export handlers.
+- Use of `DataProvider` for parameterised scenarios and Reflection for private methods/final classes.
+- Standardised file organisation and naming convention under `tests/Unit/` mirroring `lib/` structure.
+- Resolve the `phpunit-unit.xml` Db exclusion that currently hides Db handler coverage.
+- CI integration: PCOV-instrumented run wired into `composer check:strict`.
+
 ## Problem
 Achieve comprehensive unit test code coverage for all PHP source files in OpenRegister's `lib/` directory (excluding `Migration/` and `AppInfo/Application.php`), targeting 75% line and method coverage as the enforced gate with a stretch goal of 100%. This spec defines the testing standards, mocking strategies, coverage enforcement mechanisms, and per-category test requirements that ensure every code path -- happy flows, error branches, edge cases, and boundary conditions -- is exercised by automated tests.
 


### PR DESCRIPTION
## Summary

Adds the validator-required `## Why` and `## What Changes` sections to four OpenSpec proposals in batch D:

- `api-test-coverage`
- `edepot-transfer`
- `geo-metadata-kaart`
- `unit-test-coverage`

`fix-date-histogram-mariadb` already had both sections.

No code changes, no tasks.md status changes, no archives.

## Verification against current code

- **fix-date-histogram-mariadb** -- Phase 1 helper `buildDateKeyExpr()` is already present in `lib/Db/MagicMapper/MagicFacetHandler.php:1848` and platform-aware. Phase 2 still pending: `MariaDbFacetHandler.php:1238` and `MetaDataFacetHandler.php:1158` still return `'%Y-%u'` (not ISO `%x-%v`); `MagicFacetHandler.php:1430` still calls `strtotime($dateKey)` for week bounds (the documented bug). Spec accurately describes remaining work.
- **api-test-coverage** -- 455 routes / 85 controllers (incl. 13 Settings) verified. Existing collections live in `tests/postman/`, `tests/newman/`, `tests/integration/`, `tests/performance/`. PCOV + Newman pipeline not yet present. Numbers in proposal narrative (~386 routes / 50 controllers / 71 covered) are slightly low vs current count (455/85) but ballpark accurate.
- **unit-test-coverage** -- 708 PHP files in `lib/`, 422 unit tests in `tests/Unit/`. Coverage gate not enforced in `composer check:strict` today. `phpunit-unit.xml` exists separately from `phpunit.xml`. Spec is consistent with current state.
- **geo-metadata-kaart** -- No shipped geo code in `lib/Service/Geo*` or comparable; only a BAG settings-register JSON exists. No overlap with already-shipped work; the spec is unblocked.
- **edepot-transfer** -- Substantial e-Depot scaffolding ALREADY shipped: `lib/Service/Edepot/{EdepotTransferService,MdtoXmlGenerator,SipPackageBuilder,TransferListService}.php`, `lib/Service/Edepot/Transport/{OpenConnectorTransport,RestApiTransport,SftpTransport,TransportInterface,TransportResult}.php`, plus `lib/Service/TmloService.php`, `lib/Controller/TmloController.php`, `lib/Controller/Settings/EdepotSettingsController.php`. The proposal is still relevant as a formal spec but should be reframed against the existing implementation rather than as greenfield. Flagged for follow-up; left untouched per task scope (no code mods).

## Validation

`openspec validate <spec> --type change`:
- api-test-coverage: VALID
- fix-date-histogram-mariadb: VALID
- geo-metadata-kaart: VALID
- edepot-transfer: still INVALID -- pre-existing issue, no `specs/` deltas folder (greenfield stub).
- unit-test-coverage: still INVALID -- pre-existing issue, `specs/unit-test-coverage/spec.md` uses `## Requirements` instead of `## ADDED Requirements`.

The two remaining failures are unrelated to the Why/What gap and out of scope for this batch.

## Test plan

- [x] `openspec validate` run on all 5 specs
- [x] No tasks.md modifications
- [x] No code modifications
- [x] Branch based on `platform-integration-2026-04`