### PR TITLE
fix(tasks): align TasksProvider::create with TaskService::createTask signature (closes #1539)

### DIFF
--- a/lib/Service/Integration/BuiltinProviders/TasksProvider.php
+++ b/lib/Service/Integration/BuiltinProviders/TasksProvider.php
@@ -29,9 +29,12 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Service\Integration\BuiltinProviders;
 
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Exception\NotImplementedException;
 use OCA\OpenRegister\Exception\NoVtodoCalendarException;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
+use OCA\OpenRegister\Service\ObjectService;
 use OCA\OpenRegister\Service\TaskService;
 use OCP\IL10N;
 
@@ -48,13 +51,19 @@ class TasksProvider extends AbstractIntegrationProvider
     /**
      * Constructor.
      *
-     * @param TaskService $taskService Tasks service.
-     * @param IL10N       $l10n        Localisation.
+     * @param TaskService    $taskService    Tasks service.
+     * @param RegisterMapper $registerMapper Register lookup (slug/uuid/id → entity).
+     * @param SchemaMapper   $schemaMapper   Schema lookup (slug/uuid/id → entity).
+     * @param ObjectService  $objectService  Object lookup (for the LINK label title).
+     * @param IL10N          $l10n           Localisation.
      *
      * @return void
      */
     public function __construct(
         private TaskService $taskService,
+        private RegisterMapper $registerMapper,
+        private SchemaMapper $schemaMapper,
+        private ObjectService $objectService,
         private IL10N $l10n,
     ) {
     }//end __construct()
@@ -155,26 +164,59 @@ class TasksProvider extends AbstractIntegrationProvider
     /**
      * Create a VTODO task linked to the given OR object.
      *
+     * Accepts the per-provider `(register, schema, objectId)` triple
+     * (slugs OR ids) and a free-form payload. Resolves the register +
+     * schema entities so the task carries the int ids that
+     * `TaskService::createTask` expects, and looks up the object for the
+     * RFC 9253 LINK label. The user's default VTODO calendar is
+     * auto-discovered downstream — `payload.calendarId` is ignored.
+     *
+     * Payload keys honoured: `summary`, `description`, `priority`, `due`,
+     * `status`. Anything else is ignored.
+     *
      * @param string              $register Register slug or numeric id.
      * @param string              $schema   Schema slug or numeric id.
      * @param string              $objectId Owning object uuid.
      * @param array<string,mixed> $payload  Task payload.
      *
      * @return array<string,mixed> Created task row.
+     *
+     * @throws \RuntimeException When the register/schema can't be resolved
+     *                           or the underlying VTODO write fails.
      */
     public function create(string $register, string $schema, string $objectId, array $payload): array
     {
-        $calendarId  = (string) ($payload['calendarId'] ?? '');
-        $summary     = (string) ($payload['summary'] ?? '');
-        $description = (string) ($payload['description'] ?? '');
-        $due         = isset($payload['due']) === true ? (string) $payload['due'] : null;
-        $priority    = isset($payload['priority']) === true ? (int) $payload['priority'] : null;
+        $registerEntity = $this->registerMapper->find(id: $register);
+        $schemaEntity   = $this->schemaMapper->find(id: $schema);
 
-        // TODO(#1539): call signature mismatched against TaskService::createTask
-        // (expects int registerId, int schemaId, string objectUuid, string objectTitle, array data) —
-        // suppressing here so phpcs stays green; fix tracked in #1539.
-        // @phpcs:ignore CustomSniffs.Functions.NamedParameters
-        $task = $this->taskService->createTask($calendarId, $summary, $description, $due, $priority, $objectId);
+        // Object lookup is best-effort — the LINK label is cosmetic. A
+        // missing object still allows the task to be created with a
+        // synthetic fallback title; the linked-entity scan finds it via
+        // the X-OPENREGISTER-OBJECT uuid regardless.
+        $objectEntity = $this->objectService->find(
+            id: $objectId,
+            register: $registerEntity,
+            schema: $schemaEntity
+        );
+        $objectTitle  = $objectEntity?->getName() ?? $objectId;
+
+        $data = [
+            'summary'     => (string) ($payload['summary'] ?? ''),
+            'description' => (string) ($payload['description'] ?? ''),
+            'priority'    => isset($payload['priority']) === true ? (int) $payload['priority'] : 0,
+            'status'      => (string) ($payload['status'] ?? 'NEEDS-ACTION'),
+        ];
+        if (isset($payload['due']) === true) {
+            $data['due'] = (string) $payload['due'];
+        }
+
+        $task = $this->taskService->createTask(
+            registerId: $registerEntity->getId(),
+            schemaId: $schemaEntity->getId(),
+            objectUuid: $objectId,
+            objectTitle: $objectTitle,
+            data: $data
+        );
 
         if ($task === null) {
             throw new \RuntimeException('TaskService::createTask returned null — calendar invalid or auth failure.');

--- a/tests/Unit/Service/Integration/BuiltinProvidersMetadataTest.php
+++ b/tests/Unit/Service/Integration/BuiltinProvidersMetadataTest.php
@@ -29,6 +29,11 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Tests\Unit\Service\Integration;
 
 use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Exception\NotImplementedException;
 use OCA\OpenRegister\Service\FileService;
 use OCA\OpenRegister\Service\Integration\BuiltinProviders\AuditTrailProvider;
@@ -37,6 +42,7 @@ use OCA\OpenRegister\Service\Integration\BuiltinProviders\NotesProvider;
 use OCA\OpenRegister\Service\Integration\BuiltinProviders\TagsProvider;
 use OCA\OpenRegister\Service\Integration\BuiltinProviders\TasksProvider;
 use OCA\OpenRegister\Service\NoteService;
+use OCA\OpenRegister\Service\ObjectService;
 use OCA\OpenRegister\Service\TaskService;
 use OCP\IL10N;
 use OCP\SystemTag\ISystemTagManager;
@@ -117,10 +123,7 @@ class BuiltinProvidersMetadataTest extends TestCase
 
     public function testTasksProviderMetadata(): void
     {
-        $provider = new TasksProvider(
-            $this->createMock(TaskService::class),
-            $this->buildL10n(),
-        );
+        $provider = $this->buildTasksProvider($this->createMock(TaskService::class));
 
         $this->assertSame('tasks', $provider->getId());
         $this->assertSame('Tasks', $provider->getLabel());
@@ -130,13 +133,118 @@ class BuiltinProvidersMetadataTest extends TestCase
 
     public function testTasksProviderUpdateRejectsBadEntityId(): void
     {
-        $provider = new TasksProvider(
-            $this->createMock(TaskService::class),
-            $this->buildL10n(),
-        );
+        $provider = $this->buildTasksProvider($this->createMock(TaskService::class));
         $this->expectException(NotImplementedException::class);
         $provider->update('r', 's', 'o', 'not-a-composite', []);
     }//end testTasksProviderUpdateRejectsBadEntityId()
+
+    public function testTasksProviderCreateResolvesRegisterSchemaAndObjectTitle(): void
+    {
+        $taskService = $this->createMock(TaskService::class);
+        $registerMapper = $this->createMock(RegisterMapper::class);
+        $schemaMapper = $this->createMock(SchemaMapper::class);
+        $objectService = $this->createMock(ObjectService::class);
+
+        $register = new Register();
+        $register->setId(42);
+        $schema = new Schema();
+        $schema->setId(7);
+        $object = new ObjectEntity();
+        $object->setName('My Object');
+
+        $registerMapper->expects($this->once())->method('find')->with('my-register')->willReturn($register);
+        $schemaMapper->expects($this->once())->method('find')->with('my-schema')->willReturn($schema);
+        $objectService->expects($this->once())
+            ->method('find')
+            ->with('obj-uuid-1', [], false, $register, $schema)
+            ->willReturn($object);
+
+        $taskService->expects($this->once())
+            ->method('createTask')
+            ->with(
+                42,
+                7,
+                'obj-uuid-1',
+                'My Object',
+                [
+                    'summary'     => 'Do the thing',
+                    'description' => 'Details here',
+                    'priority'    => 5,
+                    'status'      => 'NEEDS-ACTION',
+                    'due'         => '2026-06-01T12:00:00Z',
+                ]
+            )
+            ->willReturn(['id' => 'cal/task.ics', 'summary' => 'Do the thing']);
+
+        $provider = new TasksProvider(
+            taskService: $taskService,
+            registerMapper: $registerMapper,
+            schemaMapper: $schemaMapper,
+            objectService: $objectService,
+            l10n: $this->buildL10n()
+        );
+
+        $result = $provider->create('my-register', 'my-schema', 'obj-uuid-1', [
+            'summary'     => 'Do the thing',
+            'description' => 'Details here',
+            'priority'    => 5,
+            'due'         => '2026-06-01T12:00:00Z',
+            // calendarId is intentionally ignored — TaskService auto-finds.
+            'calendarId'  => 'this-should-be-ignored',
+        ]);
+
+        $this->assertSame(['id' => 'cal/task.ics', 'summary' => 'Do the thing'], $result);
+    }//end testTasksProviderCreateResolvesRegisterSchemaAndObjectTitle()
+
+    public function testTasksProviderCreateFallsBackToObjectIdWhenObjectMissing(): void
+    {
+        $taskService = $this->createMock(TaskService::class);
+        $registerMapper = $this->createMock(RegisterMapper::class);
+        $schemaMapper = $this->createMock(SchemaMapper::class);
+        $objectService = $this->createMock(ObjectService::class);
+
+        $register = new Register();
+        $register->setId(1);
+        $schema = new Schema();
+        $schema->setId(2);
+
+        $registerMapper->method('find')->willReturn($register);
+        $schemaMapper->method('find')->willReturn($schema);
+        $objectService->method('find')->willReturn(null);
+
+        $taskService->expects($this->once())
+            ->method('createTask')
+            ->with(
+                1,
+                2,
+                'missing-uuid',
+                'missing-uuid',
+                $this->callback(static fn (array $d): bool => $d['summary'] === 'x')
+            )
+            ->willReturn(['id' => 'cal/task.ics']);
+
+        $provider = new TasksProvider(
+            taskService: $taskService,
+            registerMapper: $registerMapper,
+            schemaMapper: $schemaMapper,
+            objectService: $objectService,
+            l10n: $this->buildL10n()
+        );
+
+        $result = $provider->create('r', 's', 'missing-uuid', ['summary' => 'x']);
+        $this->assertSame(['id' => 'cal/task.ics'], $result);
+    }//end testTasksProviderCreateFallsBackToObjectIdWhenObjectMissing()
+
+    private function buildTasksProvider(TaskService $taskService): TasksProvider
+    {
+        return new TasksProvider(
+            taskService: $taskService,
+            registerMapper: $this->createMock(RegisterMapper::class),
+            schemaMapper: $this->createMock(SchemaMapper::class),
+            objectService: $this->createMock(ObjectService::class),
+            l10n: $this->buildL10n()
+        );
+    }//end buildTasksProvider()
 
     public function testTagsProviderMetadata(): void
     {


### PR DESCRIPTION
## Summary

Closes #1539. \`TasksProvider::create()\` was calling \`TaskService::createTask\` with 6 positional args of the wrong types — a latent TypeError that would have crashed any UI flow hitting the create endpoint. The phpcs cleanup in #1562 had to suppress the violation with a \`@phpcs:ignore\` + TODO pointer. This PR replaces both with a real fix.

## What changed

- **Inject \`RegisterMapper\`, \`SchemaMapper\`, \`ObjectService\`** so the provider can resolve \`(register, schema, objectId)\` triples (slugs OR ids) into the int ids \`TaskService::createTask\` expects, plus fetch the object's title for the RFC 9253 LINK label.
- **Build the \`array \$data\` shape** \`TaskService::createTask\` actually wants (\`summary\`, \`description\`, \`priority\`, \`due\`, \`status\`).
- **\`payload.calendarId\` is now ignored** — TaskService auto-discovers the user's default VTODO calendar via \`findUserCalendar()\`.
- **Removed the TODO + \`@phpcs:ignore\`**, and switched the call to named parameters per project phpcs rule.

## Behaviour notes

- **Object lookup is best-effort.** When the object can't be found the LINK label falls back to the bare uuid — the task still gets created and the linked-entity scan finds it via \`X-OPENREGISTER-OBJECT\`.
- \`RegisterMapper::find()\` / \`SchemaMapper::find()\` will throw if the identifier is genuinely unknown; that bubbles up as 5xx, which is the right signal for a malformed request.

## Tests

Added 2 unit tests in \`BuiltinProvidersMetadataTest\`:
- \`testTasksProviderCreateResolvesRegisterSchemaAndObjectTitle\` — golden path: register/schema resolved, object title looked up, full data shape forwarded to TaskService
- \`testTasksProviderCreateFallsBackToObjectIdWhenObjectMissing\` — missing-object path: title falls back to uuid, task still creates

Updated the two pre-existing tests to use a \`buildTasksProvider()\` helper that constructs with the new mocks.

## Verification

- ✅ \`composer phpcs\` on \`TasksProvider.php\` → 0 errors
- ✅ \`phpunit tests/Unit/Service/Integration\` → 101 tests, 321 assertions, 0 errors, 0 failures

## Test plan

- [ ] Manual: POST a task via the TasksProvider create endpoint against a real OR object — confirm the task is created and shows the correct LINK label in the CalDAV calendar
- [ ] Manual: POST with a non-existent register/schema → expect a clean 4xx/5xx error, not a TypeError