### PR TITLE
chore(deps): preset lockfile 3.7.1 -> 3.8.0 (BreadcrumbList + TechArticle + IndexNow)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1912,9 +1912,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.7.0.tgz",
-      "integrity": "sha512-AS6YyXf0NxsTNgxX101+ca0WYxCBRXiKiSpeokWYaIHSluDozsVSs3hH0iwjYZlDyA58RuQm7EydrRh+CD9Vlw==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.8.0.tgz",
+      "integrity": "sha512-aakDh5eyzA4qMhExiU+gOCVLviB/ol8UMulFHiFKz5lKGEf5AKPR7NDuE6rnBpS5qakGyiCwgLSojP3HnBROCA==",
       "license": "EUPL-1.2",
       "bin": {
         "validate-ai-baseline": "bin/validate-ai-baseline.mjs"
@@ -20182,9 +20182,9 @@
       "optional": true
     },
     "@conduction/docusaurus-preset": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.7.0.tgz",
-      "integrity": "sha512-AS6YyXf0NxsTNgxX101+ca0WYxCBRXiKiSpeokWYaIHSluDozsVSs3hH0iwjYZlDyA58RuQm7EydrRh+CD9Vlw=="
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.8.0.tgz",
+      "integrity": "sha512-aakDh5eyzA4qMhExiU+gOCVLviB/ol8UMulFHiFKz5lKGEf5AKPR7NDuE6rnBpS5qakGyiCwgLSojP3HnBROCA=="
     },
     "@csstools/cascade-layer-name-parser": {
       "version": "2.0.4",


### PR DESCRIPTION
Preset 3.8.0 adds BreadcrumbList on marketing pages (via DetailHero), TechArticle on docs pages (via DocItem swizzle), and IndexNow plugin for Bing recrawl acceleration.