### PR TITLE
fix(docs): descriptive homepage title (#80)

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -228,7 +228,7 @@ const WIDGETS = [
 export default function Home() {
   return (
     <Layout
-      title="OpenRegister"
+      title="OpenRegister, schema-driven object store for Nextcloud"
       description="Schema-driven object store with audit trail. The data foundation underneath every Conduction workspace app."
     >
       <main className="marketing-page">


### PR DESCRIPTION
Part of the SEO epic (ConductionNL/.github#75) and closes ConductionNL/.github#80.

Replaces the bare-brand Layout title with a descriptive form so SERPs surface the keyword payload before the site-title suffix Docusaurus appends. No copy or component changes beyond the title prop.

Note: targeting `documentation` directly because the `development` branch was deleted from this repo after the most recent sync (PR #1585 merged 2026-05-19). This single PR both lands the fix and fires the deploy.