### PR TITLE
feat(manifest): inject runtime.user.* context from current-user-schema calculations

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -206,6 +206,8 @@ return [
         ['name' => 'Settings\ValidationSettings#validateAllObjects', 'url' => '/api/settings/validate-all-objects', 'verb' => 'POST'],
         ['name' => 'Settings\ValidationSettings#massValidateObjects', 'url' => '/api/settings/mass-validate', 'verb' => 'POST'],
         ['name' => 'Settings\ValidationSettings#predictMassValidationMemory', 'url' => '/api/settings/mass-validate/memory-prediction', 'verb' => 'POST'],
+        // Manifest endpoint — returns host-app manifest enriched with runtime.user context.
+        ['name' => 'manifest#index', 'url' => '/api/manifest/{appId}', 'verb' => 'GET', 'requirements' => ['appId' => '[^/]+']],
         // Heartbeat - Keep-alive endpoint for long-running operations.
         ['name' => 'heartbeat#heartbeat', 'url' => '/api/heartbeat', 'verb' => 'GET'],
         // Prometheus metrics endpoint.

--- a/lib/Controller/ManifestController.php
+++ b/lib/Controller/ManifestController.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * OpenRegister ManifestController
+ *
+ * Exposes a per-app `/api/manifest/{appId}` endpoint that returns the host
+ * app's bundled manifest.json enriched with a `runtime.user` block built
+ * from the authenticated user's OpenRegister profile object.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/manifest-user-context/tasks.md
+ *
+ * @psalm-suppress UnusedClass
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use OCA\OpenRegister\Service\ManifestService;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Serves enriched manifests for host apps.
+ *
+ * The endpoint is public (no CSRF, no admin) so that unauthenticated clients
+ * can still load a manifest and receive `runtime.user = null`; public pages
+ * are filtered by nc-vue using that null signal.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class ManifestController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param string          $appName         The app name ('openregister').
+     * @param IRequest        $request         The HTTP request.
+     * @param ManifestService $manifestService Service that enriches manifests.
+     * @param IAppManager     $appManager      Nextcloud app manager (path resolution).
+     * @param LoggerInterface $logger          PSR logger.
+     *
+     * @return void
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly ManifestService $manifestService,
+        private readonly IAppManager $appManager,
+        private readonly LoggerInterface $logger
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * Return the manifest for `appId`, enriched with `runtime.user` context.
+     *
+     * GET /index.php/apps/openregister/api/manifest/{appId}
+     *
+     * @param string $appId The Nextcloud app ID of the calling application.
+     *
+     * @return JSONResponse Enriched manifest, or 404/500 on failure.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     * @PublicPage
+     */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    #[PublicPage]
+    public function index(string $appId): JSONResponse
+    {
+        // Sanitise: appId must be a valid NC app slug (alphanumeric + underscore/hyphen).
+        if (preg_match('/^[a-z0-9_-]+$/i', $appId) !== 1) {
+            return new JSONResponse(['error' => 'Invalid app ID.'], Http::STATUS_BAD_REQUEST);
+        }
+
+        // Resolve the app's manifest.json path via the app manager.
+        $manifest = $this->loadBundledManifest(appId: $appId);
+        if ($manifest === null) {
+            return new JSONResponse(
+                ['error' => sprintf('Manifest not found for app "%s".', $appId)],
+                Http::STATUS_NOT_FOUND
+            );
+        }
+
+        try {
+            $enriched = $this->manifestService->getEnrichedManifest(manifest: $manifest);
+            return new JSONResponse($enriched);
+        } catch (Throwable $e) {
+            $this->logger->error(
+                message: sprintf('[ManifestController] Enrichment failed for app "%s": %s', $appId, $e->getMessage()),
+                context: ['file' => __FILE__, 'line' => __LINE__, 'appId' => $appId]
+            );
+            return new JSONResponse(['error' => 'Internal server error.'], Http::STATUS_INTERNAL_SERVER_ERROR);
+        }
+    }//end index()
+
+    /**
+     * Load and JSON-decode a host app's bundled `src/manifest.json`.
+     *
+     * @param string $appId The Nextcloud app ID.
+     *
+     * @return array<string, mixed>|null Decoded manifest, or null if not readable.
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     */
+    private function loadBundledManifest(string $appId): ?array
+    {
+        try {
+            $appPath = $this->appManager->getAppPath(appId: $appId);
+        } catch (Throwable $e) {
+            $this->logger->debug(
+                message: sprintf('[ManifestController] App "%s" path not found: %s', $appId, $e->getMessage()),
+                context: ['file' => __FILE__, 'line' => __LINE__]
+            );
+            return null;
+        }
+
+        $manifestPath = $appPath.'/src/manifest.json';
+        if (is_readable($manifestPath) === false) {
+            $this->logger->debug(
+                message: sprintf('[ManifestController] manifest.json not readable at "%s"', $manifestPath),
+                context: ['file' => __FILE__, 'line' => __LINE__]
+            );
+            return null;
+        }
+
+        $raw = file_get_contents($manifestPath);
+        if ($raw === false) {
+            return null;
+        }
+
+        $decoded = json_decode($raw, associative: true);
+        if (json_last_error() !== JSON_ERROR_NONE || is_array($decoded) === false) {
+            $this->logger->warning(
+                message: sprintf('[ManifestController] manifest.json for "%s" is invalid JSON', $appId),
+                context: ['file' => __FILE__, 'line' => __LINE__]
+            );
+            return null;
+        }
+
+        return $decoded;
+    }//end loadBundledManifest()
+}//end class

