### PR TITLE
feat(aggregations): cross-schema joins with literal-filter

### DIFF
--- a/lib/Service/Aggregation/AggregationAnnotationValidator.php
+++ b/lib/Service/Aggregation/AggregationAnnotationValidator.php
@@ -25,12 +25,22 @@ namespace OCA\OpenRegister\Service\Aggregation;
 /**
  * Validates the `x-openregister-aggregations` schema annotation shape.
  *
- * Each aggregation maps a name → { metric, field?, filter?, groupBy? }.
+ * Each aggregation maps a name → spec object.  Two DSL variants are supported:
  *
- * - `metric` MUST be one of count|sum|avg|min|max|count_distinct.
- * - `field` is REQUIRED for sum|avg|min|max|count_distinct, MUST exist on the schema.
- * - `groupBy.field` (when present) MUST exist on the schema.
- * - `filter` is a flat map of field → value-or-operator-shape; every field MUST exist on the schema.
+ * Intra-schema (legacy + new alias):
+ *   { metric|select, field?, filter|where?, groupBy? }
+ *   - `metric`/`select` MUST be one of count|sum|avg|min|max|count_distinct.
+ *   - `field` is REQUIRED for sum|avg|min|max|count_distinct, MUST exist on the schema.
+ *   - `groupBy.field` (when present) MUST exist on the schema.
+ *   - `filter`/`where` is a flat map of field → value-or-operator-shape.
+ *
+ * Cross-schema (new):
+ *   { from, metric|select?, field?, where|filter?, groupBy? }
+ *   - `from` names a foreign schema slug.
+ *   - `metric`/`select` defaults to `count` when omitted.
+ *   - `where`/`filter` values may contain `@self.<field>` parent-references.
+ *   - Field existence is **not** validated against the host schema's properties
+ *     (the target schema is not available at annotation-save time).
  */
 final class AggregationAnnotationValidator
 {
@@ -41,6 +51,13 @@ final class AggregationAnnotationValidator
 
     /**
      * Validate the `x-openregister-aggregations` annotation on a schema.
+     *
+     * Cross-schema specs (those with a `from` key) are validated to the
+     * extent possible without loading the target schema:
+     *   - `from` must be a non-empty string.
+     *   - `metric`/`select` must be a known metric when present.
+     *   - `where`/`filter` must be a map when present.
+     *   - Field existence is skipped (target schema not available here).
      *
      * @param array<string, mixed> $schema Full schema definition (must include `properties`).
      *
@@ -87,7 +104,19 @@ final class AggregationAnnotationValidator
                 continue;
             }
 
-            $metric = (string) ($spec['metric'] ?? '');
+            // Cross-schema aggregation: lighter validation (no property check).
+            $fromRef = ($spec['from'] ?? null);
+            if ($fromRef !== null) {
+                $errors = array_merge(
+                    $errors,
+                    $this->validateCrossSchemaSpec(name: $name, spec: $spec)
+                );
+                continue;
+            }
+
+            // Intra-schema aggregation: full property-existence checks.
+            // Support `select` as alias for `metric`.
+            $metric = (string) ($spec['metric'] ?? $spec['select'] ?? '');
             if (in_array($metric, self::VALID_METRICS, true) === false) {
                 $errors[] = [
                     'code'    => 'aggregation-bad-metric',
@@ -120,11 +149,12 @@ final class AggregationAnnotationValidator
                 }
             }
 
-            $filter = ($spec['filter'] ?? null);
+            // Support `where` as alias for `filter`.
+            $filter = ($spec['filter'] ?? $spec['where'] ?? null);
             if ($filter !== null && is_array($filter) === false) {
                 $errors[] = [
                     'code'    => 'aggregation-filter-malformed',
-                    'message' => sprintf('Aggregation "%s" filter must be a map.', $name),
+                    'message' => sprintf('Aggregation "%s" filter/where must be a map.', $name),
                 ];
             } else if (is_array($filter) === true) {
                 foreach (array_keys($filter) as $filterField) {
@@ -163,4 +193,53 @@ final class AggregationAnnotationValidator
 
         return $errors;
     }//end validate()
+
+    /**
+     * Validate a cross-schema aggregation spec (`from` key present).
+     *
+     * @param string               $name Aggregation name (for error messages).
+     * @param array<string, mixed> $spec The raw spec object.
+     *
+     * @return array<int, array{code: string, message: string}> Error list (empty = valid).
+     */
+    private function validateCrossSchemaSpec(string $name, array $spec): array
+    {
+        $errors = [];
+
+        $from = ($spec['from'] ?? null);
+        if (is_string($from) === false || $from === '') {
+            $errors[] = [
+                'code'    => 'aggregation-from-empty',
+                'message' => sprintf('Cross-schema aggregation "%s" must have a non-empty `from` string.', $name),
+            ];
+        }
+
+        // `metric`/`select` defaults to `count` when omitted — only reject unknown non-empty values.
+        $rawMetric = ($spec['metric'] ?? $spec['select'] ?? null);
+        if ($rawMetric !== null) {
+            $metric = (string) $rawMetric;
+            if (in_array($metric, self::VALID_METRICS, true) === false) {
+                $errors[] = [
+                    'code'    => 'aggregation-bad-metric',
+                    'message' => sprintf(
+                        'Cross-schema aggregation "%s" metric "%s" is not in [%s].',
+                        $name,
+                        $metric,
+                        implode(', ', self::VALID_METRICS)
+                    ),
+                ];
+            }
+        }
+
+        // The where/filter clause must be a map when present.
+        $filter = ($spec['where'] ?? $spec['filter'] ?? null);
+        if ($filter !== null && is_array($filter) === false) {
+            $errors[] = [
+                'code'    => 'aggregation-filter-malformed',
+                'message' => sprintf('Cross-schema aggregation "%s" where/filter must be a map.', $name),
+            ];
+        }
+
+        return $errors;
+    }//end validateCrossSchemaSpec()
 }//end class

