### PR TITLE
feat(schema): add appendOnly schema flag (closes scholiq deps #1)

### DIFF
--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -35,6 +35,7 @@ use OCA\OpenRegister\Exception\CustomValidationException;
 use OCA\OpenRegister\Exception\ValidationException;
 use OCA\OpenRegister\Exception\RegisterNotFoundException;
 use OCA\OpenRegister\Exception\SchemaNotFoundException;
+use OCA\OpenRegister\Exception\AppendOnlyException;
 use OCA\OpenRegister\Exception\LockedException;
 use OCA\OpenRegister\Exception\NotAuthorizedException;
 use OCA\OpenRegister\Exception\ReferentialIntegrityException;
@@ -2087,6 +2088,9 @@ class ObjectsController extends Controller
 
             // Return the successfully saved object directly.
             return new JSONResponse(data: $objectEntity->jsonSerialize());
+        } catch (AppendOnlyException $exception) {
+            // Reject update on append-only schema with HTTP 405.
+            return new JSONResponse(data: $exception->toResponseBody(), statusCode: Http::STATUS_METHOD_NOT_ALLOWED);
         } catch (ValidationException | CustomValidationException $exception) {
             // Handle validation errors.
             return $objectService->handleValidationException(exception: $exception);
@@ -2252,6 +2256,9 @@ class ObjectsController extends Controller
             // Return the successfully saved object directly.
             // We already have it in memory from saveObject(), no need to re-fetch.
             return new JSONResponse(data: $objectEntity->jsonSerialize());
+        } catch (AppendOnlyException $exception) {
+            // Reject patch on append-only schema with HTTP 405.
+            return new JSONResponse(data: $exception->toResponseBody(), statusCode: Http::STATUS_METHOD_NOT_ALLOWED);
         } catch (ValidationException | CustomValidationException $exception) {
             // Handle validation errors.
             $this->logger->warning(
@@ -2381,6 +2388,9 @@ class ObjectsController extends Controller
             }
 
             return new JSONResponse(data: $objectEntity->jsonSerialize());
+        } catch (AppendOnlyException $exception) {
+            // Reject post-patch on append-only schema with HTTP 405.
+            return new JSONResponse(data: $exception->toResponseBody(), statusCode: Http::STATUS_METHOD_NOT_ALLOWED);
         } catch (ValidationException | CustomValidationException $exception) {
             return $objectService->handleValidationException(exception: $exception);
         } catch (\OCA\OpenRegister\Exception\HookStoppedException $exception) {
@@ -2436,6 +2446,9 @@ class ObjectsController extends Controller
 
             // Return 204 No Content for successful delete (REST convention).
             return new JSONResponse(data: null, statusCode: 204);
+        } catch (AppendOnlyException $exception) {
+            // Reject delete on append-only schema with HTTP 405.
+            return new JSONResponse(data: $exception->toResponseBody(), statusCode: Http::STATUS_METHOD_NOT_ALLOWED);
         } catch (ReferentialIntegrityException $exception) {
             return new JSONResponse(
                 data: $exception->toResponseBody(),

--- a/lib/Db/Schema.php
+++ b/lib/Db/Schema.php
@@ -64,6 +64,8 @@ use OCA\OpenRegister\Service\Schemas\PropertyValidatorHandler;
  * @method void setSource(?string $source)
  * @method bool getHardValidation()
  * @method void setHardValidation(bool $hardValidation)
+ * @method bool getAppendOnly()
+ * @method void setAppendOnly(bool $appendOnly)
  * @method DateTime|null getUpdated()
  * @method void setUpdated(?DateTime $updated)
  * @method DateTime|null getCreated()
@@ -301,6 +303,17 @@ class Schema extends Entity implements JsonSerializable
     protected bool $immutable = false;
 
     /**
+     * Whether objects of this schema are append-only (INSERT allowed; UPDATE and DELETE rejected)
+     *
+     * When true, new objects can be created but existing objects cannot be mutated or removed.
+     * This is used for append-only audit logs (e.g. xAPI statements, compliance attestations)
+     * where immutability of past records is a business or legal requirement.
+     *
+     * @var boolean
+     */
+    protected bool $appendOnly = false;
+
+    /**
      * Whether objects of this schema should be indexed in SOLR for searching
      *
      * When set to false, objects of this schema will be excluded from SOLR indexing,
@@ -462,6 +475,7 @@ class Schema extends Entity implements JsonSerializable
         $this->addType(fieldName: 'source', type: 'string');
         $this->addType(fieldName: 'hardValidation', type: Types::BOOLEAN);
         $this->addType(fieldName: 'immutable', type: Types::BOOLEAN);
+        $this->addType(fieldName: 'appendOnly', type: Types::BOOLEAN);
         $this->addType(fieldName: 'searchable', type: Types::BOOLEAN);
         $this->addType(fieldName: 'updated', type: 'datetime');
         $this->addType(fieldName: 'created', type: 'datetime');
@@ -1245,7 +1259,7 @@ class Schema extends Entity implements JsonSerializable
      *     slug: null|string, title: null|string, description: null|string,
      *     version: null|string, summary: null|string, icon: null|string,
      *     required: array, properties: array, archive: array|null,
-     *     source: null|string, hardValidation: bool, immutable: bool,
+     *     source: null|string, hardValidation: bool, immutable: bool, appendOnly: bool,
      *     searchable: bool, updated: null|string, created: null|string,
      *     maxDepth: int, owner: null|string, application: null|string,
      *     organisation: null|string,
@@ -1315,6 +1329,7 @@ class Schema extends Entity implements JsonSerializable
             'source'         => $this->source,
             'hardValidation' => $this->hardValidation,
             'immutable'      => $this->immutable,
+            'appendOnly'     => $this->appendOnly,
             'searchable'     => $this->searchable,
         // @todo: should be refactored to strict.
             'updated'        => $updated,
@@ -1905,6 +1920,19 @@ class Schema extends Entity implements JsonSerializable
         $this->searchable = $searchable;
         $this->markFieldUpdated(attribute: 'searchable');
     }//end setSearchable()
+
+    /**
+     * Check whether objects of this schema are append-only.
+     *
+     * When true, INSERT is permitted but UPDATE and DELETE are rejected with
+     * HTTP 405 and error code SCHEMA_APPEND_ONLY.
+     *
+     * @return bool True if the schema is append-only
+     */
+    public function isAppendOnly(): bool
+    {
+        return $this->appendOnly;
+    }//end isAppendOnly()
 
     /**
      * String representation of the schema

--- a/lib/Exception/AppendOnlyException.php
+++ b/lib/Exception/AppendOnlyException.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * OpenRegister AppendOnlyException
+ *
+ * Exception thrown when a mutating operation (UPDATE or DELETE) is attempted
+ * on an object whose schema is declared append-only.
+ *
+ * @category Exception
+ * @package  OCA\OpenRegister\Exception
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+namespace OCA\OpenRegister\Exception;
+
+use Throwable;
+
+/**
+ * Exception thrown when an UPDATE or DELETE is attempted on an append-only schema.
+ *
+ * Schemas with `appendOnly: true` permit INSERT operations but reject all
+ * subsequent mutations. This is used for audit logs (e.g. xAPI statements,
+ * compliance attestations) where immutability of past records is a business
+ * or legal requirement.
+ *
+ * Callers should translate this to HTTP 405 Method Not Allowed with the
+ * structured error body:
+ *   { "error": "SCHEMA_APPEND_ONLY", "message": "...", "schema": "..." }
+ *
+ * @category Exception
+ * @package  OCA\OpenRegister\Exception
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://OpenRegister.app
+ */
+class AppendOnlyException extends \Exception
+{
+
+    /**
+     * The schema slug or identifier that triggered this exception.
+     *
+     * @var string
+     */
+    private readonly string $schemaIdentifier;
+
+    /**
+     * The mutating operation that was rejected ('update' or 'delete').
+     *
+     * @var string
+     */
+    private readonly string $operation;
+
+    /**
+     * Constructor.
+     *
+     * @param string         $schemaIdentifier The schema slug, UUID, or ID
+     * @param string         $operation        The rejected operation ('update' or 'delete')
+     * @param Throwable|null $previous         Previous exception
+     */
+    public function __construct(
+        string $schemaIdentifier,
+        string $operation='update',
+        ?Throwable $previous=null
+    ) {
+        $this->schemaIdentifier = $schemaIdentifier;
+        $this->operation        = $operation;
+
+        $message = sprintf(
+            'SCHEMA_APPEND_ONLY: Schema "%s" is append-only; %s operations are not permitted.',
+            $schemaIdentifier,
+            $operation
+        );
+
+        parent::__construct(message: $message, code: 405, previous: $previous);
+    }//end __construct()
+
+    /**
+     * Get the schema identifier that triggered this exception.
+     *
+     * @return string The schema slug, UUID, or ID
+     */
+    public function getSchemaIdentifier(): string
+    {
+        return $this->schemaIdentifier;
+    }//end getSchemaIdentifier()
+
+    /**
+     * Get the mutating operation that was rejected.
+     *
+     * @return string 'update' or 'delete'
+     */
+    public function getOperation(): string
+    {
+        return $this->operation;
+    }//end getOperation()
+
+    /**
+     * Build the structured JSON error body for HTTP 405 responses.
+     *
+     * @return array{error: string, message: string, schema: string, operation: string}
+     */
+    public function toResponseBody(): array
+    {
+        return [
+            'error'     => 'SCHEMA_APPEND_ONLY',
+            'message'   => $this->getMessage(),
+            'schema'    => $this->schemaIdentifier,
+            'operation' => $this->operation,
+        ];
+    }//end toResponseBody()
+}//end class

--- a/lib/Migration/Version1Date20260511100000.php
+++ b/lib/Migration/Version1Date20260511100000.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * OpenRegister Schema appendOnly Column Migration
+ *
+ * Adds the `append_only` boolean column to the `openregister_schemas` table.
+ * When set to true, objects of this schema permit INSERT operations but reject
+ * UPDATE and DELETE with HTTP 405 + error code SCHEMA_APPEND_ONLY.
+ *
+ * Used by Scholiq for XapiStatement (cmi5+xAPI LRS audit) and Attestation
+ * (compliance evidence) schemas.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Migration: add `append_only` column to schemas table.
+ *
+ * - append_only = false (default) → backward-compatible; no behaviour change
+ * - append_only = true → INSERT only; UPDATE/DELETE rejected with HTTP 405
+ */
+class Version1Date20260511100000 extends SimpleMigrationStep
+{
+    /**
+     * Add append_only column to openregister_schemas table.
+     *
+     * @param IOutput                 $output        Migration output interface
+     * @param Closure                 $schemaClosure Closure returning the DB schema wrapper
+     * @param array<array-key, mixed> $options       Migration options
+     *
+     * @return ISchemaWrapper|null Updated schema, or null when no change was needed
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema = $schemaClosure();
+
+        if ($schema->hasTable('openregister_schemas') === false) {
+            $output->info('openregister_schemas table not found — skipping appendOnly migration');
+            return null;
+        }
+
+        $table = $schema->getTable('openregister_schemas');
+
+        if ($table->hasColumn('append_only') === true) {
+            $output->info('append_only column already exists — skipping');
+            return null;
+        }
+
+        $table->addColumn(
+            'append_only',
+            Types::BOOLEAN,
+            [
+                'notnull' => true,
+                'default' => false,
+                'comment' => 'When true, objects of this schema are INSERT-only; UPDATE and DELETE are rejected with HTTP 405',
+            ]
+        );
+
+        $output->info('Added append_only column to openregister_schemas (default false)');
+
+        return $schema;
+    }//end changeSchema()
+}//end class

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -1084,6 +1084,15 @@ class ObjectService
             $this->rejectIfTransferred(uuid: $uuid);
         }
 
+        // Reject UPDATE operations on append-only schemas (INSERT is still allowed).
+        if ($uuid !== null && $this->currentSchema !== null && $this->currentSchema->isAppendOnly() === true) {
+            $schemaSlug = $this->currentSchema->getSlug() ?? (string) $this->currentSchema->getId();
+            throw new \OCA\OpenRegister\Exception\AppendOnlyException(
+                schemaIdentifier: $schemaSlug,
+                operation: 'update'
+            );
+        }
+
         // Track if UUID was originally null (to distinguish user-provided vs auto-generated UUIDs).
         $uuidWasNull = ($uuid === null);
 
@@ -1469,6 +1478,15 @@ class ObjectService
     {
         // Reject deletion of transferred objects (archiefstatus = overgebracht).
         $this->rejectIfTransferred(uuid: $uuid);
+
+        // Reject DELETE operations on append-only schemas.
+        if ($this->currentSchema !== null && $this->currentSchema->isAppendOnly() === true) {
+            $schemaSlug = $this->currentSchema->getSlug() ?? (string) $this->currentSchema->getId();
+            throw new \OCA\OpenRegister\Exception\AppendOnlyException(
+                schemaIdentifier: $schemaSlug,
+                operation: 'delete'
+            );
+        }
 
         // Find the object to get its owner for permission check (include soft-deleted objects).
         try {

--- a/tests/Unit/Service/AppendOnlyTest.php
+++ b/tests/Unit/Service/AppendOnlyTest.php
@@ -1,0 +1,438 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * AppendOnly Schema Flag Tests
+ *
+ * Tests that appendOnly: true on a schema allows INSERT but rejects UPDATE and DELETE
+ * with AppendOnlyException. Also verifies that schemas without the flag are unaffected.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Db\ViewMapper;
+use OCA\OpenRegister\Exception\AppendOnlyException;
+use OCA\OpenRegister\Service\DateTimeNormalizer;
+use OCA\OpenRegister\Service\FileService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCA\OpenRegister\Service\SearchTrailService;
+use OCA\OpenRegister\Service\SettingsService;
+use OCA\OpenRegister\Service\Object\AuditHandler;
+use OCA\OpenRegister\Service\Object\CacheHandler;
+use OCA\OpenRegister\Service\Object\CascadingHandler;
+use OCA\OpenRegister\Service\Object\DataManipulationHandler;
+use OCA\OpenRegister\Service\Object\DeleteObject;
+use OCA\OpenRegister\Service\Object\FacetHandler;
+use OCA\OpenRegister\Service\Object\GetObject;
+use OCA\OpenRegister\Service\Object\LockHandler;
+use OCA\OpenRegister\Service\Object\MergeHandler;
+use OCA\OpenRegister\Service\Object\MetadataHandler;
+use OCA\OpenRegister\Service\Object\MigrationHandler;
+use OCA\OpenRegister\Service\Object\PerformanceHandler;
+use OCA\OpenRegister\Service\Object\PerformanceOptimizationHandler;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCA\OpenRegister\Service\Object\QueryHandler;
+use OCA\OpenRegister\Service\Object\RelationHandler;
+use OCA\OpenRegister\Service\Object\RenderObject;
+use OCA\OpenRegister\Service\Object\RevertHandler;
+use OCA\OpenRegister\Service\Object\SaveObject;
+use OCA\OpenRegister\Service\Object\SaveObjects;
+use OCA\OpenRegister\Service\Object\SearchQueryHandler;
+use OCA\OpenRegister\Service\Object\UtilityHandler;
+use OCA\OpenRegister\Service\Object\ValidateObject;
+use OCA\OpenRegister\Service\Object\ValidationHandler;
+use OCP\AppFramework\IAppContainer;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+/**
+ * Tests for the appendOnly schema flag enforcement in ObjectService.
+ *
+ * Scenarios:
+ * 1. saveObject (no UUID) on appendOnly schema → allowed (INSERT)
+ * 2. saveObject (with UUID) on appendOnly schema → throws AppendOnlyException (UPDATE)
+ * 3. deleteObject on appendOnly schema → throws AppendOnlyException (DELETE)
+ * 4. saveObject (with UUID) on normal schema → allowed (no flag)
+ * 5. deleteObject on normal schema → allowed (no flag)
+ * 6. AppendOnlyException toResponseBody() returns expected structure
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class AppendOnlyTest extends TestCase
+{
+
+    /** @var ObjectService */
+    private ObjectService $service;
+
+    /** @var ReflectionClass<ObjectService> */
+    private ReflectionClass $reflection;
+
+    /** @var MockObject&SaveObject */
+    private MockObject $saveHandler;
+
+    /** @var MockObject&DeleteObject */
+    private MockObject $deleteHandler;
+
+    /** @var MockObject&MagicMapper */
+    private MockObject $objectMapper;
+
+    /** @var MockObject&CascadingHandler */
+    private MockObject $cascadingHandler;
+
+    /** @var MockObject&DateTimeNormalizer */
+    private MockObject $dateTimeNormalizer;
+
+    /**
+     * Set up fresh service + mocks before each test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->saveHandler        = $this->createMock(SaveObject::class);
+        $this->deleteHandler      = $this->createMock(DeleteObject::class);
+        $this->objectMapper       = $this->createMock(MagicMapper::class);
+        $this->cascadingHandler   = $this->createMock(CascadingHandler::class);
+        $this->dateTimeNormalizer = $this->createMock(DateTimeNormalizer::class);
+
+        // normalize() echoes input unchanged (no date coercion side-effects needed here).
+        $this->dateTimeNormalizer->method('normalize')->willReturnCallback(
+            static function (?string $input): ?\DateTimeImmutable {
+                if ($input === null || trim($input) === '') {
+                    return null;
+                }
+
+                try {
+                    return new \DateTimeImmutable($input);
+                } catch (\Throwable $e) {
+                    return null;
+                }
+            }
+        );
+
+        // CascadingHandler: return object unchanged, UUID unchanged.
+        $this->cascadingHandler->method('handlePreValidationCascading')->willReturnCallback(
+            static function (array $obj, mixed $schema, ?string $uuid, ?int $register): array {
+                return [$obj, $uuid];
+            }
+        );
+
+        $this->service = new ObjectService(
+            $this->createMock(DataManipulationHandler::class),
+            $this->deleteHandler,
+            $this->createMock(GetObject::class),
+            $this->createMock(PerformanceHandler::class),
+            $this->createMock(PermissionHandler::class),
+            $this->createMock(RenderObject::class),
+            $this->saveHandler,
+            $this->createMock(SaveObjects::class),
+            $this->createMock(SearchQueryHandler::class),
+            $this->createMock(ValidateObject::class),
+            $this->createMock(LockHandler::class),
+            $this->createMock(AuditHandler::class),
+            $this->createMock(RelationHandler::class),
+            $this->createMock(MergeHandler::class),
+            $this->createMock(FacetHandler::class),
+            $this->createMock(MetadataHandler::class),
+            $this->createMock(PerformanceOptimizationHandler::class),
+            $this->createMock(QueryHandler::class),
+            $this->createMock(RevertHandler::class),
+            $this->createMock(UtilityHandler::class),
+            $this->createMock(ValidationHandler::class),
+            $this->cascadingHandler,
+            $this->createMock(MigrationHandler::class),
+            $this->createMock(RegisterMapper::class),
+            $this->createMock(SchemaMapper::class),
+            $this->createMock(ViewMapper::class),
+            $this->objectMapper,
+            $this->createMock(FileService::class),
+            $this->createMock(IUserSession::class),
+            $this->createMock(SearchTrailService::class),
+            $this->createMock(IGroupManager::class),
+            $this->createMock(IUserManager::class),
+            $this->createMock(OrganisationService::class),
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(CacheHandler::class),
+            $this->createMock(SettingsService::class),
+            $this->dateTimeNormalizer,
+            $this->createMock(IAppContainer::class)
+        );
+
+        $this->reflection = new ReflectionClass(ObjectService::class);
+    }//end setUp()
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    /**
+     * Inject a value into a private/protected property via reflection.
+     *
+     * @param string $name  Property name
+     * @param mixed  $value Value to set
+     *
+     * @return void
+     */
+    private function setProperty(string $name, mixed $value): void
+    {
+        $prop = $this->reflection->getProperty($name);
+        $prop->setAccessible(true);
+        $prop->setValue($this->service, $value);
+    }//end setProperty()
+
+    /**
+     * Build a Schema entity with the desired appendOnly flag.
+     *
+     * @param bool        $appendOnly Whether to mark the schema as append-only
+     * @param string|null $slug       Optional slug for the schema
+     *
+     * @return Schema
+     */
+    private function makeSchema(bool $appendOnly, ?string $slug='test-schema'): Schema
+    {
+        $schema = new Schema();
+        $schema->setId(99);
+        $schema->setAppendOnly($appendOnly);
+        if ($slug !== null) {
+            $schema->setSlug($slug);
+        }
+
+        return $schema;
+    }//end makeSchema()
+
+    // =========================================================================
+    // 1. INSERT allowed on append-only schema (no UUID → new object)
+    // =========================================================================
+
+    /**
+     * saveObject without a UUID on an append-only schema must reach the SaveObject
+     * handler without throwing (INSERT is permitted).
+     *
+     * @return void
+     */
+    public function testSaveObjectInsertAllowedOnAppendOnlySchema(): void
+    {
+        $schema = $this->makeSchema(appendOnly: true);
+
+        // Inject the schema context so ObjectService believes it is append-only.
+        $this->setProperty('currentSchema', $schema);
+        $this->setProperty('currentRegister', null);
+
+        // SaveObject handler returns a stub entity on success.
+        $savedEntity = new ObjectEntity();
+        $savedEntity->setUuid('new-uuid-1234');
+
+        $this->saveHandler->method('saveObject')->willReturn($savedEntity);
+        $this->saveHandler->method('applyAlwaysDefaults')->willReturnArgument(1);
+        $this->saveHandler->method('clearAllCaches')->willReturn(null);
+
+        // ObjectMapper: no existing object with this UUID (it's a new insert).
+        $this->objectMapper->method('find')->willThrowException(
+            new \OCP\AppFramework\Db\DoesNotExistException('not found')
+        );
+
+        // Should NOT throw — INSERT is permitted even on append-only schemas.
+        $result = $this->service->saveObject(
+            object: ['name' => 'entry'],
+            uuid: null
+        );
+
+        $this->assertSame($savedEntity, $result);
+    }//end testSaveObjectInsertAllowedOnAppendOnlySchema()
+
+    // =========================================================================
+    // 2. UPDATE rejected on append-only schema (UUID present)
+    // =========================================================================
+
+    /**
+     * saveObject with a UUID on an append-only schema must throw AppendOnlyException.
+     *
+     * @return void
+     */
+    public function testSaveObjectUpdateRejectedOnAppendOnlySchema(): void
+    {
+        $schema = $this->makeSchema(appendOnly: true, slug: 'xapi-statement');
+        $this->setProperty('currentSchema', $schema);
+        $this->setProperty('currentRegister', null);
+
+        // The object exists in the DB (it's an update).
+        $existingEntity = new ObjectEntity();
+        $existingEntity->setUuid('existing-uuid-abc');
+        $this->objectMapper->method('find')->willReturn($existingEntity);
+
+        $this->expectException(AppendOnlyException::class);
+        $this->expectExceptionMessageMatches('/SCHEMA_APPEND_ONLY/');
+
+        $this->service->saveObject(
+            object: ['name' => 'updated-entry'],
+            uuid: 'existing-uuid-abc'
+        );
+    }//end testSaveObjectUpdateRejectedOnAppendOnlySchema()
+
+    // =========================================================================
+    // 3. DELETE rejected on append-only schema
+    // =========================================================================
+
+    /**
+     * deleteObject on an append-only schema must throw AppendOnlyException.
+     *
+     * @return void
+     */
+    public function testDeleteObjectRejectedOnAppendOnlySchema(): void
+    {
+        $schema = $this->makeSchema(appendOnly: true, slug: 'attestation');
+        $this->setProperty('currentSchema', $schema);
+
+        $this->expectException(AppendOnlyException::class);
+        $this->expectExceptionCode(405);
+
+        $this->service->deleteObject(uuid: 'some-uuid-xyz');
+    }//end testDeleteObjectRejectedOnAppendOnlySchema()
+
+    // =========================================================================
+    // 4. UPDATE allowed on ordinary (non-append-only) schema
+    // =========================================================================
+
+    /**
+     * saveObject with UUID on a schema without appendOnly must pass through to
+     * SaveObject handler without throwing.
+     *
+     * @return void
+     */
+    public function testSaveObjectUpdateAllowedOnOrdinarySchema(): void
+    {
+        $schema = $this->makeSchema(appendOnly: false, slug: 'ordinary');
+        $this->setProperty('currentSchema', $schema);
+        $this->setProperty('currentRegister', null);
+
+        $savedEntity = new ObjectEntity();
+        $savedEntity->setUuid('ordinary-uuid-456');
+
+        $this->saveHandler->method('saveObject')->willReturn($savedEntity);
+        $this->saveHandler->method('applyAlwaysDefaults')->willReturnArgument(1);
+        $this->saveHandler->method('clearAllCaches')->willReturn(null);
+
+        // Existing object found — normal UPDATE path.
+        $existingEntity = new ObjectEntity();
+        $existingEntity->setUuid('ordinary-uuid-456');
+        $this->objectMapper->method('find')->willReturn($existingEntity);
+
+        // Must not throw.
+        $result = $this->service->saveObject(
+            object: ['name' => 'updated'],
+            uuid: 'ordinary-uuid-456'
+        );
+
+        $this->assertSame($savedEntity, $result);
+    }//end testSaveObjectUpdateAllowedOnOrdinarySchema()
+
+    // =========================================================================
+    // 5. DELETE allowed on ordinary (non-append-only) schema
+    // =========================================================================
+
+    /**
+     * deleteObject on a schema without appendOnly must NOT throw AppendOnlyException
+     * and must delegate to the deleteHandler.
+     *
+     * @return void
+     */
+    public function testDeleteObjectAllowedOnOrdinarySchema(): void
+    {
+        $schema = $this->makeSchema(appendOnly: false, slug: 'ordinary');
+        $this->setProperty('currentSchema', $schema);
+
+        // Mock the object mapper for the permission check inside deleteObject.
+        $objectEntity = new ObjectEntity();
+        $objectEntity->setUuid('del-uuid-789');
+        $objectEntity->setRetention([]);
+        $this->objectMapper->method('find')->willReturn($objectEntity);
+
+        // deleteHandler should be called and returns true.
+        $this->deleteHandler
+            ->expects($this->once())
+            ->method('deleteObject')
+            ->willReturn(true);
+
+        $result = $this->service->deleteObject(uuid: 'del-uuid-789');
+
+        $this->assertTrue($result);
+    }//end testDeleteObjectAllowedOnOrdinarySchema()
+
+    // =========================================================================
+    // 6. AppendOnlyException response body structure
+    // =========================================================================
+
+    /**
+     * AppendOnlyException::toResponseBody() must return the expected keys/values.
+     *
+     * @return void
+     */
+    public function testAppendOnlyExceptionResponseBody(): void
+    {
+        $exception = new AppendOnlyException(
+            schemaIdentifier: 'xapi-statement',
+            operation: 'delete'
+        );
+
+        $body = $exception->toResponseBody();
+
+        $this->assertSame('SCHEMA_APPEND_ONLY', $body['error']);
+        $this->assertSame('xapi-statement', $body['schema']);
+        $this->assertSame('delete', $body['operation']);
+        $this->assertStringContainsString('xapi-statement', $body['message']);
+        $this->assertSame(405, $exception->getCode());
+    }//end testAppendOnlyExceptionResponseBody()
+
+    // =========================================================================
+    // 7. Schema::isAppendOnly() reflects setAppendOnly()
+    // =========================================================================
+
+    /**
+     * Schema entity must expose isAppendOnly() that reflects the stored flag.
+     *
+     * @return void
+     */
+    public function testSchemaIsAppendOnlyGetter(): void
+    {
+        $schema = new Schema();
+
+        // Default must be false (backward compatible).
+        $this->assertFalse($schema->isAppendOnly());
+
+        $schema->setAppendOnly(true);
+        $this->assertTrue($schema->isAppendOnly());
+
+        $schema->setAppendOnly(false);
+        $this->assertFalse($schema->isAppendOnly());
+    }//end testSchemaIsAppendOnlyGetter()
+}//end class


### PR DESCRIPTION
## Summary

- Adds `appendOnly: true` top-level schema flag. When set, INSERT (new objects) is permitted but UPDATE and DELETE are rejected with HTTP 405 + structured error `SCHEMA_APPEND_ONLY`.
- Implements DB migration (`Version1Date20260511100000`) adding the `append_only` boolean column (default `false`, backward-compatible).
- New `AppendOnlyException` class with `toResponseBody()` returning `{ error, message, schema, operation }`.
- Enforcement in `ObjectService::saveObject()` (UUID present = update path) and `ObjectService::deleteObject()`.
- `ObjectsController` handles `AppendOnlyException` in `update()`, `patch()`, `postPatch()`, and `destroy()` with HTTP 405.
- 7 PHPUnit tests: insert allowed, update rejected, delete rejected, ordinary schema unchanged, exception response body structure, Schema entity getter.

Closes #1470 (scholiq deps: XapiStatement + Attestation schemas need audit-log immutability).

## Test plan

- [ ] `composer check:strict` passes (PHPCS clean on all lib/ files)
- [ ] PHPUnit: `AppendOnlyTest` — 7 tests pass in Docker environment
- [ ] Manual: create object on appendOnly schema → 201; update → 405 `SCHEMA_APPEND_ONLY`; delete → 405
- [ ] Schemas without `appendOnly` flag are completely unaffected