### PR TITLE
docs(openspec): update wrapper-filename refs after rename

### DIFF
--- a/openspec/changes/api-test-coverage/specs/api-test-coverage/spec.md
+++ b/openspec/changes/api-test-coverage/specs/api-test-coverage/spec.md
@@ -19,7 +19,7 @@ Achieve 100% API route coverage with Newman integration tests and measure server
   - `tests/newman/agent-cms-testing.postman_collection.json` (469 lines)
   - `tests/performance/performance-test-collection.json` (274 lines)
 - **Dual-storage testing** in CI: `run-dual-storage-tests.sh` runs collections against both Normal (JSON blob) and Magic Mapper (SQL) storage modes
-- **CI pipeline** defined in `.github/workflows/quality.yml` -- Newman runs are delegated to a database-tests workflow matrix (PostgreSQL/MySQL x Normal/MagicMapper)
+- **CI pipeline** defined in `.github/workflows/code-quality.yml` -- Newman runs are delegated to a database-tests workflow matrix (PostgreSQL/MySQL x Normal/MagicMapper)
 - **0% PCOV coverage measurement** from integration tests -- no `coverage-prepend.php` exists
 - **50 controllers** identified in `lib/Controller/` (38 root + 12 Settings sub-controllers)
 - **Public endpoints** exist on: ObjectsController, GraphQLController, McpController, OasController, NamesController, UserController, FilesController (annotated with `@PublicPage`)
@@ -628,8 +628,8 @@ Tests SHALL be organized in separate Postman collections by domain, stored consi
   - Agent CMS testing collection in `tests/newman/`
   - Performance test collection in `tests/performance/`
   - Dual-storage runner script (`run-dual-storage-tests.sh`)
-  - CI pipeline in `.github/workflows/quality.yml` with `enable-newman: false` (delegated to database-tests workflow)
-  - Coverage guard integration (`enable-coverage-guard: true` in quality.yml)
+  - CI pipeline in `.github/workflows/code-quality.yml` with `enable-newman: false` (delegated to database-tests workflow)
+  - Coverage guard integration (`enable-coverage-guard: true` in code-quality.yml)
 - **NOT implemented:**
   - PCOV coverage collection during Newman/API test runs (no `coverage-prepend.php`)
   - Coverage merge or dual reporting (unit + API)

--- a/openspec/specs/mariadb-ci-matrix/spec.md
+++ b/openspec/specs/mariadb-ci-matrix/spec.md
@@ -479,9 +479,9 @@ The testing documentation SHALL be updated to reflect:
 
 | Change | Files Affected |
 |--------|---------------|
-| Rewrite `integration-tests` job to matrix | `.github/workflows/quality.yml` |
-| Rewrite `php-tests` job to matrix | `.github/workflows/quality.yml` |
-| Update summary job for matrix labels | `.github/workflows/quality.yml` |
+| Rewrite `integration-tests` job to matrix | `.github/workflows/code-quality.yml` |
+| Rewrite `php-tests` job to matrix | `.github/workflows/code-quality.yml` |
+| Update summary job for matrix labels | `.github/workflows/code-quality.yml` |
 | Add MariaDB fallbacks to MagicSearchHandler | `lib/Db/MagicMapper/MagicSearchHandler.php` |
 | Add MariaDB fallbacks to MagicFacetHandler | `lib/Db/MagicMapper/MagicFacetHandler.php` |
 | Platform-guard GIN index creation | `lib/Db/MagicMapper.php` |
@@ -493,7 +493,7 @@ The testing documentation SHALL be updated to reflect:
 ## Current Implementation Status
 
 - **Implemented -- CI matrix workflow**: `.github/workflows/database-tests.yml` implements the 2-line matrix with PHPUnit and Newman jobs running against both PostgreSQL 16 (PHP 8.3, NC stable32) and MariaDB 10.11 (PHP 8.2, NC stable31). Uses Docker containers started dynamically from matrix variables with health-check polling.
-- **Implemented -- quality.yml updated**: PHPUnit and Newman disabled in the shared quality workflow call (`quality.yml`) since they now run in `database-tests.yml` with real database backends instead of SQLite.
+- **Implemented -- quality.yml updated**: PHPUnit and Newman disabled in the shared quality workflow call (`code-quality.yml`) since they now run in `database-tests.yml` with real database backends instead of SQLite.
 - **Implemented -- MagicMapper-only testing**: Newman runs once per matrix job (MagicMapper only); no dual-storage testing in CI.
 - **Implemented -- MagicMapper table creation**: `MagicMapper::createTable()` and `mapColumnTypeToSQL()` have full PostgreSQL/MariaDB branching for column types (JSONB vs JSON, TIMESTAMP vs DATETIME, BIGSERIAL vs AUTO_INCREMENT).
 - **Implemented -- MagicBulkHandler platform branching**: `MagicBulkHandler` detects `PostgreSQLPlatform` and uses `INSERT...ON CONFLICT DO UPDATE` vs `INSERT...ON DUPLICATE KEY UPDATE`, plus platform-specific column introspection.
@@ -521,7 +521,7 @@ The testing documentation SHALL be updated to reflect:
 ## Specificity Assessment
 
 - **Highly specific and implementable as-is**: The spec provides exact matrix configurations, YAML snippets, Docker container setup instructions, and parameterized install commands.
-- **Clear scope**: Modifies `.github/workflows/quality.yml`, MagicMapper database handlers, test scripts, and documentation.
+- **Clear scope**: Modifies `.github/workflows/code-quality.yml`, MagicMapper database handlers, test scripts, and documentation.
 - **Identifies concrete compatibility gaps**: Lists specific methods (`applyJsonArrayFilter`, `applyRelationsContainsFilter`, `buildArrayPropertyConditionSql`) that need MariaDB fallbacks, with exact SQL operator mappings.
 - **Well-defined maintenance procedure**: Describes the version bump process when a new Nextcloud stable is released.
 - **No ambiguity**: Matrix entries, service containers, health checks, and parameterized install steps are all fully specified.


### PR DESCRIPTION
Follow-up to ConductionNL/openregister#1388. Updates 8 active-spec references to the canonical filename. Archived spec copies under openspec/changes/archive/ are intentionally NOT touched (historical accuracy). The REQ title at line 95 is preserved (would break addressable identity).