### PR TITLE
chore(deps): preset lockfile 3.6.2 -> 3.7.0 (sitemap lastmod auto-applies)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openregister-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@conduction/docusaurus-preset": "^2.10.0",
+        "@conduction/docusaurus-preset": "^3.5.0",
         "@docusaurus/core": "^3.7.0",
         "@docusaurus/preset-classic": "^3.7.0",
         "@docusaurus/theme-mermaid": "^3.7.0",
@@ -1912,10 +1912,13 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-2.10.0.tgz",
-      "integrity": "sha512-YLYjKv4OmlP/XzXh9kS0/4IEV9zXldE9h1nhzb3GAVTblt+ZkYRnzvthkqm0PMD1P8Ou4tbBvTt1VgjlsjYMKg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.7.0.tgz",
+      "integrity": "sha512-AS6YyXf0NxsTNgxX101+ca0WYxCBRXiKiSpeokWYaIHSluDozsVSs3hH0iwjYZlDyA58RuQm7EydrRh+CD9Vlw==",
       "license": "EUPL-1.2",
+      "bin": {
+        "validate-ai-baseline": "bin/validate-ai-baseline.mjs"
+      },
       "peerDependencies": {
         "@docusaurus/core": "^3.0.0",
         "@docusaurus/preset-classic": "^3.0.0",
@@ -20179,9 +20182,9 @@
       "optional": true
     },
     "@conduction/docusaurus-preset": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-2.10.0.tgz",
-      "integrity": "sha512-YLYjKv4OmlP/XzXh9kS0/4IEV9zXldE9h1nhzb3GAVTblt+ZkYRnzvthkqm0PMD1P8Ou4tbBvTt1VgjlsjYMKg=="
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.7.0.tgz",
+      "integrity": "sha512-AS6YyXf0NxsTNgxX101+ca0WYxCBRXiKiSpeokWYaIHSluDozsVSs3hH0iwjYZlDyA58RuQm7EydrRh+CD9Vlw=="
     },
     "@csstools/cascade-layer-name-parser": {
       "version": "2.0.4",


### PR DESCRIPTION
Preset 3.7.0 wraps user opts.presets so DEFAULT_SITEMAP_OPTIONS deep-merges into the classic preset's sitemap config. lastmod auto-applies. Validator's lastmod check is hard-fail again.