### PR TITLE
Specs: text-extraction-eml (#1438)

### DIFF
--- a/openspec/changes/text-extraction-eml/.openspec.yaml
+++ b/openspec/changes/text-extraction-eml/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/text-extraction-eml/design.md
+++ b/openspec/changes/text-extraction-eml/design.md
@@ -1,0 +1,189 @@
+## Context
+
+`TextExtractionService` (in `lib/Service/`) is OpenRegister's text-from-files extractor. The current cascade in `extractSourceText` covers PDF (smalot/pdfparser), Word documents (PhpWord), spreadsheets (PhpSpreadsheet), and plain-text MIMEs. EML files (`message/rfc822`) fall off the end — the cascade returns null. Downstream entity-recognition produces nothing for emails.
+
+Two consumer needs drive the shape:
+
+1. **Entity detection**: wants a single flat plain-text string. Current pattern across all extractors. Needs headers (which carry PII — sender / recipient names + emails) and body, plus the text content of any extractable attachment so detection sees a complete picture of the email's content.
+2. **PDF rendering** (DocuDesk's paired `eml-pdf-assembly`): wants structured access to headers, both plain-text and HTML body parts, and the raw attachment bytes. HTML body is preferred for fidelity when the recipient sees the rendered email; plain-text body is the fallback. Attachments need to be embeddable as PDF/A-3 file attachments AND optionally rendered into pages.
+
+A single flat-text return doesn't serve the second need. The change adds a structured-parse method alongside the flat extraction. Both delegate to a shared parser wrapping `zbateson/mail-mime-parser`.
+
+The library choice rules out alternatives that add operational requirements:
+
+- `php-mime-mail-parser/php-mime-mail-parser` requires the PECL `mailparse` extension, which isn't installed in many shared hosting / containerised setups.
+- The PHP `imap` extension is deprecated for removal in PHP 8.4.
+- Hand-rolled regex parsing on RFC 822 is a nest of edge cases; reliability would suffer.
+
+`zbateson/mail-mime-parser` is pure PHP, modern, MIT-licensed, and well-tested. ~200KB on disk.
+
+The capability scope follows the precedent set by `entity-relation-grondslagen`: spec ONLY the new EML extension; do not retroactively spec the broader `TextExtractionService` surface (PDF, Word, spreadsheet) which is implemented but currently uncovered by an OpenSpec capability. That broader retrofit is its own concern.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- EML inputs to `TextExtractionService::extractFile()` produce populated plain-text — headers + body + recursively-extracted attachment text — instead of null.
+- A new public method `parseEmlStructured()` returns a structured representation suitable for DocuDesk's `eml-pdf-assembly` to consume.
+- Both flat and structured paths share one underlying parser. No code duplication.
+- HTML body is preserved in the structured path (for high-fidelity downstream rendering); plain-text body remains the canonical input to entity detection.
+- Recursive depth on nested EML attachments is bounded (depth 3) to defend against malicious nesting.
+
+**Non-Goals:**
+
+- Retrofit OpenSpec capability for the broader `TextExtractionService` surface.
+- Decrypt S/MIME or PGP-encrypted EML bodies.
+- Parse mailbox container formats (`mbox`, `pst`, `mst`) — those wrap EMLs and are a separate concern.
+- Extract calendar invite bodies (`text/calendar`) — they're listed as attachments in v1.
+- Configurable header inclusion in the flat plain-text path. Always-on; future toggle if needed.
+- Async extraction. Synchronous in v1.
+- Storage of structured parse results. The structured-parse method is read-on-demand; callers cache themselves if needed.
+
+## Decisions
+
+### D1. `zbateson/mail-mime-parser` over alternatives
+
+Pure-PHP RFC 822 / MIME parser with no extension dependency. Handles malformed messages gracefully (real-world EMLs from production environments are often non-conforming; the parser tolerates this). MIT-licensed. ~200KB on disk; minimal dependency cost.
+
+**Alternative considered:** `php-mime-mail-parser`. Faster (uses C-level `mailparse` PECL extension) but requires the extension to be installed. Many hosted Nextcloud setups won't have it. Rejected.
+
+### D2. Flat plain-text path: headers + body + recursive attachments inline
+
+The output structure for the existing extractor pattern (`extractEml` returns string) is fixed:
+
+```
+From: <header value>
+To: <header value>
+Cc: <header value>
+Subject: <header value>
+Date: <header value>
+
+<body — plain text from text/plain, or HTML stripped to text>
+
+--- Attachment: <filename> ---
+<recursively-extracted text from the attachment via TextExtractionService>
+
+--- Attachment: <filename> (<mimeType>, not extractable) ---
+```
+
+Extractable types for recursion: `application/pdf`, the Word MIMEs (DOCX/DOC), text MIMEs, `message/rfc822` (recursive EML). Anything else lists by name + MIME only.
+
+**Rationale:** entity detection expects a single string. Inlining attachment text means PERSON / ORGANIZATION mentions inside attached PDFs are detected as part of the same document. Without inlining, attachments would produce no entities.
+
+**Trade-off:** the flat-text path produces a longer string than the email body alone. Acceptable; entity detection scales linearly with input length and these strings are still small (typical email + attachment text is well under 1 MB).
+
+### D3. Structured parse: `EmlStructure` value object
+
+`parseEmlStructured(File)` returns an immutable value object:
+
+```php
+final class EmlStructure {
+    public readonly array $headers;       // ['from' => string, 'to' => string[], 'cc' => string[], 'subject' => string, 'date' => DateTimeImmutable, 'messageId' => string|null, ...]
+    public readonly EmlBody $body;        // ['plainText' => string|null, 'html' => string|null]
+    public readonly array $attachments;   // EmlAttachment[]
+}
+
+final class EmlAttachment {
+    public readonly string $filename;
+    public readonly string $mimeType;
+    public readonly string $content;      // raw bytes
+    public readonly bool $isInline;
+    public readonly ?string $contentId;   // for inline images referenced by HTML body
+    public readonly ?EmlStructure $nestedEml;  // populated if mimeType === 'message/rfc822'
+}
+```
+
+**Body shape:** both `plainText` and `html` populated when each part exists. Consumer chooses. The flat path picks `plainText`, falling back to HTML stripped to text. The PDF rendering path (DocuDesk's `eml-pdf-assembly`) picks `html` for fidelity, falling back to `plainText` wrapped in `<pre>`.
+
+**Headers:** parsed and normalised. `to` and `cc` are arrays even when the original header has a single recipient (consumers don't have to special-case scalar vs array). `date` is a `DateTimeImmutable` parsed from RFC 2822 / 5322 date format; if the date is malformed, the field is null.
+
+**Attachments:** ordered as encountered in the multipart structure. Inline attachments (referenced by `cid:` in HTML body) carry `contentId`; consumers rendering HTML can resolve them.
+
+**Nested EML:** if an attachment is `message/rfc822`, the parser recursively builds an `EmlStructure` for it (subject to depth limit per D5). Consumers can walk the tree without re-parsing.
+
+### D4. `EmlParser` is the shared underlying parser
+
+Both `extractEml()` and `parseEmlStructured()` delegate to a shared `lib/Service/TextExtraction/EmlParser.php`:
+
+```php
+class EmlParser {
+    public function parse(File $file): EmlStructure;          // primary parse — returns the rich object
+    public function flatten(EmlStructure $structure): string; // build the flat plain-text from a structure
+}
+```
+
+`extractEml` calls `parse()` then `flatten()`. `parseEmlStructured` calls `parse()` and returns the result directly. Single source of truth for parsing logic; flattening is a pure function of the structure.
+
+**Rationale:** avoids two divergent parse paths drifting out of sync. Bug fixes (header normalisation, encoding handling, etc.) propagate to both consumers.
+
+### D5. Recursive attachment depth limit: 3
+
+Nested `message/rfc822` attachments are followed via `nestedEml` up to depth 3. Beyond that, the outermost attachment carries `nestedEml: null` even though it's an EML — consumers see the bytes but no structured recursion. The flat path follows the same limit: deeply nested EMLs are listed as attachments without further extraction.
+
+**Rationale:** defends against malicious or accidental deep nesting (forwarded chains, archive-extracted threads). 3 levels covers realistic forwarding patterns ("forwarded forwarded message"); deeper would be a red flag.
+
+**Trade-off:** legitimate deeper nesting (rare) loses structure. Acceptable; consumers can re-invoke `parseEmlStructured` on the bytes if they really need to go deeper.
+
+### D6. HTML body stripped to text (for the flat path) — modest implementation
+
+When `text/plain` is missing or empty in the flat-extraction path:
+
+1. Take the `text/html` part.
+2. Drop `<style>` and `<script>` content (block-level removal — content between opening and closing tags is removed).
+3. Strip remaining tags via PHP's `strip_tags()`.
+4. Decode HTML entities (`html_entity_decode`).
+5. Collapse runs of whitespace into single spaces; preserve line breaks where the original HTML had `<br>`, `<p>`, or block-level elements (rough heuristic — replace these with newlines before stripping).
+
+Not a full HTML→text conversion. Good enough for entity detection — names and email addresses survive. Layout fidelity is irrelevant here (the structured path preserves the HTML for proper rendering).
+
+### D7. Header normalisation and encoding
+
+Headers are decoded from RFC 2047 encoded-word form (`=?utf-8?b?...?=`) into plain UTF-8 strings. Non-ASCII bodies are normalised to UTF-8 via the parser's built-in handling. Malformed encoding is best-effort: the parser falls back to `mb_detect_encoding` + `mb_convert_encoding` to UTF-8.
+
+**Edge case:** an EML with no `Date:` header. The structured `date` field is null; the flat path omits the line. Both paths tolerate the absence.
+
+### D8. `extractFile` integration — additive cascade branch
+
+`TextExtractionService::extractSourceText` (or its sibling cascade method) gains a branch for `message/rfc822`:
+
+```
+if (in_array($mimeType, $textMimeTypes) === true || strpos($mimeType, 'text/') === 0) { /* existing */ }
+else if ($mimeType === 'application/pdf')                                              { /* existing */ }
+else if ($this->isWordDocument(mimeType: $mimeType) === true)                          { /* existing */ }
+else if ($this->isSpreadsheet(mimeType: $mimeType) === true)                           { /* existing */ }
+else if ($mimeType === 'message/rfc822')                                               { return $this->extractEml($file); }   // NEW
+else                                                                                   { /* existing fallthrough */ }
+```
+
+Cascade order kept consistent with existing pattern. EML appears after the heaviest existing branches, near the end.
+
+## Risks / Trade-offs
+
+- **[Malformed EMLs from production]** → Mitigation: `zbateson/mail-mime-parser` tolerates malformed input gracefully. The parser's defensive handling is one of the reasons it was chosen.
+- **[Attachment recursion depth — denial-of-service]** → Mitigation per D5: depth limit 3.
+- **[Large EMLs with many attachments — extraction time]** → Mitigation: recursive extraction reuses `TextExtractionService`'s existing per-type extractors; each is bounded; total time dominated by the single most expensive attachment. Documented in performance section. If problematic, follow-up to async processing.
+- **[Encrypted EML]** → Out of scope. Encrypted body returns the encrypted blob's text representation (gibberish for entity detection); no decryption attempt. Future change handles S/MIME / PGP.
+- **[Calendar attachments not text-extracted]** → Acceptable; calendars list as attachments by name + MIME. Future change adds a calendar branch to TextExtractionService if needed.
+- **[Inline attachments referenced by `cid:` in HTML body]** → For DocuDesk's PDF rendering, inline images need to be accessible to the renderer. The structured path provides them via `EmlAttachment.contentId`; consumer resolves the reference. Documented in the structured-parse spec.
+- **[Behaviour change for tenants relying on EML returning empty]** → Unlikely but possible. CHANGELOG entry under "Behavior changes" makes the new behaviour explicit. If a tenant truly wanted EML to be skipped, a follow-up could add a per-tenant config flag.
+
+## Migration Plan
+
+1. Land `zbateson/mail-mime-parser` in `composer.json`. CI / build pipeline picks it up.
+2. Land `EmlStructure`, `EmlAttachment`, and `EmlParser` value-object / service classes.
+3. Land the cascade branch in `TextExtractionService::extractSourceText` and the public `parseEmlStructured` method.
+4. Land unit tests covering extraction paths and edge cases.
+5. Release. Existing extracted-text records for EMLs (which were null) are not re-extracted automatically. New EML inputs produce populated text. Re-extraction is opt-in via the existing `forceReExtract` parameter.
+
+**Rollback:** revert the cascade branch — EML inputs return null again. The new public method becomes an unused service method (no harm). `composer.json` revert removes the dep. Rollback is per-commit clean.
+
+## Seed Data
+
+Not applicable — this change adds a service method and a parser, not new schemas.
+
+## Open Questions
+
+- **Attachment-bytes lifetime in `EmlStructure`** — the structured parse holds attachment content in memory. For large EMLs (multi-megabyte attachments), this could pressure memory. Provisional: accept the cost in v1; if a real workload pushes against limits, follow-up to a streaming / lazy-load API where `content` is replaced with a callback.
+- **`html2text` library vs hand-rolled stripping** — design D6 sketches a hand-rolled approach. Several PHP libraries do this better (e.g. `voku/html2text`, `html2text/html2text`). Provisional: hand-rolled is simpler for v1 (one fewer dep); switch to a library if entity detection misses entities due to poor stripping. Confirm at apply time.
+- **Should `parseEmlStructured` be cached?** — the parse is non-trivial; if called repeatedly for the same file, the cost compounds. Provisional: rely on the consumer to cache (they hold the structure for as long as they need). If a use case emerges for service-level caching, follow-up.
+- **Error handling on partial-parse failure** — `zbateson/mail-mime-parser` throws on truly broken input. Provisional: catch and log; return null from `extractEml` (preserving the existing pattern of "extraction failed → null"). For `parseEmlStructured`, throw a typed `EmlParseException`. Consumers handle as they see fit.

--- a/openspec/changes/text-extraction-eml/proposal.md
+++ b/openspec/changes/text-extraction-eml/proposal.md
@@ -1,0 +1,116 @@
+## Why
+
+OpenRegister's `TextExtractionService` covers PDFs (smalot/pdfparser), Word documents (PhpWord), spreadsheets, and plain-text MIMEs — but not EML. Email files are a regular input for government anonymisation workflows (Wob/Woo correspondence, complaint dossiers, internal email archives), and the current pipeline rejects them: detection skips the file, downstream apps that depend on extraction (DocuDesk's anonymisation, anything else doing entity recognition over email archives) see nothing.
+
+The DocuDesk change `anonymise-output-as-pdf-by-default` has a soft dependency on this work — its EmlBackend in the conversion cascade can't activate until `TextExtractionService` returns something for `message/rfc822`. Until then, EML inputs in DocuDesk's default PDF mode 422 with a known fallback hint.
+
+This change adds EML support to `TextExtractionService` via `zbateson/mail-mime-parser`. Two outputs:
+
+1. **Plain-text extraction** (existing pattern) — headers (From/To/Cc/Subject/Date) followed by the email body (preferring `text/plain`, falling back to HTML stripped to text), followed by recursively-extracted text from each attachment of a known extractable type. One flat string suitable for entity detection. Replaces the current "EML returns null/empty" gap.
+2. **Structured parse** (new public API) — a richer return shape carrying the headers, both `text/plain` and `text/html` body parts (when available), and the list of attachments with their raw bytes + MIME + filename. This exists specifically to enable downstream apps (DocuDesk first, via the paired `eml-pdf-assembly` change) to build a PDF that combines email content with attachment rendering or embedding.
+
+## What Changes
+
+- **NEW dep:** `zbateson/mail-mime-parser` added to OpenRegister's `composer.json`. Pure-PHP RFC 822 parser; no PHP extension requirement (avoids the deprecated `imap` extension and the optional `mailparse` PECL extension).
+- **NEW:** MIME detection for `message/rfc822` in `TextExtractionService::extractSourceText` — the existing if/else cascade gains an EML branch alongside PDF, Word, spreadsheet, and text branches.
+- **NEW:** Private method `extractEml(\OCP\Files\File $file): ?string` returning the flat plain-text representation. Includes a header block, body content, and recursively-extracted attachment text.
+- **NEW:** Public method `parseEmlStructured(\OCP\Files\File $file): EmlStructure` (new value-object class `lib/Service/TextExtraction/EmlStructure.php`). Returns a richer object with headers, body (both `plainText` and `html` populated when each part exists), and an attachments list with bytes + MIME + filename. Recursive: an EML attachment carries a nested `EmlStructure`.
+- **NEW:** HTML body fallback for the flat plain-text path. When `text/plain` is missing or empty, strip `text/html` to text (drop `<style>` / `<script>` content, strip tags, collapse whitespace). The structured-parse path keeps both bodies separate; the consumer chooses.
+- **NEW:** Recursive attachment text extraction in the flat plain-text path. For each attachment of a known extractable MIME (`application/pdf`, Word, plain-text), the method calls back into `TextExtractionService` and inlines the extracted text under a marker (`--- Attachment: <filename> ---`). Non-extractable attachments are listed by name + MIME at their position in the multipart structure.
+- **NEW capability:** `text-extraction-eml`. Tightly scoped — covers ONLY the EML extension. The broader `TextExtractionService` surface (existing PDF/Word/spreadsheet support) remains uncovered by an OpenSpec capability spec; retrofitting that is out of scope here, same way `entity-relation-grondslagen` didn't try to retrofit the entity-recognition surface.
+- **NO new endpoints.** Extraction is invoked through the existing `extractFile($fileId)` path. The structured-parse method is a service-level addition consumed via DI from cooperating services (DocuDesk's EmlBackend, future consumers).
+- **NO breaking change.** Callers that today see "EML returns null" continue to work — they now see populated text. No existing extracted-text contract is modified for non-EML files.
+
+### Output shape (flat plain-text extraction)
+
+```
+From: Burgemeester De Vries <burg@gemeente.nl>
+To: Raadslid Bakker <s.bakker@gemeente.nl>; ...
+Cc: ...
+Subject: Beantwoording Woo-verzoek 2025-017
+Date: 2026-04-12T11:00:00Z
+
+Geachte raadslid,
+
+(... body text ...)
+
+--- Attachment: bijlage-1.pdf ---
+(... extracted text from the PDF attachment ...)
+
+--- Attachment: image.png (image/png, not extractable) ---
+```
+
+### Output shape (structured parse)
+
+```php
+EmlStructure {
+    headers: [
+        'from' => 'Burgemeester De Vries <burg@gemeente.nl>',
+        'to' => ['Raadslid Bakker <s.bakker@gemeente.nl>', ...],
+        'cc' => [...],
+        'subject' => 'Beantwoording Woo-verzoek 2025-017',
+        'date' => DateTimeImmutable('2026-04-12T11:00:00Z'),
+        'messageId' => '...@gemeente.nl',
+    ],
+    body: [
+        'plainText' => 'Geachte raadslid, ...',
+        'html' => '<p>Geachte raadslid, ...</p>',
+    ],
+    attachments: [
+        EmlAttachment {
+            filename: 'bijlage-1.pdf',
+            mimeType: 'application/pdf',
+            content: <bytes>,
+            isInline: false,
+            contentId: null,
+            nestedEml: null,
+        },
+        EmlAttachment {
+            filename: 'forwarded.eml',
+            mimeType: 'message/rfc822',
+            content: <bytes>,
+            isInline: false,
+            contentId: null,
+            nestedEml: EmlStructure { ... },  // recursive
+        },
+    ],
+}
+```
+
+### Out of scope
+
+- **Calendar invites** (`text/calendar`, `.ics`) embedded in EML — text extraction of calendar bodies is a separate concern; v1 lists them as attachments.
+- **Encrypted EML** (S/MIME, PGP) — extraction returns the encrypted blob's headers only; body/attachments are not decrypted. Decryption integration is a separate change.
+- **Mail-archive containers** (`mbox`, `pst`, `mst`) — these aren't EMLs; if support is wanted, a separate change handles the container format and recurses per-message into this EML parser.
+- **A retrofit OpenSpec capability for the broader TextExtractionService surface** (PDF, Word, spreadsheet) — out of scope here. This change covers EML only.
+- **Asynchronous extraction** for very large EMLs with many attachments — synchronous in v1.
+- **Configurable header inclusion** for the flat plain-text path — always-on in v1; if a tenant wants body-only, a follow-up adds the toggle.
+- **Recursive attachment depth limit** — the parser may be vulnerable to malicious nesting (EML containing EML containing EML ...). v1 caps at depth 3 with a hard limit; deeper nesting is not extracted and the outermost attachment is listed by name only.
+
+## Capabilities
+
+### New Capabilities
+
+- `text-extraction-eml`: EML support in `TextExtractionService` — flat plain-text extraction (headers + body + recursively-extracted attachment text) and a structured-parse method returning headers, body (plain + html), and attachments-with-bytes.
+
+### Modified Capabilities
+
+(none — the broader `TextExtractionService` surface is currently uncovered by an OpenSpec capability; this change does not retrofit it. See `Out of scope`.)
+
+## Impact
+
+- **Code (openregister):**
+  - `composer.json` — add `zbateson/mail-mime-parser`.
+  - `lib/Service/TextExtractionService.php` — extend the MIME branch with `message/rfc822`. Add private `extractEml()` method.
+  - `lib/Service/TextExtraction/EmlStructure.php` — NEW value object class for the structured parse result.
+  - `lib/Service/TextExtraction/EmlAttachment.php` — NEW value object class for individual attachments.
+  - `lib/Service/TextExtraction/EmlParser.php` — NEW. Wraps `zbateson/mail-mime-parser`; provides both the flat-text and structured-parse paths. `TextExtractionService` delegates to it.
+- **API contract:** No changes to existing API. The flat-text path now returns populated content for EML inputs (where it previously returned null/empty). The new `parseEmlStructured()` method is a service-level addition; callers acquire `TextExtractionService` via DI and call the new method. No HTTP surface changes.
+- **Cross-app:**
+  - Unblocks DocuDesk's `anonymise-output-as-pdf-by-default` EML branch.
+  - Paired with DocuDesk's `eml-pdf-assembly` change which uses the structured parse to render headers + body (HTML when available) + attachments into a PDF/A-3b.
+  - opencatalogi and softwarecatalog don't currently extract EML; unaffected.
+- **Performance:** Per-EML extraction adds a parse step. For typical emails (<1 MB, <5 attachments), well under a second. Large attachments contribute their own extraction cost (recursive PDF parse, etc.) — bounded by the existing per-type extractors. Depth-3 recursion limit caps worst case.
+- **Privacy / compliance:** EML headers and bodies often carry PII; making them visible to entity detection improves anonymisation completeness. No new data leaves the OR boundary.
+- **Tests:** Unit tests for the EML parser covering: header extraction, plain-text body, HTML body fallback, multipart structures, attachments (extractable + non-extractable), nested EML, depth limit, malformed EML graceful-fail.
+- **Migration:** None. No DB changes. EML inputs that today produce no extracted text will start producing content after the change ships. If a tenant relied on EML files producing empty extraction (unlikely), they get a behaviour change — documented in CHANGELOG under "Behavior changes".

--- a/openspec/changes/text-extraction-eml/specs/text-extraction-eml/spec.md
+++ b/openspec/changes/text-extraction-eml/specs/text-extraction-eml/spec.md
@@ -1,0 +1,199 @@
+---
+status: draft
+---
+
+# Text Extraction — EML
+
+## Purpose
+
+Defines EML (`message/rfc822`) text extraction in OpenRegister's `TextExtractionService`. Two output paths share an underlying parser based on `zbateson/mail-mime-parser`: a flat plain-text path (the existing `TextExtractionService` pattern, extended to EML), and a new structured-parse path that exposes headers, both `text/plain` and `text/html` body parts, and attachment bytes for downstream rich-rendering consumers (DocuDesk's `eml-pdf-assembly` first).
+
+## ADDED Requirements
+
+### Requirement: `TextExtractionService` MUST handle `message/rfc822` MIME inputs
+
+The MIME branch in `extractSourceText` (or equivalent cascade method) MUST recognise `message/rfc822` and delegate to a private `extractEml(File $file): ?string` method. The method MUST return populated plain text (not null) for valid EML inputs.
+
+#### Scenario: EML input produces populated extracted text
+
+- **GIVEN** an EML file (mime `message/rfc822`) with headers and a `text/plain` body
+- **WHEN** `TextExtractionService::extractFile($fileId)` is called
+- **THEN** the persisted extracted-text for the file is non-empty
+- **AND** the text contains at minimum the email's body content
+
+#### Scenario: Pre-change EML inputs that previously returned null now return populated text
+
+- **GIVEN** an EML file that had been processed before this change landed (resulting in null / empty extracted text)
+- **WHEN** the file is re-extracted via `forceReExtract: true`
+- **THEN** the persisted extracted-text is now populated per the v1 EML extraction shape
+
+### Requirement: The flat plain-text output MUST include headers, body, and recursively-extracted attachment text
+
+The flat output (returned by `extractEml`) MUST be ordered:
+
+1. Header block: `From:`, `To:`, `Cc:` (when present), `Subject:`, `Date:` (when present). One header per line. After the block, a blank line.
+2. Body content: `text/plain` if present; otherwise `text/html` stripped to text.
+3. For each attachment, in multipart-document order:
+   - If the attachment's MIME is recursively extractable (`application/pdf`, the Word DOCX/DOC MIMEs, text MIMEs, or `message/rfc822` for nested EML), the method MUST call `TextExtractionService` for that attachment and inline the result under a marker line `--- Attachment: <filename> ---`.
+   - Otherwise, the marker line MUST be `--- Attachment: <filename> (<mimeType>, not extractable) ---` with no body following.
+
+#### Scenario: Header block precedes body
+
+- **GIVEN** an EML with `From: alice@example`, `To: bob@example`, `Subject: Hi`, `Date: 2026-04-12T11:00:00Z`, and a body "Hello Bob"
+- **WHEN** `extractEml` runs
+- **THEN** the output begins with `From: alice@example` (and the other headers in order)
+- **AND** a blank line separates the header block from the body
+- **AND** the body content "Hello Bob" follows
+
+#### Scenario: HTML-only body falls back to stripped text
+
+- **GIVEN** an EML whose body has only a `text/html` part (no `text/plain`)
+- **WHEN** `extractEml` runs
+- **THEN** the body section contains the HTML stripped to text (no `<p>`, `<a>` tags; entities decoded; whitespace collapsed)
+
+#### Scenario: Recursive attachment extraction for PDF attachment
+
+- **GIVEN** an EML with a PDF attachment named `report.pdf`
+- **WHEN** `extractEml` runs
+- **THEN** the output contains a marker line `--- Attachment: report.pdf ---`
+- **AND** below the marker, the extracted text from the PDF is inlined
+
+#### Scenario: Non-extractable attachment listed by name + MIME
+
+- **GIVEN** an EML with a PNG attachment named `image.png`
+- **WHEN** `extractEml` runs
+- **THEN** the output contains exactly one marker line `--- Attachment: image.png (image/png, not extractable) ---`
+- **AND** no body content follows the marker
+
+### Requirement: A new public method `parseEmlStructured()` MUST return an `EmlStructure` value object
+
+The method MUST be public and accept an `\OCP\Files\File`. It MUST return an immutable `EmlStructure` value object with:
+
+- `headers` — associative array including `from` (string), `to` (string array), `cc` (string array), `subject` (string), `date` (DateTimeImmutable or null), `messageId` (string or null), and any other parsed headers the implementation chooses to expose.
+- `body` — value object with `plainText` (string or null) AND `html` (string or null). Both populated when each part exists; either or both can be null.
+- `attachments` — array of `EmlAttachment` value objects in multipart order.
+
+#### Scenario: Structured parse returns populated headers
+
+- **GIVEN** an EML with full standard headers
+- **WHEN** `parseEmlStructured($file)` is called
+- **THEN** `result.headers['from']` is the parsed From line (RFC 2047-decoded if encoded)
+- **AND** `result.headers['to']` is an array of recipients
+- **AND** `result.headers['date']` is a `DateTimeImmutable` matching the Date header
+
+#### Scenario: Both plainText and html bodies are exposed when present
+
+- **GIVEN** a multipart EML with both `text/plain` and `text/html` parts
+- **WHEN** `parseEmlStructured` runs
+- **THEN** `result.body['plainText']` contains the plain part
+- **AND** `result.body['html']` contains the HTML part
+- **AND** both are populated (consumer chooses)
+
+#### Scenario: Single-body EMLs populate only the present part
+
+- **GIVEN** an EML with only a `text/html` part
+- **WHEN** `parseEmlStructured` runs
+- **THEN** `result.body['plainText']` is null
+- **AND** `result.body['html']` contains the HTML
+
+#### Scenario: Date header malformed — date field is null
+
+- **GIVEN** an EML whose Date header is unparseable
+- **WHEN** `parseEmlStructured` runs
+- **THEN** `result.headers['date']` is null
+- **AND** the rest of the structure is populated normally
+- **AND** no exception is thrown
+
+### Requirement: Each `EmlAttachment` MUST carry filename, MIME type, raw bytes, and inline / contentId metadata
+
+Each entry in `EmlStructure.attachments[]` MUST be an `EmlAttachment` with:
+
+- `filename` (string) — from the Content-Disposition header or generated if missing.
+- `mimeType` (string) — from Content-Type.
+- `content` (string of raw bytes — base64-decoded as needed).
+- `isInline` (bool) — true if the attachment has Content-Disposition: inline.
+- `contentId` (string or null) — for HTML body references via `cid:` URLs.
+- `nestedEml` (`EmlStructure` or null) — populated if `mimeType === 'message/rfc822'` and the depth limit is not exceeded.
+
+#### Scenario: Standard PDF attachment
+
+- **GIVEN** an EML with a single PDF attachment
+- **WHEN** structured-parse runs
+- **THEN** `result.attachments[0]` has `filename: "<original.pdf>"`, `mimeType: "application/pdf"`, populated `content` bytes, `isInline: false`, `contentId: null`, `nestedEml: null`
+
+#### Scenario: Inline image attachment
+
+- **GIVEN** an EML where the HTML body references an inline image via `<img src="cid:image1@example">`
+- **AND** the EML carries the inline image as an attachment with Content-ID `<image1@example>`
+- **WHEN** structured-parse runs
+- **THEN** the matching attachment has `isInline: true`, `contentId: "image1@example"`
+
+#### Scenario: Nested EML attachment
+
+- **GIVEN** an EML that contains another EML as an attachment (forwarded message)
+- **WHEN** structured-parse runs
+- **THEN** the nested attachment has `mimeType: "message/rfc822"`, `nestedEml` populated with its own `EmlStructure`
+
+### Requirement: Recursive nesting of `message/rfc822` MUST be capped at depth 3
+
+The structured parse MUST follow `message/rfc822` attachments recursively, but only up to depth 3. Beyond that, the attachment's `nestedEml` MUST be null even though the MIME indicates an EML. The flat path MUST follow the same limit — at depth 3+, EML attachments are listed by name only without inline extraction.
+
+#### Scenario: Depth-3 EML chain is fully recursed
+
+- **GIVEN** EML A containing EML B containing EML C containing EML D
+- **WHEN** `parseEmlStructured(A)` runs
+- **THEN** A → B → C are recursed (`nestedEml` populated through C)
+- **AND** the C-level EmlStructure for D's attachment has `nestedEml: null`
+
+#### Scenario: Depth-4+ chain stops at the limit
+
+- **GIVEN** an EML chain longer than depth 3
+- **WHEN** the parse runs
+- **THEN** at the depth-3 level, the next-level EML attachment carries `nestedEml: null` even though `mimeType: "message/rfc822"`
+- **AND** no exception is thrown
+- **AND** a debug-level log entry notes the depth-cap activation
+
+### Requirement: Header block in flat output MUST decode RFC 2047 encoded-words
+
+When a header value uses RFC 2047 encoded-word form (`=?utf-8?B?<base64>?=` or `=?utf-8?Q?<quoted-printable>?=`), the flat output MUST contain the decoded plain UTF-8 string. Encoded-word artefacts MUST NOT leak into the output.
+
+#### Scenario: Encoded-word From header is decoded
+
+- **GIVEN** an EML whose From header is `From: =?utf-8?B?QnVyZ2VtZWVzdGVyIERlIFZyaWVz?= <burg@gemeente.nl>`
+- **WHEN** `extractEml` runs
+- **THEN** the From line in the output is `From: Burgemeester De Vries <burg@gemeente.nl>` (decoded)
+
+### Requirement: Malformed input MUST NOT throw from `extractEml`; structured-parse MAY throw a typed exception
+
+`extractEml` MUST follow the existing extraction-failure pattern — return null on irrecoverable parse error, log the error. `parseEmlStructured` MAY throw a typed `EmlParseException` for malformed input; consumers handle the exception as they see fit. Both paths MUST handle minor malformations (missing optional headers, unusual encoding, extra whitespace) gracefully without raising errors.
+
+#### Scenario: Catastrophically broken EML returns null from extractEml
+
+- **GIVEN** a file that's labelled `message/rfc822` but contains binary garbage
+- **WHEN** `TextExtractionService::extractFile` runs
+- **THEN** the extracted-text is null (or the existing failure marker)
+- **AND** an error is logged with details
+- **AND** no exception propagates to the caller
+
+#### Scenario: Catastrophically broken EML throws from parseEmlStructured
+
+- **GIVEN** the same broken file
+- **WHEN** `parseEmlStructured($file)` is called directly
+- **THEN** `EmlParseException` is thrown
+- **AND** the exception's message identifies the parse failure point
+
+### Requirement: The change MUST NOT modify behaviour for non-EML files
+
+All existing MIME branches in `TextExtractionService` (PDF, Word, spreadsheet, plain text) MUST behave identically before and after this change. The new EML branch is additive and orthogonal.
+
+#### Scenario: PDF extraction unchanged
+
+- **GIVEN** a PDF file
+- **WHEN** `extractFile` runs after this change is applied
+- **THEN** the extracted text is identical to what the pre-change code produced for the same file
+
+#### Scenario: Word document extraction unchanged
+
+- **GIVEN** a DOCX file
+- **WHEN** `extractFile` runs after this change is applied
+- **THEN** the extracted text is identical to pre-change behaviour

--- a/openspec/changes/text-extraction-eml/specs/text-extraction-eml/spec.md
+++ b/openspec/changes/text-extraction-eml/specs/text-extraction-eml/spec.md
@@ -51,6 +51,14 @@ The flat output (returned by `extractEml`) MUST be ordered:
 - **WHEN** `extractEml` runs
 - **THEN** the body section contains the HTML stripped to text (no `<p>`, `<a>` tags; entities decoded; whitespace collapsed)
 
+#### Scenario: multipart/alternative — `text/plain` is preferred when both parts are present
+
+- **GIVEN** an EML with a `multipart/alternative` body containing both a `text/plain` part ("Hello Bob") and a `text/html` part (`<p>Hello <b>Bob</b></p>`)
+- **WHEN** `extractEml` runs
+- **THEN** the body section MUST contain the `text/plain` content "Hello Bob"
+- **AND** the body section MUST NOT contain raw HTML tags (`<p>`, `<b>`)
+- **AND** the HTML part MUST NOT be concatenated to the plain part — only one is emitted
+
 #### Scenario: Recursive attachment extraction for PDF attachment
 
 - **GIVEN** an EML with a PDF attachment named `report.pdf`
@@ -85,16 +93,16 @@ The method MUST be public and accept an `\OCP\Files\File`. It MUST return an imm
 
 - **GIVEN** a multipart EML with both `text/plain` and `text/html` parts
 - **WHEN** `parseEmlStructured` runs
-- **THEN** `result.body['plainText']` contains the plain part
-- **AND** `result.body['html']` contains the HTML part
+- **THEN** `result.body->plainText` contains the plain part
+- **AND** `result.body->html` contains the HTML part
 - **AND** both are populated (consumer chooses)
 
 #### Scenario: Single-body EMLs populate only the present part
 
 - **GIVEN** an EML with only a `text/html` part
 - **WHEN** `parseEmlStructured` runs
-- **THEN** `result.body['plainText']` is null
-- **AND** `result.body['html']` contains the HTML
+- **THEN** `result.body->plainText` is null
+- **AND** `result.body->html` contains the HTML
 
 #### Scenario: Date header malformed — date field is null
 
@@ -108,9 +116,9 @@ The method MUST be public and accept an `\OCP\Files\File`. It MUST return an imm
 
 Each entry in `EmlStructure.attachments[]` MUST be an `EmlAttachment` with:
 
-- `filename` (string) — from the Content-Disposition header or generated if missing.
+- `filename` (string) — from the Content-Disposition `filename` parameter; if absent, from the Content-Type `name` parameter; if both are absent, generated as `attachment-<n>` where `<n>` is the 1-indexed position of the attachment in the multipart-document order. The generated form MUST always be a non-empty string so consumers can render it as a label without special-casing empty names.
 - `mimeType` (string) — from Content-Type.
-- `content` (string of raw bytes — base64-decoded as needed).
+- `content` (string) — MUST be the decoded binary content of the attachment (NOT re-encoded or kept as the MIME-transport base64 string). `zbateson/mail-mime-parser` returns decoded bytes from `$part->getContent()` by default; implementations MUST use that path, not `$part->getRawContent()`. Consumers (e.g. DocuDesk's `eml-pdf-assembly` building PDF/A-3 file attachments or `data:` URIs) can rely on `content` being raw bytes ready to embed, and MUST NOT base64-decode it again.
 - `isInline` (bool) — true if the attachment has Content-Disposition: inline.
 - `contentId` (string or null) — for HTML body references via `cid:` URLs.
 - `nestedEml` (`EmlStructure` or null) — populated if `mimeType === 'message/rfc822'` and the depth limit is not exceeded.
@@ -134,16 +142,23 @@ Each entry in `EmlStructure.attachments[]` MUST be an `EmlAttachment` with:
 - **WHEN** structured-parse runs
 - **THEN** the nested attachment has `mimeType: "message/rfc822"`, `nestedEml` populated with its own `EmlStructure`
 
+#### Scenario: Attachment with neither Content-Disposition filename nor Content-Type name
+
+- **GIVEN** an EML whose second attachment has no `filename` parameter on either Content-Disposition or Content-Type
+- **WHEN** structured-parse runs
+- **THEN** `result.attachments[1].filename` MUST be `attachment-2` (1-indexed position fallback)
+- **AND** the value MUST NOT be empty or null
+
 ### Requirement: Recursive nesting of `message/rfc822` MUST be capped at depth 3
 
-The structured parse MUST follow `message/rfc822` attachments recursively, but only up to depth 3. Beyond that, the attachment's `nestedEml` MUST be null even though the MIME indicates an EML. The flat path MUST follow the same limit — at depth 3+, EML attachments are listed by name only without inline extraction.
+The structured parse MUST follow `message/rfc822` attachments recursively, but only up to depth 3. **Depth is measured as the number of recursive `parseEmlStructured` calls made from the root**: the root EML is depth 0, the first nested EML is depth 1, etc. The limit of 3 therefore permits three nested calls — once a parse at depth 3 has completed, any further `message/rfc822` attachments inside it MUST have `nestedEml: null`. The flat path MUST follow the same limit — at the same depth boundary, EML attachments are listed by name only without inline extraction.
 
 #### Scenario: Depth-3 EML chain is fully recursed
 
-- **GIVEN** EML A containing EML B containing EML C containing EML D
+- **GIVEN** EML A (depth 0) containing EML B (depth 1) containing EML C (depth 2) containing EML D (depth 3)
 - **WHEN** `parseEmlStructured(A)` runs
-- **THEN** A → B → C are recursed (`nestedEml` populated through C)
-- **AND** the C-level EmlStructure for D's attachment has `nestedEml: null`
+- **THEN** A, B, C, and D are all parsed (`nestedEml` populated on A.attachments[B], B.attachments[C], and C.attachments[D])
+- **AND** any `message/rfc822` attachment inside D (which would be at depth 4) has `nestedEml: null`
 
 #### Scenario: Depth-4+ chain stops at the limit
 
@@ -163,9 +178,9 @@ When a header value uses RFC 2047 encoded-word form (`=?utf-8?B?<base64>?=` or `
 - **WHEN** `extractEml` runs
 - **THEN** the From line in the output is `From: Burgemeester De Vries <burg@gemeente.nl>` (decoded)
 
-### Requirement: Malformed input MUST NOT throw from `extractEml`; structured-parse MAY throw a typed exception
+### Requirement: Malformed input MUST NOT throw from `extractEml`; `parseEmlStructured` MUST throw a typed exception
 
-`extractEml` MUST follow the existing extraction-failure pattern — return null on irrecoverable parse error, log the error. `parseEmlStructured` MAY throw a typed `EmlParseException` for malformed input; consumers handle the exception as they see fit. Both paths MUST handle minor malformations (missing optional headers, unusual encoding, extra whitespace) gracefully without raising errors.
+`extractEml` MUST follow the existing extraction-failure pattern — return null on irrecoverable parse error and log the error. `parseEmlStructured` MUST throw a typed `EmlParseException` on irrecoverable malformed input (it MUST NOT return null, an empty `EmlStructure`, or a partially-populated one in this case); consumers rely on exception propagation to drive their fallback paths (e.g. DocuDesk's `eml-pdf-assembly` falls back to flat `extractEml` text when `parseEmlStructured` throws — silently returning a partial result would skip that fallback and produce a corrupt PDF). Both paths MUST handle minor malformations (missing optional headers, unusual encoding, extra whitespace) gracefully without raising errors.
 
 #### Scenario: Catastrophically broken EML returns null from extractEml
 
@@ -181,6 +196,45 @@ When a header value uses RFC 2047 encoded-word form (`=?utf-8?B?<base64>?=` or `
 - **WHEN** `parseEmlStructured($file)` is called directly
 - **THEN** `EmlParseException` is thrown
 - **AND** the exception's message identifies the parse failure point
+
+### Requirement: `extractEml` and `parseEmlStructured` MUST NOT log PII (ADR-005)
+
+EML headers and bodies contain PII by definition: email addresses, display names, subject lines, and body text. Per ADR-005 ("NO PII in logs, error responses, or debug output"), both methods MUST NOT include any of the following in log lines, exception messages that are subsequently logged, error responses, or debug output:
+
+- email addresses (From, To, Cc, Bcc, Reply-To headers)
+- display names
+- Subject header content
+- body content (plain-text or HTML)
+- attachment filenames (which can themselves carry PII, e.g. `paspoort-de_vries.pdf`)
+
+Permitted log content is restricted to **structural** failure information: the Nextcloud file ID, the MIME type, the parser exception class name, and the depth at which a recursion-limit was hit. When the underlying `zbateson/mail-mime-parser` raises an exception whose message embeds PII (e.g. a header excerpt), implementations MUST sanitize the message — replace addresses / names / subjects with `<redacted>` — before logging or rethrowing.
+
+#### Scenario: Parser failure log contains no PII
+
+- **GIVEN** an EML with `From: alice@example.com` and `Subject: Confidential — case 123`
+- **AND** the parser fails (zbateson exception including the From and Subject in its message)
+- **WHEN** `extractEml` runs and the failure is logged
+- **THEN** the log entry MUST NOT contain `alice@example.com`, "Confidential", or "case 123"
+- **AND** the log entry MUST contain at most: the file ID, the MIME type `message/rfc822`, the exception class name, and any sanitised structural detail
+
+#### Scenario: `EmlParseException` message is sanitised before logging
+
+- **GIVEN** `parseEmlStructured` is called on a malformed EML and the underlying parser raises an exception whose `getMessage()` embeds a header value
+- **WHEN** the consumer catches the exception and the implementation logs it
+- **THEN** the logged message MUST have addresses, names, and subject content replaced with `<redacted>`
+- **AND** the exception class name and the file ID MUST remain in the log line
+
+### Requirement: Non-UTF-8 body parts SHOULD be transcoded to UTF-8
+
+When a body part declares a character set other than UTF-8 (e.g. `Content-Type: text/plain; charset=ISO-8859-1` or `charset=Windows-1252` — common in legacy Dutch government archives), both `extractEml` and `parseEmlStructured` SHOULD transcode the bytes to UTF-8 before exposing them in the flat output or the `EmlStructure.body` fields. The recommended implementation uses `mb_detect_encoding` (with a candidate list including the declared charset) followed by `mb_convert_encoding` to UTF-8.
+
+If transcoding fails (an undetectable or unsupported source charset), the raw bytes MAY be included as-is and an implementation-internal log entry SHOULD note the transcode failure (subject to the no-PII Requirement above — only the failure reason and charset name, not the body content).
+
+#### Scenario: ISO-8859-1 body is transcoded to UTF-8
+
+- **GIVEN** an EML with `Content-Type: text/plain; charset=ISO-8859-1` and a body containing the bytes for "Café" in ISO-8859-1 encoding (`C` `a` `f` `0xE9`)
+- **WHEN** `extractEml` runs
+- **THEN** the body section in the flat output contains the UTF-8 string `Café` (bytes `C` `a` `f` `0xC3 0xA9`)
 
 ### Requirement: The change MUST NOT modify behaviour for non-EML files
 

--- a/openspec/changes/text-extraction-eml/tasks.md
+++ b/openspec/changes/text-extraction-eml/tasks.md
@@ -1,0 +1,63 @@
+## 1. Composer dependency
+
+- [ ] 1.1 Add `zbateson/mail-mime-parser` (latest stable, expected `^3.x`) to OpenRegister's `composer.json` under `require`. Run `composer update zbateson/mail-mime-parser` and commit `composer.lock`.
+- [ ] 1.2 Run `composer install` in CI / build pipeline; confirm no conflicts with existing PhpWord, smalot/pdfparser, or other deps.
+
+## 2. Value-object classes
+
+- [ ] 2.1 Create `lib/Service/TextExtraction/EmlBody.php` — immutable value object with `plainText: ?string` and `html: ?string`. Constructor + readonly properties.
+- [ ] 2.2 Create `lib/Service/TextExtraction/EmlAttachment.php` — immutable value object with `filename`, `mimeType`, `content` (raw bytes string), `isInline`, `contentId`, `nestedEml: ?EmlStructure`. Constructor + readonly properties.
+- [ ] 2.3 Create `lib/Service/TextExtraction/EmlStructure.php` — immutable value object with `headers: array`, `body: EmlBody`, `attachments: EmlAttachment[]`. Constructor + readonly properties + JsonSerializable for any future REST surface.
+- [ ] 2.4 Create `lib/Exception/EmlParseException.php` extending the existing OpenRegister exception base (or `\Exception` if none). Carries an optional cause string identifying the parse-failure point.
+
+## 3. EmlParser service
+
+- [ ] 3.1 Create `lib/Service/TextExtraction/EmlParser.php`. Constructor takes the logger and (lazily) `TextExtractionService` (avoid circular DI — inject via the container with a method).
+- [ ] 3.2 Implement `parse(File $file): EmlStructure` using `\ZBateson\MailMimeParser\MailMimeParser`. Loop through headers — extract From, To, Cc, Subject, Date, Message-ID. Decode RFC 2047 encoded-words via the parser's built-in handling. Date parsing: try `DateTimeImmutable::createFromFormat` with RFC 2822 / 5322 patterns; fall back to null on failure.
+- [ ] 3.3 Implement body extraction: get `text/plain` and `text/html` parts independently; populate `EmlBody` with both (or null per part).
+- [ ] 3.4 Implement attachment extraction: walk `getAllAttachmentParts()`. For each: filename (from Content-Disposition or Content-Type `name`), mimeType, content (raw bytes), isInline (Content-Disposition: inline), contentId (Content-ID header, stripping angle brackets).
+- [ ] 3.5 Implement recursive `nestedEml` for `message/rfc822` attachments. Pass a depth parameter (default 0). Recursive call increments depth. At depth 3, set `nestedEml: null` and emit a debug log "EML nesting depth limit reached".
+- [ ] 3.6 Implement `flatten(EmlStructure $structure, int $depth = 0): string` — builds the flat plain-text per spec D2: header block, blank line, body (plainText preferred; HTML stripped to text fallback), attachments. For extractable attachments (PDF / Word / text / nested EML), call `TextExtractionService` to get attachment text and inline. For non-extractable, marker line only.
+- [ ] 3.7 Implement HTML→text helper for the flat-path body fallback. Drop `<style>`, `<script>` content (block-level removal). Convert `<br>`, `<p>`, block-level tags to newlines. Strip remaining tags via `strip_tags()`. Decode entities via `html_entity_decode()`. Collapse whitespace runs.
+- [ ] 3.8 Implement encoding fallback: if `mb_check_encoding($value, 'UTF-8')` is false, run `mb_detect_encoding` then `mb_convert_encoding` to UTF-8.
+- [ ] 3.9 Wrap parse failures: `parse()` throws `EmlParseException` on irrecoverable error. `flatten()` does not throw (works on a successfully-parsed structure).
+
+## 4. TextExtractionService integration
+
+- [ ] 4.1 In `lib/Service/TextExtractionService.php`, locate `extractSourceText` (or the cascade method). Add a new `else if ($mimeType === 'message/rfc822')` branch. Inside, call private `extractEml($file)`.
+- [ ] 4.2 Implement `private function extractEml(File $file): ?string`. Try `EmlParser::parse($file)` then `EmlParser::flatten()` and return the result. On `EmlParseException`, log the error and return null (matching the existing failure pattern).
+- [ ] 4.3 Add public method `parseEmlStructured(File $file): EmlStructure`. Direct delegate to `EmlParser::parse()`. Throws `EmlParseException` on irrecoverable error (caller handles).
+- [ ] 4.4 Confirm DI wiring: `EmlParser` resolves correctly with its dependencies; `TextExtractionService` can call its private `extractEml` and the public `parseEmlStructured`.
+
+## 5. Unit tests
+
+- [ ] 5.1 `tests/unit/Service/TextExtraction/EmlParserTest.php` — fixture EMLs in `tests/Fixtures/eml/`. Cover: simple text-only EML; multipart text+html EML; encoded-word headers; missing/malformed Date; non-ASCII bodies; PDF attachment; image attachment (non-extractable); nested EML at depth 1, 2, 3, 4 (depth limit); inline image with Content-ID; missing required headers (graceful tolerance); broken-binary input throwing EmlParseException.
+- [ ] 5.2 `tests/unit/Service/TextExtractionServiceTest.php` — extension covering the new MIME branch: EML input produces populated text via `extractFile`; the public `parseEmlStructured` returns an EmlStructure; non-EML files (PDF, DOCX) extraction is unchanged after this change.
+- [ ] 5.3 Test `flatten()` output structure: header block before body; `--- Attachment: ... ---` markers; non-extractable attachment marker shape; recursive attachment text inlined.
+- [ ] 5.4 Test HTML→text helper: handles `<style>`, `<script>`, common block elements, entity decoding, whitespace collapse.
+- [ ] 5.5 Test encoding fallback: non-UTF-8 input (e.g. ISO-8859-1 body) is converted to UTF-8 in the flat output.
+
+## 6. Integration tests
+
+- [ ] 6.1 Newman / Postman or PHPUnit functional: upload a real-world-ish EML; trigger `extractFile`; verify the persisted extracted-text is populated and contains expected content.
+- [ ] 6.2 Functional: upload an EML with a PDF attachment; verify the extracted text contains both the email body AND the PDF's text under the attachment marker.
+- [ ] 6.3 Functional: call `parseEmlStructured` from a test consumer (e.g. a temporary command); verify the returned structure matches the fixture's headers, body, and attachments.
+
+## 7. Cross-app coordination
+
+- [ ] 7.1 Notify DocuDesk team: structured-parse method available; the paired `eml-pdf-assembly` change can now be implemented.
+- [ ] 7.2 No DocuDesk-side change is part of this OR change. The DocuDesk EmlBackend in `pdf-conversion` (Change A) does NOT need updating until the paired `eml-pdf-assembly` change ships — Change A's EmlBackend currently reports `isAvailable: false` until OR's EML support exists. After this change ships, that backend's `isAvailable` returns true; DocuDesk's `eml-pdf-assembly` then upgrades the EmlBackend's `convert()` to use the structured parse.
+
+## 8. Documentation
+
+- [ ] 8.1 Add a section to `docs/` (extend an existing extraction-related doc or create a new one) describing the EML extraction shape — flat output structure, structured-parse API, depth limit, library used.
+- [ ] 8.2 CHANGELOG entry under "Added": EML support in `TextExtractionService` (flat plain-text via `extractFile`; structured parse via `parseEmlStructured`); new `zbateson/mail-mime-parser` dependency.
+- [ ] 8.3 CHANGELOG entry under "Behavior changes": EML inputs that previously produced null / empty extracted text now produce populated content. Tenants that relied on EMLs being skipped (unlikely) need to revisit their pipelines.
+
+## 9. Quality and verification
+
+- [ ] 9.1 Run the full unit + functional test suite — clean.
+- [ ] 9.2 Run static analysis (Psalm / PHPStan at project strictness) — clean.
+- [ ] 9.3 Run code style (PHPCS at project config) — clean.
+- [ ] 9.4 Manual smoke against a live stack: place a sample EML with attachments via NC Files; trigger extraction; verify the extracted-text in OR's metadata; call `parseEmlStructured` from a test invocation and verify the structure.
+- [ ] 9.5 Run `openspec validate text-extraction-eml` — clean.

--- a/openspec/changes/text-extraction-eml/tasks.md
+++ b/openspec/changes/text-extraction-eml/tasks.md
@@ -15,12 +15,14 @@
 - [ ] 3.1 Create `lib/Service/TextExtraction/EmlParser.php`. Constructor takes the logger and (lazily) `TextExtractionService` (avoid circular DI — inject via the container with a method).
 - [ ] 3.2 Implement `parse(File $file): EmlStructure` using `\ZBateson\MailMimeParser\MailMimeParser`. Loop through headers — extract From, To, Cc, Subject, Date, Message-ID. Decode RFC 2047 encoded-words via the parser's built-in handling. Date parsing: try `DateTimeImmutable::createFromFormat` with RFC 2822 / 5322 patterns; fall back to null on failure.
 - [ ] 3.3 Implement body extraction: get `text/plain` and `text/html` parts independently; populate `EmlBody` with both (or null per part).
-- [ ] 3.4 Implement attachment extraction: walk `getAllAttachmentParts()`. For each: filename (from Content-Disposition or Content-Type `name`), mimeType, content (raw bytes), isInline (Content-Disposition: inline), contentId (Content-ID header, stripping angle brackets).
+- [ ] 3.4 Implement attachment extraction: walk `getAllAttachmentParts()`. For each: filename (resolution order: Content-Disposition `filename` → Content-Type `name` → generated `attachment-<1-indexed-position>`; the generated form MUST always be non-empty), mimeType, content (MUST be the **decoded** bytes via `$part->getContent()` — NOT `getRawContent()` — so consumers can embed them as PDF/A-3 file attachments or `data:` URIs without further decoding), isInline (Content-Disposition: inline), contentId (Content-ID header, stripping angle brackets).
 - [ ] 3.5 Implement recursive `nestedEml` for `message/rfc822` attachments. Pass a depth parameter (default 0). Recursive call increments depth. At depth 3, set `nestedEml: null` and emit a debug log "EML nesting depth limit reached".
 - [ ] 3.6 Implement `flatten(EmlStructure $structure, int $depth = 0): string` — builds the flat plain-text per spec D2: header block, blank line, body (plainText preferred; HTML stripped to text fallback), attachments. For extractable attachments (PDF / Word / text / nested EML), call `TextExtractionService` to get attachment text and inline. For non-extractable, marker line only.
 - [ ] 3.7 Implement HTML→text helper for the flat-path body fallback. Drop `<style>`, `<script>` content (block-level removal). Convert `<br>`, `<p>`, block-level tags to newlines. Strip remaining tags via `strip_tags()`. Decode entities via `html_entity_decode()`. Collapse whitespace runs.
 - [ ] 3.8 Implement encoding fallback: if `mb_check_encoding($value, 'UTF-8')` is false, run `mb_detect_encoding` then `mb_convert_encoding` to UTF-8.
-- [ ] 3.9 Wrap parse failures: `parse()` throws `EmlParseException` on irrecoverable error. `flatten()` does not throw (works on a successfully-parsed structure).
+- [ ] 3.9 Wrap parse failures: `parse()` MUST throw `EmlParseException` on irrecoverable error — NOT return null, NOT return a partially-populated `EmlStructure`. `flatten()` does not throw (works on a successfully-parsed structure).
+- [ ] 3.10 Sanitise log lines and exception messages per ADR-005: when logging a parser failure or rethrowing an exception that will be logged, replace email addresses, display names, Subject content, body content, and attachment filenames with `<redacted>`. Permitted log payload: file ID, MIME type, exception class name, structural detail (depth-limit hit, etc.). Apply this in both `extractEml`'s catch block and `EmlParser::parse`'s sanitised re-throw.
+- [ ] 3.11 Implement the flat-path multipart/alternative preference explicitly: when a body has both a `text/plain` and a `text/html` part in a `multipart/alternative`, `flatten()` MUST use the `text/plain` content and MUST NOT concatenate the HTML.
 
 ## 4. TextExtractionService integration
 
@@ -36,6 +38,11 @@
 - [ ] 5.3 Test `flatten()` output structure: header block before body; `--- Attachment: ... ---` markers; non-extractable attachment marker shape; recursive attachment text inlined.
 - [ ] 5.4 Test HTML→text helper: handles `<style>`, `<script>`, common block elements, entity decoding, whitespace collapse.
 - [ ] 5.5 Test encoding fallback: non-UTF-8 input (e.g. ISO-8859-1 body) is converted to UTF-8 in the flat output.
+- [ ] 5.6 Test multipart/alternative preference: an EML with both `text/plain` and `text/html` parts emits only the `text/plain` content from `flatten()`; the HTML is NOT concatenated.
+- [ ] 5.7 Test missing-filename fallback: an attachment with neither Content-Disposition `filename` nor Content-Type `name` MUST get the generated `attachment-<n>` (1-indexed position) and MUST NOT be empty.
+- [ ] 5.8 Test `content` encoding: the attachment's `content` field MUST hold the decoded binary bytes, not the base64 transport string. Assert by re-encoding and comparing against the raw attachment bytes of the source EML.
+- [ ] 5.9 Test PII-redacted logging: induce a parser failure on an EML with sensitive From / Subject / body content; capture the log line and assert that none of the PII appears and only the file ID, MIME type, exception class, and sanitised structural detail are present.
+- [ ] 5.10 Test that `parseEmlStructured` throws (never returns null or a partial structure) on irrecoverable malformed input. Assert exception class is `EmlParseException`.
 
 ## 6. Integration tests
 


### PR DESCRIPTION
## Summary

Adds the OpenSpec change directory for **text-extraction-eml** — extending `TextExtractionService` with EML support via `zbateson/mail-mime-parser`. Two outputs share the parser:

- Flat plain-text extraction (headers + body + recursively-extracted attachment text inline) — used for entity detection.
- A new public `parseEmlStructured()` returning headers + both `text/plain` and `text/html` body parts + attachments-with-bytes (recursive `nestedEml` capped at depth 3) — used for downstream PDF assembly.

Tightly scoped — this PR is **specs only**, no implementation. It also does not retrofit the broader `TextExtractionService` surface, which is currently uncovered by an OpenSpec capability.

Refs: #1438
Pair: [ConductionNL/docudesk#135](https://github.com/ConductionNL/docudesk/pull/135) — DocuDesk's `eml-pdf-assembly` (hard dep) and `anonymise-output-as-pdf-by-default` (soft dep) depend on this.

## Test plan

- [ ] Review `openspec/changes/text-extraction-eml/{proposal,design,tasks}.md` and the `text-extraction-eml/spec.md` delta
- [ ] Confirm `parseEmlStructured()` return shape matches the DocuDesk-side consumer expectations in PR #135 (`EmlPdfAssemblyService`)
- [ ] Confirm depth-3 nested-EML cap is acceptable
- [ ] `openspec validate` (when the implementation PR lands)