### PR TITLE
Specs: entity-relation-grondslagen (#1435)

### DIFF
--- a/openspec/changes/entity-relation-grondslagen/.openspec.yaml
+++ b/openspec/changes/entity-relation-grondslagen/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/entity-relation-grondslagen/design.md
+++ b/openspec/changes/entity-relation-grondslagen/design.md
@@ -1,0 +1,119 @@
+## Context
+
+`EntityRelation` (`lib/Db/EntityRelation.php`) is the join row between a detected entity and its location — chunk, file, object, or email — plus position offsets, confidence, detection method, and the anonymisation outcome (`anonymized`, `anonymizedValue`). It is OpenRegister's authoritative record of "which entity was found where, at what confidence, and what was done about it."
+
+What it does NOT carry is *why* a redaction was applied. Consumer apps — DocuDesk first — record per-anonymisation legal bases (Woo Art. 5 grondslagen and similar) for compliance reporting and audit. Today this metadata has no home: stuffing it into consumer-app schemas decouples it from the actual EntityRelation row that drove the redaction, and leaves the audit trail incomplete.
+
+The minimal correct surface is one optional field on `EntityRelation`: a JSON array of UUIDs that reference whatever vocabulary the consumer app uses (DocuDesk's `base` schema, in the in-flight `add-dossier-schema` change). OpenRegister stores the array verbatim. It does not validate the UUIDs because the vocabulary lives in another register owned by another app — cross-app referential integrity at this layer would be a coupling we don't want.
+
+The anonymise endpoint (`FileService::anonymizeDocument` and the controller routes that call it) needs to learn three things:
+
+1. Accept `bases` per entity in the request payload.
+2. Persist them on the matching `EntityRelation` row alongside `anonymized` / `anonymizedValue`.
+3. **Strip** `bases` from each entry before forwarding the entity list to OpenAnonymiser. Bases are decision metadata, not redaction input — OpenAnonymiser doesn't need them and the contract there should remain unchanged.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add an optional `bases` JSON column on the `oc_openregister_entity_relations` table.
+- Extend `EntityRelation` with a getter/setter for `bases` following the existing Nextcloud `Entity` base-class pattern.
+- Extend the anonymise endpoint to accept, persist, and strip per-entity `bases` as described.
+- Make the change additive and non-breaking: callers that don't pass `bases` see identical behaviour to today; OpenAnonymiser sees an unchanged payload.
+- Provide a forward-only, zero-downtime migration.
+
+**Non-Goals:**
+
+- Validate that base UUIDs resolve. OpenRegister does not own the vocabulary; cross-app validation is the consumer app's responsibility.
+- Spec the broader entity-recognition / anonymisation pipeline. `FileService::anonymizeDocument`, `EntityRelation`, `EntityRecognitionHandler` are implemented but not currently covered by an OpenSpec capability. Retrofitting a full capability spec for that surface is out of scope here; this change only specs the new bases-related behaviour.
+- Provide a separate "set bases on EntityRelation" API. Bases are set as part of the anonymise call. If a future use case needs to attach bases without anonymising, it can be added as a follow-up.
+- Provide a prohibition gate. Validating that the right entities were selected for anonymisation is a consumer-app concern (DocuDesk implements this in the paired change `anonymisation-grondslagen-and-prohibition-gate`).
+
+## Decisions
+
+### D1. `bases` is a JSON column, not a join table
+
+The column is a JSON array of strings (UUIDs). No separate `entity_relation_base` join table.
+
+**Rationale:**
+
+- **Nextcloud convention.** Nextcloud's storage layer treats moderate-cardinality multi-valued attributes as JSON columns by default; join tables are reserved for relationships requiring foreign-key integrity, indexed reverse-lookup, or cross-record constraints. None of those apply here — bases are a per-row tag list.
+- **Parity with `dossier.bases[]`.** DocuDesk's `dossier` schema (in-flight) uses an `array of $ref` to `base` objects. Mirroring that shape on the EntityRelation row keeps the mental model uniform across the system.
+- **Zero foreign-key coupling.** OpenRegister does not own the `base` vocabulary; storing UUIDs as JSON strings sidesteps the question of whether to enforce FK constraints across registers.
+
+**Alternative considered:** A `entity_relation_bases` join table with `(entity_relation_id, base_uuid)`. Rejected: introduces a second migration, two write points to keep in sync, and reverse-lookup queries that aren't part of any current use case. Can be added later if compliance reporting demands it.
+
+### D2. No validation that base UUIDs resolve
+
+The mapper accepts any string array. Whether the UUIDs point to actual `base` objects in DocuDesk's register (or any register) is the consumer app's problem.
+
+**Rationale:**
+
+- The `base` vocabulary lives in DocuDesk's `dossier` register. OpenRegister doesn't own it and shouldn't reach into another app's data to validate.
+- The consumer app already validates the picker output before sending. Double-validation at the OpenRegister layer adds latency without catching new cases.
+- Cross-register referential integrity is a known harder problem in OpenRegister; deferring it here is consistent with how other cross-app references work.
+
+**Mitigation for the dangling-reference risk:** the consumer app should mark its canonical `base` seed objects as immutable (DocuDesk already does this per ADR-016 + the `add-dossier-schema` design). Tenant-created bases are deletable but rare; if a delete leaves dangling references on EntityRelation rows, the references read as "unknown grondslag" — degraded but not broken.
+
+### D3. Strip happens after persistence, before the OpenAnonymiser call
+
+Order in `FileService::anonymizeDocument`:
+
+```
+   1. for each entry in payload.entities:
+        find or upsert the EntityRelation row, write anonymized/anonymizedValue + bases
+   2. clone the entity list with `bases` removed from each entry
+   3. forward the cloned list to OpenAnonymiser
+```
+
+**Rationale:** The persistence step is the source of truth for "what was decided". The OpenAnonymiser call is downstream, with a contract that does not include bases. Stripping after persistence ensures the audit record is complete even if the OpenAnonymiser call fails (failure is reported back; bases are still recorded with the relation in `anonymized: false` state, which is recoverable on retry).
+
+**Alternative considered:** Strip first, persist after the OpenAnonymiser response. Rejected: if OpenAnonymiser succeeds and the persist fails, the redaction happened but the grondslag is lost — a worse outcome than the reverse.
+
+### D4. Bases payload is set per entity, not per request
+
+Each entry in `payload.entities[]` carries its own `bases`. There is no top-level `bases` field that applies to all entries.
+
+**Rationale:** Per-entity grondslagen are the legal reality — different entities in the same document can be anonymised under different bases (a name = `persoonsgegevens`, a competitor's pricing offer = `bedrijfs-fabricagegegevens`). A top-level field would force consumers to either degrade to a "common denominator" or duplicate the logic.
+
+The consumer app is responsible for any "apply to all" UX (e.g. a checkbox that fans the dossier's bases out to every entity client-side); OpenRegister sees only the per-entity result.
+
+### D5. Empty / null `bases` is allowed
+
+A row with `bases: null` or `bases: []` represents "anonymisation happened, no grondslag was attached". This stays valid because:
+
+- Existing rows (pre-migration) have `bases: null`. We don't backfill.
+- Some consumer flows may not record grondslagen yet (or ever — generic file-sanitisation flows have no grondslag concept).
+
+The column is nullable; the JSON array, when present, has no `minItems` constraint.
+
+### D6. Migration is forward-only and idempotent
+
+The migration class adds the column with `notnull => false` and `default => null`. No data migration. Re-running the migration is a no-op (the column-add primitive is idempotent in Nextcloud's schema migration framework).
+
+**Rollback:** drop the column. Existing callers that started passing `bases` would silently lose them on writes after rollback; this is acceptable for an emergency-only path.
+
+## Risks / Trade-offs
+
+- **[Dangling base UUIDs after consumer-side delete]** → Mitigation per D2: consumer app marks canonical seeds as immutable; tenant-created bases are rare to delete; readers tolerate "unknown grondslag" gracefully.
+- **[Partial anonymise call: persist succeeds, OpenAnonymiser fails]** → Acceptable. The EntityRelation row reflects "intended" state with `anonymized: false`; retry re-issues the anonymise call. This was already the failure mode pre-change for `anonymized` / `anonymizedValue`; bases inherit the same semantics.
+- **[Consumer app that wraps the call differently]** → If a consumer ever calls `FileService::anonymizeDocument` directly with a stale payload shape (no `bases` field), the call still works and bases default to null. Backwards-compatible.
+- **[JSON column query performance]** → Negligible. Reverse lookups ("show me all relations under grondslag X") are not a current use case; if they emerge, a generated index on the JSON path or a materialised view is a follow-up.
+
+## Migration Plan
+
+1. Land `EntityRelation` field + `EntityRelationMapper` persistence + new migration class in one PR.
+2. Apply migration on dev / staging — column appears as nullable JSON. Existing rows have `null`. Smoke-test: run an anonymise call without `bases` (existing behaviour) and with `bases` (new behaviour).
+3. Update `FileService::anonymizeDocument` to accept, persist, and strip. Smoke-test the OpenAnonymiser leg — the request body should be unchanged from today's shape.
+4. Release. Consumer apps (DocuDesk first) start sending `bases`.
+
+**Rollback:** drop the column via a reverse migration. Bases sent by callers after rollback are silently ignored. Consumer apps must be redeployed to stop sending the field if rollback is permanent; in practice rollback is for emergencies and consumer apps tolerate the field being silently dropped.
+
+## Seed Data
+
+Not applicable — this change adds a column to an existing DB table, not new schemas or registers. The `base` vocabulary that bases reference lives in DocuDesk and is seeded there per the in-flight `add-dossier-schema` change.
+
+## Open Questions
+
+- Whether to add a generated index on the JSON column for compliance-reporting queries. **Resolution:** defer until a real query workload appears. JSON column queries on small per-row arrays are inexpensive at expected volumes.
+- Whether the strip step should also happen if a future caller passes other DocuDesk-specific decoration fields (notes, audit hints). **Resolution:** out of scope. The strip is targeted at `bases` specifically. If other decoration fields appear, this design is the precedent for handling them — strip in the same place, with the same rationale.

--- a/openspec/changes/entity-relation-grondslagen/proposal.md
+++ b/openspec/changes/entity-relation-grondslagen/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+`EntityRelation` records the link between a detected entity and the chunk/file/object/email it was found in, plus its anonymisation outcome (`anonymized`, `anonymizedValue`). What it does NOT record is the **legal basis** (grondslag) under which the anonymisation was performed.
+
+Consuming apps — primarily DocuDesk — need to associate per-entity legal bases (Woo Art. 5 grondslagen and equivalents) with each anonymisation event for audit, compliance reporting (Wet open overheid), and downstream rendering (e.g. attaching a "grondslagenpagina" to the anonymised document). Today this metadata has nowhere to live. The choices were either to scatter it across consumer-app schemas (loses the link to the actual EntityRelation row that drove the redaction) or to never persist it (loses the audit trail entirely).
+
+This change adds a single optional `bases` JSON column to `EntityRelation` and extends the anonymise endpoint to accept and persist these bases per entity. The bases MUST be stripped from the payload before forwarding to OpenAnonymiser — they are metadata about the decision, not input to the redaction tool.
+
+## What Changes
+
+- **NEW:** Optional `bases` JSON column on `EntityRelation` — array of UUIDs referencing `base` schema objects (the grondslag vocabulary owned by the consuming app, e.g. DocuDesk's `dossier` register). OpenRegister stores the array verbatim; it does NOT validate that the UUIDs resolve, since the vocabulary lives outside OpenRegister's own schemas.
+- **MODIFIED:** The anonymise endpoint (`FileService::anonymizeDocument` and the controller routes that call it) accepts an optional `bases` array per entity in the request payload. When present, the bases are persisted on the matching `EntityRelation` row alongside the existing `anonymized` / `anonymizedValue` fields.
+- **MODIFIED:** Before forwarding the entity list to OpenAnonymiser, the service MUST strip the `bases` field from each entry. OpenAnonymiser's contract is unchanged.
+- **NEW:** Database migration adds the `bases` column to the `oc_openregister_entity_relations` table as a nullable JSON column. Existing rows are unaffected (column defaults to NULL).
+- **NO trigger-side changes.** No new endpoints, no breaking changes to existing API. Callers that don't pass `bases` see identical behaviour to today.
+- **NO prohibition gate.** Validating that "the right entities were selected for anonymisation" is the consumer app's responsibility (DocuDesk implements this against its own `publicationProhibition` schema in a paired change). OpenRegister stays a generic anonymise primitive.
+
+## Capabilities
+
+### New Capabilities
+
+- `entity-relation-grondslagen`: optional bases-link on `EntityRelation`; the anonymise endpoint's contract for accepting, persisting, and stripping per-entity bases.
+
+### Modified Capabilities
+
+(none — the broader entity-recognition / anonymisation pipeline is implemented but currently uncovered by an OpenSpec capability; this change does not retroactively spec it. See `Out of scope` in design.md.)
+
+## Impact
+
+- **Code (openregister):**
+  - `lib/Db/EntityRelation.php` — new `bases` field (JSON, nullable, default null); getter/setter via Nextcloud's Entity base class pattern.
+  - `lib/Db/EntityRelationMapper.php` — persistence handles the new column.
+  - Migration class under `lib/Migration/` — adds the column. Idempotent; safe on existing installs.
+  - `lib/Service/FileService.php` (or the equivalent path that today calls OpenAnonymiser) — accept `bases` per entity, persist on EntityRelation, strip before forwarding.
+- **API contract:** Anonymise endpoint payload gains an optional `bases` field per entity entry. Additive, non-breaking. Existing callers (and OpenAnonymiser) see no change.
+- **Cross-app:**
+  - **DocuDesk** is the immediate consumer; the paired change `anonymisation-grondslagen-and-prohibition-gate` in DocuDesk relies on this work landing.
+  - **opencatalogi** and **softwarecatalog** do not call the anonymise endpoint; unaffected.
+  - The `base` vocabulary itself lives in DocuDesk (per the in-flight `add-dossier-schema` change). OpenRegister does not own or validate that vocabulary.
+- **Database:** One column added to one table. Migration is forward-only and zero-downtime.
+- **Tests:** Mapper unit tests for the new column. Service-level tests for the persist + strip path.

--- a/openspec/changes/entity-relation-grondslagen/specs/entity-relation-grondslagen/spec.md
+++ b/openspec/changes/entity-relation-grondslagen/specs/entity-relation-grondslagen/spec.md
@@ -6,7 +6,7 @@ status: draft
 
 ## Purpose
 
-Defines an optional `bases` link on `EntityRelation` and the contract by which the anonymise endpoint accepts, persists, and strips per-entity legal bases (grondslagen). The link is consumer-app-agnostic — OpenRegister stores the array of UUIDs verbatim and does not validate that they resolve to real `base` objects (the vocabulary lives in the consumer app).
+Defines an optional `bases` link on `EntityRelation` and the contract by which the anonymise endpoint accepts, persists, and strips per-entity legal bases (grondslagen). The link is consumer-app-agnostic — OpenRegister stores the array of UUIDs verbatim and does not validate that they resolve to real `base` objects (the vocabulary lives in the consumer app). Writes are audit-logged and inherit the anonymise endpoint's existing authorization model.
 
 ## ADDED Requirements
 
@@ -20,59 +20,109 @@ The `EntityRelation` PHP entity (`lib/Db/EntityRelation.php`) MUST expose `getBa
 
 - **GIVEN** an OpenRegister install with existing `EntityRelation` rows
 - **WHEN** the migration is applied
-- **THEN** the `bases` column is added to `oc_openregister_entity_relations`
-- **AND** every existing row reads with `bases = null` via `EntityRelation::getBases()`
-- **AND** no other columns or rows are modified
+- **THEN** the `bases` column MUST be added to `oc_openregister_entity_relations`
+- **AND** every existing row MUST read with `bases = null` via `EntityRelation::getBases()`
+- **AND** no other columns or rows MUST be modified
 
 #### Scenario: Migration is idempotent
 
 - **GIVEN** the migration has already been applied
 - **WHEN** the migration runs again (e.g. on upgrade after a previous deploy)
-- **THEN** the migration is a no-op
-- **AND** no error is raised
+- **THEN** the migration MUST be a no-op
+- **AND** no error MUST be raised
 
 #### Scenario: Mapper reads and writes bases
 
 - **GIVEN** an `EntityRelation` row with `bases = ["uuid-a", "uuid-b"]` written via the mapper
 - **WHEN** the row is read back via `EntityRelationMapper::find($id)`
-- **THEN** `getBases()` returns the array `["uuid-a", "uuid-b"]`
-- **AND** `jsonSerialize()` includes `bases` in its output
+- **THEN** `getBases()` MUST return the array `["uuid-a", "uuid-b"]`
+- **AND** `jsonSerialize()` MUST include `bases` in its output
 
 #### Scenario: Empty array is accepted and distinct from null
 
 - **WHEN** `setBases([])` is called and the row is persisted
-- **THEN** subsequent reads return `bases = []` (an empty array, not null)
-- **AND** `jsonSerialize()['bases']` is `[]`
-
-#### Scenario: Non-UUID strings are accepted by the mapper layer
-
-- **WHEN** `setBases(["not-a-uuid", "12345"])` is called and persisted
-- **THEN** the call succeeds (the mapper does not validate UUID format)
-- **AND** the values are returned verbatim on read
+- **THEN** subsequent reads MUST return `bases = []` (an empty array, not null)
+- **AND** `jsonSerialize()['bases']` MUST be `[]`
 
 ### Requirement: The anonymise endpoint MUST accept per-entity `bases` in the request payload
 
-The anonymise endpoint (currently `FileService::anonymizeDocument(node, payload)` and the controller routes that wrap it) MUST accept an optional `bases` field on each entry in `payload.entities[]`. The field MUST be either absent, `null`, or an array of strings. The field's presence MUST NOT change any existing behaviour for callers that omit it.
+The anonymise endpoint (currently `FileService::anonymizeDocument(node, payload)` and the controller routes that wrap it) MUST accept an optional `bases` field on each entry in `payload.entities[]`. The field MUST be either absent, `null`, or an array of strings (see also the endpoint-shape-validation Requirement below). The field's presence MUST NOT change any existing behaviour for callers that omit it.
 
 #### Scenario: Anonymise call without bases preserves today's behaviour
 
 - **GIVEN** a request payload with entities that have no `bases` field
 - **WHEN** the anonymise endpoint processes the request
-- **THEN** the matching `EntityRelation` rows are written with `bases = null`
-- **AND** the request forwarded to OpenAnonymiser contains exactly the same fields it would have contained before this change
+- **THEN** the matching `EntityRelation` rows MUST be written with `bases = null`
+- **AND** the request forwarded to OpenAnonymiser MUST contain exactly the same fields it would have contained before this change
 
 #### Scenario: Anonymise call with bases populates EntityRelation
 
 - **GIVEN** a request payload with `entities: [{entityId: 42, bases: ["uuid-a"]}, {entityId: 43, bases: ["uuid-b", "uuid-c"]}]`
 - **WHEN** the anonymise endpoint processes the request
-- **THEN** the EntityRelation row for entity 42 has `bases = ["uuid-a"]`
-- **AND** the EntityRelation row for entity 43 has `bases = ["uuid-b", "uuid-c"]`
+- **THEN** the EntityRelation row for entity 42 MUST have `bases = ["uuid-a"]`
+- **AND** the EntityRelation row for entity 43 MUST have `bases = ["uuid-b", "uuid-c"]`
 
 #### Scenario: Bases field with empty array writes empty array
 
 - **GIVEN** a payload entry with `bases: []`
 - **WHEN** the anonymise endpoint processes it
-- **THEN** the matching EntityRelation row has `bases = []` (empty array, not null)
+- **THEN** the matching EntityRelation row MUST have `bases = []` (empty array, not null)
+
+### Requirement: The anonymise endpoint MUST validate the SHAPE of `bases` at the entry point but MUST NOT validate its CONTENT
+
+At the endpoint layer (controller / `FileService::anonymizeDocument`), the `bases` field on each entry of `payload.entities[]` MUST be one of:
+
+- absent,
+- `null`,
+- an array whose every element is a string.
+
+Any other shape — a non-array value (e.g. a number, an object, a single string), or an array containing non-string elements — MUST be rejected with an HTTP 400 response. The 400 response body MUST identify the offending entry by index so the caller can fix the right entry in a multi-entity payload.
+
+At the mapper layer, no further validation MUST be applied: the elements of the `bases` array MUST be persisted verbatim regardless of their content (UUID-shaped, garbage strings, or empty strings). This two-layer contract exists deliberately — endpoint validation rejects ill-typed input early, while the mapper remains content-agnostic so the consumer-app's vocabulary can evolve without OR changes.
+
+#### Scenario: Endpoint rejects `bases` as a non-array
+
+- **GIVEN** a payload entry with `bases: "uuid-a"` (a string, not an array)
+- **WHEN** the anonymise endpoint processes the request
+- **THEN** the response MUST be HTTP 400
+- **AND** no EntityRelation row MUST be modified
+
+#### Scenario: Endpoint rejects array elements that are not strings
+
+- **GIVEN** a payload entry at index 1 with `bases: ["uuid-a", 42]`
+- **WHEN** the anonymise endpoint processes the request
+- **THEN** the response MUST be HTTP 400
+- **AND** the error body MUST identify entity index `1` as the offending entry
+
+#### Scenario: Mapper accepts any string content
+
+- **GIVEN** a validated payload with `bases: ["not-a-uuid", "12345", ""]`
+- **WHEN** the endpoint forwards the payload to the mapper layer
+- **THEN** the row MUST be persisted with the values verbatim
+- **AND** no error MUST be raised
+
+### Requirement: `bases` writes MUST inherit the anonymise endpoint's existing authorization (ADR-005 / ADR-023)
+
+The anonymise endpoint already enforces a per-object authorization check (the caller MUST have write access to the file/object being anonymised). Setting `bases` MUST require no additional authorization beyond that check — `bases` is metadata attached to an existing anonymisation operation that the caller is already authorized to perform. There MUST be no separate group, role, or action-level permission for `bases` writes in this change.
+
+A caller who cannot anonymise a given object MUST NOT be able to set `bases` on its EntityRelation rows, because the persist step (next Requirement) runs only after the endpoint's existing authorization has passed. A caller who CAN anonymise the object MUST be able to set arbitrary `bases` strings as part of that operation.
+
+This decision is recorded explicitly so reviewers and implementers can reason about the authorization surface: there is intentionally NO extra check, and that absence is the intended contract — not an oversight. If a future change introduces a separate action-level permission for `bases` (per ADR-023), it MUST add a new Requirement here.
+
+#### Scenario: Unauthorized caller cannot anonymise and therefore cannot set bases
+
+- **GIVEN** a user without write access to file `F`
+- **WHEN** the user POSTs an anonymise request for `F` with `bases` populated
+- **THEN** the existing endpoint authorization check MUST fail and the request MUST be rejected (HTTP 403)
+- **AND** no EntityRelation row for `F` MUST be modified
+- **AND** no bases value MUST be persisted
+
+#### Scenario: Authorized caller can set bases as part of anonymisation
+
+- **GIVEN** a user with write access to file `F`
+- **WHEN** the user POSTs an anonymise request for `F` with `bases: ["uuid-a"]`
+- **THEN** the request MUST succeed
+- **AND** the EntityRelation row's `bases` value MUST be `["uuid-a"]`
 
 ### Requirement: The anonymise endpoint MUST persist bases BEFORE forwarding to OpenAnonymiser
 
@@ -82,16 +132,73 @@ The order of operations in the anonymise endpoint MUST be: (1) for each entry, f
 
 - **GIVEN** a successful anonymise request with bases populated
 - **WHEN** the endpoint runs
-- **THEN** the EntityRelation rows are written before the HTTP call to OpenAnonymiser is issued
-- **AND** the persist write includes the bases values
+- **THEN** the EntityRelation rows MUST be written before the HTTP call to OpenAnonymiser is issued
+- **AND** the persist write MUST include the bases values
 
 #### Scenario: Persist survives an OpenAnonymiser failure
 
 - **GIVEN** a request whose OpenAnonymiser call fails (network timeout, 500 response)
 - **WHEN** the endpoint processes the request
-- **THEN** the EntityRelation rows have been written with `bases` populated
-- **AND** the rows have `anonymized = false` (or whatever the existing pre-change semantics dictate for failed redaction)
-- **AND** a retry of the same request succeeds in transitioning the rows to `anonymized = true` without re-prompting the caller for `bases`
+- **THEN** the EntityRelation rows MUST have been written with `bases` populated
+- **AND** the rows MUST have `anonymized = false` (or the existing pre-change semantics for failed redaction)
+
+### Requirement: `bases` writes MUST be recorded in OpenRegister's audit trail (ADR-022 / Woo compliance)
+
+Every mutation of an `EntityRelation` row that sets or changes the `bases` value MUST produce an entry in the OpenRegister audit trail. The audit entry MUST include the actor (Nextcloud user UID — per ADR-005, never the display name), the timestamp, the row's stable identifier, and both the previous and new `bases` values. Reads of `EntityRelation` rows MUST NOT produce audit entries.
+
+The audit entry MUST be written through OpenRegister's existing immutable-audit-trail subsystem (the same one that records other `EntityRelation` mutations), not by direct mapper writes that bypass audit. This is the load-bearing compliance requirement of the change — without it, a Woo officer cannot reconstruct which grondslag justified a given redaction, defeating the feature's stated purpose.
+
+#### Scenario: Setting bases for the first time produces an audit entry
+
+- **GIVEN** a request that sets `bases: ["uuid-a"]` on a new EntityRelation row (no prior value)
+- **WHEN** the row is persisted
+- **THEN** an audit-trail entry MUST exist for that row referencing the action (e.g. `entity_relation_bases_set` or OR's equivalent), the acting user's UID, an ISO-8601 timestamp, the row's identifier, `previousBases: null`, and `newBases: ["uuid-a"]`
+
+#### Scenario: Updating bases produces an audit entry with old + new values
+
+- **GIVEN** an EntityRelation row with `bases: ["uuid-a"]`
+- **WHEN** a subsequent anonymise call sets `bases: ["uuid-a", "uuid-b"]`
+- **THEN** an audit-trail entry MUST be written with `previousBases: ["uuid-a"]` and `newBases: ["uuid-a", "uuid-b"]`
+
+#### Scenario: Reads do not produce audit entries
+
+- **WHEN** an `EntityRelation` row with non-null `bases` is read via `EntityRelationMapper::find` or `findEntitiesForFile`
+- **THEN** no audit-trail entry MUST be produced for the read
+
+### Requirement: A retry that omits `bases` MUST reuse the persisted values
+
+When the anonymise endpoint receives a retry request where `bases` is absent from one or more entries that previously had `bases` persisted (i.e. the EntityRelation row already exists with non-null `bases`), the endpoint MUST NOT overwrite the persisted values. The retry MUST proceed with the OpenAnonymiser call using the persisted `bases` for downstream behaviour (audit trail, consumer-app summary rendering), without requiring the caller to resupply `bases`.
+
+A retry that DOES include `bases` MUST overwrite the persisted values; the resulting audit entry MUST record the previous-vs-new transition per the audit-trail Requirement. The endpoint MUST distinguish three caller intents:
+
+- field **absent** → reuse persisted value (no audit entry for `bases` field)
+- field **present and `null`** → set to `null` (explicit clear, audit-logged)
+- field **present and `[]`** → set to `[]` (explicit empty, audit-logged)
+
+This contract lets DocuDesk's `anonymisation-grondslagen-and-prohibition-gate` issue retries after a gate-fail without re-prompting the operator for grondslagen.
+
+#### Scenario: Retry without `bases` preserves the persisted value
+
+- **GIVEN** an EntityRelation row with `bases: ["uuid-a"]` and `anonymized: false` (previous OpenAnonymiser call failed)
+- **WHEN** a retry request arrives for the same entity with no `bases` field in the payload
+- **THEN** the EntityRelation row's `bases` MUST remain `["uuid-a"]` (unchanged)
+- **AND** the retry MUST proceed with the OpenAnonymiser call using the persisted bases
+- **AND** on success the row MUST transition to `anonymized: true` with `bases` unchanged
+- **AND** no audit-trail entry MUST be produced specifically for the `bases` field (other audit entries for the anonymised-flag transition follow existing OR semantics and are out of scope of this Requirement)
+
+#### Scenario: Retry with new `bases` overwrites the persisted value
+
+- **GIVEN** an EntityRelation row with `bases: ["uuid-a"]`
+- **WHEN** a retry request arrives for the same entity with `bases: ["uuid-b"]`
+- **THEN** the EntityRelation row's `bases` MUST be updated to `["uuid-b"]`
+- **AND** an audit-trail entry MUST record the transition (`previousBases: ["uuid-a"]`, `newBases: ["uuid-b"]`)
+
+#### Scenario: Retry with explicit `bases: null` clears the persisted value
+
+- **GIVEN** an EntityRelation row with `bases: ["uuid-a"]`
+- **WHEN** a retry request arrives with `bases: null`
+- **THEN** the EntityRelation row's `bases` MUST be set to `null`
+- **AND** the transition MUST be audit-logged (`previousBases: ["uuid-a"]`, `newBases: null`)
 
 ### Requirement: The anonymise endpoint MUST strip `bases` from the payload before forwarding to OpenAnonymiser
 
@@ -101,42 +208,55 @@ Before issuing the HTTP call to OpenAnonymiser, the service MUST construct a cop
 
 - **GIVEN** a request payload with bases populated on every entry
 - **WHEN** the anonymise endpoint forwards to OpenAnonymiser
-- **THEN** the request body to OpenAnonymiser contains no `bases` field on any entity entry
-- **AND** all other fields (`text`, `entityType`, `score`, etc.) are forwarded unchanged
+- **THEN** the request body to OpenAnonymiser MUST contain no `bases` field on any entity entry
+- **AND** all other fields (`text`, `entityType`, `score`, etc.) MUST be forwarded unchanged
 
 #### Scenario: Mixed payload — some entries with bases, some without
 
 - **GIVEN** a payload where entries 1, 3 have `bases` populated and entry 2 has none
 - **WHEN** the endpoint forwards to OpenAnonymiser
-- **THEN** the forwarded request has no `bases` field on any of the three entries
-- **AND** entries 1, 3 still have their EntityRelation rows updated with the supplied bases
+- **THEN** the forwarded request MUST have no `bases` field on any of the three entries
+- **AND** entries 1, 3 MUST still have their EntityRelation rows updated with the supplied bases
 
 ### Requirement: OpenRegister MUST NOT validate that `bases` UUIDs resolve
 
-The persistence layer accepts any string array. OpenRegister MUST NOT issue any cross-register lookup to verify that the supplied UUIDs correspond to actual objects in any register. The vocabulary that bases reference is owned by the consumer app.
+The persistence layer accepts any string array. OpenRegister MUST NOT issue any cross-register lookup to verify that the supplied UUIDs correspond to actual objects in any register. The vocabulary that bases reference is owned by the consumer app (see Notes for the canonical DocuDesk `base` vocabulary).
 
 #### Scenario: Unknown UUID strings are accepted
 
-- **GIVEN** a payload with `bases: ["00000000-0000-0000-0000-000000000000"]` (UUID that doesn't resolve)
+- **GIVEN** a payload with `bases: ["00000000-0000-0000-0000-000000000000"]` (a UUID that doesn't resolve to any object)
 - **WHEN** the endpoint processes the request
-- **THEN** the row is persisted with the value verbatim
-- **AND** no error is raised
-- **AND** no cross-register query is issued
-
-#### Scenario: Garbage strings are accepted
-
-- **GIVEN** a payload with `bases: ["not-even-a-uuid", ""]`
-- **WHEN** the endpoint processes the request
-- **THEN** the row is persisted with the values verbatim
+- **THEN** the row MUST be persisted with the value verbatim
+- **AND** no error MUST be raised
+- **AND** no cross-register query MUST be issued
 
 ### Requirement: The change MUST be additive and non-breaking
 
-Existing callers (and the OpenAnonymiser contract) MUST be unaffected when no `bases` field is present in any entry of the payload. No existing field is removed, renamed, or repurposed. No existing scenario in any other capability is invalidated.
+Existing callers (and the OpenAnonymiser contract) MUST be unaffected when no `bases` field is present in any entry of the payload. No existing field is removed, renamed, or repurposed. No existing scenario in any other capability MUST be invalidated.
 
 #### Scenario: Pre-change client continues to work
 
 - **GIVEN** a client that constructs anonymise payloads using the pre-change schema (no `bases` field anywhere)
 - **WHEN** that client sends a request to the anonymise endpoint
-- **THEN** the request succeeds with identical behaviour to before this change
-- **AND** the resulting EntityRelation rows have `bases = null`
-- **AND** the OpenAnonymiser request body is identical to what it would have been pre-change
+- **THEN** the request MUST succeed with identical behaviour to before this change
+- **AND** the resulting EntityRelation rows MUST have `bases = null`
+- **AND** the OpenAnonymiser request body MUST be identical to what it would have been pre-change
+
+## Notes
+
+### Consumer-owned vocabulary
+
+The `bases` array contains UUID-shaped strings whose meaning is defined by the consumer app, not by OpenRegister. OpenRegister persists the array verbatim and never resolves the UUIDs (see Requirement: *OpenRegister MUST NOT validate that bases UUIDs resolve*).
+
+For DocuDesk-driven anonymisation — the first consumer of this capability — the UUIDs SHOULD resolve to objects in the `base` register defined by DocuDesk's [`add-dossier-schema`](https://github.com/ConductionNL/docudesk/pull/135) change. That schema seeds six canonical Woo Art. 5 *uitzonderingsgronden*:
+
+| Slug | Woo Art. 5 reference | Description (NL, excerpt) |
+|---|---|---|
+| `persoonsgegevens` | Art. 5.1 Woo jo. AVG Art. 4 lid 1 | Herleidbare gegevens van een natuurlijke persoon. |
+| `bijzondere-persoonsgegevens` | Art. 5.1 Woo jo. AVG Art. 9 | Bijzondere persoonsgegevens (medisch, religieus, etc.). |
+| `strafrechtelijk` | Art. 5.1 Woo jo. AVG Art. 10 | Strafrechtelijke gegevens. |
+| `bedrijfs-fabricagegegevens` | Art. 5.1 sub c Woo | Vertrouwelijke bedrijfs- en fabricagegegevens. |
+| `onevenredige-benadeling` | Art. 5.2 Woo | Onevenredige benadeling van betrokkenen of derden. |
+| `nationale-veiligheid` | Art. 5.1 sub a/b Woo | Nationale veiligheid / opsporing. |
+
+Other consumers MAY define their own `base` vocabulary; OpenRegister does not enforce a single registry. Consumers MUST handle the case where a stored `bases` UUID does not resolve to a known `base` object (e.g. by surfacing it as "onbekende grondslag" or filtering it from rendered summaries) — this graceful-degradation behaviour is the consumer's responsibility, not OpenRegister's.

--- a/openspec/changes/entity-relation-grondslagen/specs/entity-relation-grondslagen/spec.md
+++ b/openspec/changes/entity-relation-grondslagen/specs/entity-relation-grondslagen/spec.md
@@ -1,0 +1,142 @@
+---
+status: draft
+---
+
+# Entity Relation Grondslagen
+
+## Purpose
+
+Defines an optional `bases` link on `EntityRelation` and the contract by which the anonymise endpoint accepts, persists, and strips per-entity legal bases (grondslagen). The link is consumer-app-agnostic — OpenRegister stores the array of UUIDs verbatim and does not validate that they resolve to real `base` objects (the vocabulary lives in the consumer app).
+
+## ADDED Requirements
+
+### Requirement: `EntityRelation` MUST gain an optional `bases` JSON column
+
+The `oc_openregister_entity_relations` table MUST gain a column named `bases` of type JSON (or the platform-equivalent JSON column type), nullable, with default `NULL`. The column MUST hold either `NULL`, an empty array `[]`, or an array of strings (UUIDs). No JSON-schema validation of the array contents is enforced at the database or mapper layer.
+
+The `EntityRelation` PHP entity (`lib/Db/EntityRelation.php`) MUST expose `getBases(): ?array` and `setBases(?array $bases): void`, registered via `addType('bases', 'json')` in the constructor. Existing rows (pre-migration) MUST read as `bases = null` without errors.
+
+#### Scenario: Migration adds the column without disturbing existing rows
+
+- **GIVEN** an OpenRegister install with existing `EntityRelation` rows
+- **WHEN** the migration is applied
+- **THEN** the `bases` column is added to `oc_openregister_entity_relations`
+- **AND** every existing row reads with `bases = null` via `EntityRelation::getBases()`
+- **AND** no other columns or rows are modified
+
+#### Scenario: Migration is idempotent
+
+- **GIVEN** the migration has already been applied
+- **WHEN** the migration runs again (e.g. on upgrade after a previous deploy)
+- **THEN** the migration is a no-op
+- **AND** no error is raised
+
+#### Scenario: Mapper reads and writes bases
+
+- **GIVEN** an `EntityRelation` row with `bases = ["uuid-a", "uuid-b"]` written via the mapper
+- **WHEN** the row is read back via `EntityRelationMapper::find($id)`
+- **THEN** `getBases()` returns the array `["uuid-a", "uuid-b"]`
+- **AND** `jsonSerialize()` includes `bases` in its output
+
+#### Scenario: Empty array is accepted and distinct from null
+
+- **WHEN** `setBases([])` is called and the row is persisted
+- **THEN** subsequent reads return `bases = []` (an empty array, not null)
+- **AND** `jsonSerialize()['bases']` is `[]`
+
+#### Scenario: Non-UUID strings are accepted by the mapper layer
+
+- **WHEN** `setBases(["not-a-uuid", "12345"])` is called and persisted
+- **THEN** the call succeeds (the mapper does not validate UUID format)
+- **AND** the values are returned verbatim on read
+
+### Requirement: The anonymise endpoint MUST accept per-entity `bases` in the request payload
+
+The anonymise endpoint (currently `FileService::anonymizeDocument(node, payload)` and the controller routes that wrap it) MUST accept an optional `bases` field on each entry in `payload.entities[]`. The field MUST be either absent, `null`, or an array of strings. The field's presence MUST NOT change any existing behaviour for callers that omit it.
+
+#### Scenario: Anonymise call without bases preserves today's behaviour
+
+- **GIVEN** a request payload with entities that have no `bases` field
+- **WHEN** the anonymise endpoint processes the request
+- **THEN** the matching `EntityRelation` rows are written with `bases = null`
+- **AND** the request forwarded to OpenAnonymiser contains exactly the same fields it would have contained before this change
+
+#### Scenario: Anonymise call with bases populates EntityRelation
+
+- **GIVEN** a request payload with `entities: [{entityId: 42, bases: ["uuid-a"]}, {entityId: 43, bases: ["uuid-b", "uuid-c"]}]`
+- **WHEN** the anonymise endpoint processes the request
+- **THEN** the EntityRelation row for entity 42 has `bases = ["uuid-a"]`
+- **AND** the EntityRelation row for entity 43 has `bases = ["uuid-b", "uuid-c"]`
+
+#### Scenario: Bases field with empty array writes empty array
+
+- **GIVEN** a payload entry with `bases: []`
+- **WHEN** the anonymise endpoint processes it
+- **THEN** the matching EntityRelation row has `bases = []` (empty array, not null)
+
+### Requirement: The anonymise endpoint MUST persist bases BEFORE forwarding to OpenAnonymiser
+
+The order of operations in the anonymise endpoint MUST be: (1) for each entry, find or upsert the `EntityRelation` row writing the existing fields (`anonymized`, `anonymizedValue`, etc.) plus `bases`; then (2) construct the request to OpenAnonymiser with `bases` stripped from each entry; then (3) forward to OpenAnonymiser. Persistence MUST NOT be conditional on the OpenAnonymiser call succeeding.
+
+#### Scenario: Persist precedes the OpenAnonymiser call
+
+- **GIVEN** a successful anonymise request with bases populated
+- **WHEN** the endpoint runs
+- **THEN** the EntityRelation rows are written before the HTTP call to OpenAnonymiser is issued
+- **AND** the persist write includes the bases values
+
+#### Scenario: Persist survives an OpenAnonymiser failure
+
+- **GIVEN** a request whose OpenAnonymiser call fails (network timeout, 500 response)
+- **WHEN** the endpoint processes the request
+- **THEN** the EntityRelation rows have been written with `bases` populated
+- **AND** the rows have `anonymized = false` (or whatever the existing pre-change semantics dictate for failed redaction)
+- **AND** a retry of the same request succeeds in transitioning the rows to `anonymized = true` without re-prompting the caller for `bases`
+
+### Requirement: The anonymise endpoint MUST strip `bases` from the payload before forwarding to OpenAnonymiser
+
+Before issuing the HTTP call to OpenAnonymiser, the service MUST construct a copy of the entity list with the `bases` field removed from every entry. The OpenAnonymiser request body MUST be byte-equivalent to what it would have been before this change (modulo any other unrelated field reorderings introduced by the JSON encoder).
+
+#### Scenario: OpenAnonymiser sees no `bases` field
+
+- **GIVEN** a request payload with bases populated on every entry
+- **WHEN** the anonymise endpoint forwards to OpenAnonymiser
+- **THEN** the request body to OpenAnonymiser contains no `bases` field on any entity entry
+- **AND** all other fields (`text`, `entityType`, `score`, etc.) are forwarded unchanged
+
+#### Scenario: Mixed payload — some entries with bases, some without
+
+- **GIVEN** a payload where entries 1, 3 have `bases` populated and entry 2 has none
+- **WHEN** the endpoint forwards to OpenAnonymiser
+- **THEN** the forwarded request has no `bases` field on any of the three entries
+- **AND** entries 1, 3 still have their EntityRelation rows updated with the supplied bases
+
+### Requirement: OpenRegister MUST NOT validate that `bases` UUIDs resolve
+
+The persistence layer accepts any string array. OpenRegister MUST NOT issue any cross-register lookup to verify that the supplied UUIDs correspond to actual objects in any register. The vocabulary that bases reference is owned by the consumer app.
+
+#### Scenario: Unknown UUID strings are accepted
+
+- **GIVEN** a payload with `bases: ["00000000-0000-0000-0000-000000000000"]` (UUID that doesn't resolve)
+- **WHEN** the endpoint processes the request
+- **THEN** the row is persisted with the value verbatim
+- **AND** no error is raised
+- **AND** no cross-register query is issued
+
+#### Scenario: Garbage strings are accepted
+
+- **GIVEN** a payload with `bases: ["not-even-a-uuid", ""]`
+- **WHEN** the endpoint processes the request
+- **THEN** the row is persisted with the values verbatim
+
+### Requirement: The change MUST be additive and non-breaking
+
+Existing callers (and the OpenAnonymiser contract) MUST be unaffected when no `bases` field is present in any entry of the payload. No existing field is removed, renamed, or repurposed. No existing scenario in any other capability is invalidated.
+
+#### Scenario: Pre-change client continues to work
+
+- **GIVEN** a client that constructs anonymise payloads using the pre-change schema (no `bases` field anywhere)
+- **WHEN** that client sends a request to the anonymise endpoint
+- **THEN** the request succeeds with identical behaviour to before this change
+- **AND** the resulting EntityRelation rows have `bases = null`
+- **AND** the OpenAnonymiser request body is identical to what it would have been pre-change

--- a/openspec/changes/entity-relation-grondslagen/tasks.md
+++ b/openspec/changes/entity-relation-grondslagen/tasks.md
@@ -1,0 +1,55 @@
+## 1. Database migration
+
+- [ ] 1.1 Add a new migration class under `lib/Migration/` (next-available version, e.g. `Version<X>Date<Y>.php`) that adds a nullable JSON column `bases` to `oc_openregister_entity_relations`. Use the platform's existing JSON column type (JSON on MySQL/MariaDB, JSON / JSONB on PostgreSQL — match what other JSON columns in OpenRegister use today, e.g. on `oc_openregister_objects`). Default value: NULL.
+- [ ] 1.2 Verify the migration is idempotent: running it twice on the same database is a no-op (Nextcloud's `addColumn` primitive is idempotent — confirm via dry-run or unit test).
+- [ ] 1.3 Smoke-test the migration on a populated dev database: confirm existing `EntityRelation` rows are read correctly post-migration and `bases` reads as `null` for all of them.
+
+## 2. EntityRelation entity + mapper
+
+- [ ] 2.1 Add `protected ?array $bases = null;` to `lib/Db/EntityRelation.php`.
+- [ ] 2.2 Add `addType(fieldName: 'bases', type: 'json');` in `EntityRelation::__construct()`.
+- [ ] 2.3 Add the `getBases(): ?array` and `setBases(?array $bases): void` magic-method docblocks to the class header (mirroring the existing pattern for other fields). The getters/setters are auto-provided by Nextcloud's `Entity` base class once `addType` is registered.
+- [ ] 2.4 Update `jsonSerialize()` to include `bases` in the returned array. Order it after `anonymizedValue` for consistency.
+- [ ] 2.5 Update the psalm/phpdoc return type on `jsonSerialize` to include `bases`.
+- [ ] 2.6 Confirm `EntityRelationMapper` (`lib/Db/EntityRelationMapper.php`) does not need changes — Nextcloud's `QBMapper` automatically handles columns registered via `addType`. If the mapper has any column-list handling that's NOT auto-derived (e.g. manual `select(...)` lists), update those to include `bases`.
+
+## 3. Anonymise endpoint integration
+
+- [ ] 3.1 In `FileService::anonymizeDocument(node, payload)` (or the equivalent service method that the controller routes call), accept an optional `bases` field on each entry in `payload.entities[]`. Validate at the entry point: the field, when present, MUST be either `null` or an array of strings. Reject malformed input with a 400-level error.
+- [ ] 3.2 Implement the persist-then-strip order. For each entry in `payload.entities[]`:
+  - locate or upsert the `EntityRelation` row for `(entityId, fileId/objectId/chunkId)`,
+  - set `anonymized`, `anonymizedValue`, `bases` on the row,
+  - persist the row.
+  Persistence MUST happen before the OpenAnonymiser HTTP call.
+- [ ] 3.3 Construct the OpenAnonymiser request body from a copy of `payload.entities[]` with `bases` removed from every entry. Confirm by inspection that the request body to OpenAnonymiser is byte-equivalent to the pre-change shape (modulo unrelated JSON encoder ordering).
+- [ ] 3.4 Confirm the mapper does NOT issue any cross-register lookup to validate the supplied UUIDs. The persistence layer accepts any string array.
+
+## 4. Unit tests
+
+- [ ] 4.1 Add `tests/unit/Db/EntityRelationTest.php` covering: `getBases`/`setBases` round-trip; `jsonSerialize` includes `bases`; null vs empty-array distinction is preserved.
+- [ ] 4.2 Add `tests/unit/Db/EntityRelationMapperTest.php` (or extend an existing suite) covering: insert with bases; insert without bases (defaults to null); update bases on existing row; non-UUID strings are accepted; idempotent migration smoke test.
+- [ ] 4.3 Add `tests/unit/Service/FileServiceTest.php` cases for the anonymise-endpoint integration: persist precedes OpenAnonymiser call; OpenAnonymiser receives a request body without `bases`; OpenAnonymiser failure preserves the persisted bases on the row.
+
+## 5. Integration tests
+
+- [ ] 5.1 Add a Newman/Postman integration test (or extend the existing collection) for the anonymise endpoint with a `bases`-populated payload. Verify: 200 response; EntityRelation row queried directly returns the correct bases.
+- [ ] 5.2 Add an integration test for the no-bases path: pre-change-shape payload still works, returns identical behaviour.
+
+## 6. Cross-app regression check
+
+- [ ] 6.1 Manually run the opencatalogi anonymise flow (if any — opencatalogi is not a known anonymise consumer, but per OR project rules: regression-test it). Confirm no break.
+- [ ] 6.2 Smoke-test against DocuDesk's existing anonymise calls (without `bases`). Confirm no break.
+- [ ] 6.3 Inspect the OpenAnonymiser request body via debug logging on a single test call. Confirm the body shape is unchanged from pre-change.
+
+## 7. Documentation
+
+- [ ] 7.1 Add an entry to `CHANGELOG.md` under Added describing the new optional `bases` column on `EntityRelation` and the anonymise endpoint's persist+strip behaviour.
+- [ ] 7.2 Update the OpenAnonymiser interface contract documentation (if one exists in `docs/`) to note that `bases` is recognised but stripped before the call. If no such doc exists, add a one-line comment on `FileService::anonymizeDocument` referencing the strip behaviour.
+
+## 8. Quality and verification
+
+- [ ] 8.1 Run the full unit test suite — clean.
+- [ ] 8.2 Run static analysis (Psalm / PHPStan at the project's configured strictness) — clean.
+- [ ] 8.3 Run code style (PHPCS at project config) — clean.
+- [ ] 8.4 Manual smoke against a live stack: anonymise call with bases populated, confirm EntityRelation row has bases populated, confirm OpenAnonymiser was not sent the bases.
+- [ ] 8.5 Run `openspec validate entity-relation-grondslagen` — clean.

--- a/openspec/changes/entity-relation-grondslagen/tasks.md
+++ b/openspec/changes/entity-relation-grondslagen/tasks.md
@@ -15,20 +15,31 @@
 
 ## 3. Anonymise endpoint integration
 
-- [ ] 3.1 In `FileService::anonymizeDocument(node, payload)` (or the equivalent service method that the controller routes call), accept an optional `bases` field on each entry in `payload.entities[]`. Validate at the entry point: the field, when present, MUST be either `null` or an array of strings. Reject malformed input with a 400-level error.
+- [ ] 3.1 In `FileService::anonymizeDocument(node, payload)` (or the equivalent service method that the controller routes call), accept an optional `bases` field on each entry in `payload.entities[]`. Validate the **shape** at the entry point only: when present, the field MUST be either `null` or an array whose every element is a string. Reject malformed shape (non-array values, non-string array elements) with HTTP 400 and include the offending entity index in the error body. Do NOT validate the **content** of strings — the mapper layer is intentionally content-agnostic (see the spec's two-layer endpoint/mapper Requirement).
 - [ ] 3.2 Implement the persist-then-strip order. For each entry in `payload.entities[]`:
   - locate or upsert the `EntityRelation` row for `(entityId, fileId/objectId/chunkId)`,
+  - apply the retry-omit semantics from task 3.6,
   - set `anonymized`, `anonymizedValue`, `bases` on the row,
   - persist the row.
   Persistence MUST happen before the OpenAnonymiser HTTP call.
 - [ ] 3.3 Construct the OpenAnonymiser request body from a copy of `payload.entities[]` with `bases` removed from every entry. Confirm by inspection that the request body to OpenAnonymiser is byte-equivalent to the pre-change shape (modulo unrelated JSON encoder ordering).
 - [ ] 3.4 Confirm the mapper does NOT issue any cross-register lookup to validate the supplied UUIDs. The persistence layer accepts any string array.
+- [ ] 3.5 Wire `bases` mutations through OpenRegister's existing immutable-audit-trail subsystem — the same path that records other `EntityRelation` mutations (grep `EntityRelationMapper` + audit-trail wiring to find it). Every set/update of `bases` MUST produce an audit entry that includes `previousBases`, `newBases`, the acting user UID (NOT display name, per ADR-005), the timestamp, and the row identifier. Reads MUST NOT produce audit entries. Reference: ADR-022.
+- [ ] 3.6 Implement retry-omit semantics: when a retry payload omits the `bases` field for an entity whose EntityRelation row already has a non-null persisted value, REUSE the persisted value (do not overwrite, do not audit-log the unchanged `bases` field). Distinguish three caller intents in the validation/dispatch layer:
+  - field **absent** → reuse persisted value, no audit entry for `bases`
+  - field present and `null` → set to `null` (explicit clear, audit-logged)
+  - field present and `[]` → set to empty array (audit-logged)
+- [ ] 3.7 Confirm the anonymise endpoint's existing per-object authorization (write-access to the file/object being anonymised) is the **only** auth check on the `bases` write path. No extra group/role check is added. Cross-reference ADR-005 + ADR-023 in the PR description so the absence-of-extra-check is intentional rather than oversight. If a future change wants action-level authz on `bases`, it MUST add a new spec Requirement.
 
 ## 4. Unit tests
 
 - [ ] 4.1 Add `tests/unit/Db/EntityRelationTest.php` covering: `getBases`/`setBases` round-trip; `jsonSerialize` includes `bases`; null vs empty-array distinction is preserved.
 - [ ] 4.2 Add `tests/unit/Db/EntityRelationMapperTest.php` (or extend an existing suite) covering: insert with bases; insert without bases (defaults to null); update bases on existing row; non-UUID strings are accepted; idempotent migration smoke test.
 - [ ] 4.3 Add `tests/unit/Service/FileServiceTest.php` cases for the anonymise-endpoint integration: persist precedes OpenAnonymiser call; OpenAnonymiser receives a request body without `bases`; OpenAnonymiser failure preserves the persisted bases on the row.
+- [ ] 4.4 Add `tests/unit/Service/FileServiceShapeValidationTest.php` covering: endpoint rejects `bases: "string"` with 400; endpoint rejects `bases: ["uuid", 42]` with 400; endpoint accepts `bases: ["any", "strings"]` and the mapper persists them verbatim; the 400 error body identifies the offending entity index.
+- [ ] 4.5 Add `tests/unit/Service/FileServiceAuditTrailTest.php` covering: first-time set produces an audit entry with `previousBases: null` + `newBases: <array>`; update produces audit entry with old + new values; read does NOT produce audit entry; the audit entry references the user UID, not the display name (ADR-005).
+- [ ] 4.6 Add `tests/unit/Service/FileServiceRetryTest.php` covering: retry-omit reuses persisted `bases` without audit-logging the unchanged field; retry with new `bases` overwrites and audit-logs the transition; retry with explicit `null` clears and audit-logs; the three caller intents (absent / present-null / present-empty-array) are distinguished correctly.
+- [ ] 4.7 Add `tests/unit/Service/FileServiceAuthorizationTest.php` covering: a caller without write-access to the target file/object is rejected with HTTP 403 and NO `bases` value is persisted on any EntityRelation row for that file; a caller with write-access can set arbitrary `bases` strings as part of the anonymise call.
 
 ## 5. Integration tests
 


### PR DESCRIPTION
## Summary

Adds the OpenSpec change directory for **entity-relation-grondslagen** — extending `EntityRelation` with an optional `bases` JSON column so the anonymise endpoint can persist legal-basis (Woo Art. 5 *grondslag*) references per entity. Bases are stripped from the payload before forwarding to OpenAnonymiser, so the upstream service contract is unchanged.

Backwards-compatible: callers that omit `bases` see identical behaviour.

Tightly scoped — this PR is **specs only**, no implementation. It also does not retrofit the broader `EntityRelation` surface, which is currently uncovered by an OpenSpec capability.

Refs: #1435
Pair: [ConductionNL/docudesk#135](https://github.com/ConductionNL/docudesk/pull/135) — DocuDesk's `anonymisation-grondslagen-summary` (hard dep) and `anonymisation-grondslagen-and-prohibition-gate` (soft dep) depend on this.

## Test plan

- [ ] Review `openspec/changes/entity-relation-grondslagen/{proposal,design,tasks}.md` and the `entity-relation-grondslagen/spec.md` delta
- [ ] Confirm Requirements / Scenarios match the DocuDesk-side consumer expectations in PR #135
- [ ] `openspec validate` (when the implementation PR lands)