### PR TITLE
feat(import): per-row error CSV in import response envelope

### DIFF
--- a/lib/Controller/RegistersController.php
+++ b/lib/Controller/RegistersController.php
@@ -1224,12 +1224,21 @@ class RegistersController extends Controller
                     break;
             }//end switch
 
-            return new JSONResponse(
-                data: [
-                    'message' => 'Import successful',
-                    'summary' => $summary,
-                ]
-            );
+            // Attach a downloadable per-row error CSV when the summary
+            // surfaces row-level failures. Base64 keeps the artefact in the
+            // existing JSON envelope so the frontend can offer a download
+            // without a second round-trip.
+            $errorsCsv    = $this->importService->serializeErrorsToCsv(summary: $summary);
+            $responseData = [
+                'message' => 'Import successful',
+                'summary' => $summary,
+            ];
+            if ($errorsCsv !== '') {
+                $responseData['errors_csv']          = base64_encode($errorsCsv);
+                $responseData['errors_csv_filename'] = 'import_errors.csv';
+            }
+
+            return new JSONResponse(data: $responseData);
         } catch (Exception $e) {
             return new JSONResponse(data: ['error' => $e->getMessage()], statusCode: 400);
         }//end try

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -141,16 +141,22 @@ class ImportService
     private readonly IJobList $jobList;
 
     /**
-     * Constructor for the ImportService
+     * Translation CSV codec for column projection on import/export.
      *
-     * @param SchemaMapper    $schemaMapper  The schema mapper
-     * @param ObjectService   $objectService The object service
-     * @param LoggerInterface $logger        The logger interface
-     * @param IGroupManager   $groupManager  The group manager
-     * @param IJobList        $jobList       The background job list
+     * @var \OCA\OpenRegister\Service\Translation\TranslationCsvCodec
      */
     private readonly \OCA\OpenRegister\Service\Translation\TranslationCsvCodec $translationCsvCodec;
 
+    /**
+     * Constructor for the ImportService
+     *
+     * @param SchemaMapper                                              $schemaMapper        The schema mapper
+     * @param ObjectService                                             $objectService       The object service
+     * @param LoggerInterface                                           $logger              The logger interface
+     * @param IGroupManager                                             $groupManager        The group manager
+     * @param IJobList                                                  $jobList             The background job list
+     * @param \OCA\OpenRegister\Service\Translation\TranslationCsvCodec $translationCsvCodec Translation CSV codec
+     */
     public function __construct(
         SchemaMapper $schemaMapper,
         ObjectService $objectService,
@@ -159,11 +165,11 @@ class ImportService
         IJobList $jobList,
         \OCA\OpenRegister\Service\Translation\TranslationCsvCodec $translationCsvCodec
     ) {
-        $this->schemaMapper        = $schemaMapper;
-        $this->objectService       = $objectService;
-        $this->logger              = $logger;
-        $this->groupManager        = $groupManager;
-        $this->jobList             = $jobList;
+        $this->schemaMapper  = $schemaMapper;
+        $this->objectService = $objectService;
+        $this->logger        = $logger;
+        $this->groupManager  = $groupManager;
+        $this->jobList       = $jobList;
         $this->translationCsvCodec = $translationCsvCodec;
 
         // Initialize cache arrays to prevent issues.
@@ -1723,4 +1729,124 @@ class ImportService
             maxObjects: $maxObjects
         );
     }//end scheduleSmartSolrWarmup()
