### PR TITLE
feat(opsx batch 2): apply + archive shipped specs

### DIFF
--- a/openspec/changes/data-import-export/tasks.md
+++ b/openspec/changes/data-import-export/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: Data Import and Export
 
-> **Status (Phase 2):** OpenRegister already ships a full Excel + CSV import/export pipeline (`ImportService` + `ExportService`) plus a configuration-level JSON portability path (`ConfigurationService::importFromJson` / `exportConfig`). Phase 2 is a documentation-vs-implementation sync — every Excel/CSV/JSON requirement has shipped code with file:line evidence. Downloadable per-schema import templates ship via `RegistersController::importTemplate`. The XML / ODS formats, structured rollback, downloadable error files, and full streaming progress endpoint remain genuinely open. **9 of 12 tasks tickably complete.**
+> **Status (Phase 2, updated 2026-05-01):** OpenRegister already ships a full Excel + CSV import/export pipeline (`ImportService` + `ExportService`) plus a configuration-level JSON portability path (`ConfigurationService::importFromJson` / `exportConfig`). Phase 2 is a documentation-vs-implementation sync — every Excel/CSV/JSON requirement has shipped code with file:line evidence. Downloadable per-schema import templates ship via `RegistersController::importTemplate`. The XML / ODS formats, structured rollback, downloadable error files, and full streaming progress endpoint remain genuinely open. **12 of 15 tasks shipped (9 implemented + 3 test coverage); 3 open are: downloadable error CSV, SSE progress (gated on realtime-updates), transactional rollback.**
 
 ## Implemented
 

--- a/openspec/changes/deprecate-published-metadata/tasks.md
+++ b/openspec/changes/deprecate-published-metadata/tasks.md
@@ -1,5 +1,9 @@
 # Tasks: Deprecate Published/Depublished Object Metadata
 
+> **Status (2026-05-01):** All OpenRegister-scope work is complete (Phases 1–3, 8 in-repo testing). Remaining 19 `[ ]` items live entirely in **Phases 4–7**, all explicitly marked **OUT OF SCOPE** in their headers (opencatalogi backend + frontend, softwarecatalogus frontend, schema migration guide). Plus 2 cross-repo testing items in Phase 8 (lines 95–96). **Nothing actionable remains in this repo.**
+>
+> Recommend opening cross-repo follow-up issues for the 5 deferred phases and archiving this change. The OpenRegister production code paths no longer reference `_published` / `_depublished` columns, magic-table migration is shipped, and frontend cleanup landed in the referenced PRs (#1129, #1130, #1131).
+
 ## Phase 1: OpenRegister Core Cleanup (COMPLETED - already done prior to this change)
 
 ### MagicMapper Column and Metadata Removal

--- a/openspec/changes/file-actions/tasks.md
+++ b/openspec/changes/file-actions/tasks.md
@@ -1,5 +1,12 @@
 # Tasks: File Actions
 
+> **Status (2026-05-01 audit):** routes for all file-action endpoints registered in commit 9c1b70533. Spot-check of "[x]" ticks identified two phantom claims that are now corrected:
+>
+> - **Phase 5 lock unit tests (lines 73 / 74 / 75 originally ticked)** — `FileLockHandlerTest` was missing the non-owner-unlock, admin-force-unlock, and TTL-expiry cases. Controller-level `testUnlockNonOwner` exists in `FilesControllerFileActionsTest`, but the handler-level cases were absent. Added in this batch (`testUnlockByNonOwnerThrows`, `testAdminForceUnlockSucceeds`, `testTtlExpiryAutoClears`).
+> - **Phase 4 version-restore unit test (line 56 was correctly `[ ]`)** — added `testRestoreVersionRejectsMalformedId` to cover the parse-side defensive path.
+>
+> **Genuine architectural gap surfaced (NOT silently fixed):** `FileLockHandler` stores locks in a private in-memory `$locks` array (no `FileMapper` write-through, no `oc_openregister_files.locked_by`/`locked_at`/`lock_expires` persistence). The migration columns from Phase 1 are present but unused. **Locks evaporate between requests.** This makes Phase 1 line 7 (FileLockHandler creation) and Phase 5 lock-acquisition checks structurally insufficient for production use. Tracked as a follow-up; no fix in this batch because it requires a `FileMapper` File-entity that does not yet exist (Phase 1 line 6 still `[ ]`).
+
 ## Phase 1: Database and Infrastructure
 
 - [x] Migration: Add `description`, `category`, `locked_by`, `locked_at`, `lock_expires`, `download_count` columns to `oc_openregister_files` table
@@ -53,7 +60,7 @@
 - [ ] Generate audit trail entry on version restore
 - [x] Dispatch `nl.openregister.object.file.version_restored` event
 - [x] Write unit test for version listing
-- [ ] Write unit test for version restore
+- [x] Write unit test for version restore (parse-side: `testRestoreVersionRejectsMalformedId`)
 - [x] Write unit test for graceful degradation without files_versions
 
 ## Phase 5: File Locking

--- a/openspec/changes/nextcloud-entity-relations/tasks.md
+++ b/openspec/changes/nextcloud-entity-relations/tasks.md
@@ -1,5 +1,9 @@
 # Tasks: Nextcloud Entity Relations
 
+> **Status (2026-05-01):** All backend work shipped — tables (`Version1Date20260326000000`), entities/mappers, services, controllers, routes, cleanup listeners, CloudEvents, audit trails, and unit tests are in place (44/53). The 9 open items split into:
+> - **Frontend Vue components (6 items):** `EmailsTab.vue`, `EventsTab.vue`, `ContactsTab.vue`, `DeckTab.vue`, `RelationsTab.vue`, entity stores. Frontend-Vue work, separate scope from this PHP-backend pass.
+> - **Integration tests (3 items):** Greenmail (mail), CalDAV (events), CardDAV (contacts) — require live Nextcloud services and a fixture stack the unit-test pass cannot reach.
+
 ## Database & Infrastructure
 - [x] Create database migration for openregister_email_links, openregister_contact_links, openregister_deck_links tables
 - [x] Create EmailLink entity and EmailLinkMapper

--- a/openspec/changes/opt-in-files-extend/tasks.md
+++ b/openspec/changes/opt-in-files-extend/tasks.md
@@ -1,3 +1,9 @@
+> **Status (2026-05-01):** All in-repo openregister work shipped. Sections 1–6 + 8.1 are complete (24/32 ticked). Remaining 8 items split into two non-actionable groups:
+> - **Section 7 (4 items):** opencatalogi public-API doc updates — explicitly DEFERRED to a cross-repo issue (`ConductionNL/opencatalogi#TBD`). Cannot land in openregister.
+> - **Section 8.2–8.5 (4 items):** manual smoke checklists + `/opsx:verify` invocation — for the user post-merge, not agent-actionable.
+>
+> Recommend marking this change ready for archive after the cross-repo opencatalogi issue is opened.
+
 ## 1. FileMapper batched lookup
 
 - [x] 1.1 Add `getFileIdsForObjects(array $uuids): array<string, int[]>` to `lib/Db/FileMapper.php` (or the appropriate file-lookup component if it lives elsewhere). Implementation MUST issue a single SQL query for the entire input set and return a map keyed by object UUID with an array of file IDs as the value. UUIDs with no files MUST be present in the result with an empty array.

--- a/tests/Unit/Service/File/FileLockHandlerTest.php
+++ b/tests/Unit/Service/File/FileLockHandlerTest.php
@@ -146,4 +146,89 @@ class FileLockHandlerTest extends TestCase
         $this->assertNotNull($info);
         $this->assertEquals('user-1', $info['lockedBy']);
     }
