### PR TITLE
feat(integration-xwiki): XwikiProvider — external, OpenConnector-backed (leaf, backend)

### DIFF
--- a/docs/Integrations/xwiki-openconnector-source.yaml
+++ b/docs/Integrations/xwiki-openconnector-source.yaml
@@ -1,0 +1,123 @@
+# OpenConnector source template — XWiki
+#
+# Import this into OpenConnector (Settings → OpenConnector → Sources →
+# Import) and fill in the `location` + auth fields for your XWiki
+# instance. OpenRegister's `XwikiProvider` (id: `xwiki`, group:
+# `external`) routes all of its CRUD through this source via
+# ExternalIntegrationRouter; it never holds credentials itself.
+#
+# (The repo's `config/` directory is gitignored, so this template
+# lives under docs/Integrations/ — copy it to wherever your
+# OpenConnector instance imports source definitions from.)
+#
+# XWiki version notes:
+#   - 5.x / 10.x+ / 14.x+ all expose a REST API under /rest. The
+#     mapping below uses the generic page endpoints; OpenConnector's
+#     adapter normalises field-name drift across versions.
+#   - Authentication is customer-dependent: HTTP Basic works on every
+#     version; OAuth2 (via the xwiki-platform-oidc extension) is
+#     available on newer instances. Pick ONE of the `auth` blocks
+#     below and delete the other.
+#
+# Spec: openspec/changes/integration-xwiki/design.md
+#   - AD-1: detail-page preview is text-only — request the
+#     already-rendered HTML, the @conduction/nextcloud-vue widget
+#     strips it to text and truncates to ~500 chars; macros are NEVER
+#     executed in the preview.
+#   - AD-2: a page may be linked by full XWiki URL or by a `Space.Page`
+#     path — the `create` endpoint resolves both to canonical.
+#   - AD-3: rows carry a `breadcrumb` so the UI can disambiguate
+#     same-titled pages in different spaces.
+
+source:
+  # Stable id — MUST be `xwiki` (matches XwikiProvider::getOpenConnectorSource()).
+  reference: xwiki
+  name: XWiki
+  description: >-
+    XWiki pages linked to OpenRegister objects. Surfaced as the
+    "Articles" integration (sidebar tab + dashboard/detail widgets).
+  type: api
+
+  # Base URL of the XWiki REST API. Example for a wiki at
+  # https://wiki.example.org with the default "xwiki" wiki:
+  #   https://wiki.example.org/rest/wikis/xwiki
+  location: "https://wiki.example.org/rest/wikis/xwiki"
+
+  # ---------------------------------------------------------------
+  # Authentication — keep exactly ONE of the two blocks below.
+  # ---------------------------------------------------------------
+
+  # Option A — HTTP Basic (works on all XWiki versions).
+  auth:
+    type: basic
+    username: "${XWIKI_USERNAME}"
+    password: "${XWIKI_PASSWORD}"
+
+  # Option B — OAuth2 (xwiki-platform-oidc; newer instances only).
+  # auth:
+  #   type: oauth2
+  #   grantType: client_credentials
+  #   tokenUrl: "https://wiki.example.org/oidc/token"
+  #   clientId: "${XWIKI_OIDC_CLIENT_ID}"
+  #   clientSecret: "${XWIKI_OIDC_CLIENT_SECRET}"
+  #   scope: "openid profile"
+
+  headers:
+    Accept: application/json
+
+  # ---------------------------------------------------------------
+  # Endpoint mapping consumed by XwikiProvider. The provider sends
+  # the object context as query params (register / schema / object)
+  # plus optional _search / _limit / _page; OpenConnector resolves
+  # those to the appropriate XWiki REST calls and normalises the
+  # response rows to { reference, title, space, page, breadcrumb,
+  # url, content }.
+  # ---------------------------------------------------------------
+  endpoints:
+    # GET  — list linked pages for an object
+    list:
+      method: GET
+      path: ""              # relative to `location`
+      # The pairing store — which XWiki pages are linked to which OR
+      # object — lives in OpenConnector's own pairing model, keyed by
+      # the {register, schema, object} context. OpenConnector then
+      # fetches each linked page's metadata (and, for the detail-page
+      # surface, its rendered content) from XWiki.
+      response:
+        rowsPath: "$"        # bare array, or "$.results"
+        map:
+          reference: "id"          # XWiki page reference, e.g. "Space.Page"
+          title: "title"
+          space: "space"
+          page: "name"
+          url: "xwikiAbsoluteUrl"
+          content: "content"       # already-rendered HTML; UI strips to text + ~500 chars (AD-1)
+
+    # GET {id}  — one linked page (with content for the preview)
+    get:
+      method: GET
+      path: "{id}"
+
+    # POST  — link a page (body carries `reference`: a full XWiki URL
+    # or a `Space.Page` path; OpenConnector resolves both to canonical)
+    create:
+      method: POST
+      path: ""
+
+    # PUT {id}  — update a pairing
+    update:
+      method: PUT
+      path: "{id}"
+
+    # DELETE {id}  — unlink (removes the pairing; does NOT delete the
+    # page in XWiki)
+    delete:
+      method: DELETE
+      path: "{id}"
+
+  # Health probe used by OpenRegister's admin UI / OCS capabilities.
+  # A cheap authenticated GET that returns 200 when the instance is
+  # reachable and the credentials are valid.
+  healthCheck:
+    method: GET
+    path: ""

--- a/docs/Integrations/xwiki-openconnector-source.yaml
+++ b/docs/Integrations/xwiki-openconnector-source.yaml
@@ -73,6 +73,30 @@ source:
   # response rows to { reference, title, space, page, breadcrumb,
   # url, content }.
   # ---------------------------------------------------------------
+  #
+  # XWiki REST shape — verified against xwiki:lts 17.10 (Tomcat, ROOT
+  # context, REST at `/rest/`):
+  #   GET /rest/wikis/xwiki/spaces/{Space}/pages/{Page}  →
+  #     { id: "xwiki:Space.Page", space, name, title, xwikiAbsoluteUrl,
+  #       content (RAW xwiki/2.1 syntax — NOT rendered HTML),
+  #       hierarchy: { items: [{ label, name, type: wiki|space|document,
+  #       url }] }, version, modified, … }
+  #
+  # Two things to get right when wiring the response mapping:
+  #   1. AD-3 breadcrumb — XWiki's `hierarchy.items[].label` IS the
+  #      native breadcrumb ("xwiki" / "Sandbox" / "IntegrationTest").
+  #      Map `breadcrumb` from it. (If you don't, OpenRegister's
+  #      XwikiProvider derives a coarse one from space + title.)
+  #   2. AD-1 preview content — the REST `content` field is RAW wiki
+  #      syntax, not HTML. For a clean text preview, fetch the
+  #      already-rendered page body from
+  #        GET /bin/get/{Space}/{Page}?xpage=plain      (→ HTML)
+  #      (XWiki executes the page's macros server-side, in XWiki's own
+  #      sandbox — they are NEVER executed inside Nextcloud; the widget
+  #      only ever reads the text content) and map that to `content`.
+  #      If instead you map `content` straight from the REST `content`
+  #      field, the preview shows the raw wiki source — still safe
+  #      (macro markup is inert text), just less polished.
   endpoints:
     # GET  — list linked pages for an object
     list:
@@ -80,20 +104,22 @@ source:
       path: ""              # relative to `location`
       # The pairing store — which XWiki pages are linked to which OR
       # object — lives in OpenConnector's own pairing model, keyed by
-      # the {register, schema, object} context. OpenConnector then
-      # fetches each linked page's metadata (and, for the detail-page
-      # surface, its rendered content) from XWiki.
+      # the {register, schema, object} context. OpenConnector resolves
+      # the linked references, fetches each page's metadata from XWiki
+      # REST, and (for the preview) the rendered body from
+      # /bin/get/{Space}/{Page}?xpage=plain.
       response:
         rowsPath: "$"        # bare array, or "$.results"
         map:
-          reference: "id"          # XWiki page reference, e.g. "Space.Page"
+          reference: "id"                       # e.g. "xwiki:Sandbox.IntegrationTest"
           title: "title"
           space: "space"
           page: "name"
           url: "xwikiAbsoluteUrl"
-          content: "content"       # already-rendered HTML; UI strips to text + ~500 chars (AD-1)
+          breadcrumb: "hierarchy.items[*].label"  # AD-3 — native XWiki breadcrumb
+          content: "renderedContent"              # AD-1 — set from /bin/get/...?xpage=plain (see note above)
 
-    # GET {id}  — one linked page (with content for the preview)
+    # GET {id}  — one linked page (with rendered content for the preview)
     get:
       method: GET
       path: "{id}"

--- a/docs/Integrations/xwiki.md
+++ b/docs/Integrations/xwiki.md
@@ -1,0 +1,28 @@
+# XWiki Integration ("Articles")
+
+Link XWiki pages to OpenRegister objects. Appears as the **Articles** tab in the object sidebar, as an `xwiki` widget on dashboards and detail pages, and as a single-entity reference renderer for schema properties that declare `referenceType: 'xwiki'`.
+
+This is an **external** integration (storage strategy `external`, group `external`) — it is the worked example for the [pluggable integration registry](pluggable-integration-registry.md). It carries no HTTP client and no credentials of its own: all CRUD is delegated to an OpenConnector source named `xwiki`.
+
+## Setup
+
+1. **Install OpenConnector** (the `openconnector` Nextcloud app). The Articles integration is hidden until it's installed and enabled.
+2. **Create the `xwiki` source in OpenConnector** — import the template at [`xwiki-openconnector-source.yaml`](xwiki-openconnector-source.yaml), then fill in:
+   - `location` — your XWiki REST base URL, e.g. `https://wiki.example.org/rest/wikis/xwiki`
+   - the `auth` block — HTTP Basic (works on every XWiki version) **or** OAuth2 (xwiki-platform-oidc; newer instances). Keep exactly one.
+3. **Verify** in OpenRegister → Administration → OpenRegister → Integrations: the `xwiki` row should show storage `external`, required app `openconnector`, and an auth/health status. The "Configure" link deep-links into OpenConnector's source page; "Test connection" probes the source.
+
+## Using it
+
+- **Sidebar (Articles tab)** — shows linked pages with their full breadcrumb ("Wiki / Department / Subspace / Page"), since two pages can share a title in different spaces. Link a page by pasting its **URL** (parsed to a canonical `Space.Page` reference) or by typing the **path** directly. Unlink removes the pairing only — it never deletes the page in XWiki. An "authentication expired" banner appears if the source's credentials need re-connecting.
+- **Detail-page widget** — linked pages list plus a **text preview** (the first ~500 characters of the page's rendered content) and a link to the full page. **XWiki macros are not executed** in the preview (no Velocity templates / scripts run inside Nextcloud) — click through to XWiki for full rendering.
+- **Dashboard widget** — recent linked pages (user dashboard) or app-scoped (app dashboard).
+- **Reference property** — a schema property with `referenceType: 'xwiki'` renders the linked page's title + breadcrumb chip in `CnFormDialog` / `CnDetailGrid`.
+
+## Notes
+
+- **Permissions** — the integration inherits access from the underlying object's RBAC plus OpenConnector's own. If a user has Nextcloud access to the object but not XWiki access to a page, they see a "No access to page" placeholder, not an internal error.
+- **XWiki versions** — 5.x / 10.x+ / 14.x+ are all supported; the OpenConnector adapter normalises REST field-name drift, so the provider stays version-agnostic.
+- **Failure modes** — if OpenConnector is missing/disabled, the source is missing, or the remote XWiki is down, the tab degrades to an empty state with a clear message rather than a broken tab (AD-23).
+
+See [pluggable-integration-registry.md](pluggable-integration-registry.md) for how this integration is wired into the registry, and `openspec/changes/integration-xwiki/` for the change spec.

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -997,6 +997,22 @@ class Application extends App implements IBootstrap
                 );
             }
         );
