### PR TITLE
openspec: office-document-sanitization scaffolding

### DIFF
--- a/openspec/changes/office-document-sanitization/.openspec.yaml
+++ b/openspec/changes/office-document-sanitization/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-18

--- a/openspec/changes/office-document-sanitization/design.md
+++ b/openspec/changes/office-document-sanitization/design.md
@@ -1,0 +1,245 @@
+## Context
+
+OpenRegister's anonymisation pipeline relies on PhpWord's high-level walker to mutate text in `.docx` files. The walker handles run-level text replacement well but is structurally blind to:
+
+- **Comments** (`word/comments.xml` + inline `commentRangeStart` / `commentRangeEnd` / `commentReference` markers). PhpWord 1.3 exposes `getComments()` for read access but lacks a clean removal API.
+- **Tracked changes** (`<w:ins>` / `<w:del>` wrappers with author attributes). PhpWord does not model these as first-class objects; on round-trip write, PhpWord silently drops some — but the loss is unreliable and undocumented, and it doesn't strip the `customXml/people.xml` part that carries reviewer identities.
+- **Revision history / version markers** (`w:rsid*` attributes, document-level revision tracking elements).
+- **Document metadata** (`docProps/core.xml`, `docProps/app.xml`, `docProps/custom.xml`) — Author, Last-Modified-By, Title, Subject, Manager, Company, Keywords, custom properties. Frequently contains real human names.
+- **Person-identifying field codes** (`{AUTHOR}`, `{USERNAME}`, `{USERINITIALS}`, `{LASTSAVEDBY}`). Stored as `<w:fldSimple w:instr=" AUTHOR ">` or the multi-element `<w:fldChar>` / `<w:instrText>` form. Cached result text leaks the resolved value.
+- **Custom XML parts** (`customXml/item*.xml`) — companies use these to embed structured data via Word Content Controls. Often contains far more PII than the visible document (CRM-templated letters with full addressee records).
+- **Hyperlinks** — visible text gets walker-anonymised but the URL in `_rels/document.xml.rels` survives. URLs often carry PII (`mailto:p.jansen@…`, query strings with case numbers).
+
+OpenDocument Text (`.odt`) has analogous structures (`office:annotation`, `text:tracked-changes`, `meta.xml` fields, `text:a xlink:href` hyperlinks) and is not currently supported by the pipeline at all — `TextExtractionService` returns null for ODT, and `DocumentProcessingHandler` dispatches it to a raw-text replacer that corrupts the ZIP container.
+
+The cleanest fix is **XML-level surgery on a temp copy** of the file, ahead of the entity-anonymisation walker. PhpWord round-trip is rejected because it would either over-strip (losing styles and formatting) or under-strip (leaving orphan content-type references). Native ZIP-and-XML manipulation gives surgical control with no fidelity loss.
+
+The originals are preserved by design: the sanitiser operates on a temp file copy and returns a path to the sanitised output. The caller is responsible for placing the output wherever its convention dictates (anonymisation flow → dossier folder; future use cases → wherever they want).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A new `OfficeDocumentSanitizer` produces a sanitised derivative of a `.docx` or `.odt` input. The original file is untouched.
+- The sanitised output opens cleanly in Microsoft Word (current LTSC and 365 channels) AND LibreOffice (24.x or later) without "found unreadable content" recovery warnings.
+- The sanitiser removes / scrubs the categories enumerated in Context above: comments, tracked changes, revision history, metadata, person field codes, custom XML, hyperlinks (flatten).
+- A `SanitizationReport` value object captures per-category counts; persisted on the anonymisation log row for audit.
+- Sanitisation is invoked transparently by `DocumentProcessingHandler::anonymizeDocument` for DOCX / ODT inputs.
+- ODT (the format) is handled symmetrically with DOCX — no second-class status.
+
+**Non-Goals:**
+
+- Deeper walker traversal (tables / lists / headers / footers / footnotes / endnotes). The sister change `text-extraction-office-completeness` covers this. Sanitiser preserves these structures untouched.
+- Word "Document Inspector" feature parity. Inspector covers ink, smart tags, embedded objects, etc. — not in this change.
+- Reverse operation (un-sanitise). One-way only; original is the source of truth for the unsanitised content.
+- Encrypted document handling. Password-protected DOCX / ODT raises `SanitizationException`; caller decides fallback.
+- Sanitiser configuration knobs (per-tenant on/off, per-category toggles). v1 always-on, all categories. Configuration is a follow-up if real demand emerges.
+- Streaming / partial processing. v1 reads the whole ZIP container, mutates, writes. For 100MB+ documents this is memory-pressured; acceptable in v1 (Office docs are rarely that large in practice).
+
+## Decisions
+
+### D1. XML surgery on a temp ZIP copy (not PhpWord round-trip)
+
+Sanitiser opens the input file as a `ZipArchive`. For each XML part that needs surgery (`word/document.xml`, `word/comments*.xml`, `word/header*.xml`, `word/footer*.xml`, `word/footnotes.xml`, `word/endnotes.xml`, `docProps/*.xml`, `_rels/*.rels`, `[Content_Types].xml`, `customXml/*.xml`), it:
+
+1. Reads the part as a string.
+2. Loads into a `DOMDocument` with namespace-aware processing.
+3. Performs XPath-driven node removal / mutation.
+4. Serialises back to XML string.
+5. Writes the new string into the temp ZIP under the original part name.
+
+Parts that are removed entirely (`word/comments.xml`, `customXml/*`) are also removed from `[Content_Types].xml` (the `Override` element for that part path) AND from `_rels/document.xml.rels` (the `Relationship` element for that target).
+
+**Alternative considered:** PhpWord round-trip (read → modify object model → write). Rejected because:
+- PhpWord drops formatting and custom XML on write — unacceptable fidelity loss.
+- PhpWord has no comments / tracked-changes mutation API; surgery would still need ZIP-level access.
+- Two-pass (PhpWord then ZIP) doubles the work without clear benefit.
+
+**Alternative considered:** `phpoffice/phpword`-internal `PhpOffice\PhpWord\Writer\Word2007\Part\Document` for direct writer access. Rejected — internal API, no stable contract, regressions per PhpWord minor version.
+
+### D2. Per-format strategy pattern
+
+```php
+interface SanitizerInterface {
+    public function supports(string $mimeType): bool;
+    public function sanitize(string $sourcePath, string $destPath): SanitizationReport;
+}
+
+class DocxSanitizer implements SanitizerInterface { ... }
+class OdtSanitizer implements SanitizerInterface { ... }
+
+class OfficeDocumentSanitizer {
+    /** @var SanitizerInterface[] */ private array $strategies;
+
+    public function sanitize(int $fileId): SanitizationResult; // (path, report)
+}
+```
+
+The orchestrator resolves the input file via NC's `IRootFolder`, MIME-sniffs it, picks the strategy, runs it on a temp copy. Returns a tuple of (sanitised path, report).
+
+**Rationale:** keeping DOCX and ODT logic in separate classes avoids tangled conditionals. Adding PPTX / ODS later (out of scope here) means a new strategy class without touching existing ones.
+
+### D3. Tracked-changes resolution: accept all inserts, drop all deletions
+
+In `<w:ins>...</w:ins>`: unwrap — keep the inner runs (insertion accepted). In `<w:del>...</w:del>`: remove the whole element (deletion accepted; deleted text gone). Revision attributes (`w:rsidR`, `w:rsidRPr`, `w:rsidDel`) on runs / paragraphs / cells are stripped via attribute removal in a final XPath pass.
+
+For ODT: `text:tracked-changes` container removed. Inline `text:change-start` and `text:change-end` markers paired with their `text:change-id`: looked up in the now-removed container to determine accept vs reject. Without the container, assume "accept all visible content" — the `text:change-end` markers and their inline content are kept, `text:change` (delete markers in-text) are removed along with their referenced ranges.
+
+**Rationale:** "accept all changes" matches the user's intent ("only keep the definitive text"). Accepting deletions (keeping the deleted text) is the opposite of what an operator anonymising the document wants.
+
+**Trade-off:** if a tracked-change deletion was a valid edit (an author removed a draft sentence intentionally), accepting it as "drop" matches Word's "Accept All Changes" command — the standard Office-tool semantics. Operators familiar with Word will not be surprised.
+
+### D4. Custom XML parts: strip all
+
+Every part path matching `customXml/item*.xml` and `customXml/itemProps*.xml` is removed from the ZIP. Corresponding entries in `[Content_Types].xml` and `_rels/*.rels` are removed. In `word/document.xml`, any `<w:sdt>` element whose `<w:sdtPr><w:dataBinding ...>` references one of these parts: the `<w:sdt>` wrapper is replaced by its `<w:sdtContent>` inner content (preserving the visible text that was bound).
+
+**Rationale:** custom XML carries CRM-templated data with PII not visible in the document body. Stripping preserves the visible (already PII-bearing in body text, walker-anonymisable) while removing the hidden duplicate.
+
+**Trade-off:** content controls bound to data sources lose their binding. After sanitisation, re-saving the document in Word will not re-populate the controls from data. Acceptable: the anonymised derivative is meant to be a frozen artefact, not a re-editable template.
+
+### D5. Document metadata: sentinel replacement, not deletion
+
+For each metadata field listed in proposal § "What Changes" (`dc:creator`, `cp:lastModifiedBy`, `dc:title`, `dc:subject`, `cp:keywords`, `dc:description`, `cp:category`, `cp:contentStatus`, `Company`, `Manager`), the element's text content is replaced with the string **`DocuDesk Anonymisation`**. The element is preserved structurally — Word, LibreOffice, and downstream tools see a well-formed `<dc:creator>DocuDesk Anonymisation</dc:creator>` rather than an absent tag.
+
+Fields not in the strip list (e.g. `dcterms:created`, `dcterms:modified` timestamps) are preserved as-is; they don't carry PII.
+
+Custom doc properties under `docProps/custom.xml`: every `<property>` is preserved structurally but its inner `<vt:lpwstr>` / `<vt:lpstr>` value is replaced with the sentinel. Type-coercion concerns (a `<vt:i4>` integer property being replaced with a string) are avoided by skipping non-string-typed custom properties — they remain untouched.
+
+**Rationale (sentinel over empty):** preserving the element with a sentinel value:
+1. Tells anyone opening the document the doc was processed (audit trail in-file).
+2. Defends against Word's "fill missing metadata on save" behaviour, which would otherwise re-populate `<dc:creator>` with the current logged-in user on next save — re-leaking PII.
+3. Survives downstream tools that fail on missing-element vs empty-string mismatches.
+
+**Trade-off:** the sentinel is a tool brand ("DocuDesk Anonymisation"). Some legal teams prefer a generic "Anonymous" or "Redacted". The sentinel string is a single config value (constant on the sanitiser) and can be changed by a one-line patch later without touching the surgery logic.
+
+### D6. Person-identity field codes: drop the whole field
+
+Two OOXML forms exist:
+
+```xml
+<!-- Simple form -->
+<w:fldSimple w:instr=" AUTHOR ">
+    <w:r><w:t>Robert Zondervan</w:t></w:r>
+</w:fldSimple>
+
+<!-- Complex form -->
+<w:r><w:fldChar w:fldCharType="begin"/></w:r>
+<w:r><w:instrText> USERNAME </w:instrText></w:r>
+<w:r><w:fldChar w:fldCharType="separate"/></w:r>
+<w:r><w:t>Robert Zondervan</w:t></w:r>
+<w:r><w:fldChar w:fldCharType="end"/></w:r>
+```
+
+Sanitiser matches both forms. The instruction is normalised (case-insensitive, whitespace-stripped) and compared against the strip list: `AUTHOR`, `USERNAME`, `USERINITIALS`, `LASTSAVEDBY`. On match, the whole field (wrapper + cached result inner runs) is removed.
+
+Other fields (`DATE`, `TIME`, `PAGE`, `NUMPAGES`, `FILENAME`, `TITLE`, etc.) are preserved. `FILENAME` may leak PII if the file is named `Verklaring-Jan-Jansen.docx`, but renaming is the operator's responsibility — sanitising the document content is the scope of this change.
+
+For ODT: equivalent inline placeholders `text:author-name`, `text:author-initials`, `text:initial-creator` are removed in their entirety (no inner content needed — these have no separately-cached result, they're rendered live by the viewer).
+
+**Rationale:** dropping cached + source together prevents the walker from later encountering a bare "Robert Zondervan" text run with no field context (which would have to be detected as a PERSON entity and substituted — extra work the sanitiser obviates).
+
+### D7. Hyperlinks: flatten, drop URL + relationship
+
+For each `<w:hyperlink>` element in `document.xml` / headers / footers / footnotes:
+
+1. Note the `r:id` attribute.
+2. Replace the `<w:hyperlink>` element with its inner `<w:r>` runs (text content kept).
+3. In `_rels/document.xml.rels` (or the rels file paired with the part), remove the `<Relationship>` element with the matched `Id`.
+
+For ODT: `<text:a xlink:href="...">inner content</text:a>` is replaced with the inner content (effectively becoming a `<text:span>`). No relationship file equivalent — the URL was inline.
+
+Result: the visible link text remains and will be walker-anonymised in the entity pass. The URL is gone — no `mailto:p.jansen@…` survives.
+
+**Edge case:** internal-document anchors (`#bookmark1`, `_Toc12345`). These have no PII and arguably should be preserved as live links. v1 strips them anyway — internal anchors are uncommon in Woo/dossier correspondence. Future refinement can preserve internal anchors if a real workflow needs them.
+
+### D8. Original preservation via temp-file pipeline
+
+```php
+$temp = $this->tempManager->getTemporaryFile('.docx'); // NC's ITempManager
+copy($sourceNCFile->getStoragePath(), $temp);
+$report = $strategy->sanitize($temp, $temp); // in-place on the temp copy
+return new SanitizationResult(path: $temp, report: $report);
+```
+
+`OfficeDocumentSanitizer::sanitize($fileId)` returns the path AND the report. Caller is responsible for moving / uploading the sanitised output to its destination, and for cleaning up the temp file when done (NC's `ITempManager` auto-cleans at request end as a safety net).
+
+**Rationale:** decouples the sanitiser from the destination convention. `DocumentProcessingHandler` calls it, then runs the walker on the temp file, then writes the final anonymised output to the dossier folder per existing flow. The temp file is the working canvas.
+
+### D9. Sanitisation report shape and persistence
+
+```php
+final class SanitizationReport implements \JsonSerializable {
+    public readonly int $commentsRemoved;
+    public readonly int $trackedChangesAccepted;
+    public readonly int $trackedChangesDropped;
+    public readonly int $revisionAttributesStripped;
+    public readonly int $hyperlinksFlattened;
+    public readonly int $metadataFieldsScrubbed;
+    public readonly int $customXmlPartsDropped;
+    public readonly int $fieldCodesStripped;
+    public readonly string $sentinelApplied;
+
+    public function jsonSerialize(): array { ... }
+}
+```
+
+Persisted on `AnonymizationLog.sanitization` (new JSON column). DocuDesk reads this from the log row via the existing anonymisation-log API. Format: JSON object with the above keys; tooling can extend with new keys without migration (JSON column, additive).
+
+### D10. Validation gate: Word + LibreOffice reopen test
+
+Before any DOCX-sanitiser task is marked done, the implementer MUST:
+
+1. Take a sample `.docx` that contains comments, tracked changes, custom XML, hyperlinks, person-identity fields, and rich metadata.
+2. Run it through `DocxSanitizer`.
+3. Open the sanitised output in **Microsoft Word** (current LTSC or 365 channel).
+4. Open the sanitised output in **LibreOffice** (24.x or newer).
+5. **Required outcome:** both open without any "found unreadable content / want to recover?" warning. The visible content matches what was visible before sanitisation, minus stripped structures.
+
+Same validation gate for `.odt` with Word and LibreOffice — Word can open ODT and is the more sensitive reader.
+
+If the gate fails:
+- "Repair" warning = orphan reference somewhere. Diff `[Content_Types].xml`, `_rels/*.rels`, and the document body to find the dangling ref. Fix the surgery to update the matching index/rels file.
+- Visible content corruption = surgery went too deep. Probably an `<w:sdt>` wrapper that should have kept its `<w:sdtContent>`, or a hyperlink whose inner runs were dropped instead of preserved.
+
+Sample fixture in `tests/Fixtures/sanitization/` for repeatable validation.
+
+### D11. Logging follows ADR-005 (no PII)
+
+Per ADR-005, sanitiser logs may NOT contain comment text, tracked-change text, metadata values, custom XML content, hyperlink URLs, or any other field that could carry PII. Permitted log content: file ID, MIME type, counts (per `SanitizationReport`), strategy class name, structural error detail (e.g. "missing [Content_Types].xml entry for word/comments.xml").
+
+`SanitizationException` messages are sanitised before logging — they MAY reference part paths and OOXML / ODT element names but MUST NOT include content.
+
+## Risks / Trade-offs
+
+- **[Word "found unreadable content" warning after sanitisation]** → Mitigation per D10: validation gate against Word + LibreOffice with rich fixture; any orphan reference fixed before task close.
+- **[Custom XML data bindings break]** → Acceptable per D4; the anonymised derivative is a frozen artefact, not a re-editable template. Documented in CHANGELOG and proposal § "Out of scope".
+- **[Sentinel string brand "DocuDesk Anonymisation"]** → Single constant; legal teams can patch to "Anonymous" or any string. Surfaced in D5 as a known soft preference.
+- **[Performance on large documents (>10 MB body)]** → DOMDocument loads the whole XML into memory; for 50MB+ documents this is memory-pressured. Acceptable: real-world Woo docs are well under 10 MB. If 100MB+ workloads emerge, follow-up to streaming XMLReader/XMLWriter approach (substantially more complex; defer until needed).
+- **[Encrypted DOCX / ODT]** → Per D2 (orchestrator), `ZipArchive::open` fails on encrypted documents (returns an error code); orchestrator translates this into `SanitizationException("encrypted document — cannot sanitize")` and the caller decides UI behaviour (e.g. DocuDesk shows "Cannot anonymise an encrypted document").
+- **[Word reading sanitised file silently downgrades feature support]** → Word generally tolerates missing optional parts gracefully. If a downgrade is observed (e.g. "compatibility mode" badge), document in CHANGELOG as expected behaviour.
+- **[Internal-anchor hyperlinks stripped]** → Per D7 edge case. Documented; future refinement if needed.
+- **[Operator surprise — anonymised doc no longer has reviewer comments]** → DocuDesk surfaces the sanitisation report counts in the per-file anonymisation summary. Operator sees "12 comments removed" in the UI; informational, not a confirmation gate (since the sanitisation is non-destructive — the original is preserved).
+- **[ODT-side incomplete revision history]** → ODT's `text:tracked-changes` is the canonical store of insert/delete metadata. Removing it before resolving accept-vs-reject means insert markers become unresolvable. Mitigation: parse the container BEFORE removal, walk inline `text:change-end` and `text:change-start` markers using the parsed metadata, THEN remove the container.
+
+## Migration Plan
+
+1. Add the `sanitization` JSON column to `AnonymizationLog` (one migration; nullable; default null).
+2. Land the `SanitizerInterface`, `DocxSanitizer`, `OdtSanitizer`, `OfficeDocumentSanitizer`, `SanitizationReport`, `SanitizationException` classes.
+3. Wire `OfficeDocumentSanitizer` into `DocumentProcessingHandler::anonymizeDocument` — sanitise before walker pass for DOCX / ODT.
+4. Persist `SanitizationReport` JSON onto the anonymisation log row.
+5. Add the test fixtures and the validation gate per D10.
+6. Release. Existing anonymisation-log rows have `sanitization: null` (interpreted by DocuDesk's report renderer as "pre-sanitisation run; no data"). New anonymisations carry the populated report.
+
+**Rollback:** revert the `DocumentProcessingHandler` wiring change. Sanitiser classes become unused. JSON column on `AnonymizationLog` is benign (nullable, no required writes). Revert is per-commit clean.
+
+## Seed Data
+
+Not applicable — this change adds a service and a parser, not new OpenRegister schemas. No `_registers.json` entries required.
+
+## Open Questions
+
+- **Sentinel string choice (`DocuDesk Anonymisation` vs `Anonymous` vs configurable)** — provisional `DocuDesk Anonymisation` per Decisions D5. If a legal review wants generic, swap the constant. Configurable per-tenant is a follow-up only if multiple tenants want different sentinels.
+- **Should `text:user-defined` fields under ODT `meta.xml` be scrubbed individually or all dropped?** — provisional: scrub individually (replace each value with sentinel). All-drop would simplify but risks downstream tools that expect specific custom fields to exist.
+- **Hyperlink internal anchors (`#bookmark1`)** — provisional: strip (per D7 edge case). If operators need internal navigation preserved in anonymised derivatives, follow-up.
+- **PhpWord-DOC (legacy binary) handling** — provisional: legacy `.doc` is read-only via PhpWord-DOC reader, NOT sanitised. Confirm at apply time whether the existing pipeline accepts `.doc` for anonymisation at all (it may already 422 on unsupported input).
+- **Audit-log visibility in DocuDesk UI** — provisional: DocuDesk renders sanitisation counts as a Twig block in the grondslagen summary report. UX detail is DocuDesk-side, not specified here.

--- a/openspec/changes/office-document-sanitization/proposal.md
+++ b/openspec/changes/office-document-sanitization/proposal.md
@@ -1,0 +1,122 @@
+## Why
+
+OpenRegister's anonymisation pipeline for Word documents has a structural gap: the current `DocumentProcessingHandler::replaceWords` walker only mutates text runs it can reach via PhpWord's high-level API. It does not address the non-text structures inside `.docx` that carry author identity and stale content — comments, tracked changes, revision history, document metadata (Author, Last-Modified-By, Title, Subject), person-identifying field codes (`AUTHOR`, `USERNAME`, `LASTSAVEDBY`), custom XML data bindings, and hyperlinks. These structures regularly carry PII that bypasses entity detection AND survives the anonymisation pass. Operators publishing anonymised Woo/dossier documents have been leaking names through reviewer comments and tracked-change author attributes without realising.
+
+OpenDocument Text (`.odt`) is worse off: the file falls through `TextExtractionService::extractFile` to "unsupported" (no detection at all), and the anonymisation path dispatches to `replaceWordsInTextDocument` which does raw string replacement on the ZIP container — corrupting any `.odt` it touches.
+
+This change introduces a **document sanitiser** that runs ahead of the anonymisation walker. It produces a derivative file (originals are preserved) by performing XML-level surgery on the `.docx` / `.odt` ZIP container to:
+
+- strip comments, tracked-change markup (accepting all inserts, dropping deletions), revision history, custom XML parts;
+- replace document metadata with a sentinel value;
+- strip person-identifying field codes (wrapper + cached result);
+- flatten hyperlinks to plain text (drop URL + relationship, keep visible text).
+
+After sanitisation, the cleaned derivative is passed to the existing walker for entity detection and anonymisation. ODT is added as a supported format alongside DOCX.
+
+The sister change **`text-extraction-office-completeness`** (separate proposal) covers the deeper walker traversal (tables, lists, headers, footers, footnotes, endnotes) and ODT extraction/anonymisation paths. The two changes can land independently — this one fixes structural leakage; the next expands content coverage.
+
+## What Changes
+
+- **NEW:** Service `lib/Service/File/OfficeDocumentSanitizer.php` orchestrates format-aware sanitisation. Format detection by MIME (`application/vnd.openxmlformats-officedocument.wordprocessingml.document` for DOCX; `application/vnd.oasis.opendocument.text` for ODT) routes to a per-format sanitiser strategy.
+- **NEW:** `lib/Service/File/Sanitizer/DocxSanitizer.php` performs XML-level surgery on a copy of the input `.docx`:
+  - Removes the entire `word/comments.xml` part, `word/commentsExtended.xml`, `word/commentsIds.xml`, and `word/people.xml`; drops their entries from `[Content_Types].xml` and `word/_rels/document.xml.rels`; removes inline `<w:commentRangeStart>`, `<w:commentRangeEnd>`, `<w:commentReference>` nodes from `document.xml`, headers, footers, footnotes, endnotes.
+  - Accepts all tracked changes: in `document.xml` and all referenced parts, unwraps `<w:ins>` (keeps inner content), removes `<w:del>` (drops deleted content), strips revision attributes (`w:rsidR`, `w:rsidRPr`, `w:rsidDel`).
+  - Removes `customXml/*.xml` parts entirely; drops their content-type entries and document-level relationships. Removes the corresponding `<w:dataBinding>` and `<w:sdt>` wrappers in `document.xml` (preserving inner `<w:r>` runs so visible text is kept).
+  - Replaces `docProps/core.xml`, `docProps/app.xml`, `docProps/custom.xml` field values for `dc:creator`, `cp:lastModifiedBy`, `dc:title`, `dc:subject`, `cp:keywords`, `dc:description`, `cp:category`, `cp:contentStatus`, `Company`, `Manager` with the sentinel string `DocuDesk Anonymisation`. Unknown / extension fields are emptied.
+  - Strips person-identity field codes by matching `<w:fldSimple w:instr=" AUTHOR ">`, `USERNAME`, `USERINITIALS`, `LASTSAVEDBY` (case-insensitive, whitespace-tolerant) and the multi-element `<w:fldChar>` / `<w:instrText>` form. Removes the wrapper element and its cached result inner runs. Other field codes (`DATE`, `TIME`, `PAGE`, `NUMPAGES`, etc.) are preserved.
+  - Flattens hyperlinks: replaces every `<w:hyperlink>` element with its inner `<w:r>` runs (visible text kept), removes the relationship entry from `_rels/document.xml.rels` for the hyperlink's `r:id`.
+- **NEW:** `lib/Service/File/Sanitizer/OdtSanitizer.php` performs the equivalent XML surgery on a copy of the input `.odt`:
+  - Removes all `office:annotation` elements (comments).
+  - Removes `text:tracked-changes` container; for inline `text:change`, `text:change-start`, `text:change-end` markers: accept inserts (keep referenced content), drop deletes (remove the referenced ranges).
+  - Replaces `meta.xml` fields `dc:creator`, `meta:initial-creator`, `dc:title`, `dc:subject`, `meta:keyword`, `meta:user-defined` with sentinel / empty per the same rules as DOCX.
+  - Flattens `text:a xlink:href` hyperlinks to plain `text:span` content.
+  - Removes person-identity placeholder elements: `text:author-name`, `text:author-initials`, `text:initial-creator`.
+- **NEW:** `lib/Service/File/SanitizationReport.php` value object capturing per-run counts (comments removed, tracked-change groups accepted, hyperlinks flattened, metadata fields scrubbed, custom XML parts dropped, field codes stripped). Returned to the caller alongside the sanitised file path.
+- **NEW:** Sanitisation runs on a copy at a temp path (under Nextcloud's temp dir). The **original file is never mutated**. The caller owns the lifecycle of the sanitised output — it lands wherever the anonymisation flow places its derivative (existing `AnonymizationLog` / dossier-folder convention applies).
+- **MODIFIED:** `lib/Service/File/DocumentProcessingHandler::anonymizeDocument` calls `OfficeDocumentSanitizer::sanitize($fileId)` before the walker pass when the input MIME matches DOCX or ODT. The walker pass then operates on the sanitised derivative.
+- **MODIFIED:** `AnonymizationLog` (or the existing log record carrying anonymisation results) gains a `sanitization` JSON column holding the `SanitizationReport` payload, so operators can audit what was removed.
+- **NEW capability:** `office-document-sanitization`. Scoped to the sanitiser surface only (DOCX + ODT structural cleanup). The existing walker / detection surfaces remain covered by other changes (entity-relation-grondslagen for detection; sister change `text-extraction-office-completeness` for deeper traversal).
+- **NO new endpoints.** Sanitisation is internal to the anonymisation pipeline. The existing `POST /api/objects/{id}/anonymize` endpoint runs sanitisation transparently; no client-side change required.
+- **NO breaking change.** Documents previously anonymised without sanitisation continue to exist; new anonymisations produce sanitised derivatives. Originals are preserved in both cases (and were already preserved in the existing flow).
+
+### Pipeline shape
+
+```
+INPUT (.docx / .odt — original, in NC Files)
+    │
+    ├──► copy to /tmp/openregister-sanitize-<uuid>.<ext>
+    │
+    ├──► OfficeDocumentSanitizer (XML-surgery on the tmp copy)
+    │       • strip comments, tracked-change markup, revision history
+    │       • strip custom XML parts (and inline data-binding wrappers)
+    │       • scrub metadata → "DocuDesk Anonymisation" sentinel
+    │       • strip person-identity field codes
+    │       • flatten hyperlinks
+    │
+    ├──► cleaned derivative passed to DocumentProcessingHandler walker
+    │       • entity detection
+    │       • entity substitution
+    │
+    └──► anonymised output written to dossier folder (existing flow)
+
+ORIGINAL file: untouched, in its original location.
+TEMP copy:    deleted after the pipeline completes.
+SANITIZATION REPORT: persisted on the AnonymizationLog row.
+```
+
+### Output shape (sanitisation report)
+
+```php
+SanitizationReport {
+    commentsRemoved: 12,
+    trackedChangesAccepted: 7,     // insert groups
+    trackedChangesDropped: 3,      // delete groups
+    revisionAttributesStripped: 84,
+    hyperlinksFlattened: 4,
+    metadataFieldsScrubbed: 6,
+    customXmlPartsDropped: 1,
+    fieldCodesStripped: 2,         // AUTHOR / USERNAME / etc.
+    sentinelApplied: "DocuDesk Anonymisation",
+}
+```
+
+### Out of scope
+
+- **Deeper walker traversal** (tables / lists / headers / footers / footnotes) — handled by sister change `text-extraction-office-completeness`. This change preserves these structures untouched; the walker change extends coverage.
+- **Embedded images / drawings** — no OCR; image text is not extracted or anonymised. Out of scope.
+- **OOXML revision IDs beyond w:rsid\* attributes on runs/paragraphs** — section-level rsid attributes are preserved (they don't carry PII directly). Forensic correlation is acknowledged but not addressed.
+- **Encrypted DOCX / ODT** — password-protected files cannot be opened by the sanitiser; the pipeline raises a typed exception and the caller falls back to "refuse-to-anonymise" with an operator notice.
+- **RTF, DOC (legacy binary), PPTX, ODS, ODP** — out of scope. Sanitisation targets the XML-container Office formats only (DOCX, ODT). Legacy `.doc` continues to be extracted via existing PhpWord-DOC reader without sanitisation (its content-leakage surface is different and beyond this change).
+- **Word "Document Inspector" parity** — Microsoft's Inspector covers a wider set of structures (ink, smart tags, embedded objects). This change covers the PII-bearing subset relevant to Woo/dossier anonymisation. Future extension covers additional structures if operator workflows surface a need.
+- **Reverse operation** — sanitisation is one-way. There is no "restore comments / restore tracked changes" path. The original is preserved separately; that is the only source for the unsanitised content.
+
+## Capabilities
+
+### New Capabilities
+
+- `office-document-sanitization`: XML-level surgery on `.docx` and `.odt` files removing PII-bearing and identity-bearing structures (comments, tracked changes, revision history, person-identifying metadata, custom XML data bindings, person-identifying field codes, hyperlinks) ahead of the entity-anonymisation walker. Operates on a temp copy so the original is preserved. Produces a sanitisation report with per-category counts for audit.
+
+### Modified Capabilities
+
+(none — the sanitiser is a new surface; no existing OpenSpec capability covers `DocumentProcessingHandler` or `TextExtractionService` today.)
+
+## Impact
+
+- **Code (openregister):**
+  - `lib/Service/File/OfficeDocumentSanitizer.php` — NEW orchestrator.
+  - `lib/Service/File/Sanitizer/DocxSanitizer.php` — NEW DOCX strategy.
+  - `lib/Service/File/Sanitizer/OdtSanitizer.php` — NEW ODT strategy.
+  - `lib/Service/File/Sanitizer/SanitizerInterface.php` — NEW interface (per-format strategies implement).
+  - `lib/Service/File/SanitizationReport.php` — NEW value object.
+  - `lib/Exception/SanitizationException.php` — NEW typed exception.
+  - `lib/Service/File/DocumentProcessingHandler.php` — MODIFIED `anonymizeDocument` to call the sanitiser ahead of the walker for DOCX/ODT inputs.
+  - `lib/Db/AnonymizationLog.php` + migration — MODIFIED to add `sanitization` JSON column.
+- **API contract:** No HTTP changes. The existing `POST /api/objects/{id}/anonymize` endpoint runs sanitisation transparently. Response gains a `sanitization` object alongside the existing anonymisation result (additive, non-breaking).
+- **Cross-app:**
+  - DocuDesk's anonymisation UI gains a "Sanitisation summary" block in the per-file report. Implementation lives in DocuDesk; this OR change exposes the data.
+  - DocuDesk's `grondslagen-summary` Twig templates may render the sanitisation counts as an additional table block (operator decision; not specified here).
+  - opencatalogi / softwarecatalog: unaffected.
+- **Performance:** Adds an XML parse + serialize pass per `.docx`/`.odt` input. Typical files (<5 MB, ~100 paragraphs, <50 comments, <100 tracked changes) complete in well under a second. Large files (megabytes of body content, hundreds of comments) are bounded by the parser's linear cost. No new external services; all in-process.
+- **Privacy / compliance:** Major win — removes a class of silent PII leakage (comments, tracked-change authors, document metadata, person-identity field codes). The sanitisation report provides audit evidence per ADR-005's compliance posture.
+- **Tests:** Unit tests for `DocxSanitizer` and `OdtSanitizer` covering each strip category individually + combined. Integration test verifying Word + LibreOffice reopen the sanitised output without "found unreadable content" warnings (validation gate before claiming task done).
+- **Migration:** One migration adding the `sanitization` JSON column to the anonymisation-log table. Backfill is not required (existing rows have `null`; that's interpreted as "pre-sanitisation run").

--- a/openspec/changes/office-document-sanitization/specs/office-document-sanitization/spec.md
+++ b/openspec/changes/office-document-sanitization/specs/office-document-sanitization/spec.md
@@ -1,0 +1,376 @@
+---
+status: draft
+---
+
+# Office Document Sanitization
+
+## Purpose
+
+Defines a new sanitiser service that performs XML-level surgery on `.docx` and `.odt` files to remove PII-bearing and identity-bearing structures (comments, tracked changes, revision history, person-identifying metadata, custom XML data bindings, person-identifying field codes, hyperlinks) ahead of OpenRegister's entity-anonymisation walker. The original file is preserved — sanitisation operates on a temp copy and returns the sanitised path plus a per-category audit report.
+
+## ADDED Requirements
+
+### Requirement: `OfficeDocumentSanitizer` MUST sanitise DOCX and ODT inputs without mutating the original file
+
+The orchestrator service `OCA\OpenRegister\Service\File\OfficeDocumentSanitizer` MUST expose a `sanitize(int $fileId): SanitizationResult` method. The method MUST:
+
+- Resolve the file via `IRootFolder` (or equivalent NC file resolution).
+- Copy the file's bytes to a temporary path obtained from `ITempManager`.
+- Select a format-specific strategy (`DocxSanitizer` for DOCX MIME, `OdtSanitizer` for ODT MIME).
+- Invoke the strategy on the temp copy.
+- Return a `SanitizationResult` value object carrying the sanitised file's temp path AND the `SanitizationReport`.
+- Leave the original file (in NC Files storage) byte-identical to its pre-call state.
+
+#### Scenario: DOCX with comments and tracked changes produces a sanitised temp file
+
+- **GIVEN** a `.docx` file in NC Files containing 5 comments and 3 tracked-change groups
+- **WHEN** `OfficeDocumentSanitizer::sanitize($fileId)` is called
+- **THEN** the returned `SanitizationResult.path` points to a temp file that opens cleanly in Word and LibreOffice
+- **AND** the temp file contains 0 comments and no tracked-change markup
+- **AND** the original NC file is byte-identical to its state before the call
+- **AND** the returned `SanitizationResult.report.commentsRemoved` equals 5
+- **AND** the returned `SanitizationResult.report.trackedChangesAccepted + trackedChangesDropped` equals 3
+
+#### Scenario: ODT input dispatches to OdtSanitizer
+
+- **GIVEN** a `.odt` file in NC Files (MIME `application/vnd.oasis.opendocument.text`)
+- **WHEN** `OfficeDocumentSanitizer::sanitize($fileId)` is called
+- **THEN** the file is dispatched to `OdtSanitizer` (not `DocxSanitizer`)
+- **AND** the returned `SanitizationResult.path` points to a sanitised `.odt`
+- **AND** the file opens cleanly in LibreOffice and Microsoft Word
+
+#### Scenario: Unsupported MIME raises SanitizationException
+
+- **GIVEN** a file whose MIME is neither DOCX nor ODT (e.g. `application/pdf`)
+- **WHEN** `OfficeDocumentSanitizer::sanitize($fileId)` is called
+- **THEN** `SanitizationException` is thrown
+- **AND** the exception message identifies the unsupported MIME type
+- **AND** no temp file is created (or any created file is cleaned up before the exception propagates)
+
+### Requirement: `DocxSanitizer` MUST remove all comments and inline comment references from a `.docx`
+
+The DOCX strategy MUST remove from the ZIP container:
+
+- The parts `word/comments.xml`, `word/commentsExtended.xml`, `word/commentsIds.xml`, and `word/people.xml` if present.
+- Their entries in `[Content_Types].xml` (matching `<Override PartName="/word/comments.xml" ...>` etc.).
+- Their entries in `word/_rels/document.xml.rels` (matching the relationship whose target is the removed part).
+
+Additionally, the sanitiser MUST remove inline comment-reference nodes from `word/document.xml`, all `word/header*.xml`, all `word/footer*.xml`, `word/footnotes.xml`, and `word/endnotes.xml`:
+
+- `<w:commentRangeStart>`
+- `<w:commentRangeEnd>`
+- `<w:commentReference>`
+
+The `SanitizationReport.commentsRemoved` counter MUST equal the number of distinct comments removed (counted once per comment, not once per inline reference).
+
+#### Scenario: Sanitised DOCX has no comments part
+
+- **GIVEN** a DOCX with `word/comments.xml` containing 3 comments
+- **WHEN** `DocxSanitizer::sanitize` runs
+- **THEN** the sanitised ZIP MUST NOT contain `word/comments.xml`
+- **AND** `[Content_Types].xml` MUST NOT contain an `Override` entry for `/word/comments.xml`
+- **AND** `word/_rels/document.xml.rels` MUST NOT contain a `Relationship` whose `Target` is `comments.xml`
+- **AND** the report's `commentsRemoved` equals 3
+
+#### Scenario: Inline comment references removed from headers and footers
+
+- **GIVEN** a DOCX with a comment anchored to text inside `word/header1.xml`
+- **WHEN** sanitisation runs
+- **THEN** `word/header1.xml` in the output MUST NOT contain any `<w:commentRangeStart>`, `<w:commentRangeEnd>`, or `<w:commentReference>` elements
+- **AND** the visible header text (the runs that were inside the comment range) is preserved
+
+### Requirement: `DocxSanitizer` MUST accept all tracked changes (keep inserts, drop deletions)
+
+The sanitiser MUST process all parts in the ZIP that can contain track-change markup (`word/document.xml`, headers, footers, footnotes, endnotes, comments — though comments are removed entirely per the previous Requirement):
+
+- Every `<w:ins>...</w:ins>` element MUST be unwrapped: its inner content is preserved, the wrapper element is removed.
+- Every `<w:del>...</w:del>` element MUST be removed entirely, including its inner content.
+- Revision attributes (`w:rsidR`, `w:rsidRPr`, `w:rsidDel`, `w:rsidTr`, `w:rsidP`) on runs, paragraphs, table rows, and cells MUST be stripped.
+
+The `SanitizationReport.trackedChangesAccepted` counter MUST equal the count of `<w:ins>` groups unwrapped; `trackedChangesDropped` MUST equal the count of `<w:del>` groups removed; `revisionAttributesStripped` MUST equal the total count of revision attributes stripped.
+
+#### Scenario: Accepted insert preserves the inserted text
+
+- **GIVEN** a DOCX with a paragraph containing `<w:ins><w:r><w:t>nieuw bewijs</w:t></w:r></w:ins>`
+- **WHEN** sanitisation runs
+- **THEN** the sanitised document contains the text "nieuw bewijs" in that paragraph
+- **AND** the `<w:ins>` wrapper is gone
+- **AND** the report's `trackedChangesAccepted` is incremented by 1
+
+#### Scenario: Dropped deletion removes the deleted text
+
+- **GIVEN** a DOCX with `<w:del><w:r><w:delText>oude tekst</w:delText></w:r></w:del>` in a paragraph
+- **WHEN** sanitisation runs
+- **THEN** the text "oude tekst" MUST NOT appear in the sanitised document
+- **AND** the `<w:del>` element MUST NOT appear in the sanitised XML
+- **AND** the report's `trackedChangesDropped` is incremented by 1
+
+#### Scenario: Revision attributes stripped from runs and paragraphs
+
+- **GIVEN** a DOCX paragraph `<w:p w:rsidR="0001ABC" w:rsidP="0001DEF"><w:r w:rsidRPr="0002ABC">...</w:r></w:p>`
+- **WHEN** sanitisation runs
+- **THEN** the sanitised paragraph element MUST NOT have `w:rsidR` or `w:rsidP` attributes
+- **AND** the sanitised run element MUST NOT have `w:rsidRPr`
+- **AND** the visible content is preserved
+
+### Requirement: `DocxSanitizer` MUST strip all `customXml/*` parts and unwrap their data-bound content controls
+
+The sanitiser MUST remove every part whose path matches `customXml/item*.xml` or `customXml/itemProps*.xml` from the ZIP, along with the corresponding entries in `[Content_Types].xml` and any `_rels/*.rels` file referencing them.
+
+In `word/document.xml` and all body-bearing parts (headers, footers, footnotes, endnotes), every `<w:sdt>` element containing a `<w:sdtPr><w:dataBinding ...>` child MUST be unwrapped: the `<w:sdt>` wrapper is replaced by the children of its `<w:sdtContent>` child (visible content preserved); the `<w:sdtPr>` block is discarded.
+
+The `SanitizationReport.customXmlPartsDropped` counter MUST equal the number of custom-XML item parts removed.
+
+#### Scenario: Custom XML parts and their references are removed
+
+- **GIVEN** a DOCX with `customXml/item1.xml` and `customXml/itemProps1.xml`
+- **AND** `[Content_Types].xml` containing `Override` entries for both
+- **AND** `word/_rels/document.xml.rels` containing a relationship targeting `customXml/item1.xml`
+- **WHEN** sanitisation runs
+- **THEN** neither `customXml/item1.xml` nor `customXml/itemProps1.xml` appears in the sanitised ZIP
+- **AND** the `Override` entries for both are removed from `[Content_Types].xml`
+- **AND** the matching `Relationship` is removed from `word/_rels/document.xml.rels`
+- **AND** the report's `customXmlPartsDropped` is 1 (counting `item1.xml` as one logical part with its props)
+
+#### Scenario: Data-bound content control preserves visible text
+
+- **GIVEN** a DOCX with `<w:sdt><w:sdtPr><w:dataBinding w:xpath="/root/name" /></w:sdtPr><w:sdtContent><w:r><w:t>Jan de Vries</w:t></w:r></w:sdtContent></w:sdt>`
+- **WHEN** sanitisation runs
+- **THEN** the sanitised body contains the text "Jan de Vries" (visible content preserved)
+- **AND** the `<w:sdt>`, `<w:sdtPr>`, and `<w:sdtContent>` elements are gone (unwrapped)
+
+### Requirement: `DocxSanitizer` MUST replace document metadata fields with the sanitisation sentinel
+
+In `docProps/core.xml`, the following elements MUST have their text content replaced with the string `DocuDesk Anonymisation`:
+
+- `dc:creator`
+- `cp:lastModifiedBy`
+- `dc:title`
+- `dc:subject`
+- `cp:keywords`
+- `dc:description`
+- `cp:category`
+- `cp:contentStatus`
+
+In `docProps/app.xml`, the following elements MUST have their text content replaced with `DocuDesk Anonymisation`:
+
+- `Company`
+- `Manager`
+
+In `docProps/custom.xml`, every `<property>` whose value type is `<vt:lpwstr>` or `<vt:lpstr>` MUST have its inner string replaced with `DocuDesk Anonymisation`. Non-string-typed custom properties (`<vt:i4>`, `<vt:bool>`, `<vt:filetime>`, etc.) MUST be preserved unchanged.
+
+The element MUST be preserved structurally — Word and LibreOffice MUST see a well-formed `<dc:creator>DocuDesk Anonymisation</dc:creator>` rather than a missing element. Timestamp fields (`dcterms:created`, `dcterms:modified`) MUST be preserved unchanged (they do not carry PII).
+
+The `SanitizationReport.metadataFieldsScrubbed` counter MUST equal the count of metadata elements whose values were replaced; `SanitizationReport.sentinelApplied` MUST equal the sentinel string used.
+
+#### Scenario: Author and Title scrubbed to sentinel
+
+- **GIVEN** a DOCX with `docProps/core.xml` containing `<dc:creator>Robert Zondervan</dc:creator><dc:title>Confidentieel: Woo-verzoek 2026-017</dc:title>`
+- **WHEN** sanitisation runs
+- **THEN** `docProps/core.xml` in the sanitised ZIP contains `<dc:creator>DocuDesk Anonymisation</dc:creator>`
+- **AND** `<dc:title>DocuDesk Anonymisation</dc:title>`
+- **AND** the report's `metadataFieldsScrubbed` is at least 2
+- **AND** the report's `sentinelApplied` equals `DocuDesk Anonymisation`
+
+#### Scenario: Timestamps are preserved
+
+- **GIVEN** a DOCX with `<dcterms:created xsi:type="dcterms:W3CDTF">2025-11-20T10:14:00Z</dcterms:created>`
+- **WHEN** sanitisation runs
+- **THEN** the `<dcterms:created>` element retains its original value `2025-11-20T10:14:00Z`
+
+#### Scenario: Non-string custom property preserved
+
+- **GIVEN** a DOCX with `docProps/custom.xml` containing `<property fmtid="..." pid="2" name="DocumentVersion"><vt:i4>3</vt:i4></property>`
+- **WHEN** sanitisation runs
+- **THEN** the property's `<vt:i4>3</vt:i4>` is preserved unchanged (not replaced with a string sentinel that would break type expectations)
+
+### Requirement: `DocxSanitizer` MUST strip person-identity field codes (wrapper + cached result)
+
+The sanitiser MUST identify and remove fields whose instruction (`w:instr` attribute on `<w:fldSimple>` or `<w:instrText>` content in the multi-element form) matches any of (case-insensitive, whitespace-tolerant):
+
+- `AUTHOR`
+- `USERNAME`
+- `USERINITIALS`
+- `LASTSAVEDBY`
+
+For the simple form `<w:fldSimple w:instr=" AUTHOR ">...inner runs...</w:fldSimple>`: the entire element including inner runs MUST be removed.
+
+For the complex form (`<w:fldChar w:fldCharType="begin"/>` → `<w:instrText>` → `<w:fldChar w:fldCharType="separate"/>` → cached result runs → `<w:fldChar w:fldCharType="end"/>`): all runs from begin to end inclusive MUST be removed.
+
+Fields whose instruction matches anything OTHER than the strip list (e.g. `DATE`, `TIME`, `PAGE`, `NUMPAGES`, `FILENAME`, `TITLE`, `REF`) MUST be preserved.
+
+The `SanitizationReport.fieldCodesStripped` counter MUST equal the count of fields removed (counted by field, not by element).
+
+#### Scenario: Simple AUTHOR field is removed with its cached value
+
+- **GIVEN** a DOCX with `<w:fldSimple w:instr=" AUTHOR "><w:r><w:t>Robert Zondervan</w:t></w:r></w:fldSimple>`
+- **WHEN** sanitisation runs
+- **THEN** the text "Robert Zondervan" MUST NOT appear in the sanitised document
+- **AND** the `<w:fldSimple>` wrapper is gone
+- **AND** the report's `fieldCodesStripped` is incremented by 1
+
+#### Scenario: Complex USERNAME field is removed end-to-end
+
+- **GIVEN** a DOCX with the complex-form field sequence for `USERNAME` (begin → instrText `" USERNAME "` → separate → cached `Jane Doe` → end)
+- **WHEN** sanitisation runs
+- **THEN** all five runs of the sequence are gone
+- **AND** the text "Jane Doe" MUST NOT appear in the sanitised document
+
+#### Scenario: DATE field is preserved
+
+- **GIVEN** a DOCX with `<w:fldSimple w:instr=" DATE \@ &quot;yyyy-MM-dd&quot; "><w:r><w:t>2026-05-18</w:t></w:r></w:fldSimple>`
+- **WHEN** sanitisation runs
+- **THEN** the `<w:fldSimple>` element is preserved unchanged
+- **AND** the report's `fieldCodesStripped` is NOT incremented for this field
+
+### Requirement: `DocxSanitizer` MUST flatten hyperlinks (drop URL + relationship, keep visible text)
+
+The sanitiser MUST process every `<w:hyperlink>` element in `word/document.xml`, all `word/header*.xml`, all `word/footer*.xml`, `word/footnotes.xml`, and `word/endnotes.xml`:
+
+- The `<w:hyperlink>` element MUST be replaced by its inner `<w:r>` (run) children. Inner content is preserved.
+- If the hyperlink has an `r:id` attribute, the corresponding `<Relationship>` element MUST be removed from the rels file paired with the part (`word/_rels/document.xml.rels` for document.xml; `word/_rels/header1.xml.rels` for header1.xml; etc.).
+- Internal-anchor hyperlinks (those with `w:anchor` but no `r:id`) are still flattened — the wrapper goes, content stays. There is no rels entry to remove for internal anchors.
+
+The `SanitizationReport.hyperlinksFlattened` counter MUST equal the count of `<w:hyperlink>` elements flattened.
+
+#### Scenario: External hyperlink is flattened and its rels entry removed
+
+- **GIVEN** a DOCX with `<w:hyperlink r:id="rId7"><w:r><w:t>contact</w:t></w:r></w:hyperlink>`
+- **AND** `word/_rels/document.xml.rels` containing `<Relationship Id="rId7" Type="...hyperlink" Target="mailto:p.jansen@example.com" TargetMode="External"/>`
+- **WHEN** sanitisation runs
+- **THEN** the sanitised document contains the text "contact" (visible text preserved)
+- **AND** no `<w:hyperlink>` element remains in document.xml
+- **AND** the `Relationship` element with `Id="rId7"` MUST NOT appear in `word/_rels/document.xml.rels`
+- **AND** the report's `hyperlinksFlattened` is incremented by 1
+
+#### Scenario: Internal anchor hyperlink is flattened
+
+- **GIVEN** a DOCX with `<w:hyperlink w:anchor="_Toc12345"><w:r><w:t>Zie hoofdstuk 4</w:t></w:r></w:hyperlink>`
+- **WHEN** sanitisation runs
+- **THEN** the wrapper is gone; the text "Zie hoofdstuk 4" remains
+- **AND** the report's `hyperlinksFlattened` is incremented by 1
+
+### Requirement: `OdtSanitizer` MUST sanitise `.odt` files in parity with `DocxSanitizer`
+
+The ODT strategy MUST remove or scrub the ODT-equivalent structures inside `content.xml`, `styles.xml`, and `meta.xml`:
+
+- **Comments:** every `office:annotation` and `office:annotation-end` element removed entirely (their inline text content goes with them).
+- **Tracked changes:** the `text:tracked-changes` container in `content.xml` parsed for accept/reject mapping; then accept-all is applied — `text:change-start` and `text:change-end` markers around inserted ranges are removed but inner content kept; ranges covered by deletion markers are removed entirely. After processing, the `text:tracked-changes` container element itself is removed.
+- **Metadata:** in `meta.xml`, the elements `dc:creator`, `meta:initial-creator`, `dc:title`, `dc:subject`, `meta:keyword`, and `dc:description` have their text content replaced with `DocuDesk Anonymisation`. Every `meta:user-defined` element MUST have its text content replaced with `DocuDesk Anonymisation` unless its `meta:value-type` attribute is non-string (e.g. `boolean`, `date`, `float`), in which case the element is preserved unchanged.
+- **Hyperlinks:** every `text:a` element flattened — wrapper removed, inner content preserved.
+- **Person-identity placeholders:** every `text:author-name`, `text:author-initials`, and `text:initial-creator` element removed entirely.
+
+The same `SanitizationReport` shape MUST be produced.
+
+#### Scenario: ODT comments removed
+
+- **GIVEN** an ODT containing 4 `office:annotation` elements in `content.xml`
+- **WHEN** `OdtSanitizer::sanitize` runs
+- **THEN** the sanitised `content.xml` contains 0 `office:annotation` elements
+- **AND** the report's `commentsRemoved` equals 4
+
+#### Scenario: ODT metadata scrubbed to sentinel
+
+- **GIVEN** an ODT with `<dc:creator>S. de Vries</dc:creator><dc:title>Notitie burgemeester</dc:title>` in `meta.xml`
+- **WHEN** `OdtSanitizer::sanitize` runs
+- **THEN** the sanitised `meta.xml` contains `<dc:creator>DocuDesk Anonymisation</dc:creator>`
+- **AND** `<dc:title>DocuDesk Anonymisation</dc:title>`
+
+#### Scenario: ODT hyperlink flattened
+
+- **GIVEN** an ODT with `<text:a xlink:href="mailto:p.jansen@example.com">contact</text:a>` inside a paragraph
+- **WHEN** sanitisation runs
+- **THEN** the paragraph contains the text "contact" (preserved)
+- **AND** no `text:a` element remains
+- **AND** no `xlink:href` referencing the mailto URL is anywhere in the sanitised document
+
+#### Scenario: ODT author placeholder removed
+
+- **GIVEN** an ODT containing `<text:p>Opgesteld door <text:author-name>S. de Vries</text:author-name> op <text:date/></text:p>`
+- **WHEN** sanitisation runs
+- **THEN** the `<text:author-name>` element is gone (along with the cached "S. de Vries" content)
+- **AND** the `<text:date>` element is preserved (it's not in the strip list)
+- **AND** surrounding text "Opgesteld door" and "op" is preserved
+
+### Requirement: Sanitised output MUST open cleanly in Microsoft Word and LibreOffice
+
+For every sanitiser implementation, the output file MUST be openable in both:
+
+- Microsoft Word (Office 365 current channel OR Office LTSC current branch)
+- LibreOffice (24.x or newer)
+
+without the application displaying a "found unreadable content / want to recover?" recovery dialog. Visible content MUST match the pre-sanitisation document minus the structures listed in this spec.
+
+The validation MUST be performed against a test fixture document containing at minimum: 3 comments, 2 accepted-insert track-change groups, 2 dropped-delete track-change groups, 2 custom XML parts with bound content controls, 1 external hyperlink, 1 AUTHOR field, populated `dc:creator` and `dc:title` metadata.
+
+The validation MUST be performed before a sanitiser implementation is marked done in tasks.md.
+
+#### Scenario: Word opens the sanitised file without recovery prompt
+
+- **GIVEN** a sanitised DOCX produced from the validation fixture
+- **WHEN** the file is opened in Microsoft Word (current channel)
+- **THEN** Word displays the document normally
+- **AND** no recovery dialog appears
+- **AND** no "compatibility mode" badge appears that did not also appear on the unsanitised fixture
+
+#### Scenario: LibreOffice opens the sanitised file without recovery prompt
+
+- **GIVEN** the same sanitised DOCX
+- **WHEN** the file is opened in LibreOffice 24.x or newer
+- **THEN** LibreOffice displays the document normally
+- **AND** no recovery dialog appears
+
+### Requirement: Sanitisation report MUST be persisted on the anonymisation log
+
+After `DocumentProcessingHandler::anonymizeDocument` invokes `OfficeDocumentSanitizer::sanitize`, the resulting `SanitizationReport` (serialised as JSON) MUST be written to the `sanitization` column on the anonymisation log row that records the anonymisation operation. The column MUST be of JSON type, nullable, with `null` as the default.
+
+Anonymisations performed without sanitisation (legacy rows OR non-Office formats) MUST have `sanitization = null`. Consumers (DocuDesk's report renderer) MUST interpret `null` as "no sanitisation data; pre-sanitisation run or non-applicable format" and MUST NOT raise an error.
+
+#### Scenario: Office anonymisation populates the sanitization column
+
+- **GIVEN** a DOCX file is anonymised via `POST /api/objects/{id}/anonymize`
+- **WHEN** the request completes successfully
+- **THEN** the corresponding `AnonymizationLog` row's `sanitization` column contains a JSON object with the keys: `commentsRemoved`, `trackedChangesAccepted`, `trackedChangesDropped`, `revisionAttributesStripped`, `hyperlinksFlattened`, `metadataFieldsScrubbed`, `customXmlPartsDropped`, `fieldCodesStripped`, `sentinelApplied`
+
+#### Scenario: PDF anonymisation leaves sanitization column null
+
+- **GIVEN** a PDF file is anonymised
+- **WHEN** the operation completes
+- **THEN** the `sanitization` column on the resulting log row is `null` (sanitisation does not apply to PDF in this change)
+
+### Requirement: Sanitiser logs MUST NOT contain PII (ADR-005)
+
+Per ADR-005, sanitiser log lines, exception messages, and debug output MUST NOT include:
+
+- Comment text content
+- Tracked-change text content (inserted or deleted)
+- Metadata field values (Author, Title, Subject, etc. — pre-sanitisation values)
+- Custom XML content
+- Hyperlink URLs or display text
+- Field-code cached result values
+
+Permitted log content is restricted to: the Nextcloud file ID, the MIME type, the strategy class name, the per-category counts from `SanitizationReport`, and structural error details (e.g. "missing [Content_Types].xml entry for word/comments.xml", "ZipArchive::open returned error code 19").
+
+`SanitizationException` messages MUST follow the same constraint — they MAY reference part paths and OOXML / ODT element names, but MUST NOT include content.
+
+#### Scenario: Sanitiser failure log contains no document content
+
+- **GIVEN** a DOCX with `dc:creator: Robert Zondervan` and a comment "Bespreken met Jan op vrijdag"
+- **AND** the sanitiser fails partway with an internal exception
+- **WHEN** the failure is logged
+- **THEN** the log entry MUST NOT contain "Robert Zondervan", "Bespreken", or "Jan"
+- **AND** the log entry MUST contain at most: the file ID, the MIME type, the strategy class name, the exception class name, and the structural detail
+
+### Requirement: Encrypted DOCX / ODT MUST raise `SanitizationException`
+
+Password-protected or otherwise encrypted DOCX / ODT files cannot be sanitised. When `ZipArchive::open` or its equivalent returns an error indicating encryption, the orchestrator MUST throw `SanitizationException` with a typed reason (e.g. enum value or message identifying "encrypted document"). The exception MUST be catchable by `DocumentProcessingHandler::anonymizeDocument` so the caller can produce an operator-facing error rather than crashing.
+
+The exception MUST NOT contain the file's contents or filename in its message (per ADR-005).
+
+#### Scenario: Encrypted DOCX raises SanitizationException
+
+- **GIVEN** a password-protected `.docx` file in NC Files
+- **WHEN** `OfficeDocumentSanitizer::sanitize($fileId)` is called
+- **THEN** `SanitizationException` is thrown
+- **AND** the exception's reason or message identifies the cause as encryption (NOT the filename or content)
+- **AND** no temp file lingers after the exception propagates (or the orchestrator has cleaned it up)

--- a/openspec/changes/office-document-sanitization/tasks.md
+++ b/openspec/changes/office-document-sanitization/tasks.md
@@ -1,0 +1,163 @@
+## 1. Value objects and exception
+
+- [ ] 1.1 Create `lib/Service/File/SanitizationReport.php` — immutable value object with readonly properties: `commentsRemoved: int`, `trackedChangesAccepted: int`, `trackedChangesDropped: int`, `revisionAttributesStripped: int`, `hyperlinksFlattened: int`, `metadataFieldsScrubbed: int`, `customXmlPartsDropped: int`, `fieldCodesStripped: int`, `sentinelApplied: string`. Implement `JsonSerializable` returning the keys in the same order.
+- [ ] 1.2 Create `lib/Service/File/SanitizationResult.php` — value object with `path: string` (sanitised temp file) and `report: SanitizationReport`.
+- [ ] 1.3 Create `lib/Exception/SanitizationException.php` extending `\Exception`. Add a public-readonly `reason: string` field (`unsupported-mime` | `encrypted` | `corrupt-zip` | `internal`) for typed catch-handling. Exception messages MUST NOT include filename or content (ADR-005); only the reason code and structural detail.
+- [ ] 1.4 Create the `SentinelStrings` constant holder (or place constants directly on `OfficeDocumentSanitizer`): `SENTINEL = 'DocuDesk Anonymisation'`. Document via a code comment that this is intentionally a tool brand (per design D5).
+
+## 2. Strategy interface and orchestrator
+
+- [ ] 2.1 Create `lib/Service/File/Sanitizer/SanitizerInterface.php`:
+  ```php
+  interface SanitizerInterface {
+      public function supports(string $mimeType): bool;
+      public function sanitize(string $sourcePath, string $destPath): SanitizationReport;
+  }
+  ```
+- [ ] 2.2 Create `lib/Service/File/OfficeDocumentSanitizer.php` — orchestrator. Constructor: `IRootFolder $rootFolder, ITempManager $tempManager, LoggerInterface $logger, SanitizerInterface[] $strategies` (DI-injected list of strategies).
+- [ ] 2.3 Implement `OfficeDocumentSanitizer::sanitize(int $fileId): SanitizationResult`:
+    1. Resolve `$file = $this->rootFolder->getById($fileId)[0]` (with empty-result check → throw `SanitizationException` reason `unsupported-mime`).
+    2. Read `$mimeType = $file->getMimeType()`.
+    3. Find a matching strategy via `$strategy->supports($mimeType)` → first match wins; no match throws `SanitizationException` reason `unsupported-mime`.
+    4. Allocate a temp file via `$tempManager->getTemporaryFile($extensionForMime)`.
+    5. `copy($file->fopen('r'), $tempPath)` (or NC equivalent — `fopen → stream_copy_to_stream`).
+    6. Call `$report = $strategy->sanitize($tempPath, $tempPath)`.
+    7. Log a single info-level line with `fileId`, `mimeType`, `strategy class`, and the counts (ADR-005 compliant — counts only, no content).
+    8. Return `new SanitizationResult($tempPath, $report)`.
+
+## 3. DocxSanitizer implementation
+
+- [ ] 3.1 Create `lib/Service/File/Sanitizer/DocxSanitizer.php` implementing `SanitizerInterface`. `supports()` matches `application/vnd.openxmlformats-officedocument.wordprocessingml.document`.
+- [ ] 3.2 Implement `sanitize($sourcePath, $destPath)` using `ZipArchive`. If source != dest, copy first. Open with `ZipArchive::open($destPath, ZipArchive::RDONLY)` — read all part names; then re-open writeable. On open failure code matching encryption (`ZipArchive::ER_NOZIP`, `ZipArchive::ER_INVAL` paired with detected encryption magic bytes), throw `SanitizationException` reason `encrypted`.
+- [ ] 3.3 **Comment removal** — implement helper `removeComments(ZipArchive $zip, SanitizationReport $report): void`:
+    - Read `word/comments.xml`; count distinct `<w:comment w:id="...">` elements; record count.
+    - Delete `word/comments.xml`, `word/commentsExtended.xml`, `word/commentsIds.xml`, `word/people.xml` from the zip.
+    - Parse `[Content_Types].xml`; remove `<Override PartName="/word/comments.xml" .../>` (and the three sibling parts).
+    - Parse `word/_rels/document.xml.rels`; remove `<Relationship>` entries whose `Target` is any of `comments.xml`, `commentsExtended.xml`, `commentsIds.xml`, `people.xml`.
+    - For each XML part `word/document.xml`, `word/header*.xml`, `word/footer*.xml`, `word/footnotes.xml`, `word/endnotes.xml`: load as `DOMDocument`; XPath remove `//w:commentRangeStart`, `//w:commentRangeEnd`, `//w:commentReference`; serialise back.
+- [ ] 3.4 **Tracked-change resolution** — implement helper `acceptTrackedChanges(ZipArchive $zip, SanitizationReport $report): void`:
+    - For each XML body-bearing part: load as DOMDocument; for each `<w:ins>` element, replace it with its child nodes (unwrap); for each `<w:del>` element, remove it entirely. Increment `trackedChangesAccepted` per ins, `trackedChangesDropped` per del.
+    - Final attribute-strip pass: walk all elements; remove attributes `w:rsidR`, `w:rsidRPr`, `w:rsidDel`, `w:rsidTr`, `w:rsidP`. Increment `revisionAttributesStripped` per attribute removed.
+- [ ] 3.5 **Custom XML strip** — implement helper `stripCustomXml(ZipArchive $zip, SanitizationReport $report): void`:
+    - Enumerate all part paths matching regex `^customXml/item\d*\.xml$` or `^customXml/itemProps\d*\.xml$`. Count logical parts (one per `item<n>.xml`).
+    - Delete the matching parts from the zip.
+    - Remove their `<Override>` entries from `[Content_Types].xml`.
+    - Remove `<Relationship>` entries in `word/_rels/document.xml.rels` targeting `customXml/*`.
+    - For each body-bearing XML part: find `<w:sdt>` elements with a `<w:sdtPr>/<w:dataBinding>` descendant; replace each `<w:sdt>` with the child nodes of its `<w:sdtContent>` (unwrap-preserving-visible-content).
+- [ ] 3.6 **Metadata scrub** — implement helper `scrubMetadata(ZipArchive $zip, SanitizationReport $report): void`:
+    - Parse `docProps/core.xml`; for each of `dc:creator`, `cp:lastModifiedBy`, `dc:title`, `dc:subject`, `cp:keywords`, `dc:description`, `cp:category`, `cp:contentStatus`: if the element exists with non-empty content, replace its text content with the sentinel and increment `metadataFieldsScrubbed`.
+    - Parse `docProps/app.xml`; same treatment for `Company`, `Manager`.
+    - Parse `docProps/custom.xml` (if present); for each `<property>` containing `<vt:lpwstr>` or `<vt:lpstr>`, replace the inner string with sentinel and increment counter. Skip non-string-typed properties (`<vt:i4>`, `<vt:bool>`, etc.) — leave unchanged.
+    - Set `SanitizationReport.sentinelApplied = OfficeDocumentSanitizer::SENTINEL`.
+- [ ] 3.7 **Field-code strip** — implement helper `stripFieldCodes(ZipArchive $zip, SanitizationReport $report): void`:
+    - Strip-list = `['AUTHOR', 'USERNAME', 'USERINITIALS', 'LASTSAVEDBY']` (case-insensitive comparison).
+    - For each body-bearing XML part: load DOMDocument.
+    - Simple form: XPath `//w:fldSimple[@w:instr]`. For each, normalise `w:instr` attribute (trim, uppercase, strip backslash-flags after the field name). If the field name is in the strip list, remove the element. Increment `fieldCodesStripped`.
+    - Complex form: walk children of paragraphs sequentially. Find `<w:r>` containing `<w:fldChar w:fldCharType="begin"/>`. Read forward until the next `<w:fldChar w:fldCharType="separate"/>`, collecting any `<w:instrText>` content. Normalise the collected instruction. If it's in the strip list, remove all runs from begin through the matching `end` fldChar (inclusive). Increment counter once per field.
+- [ ] 3.8 **Hyperlink flatten** — implement helper `flattenHyperlinks(ZipArchive $zip, SanitizationReport $report): void`:
+    - For each body-bearing XML part: load DOMDocument.
+    - For each `<w:hyperlink>` element: read `r:id` (if any). Replace the element with its `<w:r>` children. Increment counter.
+    - Collect the set of `r:id` values seen.
+    - Open the rels file paired with the part (`word/_rels/<part>.rels`); remove `<Relationship>` entries whose `Id` is in the collected set AND whose `Type` ends with `/hyperlink`.
+- [ ] 3.9 Orchestrate: in `sanitize()`, call helpers in order: comments → tracked-changes → custom-xml → metadata → field-codes → hyperlinks. Each writes back to the zip via `ZipArchive::addFromString` (replacing the part). `ZipArchive::close()` commits.
+- [ ] 3.10 Return the populated `SanitizationReport`.
+
+## 4. OdtSanitizer implementation
+
+- [ ] 4.1 Create `lib/Service/File/Sanitizer/OdtSanitizer.php` implementing `SanitizerInterface`. `supports()` matches `application/vnd.oasis.opendocument.text`.
+- [ ] 4.2 Open the ODT zip via `ZipArchive`. ODT zip-encryption detection: `ZipArchive::open` returns specific error codes for encrypted entries; throw `SanitizationException` reason `encrypted`.
+- [ ] 4.3 **Comment removal** — load `content.xml` as DOMDocument. XPath remove `//office:annotation` and `//office:annotation-end`. Increment `commentsRemoved` per `office:annotation` removed.
+- [ ] 4.4 **Tracked-change resolution** — locate the `text:tracked-changes` container in `content.xml`. Parse the contained `text:changed-region` entries to build an accept/reject map by `text:id`. Then walk `content.xml`:
+    - `text:change-start` + matching `text:change-end` around an inserted range: remove the start/end markers only; keep the content between them. Increment `trackedChangesAccepted`.
+    - `text:change` (delete marker — used for deleted ranges that are not rendered in the current view): the marker references a `text:id`; look up the changed-region's content via `text:deletion`; remove the marker AND any inline rendering of the deleted text. Increment `trackedChangesDropped`.
+    - Remove the `text:tracked-changes` container element itself after processing.
+- [ ] 4.5 **Metadata scrub** — load `meta.xml`. For each of `dc:creator`, `meta:initial-creator`, `dc:title`, `dc:subject`, `meta:keyword`, `dc:description`: replace text content with sentinel; increment counter.
+    - For each `meta:user-defined` element: if `meta:value-type` attribute is absent OR equals `string`, replace text content with sentinel; increment counter. Otherwise preserve unchanged.
+- [ ] 4.6 **Hyperlink flatten** — XPath `//text:a` in `content.xml`. For each, replace with its child nodes (text + spans). Increment counter. (No rels file equivalent — the href was inline.)
+- [ ] 4.7 **Person-identity placeholder removal** — XPath remove `//text:author-name`, `//text:author-initials`, `//text:initial-creator` in `content.xml`. Increment `fieldCodesStripped` per element removed (re-using the DOCX counter; ODT terminology is "placeholder" but the report key stays uniform).
+- [ ] 4.8 Set `sentinelApplied`; close the zip; return report.
+
+## 5. AnonymizationLog persistence
+
+- [ ] 5.1 Add migration `lib/Migration/VersionXXXXXX/AddSanitizationColumn.php` adding a `sanitization` JSON column (nullable, default null) to the anonymisation log table.
+- [ ] 5.2 Update `lib/Db/AnonymizationLog.php` (or whatever the equivalent entity class is named in the current code) to add a `sanitization: ?array` property, getter, setter, and `setSanitization($report->jsonSerialize())` integration.
+- [ ] 5.3 If the project uses a mapper-based persistence pattern for this log, update the mapper to (a) read JSON column → array, (b) write array → JSON column. If the JSON-column adapter is already generic, no mapper change.
+
+## 6. DocumentProcessingHandler integration
+
+- [ ] 6.1 In `lib/Service/File/DocumentProcessingHandler.php::anonymizeDocument`, after the file is resolved and before the walker pass:
+    - Read `$mimeType = $file->getMimeType()`.
+    - If `OfficeDocumentSanitizer::isSanitizable($mimeType)` (a public helper that mirrors strategy `supports()` across all strategies): call `$result = $this->sanitizer->sanitize($fileId)`. Catch `SanitizationException`:
+        - `reason: encrypted` → translate to an `AnonymizationException` ("cannot anonymise encrypted document"); abort.
+        - other reasons → log and rethrow.
+    - Use `$result->path` as the working file for the rest of the pipeline (walker pass).
+    - Persist `$result->report->jsonSerialize()` onto the AnonymizationLog row created for this anonymisation.
+- [ ] 6.2 For non-Office MIMEs (PDF, plain text, etc.), the existing pipeline runs unchanged. The `sanitization` column stays null.
+- [ ] 6.3 Lifecycle: after the walker writes the anonymised output to its destination, the temp file from `SanitizationResult.path` is no longer needed. `ITempManager` auto-cleans at request end; explicit `unlink` not required.
+
+## 7. DI wiring
+
+- [ ] 7.1 Register `OfficeDocumentSanitizer` in `lib/AppInfo/Application.php` (or wherever DI is configured for services). Register `DocxSanitizer` and `OdtSanitizer` as factories that produce instances; bind them as the `$strategies` array on `OfficeDocumentSanitizer` constructor.
+- [ ] 7.2 Inject `OfficeDocumentSanitizer` into `DocumentProcessingHandler` constructor.
+
+## 8. Test fixtures
+
+- [ ] 8.1 Create `tests/Fixtures/sanitization/sample.docx` containing: 3 comments, 2 accepted-insert tracked-change groups, 2 dropped-delete tracked-change groups, 1 `customXml/item1.xml` with a bound `<w:sdt>`, 1 external hyperlink with rels entry, 1 internal-anchor hyperlink, 1 simple-form AUTHOR field, 1 complex-form USERNAME field, populated metadata (`dc:creator`, `dc:title`, `dc:subject`, `cp:keywords`).
+- [ ] 8.2 Create `tests/Fixtures/sanitization/sample.odt` containing the ODT equivalent: 3 `office:annotation` elements, tracked-changes with both accepts and deletes, populated `meta.xml`, 1 `text:a` hyperlink, 1 `text:author-name` placeholder.
+
+## 9. Unit tests
+
+- [ ] 9.1 `tests/unit/Service/File/Sanitizer/DocxSanitizerTest.php` — cover each Requirement / Scenario from the spec:
+    - Comments removed from comments part, content-types, rels, and inline references.
+    - Inserts accepted (inner content preserved); deletes dropped.
+    - Revision attributes stripped from runs / paragraphs.
+    - Custom XML parts removed; data-bound sdt unwrapped preserving visible content.
+    - Metadata scrubbed to sentinel; timestamps preserved; non-string custom properties preserved.
+    - AUTHOR / USERNAME / USERINITIALS / LASTSAVEDBY fields stripped (both forms); DATE preserved.
+    - Hyperlinks flattened; rels entry removed; internal anchor flattened with no rels entry to remove.
+    - Each counter on `SanitizationReport` matches the fixture's expected counts.
+    - Encrypted DOCX raises `SanitizationException` reason `encrypted`.
+- [ ] 9.2 `tests/unit/Service/File/Sanitizer/OdtSanitizerTest.php` — cover Requirements / Scenarios for ODT.
+- [ ] 9.3 `tests/unit/Service/File/OfficeDocumentSanitizerTest.php` — orchestrator: dispatch to correct strategy per MIME; unsupported MIME raises; original file in NC Files is byte-identical post-call (using a mock IRootFolder).
+- [ ] 9.4 `tests/unit/Service/File/SanitizationReportTest.php` — `jsonSerialize()` produces the expected key set.
+- [ ] 9.5 PII-redacted logging test: induce a sanitiser failure mid-process; capture the log line; assert no document content appears in it (only file ID, MIME, strategy, exception class, structural detail).
+
+## 10. Integration tests
+
+- [ ] 10.1 `tests/integration/.../DocumentProcessingHandlerSanitizationTest.php` — upload `tests/Fixtures/sanitization/sample.docx` to NC Files via a test helper; trigger anonymisation via the existing entry point; assert:
+    - The anonymised output is written.
+    - The original NC file is byte-identical to the pre-call state.
+    - The AnonymizationLog row for this run has the `sanitization` column populated with non-null JSON containing all expected counters.
+- [ ] 10.2 Same flow for `sample.odt`.
+- [ ] 10.3 Integration test for the non-Office path: upload a PDF; trigger anonymisation; verify `sanitization` column is null.
+
+## 11. Manual validation gate (BLOCKING)
+
+- [ ] 11.1 Take `tests/Fixtures/sanitization/sample.docx`. Run it through `DocxSanitizer` via a small CLI script or PHPUnit invocation. Save the output to disk.
+- [ ] 11.2 Open the output in **Microsoft Word** (current channel — Office 365 current OR LTSC current). Required: opens without "found unreadable content / want to recover?" dialog. Visible content matches pre-sanitisation minus stripped structures.
+- [ ] 11.3 Open the same output in **LibreOffice** (24.x or newer). Required: opens without recovery dialog.
+- [ ] 11.4 Take `tests/Fixtures/sanitization/sample.odt`. Same drill: run through `OdtSanitizer`, open in LibreOffice AND Word (Word reads ODT but is the more sensitive reader). Required: both open cleanly.
+- [ ] 11.5 Record the validation pass in the PR description (Word version, LibreOffice version, screenshots if practical). Do NOT mark tasks 3 / 4 done until this gate passes.
+
+## 12. DocuDesk surface (cross-app coordination)
+
+- [ ] 12.1 No DocuDesk-side code change is part of THIS change. The sanitisation data lands on the AnonymizationLog row and is exposed via the existing log-fetch API (`GET /api/objects/{id}/anonymization-log` or equivalent). DocuDesk's grondslagen-summary renderer can pick it up in a follow-up.
+- [ ] 12.2 Open a tracking issue in DocuDesk for the operator-facing summary block ("Sanitisation summary: 12 comments removed, 7 tracked-change groups accepted, …"). Reference this OR change.
+
+## 13. Documentation
+
+- [ ] 13.1 Extend `docs/features.md` (or the equivalent file documenting anonymisation features) with a "Document sanitisation" subsection: what it strips, when it runs, where the audit report lives. Reference design.md decisions D5 (sentinel) and D7 (hyperlink flatten).
+- [ ] 13.2 Add CHANGELOG entry under "Added": Office document sanitiser (DOCX + ODT) — strips comments, tracked changes, revision history, person metadata, custom XML, person field codes; flattens hyperlinks. Runs automatically as part of anonymisation. Audit report persisted on AnonymizationLog.
+- [ ] 13.3 Add CHANGELOG entry under "Behavior changes": Anonymisation of Office documents now produces a sanitised derivative; reviewer comments and tracked-change author metadata are removed from the output. Original files are preserved unchanged.
+
+## 14. Quality and verification
+
+- [ ] 14.1 `composer check:strict` clean (lint, phpcs, phpmd, psalm, phpstan, tests).
+- [ ] 14.2 `openspec validate office-document-sanitization` clean.
+- [ ] 14.3 Manual smoke against the dev stack: upload a `.docx` with comments + tracked changes via NC Files; trigger anonymisation; inspect the resulting file in Word/LibreOffice; inspect the AnonymizationLog row in the DB.
+- [ ] 14.4 PHPCS / Conduction custom rules — named parameters where required (per Conduction's custom PHPCS sniff). All new code passes without suppressions.
+
+## 15. Cross-app spec maintenance
+
+- [ ] 15.1 Update the new spec `openspec/specs/office-document-sanitization/spec.md` (created on apply) — already lists this change. No other spec touch.
+- [ ] 15.2 Confirm no other existing spec mentions "anonymisation" in a way that needs an OpenSpec changes-list update. If the `entity-relation-grondslagen` spec references "document sanitisation" pre-emptively, add this change to its references; otherwise leave alone.


### PR DESCRIPTION
## Summary

- Scaffolds the openspec change `office-document-sanitization` — XML-level sanitiser that runs ahead of entity anonymisation on `.docx` and `.odt` inputs.
- Strips identity-bearing structures (comments, tracked changes, revision history, document metadata, person-identifying field codes, custom XML data bindings); flattens hyperlinks.
- Original file preserved (sanitiser operates on a temp copy); produces a `SanitizationReport` value object for audit, persisted on `AnonymizationLog.sanitization` (new JSON column).

## What's in this PR

Pure openspec scaffolding — no implementation code yet. Four artifacts:

- `proposal.md` — why / what changes / capability / impact
- `design.md` — 11 decisions including XML-surgery rationale (D1), per-format strategy (D2), tracked-change accept-all semantics (D3), custom XML strip rationale (D4), metadata sentinel `"DocuDesk Anonymisation"` (D5), person-field-code handling (D6), hyperlink flatten (D7), temp-file pipeline (D8), report shape (D9), and the BLOCKING Word + LibreOffice reopen validation gate (D10)
- `specs/office-document-sanitization/spec.md` — 11 ADDED Requirements with scenarios covering all the above + ADR-005 logging compliance and encrypted-document handling
- `tasks.md` — 15 sections from value objects through DI wiring, fixtures, unit + integration tests, the manual validation gate (BLOCKING), docs, and spec maintenance

`openspec validate office-document-sanitization` — clean.

## Why now

This is part of the "anonimiseren bij de bron" arc. Current `DocumentProcessingHandler` anonymises text in body paragraphs but leaves comments, tracked-change authors, document metadata, and custom XML data bindings — every one of which can carry PII that survives the operation. This change closes that gap before the deeper walker (sister change) extends content coverage.

## Composition

This change pairs with sister `text-extraction-office-completeness` (separate PR). Sanitiser strips wrappers; walker traverses content. Both target DOCX + ODT. Sanitiser is correctness-fix; walker is coverage-expansion. They can land independently.

## Status

Ready for team review. No implementation work has started — `/opsx:apply` runs only after this PR merges.

## Test plan

- [ ] Review artifact set for completeness vs. the discovered scope
- [ ] Validate design.md decisions D1-D10 align with team conventions
- [ ] Confirm capability name `office-document-sanitization` is acceptable
- [ ] Confirm sentinel value `"DocuDesk Anonymisation"` (D5) is acceptable, or propose alternative