### PR TITLE
fix(RegisterMapper): portable schema lookup, no MySQL REGEXP (closes openbuilt#50)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,6 +97,7 @@
 		"opis/json-schema": "^2.3",
 		"phpoffice/phpspreadsheet": "^5.0",
 		"phpoffice/phpword": "^1.2",
+		"react/async": "^4.3",
 		"react/event-loop": "^1.5",
 		"react/promise": "^3.2",
 		"smalot/pdfparser": "^2.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26e59fd384963cc48ffdd09b8ef0ea1c",
+    "content-hash": "ea1d60102900aa5e48680d20ba970471",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -2743,6 +2743,81 @@
                 "source": "https://github.com/ralouphie/getallheaders/tree/develop"
             },
             "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "react/async",
+            "version": "v4.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/async.git",
+                "reference": "635d50e30844a484495713e8cb8d9e079c0008a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/async/zipball/635d50e30844a484495713e8cb8d9e079c0008a5",
+                "reference": "635d50e30844a484495713e8cb8d9e079c0008a5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.8 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.10.39",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Async\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async utilities and fibers for ReactPHP",
+            "keywords": [
+                "async",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/async/issues",
+                "source": "https://github.com/reactphp/async/tree/v4.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-04T14:40:02+00:00"
         },
         {
             "name": "react/event-loop",

--- a/lib/Db/RegisterMapper.php
+++ b/lib/Db/RegisterMapper.php
@@ -776,25 +776,79 @@ class RegisterMapper extends QBMapper
      */
     public function getFirstRegisterWithSchema(int $schemaId): ?int
     {
+        // The previous implementation used MySQL's `REGEXP` operator
+        // with `[[:<:]]N[[:>:]]` word-boundary syntax. SQLite ships
+        // without REGEXP (no user function registered), so every CI
+        // run on the default sqlite quality-workflow threw
+        // "no such function: REGEXP" (openbuilt#50).
+        //
+        // Two-stage portable lookup:
+        //
+        //   1. Use a portable `LIKE` filter to narrow rows to those
+        //      whose `schemas` column TEXT happens to contain the ID
+        //      somewhere. This is a fast prefilter — produces zero
+        //      false-negatives (every real match is a substring) and
+        //      some false-positives (e.g. id 12 matching "123").
+        //   2. Decode the `schemas` JSON in PHP and check exact
+        //      membership to eliminate the false-positives.
+        //
+        // Registers are O(10s) per install, so the PHP filter cost is
+        // trivial; the prefilter keeps us from materialising the full
+        // table when most rows don't contain the digit at all.
         $qb = $this->db->getQueryBuilder();
-
-        // REGEXP: match number with optional whitespace and newlines.
-        $pattern = '[[:<:]]'.$schemaId.'[[:>:]]';
-
-        $qb->select('id')
+        $qb->select('id', 'schemas')
             ->from('openregister_registers')
-            ->where('`schemas` REGEXP :pattern')
-            ->setParameter('pattern', $pattern)
-            ->setMaxResults(1);
+            ->where(
+                $qb->expr()->like(
+                    'schemas',
+                    $qb->createNamedParameter('%'.$schemaId.'%')
+                )
+            );
 
-        $result = $qb->executeQuery()->fetchOne();
+        $candidates = $qb->executeQuery()->fetchAllAssociative();
+        $needle     = (string) $schemaId;
 
-        if ($result !== false) {
-            return (int) $result;
+        foreach ($candidates as $row) {
+            $schemas = $this->decodeSchemasField(raw: ($row['schemas'] ?? null));
+            foreach ($schemas as $candidate) {
+                if ((string) $candidate === $needle) {
+                    return (int) $row['id'];
+                }
+            }
         }
 
         return null;
     }//end getFirstRegisterWithSchema()
+
+    /**
+     * Decode the persisted `schemas` column into a flat ID list.
+     *
+     * Accepts the column's raw value (typically a JSON array) and
+     * returns the contained schema IDs. Tolerates legacy shapes
+     * (comma-separated string) and unexpected types by returning [].
+     *
+     * @param mixed $raw The raw column value
+     *
+     * @return array<int,int|string>
+     */
+    private function decodeSchemasField(mixed $raw): array
+    {
+        if (is_array($raw) === true) {
+            return $raw;
+        }
+
+        if (is_string($raw) === true && $raw !== '') {
+            $decoded = json_decode($raw, true);
+            if (is_array($decoded) === true) {
+                return $decoded;
+            }
+
+            // Legacy comma-separated fallback.
+            return array_filter(array_map('trim', explode(',', $raw)));
+        }
+
+        return [];
+    }//end decodeSchemasField()
 
     /**
      * Check if a register has a schema with a specific title


### PR DESCRIPTION
## Summary

\`RegisterMapper::getFirstRegisterWithSchema\` used MySQL's \`REGEXP\` operator with \`[[:<:]]N[[:>:]]\` word-boundary syntax. SQLite ships without REGEXP, so every CI run on the quality-workflow's default sqlite database threw \`SQLSTATE[HY000]: General error: 1 no such function: REGEXP\` and the PermissionHandler couldn't resolve register → schema membership.

## Approach

Two-stage portable lookup:

1. **Prefilter via portable LIKE** — \`schemas LIKE %{id}%\`. Fast, no false-negatives, a few false-positives (id 12 matches "123").
2. **Exact-match in PHP** — decode the \`schemas\` JSON column and check membership.

Registers are O(10s) per install, so the PHP filter cost is negligible. The prefilter keeps us from materialising the full table when most rows don't contain the digit at all.

Also extracted \`decodeSchemasField\` to tolerate the legacy comma-separated shape some older installs still have.

## Test plan

- [ ] CI green on sqlite (the failing path)
- [ ] CI green on mysql/mariadb (sanity)
- [ ] Manual: in dev container, call any code path that hits PermissionHandler — no REGEXP errors in logs
- [ ] OpenBuilt CI seed steps no longer log "no such function: REGEXP"

Closes openbuilt#50.