### PR TITLE
feat(audit-trail): tenant-key API (closes scholiq deps #2)

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -108,6 +108,7 @@ use OCA\OpenRegister\Service\Chat\MessageHistoryHandler;
 use OCA\OpenRegister\Service\Chat\ToolManagementHandler;
 use OCA\OpenRegister\Service\TextExtractionService;
 use OCA\OpenRegister\Service\SettingsService;
+use OCA\OpenRegister\Service\TenantKeyService;
 use OCA\OpenRegister\Service\Settings\ValidationOperationsHandler;
 use OCA\OpenRegister\Service\Settings\SearchBackendHandler;
 use OCA\OpenRegister\Service\Settings\LlmSettingsHandler;
@@ -694,6 +695,19 @@ class Application extends App implements IBootstrap
                     cacheSettingsHandler: $container->get(CacheSettingsHandler::class),
                     solrSettingsHandler: $container->get(SolrSettingsHandler::class),
                     cfgSettingsHandler: $container->get(ConfigurationSettingsHandler::class)
+                );
+            }
+        );
+
+        // Register TenantKeyService for audit-trail HMAC key management.
+        $context->registerService(
+            TenantKeyService::class,
+            function (ContainerInterface $container) {
+                return new TenantKeyService(
+                    db: $container->get('OCP\IDBConnection'),
+                    crypto: $container->get('OCP\Security\ICrypto'),
+                    secureRandom: $container->get('OCP\Security\ISecureRandom'),
+                    logger: $container->get('Psr\Log\LoggerInterface')
                 );
             }
         );

