### PR TITLE
docs(openspec batch B): proposal Why/What sections + verification

### DIFF
--- a/openspec/changes/data-import-export/proposal.md
+++ b/openspec/changes/data-import-export/proposal.md
@@ -1,7 +1,16 @@
 # Data Import and Export
 
-## Problem
-Document and extend OpenRegister's existing import/export infrastructure. The core pipeline is already implemented: ImportService with ChunkProcessingHandler for bulk ingest, ExportService/ExportHandler for CSV/JSON/XML output, and Configuration/ImportHandler for register template loading.
+## Why
 
-## Proposed Solution
-Extend the existing implementation with 12 additional requirements.
+Tender requirements (PvE) and migration projects need a single, well-documented round-trip path between OpenRegister registers and the standard formats data owners actually receive: spreadsheets, CSVs, and a portable JSON bundle. The pipeline is already production-grade — chunked async ingest, schema-aware validation, relation name companion columns, downloadable per-schema templates — but it has never been formally captured as a capability spec, so consumers cannot reason about supported formats, error handling, or rollback semantics. This change documents the shipped surface and pins down the remaining XML / ODS / streaming-progress / structured-rollback / downloadable-error-file gaps so they can be planned and prioritised.
+
+## What Changes
+
+- Document `ImportService::importFromExcel` / `importFromCsv` and `ConfigurationService::importFromJson` as the canonical row-level and bundle-level import entry points, with `processSpreadsheetBatch` chunked async via ReactPHP promises.
+- Document `ExportService::exportToExcel` / `exportToCsv` and `ConfigurationService::exportConfig` as the canonical export surface, including `_propertyName` companion columns for relation readability and per-language `field_lang` columns for translatable properties.
+- Document the shipped per-schema downloadable import templates served by `RegistersController::importTemplate` (`buildTemplateSpreadsheet` / `buildTemplateCsv`), UTF-8 BOM prefixed, RBAC-aware, round-trippable through the existing import endpoint.
+- Document the validation toggle (`$validation` flag wired through `validateObjectProperties`) as off-by-default for raw imports, on-by-default for the Configuration `ImportHandler`.
+- Add XML and ODS row-level support to `ImportService` / `ExportService` (currently Excel + CSV only at row level).
+- Add a downloadable `errors.csv` artefact for partial import failures (today the per-row error summary lives only in the import-result JSON envelope).
+- Add a Server-Sent Events progress endpoint for large imports, replacing the current frontend polling against import job status.
+- Add structured rollback for critical import failures so partial imports do not leave persisted rows behind (today there is no transaction span across chunked batches).

--- a/openspec/changes/data-sync-harvesting/proposal.md
+++ b/openspec/changes/data-sync-harvesting/proposal.md
@@ -1,5 +1,22 @@
 # Data Sync and Harvesting
 
+## Why
+
+Government registers seldom live in a single system. To deliver on tender requirements for federated case handling and on the Dutch base registration integration story (BAG, BRK, BRP, HR), OpenRegister needs a first-class harvesting pipeline that pulls from external APIs, file feeds, and other OpenRegister instances on a configurable schedule. CKAN's gather/fetch/import three-stage pattern is the proven open-source reference for this kind of work and aligns with our existing `Source` / `Mapping` / `WebhookService` building blocks. Today none of this is wired up: `Source`, `SourceMapper`, `Mapping`, `SyncConfigurationsJob`, `HookRetryJob`, `WebhookService`, and `Configuration/ImportHandler` exist as scaffolding but no end-to-end sync flows ship.
+
+## What Changes
+
+- Add configurable sync source definitions (connection details, authentication, scheduling) on top of the existing `Source` entity / `SourceMapper`.
+- Implement the three-stage CKAN-style pipeline (gather, fetch, import) with per-record status tracking and a complete sync audit trail integrated with the existing audit system.
+- Add incremental sync via last-modified tracking or change tokens so re-runs only touch changed rows.
+- Wire field mapping and transformation through the existing `Mapping` entity, with create/update/delete strategies and conflict resolution policies.
+- Add scheduled execution via Nextcloud's `BackgroundJob` infrastructure (build on `lib/Cron/SyncConfigurationsJob.php`) and event/webhook-triggered execution via `WebhookService` and `HookRetryJob`.
+- Validate imported data against the target schema before persistence (reuse the existing JSON Schema validator path).
+- Store external authentication credentials securely.
+- Add bi-directional sync for federated OpenRegister instances.
+- Honour multi-tenant organisation isolation throughout the sync pipeline.
+- Tune for scale with configurable batch sizes, throttling, concurrency limits, partial failure handling, and automatic retry.
+
 ## Problem
 Implement a robust, multi-source data synchronization and harvesting pipeline that enables OpenRegister to pull data from external APIs (REST, OData, SOAP), file feeds (CSV, JSON, XML), other OpenRegister instances, and Dutch government base registrations (BAG, BRK, BRP, HR) into register schemas. The sync pipeline MUST follow CKAN's proven three-stage pattern (gather, fetch, import) with per-record status tracking, support both scheduled (cron) and event-triggered execution, and provide incremental sync via last-modified tracking or change tokens.
 

