### PR TITLE
fix(docs): hand-written meta descriptions (#81)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,3 +1,8 @@
+---
+title: Installation
+description: Install OpenRegister on Nextcloud. App-store install, Docker dev setup, PostgreSQL, MariaDB and MongoDB backends with the full configuration guide.
+---
+
 # Installation Guide
 
 This guide covers all installation methods for OpenRegister, from the Nextcloud App Store to Docker development environments.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,3 +1,8 @@
+---
+title: Introduction
+description: Get started with OpenRegister, the schema-driven object store for Nextcloud. JSON Schema validation, REST and GraphQL APIs, audit logs built in.
+---
+
 # Introduction
 
 Open Register is a versatile system for creating and managing domain-specific or organizational data registers. Whether you need to build a social security database, manage client information, or create any other structured data repository, Open Register provides a storage-independent solution for managing and validating data objects.


### PR DESCRIPTION
Part of ConductionNL/.github#75 SEO epic and ConductionNL/.github#81.

Hand-written meta descriptions on the highest-traffic pages of this site (homepage + intro + install where applicable). 140-160 chars, keyword-loaded, no em-dashes per Conduction brand rules. Docusaurus auto-emits these as both `<meta name=description>` and `<meta property=og:description>`.