--- a/lib/Migration/Version1Date20260511100000.php
+++ b/lib/Migration/Version1Date20260511100000.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Migration creating `openregister_tenant_keys`.
+ *
+ * Stores per-tenant HMAC signing keys for the audit-trail hash-chain
+ * (ADR-022 "audit-hash-chain" row).  Each row holds:
+ *
+ *  - tenant_id     — opaque tenant identifier (e.g. organisation UUID)
+ *  - encrypted_key — AES-256-GCM ciphertext produced by OCP\Security\ICrypto
+ *  - status        — 'active' | 'retired'  (one active row per tenant)
+ *  - created_at    — ISO-8601 issuance / rotation timestamp (VARCHAR to
+ *                    avoid timezone drift across DB engines)
+ *
+ * Retired rows are kept so verifiers can re-check older evidence records
+ * that were signed under the previous key.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/scholiq-deps/tenant-key-api/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Creates the openregister_tenant_keys table.
+ */
+class Version1Date20260511100000 extends SimpleMigrationStep
+{
+    /**
+     * Change the database schema.
+     *
+     * @param IOutput                 $output        Output for the migration process
+     * @param Closure                 $schemaClosure The schema closure
+     * @param array<array-key, mixed> $options       Migration options
+     *
+     * @return null|ISchemaWrapper
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        // @var ISchemaWrapper $schema
+        $schema = $schemaClosure();
+
+        if ($schema->hasTable(tableName: 'openregister_tenant_keys') === true) {
+            return null;
+        }
+
+        $table = $schema->createTable(tableName: 'openregister_tenant_keys');
+
+        $table->addColumn(
+            name: 'id',
+            typeName: Types::BIGINT,
+            options: [
+                'autoincrement' => true,
+                'notnull'       => true,
+            ]
+        );
+
+        $table->addColumn(
+            name: 'tenant_id',
+            typeName: Types::STRING,
+            options: [
+                'notnull' => true,
+                'length'  => 255,
+                'comment' => 'Opaque tenant identifier (organisation UUID or similar)',
+            ]
+        );
+
+        $table->addColumn(
+            name: 'encrypted_key',
+            typeName: Types::TEXT,
+            options: [
+                'notnull' => true,
+                'comment' => 'ICrypto-encrypted 256-bit HMAC key (AES-256-GCM ciphertext)',
+            ]
+        );
+
+        $table->addColumn(
+            name: 'status',
+            typeName: Types::STRING,
+            options: [
+                'notnull' => true,
+                'length'  => 16,
+                'default' => 'active',
+                'comment' => '"active" = current key; "retired" = superseded by rotation',
+            ]
+        );
+
+        $table->addColumn(
+            name: 'created_at',
+            typeName: Types::STRING,
+            options: [
+                'notnull' => true,
+                'length'  => 32,
+                'comment' => 'ISO-8601 key issuance / rotation timestamp',
+            ]
+        );
+
+        $table->setPrimaryKey(columnNames: ['id']);
+        $table->addIndex(
+            columnNames: ['tenant_id', 'status'],
+            indexName: 'idx_or_tkeys_tenant_status'
+        );
+        $table->addIndex(
+            columnNames: ['tenant_id'],
+            indexName: 'idx_or_tkeys_tenant_id'
+        );
+
+        return $schema;
+
+    }//end changeSchema()
+}//end class

--- a/lib/Service/TenantKeyService.php
+++ b/lib/Service/TenantKeyService.php
@@ -1,0 +1,290 @@
+<?php
+
+/**
+ * Tenant HMAC Key Service
+ *
+ * Manages per-tenant HMAC signing keys for the audit-trail hash-chain.
+ * Each tenant has exactly one active 256-bit key at a time. On first
+ * access a fresh key is generated, encrypted at rest via ICrypto, and
+ * persisted. Annual rotation is driven by admin action or cron; this
+ * method always returns the CURRENT active key.
+ *
+ * Security design:
+ * - Keys are NEVER exposed through any REST endpoint.
+ * - Storage is encrypted via OCP\Security\ICrypto (AES-256-GCM + HMAC
+ *   with the instance secret as the wrapping key).
+ * - This service is an internal server-side API only; it is not wired
+ *   into any HTTP controller.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/scholiq-deps/tenant-key-api/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use DateTime;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Security\ICrypto;
+use OCP\Security\ISecureRandom;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Provides per-tenant HMAC keys for audit-trail evidence signing.
+ *
+ * @package OCA\OpenRegister\Service
+ *
+ * @psalm-suppress UnusedClass
+ */
+class TenantKeyService
+{
+    /**
+     * Table that stores encrypted tenant keys.
+     *
+     * @var string
+     */
+    private const TABLE = 'openregister_tenant_keys';
+
+    /**
+     * Length of the random key material in bytes (256 bits).
+     *
+     * @var int
+     */
+    private const KEY_BYTES = 32;
+
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection   $db           Database connection
+     * @param ICrypto         $crypto       Nextcloud crypto service (encrypt/decrypt at rest)
+     * @param ISecureRandom   $secureRandom Nextcloud CSPRNG
+     * @param LoggerInterface $logger       PSR logger
+     */
+    public function __construct(
+        private readonly IDBConnection $db,
+        private readonly ICrypto $crypto,
+        private readonly ISecureRandom $secureRandom,
+        private readonly LoggerInterface $logger
+    ) {
+    }//end __construct()
+
+    /**
+     * Return the current active HMAC key for the given tenant.
+     *
+     * On the very first call for a tenant a fresh 256-bit key is generated,
+     * encrypted, stored, and returned.  Subsequent calls return the same
+     * plaintext key until a rotation is performed.
+     *
+     * @param string $tenantId Tenant identifier (e.g. organisation UUID)
+     *
+     * @return string Raw binary key material (32 bytes / 256 bit)
+     *
+     * @throws RuntimeException When key decryption fails
+     *
+     * @spec openspec/changes/scholiq-deps/tenant-key-api/tasks.md
+     */
+    public function getCurrentTenantKey(string $tenantId): string
+    {
+        $row = $this->fetchActiveRow(tenantId: $tenantId);
+
+        if ($row === null) {
+            return $this->bootstrapKey(tenantId: $tenantId);
+        }
+
+        return $this->decrypt(ciphertext: $row['encrypted_key'], tenantId: $tenantId);
+    }//end getCurrentTenantKey()
+
+    /**
+     * Rotate the HMAC key for the given tenant.
+     *
+     * The old key is retained in the table (status = 'retired') so that
+     * verifiers can still re-check evidence records signed under it.
+     * A fresh key is inserted with status = 'active'.
+     *
+     * @param string $tenantId Tenant identifier
+     *
+     * @return array{
+     *     old: string,
+     *     new: string,
+     *     rotated_at: string
+     * } Old plaintext key, new plaintext key, and ISO-8601 rotation timestamp
+     *
+     * @throws RuntimeException When key decryption or encryption fails
+     *
+     * @spec openspec/changes/scholiq-deps/tenant-key-api/tasks.md
+     */
+    public function rotateTenantKey(string $tenantId): array
+    {
+        $oldRow = $this->fetchActiveRow(tenantId: $tenantId);
+        $oldKey = null;
+
+        if ($oldRow !== null) {
+            $oldKey = $this->decrypt(ciphertext: $oldRow['encrypted_key'], tenantId: $tenantId);
+            $this->retireRow(id: (int) $oldRow['id']);
+        }
+
+        $newKey    = $this->generateKey();
+        $rotatedAt = (new DateTime())->format('c');
+        $this->insertKey(tenantId: $tenantId, rawKey: $newKey, rotatedAt: $rotatedAt);
+
+        $this->logger->info(
+            'Rotated tenant HMAC key',
+            ['tenant_id' => $tenantId, 'rotated_at' => $rotatedAt]
+        );
+
+        return [
+            'old'        => $oldKey ?? '',
+            'new'        => $newKey,
+            'rotated_at' => $rotatedAt,
+        ];
+    }//end rotateTenantKey()
+
+    /**
+     * Fetch the active key row for a tenant, or null if none exists.
+     *
+     * @param string $tenantId Tenant identifier
+     *
+     * @return array<string,mixed>|null Database row or null
+     */
+    private function fetchActiveRow(string $tenantId): ?array
+    {
+        $qb = $this->db->getQueryBuilder();
+
+        $qb->select('id', 'encrypted_key')
+            ->from(self::TABLE)
+            ->where(
+                $qb->expr()->eq(
+                    'tenant_id',
+                    $qb->createNamedParameter($tenantId, IQueryBuilder::PARAM_STR)
+                )
+            )
+            ->andWhere(
+                $qb->expr()->eq(
+                    'status',
+                    $qb->createNamedParameter('active', IQueryBuilder::PARAM_STR)
+                )
+            )
+            ->orderBy('id', 'DESC')
+            ->setMaxResults(1);
+
+        $result = $qb->executeQuery();
+        $row    = $result->fetch();
+        $result->closeCursor();
+
+        return ($row === false) ? null : $row;
+    }//end fetchActiveRow()
+
+    /**
+     * Generate a fresh key, persist it, and return the plaintext key.
+     *
+     * @param string $tenantId Tenant identifier
+     *
+     * @return string Raw plaintext key material
+     */
+    private function bootstrapKey(string $tenantId): string
+    {
+        $rawKey   = $this->generateKey();
+        $issuedAt = (new DateTime())->format('c');
+        $this->insertKey(tenantId: $tenantId, rawKey: $rawKey, rotatedAt: $issuedAt);
+
+        $this->logger->info(
+            'Bootstrapped new tenant HMAC key',
+            ['tenant_id' => $tenantId, 'issued_at' => $issuedAt]
+        );
+
+        return $rawKey;
+    }//end bootstrapKey()
+
+    /**
+     * Generate 256 bits of cryptographically secure random key material.
+     *
+     * Returns the raw bytes encoded as a 64-character lowercase hex string
+     * so the value is safely stored / transported as a string.
+     *
+     * @return string 64-character hex string (32 raw bytes)
+     */
+    private function generateKey(): string
+    {
+        // ISecureRandom::generate produces URL-safe chars; we need raw bytes.
+        // Use random_bytes (CSPRNG) and encode as hex for safe string storage.
+        return bin2hex(random_bytes(self::KEY_BYTES));
+    }//end generateKey()
+
+    /**
+     * Encrypt and insert a new active key row.
+     *
+     * @param string $tenantId  Tenant identifier
+     * @param string $rawKey    Plaintext key (64-char hex)
+     * @param string $rotatedAt ISO-8601 timestamp
+     *
+     * @return void
+     */
+    private function insertKey(string $tenantId, string $rawKey, string $rotatedAt): void
+    {
+        $encrypted = $this->crypto->encrypt($rawKey);
+
+        $qb = $this->db->getQueryBuilder();
+        $qb->insert(self::TABLE)
+            ->values(
+                    [
+                        'tenant_id'     => $qb->createNamedParameter($tenantId, IQueryBuilder::PARAM_STR),
+                        'encrypted_key' => $qb->createNamedParameter($encrypted, IQueryBuilder::PARAM_STR),
+                        'status'        => $qb->createNamedParameter('active', IQueryBuilder::PARAM_STR),
+                        'created_at'    => $qb->createNamedParameter($rotatedAt, IQueryBuilder::PARAM_STR),
+                    ]
+                    )
+            ->executeStatement();
+    }//end insertKey()
+
+    /**
+     * Mark a key row as retired.
+     *
+     * @param int $id Primary key of the row to retire
+     *
+     * @return void
+     */
+    private function retireRow(int $id): void
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->update(self::TABLE)
+            ->set('status', $qb->createNamedParameter('retired', IQueryBuilder::PARAM_STR))
+            ->where(
+                $qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT))
+            )
+            ->executeStatement();
+    }//end retireRow()
+
+    /**
+     * Decrypt a ciphertext produced by ICrypto::encrypt.
+     *
+     * @param string $ciphertext Encrypted key material
+     * @param string $tenantId   Tenant identifier (used only for log context)
+     *
+     * @return string Plaintext key material
+     *
+     * @throws RuntimeException When decryption produces an empty result
+     */
+    private function decrypt(string $ciphertext, string $tenantId): string
+    {
+        $plaintext = $this->crypto->decrypt($ciphertext);
+
+        if ($plaintext === '') {
+            throw new RuntimeException(
+                "TenantKeyService: decryption returned empty string for tenant '{$tenantId}'"
+            );
+        }
+
+        return $plaintext;
+    }//end decrypt()
+}//end class

