### PR TITLE
docs(openspec batch C): proposal Why/What sections + verification

### DIFF
--- a/openspec/changes/auth-system/proposal.md
+++ b/openspec/changes/auth-system/proposal.md
@@ -1,5 +1,22 @@
 # Authentication and Authorization System
 
+## Why
+
+OpenRegister is consumed by browsers (Nextcloud session), API clients (Basic, JWT, API key), MCP clients, and SSO-fronted external systems. Without a single, documented identity model, RBAC decisions become inconsistent across access methods (REST, GraphQL, MCP, public endpoints) and external identities cannot be reliably mapped to Nextcloud groups. 67% of analysed tenders require SSO/identity integration and 86% require RBAC per zaaktype, so the auth/authz baseline must be defined as a first-class capability rather than as ad-hoc per-controller logic.
+
+## What Changes
+
+- Document multiple authentication methods that all resolve to a Nextcloud `IUser` before RBAC evaluation: session cookie, HTTP Basic, JWT bearer, OAuth2 bearer, and API key
+- Define the `Consumer` entity as the single bridge from external identities (JWT issuer/subject, OAuth client, API key) to a Nextcloud user with optional IP/CORS restrictions
+- Define a unified RBAC model layered over Nextcloud groups: schema-level, property-level, and row-level checks all driven by the resolved identity
+- Define the role hierarchy: admin bypass, owner privileges (creator), public access (unauthenticated), and authenticated default access
+- Define group-based access with conditional matching and dynamic variables (`$organisation`, `$userId`, `$now`)
+- Require multi-tenancy isolation: every authenticated request scopes data to the user's active organisation via `MultiTenancyTrait`
+- Require public endpoints to use Nextcloud's `#[PublicPage]` annotation framework with mixed-visibility enforcement
+- Require SSO via SAML, OIDC, and LDAP through Nextcloud's identity providers (no app-local SSO stack)
+- Require rate limiting, authentication audit events, permission caching, per-Consumer CORS/CSRF policy, MCP auth, service-to-service outbound tokens, and input sanitisation against XSS/injection
+- Codify all of the above in `specs/auth-system/spec.md` so dependent capabilities (`rbac-scopes`, `row-field-level-security`, `tenant-isolation-audit`) can reference one canonical source
+
 ## Problem
 Define the authentication and authorization system for OpenRegister, supporting Nextcloud session auth, Basic Auth for API consumers, JWT bearer tokens for external systems, API key auth for MCP and service-to-service integration, and SSO integration via SAML/OIDC. The auth system MUST map all external identities to Nextcloud users via the Consumer entity and enforce consistent RBAC across every access method (REST, GraphQL, MCP, public endpoints), ensuring that a single identity model drives schema-level, property-level, and row-level security decisions.
 

--- a/openspec/changes/authorization-rbac-enhancement/proposal.md
+++ b/openspec/changes/authorization-rbac-enhancement/proposal.md
@@ -1,5 +1,27 @@
 # Proposal: authorization-rbac-enhancement
 
+## Why
+
+OpenRegister's three-level RBAC (schema-level via `PermissionHandler`, row-level via `MagicRbacHandler`, field-level via `PropertyRbacHandler`) is already the highest-demand capability across all analysed tender clusters (1505 combined requirements in 405 tenders). The shipped `rbac-scopes` and `row-field-level-security` capabilities cover the engine and condition matching; what's still missing is the administrative surface that municipalities ask for: a central admin UI for roles and permissions, named role definitions, delegation workflows, automatic LDAP/AD group mapping, and explicit public access scopes. This change layers admin tooling and named roles on top of the existing RBAC engine so beheerders kunnen zonder programmeerkennis autorisaties beheren.
+
+## What Changes
+
+- Add named role definitions (Viewer, Editor, Manager, Archivist, custom) as first-class entities mapped to permission sets reusable across registers/schemas
+- Add a central authorization admin UI listing all assignments with search, filter, and bulk-edit
+- Add CRUD+L (Create, Read, Update, Delete, List) granularity at register and schema levels by extending the existing `authorization` block on Register/Schema
+- Add register/schema permission inheritance with explicit override semantics (register defaults cascade until a schema sets its own block)
+- Add delegation: a register manager can grant/revoke roles within their scope without system-admin access
+- Add an LDAP/AD group mapping configuration so external directory groups resolve to OpenRegister roles automatically
+- Add explicit public-access toggles per register/schema separate from authenticated user permissions
+- Add field-level visibility rules driven by named roles (extends existing `PropertyRbacHandler`)
+- Acceptance: row-level filtering must add < 50ms overhead to typical list queries (matches existing `MagicRbacHandler` performance budget)
+
+## Capabilities
+
+### Modified Capabilities
+- `rbac-scopes`: Adds named role definitions, admin UI, delegation, LDAP/AD mapping, and explicit public-access toggles on top of the existing scope engine
+- `row-field-level-security`: Adds named-role-driven field visibility configuration on top of the existing handler
+
 ## Summary
 
 Implement fine-grained role-based access control (RBAC) for OpenRegister, enabling per-schema, per-register, and per-object authorization with row-level security and team-based access control. This extends Nextcloud's built-in group system with OpenRegister-specific permission scopes that match the granularity required by Dutch government organisations.

