### PR TITLE
feat(openspec): four OR abstraction specs from the 2026-05-03 audit

### DIFF
--- a/openspec/changes/i18n-api-language-negotiation/design.md
+++ b/openspec/changes/i18n-api-language-negotiation/design.md
@@ -1,0 +1,107 @@
+# Design: i18n API Language Negotiation
+
+## Reuse analysis
+
+- `lib/Middleware/LanguageMiddleware.php` already parses
+  `Accept-Language` and the `_translations=all` query param; we add
+  the new query lookups + write-side header in the same hook.
+- `lib/Service/LanguageService.php` already exposes the
+  `preferredLanguage` field + `parseAcceptLanguageHeader()`; we add
+  setters/getters for the new `targetLanguage` (write-side) and
+  `requestedLanguageSource` (introspection).
+- `lib/Service/Object/TranslationHandler::normalizeTranslationsForSave`
+  already wraps non-language-keyed bodies under the register's
+  default language; we extend it to honour the target-language
+  header.
+- `lib/Db/Register::getDefaultLanguage()` is the existing default
+  fallback; unchanged.
+
+## Request-side resolution chain
+
+```
+1. ?_lang=<bcp47>          (canonical query param)
+2. ?language=<bcp47>        (alias)
+3. Accept-Language header  (RFC 9110)
+4. Register default        (first element of Register.languages)
+5. 'nl'                    (hardcoded fallback)
+```
+
+The middleware iterates this chain and stops at the first valid BCP-47
+tag. Invalid input at any step (e.g. `?_lang=garbage`) MUST log a
+warning AND fall through; we never 400 on a malformed language
+parameter.
+
+## Write-side wrap behaviour
+
+Three input shapes; the handler dispatches based on which:
+
+```php
+// Shape A (legacy): scalar body, no header → wrap under register default
+PATCH /api/.../obj-uuid
+Content-Type: application/json
+{ "title": "Hello" }
+// → stored as { "title": { "nl": "Hello" } } when default is nl
+
+// Shape B (new): scalar body + target-language header → wrap under target
+PATCH /api/.../obj-uuid
+Content-Type: application/json
+X-Translation-Target-Language: en
+{ "title": "Hello" }
+// → stored as { "title": { "en": "Hello" } }
+
+// Shape C (existing full-object): language-keyed body, no header → as-is
+PATCH /api/.../obj-uuid
+Content-Type: application/json
+{ "title": { "nl": "Hallo", "en": "Hello" } }
+// → stored as-is
+
+// Shape D (CONFLICT): language-keyed body + header → 400
+PATCH /api/.../obj-uuid
+Content-Type: application/json
+X-Translation-Target-Language: en
+{ "title": { "nl": "Hallo", "en": "Hello" } }
+// → 400 TranslationTargetConflictException
+```
+
+Shape D rejection is intentional: a client sending both is signalling
+conflicting intent; failing fast surfaces the bug to the consumer.
+
+## Why query overrides header
+
+ADR-025's open-question 2 picked query-overrides-header. Rationale:
+
+- Query parameters are explicit per-request override; users hit
+  `?_lang=fr` to force French regardless of what their browser sends.
+- `Accept-Language` is the browser-default fallback; it should
+  always be the lower-priority fallback for explicit requests.
+- Mixing `?_lang=fr` + `Accept-Language: nl` is the typical "user
+  switched language in the UI but their browser still has Dutch as
+  default" case — query winning is what the user expects.
+
+## Fallback laxity
+
+Per ADR-025 open-question 7, OR accepts any BCP-47 tag on the query
+parameter and lets the existing fallback chain resolve. A request for
+`?_lang=zz-NEVER` resolves through:
+
+1. No `zz-NEVER` row → fallback to register default (`nl`)
+2. Response: `Content-Language: nl`, `X-Content-Language-Fallback: true`
+
+The client gets a usable response and clear signalling that fallback
+happened. No 406; no 300. This matches `Accept-Language` behaviour.
+
+## Open design questions
+
+1. **Should the header be `X-Translation-Target-Language` or
+   `X-Content-Language` (as a write-side echo)?** Picked the explicit
+   prefix to avoid confusion with the response `Content-Language`.
+   `X-Translation-Target-Language` is verbose but unambiguous.
+2. **What if the target-language header is set on a GET request?**
+   Currently the middleware only consumes it on POST/PUT/PATCH
+   (Phase 2 task). On GET it's silently ignored — defer until a use
+   case surfaces.
+3. **Should the request-side query be `_lang` or `lang` (no
+   underscore)?** Picked `_lang` to match the existing
+   `_translations=all` convention in OR's URL parameters. The bare
+   `?language=` alias is offered for clients that find `_lang`
+   unfamiliar.

--- a/openspec/changes/i18n-api-language-negotiation/proposal.md
+++ b/openspec/changes/i18n-api-language-negotiation/proposal.md
@@ -1,0 +1,108 @@
+# i18n API Language Negotiation
+
+## Why
+
+OpenRegister's HTTP API parses `Accept-Language` headers and returns
+`Content-Language` + `X-Content-Language-Fallback`, but the
+request-side surface is incomplete: there's no `?_lang=` query
+parameter for explicit override (only `_translations=all` is
+recognised), and PATCH/PUT bodies are silently treated as updates to
+the register's default language with no way for clients to indicate
+they're sending an English-only edit.
+
+The OR-abstraction audit (R5, 2026-05-03) flagged this as the
+practical adoption blocker for opencatalogi (every UI language
+selector needs `?_lang=`), decidesk (translation editing needs the
+write-side header), and any external integration that wants to
+request a specific language without manipulating its `Accept-Language`
+header.
+
+Hydra ADR-025 (Proposed, 2026-05-03) ratified the API contract; this
+change is the second half of its implementation. The companion change
+`i18n-source-of-truth` covers the schema/DB/render-metadata side.
+
+## What Changes
+
+- Extend `lib/Middleware/LanguageMiddleware::beforeController` to
+  honour query parameters, in this priority order:
+  1. `?_lang=<bcp47>` (canonical name)
+  2. `?language=<bcp47>` (alias)
+  3. `Accept-Language: <RFC 9110>` header (current; lower priority)
+  4. Default — register's first language, or `nl`
+- Extend `LanguageMiddleware::afterController` to read an optional
+  `X-Translation-Target-Language` request header on write requests
+  (POST / PUT / PATCH); when present, write logic MUST treat the
+  request body as an update to that target language instead of the
+  register default.
+- Update `lib/Service/Object/TranslationHandler::normalizeTranslationsForSave`
+  to consume the `X-Translation-Target-Language` value so requests
+  like `PATCH /api/objects/{r}/{s}/{id} { "title": "Welcome" }` with
+  `X-Translation-Target-Language: en` wrap as `{ title: { en: "Welcome" } }`
+  instead of the register's default-language wrap.
+- Add a new validation helper that confirms a body either declares a
+  full language-keyed object (existing path — `{ title: { nl: ..., en: ... }}`)
+  OR a single-language scalar paired with `X-Translation-Target-Language`
+  (new path) OR a single-language scalar paired with no header (legacy
+  path — interpreted as register default). Conflicting bodies (full
+  language object + header) MUST return `400 Bad Request`.
+- Document the precedence and write-side contract in
+  `register-i18n/spec.md` (existing spec) and in this change's spec.
+- Add a Newman collection covering: `?_lang=` overrides
+  Accept-Language; `?language=` alias works; both query + header
+  resolves to query winning; missing-translation 200 fallback;
+  `X-Translation-Target-Language` write-side wrap; conflicting body +
+  header rejection.
+
+## Problem
+
+The current API forces consumers into Accept-Language manipulation,
+which is awkward for:
+
+1. **UI language switchers** — clicking "Switch to English" should
+   issue `GET /api/objects/.../?_lang=en`; today the UI has to mutate
+   `axios.defaults.headers.common['Accept-Language']` globally, which
+   leaks across components.
+2. **Translation editors** — editing only the English translation
+   means sending the full `{ nl: "...", en: "Welcome" }` object
+   (forces the editor to know the Dutch source); sending just
+   `{ "title": "Welcome" }` today silently overwrites the Dutch
+   source. The header gives editors a clean shortcut.
+3. **External clients** — non-browser HTTP clients (cron jobs,
+   integrations, Newman tests) want explicit query parameters; today
+   they have to format proper `Accept-Language` strings with quality
+   factors.
+
+## Proposed Solution
+
+Extend the existing middleware and translation handler. No DB
+migration; no breaking change to current consumers (`Accept-Language`
+keeps working). New behaviour is opt-in via either the query param or
+the new write-side header.
+
+The companion `i18n-source-of-truth` change ships independently; the
+two share no code dependency, just a logical pairing under ADR-025.
+
+## Out of scope
+
+- The schema-level `sourceLanguage` modifier and the
+  `openregister_translations.source_language` column — companion
+  change `i18n-source-of-truth`.
+- An `X-Source-Language` response header on write responses
+  (informational only on reads; the write-side echo is not specified
+  by ADR-025).
+- A `?_languageVariants=title,description` mixed-mode parameter to
+  return a single language for some properties and full language
+  objects for others — defer to a successor change once the basic
+  contract has consumers.
+- 406 Not Acceptable when zero languages match — keep the silent 200
+  fallback per ADR-025; revisit if integrations report it as a
+  blocker.
+
+## See also
+
+- Hydra ADR-025 (i18n source-of-truth + API language negotiation) —
+  the parent decision.
+- `openregister/openspec/changes/i18n-source-of-truth/` — companion
+  change.
+- `.claude/audit-2026-05-03/research/R5-or-api-language-negotiation.md` —
+  the audit research informing this change.

