### PR TITLE
docs: align development docs with the documentation branch

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,4 +10,4 @@ jobs:
   deploy:
     uses: ConductionNL/.github/.github/workflows/documentation.yml@main
     with:
-      cname: openregisters.app
+      cname: openregister.conduction.nl

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -1,23 +1,35 @@
 // @ts-check
-// Note: type annotations allow type checking and IDEs autocompletion
 
-/** @type {import('@docusaurus/types').Config} */
-const config = {
-  title: 'Open Register',
-  tagline: 'Flexible object management for Nextcloud',
-  url: 'https://openregisters.app',
+/**
+ * OpenRegister documentation site.
+ *
+ * Built on @conduction/docusaurus-preset for brand defaults (tokens,
+ * theme swizzles for Navbar / Footer, four-locale i18n scaffolding,
+ * KvK / BTW copyright). Site-specific overrides — locales, sidebar
+ * path, mermaid theme, redocusaurus OAS routes, custom prism themes,
+ * openregister-only navbar items — are passed through createConfig() opts.
+ */
+
+const { createConfig, baseFooterLinks } = require('@conduction/docusaurus-preset');
+
+/* createConfig replaces themes wholesale when `themes:` is passed, so
+   we re-include the brand theme plugin alongside @docusaurus/theme-mermaid.
+   Without the brand theme entry the Navbar/Footer swizzles and
+   brand.css auto-load would silently drop. */
+const BRAND_THEME = require.resolve('@conduction/docusaurus-preset/theme');
+
+const config = createConfig({
+  title: 'OpenRegister',
+  tagline: 'Schemas, registers, structured data objects. The typed-data backbone underneath every other Conduction app.',
+  url: 'https://openregister.conduction.nl',
   baseUrl: '/',
-  
-  // GitHub pages deployment config
-  organizationName: 'conductionnl',
+
+  organizationName: 'ConductionNL',
   projectName: 'openregister',
-  trailingSlash: false,
 
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
-
-  // Even if you don't use internalization, you can use this field to set useful
-  // metadata like html lang
+  /* The brand preset's default i18n block (nl/en/de/fr) is replaced
+     wholesale here. OpenRegister docs ship with NL + EN translation
+     surfaces; keep both. */
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'nl'],
@@ -27,120 +39,138 @@ const config = {
     },
   },
 
+  /* The openregister docs source lives at the repo root of `docs/`
+     rather than under a `docs/` subfolder, so we override the preset's
+     default `presets:` block to point `docs.path` at './' and disable
+     the blog plugin. customCss carries openregister-specific CSS only —
+     brand tokens and the theme swizzles are auto-loaded by the brand
+     theme entry in `themes:` below.
+
+     redocusaurus stays as a sibling preset entry so the OAS routes at
+     /api and /api/clientRegister keep working. */
   presets: [
     [
       'classic',
-      /** @type {import('@docusaurus/preset-classic').Options} */
-      ({
+      {
         docs: {
           path: './',
-          exclude: ['**/node_modules/**'],
+          /* docs.path: './' makes plugin-content-docs scan every file
+             in docs/, which collides with plugin-content-pages's own
+             scan of docs/src/pages/. Exclude src/ (pages live there)
+             plus the standard node_modules bucket.
+
+             Also excludes a handful of session-summary / dev-note
+             files that contain raw `<` characters (e.g. `<= 100 chars`,
+             `<2026-01-05`, `width=100%`) the MDX 3 parser rejects. They
+             pre-date this preset migration and are not user-facing
+             docs; leaving them out of the scan is the lowest-risk fix.
+             Track properly in a follow-up MDX-cleanup PR. */
+          exclude: [
+            '**/node_modules/**',
+            'src/**',
+            'Features/faceting.md',
+            'Features/endpoints.md',
+            'features/workflow-operations.md',
+            'development-notes/magic-mapper-auto-table-creation.md',
+            'development-notes/session-summary-2026-01-05-final-extended.md',
+            'development-notes/session-summary-2026-01-05-final.md',
+            'development/configuration-dependencies.md',
+            'development/csv-duplicate-handling.md',
+            'development/magic-mapper.md',
+            'user-guide/importing-data.md',
+            'user/n8n-visual-guide-template.md',
+            'user/n8n-workflow-configuration.md',
+          ],
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl:
-            'https://github.com/conductionnl/openregister/tree/main/docs/',
+          editUrl: 'https://github.com/ConductionNL/openregister/tree/main/docs/',
         },
         blog: false,
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
-      }),
+      },
     ],
     [
       'redocusaurus',
       {
-        // Plugin Options for loading OpenAPI files
         specs: [
-          // Pass it a path to a local OpenAPI YAML file
           {
-            // Redocusaurus will automatically bundle your spec into a single file during the build
             id: 'open-register',
             spec: 'static/oas/open-register.json',
             route: '/api',
           },
           {
-            // Redocusaurus will automatically bundle your spec into a single file during the build
             id: 'client-registers',
             spec: 'static/oas/clientRegisters.json',
             route: '/api/clientRegister',
           },
         ],
-        // Theme Options for modifying how redoc renders them
         theme: {
-          // Change with your site colors
           primaryColor: '#1890ff',
         },
       },
-    ]
+    ],
   ],
 