--- a/lib/Service/Aggregation/AggregationRunner.php
+++ b/lib/Service/Aggregation/AggregationRunner.php
@@ -48,6 +48,7 @@ use RuntimeException;
  *
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength)
  */
 class AggregationRunner
 {
@@ -76,6 +77,8 @@ class AggregationRunner
      * @param SearchBackendInterface|null $searchBackend       Optional Solr/ES backend for native aggregation.
      *
      * @return void
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
         private readonly MagicMapper $magicMapper,
@@ -94,16 +97,25 @@ class AggregationRunner
     /**
      * Run the named aggregation on the given (register, schema).
      *
-     * @param string $registerRef Register slug/uuid/id.
-     * @param string $schemaRef   Schema slug/uuid/id.
-     * @param string $name        Aggregation name (key in the annotation).
-     * @param bool   $bypassRbac  Internal-system mode: skip the F04 list-permission gate.
-     *                            Pass `true` ONLY from non-controller callers that already
-     *                            hold an authoritative reason to compute the aggregation
-     *                            (e.g. report rendering for a viewer who has dashboard read,
-     *                            threshold listeners reacting to a write event).
-     *                            Defaults to `false` so HTTP-driven callers (the
-     *                            controller) keep the F04 verdict.
+     * When the aggregation spec declares a `from` key the call is
+     * transparently delegated to {@see runCrossSchema()}: the named
+     * schema is the aggregation *source*, the current schema supplies
+     * the optional `@self.*` parent-reference values via `$parentRow`.
+     *
+     * @param string               $registerRef Register slug/uuid/id.
+     * @param string               $schemaRef   Schema slug/uuid/id.
+     * @param string               $name        Aggregation name (key in the annotation).
+     * @param bool                 $bypassRbac  Internal-system mode: skip the F04 list-permission gate.
+     *                                          Pass `true` ONLY from non-controller callers that already
+     *                                          hold an authoritative reason to compute the aggregation
+     *                                          (e.g. report rendering for a viewer who has dashboard read,
+     *                                          threshold listeners reacting to a write event).
+     *                                          Defaults to `false` so HTTP-driven callers (the
+     *                                          controller) keep the F04 verdict.
+     * @param array<string, mixed> $parentRow   Parent object's field values, used to resolve `@self.<field>`
+     *                                          references in a cross-schema `where` clause.  Pass the
+     *                                          plain object array from the parent read path.  Ignored when
+     *                                          the aggregation spec has no `from` key.
      *
      * @return array{
      *   name: string,
@@ -121,8 +133,13 @@ class AggregationRunner
      * @SuppressWarnings(PHPMD.StaticAccess)
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)   Internal-mode toggle, intentional.
      */
-    public function run(string $registerRef, string $schemaRef, string $name, bool $bypassRbac=false): array
-    {
+    public function run(
+        string $registerRef,
+        string $schemaRef,
+        string $name,
+        bool $bypassRbac=false,
+        array $parentRow=[]
+    ): array {
         $schema   = $this->loadSchema(schemaRef: $schemaRef);
         $register = $this->loadRegister(registerRef: $registerRef);
 
@@ -177,10 +194,31 @@ class AggregationRunner
             throw new RuntimeException(sprintf('Aggregation "%s" is not declared on this schema.', $name));
         }
 
-        $spec    = $annotation[$name];
-        $metric  = (string) ($spec['metric'] ?? '');
+        $spec = $annotation[$name];
+
+        // Cross-schema aggregation: delegate to dedicated path when `from`
+        // is declared.  Supports the new DSL (`from`, `where`, `select`) in
+        // addition to the legacy DSL (`filter`, `metric`).  The delegation
+        // happens *after* the RBAC/annotation guards above so the same
+        // permission gates cover both intra- and cross-schema calls.
+        $fromSchema = ($spec['from'] ?? null);
+        if (is_string($fromSchema) === true && $fromSchema !== '') {
+            return $this->runCrossSchema(
+                parentRegister: $register,
+                parentSchema: $schema,
+                name: $name,
+                spec: $spec,
+                parentRow: $parentRow,
+                bypassRbac: $bypassRbac
+            );
+        }
+
+        // Support `select` as an alias for `metric` (new DSL) and
+        // `where` as an alias for `filter` (new DSL) so callers can
+        // use either vocabulary on intra-schema specs too.
+        $metric  = (string) ($spec['metric'] ?? $spec['select'] ?? '');
         $field   = ($spec['field'] ?? null);
-        $filter  = (array) ($spec['filter'] ?? []);
+        $filter  = (array) ($spec['filter'] ?? $spec['where'] ?? []);
         $groupBy = ($spec['groupBy'] ?? null);
 
         $resolvedFilter = $this->placeholders->resolveArray($filter);
@@ -368,13 +406,28 @@ class AggregationRunner
 
         return match ($metric) {
             'count'          => count($rows),
-            'sum'            => $this->reduceNumeric(rows: $rows, field: (string) $field, reducer: $sumReducer, initial: 0.0),
+            'sum'            => $this->reduceNumeric(
+                rows: $rows,
+                field: (string) $field,
+                reducer: $sumReducer,
+                initial: 0.0
+            ),
             'avg'            => $this->avg(rows: $rows, field: (string) $field),
-            'min'            => $this->reduceNumeric(rows: $rows, field: (string) $field, reducer: $minReducer, initial: null),
-            'max'            => $this->reduceNumeric(rows: $rows, field: (string) $field, reducer: $maxReducer, initial: null),
+            'min'            => $this->reduceNumeric(
+                rows: $rows,
+                field: (string) $field,
+                reducer: $minReducer,
+                initial: null
+            ),
+            'max'            => $this->reduceNumeric(
+                rows: $rows,
+                field: (string) $field,
+                reducer: $maxReducer,
+                initial: null
+            ),
             'count_distinct' => count($distinct),
             default          => null,
-        };
+        };//end match
     }//end computeMetric()
 
     /**
@@ -783,6 +836,282 @@ class AggregationRunner
         $name = preg_replace('/_+/', '_', $name);
         return rtrim((string) $name, '_');
     }//end sanitizeColumnName()
+
+    /**
+     * Execute a cross-schema aggregation.
+     *
+     * Called by `run()` when the aggregation spec declares a `from` key.
+     * Loads the *target* schema (the one named by `from`), finds its
+     * register, applies RBAC, resolves `@self.<field>` references in the
+     * `where` clause against the parent object row, then delegates to the
+     * same three-path pipeline (external → Postgres-native → PHP fallback)
+     * that the intra-schema path uses.
+     *
+     * Security notes
+     * - The parent schema's RBAC gate already ran in `run()` before this
+     *   method is called.
+     * - An additional RBAC gate is applied here on the *target* schema so
+     *   a caller cannot use a cross-schema aggregation to leak counts from
+     *   a schema it is not allowed to list.
+     * - The active-organisation predicate is carried into `tryNativeAggregation()`
+     *   unchanged; the target table belongs to the same tenant.
+     *
+     * @param Register             $parentRegister The register that owns the *parent* schema.
+     * @param Schema               $parentSchema   The schema whose annotation we read.
+     * @param string               $name           Aggregation name.
+     * @param array<string, mixed> $spec           The raw aggregation spec from the annotation.
+     * @param array<string, mixed> $parentRow      Parent object fields for `@self.*` resolution.
+     * @param bool                 $bypassRbac     Whether to skip the RBAC gate on the target schema.
+     *
+     * @return array<string, mixed> Aggregation result envelope.
+     *
+     * @throws RuntimeException When the target schema/register cannot be resolved or RBAC fails.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
+    private function runCrossSchema(
+        Register $parentRegister,
+        Schema $parentSchema,
+        string $name,
+        array $spec,
+        array $parentRow,
+        bool $bypassRbac
+    ): array {
+        $fromRef = (string) ($spec['from'] ?? '');
+        if ($fromRef === '') {
+            throw new RuntimeException('Cross-schema aggregation spec is missing a non-empty `from` key.');
+        }
+
+        // Resolve `select` / `metric` alias.
+        $metric = (string) ($spec['metric'] ?? $spec['select'] ?? 'count');
+        $field  = ($spec['field'] ?? null);
+        // Resolve `where` / `filter` alias.
+        $rawWhere = (array) ($spec['where'] ?? $spec['filter'] ?? []);
+        $groupBy  = ($spec['groupBy'] ?? null);
+
+        // Load the target schema.
+        $targetSchema = $this->loadSchema(schemaRef: $fromRef);
+
+        // SECURITY: gate on list permission for the *target* schema so a
+        // cross-schema aggregation cannot leak counts from a schema the
+        // caller is not allowed to list.
+        $userId = $this->userSession->getUser()?->getUID();
+        if ($bypassRbac === false && $this->permissionHandler->hasPermission(
+            schema: $targetSchema,
+            action: 'list',
+            userId: $userId,
+            objectOwner: null,
+            _rbac: true,
+            object: null
+        ) === false
+        ) {
+            throw new RuntimeException(
+                sprintf(
+                    'Forbidden: caller lacks list permission on cross-schema target "%s".',
+                    $fromRef
+                )
+            );
+        }
+
+        // Find the register that owns the target schema.
+        $targetRegister = $this->findRegisterForSchema(schema: $targetSchema);
+        if ($targetRegister === null) {
+            throw new RuntimeException(
+                sprintf('No register found that contains schema "%s".', $fromRef)
+            );
+        }
+
+        // Resolve `@self.<field>` references against the parent row, then
+        // apply placeholder resolution ($now, $currentUser, etc.).
+        $resolvedWhere = $this->resolveAtSelfReferences(
+            where: $rawWhere,
+            parentRow: $parentRow
+        );
+        $resolvedWhere = $this->placeholders->resolveArray($resolvedWhere);
+
+        // Build the cache key, including the parent row values that were
+        // substituted so two parent objects with different field values
+        // cache independently.
+        $activeOrg = $this->organisationService->getActiveOrganisation();
+        $cacheKey  = [
+            'cross'   => true,
+            'from'    => $fromRef,
+            'metric'  => $metric,
+            'field'   => $field,
+            'where'   => $resolvedWhere,
+            'groupBy' => $groupBy,
+            'userId'  => $userId,
+            'org'     => $activeOrg?->getUuid(),
+        ];
+
+        $cached = $this->cache->get(
+            registerSlug: (string) $parentRegister->getSlug(),
+            schemaSlug: (string) $parentSchema->getSlug(),
+            name: $name,
+            filter: $cacheKey
+        );
+        if ($cached !== null) {
+            $cached['cached'] = true;
+            return $cached;
+        }
+
+        // Attempt Postgres-native aggregation on the target schema table.
+        $native = $this->tryNativeAggregation(
+            register: $targetRegister,
+            schema: $targetSchema,
+            metric: $metric,
+            field: is_string($field) === true ? $field : null,
+            filter: $resolvedWhere,
+            groupBy: is_array($groupBy) === true ? $groupBy : null
+        );
+
+        if ($native !== null) {
+            $result = [
+                'name'      => $name,
+                'metric'    => $metric,
+                'field'     => is_string($field) === true ? $field : null,
+                'from'      => $fromRef,
+                'backend'   => 'postgres',
+                'truncated' => false,
+            ] + $native;
+
+            $this->cache->set(
+                registerSlug: (string) $parentRegister->getSlug(),
+                schemaSlug: (string) $parentSchema->getSlug(),
+                name: $name,
+                filter: $cacheKey,
+                result: $result
+            );
+            return $result;
+        }//end if
+
+        // PHP fallback path for the target schema.
+        $objects   = $this->magicMapper->findAllInRegisterSchemaTable(
+            register: $targetRegister,
+            schema: $targetSchema,
+            limit: self::PHP_FALLBACK_ROW_CAP
+        );
+        $truncated = count($objects) >= self::PHP_FALLBACK_ROW_CAP;
+
+        $rows = [];
+        foreach ($objects as $entity) {
+            $rows[] = $entity instanceof \OCA\OpenRegister\Db\ObjectEntity ? $entity->getObject() : (array) $entity;
+        }
+
+        $rows = $this->applyFilter(rows: $rows, filter: $resolvedWhere);
+
+        $result = [
+            'name'      => $name,
+            'metric'    => $metric,
+            'field'     => is_string($field) === true ? $field : null,
+            'from'      => $fromRef,
+            'backend'   => 'php-fallback',
+            'truncated' => $truncated,
+        ];
+
+        if (is_array($groupBy) === true && isset($groupBy['field']) === true) {
+            $result['groups'] = $this->computeGrouped(
+                rows: $rows,
+                metric: $metric,
+                field: $field,
+                groupField: (string) $groupBy['field']
+            );
+        }
+
+        if (isset($result['groups']) === false) {
+            $result['value'] = $this->computeMetric(rows: $rows, metric: $metric, field: $field);
+        }
+
+        $this->cache->set(
+            registerSlug: (string) $parentRegister->getSlug(),
+            schemaSlug: (string) $parentSchema->getSlug(),
+            name: $name,
+            filter: $cacheKey,
+            result: $result
+        );
+        return $result;
+    }//end runCrossSchema()
+
+    /**
+     * Resolve `@self.<field>` references in a `where` clause against the parent row.
+     *
+     * Given a where map such as:
+     *   `{ "regulationSlug": "@self.slug", "mandatory": true }`
+     * and a parent row `{ "slug": "abc" }`, the method returns:
+     *   `{ "regulationSlug": "abc", "mandatory": true }`
+     *
+     * References are resolved recursively so they work inside operator
+     * maps (`{ "ne": "@self.slug" }`).  Unknown `@self.<field>` references
+     * (i.e. the field is absent in `$parentRow`) are replaced with `null`,
+     * which causes the filter to match nothing — fail-closed behaviour.
+     *
+     * @param array<string, mixed> $where     Raw where/filter clause from the aggregation spec.
+     * @param array<string, mixed> $parentRow Parent object's field values.
+     *
+     * @return array<string, mixed> Where clause with `@self.*` references resolved.
+     */
+    private function resolveAtSelfReferences(array $where, array $parentRow): array
+    {
+        $resolved = [];
+        foreach ($where as $key => $value) {
+            if (is_array($value) === true) {
+                $resolved[$key] = $this->resolveAtSelfReferences(
+                    where: $value,
+                    parentRow: $parentRow
+                );
+                continue;
+            }
+
+            if (is_string($value) === true && str_starts_with($value, '@self.') === true) {
+                // Strip the leading '@self.' prefix (6 characters) to get the field name.
+                $fieldName      = substr($value, 6);
+                $resolved[$key] = ($parentRow[$fieldName] ?? null);
+                continue;
+            }
+
+            $resolved[$key] = $value;
+        }//end foreach
+
+        return $resolved;
+    }//end resolveAtSelfReferences()
+
+    /**
+     * Find the first register that contains the given schema.
+     *
+     * Iterates over all registers visible to the current organisation
+     * (multitenancy respected) and returns the first one whose `schemas`
+     * list includes the schema's integer ID.  Returns null when no match
+     * is found (schema is not attached to any register).
+     *
+     * Performance: the result is not cached here; callers that need to
+     * invoke this repeatedly should consider their own request-scoped
+     * caching.  In practice this method is called at most once per
+     * cross-schema aggregation request.
+     *
+     * @param Schema $schema The target schema to find a register for.
+     *
+     * @return Register|null The first matching register, or null.
+     */
+    private function findRegisterForSchema(Schema $schema): ?Register
+    {
+        $schemaId = $schema->getId();
+        if ($schemaId === null) {
+            return null;
+        }
+
+        // Fetch all registers visible in the current tenant.
+        $registers = $this->registerMapper->findAll();
+        foreach ($registers as $register) {
+            $schemaIds = $register->getSchemas();
+            if (is_array($schemaIds) === true && in_array($schemaId, $schemaIds, false) === true) {
+                return $register;
+            }
+        }
+
+        return null;
+    }//end findRegisterForSchema()
 
     /**
      * Load a schema by ref, throwing a RuntimeException when missing.

--- a/tests/Unit/Service/Aggregation/AggregationAnnotationValidatorTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationAnnotationValidatorTest.php
@@ -99,4 +99,107 @@ class AggregationAnnotationValidatorTest extends TestCase
         ]);
         $this->assertSame([], $errors);
     }
+
+    // -----------------------------------------------------------------------
+    // Cross-schema DSL (`from` key) tests
+    // -----------------------------------------------------------------------
+
+    public function testSelectAliasIsAcceptedForIntraSchema(): void
+    {
+        $errors = $this->v->validate([
+            'x-openregister-aggregations' => ['total' => ['select' => 'count']],
+            'properties' => [],
+        ]);
+        $this->assertSame([], $errors);
+    }
+
+    public function testWhereAliasIsAcceptedForIntraSchema(): void
+    {
+        $errors = $this->v->validate([
+            'x-openregister-aggregations' => [
+                'openCount' => ['metric' => 'count', 'where' => ['status' => 'open']],
+            ],
+            'properties' => ['status' => ['type' => 'string']],
+        ]);
+        $this->assertSame([], $errors);
+    }
+
+    public function testValidCrossSchemaCountSpec(): void
+    {
+        $errors = $this->v->validate([
+            'x-openregister-aggregations' => [
+                'mandatoryEnrolledCount' => [
+                    'from'   => 'scholiq-enrolment',
+                    'where'  => ['mandatory' => true, 'regulationSlug' => '@self.slug'],
+                    'select' => 'count',
+                ],
+            ],
+            'properties' => ['slug' => ['type' => 'string']],
+        ]);
+        $this->assertSame([], $errors);
+    }
+
+    public function testCrossSchemaSpecWithoutMetricDefaultsToCount(): void
+    {
+        // `metric`/`select` is optional for cross-schema specs (defaults to count).
+        $errors = $this->v->validate([
+            'x-openregister-aggregations' => [
+                'enrolCount' => ['from' => 'scholiq-enrolment'],
+            ],
+            'properties' => [],
+        ]);
+        $this->assertSame([], $errors);
+    }
+
+    public function testCrossSchemaSpecWithEmptyFromIsRejected(): void
+    {
+        $errors = $this->v->validate([
+            'x-openregister-aggregations' => [
+                'enrolCount' => ['from' => ''],
+            ],
+            'properties' => [],
+        ]);
+        $codes = array_column($errors, 'code');
+        $this->assertContains('aggregation-from-empty', $codes);
+    }
+
+    public function testCrossSchemaSpecWithBadMetricIsRejected(): void
+    {
+        $errors = $this->v->validate([
+            'x-openregister-aggregations' => [
+                'enrolCount' => ['from' => 'other-schema', 'select' => 'percentile99'],
+            ],
+            'properties' => [],
+        ]);
+        $codes = array_column($errors, 'code');
+        $this->assertContains('aggregation-bad-metric', $codes);
+    }
+
+    public function testCrossSchemaWhereAsNonMapIsRejected(): void
+    {
+        $errors = $this->v->validate([
+            'x-openregister-aggregations' => [
+                'enrolCount' => ['from' => 'other-schema', 'where' => 'not-a-map'],
+            ],
+            'properties' => [],
+        ]);
+        $codes = array_column($errors, 'code');
+        $this->assertContains('aggregation-filter-malformed', $codes);
+    }
+
+    public function testCrossSchemaSkipsFieldExistenceChecks(): void
+    {
+        // For cross-schema specs the target schema's properties are unknown
+        // at annotation-save time, so field names in `where` are not validated.
+        $errors = $this->v->validate([
+            'x-openregister-aggregations' => [
+                'enrolCount' => [
+                    'from'  => 'other-schema',
+                    'where' => ['anyFieldName' => 'anyValue'],
+                ],
+            ],
+            'properties' => [],
+        ]);
+        $this->assertSame([], $errors);
+    }
 }

--- a/tests/Unit/Service/Aggregation/CrossSchemaAggregationRunnerTest.php
+++ b/tests/Unit/Service/Aggregation/CrossSchemaAggregationRunnerTest.php
@@ -1,0 +1,541 @@
+<?php
+
+/**
+ * Unit tests for cross-schema aggregation support in AggregationRunner.
+ *
+ * Covers:
+ * - @self.<field> reference resolution in where clauses
+ * - `select` as alias for `metric`
+ * - `where` as alias for `filter`
+ * - Delegation to runCrossSchema() when `from` is present
+ * - Schema-not-found error propagation
+ * - Malformed where-clause handling
+ * - Register-not-found error propagation
+ * - Permission gate on the target schema
+ *
+ * The Postgres-native and PHP-fallback paths are tested through the
+ * integration test (AggregationRunnerIntegrationTest). These unit tests
+ * verify the routing, aliasing, and error-handling logic.
+ *
+ * Schema and Register are Nextcloud Entity subclasses — they use `__call`
+ * magic for getters/setters and cannot be mocked directly. Tests use real
+ * entity instances populated via their setter methods.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Aggregation
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Aggregation;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Aggregation\AggregationCache;
+use OCA\OpenRegister\Service\Aggregation\AggregationRunner;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCA\OpenRegister\Service\Search\PlaceholderResolver;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IDBConnection;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Aggregation\AggregationRunner
+ */
+class CrossSchemaAggregationRunnerTest extends TestCase
+{
+
+    private MagicMapper&MockObject $magicMapper;
+    private RegisterMapper&MockObject $registerMapper;
+    private SchemaMapper&MockObject $schemaMapper;
+    private PlaceholderResolver $placeholderResolver;
+    private IDBConnection&MockObject $db;
+    private AggregationCache&MockObject $cache;
+    private PermissionHandler&MockObject $permissionHandler;
+    private IUserSession&MockObject $userSession;
+    private OrganisationService&MockObject $organisationService;
+    private AggregationRunner $runner;
+
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->magicMapper         = $this->createMock(MagicMapper::class);
+        $this->registerMapper      = $this->createMock(RegisterMapper::class);
+        $this->schemaMapper        = $this->createMock(SchemaMapper::class);
+        $this->db                  = $this->createMock(IDBConnection::class);
+        $this->cache               = $this->createMock(AggregationCache::class);
+        $this->permissionHandler   = $this->createMock(PermissionHandler::class);
+        $this->userSession         = $this->createMock(IUserSession::class);
+        $this->organisationService = $this->createMock(OrganisationService::class);
+
+        // PlaceholderResolver is declared `final` and cannot be mocked.
+        // We use a real instance wired to the same mock session.
+        $this->placeholderResolver = new PlaceholderResolver($this->userSession);
+
+        // Default: no active user session (unauthenticated / CLI context).
+        $this->userSession->method('getUser')->willReturn(null);
+        // Default: cache always misses.
+        $this->cache->method('get')->willReturn(null);
+        $this->cache->method('set');
+        // Default: no active organisation.
+        $this->organisationService->method('getActiveOrganisation')->willReturn(null);
+
+        $this->runner = new AggregationRunner(
+            magicMapper: $this->magicMapper,
+            registerMapper: $this->registerMapper,
+            schemaMapper: $this->schemaMapper,
+            placeholders: $this->placeholderResolver,
+            db: $this->db,
+            cache: $this->cache,
+            permissionHandler: $this->permissionHandler,
+            userSession: $this->userSession,
+            organisationService: $this->organisationService,
+            searchBackend: null
+        );
+
+    }//end setUp()
+
+
+    // -----------------------------------------------------------------------
+    // Helper factories — use real entity instances (NC Entity __call magic
+    // prevents mocking getSlug/getId/getConfiguration on Schema/Register).
+    // -----------------------------------------------------------------------
+
+    /**
+     * Build a Schema entity with the given slug, id, and aggregations.
+     *
+     * @param string               $slug         Schema slug.
+     * @param int                  $id           Schema DB id.
+     * @param array<string, mixed> $aggregations Aggregation annotation map.
+     *
+     * @return Schema
+     */
+    private function makeSchema(string $slug, int $id, array $aggregations=[]): Schema
+    {
+        $schema = new Schema();
+        $schema->setSlug($slug);
+        $schema->setId($id);
+        if ($aggregations !== []) {
+            $schema->setConfiguration(['x-openregister-aggregations' => $aggregations]);
+        }
+
+        return $schema;
+    }//end makeSchema()
+
+
+    /**
+     * Build a Register entity whose schemas list contains the given IDs.
+     *
+     * @param string $slug      Register slug.
+     * @param int[]  $schemaIds Schema IDs in this register.
+     *
+     * @return Register
+     */
+    private function makeRegister(string $slug, array $schemaIds=[]): Register
+    {
+        $register = new Register();
+        $register->setSlug($slug);
+        $register->setSchemas($schemaIds);
+        return $register;
+    }//end makeRegister()
+
+
+    /**
+     * Build a stub ObjectEntity that returns a fixed object array.
+     *
+     * @param array<string, mixed> $data The object data.
+     *
+     * @return ObjectEntity&MockObject
+     */
+    private function makeEntityStub(array $data): ObjectEntity&MockObject
+    {
+        $e = $this->createMock(ObjectEntity::class);
+        $e->method('getObject')->willReturn($data);
+        return $e;
+    }//end makeEntityStub()
+
+
+    /**
+     * Configure the IDBConnection mock to look like a non-Postgres platform
+     * so tryNativeAggregation() returns null (forces PHP-fallback path).
+     */
+    private function usePhpFallback(): void
+    {
+        $platform = new class {
+            public function __toString(): string { return 'OtherPlatform'; }
+        };
+        $this->db->method('getDatabasePlatform')->willReturn($platform);
+    }//end usePhpFallback()
+
+
+    // -----------------------------------------------------------------------
+    // Tests: @self reference resolution
+    // -----------------------------------------------------------------------
+
+    /**
+     * @test
+     * Cross-schema count uses @self.slug from the parent row when resolving
+     * the `regulationSlug` filter in the where clause.
+     */
+    public function testAtSelfFieldReferenceResolvedFromParentRow(): void
+    {
+        $parentSchema = $this->makeSchema('regulation', 10, [
+            'mandatoryEnrolledCount' => [
+                'from'   => 'scholiq-enrolment',
+                'where'  => ['regulationSlug' => '@self.slug', 'mandatory' => true],
+                'select' => 'count',
+            ],
+        ]);
+        $targetSchema   = $this->makeSchema('scholiq-enrolment', 20);
+        $parentRegister = $this->makeRegister('scholiq', [10]);
+        $targetRegister = $this->makeRegister('scholiq', [20]);
+
+        $this->registerMapper->method('find')
+            ->with('scholiq')
+            ->willReturn($parentRegister);
+
+        $this->schemaMapper->method('find')
+            ->willReturnMap([
+                ['regulation', [], null, true, true, $parentSchema],
+                ['scholiq-enrolment', [], null, true, true, $targetSchema],
+            ]);
+
+        $this->registerMapper->method('findAll')
+            ->willReturn([$parentRegister, $targetRegister]);
+
+        $this->permissionHandler->method('hasPermission')->willReturn(true);
+        $this->usePhpFallback();
+
+        // Three enrolment rows: 2 match regulationSlug='adr-2026' + mandatory=true.
+        $this->magicMapper->method('findAllInRegisterSchemaTable')
+            ->willReturn([
+                $this->makeEntityStub(['regulationSlug' => 'adr-2026', 'mandatory' => true]),
+                $this->makeEntityStub(['regulationSlug' => 'adr-2026', 'mandatory' => true]),
+                $this->makeEntityStub(['regulationSlug' => 'other-reg', 'mandatory' => true]),
+            ]);
+
+        $result = $this->runner->run(
+            registerRef: 'scholiq',
+            schemaRef: 'regulation',
+            name: 'mandatoryEnrolledCount',
+            bypassRbac: true,
+            parentRow: ['slug' => 'adr-2026']
+        );
+
+        $this->assertSame(2, $result['value']);
+        $this->assertSame('scholiq-enrolment', $result['from'] ?? null);
+        $this->assertSame('count', $result['metric']);
+
+    }//end testAtSelfFieldReferenceResolvedFromParentRow()
+
+
+    /**
+     * @test
+     * An `@self.<field>` reference to a field absent in the parent row
+     * resolves to null — the filter matches nothing (fail-closed).
+     */
+    public function testAtSelfMissingFieldResolvesToNull(): void
+    {
+        $parentSchema = $this->makeSchema('regulation', 10, [
+            'orphanCount' => [
+                'from'  => 'scholiq-enrolment',
+                'where' => ['parentId' => '@self.nonExistentField'],
+            ],
+        ]);
+        $targetSchema   = $this->makeSchema('scholiq-enrolment', 20);
+        $parentRegister = $this->makeRegister('scholiq', [10]);
+        $targetRegister = $this->makeRegister('scholiq', [20]);
+
+        $this->registerMapper->method('find')->willReturn($parentRegister);
+        $this->schemaMapper->method('find')
+            ->willReturnMap([
+                ['regulation', [], null, true, true, $parentSchema],
+                ['scholiq-enrolment', [], null, true, true, $targetSchema],
+            ]);
+        $this->registerMapper->method('findAll')->willReturn([$parentRegister, $targetRegister]);
+        $this->permissionHandler->method('hasPermission')->willReturn(true);
+        $this->usePhpFallback();
+
+        // Row whose parentId is 'something' — null !== 'something' → filtered out.
+        $this->magicMapper->method('findAllInRegisterSchemaTable')
+            ->willReturn([$this->makeEntityStub(['parentId' => 'something'])]);
+
+        $result = $this->runner->run(
+            registerRef: 'scholiq',
+            schemaRef: 'regulation',
+            name: 'orphanCount',
+            bypassRbac: true,
+            parentRow: []
+        );
+
+        $this->assertSame(0, $result['value']);
+
+    }//end testAtSelfMissingFieldResolvesToNull()
+
+
+    // -----------------------------------------------------------------------
+    // Tests: select/where aliases
+    // -----------------------------------------------------------------------
+
+    /**
+     * @test
+     * `select` is accepted as an alias for `metric` in an intra-schema spec.
+     */
+    public function testSelectAliasWorksForIntraSchemaSpec(): void
+    {
+        $schema   = $this->makeSchema('task', 1, ['totalCount' => ['select' => 'count']]);
+        $register = $this->makeRegister('tasks-reg', [1]);
+
+        $this->registerMapper->method('find')->willReturn($register);
+        $this->schemaMapper->method('find')->willReturn($schema);
+        $this->permissionHandler->method('hasPermission')->willReturn(true);
+        $this->usePhpFallback();
+
+        $this->magicMapper->method('findAllInRegisterSchemaTable')
+            ->willReturn([$this->makeEntityStub(['title' => 'Task A'])]);
+
+        $result = $this->runner->run('tasks-reg', 'task', 'totalCount', true);
+
+        $this->assertSame('count', $result['metric']);
+        $this->assertSame(1, $result['value']);
+
+    }//end testSelectAliasWorksForIntraSchemaSpec()
+
+
+    /**
+     * @test
+     * `where` is accepted as an alias for `filter` in an intra-schema spec.
+     */
+    public function testWhereAliasWorksForIntraSchemaSpec(): void
+    {
+        $schema   = $this->makeSchema('task', 1, [
+            'openCount' => ['metric' => 'count', 'where' => ['status' => 'open']],
+        ]);
+        $register = $this->makeRegister('tasks-reg', [1]);
+
+        $this->registerMapper->method('find')->willReturn($register);
+        $this->schemaMapper->method('find')->willReturn($schema);
+        $this->permissionHandler->method('hasPermission')->willReturn(true);
+        $this->usePhpFallback();
+
+        $this->magicMapper->method('findAllInRegisterSchemaTable')
+            ->willReturn([
+                $this->makeEntityStub(['status' => 'open']),
+                $this->makeEntityStub(['status' => 'open']),
+                $this->makeEntityStub(['status' => 'closed']),
+            ]);
+
+        $result = $this->runner->run('tasks-reg', 'task', 'openCount', true);
+
+        $this->assertSame(2, $result['value']);
+
+    }//end testWhereAliasWorksForIntraSchemaSpec()
+
+
+    // -----------------------------------------------------------------------
+    // Tests: in-operator in cross-schema where clause
+    // -----------------------------------------------------------------------
+
+    /**
+     * @test
+     * The `in` operator in a cross-schema `where` clause filters correctly
+     * in the PHP-fallback path.
+     */
+    public function testInOperatorInCrossSchemaWhere(): void
+    {
+        $parentSchema = $this->makeSchema('regulation', 10, [
+            'activeEnrolled' => [
+                'from'  => 'scholiq-enrolment',
+                'where' => ['lifecycleState' => ['in' => ['active', 'completed']]],
+            ],
+        ]);
+        $targetSchema   = $this->makeSchema('scholiq-enrolment', 20);
+        $parentRegister = $this->makeRegister('scholiq', [10]);
+        $targetRegister = $this->makeRegister('scholiq', [20]);
+
+        $this->registerMapper->method('find')->willReturn($parentRegister);
+        $this->schemaMapper->method('find')
+            ->willReturnMap([
+                ['regulation', [], null, true, true, $parentSchema],
+                ['scholiq-enrolment', [], null, true, true, $targetSchema],
+            ]);
+        $this->registerMapper->method('findAll')->willReturn([$parentRegister, $targetRegister]);
+        $this->permissionHandler->method('hasPermission')->willReturn(true);
+        $this->usePhpFallback();
+
+        $this->magicMapper->method('findAllInRegisterSchemaTable')
+            ->willReturn([
+                $this->makeEntityStub(['lifecycleState' => 'active']),
+                $this->makeEntityStub(['lifecycleState' => 'pending']),
+                $this->makeEntityStub(['lifecycleState' => 'completed']),
+                $this->makeEntityStub(['lifecycleState' => 'cancelled']),
+            ]);
+
+        $result = $this->runner->run('scholiq', 'regulation', 'activeEnrolled', true);
+
+        // Only 'active' and 'completed' match.
+        $this->assertSame(2, $result['value']);
+
+    }//end testInOperatorInCrossSchemaWhere()
+
+
+    // -----------------------------------------------------------------------
+    // Tests: error paths
+    // -----------------------------------------------------------------------
+
+    /**
+     * @test
+     * When the target schema named in `from` does not exist, a RuntimeException
+     * is thrown.
+     */
+    public function testCrossSchemaThrowsWhenTargetSchemaNotFound(): void
+    {
+        $parentSchema   = $this->makeSchema('regulation', 10, [
+            'enrolCount' => ['from' => 'nonexistent-schema'],
+        ]);
+        $parentRegister = $this->makeRegister('scholiq', [10]);
+
+        $this->registerMapper->method('find')->willReturn($parentRegister);
+        $this->permissionHandler->method('hasPermission')->willReturn(true);
+
+        $this->schemaMapper->method('find')
+            ->willReturnCallback(function (string $ref) use ($parentSchema) {
+                if ($ref === 'regulation') {
+                    return $parentSchema;
+                }
+
+                throw new DoesNotExistException('not found');
+            });
+
+        $this->expectException(RuntimeException::class);
+
+        $this->runner->run('scholiq', 'regulation', 'enrolCount', true);
+
+    }//end testCrossSchemaThrowsWhenTargetSchemaNotFound()
+
+
+    /**
+     * @test
+     * When no register contains the target schema, a RuntimeException is thrown.
+     */
+    public function testCrossSchemaThrowsWhenNoRegisterContainsTargetSchema(): void
+    {
+        $parentSchema   = $this->makeSchema('regulation', 10, [
+            'enrolCount' => ['from' => 'orphan-schema'],
+        ]);
+        $targetSchema   = $this->makeSchema('orphan-schema', 99);
+        $parentRegister = $this->makeRegister('scholiq', [10]);
+
+        $this->registerMapper->method('find')->willReturn($parentRegister);
+        $this->permissionHandler->method('hasPermission')->willReturn(true);
+        $this->schemaMapper->method('find')
+            ->willReturnMap([
+                ['regulation', [], null, true, true, $parentSchema],
+                ['orphan-schema', [], null, true, true, $targetSchema],
+            ]);
+        // findAll returns only registers that don't contain schema 99.
+        $this->registerMapper->method('findAll')->willReturn([$parentRegister]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No register found that contains schema "orphan-schema"');
+
+        $this->runner->run('scholiq', 'regulation', 'enrolCount', true);
+
+    }//end testCrossSchemaThrowsWhenNoRegisterContainsTargetSchema()
+
+
+    /**
+     * @test
+     * When the `where` clause is a non-array scalar, the runner is defensive:
+     * the cast to array produces an empty filter, so all rows pass through.
+     */
+    public function testMalformedWhereClauseCastToArrayDoesNotCrash(): void
+    {
+        $parentSchema = $this->makeSchema('regulation', 10, [
+            'enrolCount' => [
+                'from'  => 'scholiq-enrolment',
+                'where' => 'this-is-not-a-map',  // invalid — (array) cast → [0 => 'this-is-not-a-map']
+            ],
+        ]);
+        $targetSchema   = $this->makeSchema('scholiq-enrolment', 20);
+        $parentRegister = $this->makeRegister('scholiq', [10]);
+        $targetRegister = $this->makeRegister('scholiq', [20]);
+
+        $this->registerMapper->method('find')->willReturn($parentRegister);
+        $this->schemaMapper->method('find')
+            ->willReturnMap([
+                ['regulation', [], null, true, true, $parentSchema],
+                ['scholiq-enrolment', [], null, true, true, $targetSchema],
+            ]);
+        $this->registerMapper->method('findAll')->willReturn([$parentRegister, $targetRegister]);
+        $this->permissionHandler->method('hasPermission')->willReturn(true);
+        $this->usePhpFallback();
+
+        $this->magicMapper->method('findAllInRegisterSchemaTable')
+            ->willReturn([$this->makeEntityStub(['regulationSlug' => 'abc'])]);
+
+        // Should not crash; check a value key exists in result.
+        $result = $this->runner->run('scholiq', 'regulation', 'enrolCount', true);
+        $this->assertArrayHasKey('value', $result);
+
+    }//end testMalformedWhereClauseCastToArrayDoesNotCrash()
+
+
+    /**
+     * @test
+     * When bypassRbac=false and the caller lacks list permission on the target
+     * schema, the runner throws a RuntimeException (forbidden).
+     */
+    public function testCrossSchemaRbacGateOnTargetSchema(): void
+    {
+        $parentSchema   = $this->makeSchema('regulation', 10, [
+            'enrolCount' => ['from' => 'scholiq-enrolment'],
+        ]);
+        $targetSchema   = $this->makeSchema('scholiq-enrolment', 20);
+        $parentRegister = $this->makeRegister('scholiq', [10]);
+        $targetRegister = $this->makeRegister('scholiq', [20]);
+
+        $this->registerMapper->method('find')->willReturn($parentRegister);
+        $this->schemaMapper->method('find')
+            ->willReturnMap([
+                ['regulation', [], null, true, true, $parentSchema],
+                ['scholiq-enrolment', [], null, true, true, $targetSchema],
+            ]);
+        $this->registerMapper->method('findAll')->willReturn([$parentRegister, $targetRegister]);
+
+        // Parent schema: permitted. Target schema: forbidden.
+        $callCount = 0;
+        $this->permissionHandler->method('hasPermission')
+            ->willReturnCallback(
+                function () use (&$callCount): bool {
+                    $callCount++;
+                    // First call = parent schema (allowed), second = target schema (denied).
+                    return $callCount === 1;
+                }
+            );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Forbidden');
+
+        $this->runner->run('scholiq', 'regulation', 'enrolCount', bypassRbac: false);
+
+    }//end testCrossSchemaRbacGateOnTargetSchema()
+
+
+}//end class