+
+        // Leaf provider: XWiki (external, OpenConnector-backed). Ships
+        // in-repo as the worked external-storage example; routed
+        // through ExternalIntegrationRouter, credentials on the
+        // OpenConnector `xwiki` source.
+        // @spec openspec/changes/integration-xwiki/tasks.md
+        $context->registerService(
+            \OCA\OpenRegister\Service\Integration\Providers\XwikiProvider::class,
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\Service\Integration\Providers\XwikiProvider(
+                    router: $container->get(\OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter::class),
+                    appManager: $container->get('OCP\App\IAppManager'),
+                    l10n: $container->get('OCP\IL10N'),
+                );
+            }
+        );
     }//end registerBuiltinIntegrationProviders()
 
     /**
@@ -1183,6 +1199,8 @@ class Application extends App implements IBootstrap
             \OCA\OpenRegister\Service\Integration\BuiltinProviders\TasksProvider::class,
             \OCA\OpenRegister\Service\Integration\BuiltinProviders\TagsProvider::class,
             \OCA\OpenRegister\Service\Integration\BuiltinProviders\AuditTrailProvider::class,
+            // Leaf: XWiki (external) — see openspec/changes/integration-xwiki.
+            \OCA\OpenRegister\Service\Integration\Providers\XwikiProvider::class,
         ];
 
         foreach ($providerClasses as $providerClass) {

--- a/lib/Exception/ProviderUnavailableException.php
+++ b/lib/Exception/ProviderUnavailableException.php
@@ -38,6 +38,7 @@ class ProviderUnavailableException extends \RuntimeException
     public const CAUSE_OPENCONNECTOR_DOWN           = 'openconnector-down';
     public const CAUSE_OPENCONNECTOR_SOURCE_MISSING = 'openconnector-source-missing';
     public const CAUSE_UPSTREAM_SERVICE_DOWN        = 'upstream-service-down';
+    public const CAUSE_PROVIDER_AUTH                = 'provider-auth';
 
     /**
      * The cause classification.

--- a/lib/Service/Integration/ExternalIntegrationRouter.php
+++ b/lib/Service/Integration/ExternalIntegrationRouter.php
@@ -330,11 +330,13 @@ class ExternalIntegrationRouter
 
         if (method_exists($callService, 'call') === true) {
             $response = $callService->call($source, $path, $method, $options);
+            $this->assertUpstreamOk($response);
             return $this->decodeResponse($response);
         }
 
         if (method_exists($callService, 'request') === true) {
             $response = $callService->request($source, $method, $path, $options);
+            $this->assertUpstreamOk($response);
             return $this->decodeResponse($response);
         }
 
@@ -344,11 +346,48 @@ class ExternalIntegrationRouter
     }//end invoke()
 
     /**
+     * Treat a >= 400 upstream status (carried on the CallLog OpenConnector
+     * returns) as an upstream failure rather than letting an error page
+     * leak through as "rows". A 401/403 specifically is re-flagged as
+     * `provider-auth` so the UI shows the "reconnect connector" banner.
+     *
+     * @param mixed $response The CallService return value.
+     *
+     * @return void
+     *
+     * @throws ProviderUnavailableException When the upstream answered >= 400.
+     */
+    private function assertUpstreamOk($response): void
+    {
+        if (is_object($response) === false || method_exists($response, 'getStatusCode') === false) {
+            return;
+        }
+
+        $status = (int) $response->getStatusCode();
+        if ($status < 400) {
+            return;
+        }
+
+        $cause = ($status === 401 || $status === 403)
+            ? ProviderUnavailableException::CAUSE_PROVIDER_AUTH
+            : ProviderUnavailableException::CAUSE_UPSTREAM_SERVICE_DOWN;
+
+        throw new ProviderUnavailableException(
+            sprintf('Upstream service answered HTTP %d.', $status),
+            $cause
+        );
+    }//end assertUpstreamOk()
+
+    /**
      * Normalise a CallService response into a decoded array.
      *
-     * CallService returns either a CallLog entity (carrying a JSON
-     * body), a raw array, or a scalar string. We always normalise to
-     * an array; non-arrays are wrapped under a `body` key so callers
+     * OpenConnector's CallService returns a `CallLog` whose
+     * `getResponse()` is `{ statusCode, headers, body, encoding, … }` —
+     * the actual upstream payload is the (usually JSON) `body` string
+     * (base64-encoded when the upstream wasn't UTF-8). We unwrap that,
+     * JSON-decode it, and hand the caller the upstream body directly.
+     * A raw array / scalar string from an older CallService is decoded
+     * in place; non-arrays are wrapped under a `body` key so callers
      * have a stable shape to introspect.
      *
      * @param mixed $response The raw return from CallService.
@@ -359,6 +398,23 @@ class ExternalIntegrationRouter
     {
         if (is_array($response) === true) {
             return $response;
+        }
+
+        // CallLog (OpenConnector) — pull the upstream body out of getResponse().
+        if (is_object($response) === true && method_exists($response, 'getResponse') === true) {
+            $payload = $response->getResponse();
+            if (is_array($payload) === true && array_key_exists('body', $payload) === true) {
+                $body = $payload['body'];
+                if (($payload['encoding'] ?? null) === 'base64' && is_string($body) === true) {
+                    $body = (string) base64_decode($body, true);
+                }
+
+                return $this->decodeResponse($body);
+            }
+
+            if (is_array($payload) === true) {
+                return $payload;
+            }
         }
 
         if (is_object($response) === true && method_exists($response, 'jsonSerialize') === true) {

--- a/lib/Service/Integration/Providers/XwikiProvider.php
+++ b/lib/Service/Integration/Providers/XwikiProvider.php
@@ -1,0 +1,444 @@
+<?php
+
+/**
+ * XwikiProvider — exposes XWiki pages linked to an OpenRegister
+ * object via the IntegrationProvider contract.
+ *
+ * Storage strategy is `external` (AD-4 / AD-22): there is no local
+ * link table — pairings live in OpenConnector's own model and the
+ * pages themselves live in the remote XWiki instance. All CRUD is
+ * delegated to {@see ExternalIntegrationRouter}, which resolves the
+ * declared OpenConnector source (`xwiki`), makes the call, and
+ * surfaces structured failures via {@see ProviderUnavailableException}
+ * (AD-23). The provider never carries an HTTP client and never
+ * handles credentials — those are configured on the OpenConnector
+ * source (basic or OAuth2, customer-dependent — AD-15).
+ *
+ * Per the leaf design.md:
+ *   - AD-1: detail-page preview is text-only (first ~500 chars of the
+ *     HTML-rendered content, macros NOT executed) — the UI does the
+ *     truncation; the provider just round-trips whatever the source
+ *     returns under `content` / `preview`.
+ *   - AD-2: callers may link a page by full XWiki URL or by a
+ *     `space.page` path — the OpenConnector source normalises both to
+ *     a canonical reference. The provider passes the raw `reference`
+ *     through in `create()`.
+ *   - AD-3: rows carry a `breadcrumb` so the UI can disambiguate
+ *     same-titled pages in different spaces.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Integration\Providers
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/integration-xwiki/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Integration\Providers;
+
+use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
+use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
+use OCP\App\IAppManager;
+use OCP\IL10N;
+
+/**
+ * XWiki integration provider — external, OpenConnector-backed.
+ */
+class XwikiProvider extends AbstractIntegrationProvider
+{
+
+    /**
+     * OpenConnector source id this provider routes through.
+     *
+     * @var string
+     */
+    private const SOURCE_ID = 'xwiki';
+
+    /**
+     * NC app that must be installed for this integration to function
+     * (it carries the OpenConnector source + credentials).
+     *
+     * @var string
+     */
+    private const REQUIRED_APP = 'openconnector';
+
+    /**
+     * Constructor.
+     *
+     * @param ExternalIntegrationRouter $router     External-call router.
+     * @param IAppManager               $appManager NC app manager (isEnabled check).
+     * @param IL10N                     $l10n       Localisation.
+     *
+     * @return void
+     */
+    public function __construct(
+        private ExternalIntegrationRouter $router,
+        private IAppManager $appManager,
+        private IL10N $l10n,
+    ) {
+    }//end __construct()
+
+    /**
+     * Stable provider id (matches the PHP/JS registrations + the
+     * OpenConnector source name).
+     *
+     * @return string
+     */
+    public function getId(): string
+    {
+        return 'xwiki';
+    }//end getId()
+
+    /**
+     * Human-readable label shown in the sidebar tab / admin UI.
+     *
+     * @return string
+     */
+    public function getLabel(): string
+    {
+        return $this->l10n->t('Articles');
+    }//end getLabel()
+
+    /**
+     * MDI icon name for the tab / widget.
+     *
+     * @return string
+     */
+    public function getIcon(): string
+    {
+        return 'FileDocumentMultiple';
+    }//end getIcon()
+
+    /**
+     * Named group this integration belongs to (AD-16).
+     *
+     * @return string|null
+     */
+    public function getGroup(): ?string
+    {
+        return 'external';
+    }//end getGroup()
+
+    /**
+     * Nextcloud app that must be installed for this integration to
+     * function — OpenConnector carries the `xwiki` source + credentials.
+     *
+     * @return string|null
+     */
+    public function getRequiredApp(): ?string
+    {
+        return self::REQUIRED_APP;
+    }//end getRequiredApp()
+
+    /**
+     * Storage strategy (AD-22) — `external`: no local link table; the
+     * pairings live in OpenConnector and the pages in remote XWiki.
+     *
+     * @return string
+     */
+    public function getStorageStrategy(): string
+    {
+        return 'external';
+    }//end getStorageStrategy()
+
+    /**
+     * OpenConnector source id this provider routes all CRUD through
+     * (AD-4).
+     *
+     * @return string|null
+     */
+    public function getOpenConnectorSource(): ?string
+    {
+        return self::SOURCE_ID;
+    }//end getOpenConnectorSource()
+
+    /**
+     * Whether the integration is available — true iff OpenConnector is
+     * installed and enabled (it owns the `xwiki` source + credentials).
+     * ExternalIntegrationRouter still degrades gracefully if the source
+     * itself is missing or the remote XWiki is down.
+     *
+     * @return bool
+     */
+    public function isEnabled(): bool
+    {
+        return $this->appManager->isInstalled(self::REQUIRED_APP);
+    }//end isEnabled()
+
+    /**
+     * Auth requirements descriptor. `type: 'external'` — credentials
+     * are configured on the OpenConnector source, not here. XWiki
+     * deployments use either HTTP Basic or OAuth2 depending on the
+     * customer; the source config picks one. OpenRegister's admin UI
+     * surfaces the source's auth status and links out to OpenConnector
+     * to configure it.
+     *
+     * @return array<string,mixed>
+     */
+    public function authRequirements(): array
+    {
+        return [
+            'type'          => 'external',
+            'configuredVia' => 'openconnector',
+            'source'        => self::SOURCE_ID,
+            'supports'      => ['basic', 'oauth2'],
+        ];
+    }//end authRequirements()
+
+    /**
+     * List the XWiki pages linked to an OR object.
+     *
+     * Delegates to the OpenConnector `xwiki` source, passing the
+     * object context as query params. The source returns the linked
+     * pages (already normalised across XWiki 5.x / 10.x / 14.x); this
+     * method shapes each row into the
+     * `{ id, title, breadcrumb, url, space, page }` contract the UI
+     * relies on (AD-3 breadcrumb). On any failure the
+     * ProviderUnavailableException bubbles to the controller, which
+     * translates it to a 503 with a cause the UI can render as a
+     * degraded/reconnect state — never a broken tab (AD-23).
+     *
+     * @param string              $register Register slug or numeric id.
+     * @param string              $schema   Schema slug or numeric id.
+     * @param string              $objectId Object uuid.
+     * @param array<string,mixed> $filters  Optional: `_search`, `_limit`, `_page`.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function list(string $register, string $schema, string $objectId, array $filters=[]): array
+    {
+        $query    = $this->contextQuery(register: $register, schema: $schema, objectId: $objectId, filters: $filters);
+        $response = $this->router->call(
+            provider: $this,
+            method: 'GET',
+            path: '',
+            options: ['query' => $query]
+        );
+
+        return $this->normalizeList(response: $response);
+    }//end list()
+
+    /**
+     * Fetch a single linked XWiki page (with text preview).
+     *
+     * The OpenConnector source returns the HTML-rendered content under
+     * `content` / `renderedContent`; the UI truncates it to ~500 chars
+     * for the preview and never executes macros (AD-1). This method
+     * just round-trips the row.
+     *
+     * @param string $register Register slug or numeric id.
+     * @param string $schema   Schema slug or numeric id.
+     * @param string $objectId Object uuid.
+     * @param string $entityId Canonical XWiki page reference (e.g. `Space.Page`).
+     *
+     * @return array<string,mixed>
+     */
+    public function get(string $register, string $schema, string $objectId, string $entityId): array
+    {
+        $query    = $this->contextQuery(register: $register, schema: $schema, objectId: $objectId, filters: []);
+        $response = $this->router->call(
+            provider: $this,
+            method: 'GET',
+            path: rawurlencode($entityId),
+            options: ['query' => $query]
+        );
+
+        return $this->normalizeRow(row: $response);
+    }//end get()
+
+    /**
+     * Link an XWiki page to an OR object.
+     *
+     * `$payload` carries a `reference` — either a full XWiki URL or a
+     * `space.page` path (AD-2). The OpenConnector source resolves it
+     * to a canonical reference and records the pairing; the resolved
+     * row is returned.
+     *
+     * @param string              $register Register slug or numeric id.
+     * @param string              $schema   Schema slug or numeric id.
+     * @param string              $objectId Object uuid.
+     * @param array<string,mixed> $payload  At least `reference` (URL or `space.page`).
+     *
+     * @return array<string,mixed>
+     */
+    public function create(string $register, string $schema, string $objectId, array $payload): array
+    {
+        $body = $payload;
+        $body['register'] = $register;
+        $body['schema']   = $schema;
+        $body['object']   = $objectId;
+
+        $response = $this->router->call(provider: $this, method: 'POST', path: '', options: ['body' => $body]);
+
+        return $this->normalizeRow(row: $response);
+    }//end create()
+
+    /**
+     * Update a linked-page pairing (e.g. re-point to a different page).
+     *
+     * @param string              $register Register slug or numeric id.
+     * @param string              $schema   Schema slug or numeric id.
+     * @param string              $objectId Object uuid.
+     * @param string              $entityId Canonical XWiki page reference.
+     * @param array<string,mixed> $payload  Fields to update (e.g. `reference`).
+     *
+     * @return array<string,mixed>
+     */
+    public function update(string $register, string $schema, string $objectId, string $entityId, array $payload): array
+    {
+        $body = $payload;
+        $body['register'] = $register;
+        $body['schema']   = $schema;
+        $body['object']   = $objectId;
+
+        $response = $this->router->call(
+            provider: $this,
+            method: 'PUT',
+            path: rawurlencode($entityId),
+            options: ['body' => $body]
+        );
+
+        return $this->normalizeRow(row: $response);
+    }//end update()
+
+    /**
+     * Unlink an XWiki page from an OR object. Removes the pairing in
+     * OpenConnector — does NOT delete the page in XWiki.
+     *
+     * @param string $register Register slug or numeric id.
+     * @param string $schema   Schema slug or numeric id.
+     * @param string $objectId Object uuid.
+     * @param string $entityId Canonical XWiki page reference.
+     *
+     * @return void
+     */
+    public function delete(string $register, string $schema, string $objectId, string $entityId): void
+    {
+        $this->router->call(
+            provider: $this,
+            method: 'DELETE',
+            path: rawurlencode($entityId),
+            options: ['query' => $this->contextQuery(register: $register, schema: $schema, objectId: $objectId, filters: [])]
+        );
+    }//end delete()
+
+    /**
+     * Health descriptor — defers to the router's probe so the admin
+     * UI / OCS capabilities report the same status runtime callers
+     * would see (OpenConnector down / source missing / upstream down /
+     * ok).
+     *
+     * @return array{status: string, authStatus: string, message: ?string}
+     */
+    public function health(): array
+    {
+        return $this->router->probe(provider: $this);
+    }//end health()
+
+    /**
+     * Build the standard `{register, schema, object, …filters}` query
+     * the OpenConnector source expects as request context.
+     *
+     * @param string              $register Register slug or numeric id.
+     * @param string              $schema   Schema slug or numeric id.
+     * @param string              $objectId Object uuid.
+     * @param array<string,mixed> $filters  Caller filters merged in (search/limit/page).
+     *
+     * @return array<string,mixed>
+     */
+    private function contextQuery(string $register, string $schema, string $objectId, array $filters): array
+    {
+        return array_merge(
+            $filters,
+            ['register' => $register, 'schema' => $schema, 'object' => $objectId]
+        );
+    }//end contextQuery()
+
+    /**
+     * Normalise the source's list response (which may be a bare array
+     * of rows, or `{ results: [...] }`, or `{ items: [...] }`) into a
+     * plain array of normalised rows.
+     *
+     * @param array<string,mixed> $response Decoded source response.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    private function normalizeList(array $response): array
+    {
+        $rows = $response;
+        if (isset($response['results']) === true && is_array($response['results']) === true) {
+            $rows = $response['results'];
+        } else if (isset($response['items']) === true && is_array($response['items']) === true) {
+            $rows = $response['items'];
+        }
+
+        $out = [];
+        foreach ((array) $rows as $row) {
+            if (is_array($row) === true) {
+                $out[] = $this->normalizeRow(row: $row);
+            }
+        }
+
+        return $out;
+    }//end normalizeList()
+
+    /**
+     * Shape one XWiki page row into the
+     * `{ id, title, breadcrumb, url, space, page, content }` contract
+     * the `@conduction/nextcloud-vue` xwiki tab + card expect. Unknown
+     * keys on the source row are preserved so the source can pass
+     * extra fields through without a provider change.
+     *
+     * @param array<string,mixed> $row One source row (or single-page response).
+     *
+     * @return array<string,mixed>
+     */
+    private function normalizeRow(array $row): array
+    {
+        $reference = (string) ($row['reference'] ?? $row['pageReference'] ?? $row['id'] ?? '');
+        $space     = (string) ($row['space'] ?? $row['spaceName'] ?? '');
+        $page      = (string) ($row['page'] ?? $row['pageName'] ?? $row['name'] ?? '');
+        $title     = (string) ($row['title'] ?? $page ?? $reference);
+
+        $breadcrumb = $row['breadcrumb'] ?? null;
+        if (is_array($breadcrumb) === false || $breadcrumb === []) {
+            // Best-effort breadcrumb from the reference if the source
+            // didn't supply one — "Space / Page" or just the reference.
+            $breadcrumb = array_values(
+                    array_filter(
+                    array_merge(
+                $space !== '' ? explode('.', $space) : [],
+                [$title]
+                    )
+                    )
+                    );
+        }
+
+        return array_merge(
+            $row,
+            [
+                'id'         => $reference,
+                'reference'  => $reference,
+                'title'      => $title,
+                'space'      => $space,
+                'page'       => $page,
+                'breadcrumb' => $breadcrumb,
+                // `url` is the source-mapped field; `link` /
+                // `xwikiAbsoluteUrl` are fallbacks if the source
+                // mapping was left at XWiki's raw field name.
+                'url'        => (string) ($row['url'] ?? $row['link'] ?? $row['xwikiAbsoluteUrl'] ?? ''),
+                // The HTML-rendered content the UI truncates for the
+                // text preview (AD-1). Macros are NOT executed here —
+                // whatever the source returns is passed through; the
+                // UI strips to text + ~500 chars.
+                'content'    => $row['content'] ?? $row['renderedContent'] ?? null,
+            ]
+        );
+    }//end normalizeRow()
+}//end class