-  themeConfig:
-    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
-    ({
-      navbar: {
-        title: 'Open Register',
-        logo: {
-          alt: 'Open Register Logo',
-          src: 'img/logo.svg',
-        },
-        items: [
-          {
-            type: 'docSidebar',
-            sidebarId: 'tutorialSidebar',
-            position: 'left',
-            label: 'Documentation',
-          },
-          {
-            href: '/api',
-            label: 'API Documentation',
-            position: 'right',
-          },
-          {
-            href: 'https://github.com/conductionnl/openregister',
-            label: 'GitHub',
-            position: 'right',
-          },
-          {
-            type: 'localeDropdown',
-            position: 'right',
-          },
-        ],
+  themes: [BRAND_THEME, '@docusaurus/theme-mermaid'],
+
+  /* Brand navbar provides locale dropdown + GitHub by default; we
+     replace items[] with openregister's own (Documentation sidebar
+     link, API documentation, GitHub link, locale dropdown). */
+  navbar: {
+    items: [
+      {
+        type: 'docSidebar',
+        sidebarId: 'tutorialSidebar',
+        position: 'left',
+        label: 'Documentation',
       },
-      footer: {
-        style: 'dark',
-        links: [
-          {
-            title: 'Docs',
-            items: [
-              {
-                label: 'Documentation',
-                to: '/docs/intro',
-              },
-            ],
-          },
-          {
-            title: 'Community',
-            items: [
-              {
-                label: 'GitHub',
-                href: 'https://github.com/conductionnl/openregister',
-              },
-            ],
-          },
-        ],
-        copyright: `Copyright © ${new Date().getFullYear()} for <a href="https://openwebconcept.nl">Open Webconcept</a> by <a href="https://conduction.nl">Conduction B.V.</a>`,
+      {
+        href: '/api',
+        label: 'API Documentation',
+        position: 'right',
       },
-      prism: {
-        theme: require('prism-react-renderer/themes/github'),
-        darkTheme: require('prism-react-renderer/themes/dracula'),
+      {
+        href: 'https://github.com/ConductionNL/openregister',
+        label: 'GitHub',
+        position: 'right',
       },
-      mermaid: {
-        theme: { light: 'default', dark: 'dark' },
-      },
-    }),
-  markdown: {
-    mermaid: true,
+      { type: 'localeDropdown', position: 'right' },
+    ],
   },
-  themes: ['@docusaurus/theme-mermaid'],
+
+  /* Per-property footer override (preset 1.2.0+): we pass `links` only,
+     so the brand `style: 'dark'` and the brand KvK/BTW/IBAN/address
+     copyright string both inherit unchanged. Single-column brand
+     "Conduction" anchor pulled from baseFooterLinks(). */
+  footer: {
+    links: [
+      ...baseFooterLinks().filter((column) => column.title === 'Conduction'),
+    ],
+  },
+
+  /* Drop the canal-footer's boat-sinking + kade-cyclist mini-games
+     on this product-page footer (preset 1.3.0+). The static skyline +
+     canal decoration are kept; the interactive layer goes away. */
+  minigames: false,
+
+  /* themeConfig is shallow-merged into the preset's defaults
+     (colorMode + navbar + footer). prism + mermaid land alongside. */
+  themeConfig: {
+    prism: {
+      theme: require('prism-react-renderer/themes/github'),
+      darkTheme: require('prism-react-renderer/themes/dracula'),
+    },
+    mermaid: {
+      theme: { light: 'default', dark: 'dark' },
+    },
+  },
+});
+
+/* createConfig doesn't pass-through arbitrary top-level fields; assign
+   markdown directly so it makes it into the final Docusaurus config. */
+config.markdown = {
+  mermaid: true,
 };
 
 module.exports = config;

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,13 +1,14 @@
 {
-  "name": "open-catalogi-docs",
+  "name": "openregister-docs",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "open-catalogi-docs",
+      "name": "openregister-docs",
       "version": "0.0.0",
       "dependencies": {
+        "@conduction/docusaurus-preset": "^1.5.1",
         "@docusaurus/core": "^3.7.0",
         "@docusaurus/preset-classic": "^3.7.0",
         "@docusaurus/theme-mermaid": "^3.7.0",
@@ -1908,6 +1909,18 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@conduction/docusaurus-preset": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.5.1.tgz",
+      "integrity": "sha512-xKcq6OHKvKMHopqP7PzOjviyLe5D91Za9qpY2teMiLN9jOOfbhM1lvv/dK+o7N+kK0ATolM7rOZOHNZwfIIaNQ==",
+      "license": "EUPL-1.2",
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "@docusaurus/preset-classic": "^3.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@csstools/cascade-layer-name-parser": {
@@ -20164,6 +20177,11 @@
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "optional": true
+    },
+    "@conduction/docusaurus-preset": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.5.1.tgz",
+      "integrity": "sha512-xKcq6OHKvKMHopqP7PzOjviyLe5D91Za9qpY2teMiLN9jOOfbhM1lvv/dK+o7N+kK0ATolM7rOZOHNZwfIIaNQ=="
     },
     "@csstools/cascade-layer-name-parser": {
       "version": "2.0.4",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
+    "@conduction/docusaurus-preset": "^1.5.1",
     "@docusaurus/core": "^3.7.0",
     "@docusaurus/preset-classic": "^3.7.0",
     "@docusaurus/theme-mermaid": "^3.7.0",

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -1,41 +1,267 @@
+/**
+ * OpenRegister landing page.
+ *
+ * Composes the brand <DetailHero> + <WidgetShelf> from
+ * @conduction/docusaurus-preset/components, mirroring the connext page
+ * at sites/www/src/pages/apps/openregister.mdx.
+ *
+ * Written as .js (not .mdx) because the docs site has the docs plugin
+ * pointed at `path: './'`, and an MDX file in src/pages/ trips the
+ * MDX-ESM parser even with the docs plugin's `src/**` exclude — likely
+ * a quirk of how mdx-loader's micromark stack reuses parser state
+ * across files in this Docusaurus 3.10 + this preset combination.
+ * Authoring the page in JSX keeps the same component composition.
+ */
+
 import React from 'react';
-import clsx from 'clsx';
-import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
-import HomepageFeatures from '@site/src/components/HomepageFeatures';
+import {
+  DetailHero,
+  WidgetShelf,
+  AppMock,
+} from '@conduction/docusaurus-preset/components';
 
-import styles from './index.module.css';
+const OPENREGISTER_ICON = (
+  <svg viewBox="0 0 24 24">
+    <ellipse cx="12" cy="6" rx="8" ry="3" />
+    <path d="M4 6v12c0 1.7 3.6 3 8 3s8-1.3 8-3V6" />
+    <path d="M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3" />
+  </svg>
+);
 
-function HomepageHeader() {
-  const {siteConfig} = useDocusaurusContext();
+const TAGLINE = (
+  <>
+    Schemas, registers, structured data objects. The typed-data backbone
+    underneath every other Conduction app, and the install you reach for
+    first. Define a schema once, get a REST and GraphQL API, validation,
+    an audit log, and a citation-stable identifier per record.
+  </>
+);
+
+function RecentRecordsPanel() {
+  const tones = [
+    'var(--c-forest-300)',
+    'var(--c-lavender-300)',
+    'var(--c-mint-300)',
+    'var(--c-terracotta-300)',
+    'var(--c-forest-300)',
+  ];
   return (
-    <header className={clsx('hero hero--primary', styles.heroBanner)}>
-      <div className="container">
-        <h1 className="hero__title">{siteConfig.title}</h1>
-        <p className="hero__subtitle">{siteConfig.tagline}</p>
-        <div className={styles.buttons}>
-          <Link
-            className="button button--secondary button--lg"
-            to="/docs/intro">
-            Documentation
-          </Link>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      {tones.map((tone, i) => (
+        <div
+          key={i}
+          style={{ display: 'flex', alignItems: 'center', gap: 8 }}
+        >
+          <span
+            style={{
+              width: 18,
+              height: 18,
+              borderRadius: 2,
+              background: tone,
+              flexShrink: 0,
+            }}
+          />
+          <div
+            style={{
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 3,
+            }}
+          >
+            <div
+              style={{
+                height: 4,
+                width: '70%',
+                background: 'var(--c-cobalt-700)',
+                borderRadius: 1,
+              }}
+            />
+            <div
+              style={{
+                height: 3,
+                width: '50%',
+                background: 'var(--c-cobalt-200)',
+                borderRadius: 1,
+              }}
+            />
+          </div>
+          <div
+            style={{
+              height: 3,
+              width: 22,
+              background: 'var(--c-cobalt-100)',
+              borderRadius: 1,
+            }}
+          />
         </div>
-      </div>
-    </header>
+      ))}
+    </div>
   );
 }
 
+function SchemaActivityPanel() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+        <div
+          style={{
+            fontFamily: 'var(--conduction-typography-font-family-code)',
+            fontSize: 26,
+            fontWeight: 700,
+            color: 'var(--c-cobalt-900)',
+          }}
+        >
+          847
+        </div>
+        <div
+          style={{
+            fontFamily: 'var(--conduction-typography-font-family-code)',
+            fontSize: 11,
+            fontWeight: 600,
+            color: 'var(--c-mint-500)',
+          }}
+        >
+          +12%
+        </div>
+      </div>
+      <svg
+        viewBox="0 0 200 60"
+        preserveAspectRatio="none"
+        style={{ width: '100%', height: 50 }}
+      >
+        <path
+          d="M 0 48 L 28 36 L 56 42 L 84 24 L 112 30 L 140 16 L 168 22 L 200 8"
+          stroke="var(--c-blue-cobalt)"
+          strokeWidth="2"
+          fill="none"
+        />
+        <path
+          d="M 0 48 L 28 36 L 56 42 L 84 24 L 112 30 L 140 16 L 168 22 L 200 8 L 200 60 L 0 60 Z"
+          fill="var(--c-cobalt-100)"
+        />
+        <circle cx="200" cy="8" r="3" fill="var(--c-orange-knvb)" />
+      </svg>
+    </div>
+  );
+}
+
+function AuditTrailPanel() {
+  const rows = [
+    { tone: 'var(--c-mint-500)', label: 'WRITE', w: '85%' },
+    { tone: 'var(--c-cobalt-300)', label: 'READ', w: '70%' },
+    { tone: 'var(--c-lavender-300)', label: 'WRITE', w: '60%' },
+    { tone: 'var(--c-cobalt-300)', label: 'READ', w: '50%' },
+    { tone: 'var(--c-orange-knvb)', label: 'SCHEMA', w: '45%' },
+  ];
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      {rows.map((row, i) => (
+        <div
+          key={i}
+          style={{ display: 'flex', alignItems: 'center', gap: 8 }}
+        >
+          <span
+            style={{
+              width: 14,
+              height: 16,
+              clipPath: 'var(--hex-pointy-top)',
+              background: row.tone,
+              flexShrink: 0,
+            }}
+          />
+          <div
+            style={{
+              fontFamily: 'var(--conduction-typography-font-family-code)',
+              fontSize: 8,
+              fontWeight: 700,
+              letterSpacing: '0.05em',
+              color: 'var(--c-cobalt-700)',
+              minWidth: 42,
+            }}
+          >
+            {row.label}
+          </div>
+          <div
+            style={{
+              flex: 1,
+              height: 6,
+              background: 'var(--c-cobalt-50)',
+              borderRadius: 1,
+              overflow: 'hidden',
+            }}
+          >
+            <div
+              style={{
+                height: '100%',
+                width: row.w,
+                background: 'var(--c-cobalt-300)',
+                borderRadius: 1,
+              }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const WIDGETS = [
+  {
+    title: 'Schema-driven JSON store',
+    desc: 'Define a register shape in JSON Schema, get a typed object store. Every write is validated, every record lands with a citation-stable identifier.',
+    panel: <RecentRecordsPanel />,
+  },
+  {
+    title: 'REST and GraphQL, auto-generated',
+    desc: 'Both APIs roll out of the schema. No controllers to write, no spec to update when the schema changes, no glue code between OpenRegister and the apps that consume it.',
+    panel: <SchemaActivityPanel />,
+  },
+  {
+    title: 'Signed audit log per record',
+    desc: 'Every read, write, and schema change leaves a tamper-evident trail. WOO and BIO compliance evidence ships with the install, no spreadsheet exports at audit time.',
+    panel: <AuditTrailPanel />,
+  },
+];
+
 export default function Home() {
-  const {siteConfig} = useDocusaurusContext();
   return (
     <Layout
-      title={`${siteConfig.title}`}
-      description="Flexible object management for Nextcloud">
-      <HomepageHeader />
-      <main>
-        <HomepageFeatures />
+      title="OpenRegister"
+      description="Schema-driven object store with audit trail. The data foundation underneath every Conduction workspace app."
+    >
+      <main className="marketing-page">
+        <DetailHero
+          background="cobalt"
+          appId="openregister"
+          status={{ label: 'Stable', color: 'var(--c-mint-500)' }}
+          version="v3.1"
+          locales="NL · EN"
+          title="OpenRegister"
+          tagline={TAGLINE}
+          primaryCta={{
+            label: 'Install from app store',
+            href: 'https://apps.nextcloud.com/apps/openregister',
+            tone: 'orange',
+          }}
+          secondaryCta={{ label: 'Read the docs', href: '/docs/intro' }}
+          tertiaryCta={{
+            label: 'View on GitHub',
+            href: 'https://github.com/ConductionNL/openregister',
+          }}
+          iconColor="var(--c-orange-knvb)"
+          icon={OPENREGISTER_ICON}
+          illustration={<AppMock app="openregister" />}
+        />
+
+        <WidgetShelf
+          eyebrow="Widgets we ship"
+          title="On every Nextcloud dashboard."
+          lede="Install OpenRegister and the home screen surfaces what changed in your data, what people search for, and what slipped through validation."
+          widgets={WIDGETS}
+        />
       </main>
     </Layout>
   );
-} 
+}

--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,1 +1,1 @@
-openregisters.app
+openregister.conduction.nl


### PR DESCRIPTION
The live docs site (openregister.conduction.nl) deploys from the `documentation` branch — on @conduction/docusaurus-preset, brand <DetailHero>/<WidgetShelf>/<AppMock> landing, locales:['en','nl']. `development` still carried the pre-migration preset-classic / openregisters.app / stock-template setup. This brings `development`'s `docs/` + `documentation.yml` in line with what's actually live. Build verified locally.