### PR TITLE
fix(FilesController): normalize 'file' field uploads in filesMultipart

### DIFF
--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -616,7 +616,7 @@ class FilesController extends Controller
             'tmp_name' => $files['tmp_name'] ?? '',
             'error'    => $files['error'] ?? UPLOAD_ERR_NO_FILE,
             'size'     => $files['size'] ?? 0,
-            'share'    => $data['share'] === 'true',
+            'share'    => $this->parseBool(value: $data['share'] ?? false),
             'tags'     => $tags,
         ];
     }//end normalizeSingleFile()
@@ -685,7 +685,7 @@ class FilesController extends Controller
                 'tmp_name' => $tmpNameArray[$i] ?? '',
                 'error'    => $errorArray[$i] ?? $errorScalar ?? UPLOAD_ERR_NO_FILE,
                 'size'     => $sizeArray[$i] ?? $sizeScalar ?? 0,
-                'share'    => $data['share'] === 'true',
+                'share'    => $this->parseBool(value: $data['share'] ?? false),
                 'tags'     => $tags,
             ];
         }//end for

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -548,11 +548,12 @@ class FilesController extends Controller
             $uploadedFiles = $this->normalizeMultipartFiles(files: $files, data: $data);
         }
 
-        // Check for single file upload.
+        // Check for single file upload via the 'file' field. Run it through
+        // the same normalizer as 'files[]' so 'share' and 'tags' are populated.
         $uploadedFile = $this->request->getUploadedFile('file');
 
         if (empty($uploadedFile) === false) {
-            $uploadedFiles[] = $uploadedFile;
+            $uploadedFiles[] = $this->normalizeSingleFile(files: $uploadedFile, data: $data);
         }
 
         if (empty($uploadedFiles) === true) {

--- a/tests/Unit/Controller/FilesControllerTest.php
+++ b/tests/Unit/Controller/FilesControllerTest.php
@@ -1596,10 +1596,62 @@ class FilesControllerTest extends TestCase
                 }
                 return null;
             });
-        $this->request->method('getParams')->willReturn([]);
+        $this->request->method('getParams')->willReturn([
+            'share' => 'true',
+            'tags' => 'a,b',
+        ]);
 
         $result = $this->invokePrivateMethod('extractUploadedFiles', []);
         $this->assertCount(1, $result);
+
+        // Regression guard: the 'file' branch must run through normalizeSingleFile
+        // so 'share' and 'tags' are populated. Without this, processUploadedFiles
+        // dereferences $file['share'] and throws a TypeError (null given).
+        $this->assertSame('single.txt', $result[0]['name']);
+        $this->assertArrayHasKey('share', $result[0]);
+        $this->assertIsBool($result[0]['share']);
+        $this->assertTrue($result[0]['share']);
+        $this->assertArrayHasKey('tags', $result[0]);
+        $this->assertSame(['a', 'b'], $result[0]['tags']);
+    }
+
+    /**
+     * @dataProvider shareValueProvider
+     */
+    public function testExtractUploadedFilesShareParsing(mixed $shareInput, bool $expected): void
+    {
+        $uploadedFile = [
+            'name' => 'single.txt',
+            'type' => 'text/plain',
+            'tmp_name' => '/tmp/phpSingle',
+            'error' => 0,
+            'size' => 100,
+        ];
+
+        $this->request->method('getUploadedFile')
+            ->willReturnCallback(function ($key) use ($uploadedFile) {
+                return $key === 'file' ? $uploadedFile : null;
+            });
+        $this->request->method('getParams')->willReturn(['share' => $shareInput]);
+
+        $result = $this->invokePrivateMethod('extractUploadedFiles', []);
+        $this->assertSame($expected, $result[0]['share']);
+    }
+
+    public static function shareValueProvider(): array
+    {
+        return [
+            'string true'  => ['true', true],
+            'string TRUE'  => ['TRUE', true],
+            'string 1'     => ['1', true],
+            'string yes'   => ['yes', true],
+            'string on'    => ['on', true],
+            'bool true'    => [true, true],
+            'string false' => ['false', false],
+            'string 0'     => ['0', false],
+            'bool false'   => [false, false],
+            'empty string' => ['', false],
+        ];
     }
 
     public function testExtractUploadedFilesMultipart(): void


### PR DESCRIPTION
## Summary
- POST to \`/api/objects/{register}/{schema}/{id}/filesMultipart\` with a single file in the \`file\` field returned 500 because \`extractUploadedFiles()\` appended the raw \`$_FILES\` entry without running it through \`normalizeSingleFile\`. \`processUploadedFiles\` then dereferenced \`$file['share']\`, which was missing, throwing the error: \`TypeError: FileService::addFile(): Argument #4 ($share) must be of type bool, null given\`.
- Route the \`file\` branch through \`normalizeSingleFile\`, the same normalizer that the \`files[]\` branch already uses. Both upload patterns now succeed.

## Background
Surfaced while writing the new Conduction Academy tutorial on uploading files to a Woo publication. The tutorial walks through four upload modes; this was the only one that returned a 500.

## Test plan
- [x] \`curl -F "file=@./test.txt" -F "share=true" .../filesMultipart\` returns 200 with a normalized file object
- [x] \`curl -F "files[]=@./test.txt" -F "share=true" .../filesMultipart\` continues to return 200
- [x] \`curl -F "files[]=@./a.txt" -F "files[]=@./b.txt" .../filesMultipart\` continues to return a two-element array
- [x] CI passes