### PR TITLE
feat(openspec): openregister-legacy-quality-cleanup tracking change

### DIFF
--- a/openspec/changes/openregister-legacy-quality-cleanup/proposal.md
+++ b/openspec/changes/openregister-legacy-quality-cleanup/proposal.md
@@ -1,0 +1,102 @@
+# OpenRegister Legacy Quality Cleanup
+
+## Why
+
+The OR-abstraction audit (2026-05-03, stream 3 + the quality-gates
+cleanup at session start) flagged that openregister's quality gates
+have legacy debt absorbed via baselines and exclude patterns.
+OpenRegister is the heaviest app in the portfolio: 87 phpcs.xml
+exclude-patterns, a 335-line phpmd.baseline.xml across 142 files, and
+a 7,471-line phpstan-baseline.neon. Burning these down keeps PR diffs
+honest — gates catch real regressions rather than silently absorbing
+already-broken code.
+
+This is a tracking change so the burn-down work can be picked up later
+without re-running the audit. It is spec-only; no code changes are
+proposed in this change. The actual file-by-file work will land in
+follow-up PRs grouped by directory cluster.
+
+## What Changes
+
+- Burn down the 87 phpcs.xml exclude-patterns. The legacy-debt block
+  was added during the 2026-05-03 audit to keep the gate green while
+  the rest of OR was being normalised. Each file gets proper
+  docblocks + named-parameter call audits, then the exclude is
+  dropped and the gate stays green.
+- Burn down the 335-line phpmd.baseline.xml across 142 files.
+  Categories per audit:
+  - ElseExpression (147 violations)
+  - CyclomaticComplexity (62)
+  - NPathComplexity (44)
+  - MissingImport (41)
+  - ExcessiveMethodLength (24)
+  - StaticAccess (19)
+  - LongVariable (17)
+  - UndefinedVariable (14)
+  - UnusedFormalParameter (13)
+  - ShortVariable (13)
+- Verify phpstan-baseline.neon is auto-managed and currently clean.
+  If errors regressed since last regeneration, capture them in a
+  fresh baseline before starting cluster work so the gate stays
+  representative.
+- Wire phpcs/phpmd/phpstan into CI as the unified quality gate so
+  future PRs cannot regress, and so cluster removal is blocked on a
+  clean run.
+
+## Problem
+
+Baselines exist because the audit produced a mechanical work pile
+faster than any single PR could absorb. Blocking every PR while the
+335-line phpmd baseline gets cleared would freeze the repo for
+weeks; the alternative — silently rolling forward — defeats the
+purpose of having gates at all. The agreed compromise is to capture
+the debt as a baseline, then burn it down deliberately on a per-
+cluster cadence.
+
+Now is the time to clear them because the per-app OR-abstraction
+adoption work (Hydra ADR-022) is touching the same files. Any
+cluster cleanup that happens in parallel with adoption work
+amortises across both efforts: one round of file-edits, two
+audit-debts cleared.
+
+## Proposed Solution
+
+File-by-file cleanup phased by directory cluster, following the
+12-bucket grouping from `.claude/audit-2026-05-03/03-repo-hygiene.md`:
+
+1. Controllers (`lib/Controller/`)
+2. Services — core (`lib/Service/`)
+3. Services — object-graph (`lib/Service/ObjectHandlers/`)
+4. Db mappers (`lib/Db/`)
+5. Db entities (`lib/Db/`)
+6. Migrations (`lib/Migration/`)
+7. Cron / background jobs (`lib/Cron/`, `lib/BackgroundJob/`)
+8. Repair steps (`lib/Repair/`)
+9. Settings (`lib/Settings/`)
+10. Util / helpers (`lib/Service/`, `lib/Helper/`)
+11. Tests (`tests/`)
+12. Bootstrap / appinfo (`lib/AppInfo/`, `appinfo/`)
+
+Each phase removes its bucket's exclude-pattern entries from
+phpcs.xml and its violations from phpmd.baseline.xml. Gate stays
+green between buckets — no bucket merges until that bucket's gate
+is clean.
+
+Estimated effort: 8-12 PRs over 2-3 sprints for the full burn-down.
+
+## Out of scope
+
+- Refactoring beyond what the sniff requires
+- New features (separate adoption-spec changes own those)
+- Test additions (separate test-coverage spec change if needed)
+- Phpstan rule-level changes (use existing config; baseline only)
+
+## See also
+
+- `.claude/audit-2026-05-03/03-repo-hygiene.md` (audit research,
+  canonical source for bucket groupings and category counts)
+- `phpcs.xml` (the legacy-debt baseline section)
+- `phpmd.baseline.xml` (the PHPMD baseline file)
+- `phpstan-baseline.neon` (the PHPStan baseline file)
+- Hydra ADR-022 (apps consume OR abstractions) — quality conventions
+- `composer.json` `check:strict` script (the unified gate target)

