### PR TITLE
feat(notifications): calculatedChange trigger (closes scholiq deps #3)

### DIFF
--- a/lib/Listener/AnnotationNotificationListener.php
+++ b/lib/Listener/AnnotationNotificationListener.php
@@ -81,11 +81,26 @@ class AnnotationNotificationListener implements IEventListener
         }
 
         if ($event instanceof ObjectUpdatedEvent) {
-            $object = $this->extractObject(event: $event);
-            if ($object !== null) {
-                $this->dispatcher->dispatch(object: $object, trigger: 'updated');
-            }
-        }
+            $newObject = $event->getNewObject();
+            $oldObject = $event->getOldObject();
+
+            $this->dispatcher->dispatch(object: $newObject, trigger: 'updated');
+
+            // Also evaluate calculatedChange rules when both old and new
+            // objects are available. Pass the previous and new calculated
+            // field values so the dispatcher can detect boundary crossings
+            // without re-reading versioned history.
+            if ($oldObject !== null) {
+                $this->dispatcher->dispatch(
+                    object: $newObject,
+                    trigger: 'calculatedChange',
+                    context: [
+                        '_newData' => $newObject->getObject() ?? [],
+                        '_oldData' => $oldObject->getObject() ?? [],
+                    ]
+                );
+            }//end if
+        }//end if
     }//end handle()
 
     /**

--- a/lib/Service/Notification/AnnotationNotificationDispatcher.php
+++ b/lib/Service/Notification/AnnotationNotificationDispatcher.php
@@ -92,8 +92,9 @@ class AnnotationNotificationDispatcher
      * Fire any notifications declared on the schema whose trigger matches.
      *
      * @param ObjectEntity         $object  The object the event happened on.
-     * @param string               $trigger 'created' | 'updated' | 'transition'.
-     * @param array<string, mixed> $context Trigger-specific extras (e.g. `action`, `from`, `to`).
+     * @param string               $trigger 'created' | 'updated' | 'transition' | 'calculatedChange'.
+     * @param array<string, mixed> $context Trigger-specific extras (e.g. `action`, `from`, `to`,
+     *                                      `_newData`, `_oldData` for calculatedChange).
      *
      * @return void
      *
@@ -772,11 +773,18 @@ class AnnotationNotificationDispatcher
     /**
      * Decide whether a notification's `trigger` block matches the active event.
      *
+     * For `calculatedChange` triggers, both `condition` (new value) and
+     * `previously` (old value) must be satisfied for the rule to fire —
+     * this is the boundary-crossing / debounce check.
+     *
      * @param array<string, mixed> $triggerSpec The declared `trigger` sub-document.
      * @param string               $trigger     The active event type.
      * @param array<string, mixed> $context     Per-event context (e.g. `action`).
      *
      * @return bool True when the rule should fire for this event.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
      */
     private function matches(array $triggerSpec, string $trigger, array $context): bool
     {
@@ -797,8 +805,87 @@ class AnnotationNotificationDispatcher
             }
         }
 
+        // `calculatedChange` boundary-crossing check.
+        // `field` names the calculated property to monitor.
+        // `condition` operators the NEW value must satisfy.
+        // `previously` operators the OLD value must satisfy.
+        // Both must hold simultaneously. When either condition or
+        // previously is absent the gate is open (partial spec is treated
+        // as "just the declared side must match"). When _newData/_oldData
+        // are absent in context (e.g. missing old object) the check
+        // cannot be evaluated and the rule is skipped (fail-closed).
+        if ($trigger === 'calculatedChange') {
+            $field = (string) ($triggerSpec['field'] ?? '');
+            if ($field === '') {
+                return false;
+            }
+
+            $newData = ($context['_newData'] ?? null);
+            $oldData = ($context['_oldData'] ?? null);
+            if (is_array($newData) === false || is_array($oldData) === false) {
+                return false;
+            }
+
+            $newValue = ($newData[$field] ?? null);
+            $oldValue = ($oldData[$field] ?? null);
+
+            $condition  = ($triggerSpec['condition'] ?? null);
+            $previously = ($triggerSpec['previously'] ?? null);
+
+            if (is_array($condition) === true
+                && $this->numericConditionMatches(value: $newValue, operators: $condition) === false
+            ) {
+                return false;
+            }
+
+            if (is_array($previously) === true
+                && $this->numericConditionMatches(value: $oldValue, operators: $previously) === false
+            ) {
+                return false;
+            }
+        }//end if
+
         return true;
     }//end matches()
