### PR TITLE
fix(Db): remove duplicate linked-entity property declarations in Organisation

### DIFF
--- a/lib/Db/Organisation.php
+++ b/lib/Db/Organisation.php
@@ -284,27 +284,6 @@ class Organisation extends Entity implements JsonSerializable
      */
     protected ?array $roles = null;
 
-    /** @var array|null Linked mail app data */
-    protected ?array $mail = null;
-
-    /** @var array|null Linked contacts app data */
-    protected ?array $contacts = null;
-
-    /** @var array|null Linked notes app data */
-    protected ?array $notes = null;
-
-    /** @var array|null Linked todos app data */
-    protected ?array $todos = null;
-
-    /** @var array|null Linked calendar app data */
-    protected ?array $calendar = null;
-
-    /** @var array|null Linked talk app data */
-    protected ?array $talk = null;
-
-    /** @var array|null Linked deck app data */
-    protected ?array $deck = null;
-
     /**
      * User count for this organisation (computed property, not stored in database)
      *


### PR DESCRIPTION
`Organisation.php` on `development` carries **two** parallel sets of the seven linked-entity properties (mail / contacts / notes / todos / calendar / talk / deck) — a terse "Linked X app data" set and a fully-documented "Linked X entity IDs" set — from a merge collision between two PRs that both added the unified-Nextcloud-entity-linking feature. PHP fatal-errors at class load (`Cannot redeclare OCA\OpenRegister\Db\Organisation::$mail`), so `occ app:enable openregister` breaks on `development` — and therefore every dependent app's dev/CI that installs OR `development`.

Removed the terse duplicate set; kept the fully-documented one. The constructor's `addType()` calls and `jsonSerialize()`'s `_*` keys reference the properties by name, so they're unaffected. `php -l` clean; no property name now appears twice.

(Surfaced while fixing OpenBuilt's CI — its Newman job needs to install OR `development` to get the runtime-schema-API + lifecycle features, which currently fails at app-enable on this.)