### PR TITLE
deps: declare react/async explicitly (closes openbuilt#49)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,6 +97,7 @@
 		"opis/json-schema": "^2.3",
 		"phpoffice/phpspreadsheet": "^5.0",
 		"phpoffice/phpword": "^1.2",
+		"react/async": "^4.3",
 		"react/event-loop": "^1.5",
 		"react/promise": "^3.2",
 		"smalot/pdfparser": "^2.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26e59fd384963cc48ffdd09b8ef0ea1c",
+    "content-hash": "ea1d60102900aa5e48680d20ba970471",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -2743,6 +2743,81 @@
                 "source": "https://github.com/ralouphie/getallheaders/tree/develop"
             },
             "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "react/async",
+            "version": "v4.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/async.git",
+                "reference": "635d50e30844a484495713e8cb8d9e079c0008a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/async/zipball/635d50e30844a484495713e8cb8d9e079c0008a5",
+                "reference": "635d50e30844a484495713e8cb8d9e079c0008a5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.8 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.10.39",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Async\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async utilities and fibers for ReactPHP",
+            "keywords": [
+                "async",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/async/issues",
+                "source": "https://github.com/reactphp/async/tree/v4.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-04T14:40:02+00:00"
         },
         {
             "name": "react/event-loop",


### PR DESCRIPTION
## Summary

\`React\\Async\\await()\` is called from four runtime paths in this repo:

- \`lib/Service/ObjectService.php:81,910\`
- \`lib/Service/ImportService.php:43\`
- \`lib/Service/ExportService.php:46\`
- \`lib/Db/ObjectHandlers/HyperFacetHandler.php:495\`

but \`react/async\` is not declared in \`composer.json\`. It was only resolving transitively, which silently broke on stable31/32/33 CI installs of OpenBuilt — every seed step (SeedHelloWorld, PopulateApplicationPermissions, template lookup) threw \`Call to undefined function React\\Async\\await()\` and blocked Newman.

Declare the dep explicitly at the current major (\`^4.3\`); it requires \`react/promise: ^3\` which we already have.

## Test plan

- [ ] CI green (PHPUnit + lint + Psalm)
- [ ] OpenBuilt CI (downstream consumer) no longer raises \`React\\Async\\await\` undefined-function errors during seed
- [ ] Local \`composer install\` resolves \`react/async\` into \`vendor/react/async\`

Closes openbuilt#49.