--- a/lib/Service/ManifestService.php
+++ b/lib/Service/ManifestService.php
@@ -1,0 +1,285 @@
+<?php
+
+/**
+ * OpenRegister ManifestService
+ *
+ * Enriches a host-app manifest.json with a `runtime.user` block derived
+ * from the requesting user's OpenRegister profile object.
+ *
+ * Behaviour summary
+ * -----------------
+ * 1. If the manifest carries no `currentUserSchema` key → return unchanged.
+ * 2. Anonymous request            → `runtime.user = null`.
+ * 3. Logged-in user, no profile   → `runtime.user = { id, roles: ["learner"] }`.
+ * 4. Logged-in user, profile found → `runtime.user` populated with every
+ *    `x-openregister-calculations.*` field evaluated against the profile object.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/manifest-user-context/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use DateTimeInterface;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Calculation\CalculationEvaluator;
+use OCA\OpenRegister\Service\Calculation\EvaluationException;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Enriches a manifest with `runtime.user` context for the authenticated user.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class ManifestService
+{
+    /**
+     * Constructor.
+     *
+     * @param ObjectService        $objectService OR object retrieval service.
+     * @param SchemaMapper         $schemaMapper  Schema lookup by slug.
+     * @param CalculationEvaluator $evaluator     Expression evaluator.
+     * @param IUserSession         $userSession   Nextcloud user session.
+     * @param LoggerInterface      $logger        PSR logger.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly ObjectService $objectService,
+        private readonly SchemaMapper $schemaMapper,
+        private readonly CalculationEvaluator $evaluator,
+        private readonly IUserSession $userSession,
+        private readonly LoggerInterface $logger
+    ) {
+    }//end __construct()
+
+    /**
+     * Return the manifest enriched with a `runtime.user` block.
+     *
+     * @param array<string, mixed> $manifest Parsed manifest.json from the calling app.
+     *
+     * @return array<string, mixed> Enriched manifest (original if no `currentUserSchema`).
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    public function getEnrichedManifest(array $manifest): array
+    {
+        // 1. No currentUserSchema declared → return unchanged.
+        $schemaSlug = ($manifest['currentUserSchema'] ?? null);
+        if ($schemaSlug === null || $schemaSlug === '') {
+            return $manifest;
+        }
+
+        // 2. Anonymous request → runtime.user = null.
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            $manifest['runtime']['user'] = null;
+            return $manifest;
+        }
+
+        $userId = $user->getUID();
+
+        // 3. Try to find the user's profile object in OR.
+        $profileObject = $this->resolveUserProfile(schemaSlug: (string) $schemaSlug, userId: $userId);
+
+        if ($profileObject === null) {
+            // 4a. No profile → minimal fallback.
+            $manifest['runtime']['user'] = [
+                'id'    => $userId,
+                'roles' => ['learner'],
+            ];
+            return $manifest;
+        }
+
+        // 4b. Profile found → evaluate calculations and inject.
+        $manifest['runtime']['user'] = $this->buildUserContext(
+            userId: $userId,
+            profile: $profileObject,
+            schemaSlug: (string) $schemaSlug
+        );
+
+        return $manifest;
+    }//end getEnrichedManifest()
+
+    /**
+     * Locate the user's profile object for the given schema slug.
+     *
+     * Filters by `ncUserId === $userId` inside the magic table for that schema.
+     *
+     * @param string $schemaSlug Schema slug declared in the manifest.
+     * @param string $userId     Nextcloud user ID.
+     *
+     * @return ObjectEntity|null The profile object, or null if not found.
+     */
+    private function resolveUserProfile(string $schemaSlug, string $userId): ?ObjectEntity
+    {
+        try {
+            $schemas = $this->schemaMapper->findBySlug(slug: $schemaSlug, limit: 1);
+            if (count($schemas) === 0) {
+                $this->logger->debug(
+                    message: sprintf('[ManifestService] Schema "%s" not found', $schemaSlug),
+                    context: ['file' => __FILE__, 'line' => __LINE__]
+                );
+                return null;
+            }
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                message: sprintf('[ManifestService] Schema lookup failed for "%s": %s', $schemaSlug, $e->getMessage()),
+                context: ['file' => __FILE__, 'line' => __LINE__]
+            );
+            return null;
+        }
+
+        try {
+            $results = $this->objectService->findAll(
+                config: [
+                    'limit'   => 1,
+                    'filters' => [
+                        'schema'   => $schemaSlug,
+                        'ncUserId' => $userId,
+                    ],
+                ],
+                _rbac: false,
+                _multitenancy: false
+            );
+
+            return count($results) > 0 ? $results[0] : null;
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                message: sprintf('[ManifestService] Profile lookup failed for user "%s": %s', $userId, $e->getMessage()),
+                context: ['file' => __FILE__, 'line' => __LINE__]
+            );
+            return null;
+        }//end try
+    }//end resolveUserProfile()
+
+    /**
+     * Build the `runtime.user` block from the profile object.
+     *
+     * Seeds the block with the raw profile payload and then overlays every
+     * `x-openregister-calculations.*` result that is NOT materialised
+     * (materialised fields are already in the stored data). Non-materialised
+     * calculations are evaluated at read-time here so that the manifest always
+     * reflects the freshest derived state.
+     *
+     * @param string       $userId     Nextcloud user ID (always included as `id`).
+     * @param ObjectEntity $profile    The user's profile object entity.
+     * @param string       $schemaSlug Schema slug (used for schema re-lookup to read calcs).
+     *
+     * @return array<string, mixed> The `runtime.user` data block.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    private function buildUserContext(string $userId, ObjectEntity $profile, string $schemaSlug): array
+    {
+        $data = $profile->getObject() ?? [];
+
+        // Always surface the Nextcloud user ID as `id`.
+        $context = array_merge($data, ['id' => $userId]);
+
+        // Evaluate non-materialised calculations to enrich the context.
+        $calcs = $this->getCalculations(schemaSlug: $schemaSlug);
+        if ($calcs === null) {
+            return $context;
+        }
+
+        // Build @self metadata the same way the listener does, so expressions
+        // referencing @self.created / @self.updated work correctly.
+        $created       = $profile->getCreated();
+        $updated       = $profile->getUpdated();
+        $data['@self'] = [
+            'id'       => $profile->getUuid(),
+            'uuid'     => $profile->getUuid(),
+            'register' => $profile->getRegister(),
+            'schema'   => $profile->getSchema(),
+            'owner'    => $profile->getOwner(),
+            'created'  => $created !== null ? $created->format(DateTimeInterface::ATOM) : null,
+            'updated'  => $updated !== null ? $updated->format(DateTimeInterface::ATOM) : null,
+        ];
+
+        foreach ($calcs as $name => $spec) {
+            if (is_array($spec) === false) {
+                continue;
+            }
+
+            try {
+                $value = $this->evaluator->evaluate($data, ($spec['expression'] ?? null));
+            } catch (EvaluationException $e) {
+                $this->logger->warning(
+                    message: sprintf(
+                        '[ManifestService] Calculation "%s" failed for user "%s": %s',
+                        (string) $name,
+                        $userId,
+                        $e->getMessage()
+                    ),
+                    context: ['file' => __FILE__, 'line' => __LINE__]
+                );
+                continue;
+            }
+
+            // Only inject non-materialised computations here; materialised ones
+            // are already stored in the profile payload and surfaced via $context.
+            $materialise = ($spec['materialise'] ?? false);
+            if ($materialise !== true) {
+                $context[(string) $name] = $this->serialise(value: $value);
+            }
+        }//end foreach
+
+        return $context;
+    }//end buildUserContext()
+
+    /**
+     * Read `x-openregister-calculations` from the schema identified by slug.
+     *
+     * @param string $schemaSlug The schema slug.
+     *
+     * @return array<string, mixed>|null The calculations map, or null when absent.
+     */
+    private function getCalculations(string $schemaSlug): ?array
+    {
+        try {
+            $schemas = $this->schemaMapper->findBySlug(slug: $schemaSlug, limit: 1);
+        } catch (Throwable) {
+            return null;
+        }
+
+        if (count($schemas) === 0) {
+            return null;
+        }
+
+        $config = ($schemas[0]->getConfiguration() ?? []);
+        $calcs  = ($config['x-openregister-calculations'] ?? null);
+        return is_array($calcs) === true ? $calcs : null;
+    }//end getCalculations()
+
+    /**
+     * Serialise a calculation result into a JSON-friendly value.
+     *
+     * @param mixed $value Raw evaluator output.
+     *
+     * @return mixed JSON-safe representation.
+     */
+    private function serialise(mixed $value): mixed
+    {
+        if ($value instanceof DateTimeInterface) {
+            return $value->format(DATE_ATOM);
+        }
+
+        return $value;
+    }//end serialise()
+}//end class

