### PR TITLE
feat(openspec): openregister-adopt-app-manifest — Tier 1–2 manifest adoption

### DIFF
--- a/openspec/changes/openregister-adopt-app-manifest/design.md
+++ b/openspec/changes/openregister-adopt-app-manifest/design.md
@@ -1,0 +1,187 @@
+# Design — OpenRegister adopts the app manifest
+
+## Approach
+
+Adopt `@conduction/nextcloud-vue`'s app-manifest pattern in **two phases on
+one branch**:
+
+- **Phase A — Tier 1.** Generate `src/manifest.json` from the existing
+  router. Wire `useAppManifest('openregister', bundled)` in `src/main.js`.
+  The router itself keeps its direct component imports. The manifest is
+  validated (build-time `check:manifest`, runtime schema validation in the
+  composable) but is not yet driving the dispatch.
+- **Phase B — Tier 2.** Introduce `CnPageRenderer` for the schema-driven
+  routes (Registers, Schemas, Objects, Sources, Endpoints, Search,
+  Applications, Entities). Each of these has a clean
+  `type:"index"`/`type:"detail"` mapping. Admin / log / settings routes
+  remain on direct imports through `type:"custom"` + the consumer-supplied
+  `customComponents` map.
+
+Tier 3 (`CnAppNav` replacing the bespoke `NcAppNavigation` mount) and
+Tier 4 (`CnAppRoot` full shell) are explicitly deferred. OR's existing
+`App.vue` orchestrates loading state, OpenRegister availability checks,
+sidebar provisioning, and admin-only navigation gating that do not yet have
+a clean `CnAppRoot` analogue. Pushing them through Tier 4 prematurely would
+force a bespoke `customRootComponents` escape hatch and lose the foundation-
+sets-the-pattern intent.
+
+## Page-type mapping
+
+OR has 30 routes today. Mapping to the closed enum:
+
+| Page id | Route | Type | Note |
+|---|---|---|---|
+| `Dashboard` | `/` | `dashboard` | Existing DashboardIndex.vue widgetises cleanly |
+| `Registers` | `/registers` | `index` | Schema-driven list of Register objects |
+| `RegisterDetail` | `/registers/:id` | `detail` | Schema-driven detail view |
+| `Schemas` | `/schemas` | `index` | Schema-driven list of Schema objects |
+| `SchemaDetails` | `/schemas/:id` | `detail` | |
+| `Sources` | `/sources` | `index` | |
+| `Objects` | `/objects` | `index` | Generic objects list with filters |
+| `Search` | `/tables` | `index` | Magic-table faceted search |
+| `Endpoints` | `/endpoints` | `index` | |
+| `Applications` | `/applications` | `index` | |
+| `ApplicationDetails` | `/applications/:id` | `detail` | |
+| `Entities` | `/entities` | `index` | |
+| `EntityDetail` | `/entities/:id` | `detail` | |
+| `Organisations` | `/organisation` | `custom` | Tenant-aware bespoke widgets |
+| `Configurations` | `/configurations` | `custom` | Settings-shaped, no schema |
+| `AuditTrail` | `/audit-trails` | `custom` | Logs viewer; needs `type:"logs"` future built-in |
+| `SearchTrail` | `/search-trails` | `custom` | Same — log viewer |
+| `Webhooks` | `/webhooks` | `custom` | Bespoke pipeline UI |
+| `WebhookLogs` | `/webhooks/logs` | `custom` | |
+| `Templates` | `/templates` | `custom` | Bespoke template editor |
+| `Agents` | `/agents` | `custom` | AI agents config UI |
+| `Chat` | `/chat` | `custom` | Realtime chat shell |
+| `Files` | `/files` | `custom` | Files workspace, not standard list |
+| `Deleted` | `/deleted` | `custom` | Recycle-bin view |
+| `AVG` | `/avg` | `custom` | Verwerkingsregister bespoke UI |
+| `Reports` | `/reports` | `custom` | Could move to `dashboard` but uses non-widget layout |
+| `ReportView` | `/reports/:id` | `custom` | Same |
+| `MyAccount` | `/mijn-account` | `custom` | Bespoke account/profile view |
+
+**Tally:** 1 dashboard + 8 index + 4 detail + 17 custom = 30 routes. The
+17/30 custom share (57%) is high. That is **expected** for the foundation
+repo and is the trigger for Open Question 2 below.
+
+## Menu mapping
+
+The existing `App.vue` / `NcAppNavigation` listing maps to one `menu` array
+with two `section` values:
+
+```jsonc
+[
+  { "id": "Dashboard",       "label": "openregister.dashboard",       "icon": "icon-category-dashboard", "route": "Dashboard",     "section": "main",     "order": 10 },
+  { "id": "Registers",       "label": "openregister.registers",       "icon": "icon-database",           "route": "Registers",     "section": "main",     "order": 20 },
+  { "id": "Schemas",         "label": "openregister.schemas",         "icon": "icon-quota",              "route": "Schemas",       "section": "main",     "order": 30 },
+  { "id": "Objects",         "label": "openregister.objects",         "icon": "icon-folder",             "route": "Objects",       "section": "main",     "order": 40 },
+  { "id": "Search",          "label": "openregister.search",          "icon": "icon-search",             "route": "Search",        "section": "main",     "order": 50 },
+  { "id": "Sources",         "label": "openregister.sources",         "icon": "icon-link",               "route": "Sources",       "section": "main",     "order": 60 },
+  { "id": "Endpoints",       "label": "openregister.endpoints",       "icon": "icon-api",                "route": "Endpoints",     "section": "main",     "order": 70 },
+  { "id": "Configurations",  "label": "openregister.configurations",  "icon": "icon-settings",           "route": "Configurations","section": "settings", "order": 80 },
+  { "id": "AuditTrail",      "label": "openregister.auditTrail",      "icon": "icon-history",            "route": "AuditTrail",    "section": "settings", "order": 81 },
+  { "id": "Settings",        "label": "openregister.settings",        "icon": "icon-settings",           "route": "MyAccount",     "section": "settings", "order": 99 }
+]
+```
+
+`label` values are i18n keys per ADR-024 §6 / ADR-007. The strings live in
+`l10n/{en,nl}.js` keyed by the `appname.<key>` pattern.
+
+## Files affected
+
+- **New**:
+  - `src/manifest.json` (~140 lines: 30 pages + 10 menu items + dependencies + version + $schema)
+  - `docs/manifest.md` (~80 lines: page-type mapping and rationale)
+- **Modified (Phase A)**:
+  - `src/main.js` — add `import bundled from './manifest.json'` and pass to
+    `useAppManifest('openregister', bundled)`. The composable's return is
+    not consumed yet at Tier 1; the wiring exists so Tier 2 can flip on.
+  - `package.json` — add `"check:manifest": "node node_modules/@conduction/nextcloud-vue/bin/validate-manifest.js src/manifest.json"` to `scripts`.
+- **Modified (Phase B)**:
+  - `src/router/index.js` — replace the schema-driven imports with
+    `CnPageRenderer` lookups keyed by the manifest. Admin / custom routes
+    keep their direct imports via the `customComponents` registry.
+- **Untouched**: `src/App.vue`, `src/views/**`, `src/store/**`, every
+  controller / mapper / service in `lib/`. Manifest adoption at Tier 1-2 is
+  zero-touch on the views themselves.
+
+## Citations and dependencies
+
+OR's manifest is the consumer side of an already-shipped library spec. It
+also references several OR specs that just merged in #1420; those are NOT
+adopted by this change but are listed so the manifest can layer on top of
+them later:
+
+- **Library contract**:
+  `nextcloud-vue/openspec/changes/add-json-manifest-renderer/specs/json-manifest-renderer/spec.md`
+  — 17 REQ-JMR-* requirements that this manifest must satisfy.
+- **Schema source**:
+  `nextcloud-vue/src/schemas/app-manifest.schema.json` — pinned via `$schema`
+  in `manifest.json`. Apps MUST NOT fork or duplicate this schema (ADR-024
+  §1).
+- **Cross-app convention**:
+  `hydra/openspec/architecture/adr-024-app-manifest.md` — fleet-wide
+  adoption ADR. This change is the per-app adoption ADR-024 §9 calls for.
+- **Loader**: `nextcloud-vue/src/composables/useAppManifest.js` — silent
+  fallback on `/api/manifest` 404; bundled-only path is CSP-clean.
+- **Renderer**: `nextcloud-vue/src/components/CnPageRenderer/` — Phase B
+  dispatches schema-driven routes through this component.
+- **Existing OR specs to layer on later (NOT adopted in this change)**:
+  - `openregister/openspec/specs/register-resolver-service/spec.md` — once
+    the `pages[].config.{register, schema}` references resolve to slugs,
+    Phase B's `CnPageRenderer` calls into the resolver instead of inline
+    `getValueString(...)`. Tracked as a follow-up.
+  - `openregister/openspec/specs/pluggable-integration-registry/spec.md` —
+    Tier-3+ App Builder hooks (admin reorders menu via `/api/manifest`)
+    will register through this. Out of scope here.
+  - `openregister/openspec/specs/i18n-source-of-truth/spec.md` and
+    `openregister/openspec/specs/i18n-api-language-negotiation/spec.md` —
+    the manifest's `label` / `title` are i18n keys per ADR-024 §6 + ADR-007
+    + ADR-025; `App.vue`'s language negotiation is the consumer side.
+  - `nextcloud-vue/openspec/changes/multi-tenancy-context/` (#113) — the
+    tenant badge slot in `CnAppRoot` (Tier 4) is the future home for OR's
+    tenant context. Tier 1-2 doesn't expose it.
+
+## Out of scope
+
+- **Backend `/api/manifest` endpoint.** Deferred to a follow-up change. The
+  composable silently falls back to bundled-only on 404, so absence is not
+  a regression. The follow-up is driven by an App Builder use case (admin
+  reorders menu, hides pages, overrides locale per tenant) — not by the
+  Tier 1-2 work.
+- **Tier 3 (`CnAppNav`)** — replacing the existing `NcAppNavigation` mount
+  in `App.vue` is a separate change.
+- **Tier 4 (`CnAppRoot`)** — same reasoning. OR's `App.vue` orchestrates
+  enough bespoke loading / availability / sidebar logic that a clean Tier 4
+  swap is not yet justified.
+- **Schema enum extension.** If `type:"custom"` proportion stays >50% after
+  Tier 2 lands, the right move is a library-side openspec change adding new
+  built-in types (e.g. `type:"logs"`, `type:"settings"`). That is a
+  nextcloud-vue change, not an OR change.
+- **Reviewer-side drift gate.** A future Hydra gate that diffs
+  `src/manifest.json` against `src/router/index.js` route names to catch
+  missing manifest entries is desirable (pairs with ADR-029 route-
+  reachability). Out of scope here.
+
+## Open questions
+
+1. **Backend `/api/manifest` ownership** — when OR ships its own endpoint,
+   should it be a thin per-app passthrough or should OR centralise the
+   endpoint for every Conduction app on top of it (one OR endpoint that
+   returns the merged manifest for the calling appId)? Per-app is the
+   ADR-024 default; OR-central is tempting because the foundation already
+   owns the multi-tenancy + RBAC layer the App Builder would need. Defer to
+   the App Builder change.
+2. **Page-type enum extensibility** — OR's 17/30 custom share is the highest
+   single signal in the fleet that the closed `type` enum is too narrow.
+   Should we open a nextcloud-vue change adding `type:"logs"` (audit-trail-
+   shaped), `type:"settings"` (form-page-shaped), and possibly
+   `type:"chat"` / `type:"files"` (workspace-shaped) as built-ins? The cost
+   is library-side; the gain is every consumer reduces its `type:"custom"`
+   share. Surface this as a follow-up nextcloud-vue change once Tier 2
+   lands.
+3. **Manifest version semver** — start at `0.1.0`. Bump to `0.2.0` when
+   Phase B (Tier 2) ships. Hold at sub-1.0.0 until the page-type-enum
+   question is resolved upstream — bumping to `1.0.0` while the underlying
+   schema is still expected to grow new built-in types would force a
+   premature `manifest.version` major-bump cascade across consumers.

--- a/openspec/changes/openregister-adopt-app-manifest/proposal.md
+++ b/openspec/changes/openregister-adopt-app-manifest/proposal.md
@@ -1,0 +1,130 @@
+# OpenRegister — Adopt App Manifest (Tier 1 → Tier 2)
+
+## Why
+
+OpenRegister is the platform foundation. Every other Conduction app (decidesk,
+opencatalogi, docudesk, mydash, softwarecatalog, procest, pipelinq, larpingapp,
+zaakafhandelapp, openconnector) sits on top of OR's data layer and is expected
+to adopt the `@conduction/nextcloud-vue` app-manifest pattern per
+[ADR-024](../../../../hydra/openspec/architecture/adr-024-app-manifest.md).
+Today OR ships its own bespoke `src/router/index.js` (95 lines, 30 routes) with
+no `manifest.json`, no `useAppManifest` wiring, and no `CnAppRoot` shell. The
+foundation is the only repo in the fleet that does not eat its own dogfood.
+
+That is a credibility problem. Decidesk has been Tier-4 since v0.3.0 (39 pages,
+8 menu entries, depending on `["openregister"]`). Two reviewer false-positives
+during the 2026-05-03 audit cited "OR's router is the canonical pattern" — the
+canonical pattern is the manifest, and OR not adopting it actively confuses
+the fleet.
+
+This change brings OR onto the manifest. **Tier 1 first, then Tier 2.** OR has
+~30 admin / settings / log views (ConfigurationsIndex, AuditTrailIndex,
+SearchTrailIndex, WebhooksIndex, AgentsIndex, ChatIndex, FilesIndex, etc.)
+that do not map cleanly into the closed `type` enum (`index | detail |
+dashboard | custom`). Forcing the whole router into Tier 4 would create a
+sprawl of `type:"custom"` entries and lock OR's bespoke pages to the registry-
+component pattern before we know whether the library should grow new built-in
+types. Tier 1 (`useAppManifest` only) gives the consumer app-builder hook with
+zero shell change. Tier 2 (`+ CnPageRenderer`) lets the schema-driven views
+(Registers, Schemas, Objects, Sources, Endpoints, Search, Settings) move to
+the renderer — the views that genuinely fit `index | detail`. Admin pages
+stay on the existing components and are flagged `type:"custom"`.
+
+## What Changes
+
+- Add **`src/manifest.json`** at the OR root, validated against the canonical
+  schema URL (`@conduction/nextcloud-vue/src/schemas/app-manifest.schema.json`).
+  Generated from the existing 30 routes in `src/router/index.js`.
+- Set `manifest.version` to `0.1.0` (initial Tier 1) — bumps to `0.2.0` once
+  Tier 2 is wired through `CnPageRenderer`. Stays sub-1.0.0 until the closed
+  `type` enum question is resolved (see Open Questions in design.md).
+- Set `manifest.dependencies` to `[]` — OR has no upstream Conduction-app
+  dependencies. Per ADR-024 §10, this is the only sensible value for the
+  foundation repo. (`mydash` is the other repo with `[]`; everything else
+  depends on at least `["openregister"]`.)
+- Add **manifest entries** for the 8 schema-driven page pairs that fit
+  `type:"index"`/`type:"detail"`: Registers, Schemas, Objects, Sources,
+  Endpoints, Search (`/tables`), Applications, Entities. The Dashboard page
+  becomes `type:"dashboard"`.
+- Add **`type:"custom"` entries** for the admin / log / settings pages that
+  don't fit the closed enum: Configurations, AuditTrail, SearchTrail,
+  Webhooks, WebhookLogs, Templates, Agents, Chat, Files, Deleted,
+  Organisations, AVG, Reports (index + detail), MyAccount.
+- Add **`menu[]`** with the existing top-level navigation entries plus a
+  `section: "settings"` block for Configurations / Logs / Settings.
+- Wire `useAppManifest('openregister', bundled)` in `src/main.js` (Tier 1
+  loader). The composable's silent fallback on `/api/manifest` 404 means
+  no backend changes are required to ship.
+- Add **`npm run check:manifest`** to `package.json` per ADR-024 §5; CI fails
+  on schema errors.
+- Add **`docs/manifest.md`** documenting the OR-specific page-type mapping
+  (which routes are which type, why admin pages are `custom`).
+- **Backend `/api/manifest` endpoint** — explicitly **deferred** to a
+  follow-up change. The Tier 1-2 work doesn't need it; an admin-customisation
+  use case (App Builder hide-page / reorder-menu) is the right driver. Spec
+  the deferral in `tasks.md` so the gap is tracked.
+- **Tier 3 (`+ CnAppNav`) and Tier 4 (`CnAppRoot` full shell)** — explicitly
+  **deferred** to a successor change. OR's existing `App.vue` mounts the
+  Nextcloud `NcAppNavigation` directly and shares the sidebar with admin
+  workflows; the cost of unwinding that for `CnAppNav` is not justified at
+  this stage.
+
+## Capabilities
+
+### New Capabilities
+
+- `openregister-app-manifest`: a `src/manifest.json` describing OR's UI shape
+  (menu, pages, dependencies) per the canonical schema, consumed by
+  `useAppManifest('openregister', bundled)` at runtime, validated at build
+  time via `npm run check:manifest`. Tier 1 + Tier 2 (`CnPageRenderer` for
+  schema-driven views).
+
+### Modified Capabilities
+
+*(none — the manifest is purely additive at Tier 1; Tier 2 swaps the
+schema-driven views' router-view dispatch from direct component imports to
+`CnPageRenderer` but does not modify the views themselves.)*
+
+## Impact
+
+- **New files**:
+  - `openregister/src/manifest.json` (~50 page entries, ~10 menu entries)
+  - `openregister/docs/manifest.md` (mapping rationale)
+- **Modified files**:
+  - `openregister/src/main.js` — add `useAppManifest` wiring (Tier 1)
+  - `openregister/src/router/index.js` — Tier 2 only: dispatch schema-driven
+    routes through `CnPageRenderer` instead of direct imports
+  - `openregister/package.json` — add `check:manifest` script
+- **No backend changes** — `/api/manifest` is deferred.
+- **No schema/register changes** — manifest is FE-only per ADR-024.
+- **Dependency**: pinned floor of `@conduction/nextcloud-vue` ≥ the version
+  that ships `useAppManifest`, `CnPageRenderer`, and the schema. Recorded in
+  `package.json` peerDependencies.
+- **Validates against**: shared schema at
+  `nextcloud-vue/src/schemas/app-manifest.schema.json` (153 lines, JSON
+  Schema draft 2020-12, 17 REQ-JMR-* requirements at
+  `nextcloud-vue/openspec/changes/add-json-manifest-renderer/`).
+- **References in the audit**:
+  - `.claude/audit-2026-05-03/research/R6-manifest-json.md` — full pattern
+    reference; flags OR as "Tier 1-2 first"
+  - `.claude/audit-2026-05-03/00-executive-summary.md §1` — adoption-not-
+    feature-work as the headline cleanup theme
+  - ADR-024 §10 — `manifest.dependencies = []` is the correct value for OR
+
+## Risks
+
+- **Closed `type` enum vs. OR's bespoke pages.** Mitigated by accepting
+  `type:"custom"` for ~20 of OR's 30 routes at this stage. If `custom`
+  proportion stays >50% after Tier 2 lands, that is a signal to either grow
+  the library's enum (new built-ins like `type:"logs"`, `type:"settings"`,
+  `type:"chat"`) or scope OR's router differently. Tracked as Open Question 2
+  in design.md.
+- **Tier 2 router wiring touches every schema-driven view.** Mitigated by
+  shipping Tier 1 alone first (manifest exists, but router stays direct-
+  import); Tier 2 lands as a follow-up commit on the same branch once the
+  manifest itself is validated. Each schema-driven route gets a regression
+  test confirming it still resolves and renders.
+- **Manifest drift from router.** Mitigated by `check:manifest` (build-time
+  schema validation) plus a planned reviewer-side gate that diffs
+  `src/manifest.json` against `src/router/index.js` route names — captured
+  as a follow-up in `tasks.md` §6.