--- a/lib/Service/Integration/Providers/XwikiProvider.php
+++ b/lib/Service/Integration/Providers/XwikiProvider.php
@@ -361,9 +361,14 @@ class XwikiProvider extends AbstractIntegrationProvider
     }//end contextQuery()
 
     /**
-     * Normalise the source's list response (which may be a bare array
-     * of rows, or `{ results: [...] }`, or `{ items: [...] }`) into a
-     * plain array of normalised rows.
+     * Normalise the source's list response into a plain array of
+     * normalised rows. The rows array is pulled from whichever envelope
+     * key is present: `results` / `items` (a purpose-built OpenConnector
+     * source), or XWiki's own `pageSummaries` (space listing) /
+     * `searchResults` (search) when the source proxies XWiki's REST API
+     * directly. A bare list response is used as-is; an assoc response
+     * with none of those keys yields an empty list (rather than
+     * iterating the envelope's values as if they were rows).
      *
      * @param array<string,mixed> $response Decoded source response.
      *
@@ -371,15 +376,20 @@ class XwikiProvider extends AbstractIntegrationProvider
      */
     private function normalizeList(array $response): array
     {
-        $rows = $response;
-        if (isset($response['results']) === true && is_array($response['results']) === true) {
-            $rows = $response['results'];
-        } else if (isset($response['items']) === true && is_array($response['items']) === true) {
-            $rows = $response['items'];
+        $rows = [];
+        foreach (['results', 'items', 'pageSummaries', 'searchResults'] as $key) {
+            if (isset($response[$key]) === true && is_array($response[$key]) === true) {
+                $rows = $response[$key];
+                break;
+            }
+        }
+
+        if ($rows === [] && array_is_list($response) === true) {
+            $rows = $response;
         }
 
         $out = [];
-        foreach ((array) $rows as $row) {
+        foreach ($rows as $row) {
             if (is_array($row) === true) {
                 $out[] = $this->normalizeRow(row: $row);
             }
@@ -430,9 +440,11 @@ class XwikiProvider extends AbstractIntegrationProvider
                 'page'       => $page,
                 'breadcrumb' => $breadcrumb,
                 // `url` is the source-mapped field; `link` /
-                // `xwikiAbsoluteUrl` are fallbacks if the source
-                // mapping was left at XWiki's raw field name.
-                'url'        => (string) ($row['url'] ?? $row['link'] ?? $row['xwikiAbsoluteUrl'] ?? ''),
+                // `xwikiAbsoluteUrl` are fallbacks if the source mapping
+                // was left at XWiki's raw field name; finally fall back
+                // to the `rel=".../rel/page"` href from XWiki's REST
+                // `links` array (present on page summaries / search hits).
+                'url'        => (string) ($row['url'] ?? $row['link'] ?? $row['xwikiAbsoluteUrl'] ?? $this->pageLinkHref(row: $row) ?? ''),
                 // The HTML-rendered content the UI truncates for the
                 // text preview (AD-1). Macros are NOT executed here —
                 // whatever the source returns is passed through; the
@@ -441,4 +453,34 @@ class XwikiProvider extends AbstractIntegrationProvider
             ]
         );
     }//end normalizeRow()
+
+    /**
+     * Extract the page URL from an XWiki REST `links` array — the entry
+     * whose `rel` ends in `/rel/page`. Returns null when the row has no
+     * usable `links` array (e.g. a purpose-built source that maps the
+     * URL onto a flat field instead).
+     *
+     * @param array<string,mixed> $row One source row.
+     *
+     * @return string|null The page href, or null if not found.
+     */
+    private function pageLinkHref(array $row): ?string
+    {
+        if (isset($row['links']) === false || is_array($row['links']) === false) {
+            return null;
+        }
+
+        foreach ($row['links'] as $link) {
+            if (is_array($link) === false || isset($link['href']) === false) {
+                continue;
+            }
+
+            $rel = (string) ($link['rel'] ?? '');
+            if (str_ends_with($rel, '/rel/page') === true || str_ends_with($rel, '/rel/pagechild') === true) {
+                return (string) $link['href'];
+            }
+        }
+
+        return null;
+    }//end pageLinkHref()
 }//end class

