### PR TITLE
fix(ci): wait for Apache + OpenRegister API before running Newman

### DIFF
--- a/.github/workflows/api-test-coverage.yml
+++ b/.github/workflows/api-test-coverage.yml
@@ -98,6 +98,41 @@ jobs:
           docker exec nextcloud su -s /bin/bash www-data -c "php /var/www/html/occ app:enable openregister"
           docker exec nextcloud su -s /bin/bash www-data -c "php /var/www/html/occ app:list" | grep openregister
 
+      - name: Wait for Apache + OpenRegister API to serve HTTP
+        # `occ status` only proves the DB-side install completed; Apache may
+        # still not be answering on :8080. The Newman suite runs from the
+        # host and previously hit `[errored]` on every request because the
+        # HTTP listener wasn't ready yet. Poll both the NC entry page (proves
+        # Apache is up + port-forwarded) and the OpenRegister settings
+        # endpoint (proves the app is enabled + dispatching).
+        run: |
+          # 1. Apache reachable on the host-mapped port.
+          for i in $(seq 1 60); do
+            if curl -fsS -o /dev/null -w '' http://localhost:8080/status.php; then
+              echo "✓ Apache responding on localhost:8080 (try $i)"
+              break
+            fi
+            echo "Waiting for Apache... ($i/60)"
+            sleep 2
+          done
+
+          # 2. OpenRegister API dispatching (admin GET against a stable endpoint).
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' \
+              -u admin:admin \
+              http://localhost:8080/index.php/apps/openregister/api/settings/rbac || echo "000")
+            if [ "$code" = "200" ] || [ "$code" = "401" ] || [ "$code" = "405" ]; then
+              echo "✓ OpenRegister API responding (HTTP $code, try $i)"
+              break
+            fi
+            echo "Waiting for OpenRegister API... (try $i, last HTTP=$code)"
+            sleep 2
+          done
+
+          # 3. Final sanity probe — fail fast if still down.
+          curl -fsS -u admin:admin http://localhost:8080/index.php/apps/openregister/api/settings/rbac -o /dev/null \
+            || (echo "::error::OpenRegister API still not responding after wait" && exit 1)
+
       - name: Run Newman orchestrator
         env:
           BASE_URL: http://localhost:8080


### PR DESCRIPTION
## Summary

The api-test-coverage workflow has been failing on every PR (including \`development\` itself) with every request \`[errored]\` from the very first call. Root cause: \`occ status\` returns "installed: true" as soon as the DB-side install completes, but **Apache hasn't necessarily bound :80 yet**. The host-mapped \`:8080\` then doesn't forward, so Newman's first \`PATCH http://localhost:8080/.../settings/rbac\` hits a network error.

## What changed

Added a new step between "Enable openregister app" and "Run Newman orchestrator":

\`\`\`yaml
- name: Wait for Apache + OpenRegister API to serve HTTP
\`\`\`

That step does 3 polls:

1. **Apache reachable** — \`curl -fsS http://localhost:8080/status.php\` until 200. Proves the host port-forward is wired.
2. **OpenRegister API dispatching** — \`curl -u admin:admin .../api/settings/rbac\` until 200/401/405. Proves the app is enabled and dispatching.
3. **Final sanity probe** — one more \`curl -fsS\` against the same endpoint; if still down, emit \`::error::\` and fail fast (cleaner than 100s of Newman \`[errored]\` lines).

Both polls cap at 60 attempts × 2s = 120s — plenty of headroom even on a slow runner.

## Why \`occ\` isn't enough

\`occ status\` uses the PHP CLI which talks straight to the DB. It returns "installed: true" the moment the DB tables are seeded, regardless of whether Apache has started accepting connections. The mismatch between "DB ready" and "HTTP ready" is what causes the flaky-looking failures.

## Verification

Can't fully reproduce locally without spinning up the CI compose stack, but:
- ✅ YAML is valid (\`python -c "import yaml; yaml.safe_load(...)"\`)
- ✅ Curl polls use \`-fsS\` for predictable exit codes
- ✅ The accept-list for the API probe (200/401/405) handles the case where the rbac route exists but the GET shape isn't what the suite eventually uses
- ✅ Fail-fast at the end means we get a clear "::error:: OpenRegister API still not responding" instead of 100 \`[errored]\` lines if something is genuinely broken

The real test is the next CI run on this PR.

## Test plan

- [ ] Workflow runs on this PR's push; "Wait for Apache + OpenRegister API to serve HTTP" step succeeds
- [ ] Newman orchestrator runs without the \`[errored]\` cascade
- [ ] Newman either passes (real green) or fails with actual test failures (not network errors)
- [ ] After merge, the existing red Newman runs on every open PR can be re-triggered and should pass too