--- a/openspec/changes/i18n-api-language-negotiation/specs/i18n-api-language-negotiation/spec.md
+++ b/openspec/changes/i18n-api-language-negotiation/specs/i18n-api-language-negotiation/spec.md
@@ -1,0 +1,144 @@
+i18n-api-language-negotiation
+---
+status: draft
+---
+# i18n API Language Negotiation
+
+## Purpose
+
+Implement the request/response API contract half of hydra ADR-025: a
+canonical `?_lang=` query parameter (with `?language=` alias) for
+explicit per-request language override; a write-side
+`X-Translation-Target-Language` header to disambiguate which
+language a scalar PATCH/PUT/POST body targets; explicit precedence
+between query, header, and `Accept-Language`; lax fallback that never
+406s. The companion change `i18n-source-of-truth` covers the
+schema/DB/render-metadata side.
+
+## ADDED Requirements
+
+### Requirement: The system MUST accept `?_lang=` and `?language=` query parameters
+
+`LanguageMiddleware::beforeController` MUST honour these query parameters as the highest-priority source for the requested language. `?_lang=` is the canonical name; `?language=` is an accepted alias. When both are present on the same request, `?_lang=` wins.
+
+#### Scenario: Resolve language from `?_lang=` query parameter
+- GIVEN a request `GET /api/objects/r/s/uuid?_lang=fr`
+- AND the client also sends `Accept-Language: nl`
+- WHEN the middleware resolves
+- THEN `LanguageService::getPreferredLanguage()` MUST return `"fr"`
+- AND `LanguageService::getRequestedLanguageSource()` MUST return `"query"`
+
+#### Scenario: `?language=` alias works identically
+- GIVEN a request `GET /api/objects/r/s/uuid?language=fr`
+- WHEN the middleware resolves
+- THEN `LanguageService::getPreferredLanguage()` MUST return `"fr"`
+- AND `LanguageService::getRequestedLanguageSource()` MUST return `"query"`
+
+#### Scenario: `?_lang=` wins over `?language=` on conflict
+- GIVEN a request `GET /api/objects/r/s/uuid?_lang=en&language=fr`
+- WHEN the middleware resolves
+- THEN `LanguageService::getPreferredLanguage()` MUST return `"en"` (canonical wins)
+
+### Requirement: Resolution precedence MUST be query → header → register-default → 'nl'
+
+When multiple sources of language are available, the middleware MUST resolve in this order, stopping at the first valid BCP-47 tag:
+
+1. `?_lang=<bcp47>` query parameter
+2. `?language=<bcp47>` query parameter (alias)
+3. `Accept-Language` header (existing RFC 9110 parsing)
+4. Register default (`Register::getDefaultLanguage()` — first element of `Register.languages`)
+5. Hardcoded fallback `"nl"`
+
+#### Scenario: Default fallback when nothing is set
+- GIVEN a request with no `?_lang=`, no `?language=`, and no `Accept-Language`
+- AND the resolved register has `languages = ["nl", "en"]`
+- WHEN the middleware resolves
+- THEN `LanguageService::getPreferredLanguage()` MUST return `"nl"` (register default)
+- AND `LanguageService::getRequestedLanguageSource()` MUST return `"default"`
+
+#### Scenario: Hardcoded `nl` fallback when register has no languages
+- GIVEN a request with no language hints
+- AND the resolved register's `languages` field is empty/null
+- WHEN the middleware resolves
+- THEN `LanguageService::getPreferredLanguage()` MUST return `"nl"`
+- AND `LanguageService::getRequestedLanguageSource()` MUST return `"default"`
+
+### Requirement: Invalid BCP-47 tags on query parameters MUST fall through, not 400
+
+If `?_lang=` or `?language=` is set but does NOT match the BCP-47 syntax (basic regex `^[a-z]{2,3}(-[A-Z]{2})?$`), the middleware MUST log a warning AND continue resolution down the priority chain. The request MUST NOT 400; the client receives a usable fallback response.
+
+#### Scenario: Invalid `?_lang=` falls through to Accept-Language
+- GIVEN a request `GET /api/objects/r/s/uuid?_lang=GARBAGE_TAG`
+- AND `Accept-Language: en`
+- WHEN the middleware resolves
+- THEN a `LoggerInterface::warning()` MUST be emitted: `Invalid ?_lang value 'GARBAGE_TAG' — falling through`
+- AND `LanguageService::getPreferredLanguage()` MUST return `"en"` (Accept-Language)
+- AND the request MUST NOT 400
+
+### Requirement: The write-side `X-Translation-Target-Language` header MUST be honoured on POST/PUT/PATCH
+
+When a write request (POST / PUT / PATCH) carries `X-Translation-Target-Language: <bcp47>`, OR MUST treat scalar (non-language-keyed) body values for translatable properties as updates to the target language. The header MUST NOT affect read requests (GET / HEAD).
+
+#### Scenario: Target-language header wraps scalar body
+- GIVEN a PATCH request body `{"title": "Welcome"}`
+- AND the request carries `X-Translation-Target-Language: en`
+- AND the schema declares `title` as translatable
+- WHEN OR persists the change
+- THEN the stored object MUST have `title.en = "Welcome"`
+- AND `title.nl` (the register default) MUST be unchanged
+
+#### Scenario: Target-language header on GET is silently ignored
+- GIVEN a GET request with `X-Translation-Target-Language: en`
+- WHEN OR resolves
+- THEN the header MUST be silently ignored (no warning, no error)
+- AND `LanguageService::getTargetLanguage()` MUST return null
+
+### Requirement: Conflict between full language-object body + target-language header MUST 400
+
+If a write request body sends a full language-keyed object for a translatable property AND the request also carries `X-Translation-Target-Language`, OR MUST return `400 Bad Request` with a `TranslationTargetConflictException`-shaped error body.
+
+#### Scenario: Conflict triggers 400
+- GIVEN a PATCH body `{"title": {"nl": "Hallo", "en": "Welcome"}}`
+- AND the request carries `X-Translation-Target-Language: en`
+- WHEN OR receives the request
+- THEN OR MUST return status `400 Bad Request`
+- AND the response body MUST include `error.code: "TRANSLATION_TARGET_CONFLICT"`, `error.property: "title"`, `error.targetLanguage: "en"`
+
+### Requirement: Legacy scalar-body without header MUST preserve current behaviour
+
+When a write request sends a scalar body for a translatable property AND no `X-Translation-Target-Language` header, OR MUST wrap the value under the register's default language (existing behaviour). This preserves backwards compatibility with consumers that haven't adopted the new header.
+
+#### Scenario: Legacy scalar body wraps under register default
+- GIVEN a PATCH body `{"title": "Welcome"}`
+- AND no `X-Translation-Target-Language` header
+- AND the register's `defaultLanguage = "nl"`
+- WHEN OR persists the change
+- THEN the stored object MUST have `title.nl = "Welcome"` (existing behaviour)
+
+### Requirement: Both query parameter and header MAY appear on a single request
+
+When both a query parameter (`?_lang=` / `?language=`) and the `X-Translation-Target-Language` header appear on a write request, OR MUST treat them independently:
+
+- The query parameter governs the language of the *response* (controls how OR renders the response object).
+- The header governs the language of the *body* (controls how OR interprets the request body).
+
+These two surfaces are distinct contracts and MUST NOT influence each other.
+
+#### Scenario: Read in English while writing the German translation
+- GIVEN a PATCH request `PATCH /api/objects/r/s/uuid?_lang=en`
+- AND request body `{"title": "Willkommen"}`
+- AND `X-Translation-Target-Language: de`
+- WHEN OR processes the request
+- THEN the stored object MUST have `title.de = "Willkommen"` (header governs body)
+- AND the response body MUST be rendered in English (query governs response)
+- AND the response MUST include header `Content-Language: en`
+
+### Requirement: Bulk listings MUST honour the same precedence
+
+`GET /api/objects/{r}/{s}` (the bulk listing endpoint) MUST honour the same query-parameter precedence as single-object reads. Every object in the response MUST be rendered in the resolved language.
+
+#### Scenario: Bulk list in a specific language
+- GIVEN 5 objects with translatable `title` properties
+- WHEN `GET /api/objects/r/s?_lang=fr` is called
+- THEN every object's `title` in the response MUST be rendered in French (or fall through to the fallback chain per object)
+- AND the response MUST include header `Content-Language: fr`