+
+    /**
+     * Test unlocking by a non-owner without force throws exception.
+     *
+     * Covers tasks.md Phase 5: "Write unit test for unlock by non-owner (403)"
+     * at the handler level (controller-level coverage already exists in
+     * FilesControllerFileActionsTest::testUnlockNonOwner).
+     */
+    public function testUnlockByNonOwnerThrows(): void
+    {
+        // user-1 locks the file.
+        $user1 = $this->createMock(IUser::class);
+        $user1->method('getUID')->willReturn('user-1');
+        $user2 = $this->createMock(IUser::class);
+        $user2->method('getUID')->willReturn('user-2');
+
+        // First call(s) return user-1 (during lockFile), then user-2 (during unlockFile).
+        $this->userSession->method('getUser')->willReturnOnConsecutiveCalls(
+            $user1,
+            $user2,
+            $user2
+        );
+
+        $this->handler->lockFile(99);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Only the lock owner or an admin can unlock this file');
+        $this->handler->unlockFile(99);
+    }
+
+    /**
+     * Test admin force-unlock succeeds even when not the lock owner.
+     *
+     * Covers tasks.md Phase 5: "Write unit test for admin force-unlock".
+     */
+    public function testAdminForceUnlockSucceeds(): void
+    {
+        $owner = $this->createMock(IUser::class);
+        $owner->method('getUID')->willReturn('owner');
+        $admin = $this->createMock(IUser::class);
+        $admin->method('getUID')->willReturn('admin');
+
+        // owner locks, then admin force-unlocks.
+        $this->userSession->method('getUser')->willReturnOnConsecutiveCalls(
+            $owner,
+            $admin,
+            $admin,
+            $admin
+        );
+
+        // Group manager treats 'admin' as admin user.
+        $this->groupManager->method('isAdmin')->willReturnCallback(
+            static fn (string $uid): bool => ($uid === 'admin')
+        );
+
+        $this->handler->lockFile(123);
+
+        $result = $this->handler->unlockFile(123, true);
+        $this->assertFalse($result['locked']);
+        $this->assertFalse($this->handler->isLocked(123));
+    }
+
+    /**
+     * Test that an expired lock is auto-cleared by getLockInfo (TTL expiry).
+     *
+     * Covers tasks.md Phase 5: "Write unit test for TTL expiry". Since the
+     * handler stores locks in memory and uses DateTime comparisons, we drive
+     * expiry by setting a TTL of 0 minutes which immediately marks the lock
+     * as expired on the next read.
+     */
+    public function testTtlExpiryAutoClears(): void
+    {
+        $this->mockUser('user-1');
+
+        // TTL of 0 minutes — expiresAt is `now`, so the next isLocked()
+        // read passes the `<=` check and auto-clears the lock.
+        $this->handler->lockFile(7, 0);
+
+        // Brief wait equivalent: ensure clock has progressed at least 1us
+        // by re-reading. PHP DateTime comparison is microsecond-aware on
+        // most platforms; the `<=` in getLockInfo is inclusive so even an
+        // identical timestamp triggers expiry.
+        $this->assertFalse($this->handler->isLocked(7));
+        $this->assertNull($this->handler->getLockInfo(7));
+    }
 }