--- a/openspec/changes/openregister-legacy-quality-cleanup/tasks.md
+++ b/openspec/changes/openregister-legacy-quality-cleanup/tasks.md
@@ -1,0 +1,101 @@
+# Tasks: OpenRegister Legacy Quality Cleanup
+
+## Phase 1 — Inventory + planning
+
+- [ ] Run `composer phpcs` and capture current baseline error count
+      (target line: starting from the 87 exclude-patterns in
+      phpcs.xml's legacy-debt block)
+- [ ] Run `composer phpmd` and capture current violation count
+      (target line: starting from 335-line phpmd.baseline.xml across
+      142 files)
+- [ ] Run `composer phpstan` and capture current error count
+      (target line: starting from 7,471-line phpstan-baseline.neon)
+- [ ] Group errors by directory cluster (12 buckets per audit)
+- [ ] Create per-cluster sub-issues with owner assignments and
+      target sprint
+- [ ] Confirm CI runs `composer check:strict` on every PR before
+      starting burn-down work
+
+## Phase 2 — PHPCS burn-down (per directory cluster)
+
+For each cluster: fix errors, remove the phpcs.xml `<exclude-pattern>`
+entries for that bucket, verify gate stays green, ship one PR.
+
+- [ ] Bucket 1: Controllers (`lib/Controller/`)
+- [ ] Bucket 2: Services — core (`lib/Service/`)
+- [ ] Bucket 3: Services — object-graph (`lib/Service/ObjectHandlers/`)
+- [ ] Bucket 4: Db mappers (`lib/Db/*Mapper.php`)
+- [ ] Bucket 5: Db entities (`lib/Db/*.php` excl. mappers)
+- [ ] Bucket 6: Migrations (`lib/Migration/`)
+- [ ] Bucket 7: Cron / background jobs (`lib/Cron/`,
+      `lib/BackgroundJob/`)
+- [ ] Bucket 8: Repair steps (`lib/Repair/`)
+- [ ] Bucket 9: Settings (`lib/Settings/`)
+- [ ] Bucket 10: Util / helpers (`lib/Service/`, `lib/Helper/`)
+- [ ] Bucket 11: Tests (`tests/`)
+- [ ] Bucket 12: Bootstrap / appinfo (`lib/AppInfo/`, `appinfo/`)
+- [ ] Once all 12 buckets are clean, drop the legacy-debt block from
+      phpcs.xml entirely
+
+## Phase 3 — PHPMD burn-down
+
+Work the categories in roughly volume-descending order so the
+baseline shrinks visibly between PRs. Each task is the full sweep
+across all 142 baselined files for that category.
+
+- [ ] ElseExpression (147 violations) — re-shape `if/else` chains
+      to early-return / guard clauses
+- [ ] CyclomaticComplexity (62) — extract methods to flatten
+      branches
+- [ ] NPathComplexity (44) — split branches into named helpers
+- [ ] MissingImport (41) — add `use` statements; remove inline
+      FQCNs
+- [ ] ExcessiveMethodLength (24) — extract helpers; pull internals
+      into private methods
+- [ ] StaticAccess (19) — replace static calls with DI services
+- [ ] LongVariable (17) — rename variables to <=20 chars
+- [ ] UndefinedVariable (14) — initialise variables on all paths;
+      fix typos
+- [ ] UnusedFormalParameter (13) — remove dead params; if
+      interface-mandated, document with `@SuppressWarnings`
+- [ ] ShortVariable (13) — rename single-char variables
+- [ ] After each category: regenerate phpmd.baseline.xml and confirm
+      line count drops
+- [ ] Once baseline reaches 0 lines: delete phpmd.baseline.xml and
+      drop `--baseline-file` from composer.json's phpmd script
+
+## Phase 4 — PHPStan burn-down
+
+- [ ] Inventory phpstan-baseline.neon by error type and file
+- [ ] Group errors by directory cluster (re-use Phase 2's 12 buckets)
+- [ ] Burn down per-bucket; regenerate baseline after each PR
+- [ ] Per-bucket common patterns to fix:
+  - [ ] Missing return-type / param-type declarations
+  - [ ] Mixed types (specify generic / union)
+  - [ ] Strict-comparison nudges (`==` to `===`)
+  - [ ] Possibly-null dereferences (add null guards)
+- [ ] Once baseline reaches 0 lines: delete phpstan-baseline.neon
+
+## Phase 5 — CI integration
+
+- [ ] Verify `composer check:strict` runs in CI on every PR (PHPCS,
+      PHPMD, PHPStan, Psalm)
+- [ ] Add PR template checkbox: "Burn-down PR? Cite cluster + before/
+      after baseline counts"
+- [ ] Once all baselines are empty:
+  - [ ] Delete `phpmd.baseline.xml`
+  - [ ] Delete `phpstan-baseline.neon`
+  - [ ] Drop the legacy-debt section from `phpcs.xml`
+  - [ ] Drop `--baseline-file` from composer.json's phpmd script
+- [ ] Add a smoke-test cron that runs `composer check:strict` weekly
+      on `development` to catch silent baseline regression
+
+## Phase 6 — Documentation
+
+- [ ] Update README quality-gates section to reflect zero-baseline
+      state
+- [ ] Note in `app-config.json` that legacy quality cleanup is done
+- [ ] Cross-link the 2026-05-03 audit report from
+      `docs/development/quality.md` so the historical context survives
+- [ ] Close the burn-down tracking issue once the last baseline
+      line is removed


### PR DESCRIPTION
## Summary

Drafts the openspec change that captures OR's legacy quality-debt cleanup as a tracked initiative. **Spec-only, markdown-only.**

Documents the baseline state observed during the 2026-05-03 OR-abstraction audit:
- ~87 phpcs.xml exclude-patterns
- 335-line phpmd.baseline.xml across 142 files
- 7,471-line phpstan-baseline.neon

Phases the burn-down per directory cluster (BackgroundJob / Controllers / Db / Service/Aggregation / Service/File / Service/Translation / etc.). Each phase removes its bucket from the baseline and verifies the gate stays green.

## Note on dependencies

This spec describes the WORK; landing it as actual enforcement requires the underlying PHPCS/PHPMD baseline files to first reach `origin/development` (currently those live on an unmerged feature branch from earlier in the audit). The implementation phase will sequence: (1) merge the underlying baseline to dev, (2) burn down per cluster.

## Auto-merge

Markdown-only per `feedback_pr-merge-authority.md` — admin-merging on creation.