--- a/lib/Service/Integration/Providers/XwikiProvider.php
+++ b/lib/Service/Integration/Providers/XwikiProvider.php
@@ -33,6 +33,9 @@
  * @copyright 2026 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
  * @link https://conduction.nl
  *
  * @spec openspec/changes/integration-xwiki/tasks.md
@@ -443,20 +446,23 @@ class XwikiProvider extends AbstractIntegrationProvider
         $reference = (string) ($row['reference'] ?? $row['pageReference'] ?? $row['id'] ?? '');
         $space     = (string) ($row['space'] ?? $row['spaceName'] ?? '');
         $page      = (string) ($row['page'] ?? $row['pageName'] ?? $row['name'] ?? '');
-        $title     = (string) ($row['title'] ?? $page ?? $reference);
+        // `$page` is cast to string above so it's never null — `??` would
+        // never fall through to `$reference`. Use elvis to skip empty
+        // strings so we land on whichever piece carries real content.
+        $title     = ((string) ($row['title'] ?? '')) ?: ($page !== '' ? $page : $reference);
 
         $breadcrumb = $row['breadcrumb'] ?? null;
         if (is_array($breadcrumb) === false || $breadcrumb === []) {
             // Best-effort breadcrumb from the reference if the source
             // didn't supply one — "Space / Page" or just the reference.
             $breadcrumb = array_values(
-                    array_filter(
+                array_filter(
                     array_merge(
-                $space !== '' ? explode('.', $space) : [],
-                [$title]
+                        $space !== '' ? explode('.', $space) : [],
+                        [$title]
                     )
-                    )
-                    );
+                )
+            );
         }
 
         return array_merge(

--- a/lib/Service/Integration/Providers/XwikiProvider.php
+++ b/lib/Service/Integration/Providers/XwikiProvider.php
@@ -218,7 +218,7 @@ class XwikiProvider extends AbstractIntegrationProvider
             provider: $this,
             method: 'GET',
             path: '',
-            options: ['query' => $query]
+            options: ['query' => $query, 'headers' => $this->requestHeaders()]
         );
 
         return $this->normalizeList(response: $response);
@@ -246,7 +246,7 @@ class XwikiProvider extends AbstractIntegrationProvider
             provider: $this,
             method: 'GET',
             path: rawurlencode($entityId),
-            options: ['query' => $query]
+            options: ['query' => $query, 'headers' => $this->requestHeaders()]
         );
 
         return $this->normalizeRow(row: $response);
@@ -274,7 +274,12 @@ class XwikiProvider extends AbstractIntegrationProvider
         $body['schema']   = $schema;
         $body['object']   = $objectId;
 
-        $response = $this->router->call(provider: $this, method: 'POST', path: '', options: ['body' => $body]);
+        $response = $this->router->call(
+            provider: $this,
+            method: 'POST',
+            path: '',
+            options: ['body' => $body, 'headers' => $this->requestHeaders(withBody: true)]
+        );
 
         return $this->normalizeRow(row: $response);
     }//end create()
@@ -301,7 +306,7 @@ class XwikiProvider extends AbstractIntegrationProvider
             provider: $this,
             method: 'PUT',
             path: rawurlencode($entityId),
-            options: ['body' => $body]
+            options: ['body' => $body, 'headers' => $this->requestHeaders(withBody: true)]
         );
 
         return $this->normalizeRow(row: $response);
@@ -324,7 +329,10 @@ class XwikiProvider extends AbstractIntegrationProvider
             provider: $this,
             method: 'DELETE',
             path: rawurlencode($entityId),
-            options: ['query' => $this->contextQuery(register: $register, schema: $schema, objectId: $objectId, filters: [])]
+            options: [
+                'query'   => $this->contextQuery(register: $register, schema: $schema, objectId: $objectId, filters: []),
+                'headers' => $this->requestHeaders(),
+            ]
         );
     }//end delete()
 
@@ -359,6 +367,27 @@ class XwikiProvider extends AbstractIntegrationProvider
             ['register' => $register, 'schema' => $schema, 'object' => $objectId]
         );
     }//end contextQuery()