--- a/tests/Unit/Controller/ManifestControllerTest.php
+++ b/tests/Unit/Controller/ManifestControllerTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * Unit tests for ManifestController.
+ *
+ * @category Test
+ * @package  Unit\Controller
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use OCA\OpenRegister\Controller\ManifestController;
+use OCA\OpenRegister\Service\ManifestService;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests for ManifestController.
+ */
+class ManifestControllerTest extends TestCase
+{
+    /** @var ManifestService&MockObject */
+    private ManifestService $manifestService;
+
+    /** @var IAppManager&MockObject */
+    private IAppManager $appManager;
+
+    /** @var IRequest&MockObject */
+    private IRequest $request;
+
+    /** @var LoggerInterface&MockObject */
+    private LoggerInterface $logger;
+
+    private ManifestController $controller;
+
+    /**
+     * Set up mocks.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->manifestService = $this->createMock(ManifestService::class);
+        $this->appManager      = $this->createMock(IAppManager::class);
+        $this->request         = $this->createMock(IRequest::class);
+        $this->logger          = $this->createMock(LoggerInterface::class);
+
+        $this->controller = new ManifestController(
+            'openregister',
+            $this->request,
+            $this->manifestService,
+            $this->appManager,
+            $this->logger
+        );
+    }//end setUp()
+
+    /**
+     * An invalid app ID (contains special chars) must return 400.
+     *
+     * @return void
+     */
+    public function testInvalidAppIdReturnsBadRequest(): void
+    {
+        $result = $this->controller->index('../evil');
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $result->getStatus());
+    }//end testInvalidAppIdReturnsBadRequest()
+
+    /**
+     * When the app manager cannot find the app path, return 404.
+     *
+     * @return void
+     */
+    public function testUnknownAppReturnsNotFound(): void
+    {
+        $this->appManager
+            ->method('getAppPath')
+            ->willThrowException(new \Exception('App not found'));
+
+        $result = $this->controller->index('nonexistent-app');
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $result->getStatus());
+    }//end testUnknownAppReturnsNotFound()
+
+    /**
+     * A valid app with a readable manifest.json is enriched and returned.
+     *
+     * Uses a real temporary file to simulate the manifest on disk.
+     *
+     * @return void
+     */
+    public function testValidAppReturnsEnrichedManifest(): void
+    {
+        // Write a temp manifest.json.
+        $tmpDir = sys_get_temp_dir().'/manifest_ctrl_test_'.uniqid('', true);
+        mkdir($tmpDir.'/src', 0755, true);
+        file_put_contents(
+            $tmpDir.'/src/manifest.json',
+            json_encode(['version' => '1.0.0', 'currentUserSchema' => 'user-profile'])
+        );
+
+        $this->appManager
+            ->method('getAppPath')
+            ->willReturn($tmpDir);
+
+        $enriched = [
+            'version'           => '1.0.0',
+            'currentUserSchema' => 'user-profile',
+            'runtime'           => ['user' => ['id' => 'alice']],
+        ];
+
+        $this->manifestService
+            ->expects($this->once())
+            ->method('getEnrichedManifest')
+            ->willReturn($enriched);
+
+        $result = $this->controller->index('myapp');
+
+        $this->assertSame(Http::STATUS_OK, $result->getStatus());
+        $data = $result->getData();
+        $this->assertSame('alice', $data['runtime']['user']['id']);
+
+        // Clean up.
+        unlink($tmpDir.'/src/manifest.json');
+        rmdir($tmpDir.'/src');
+        rmdir($tmpDir);
+    }//end testValidAppReturnsEnrichedManifest()
+
+    /**
+     * When ManifestService throws, the controller returns 500.
+     *
+     * @return void
+     */
+    public function testServiceExceptionReturnsInternalServerError(): void
+    {
+        $tmpDir = sys_get_temp_dir().'/manifest_ctrl_err_'.uniqid('', true);
+        mkdir($tmpDir.'/src', 0755, true);
+        file_put_contents(
+            $tmpDir.'/src/manifest.json',
+            json_encode(['version' => '1.0.0'])
+        );
+
+        $this->appManager
+            ->method('getAppPath')
+            ->willReturn($tmpDir);
+
+        $this->manifestService
+            ->method('getEnrichedManifest')
+            ->willThrowException(new \RuntimeException('DB offline'));
+
+        $result = $this->controller->index('myapp');
+
+        $this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $result->getStatus());
+
+        // Clean up.
+        unlink($tmpDir.'/src/manifest.json');
+        rmdir($tmpDir.'/src');
+        rmdir($tmpDir);
+    }//end testServiceExceptionReturnsInternalServerError()
+}//end class