--- a/tests/Unit/Service/TenantKeyServiceTest.php
+++ b/tests/Unit/Service/TenantKeyServiceTest.php
@@ -1,0 +1,444 @@
+<?php
+
+/**
+ * Unit tests for TenantKeyService.
+ *
+ * Covers:
+ *  - Fresh-tenant bootstrap: first call inserts a new active key and returns it.
+ *  - Idempotency: repeated calls for the same tenant return the same plaintext key.
+ *  - Rotation: rotateTenantKey() returns old + new keys and new key differs from old.
+ *  - Rotation from scratch: rotateTenantKey() on a tenant with no prior key still works.
+ *  - Retired rows are not returned by getCurrentTenantKey() after rotation.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/scholiq-deps/tenant-key-api/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use OCA\OpenRegister\Service\TenantKeyService;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Security\ICrypto;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for TenantKeyService.
+ *
+ * The DB is simulated by an in-memory array ($store) that the fluent
+ * IQueryBuilder mock writes to / reads from.  The mock intercepts the
+ * tenantId parameter via createNamedParameter so SELECT can be filtered
+ * by tenant correctly.
+ *
+ * @psalm-suppress MissingConstructor
+ */
+class TenantKeyServiceTest extends TestCase
+{
+
+    /**
+     * @var ICrypto&MockObject
+     */
+    private ICrypto $crypto;
+
+    /**
+     * @var ISecureRandom&MockObject
+     */
+    private ISecureRandom $secureRandom;
+
+    /**
+     * @var LoggerInterface&MockObject
+     */
+    private LoggerInterface $logger;
+
+    /**
+     * In-memory store simulating the openregister_tenant_keys table.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    private array $store = [];
+
+    /**
+     * @var integer Auto-increment counter for row IDs.
+     */
+    private int $nextId = 1;
+
+    /**
+     * Most-recently seen tenant_id passed to createNamedParameter.
+     * Used by the SELECT mock to filter rows.
+     *
+     * @var string
+     */
+    private string $lastTenantId = '';
+
+    // -------------------------------------------------------------------------
+    // setUp helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Build a fresh TenantKeyService backed by the in-memory store mock.
+     *
+     * @return TenantKeyService
+     */
+    private function makeService(): TenantKeyService
+    {
+        $this->store        = [];
+        $this->nextId       = 1;
+        $this->lastTenantId = '';
+
+        $this->crypto = $this->createMock(ICrypto::class);
+        $this->crypto->method('encrypt')->willReturnCallback(
+            fn(string $plain): string => 'ENC:'.$plain
+        );
+        $this->crypto->method('decrypt')->willReturnCallback(
+            fn(string $cipher): string => str_starts_with($cipher, 'ENC:') ? substr($cipher, 4) : ''
+        );
+
+        $this->secureRandom = $this->createMock(ISecureRandom::class);
+        $this->logger       = $this->createMock(LoggerInterface::class);
+
+        $db = $this->buildDb();
+
+        return new TenantKeyService(
+            db: $db,
+            crypto: $this->crypto,
+            secureRandom: $this->secureRandom,
+            logger: $this->logger
+        );
+    }//end makeService()
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * On first call for a fresh tenant, a 64-char hex key is bootstrapped.
+     */
+    public function testBootstrapCreatesKeyOnFirstCall(): void
+    {
+        $svc = $this->makeService();
+        $key = $svc->getCurrentTenantKey('tenant-abc');
+
+        $this->assertNotEmpty($key, 'Key must not be empty');
+        $this->assertSame(64, strlen($key), 'Key must be 64 hex chars (256 bits)');
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $key, 'Key must be lowercase hex');
+    }//end testBootstrapCreatesKeyOnFirstCall()
+
+    /**
+     * After bootstrap, exactly one active row exists in the store.
+     */
+    public function testBootstrapInsertsExactlyOneActiveRow(): void
+    {
+        $svc = $this->makeService();
+        $svc->getCurrentTenantKey('tenant-abc');
+
+        $active = array_filter(
+            $this->store,
+            fn($row) => $row['tenant_id'] === 'tenant-abc' && $row['status'] === 'active'
+        );
+
+        $this->assertCount(1, $active, 'Exactly one active row must be inserted on bootstrap');
+    }//end testBootstrapInsertsExactlyOneActiveRow()
+
+    /**
+     * Repeated calls return the same plaintext key (no extra rows inserted).
+     */
+    public function testRepeatedCallsReturnSameKey(): void
+    {
+        $svc    = $this->makeService();
+        $first  = $svc->getCurrentTenantKey('tenant-xyz');
+        $second = $svc->getCurrentTenantKey('tenant-xyz');
+
+        $this->assertSame($first, $second, 'Repeated calls must return the same key');
+
+        $allRows = array_filter($this->store, fn($row) => $row['tenant_id'] === 'tenant-xyz');
+        $this->assertCount(1, $allRows, 'Only one row must exist after repeated reads');
+    }//end testRepeatedCallsReturnSameKey()
+
+    /**
+     * Different tenants each get a valid key (both are 64-char hex).
+     */
+    public function testDifferentTenantsReceiveValidKeys(): void
+    {
+        $svc  = $this->makeService();
+        $keyA = $svc->getCurrentTenantKey('tenant-a');
+        $keyB = $svc->getCurrentTenantKey('tenant-b');
+
+        $this->assertSame(64, strlen($keyA));
+        $this->assertSame(64, strlen($keyB));
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $keyA);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $keyB);
+    }//end testDifferentTenantsReceiveValidKeys()
+
+    /**
+     * Rotation on a bootstrapped tenant returns old key, new key, and timestamp.
+     * The new key is a valid hex string and differs from the old.
+     */
+    public function testRotationReturnsBothKeysAndTimestamp(): void
+    {
+        $svc      = $this->makeService();
+        $original = $svc->getCurrentTenantKey('tenant-rot');
+
+        $result = $svc->rotateTenantKey('tenant-rot');
+
+        $this->assertArrayHasKey('old', $result);
+        $this->assertArrayHasKey('new', $result);
+        $this->assertArrayHasKey('rotated_at', $result);
+        $this->assertSame($original, $result['old'], 'old must equal the pre-rotation active key');
+        $this->assertNotEmpty($result['new'], 'new key must not be empty');
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $result['new']);
+        $this->assertNotSame($result['old'], $result['new'], 'New key must differ from old key');
+        $this->assertNotEmpty($result['rotated_at']);
+    }//end testRotationReturnsBothKeysAndTimestamp()
+
+    /**
+     * After rotation, getCurrentTenantKey returns the new key, not the old one.
+     */
+    public function testCurrentKeyAfterRotationIsNewKey(): void
+    {
+        $svc = $this->makeService();
+        $svc->getCurrentTenantKey('tenant-rot2');
+        $result  = $svc->rotateTenantKey('tenant-rot2');
+        $current = $svc->getCurrentTenantKey('tenant-rot2');
+
+        $this->assertSame($result['new'], $current, 'getCurrentTenantKey must return new key after rotation');
+    }//end testCurrentKeyAfterRotationIsNewKey()
+
+    /**
+     * After rotation the old row is retired (status = 'retired'), not deleted.
+     */
+    public function testRotationRetiresPreviousRow(): void
+    {
+        $svc = $this->makeService();
+        $svc->getCurrentTenantKey('tenant-retire');
+        $svc->rotateTenantKey('tenant-retire');
+
+        $retired = array_filter(
+            $this->store,
+            fn($row) => $row['tenant_id'] === 'tenant-retire' && $row['status'] === 'retired'
+        );
+
+        $this->assertCount(1, $retired, 'Previous row must be retired, not deleted');
+    }//end testRotationRetiresPreviousRow()
+
+    /**
+     * Rotation on a tenant with no prior key still succeeds.
+     * old is empty string, new is a valid 64-char hex key.
+     */
+    public function testRotationWithNoPriorKeySucceeds(): void
+    {
+        $svc    = $this->makeService();
+        $result = $svc->rotateTenantKey('brand-new-tenant');
+
+        $this->assertSame('', $result['old'], 'old must be empty string when no prior key exists');
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $result['new']);
+    }//end testRotationWithNoPriorKeySucceeds()
+
+    /**
+     * After rotation the store has exactly one active row and one retired row.
+     */
+    public function testStoreStateAfterRotation(): void
+    {
+        $svc = $this->makeService();
+        $svc->getCurrentTenantKey('tenant-state');
+        $svc->rotateTenantKey('tenant-state');
+
+        $tenantRows = array_values(
+            array_filter($this->store, fn($row) => $row['tenant_id'] === 'tenant-state')
+        );
+
+        $this->assertCount(2, $tenantRows, 'Two rows must exist: one retired, one active');
+
+        $statuses = array_column($tenantRows, 'status');
+        $this->assertContains('active', $statuses);
+        $this->assertContains('retired', $statuses);
+    }//end testStoreStateAfterRotation()
+
+    /**
+     * Encrypted keys are stored with the ENC: prefix (simulating ICrypto).
+     */
+    public function testEncryptedKeyIsStoredEncrypted(): void
+    {
+        $svc = $this->makeService();
+        $svc->getCurrentTenantKey('tenant-enc');
+
+        $rows = array_values(
+            array_filter($this->store, fn($row) => $row['tenant_id'] === 'tenant-enc')
+        );
+
+        $this->assertCount(1, $rows);
+        $this->assertStringStartsWith('ENC:', $rows[0]['encrypted_key'], 'Key must be stored encrypted');
+    }//end testEncryptedKeyIsStoredEncrypted()
+
+    /**
+     * The returned key is the decrypted plaintext, not the ciphertext.
+     */
+    public function testReturnedKeyIsPlaintext(): void
+    {
+        $svc = $this->makeService();
+        $key = $svc->getCurrentTenantKey('tenant-pt');
+
+        $this->assertStringNotContainsString('ENC:', $key, 'Returned key must be plaintext, not ciphertext');
+    }//end testReturnedKeyIsPlaintext()
+
+    // -------------------------------------------------------------------------
+    // Mock builder
+    // -------------------------------------------------------------------------
+
+    /**
+     * Build the IDBConnection mock backed by $this->store.
+     *
+     * @return IDBConnection&MockObject
+     */
+    private function buildDb(): IDBConnection&MockObject
+    {
+        $db = $this->createMock(IDBConnection::class);
+        $db->method('getQueryBuilder')->willReturnCallback(
+            fn() => $this->buildQb()
+        );
+
+        return $db;
+    }//end buildDb()
+
+    /**
+     * Build one IQueryBuilder mock that talks to $this->store.
+     *
+     * The builder tracks: op type (insert|update), values array, and set columns.
+     * createNamedParameter records the tenant_id (first non-status, non-ENC string < 100 chars
+     * that doesn't look like an ISO timestamp) into $this->lastTenantId.
+     *
+     * @return IQueryBuilder&MockObject
+     */
+    private function buildQb(): IQueryBuilder&MockObject
+    {
+        $expr = $this->createMock(IExpressionBuilder::class);
+        $expr->method('eq')->willReturn('1=1');
+
+        $qb = $this->createMock(IQueryBuilder::class);
+
+        // Mutable op-context captured by closures.
+        $ctx = ['type' => null, 'values' => [], 'set' => []];
+
+        $qb->method('select')->willReturn($qb);
+        $qb->method('from')->willReturn($qb);
+        $qb->method('where')->willReturn($qb);
+        $qb->method('andWhere')->willReturn($qb);
+        $qb->method('orderBy')->willReturn($qb);
+        $qb->method('setMaxResults')->willReturn($qb);
+        $qb->method('expr')->willReturn($expr);
+
+        $qb->method('insert')->willReturnCallback(
+                function (string $table) use ($qb, &$ctx) {
+                    $ctx['type'] = 'insert';
+                    return $qb;
+                }
+                );
+
+        $qb->method('update')->willReturnCallback(
+                function (string $table) use ($qb, &$ctx) {
+                    $ctx['type'] = 'update';
+                    return $qb;
+                }
+                );
+
+        $qb->method('values')->willReturnCallback(
+                function (array $values) use ($qb, &$ctx) {
+                    $ctx['values'] = $values;
+                    return $qb;
+                }
+                );
+
+        $qb->method('set')->willReturnCallback(
+                function (string $col, mixed $val) use ($qb, &$ctx) {
+                    $ctx['set'][$col] = $val;
+                    return $qb;
+                }
+                );
+
+        // CreateNamedParameter: return the plain value and track tenant ID.
+        // Sniff the tenant_id: anything that looks like our tenant UUID/string
+        // (not 'active'/'retired', not 'ENC:*', not an ISO date, shorter than 100 chars).
+        $knownStatuses = ['active', 'retired'];
+        $qb->method('createNamedParameter')->willReturnCallback(
+            function (mixed $value) use ($knownStatuses) {
+                if (is_string($value) === true
+                    && strlen($value) < 100
+                    && in_array($value, $knownStatuses, true) === false
+                    && str_starts_with($value, 'ENC:') === false
+                    && preg_match('/^\d{4}-/', $value) === 0
+                ) {
+                    $this->lastTenantId = $value;
+                }
+
+                return $value;
+            }
+        );
+
+        // ExecuteQuery: SELECT returns matching active rows for lastTenantId.
+        $qb->method('executeQuery')->willReturnCallback(
+            function () {
+                $tid      = $this->lastTenantId;
+                $matching = array_values(
+                    array_filter(
+                        $this->store,
+                        fn($row) => $row['tenant_id'] === $tid && $row['status'] === 'active'
+                    )
+                );
+                // Sort by id DESC (service picks setMaxResults(1) = most-recent active row).
+                usort($matching, fn($a, $b) => $b['id'] <=> $a['id']);
+                $remaining = $matching;
+
+                $result = $this->createMock(\OCP\DB\IResult::class);
+                $result->method('fetch')->willReturnCallback(
+                    function () use (&$remaining) {
+                        return (empty($remaining) === true) ? false : array_shift($remaining);
+                    }
+                );
+                $result->method('closeCursor')->willReturn(true);
+
+                return $result;
+            }
+        );
+
+        // ExecuteStatement: INSERT or UPDATE against $this->store.
+        $qb->method('executeStatement')->willReturnCallback(
+            function () use (&$ctx) {
+                if ($ctx['type'] === 'insert') {
+                    $id = $this->nextId++;
+                    $this->store[$id] = [
+                        'id'            => $id,
+                        'tenant_id'     => $ctx['values']['tenant_id'],
+                        'encrypted_key' => $ctx['values']['encrypted_key'],
+                        'status'        => $ctx['values']['status'],
+                        'created_at'    => $ctx['values']['created_at'],
+                    ];
+                } else if ($ctx['type'] === 'update') {
+                    // Retire all active rows for the current tenant.
+                    $tid = $this->lastTenantId;
+                    foreach ($this->store as $id => $row) {
+                        if ($row['tenant_id'] === $tid && $row['status'] === 'active') {
+                            $this->store[$id]['status'] = $ctx['set']['status'] ?? 'retired';
+                        }
+                    }
+                }
+
+                return 1;
+            }
+        );
+
+        return $qb;
+    }//end buildQb()
+}//end class


