### PR TITLE
Fix JSON deleted column index migrations

### DIFF
--- a/lib/Migration/Version1Date20250828120000.php
+++ b/lib/Migration/Version1Date20250828120000.php
@@ -24,6 +24,7 @@ namespace OCA\OpenRegister\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -74,6 +75,11 @@ class Version1Date20250828120000 extends SimpleMigrationStep
         ];
 
         foreach ($singleIndexes as $column => $indexName) {
+            if ($table->hasColumn($column) && $this->canUseBtreeIndex($table, $column) === false) {
+                $output->info("Skipped index {$indexName} on JSON column {$column}");
+                continue;
+            }
+
             if ($table->hasColumn($column) && !$table->hasIndex($indexName)) {
                 $table->addIndex([$column], $indexName);
                 $output->info("Added index {$indexName} on column {$column}");
@@ -121,6 +127,12 @@ class Version1Date20250828120000 extends SimpleMigrationStep
                     $allColumnsExist = false;
                     break;
                 }
+
+                if ($this->canUseBtreeIndex($table, $column) === false) {
+                    $allColumnsExist = false;
+                    $output->info("Skipped composite index {$indexName} because {$column} is a JSON column");
+                    break;
+                }
             }
             
             if ($allColumnsExist) {
@@ -137,6 +149,23 @@ class Version1Date20250828120000 extends SimpleMigrationStep
         return $schema;
 
     }//end changeSchema()
+
+
+    /**
+     * Checks whether a column can be used in a regular btree index.
+     *
+     * JSON columns do not have a default btree operator class in PostgreSQL and
+     * also need special handling on other supported databases.
+     *
+     * @param mixed  $table  The table definition
+     * @param string $column The column name
+     *
+     * @return bool
+     */
+    private function canUseBtreeIndex($table, string $column): bool
+    {
+        return $table->getColumn($column)->getType()->getName() !== Types::JSON;
+    }//end canUseBtreeIndex()
 
 
 }//end class

--- a/lib/Migration/Version1Date20250902140000.php
+++ b/lib/Migration/Version1Date20250902140000.php
@@ -6,6 +6,7 @@ namespace OCA\OpenRegister\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -86,7 +87,14 @@ class Version1Date20250902140000 extends SimpleMigrationStep
         }
 
         // Soft delete filtering
-        if (!$table->hasIndex('objects_deleted_idx')) {
+        if (
+            $table->hasColumn('deleted')
+            && $table->getColumn('deleted')->getType()->getName() === Types::JSON
+        ) {
+            $output->info('Skipped index objects_deleted_idx because deleted is a JSON column');
+        } elseif ($table->hasColumn('deleted') === false) {
+            $output->info('Skipped index objects_deleted_idx because deleted column does not exist');
+        } elseif (!$table->hasIndex('objects_deleted_idx')) {
             $table->addIndex(['deleted'], 'objects_deleted_idx');
             $output->info('Added index objects_deleted_idx for soft delete filtering');
         }


### PR DESCRIPTION
## Summary
- Skip regular btree index creation for JSON columns in the faceting performance migration.
- Skip composite indexes that include JSON columns, including the `deleted` lifecycle indexes.
- Prevent the later duplicate `objects_deleted_idx` migration from indexing `openregister_objects.deleted` when it is JSON.

## Root Cause
`openregister_objects.deleted` is created as `Types::JSON` in `Version1Date20250321061615.php`, but later migrations attempted to create normal btree indexes on that column. PostgreSQL rejects this with `data type json has no default operator class for access method "btree"`.

## Impact
This prevents upgrades, from failing on PostgreSQL when the migration chain reaches the deleted-column indexes. The guard also keeps MariaDB/MySQL on the safer path by avoiding plain indexes on JSON columns.

## Validation
- `php -l lib/Migration/Version1Date20250828120000.php`
- `php -l lib/Migration/Version1Date20250902140000.php`
- `git diff --check`