+
+    /**
+     * Evaluate a set of plain comparison operators against a numeric value.
+     *
+     * Operators mirror the JSON-schema style used by the notification spec:
+     * `lt`, `lte`, `gt`, `gte`, `eq`, `ne`. All comparisons are numeric
+     * (int/float); a non-numeric value returns false for every ordering
+     * operator (`lt`, `lte`, `gt`, `gte`) and casts to string for `eq`/`ne`.
+     *
+     * Multiple operators in the map are ANDed together (all must hold).
+     *
+     * @param mixed                $value     The field value to test.
+     * @param array<string, mixed> $operators Map of operator → threshold (e.g. `['lt' => 0.85]`).
+     *
+     * @return bool True when the value satisfies every declared operator.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    private function numericConditionMatches(mixed $value, array $operators): bool
+    {
+        foreach ($operators as $op => $threshold) {
+            $numeric = is_numeric($value) === true && is_numeric($threshold) === true;
+            $result  = match ((string) $op) {
+                'lt'  => $numeric && (float) $value < (float) $threshold,
+                'lte' => $numeric && (float) $value <= (float) $threshold,
+                'gt'  => $numeric && (float) $value > (float) $threshold,
+                'gte' => $numeric && (float) $value >= (float) $threshold,
+                'eq'  => (string) $value === (string) $threshold,
+                'ne'  => (string) $value !== (string) $threshold,
+                default => false,
+            };
+
+            if ($result === false) {
+                return false;
+            }
+        }
+
+        return true;
+    }//end numericConditionMatches()
 
     /**
      * Resolve a `recipients` block to a flat list of UIDs.

--- a/lib/Service/Notification/NotificationAnnotationValidator.php
+++ b/lib/Service/Notification/NotificationAnnotationValidator.php
@@ -38,7 +38,7 @@ namespace OCA\OpenRegister\Service\Notification;
 final class NotificationAnnotationValidator
 {
 
-    private const VALID_TRIGGERS = ['created', 'updated', 'transition', 'scheduled', 'threshold'];
+    private const VALID_TRIGGERS = ['created', 'updated', 'transition', 'scheduled', 'threshold', 'calculatedChange'];
 
     private const VALID_RECIPIENT_KINDS = ['users', 'field', 'groups', 'relation', 'object-acl', 'expression'];
 
@@ -151,6 +151,55 @@ final class NotificationAnnotationValidator
                         ),
                     ];
                 }
+            }//end if
+
+            if ($triggerType === 'calculatedChange') {
+                $field = is_array($trigger) === true ? ($trigger['field'] ?? null) : null;
+                if (is_string($field) === false || $field === '') {
+                    $errors[] = [
+                        'code'    => 'notification-calculated-change-no-field',
+                        'message' => sprintf(
+                            'Notification "%s" trigger.type=calculatedChange requires trigger.field (non-empty string).',
+                            $name
+                        ),
+                    ];
+                }
+
+                $validOps = ['lt', 'lte', 'gt', 'gte', 'eq', 'ne'];
+
+                foreach (['condition', 'previously'] as $clauseKey) {
+                    $clause = is_array($trigger) === true ? ($trigger[$clauseKey] ?? null) : null;
+                    if ($clause === null) {
+                        continue;
+                    }
+
+                    if (is_array($clause) === false || count($clause) === 0) {
+                        $errors[] = [
+                            'code'    => 'notification-calculated-change-bad-clause',
+                            'message' => sprintf(
+                                'Notification "%s" trigger.%s must be a non-empty operator map.',
+                                $name,
+                                $clauseKey
+                            ),
+                        ];
+                        continue;
+                    }
+
+                    foreach (array_keys($clause) as $op) {
+                        if (in_array((string) $op, $validOps, true) === false) {
+                            $errors[] = [
+                                'code'    => 'notification-calculated-change-bad-op',
+                                'message' => sprintf(
+                                    'Notification "%s" trigger.%s operator "%s" must be one of [%s].',
+                                    $name,
+                                    $clauseKey,
+                                    (string) $op,
+                                    implode(', ', $validOps)
+                                ),
+                            ];
+                        }
+                    }
+                }//end foreach
             }//end if
 
             $channels = ($spec['channels'] ?? []);

--- a/tests/Unit/Service/Notification/CalculatedChangeTriggerTest.php
+++ b/tests/Unit/Service/Notification/CalculatedChangeTriggerTest.php
@@ -1,0 +1,380 @@
+<?php
+
+/**
+ * OpenRegister CalculatedChangeTriggerTest
+ *
+ * Unit tests for the `calculatedChange` notification trigger (issue #1470 §3).
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Notification
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Notification;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Notification\AnnotationNotificationDispatcher;
+use OCP\Activity\IManager as IActivityManager;
+use OCP\Http\Client\IClientService;
+use OCP\IGroupManager;
+use OCP\IServerContainer;
+use OCP\IUserManager;
+use OCP\Mail\IMailer;
+use OCP\Notification\IManager as INotificationManager;
+use OCP\Notification\INotification;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests for the calculatedChange notification trigger.
+ *
+ * Covers four debounce scenarios from the spec (issue #1470 §3):
+ * (a) First save below threshold — old value also below — no crossing.
+ * (b) Above-then-below crossing — both clauses satisfied — fires.
+ * (c) Below-then-still-below — previously clause fails — debounced.
+ * (d) Condition clause fails — new value not below threshold — no fire.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class CalculatedChangeTriggerTest extends TestCase
+{
+
+    /** @var SchemaMapper&MockObject */
+    private SchemaMapper $schemaMapper;
+
+    /** @var INotificationManager&MockObject */
+    private INotificationManager $notificationManager;
+
+    /** @var LoggerInterface&MockObject */
+    private LoggerInterface $logger;
+
+    /** @var IGroupManager&MockObject */
+    private IGroupManager $groupManager;
+
+    /** @var IUserManager&MockObject */
+    private IUserManager $userManager;
+
+    /** @var IMailer&MockObject */
+    private IMailer $mailer;
+
+    /** @var IActivityManager&MockObject */
+    private IActivityManager $activityManager;
+
+    /** @var IClientService&MockObject */
+    private IClientService $httpClient;
+
+    /** @var IServerContainer&MockObject */
+    private IServerContainer $serverContainer;
+
+
+    /**
+     * Set up mocks shared across all test methods.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->schemaMapper        = $this->createMock(SchemaMapper::class);
+        $this->notificationManager = $this->createMock(INotificationManager::class);
+        $this->logger              = $this->createMock(LoggerInterface::class);
+        $this->groupManager        = $this->createMock(IGroupManager::class);
+        $this->userManager         = $this->createMock(IUserManager::class);
+        $this->mailer              = $this->createMock(IMailer::class);
+        $this->activityManager     = $this->createMock(IActivityManager::class);
+        $this->httpClient          = $this->createMock(IClientService::class);
+        $this->serverContainer     = $this->createMock(IServerContainer::class);
+
+        // All UIDs resolve as real users so recipient filtering never drops them.
+        $this->userManager->method('userExists')->willReturn(true);
+
+    }//end setUp()
+
+
+    /**
+     * (a) First save: both new and old values are below 0.85.
+     * The `previously` clause (gte: 0.85) is NOT satisfied by the old value,
+     * so no boundary crossing occurred — the rule must NOT fire.
+     *
+     * @return void
+     */
+    public function testFirstSaveBelowThresholdDoesNotFire(): void
+    {
+        $schema = $this->schemaWithRule(condition: ['lt' => 0.85], previously: ['gte' => 0.85]);
+        $this->schemaMapper->method('find')->willReturn($schema);
+
+        $this->notificationManager->expects($this->never())->method('createNotification');
+
+        $dispatcher = $this->makeDispatcher();
+        $dispatcher->dispatch(
+            $this->objectWithCoverage(0.70),
+            'calculatedChange',
+            [
+                '_newData' => ['coveragePercent' => 0.70],
+                '_oldData' => ['coveragePercent' => 0.72],
+            ]
+        );
+
+    }//end testFirstSaveBelowThresholdDoesNotFire()
+
+
+    /**
+     * (b) Above-then-below crossing: old value was >= 0.85, new value is < 0.85.
+     * Both clauses are satisfied — the rule must fire exactly once.
+     *
+     * @return void
+     */
+    public function testAboveThenBelowCrossingFires(): void
+    {
+        $schema = $this->schemaWithRule(condition: ['lt' => 0.85], previously: ['gte' => 0.85]);
+        $this->schemaMapper->method('find')->willReturn($schema);
+
+        $delivered = [];
+        $this->captureDeliveredUids($delivered);
+
+        $dispatcher = $this->makeDispatcher();
+        $dispatcher->dispatch(
+            $this->objectWithCoverage(0.80),
+            'calculatedChange',
+            [
+                '_newData' => ['coveragePercent' => 0.80],
+                '_oldData' => ['coveragePercent' => 0.90],
+            ]
+        );
+
+        $this->assertSame(['officer'], $delivered, 'Notification must fire on a genuine boundary crossing.');
+
+    }//end testAboveThenBelowCrossingFires()
+
+
+    /**
+     * (c) Below-then-still-below: old value was already below 0.85.
+     * The `previously` (gte: 0.85) clause is NOT satisfied — debounce, no fire.
+     *
+     * @return void
+     */
+    public function testBelowThenStillBelowDebouncesAndDoesNotFire(): void
+    {
+        $schema = $this->schemaWithRule(condition: ['lt' => 0.85], previously: ['gte' => 0.85]);
+        $this->schemaMapper->method('find')->willReturn($schema);
+
+        $this->notificationManager->expects($this->never())->method('createNotification');
+
+        $dispatcher = $this->makeDispatcher();
+        $dispatcher->dispatch(
+            $this->objectWithCoverage(0.75),
+            'calculatedChange',
+            [
+                '_newData' => ['coveragePercent' => 0.75],
+                '_oldData' => ['coveragePercent' => 0.80],
+            ]
+        );
+
+    }//end testBelowThenStillBelowDebouncesAndDoesNotFire()
+
+
+    /**
+     * (d) Both `condition` AND `previously` must hold.
+     * The condition clause fails (new value is above 0.85), so no fire.
+     *
+     * @return void
+     */
+    public function testConditionClauseFailureBlocksFire(): void
+    {
+        $schema = $this->schemaWithRule(condition: ['lt' => 0.85], previously: ['gte' => 0.85]);
+        $this->schemaMapper->method('find')->willReturn($schema);
+
+        $this->notificationManager->expects($this->never())->method('createNotification');
+
+        $dispatcher = $this->makeDispatcher();
+        $dispatcher->dispatch(
+            $this->objectWithCoverage(0.90),
+            'calculatedChange',
+            [
+                '_newData' => ['coveragePercent' => 0.90],
+                '_oldData' => ['coveragePercent' => 0.95],
+            ]
+        );
+
+    }//end testConditionClauseFailureBlocksFire()
+
+
+    /**
+     * When _oldData is absent from context the rule is skipped (fail-closed).
+     * Better to miss a notification than to fire spuriously without proof of crossing.
+     *
+     * @return void
+     */
+    public function testMissingOldDataSkipsRule(): void
+    {
+        $schema = $this->schemaWithRule(condition: ['lt' => 0.85], previously: ['gte' => 0.85]);
+        $this->schemaMapper->method('find')->willReturn($schema);
+
+        $this->notificationManager->expects($this->never())->method('createNotification');
+
+        $dispatcher = $this->makeDispatcher();
+        $dispatcher->dispatch(
+            $this->objectWithCoverage(0.80),
+            'calculatedChange',
+            ['_newData' => ['coveragePercent' => 0.80]]
+        );
+
+    }//end testMissingOldDataSkipsRule()
+
+
+    /**
+     * Without condition or previously the gate is open — fires on every
+     * calculatedChange event for the named field.
+     *
+     * @return void
+     */
+    public function testOpenGateWithoutConditionOrPreviouslyFires(): void
+    {
+        $schema = $this->schemaWithRule(condition: null, previously: null);
+        $this->schemaMapper->method('find')->willReturn($schema);
+
+        $delivered = [];
+        $this->captureDeliveredUids($delivered);
+
+        $dispatcher = $this->makeDispatcher();
+        $dispatcher->dispatch(
+            $this->objectWithCoverage(0.80),
+            'calculatedChange',
+            [
+                '_newData' => ['coveragePercent' => 0.80],
+                '_oldData' => ['coveragePercent' => 0.90],
+            ]
+        );
+
+        $this->assertSame(['officer'], $delivered);
+
+    }//end testOpenGateWithoutConditionOrPreviouslyFires()
+
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Build a schema with a single `calculatedChange` notification rule
+     * monitoring the `coveragePercent` field.
+     *
+     * @param array<string, float|int|string>|null $condition  Operators the new value must satisfy.
+     * @param array<string, float|int|string>|null $previously Operators the old value must satisfy.
+     *
+     * @return Schema
+     */
+    private function schemaWithRule(?array $condition, ?array $previously): Schema
+    {
+        $trigger = ['type' => 'calculatedChange', 'field' => 'coveragePercent'];
+        if ($condition !== null) {
+            $trigger['condition'] = $condition;
+        }
+
+        if ($previously !== null) {
+            $trigger['previously'] = $previously;
+        }
+
+        $schema = new Schema();
+        $schema->setId(1);
+        $schema->setSlug('coverage-schema');
+        $schema->setConfiguration(
+            [
+                'x-openregister-notifications' => [
+                    'officerAlertOnCoverageDrop' => [
+                        'trigger'    => $trigger,
+                        'recipients' => [['kind' => 'users', 'users' => ['officer']]],
+                        'channels'   => ['nc-notification'],
+                        'subject'    => 'Coverage dropped below threshold',
+                    ],
+                ],
+            ]
+        );
+        return $schema;
+
+    }//end schemaWithRule()
+
+
+    /**
+     * Build a minimal ObjectEntity carrying a `coveragePercent` value.
+     *
+     * @param float $coverage Coverage percentage (0 to 1).
+     *
+     * @return ObjectEntity
+     */
+    private function objectWithCoverage(float $coverage): ObjectEntity
+    {
+        $object = new ObjectEntity();
+        $object->setUuid('obj-uuid-1');
+        $object->setSchema('coverage-schema');
+        $object->setRegister('reg-1');
+        $object->setObject(['coveragePercent' => $coverage]);
+        return $object;
+
+    }//end objectWithCoverage()
+
+
+    /**
+     * Build the dispatcher under test with minimal mocks.
+     *
+     * @return AnnotationNotificationDispatcher
+     */
+    private function makeDispatcher(): AnnotationNotificationDispatcher
+    {
+        return new AnnotationNotificationDispatcher(
+            $this->schemaMapper,
+            $this->notificationManager,
+            $this->logger,
+            $this->groupManager,
+            $this->userManager,
+            $this->mailer,
+            $this->activityManager,
+            $this->httpClient,
+            $this->serverContainer
+        );
+
+    }//end makeDispatcher()
+
+
+    /**
+     * Stub INotificationManager so each notify() call appends the recipient
+     * uid to $delivered.
+     *
+     * @param array<int, string> $delivered Out-param accumulating delivered uids.
+     *
+     * @return void
+     */
+    private function captureDeliveredUids(array &$delivered): void
+    {
+        $this->notificationManager->method('createNotification')
+            ->willReturnCallback(
+                function () use (&$delivered) {
+                    $notif = $this->createMock(INotification::class);
+                    $notif->method('setApp')->willReturnSelf();
+                    $notif->method('setUser')->willReturnCallback(
+                    function (string $uid) use ($notif, &$delivered) {
+                        $delivered[] = $uid;
+                        return $notif;
+                    }
+                    );
+                    $notif->method('setDateTime')->willReturnSelf();
+                    $notif->method('setObject')->willReturnSelf();
+                    $notif->method('setSubject')->willReturnSelf();
+                    return $notif;
+                }
+            );
+
+    }//end captureDeliveredUids()
+}//end class