+
+    /**
+     * Serialize per-row import errors to a UTF-8 CSV blob with BOM.
+     *
+     * Walks the sheet-based import summary, extracting any `errors` entries
+     * and emitting one row per failure. Columns: `sheet`, `row`, `field`,
+     * `error_message`, `original_value`. Output is UTF-8 with BOM so Excel
+     * opens it cleanly (matches the existing template-export pattern).
+     *
+     * Returns an empty string when the summary contains no errors so callers
+     * can cheaply skip attaching the artefact.
+     *
+     * @param array<string, mixed> $summary The sheet-based import summary as
+     *                                      returned by importFromExcel /
+     *                                      importFromCsv.
+     *
+     * @return string The CSV payload (UTF-8 BOM prefixed) or empty string.
+     *
+     * @phpstan-param array<string, array{errors?: array<int, mixed>}> $summary
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Error envelopes carry several optional shapes.
+     *
+     * @spec openspec/changes/data-import-export/tasks.md#task-error-csv
+     */
+    public function serializeErrorsToCsv(array $summary): string
+    {
+        $errors = [];
+
+        foreach ($summary as $sheetTitle => $sheetData) {
+            if (is_array($sheetData) === false) {
+                continue;
+            }
+
+            $sheetErrors = $sheetData['errors'] ?? [];
+            if (is_array($sheetErrors) === false || count($sheetErrors) === 0) {
+                continue;
+            }
+
+            foreach ($sheetErrors as $error) {
+                if (is_array($error) === false) {
+                    $error = ['error' => (string) $error];
+                }
+
+                $originalValue = ($error['object'] ?? ($error['original_value'] ?? ''));
+                $errors[]      = [
+                    'sheet'          => (string) ($error['sheet'] ?? $sheetTitle),
+                    'row'            => (string) ($error['row'] ?? ''),
+                    'field'          => (string) ($error['field'] ?? ($error['type'] ?? '')),
+                    'error_message'  => (string) ($error['error'] ?? ''),
+                    'original_value' => $this->stringifyOriginalValue(value: $originalValue),
+                ];
+            }//end foreach
+        }//end foreach
+
+        if (count($errors) === 0) {
+            return '';
+        }
+
+        $headers = ['sheet', 'row', 'field', 'error_message', 'original_value'];
+
+        $stream = fopen('php://temp', 'r+');
+        if ($stream === false) {
+            return '';
+        }
+
+        // Excel needs the UTF-8 BOM to detect encoding.
+        fwrite($stream, "\xEF\xBB\xBF");
+        fputcsv($stream, $headers);
+
+        foreach ($errors as $row) {
+            fputcsv(
+                $stream,
+                [
+                    $row['sheet'],
+                    $row['row'],
+                    $row['field'],
+                    $row['error_message'],
+                    $row['original_value'],
+                ]
+            );
+        }
+
+        rewind($stream);
+        $csv = stream_get_contents($stream);
+        fclose($stream);
+
+        return $csv === false ? '' : $csv;
+
+    }//end serializeErrorsToCsv()
+
+    /**
+     * Stringify the `original_value` carried by an error entry.
+     *
+     * Errors collected by the import pipeline embed either a row-level scalar
+     * (e.g. a malformed cell), an associative array (the parsed object that
+     * failed validation), or nothing at all. A single CSV cell needs a stable
+     * string projection of all three.
+     *
+     * @param mixed $value The raw value lifted off the error envelope.
+     *
+     * @return string Compact string representation suitable for a CSV cell.
+     */
+    private function stringifyOriginalValue(mixed $value): string
+    {
+        if ($value === null || $value === '') {
+            return '';
+        }
+
+        if (is_scalar($value) === true) {
+            return (string) $value;
+        }
+
+        if (is_array($value) === true || is_object($value) === true) {
+            $encoded = json_encode($value, (JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            return $encoded === false ? '' : $encoded;
+        }
+
+        return '';
+
+    }//end stringifyOriginalValue()
 }//end class

--- a/openspec/changes/data-import-export/tasks.md
+++ b/openspec/changes/data-import-export/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: Data Import and Export
 
-> **Status (Phase 2, updated 2026-05-01):** OpenRegister already ships a full Excel + CSV import/export pipeline (`ImportService` + `ExportService`) plus a configuration-level JSON portability path (`ConfigurationService::importFromJson` / `exportConfig`). Phase 2 is a documentation-vs-implementation sync — every Excel/CSV/JSON requirement has shipped code with file:line evidence. Downloadable per-schema import templates ship via `RegistersController::importTemplate`. The XML / ODS formats, structured rollback, downloadable error files, and full streaming progress endpoint remain genuinely open. **12 of 15 tasks shipped (9 implemented + 3 test coverage); 3 open are: downloadable error CSV, SSE progress (gated on realtime-updates), transactional rollback.**
+> **Status (Phase 2, updated 2026-05-01):** OpenRegister already ships a full Excel + CSV import/export pipeline (`ImportService` + `ExportService`) plus a configuration-level JSON portability path (`ConfigurationService::importFromJson` / `exportConfig`). Phase 2 is a documentation-vs-implementation sync — every Excel/CSV/JSON requirement has shipped code with file:line evidence. Downloadable per-schema import templates ship via `RegistersController::importTemplate`. Per-row import-error CSV now ships in the import response envelope (`errors_csv` field, base64-encoded UTF-8 with BOM). The XML / ODS formats, structured rollback, and full streaming progress endpoint remain genuinely open. **13 of 15 tasks shipped (10 implemented + 3 test coverage); 2 open are: SSE progress (gated on realtime-updates), transactional rollback.**
 
 ## Implemented
 
@@ -24,7 +24,7 @@
 
 ## Open
 
-- [ ] **Import MUST provide detailed error reporting with downloadable error files.** Partial — `ImportService` returns a per-row error summary in the import result envelope, but a downloadable "errors.csv" artefact is not generated. **Open** — additive feature gated on a UX decision about format (CSV row-by-row vs JSON envelope).
+- [x] **Import MUST provide detailed error reporting with downloadable error files.** Shipped — `ImportService::serializeErrorsToCsv` walks the sheet-based summary and emits a UTF-8 BOM CSV (`sheet`, `row`, `field`, `error_message`, `original_value`). `RegistersController::import` attaches the artefact to the JSON response as a base64-encoded `errors_csv` field plus an `errors_csv_filename` hint, so the frontend can offer a download without a second round-trip. The serializer collapses validation, schema-not-found, and row-parse error shapes into a single column projection. Unit coverage in [`tests/Unit/Service/ImportServiceErrorsCsvTest.php`](../../../tests/Unit/Service/ImportServiceErrorsCsvTest.php).
 
 - [ ] **Import MUST support progress tracking for large datasets.** Partial — the chunked-batch architecture documented in the `ImportService` class docblock provides progress hooks (the import is processed in chunks with summary aggregation), but a streaming `Server-Sent Events` progress endpoint surface is not exposed. The frontend currently polls the import job status. **Open** — depends on the realtime-updates SSE work to ship first.
 
@@ -34,6 +34,7 @@
 
 - [x] [`tests/Service/ImportServiceIntegrationTest`](../../../tests/Service/ImportServiceIntegrationTest.php) — 30 integration tests covering import-time validation, CSV row transformation, Excel multi-sheet processing, and SOLR warmup integration.
 - [x] [`tests/Unit/Service/ImportServiceTest`](../../../tests/Unit/Service/ImportServiceTest.php) — 140 unit tests for the row-transformation primitives.
+- [x] [`tests/Unit/Service/ImportServiceErrorsCsvTest`](../../../tests/Unit/Service/ImportServiceErrorsCsvTest.php) — 7 unit tests covering the per-row error CSV serialiser (BOM prefix, header shape, validation/row/schema error shapes, multi-sheet aggregation, defensive skipping of malformed sheet entries).
 - [x] [`tests/Unit/Service/ExportServiceTest`](../../../tests/Unit/Service/ExportServiceTest.php) + `ExportServiceCoverageTest` + `ExportServiceGapTest` — 58 tests covering header generation, name-companion resolution, FLS-aware column emission.
 
 ## Architecture (decisions taken)

--- a/openspec/changes/deprecate-published-metadata/tasks.md
+++ b/openspec/changes/deprecate-published-metadata/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: Deprecate Published/Depublished Object Metadata
 
-> **Status (2026-05-01):** All OpenRegister-scope work is complete (Phases 1–3, 8 in-repo testing). Remaining 19 `[ ]` items live entirely in **Phases 4–7**, all explicitly marked **OUT OF SCOPE** in their headers (opencatalogi backend + frontend, softwarecatalogus frontend, schema migration guide). Plus 2 cross-repo testing items in Phase 8 (lines 95–96). **Nothing actionable remains in this repo.**
+> **Status (2026-05-01):** All OpenRegister-scope work is complete (Phases 1–3, 8 in-repo testing). Cross-repo Phase 4 partially shipped against opencatalogi (PublicationsController `_universalOrderFields` cleanup + PublicationService docblock cleanup landed in opencatalogi PR `docs/public-api-files-extend-2026-05-01`). The remaining items live in **Phases 4–7**, marked **OUT OF SCOPE** in their headers (opencatalogi event listeners, opencatalogi frontend, softwarecatalogus frontend, schema migration guide). The deeper Phase 4 work (EventService / Object*EventListener publish-state checks) needs a careful migration to RBAC `$now` rules — not a mechanical drop — and is left for a dedicated follow-up issue.
 >
 > Recommend opening cross-repo follow-up issues for the 5 deferred phases and archiving this change. The OpenRegister production code paths no longer reference `_published` / `_depublished` columns, magic-table migration is shipped, and frontend cleanup landed in the referenced PRs (#1129, #1130, #1131).
 
@@ -62,14 +62,20 @@
 - [x] Remove published CSS classes from schema modals (#1130)
 - [x] Remove published from type definitions and mock data (#1130)
 
-## Phase 4: OpenCatalogi Backend (OUT OF SCOPE - separate repo)
+## Phase 4: OpenCatalogi Backend (PARTIAL — see follow-up issue)
 
 - [ ] Remove `isObjectPublished()` from `EventService`; replace published-state checks with RBAC-based logic
+  - **Deferred** — `EventService::handleObjectCreateEvents` / `handleObjectUpdateEvents` use `isObjectPublished` to gate auto-publish-attachments. Replacing with RBAC `$now` rules is a behaviour migration, not a delete; needs a dedicated review of the publication workflow. Tracked in opencatalogi follow-up issue.
 - [ ] Remove `@self.published`/`@self.depublished` reads from `ObjectCreatedEventListener`
+  - **Deferred** — same rationale as above; the listener feeds EventService.
 - [ ] Remove `isObjectEntityPublished()` and `isObjectPublished()` from `ObjectUpdatedEventListener`
+  - **Deferred** — same rationale.
 - [ ] Remove `@self.published`/`@self.depublished` reads from `ObjectUpdatedEventListener`
-- [ ] Remove `'published'` and `'depublished'` from `$universalOrderFields` in `PublicationsController`
-- [ ] Update `PublicationService` docblock examples referencing `@self.published` ordering
+  - **Deferred** — same rationale.
+- [x] Remove `'published'` and `'depublished'` from `$universalOrderFields` in `PublicationsController`
+  - **Shipped** — `_published` / `_depublished` removed from the multi-register universal-order allowlist (opencatalogi PR `docs/public-api-files-extend-2026-05-01`). Trailing comment points readers at this openregister change for context.
+- [x] Update `PublicationService` docblock examples referencing `@self.published` ordering
+  - **Shipped** — three docblock / inline-comment references replaced with `@self.created` (same opencatalogi PR).
 
 ## Phase 5: OpenCatalogi Frontend (OUT OF SCOPE - separate repo)
 

--- a/openspec/changes/opt-in-files-extend/tasks.md
+++ b/openspec/changes/opt-in-files-extend/tasks.md
@@ -1,8 +1,6 @@
-> **Status (2026-05-01):** All in-repo openregister work shipped. Sections 1–6 + 8.1 are complete (24/32 ticked). Remaining 8 items split into two non-actionable groups:
-> - **Section 7 (4 items):** opencatalogi public-API doc updates — explicitly DEFERRED to a cross-repo issue (`ConductionNL/opencatalogi#TBD`). Cannot land in openregister.
-> - **Section 8.2–8.5 (4 items):** manual smoke checklists + `/opsx:verify` invocation — for the user post-merge, not agent-actionable.
+> **Status (2026-05-01):** All in-repo openregister work shipped. Sections 1–7 + 8.1 are complete (28/32 ticked). Section 7 doc work landed in opencatalogi PR `docs/public-api-files-extend-2026-05-01` (`docs/features/public-api-files-extend.md` + features README link). Remaining 4 items live in Section 8.2–8.5 — manual smoke checklists + `/opsx:verify` invocation — for the user post-merge, not agent-actionable.
 >
-> Recommend marking this change ready for archive after the cross-repo opencatalogi issue is opened.
+> Recommend marking this change ready for archive after the user runs the smoke checklist.
 
 ## 1. FileMapper batched lookup
 
@@ -70,14 +68,18 @@
 - [x] 6.4 Verify ADR-002 (REST API conventions) does not need an amendment. The `_extend` mechanism predates this change; we are extending its applicability, not introducing new convention.
   - Confirmed. ADR-002 covers URL structure, HTTP methods, pagination, error responses, CORS, and authentication. The `_extend` query parameter is a pre-existing convention; this change only adds a new recognized key (`@self.files`/`_files`) — no new convention. No ADR amendment required.
 
-## 7. Documentation — opencatalogi (DOCS-ONLY follow-up)
+## 7. Documentation — opencatalogi (DOCS-ONLY)
 
-> **DEFERRED to a separate cross-repo issue against opencatalogi.** This change cannot land opencatalogi commits in the openregister repo. The following bullets are documentation-only updates that opencatalogi must publish to reflect the new inherited contract. Recommend opening `ConductionNL/opencatalogi#TBD` to track them.
+> **Shipped in opencatalogi PR `docs/public-api-files-extend-2026-05-01`.** New doc at `docs/features/public-api-files-extend.md` plus link from `docs/features/README.md`. Inherited-contract framing: opencatalogi adopts the openregister `@self.files` opt-in directly without code changes.
 
-- [ ] 7.1 Update opencatalogi public API docs for `GET /publications/{catalogSlug}/{id}`: document the BREAKING change. Default `@self.files` is now a list of file IDs; full metadata requires `?_extend[]=@self.files` or `?_extend[]=_files`.
-- [ ] 7.2 Update opencatalogi public API docs for `GET /publications/{catalogSlug}`: document the new `@self.files` field in list responses (lightweight IDs by default; opt-in for full metadata; perf warning).
-- [ ] 7.3 Add the same perf warning verbatim to opencatalogi list-endpoint documentation: list-with-extend on files is heavily discouraged and causes degraded performance.
-- [ ] 7.4 Confirm `PublicationsController::attachments()` documentation explicitly notes it is the recommended path for full attachment metadata when many publications need files at once (existing endpoint, unchanged).
+- [x] 7.1 Update opencatalogi public API docs for `GET /publications/{catalogSlug}/{id}`: document the BREAKING change. Default `@self.files` is now a list of file IDs; full metadata requires `?_extend[]=@self.files` or `?_extend[]=_files`.
+  - Documented in the new `docs/features/public-api-files-extend.md` ("Default response shape" + "Opt-in response shape" + "Show endpoint — both shapes are cheap" sections).
+- [x] 7.2 Update opencatalogi public API docs for `GET /publications/{catalogSlug}`: document the new `@self.files` field in list responses (lightweight IDs by default; opt-in for full metadata; perf warning).
+  - Documented in the same file ("List endpoints — performance warning" section, with default vs opt-in curl examples).
+- [x] 7.3 Add the same perf warning verbatim to opencatalogi list-endpoint documentation: list-with-extend on files is heavily discouraged and causes degraded performance.
+  - Verbatim warning included in the "List endpoints — performance warning" section.
+- [x] 7.4 Confirm `PublicationsController::attachments()` documentation explicitly notes it is the recommended path for full attachment metadata when many publications need files at once (existing endpoint, unchanged).
+  - "When to use the dedicated `attachments` endpoint" section calls it out as the recommended path; cross-references the attachments controller as unchanged.
 
 ## 8. Verification
 

--- a/tests/Unit/Service/ImportServiceErrorsCsvTest.php
+++ b/tests/Unit/Service/ImportServiceErrorsCsvTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * ImportService Errors CSV Serializer Tests
+ *
+ * Validates the per-row error CSV serializer wired into the import response
+ * envelope (data-import-export Phase 2 task: downloadable error CSV).
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author   Conduction Development Team <dev@conductio.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link     https://OpenRegister.app
+ *
+ * @spec openspec/changes/data-import-export/tasks.md#task-error-csv
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\ImportService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\Translation\TranslationCsvCodec;
+use OCP\BackgroundJob\IJobList;
+use OCP\IGroupManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests the per-row error CSV serializer.
+ */
+class ImportServiceErrorsCsvTest extends TestCase
+{
+
+    /**
+     * @var ImportService
+     */
+    private ImportService $service;
+
+
+    protected function setUp(): void
+    {
+        /** @var SchemaMapper&MockObject $schemaMapper */
+        $schemaMapper = $this->createMock(SchemaMapper::class);
+        /** @var ObjectService&MockObject $objectService */
+        $objectService = $this->createMock(ObjectService::class);
+        /** @var LoggerInterface&MockObject $logger */
+        $logger = $this->createMock(LoggerInterface::class);
+        /** @var IGroupManager&MockObject $groupManager */
+        $groupManager = $this->createMock(IGroupManager::class);
+        /** @var IJobList&MockObject $jobList */
+        $jobList = $this->createMock(IJobList::class);
+        /** @var TranslationCsvCodec&MockObject $translationCsvCodec */
+        $translationCsvCodec = $this->createMock(TranslationCsvCodec::class);
+
+        $this->service = new ImportService(
+            $schemaMapper,
+            $objectService,
+            $logger,
+            $groupManager,
+            $jobList,
+            $translationCsvCodec
+        );
+
+    }//end setUp()
+
+
+    /**
+     * An empty summary returns an empty string so callers can skip attaching
+     * the artefact entirely.
+     */
+    public function testReturnsEmptyStringWhenNoErrorsPresent(): void
+    {
+        $summary = [
+            'people' => [
+                'found'   => 5,
+                'created' => [['id' => 1]],
+                'errors'  => [],
+            ],
+        ];
+
+        $this->assertSame('', $this->service->serializeErrorsToCsv(summary: $summary));
+
+    }//end testReturnsEmptyStringWhenNoErrorsPresent()
+
+
+    /**
+     * The output starts with the UTF-8 BOM so Excel detects encoding.
+     */
+    public function testIncludesUtf8BomPrefix(): void
+    {
+        $summary = [
+            'people' => [
+                'errors' => [
+                    [
+                        'row'   => 4,
+                        'error' => 'Something broke',
+                    ],
+                ],
+            ],
+        ];
+
+        $csv = $this->service->serializeErrorsToCsv(summary: $summary);
+
+        $this->assertStringStartsWith("\xEF\xBB\xBF", $csv);
+
+    }//end testIncludesUtf8BomPrefix()
+
+
+    /**
+     * The header row matches the documented column order.
+     */
+    public function testEmitsExpectedHeaderRow(): void
+    {
+        $summary = [
+            'people' => [
+                'errors' => [
+                    [
+                        'row'   => 4,
+                        'error' => 'broken',
+                    ],
+                ],
+            ],
+        ];
+
+        $csv  = $this->service->serializeErrorsToCsv(summary: $summary);
+        $body = ltrim($csv, "\xEF\xBB\xBF");
+        $this->assertStringStartsWith(
+            "sheet,row,field,error_message,original_value\n",
+            $body
+        );
+
+    }//end testEmitsExpectedHeaderRow()
+
+
+    /**
+     * Validation-shaped errors (with `object`/`error`/`type`) round-trip
+     * cleanly: type collapses into `field`, the failing object becomes
+     * the JSON-encoded `original_value`.
+     */
+    public function testValidationErrorShapeRendersCorrectly(): void
+    {
+        $summary = [
+            'people' => [
+                'errors' => [
+                    [
+                        'sheet'  => 'people',
+                        'object' => ['name' => 'Alice', 'age' => 'not-a-number'],
+                        'error'  => 'age must be integer',
+                        'type'   => 'ValidationException',
+                    ],
+                ],
+            ],
+        ];
+
+        $csv  = $this->service->serializeErrorsToCsv(summary: $summary);
+        $body = ltrim($csv, "\xEF\xBB\xBF");
+
+        $this->assertStringContainsString('ValidationException', $body);
+        $this->assertStringContainsString('age must be integer', $body);
+        $this->assertStringContainsString('"Alice"', $body);
+        $this->assertStringContainsString('not-a-number', $body);
+
+    }//end testValidationErrorShapeRendersCorrectly()
+
+
+    /**
+     * Row-shaped errors (header parse failures) keep their row number and
+     * fall back to the sheet key when no `sheet` is set on the entry.
+     */
+    public function testRowParseErrorUsesSheetKeyAsFallback(): void
+    {
+        $summary = [
+            'imports' => [
+                'errors' => [
+                    [
+                        'row'    => 1,
+                        'object' => [],
+                        'error'  => 'No valid headers found in CSV file',
+                    ],
+                ],
+            ],
+        ];
+
+        $csv  = $this->service->serializeErrorsToCsv(summary: $summary);
+        $body = ltrim($csv, "\xEF\xBB\xBF");
+
+        $this->assertStringContainsString(
+            'imports,1,,"No valid headers found in CSV file"',
+            $body
+        );
+
+    }//end testRowParseErrorUsesSheetKeyAsFallback()
+
+
+    /**
+     * Errors from multiple sheets are concatenated into a single CSV.
+     */
+    public function testCombinesErrorsAcrossSheets(): void
+    {
+        $summary = [
+            'people' => [
+                'errors' => [
+                    ['row' => 2, 'error' => 'people row 2 broken'],
+                ],
+            ],
+            'orgs'   => [
+                'errors' => [
+                    ['row' => 3, 'error' => 'orgs row 3 broken'],
+                ],
+            ],
+        ];
+
+        $csv  = $this->service->serializeErrorsToCsv(summary: $summary);
+        $body = ltrim($csv, "\xEF\xBB\xBF");
+
+        // 1 header row + 2 data rows + trailing newline.
+        $this->assertSame(3, substr_count($body, "\n"));
+        $this->assertStringContainsString('people row 2 broken', $body);
+        $this->assertStringContainsString('orgs row 3 broken', $body);
+
+    }//end testCombinesErrorsAcrossSheets()
+
+
+    /**
+     * Sheets with no `errors` key (or with non-array values) are silently
+     * skipped — the serializer never throws on a partial summary.
+     */
+    public function testSkipsSheetsWithoutErrors(): void
+    {
+        $summary = [
+            'people' => [
+                'created' => [['id' => 1]],
+            ],
+            'orgs'   => [
+                'errors' => 'not-an-array',
+            ],
+            'cities' => [
+                'errors' => [
+                    ['row' => 7, 'error' => 'cities row 7 broken'],
+                ],
+            ],
+        ];
+
+        $csv  = $this->service->serializeErrorsToCsv(summary: $summary);
+        $body = ltrim($csv, "\xEF\xBB\xBF");
+
+        $this->assertStringContainsString('cities row 7 broken', $body);
+        $this->assertStringNotContainsString('orgs', $body);
+
+    }//end testSkipsSheetsWithoutErrors()
+
+
+}//end class


### PR DESCRIPTION
## Summary

- Closes the data-import-export "downloadable error files" task (12/15 -> 13/15 in the spec banner).
- ImportService::serializeErrorsToCsv() walks the sheet-based summary, collapses validation/schema/row-parse error shapes into a single column projection (sheet, row, field, error_message, original_value), emits UTF-8 with BOM so Excel detects encoding.
- RegistersController::import attaches the artefact to the JSON response as a base64-encoded errors_csv field plus an errors_csv_filename hint, so the frontend can offer a download without a second round-trip.
- 7 unit tests cover BOM prefix, header shape, validation/row/schema error shapes, multi-sheet aggregation, defensive skipping of malformed sheet entries.

Also ticks matching cross-repo opencatalogi tasks:
- opt-in-files-extend Section 7 (4 boxes) -- opencatalogi public-API doc landed in companion opencatalogi PR.
- deprecate-published-metadata Phase 4 -- partial: PublicationsController::\$universalOrderFields cleanup + PublicationService docblock cleanup landed in the same companion PR. Deeper EventService / event-listener migration to RBAC \$now rules remains deferred -- needs a behaviour migration, not a delete, so left for a dedicated follow-up issue.

## Test plan

- [x] PHPCS clean on lib/Service/ImportService.php and lib/Controller/RegistersController.php
- [x] 7 unit tests for serializeErrorsToCsv cover empty summary, BOM prefix, header row, validation-error shape, row-parse-error shape, multi-sheet aggregation, malformed-sheet skip
- [ ] Manual smoke: POST /api/registers/{id}/import?validation=true with a CSV containing an invalid row, confirm response carries errors_csv + errors_csv_filename