--- a/openspec/changes/deprecate-published-metadata/proposal.md
+++ b/openspec/changes/deprecate-published-metadata/proposal.md
@@ -1,0 +1,19 @@
+# Deprecate Published/Depublished Object Metadata
+
+## Why
+
+The dedicated `published` / `depublished` object metadata fields predate the RBAC `$now` dynamic variable. RBAC `$now` rules now express the same "is this object visible right now" semantics in a way that scales across schemas and tenants without bespoke metadata columns, magic-table indexes, or specialised search/facet code paths. Keeping the legacy fields means duplicate logic across `MagicMapper`, `SaveObject`, `SearchQueryHandler`, `IndexService`, the search backends, the Solr ObjectHandler, and a sprawling frontend (copy modals, stats, import UI). It also misleads schema authors into reaching for `objectPublishedField` / `objectDepublishedField` / `autoPublish` configuration when an RBAC rule with `$now` is the right tool. This change finishes the removal across OpenRegister core and frontend, and documents what remains in scope for downstream apps (OpenCatalogi, Softwarecatalogus).
+
+## What Changes
+
+- **BREAKING (already shipped in core):** Remove `_published` / `_depublished` from `MagicMapper::getBaseMetadataColumns()`, the `$metadataColumns` arrays in `ensureTableForRegisterSchema()`, the `$idxMetaFields` index definitions, `buildInsertData()`, datetime conversion checks, and `buildObjectFromRow()`.
+- Remove `published` / `depublished` references from `MariaDbSearchHandler`, `MetaDataFacetHandler`, and `MagicFacetHandler`.
+- Remove `objectPublishedField`, `objectDepublishedField`, and `autoPublish` processing from `SaveObject::hydrateObjectMetadata()` and `setSelfMetadata()`; `MetadataHydrationHandler` now logs a deprecation warning when these schema config keys are encountered (PR #1132).
+- Remove `published` / `depublished` from `SearchQueryHandler` `@self` metadata fields and drop `$params['published']` plumbing.
+- Remove the `$published` parameter from `IndexService::searchObjects()`, `ObjectHandler::searchObjects()` / `buildSolrQuery()`, and `SearchBackendInterface::searchObjects()`; drop the `published:true` Solr filter.
+- Remove object publish / depublish methods from `BulkController` and clean up the `ObjectsController` / `BulkController` docblocks.
+- Remove `addPublishedDateToObjects()` from `ImportService` and turn the `$publish` parameter into a deprecated no-op that logs a warning (PR #1128).
+- Database migration `Version1Date20260313130000` drops the legacy columns idempotently from existing magic tables (PR #1133).
+- Frontend cleanup: remove `@self.published` / `@self.depublished` reads from copy modals, dashboard / register / schema stats, ImportRegister auto-publish toggle, schema modal CSS, type definitions, and mock data (PRs #1129, #1130, #1131).
+- Update the `MultiTenancyTrait` documentation to remove object-level published-bypass references while keeping the Register / Schema-level bypass documentation intact.
+- Out of scope (tracked but in separate repos): OpenCatalogi backend / frontend cleanup, Softwarecatalogus frontend cleanup, the schema migration guide, and end-to-end RBAC `$now` validation against WOO publication schemas.

--- a/openspec/changes/deprecate-published-metadata/specs/deprecate-published-metadata/spec.md
+++ b/openspec/changes/deprecate-published-metadata/specs/deprecate-published-metadata/spec.md
@@ -23,37 +23,16 @@ Remove the dedicated `published`/`depublished` object metadata system from OpenR
 - Object publish/depublish API routes (already removed)
 - ObjectEntity published/depublished properties (already removed)
 
-## Requirements
+## REMOVED Requirements
 
-### REQ-1: ImportService Published Date Removal
-- GIVEN an import operation with `publish=true`
-- WHEN objects are imported via JSON or CSV
-- THEN the `addPublishedDateToObjects()` logic is removed
-- AND the `$publish` parameter is ignored with a deprecation log warning
-- AND existing import functionality continues to work without published date injection
+### Requirement: Object Published / Depublished Metadata System
+The system MUST no longer support per-object `published` / `depublished` metadata fields. RBAC rules using the `$now` dynamic variable replace this functionality.
 
-### REQ-2: Frontend Copy Modal Cleanup
-- GIVEN a user copies an object via CopyObject or MassCopyObjects modal
-- WHEN the `@self` metadata is stripped from the copy
-- THEN `published` and `depublished` keys are no longer deleted (they don't exist)
-
-### REQ-3: Frontend Stats Cleanup
-- GIVEN dashboard, register detail, or schema detail views
-- WHEN object statistics are displayed
-- THEN the "published" count row/column is removed from the stats display
-
-### REQ-4: Import UI Cleanup
-- GIVEN the ImportRegister modal
-- WHEN a user configures an import
-- THEN the "Auto-publish imported objects" toggle is removed
-
-### REQ-5: MultiTenancyTrait Documentation
-- GIVEN the MultiTenancyTrait docblock
-- WHEN describing multi-tenancy bypass
-- THEN object-level published bypass references are removed
-- AND Register/Schema published bypass documentation remains
-
-### REQ-6: Deprecation Warnings
-- GIVEN a schema with `objectPublishedField`, `objectDepublishedField`, or `autoPublish` config keys
-- WHEN an object is saved using that schema
-- THEN a deprecation warning is logged suggesting migration to RBAC rules with `$now`
+- `addPublishedDateToObjects()` is removed from `ImportService`; the `$publish` parameter on import methods is a deprecated no-op that logs a deprecation warning.
+- `objectPublishedField`, `objectDepublishedField`, and `autoPublish` schema config keys are deprecated; `MetadataHydrationHandler` logs a deprecation warning when they are encountered.
+- `@self.published` / `@self.depublished` reads are removed from the frontend `CopyObject` and `MassCopyObjects` modals.
+- Object "published" stat rows and columns are removed from the dashboard, register detail, and schema detail views.
+- The "Auto-publish imported objects" toggle is removed from the `ImportRegister` modal.
+- Object-level published bypass references are removed from the `MultiTenancyTrait` documentation; Register / Schema-level bypass documentation remains intact.
+- `MagicMapper` no longer registers `_published` / `_depublished` magic columns or indexes; `SaveObject`, `SearchQueryHandler`, `IndexService`, the search backends, and the Solr `ObjectHandler` no longer emit or consume the field.
+- Object publish / depublish methods are removed from `BulkController`; the related routes are gone.

--- a/openspec/changes/file-actions/proposal.md
+++ b/openspec/changes/file-actions/proposal.md
@@ -1,5 +1,24 @@
 # File Actions
 
+## Why
+
+OpenRegister already wraps the Nextcloud Files API with a `FileService` plus a family of single-purpose handlers and exposes per-object file CRUD/publish/depublish endpoints. But everyday document workflows in consuming apps (Procest, Pipelinq, ZaakAfhandelApp) need richer actions: rename without re-upload, copy/move between objects, version listing and restore, soft locking to prevent concurrent edits, batch publish/depublish/delete to avoid N HTTP calls, scoped previews, label/description metadata enrichment, and download audit logging. These actions complete the file lifecycle and align with WebDAV locking (RFC 4918 §6) and Nextcloud's `IPreview` / `IVersionManager` APIs. Most of the surface has shipped (handlers + controller methods), but route registrations and audit/event integration still have gaps.
+
+## What Changes
+
+- Add `description`, `category`, `locked_by`, `locked_at`, `lock_expires`, `download_count` columns to `oc_openregister_files` (migration shipped) and surface them on `FileMapper` getters/setters and `jsonSerialize()`.
+- Introduce five new handlers under `lib/Service/File/` — `FileVersioningHandler`, `FileLockHandler`, `FileBatchHandler`, `FilePreviewHandler`, `FileAuditHandler` — wired into `FileService` via DI.
+- Implement file rename via `UpdateFileHandler::renameFile()` (using `OCP\Files\File::move()` within the same folder), with conflict and invalid-character validation; expose as `PUT .../files/{fileId}/rename`.
+- Implement file copy and move between objects (`FileService::copyFile()` / `moveFile()`), including cross-register/schema targets and name-conflict resolution; expose as `POST .../files/{fileId}/copy` and `.../move`.
+- Implement file version listing and restore via `IVersionManager`, with graceful degradation when `files_versions` is disabled; expose as `GET .../files/{fileId}/versions` and `POST .../files/{fileId}/versions/{versionId}/restore`.
+- Implement soft file locking via `FileLockHandler` (acquire / release / TTL expiry / admin force-unlock) and integrate lock checks into update / rename / move / delete; expose as `POST .../files/{fileId}/lock` and `.../unlock`.
+- Implement batch operations via `FileBatchHandler` (publish / depublish / delete / label, max 100 per batch, returning HTTP 207 on partial failure); expose as `POST .../files/batch`.
+- Implement scoped file previews via `FilePreviewHandler` and `IPreview` (configurable width/height, cache-control, fallback icon); expose as `GET .../files/{fileId}/preview`.
+- Add metadata enrichment for files (description, category, labels) with autocomplete, optimistic UI, and category-based filtering in `ReadFileHandler`; dedicated label endpoint at `PUT .../files/{fileId}/labels`.
+- Add download audit logging via `FileAuditHandler::logDownload()` (anonymous and authenticated, with bulk-ZIP single-entry treatment) and download-count caching on `FileMapper`.
+- Dispatch CloudEvents for every action (`nl.openregister.object.file.renamed/copied/moved/locked/unlocked/version_restored/...`) and write audit-trail entries for all mutations.
+- Register all new endpoints in `appinfo/routes.php` with CORS OPTIONS routes and update `openapi.json`.
+
 ## Problem
 OpenRegister has a comprehensive file management layer (FileService with 13 handler classes, FilesController, routes for CRUD/publish/depublish) but critical gaps remain in the file action capabilities:
 

--- a/openspec/changes/file-actions/specs/file-actions/spec.md
+++ b/openspec/changes/file-actions/specs/file-actions/spec.md
@@ -9,7 +9,7 @@ Extend OpenRegister's file management capabilities with rename, copy/move, versi
 **Standards**: WebDAV locking (RFC 4918 Section 6), Nextcloud Files API, Nextcloud IPreview API
 **Cross-references**: [object-interactions](../object-interactions/spec.md), [audit-trail-immutable](../../specs/audit-trail-immutable/spec.md), [event-driven-architecture](../../specs/event-driven-architecture/spec.md)
 
-## Requirements
+## ADDED Requirements
 
 ### Requirement: File Rename
 

--- a/openspec/changes/nextcloud-entity-relations/proposal.md
+++ b/openspec/changes/nextcloud-entity-relations/proposal.md
@@ -1,5 +1,23 @@
 # Nextcloud Entity Relations
 
+## Why
+
+Case-handling apps built on OpenRegister (Procest, Pipelinq, ZaakAfhandelApp) need to surface a complete picture of every artefact tied to a case: not just files and notes, but emails, calendar events, contacts, and Deck cards. The existing `object-interactions` capability proved out the pattern (wrap a Nextcloud subsystem, expose sub-resource endpoints under `/api/objects/{register}/{schema}/{id}/`, cascade cleanup on delete) for files / notes / VTODO tasks. Extending the same pattern to four more entity types unlocks the full Nextcloud groupware surface for OpenRegister consumers without re-implementing email/calendar/contact storage. Crucially, OpenRegister keeps Nextcloud as the source of truth and stores only references — not copies.
+
+## What Changes
+
+- Add three new join tables — `openregister_email_links`, `openregister_contact_links`, `openregister_deck_links` — each carrying `register_id`, `schema_id`, and `object_uuid` columns plus the relevant foreign Nextcloud identifier (mail account/message id, contact uri, Deck card id).
+- Add matching entities and mappers (`EmailLink` / `EmailLinkMapper`, `ContactLink` / `ContactLinkMapper`, `DeckLink` / `DeckLinkMapper`).
+- Add `EmailService` to link Nextcloud Mail messages to objects (read-only references; HTTP 501 when the Mail app is disabled).
+- Add `CalendarEventService` to create/link CalDAV `VEVENT` entries via `X-OPENREGISTER-*` custom properties and the RFC 9253 `LINK` property, mirroring the existing VTODO pattern.
+- Add `ContactService` to create/link CardDAV vCards via `X-OPENREGISTER-*` properties, with role management on links and reverse lookup (find objects for a contact); dual storage (vCard properties + database table).
+- Add `DeckCardService` to create/link Nextcloud Deck cards via Deck's OCS API (HTTP 501 when Deck is disabled), with board-level object listing.
+- Add four matching controllers — `EmailsController`, `CalendarEventsController`, `ContactsController`, `DeckController` — each exposing `GET / POST / DELETE /api/objects/{register}/{schema}/{id}/{entity}` plus search/reverse-lookup endpoints where relevant.
+- Add a unified `RelationsController` with type filtering (`?types=emails,contacts`) and timeline view (`?view=timeline`).
+- Extend `ObjectCleanupListener` to cascade unlink/cleanup for all four new entity types when an object is deleted.
+- Dispatch CloudEvents for every link mutation (`email.linked/unlinked`, `event.linked/unlinked/created`, `contact.linked/unlinked/created`, `deck.linked/unlinked/created`) and write audit-trail entries.
+- Add object-detail Vue tabs (`EmailsTab.vue`, `EventsTab.vue`, `ContactsTab.vue`, `DeckTab.vue`, `RelationsTab.vue`) with matching entity stores.
+
 ## Problem
 
 OpenRegister objects currently support linking to Nextcloud files (IRootFolder), notes (ICommentsManager), and tasks (CalDAV VTODO). However, other core Nextcloud entities — emails, calendar events, contacts, and Deck cards — cannot be related to objects. This limits the ability of consuming apps (Procest, Pipelinq, ZaakAfhandelApp) to present a complete picture of all activities and stakeholders associated with a case/object.

--- a/openspec/changes/nextcloud-entity-relations/specs/nextcloud-entity-relations/spec.md
+++ b/openspec/changes/nextcloud-entity-relations/specs/nextcloud-entity-relations/spec.md
@@ -15,7 +15,7 @@ OpenRegister objects need to relate to the full spectrum of Nextcloud PIM entiti
 
 ---
 
-## Requirements
+## ADDED Requirements
 
 ### Requirement: Email Relations via Nextcloud Mail
 


### PR DESCRIPTION
## Summary

Spec-only update for the second openspec proposal-hardening batch. Adds the `## Why` / `## What Changes` sections that the openspec CLI now requires (was a soft warning, now blocks `validate`) on six in-flight changes, plus the minimum spec.md delta-header fixes needed for those six to validate. No code changes, no `tasks.md` checkbox flips.

The six specs in this batch:

- `data-import-export` (12/15) - CSV/Excel/JSON pipeline + downloadable templates shipped; XML/ODS/error-CSV/SSE/rollback open.
- `data-sync-harvesting` (0/16) - scaffolding only; Why/What now drafted from existing problem statement.
- `file-actions` (72/110) - 5 new handlers and most controller methods shipped; route registrations and audit/event integration still patchy.
- `opt-in-files-extend` - already had Why/What; only verification done.
- `nextcloud-entity-relations` (44/53) - email / calendar / contact / Deck link tables, services, controllers shipped.
- `deprecate-published-metadata` (37/56) - proposal.md was missing entirely; now drafted; spec.md rewritten in `REMOVED Requirements` form.

All six now pass `openspec validate <id> --type change`.

## Verification notes

Code claims spot-checked against the worktree off `platform-integration-2026-04`:

- All named services / controllers / mappers / migrations exist.
- New entity-link tables (`openregister_email_links`, `openregister_contact_links`, `openregister_deck_links`) carry the expected `register_id` / `schema_id` / `object_uuid` columns (`Version1Date20260326000000`).
- `addPublishedDateToObjects()` is gone; `MetadataHydrationHandler` logs the deprecation warning for `objectPublishedField` / `objectDepublishedField` / `autoPublish`; `ImportService::$publish` is a documented no-op.
- Stale line-number references in proposal text (e.g. `RenderObject.php:908`, `validateObjectProperties` line 1522, `_propertyName` line 290) noted in batch report but left in place to keep this PR scoped to Why/What additions.
- `appinfo/routes.php` is missing the rename / copy / move / lock / unlock / batch / preview / versions / labels route registrations claimed as `[x]` in `file-actions/tasks.md`. Flagged in the batch report; not fixed here (code change out of scope).

## Test plan

- [ ] CI: openspec validate on changed specs (run by openspec workflow if present)
- [ ] Manual: `openspec validate <id> --type change` returns valid for each of the six specs