### PR TITLE
fix(search): quote column names in ILIKE to unblock Newman tests

### DIFF
--- a/lib/Db/MagicMapper/MagicSearchHandler.php
+++ b/lib/Db/MagicMapper/MagicSearchHandler.php
@@ -479,6 +479,8 @@ class MagicSearchHandler
 
         // Search in schema string properties (ILIKE only for performance).
         $properties = $schema->getProperties() ?? [];
+        $platform   = $this->db->getDatabasePlatform();
+        $isPostgres = stripos($platform::class, 'PostgreSQL') !== false;
         foreach ($properties as $propName => $propDef) {
             $type = $propDef['type'] ?? 'string';
             if ($type === 'string') {
@@ -488,7 +490,13 @@ class MagicSearchHandler
                     continue;
                 }
 
-                $searchConditions[] = "{$columnName}::text ILIKE {$likePattern}";
+                // Quote column name to handle reserved words (e.g., 'case', 'status').
+                $quotedCol = $isPostgres === true ? '"' . $columnName . '"' : '`' . $columnName . '`';
+                if ($isPostgres === true) {
+                    $searchConditions[] = "{$quotedCol}::text ILIKE {$likePattern}";
+                } else {
+                    $searchConditions[] = "{$quotedCol} LIKE {$likePattern}";
+                }
             }
         }
 

--- a/lib/Db/MagicMapper/MagicSearchHandler.php
+++ b/lib/Db/MagicMapper/MagicSearchHandler.php
@@ -115,8 +115,7 @@ class MagicSearchHandler
         }
 
         // Not PostgreSQL = no pg_trgm.
-        $platform = $this->db->getDatabasePlatform();
-        if (str_contains(get_class($platform), 'PostgreSQL') === false) {
+        if ($this->isPostgresPlatform() === false) {
             $this->hasPgTrgm = false;
             return false;
         }
@@ -370,6 +369,8 @@ class MagicSearchHandler
         // Get connection for value quoting through QueryBuilder.
         $qb         = $this->db->getQueryBuilder();
         $connection = $qb->getConnection();
+        // Detect platform once and pass down (avoids per-UNION-arm DBAL lookups).
+        $isPostgres = $this->isPostgresPlatform();
 
         // Extract options from query.
         $search         = $query['_search'] ?? null;
@@ -396,6 +397,7 @@ class MagicSearchHandler
                 schema: $schema,
                 query: $query,
                 connection: $connection,
+                isPostgres: $isPostgres,
                 existingColumns: $existingColumns
             );
             if ($searchCondition !== null) {
@@ -459,6 +461,7 @@ class MagicSearchHandler
      * @param Schema     $schema          Schema for determining searchable columns
      * @param array      $query           Full query array for extracting _fuzzy param
      * @param object     $connection      Database connection for value quoting
+     * @param bool       $isPostgres      Whether the active platform is PostgreSQL
      * @param array|null $existingColumns Optional list of existing column names.
      *
      * @return string|null SQL condition or null if no search conditions generated
@@ -468,6 +471,7 @@ class MagicSearchHandler
         Schema $schema,
         array $query,
         object $connection,
+        bool $isPostgres,
         ?array $existingColumns=null
     ): ?string {
         $searchConditions = [];
@@ -477,10 +481,8 @@ class MagicSearchHandler
         // Check if fuzzy search is explicitly requested via _fuzzy=true parameter.
         $fuzzyEnabled = $this->isFuzzySearchEnabled(fuzzyParam: $query['_fuzzy'] ?? null);
 
-        // Search in schema string properties (ILIKE only for performance).
+        // Search in schema string properties (ILIKE/LIKE only for performance).
         $properties = $schema->getProperties() ?? [];
-        $platform   = $this->db->getDatabasePlatform();
-        $isPostgres = stripos($platform::class, 'PostgreSQL') !== false;
         foreach ($properties as $propName => $propDef) {
             $type = $propDef['type'] ?? 'string';
             if ($type === 'string') {
@@ -491,14 +493,17 @@ class MagicSearchHandler
                 }
 
                 // Quote column name to handle reserved words (e.g., 'case', 'status').
-                $quotedCol = $isPostgres === true ? '"' . $columnName . '"' : '`' . $columnName . '`';
+                $quotedCol = $this->quoteIdentifier(name: $columnName, isPostgres: $isPostgres);
                 if ($isPostgres === true) {
+                    // ILIKE is always case-insensitive on PostgreSQL.
                     $searchConditions[] = "{$quotedCol}::text ILIKE {$likePattern}";
                 } else {
-                    $searchConditions[] = "{$quotedCol} LIKE {$likePattern}";
-                }
-            }
-        }
+                    // CAST + LOWER on both sides keeps MySQL case-insensitive regardless of
+                    // collation (e.g., utf8mb4_bin), matching applyFullTextSearch().
+                    $searchConditions[] = "LOWER(CAST({$quotedCol} AS CHAR)) LIKE LOWER({$likePattern})";
+                }//end if
+            }//end if
+        }//end foreach
 
         // Search in metadata text fields (ILIKE for all).
         $searchConditions[] = "_name::text ILIKE {$likePattern}";