--- a/openspec/changes/enhanced-audit-trail/proposal.md
+++ b/openspec/changes/enhanced-audit-trail/proposal.md
@@ -1,5 +1,26 @@
 # Proposal: enhanced-audit-trail
 
+## Why
+
+Government tenders (56-58% of analysed 39K tenders) require both immutable audit trails with tamper-evidence and GDPR Article 30 processing registers (verwerkingsregister). OpenRegister already has a functional `AuditTrail` entity with verwerkingenlogging fields (`processingActivityId`, `organisationId`, etc.) and the canonical `audit-trail-immutable` and `audit-hash-chain` capabilities are already shipped. This proposal captures the remaining audit UX gaps: a field-level diff viewer, bulk-operation summary entries, audit export endpoints, optional read-access logging, and a stable verwerkingenlogging API for external compliance reporting.
+
+## What Changes
+
+- Add a chronological audit trail viewer in the object detail UI with expandable old/new value diffs
+- Persist field-level change records (old value, new value) for every create/update/delete via the existing `AuditTrail` entity
+- Add bulk-operation summary audit entries that link to individual change records for imports, mass updates, and mass deletes
+- Add audit trail export endpoints (JSON and CSV) for compliance reporting and AP audits
+- Add optional read-access logging per schema for objects containing personal data (AVG Article 30 read events)
+- Add API mutation logging that records the calling Consumer/token identity alongside the user
+- Make audit retention configurable per register/schema with a default of 10 years
+- Surface the verwerkingenlogging API as a documented public capability for external compliance systems
+
+## Capabilities
+
+### Modified Capabilities
+- `audit-trail-immutable`: Adds field-level diff metadata, bulk summary linkage, and read-access events
+- `verwerkingsregister-api`: Documents the externally consumable surface, JSON/CSV export, and Consumer attribution
+
 ## Summary
 
 Implement a complete, immutable audit trail on all object mutations in OpenRegister, recording who changed what, when, with old/new values. Includes verwerkingenlogging for AVG/GDPR compliance and integration with BIO logging requirements. This is distinct from the archived `audit-trail-immutable` change by focusing on the practical audit UX, verwerkingenlogging API, and zaak-history integration rather than the cryptographic storage layer.

--- a/openspec/changes/retention-management/proposal.md
+++ b/openspec/changes/retention-management/proposal.md
@@ -1,5 +1,25 @@
 # Proposal: retention-management
 
+## Why
+
+Dutch government organisations are legally required to manage retention periods (bewaartermijnen) and destruction of records per the Archiefwet 1995. OpenRegister already has a basic `retention` field on `ObjectEntity`, an `archive` block on `Schema`, and an `AvgRetentionJob` background job, but lacks the configurable lifecycle management that municipalities expect: selectielijsten configuration, derived archiefactiedatum calculation, multi-step destruction approval, legal holds, and a retention dashboard. Market intelligence shows 154+ tenders require retention management and 189 tenders require the destruction workflow that depends on it; this proposal adds the missing per-schema/per-register configuration surface and the operational tooling around the existing job.
+
+## What Changes
+
+- Add MDTO-aligned archival metadata fields to the object `retention` JSON (`archiefnominatie`, `archiefactiedatum`, `archiefstatus`, `bewaartermijn`, `vernietigingsdatum`)
+- Add per-schema and per-register retention configuration with inheritance (register defaults, schema overrides) and resultaattype-aware periods
+- Add configurable retention start triggers (creation date, modification date, closure date, custom field) with automatic archiefactiedatum calculation
+- Add a retention dashboard listing upcoming expirations, overdue items, and held items grouped by register/schema
+- Add manual override endpoints so authorised users can adjust retention period and destruction date per object
+- Add VNG Selectielijst category mapping to schemas/registers so resultaattypen drive retention
+- Extend the existing `AvgRetentionJob` to flag (not destroy) objects past their retention date for review
+- Document integration with the shipped `archival-destruction-workflow` so destruction execution stays out of scope
+
+## Capabilities
+
+### Modified Capabilities
+- `retention-management`: Adds per-schema configuration surface, retention dashboard, manual overrides, selectielijst mapping, and start-trigger derivation on top of the existing MDTO metadata model
+
 ## Summary
 
 Implement configurable retention period management for OpenRegister objects, enabling organisations to assign, track, and enforce retention schedules (bewaartermijnen) per object type, schema, or register. Includes automatic flagging when retention expires and integration with selectielijsten from the VNG.

