### PR TITLE
Specs: anonymiser-backend-selection (#1497)

### DIFF
--- a/openspec/changes/anonymiser-backend-selection/.openspec.yaml
+++ b/openspec/changes/anonymiser-backend-selection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-12

--- a/openspec/changes/anonymiser-backend-selection/design.md
+++ b/openspec/changes/anonymiser-backend-selection/design.md
@@ -1,0 +1,136 @@
+# Design — `anonymiser-backend-selection`
+
+## Context
+
+OpenRegister has five recognition methods registered in `EntityRecognitionHandler` (`regex`, `presidio`, `openanonymiser`, `llm`, `hybrid`) and persists the operator's choice plus endpoint URLs inside the `fileManagement` `IAppConfig` blob via `FileSettingsHandler`. The dispatch layer (`EntityRecognitionHandler::detect*`) works, but everything **around** the dispatch is missing: there is no consolidated state-query API, no admin selector UI, no "is this backend actually reachable right now?" indicator, and no canonical rule for what should happen when the selected method is not actually usable. Consumer apps that need to surface backend state to operators (DocuDesk's `anonymiser-backend-warning`) currently have no contract to consume.
+
+This change closes those gaps with a typed service + OCS endpoint + admin UI, **without** disturbing `EntityRecognitionHandler` or the `fileManagement` storage shape.
+
+## Decisions
+
+### D1: PHP service + OCS endpoint — both, not either-or
+
+Both surfaces are needed:
+
+- **PHP service** (`AnonymisationBackendService::getState()`) for in-process consumers: cron jobs, other OR controllers, future capabilities that want to gate behaviour on the active method.
+- **OCS endpoint** (`GET /api/admin/anonymisation/backend-state`) for cross-app consumers (DocuDesk's warning banner runs in a different PHP process and must reach OR over HTTP).
+
+The endpoint is a thin wrapper over the service. There is exactly one place that resolves state; the OCS handler reads it and serialises it. No duplicated precedence logic.
+
+### D2: `BackendState` value-object shape
+
+```
+BackendState {
+  entityRecognitionEnabled: bool
+  activeMethod: 'regex' | 'presidio' | 'openanonymiser' | 'llm' | 'hybrid'
+  effectiveMethod: 'regex' | 'presidio' | 'openanonymiser' | 'llm' | 'hybrid'
+  backends: [
+    {
+      name: <method enum>,
+      available: bool,    // can be reached right now (ExApp installed+enabled, or endpoint reachable, or "always" for regex)
+      configured: bool,   // admin has set it up (endpoint URL present, or ExApp registered)
+      lastProbedAt: ISO-8601 | null,
+      latencyMs: int | null
+    }
+  ]
+}
+```
+
+Two flags per backend, not one. `configured` tracks operator intent (the endpoint URL was set, or the ExApp was installed). `available` tracks runtime reachability (the probe succeeded recently). Both matter independently: a configured-but-unreachable backend is a different incident than an unconfigured one, and the admin UI surfaces each differently.
+
+### D3: Canonical "no backend" determination rule
+
+`effectiveMethod` is computed as:
+
+1. If `entityRecognitionEnabled === false` → `effectiveMethod := 'regex'`.
+2. Else if `activeMethod === 'regex'` → `effectiveMethod := 'regex'`.
+3. Else if `backends[activeMethod].available === true AND backends[activeMethod].configured === true` → `effectiveMethod := activeMethod`.
+4. Else → `effectiveMethod := 'regex'`.
+
+The rule lives in `AnonymisationBackendService::getState()`. Callers MUST consume `effectiveMethod`, never recompute it themselves. This is what DocuDesk's warning banner reads: "if `effectiveMethod !== activeMethod`, the selected backend is not in use right now; if `effectiveMethod === 'regex'` and the operator did not explicitly choose regex, render the warning."
+
+For the `hybrid` method specifically: `available` is the AND of the methods it composes (`regex`, `presidio`, and `openanonymiser` under current `EntityRecognitionHandler::detectEntitiesHybrid` semantics). If any composed backend is unavailable, `hybrid` itself is unavailable and falls through to `regex`. This is conservative — a future change can introduce partial-degradation semantics if there is a use case.
+
+### D4: Admin UI placement — extend the existing `OpenRegisterAdmin` settings page
+
+OR already has one admin settings panel registered via `lib/Settings/OpenRegisterAdmin.php`. Rather than introduce a separate admin page (clutters Nextcloud's settings sidebar), add an **"Anonimiseren"** section *within* that existing panel. The section is a Vue component rendered into the same admin SPA, reusing the OR admin Vue router.
+
+Layout (behaviour, not pixels):
+
+- A method selector — radio group or `<select>` over the five supported methods.
+- Per-method configuration sub-section visible when that method is selected:
+  - For `presidio`, `llm`: a URL input bound to the relevant `*ApiEndpoint` IAppConfig field.
+  - For `openanonymiser`: a read-only ExApp-availability indicator showing whether `openanonymiser_light` and/or `openanonymiser` ExApps are installed and enabled via AppAPI, with a deep link to `/settings/apps/discover/{appid}` when an ExApp is missing.
+  - For `hybrid`: a summary of which composed backends are available, with their own configuration links.
+  - For `regex`: a single explanatory paragraph (no config needed).
+- A **Test connection** button per applicable backend (everything except `regex`), wired to the `POST /api/admin/anonymisation/test-connection` endpoint.
+- A live availability indicator per backend (dot + label: "available" / "unreachable" / "not configured" / "not detectable"), rendered from `BackendState.backends[].available` and re-fetched on configuration save.
+
+### D5: AppAPI / ExApp availability detection
+
+Use Nextcloud's `IAppManager` to check whether the OpenAnonymiser ExApps are installed and enabled. AppAPI itself is required to install ExApps in the first place; if `IAppManager` does not expose AppAPI-derived state, fall back to checking standard app enablement and surface a "not detectable" state with a clear admin-side message.
+
+The detection happens at probe time, not at startup. The state-query response is computed from a per-process cache that respects the 60s TTL (see D7).
+
+### D6: Test-connection probe
+
+Behaviour, per backend:
+
+- `presidio`, `llm`: HTTP `GET` (or `HEAD`) against the configured endpoint's health path (Presidio exposes `/health`; LLM endpoint health path is operator-configurable, defaulting to the bare endpoint root). Timeout: 2s default, configurable via `anonymisation.probe_timeout`. Successful 2xx → reachable. Anything else (timeout, 4xx, 5xx, DNS failure) → unreachable, with a structured error code (`timeout`, `dns_error`, `http_4xx`, `http_5xx`, `connect_refused`).
+- `openanonymiser`: AppAPI registry lookup. The probe queries `IAppManager` to confirm the ExApp is enabled and reports back as `{reachable: true|false, error: 'exapp_not_installed' | 'exapp_disabled' | 'appapi_missing' | null, latencyMs: 0}`. There is no HTTP probe — AppAPI mediates ExApp invocation, so its availability is the right signal.
+- `regex`: trivial probe — always returns `{reachable: true, latencyMs: 0}`. The button is hidden in the UI for `regex` since there is nothing to probe.
+- `hybrid`: composite probe — runs the underlying backends' probes and aggregates. Reachable iff each composed backend is reachable.
+
+The probe endpoint accepts a `method` parameter and returns the probe result. The button in the UI calls this endpoint and updates the indicator without a full state-query refetch.
+
+### D7: Probe-result caching
+
+To keep the state-query endpoint cheap, probe results are cached:
+
+- **Cache key:** `anonymisation.probe_cache.<method>` in `IAppConfig`.
+- **Value:** JSON `{reachable, latencyMs, error?, probedAt: ISO-8601}`.
+- **TTL:** 60 seconds, configurable via `anonymisation.probe_cache_ttl` (range 10–600 seconds).
+- **Read path:** `getState()` reads the cache; if a cached result is younger than the TTL, it is used. Otherwise a fresh probe runs synchronously and the result is written back. This bounds the worst-case latency of the state-query endpoint to one probe round-trip.
+- **Bypass path:** the `POST .../test-connection` endpoint always issues a fresh probe (cache bypass) and writes the result to the cache. Press-the-button = re-probe-now.
+
+The cache is **transient state**, not persisted configuration. Storing it in `IAppConfig` (rather than memory) is pragmatic for multi-process deployments; the spec calls the cache storage location implementation-internal and reserves the right to move it to a shared cache (Redis) later without re-speccing.
+
+### D8: Authorisation
+
+The two new OCS endpoints require admin group membership, matching the existing OR admin endpoint convention. Non-admin callers receive HTTP 403 with the OR-standard error body shape. The admin Vue panel uses the same admin-only routes — no separate authorisation path.
+
+Service-layer callers (other OR services using `AnonymisationBackendService::getState()` directly) are trusted; the service does not enforce authorisation. Authorisation is a controller-layer concern in OR.
+
+### D9: Naming
+
+- Service: `OCA\OpenRegister\Service\Anonymisation\AnonymisationBackendService`
+- Value object: `OCA\OpenRegister\Service\Anonymisation\BackendState`
+- Probe: `OCA\OpenRegister\Service\Anonymisation\BackendProbe`
+- Controller: extend an existing admin controller, **or** `OCA\OpenRegister\Controller\AnonymisationAdminController` — leave to implementation; both are acceptable.
+- OCS routes: under `/api/admin/anonymisation/...` to align with the broader OR admin route family.
+
+## Risks
+
+**[R1 — Synchronous probes make state-query slow when remotes are slow]**
+The 60s cache keeps the steady-state response fast, but a cold cache means the first call after install pays one probe round-trip per method. With 2s default timeout and four probe-able methods (presidio, openanonymiser, llm, hybrid), worst case is ~6s on cold cache (presidio + llm probed; openanonymiser is AppAPI-local; hybrid reuses prior probes within the same call).
+→ Mitigation: parallel probes inside `getState()` when populating cold cache (PHP `ReactPHP`/`Guzzle async` is available in OR — use whichever is already in vendor). Worst case drops to ~2s. Document the cold-cache cost in admin docs and add a startup warm-up job (post-install hook calls `getState()` once, populates the cache before any user-facing call).
+
+**[R2 — AppAPI / IAppManager API surface differs across Nextcloud versions]**
+ExApp availability detection depends on capabilities of `IAppManager` that may not be present in older NC versions, or on AppAPI ExApp-specific methods that vary.
+→ Mitigation: feature-detect at runtime. Wrap the lookup in a `try/catch` + capability probe; on failure, return `{available: false, error: 'appapi_missing', ...}` rather than blowing up the state-query. The admin UI surfaces "not detectable" with a hint to install AppAPI.
+
+**[R3 — `fileManagement` blob storage may shift under a future change]**
+This change reads `entityRecognitionMethod`, `*ApiEndpoint`, and `entityRecognitionEnabled` out of the blob. If the storage shape changes, the service needs adapting.
+→ Mitigation: read through `FileSettingsHandler` (the existing accessor), not by parsing the blob directly. If `FileSettingsHandler` changes signature, the dependency is explicit and easy to follow. The spec declares storage shape as implementation-internal; consumers MUST go through the service.
+
+**[R4 — Probe-driven side effects on remote endpoints]**
+Some Presidio / LLM deployments may log every probe; high-frequency probes (e.g. an admin who reloads the panel repeatedly) could spam ops logs at the remote.
+→ Mitigation: the 60s cache TTL means the state-query path probes at most once per minute per backend. The "Test connection" button bypasses cache but is operator-triggered, not automatic. Documented as expected behaviour.
+
+**[R5 — Naming collision with hypothetical future OR-level anonymisation orchestration]**
+The names `AnonymisationBackendService` / `BackendState` are scoped to *backend selection* and *reachability*. If a future change introduces a full anonymisation-orchestration service, those names may need disambiguation.
+→ Mitigation: place this change's classes under the `Service\Anonymisation\` namespace; the future orchestrator can live alongside without colliding (e.g. `Service\Anonymisation\AnonymisationOrchestratorService`). Recorded here so the namespace decision is intentional.
+
+## Open Questions
+
+None for v1 scope. The candidate follow-ups (multi-tier fallback, normalised storage, backend abstraction) are tracked in the proposal's *Out of scope* list rather than as in-spec open questions, since they do not need to resolve before this change ships.

--- a/openspec/changes/anonymiser-backend-selection/proposal.md
+++ b/openspec/changes/anonymiser-backend-selection/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+OpenRegister already supports five entity-recognition methods in `EntityRecognitionHandler` (`regex`, `presidio`, `openanonymiser`, `llm`, `hybrid`) and stores the selected method plus per-backend endpoint URLs inside the `fileManagement` `IAppConfig` blob (`entityRecognitionMethod`, `presidioApiEndpoint`, `openAnonymiserApiEndpoint`, etc.). What it does **not** have:
+
+1. A first-class **state-query API** that consumer apps can read to answer "is a non-regex backend actually configured *and* available right now?". DocuDesk's [`anonymiser-backend-warning` change](https://github.com/ConductionNL/docudesk/pull/135) names exactly this query as a Hard cross-app dependency — the admin warning banner cannot render without it.
+2. A **consolidated admin selector UI** for picking the method, configuring per-backend endpoints, observing live availability for ExApp backends (via AppAPI), and probing reachability with a test-connection button. Today these knobs are scattered across the `fileManagement` blob and there is no live availability signal.
+
+Without (1), every consumer would have to read the raw `fileManagement` blob and reimplement the "is this backend actually usable?" logic locally — a duplication that will drift. Without (2), admins have no in-app discovery path: they have to find out from logs or end-user complaints that their selected backend isn't reachable.
+
+This change introduces the typed state-query API, the admin selector UI, and the canonical "no backend" determination rule. It is **specs only** — implementation lands in a follow-up PR.
+
+## What Changes
+
+- **NEW** capability `anonymiser-backend-selection`.
+- **NEW** typed service `OCA\OpenRegister\Service\Anonymisation\AnonymisationBackendService` (or equivalent location) exposing `getState(): BackendState`. `BackendState` is a value object with `activeMethod`, `entityRecognitionEnabled`, `effectiveMethod` (resolved per the "no backend" rule), and a per-backend list of `{name, available, configured}` flags.
+- **NEW** admin-only OCS endpoint `GET /apps/openregister/api/admin/anonymisation/backend-state` returning the same `BackendState` as JSON. Single source of truth: the endpoint calls into the PHP service; no parallel implementation.
+- **NEW** admin settings panel (`Anonimiseren` section under the existing `OpenRegisterAdmin` settings page) where admins:
+  - pick the active method from the five supported values;
+  - configure per-backend endpoint URLs where applicable (`presidioApiEndpoint`, `openAnonymiserApiEndpoint`, future LLM endpoint);
+  - see live availability indicators per backend (AppAPI-derived for the two OpenAnonymiser ExApps; reachability-probe-derived for HTTP endpoints);
+  - press a per-backend **Test connection** button that issues a synthetic probe and reports latency + reachability.
+- **NEW** canonical "no backend" determination rule. `effectiveMethod` resolves to `regex` when (a) `entityRecognitionEnabled` is `false`, OR (b) the active method ≠ `regex` AND that backend's `{available AND configured}` is `false`. The rule lives in the service, never in callers.
+- **NEW** authorisation contract: the state-query OCS endpoint is admin-only (requires the admin group). Non-admin callers receive 403 matching OR's existing admin-endpoint convention.
+- **UNCHANGED** storage shape. The `fileManagement` `IAppConfig` blob continues to hold persisted state. This change reads it through the new service and adds no new persisted fields; live availability + probe results are computed on read, not persisted.
+- **UNCHANGED** dispatch in `EntityRecognitionHandler`. This change adds a layer **above** the existing dispatch; it does not replace or modify per-method execution.
+
+### Out of scope
+
+- A backend abstraction (`BackendInterface` + per-method handlers). Could come later; not needed for the state query + UI.
+- Multi-tier fallback policy ("if `openanonymiser` is unavailable, use `presidio`"). Deferred — current effective-method rule is binary: "active OR regex".
+- Migrating the `fileManagement` `IAppConfig` blob into normalised storage. Implementation-internal; may evolve under a separate change.
+- Audit-trail entries for backend-selection changes. Not needed for v1 — admin settings audit is a cross-cutting OR concern, not specific to this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `anonymiser-backend-selection`: typed state-query API + admin selector UI + canonical "no backend" determination rule.
+
+### Modified Capabilities
+
+(none — `entity-recognition` and `text-extraction` capabilities are not yet covered by OpenSpec, so this change introduces the first capability over the anonymisation surface without modifying any existing one.)
+
+## Cross-app Dependencies
+
+- **Soft** — `docudesk:anonymiser-backend-warning` — consumer. DocuDesk's admin warning banner queries the new state-query OCS endpoint to determine whether to render the "no backend configured" warning. Either change can land first: until OR lands, DocuDesk's banner falls through to "always show / never show" per its own default; until DocuDesk lands, OR's endpoint has one fewer consumer.
+
+Track as a `Depends on` link between this change's GitHub issue (#1497) and DocuDesk PR #135's tracking issue once it exists.
+
+## Impact
+
+- **Code (openregister):**
+  - NEW `lib/Service/Anonymisation/AnonymisationBackendService.php` — typed service implementing `getState()`, the precedence rule, and probe orchestration.
+  - NEW `lib/Service/Anonymisation/BackendState.php` — value object.
+  - NEW `lib/Service/Anonymisation/BackendProbe.php` (or similar) — per-method reachability probe; emits `{reachable, latencyMs, error?}`. Caches results per-endpoint for 60s (configurable via `anonymisation.probe_cache_ttl`).
+  - NEW controller method (extend an existing admin controller or add `lib/Controller/AnonymisationAdminController.php`) handling `GET /api/admin/anonymisation/backend-state` plus `POST /api/admin/anonymisation/test-connection`.
+  - NEW Vue admin panel — Anonimiseren section in the OR admin settings (`src/views/admin/AnonymisationBackend.vue` or equivalent), wired into the existing admin Vue router.
+  - `lib/Settings/OpenRegisterAdmin.php` — register the new admin panel section.
+- **API contract:** two new admin-only OCS endpoints (`backend-state` GET; `test-connection` POST). No changes to existing endpoints.
+- **Storage:** reads existing `fileManagement` `IAppConfig` keys via `FileSettingsHandler`. No new persisted state. Probe-result cache lives in `IAppConfig` under a dedicated key (`anonymisation.probe_cache`) with TTL eviction; treated as transient state.
+- **AppAPI integration:** the service checks for AppAPI presence via Nextcloud's `IAppManager` / OCP container; falls back to "not detectable" when AppAPI is not installed (with a clear admin-side hint).
+- **Cross-app:** unblocks DocuDesk's `anonymiser-backend-warning`. No effect on other apps.
+- **Tests:**
+  - Unit: precedence rules of `effectiveMethod`; probe caching; AppAPI feature-detection fallback.
+  - Integration: OCS endpoint returns the expected shape; admin-only authorisation; error responses match the OR convention.
+  - Browser (Playwright MCP via `browser-1`): admin can pick a method, configure an endpoint, press Test connection, see the live availability indicator update.
+- **Migration:** None. Existing `fileManagement` values continue to be read by `EntityRecognitionHandler`; the new service reads the same keys.
+- **Documentation:** add `docs/admin/anonymisation-backends.md` describing the five methods, the discovery flow, and the AppAPI dependency for ExApp methods.

--- a/openspec/changes/anonymiser-backend-selection/specs/anonymiser-backend-selection/spec.md
+++ b/openspec/changes/anonymiser-backend-selection/specs/anonymiser-backend-selection/spec.md
@@ -1,0 +1,183 @@
+# Capability: `anonymiser-backend-selection`
+
+## Purpose
+
+Provide a typed state-query API and an admin selector UI for OpenRegister's anonymisation backends, plus the canonical determination rule for the *effective* recognition method given the operator's choice, per-backend configuration, and live availability. Consumer apps (notably DocuDesk's admin warning banner) read this state to render operator-facing UX without reimplementing the precedence rule locally.
+
+## ADDED Requirements
+
+### Requirement: A `BackendState` value object MUST exist that encodes the active method, the effective method, and per-backend availability + configuration
+
+The system SHALL define a `BackendState` value object with the following fields: `entityRecognitionEnabled` (boolean), `activeMethod` (enum of `regex` / `presidio` / `openanonymiser` / `llm` / `hybrid`), `effectiveMethod` (same enum), and `backends` (array of per-method `BackendInfo` records). Each `BackendInfo` record SHALL carry `name` (the method enum), `available` (boolean), `configured` (boolean), `lastProbedAt` (ISO-8601 timestamp or null), and `latencyMs` (integer or null). The two flags `available` and `configured` SHALL be independent — a backend MAY be configured but unreachable (latest probe failed), or available but not configured (e.g. an installed ExApp without a matching operator-selected method).
+
+#### Scenario: A configured-but-unreachable backend is distinguished from an unconfigured one
+- **GIVEN** an admin has set `presidioApiEndpoint` to a host that no longer responds
+- **WHEN** the state is queried
+- **THEN** `backends[presidio].configured` is `true`
+- **AND** `backends[presidio].available` is `false`
+- **AND** the failure reason is reflected in the cached probe result (recoverable via the probe endpoint)
+
+#### Scenario: An installed ExApp without operator selection is reported as available but the method is not necessarily effective
+- **GIVEN** the `openanonymiser_light` ExApp is installed and enabled via AppAPI, but the admin has selected `regex` as `entityRecognitionMethod`
+- **WHEN** the state is queried
+- **THEN** `backends[openanonymiser].available` is `true`
+- **AND** `backends[openanonymiser].configured` is `true`
+- **AND** `activeMethod` is `regex`
+- **AND** `effectiveMethod` is `regex`
+
+### Requirement: `AnonymisationBackendService::getState()` MUST be the single source of truth for backend state
+
+The system SHALL expose a typed PHP service method that returns a fully-resolved `BackendState`. All other consumers — in-process callers, the OCS endpoint, the admin UI — SHALL obtain state by calling this method, not by reading the underlying `IAppConfig` storage directly. The service MUST be the only code path that applies the `effectiveMethod` precedence rule.
+
+#### Scenario: An in-process consumer reads state via the service
+- **WHEN** another OpenRegister service calls `AnonymisationBackendService::getState()`
+- **THEN** it receives a `BackendState` populated with the current `activeMethod`, the computed `effectiveMethod`, and per-backend `available` / `configured` flags consistent with the latest probe cache
+
+#### Scenario: The OCS endpoint is a thin wrapper over the service
+- **WHEN** a consumer calls `GET /api/admin/anonymisation/backend-state`
+- **THEN** the controller calls `AnonymisationBackendService::getState()` and serialises the result
+- **AND** there is no parallel implementation of the precedence rule in the controller layer
+
+### Requirement: The `effectiveMethod` MUST resolve to `regex` when entity recognition is disabled OR the active backend is not usable
+
+The system SHALL compute `effectiveMethod` according to these rules, applied in order:
+
+1. If `entityRecognitionEnabled` is `false`, `effectiveMethod` is `regex`.
+2. Else if `activeMethod` is `regex`, `effectiveMethod` is `regex`.
+3. Else if `backends[activeMethod].available` is `true` AND `backends[activeMethod].configured` is `true`, `effectiveMethod` is `activeMethod`.
+4. Otherwise, `effectiveMethod` is `regex`.
+
+For the `hybrid` method specifically, `backends[hybrid].available` SHALL be the logical AND of the availability flags of the methods that `EntityRecognitionHandler::detectEntitiesHybrid` composes (currently `regex`, `presidio`, and `openanonymiser`). If any composed backend is unavailable, `hybrid` itself is unavailable.
+
+#### Scenario: Recognition disabled forces effectiveMethod to regex
+- **GIVEN** `entityRecognitionEnabled` is `false` and `activeMethod` is `hybrid`
+- **WHEN** the state is queried
+- **THEN** `effectiveMethod` is `regex`
+
+#### Scenario: Active method unreachable falls through to regex
+- **GIVEN** `activeMethod` is `presidio` and `backends[presidio].available` is `false`
+- **WHEN** the state is queried
+- **THEN** `effectiveMethod` is `regex`
+- **AND** `activeMethod` remains `presidio` in the response (operator intent is preserved)
+
+#### Scenario: Active method available and configured passes through
+- **GIVEN** `activeMethod` is `openanonymiser`, the ExApp is installed and enabled, and `entityRecognitionEnabled` is `true`
+- **WHEN** the state is queried
+- **THEN** `effectiveMethod` is `openanonymiser`
+
+#### Scenario: Hybrid degrades when a composed backend is unavailable
+- **GIVEN** `activeMethod` is `hybrid`, `backends[regex].available` is `true`, `backends[openanonymiser].available` is `true`, but `backends[presidio].available` is `false`
+- **WHEN** the state is queried
+- **THEN** `backends[hybrid].available` is `false`
+- **AND** `effectiveMethod` is `regex`
+
+### Requirement: An admin-only OCS endpoint MUST expose the backend state
+
+The system SHALL expose `GET /apps/openregister/api/admin/anonymisation/backend-state` returning the JSON serialisation of `BackendState`. The endpoint SHALL require admin group membership; non-admin callers SHALL receive HTTP 403 with the OpenRegister-standard error body shape. The response SHALL be HTTP 200 with `Content-Type: application/json` on success.
+
+#### Scenario: Admin gets the state
+- **GIVEN** a session authenticated as an admin user
+- **WHEN** the client calls `GET /apps/openregister/api/admin/anonymisation/backend-state`
+- **THEN** the response is HTTP 200
+- **AND** the body matches the `BackendState` shape
+
+#### Scenario: Non-admin is rejected
+- **GIVEN** a session authenticated as a non-admin user
+- **WHEN** the client calls `GET /apps/openregister/api/admin/anonymisation/backend-state`
+- **THEN** the response is HTTP 403 with the OpenRegister-standard error body
+
+#### Scenario: Unauthenticated caller is rejected
+- **GIVEN** no session
+- **WHEN** the client calls `GET /apps/openregister/api/admin/anonymisation/backend-state`
+- **THEN** the response is HTTP 401 (Nextcloud's session-required path), not 200 with an anonymous state
+
+### Requirement: A per-backend `test-connection` probe MUST be exposed via an admin OCS endpoint
+
+The system SHALL expose `POST /apps/openregister/api/admin/anonymisation/test-connection` accepting a JSON body `{method: <method-enum>}` and returning a `ProbeResult` JSON object with fields `reachable` (boolean), `latencyMs` (integer or null), `error` (string or null, drawn from the set `timeout` / `dns_error` / `http_4xx` / `http_5xx` / `connect_refused` / `exapp_not_installed` / `exapp_disabled` / `appapi_missing` / `not_configured`), and `probedAt` (ISO-8601 timestamp). The probe SHALL bypass the state-query cache and issue a fresh probe. The endpoint SHALL be admin-only.
+
+#### Scenario: Test connection against a reachable Presidio endpoint
+- **GIVEN** `presidioApiEndpoint` points at a reachable Presidio instance
+- **WHEN** the admin posts `{method: "presidio"}` to the test-connection endpoint
+- **THEN** the response is `{reachable: true, latencyMs: <small int>, error: null, probedAt: ...}`
+
+#### Scenario: Test connection against an unreachable endpoint reports the error code
+- **GIVEN** `presidioApiEndpoint` is `http://nope.invalid:8080`
+- **WHEN** the admin posts `{method: "presidio"}` to the test-connection endpoint
+- **THEN** the response is `{reachable: false, error: "dns_error", latencyMs: null, probedAt: ...}`
+
+#### Scenario: Test connection for `openanonymiser` queries AppAPI rather than HTTP
+- **GIVEN** the `openanonymiser_light` ExApp is installed and enabled via AppAPI
+- **WHEN** the admin posts `{method: "openanonymiser"}` to the test-connection endpoint
+- **THEN** the response is `{reachable: true, error: null, latencyMs: 0, probedAt: ...}`
+- **AND** no HTTP request was issued to any external endpoint
+
+#### Scenario: Test connection for `regex` is a trivial success
+- **WHEN** the admin posts `{method: "regex"}` to the test-connection endpoint
+- **THEN** the response is `{reachable: true, error: null, latencyMs: 0, probedAt: ...}`
+
+### Requirement: Probe results MUST be cached with a 60-second default TTL
+
+The state-query path SHALL consume cached probe results when they are younger than the configured TTL (`anonymisation.probe_cache_ttl`, default 60s, valid range 10–600s). Cache entries older than the TTL SHALL trigger a fresh probe synchronously, and the new result SHALL be written back to the cache. The `test-connection` endpoint SHALL always issue a fresh probe regardless of cache age and write its result to the cache.
+
+#### Scenario: Cached result within TTL is reused
+- **GIVEN** the probe for `presidio` was last run 30 seconds ago and is cached as `{reachable: true, latencyMs: 12}`
+- **WHEN** `getState()` is called
+- **THEN** the cached result is returned and no new probe is issued
+
+#### Scenario: Cached result older than TTL triggers fresh probe
+- **GIVEN** the probe for `presidio` was last run 70 seconds ago (TTL is 60s)
+- **WHEN** `getState()` is called
+- **THEN** a fresh probe is issued
+- **AND** the new result is written to the cache
+- **AND** the new result is included in the returned `BackendState`
+
+#### Scenario: Test-connection bypasses cache
+- **GIVEN** the probe for `presidio` was cached 5 seconds ago
+- **WHEN** the admin posts `{method: "presidio"}` to the test-connection endpoint
+- **THEN** a fresh probe is issued (the cache is bypassed)
+- **AND** the new result is written to the cache, overwriting the previous entry
+
+### Requirement: ExApp availability MUST be derived from AppAPI / `IAppManager`, with a documented fallback when AppAPI is not detectable
+
+For the `openanonymiser` method, `available` SHALL be `true` if and only if an OpenAnonymiser ExApp (`openanonymiser_light` OR `openanonymiser`) is installed and enabled via AppAPI as reported by `IAppManager`. If AppAPI is not present on the instance (the capability lookup fails), the probe SHALL return `{reachable: false, error: "appapi_missing"}` and the admin UI SHALL surface a hint to install AppAPI rather than silently degrading.
+
+#### Scenario: ExApp installed and enabled
+- **GIVEN** `openanonymiser_light` is installed and enabled via AppAPI
+- **WHEN** the state is queried
+- **THEN** `backends[openanonymiser].available` is `true`
+- **AND** `backends[openanonymiser].configured` is `true`
+
+#### Scenario: ExApp not installed
+- **GIVEN** neither `openanonymiser_light` nor `openanonymiser` is installed
+- **WHEN** the state is queried
+- **THEN** `backends[openanonymiser].available` is `false`
+- **AND** the cached probe error is `exapp_not_installed`
+
+#### Scenario: AppAPI missing from the instance
+- **GIVEN** AppAPI is not installed on the Nextcloud instance
+- **WHEN** the state is queried
+- **THEN** `backends[openanonymiser].available` is `false`
+- **AND** the cached probe error is `appapi_missing`
+- **AND** the admin UI displays a hint to install AppAPI
+
+### Requirement: An admin settings panel MUST exist where admins pick the active method and configure per-backend endpoints
+
+The system SHALL render an Anonimiseren section within the existing OpenRegisterAdmin settings page. The section SHALL allow an admin to select the active method from `regex` / `presidio` / `openanonymiser` / `llm` / `hybrid`, configure endpoint URLs for HTTP-based methods (`presidio`, `llm`) where applicable, see a live availability indicator per backend, observe AppAPI-derived ExApp availability for `openanonymiser`, and trigger a test-connection probe per applicable backend. All admin-visible strings SHALL be provided in NL and EN per ADR-005. The panel SHALL meet WCAG AA — focus order, contrast, and keyboard operability of the selector, inputs, and buttons.
+
+#### Scenario: Admin picks a method and the choice persists
+- **GIVEN** the admin opens the Anonimiseren section
+- **WHEN** they select `openanonymiser`, save, and reload
+- **THEN** `openanonymiser` remains selected
+- **AND** the `entityRecognitionMethod` IAppConfig field is updated
+
+#### Scenario: Admin presses Test connection and the indicator updates
+- **GIVEN** `presidio` is selected with a configured endpoint
+- **WHEN** the admin presses **Test connection** for `presidio`
+- **THEN** the indicator updates with the probe result (reachable / unreachable + latency)
+- **AND** no full page reload is required
+
+#### Scenario: ExApp deep link is shown when an OpenAnonymiser ExApp is missing
+- **GIVEN** `openanonymiser_light` is not installed
+- **WHEN** the admin views the openanonymiser sub-section
+- **THEN** the panel renders a deep link to `/settings/apps/discover/openanonymiser_light`
+- **AND** the indicator shows "not configured" / "exapp_not_installed"

--- a/openspec/changes/anonymiser-backend-selection/tasks.md
+++ b/openspec/changes/anonymiser-backend-selection/tasks.md
@@ -1,0 +1,74 @@
+## 1. Service & value object
+
+- [ ] 1.1 Create `lib/Service/Anonymisation/BackendState.php` — value object with fields `entityRecognitionEnabled` (bool), `activeMethod` (enum string), `effectiveMethod` (enum string), `backends` (array of `BackendInfo` value objects with `name`, `available`, `configured`, `lastProbedAt`, `latencyMs`). Constructor + readonly properties (or `final` class with `public readonly`); `toArray()` method for OCS serialisation.
+- [ ] 1.2 Create `lib/Service/Anonymisation/BackendInfo.php` — per-backend value object (same readonly pattern).
+- [ ] 1.3 Create `lib/Service/Anonymisation/AnonymisationBackendService.php` with `getState(): BackendState`. Injects `FileSettingsHandler`, `BackendProbe`, `IAppManager`, `LoggerInterface`. Implements the precedence rule from design D3.
+- [ ] 1.4 Unit-test the precedence rule for all four branches of D3 (recognition disabled; active=regex; active≠regex with backend available+configured; active≠regex with backend unavailable or unconfigured).
+- [ ] 1.5 Unit-test `hybrid`-method handling: when any composed backend is unavailable, `hybrid` is unavailable and `effectiveMethod` falls back to `regex`.
+
+## 2. Probe
+
+- [ ] 2.1 Create `lib/Service/Anonymisation/BackendProbe.php` with `probe(string $method): ProbeResult`. `ProbeResult` is a value object with `reachable` (bool), `latencyMs` (int|null), `error` (string|null, one of the codes from design D6), `probedAt` (DateTimeInterface).
+- [ ] 2.2 Implement the per-method probe behaviour per design D6 — HTTP for `presidio`/`llm`, AppAPI lookup for `openanonymiser`, trivial for `regex`, composite for `hybrid`.
+- [ ] 2.3 Implement caching per design D7 — read/write via `IAppConfig` under `anonymisation.probe_cache.<method>`; respect `anonymisation.probe_cache_ttl` (10–600s, default 60s).
+- [ ] 2.4 Implement cache-bypass path: `probe($method, bypassCache: true)` always issues a fresh probe.
+- [ ] 2.5 Run probes in parallel inside `getState()` when populating cold cache (R1 mitigation). Use whichever async HTTP primitive is already in `vendor/` (likely Guzzle promises).
+- [ ] 2.6 Unit-test cache TTL behaviour (cached result within TTL → no probe; cached result expired → fresh probe; bypass flag → fresh probe regardless of cache state).
+- [ ] 2.7 Unit-test error mapping (timeout → `error: 'timeout'`; 4xx → `http_4xx`; DNS failure → `dns_error`; etc.).
+
+## 3. Controller & OCS endpoints
+
+- [ ] 3.1 Add `lib/Controller/AnonymisationAdminController.php` (or extend an existing admin controller — pick whichever is closer to the current OR convention; document the choice in the PR description).
+- [ ] 3.2 Add `GET /api/admin/anonymisation/backend-state` route — admin-only, returns `BackendState->toArray()` as JSON with HTTP 200.
+- [ ] 3.3 Add `POST /api/admin/anonymisation/test-connection` route — admin-only, accepts `{method}` in body, calls `BackendProbe::probe($method, bypassCache: true)`, returns `ProbeResult` as JSON.
+- [ ] 3.4 Authorisation: require admin group via OR's existing `@AdminRequired` / `IGroupManager::isAdmin` pattern. Confirm by grep against an existing admin endpoint and replicate.
+- [ ] 3.5 Integration test: as admin, `GET /backend-state` returns the expected shape; as non-admin, returns 403.
+- [ ] 3.6 Integration test: as admin, `POST /test-connection` with `{method: "presidio"}` against a known-good local Presidio returns `reachable: true`; against a non-existent endpoint returns `reachable: false, error: "dns_error"` (or `connect_refused`).
+
+## 4. Admin UI
+
+- [ ] 4.1 Add the `Anonimiseren` section to the existing OR admin Vue SPA. Component path: `src/views/admin/AnonymisationBackend.vue` (or equivalent matching the existing admin component layout).
+- [ ] 4.2 Render the method selector (radio group or `<select>` over the five methods) bound to the existing `entityRecognitionMethod` `IAppConfig` field via the existing settings update mechanism.
+- [ ] 4.3 Render per-method configuration sub-section per design D4. For `presidio` / `llm`, a URL input bound to the relevant `*ApiEndpoint` field. For `openanonymiser`, a read-only ExApp-availability indicator with `/settings/apps/discover/{appid}` deep links. For `regex`, an explanatory paragraph. For `hybrid`, a summary listing composed backends with their own configuration links.
+- [ ] 4.4 Render the live availability indicator per backend (status dot + label), driven by `BackendState.backends[].available`. Re-fetch state on configuration save.
+- [ ] 4.5 Wire the per-backend **Test connection** button to `POST /api/admin/anonymisation/test-connection`. Display the result (reachable / unreachable + latency) inline and update the indicator without a full refetch.
+- [ ] 4.6 NL + EN translations per ADR-005 — all admin-visible strings.
+- [ ] 4.7 Accessibility: WCAG AA — focus order, contrast, keyboard operability of the selector + buttons.
+
+## 5. Wiring
+
+- [ ] 5.1 Update `lib/Settings/OpenRegisterAdmin.php` to register the new Anonimiseren section. Confirm it appears in the admin settings sidebar under OpenRegister.
+- [ ] 5.2 DI registration in `lib/AppInfo/Application.php` (or wherever OR registers services) for `AnonymisationBackendService` and `BackendProbe`.
+- [ ] 5.3 Add the new routes to `appinfo/routes.php` (or the OR-specific routing config) under the admin route group.
+
+## 6. Browser verification
+
+- [ ] 6.1 Reset the local env (`bash clean-env.sh` or `/clean-env`).
+- [ ] 6.2 Using `browser-1` (Playwright MCP), navigate to Nextcloud admin settings → OpenRegister → Anonimiseren. Confirm the section renders with the five method options and the live indicators.
+- [ ] 6.3 Pick `presidio`, enter an obviously-bad URL, press Test connection. Confirm the result is "unreachable" with a meaningful error code.
+- [ ] 6.4 Pick `regex`, save. Reload. Confirm `entityRecognitionMethod` persists.
+- [ ] 6.5 With `openanonymiser_light` ExApp uninstalled, pick `openanonymiser`. Confirm the indicator shows "not configured" / "exapp_not_installed" and the deep link to `/settings/apps/discover/openanonymiser_light` is present.
+- [ ] 6.6 Capture screenshots (NL + EN) → `docs/screenshots/anonymisation-backend-*.png`.
+
+## 7. Cross-app verification
+
+- [ ] 7.1 Confirm the `GET /api/admin/anonymisation/backend-state` response shape matches the DocuDesk-side consumer expectation in `anonymiser-backend-warning` (DocuDesk PR #135). Coordinate with DocuDesk apply phase.
+- [ ] 7.2 Run DocuDesk's `anonymiser-backend-warning` integration test (when it lands) against a local OR with this change applied; confirm the warning banner renders on regex-only / unreachable-backend conditions and is suppressed when a backend is `available + configured`.
+
+## 8. Quality gates
+
+- [ ] 8.1 `composer check:strict` passes (PHPCS, PHPMD, Psalm, PHPStan).
+- [ ] 8.2 Fix any pre-existing PHPCS/PHPMD/PHPStan warnings encountered in touched files per CLAUDE.md.
+- [ ] 8.3 Unit-test coverage for new code ≥ 75% (ADR-009).
+- [ ] 8.4 No regressions in existing OR test suites (PHPUnit, eslint, stylelint).
+
+## 9. Documentation
+
+- [ ] 9.1 Add `docs/admin/anonymisation-backends.md` — describe the five methods, when to pick each, the discovery flow (AppAPI for ExApps; URL config for HTTP backends), and the "no backend" determination rule operators can rely on.
+- [ ] 9.2 Reference the screenshots from 6.6.
+- [ ] 9.3 Cross-link to DocuDesk's admin docs once `anonymiser-backend-warning` is documented there.
+
+## 10. Follow-up hand-off
+
+- [ ] 10.1 Open (or reference) the DocuDesk-side issue for `anonymiser-backend-warning` and add a `Depends on` link from this change's tracking issue (#1497).
+- [ ] 10.2 Note in `docs/admin/anonymisation-backends.md` that multi-tier fallback ("if openanonymiser unavailable, try presidio") is intentionally out of scope for v1 and may follow under a separate change if a use case emerges.


### PR DESCRIPTION
## Summary

Adds the OpenSpec change directory for **anonymiser-backend-selection** — a new OpenRegister capability covering:

- **Typed state-query API.** `AnonymisationBackendService::getState()` + admin-only OCS endpoint `GET /api/admin/anonymisation/backend-state` returning a `BackendState` value object with `activeMethod`, `effectiveMethod`, and per-backend `{available, configured, lastProbedAt, latencyMs}` flags.
- **Admin selector UI.** An "Anonimiseren" section within the existing `OpenRegisterAdmin` settings page — method picker, per-backend endpoint configuration, live availability indicators (AppAPI-derived for ExApps), per-backend **Test connection** button.
- **Canonical "no backend" determination rule.** `effectiveMethod` resolves to `regex` when recognition is disabled OR the active backend is not `available && configured`. Single source of truth in the service; consumers MUST NOT recompute.

Probe results cached 60s (configurable, 10–600s). ExApp availability derived from AppAPI / `IAppManager` with a documented `appapi_missing` fallback. Storage shape inside the `fileManagement` `IAppConfig` blob is implementation-internal — consumers go through the service, not the blob.

Specs only — no implementation in this PR.

Refs: #1497
Pair: [ConductionNL/docudesk#135](https://github.com/ConductionNL/docudesk/pull/135) — DocuDesk's `anonymiser-backend-warning` is the consumer; it cites this capability as a Hard cross-app dependency.

## Out of scope

- Backend abstraction (`BackendInterface` + per-method handlers) — not needed for state query + UI.
- Multi-tier fallback ("if openanonymiser unavailable, try presidio") — current rule is binary: active OR regex.
- Migrating `fileManagement` `IAppConfig` blob to normalised storage — separate change if needed.

## Test plan

- [ ] Review `proposal.md`, `design.md`, `tasks.md`, and the `anonymiser-backend-selection/spec.md` delta
- [ ] Confirm the `BackendState` shape matches DocuDesk's consumer expectation in PR #135's `anonymiser-backend-warning`
- [ ] Confirm the precedence rule for `effectiveMethod` (D3 in design.md) is acceptable, including the `hybrid` AND-aggregation behaviour
- [ ] Confirm the AppAPI-derived ExApp availability path (D5) + `appapi_missing` fallback handling
- [ ] `openspec validate` (when the implementation PR lands)