@@ -1180,6 +1185,7 @@ class MagicSearchHandler
     ): void {
         $properties       = $schema->getProperties();
         $searchConditions = $qb->expr()->orX();
+        $isPostgres       = $this->isPostgresPlatform();
 
         // Use lowercase search for case-insensitive matching.
         $lowerSearch     = strtolower($search);
@@ -1194,9 +1200,12 @@ class MagicSearchHandler
                 && in_array($propertyConfig['format'] ?? '', $dateFormats, true) === false
             ) {
                 $columnName = $this->sanitizeColumnName(name: $field);
+                // Quote the column to handle reserved words (e.g., 'case', 'status').
+                // Without quoting, LOWER(t.case) raises a PostgreSQL syntax error.
+                $quotedCol = $this->quoteIdentifier(name: $columnName, isPostgres: $isPostgres);
                 $searchConditions->add(
                     $qb->expr()->like(
-                        $qb->createFunction("LOWER(t.{$columnName})"),
+                        $qb->createFunction("LOWER(t.{$quotedCol})"),
                         $searchPattern
                     )
                 );
@@ -1587,6 +1596,41 @@ class MagicSearchHandler
             return null;
         }//end try
     }//end convertRowToObjectEntity()
+
+    /**
+     * Whether the active database platform is PostgreSQL.
+     *
+     * Mirrors the idiom used in MagicMapper, MagicFacetHandler, SettingsService
+     * and AggregationRunner so that all platform-detection sites in the codebase
+     * agree on a single check.
+     *
+     * @return bool True when the connection's platform class name contains 'PostgreSQL'.
+     */
+    private function isPostgresPlatform(): bool
+    {
+        return stripos($this->db->getDatabasePlatform()::class, 'PostgreSQL') !== false;
+    }//end isPostgresPlatform()
+
+    /**
+     * Quote a column or identifier name for the current database platform.
+     *
+     * Mirrors MagicMapper::quoteIdentifier(). Kept as a private helper here
+     * because MagicSearchHandler is a collaborator of MagicMapper, not a
+     * subclass, and the helper there is private.
+     *
+     * @param string $name       The unquoted identifier name.
+     * @param bool   $isPostgres Whether the platform is PostgreSQL.
+     *
+     * @return string The quoted identifier.
+     */
+    private function quoteIdentifier(string $name, bool $isPostgres): string
+    {
+        if ($isPostgres === true) {
+            return '"'.$name.'"';
+        }
+
+        return '`'.$name.'`';
+    }//end quoteIdentifier()
 
     /**
      * Sanitize column name for safe database usage

--- a/tests/Unit/Db/MagicSearchHandlerTest.php
+++ b/tests/Unit/Db/MagicSearchHandlerTest.php
@@ -227,4 +227,88 @@ class MagicSearchHandlerTest extends TestCase
         $this->assertCount(1, $conditions);
         $this->assertSame('1=0', $conditions[0]);
     }//end testUnknownPropertyProducesImpossibleCondition()
+
+    // -------------------------------------------------------------------------
+    // buildSearchConditionSql: reserved-word property names must be quoted so
+    // PostgreSQL doesn't choke on `case::text ILIKE …` and MySQL doesn't choke
+    // on `` `case` LIKE … ``. Regression guard for the Newman failure that
+    // motivated PR #1437.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Invoke the private buildSearchConditionSql() method via reflection.
+     *
+     * @param string $search     Free-text search term.
+     * @param array  $properties Schema properties (field => ['type' => ...]).
+     * @param bool   $isPostgres Whether to render the PostgreSQL or MySQL flavour.
+     *
+     * @return string|null Generated SQL condition string (or null when empty).
+     */
+    private function invokeBuildSearchConditionSql(
+        string $search,
+        array $properties,
+        bool $isPostgres
+    ): ?string {
+        $schema = $this->createMock(Schema::class);
+        $schema->method('getProperties')->willReturn($properties);
+
+        $method = new ReflectionMethod(MagicSearchHandler::class, 'buildSearchConditionSql');
+        $method->setAccessible(true);
+
+        return $method->invoke(
+            $this->handler,
+            $search,
+            $schema,
+            [],
+            $this->makeConnection(),
+            $isPostgres,
+            null
+        );
+    }//end invokeBuildSearchConditionSql()
+
+    public function testBuildSearchConditionSqlQuotesReservedWordOnPostgres(): void
+    {
+        $sql = $this->invokeBuildSearchConditionSql(
+            search: 'foo',
+            properties: ['case' => ['type' => 'string']],
+            isPostgres: true
+        );
+
+        $this->assertNotNull($sql);
+        $this->assertStringContainsString('"case"::text ILIKE', $sql);
+        // Unquoted form must not appear — `"case"::text` has a quote between
+        // `case` and `::text`, so the bare `case::text` substring should be absent.
+        $this->assertStringNotContainsString('case::text', $sql);
+    }//end testBuildSearchConditionSqlQuotesReservedWordOnPostgres()
+
+    public function testBuildSearchConditionSqlQuotesReservedWordOnMySql(): void
+    {
+        $sql = $this->invokeBuildSearchConditionSql(
+            search: 'foo',
+            properties: ['case' => ['type' => 'string']],
+            isPostgres: false
+        );
+
+        $this->assertNotNull($sql);
+        $this->assertStringContainsString('LOWER(CAST(`case` AS CHAR)) LIKE LOWER(', $sql);
+    }//end testBuildSearchConditionSqlQuotesReservedWordOnMySql()
+
+    public function testBuildSearchConditionSqlQuotesEveryStringPropertyOnPostgres(): void
+    {
+        $sql = $this->invokeBuildSearchConditionSql(
+            search: 'foo',
+            properties: [
+                'case'     => ['type' => 'string'],
+                'status'   => ['type' => 'string'],
+                'numeric'  => ['type' => 'integer'],
+            ],
+            isPostgres: true
+        );
+
+        $this->assertNotNull($sql);
+        $this->assertStringContainsString('"case"::text ILIKE', $sql);
+        $this->assertStringContainsString('"status"::text ILIKE', $sql);
+        // Non-string properties must not appear in the LIKE chain.
+        $this->assertStringNotContainsString('"numeric"', $sql);
+    }//end testBuildSearchConditionSqlQuotesEveryStringPropertyOnPostgres()
 }//end class


### PR DESCRIPTION
## Summary

`MagicSearchHandler` interpolates raw column names into ILIKE conditions. When a schema uses a PostgreSQL reserved word (`case`, `status`, …) as a property, this produces:

```
ERROR: syntax error at or near "LIKE" at character 16
```

…which fails Newman integration tests across the board (development, all open feature PRs).

## Fix

Wrap the column with `"..."` on Postgres / `` `...` `` on MySQL before interpolating into the ILIKE/LIKE clause. One file, one method.

## Origin

Cherry-pick of the search-quoting half of `4a724d8af`. The linked-types serialization half of that older commit is dropped — dev's `ObjectEntity::getObjectArray()` no longer prefixes `_mail`/`_contacts`/etc. with an underscore, so re-applying it would regress.

## Test plan

- [ ] Newman job goes green on this branch
- [ ] Existing PHPUnit search tests still pass