--- a/openspec/changes/saas-multi-tenant/proposal.md
+++ b/openspec/changes/saas-multi-tenant/proposal.md
@@ -1,5 +1,26 @@
 # Proposal: saas-multi-tenant
 
+## Why
+
+OpenRegister already has core multi-tenancy through Organisation entities, the `MultiTenancyTrait`, and `MagicOrganizationHandler` -- and the canonical capabilities `tenant-lifecycle`, `environment-otap`, `tenant-quotas`, and `tenant-isolation-audit` are already shipped. However, the SaaS deployment story still needs operational glue: a portable configuration export/import for OTAP promotion, a SaaS-grade health check surface, a tenant admin dashboard, and explicit decommissioning rules that preserve the audit trail. Government tenders (378 unique tenders, 1385 requirements across SaaS/OTAP clusters) consistently require this end-to-end SaaS readiness; this change ties the existing tenant primitives together into a deployable SaaS offering.
+
+## What Changes
+
+- Add a portable environment configuration package (schemas, registers, sources, settings) with export/import for OTAP promotion (test → acceptance → production)
+- Add per-tenant admin dashboard surfacing usage, quota consumption, and configuration overview backed by `tenant-quotas`
+- Add tenant provisioning/decommissioning APIs that wire into the existing `tenant-lifecycle` state machine and ensure audit records survive deprovisioning
+- Add SaaS operational endpoints: tenant-aware health checks, readiness probes, and graceful degradation hints
+- Document the recommended isolation model (shared-database row-level via `MultiTenancyTrait` + Organisation scoping) and tighten the cross-tenant audit guarantees from `tenant-isolation-audit`
+- Add request-context resolution (subdomain/header/Nextcloud instance) so tenant scoping is automatic across REST, GraphQL, and MCP
+
+## Capabilities
+
+### Modified Capabilities
+- `tenant-lifecycle`: Adds provisioning/decommissioning HTTP API and audit-preserving deprovisioning rules
+- `environment-otap`: Adds the configuration package format and promotion workflow between OTAP environments
+- `tenant-quotas`: Adds admin dashboard, usage metrics surface, and per-tenant overage handling
+- `tenant-isolation-audit`: Documents end-to-end SaaS isolation guarantees and request-context resolution
+
 ## Summary
 
 Implement multi-tenant data isolation, OTAP (Ontwikkel/Test/Acceptatie/Productie) environment support, and SaaS deployment readiness for OpenRegister. This enables Conduction to offer OpenRegister as a hosted SaaS service with proper tenant separation, environment promotion workflows, and the operational characteristics required by Dutch government SaaS procurement.

--- a/openspec/changes/workflow-operations/proposal.md
+++ b/openspec/changes/workflow-operations/proposal.md
@@ -1,5 +1,26 @@
 # Proposal: workflow-operations
 
