### PR TITLE
fix(magicmapper): remove dead circular-construction guard (closes #1564)

### DIFF
--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -293,13 +293,6 @@ class MagicMapper extends AbstractObjectMapper
     private ?bool $hasPgTrgm = null;
 
     /**
-     * Count of constructor calls.
-     *
-     * @var integer
-     */
-    private static int $constructCount = 0;
-
-    /**
      * Constructor for MagicMapper service.
      *
      * Initializes the service with required dependencies for database operations,
@@ -334,20 +327,12 @@ class MagicMapper extends AbstractObjectMapper
         private readonly SettingsService $settingsService,
         private readonly ContainerInterface $container
     ) {
-        self::$constructCount++;
-        if (self::$constructCount > 2) {
-            // Guard against the circular-construction case under
-            // investigation (#1564). When tripped the mapper is left
-            // without handlers — operations against it will fail
-            // explicitly rather than recursing infinitely.
-            $this->logger->warning(
-                '[MagicMapper] circular construction guard hit (count={count}) — handlers not initialized',
-                ['count' => self::$constructCount, 'app' => 'openregister']
-            );
-            return;
-        }
-
         // Initialize specialized handlers for modular functionality.
+        // The circular-construction guard that lived here previously (#1564)
+        // was a holdover from a March 2026 refactor; the cycles it guarded
+        // (CacheHandler→RegisterMapper→MagicMapper, SettingsService→MagicMapper)
+        // were since broken via lazy container resolution + the
+        // `objectMapper`-removed-from-SettingsService fix.
         $this->initializeHandlers();
     }//end __construct()
 

--- a/tests/Unit/Service/MagicMapperTest.php
+++ b/tests/Unit/Service/MagicMapperTest.php
@@ -215,12 +215,6 @@ class MagicMapperTest extends TestCase
         $this->mockSchema->setVersion('1.0');
         $this->mockSchema->testConfiguration = [];
 
-        // Reset static construct counter to avoid circular dependency guard.
-        $ref = new \ReflectionClass(MagicMapper::class);
-        $prop = $ref->getProperty('constructCount');
-        $prop->setAccessible(true);
-        $prop->setValue(null, 0);
-
         // Build a container mock that returns the DateTimeNormalizer when asked
         // — MagicMapper resolves it lazily from the container to construct
         // MagicBulkHandler, and the typed parameter rejects null.


### PR DESCRIPTION
## Summary

Closes #1564.

The static \`self::\$constructCount\` counter + \`> 2\` guard in \`MagicMapper::__construct\` was a March-2026 holdover from a refactor's debugging session — added in ef8ed0dc, kept across the \`file_put_contents('/tmp/or-debug.log', ...)\` debug logging that PR #1565 just removed.

The two circular-DI paths the guard was protecting against have both been broken via lazy container resolution since:
- **\`CacheHandler → RegisterMapper → MagicMapper\`** — \`CacheHandler\` and \`ICacheFactory\` are now resolved lazily inside \`initializeHandlers()\` (in-line comment at MagicMapper.php:397).
- **\`SettingsService → MagicMapper\`** — \`SettingsService\` removed \`MagicMapper\` from its constructor signature (private docblock at SettingsService.php:243 marks "REMOVED: Object mapper").

The full PHPUnit suite (12,226 tests / 25,949 assertions) is green after removing the guard — empirical proof that the cycle no longer trips in any covered path.

## What changed

- **\`lib/Db/MagicMapper.php\`** — dropped \`\$constructCount\` static + the guard branch from \`__construct()\`. Constructor now goes straight to \`\$this->initializeHandlers()\`. The bypassed-initialization branch is gone, which means the third+ MagicMapper construction will properly wire up its handlers if it ever happens (vs. silently returning a null-handler mapper).
- **\`tests/Unit/Service/MagicMapperTest.php\`** — removed the reflection block that reset the static counter between tests (it referenced a property that no longer exists).

## Verification

- ✅ \`composer phpcs\` on \`MagicMapper.php\` → 0 errors
- ✅ \`phpunit --filter MagicMapperTest\` → 29/29 pass
- ✅ \`phpunit -c phpunit-unit.xml\` (full) → 12,226 tests / 25,949 assertions / 0 errors / 0 failures

## Test plan

- [ ] CI Code Quality green (phpcs + phpunit ×2)
- [ ] After merge, monitor logs — if a circular-construction path was actually being protected in some untested production code path, we'd see crashes; given no prior bug reports referenced "MagicMapper handlers not initialized", this is unlikely.