--- a/openspec/changes/i18n-api-language-negotiation/tasks.md
+++ b/openspec/changes/i18n-api-language-negotiation/tasks.md
@@ -1,0 +1,78 @@
+# Tasks: i18n API Language Negotiation
+
+## Phase 1 — Request-side query parameters
+
+- [ ] Update `lib/Middleware/LanguageMiddleware::beforeController` to
+      check for `?_lang=` and `?language=` query parameters before
+      the `Accept-Language` header. Resolution order:
+      1. `?_lang=<bcp47>` (canonical)
+      2. `?language=<bcp47>` (alias)
+      3. `Accept-Language` (existing)
+      4. Default (existing — register first language, or `nl`)
+- [ ] Add a `LanguageService::setRequestedLanguageSource(string
+      $source)` enum-style flag (`'query' | 'header' | 'default'`)
+      so consumers can introspect WHY a particular language was
+      chosen. Used by the `X-Source-Language` setter in the companion
+      change for response diagnostics.
+- [ ] Validate that the resolved language is a syntactically valid
+      BCP-47 tag (basic regex). Invalid input MUST log a warning AND
+      fall through to the next priority level (do NOT 400 — clients
+      that mistype a tag should still get a usable response).
+
+## Phase 2 — Write-side target-language header
+
+- [ ] Update `lib/Middleware/LanguageMiddleware::beforeController` to
+      read `X-Translation-Target-Language` request header on POST /
+      PUT / PATCH. Stash on `LanguageService::setTargetLanguage()`.
+- [ ] Update `lib/Service/Object/TranslationHandler::normalizeTranslationsForSave`
+      to consume `LanguageService::getTargetLanguage()`:
+      - If header is set AND the body has a scalar (non-language-keyed)
+        translatable property → wrap under the target language.
+      - If header is set AND the body has a full language-keyed object
+        for that property → reject with `400 Bad Request` (conflict).
+      - If header is unset → preserve current behaviour (wrap under
+        register default).
+- [ ] Add `lib/Exception/TranslationTargetConflictException.php` for
+      the conflict case; controller catches and returns `400` with a
+      structured error body.
+
+## Phase 3 — Spec + tests
+
+- [ ] Write `specs/i18n-api-language-negotiation/spec.md` with one
+      Requirement per public surface (query precedence, header
+      precedence, write-side header, conflict rejection, BCP-47
+      validation).
+- [ ] Update `openregister/openspec/specs/register-i18n/spec.md` to
+      reflect the new request-side contract; cross-reference this
+      change.
+- [ ] Add `tests/Unit/Middleware/LanguageMiddlewareTest.php` covering:
+      `?_lang=` overrides Accept-Language, `?language=` alias,
+      conflict (both set) → query wins, invalid `?_lang=` falls
+      through to next priority, default fallback when nothing set.
+- [ ] Add `tests/Unit/Service/Object/TranslationHandlerTargetLanguageTest.php`
+      covering: scalar body + header → wrap under target, full
+      language object + header → 400 conflict, scalar body without
+      header → wrap under register default (legacy).
+- [ ] Add Newman collection
+      `tests/integration/openregister-i18n-api-language-negotiation.postman_collection.json`
+      hitting: GET with `?_lang=`, GET with `?language=`, GET with
+      both query + Accept-Language (query wins), POST with
+      `X-Translation-Target-Language`, conflict POST returning 400.
+- [ ] Wire the Newman collection into
+      `tests/newman/run-all.sh::DOMAIN_ORDER` after the
+      `i18n-source-of-truth` collection (ordering dependency on the
+      companion change shipping first; gracefully skips if companion
+      hasn't shipped).
+
+## Phase 4 — Documentation
+
+- [ ] Update `docs/i18n.md` with the request-side contract, the
+      header table, and the request-precedence ordering.
+- [ ] Add a `docs/i18n.md#client-snippets` section showing canonical
+      curl + axios + Postman invocations for: read in a language,
+      write to a target language, edit a translation without
+      touching the source.
+- [ ] Cross-reference this change from
+      `hydra/openspec/architecture/adr-025-i18n-source-of-truth.md`'s
+      "Implementation reference" section once shipped (alongside the
+      companion).

--- a/openspec/changes/i18n-source-of-truth/design.md
+++ b/openspec/changes/i18n-source-of-truth/design.md
@@ -1,0 +1,158 @@
+# Design: i18n Source of Truth
+
+## Reuse analysis
+
+- `lib/Service/TranslationProjectionService.php` already projects from
+  schema `translatable: true` properties into the sidecar table; we
+  add a third input source (the new `sourceLanguage` modifier).
+- `lib/Service/TranslationStatusService.php` already manages `status`
+  transitions (draft / machine_translated / human_reviewed /
+  approved); we add the `outdated` workflow + the source-change
+  trigger.
+- `lib/Service/Object/SaveObject.php` already emits an event on
+  property changes; we hook the source-change check into the same
+  emission path.
+- `lib/Service/Object/RenderObject.php` already supports
+  `_translations=all` for full language objects; we add
+  `_translationMeta=true` for envelope metadata.
+- `lib/Middleware/LanguageMiddleware.php` already sets
+  `Content-Language` + `X-Content-Language-Fallback` response headers;
+  we add `X-Source-Language`.
+- `lib/Db/Register.php::getDefaultLanguage()` already returns the
+  first element of `Register.languages`; we use it as the
+  zero-config fallback.
+
+## Schema property shape
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string",
+      "translatable": true,
+      "sourceLanguage": "nl"   // optional; defaults to Register.defaultLanguage
+    },
+    "categoryCode": {
+      "type": "string"
+      // not translatable; sourceLanguage MUST NOT be present
+    }
+  }
+}
+```
+
+The validator rejects `sourceLanguage` on properties without
+`translatable: true`. Allowed BCP-47 values mirror the strict pattern
+used elsewhere in OR (basic checks: lowercase 2–3 letter primary tag,
+optional `-<region>` suffix).
+
+## Object-level override shape
+
+```json
+{
+  "id": "obj-uuid",
+  "title": "Welcome",
+  "_translationMeta": {
+    "title": {
+      "sourceLanguage": "en"
+    }
+  }
+}
+```
+
+Object-level overrides are rare (most content follows the schema's
+default). They apply only to the named property. The override is
+written by clients that author content in a non-default language for a
+specific object.
+
+## Migration shape
+
+```sql
+ALTER TABLE openregister_translations
+    ADD COLUMN source_language VARCHAR(16) NOT NULL DEFAULT '';
+
+UPDATE openregister_translations t
+   SET source_language = (
+       SELECT COALESCE(r.default_language, 'nl')
+         FROM openregister_register r
+         JOIN openregister_objects o ON o.register = r.id
+        WHERE o.uuid = t.object_uuid
+   )
+ WHERE source_language = '';
+```
+
+The migration ships with a back-fill console command for
+multi-million-row installs (`php occ openregister:translations:backfill-source-language --batch-size=1000`).
+
+After a successful back-fill, a follow-up migration removes the
+`DEFAULT ''` so future rows are forced to set the column at insert
+time.
+
+## Source-change trigger
+
+In `SaveObject`, when persisting an updated object:
+
+```php
+foreach ($changedTranslatableProperties as $property => [$oldValue, $newValue]) {
+    $sourceLang = $this->resolveSourceLanguage($schema, $object, $property);
+    $oldSourceVal = $oldValue[$sourceLang] ?? null;
+    $newSourceVal = $newValue[$sourceLang] ?? null;
+    if ($oldSourceVal !== $newSourceVal) {
+        $this->translationStatusService->markDerivedTranslationsOutdated(
+            $object->getUuid(),
+            $property,
+            $sourceLang
+        );
+    }
+}
+```
+
+The check is conservative: only flips status when the source language
+value itself changed. Edits to other-language values do not trigger.
+
+## Render envelope shape
+
+```json
+{
+  "id": "obj-uuid",
+  "title": "Welcome",
+  "_meta": {
+    "languageMeta": {
+      "title": {
+        "served": "en",
+        "sourceLanguage": "nl",
+        "isSource": false,
+        "status": "approved"
+      }
+    }
+  }
+}
+```
+
+The envelope is OFF by default (no payload bloat for clients that
+don't need it). Opt in with `?_translationMeta=true`. When ON, every
+translatable property in the response gets a `languageMeta` entry.
+
+## Open design questions
+
+1. **Object-level override granularity** — the sketch allows
+   per-property override. Should we also support a top-level object
+   override (`_translationMeta._defaultSourceLanguage = "en"`) that
+   applies to every translatable property on the object? Defer; rare
+   case, can add in a follow-up if demand surfaces.
+2. **Outdated trigger immutability** — once a translation is flipped
+   to `outdated`, can a translator reset it to `approved` without
+   re-translating, or does the status service force them through
+   `human_reviewed` → `approved`? Keep flexible: status is
+   independent of the trigger; the trigger only flips OUT of approved
+   into outdated. Translators reset manually via existing
+   `setStatus()` endpoint.
+3. **Bulk back-fill performance** — the back-fill UPDATE is
+   register-scoped via JOIN; large multi-tenant installs may need
+   batched updates. The console command's `--batch-size` flag
+   handles this; default 1000 rows per batch.
+4. **`_translationMeta` query parameter naming** — alternative
+   spellings (`_lang_meta`, `_translation_meta`, `_translations_meta`).
+   Picked `_translationMeta` to match the existing
+   `_translationMeta.<prop>.sourceLanguage` body field; consistent
+   surface.

--- a/openspec/changes/i18n-source-of-truth/proposal.md
+++ b/openspec/changes/i18n-source-of-truth/proposal.md
@@ -1,0 +1,118 @@
+# i18n Source of Truth
+
+## Why
+
+OpenRegister's translation system today treats every language as a peer.
+The `openregister_translations` sidecar table tracks
+`(object_uuid, property, language, value, status)`; given a value in
+English a reader cannot tell whether English is the canonical original
+or a translation derived from Dutch. `register-i18n/spec.md` line 221
+calls for an automatic "outdated" status flip when the source value
+changes, but the column to identify the source doesn't exist.
+
+The OR-abstraction audit (R4, 2026-05-03) flagged this as the blocker
+preventing opencatalogi (and decidesk, procest) from adopting i18n at
+scale. Hydra ADR-025 (Proposed, 2026-05-03) ratified the
+source-of-truth contract; this change is the first half of its
+implementation. The companion change `i18n-api-language-negotiation`
+covers the API-side contract.
+
+## What Changes
+
+- Add a `sourceLanguage: string` schema property modifier on
+  translatable properties:
+  `{"omschrijving": {"type": "string", "translatable": true,
+  "sourceLanguage": "nl"}}`. If omitted, defaults to
+  `Register.defaultLanguage` (first element of `Register.languages`).
+- Add an optional object-level override:
+  `_translationMeta.<property>.sourceLanguage = "<bcp47>"` on the
+  object body. Used when content is authored in a non-default
+  language for that specific object.
+- Add `source_language VARCHAR(16) NOT NULL` column to
+  `openregister_translations`. New migration
+  `Version1Date20260520120000.php` adds the column with a back-fill
+  job that infers `Register.defaultLanguage` for every existing row.
+- Update `TranslationProjectionService` to populate `source_language`
+  from the schema/object resolution above.
+- Extend `TranslationStatusService` with
+  `markDerivedTranslationsOutdated(string $objectUuid, string $property,
+  string $sourceLanguage): int` that flips every non-source-language
+  Translation row to status `outdated` when the source value changes.
+- Wire the source-change automation into `SaveObject` so that
+  modifying a translatable property in the source language triggers
+  the outdated flip on every derived translation for that object +
+  property.
+- Extend `TranslationController` to accept new query filters:
+  `?sourceLanguage=<bcp47>`, `?isOutOfDate=true`,
+  `?compareToSource=true` (returns both source and translation values
+  side-by-side for review tooling).
+- Extend `RenderObject` to attach an `_meta.languageMeta` envelope
+  field when `?_translationMeta=true` is requested. The envelope
+  shape:
+  ```json
+  {
+    "_meta": {
+      "languageMeta": {
+        "<property>": {
+          "served": "en",
+          "sourceLanguage": "nl",
+          "isSource": false,
+          "status": "approved"
+        }
+      }
+    }
+  }
+  ```
+- Add `X-Source-Language: <bcp47>` response header to every endpoint
+  that returns object content. The companion `i18n-api-language-negotiation`
+  change handles the rest of the header contract.
+- Update `lib/AppInfo/Application.php` PHPDoc to list
+  `TranslationStatusService::markDerivedTranslationsOutdated` in the
+  public service surface.
+
+## Problem
+
+Without a source-language identifier, three things break:
+
+1. **Translation freshness** — when the Dutch source is edited,
+   `TranslationStatusService` cannot infer which derived translations
+   went stale. The `outdated` status defined in the spec stays
+   manual-only.
+2. **Editorial workflow** — translators hitting `GET /api/translations/...?compareToSource=true`
+   want both the source value and their target value side-by-side;
+   today there's no flag distinguishing them.
+3. **Consumer apps** — opencatalogi's planned per-property language
+   editor (`PageContentForm`, `MenuItemForm`, `PublicationDetailPage`)
+   needs to render an indicator like "Original (Dutch)" vs
+   "Translation (out of date)" — neither piece of information is
+   available without this change.
+
+## Proposed Solution
+
+Schema-property + DB-column + render-metadata, all opt-in. Existing
+schemas without `sourceLanguage` keep working; the back-fill job
+infers a sensible default. New schemas declaring `sourceLanguage`
+gain the full freshness-tracking + render-metadata behaviour. The API
+side ships in the companion change so the two can deliver
+independently.
+
+## Out of scope
+
+- Request-side language negotiation (`?_lang=`,
+  `X-Translation-Target-Language`) — companion change
+  `i18n-api-language-negotiation`.
+- Per-tenant override of `Register.defaultLanguage` — sufficient
+  flexibility comes from the property + object-level overrides; revisit
+  if multi-tenant customers need per-tenant defaults.
+- Frontend language-editing UI — opencatalogi's adoption change
+  delivers it (consumes this contract).
+
+## See also
+
+- Hydra ADR-025 (i18n source-of-truth + API language negotiation) —
+  the parent decision.
+- `openregister/openspec/specs/register-i18n/spec.md` — the
+  pre-existing partial i18n spec; this change advances it to
+  source-of-truth-aware.
+- `.claude/audit-2026-05-03/research/R4-or-i18n-source-of-truth.md` —
+  the audit research informing this change.

--- a/openspec/changes/i18n-source-of-truth/specs/i18n-source-of-truth/spec.md
+++ b/openspec/changes/i18n-source-of-truth/specs/i18n-source-of-truth/spec.md
@@ -1,0 +1,152 @@
+i18n-source-of-truth
+---
+status: draft
+---
+# i18n Source of Truth
+
+## Purpose
+
+Implement the source-of-truth half of hydra ADR-025: schemas declare
+which language is canonical for a translatable property, the
+`openregister_translations` sidecar table tracks the source-language
+of every projected translation, edits to source values automatically
+flip derived translations to `outdated`, and render responses
+optionally expose source-vs-translation metadata. The companion
+change `i18n-api-language-negotiation` covers the request/response
+contract.
+
+## ADDED Requirements
+
+### Requirement: Schemas MUST be able to declare a `sourceLanguage` per translatable property
+
+Schemas MUST accept `sourceLanguage: <bcp47>` on any property where `translatable: true`. The validator MUST reject `sourceLanguage` on properties without `translatable: true`. If a translatable property omits `sourceLanguage`, OR MUST treat the register's `defaultLanguage` (first element of `Register.languages`, falling back to `nl`) as the source language for that property.
+
+#### Scenario: Schema declares sourceLanguage on a translatable property
+- GIVEN a schema body `{"properties": {"title": {"type": "string", "translatable": true, "sourceLanguage": "nl"}}}`
+- WHEN the schema is saved
+- THEN the persisted schema MUST retain `sourceLanguage: "nl"` on the `title` property
+
+#### Scenario: Schema rejects sourceLanguage on a non-translatable property
+- WHEN a schema body `{"properties": {"code": {"type": "string", "sourceLanguage": "nl"}}}` is POSTed
+- THEN OR MUST return `400 Bad Request`
+- AND the response body MUST include `error.invalidProperty: 'code'` and `error.reason: 'sourceLanguage requires translatable: true'`
+
+#### Scenario: Translatable property without sourceLanguage falls back to register default
+- GIVEN a register with `defaultLanguage = "nl"`
+- AND a schema with `{"title": {"translatable": true}}` (no `sourceLanguage`)
+- WHEN an object is created with `title: {nl: "Hallo", en: "Hello"}`
+- THEN the projected Translation rows MUST have `source_language = "nl"` for both rows
+
+### Requirement: Objects MAY override `sourceLanguage` per property via `_translationMeta`
+
+Objects MAY include `_translationMeta.<property>.sourceLanguage = "<bcp47>"` in their body. When present, this overrides the schema default for that single object's property. When absent, the schema/register fallback chain applies.
+
+#### Scenario: Object overrides sourceLanguage for a single property
+- GIVEN a schema declaring `title.sourceLanguage = "nl"`
+- WHEN an object is POSTed with `{"title": {"nl": "x", "en": "y"}, "_translationMeta": {"title": {"sourceLanguage": "en"}}}`
+- THEN the projected Translation rows MUST have `source_language = "en"`
+- AND `_translationMeta.title.sourceLanguage = "en"` MUST be persisted on the object body
+
+### Requirement: The `openregister_translations` table MUST include a `source_language` column
+
+The migration MUST add `source_language VARCHAR(16) NOT NULL DEFAULT ''` to `openregister_translations`. A back-fill MUST set every existing row's `source_language` to the register's `default_language` (or `'nl'` when missing). After back-fill, a follow-up migration MUST drop the default value so new rows are forced to set the column explicitly.
+
+#### Scenario: Existing translation rows are back-filled
+- GIVEN `openregister_translations` contains 100 rows from before this change, each with empty `source_language`
+- AND every row's parent register has `default_language = "nl"`
+- WHEN the migration runs
+- THEN all 100 rows MUST have `source_language = "nl"` after the back-fill
+- AND `php occ openregister:translations:backfill-source-language` re-run MUST be a no-op (returns "0 rows updated")
+
+### Requirement: `TranslationProjectionService` MUST populate `source_language` on every projected row
+
+The projector MUST resolve `source_language` for each property using the lookup chain: `_translationMeta.<prop>.sourceLanguage` (object) → schema `properties.<prop>.sourceLanguage` → `Register.defaultLanguage` → `'nl'`. Every projected Translation row MUST have a non-empty `source_language` after the change ships.
+
+#### Scenario: Projection respects the resolution chain
+- GIVEN a register `defaultLanguage = "nl"`
+- AND a schema with `title.sourceLanguage = "fr"`
+- AND an object body `{"title": {"fr": "Bonjour", "en": "Hello"}, "_translationMeta": {"title": {"sourceLanguage": "en"}}}`
+- WHEN `TranslationProjectionService::project()` runs
+- THEN both projected rows for `title` MUST have `source_language = "en"` (object-level override wins)
+
+### Requirement: `TranslationStatusService` MUST flip derived rows to `outdated` on source-value change
+
+The system MUST expose `TranslationStatusService::markDerivedTranslationsOutdated(string $objectUuid, string $property, string $sourceLanguage): int` that updates every Translation row WHERE `object_uuid = $objectUuid AND property = $property AND language != $sourceLanguage` AND `status IN ('approved', 'human_reviewed', 'machine_translated')` to `status = 'outdated'`. The method MUST return the count of rows updated. A row already in `outdated` or `draft` status MUST NOT be re-flipped.
+
+#### Scenario: Source value change flips approved derived rows to outdated
+- GIVEN an object with `title.sourceLanguage = "nl"` and an approved English translation
+- WHEN `markDerivedTranslationsOutdated('obj-uuid', 'title', 'nl')` is called
+- THEN the English translation row MUST have `status = "outdated"`
+- AND the Dutch source row MUST be unchanged
+- AND the method MUST return `1` (one row flipped)
+
+#### Scenario: Already-outdated rows are not re-flipped
+- GIVEN an English translation row already in `status = "outdated"`
+- WHEN `markDerivedTranslationsOutdated('obj-uuid', 'title', 'nl')` is called
+- THEN the row MUST remain `outdated`
+- AND the method MUST NOT include this row in the returned count
+
+### Requirement: `SaveObject` MUST trigger the outdated flip on source-value change
+
+When persisting an object update, `SaveObject` MUST detect changes to a translatable property's source-language value (compare old vs new for the resolved source language) and MUST call `markDerivedTranslationsOutdated($uuid, $property, $sourceLang)` for each such change. Edits to non-source-language values MUST NOT trigger the flip.
+
+#### Scenario: Editing the Dutch source flips English translation to outdated
+- GIVEN an object with `title = {"nl": "Hallo", "en": "Hello"}`, `sourceLanguage = "nl"`, English row `status = "approved"`
+- WHEN the object is PATCHed with `title.nl = "Welkom"`
+- THEN the English translation row MUST have `status = "outdated"` after persist
+- AND a `TranslationStatusChanged` event MUST have been emitted
+
+#### Scenario: Editing the English translation does NOT flip status
+- GIVEN the same starting state
+- WHEN the object is PATCHed with `title.en = "Welcome"`
+- THEN the English row MUST stay `status = "approved"` (or be the row being edited)
+- AND no rows MUST have been flipped to outdated
+
+### Requirement: `TranslationController` MUST expose source-language query filters
+
+The translation search endpoint MUST accept three new query parameters: `?sourceLanguage=<bcp47>` (filter to rows whose source language matches), `?isOutOfDate=true` (filter to `status = "outdated"`), `?compareToSource=true` (return both source and translation values per matched row, side-by-side).
+
+#### Scenario: Filter translations by source language
+- GIVEN 5 Translation rows: 3 with `source_language = "nl"`, 2 with `source_language = "en"`
+- WHEN `GET /api/translations/search?sourceLanguage=nl` is called
+- THEN the response MUST contain exactly 3 rows
+- AND every row's `source_language` MUST equal `"nl"`
+
+#### Scenario: Filter translations to outdated only
+- GIVEN 10 rows, 3 of which have `status = "outdated"`
+- WHEN `GET /api/translations/search?isOutOfDate=true` is called
+- THEN the response MUST contain exactly 3 rows
+- AND every row's `status` MUST equal `"outdated"`
+
+#### Scenario: Compare to source returns side-by-side values
+- GIVEN an object with `title.nl = "Welkom"` and `title.en = "Hello"` (out of date)
+- WHEN `GET /api/translations/search?compareToSource=true&objectUuid=...` is called
+- THEN each returned row MUST include both `value` (the row's value, e.g. "Hello") and `sourceValue` (the source-language value, e.g. "Welkom")
+
+### Requirement: `RenderObject` MUST attach `_meta.languageMeta` when `?_translationMeta=true` is passed
+
+When the request includes `?_translationMeta=true`, `RenderObject` MUST add `_meta.languageMeta.<property>` to the response body for every translatable property that was rendered. The envelope MUST contain: `served` (the language actually returned), `sourceLanguage` (the canonical source for the property), `isSource` (boolean — true iff `served === sourceLanguage`), `status` (the translation row's status, or `"source"` for the source-language row).
+
+#### Scenario: Render with translation metadata
+- GIVEN an object with `title = {"nl": "Welkom", "en": "Hello"}`, `sourceLanguage = "nl"`
+- WHEN `GET /api/objects/{r}/{s}/{id}?_lang=en&_translationMeta=true` is called
+- THEN the response body MUST include `_meta.languageMeta.title = {served: "en", sourceLanguage: "nl", isSource: false, status: "approved"}`
+
+#### Scenario: Render without `_translationMeta` omits the envelope
+- GIVEN the same object
+- WHEN `GET /api/objects/{r}/{s}/{id}?_lang=en` is called (no `_translationMeta`)
+- THEN the response body MUST NOT contain `_meta.languageMeta`
+
+### Requirement: Responses MUST set `X-Source-Language` header
+
+For any endpoint returning object content, OR MUST set the `X-Source-Language` response header to the canonical source language for the object's primary translatable property (or, when an object has multiple translatable properties with different source languages, the most common one across the object). The header is informational; clients use it for at-a-glance "is this the original?" detection.
+
+#### Scenario: Single-source object exposes source language
+- GIVEN an object whose translatable properties all declare `sourceLanguage = "nl"`
+- WHEN any endpoint returning that object is called
+- THEN the response MUST include header `X-Source-Language: nl`
+
+#### Scenario: Mixed-source object exposes the dominant language
+- GIVEN an object with 2 translatable properties: `title.sourceLanguage = "nl"`, `description.sourceLanguage = "nl"`, `notes.sourceLanguage = "en"`
+- WHEN any endpoint returning that object is called
+- THEN the response MUST include header `X-Source-Language: nl` (2 of 3)

--- a/openspec/changes/i18n-source-of-truth/tasks.md
+++ b/openspec/changes/i18n-source-of-truth/tasks.md
@@ -1,0 +1,82 @@
+# Tasks: i18n Source of Truth
+
+## Phase 1 — Schema + entity + migration
+
+- [ ] Add `sourceLanguage: string` to the JSON-Schema validator for
+      property definitions in `lib/Db/Schema.php` (translatable
+      properties may declare it; non-translatable MUST NOT).
+- [ ] Add migration `lib/Migration/Version1Date20260520120000.php` —
+      `ALTER TABLE openregister_translations ADD COLUMN source_language
+      VARCHAR(16) NOT NULL DEFAULT '';` then a back-fill UPDATE that
+      sets `source_language = (SELECT default_language FROM
+      openregister_register WHERE id = …)` for every row.
+- [ ] Update `lib/Db/Translation.php` entity — add `sourceLanguage`
+      column property, getter/setter via QBMapper.
+- [ ] Update `lib/Db/TranslationMapper.php` to include
+      `source_language` in find/insert/update queries.
+- [ ] Add a back-fill `php occ openregister:translations:backfill-source-language`
+      idempotent command (re-runs are no-ops once every row has a
+      non-empty `source_language`).
+
+## Phase 2 — Projection + status service
+
+- [ ] Update `lib/Service/TranslationProjectionService.php` to populate
+      `source_language` from: object-level `_translationMeta.<prop>.sourceLanguage`
+      → schema property `sourceLanguage` → register `defaultLanguage`.
+- [ ] Add `lib/Service/TranslationStatusService::markDerivedTranslationsOutdated(string $objectUuid, string $property, string $sourceLanguage): int`
+      that flips every non-source-language Translation row to status
+      `outdated`. Returns count of rows flipped.
+- [ ] Wire the source-change trigger in
+      `lib/Service/Object/SaveObject.php`: when a translatable
+      property's source-language value changes (compare old vs new),
+      call `markDerivedTranslationsOutdated` for that object/property.
+      Include the trigger in the existing event-emission path so
+      consumers can subscribe.
+
+## Phase 3 — Controller + render
+
+- [ ] Extend `lib/Controller/TranslationController::search` to honour
+      `?sourceLanguage=<bcp47>`, `?isOutOfDate=true`,
+      `?compareToSource=true` query filters.
+- [ ] Update `lib/Service/Object/RenderObject.php` to attach
+      `_meta.languageMeta.<property> = { served, sourceLanguage,
+      isSource, status }` when `?_translationMeta=true` is requested.
+- [ ] Set `X-Source-Language` response header in
+      `lib/Middleware/LanguageMiddleware::afterController()` based on
+      the resolved source language for the response.
+
+## Phase 4 — Spec + tests
+
+- [ ] Write `specs/i18n-source-of-truth/spec.md` with one Requirement
+      per public surface (schema property, DB column, projection,
+      status service, controller filters, render metadata, response
+      header).
+- [ ] Update `openregister/openspec/specs/register-i18n/spec.md` to
+      remove the "Not yet implemented" line about source-of-truth and
+      automatic outdated status; cross-reference this change.
+- [ ] Add `tests/Unit/Service/TranslationProjectionServiceSourceLanguageTest.php`
+      covering: object-level override, schema-default inheritance,
+      register-default fallback.
+- [ ] Add `tests/Unit/Service/TranslationStatusServiceOutdatedTest.php`
+      covering: source-change → derived languages flipped to outdated;
+      non-source-change does NOT flip; missing `sourceLanguage` falls
+      back to register default.
+- [ ] Add `tests/Unit/Service/Object/RenderObjectLanguageMetaTest.php`
+      covering: `_meta.languageMeta` envelope present when
+      `?_translationMeta=true`, absent otherwise.
+- [ ] Add Newman collection
+      `tests/integration/openregister-i18n-source-of-truth.postman_collection.json`
+      hitting: object create with `sourceLanguage: nl`, source value
+      edit → outdated flip on derived row, controller filter
+      `?isOutOfDate=true` returns the flipped row, render with
+      `?_translationMeta=true` returns the envelope.
+- [ ] Wire the new Newman collection into
+      `tests/newman/run-all.sh::DOMAIN_ORDER` after `relations`.
+
+## Phase 5 — Documentation
+
+- [ ] Update `docs/i18n.md` (or create) describing the source-of-truth
+      model and the `sourceLanguage` schema-property contract.
+- [ ] Cross-reference this change from
+      `hydra/openspec/architecture/adr-025-i18n-source-of-truth.md`'s
+      "Implementation reference" section once shipped.

--- a/openspec/changes/pluggable-integration-registry/design.md
+++ b/openspec/changes/pluggable-integration-registry/design.md
@@ -1,0 +1,127 @@
+# Design: Pluggable Integration Registry
+
+## Reuse analysis
+
+- `OCA\OpenRegister\Service\LinkedEntityService` exists; it's the
+  existing single point of contact for "linked things." The migration
+  preserves its public API surface — `IntegrationProvider` is the new
+  internal contract, `LinkedEntityService` becomes a registry
+  consumer.
+- `OCA\OpenRegister\Db\Schema::validateLinkedTypesValue()` already
+  hooks linkedTypes validation; we swap the data source from constant
+  to registry.
+- DI tags via `lib/AppInfo/Application.php` are an existing pattern in
+  OR (e.g. `EventSubscriber` tag); we add `IntegrationProvider`
+  alongside.
+- OpenConnector handles credentials for external services already; we
+  reuse, never duplicate.
+
+## Public API shape
+
+```php
+namespace OCA\OpenRegister\Service\Integration;
+
+interface IntegrationProvider {
+    public function getId(): string;        // 'files', 'notes', etc. — the canonical key
+    public function getLabel(): string;     // human-readable, i18n key
+    public function getIcon(): string;      // icon class or URL
+    public function isEnabled(): bool;      // checks NC app installed/enabled
+    public function getStorageStrategy(): string;     // 'native' | 'external'
+    public function authRequirements(): array;        // empty for native; OAuth scope for external
+    public function linkedColumnName(): ?string;      // backwards compat: column on object's linked-things JSON
+    public function query(string $objectUuid): iterable;
+    public function mutate(string $objectUuid, array $payload): void;
+}
+
+final class IntegrationRegistry {
+    public function register(IntegrationProvider $p): void;
+    public function listAll(): iterable;       // every registered provider
+    public function listEnabled(): iterable;   // only those with isEnabled() === true
+    public function listIds(): array;          // ['files', 'notes', ...]
+    public function getById(string $id): ?IntegrationProvider;
+    public function requireById(string $id): IntegrationProvider; // throws IntegrationNotFoundException
+}
+```
+
+## Three-stage filter (per ADR-019)
+
+The service surface answers stage 1 (registry — does it exist + is
+the underlying NC app installed). The schema's `configuration.linkedTypes`
+whitelist answers stage 2. The rendering component's `excludeIntegrations`
+prop answers stage 3. This change implements stage 1 only; stages 2-3
+are existing capabilities of the schema + the FE library.
+
+## Storage strategy: native vs external
+
+- **native**: provider stores linked-thing references in OR's existing
+  per-object linked-things JSON column (preserves current behaviour).
+- **external**: provider stores nothing in OR; instead, queries flow
+  through `ExternalIntegrationRouter` which dispatches to an
+  OpenConnector source. OR shows the linked things in the UI but
+  does NOT own credentials or persistence for them.
+
+The external path is what enables OpenProject / XWiki / third-party
+service integrations without leaking credentials into OR.
+
+## Capability advertising
+
+Mobile apps and partner integrations need to discover which
+integrations a given OR install supports. The OCS capability hook
+puts this on the standard NC discovery surface:
+
+```http
+GET /ocs/v2.php/cloud/capabilities
+```
+
+```json
+{
+  "ocs": {
+    "data": {
+      "capabilities": {
+        "openregister": {
+          "integrations": ["files", "notes", "tasks", "calendar"]
+        }
+      }
+    }
+  }
+}
+```
+
+Unenabled integrations (`isEnabled() === false`) MUST NOT appear here —
+the capability map is "what works right now," not "what could work."
+
+## Parity gate
+
+A new `scripts/check-integration-parity.sh` walks both registries:
+
+1. List every backend `IntegrationProvider`'s `getId()`.
+2. Parse `nextcloud-vue/src/integrations/index.js` for every FE
+   `register({id})` call.
+3. Diff: any backend id with no matching FE registration → fail.
+4. Any FE registration with no matching backend provider → fail.
+
+Hooks into `hydra/scripts/run-hydra-gates.sh` as gate #15. Per
+ADR-019, tab-only or widget-only integrations are NOT permitted.
+
+## Migration risks
+
+- **Schema linkedTypes referencing not-yet-registered ids**: handled
+  per ADR-019 — validation is permissive on read (warns), strict on
+  write only when adding.
+- **External consumers of `TYPE_COLUMN_MAP`**: the constant is
+  private-by-convention; we mark `@deprecated` here, remove in a
+  follow-up cleanup change once built-in providers stabilise.
+
+## Open design questions
+
+1. **Should `IntegrationProvider::query()` return an iterable or a
+   collection?** Iterable wins for streaming, but most consumers
+   want a count + first 10 — a wrapper class might be cleaner.
+   Defer; v1 returns iterable, consumers wrap as needed.
+2. **Per-provider settings page?** ADR-019 mentions "unified admin UI"
+   for auth status. Out of scope for this change; surfaced via
+   capabilities + each provider's `authRequirements()`. A separate
+   admin-UI change builds the unified page.
+3. **`@deprecated TYPE_COLUMN_MAP` removal timing?** Per the migration
+   rules, deprecate-then-remove takes one release. Follow-up change
+   tracks the removal.

--- a/openspec/changes/pluggable-integration-registry/proposal.md
+++ b/openspec/changes/pluggable-integration-registry/proposal.md
@@ -1,0 +1,96 @@
+# Pluggable Integration Registry
+
+## Why
+
+`LinkedEntityService::TYPE_COLUMN_MAP` is a hardcoded PHP constant
+listing the 8 NC entity types that can be linked to OR objects (files,
+notes, tasks, calendar events, mail, contacts, deck cards, talk
+conversations). `@conduction/nextcloud-vue::CnObjectSidebar` is a Vue
+component with 5 hardcoded tabs — a glaring asymmetry the audit's
+ADR-019 review confirmed: of the 8 backend-supported types, only 5
+have sidebar UI and only 2 have widget components. Adding a new
+integration today means modifying both core OR and the shared
+component library.
+
+Hydra ADR-019 (Proposed, 2026-04-21) ratifies a two-sided
+**integration registry** as the canonical way to declare "things that
+can be linked to or rendered alongside an OpenRegister object."
+This change is the umbrella implementation cited in ADR-019's
+"Implementation reference" section.
+
+## What Changes
+
+- Add `OCA\OpenRegister\Service\Integration\IntegrationProvider`
+  PHP interface with: `getId(): string`, `getLabel(): string`,
+  `getIcon(): string`, `isEnabled(): bool`,
+  `getStorageStrategy(): 'native'|'external'`, `authRequirements():
+  array`, `linkedColumnName(): ?string`, `query(string $objectUuid):
+  iterable`, `mutate(string $objectUuid, array $payload): void`.
+- Add `OCA\OpenRegister\Service\Integration\IntegrationRegistry` —
+  DI-resolvable service exposing `register(IntegrationProvider $p)`,
+  `listAll(): iterable<IntegrationProvider>`, `listEnabled(): iterable`,
+  `listIds(): array<string>`, `getById(string $id): ?IntegrationProvider`,
+  `requireById(string $id): IntegrationProvider`. Registry is
+  auto-populated from DI tag `IntegrationProvider`.
+- Migrate the 8 built-in NC types
+  (files / notes / tasks / calendar / mail / contacts / deck / talk)
+  into 8 `IntegrationProvider` implementations under
+  `lib/Service/Integration/Builtin/`. Delete `TYPE_COLUMN_MAP`.
+- Add `OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter`
+  for `getStorageStrategy() === 'external'` providers. Routes through
+  OpenConnector for credentials (OR does not own them).
+- Update `Schema::validateLinkedTypesValue()` to consult
+  `IntegrationRegistry::listIds()` instead of the hardcoded constant.
+  Validation is permissive on read (warn-only for unknown ids), strict
+  on write.
+- Add OCS capability advertising registered integrations:
+  `GET /ocs/v2.php/cloud/capabilities` MUST include
+  `openregister.integrations: ['files', 'notes', ...]`. Mobile +
+  partner integrations discover supported types here.
+- Add CLI tools: `php occ openregister:integrations:list` (prints
+  registered providers) and `bash scripts/scaffold-integration.sh
+  <id>` (generates a skeleton — provider PHP, FE registration stub,
+  spec delta, tests).
+- Add `bash scripts/check-integration-parity.sh` as a CI gate: every
+  backend `IntegrationProvider` MUST have a matching FE registration
+  (sidebar tab + dashboard widget). Tab-only or widget-only =
+  CI-failure. Same script wired into `hydra/scripts/run-hydra-gates.sh`
+  as a new gate.
+- Companion FE work in `@conduction/nextcloud-vue` (separate change):
+  expose `OCA.OpenRegister.integrations.register({...})`, refactor
+  `CnObjectSidebar` to consume the registry, add the four widget
+  surfaces (`user-dashboard`, `app-dashboard`, `detail-page`,
+  `single-entity`).
+
+## Problem
+
+The current "linked things" model is closed; every new integration
+costs a synchronised PR across OR core + the shared component
+library, and it can't accommodate external services (OpenProject,
+XWiki, third-party connectors). The asymmetry between backend-
+supported and frontend-rendered types is a chronic source of "why
+doesn't this show up?" debugging.
+
+## Proposed Solution
+
+Two-sided registry: PHP interface + DI tag on the backend, JS
+register-call on the frontend, paired by `id`. Enforced by a parity
+gate so the two sides cannot drift. The 8 built-in types are migrated
+in this change; future integrations land as standalone "leaf" changes
+hanging off this contract.
+
+## Out of scope
+
+- The companion FE `@conduction/nextcloud-vue` change (separate spec
+  in that repo, paired via shared `id`).
+- Specific external-service providers (OpenProject, XWiki, …) — each
+  ships as its own leaf change.
+- Migrating the relations system (`RelationsService` object↔object) to
+  this registry — a future change once integrations stabilise.
+
+## See also
+
+- Hydra ADR-019 (integration registry pattern)
+- Hydra ADR-022 (apps consume OR abstractions)
+- `.claude/audit-2026-05-03/05-adr-staleness.md` — flagged ADR-019 as
+  legitimately STILL-OPEN; this is the change that closes it.

--- a/openspec/changes/pluggable-integration-registry/specs/integration-registry/spec.md
+++ b/openspec/changes/pluggable-integration-registry/specs/integration-registry/spec.md
@@ -1,0 +1,145 @@
+integration-registry
+---
+status: draft
+---
+# Integration Registry
+
+## Purpose
+
+Implement the two-sided integration-registry contract from hydra
+ADR-019: a PHP `IntegrationProvider` interface + `IntegrationRegistry`
+on the backend, an `OCA.OpenRegister.integrations.register({...})`
+call on the frontend, paired by `id`. Built-in NC integrations (files,
+notes, tasks, calendar, mail, contacts, deck, talk) ship as the first
+8 providers; external services route through OpenConnector. A CI
+parity gate prevents tab-only or widget-only registrations.
+
+## ADDED Requirements
+
+### Requirement: The system MUST define an `IntegrationProvider` interface
+
+OpenRegister MUST expose `OCA\OpenRegister\Service\Integration\IntegrationProvider` with the methods `getId(): string`, `getLabel(): string`, `getIcon(): string`, `isEnabled(): bool`, `getStorageStrategy(): string`, `authRequirements(): array`, `linkedColumnName(): ?string`, `query(string $objectUuid): iterable`, `mutate(string $objectUuid, array $payload): void`. The interface MUST be PHP-namespace-stable (changes are breaking).
+
+#### Scenario: Implementing IntegrationProvider declares an id
+- GIVEN a class `MyServiceProvider` implementing `IntegrationProvider`
+- WHEN the class is loaded
+- THEN `MyServiceProvider::getId()` MUST return a non-empty string
+- AND the string MUST be unique across all registered providers in this OR install
+
+### Requirement: The system MUST expose an `IntegrationRegistry` service
+
+OpenRegister MUST expose `OCA\OpenRegister\Service\Integration\IntegrationRegistry` as a public DI-resolvable service with: `register(IntegrationProvider $p): void`, `listAll(): iterable<IntegrationProvider>`, `listEnabled(): iterable<IntegrationProvider>`, `listIds(): array<string>`, `getById(string $id): ?IntegrationProvider`, `requireById(string $id): IntegrationProvider`. `requireById()` MUST throw `IntegrationNotFoundException` for unknown ids. Any service implementing `IntegrationProvider` and tagged `IntegrationProvider` in the DI container MUST be auto-registered at boot.
+
+#### Scenario: Auto-register a provider via DI tag
+- GIVEN `MyServiceProvider` is declared with `<service>...<tag name="IntegrationProvider"/></service>` in the DI container
+- WHEN the registry is resolved for the first time
+- THEN `IntegrationRegistry::listAll()` MUST include `MyServiceProvider`
+- AND `IntegrationRegistry::getById('my-service')` MUST return that instance
+
+#### Scenario: Filter to enabled providers
+- GIVEN two providers `Files` (enabled) and `Talk` (NC Talk app not installed, `isEnabled() === false`)
+- WHEN `listEnabled()` is called
+- THEN the iterable MUST yield `Files` only
+- AND `listAll()` MUST yield both
+
+#### Scenario: requireById throws on unknown id
+- GIVEN `MyServiceProvider` is NOT registered
+- WHEN `requireById('my-service')` is called
+- THEN the registry MUST throw `IntegrationNotFoundException`
+- AND the exception MUST expose `getId() === 'my-service'`
+
+### Requirement: The 8 built-in NC types MUST be migrated to providers
+
+OpenRegister MUST ship 8 builtin `IntegrationProvider` implementations under `lib/Service/Integration/Builtin/` for: `files`, `notes`, `tasks`, `calendar`, `mail`, `contacts`, `deck`, `talk`. Each MUST preserve the current `LinkedEntityService::TYPE_COLUMN_MAP` key as its `getId()` for backwards compatibility with existing schemas.
+
+#### Scenario: Existing schema with `linkedTypes: ['files', 'notes']` keeps working
+- GIVEN a schema configured with `configuration.linkedTypes = ['files', 'notes']` before this change
+- WHEN OR is upgraded to the version shipping the registry
+- THEN the schema MUST still load without validation errors
+- AND `IntegrationRegistry::getById('files')` MUST return the `FilesProvider`
+- AND `IntegrationRegistry::getById('notes')` MUST return the `NotesProvider`
+
+### Requirement: Schema linkedTypes validation MUST consult the registry
+
+`Schema::validateLinkedTypesValue()` MUST call `IntegrationRegistry::listIds()` instead of any hardcoded constant. Validation MUST be permissive on read (unknown ids generate a `LoggerInterface::warning()` but do NOT throw), strict on write (POST/PUT/PATCH adding an unknown id MUST return `400 Bad Request` with a structured error body pointing at the unknown id).
+
+#### Scenario: Read with stale linkedTypes id
+- GIVEN a stored schema has `configuration.linkedTypes = ['files', 'historic-removed-type']`
+- AND no provider with id `historic-removed-type` is registered
+- WHEN the schema is read via `GET /api/schemas/{id}`
+- THEN the response MUST include the schema unchanged
+- AND a warning MUST be logged: `LinkedTypes references unknown integration 'historic-removed-type'`
+
+#### Scenario: Write with unknown linkedTypes id
+- WHEN `PUT /api/schemas/{id}` is called with `configuration.linkedTypes = ['files', 'unknown-id']`
+- THEN OR MUST return `400 Bad Request`
+- AND the response body MUST include `error.unknownLinkedType: 'unknown-id'`
+- AND no other validation MUST run after this failure (short-circuit)
+
+### Requirement: External-strategy providers MUST route through OpenConnector
+
+Providers returning `getStorageStrategy() === 'external'` MUST be dispatched via `OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter`. The router MUST forward `query()` and `mutate()` calls to the OpenConnector source declared by the provider; OR MUST NOT store credentials for external integrations.
+
+#### Scenario: External provider's query goes through OpenConnector
+- GIVEN a provider `OpenProjectProvider` with `getStorageStrategy() === 'external'` referencing OpenConnector source `openproject-prod`
+- WHEN `OpenProjectProvider::query('object-uuid-123')` is called via the router
+- THEN the router MUST dispatch the query to OpenConnector source `openproject-prod`
+- AND OR's database MUST NOT receive any persistence write for this query
+- AND the router MUST surface the source's auth status (OK / needs-reauth / disconnected) on the response envelope
+
+### Requirement: Registered integrations MUST be advertised via OCS capabilities
+
+The system MUST expose `openregister.integrations` in `GET /ocs/v2.php/cloud/capabilities` as the array of currently `isEnabled()`-true provider ids. Disabled providers (NC app not installed) MUST NOT appear.
+
+#### Scenario: Capability lists enabled integrations
+- GIVEN `Files` and `Notes` providers report `isEnabled() === true`, `Talk` reports `false`
+- WHEN `GET /ocs/v2.php/cloud/capabilities` is called
+- THEN the response body MUST include `openregister.integrations: ['files', 'notes']`
+- AND the array MUST NOT include `'talk'`
+
+### Requirement: A CI parity gate MUST enforce backend ↔ frontend pairing
+
+A script `scripts/check-integration-parity.sh` MUST exit non-zero when:
+1. Any backend `IntegrationProvider::getId()` lacks a matching frontend `OCA.OpenRegister.integrations.register({id})` call in `nextcloud-vue/src/integrations/`.
+2. Any frontend registration lacks a matching backend provider.
+
+The script MUST be invoked by `hydra/scripts/run-hydra-gates.sh` as gate #15 and by the OR repo's CI workflow. Per ADR-019, tab-only or widget-only integrations are CI-blocking.
+
+#### Scenario: Backend without frontend fails the gate
+- GIVEN a backend `MyServiceProvider` exists with `getId() === 'my-service'`
+- AND `nextcloud-vue/src/integrations/index.js` does NOT call `register({id: 'my-service', ...})`
+- WHEN `bash scripts/check-integration-parity.sh` runs
+- THEN the script MUST exit with status code 1
+- AND the script MUST print: `parity: backend 'my-service' has no frontend registration`
+
+#### Scenario: Frontend without backend fails the gate
+- GIVEN no backend provider with `getId() === 'orphan'` is registered
+- AND `nextcloud-vue/src/integrations/index.js` calls `register({id: 'orphan', ...})`
+- WHEN the script runs
+- THEN the script MUST exit with status code 1
+- AND the script MUST print: `parity: frontend 'orphan' has no backend provider`
+
+### Requirement: A scaffold script MUST be provided for new integrations
+
+OpenRegister MUST ship `scripts/scaffold-integration.sh <id>` generating: a stub `lib/Service/Integration/Builtin/{Id}Provider.php`, a stub frontend registration in `nextcloud-vue/src/integrations/{id}/index.js`, a unit-test stub at `tests/Unit/Service/Integration/Builtin/{Id}ProviderTest.php`, and a stub spec delta. The script MUST refuse to overwrite existing files; safe to re-run after deletion.
+
+#### Scenario: Scaffold a new integration
+- GIVEN no integration with id `wiki` exists
+- WHEN `bash scripts/scaffold-integration.sh wiki` is run
+- THEN the script MUST create `lib/Service/Integration/Builtin/WikiProvider.php` (PHP stub implementing `IntegrationProvider`)
+- AND `nextcloud-vue/src/integrations/wiki/index.js` (FE registration stub)
+- AND `tests/Unit/Service/Integration/Builtin/WikiProviderTest.php`
+- AND a spec delta stub
+- AND running it again MUST fail with "files already exist; delete first or run with --force"
+
+### Requirement: An OCC console command MUST list registered integrations
+
+OpenRegister MUST add `openregister:integrations:list` to `php occ` listing every registered provider with: id, label, enabled-state, storage-strategy, and auth-requirements summary.
+
+#### Scenario: List integrations from the CLI
+- GIVEN providers `Files` (enabled, native, no auth), `OpenProject` (enabled, external, OAuth-required), `Talk` (disabled — NC Talk not installed)
+- WHEN `php occ openregister:integrations:list` is run
+- THEN the output MUST include rows for all 3 providers
+- AND the row for `OpenProject` MUST show `external (OpenConnector source)` for storage-strategy
+- AND the row for `Talk` MUST show `disabled` for state
+- AND no row MUST be missing from the output regardless of enabled state

--- a/openspec/changes/pluggable-integration-registry/tasks.md
+++ b/openspec/changes/pluggable-integration-registry/tasks.md
@@ -1,0 +1,104 @@
+# Tasks: Pluggable Integration Registry
+
+## Phase 1 — Backend contract
+
+- [ ] Define `lib/Service/Integration/IntegrationProvider.php` interface
+      with the methods listed in `proposal.md` (`getId`, `getLabel`,
+      `getIcon`, `isEnabled`, `getStorageStrategy`, `authRequirements`,
+      `linkedColumnName`, `query`, `mutate`).
+- [ ] Define `lib/Service/Integration/IntegrationRegistry.php` —
+      registry service with `register/listAll/listEnabled/listIds/
+      getById/requireById`.
+- [ ] Wire DI tag `IntegrationProvider` in `lib/AppInfo/Application.php`
+      so any service implementing the interface auto-registers.
+- [ ] Add `lib/Service/Integration/Exception/IntegrationNotFoundException.php`
+      and `IntegrationDisabledException.php` with `getId()` accessor.
+- [ ] Add `lib/Service/Integration/ExternalIntegrationRouter.php` —
+      dispatches to OpenConnector for `getStorageStrategy() === 'external'`
+      providers. OR does not own credentials; the router surfaces auth
+      status only.
+
+## Phase 2 — Migrate built-ins
+
+For each of files / notes / tasks / calendar / mail / contacts / deck /
+talk:
+
+- [ ] Add `lib/Service/Integration/Builtin/{Type}Provider.php`
+      implementing `IntegrationProvider`. Wraps the existing
+      handler logic for that type.
+- [ ] Confirm the provider's `getId()` matches the existing
+      `LinkedEntityService::TYPE_COLUMN_MAP` key for backwards
+      compatibility on existing `linkedTypes` configurations.
+
+After all 8 are migrated:
+
+- [ ] Mark `LinkedEntityService::TYPE_COLUMN_MAP` `@deprecated`; switch
+      every internal caller to `IntegrationRegistry::listIds()`.
+- [ ] Delete `TYPE_COLUMN_MAP` in a follow-up cleanup change once 1
+      release-cycle has passed.
+
+## Phase 3 — Schema validator + capability advertisement
+
+- [ ] Update `lib/Db/Schema.php::validateLinkedTypesValue()` to call
+      `IntegrationRegistry::listIds()` instead of the deprecated
+      constant.
+- [ ] On read: warn (non-throwing) for unknown ids — schemas with
+      stale references still load.
+- [ ] On write: reject unknown ids with a `400 Bad Request` carrying
+      a structured error pointing at the unknown id.
+- [ ] Add `lib/Capabilities/IntegrationsCapability.php` implementing
+      `OCP\Capabilities\ICapability` so registered integrations appear
+      in `GET /ocs/v2.php/cloud/capabilities` under
+      `openregister.integrations`.
+
+## Phase 4 — Tooling + CI gate
+
+- [ ] Add `php occ openregister:integrations:list` (prints registry
+      contents incl. enabled status, storage strategy, auth
+      requirements).
+- [ ] Add `scripts/scaffold-integration.sh <id>` generating: provider
+      PHP file + spec delta + unit-test stub + FE registration stub
+      (in nextcloud-vue/src/integrations/<id>/).
+- [ ] Add `scripts/check-integration-parity.sh` — exits non-zero if
+      any backend provider lacks a frontend registration entry.
+- [ ] Wire the parity script into `hydra/scripts/run-hydra-gates.sh`
+      as a new gate; document in `hydra/openspec/architecture/adr-019`
+      under "implementation reference".
+
+## Phase 5 — Spec + tests
+
+- [ ] Write `specs/integration-registry/spec.md` with one Requirement
+      per public surface (interface contract, registry behaviour,
+      schema validator, OCS capability, parity gate).
+- [ ] Add `tests/Unit/Service/Integration/IntegrationRegistryTest.php`
+      covering: register/list/getById/requireById, enabled-vs-all
+      filtering, exception paths.
+- [ ] Add `tests/Unit/Service/Integration/Builtin/<Type>ProviderTest.php`
+      for each migrated builtin (8 files).
+- [ ] Add `tests/Unit/Db/SchemaValidateLinkedTypesTest.php` — covers
+      registry-driven validation paths (warn-on-read, reject-on-write).
+- [ ] Add Newman collection
+      `tests/integration/openregister-integration-registry.postman_collection.json`
+      hitting OCS capabilities + a couple of provider-backed endpoints
+      end-to-end.
+- [ ] Wire the new collection into `tests/newman/run-all.sh::DOMAIN_ORDER`
+      after `relations`.
+
+## Phase 6 — Documentation
+
+- [ ] `docs/integrations/README.md` — developer guide: writing a new
+      provider, registering FE side, parity expectations.
+- [ ] Update `lib/AppInfo/Application.php` PHPDoc with the new public
+      services.
+- [ ] Cross-reference this change from
+      `hydra/openspec/architecture/adr-019-integration-registry.md`'s
+      "Implementation reference" once shipped.
+
+## Phase 7 — Companion FE coordination
+
+- [ ] Open `nextcloud-vue/openspec/changes/integration-registry-frontend/`
+      with the matching FE-side proposal (registry, four widget
+      surfaces, `CnObjectSidebar` refactor, snapshot tests for the 5
+      existing tabs).
+- [ ] Cross-link both changes in their `proposal.md` "See also"
+      sections; the parity gate enforces they stay in lockstep.

--- a/openspec/changes/register-resolver-service/design.md
+++ b/openspec/changes/register-resolver-service/design.md
@@ -1,0 +1,212 @@
+# Design: Register Resolver Service
+
+## Reuse analysis
+
+- `OCA\OpenRegister\Db\RegisterMapper` exposes `find()`, `findBySlug()`,
+  `findByUuid()`, `findAll()` — the resolver wraps these; no new
+  mapper methods.
+- `OCA\OpenRegister\Db\SchemaMapper` exposes `find()`, `findBySlug()`,
+  `findByUuid()` — same.
+- `OCA\OpenRegister\Db\MultiTenancyTrait::applyOrganisationFilter` is
+  already called by both mappers; the resolver inherits tenancy
+  scoping for free by going through the mappers.
+- `\OCP\IAppConfig` is the canonical store for app-level config keys;
+  no new persistence layer.
+- `\OCA\OpenRegister\Exception\OpenRegisterException` (existing
+  base class) is the parent for the three new exceptions; no new
+  exception hierarchy.
+
+## Public API shape
+
+```php
+namespace OCA\OpenRegister\Service;
+
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Service\Resolver\RegisterSchemaPair;
+use OCA\OpenRegister\Service\Resolver\Exception\MissingConfigException;
+use OCA\OpenRegister\Service\Resolver\Exception\RegisterNotFoundException;
+use OCA\OpenRegister\Service\Resolver\Exception\SchemaNotFoundException;
+
+final class RegisterResolverService {
+
+    /**
+     * Read the configured slug/UUID for a register. Throws
+     * MissingConfigException if no value is set and no default is
+     * provided.
+     *
+     * @throws MissingConfigException
+     */
+    public function resolveRegisterId(
+        string $appId,
+        string $configKey,
+        ?string $default = null,
+        ?string $organisationUuid = null,
+    ): string;
+
+    /**
+     * Same shape for schemas.
+     *
+     * @throws MissingConfigException
+     */
+    public function resolveSchemaId(
+        string $appId,
+        string $configKey,
+        ?string $default = null,
+        ?string $organisationUuid = null,
+    ): string;
+
+    /**
+     * Read + hydrate a Register entity. Throws RegisterNotFoundException
+     * if the configured slug/UUID resolves to no entity in the caller's
+     * tenant.
+     *
+     * @throws MissingConfigException
+     * @throws RegisterNotFoundException
+     */
+    public function resolveRegister(
+        string $appId,
+        string $configKey,
+        ?string $default = null,
+        ?string $organisationUuid = null,
+    ): Register;
+
+    /**
+     * Same shape for schemas.
+     *
+     * @throws MissingConfigException
+     * @throws SchemaNotFoundException
+     */
+    public function resolveSchema(
+        string $appId,
+        string $configKey,
+        ?string $default = null,
+        ?string $organisationUuid = null,
+    ): Schema;
+
+    /**
+     * Convenience: resolve a register + schema together. Returns a
+     * value object with both entities + the two resolved IDs.
+     *
+     * @throws MissingConfigException
+     * @throws RegisterNotFoundException
+     * @throws SchemaNotFoundException
+     */
+    public function resolvePair(
+        string $appId,
+        string $registerKey,
+        string $schemaKey,
+        ?string $organisationUuid = null,
+    ): RegisterSchemaPair;
+
+    /**
+     * Enumerate every `<context>_(register|schema)` config key
+     * currently set for the given app. Used by admin UIs.
+     *
+     * @return array<string,string> map of config-key → resolved value
+     */
+    public function enumerateAppConfigs(string $appId): array;
+}
+```
+
+## Naming convention
+
+The audit found apps using both `<context>_register` and bare
+`register`. The convention going forward:
+
+- `<context>_register` — the slug/UUID of the Register an app uses for
+  a given context. Examples: `theme_register`, `page_register`,
+  `catalog_register`, `listing_register`.
+- `<context>_schema` — same shape for schemas. Examples:
+  `theme_schema`, `listing_schema`.
+- Bare `register` / `schema` is grandfathered (pipelinq's existing
+  call sites) but the service treats `register` as
+  `default_register` for enumeration purposes.
+
+The capability spec documents this; per-app adoption changes either
+adopt the prefixed shape or grandfather their bare keys explicitly.
+
+## Caching behaviour
+
+Request-scoped, NOT cross-request. The cache lives on the service
+instance; with NC's DI lifecycle that's per-request. The cache is keyed
+by `"{appId}:{configKey}:{organisationUuid|''}"` so an explicit
+organisation override doesn't collide with the implicit-tenant case.
+
+Cross-request caching is out of scope. If a register is renamed mid-
+request, the resolver returns the stale entity from the cache; that's
+acceptable because admin renames trigger an explicit cache flush via
+the existing `RegisterMapper` invalidation path.
+
+## Error semantics
+
+| Failure | Exception | HTTP status hint | When |
+|---|---|---|---|
+| Config key not set + no default | `MissingConfigException` | 500 (server misconfig) | Admin forgot to set the key |
+| Config key set, register/schema doesn't exist anywhere | `RegisterNotFoundException` / `SchemaNotFoundException` | 500 (stale config) | Register was deleted but the config still references it |
+| Config key set, entity exists but not in caller's tenant | `RegisterNotFoundException` / `SchemaNotFoundException` | 404 (tenant scope) | Multi-tenant install where the caller can't see the configured register |
+
+Distinguishing the last two requires a tenant-scoping-aware check at
+the mapper layer; the resolver does it via a fall-through query that
+ignores tenant scope and compares results.
+
+## Migration path for consumers
+
+Before:
+```php
+$registerSlug = $this->appConfig->getValueString(
+    Application::APP_ID,
+    'theme_register',
+    ''
+);
+if ($registerSlug === '') {
+    return new JSONResponse(['error' => 'Theme register not configured'], 500);
+}
+$register = $this->registerMapper->findBySlug($registerSlug);
+```
+
+After:
+```php
+try {
+    $register = $this->registerResolver->resolveRegister(
+        Application::APP_ID,
+        'theme_register'
+    );
+} catch (MissingConfigException $e) {
+    return new JSONResponse([
+        'error' => 'Theme register not configured',
+        'configKey' => $e->getConfigKey(),
+    ], 500);
+} catch (RegisterNotFoundException $e) {
+    return new JSONResponse([
+        'error' => 'Theme register not found',
+        'resolvedValue' => $e->getResolvedValue(),
+    ], 500);
+}
+```
+
+Per-app adoption changes carry the bulk replacement.
+
+## Tests
+
+Unit tests cover the five public methods + `enumerateAppConfigs` with
+an in-memory IAppConfig mock + mocked mappers. Integration tests
+exercise the real Nextcloud DI graph against an in-memory SQLite to
+verify the request-scoped cache and the tenant-scoping behaviour.
+Newman covers the error-path HTTP shapes from a representative
+controller (we'll expose a debug endpoint
+`/api/admin/resolver-test/{config-key}` gated on admin only, removed
+before merge — exists only to drive the Newman test).
+
+## Open design questions
+
+1. **Should `enumerateAppConfigs` also include bare `register` /
+   `schema` keys?** Sketch says yes (treat as `default_register`); the
+   admin UI may want to flag those as "legacy convention" so consumers
+   migrate. Defer until admin UI surfaces — the data is there
+   regardless.
+2. **Bulk resolve (multiple pairs at once)?** Out of scope for v1;
+   add `resolvePairs(array $specs)` if usage patterns surface.
+3. **Frontend equivalent?** Out of scope. The FE consumes resolved
+   values via OR's REST surface (e.g. `GET /api/registers/{slug}`);
+   no need to ship a TypeScript helper.

--- a/openspec/changes/register-resolver-service/proposal.md
+++ b/openspec/changes/register-resolver-service/proposal.md
@@ -1,0 +1,127 @@
+# Register Resolver Service
+
+## Why
+
+Across the Conduction app fleet, every consumer of OpenRegister
+hand-rolls the same boilerplate: read an `IAppConfig` value of the form
+`<context>_register` / `<context>_schema`, fall back to a sensible
+default, look up the matching `Register` / `Schema` entity through
+`RegisterMapper` / `SchemaMapper`, cache the result, and proceed.
+
+The OR-abstraction audit (2026-05-03, stream 4 — hardcoded
+functionality) found this pattern duplicated in:
+
+- **opencatalogi**: 5 controllers
+  (`PublicationsController`, `ListingsController`,
+  `CatalogiController`, `ThemesController`, `PagesController`) each
+  invoke `getValueString($appName, '<context>_register' | '<context>_schema', '')`
+  inline, then resolve the matching ID/slug.
+- **pipelinq**: 8 services / background jobs
+  (`QueueService`, `DefaultQueueService`, `ContactVcardService`,
+  `ContactVcardWriterService`, …) call
+  `$appConfig->getValueString(APP_ID, 'register', '')` directly.
+- **docudesk**: an `OpenRegisterResolver` helper that shadows the
+  same pattern.
+
+Total: ~13 call sites across 3 apps. Every site pays for a stale
+default, swallows missing-config errors silently, and lacks
+multi-tenant scoping. When OR's `Register.languages` or
+`Register.organisation` evolve (per ADR-025 i18n source-of-truth, per
+the multi-tenancy enforcement in `MultiTenancyTrait`), every consumer
+has to be updated separately.
+
+A first-class `RegisterResolverService` in OR's public service layer
+gives consumers one DI-friendly entry point with consistent behaviour:
+clear errors when config is missing, optional lazy entity hydration,
+tenant-aware resolution, and a single place to evolve the contract as
+OR grows.
+
+## What Changes
+
+- Add `OCA\OpenRegister\Service\RegisterResolverService` exposing:
+  - `resolveRegisterId(string $appId, string $configKey, ?string $default = null): string` — returns the configured register slug/ID, or throws `MissingConfigException` if unset and no default was provided.
+  - `resolveSchemaId(string $appId, string $configKey, ?string $default = null): string` — same shape for schemas.
+  - `resolveRegister(string $appId, string $configKey, ?string $default = null): Register` — eager-loads the `Register` entity, throws `RegisterNotFoundException` on lookup failure.
+  - `resolveSchema(string $appId, string $configKey, ?string $default = null): Schema` — same shape for schemas.
+  - `resolvePair(string $appId, string $registerKey, string $schemaKey): RegisterSchemaPair` — convenience for the common "register + schema" case (returns a value object with both entities).
+- Add `MissingConfigException`, `RegisterNotFoundException`,
+  `SchemaNotFoundException` as thin wrappers around the existing
+  `\Exception` hierarchy so callers can catch domain-specific failures
+  without grepping error messages.
+- Honour the active organisation context (`MultiTenancyTrait`-style
+  scoping) when resolving entities, so a multi-tenant install gets the
+  caller's tenant view automatically.
+- Cache resolved entities at the request scope (`array<string,Register>`
+  / `array<string,Schema>` keyed by `($appId, $configKey)`) to avoid
+  repeated mapper hits within a single request.
+- Document the canonical `<context>_register` / `<context>_schema`
+  config key naming convention in OR's `register-resolver-service`
+  capability spec; consumers MUST use that shape so admin UIs and
+  diagnostic tooling can enumerate them uniformly.
+- Provide a Newman collection covering the success path, the
+  missing-config path, the wrong-tenant path, and a register/schema
+  that exists in the caller's tenant but not in the requested
+  organisation override.
+
+## Problem
+
+Every Conduction app re-implements the same 4–6-line resolver. The
+duplication has tangible costs:
+
+1. **Drift** — opencatalogi's resolver caches; pipelinq's doesn't.
+   docudesk silently returns empty string on misconfig; opencatalogi
+   throws. Consumers see different failure modes for the same root
+   cause.
+2. **No tenant awareness** — none of the inline call sites know about
+   `MultiTenancyTrait`. Today this is masked by the server's session
+   stamping, but ADR-025's i18n source-of-truth contract and the
+   coming "App Builder" admin UI need explicit multi-tenant resolver
+   semantics.
+3. **No diagnostics surface** — admins can't enumerate "which
+   `<context>_register` configs are set for app X?" without grepping
+   PHP source. A standard naming convention + service-level inventory
+   query enables admin tooling.
+4. **Refactor friction** — when a `Register` field is added (e.g. the
+   pending `register-i18n` source-of-truth column), every consumer
+   must be updated; with the service, OR controls the call shape.
+
+ADR-022 ("apps consume OR abstractions") covers this in principle.
+The audit's top 5 hardcoded-functionality finding ("register/schema
+slug resolvers") is the concrete instance to absorb first.
+
+## Proposed Solution
+
+A small, focused new service in `openregister/lib/Service/`. ~150 lines
+of PHP plus three exception classes and a `RegisterSchemaPair` value
+object. No DB migration; no breaking change to the existing
+`RegisterMapper` / `SchemaMapper` API surface.
+
+The five public methods cover the patterns observed in the 13 audited
+call sites. The convenience `resolvePair()` matches the "register +
+schema together" idiom that opencatalogi controllers and pipelinq
+services use most often.
+
+Adoption is opt-in per consumer; existing inline code keeps working.
+The per-app adoption changes (`{opencatalogi, pipelinq, docudesk,
+procest}-or-adoption`) carry the migrations from inline to service.
+
+## Out of scope
+
+- Admin-UI inventory of all configured `<context>_register` keys
+  (future change, gated on real demand once the service has consumers).
+- A backwards-compatibility adapter that monkeypatches consumer code
+  (consumers migrate via their own opsx changes; OR doesn't need to
+  reach in).
+- A frontend equivalent in `@conduction/nextcloud-vue` (the resolver is
+  PHP-side; the FE consumes resolved values via the existing OR REST
+  surface, so no FE change is needed in this proposal).
+
+## See also
+
+- Hydra ADR-022 (apps consume OR abstractions) — the principle this
+  realises for the register/schema-resolution pattern.
+- `.claude/audit-2026-05-03/04-hardcoded.md` — full audit listing of
+  the 13 call sites in opencatalogi (5 controllers), pipelinq (8
+  services / jobs), and docudesk (`OpenRegisterResolver`).
+- `lib/Db/MultiTenancyTrait.php` — the tenant-scoping behaviour the
+  resolver wraps.

--- a/openspec/changes/register-resolver-service/specs/register-resolver-service/spec.md
+++ b/openspec/changes/register-resolver-service/specs/register-resolver-service/spec.md
@@ -1,0 +1,128 @@
+register-resolver-service
+---
+status: draft
+---
+# Register Resolver Service
+
+## Purpose
+
+Provide a single, DI-resolvable PHP service in OpenRegister that
+consumer apps use to resolve `<context>_register` /
+`<context>_schema` `IAppConfig` keys into either bare slug/UUID
+strings or hydrated `Register` / `Schema` entities, with consistent
+error semantics, request-scoped caching, and multi-tenant scoping.
+
+Replaces the duplicated `getValueString(...)` + manual mapper-lookup
+pattern observed in 13 call sites across opencatalogi (5 controllers),
+pipelinq (8 services / jobs), and docudesk (`OpenRegisterResolver`).
+
+## ADDED Requirements
+
+### Requirement: The system MUST expose a `RegisterResolverService` resolving register IDs from app config
+
+The service MUST expose `resolveRegisterId(string $appId, string $configKey, ?string $default = null, ?string $organisationUuid = null): string` that reads `IAppConfig::getValueString($appId, $configKey, '')`, falls back to `$default` if the value is empty, and throws `MissingConfigException` if both are unset/empty. The returned string is the configured slug or UUID; the service does NOT validate that the value resolves to an entity (callers use `resolveRegister` for that).
+
+#### Scenario: Resolve a configured register slug
+- GIVEN `theme_register = 'theme-2026'` is set in app config for app `opencatalogi`
+- WHEN `resolveRegisterId('opencatalogi', 'theme_register')` is called
+- THEN the service MUST return `'theme-2026'`
+
+#### Scenario: Fall back to provided default when config is empty
+- GIVEN `theme_register` is unset for app `opencatalogi`
+- WHEN `resolveRegisterId('opencatalogi', 'theme_register', 'theme-default')` is called
+- THEN the service MUST return `'theme-default'`
+
+#### Scenario: Throw MissingConfigException when no value and no default
+- GIVEN `theme_register` is unset for app `opencatalogi`
+- WHEN `resolveRegisterId('opencatalogi', 'theme_register')` is called with no default
+- THEN the service MUST throw `MissingConfigException`
+- AND the exception MUST expose `getAppId() === 'opencatalogi'` and `getConfigKey() === 'theme_register'`
+
+### Requirement: The system MUST expose a `resolveSchemaId` method with the same shape
+
+The service MUST expose `resolveSchemaId(string $appId, string $configKey, ?string $default = null, ?string $organisationUuid = null): string` mirroring `resolveRegisterId` for schema config keys. Naming convention: `<context>_schema`.
+
+#### Scenario: Resolve a configured schema slug
+- GIVEN `listing_schema = 'listing-v2'` is set for app `opencatalogi`
+- WHEN `resolveSchemaId('opencatalogi', 'listing_schema')` is called
+- THEN the service MUST return `'listing-v2'`
+
+### Requirement: The system MUST expose `resolveRegister` returning a hydrated Register entity
+
+The service MUST expose `resolveRegister(string $appId, string $configKey, ?string $default = null, ?string $organisationUuid = null): Register` that combines `resolveRegisterId` with a `RegisterMapper` lookup. The lookup MUST honour multi-tenancy (via `MultiTenancyTrait::applyOrganisationFilter`). Throws `MissingConfigException` if the config is unset, `RegisterNotFoundException` if the configured slug/UUID doesn't resolve in the caller's tenant.
+
+#### Scenario: Resolve a configured register to its entity
+- GIVEN `theme_register = 'theme-2026'` is set for app `opencatalogi`
+- AND a Register with slug `'theme-2026'` exists in the caller's organisation
+- WHEN `resolveRegister('opencatalogi', 'theme_register')` is called
+- THEN the service MUST return the `Register` entity for `'theme-2026'`
+
+#### Scenario: Throw RegisterNotFoundException when configured slug doesn't exist in tenant
+- GIVEN `theme_register = 'theme-2026'` is set for app `opencatalogi`
+- AND no Register with slug `'theme-2026'` is visible in the caller's tenant
+- WHEN `resolveRegister('opencatalogi', 'theme_register')` is called
+- THEN the service MUST throw `RegisterNotFoundException`
+- AND the exception MUST expose `getResolvedValue() === 'theme-2026'`
+
+#### Scenario: Throw RegisterNotFoundException when entity exists in another tenant only
+- GIVEN `theme_register = 'theme-2026'` is set for app `opencatalogi`
+- AND a Register with slug `'theme-2026'` exists in a different tenant than the caller's
+- WHEN `resolveRegister('opencatalogi', 'theme_register')` is called
+- THEN the service MUST throw `RegisterNotFoundException` (tenant-scope failure, distinct from `MissingConfigException`)
+- AND the exception MUST expose `getResolvedValue() === 'theme-2026'` so callers can log it for admin diagnostics
+
+### Requirement: The system MUST expose `resolveSchema` with the same shape
+
+The service MUST expose `resolveSchema(string $appId, string $configKey, ?string $default = null, ?string $organisationUuid = null): Schema` mirroring `resolveRegister` for schemas. Throws `MissingConfigException` or `SchemaNotFoundException`.
+
+#### Scenario: Resolve a configured schema to its entity
+- GIVEN `listing_schema = 'listing-v2'` is set for app `opencatalogi`
+- AND a Schema with slug `'listing-v2'` exists in the caller's tenant
+- WHEN `resolveSchema('opencatalogi', 'listing_schema')` is called
+- THEN the service MUST return the `Schema` entity for `'listing-v2'`
+
+### Requirement: The system MUST expose `resolvePair` for the register + schema convenience case
+
+The service MUST expose `resolvePair(string $appId, string $registerKey, string $schemaKey, ?string $organisationUuid = null): RegisterSchemaPair`. The returned `RegisterSchemaPair` is a readonly value object exposing `getRegisterId(): string`, `getSchemaId(): string`, `getRegister(): Register`, `getSchema(): Schema`. Internally `resolvePair` calls `resolveRegister` + `resolveSchema` and surfaces their exceptions unchanged.
+
+#### Scenario: Resolve a register + schema pair
+- GIVEN `listing_register = 'cms'` and `listing_schema = 'listing-v2'` are both set for app `opencatalogi`
+- AND both entities exist in the caller's tenant
+- WHEN `resolvePair('opencatalogi', 'listing_register', 'listing_schema')` is called
+- THEN the service MUST return a `RegisterSchemaPair` where `getRegisterId() === 'cms'`, `getSchemaId() === 'listing-v2'`, and both entity getters return non-null
+
+### Requirement: The service MUST cache resolved entities at the request scope
+
+Within a single PHP request, repeated `resolveRegister` / `resolveSchema` calls with the same `(appId, configKey, organisationUuid)` tuple MUST hit the cache and NOT call the underlying mapper a second time. The cache MUST clear at request boundary (no cross-request caching).
+
+#### Scenario: Repeated resolve hits the cache
+- GIVEN the resolver is fresh (no cached entries)
+- AND `resolveRegister('opencatalogi', 'theme_register')` is called once and returns a Register entity
+- WHEN `resolveRegister('opencatalogi', 'theme_register')` is called a second time within the same request
+- THEN the underlying `RegisterMapper::findBySlug()` MUST be called exactly once across both invocations
+- AND the second call MUST return the same Register instance (object identity preserved)
+
+### Requirement: The system MUST expose `enumerateAppConfigs` for diagnostic surfaces
+
+The service MUST expose `enumerateAppConfigs(string $appId): array<string,string>` returning a map of every `<context>_register` and `<context>_schema` config key currently set for `$appId`, paired with its raw `IAppConfig` value (no entity resolution). Used by admin UIs and the `php occ openregister:resolver:list <app-id>` console command.
+
+#### Scenario: Enumerate every configured resolver key for an app
+- GIVEN app `opencatalogi` has `theme_register = 'theme-2026'`, `theme_schema = 'theme-v1'`, `listing_register = 'cms'` configured, plus the unrelated `auto_listing_threshold = '500'` config key
+- WHEN `enumerateAppConfigs('opencatalogi')` is called
+- THEN the service MUST return `['theme_register' => 'theme-2026', 'theme_schema' => 'theme-v1', 'listing_register' => 'cms']`
+- AND the map MUST NOT include `auto_listing_threshold` (does not match the `<context>_(register|schema)` pattern)
+
+### Requirement: The naming convention `<context>_register` / `<context>_schema` MUST be documented and recommended
+
+The service's documentation (in `docs/services/register-resolver.md` and the public PHPDoc on each resolve method) MUST state:
+
+1. Consumer apps SHOULD name register config keys `<context>_register` (e.g. `theme_register`, `listing_register`).
+2. Consumer apps SHOULD name schema config keys `<context>_schema` (e.g. `listing_schema`, `theme_schema`).
+3. The bare key `register` / `schema` is grandfathered for legacy consumers; new code MUST NOT introduce bare keys.
+4. The `enumerateAppConfigs()` method MUST surface bare keys as `default_register` / `default_schema` so admin UIs can flag them as legacy convention.
+
+#### Scenario: Documentation surfaces the convention
+- GIVEN a consumer-app developer reads OpenRegister's service docs
+- WHEN they read `docs/services/register-resolver.md`
+- THEN the page MUST state the convention explicitly
+- AND the example migration snippet MUST show `<context>_register` (not bare `register`)

--- a/openspec/changes/register-resolver-service/tasks.md
+++ b/openspec/changes/register-resolver-service/tasks.md
@@ -1,0 +1,93 @@
+# Tasks: Register Resolver Service
+
+## Phase 1 — Core service
+
+- [ ] Add `lib/Service/RegisterResolverService.php` with the five
+      public methods (`resolveRegisterId`, `resolveSchemaId`,
+      `resolveRegister`, `resolveSchema`, `resolvePair`).
+- [ ] Add `lib/Service/Resolver/RegisterSchemaPair.php` — readonly
+      value object holding `Register` + `Schema` + the two slug/ID
+      strings. Single getter per field; no setters.
+- [ ] Add `lib/Service/Resolver/Exception/MissingConfigException.php`
+      extending `\OCA\OpenRegister\Exception\OpenRegisterException`
+      with `getAppId(): string` + `getConfigKey(): string` accessors.
+- [ ] Add `lib/Service/Resolver/Exception/RegisterNotFoundException.php`
+      with `getAppId(): string` + `getConfigKey(): string` +
+      `getResolvedValue(): string`.
+- [ ] Add `lib/Service/Resolver/Exception/SchemaNotFoundException.php`
+      with the same accessors.
+- [ ] Wire `RegisterResolverService` into `lib/AppInfo/Application.php`
+      as a public DI-resolvable service.
+- [ ] Implement request-scoped caching: `array<string,Register>` keyed
+      by `"{appId}:{configKey}"` after the first lookup; the same for
+      schemas. The cache MUST clear if `MultiTenancyTrait` reports a
+      tenant switch within the same request (rare; defensive).
+
+## Phase 2 — Tenant awareness
+
+- [ ] Resolve entities through `RegisterMapper`/`SchemaMapper` in a
+      way that respects the active organisation context — i.e. by
+      calling existing `findBy*` methods that already apply
+      `applyOrganisationFilter`.
+- [ ] Add an optional second parameter `?string $organisationUuid =
+      null` to all four resolve methods; when provided, the resolver
+      MUST scope the lookup to that organisation explicitly (used by
+      cross-tenant admin tooling).
+- [ ] When the resolved Register exists but is NOT visible in the
+      caller's organisation, throw `RegisterNotFoundException` (NOT
+      `MissingConfigException`) — the config IS set, the entity IS
+      missing in the caller's tenant. Distinct error path matters for
+      admin diagnostics.
+
+## Phase 3 — Convention check + diagnostics
+
+- [ ] Document the canonical `<context>_register` /
+      `<context>_schema` config-key naming in
+      `specs/register-resolver-service/spec.md` (see Phase 4).
+- [ ] Add `RegisterResolverService::enumerateAppConfigs(string
+      $appId): array<string,string>` returning every
+      `<context>_(register|schema)` key currently set for that app —
+      single map; consumers use it for admin-UI inventory.
+- [ ] Add a `php occ openregister:resolver:list <app-id>` console
+      command that prints the same enumeration so admins have a CLI
+      diagnostic.
+
+## Phase 4 — Spec + tests
+
+- [ ] Write `specs/register-resolver-service/spec.md` with five
+      Requirements (one per public method) + the
+      `enumerateAppConfigs` requirement, each with at least one
+      Scenario (happy path) and one error Scenario.
+- [ ] Add `tests/Unit/Service/RegisterResolverServiceTest.php`
+      covering: happy path, missing config + no default, missing
+      config + default, register exists but not in tenant, schema not
+      found, request-scoped caching (mapper called once across two
+      resolve calls), `resolvePair` convenience, organisation override
+      param, and cache clear on tenant switch.
+- [ ] Add a Newman collection
+      `tests/integration/openregister-register-resolver.postman_collection.json`
+      with: a control object create via the resolver path
+      (round-trip), a misconfigured app id (404 with structured
+      error), an invalid `<context>_register` key (400 with
+      `MissingConfigException` shape), a wrong-tenant scope (404 from
+      `RegisterNotFoundException`).
+- [ ] Wire the new collection into
+      `tests/newman/run-all.sh::DOMAIN_ORDER` between `crud` and
+      `graphql` (the resolver is foundational; it should run early).
+
+## Phase 5 — Documentation + per-app adoption hooks
+
+- [ ] Update `lib/AppInfo/Application.php` PHPDoc to list
+      `RegisterResolverService` in the "public services" header
+      comment so consumer apps see it via IDE autocomplete.
+- [ ] Add `docs/services/register-resolver.md` with a 2-paragraph
+      overview + the canonical config-key convention + a "consuming
+      app migration" snippet (before/after) showing the inline
+      `getValueString` → service call.
+- [ ] Reference this change from each per-app adoption change's
+      `tasks.md` (opencatalogi, pipelinq, docudesk, procest) so the
+      apps' migrations all consume the service rather than reinvent.
+- [ ] Reference this change in
+      `hydra/openspec/architecture/adr-022-apps-consume-or-abstractions.md`
+      under "absorbed abstractions" once shipped (mirrors the audit
+      entry).


### PR DESCRIPTION
## Summary

Phase 2 of the OR-abstraction audit (2026-05-03). Four openspec changes implementing the audit's top hardcoded-functionality findings + ADR-019 + ADR-025.

- **`register-resolver-service/`** — Publishable `RegisterResolverService` that absorbs the `getValueString(...register/schema...)` pattern duplicated across **13 call sites** (opencatalogi 5, pipelinq 8, docudesk). 5 public methods + request-scoped caching + multi-tenant scoping + 3 structured exceptions + admin diagnostics.
- **`pluggable-integration-registry/`** — Implements hydra ADR-019. Two-sided registry (PHP interface + JS register call), DI-tag auto-registration, migrates 8 built-in NC types away from `LinkedEntityService::TYPE_COLUMN_MAP`, external providers via OpenConnector, OCS capability surface, CI parity gate.
- **`i18n-source-of-truth/`** — Implements hydra ADR-025 (DB/schema/render half). Schema `sourceLanguage` modifier, `Translation.source_language` column, `_meta.languageMeta` render envelope, `X-Source-Language` response header, automatic outdated-status flip on source-value change.
- **`i18n-api-language-negotiation/`** — Implements hydra ADR-025 (API contract half). `?_lang=` / `?language=` query params with explicit precedence, lax fallback (no 406), write-side `X-Translation-Target-Language` header, conflict body+header → 400.

## Test plan

- [x] No code changes; doc-only openspec change.
- [x] References resolve: ADR-019 + ADR-022 + ADR-025 in `hydra/openspec/architecture/`; audit research at `.claude/audit-2026-05-03/research/R4-*.md` + `R5-*.md` + `04-hardcoded.md`.
- [x] Each change includes proposal/tasks/design/spec — full opsx artefact set.
- [x] All four cite the same canonical audit report so future readers can trace findings → specs.

## Sequencing

Each change has its own implementation track (Phase 4 of the audit follow-up). The two i18n changes share a migration but otherwise decouple; they can ship in either order. Consumer apps' adoption changes (`{app}-adopt-manifest`, `{app}-adopt-or-abstractions`) cite these specs by their merged slugs.

## Stats

16 files, 1,979 lines of openspec content.