### PR TITLE
fix(docs): MDX + JSX syntax errors blocking deploy

### DIFF
--- a/docs/Patterns/collaborative-editing.md
+++ b/docs/Patterns/collaborative-editing.md
@@ -108,7 +108,7 @@ User A clicks Edit                │
 |---|---|---|
 | `notify_push` unreachable | Plugin falls back to polling | Subscriptions still work, latency increases |
 | Lock POST 401/403 | `useObjectLock.acquire()` rejects with `PermissionError` | Toast: "Concurrent edits are not blocked on this schema." Edit allowed without lock. |
-| Lock POST 409/423 (conflict) | rejects with `LockConflictError` | Banner: "Locked by X until <expiry>." Edit disabled. |
+| Lock POST 409/423 (conflict) | rejects with `LockConflictError` | Banner: "Locked by X until `<expiry>`." Edit disabled. |
 | Network failure on release | `beforeunload` falls back to `navigator.sendBeacon`; OR's TTL expires the lock automatically | No UX impact. |
 | Lock holder inactive | Renew skipped while document hidden | Lock TTL elapses; on next focus, `acquire()` runs again. |
 

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -235,7 +235,7 @@ export default function Home() {
         <DetailHero
           background="cobalt"
           appId="openregister"
-          {/* status + version dropped — preset 2.10+ auto-derives from appinfo/info.xml */}
+          /* status + version dropped — preset 2.10+ auto-derives from appinfo/info.xml */
           locales="NL · EN"
           title="OpenRegister"
           tagline={TAGLINE}


### PR DESCRIPTION
Two pre-existing content bugs that surfaced now the deploy actually runs.

- collaborative-editing.md:111 — `<expiry>` placeholder in a table cell, MDX 3 parses as React component. Wrapped in backticks.
- src/pages/index.js:238 — JSX comment between props (not allowed in JSX). Switched to plain JS /* */ block comment.