--- a/tests/Unit/Service/ManifestServiceTest.php
+++ b/tests/Unit/Service/ManifestServiceTest.php
@@ -1,0 +1,337 @@
+<?php
+
+/**
+ * Unit tests for ManifestService.
+ *
+ * Covers the four runtime.user scenarios:
+ *   1. Manifest with no currentUserSchema → returned unchanged.
+ *   2. Anonymous request                   → runtime.user = null.
+ *   3. Logged-in user, no profile object  → fallback { id, roles: ["learner"] }.
+ *   4. Logged-in user, profile found      → full context with calculated fields.
+ *
+ * @category Test
+ * @package  Unit\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Calculation\CalculationEvaluator;
+use OCA\OpenRegister\Service\ManifestService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit test suite for ManifestService.
+ */
+class ManifestServiceTest extends TestCase
+{
+    /** @var ObjectService&MockObject */
+    private ObjectService $objectService;
+
+    /** @var SchemaMapper&MockObject */
+    private SchemaMapper $schemaMapper;
+
+    /** @var CalculationEvaluator&MockObject */
+    private CalculationEvaluator $evaluator;
+
+    /** @var IUserSession&MockObject */
+    private IUserSession $userSession;
+
+    /** @var LoggerInterface&MockObject */
+    private LoggerInterface $logger;
+
+    private ManifestService $service;
+
+    /**
+     * Set up mocks before each test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->objectService = $this->createMock(ObjectService::class);
+        $this->schemaMapper  = $this->createMock(SchemaMapper::class);
+        $this->evaluator     = $this->createMock(CalculationEvaluator::class);
+        $this->userSession   = $this->createMock(IUserSession::class);
+        $this->logger        = $this->createMock(LoggerInterface::class);
+
+        $this->service = new ManifestService(
+            $this->objectService,
+            $this->schemaMapper,
+            $this->evaluator,
+            $this->userSession,
+            $this->logger
+        );
+    }//end setUp()
+
+    // -----------------------------------------------------------------------
+    // 1. No currentUserSchema declared
+    // -----------------------------------------------------------------------
+
+    /**
+     * Manifests without currentUserSchema must be returned exactly as provided.
+     *
+     * @return void
+     */
+    public function testManifestWithoutCurrentUserSchemaIsUnchanged(): void
+    {
+        $manifest = ['version' => '1.0.0', 'pages' => []];
+
+        $result = $this->service->getEnrichedManifest($manifest);
+
+        $this->assertSame($manifest, $result);
+    }//end testManifestWithoutCurrentUserSchemaIsUnchanged()
+
+    /**
+     * Manifest with an empty currentUserSchema string must also be unchanged.
+     *
+     * @return void
+     */
+    public function testManifestWithEmptyCurrentUserSchemaIsUnchanged(): void
+    {
+        $manifest = ['currentUserSchema' => '', 'pages' => []];
+
+        $result = $this->service->getEnrichedManifest($manifest);
+
+        $this->assertSame($manifest, $result);
+    }//end testManifestWithEmptyCurrentUserSchemaIsUnchanged()
+
+    // -----------------------------------------------------------------------
+    // 2. Anonymous request → runtime.user = null
+    // -----------------------------------------------------------------------
+
+    /**
+     * An anonymous (unauthenticated) request must yield runtime.user = null.
+     *
+     * @return void
+     */
+    public function testAnonymousRequestYieldsNullUserContext(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $manifest = ['currentUserSchema' => 'user-profile', 'pages' => []];
+        $result   = $this->service->getEnrichedManifest($manifest);
+
+        $this->assertArrayHasKey('runtime', $result);
+        $this->assertNull($result['runtime']['user']);
+    }//end testAnonymousRequestYieldsNullUserContext()
+
+    // -----------------------------------------------------------------------
+    // 3. Logged-in user but no profile object → fallback
+    // -----------------------------------------------------------------------
+
+    /**
+     * When the user is authenticated but has no profile object, the service
+     * must return the minimal fallback { id, roles: ["learner"] }.
+     *
+     * @return void
+     */
+    public function testUserWithoutProfileGetsFallback(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+
+        $this->userSession->method('getUser')->willReturn($user);
+
+        // Schema found so the findAll call is reached.
+        $schema = $this->createMock(Schema::class);
+        $this->schemaMapper
+            ->method('findBySlug')
+            ->willReturn([$schema]);
+
+        // No matching objects.
+        $this->objectService
+            ->method('findAll')
+            ->willReturn([]);
+
+        $manifest = ['currentUserSchema' => 'user-profile', 'pages' => []];
+        $result   = $this->service->getEnrichedManifest($manifest);
+
+        $this->assertArrayHasKey('runtime', $result);
+        $userCtx = $result['runtime']['user'];
+        $this->assertIsArray($userCtx);
+        $this->assertSame('alice', $userCtx['id']);
+        $this->assertSame(['learner'], $userCtx['roles']);
+    }//end testUserWithoutProfileGetsFallback()
+
+    /**
+     * When the schema is not found, the fallback is still returned gracefully.
+     *
+     * @return void
+     */
+    public function testUserWithUnknownSchemaGetsFallback(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('bob');
+
+        $this->userSession->method('getUser')->willReturn($user);
+
+        // Schema not found.
+        $this->schemaMapper
+            ->method('findBySlug')
+            ->willReturn([]);
+
+        $manifest = ['currentUserSchema' => 'nonexistent-schema', 'pages' => []];
+        $result   = $this->service->getEnrichedManifest($manifest);
+
+        $this->assertArrayHasKey('runtime', $result);
+        $userCtx = $result['runtime']['user'];
+        $this->assertIsArray($userCtx);
+        $this->assertSame('bob', $userCtx['id']);
+        $this->assertSame(['learner'], $userCtx['roles']);
+    }//end testUserWithUnknownSchemaGetsFallback()
+
+    // -----------------------------------------------------------------------
+    // 4. User with profile → full context with calculations
+    // -----------------------------------------------------------------------
+
+    /**
+     * When the user has a profile object, the service injects its data plus
+     * non-materialised calculation results into runtime.user.
+     *
+     * @return void
+     */
+    public function testUserWithProfileGetsFullContext(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('charlie');
+
+        $this->userSession->method('getUser')->willReturn($user);
+
+        // Profile object with stored data.
+        $profile = $this->createMock(ObjectEntity::class);
+        $profile->method('getObject')->willReturn([
+            'ncUserId'    => 'charlie',
+            'primaryRole' => 'compliance-officer',
+        ]);
+        $profile->method('getUuid')->willReturn('prof-uuid-1');
+        $profile->method('getRegister')->willReturn('my-register');
+        $profile->method('getSchema')->willReturn('user-profile');
+        $profile->method('getOwner')->willReturn('charlie');
+        $profile->method('getCreated')->willReturn(null);
+        $profile->method('getUpdated')->willReturn(null);
+
+        // Schema with a non-materialised calculation: displayName = concat(ncUserId, "!")
+        $schema = $this->createMock(Schema::class);
+        $schema->method('getConfiguration')->willReturn([
+            'x-openregister-calculations' => [
+                'displayName' => [
+                    'materialise' => false,
+                    'expression'  => ['concat' => [['prop' => 'ncUserId'], '!']],
+                ],
+                'storedField' => [
+                    'materialise' => true,  // should NOT be overridden here
+                    'expression'  => ['prop' => 'primaryRole'],
+                ],
+            ],
+        ]);
+
+        $this->schemaMapper
+            ->method('findBySlug')
+            ->willReturn([$schema]);
+
+        $this->objectService
+            ->method('findAll')
+            ->willReturn([$profile]);
+
+        // Evaluator returns values for each expression call.
+        $this->evaluator
+            ->method('evaluate')
+            ->willReturnCallback(static function (array $data, mixed $expr): mixed {
+                // Non-materialised displayName calculation.
+                if (is_array($expr) && isset($expr['concat'])) {
+                    return 'charlie!';
+                }
+
+                return null;
+            });
+
+        $manifest = ['currentUserSchema' => 'user-profile', 'pages' => []];
+        $result   = $this->service->getEnrichedManifest($manifest);
+
+        $this->assertArrayHasKey('runtime', $result);
+        $userCtx = $result['runtime']['user'];
+        $this->assertIsArray($userCtx);
+
+        // Core identity.
+        $this->assertSame('charlie', $userCtx['id']);
+
+        // Raw profile field surfaces in context.
+        $this->assertSame('compliance-officer', $userCtx['primaryRole']);
+
+        // Non-materialised calculation is injected.
+        $this->assertSame('charlie!', $userCtx['displayName']);
+
+        // Materialised calculation is NOT re-evaluated (so displayName from calc
+        // but storedField is already in the raw data via array_merge, not
+        // from the evaluator for materialise === true).
+        $this->assertArrayNotHasKey('storedField', $userCtx,
+            'Materialised calculations must not be re-injected by ManifestService.'
+        );
+    }//end testUserWithProfileGetsFullContext()
+
+    /**
+     * When a calculation expression throws EvaluationException, the service
+     * logs a warning and continues, omitting the failed field.
+     *
+     * @return void
+     */
+    public function testFailingCalculationIsSkippedGracefully(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('dave');
+        $this->userSession->method('getUser')->willReturn($user);
+
+        $profile = $this->createMock(ObjectEntity::class);
+        $profile->method('getObject')->willReturn(['ncUserId' => 'dave']);
+        $profile->method('getUuid')->willReturn('prof-uuid-2');
+        $profile->method('getRegister')->willReturn('reg');
+        $profile->method('getSchema')->willReturn('user-profile');
+        $profile->method('getOwner')->willReturn('dave');
+        $profile->method('getCreated')->willReturn(null);
+        $profile->method('getUpdated')->willReturn(null);
+
+        $schema = $this->createMock(Schema::class);
+        $schema->method('getConfiguration')->willReturn([
+            'x-openregister-calculations' => [
+                'broken' => [
+                    'materialise' => false,
+                    'expression'  => ['unknownOp' => []],
+                ],
+            ],
+        ]);
+
+        $this->schemaMapper->method('findBySlug')->willReturn([$schema]);
+        $this->objectService->method('findAll')->willReturn([$profile]);
+
+        $this->evaluator
+            ->method('evaluate')
+            ->willThrowException(
+                new \OCA\OpenRegister\Service\Calculation\EvaluationException('Unknown operator "unknownOp".')
+            );
+
+        $this->logger->expects($this->atLeastOnce())->method('warning');
+
+        $manifest = ['currentUserSchema' => 'user-profile', 'pages' => []];
+        $result   = $this->service->getEnrichedManifest($manifest);
+
+        $userCtx = $result['runtime']['user'];
+        $this->assertSame('dave', $userCtx['id']);
+        $this->assertArrayNotHasKey('broken', $userCtx);
+    }//end testFailingCalculationIsSkippedGracefully()
+}//end class