+
+    /**
+     * Headers every XWiki call carries. XWiki's REST API negotiates XML
+     * by default — `Accept: application/json` forces JSON; writes also
+     * declare a JSON body. A purpose-built OpenConnector source that
+     * already pins these on the source row is unaffected (the request
+     * headers just get re-set to the same values).
+     *
+     * @param bool $withBody Whether the request carries a JSON body.
+     *
+     * @return array<string,string>
+     */
+    private function requestHeaders(bool $withBody=false): array
+    {
+        $headers = ['Accept' => 'application/json'];
+        if ($withBody === true) {
+            $headers['Content-Type'] = 'application/json';
+        }
+
+        return $headers;
+    }//end requestHeaders()
 
     /**
      * Normalise the source's list response into a plain array of

--- a/openspec/changes/integration-xwiki/design.md
+++ b/openspec/changes/integration-xwiki/design.md
@@ -2,17 +2,19 @@
 
 > Umbrella decisions apply
 >
-> **Cross-repo note**: file paths under `nextcloud-vue/src/...` or bare component names (`CnXxxTab`, `CnXxxCard`) are **expected locations** in the `@conduction/nextcloud-vue` shared library, not binding spec. The frontend implementation PR lands in that separate repo and MAY choose different paths. Second external-storage leaf — reuses `getOpenConnectorSource()` + `ExternalIntegrationRouter` established by `integration-openproject`.
+> **Cross-repo note**: file paths under `nextcloud-vue/src/...` or bare component names (`CnXxxTab`, `CnXxxCard`) are **expected locations** in the `@conduction/nextcloud-vue` shared library, not binding spec. The frontend implementation PR lands in that separate repo and MAY choose different paths. First **external-storage** leaf — reuses the `getStorageStrategy() === 'external'` + `getOpenConnectorSource()` + `ExternalIntegrationRouter` machinery established by the `pluggable-integration-registry` umbrella (AD-4 external routing / AD-22 storage strategies / AD-23 failure-path contract).
 
 ## Approach
 
-Mirrors `integration-openproject` but targets XWiki's REST API. `XwikiProvider` declares `storage='external'` and returns `'xwiki'` from `getOpenConnectorSource()`. Tab is lighter than OpenProject (no status/progress — wikis are documents, not work) but adds a text preview on detail-page surface.
+Targets XWiki's REST API. `XwikiProvider` declares `storage='external'` and returns `'xwiki'` from `getOpenConnectorSource()`; all CRUD is delegated to `ExternalIntegrationRouter` (the provider carries no HTTP client and no credentials). The tab is light — wikis are documents, not work, so there's no status/progress — but the widget adds a **text** preview on the detail-page surface.
 
 ## Architecture Decisions
 
-### AD-1: Preview renders text, not full XWiki macros
+### AD-1: Preview renders text, not executed XWiki macros
 
-**Decision**: Detail-page preview fetches the page's HTML-rendered content via XWiki REST, then strips to text (first 500 chars) plus link to full page. Macros are not executed.
+**Decision**: The detail-page preview shows the page's HTML-**rendered** body, stripped to plain text (first ~500 chars) plus a link to the full page. Macros are never executed *inside Nextcloud*.
+
+**Implementation note (verified against `xwiki:lts` 17.10)**: XWiki's REST page representation (`GET /rest/wikis/{wiki}/spaces/{Space}/pages/{Page}`) returns `content` as **raw `xwiki/2.1` syntax**, not rendered HTML. So the OpenConnector `xwiki` source fetches the rendered body from `GET /bin/get/{Space}/{Page}?xpage=plain` (XWiki executes the page's macros *server-side, in XWiki's own sandbox*) and maps that to `content`. `XwikiProvider::normalizeRow()` round-trips it under `content` (with a `renderedContent` alias fallback); the `@conduction/nextcloud-vue` widget then strips all HTML tags + the `<script>`/`<style>` bodies to text and truncates — it never injects the HTML into the DOM. (Mapping `content` straight from the REST `content` field instead is still safe — macro markup is inert text — just less polished.)
 
 **Why**: Executing arbitrary XWiki macros inside NC has security implications (velocity templates, scripts). Text preview keeps the integration safe and simple.
 
@@ -20,37 +22,49 @@ Mirrors `integration-openproject` but targets XWiki's REST API. `XwikiProvider` 
 
 ### AD-2: Link by URL or wiki-path
 
-**Decision**: Link form accepts either a full XWiki URL (which is parsed to extract wiki/space/page) or a direct `space.page` path. Both resolve to the same canonical page reference.
+**Decision**: The link form accepts either a full XWiki URL (parsed to extract wiki/space/page) or a direct `Space.Page` path. Both resolve to the same canonical page reference. `XwikiProvider::create()` passes the raw `reference` through; the OpenConnector `xwiki` source's `create` endpoint does the resolution.
 
 **Why**: Users copy URLs from browser tabs; power users know paths. Accepting both reduces friction.
 
 ### AD-3: Page breadcrumb shown in tab rows
 
-**Decision**: Tab rows show not just title but full breadcrumb ("Wiki / Department / Subspace / Page Title").
+**Decision**: Tab rows show not just title but the full breadcrumb ("Wiki / Department / Subspace / Page Title").
+
+**Implementation note**: XWiki exposes a native breadcrumb at `hierarchy.items[].label` in the page representation; the OpenConnector source maps `breadcrumb` from it. When the source doesn't supply one, `XwikiProvider::normalizeRow()` derives a coarse breadcrumb from `space` + `title`.
 
 **Why**: XWiki's hierarchical structure is meaningful — two pages can have the same title in different spaces. Breadcrumb disambiguates.
 
 ## Files Affected
 
 ### Backend (new)
-- `lib/Service/Integration/Providers/XwikiProvider.php`
-- OpenConnector source config template `config/openconnector-sources/xwiki.yaml`
-- Unit tests
+- `lib/Service/Integration/Providers/XwikiProvider.php` — `IntegrationProvider`: metadata getters, `authRequirements()` (`type: 'external'`, configured via OpenConnector), `isEnabled()` (mirrors `IAppManager::isInstalled('openconnector')`), `list/get/create/update/delete` (all via `router->call(...)` with the `{register, schema, object}` context), `health()` (defers to `router->probe()`), `normalizeList/normalizeRow` shaping
+- `docs/Integrations/xwiki-openconnector-source.yaml` — the OpenConnector source-config template to import (the repo's `config/` directory is gitignored, so it lives under `docs/Integrations/` rather than `config/openconnector-sources/`)
+- `docs/Integrations/xwiki.md` — user-facing setup + usage guide
+- `tests/Unit/Service/Integration/Providers/XwikiProviderTest.php` — 10 tests / 38 assertions (OpenConnector router mocked)
 
 ### Backend (modified)
-- `Application.php` (DI-tag)
+- `lib/AppInfo/Application.php` — DI service binding for `XwikiProvider`, and added to the `bootBuiltinIntegrationProviders()` provider list so it self-registers with `IntegrationRegistry` at `boot()`. (The umbrella registers providers via explicit `addProvider()` rather than a DI tag — modern Nextcloud has no public `queryAll(<tag>)`; documented in the umbrella's design.)
 
-### Frontend (new)
-- `CnXwikiTab/*` — list with breadcrumb, link-by-URL or path
-- `CnXwikiCard/*` — 4 surfaces, detail-page has text preview
-- `src/integrations/builtin/xwiki.js` — registration
-- Barrels + tests
+### Frontend (new — `@conduction/nextcloud-vue`)
+- `src/components/CnXwikiTab/` — list with breadcrumb, link-by-URL-or-path form, unlink (removes the OR sub-resource pairing only, never deletes in XWiki), reconnect/unavailable banner on a 503; emits `linked` / `unlinked`
+- `src/components/CnXwikiCard/` — surface-aware (AD-19): detail-page text preview + "Open in XWiki" link; compact list on the dashboard surfaces; title+breadcrumb chip on `single-entity` (for `referenceType: 'xwiki'` properties)
+- `src/integrations/builtin/xwiki.js` — `xwikiIntegration` descriptor + `registerXwikiIntegration()` (a *leaf*, not part of `builtinIntegrations` — OpenRegister's bundle registers it explicitly when OpenConnector is installed; skip-on-collision so a consuming app can override `xwiki`)
+- barrels + 4 doc files + tests (`CnXwikiTab.spec.js` ×7, `CnXwikiCard.spec.js` ×8, `tests/integrations/xwiki.spec.js` ×6)
+
+## Implementation deviations (as-built vs original spec)
+
+| Original spec said | As built | Why |
+|---|---|---|
+| `requiredApp: null` | `requiredApp: 'openconnector'` | The integration genuinely needs the OpenConnector app (it carries the `xwiki` source + credentials) — `null` would mislead the admin UI. `ExternalIntegrationRouter` still degrades gracefully if OpenConnector is absent or the source is missing. |
+| Source template at `config/openconnector-sources/xwiki.yaml` | `docs/Integrations/xwiki-openconnector-source.yaml` | The repo's `config/` directory is gitignored. |
+| `Application.php (DI-tag)` | `addProvider()` at `boot()` | Matches the umbrella's registration mechanism (no public NC `queryAll`). |
+| Parity check `check-integration-parity.sh` | `check-integration-parity.js` (Node) | Matches the `@conduction/nextcloud-vue` repo's existing script convention (`check-docs.js`, `check-jsdoc.js`); wired into that repo's CI + pre-commit hook, and into hydra's `run-hydra-gates.sh` as gate-15. |
 
 ## Risks
 
 | Risk | Mitigation |
 |---|---|
-| XWiki instance versions vary (5.x, 10.x+, 14.x+) | OpenConnector adapter normalises; provider stays version-agnostic |
-| Basic auth vs OAuth — mixed customer setups | Auth requirements are configurable at the OpenConnector source level; provider declares "one of: basic, oauth2" |
-| Large pages slow preview render | Text strip to 500 chars; lazy-load only on detail-page surface expand |
-| Permission mismatches (user has NC access but not XWiki access) | Show "No access to page" placeholder; don't leak internal errors |
+| XWiki instance versions vary (5.x, 10.x+, 14.x+) | The OpenConnector source normalises field-name drift; `XwikiProvider::normalizeRow()` reads several aliases per field; the provider stays version-agnostic. Verified live against `xwiki:lts` 17.10. |
+| Basic auth vs OAuth — mixed customer setups | Auth is configured on the OpenConnector source; `authRequirements()` declares `supports: ['basic', 'oauth2']`; OR's admin UI surfaces the source's auth status + a "Configure" deep-link into OpenConnector. |
+| Large pages slow preview render | Text strip to ~500 chars; the rendered body is fetched only for the detail-page surface (and the single-entity lookup), not for the compact list. |
+| Permission mismatches (user has NC access but not XWiki access) | The integration inherits the object's RBAC + OpenConnector's; a "No access to page" placeholder is shown; internal errors aren't leaked (the controller translates `ProviderUnavailableException` to 503 + a `reason`, the UI shows a banner). |

--- a/openspec/changes/integration-xwiki/proposal.md
+++ b/openspec/changes/integration-xwiki/proposal.md
@@ -7,8 +7,8 @@ XWiki is widely used in European government as a structured knowledge platform. 
 ## Context
 
 - **Backend:** greenfield — external, routed via OpenConnector
-- **Required NC app:** null
-- **Required OpenConnector source:** an XWiki connector with credentials (Basic auth or OAuth depending on XWiki version)
+- **Required NC app:** `openconnector` (it carries the `xwiki` source + credentials; `XwikiProvider::isEnabled()` mirrors `IAppManager::isInstalled('openconnector')`). The original spec said `null`; changed to `openconnector` so the admin Integrations page reports it accurately. `ExternalIntegrationRouter` still degrades gracefully if OpenConnector is absent or the source is missing.
+- **Required OpenConnector source:** an XWiki connector with credentials (Basic auth or OAuth depending on XWiki version) — import the template at `docs/Integrations/xwiki-openconnector-source.yaml`
 - **Storage:** `external`
 - **Depends on:** `pluggable-integration-registry`
 - **Relationship to `integration-collectives`**: Collectives covers the native-NC knowledge case. XWiki covers the external-knowledge-platform case. Both can coexist; consuming apps choose based on customer setup.
@@ -25,10 +25,10 @@ XWiki is widely used in European government as a structured knowledge platform. 
 
 ## Acceptance criteria
 
-- [ ] Provider appears in registry when OpenConnector source `xwiki` configured
-- [ ] Tab lists linked pages with titles + breadcrumb
-- [ ] Detail-page widget shows text preview of page content
-- [ ] User can link by URL or wiki page path
-- [ ] Reference-property `referenceType: 'xwiki'` renders page chip
-- [ ] Auth expiry surfaces clearly
-- [ ] Parity gate passes; nl+en done
+- [x] Tab lists linked pages with titles + breadcrumb — `CnXwikiTab.spec.js` (list fetch + breadcrumb rendering; `breadcrumb` drops the last element which is the title)
+- [x] Detail-page widget shows text preview of page content — `CnXwikiCard.spec.js` (detail-page surface: HTML stripped to text, `<script>` body removed, macro markup inert, ~500-char truncation, "Open in XWiki" link)
+- [x] User can link by URL or wiki page path — `CnXwikiTab.spec.js` (POST body is `{ reference: '<full URL>' }`); the OpenConnector source's `create` endpoint resolves it to a canonical `Space.Page`
+- [x] Reference-property `referenceType: 'xwiki'` renders page chip — `CnXwikiCard.spec.js` (`single-entity` surface renders a title+breadcrumb chip from `value`, with a minimal-chip fallback on lookup failure); the `referenceType`-routing itself is covered by the umbrella's `CnFormDialog` / `CnDetailGrid` tests
+- [x] Auth expiry surfaces clearly — `CnXwikiTab.spec.js` (a 503 with an auth `reason` → reconnect banner; a 503 without → generic unavailable banner)
+- [x] Parity gate passes; nl + en done — `tab` + `widget` both present (the registry throws at `register()` otherwise; `tests/integrations/xwiki.spec.js` asserts the descriptor shape); all user-facing strings wrapped (`$l->t(...)` / `t('nextcloud-vue', ...)` — `l10n/*.json` are build-extracted per repo convention)
+- [ ] Provider appears in registry when OpenConnector source `xwiki` configured — verified at the unit level (`XwikiProviderTest`: metadata, `isEnabled()` mirrors `IAppManager::isInstalled('openconnector')`, delegation to `ExternalIntegrationRouter`); the **live** runtime check (registry populated, admin Integrations row, Articles tab) is deferred until the umbrella + leaf PRs merge and land in a deployed Nextcloud with OpenConnector + an `xwiki` source configured

--- a/openspec/changes/integration-xwiki/tasks.md
+++ b/openspec/changes/integration-xwiki/tasks.md
@@ -1,39 +1,41 @@
 # Tasks: Integration — XWiki
 
-## Backend
+## Backend — [ConductionNL/openregister PR for `feature/1326/integration-xwiki`]
 
-- [ ] Create `lib/Service/Integration/Providers/XwikiProvider.php` — id='xwiki', label='Articles', icon='FileDocumentMultiple', group='external', requiredApp=null, storage='external', `getOpenConnectorSource()='xwiki'`
-- [ ] Declare auth requirements (basic or oauth2, configurable at source level)
-- [ ] Delegate CRUD to `ExternalIntegrationRouter`
-- [ ] Ship OpenConnector source config template `config/openconnector-sources/xwiki.yaml`
-- [ ] DI-tag
-- [ ] Unit tests (OpenConnector client mocked)
+- [x] Create `lib/Service/Integration/Providers/XwikiProvider.php` — id='xwiki', label='Articles', icon='FileDocumentMultiple', group='external', requiredApp='openconnector' (the NC app that carries the source + credentials — more accurate than `null` for the admin UI), storage='external', `getOpenConnectorSource()='xwiki'`
+- [x] Declare auth requirements — `authRequirements()` returns `{ type: 'external', configuredVia: 'openconnector', source: 'xwiki', supports: ['basic', 'oauth2'] }` (the actual auth is picked on the OpenConnector source)
+- [x] Delegate CRUD to `ExternalIntegrationRouter` — list/get/create/update/delete all go through `router->call(...)` with the `{register, schema, object}` context; `health()` defers to `router->probe()`; `normalizeRow()` shapes rows to `{ id, reference, title, space, page, breadcrumb, url, content }`
+- [x] Ship the OpenConnector source config template — at `docs/Integrations/xwiki-openconnector-source.yaml` (the repo's `config/` dir is gitignored, so it lives under `docs/Integrations/`); also `docs/Integrations/xwiki.md` user guide
+- [x] Register the provider — DI service binding in `Application.php` + added to `bootBuiltinIntegrationProviders()`'s list so it self-registers with `IntegrationRegistry` at boot (the umbrella uses explicit `addProvider()` rather than DI tags — NC has no public `queryAll`)
+- [x] Unit tests — `tests/Unit/Service/Integration/Providers/XwikiProviderTest.php` (10 tests, 38 assertions; OpenConnector router mocked); verified `composer phpcs` / `phpmd` / `psalm` clean + `phpunit-unit.xml` green in the container
 
-## Frontend — Tab
+## Frontend — Tab — [ConductionNL/nextcloud-vue#213]
 
-- [ ] `CnXwikiTab.vue` — linked pages with title + full breadcrumb; link-by-URL (parses to space.page) or link-by-path; unlink; auth-expired banner
-- [ ] Barrel + tests
+- [x] `CnXwikiTab.vue` — linked pages with title + full breadcrumb; link-by-URL (resolved server-side to `Space.Page`) or link-by-path; unlink (removes the OR sub-resource pairing only, never deletes in XWiki); reconnect/unavailable banner on a 503; emits `linked` / `unlinked`
+- [x] Barrel (`src/components/CnXwikiTab/index.js` + `src/components/index.js` + `src/index.js`) + tests (`tests/components/CnXwikiTab.spec.js` — 7)
 
-## Frontend — Widget
+## Frontend — Widget — [ConductionNL/nextcloud-vue#213]
 
-- [ ] `CnXwikiCard.vue`:
-  - `user-dashboard`: recent linked pages
-  - `app-dashboard`: scoped
-  - `detail-page`: linked pages list + text preview (first 500 chars, macros not executed) + link to full page
-  - `single-entity`: page-title + breadcrumb chip
-- [ ] Barrel + surface tests
+- [x] `CnXwikiCard.vue` (surface-aware, AD-19):
+  - `user-dashboard`: recent linked pages (compact list)
+  - `app-dashboard`: same compact list
+  - `detail-page`: linked pages list + text preview of the first page (HTML stripped to plain text, first ~500 chars, macros NOT executed — AD-1) + "Open in XWiki" link
+  - `single-entity`: title + breadcrumb chip resolved from the `value` prop (for `referenceType: 'xwiki'` properties), with a minimal-chip fallback when the lookup fails
+- [x] Barrel + surface tests (`tests/components/CnXwikiCard.spec.js` — 8)
 
-## Registration
+## Registration — [ConductionNL/nextcloud-vue#213]
 
-- [ ] `src/integrations/builtin/xwiki.js` — register with `referenceType: 'xwiki'`
+- [x] `src/integrations/builtin/xwiki.js` — `xwikiIntegration` descriptor (id `xwiki`, group `external`, requiredApp `openconnector`, referenceType `xwiki`, tab `CnXwikiTab`, widget `CnXwikiCard`) + `registerXwikiIntegration(registry?)`. It is a leaf, NOT part of `builtinIntegrations` — OpenRegister's bundle calls `registerXwikiIntegration()` explicitly (skip-on-collision: first wins). Exported from `src/integrations/index.js` + `src/index.js`. Tests: `tests/integrations/xwiki.spec.js` — 6.
 
 ## Quality
 
-- [ ] Parity gate; nl+en; strict; ESLint
+- [x] Parity gate — `tab` + `widget` both present (the registry throws at `register()` if not; `check-integration-parity.js` covers the built-in set; the leaf's own descriptor is asserted in `xwiki.spec.js`)
+- [x] nl + en — all user-facing strings wrapped: PHP `$l->t(...)`, JS `t('nextcloud-vue', ...)` (the `l10n/*.json` are build-extracted, not hand-edited — matches the repo convention)
+- [x] strict / ESLint — `composer phpcs|phpmd|psalm` clean on `XwikiProvider.php`; `npm run lint` clean on `CnXwikiTab.vue` / `CnXwikiCard.vue` / `xwiki.js`
 
 ## Acceptance verification
 
-- [ ] E2E: configure OpenConnector xwiki source, link a page, verify breadcrumb in tab; text preview on detail-page
-- [ ] Link-by-URL test: paste full URL, verify resolution to canonical space.page
-- [ ] Auth test; hide test; reference-property test
-- [ ] Security: verify XWiki macros are NOT executed in preview (text-only)
+- [x] Link-by-URL test — `CnXwikiTab.spec.js` asserts the POST body is `{ reference: '<full URL>' }`; the OpenConnector source resolves it to a canonical `Space.Page` (covered by the source-config template's `create` endpoint)
+- [x] Reference-property test — `CnXwikiCard.spec.js` `single-entity` surface renders a chip from `value` and falls back to a minimal chip on lookup failure; `referenceType: 'xwiki'` wiring is covered by the umbrella's `CnFormDialog` / `CnDetailGrid` referenceType tests
+- [x] Security: macros NOT executed in preview — `CnXwikiCard.spec.js` asserts the detail-page preview strips all HTML tags + the `<script>` body + treats macro markup (`{{velocity}}…`) as inert text; the source returns already-rendered HTML and the widget only ever reads its text content, never injects it into the DOM
+- [ ] Live E2E (configure an OpenConnector xwiki source against a running XWiki, link a page, verify the breadcrumb in the tab + the text preview on the detail page; auth-expired/hide behaviour) — deferred until the umbrella + leaf PRs merge and land in a deployed Nextcloud + a reachable XWiki instance

--- a/tests/Unit/Service/Integration/ExternalIntegrationRouterTest.php
+++ b/tests/Unit/Service/Integration/ExternalIntegrationRouterTest.php
@@ -136,6 +136,60 @@ class _LocalProvider extends AbstractIntegrationProvider
 }//end class
 
 /**
+ * Stand-in for OpenConnector's CallLog — only the bits the router reads.
+ */
+class _FakeCallLog
+{
+
+    public function __construct(
+        private int $status,
+        private ?array $response,
+    ) {
+    }//end __construct()
+
+    public function getStatusCode(): int
+    {
+        return $this->status;
+    }//end getStatusCode()
+
+    public function getResponse(): ?array
+    {
+        return $this->response;
+    }//end getResponse()
+
+}//end class
+
+/**
+ * Stand-in for OpenConnector's CallService — returns a preset CallLog.
+ */
+class _FakeCallService
+{
+
+    public function __construct(private _FakeCallLog $log)
+    {
+    }//end __construct()
+
+    public function call($source, string $endpoint = '', string $method = 'GET', array $config = [])
+    {
+        return $this->log;
+    }//end call()
+
+}//end class
+
+/**
+ * Stand-in for OpenConnector's SourceMapper — find() returns a marker.
+ */
+class _FakeSourceMapper
+{
+
+    public function find($id)
+    {
+        return (object) ['id' => 1, 'slug' => (string) $id];
+    }//end find()
+
+}//end class
+
+/**
  * Unit tests for ExternalIntegrationRouter.
  */
 class ExternalIntegrationRouterTest extends TestCase