--- a/tests/Unit/Service/File/FileVersioningHandlerTest.php
+++ b/tests/Unit/Service/File/FileVersioningHandlerTest.php
@@ -107,4 +107,23 @@ class FileVersioningHandlerTest extends TestCase
         $this->appManager->method('isEnabledForUser')->willReturn(false);
         $this->assertFalse($this->handler->isVersioningEnabled());
     }
+
+    /**
+     * Test restoreVersion rejects malformed version IDs.
+     *
+     * Covers tasks.md Phase 4: "Write unit test for version restore" — at the
+     * version-id-parse level. Real Files_Versions integration is exercised via
+     * graceful-degradation paths (testRestoreVersionDisabled).
+     */
+    public function testRestoreVersionRejectsMalformedId(): void
+    {
+        $this->appManager->method('isEnabledForUser')->willReturn(true);
+        $file = $this->createMock(File::class);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid version ID format');
+
+        // Anything that doesn't yield a positive integer after stripping 'v-'.
+        $this->handler->restoreVersion($file, 'not-a-version');
+    }
 }


### PR DESCRIPTION
## Summary

Five-spec audit + small actionable shipments on the in-flight `platform-integration-2026-04` branch. Per-spec table:

| Spec | Tasks after | Status | Files touched |
|---|---|---|---|
| `data-import-export` | 12/15 | partial — banner fixed (was wrongly 9/12) | `openspec/changes/data-import-export/tasks.md` |
| `file-actions` | 76/110 (+4) | partial — phantom ticks surfaced + 4 missing unit tests added | `openspec/changes/file-actions/tasks.md`, `tests/Unit/Service/File/FileLockHandlerTest.php`, `tests/Unit/Service/File/FileVersioningHandlerTest.php` |
| `nextcloud-entity-relations` | 44/53 | nothing-actionable for PHP-backend pass — 9 open are Vue + integration tests | `openspec/changes/nextcloud-entity-relations/tasks.md` |
| `opt-in-files-extend` | 24/32 | nothing-actionable — 8 open are cross-repo opencatalogi docs + manual smoke | `openspec/changes/opt-in-files-extend/tasks.md` |
| `deprecate-published-metadata` | 37/56 | nothing-actionable — 19 open are explicitly OUT OF SCOPE (other repos) | `openspec/changes/deprecate-published-metadata/tasks.md` |

## Phantom ticks found in file-actions

1. **Phase 5 lock unit tests (lines 73 / 74 / 75) — claimed but not present at handler level.** Added the three missing tests: `testUnlockByNonOwnerThrows`, `testAdminForceUnlockSucceeds`, `testTtlExpiryAutoClears`. Controller-level `testUnlockNonOwner` did exist in `FilesControllerFileActionsTest`, but the handler-level cases were absent.
2. **Architectural gap (NOT a tick lie, but structurally insufficient):** `FileLockHandler` stores locks in a private in-memory `$locks` array with no `FileMapper` write-through. Phase-1 migration columns (`locked_by`, `locked_at`, `lock_expires`) are present but unused. Locks evaporate between requests. Surfaced in tasks.md banner; fix needs a `File` entity that doesn't exist yet (Phase 1 line 6 still `[ ]`).

Plus a small genuine ship for Phase 4 line 56: added `testRestoreVersionRejectsMalformedId` for `FileVersioningHandler::restoreVersion` parse-side defensive path.

## Validation

All 5 changes pass `openspec validate <spec> --type change`.

## Test plan

- [ ] `composer check:strict` on touched files (`tests/Unit/Service/File/FileLockHandlerTest.php`, `tests/Unit/Service/File/FileVersioningHandlerTest.php`) — local environment without composer install; PHP `-l` clean.
- [ ] PHPUnit unit run `tests/Unit/Service/File/` — local env without composer install in this worktree; relies on CI for verification.
- [ ] `openspec validate <spec> --type change` for all 5 — passes locally.

## Archive recommendation

None of the 5 specs auto-archived. Recommend opening cross-repo follow-up issues for `opt-in-files-extend` Section 7 and `deprecate-published-metadata` Phases 4-7, then archiving those two.