### PR TITLE
chore(security): require 24h cooldown on npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 1
+      include:
+        - "*"
+      exclude:
+        - "@conduction/*"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# Supply-chain hardening: reject any npm package published less than
+# 24h ago. Compromised first-party-Conduction packages are excluded via
+# Dependabot cooldown (.github/dependabot.yml); for fresh @conduction/*
+# releases, override per-install with `npm install --min-release-age=0`.
+min-release-age=1


### PR DESCRIPTION
## Summary
- `.npmrc`: add `min-release-age=1` so `npm install` rejects any package version published less than 24h ago (npm 11.5+ native; older npm silently ignores it).
- `.github/dependabot.yml`: new file with `cooldown.default-days: 1` and `@conduction/*` on the cooldown-exclude list, so first-party Conduction releases still reach this app immediately while everything else cools down for 24h.

## Why
Recent npm supply-chain attacks (shai-hulud, nx, et al.) all rely on a window between a compromised publish and detection — typically a few hours. A blanket 24h cooldown closes that window with no functional cost, and putting it on Dependabot specifically protects against the dominant vector (bot-generated bump PRs auto-merging a poisoned version).

`@conduction/*` is excluded because we publish first-party libraries (notably `@conduction/nextcloud-vue`) actively and need fresh releases to reach this app immediately.

## Release-day escape hatch
If a contributor needs to consume a freshly-published `@conduction/*` version in a transitive dep within 24h of publish, the per-install override is:
```
npm install --min-release-age=0 @conduction/pkg@x.y.z
```

## Test plan
- [ ] `npm install` still works on this branch with no version conflicts against the existing lockfile.
- [ ] Dependabot picks up the new config on next scheduled run (no manual trigger needed).