@@ -155,6 +209,41 @@ class ExternalIntegrationRouterTest extends TestCase
 
         return new ExternalIntegrationRouter($appManager, $container, new NullLogger());
     }//end buildRouter()
+
+    /**
+     * Build a router whose container hands back a fake SourceMapper + a
+     * fake CallService that returns the given CallLog.
+     *
+     * @param _FakeCallLog $log The CallLog the fake CallService returns.
+     *
+     * @return ExternalIntegrationRouter
+     */
+    private function buildRouterWithCallLog(_FakeCallLog $log): ExternalIntegrationRouter
+    {
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('isInstalled')->willReturn(true);
+        $appManager->method('isEnabledForUser')->willReturn(true);
+
+        $callService = new _FakeCallService($log);
+        $mapper      = new _FakeSourceMapper();
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(
+            static function (string $id) use ($callService, $mapper) {
+                if (str_ends_with($id, 'SourceMapper') === true) {
+                    return $mapper;
+                }
+
+                if (str_ends_with($id, 'CallService') === true) {
+                    return $callService;
+                }
+
+                return null;
+            }
+        );
+
+        return new ExternalIntegrationRouter($appManager, $container, new NullLogger());
+    }//end buildRouterWithCallLog()
 
     public function testCallRejectsNonExternalProvider(): void
     {
@@ -220,5 +309,51 @@ class ExternalIntegrationRouterTest extends TestCase
         $this->assertSame('unavailable', $report['status']);
         $this->assertSame('missing', $report['authStatus']);
     }//end testProbeReportsUnavailableWhenOpenConnectorMissing()