### PR DESCRIPTION
## Summary

- Adds `TenantKeyService` with `getCurrentTenantKey(string $tenantId): string` and `rotateTenantKey(string $tenantId): array`
- Keys are 256-bit CSPRNG values encrypted at rest via `OCP\Security\ICrypto`; never exposed through any REST endpoint
- Bootstrap on first call per tenant; subsequent reads return same plaintext key until rotation is performed
- Rotation retires the previous row (status `retired`, retained for re-verification) and inserts a fresh `active` row
- Migration `Version1Date20260511100000` creates `openregister_tenant_keys` table with `tenant_id`, `encrypted_key`, `status`, `created_at` columns
- Service wired into DI via `registerSettingsServices()` in `Application::register`

## Behaviour contract

| Scenario | Result |
|---|---|
| First call for new tenant | Generates + stores + returns fresh 64-char hex key |
| Repeated call for same tenant | Returns identical key (no new row inserted) |
| `rotateTenantKey` | Returns `{old, new, rotated_at}`; old row → `retired`; new row → `active` |
| `rotateTenantKey` on tenant with no prior key | `old = ""`, new key bootstrapped |
| `getCurrentTenantKey` after rotation | Returns new key |

## Test plan

- [x] 11 PHPUnit unit tests covering all scenarios above (run in Docker, all green)
- [x] PHPCS clean on `lib/` files in Docker container (same env as CI)
- [x] PHPMD clean
- [ ] CI quality pipeline (triggered by PR open)

**DO NOT admin-merge** — OR is production-tier; awaiting review.

Addresses: [openregister#1470 §2](https://github.com/ConductionNL/openregister/issues/1470)