--- a/tests/Unit/Service/Notification/NotificationAnnotationValidatorTest.php
+++ b/tests/Unit/Service/Notification/NotificationAnnotationValidatorTest.php
@@ -580,4 +580,111 @@ class NotificationAnnotationValidatorTest extends TestCase
         $codes = array_column($errors, 'code');
         $this->assertContains('notification-bad-organisation', $codes);
     }
+
+    // -----------------------------------------------------------------------
+    // calculatedChange trigger validation
+    // -----------------------------------------------------------------------
+
+    public function testCalculatedChangeTriggerWithValidSpecProducesNoErrors(): void
+    {
+        $errors = $this->v->validate([
+            'x-openregister-notifications' => [
+                'coverageDrop' => [
+                    'trigger' => [
+                        'type'       => 'calculatedChange',
+                        'field'      => 'coveragePercent',
+                        'condition'  => ['lt' => 0.85],
+                        'previously' => ['gte' => 0.85],
+                    ],
+                    'recipients' => [['kind' => 'users', 'users' => ['officer']]],
+                    'channels'   => ['nc-notification'],
+                    'subject'    => 'Coverage dropped',
+                ],
+            ],
+            'properties' => [],
+        ]);
+        $this->assertSame([], $errors, 'A well-formed calculatedChange spec must have no errors.');
+    }
+
+    public function testCalculatedChangeTriggerWithoutFieldIsRejected(): void
+    {
+        $errors = $this->v->validate([
+            'x-openregister-notifications' => [
+                'noField' => [
+                    'trigger' => [
+                        'type'      => 'calculatedChange',
+                        'condition' => ['lt' => 0.85],
+                    ],
+                    'recipients' => [['kind' => 'users', 'users' => ['admin']]],
+                    'channels'   => ['nc-notification'],
+                    'subject'    => 'x',
+                ],
+            ],
+            'properties' => [],
+        ]);
+        $codes = array_column($errors, 'code');
+        $this->assertContains('notification-calculated-change-no-field', $codes);
+    }
+
+    public function testCalculatedChangeTriggerWithBadConditionOpIsRejected(): void
+    {
+        $errors = $this->v->validate([
+            'x-openregister-notifications' => [
+                'badOp' => [
+                    'trigger' => [
+                        'type'      => 'calculatedChange',
+                        'field'     => 'score',
+                        'condition' => ['between' => 5],
+                    ],
+                    'recipients' => [['kind' => 'users', 'users' => ['admin']]],
+                    'channels'   => ['nc-notification'],
+                    'subject'    => 'x',
+                ],
+            ],
+            'properties' => [],
+        ]);
+        $codes = array_column($errors, 'code');
+        $this->assertContains('notification-calculated-change-bad-op', $codes);
+    }
+
+    public function testCalculatedChangeTriggerWithEmptyConditionArrayIsRejected(): void
+    {
+        $errors = $this->v->validate([
+            'x-openregister-notifications' => [
+                'emptyClause' => [
+                    'trigger' => [
+                        'type'      => 'calculatedChange',
+                        'field'     => 'score',
+                        'condition' => [],
+                    ],
+                    'recipients' => [['kind' => 'users', 'users' => ['admin']]],
+                    'channels'   => ['nc-notification'],
+                    'subject'    => 'x',
+                ],
+            ],
+            'properties' => [],
+        ]);
+        $codes = array_column($errors, 'code');
+        $this->assertContains('notification-calculated-change-bad-clause', $codes);
+    }
+
+    public function testCalculatedChangeTriggerWithoutConditionOrPreviouslyIsValid(): void
+    {
+        // Open-gate variant: field is declared but no condition/previously operators.
+        $errors = $this->v->validate([
+            'x-openregister-notifications' => [
+                'anyChange' => [
+                    'trigger' => [
+                        'type'  => 'calculatedChange',
+                        'field' => 'score',
+                    ],
+                    'recipients' => [['kind' => 'users', 'users' => ['admin']]],
+                    'channels'   => ['nc-notification'],
+                    'subject'    => 'score changed',
+                ],
+            ],
+            'properties' => [],
+        ]);
+        $this->assertSame([], $errors, 'calculatedChange without condition/previously is valid (open gate).');
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a new `calculatedChange` trigger type to `x-openregister-notifications` that fires when a materialised calculation field crosses a configurable numeric boundary (e.g. coverage drops below 85%).
- Implements debounce semantics: both `condition` (new value) and `previously` (old value) must hold simultaneously, so the rule fires only on the crossing event — not on every subsequent save while the value remains below the threshold.
- Adds validation in `NotificationAnnotationValidator` for the new trigger type, its `field`, `condition`, and `previously` clauses.

## Files changed

- `lib/Service/Notification/AnnotationNotificationDispatcher.php` — `matches()` extended for `calculatedChange`; `numericConditionMatches()` helper added
- `lib/Service/Notification/NotificationAnnotationValidator.php` — `calculatedChange` added to VALID_TRIGGERS; field/condition/previously validation added
- `lib/Listener/AnnotationNotificationListener.php` — on ObjectUpdatedEvent dispatches trigger=calculatedChange with _newData/_oldData context when old object is available
- `tests/Unit/Service/Notification/CalculatedChangeTriggerTest.php` — 6 new tests (new file)
- `tests/Unit/Service/Notification/NotificationAnnotationValidatorTest.php` — 5 new validator tests

## Test plan

- [ ] First save below threshold (old also below) — no fire
- [ ] Above-then-below crossing — fires exactly once
- [ ] Below-then-still-below — debounced, no fire
- [ ] Condition clause fails — no fire
- [ ] Missing _oldData — rule skipped (fail-closed)
- [ ] Open gate (no clauses) — fires on every calculatedChange event
- [ ] All 5 validator tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)