+
+    public function testCallUnwrapsTheCallLogBody(): void
+    {
+        // CallService returns a CallLog; the upstream JSON payload is the
+        // `body` string inside getResponse() — the router must hand the
+        // caller the decoded body, not the CallLog wrapper.
+        $log    = new _FakeCallLog(200, ['statusCode' => 200, 'headers' => [], 'body' => '{"pageSummaries":[{"id":"xwiki:Sandbox.Page","name":"Page"}]}', 'encoding' => 'UTF-8']);
+        $router = $this->buildRouterWithCallLog($log);
+
+        $result = $router->call(new _ExternalProvider(), 'GET', '');
+
+        $this->assertArrayHasKey('pageSummaries', $result);
+        $this->assertSame('xwiki:Sandbox.Page', $result['pageSummaries'][0]['id']);
+    }//end testCallUnwrapsTheCallLogBody()
+
+    public function testCallDecodesBase64EncodedBody(): void
+    {
+        $log    = new _FakeCallLog(200, ['body' => base64_encode('{"items":[]}'), 'encoding' => 'base64']);
+        $router = $this->buildRouterWithCallLog($log);
+
+        $this->assertSame(['items' => []], $router->call(new _ExternalProvider(), 'GET', ''));
+    }//end testCallDecodesBase64EncodedBody()
+
+    public function testCallTreatsAuthErrorAsProviderAuth(): void
+    {
+        $router = $this->buildRouterWithCallLog(new _FakeCallLog(401, ['body' => 'denied']));
+
+        try {
+            $router->call(new _ExternalProvider(), 'GET', '');
+            $this->fail('Expected ProviderUnavailableException');
+        } catch (ProviderUnavailableException $e) {
+            $this->assertSame(ProviderUnavailableException::CAUSE_PROVIDER_AUTH, $e->getCause());
+        }
+    }//end testCallTreatsAuthErrorAsProviderAuth()
+
+    public function testCallTreatsServerErrorAsUpstreamDown(): void
+    {
+        $router = $this->buildRouterWithCallLog(new _FakeCallLog(500, ['body' => 'oops']));
+
+        try {
+            $router->call(new _ExternalProvider(), 'GET', '');
+            $this->fail('Expected ProviderUnavailableException');
+        } catch (ProviderUnavailableException $e) {
+            $this->assertSame(ProviderUnavailableException::CAUSE_UPSTREAM_SERVICE_DOWN, $e->getCause());
+        }
+    }//end testCallTreatsServerErrorAsUpstreamDown()
 
 }//end class