--- a/openspec/changes/openregister-adopt-app-manifest/specs/openregister-app-manifest/spec.md
+++ b/openspec/changes/openregister-adopt-app-manifest/specs/openregister-app-manifest/spec.md
@@ -1,0 +1,320 @@
+# OpenRegister app-manifest capability spec
+
+## ADDED Requirements
+
+### Requirement: REQ-OR-MAN-001 Manifest file exists at canonical location
+
+OpenRegister SHALL ship a `src/manifest.json` validated against the canonical
+schema published by `@conduction/nextcloud-vue` per ADR-024 §1-2. The file
+SHALL set `$schema` to the published GitHub raw URL of
+`nextcloud-vue/src/schemas/app-manifest.schema.json`. The file MUST NOT fork
+or duplicate the schema.
+
+#### Scenario: Manifest exists and is loadable
+
+- **WHEN** the OpenRegister Vue bundle is built
+- **THEN** `src/manifest.json` is present, parses as valid JSON, and matches
+  the canonical schema (passes the build-time `npm run check:manifest` gate)
+
+#### Scenario: Schema is referenced, not duplicated
+
+- **WHEN** a reviewer inspects `src/manifest.json`
+- **THEN** the `$schema` field points at the canonical
+  `nextcloud-vue/src/schemas/app-manifest.schema.json` URL and the OR repo
+  contains no copy of that schema file
+
+---
+
+### Requirement: REQ-OR-MAN-002 Manifest declares zero Conduction-app dependencies
+
+The manifest's `dependencies` field SHALL be an empty array `[]`. OpenRegister
+is the platform foundation; it has no upstream Conduction-app dependencies.
+This matches ADR-024 §10's explicit guidance for the foundation repo (the
+only other app with `dependencies: []` is `mydash`, per the same ADR).
+
+#### Scenario: Foundation declares no dependencies
+
+- **WHEN** `src/manifest.json` is loaded
+- **THEN** `manifest.dependencies` is the empty array `[]`
+
+#### Scenario: Loader skips dependency check on empty deps
+
+- **WHEN** `useAppManifest('openregister', bundled)` runs and reads
+  `dependencies: []`
+- **THEN** `CnAppRoot`'s `dependency-check` phase is a no-op and the shell
+  enters the `loading` → `shell` transition without rendering
+  `CnDependencyMissing`
+
+---
+
+### Requirement: REQ-OR-MAN-003 Manifest declares 30 pages mapped from existing router
+
+The manifest's `pages[]` SHALL contain exactly one entry per route currently
+declared in `src/router/index.js` (30 routes today, excluding the catch-all).
+Each entry SHALL set `id` (= route name), `route` (= path pattern), `type`
+(closed enum: `index | detail | dashboard | custom`), and `title` (i18n key).
+
+The page-type mapping SHALL follow the design.md table:
+
+- 1 `dashboard` — `Dashboard` (`/`)
+- 8 `index` — `Registers`, `Schemas`, `Sources`, `Objects`, `Search`,
+  `Endpoints`, `Applications`, `Entities`
+- 4 `detail` — `RegisterDetail`, `SchemaDetails`, `ApplicationDetails`,
+  `EntityDetail`
+- 17 `custom` — `Configurations`, `AuditTrail`, `SearchTrail`, `Webhooks`,
+  `WebhookLogs`, `Templates`, `Agents`, `Chat`, `Files`, `Deleted`,
+  `Organisations`, `AVG`, `Reports`, `ReportView`, `MyAccount`, plus the
+  two log views
+
+#### Scenario: Page count matches router
+
+- **WHEN** the build runs `check:manifest`
+- **THEN** `manifest.pages[].length === 30` and each `id` is unique
+
+#### Scenario: Schema-driven pages reference OR resources by name
+
+- **WHEN** an entry has `type:"index"` or `type:"detail"`
+- **THEN** the entry's `config.{register, schema}` references the underlying
+  OR register and schema by slug (no inline duplication of the schema body)
+
+#### Scenario: Custom-typed pages declare a component
+
+- **WHEN** an entry has `type:"custom"`
+- **THEN** the entry sets `component` to a name registered in the consumer-
+  supplied `customComponents` map
+
+#### Scenario: Title is an i18n key
+
+- **WHEN** an entry's `title` is read
+- **THEN** the value matches the pattern `openregister.<key>` and resolves
+  to a translation in `l10n/{en,nl}.js` per ADR-007 / ADR-025
+
+---
+
+### Requirement: REQ-OR-MAN-004 Manifest declares menu split between main and settings sections
+
+The manifest's `menu[]` SHALL declare top-level navigation entries with
+exactly two `section` values: `"main"` for primary nav (Dashboard, Registers,
+Schemas, Objects, Search, Sources, Endpoints) and `"settings"` for the
+configuration / log / settings cluster (Configurations, AuditTrail,
+Settings).
+
+Each menu entry SHALL set `id`, `label` (i18n key), `icon`, `route`, `order`,
+and `section`.
+
+#### Scenario: Main and settings sections are populated
+
+- **WHEN** the manifest is loaded
+- **THEN** `manifest.menu[]` contains entries with `section: "main"` and
+  entries with `section: "settings"`, with no other section value
+
+#### Scenario: Menu order is monotonic per section
+
+- **WHEN** entries within a section are sorted by `order`
+- **THEN** the visible order in the rendered nav matches the manifest order
+  exactly
+
+#### Scenario: Menu labels are i18n keys
+
+- **WHEN** a menu entry's `label` is read
+- **THEN** the value matches `openregister.<key>` and resolves via the app's
+  `t()` function
+
+---
+
+### Requirement: REQ-OR-MAN-005 Loader is wired in main.js (Tier 1)
+
+`src/main.js` SHALL `import bundled from './manifest.json'` and call
+`useAppManifest('openregister', bundled)` per ADR-024 §3. This wiring SHALL
+land at Tier 1 even though the return value is not yet consumed by the
+shell — the call is the foundation that Tier 2's `CnPageRenderer`
+integration builds on.
+
+#### Scenario: Loader is invoked on bootstrap
+
+- **WHEN** the OR Vue app mounts
+- **THEN** `useAppManifest('openregister', bundled)` has been called and
+  the resulting reactive `manifest` ref is available in app scope
+
+#### Scenario: Backend 404 falls back silently
+
+- **WHEN** `/index.php/apps/openregister/api/manifest` returns 404 (the
+  endpoint is deferred)
+- **THEN** the loader keeps the bundled manifest, emits no console error,
+  and the app boots normally
+
+#### Scenario: Schema validation failure is logged but non-fatal
+
+- **WHEN** the manifest fails validation against the canonical schema
+- **THEN** `validateManifest()` logs a `console.warn` and the bundled
+  manifest is preserved (per `useAppManifest.js:99-115` behaviour)
+
+---
+
+### Requirement: REQ-OR-MAN-006 CnPageRenderer drives schema-driven routes (Tier 2)
+
+For the 8 schema-driven page pairs (`Registers`, `Schemas`, `Sources`,
+`Objects`, `Search`, `Endpoints`, `Applications`, `Entities`), `src/router/
+index.js` SHALL dispatch through `CnPageRenderer` instead of direct
+component imports. The renderer matches the current vue-router route by
+`name` against `pages[].id` and dispatches by `page.type` to a `pageTypes`
+registry — defaults `index` / `detail` / `dashboard` for these 8.
+
+`type:"custom"` routes SHALL continue to dispatch through their existing
+view components, registered in a `customComponents` map passed to the
+renderer.
+
+#### Scenario: Index route dispatches via renderer
+
+- **WHEN** the user navigates to `/registers`
+- **THEN** the route resolves to `CnPageRenderer` keyed by `id: "Registers"`
+  with `type: "index"`, which renders the schema-driven index view using the
+  manifest's `config.{register, schema, columns}`
+
+#### Scenario: Detail route dispatches via renderer
+
+- **WHEN** the user navigates to `/registers/abc-123`
+- **THEN** the route resolves to `CnPageRenderer` keyed by
+  `id: "RegisterDetail"` with `type: "detail"`, which renders the schema-
+  driven detail view with `objectId = "abc-123"`
+
+#### Scenario: Custom route dispatches via customComponents
+
+- **WHEN** the user navigates to `/audit-trails`
+- **THEN** the route resolves to `CnPageRenderer` keyed by
+  `id: "AuditTrail"` with `type: "custom"`, which looks up `component:
+  "AuditTrailIndex"` in the `customComponents` map and renders that
+
+#### Scenario: Dashboard route dispatches via renderer
+
+- **WHEN** the user navigates to `/`
+- **THEN** the route resolves to `CnPageRenderer` keyed by
+  `id: "Dashboard"` with `type: "dashboard"`, which renders the
+  widget-grid layout from `manifest.pages[].config.{widgets, layout}`
+
+---
+
+### Requirement: REQ-OR-MAN-007 Build gate validates the manifest
+
+The OR `package.json` SHALL declare a `check:manifest` script that runs the
+library's `validateManifest` CLI against `src/manifest.json` per ADR-024 §5.
+The script SHALL be invoked from CI's lint stage and SHALL fail the job on
+schema errors.
+
+#### Scenario: Valid manifest passes the gate
+
+- **WHEN** CI runs `npm run check:manifest` on a valid `src/manifest.json`
+- **THEN** the script exits 0 and the job continues
+
+#### Scenario: Invalid manifest fails the gate
+
+- **WHEN** CI runs `npm run check:manifest` on a manifest with a schema
+  violation (missing required field, unknown `type`, duplicate `id`, etc.)
+- **THEN** the script exits non-zero, prints the validation error path
+  inside the JSON, and the job fails
+
+#### Scenario: Gate is wired into composite scripts
+
+- **WHEN** `npm run check` or `npm run check:strict` is invoked
+- **THEN** `check:manifest` runs as part of the composite
+
+---
+
+### Requirement: REQ-OR-MAN-008 Manifest version reflects the adoption tier
+
+The manifest's top-level `version` SHALL follow semver of content per
+ADR-024 §7. While the underlying page-type enum question is unresolved
+(Open Question 2 in design.md), `version` SHALL stay sub-1.0.0:
+
+- `0.1.0` — Tier 1 only (loader wired; manifest declared; renderer not yet
+  driving dispatch)
+- `0.2.0` — Tier 2 wired through (renderer dispatches schema-driven routes)
+
+A bump to `1.0.0` SHALL NOT happen until either (a) the page-type enum is
+extended upstream so OR's custom share drops below 50%, or (b) ADR-024 §7
+is amended to allow stable consumers to declare 1.0.0 with a high custom
+share.
+
+#### Scenario: Tier 1 ships at 0.1.0
+
+- **WHEN** Phase A lands
+- **THEN** `manifest.version` is `"0.1.0"`
+
+#### Scenario: Tier 2 ships at 0.2.0
+
+- **WHEN** Phase B lands
+- **THEN** `manifest.version` is `"0.2.0"`
+
+#### Scenario: Sub-1.0.0 stays until upstream resolves
+
+- **WHEN** a reviewer questions the sub-1.0.0 version
+- **THEN** the answer references Open Question 2 in design.md and ADR-024 §7
+
+---
+
+### Requirement: REQ-OR-MAN-009 Backend `/api/manifest` endpoint is deferred
+
+OpenRegister SHALL NOT implement `GET /index.php/apps/openregister/api/
+manifest` as part of this change. The composable's silent fallback on 404
+makes absence non-regressive. A follow-up change driven by an admin
+customisation use case (App Builder reorders menu / hides pages / overrides
+locale per tenant) SHALL add the endpoint when needed.
+
+#### Scenario: Endpoint returns 404 today
+
+- **WHEN** a request hits `/index.php/apps/openregister/api/manifest`
+- **THEN** the response is HTTP 404 and the loader silently keeps the
+  bundled manifest
+
+#### Scenario: Follow-up change is tracked
+
+- **WHEN** a reader looks up "OR backend manifest endpoint"
+- **THEN** the answer points at the deferred follow-up task (`tasks.md`
+  §7.1) and the App Builder driver
+
+---
+
+### Requirement: REQ-OR-MAN-010 Tier 3 and Tier 4 are explicitly deferred
+
+The current change SHALL NOT replace OR's bespoke `NcAppNavigation` mount
+with `CnAppNav` (Tier 3) and SHALL NOT swap `App.vue` for `CnAppRoot`
+(Tier 4). The deferral is intentional: OR's `App.vue` orchestrates loading,
+OR-availability checks, and sidebar provisioning that do not yet have a
+clean `CnAppRoot` analogue. Tier 3 and Tier 4 each get their own follow-up
+change.
+
+#### Scenario: App.vue stays bespoke
+
+- **WHEN** the change lands
+- **THEN** `App.vue` still mounts `NcContent` + `NcAppNavigation` directly
+  and does not consume `CnAppRoot`
+
+#### Scenario: Follow-up tier changes are tracked
+
+- **WHEN** a reader looks up "Tier 3 / Tier 4 for OR"
+- **THEN** the answer points at `tasks.md` §7.3 (Tier 3) and §7.4 (Tier 4)
+
+---
+
+### Requirement: REQ-OR-MAN-011 Page-type "custom" share is acknowledged and tracked
+
+The change SHALL acknowledge that 17 of OR's 30 routes (57%) map to
+`type:"custom"` because the closed `type` enum has no `logs`, `settings`,
+`chat`, or `files` built-ins today. This high custom share is the strongest
+fleet-wide signal that the enum should grow upstream.
+
+The change SHALL track this as a follow-up nextcloud-vue change
+(`add-app-manifest-page-types`, not yet created) and SHALL NOT attempt to
+work around the enum at the OR layer (no consumer-side enum extensions).
+
+#### Scenario: Custom share is documented
+
+- **WHEN** `docs/manifest.md` is read
+- **THEN** the page-type mapping table from design.md is reproduced and
+  the custom share is called out as the trigger for upstream enum work
+
+#### Scenario: Upstream change is referenced
+
+- **WHEN** a reader asks "why is this so much custom?"
+- **THEN** the answer points at the page-type-enum follow-up in
+  `tasks.md` §7.2 and at design.md Open Question 2