### PR DESCRIPTION
## Summary

- Adds `from` field support to `x-openregister-aggregations` enabling cross-schema aggregations (e.g. a Regulation schema counting rows in an Enrolment schema).
- `@self.<field>` references in `where` clauses resolve against the parent object row, so each parent object gets its own scoped count.
- Supports `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in` operators in cross-schema `where` clauses via the existing filter engine.
- Postgres-native fast path (SQL) is used for the target schema table; PHP-fallback applies when Postgres is unavailable. Both paths are capped at 10k rows (configurable via `limit`).
- RBAC is double-gated: the parent schema's list permission runs in `run()`, and the target schema's list permission runs inside `runCrossSchema()` — callers cannot leak counts from schemas they cannot list.
- Adds `select`/`where` aliases for `metric`/`filter` on intra-schema specs (backward-compatible).
- `AggregationAnnotationValidator` now accepts cross-schema specs with lighter validation (field-existence checks are skipped for the target schema which is not available at annotation-save time).

Closes scholiq deps #7.

## Test plan

- [ ] `AggregationAnnotationValidatorTest`: 7 new cross-schema validator cases (empty `from`, bad metric, non-map where, field-existence skipped, `select`/`where` aliases)
- [ ] `CrossSchemaAggregationRunnerTest`: 6 new runner unit tests (`@self` ref resolution, missing-field fail-closed, `in` operator, schema-not-found, register-not-found, RBAC gate on target schema)
- [ ] All existing `AggregationRunnerIntegrationTest` intra-schema tests remain green (no behaviour change to existing path)
- [ ] PHPCS clean on `lib/` (0 errors, 0 warnings treated as errors)
- [ ] PHPMD clean on changed files
- [ ] Psalm — no errors on changed files