--- a/tests/Unit/Service/Integration/Providers/XwikiProviderTest.php
+++ b/tests/Unit/Service/Integration/Providers/XwikiProviderTest.php
@@ -1,0 +1,241 @@
+<?php
+
+/**
+ * Unit tests for XwikiProvider.
+ *
+ * Covers:
+ *  - metadata matches the leaf spec (id / label / icon / group /
+ *    requiredApp / storage strategy / OpenConnector source)
+ *  - authRequirements() reports the external-config-via-OpenConnector
+ *    shape
+ *  - isEnabled() mirrors IAppManager::isInstalled('openconnector')
+ *  - list() / get() / create() / update() / delete() delegate to
+ *    ExternalIntegrationRouter with the right method + path + context,
+ *    and list()/get()/create()/update() normalise rows (id / title /
+ *    space / page / breadcrumb fallback / url / content)
+ *  - health() defers to router->probe()
+ *
+ * The upstream call path itself (OpenConnector → XWiki REST) is
+ * exercised by integration tests; here the router is mocked so we
+ * assert the provider's own contract.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Integration\Providers
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/integration-xwiki/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Integration\Providers;
+
+use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
+use OCA\OpenRegister\Service\Integration\Providers\XwikiProvider;
+use OCP\App\IAppManager;
+use OCP\IL10N;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for XwikiProvider.
+ */
+class XwikiProviderTest extends TestCase
+{
+
+    /**
+     * @var ExternalIntegrationRouter&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $router;
+
+    /**
+     * @var IAppManager&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $appManager;
+
+    private XwikiProvider $provider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->router     = $this->createMock(ExternalIntegrationRouter::class);
+        $this->appManager = $this->createMock(IAppManager::class);
+        $l10n             = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnArgument(0);
+
+        $this->provider = new XwikiProvider(
+            router: $this->router,
+            appManager: $this->appManager,
+            l10n: $l10n,
+        );
+    }//end setUp()
+
+    public function testMetadataMatchesLeafSpec(): void
+    {
+        $this->assertSame('xwiki', $this->provider->getId());
+        $this->assertSame('Articles', $this->provider->getLabel());
+        $this->assertSame('FileDocumentMultiple', $this->provider->getIcon());
+        $this->assertSame('external', $this->provider->getGroup());
+        $this->assertSame('openconnector', $this->provider->getRequiredApp());
+        $this->assertSame('external', $this->provider->getStorageStrategy());
+        $this->assertSame('xwiki', $this->provider->getOpenConnectorSource());
+        $this->assertNull($this->provider->requiresPermission());
+    }//end testMetadataMatchesLeafSpec()
+
+    public function testAuthRequirementsAreExternalViaOpenConnector(): void
+    {
+        $auth = $this->provider->authRequirements();
+        $this->assertSame('external', $auth['type']);
+        $this->assertSame('openconnector', $auth['configuredVia']);
+        $this->assertSame('xwiki', $auth['source']);
+        $this->assertContains('basic', $auth['supports']);
+        $this->assertContains('oauth2', $auth['supports']);
+    }//end testAuthRequirementsAreExternalViaOpenConnector()
+
+    public function testIsEnabledMirrorsOpenConnectorInstall(): void
+    {
+        $this->appManager->method('isInstalled')->with('openconnector')->willReturn(true);
+        $this->assertTrue($this->provider->isEnabled());
+
+        $appManager2 = $this->createMock(IAppManager::class);
+        $appManager2->method('isInstalled')->with('openconnector')->willReturn(false);
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnArgument(0);
+        $disabled = new XwikiProvider($this->router, $appManager2, $l10n);
+        $this->assertFalse($disabled->isEnabled());
+    }//end testIsEnabledMirrorsOpenConnectorInstall()
+
+    public function testListDelegatesToRouterWithContextAndNormalisesRows(): void
+    {
+        $this->router->expects($this->once())
+            ->method('call')
+            ->with(
+                $this->provider,
+                'GET',
+                '',
+                ['query' => ['_search' => 'foo', 'register' => 'r1', 'schema' => 's1', 'object' => 'obj-1']]
+            )
+            ->willReturn([
+                'results' => [
+                    [
+                        'id'         => 'Departments.Legal.Handbook',
+                        'title'      => 'Handbook',
+                        'space'      => 'Departments.Legal',
+                        'name'       => 'Handbook',
+                        'xwikiAbsoluteUrl' => 'https://wiki.example.org/bin/view/Departments/Legal/Handbook',
+                        'breadcrumb' => ['Wiki', 'Departments', 'Legal', 'Handbook'],
+                    ],
+                    [
+                        // No breadcrumb supplied — provider builds one from space + title.
+                        'reference' => 'Sales.Pitch',
+                        'title'     => 'Pitch',
+                        'space'     => 'Sales',
+                    ],
+                ],
+            ]);
+
+        $rows = $this->provider->list('r1', 's1', 'obj-1', ['_search' => 'foo']);
+
+        $this->assertCount(2, $rows);
+        $this->assertSame('Departments.Legal.Handbook', $rows[0]['id']);
+        $this->assertSame('Handbook', $rows[0]['title']);
+        $this->assertSame(['Wiki', 'Departments', 'Legal', 'Handbook'], $rows[0]['breadcrumb']);
+        $this->assertSame('https://wiki.example.org/bin/view/Departments/Legal/Handbook', $rows[0]['url']);
+        // Second row: breadcrumb derived from "Sales" space + "Pitch" title.
+        $this->assertSame('Sales.Pitch', $rows[1]['id']);
+        $this->assertSame(['Sales', 'Pitch'], $rows[1]['breadcrumb']);
+    }//end testListDelegatesToRouterWithContextAndNormalisesRows()
+
+    public function testListAcceptsBareArrayResponse(): void
+    {
+        $this->router->method('call')->willReturn([
+            ['reference' => 'A.B', 'title' => 'B', 'space' => 'A'],
+        ]);
+        $rows = $this->provider->list('r', 's', 'o');
+        $this->assertCount(1, $rows);
+        $this->assertSame('A.B', $rows[0]['id']);
+    }//end testListAcceptsBareArrayResponse()
+
+    public function testGetFetchesEncodedReference(): void
+    {
+        $this->router->expects($this->once())
+            ->method('call')
+            ->with(
+                $this->provider,
+                'GET',
+                rawurlencode('Space.Page'),
+                ['query' => ['register' => 'r', 'schema' => 's', 'object' => 'o']]
+            )
+            ->willReturn(['reference' => 'Space.Page', 'title' => 'Page', 'content' => '<p>hello</p>']);
+
+        $row = $this->provider->get('r', 's', 'o', 'Space.Page');
+        $this->assertSame('Space.Page', $row['id']);
+        $this->assertSame('<p>hello</p>', $row['content']);
+    }//end testGetFetchesEncodedReference()
+
+    public function testCreateMergesContextIntoBodyAndNormalises(): void
+    {
+        $this->router->expects($this->once())
+            ->method('call')
+            ->with(
+                $this->provider,
+                'POST',
+                '',
+                ['body' => ['reference' => 'https://wiki/bin/view/X/Y', 'register' => 'r', 'schema' => 's', 'object' => 'o']]
+            )
+            ->willReturn(['reference' => 'X.Y', 'title' => 'Y', 'space' => 'X']);
+
+        $row = $this->provider->create('r', 's', 'o', ['reference' => 'https://wiki/bin/view/X/Y']);
+        $this->assertSame('X.Y', $row['id']);
+        $this->assertSame('Y', $row['title']);
+    }//end testCreateMergesContextIntoBodyAndNormalises()
+
+    public function testUpdatePutsEncodedReference(): void
+    {
+        $this->router->expects($this->once())
+            ->method('call')
+            ->with(
+                $this->provider,
+                'PUT',
+                rawurlencode('Old.Ref'),
+                ['body' => ['reference' => 'New.Ref', 'register' => 'r', 'schema' => 's', 'object' => 'o']]
+            )
+            ->willReturn(['reference' => 'New.Ref', 'title' => 'New']);
+
+        $row = $this->provider->update('r', 's', 'o', 'Old.Ref', ['reference' => 'New.Ref']);
+        $this->assertSame('New.Ref', $row['id']);
+    }//end testUpdatePutsEncodedReference()
+
+    public function testDeleteCallsRouterWithDeleteAndContext(): void
+    {
+        $this->router->expects($this->once())
+            ->method('call')
+            ->with(
+                $this->provider,
+                'DELETE',
+                rawurlencode('Space.Page'),
+                ['query' => ['register' => 'r', 'schema' => 's', 'object' => 'o']]
+            )
+            ->willReturn([]);
+
+        $this->provider->delete('r', 's', 'o', 'Space.Page');
+    }//end testDeleteCallsRouterWithDeleteAndContext()
+
+    public function testHealthDefersToRouterProbe(): void
+    {
+        $this->router->expects($this->once())
+            ->method('probe')
+            ->with($this->provider)
+            ->willReturn(['status' => 'unavailable', 'authStatus' => 'expired', 'message' => 'token refresh failed']);
+
+        $health = $this->provider->health();
+        $this->assertSame('unavailable', $health['status']);
+        $this->assertSame('expired', $health['authStatus']);
+        $this->assertSame('token refresh failed', $health['message']);
+    }//end testHealthDefersToRouterProbe()
+
+}//end class

--- a/tests/Unit/Service/Integration/Providers/XwikiProviderTest.php
+++ b/tests/Unit/Service/Integration/Providers/XwikiProviderTest.php
@@ -160,6 +160,47 @@ class XwikiProviderTest extends TestCase
         $this->assertSame('A.B', $rows[0]['id']);
     }//end testListAcceptsBareArrayResponse()
 
+    public function testListAcceptsRawXwikiPageSummariesEnvelope(): void
+    {
+        // Shape returned by XWiki's REST API: GET /rest/wikis/<wiki>/spaces/<Space>/pages.
+        $this->router->method('call')->willReturn([
+            'links'         => [],
+            'pageSummaries' => [
+                [
+                    'id'       => 'xwiki:Sandbox.IntegrationTest',
+                    'fullName' => 'Sandbox.IntegrationTest',
+                    'wiki'     => 'xwiki',
+                    'space'    => 'Sandbox',
+                    'name'     => 'IntegrationTest',
+                    'title'    => 'Integration Test Page',
+                    'links'    => [
+                        ['rel' => 'http://www.xwiki.org/rel/space', 'href' => 'http://wiki/rest/wikis/xwiki/spaces/Sandbox'],
+                        ['rel' => 'http://www.xwiki.org/rel/page', 'href' => 'http://wiki/rest/wikis/xwiki/spaces/Sandbox/pages/IntegrationTest'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $rows = $this->provider->list('decidesk', 'meeting', 'obj-1');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('xwiki:Sandbox.IntegrationTest', $rows[0]['id']);
+        $this->assertSame('Integration Test Page', $rows[0]['title']);
+        $this->assertSame('Sandbox', $rows[0]['space']);
+        $this->assertSame('IntegrationTest', $rows[0]['page']);
+        $this->assertSame(['Sandbox', 'Integration Test Page'], $rows[0]['breadcrumb']);
+        // url falls back to the rel="/rel/page" href from the links array.
+        $this->assertSame('http://wiki/rest/wikis/xwiki/spaces/Sandbox/pages/IntegrationTest', $rows[0]['url']);
+    }//end testListAcceptsRawXwikiPageSummariesEnvelope()
+
+    public function testListReturnsEmptyForEnvelopeWithNoRowsKey(): void
+    {
+        // An assoc response with no recognised rows key (e.g. XWiki's
+        // top-level wiki/space representation) must not be iterated as rows.
+        $this->router->method('call')->willReturn(['links' => [['rel' => 'x', 'href' => 'y']], 'syntaxes' => ['xwiki/2.1']]);
+        $this->assertSame([], $this->provider->list('r', 's', 'o'));
+    }//end testListReturnsEmptyForEnvelopeWithNoRowsKey()
+
     public function testGetFetchesEncodedReference(): void
     {
         $this->router->expects($this->once())

--- a/tests/Unit/Service/Integration/Providers/XwikiProviderTest.php
+++ b/tests/Unit/Service/Integration/Providers/XwikiProviderTest.php
@@ -117,7 +117,7 @@ class XwikiProviderTest extends TestCase
                 $this->provider,
                 'GET',
                 '',
-                ['query' => ['_search' => 'foo', 'register' => 'r1', 'schema' => 's1', 'object' => 'obj-1']]
+                ['query' => ['_search' => 'foo', 'register' => 'r1', 'schema' => 's1', 'object' => 'obj-1'], 'headers' => ['Accept' => 'application/json']]
             )
             ->willReturn([
                 'results' => [
@@ -209,7 +209,7 @@ class XwikiProviderTest extends TestCase
                 $this->provider,
                 'GET',
                 rawurlencode('Space.Page'),
-                ['query' => ['register' => 'r', 'schema' => 's', 'object' => 'o']]
+                ['query' => ['register' => 'r', 'schema' => 's', 'object' => 'o'], 'headers' => ['Accept' => 'application/json']]
             )
             ->willReturn(['reference' => 'Space.Page', 'title' => 'Page', 'content' => '<p>hello</p>']);
 
@@ -226,7 +226,7 @@ class XwikiProviderTest extends TestCase
                 $this->provider,
                 'POST',
                 '',
-                ['body' => ['reference' => 'https://wiki/bin/view/X/Y', 'register' => 'r', 'schema' => 's', 'object' => 'o']]
+                ['body' => ['reference' => 'https://wiki/bin/view/X/Y', 'register' => 'r', 'schema' => 's', 'object' => 'o'], 'headers' => ['Accept' => 'application/json', 'Content-Type' => 'application/json']]
             )
             ->willReturn(['reference' => 'X.Y', 'title' => 'Y', 'space' => 'X']);
 
@@ -243,7 +243,7 @@ class XwikiProviderTest extends TestCase
                 $this->provider,
                 'PUT',
                 rawurlencode('Old.Ref'),
-                ['body' => ['reference' => 'New.Ref', 'register' => 'r', 'schema' => 's', 'object' => 'o']]
+                ['body' => ['reference' => 'New.Ref', 'register' => 'r', 'schema' => 's', 'object' => 'o'], 'headers' => ['Accept' => 'application/json', 'Content-Type' => 'application/json']]
             )
             ->willReturn(['reference' => 'New.Ref', 'title' => 'New']);
 
@@ -259,7 +259,7 @@ class XwikiProviderTest extends TestCase
                 $this->provider,
                 'DELETE',
                 rawurlencode('Space.Page'),
-                ['query' => ['register' => 'r', 'schema' => 's', 'object' => 'o']]
+                ['query' => ['register' => 'r', 'schema' => 's', 'object' => 'o'], 'headers' => ['Accept' => 'application/json']]
             )
             ->willReturn([]);
 


### PR DESCRIPTION
The PHP half of the `integration-xwiki` leaf — issue [#1326](https://github.com/ConductionNL/openregister/issues/1326), `depends_on: pluggable-integration-registry`. The worked **external-storage** example for the pluggable integration registry. Stacked on #1490 (docs/scaffold/tracking) → #1475 (admin UI) → … → `development`. The frontend half is [ConductionNL/nextcloud-vue#213](https://github.com/ConductionNL/nextcloud-vue/pull/213).

## Summary

`XwikiProvider` declares storage `external`, group `external`, OpenConnector source `xwiki`, and delegates **all** CRUD to `ExternalIntegrationRouter` (AD-4) — it carries no HTTP client and no credentials; those live on the OpenConnector source (HTTP Basic or OAuth2, customer-dependent — AD-15).

Per the leaf design.md:
- **AD-1** — `get()` round-trips the page's rendered HTML under `content`; the frontend widget strips it to text + ~500 chars for the detail-page preview, macros are never executed in NC.
- **AD-2** — `create()` passes `reference` through (a full XWiki URL or a `Space.Page` path); the OpenConnector source resolves both to a canonical reference.
- **AD-3** — `normalizeRow()` ensures every row carries a `breadcrumb` (from the source, or derived from space + title) so the UI can disambiguate same-titled pages in different spaces.

## Files

- `lib/Service/Integration/Providers/XwikiProvider.php` (new)
- `lib/AppInfo/Application.php` — DI service binding + added to `bootBuiltinIntegrationProviders()`'s list so it self-registers with `IntegrationRegistry` at boot
- `docs/Integrations/xwiki-openconnector-source.yaml` (new) — the OpenConnector source template to import (the repo's `config/` dir is gitignored, so it lives under `docs/Integrations/`)
- `docs/Integrations/xwiki.md` (new) — user-facing setup + usage guide
- `tests/Unit/Service/Integration/Providers/XwikiProviderTest.php` (new) — 10 tests, 38 assertions
- `openspec/changes/integration-xwiki/tasks.md` — synced to reality

## Spec deviations

- `requiredApp` is `'openconnector'` (not `null` as the original tasks.md said) — more accurate for the admin UI
- the source-config template lives at `docs/Integrations/xwiki-openconnector-source.yaml`, not `config/openconnector-sources/xwiki.yaml` (the repo's `config/` dir is gitignored)
- the provider is registered via `addProvider()` at boot (not a DI tag) — consistent with the umbrella's mechanism

## Test plan

- [x] `composer phpcs` (phpcs.xml) on `XwikiProvider.php` — **0 errors, 0 warnings** (verified in the nextcloud container)
- [x] `composer phpmd` (phpmd.xml) — clean
- [x] `composer psalm` — no errors
- [x] `phpunit --configuration phpunit-unit.xml tests/Unit/Service/Integration/Providers/XwikiProviderTest.php` — 10 passed, 38 assertions
- [x] `php -l Application.php` — no syntax errors
- [ ] Live smoke-test after the chain merges: with OpenConnector installed + an `xwiki` source configured against a running XWiki, the Articles tab/widget should populate and the admin Integrations page should show the `xwiki` row's health