--- a/openspec/changes/openregister-adopt-app-manifest/tasks.md
+++ b/openspec/changes/openregister-adopt-app-manifest/tasks.md
@@ -1,0 +1,72 @@
+# Tasks — OpenRegister adopts the app manifest
+
+## 1. Manifest authoring (Tier 1)
+
+- [ ] 1.1 Create `src/manifest.json` with `$schema` set to the GitHub raw URL of `nextcloud-vue/src/schemas/app-manifest.schema.json` (matches `decidesk/src/manifest.json` line 2).
+- [ ] 1.2 Set top-level `version` to `"0.1.0"`.
+- [ ] 1.3 Set `dependencies` to `[]` per ADR-024 §10. OR has no upstream Conduction-app dependencies.
+- [ ] 1.4 Add `pages[]` entries — exactly 30, one per route in `src/router/index.js`. Each entry MUST set `id`, `route`, `type`, and `title`. Custom-type entries MUST also set `component` to the existing view's registered name.
+- [ ] 1.5 Mark `Dashboard` as `type:"dashboard"`. Map the existing widget config into `pages[].config.{widgets, layout}`.
+- [ ] 1.6 Mark the 8 schema-driven page pairs (Registers/Schemas/Objects/Sources/Endpoints/Search/Applications/Entities) as `type:"index"` and their detail variants as `type:"detail"`. Set `pages[].config.{register, schema}` referencing the underlying OR schemas by slug.
+- [ ] 1.7 Mark the remaining 17 routes (Configurations, AuditTrail, SearchTrail, Webhooks, WebhookLogs, Templates, Agents, Chat, Files, Deleted, Organisations, AVG, Reports, ReportView, MyAccount) as `type:"custom"` with a `component` reference. Add a comment in `docs/manifest.md` listing the rationale per route.
+- [ ] 1.8 Add `menu[]` with the navigation entries from design.md. Use `section:"main"` for primary nav, `section:"settings"` for the configuration / log / settings group. `label` values MUST be i18n keys (`openregister.<key>`), not raw strings (ADR-024 §6).
+- [ ] 1.9 Verify all `pages[].id` values are unique. The library's validator catches this but a manual scan is part of authoring.
+
+## 2. Loader wiring (Tier 1)
+
+- [ ] 2.1 Add `import bundled from './manifest.json'` to `src/main.js`.
+- [ ] 2.2 Add `import { useAppManifest } from '@conduction/nextcloud-vue'` and call `useAppManifest('openregister', bundled)` in the bootstrap. The return value can stay unused at Tier 1 — the call exists so Tier 2 can flip on.
+- [ ] 2.3 Run the app, inspect devtools network tab, verify the loader silently falls back when `/api/manifest` returns 404 (no console error).
+- [ ] 2.4 Confirm no behavioural change at Tier 1 — every existing route still resolves and renders identically. The manifest is loaded but not yet driving dispatch.
+
+## 3. Build-time validation
+
+- [ ] 3.1 Add `"check:manifest": "node node_modules/@conduction/nextcloud-vue/bin/validate-manifest.js src/manifest.json"` to `package.json` `scripts`.
+- [ ] 3.2 Wire `check:manifest` into the existing `check` / `check:strict` script chain.
+- [ ] 3.3 CI workflow update — confirm the lint job runs `npm run check:manifest`. Fail the job on schema errors.
+- [ ] 3.4 Document the contract in `docs/manifest.md`: build fails if the manifest does not validate against the canonical schema; never edit `manifest.json` past validation without re-running the check.
+
+## 4. Tier 2 wiring (CnPageRenderer for schema-driven routes)
+
+- [ ] 4.1 In `src/router/index.js`, replace the direct imports for the 8 schema-driven page pairs with a single `CnPageRenderer` lookup keyed by route name. The renderer reads `pages[].type` from the manifest and dispatches accordingly.
+- [ ] 4.2 Verify the schema-driven views (RegistersIndex, RegisterDetail, SchemasIndex, SchemaDetails, SourcesIndex, ObjectsIndex, SearchIndex, EndpointsIndex, ApplicationsIndex, ApplicationDetails, EntitiesIndex, EntityDetail) still receive the same props and behave identically. The renderer dispatches by `type`; the underlying view is unchanged.
+- [ ] 4.3 For `type:"custom"` routes, register the existing components in a `customComponents` map and pass it to the renderer's lookup. Confirm every custom route still resolves.
+- [ ] 4.4 Bump `manifest.version` to `"0.2.0"` once Tier 2 is wired through.
+
+## 5. Regression tests
+
+- [ ] 5.1 Browser test — navigate to each of the 30 routes in sequence. Each must render without error and match the pre-change screenshot. Use `browser-1` (per project rules) for sequential navigation; capture screenshots into `.playwright-mcp/manifest-tier{1,2}-route-<id>.png`.
+- [ ] 5.2 Verify `Dashboard` widgets render through the `type:"dashboard"` path identically to the pre-change DashboardIndex.vue render.
+- [ ] 5.3 Verify the schema-driven `index`/`detail` routes show identical column layouts and detail panes after Phase B.
+- [ ] 5.4 Verify `type:"custom"` routes (admin / log / settings) still render their bespoke components.
+- [ ] 5.5 Verify the `404 → /` catch-all behaviour from the pre-change router still works after Tier 2 (the manifest does not declare the catch-all; it stays a router-level rule).
+- [ ] 5.6 Verify `useAppManifest` return value matches the bundled JSON when `/api/manifest` returns 404 (manual devtools inspection).
+
+## 6. Documentation
+
+- [ ] 6.1 Add `docs/manifest.md` documenting:
+  - The page-type mapping table from design.md
+  - Why 17/30 routes are `type:"custom"` (page-type enum question)
+  - The Tier 1 → Tier 2 staging plan
+  - The deferred `/api/manifest` backend endpoint rationale
+  - The follow-up tasks tracked below in §7
+- [ ] 6.2 Update the OR `README.md` to reference `docs/manifest.md` from the architecture section.
+
+## 7. Follow-ups (out of this change)
+
+- [ ] 7.1 **Backend `/api/manifest` endpoint** — drive from an App Builder change (admin reorders menu / hides pages / overrides locale per tenant). Tracked as `openregister-app-manifest-backend` (not yet created).
+- [ ] 7.2 **Page-type enum extensions** — open a nextcloud-vue change proposing `type:"logs"`, `type:"settings"`, and possibly `type:"chat"` / `type:"files"` as built-ins. Tracked as `add-app-manifest-page-types` in nextcloud-vue (not yet created).
+- [ ] 7.3 **Tier 3 (`CnAppNav`)** — replace the bespoke `NcAppNavigation` mount in `App.vue` with `CnAppNav` reading `manifest.menu`. Tracked as `openregister-adopt-app-manifest-tier-3` (not yet created).
+- [ ] 7.4 **Tier 4 (`CnAppRoot`)** — full shell. Blocked on `CnAppRoot` exposing the loading / OR-availability / sidebar slots OR currently implements bespoke. Tracked as `openregister-adopt-app-manifest-tier-4` (not yet created).
+- [ ] 7.5 **Reviewer-side drift gate** — Hydra mechanical gate that diffs `src/manifest.json` against `src/router/index.js` route names. Pairs with ADR-029 route-reachability gate. Tracked as `hydra-gate-manifest-route-drift` (not yet created).
+- [ ] 7.6 **Use `register-resolver-service` for `pages[].config.{register, schema}`** — once Phase B lands, replace any inline `getValueString(...register/schema...)` lookups in the renderer-adjacent code with the canonical resolver service. Tracked as `openregister-manifest-uses-register-resolver`.
+
+## 8. Sign-off checklist (per ADR-024 §9)
+
+- [ ] 8.1 `src/manifest.json` exists and validates against the canonical schema.
+- [ ] 8.2 Tier choice is explicit (Tier 2 on this change; Tier 3 / Tier 4 deferred).
+- [ ] 8.3 Regression test suite confirms all 30 routes still resolve and render.
+- [ ] 8.4 Reviewer confirms the manifest does not duplicate or contradict the canonical schema (no forked schema, no extra top-level fields).
+- [ ] 8.5 `manifest.dependencies` is `[]` (foundation repo per ADR-024 §10).
+- [ ] 8.6 `manifest.version` reflects the actual Tier (0.1.0 = Tier 1 only; 0.2.0 = Tier 2 wired through).
+- [ ] 8.7 Audit references in proposal.md / design.md cite the right files (`R6-manifest-json.md`, ADR-024).


### PR DESCRIPTION
## Summary

Phase 3 of the OR-abstraction audit (2026-05-03). Per-app adoption openspec change for **openregister** — spec-only, no code changes.

Drafts the change so the implementation phase can run `/opsx-apply` against it when scheduled. References Phase 2 OR/nc-vue/hydra specs (openregister#1420, nextcloud-vue#113, hydra#218) and ADRs 022/024/025.

## Test plan

- [x] No code changes; markdown-only.
- [x] References resolve to existing audit research at `.claude/audit-2026-05-03/` (in the openregister checkout).
- [x] Cited upstream specs exist on `development`.

## Auto-merge rationale

Markdown-only PR per `feedback_pr-merge-authority.md` — admin-merged on creation.