+## Why
+
+The shipped `workflow-engine-abstraction`, `workflow-integration`, `event-driven-architecture`, and `schema-hooks` capabilities give OpenRegister a working backend pipeline (HookExecutor, n8n/Windmill adapters, registry, typed events). What's still missing is the operator-facing surface government beheerders need: a configuration UI on schemas, scheduled triggers, multi-step approval chains, execution history with monitoring, and a safe dry-run. 38% of analysed tenders require workflow/process automation with these operator capabilities; without them, workflows can only be configured by developers and approval logic must be re-implemented per project.
+
+## What Changes
+
+- Add `WorkflowExecution` entity, mapper, and migration to persist hook execution results (status, durationMs, errors, payload, executedAt) — already implemented and tested
+- Modify `HookExecutor` to persist execution history alongside its existing logger calls without failing the original hook on persistence error — already implemented
+- Add `WorkflowExecutionController` with list/show endpoints (filter by objectUuid, schemaId, hookId, status, engine, since) and admin-only delete — already implemented
+- Add `ScheduledWorkflow` entity, migration, and `ScheduledWorkflowJob` (TimedJob) that triggers workflows via the engine adapter on a configurable interval, with disabled/errored schedules skipped gracefully
+- Add `ApprovalChain` and `ApprovalStep` entities for multi-step approval state per object with role-based step assignment and reject/advance hooks
+- Add `ApprovalController` with chain CRUD and step approve/reject/status endpoints
+- Add `WorkflowEngineController::testHook()` dry-run endpoint that executes a hook with sample data derived from the schema without database persistence
+- Add Vue components: `SchemaWorkflowTab`, `HookForm`, `WorkflowExecutionPanel`, `ApprovalChainPanel`, `TestHookDialog`
+- Note: 49 of 56 tasks complete; remaining 7 are the approval-chain UI, test-hook UI, and final integration polish
+
+## Capabilities
+
+### Modified Capabilities
+- `workflow-integration`: Adds the operator-facing capabilities (configuration UI, scheduling, approval chains, execution history, dry-run) listed as "Not yet implemented" in the canonical spec
+
 ## Summary
 
 Add the missing operational capabilities for OpenRegister's workflow integration: a workflow configuration UI for schema settings, scheduled workflow triggers via Nextcloud TimedJobs, a multi-step approval chain state machine, workflow execution history with a monitoring dashboard, and a "test hook" dry-run facility. These features close the gap between the implemented backend pipeline (HookExecutor, adapters, registry) and the end-user/admin experience needed for production use in government environments.


### PR DESCRIPTION
## Summary

Adds the missing `## Why` and `## What Changes` sections to six in-flight openspec change proposals (batch C: auth/RBAC/audit/multi-tenancy/retention/workflow) so the proposal shape is consistent across the batch. Also documents overlap with already-shipped canonical specs where the stub proposals largely duplicate work.

## What's in this PR

- `auth-system` -- Why/What for the unified identity + RBAC baseline
- `authorization-rbac-enhancement` -- Why/What for the named-role admin layer on top of `rbac-scopes`/`row-field-level-security`
- `enhanced-audit-trail` -- Why/What for the audit UX layer on top of `audit-trail-immutable`/`audit-hash-chain`/`verwerkingsregister-api`
- `retention-management` -- Why/What for per-schema retention configuration on top of the existing `AvgRetentionJob`
- `saas-multi-tenant` -- Why/What for SaaS operational glue on top of `tenant-lifecycle`/`environment-otap`/`tenant-quotas`/`tenant-isolation-audit`
- `workflow-operations` -- Why/What for the operator surface on top of `workflow-integration` (49/56 tasks already done)

## Overlap findings (flagged, not closed)

These stub proposals substantially duplicate already-shipped canonical specs:
- `enhanced-audit-trail` overlaps with `openspec/specs/audit-trail-immutable/`, `openspec/specs/audit-hash-chain/`, and `openspec/specs/verwerkingsregister-api/`
- `saas-multi-tenant` overlaps with `openspec/specs/tenant-lifecycle/`, `openspec/specs/environment-otap/`, `openspec/specs/tenant-quotas/`, and `openspec/specs/tenant-isolation-audit/`
- `retention-management` (change) overlaps with `openspec/specs/retention-management/` and `openspec/specs/archival-destruction-workflow/`
- `authorization-rbac-enhancement` overlaps with `openspec/specs/rbac-scopes/` and `openspec/specs/row-field-level-security/`

These four are ripe for closure or scope-trimming once the platform-integration mega-PR lands -- not done in this PR per scope guard.

## Validation status

- `workflow-operations` -- valid (passes `openspec validate --type change`)
- The other five remain spec-shape invalid: their `specs/<capability>/spec.md` files either don't exist or use `## Requirements` rather than `## ADDED Requirements`. Fixing that is out of scope for this batch (no code/spec content changes).

## Test plan

- [ ] `openspec validate workflow-operations --type change` passes
- [ ] All six proposals render with `## Why` and `## What Changes` immediately under the title
- [ ] No code, no tasks.md, no canonical spec changes