### PR DESCRIPTION
## Summary

- Adds `ManifestService::getEnrichedManifest(array $manifest): array` — OR-side logic that reads the calling app's `currentUserSchema` declaration, finds the user's profile object (filtered by `ncUserId`), evaluates all non-materialised `x-openregister-calculations.*` expressions, and injects the result as `runtime.user` in the returned manifest.
- Adds `ManifestController` at `GET /api/manifest/{appId}` (PublicPage, NoCSRFRequired) — reads the host app's `src/manifest.json` from disk via `IAppManager::getAppPath`, delegates enrichment to `ManifestService`, returns the result as JSON.
- Registers the route in `appinfo/routes.php`.

**Four runtime.user scenarios:**
1. No `currentUserSchema` in manifest → returned unchanged (backwards-compatible).
2. Anonymous request → `runtime.user = null` (nc-vue filters to public pages).
3. Logged-in user, no profile object → `runtime.user = { id, roles: ["learner"] }`.
4. Logged-in user, profile found → full context with evaluated calculations.

Closes scholiq deps #8 — replaces cancelled nc-vue `roleAware` page resolver (ADR-024 §4).

## Test plan

- [ ] `ManifestServiceTest` — 6 unit tests (unchanged manifest, empty slug, anonymous, no profile, full context with calc injection, graceful calc failure)
- [ ] `ManifestControllerTest` — 4 unit tests (invalid app ID → 400, unknown app → 404, valid app + enrichment → 200, service exception → 500)
- [ ] CI code-quality workflow passes on branch
- [ ] Manual: `GET /index.php/apps/openregister/api/manifest/decidesk` returns manifest with or without `runtime.user` depending on auth state