### PR TITLE
chore: sync canonical root configs + mechanical phpmd cleanup

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -213,10 +213,32 @@ use OCA\OpenRegister\Service\Configuration\UploadHandler as ConfigurationUploadH
 use OCA\OpenRegister\Service\LanguageService;
 use OCA\OpenRegister\Middleware\LanguageMiddleware;
 use OCA\OpenRegister\Capabilities\UrnCapability;
+use OCA\OpenRegister\Capabilities\IntegrationsCapability;
+use OCA\OpenRegister\Controller\IntegrationsController;
+use OCA\OpenRegister\Controller\ObjectIntegrationsController;
 use OCA\OpenRegister\Mcp\IMcpToolProvider;
 use OCA\OpenRegister\Mcp\BuiltIn\RegistersToolProvider;
 use OCA\OpenRegister\Mcp\BuiltIn\SchemasToolProvider;
 use OCA\OpenRegister\Mcp\BuiltIn\ObjectsToolProvider;
+use OCA\OpenRegister\Repair\LogDanglingLinkedTypes;
+use OCA\OpenRegister\Service\Integration\BuiltinProviders\AuditTrailProvider;
+use OCA\OpenRegister\Service\Integration\BuiltinProviders\FilesProvider;
+use OCA\OpenRegister\Service\Integration\BuiltinProviders\NotesProvider;
+use OCA\OpenRegister\Service\Integration\BuiltinProviders\TagsProvider;
+use OCA\OpenRegister\Service\Integration\BuiltinProviders\TasksProvider;
+use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
+use OCA\OpenRegister\Service\Integration\IntegrationRegistry;
+use OCA\OpenRegister\Service\Integration\PropertyReferenceTypeValidator;
+use OCA\OpenRegister\Service\Integration\Providers\BookmarksProvider;
+use OCA\OpenRegister\Service\Integration\Providers\CalendarProvider;
+use OCA\OpenRegister\Service\Integration\Providers\ContactsProvider;
+use OCA\OpenRegister\Service\Integration\Providers\DeckProvider;
+use OCA\OpenRegister\Service\Integration\Providers\EmailProvider;
+use OCA\OpenRegister\Service\Integration\Providers\OpenProjectProvider;
+use OCA\OpenRegister\Service\Integration\Providers\PollsProvider;
+use OCA\OpenRegister\Service\Integration\Providers\SharesProvider;
+use OCA\OpenRegister\Service\Integration\Providers\TalkProvider;
+use OCA\OpenRegister\Service\Integration\Providers\XwikiProvider;
 use OCA\OpenRegister\Service\Mcp\McpToolsService;
 
 /**
@@ -324,7 +346,7 @@ class Application extends App implements IBootstrap
         // Pluggable-integration-registry task 4.5 (tasks.md#task-22):
         // advertise the integration registry through the OCS
         // capabilities endpoint.
-        $context->registerCapability(\OCA\OpenRegister\Capabilities\IntegrationsCapability::class);
+        $context->registerCapability(IntegrationsCapability::class);
     }//end register()
 
     /**
@@ -841,18 +863,18 @@ class Application extends App implements IBootstrap
     private function registerIntegrationRegistry(IRegistrationContext $context): void
     {
         $context->registerService(
-            \OCA\OpenRegister\Service\Integration\IntegrationRegistry::class,
+            IntegrationRegistry::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Service\Integration\IntegrationRegistry(
+                return new IntegrationRegistry(
                     logger: $container->get('Psr\Log\LoggerInterface')
                 );
             }
         );
 
         $context->registerService(
-            \OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter::class,
+            ExternalIntegrationRouter::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter(
+                return new ExternalIntegrationRouter(
                     appManager: $container->get('OCP\App\IAppManager'),
                     container: $container,
                     logger: $container->get('Psr\Log\LoggerInterface')
@@ -866,10 +888,10 @@ class Application extends App implements IBootstrap
         // validateLinkedTypesValue path so existing schemas keep
         // validating exactly as before.
         $context->registerService(
-            \OCA\OpenRegister\Service\Integration\PropertyReferenceTypeValidator::class,
+            PropertyReferenceTypeValidator::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Service\Integration\PropertyReferenceTypeValidator(
-                    registry: $container->get(\OCA\OpenRegister\Service\Integration\IntegrationRegistry::class),
+                return new PropertyReferenceTypeValidator(
+                    registry: $container->get(IntegrationRegistry::class),
                 );
             }
         );
@@ -879,10 +901,10 @@ class Application extends App implements IBootstrap
         // ids that the registry can no longer resolve. Strictly
         // informational; never throws, never modifies data.
         $context->registerService(
-            \OCA\OpenRegister\Repair\LogDanglingLinkedTypes::class,
+            LogDanglingLinkedTypes::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Repair\LogDanglingLinkedTypes(
-                    registry: $container->get(\OCA\OpenRegister\Service\Integration\IntegrationRegistry::class),
+                return new LogDanglingLinkedTypes(
+                    registry: $container->get(IntegrationRegistry::class),
                     container: $container,
                     logger: $container->get('Psr\Log\LoggerInterface')
                 );
@@ -893,12 +915,12 @@ class Application extends App implements IBootstrap
 
         // IntegrationsController — read-only API over the registry.
         $context->registerService(
-            \OCA\OpenRegister\Controller\IntegrationsController::class,
+            IntegrationsController::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Controller\IntegrationsController(
+                return new IntegrationsController(
                     appName: 'openregister',
                     request: $container->get('OCP\IRequest'),
-                    registry: $container->get(\OCA\OpenRegister\Service\Integration\IntegrationRegistry::class),
+                    registry: $container->get(IntegrationRegistry::class),
                     userSession: $container->get('OCP\IUserSession'),
                     groupManager: $container->get('OCP\IGroupManager'),
                     logger: $container->get('Psr\Log\LoggerInterface')
@@ -909,12 +931,12 @@ class Application extends App implements IBootstrap
         // ObjectIntegrationsController — object-scoped sub-resource
         // dispatch through the registry.
         $context->registerService(
-            \OCA\OpenRegister\Controller\ObjectIntegrationsController::class,
+            ObjectIntegrationsController::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Controller\ObjectIntegrationsController(
+                return new ObjectIntegrationsController(
                     appName: 'openregister',
                     request: $container->get('OCP\IRequest'),
-                    registry: $container->get(\OCA\OpenRegister\Service\Integration\IntegrationRegistry::class),
+                    registry: $container->get(IntegrationRegistry::class),
                     logger: $container->get('Psr\Log\LoggerInterface')
                 );
             }
@@ -929,10 +951,10 @@ class Application extends App implements IBootstrap
         // IntegrationsCapability — surfaces the registry through the
         // Nextcloud OCS capabilities endpoint, role-redacted per AD-17.
         $context->registerService(
-            \OCA\OpenRegister\Capabilities\IntegrationsCapability::class,
+            IntegrationsCapability::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Capabilities\IntegrationsCapability(
-                    registry: $container->get(\OCA\OpenRegister\Service\Integration\IntegrationRegistry::class),
+                return new IntegrationsCapability(
+                    registry: $container->get(IntegrationRegistry::class),
                     userSession: $container->get('OCP\IUserSession'),
                     groupManager: $container->get('OCP\IGroupManager')
                 );
@@ -959,9 +981,9 @@ class Application extends App implements IBootstrap
     private function registerBuiltinIntegrationProviders(IRegistrationContext $context): void
     {
         $context->registerService(
-            \OCA\OpenRegister\Service\Integration\BuiltinProviders\FilesProvider::class,
+            FilesProvider::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Service\Integration\BuiltinProviders\FilesProvider(
+                return new FilesProvider(
                     fileService: $container->get(\OCA\OpenRegister\Service\FileService::class),
                     container: $container,
                     l10n: $container->get('OCP\IL10N'),
@@ -970,9 +992,9 @@ class Application extends App implements IBootstrap
         );
 
         $context->registerService(
-            \OCA\OpenRegister\Service\Integration\BuiltinProviders\NotesProvider::class,
+            NotesProvider::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Service\Integration\BuiltinProviders\NotesProvider(
+                return new NotesProvider(
                     noteService: $container->get(\OCA\OpenRegister\Service\NoteService::class),
                     l10n: $container->get('OCP\IL10N'),
                 );
@@ -980,9 +1002,9 @@ class Application extends App implements IBootstrap
         );
 
         $context->registerService(
-            \OCA\OpenRegister\Service\Integration\BuiltinProviders\TasksProvider::class,
+            TasksProvider::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Service\Integration\BuiltinProviders\TasksProvider(
+                return new TasksProvider(
                     taskService: $container->get(\OCA\OpenRegister\Service\TaskService::class),
                     l10n: $container->get('OCP\IL10N'),
                 );
@@ -990,9 +1012,9 @@ class Application extends App implements IBootstrap
         );
 
         $context->registerService(
-            \OCA\OpenRegister\Service\Integration\BuiltinProviders\TagsProvider::class,
+            TagsProvider::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Service\Integration\BuiltinProviders\TagsProvider(
+                return new TagsProvider(
                     tagManager: $container->get('OCP\SystemTag\ISystemTagManager'),
                     objectMapper: $container->get('OCP\SystemTag\ISystemTagObjectMapper'),
                     l10n: $container->get('OCP\IL10N'),
@@ -1001,9 +1023,9 @@ class Application extends App implements IBootstrap
         );
 
         $context->registerService(
-            \OCA\OpenRegister\Service\Integration\BuiltinProviders\AuditTrailProvider::class,
+            AuditTrailProvider::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Service\Integration\BuiltinProviders\AuditTrailProvider(
+                return new AuditTrailProvider(
                     mapper: $container->get(\OCA\OpenRegister\Db\AuditTrailMapper::class),
                     l10n: $container->get('OCP\IL10N'),
                 );
@@ -1016,10 +1038,10 @@ class Application extends App implements IBootstrap
         // OpenConnector `xwiki` source.
         // @spec openspec/changes/integration-xwiki/tasks.md.
         $context->registerService(
-            \OCA\OpenRegister\Service\Integration\Providers\XwikiProvider::class,
+            XwikiProvider::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Service\Integration\Providers\XwikiProvider(
-                    router: $container->get(\OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter::class),
+                return new XwikiProvider(
+                    router: $container->get(ExternalIntegrationRouter::class),
                     appManager: $container->get('OCP\App\IAppManager'),
                     l10n: $container->get('OCP\IL10N'),
                 );
@@ -1031,10 +1053,10 @@ class Application extends App implements IBootstrap
         // on the OpenConnector `openproject` source.
         // @spec openspec/changes/integration-openproject/tasks.md.
         $context->registerService(
-            \OCA\OpenRegister\Service\Integration\Providers\OpenProjectProvider::class,
+            OpenProjectProvider::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Service\Integration\Providers\OpenProjectProvider(
-                    router: $container->get(\OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter::class),
+                return new OpenProjectProvider(
+                    router: $container->get(ExternalIntegrationRouter::class),
                     appManager: $container->get('OCP\App\IAppManager'),
                     l10n: $container->get('OCP\IL10N'),
                 );
@@ -1048,9 +1070,9 @@ class Application extends App implements IBootstrap
         // provider gates on its required NC app via IAppManager.
         // @spec openspec/changes/integration-calendar/tasks.md.
         $context->registerService(
-            \OCA\OpenRegister\Service\Integration\Providers\CalendarProvider::class,
+            CalendarProvider::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Service\Integration\Providers\CalendarProvider(
+                return new CalendarProvider(
                     calendarEventService: $container->get(\OCA\OpenRegister\Service\CalendarEventService::class),
                     appManager: $container->get('OCP\App\IAppManager'),
                     l10n: $container->get('OCP\IL10N'),
@@ -1060,9 +1082,9 @@ class Application extends App implements IBootstrap
 
         // @spec openspec/changes/integration-contacts/tasks.md.
         $context->registerService(
-            \OCA\OpenRegister\Service\Integration\Providers\ContactsProvider::class,
+            ContactsProvider::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Service\Integration\Providers\ContactsProvider(
+                return new ContactsProvider(
                     contactService: $container->get(\OCA\OpenRegister\Service\ContactService::class),
                     appManager: $container->get('OCP\App\IAppManager'),
                     l10n: $container->get('OCP\IL10N'),
@@ -1072,9 +1094,9 @@ class Application extends App implements IBootstrap
 
         // @spec openspec/changes/integration-deck/tasks.md.
         $context->registerService(
-            \OCA\OpenRegister\Service\Integration\Providers\DeckProvider::class,
+            DeckProvider::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Service\Integration\Providers\DeckProvider(
+                return new DeckProvider(
                     deckCardService: $container->get(\OCA\OpenRegister\Service\DeckCardService::class),
                     appManager: $container->get('OCP\App\IAppManager'),
                     l10n: $container->get('OCP\IL10N'),
@@ -1084,9 +1106,9 @@ class Application extends App implements IBootstrap
 
         // @spec openspec/changes/integration-email/tasks.md.
         $context->registerService(
-            \OCA\OpenRegister\Service\Integration\Providers\EmailProvider::class,
+            EmailProvider::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Service\Integration\Providers\EmailProvider(
+                return new EmailProvider(
                     emailService: $container->get(\OCA\OpenRegister\Service\EmailService::class),
                     appManager: $container->get('OCP\App\IAppManager'),
                     l10n: $container->get('OCP\IL10N'),
@@ -1140,9 +1162,9 @@ class Application extends App implements IBootstrap
         // against the `share` table's `note` column.
         // @spec openspec/changes/integration-shares/tasks.md.
         $context->registerService(
-            \OCA\OpenRegister\Service\Integration\Providers\SharesProvider::class,
+            SharesProvider::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Service\Integration\Providers\SharesProvider(
+                return new SharesProvider(
                     db: $container->get('OCP\IDBConnection'),
                     appManager: $container->get('OCP\App\IAppManager'),
                     l10n: $container->get('OCP\IL10N'),
@@ -1156,9 +1178,9 @@ class Application extends App implements IBootstrap
         // bookmark query to the current user.
         // @spec openspec/changes/integration-bookmarks/tasks.md.
         $context->registerService(
-            \OCA\OpenRegister\Service\Integration\Providers\BookmarksProvider::class,
+            BookmarksProvider::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Service\Integration\Providers\BookmarksProvider(
+                return new BookmarksProvider(
                     container: $container,
                     appManager: $container->get('OCP\App\IAppManager'),
                     userSession: $container->get('OCP\IUserSession'),
@@ -1172,9 +1194,9 @@ class Application extends App implements IBootstrap
         // IUserSession to scope `getRoomsForUser`.
         // @spec openspec/changes/integration-talk/tasks.md.
         $context->registerService(
-            \OCA\OpenRegister\Service\Integration\Providers\TalkProvider::class,
+            TalkProvider::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Service\Integration\Providers\TalkProvider(
+                return new TalkProvider(
                     container: $container,
                     appManager: $container->get('OCP\App\IAppManager'),
                     userSession: $container->get('OCP\IUserSession'),
@@ -1189,9 +1211,9 @@ class Application extends App implements IBootstrap
         // marker in the poll title.
         // @spec openspec/changes/integration-polls/tasks.md.
         $context->registerService(
-            \OCA\OpenRegister\Service\Integration\Providers\PollsProvider::class,
+            PollsProvider::class,
             function (ContainerInterface $container) {
-                return new \OCA\OpenRegister\Service\Integration\Providers\PollsProvider(
+                return new PollsProvider(
                     container: $container,
                     appManager: $container->get('OCP\App\IAppManager'),
                     userSession: $container->get('OCP\IUserSession'),
@@ -1419,13 +1441,13 @@ class Application extends App implements IBootstrap
                                         ['appId' => $appId, 'via' => $key, 'class' => get_class($appProvider)]
                                     );
                                     break;
-                                } else {
-                                    $resolvedClass = is_object($appProvider) === true ? get_class($appProvider) : gettype($appProvider);
-                                    $logger->warning(
-                                        '[McpToolsService] Resolved but not IMcpToolProvider',
-                                        ['appId' => $appId, 'via' => $key, 'class' => $resolvedClass]
-                                    );
                                 }
+
+                                $resolvedClass = is_object($appProvider) === true ? get_class($appProvider) : gettype($appProvider);
+                                $logger->warning(
+                                    '[McpToolsService] Resolved but not IMcpToolProvider',
+                                    ['appId' => $appId, 'via' => $key, 'class' => $resolvedClass]
+                                );
                             } catch (\Throwable $e) {
                                 $logger->warning(
                                     '[McpToolsService] Resolve failed',
@@ -1499,7 +1521,7 @@ class Application extends App implements IBootstrap
     {
         try {
             $integrationRegistry = $server->get(
-                \OCA\OpenRegister\Service\Integration\IntegrationRegistry::class
+                IntegrationRegistry::class
             );
         } catch (\Throwable $e) {
             // Registry binding not available — skip silently; the
@@ -1508,25 +1530,25 @@ class Application extends App implements IBootstrap
         }
 
         $providerClasses = [
-            \OCA\OpenRegister\Service\Integration\BuiltinProviders\FilesProvider::class,
-            \OCA\OpenRegister\Service\Integration\BuiltinProviders\NotesProvider::class,
-            \OCA\OpenRegister\Service\Integration\BuiltinProviders\TasksProvider::class,
-            \OCA\OpenRegister\Service\Integration\BuiltinProviders\TagsProvider::class,
-            \OCA\OpenRegister\Service\Integration\BuiltinProviders\AuditTrailProvider::class,
+            FilesProvider::class,
+            NotesProvider::class,
+            TasksProvider::class,
+            TagsProvider::class,
+            AuditTrailProvider::class,
             // Leaves: external (OpenConnector-backed).
             // @spec openspec/changes/integration-xwiki/tasks.md.
-            \OCA\OpenRegister\Service\Integration\Providers\XwikiProvider::class,
+            XwikiProvider::class,
             // @spec openspec/changes/integration-openproject/tasks.md.
-            \OCA\OpenRegister\Service\Integration\Providers\OpenProjectProvider::class,
+            OpenProjectProvider::class,
             // Leaves: NC-native, backend-shipped (wrap existing OR services).
             // @spec openspec/changes/integration-calendar/tasks.md.
-            \OCA\OpenRegister\Service\Integration\Providers\CalendarProvider::class,
+            CalendarProvider::class,
             // @spec openspec/changes/integration-contacts/tasks.md.
-            \OCA\OpenRegister\Service\Integration\Providers\ContactsProvider::class,
+            ContactsProvider::class,
             // @spec openspec/changes/integration-deck/tasks.md.
-            \OCA\OpenRegister\Service\Integration\Providers\DeckProvider::class,
+            DeckProvider::class,
             // @spec openspec/changes/integration-email/tasks.md.
-            \OCA\OpenRegister\Service\Integration\Providers\EmailProvider::class,
+            EmailProvider::class,
             // Leaves: NC-app-backed greenfield (registry surface only;
             // service + link table land in per-leaf follow-ups).
             // @spec openspec/changes/integration-activity/tasks.md.
@@ -1534,7 +1556,7 @@ class Application extends App implements IBootstrap
             // @spec openspec/changes/integration-analytics/tasks.md.
             \OCA\OpenRegister\Service\Integration\Providers\AnalyticsProvider::class,
             // @spec openspec/changes/integration-bookmarks/tasks.md.
-            \OCA\OpenRegister\Service\Integration\Providers\BookmarksProvider::class,
+            BookmarksProvider::class,
             // @spec openspec/changes/integration-collectives/tasks.md.
             \OCA\OpenRegister\Service\Integration\Providers\CollectivesProvider::class,
             // @spec openspec/changes/integration-cospend/tasks.md.
@@ -1548,11 +1570,11 @@ class Application extends App implements IBootstrap
             // @spec openspec/changes/integration-photos/tasks.md.
             \OCA\OpenRegister\Service\Integration\Providers\PhotosProvider::class,
             // @spec openspec/changes/integration-polls/tasks.md.
-            \OCA\OpenRegister\Service\Integration\Providers\PollsProvider::class,
+            PollsProvider::class,
             // @spec openspec/changes/integration-shares/tasks.md.
-            \OCA\OpenRegister\Service\Integration\Providers\SharesProvider::class,
+            SharesProvider::class,
             // @spec openspec/changes/integration-talk/tasks.md.
-            \OCA\OpenRegister\Service\Integration\Providers\TalkProvider::class,
+            TalkProvider::class,
             // @spec openspec/changes/integration-time-tracker/tasks.md.
             \OCA\OpenRegister\Service\Integration\Providers\TimeProvider::class,
         ];

--- a/lib/Controller/ChatStreamController.php
+++ b/lib/Controller/ChatStreamController.php
@@ -411,9 +411,10 @@ class ChatStreamController extends Controller
             if ($this->db->inTransaction() === true) {
                 if ($rollback === true) {
                     $this->db->rollBack();
-                } else {
-                    $this->db->commit();
+                    return;
                 }
+
+                $this->db->commit();
             }
         } catch (Throwable $e) {
             $this->logger->warning(

--- a/lib/Controller/OrganisationController.php
+++ b/lib/Controller/OrganisationController.php
@@ -1169,10 +1169,10 @@ class OrganisationController extends Controller
             if ($status === TenantLifecycleService::STATUS_PROVISIONING) {
                 $userId = \OC::$server->get(\OCP\IUserSession::class)->getUser()?->getUID() ?? 'admin';
                 $result = $this->tenantLifecycleService->provision($organisation, $userId);
-            } else {
-                $result = $this->tenantLifecycleService->reactivate($organisation);
+                return new JSONResponse(data: $result, statusCode: Http::STATUS_OK);
             }
 
+            $result = $this->tenantLifecycleService->reactivate($organisation);
             return new JSONResponse(data: $result, statusCode: Http::STATUS_OK);
         } catch (Exception $e) {
             $statusCode = $e->getCode() >= 400 ? $e->getCode() : Http::STATUS_INTERNAL_SERVER_ERROR;

--- a/lib/Db/AuditTrailMapper.php
+++ b/lib/Db/AuditTrailMapper.php
@@ -160,8 +160,6 @@ class AuditTrailMapper extends QBMapper
         return $this->findEntities(query: $qb);
     }//end findByImportJobId()
 
-
-
     /**
      * Finds an audit trail by id
      *
@@ -181,7 +179,6 @@ class AuditTrailMapper extends QBMapper
 
         return $this->findEntity(query: $qb);
     }//end find()
-
 
     /**
      * Find all audit trails with filters and sorting
@@ -323,9 +320,6 @@ class AuditTrailMapper extends QBMapper
 
         return $this->findEntities(query: $qb);
     }//end findAll()
-
-
-
 
     /**
      * Creates an audit trail for object changes
@@ -632,7 +626,6 @@ class AuditTrailMapper extends QBMapper
 
     }//end readProcessingActivityFromRegister()
 
-
     /**
      * Get audit trails for an object until a specific point or version
      *
@@ -703,7 +696,6 @@ class AuditTrailMapper extends QBMapper
         return $this->findEntities(query: $qb);
     }//end findByObjectUntil()
 
-
     /**
      * Check if a string is a semantic version
      *
@@ -715,7 +707,6 @@ class AuditTrailMapper extends QBMapper
     {
         return (preg_match('/^\d+\.\d+\.\d+$/', $version) === 1);
     }//end isSemanticVersion()
-
 
     /**
      * Revert an object to a previous state
@@ -766,7 +757,6 @@ class AuditTrailMapper extends QBMapper
         return $revertedObject;
     }//end revertObject()
 
-
     /**
      * Helper function to revert changes from an audit trail entry
      *
@@ -791,7 +781,6 @@ class AuditTrailMapper extends QBMapper
             }
         }
     }//end revertChanges()
-
 
     /**
      * Get statistics for audit trails with optional filtering
@@ -885,7 +874,6 @@ class AuditTrailMapper extends QBMapper
         }//end try
     }//end getStatistics()
 
-
     /**
      * Updates an entity in the database
      *
@@ -906,7 +894,6 @@ class AuditTrailMapper extends QBMapper
 
         return parent::update(entity: $entity);
     }//end update()
-
 
     /**
      * Get chart data for audit trail actions over time
@@ -1012,7 +999,6 @@ class AuditTrailMapper extends QBMapper
         }//end try
     }//end getActionChartData()
 
-
     /**
      * Get detailed statistics for audit trails including action counts within timeframe
      *
@@ -1113,7 +1099,6 @@ class AuditTrailMapper extends QBMapper
         }//end try
     }//end getDetailedStatistics()
 
-
     /**
      * Get action distribution data with percentages
      *
@@ -1192,7 +1177,6 @@ class AuditTrailMapper extends QBMapper
         }//end try
     }//end getActionDistribution()
 
-
     /**
      * Get most active objects based on audit trail activity
      *
@@ -1268,7 +1252,6 @@ class AuditTrailMapper extends QBMapper
         }//end try
     }//end getMostActiveObjects()
 
-
     /**
      * Clear expired logs from the database
      *
@@ -1317,7 +1300,6 @@ class AuditTrailMapper extends QBMapper
         }//end try
     }//end clearLogs()
 
-
     /**
      * Clear all audit trail logs (not just expired ones)
      *
@@ -1357,9 +1339,6 @@ class AuditTrailMapper extends QBMapper
             throw $e;
         }//end try
     }//end clearAllLogs()
-
-
-
 
     /**
      * Set expiry dates for audit trails based on retention period in milliseconds
@@ -1410,7 +1389,6 @@ class AuditTrailMapper extends QBMapper
             throw $e;
         }//end try
     }//end setExpiryDate()
-
 
     /**
      * Get audit trail statistics grouped by schema for multiple schemas in a single query
@@ -1479,7 +1457,6 @@ class AuditTrailMapper extends QBMapper
         }//end try
     }//end getStatisticsGroupedBySchema()
 
-
     /**
      * Create a custom audit trail entry for archival operations.
      *
@@ -1521,7 +1498,6 @@ class AuditTrailMapper extends QBMapper
 
         return $this->insert(entity: $auditTrail);
     }//end createAuditTrailEntry()
-
 
     /**
      * Get processing activities from audit trail entries.
@@ -1577,7 +1553,6 @@ class AuditTrailMapper extends QBMapper
         return array_values($activities);
     }//end getProcessingActivities()
 
-
     /**
      * Find audit trail entries by identifier.
      *
@@ -1615,7 +1590,6 @@ class AuditTrailMapper extends QBMapper
 
         return $grouped;
     }//end findByIdentifier()
-
 
     /**
      * Find audit trail entries by the actor (user UID) that produced them.
@@ -1693,6 +1667,4 @@ class AuditTrailMapper extends QBMapper
             'total'   => (int) ($row['total_count'] ?? 0),
         ];
     }//end findByActor()
-
-
 }//end class

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -1277,6 +1277,7 @@ class MagicMapper extends AbstractObjectMapper
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)   `$_` is the conventional ignore name in the metadata-column foreach
      */
     private function buildUnionSelectPart(
         string $tableName,
@@ -1299,12 +1300,13 @@ class MagicMapper extends AbstractObjectMapper
         // Cast to text for UNION type compatibility (some columns are jsonb, others text).
         $metadataColumns = $this->getMetadataColumns();
         $selectColumns   = [];
-        foreach ($metadataColumns as $metaCol => $metaDef) {
+        foreach ($metadataColumns as $metaCol => $_) {
             if ($this->columnExistsInTable(tableName: $tableName, columnName: $metaCol) === true) {
                 $selectColumns[] = "{$metaCol}::text AS {$metaCol}";
-            } else {
-                $selectColumns[] = "NULL::text AS {$metaCol}";
+                continue;
             }
+
+            $selectColumns[] = "NULL::text AS {$metaCol}";
         }
 
         /*

--- a/lib/Db/MagicMapper/MagicSearchHandler.php
+++ b/lib/Db/MagicMapper/MagicSearchHandler.php
@@ -497,11 +497,12 @@ class MagicSearchHandler
                 if ($isPostgres === true) {
                     // ILIKE is always case-insensitive on PostgreSQL.
                     $searchConditions[] = "{$quotedCol}::text ILIKE {$likePattern}";
-                } else {
-                    // CAST + LOWER on both sides keeps MySQL case-insensitive regardless of
-                    // collation (e.g., utf8mb4_bin), matching applyFullTextSearch().
-                    $searchConditions[] = "LOWER(CAST({$quotedCol} AS CHAR)) LIKE LOWER({$likePattern})";
-                }//end if
+                    continue;
+                }
+
+                // CAST + LOWER on both sides keeps MySQL case-insensitive regardless of
+                // collation (e.g., utf8mb4_bin), matching applyFullTextSearch().
+                $searchConditions[] = "LOWER(CAST({$quotedCol} AS CHAR)) LIKE LOWER({$likePattern})";
             }//end if
         }//end foreach
 

--- a/lib/Db/Schema.php
+++ b/lib/Db/Schema.php
@@ -1696,17 +1696,18 @@ class Schema extends Entity implements JsonSerializable
             if (str_starts_with((string) $key, 'x-openregister-') === true) {
                 if (in_array((string) $key, self::ANNOTATION_VOCABULARY, true) === true) {
                     $validatedConfig[$key] = $value;
-                } else {
-                    // R07: track unknown `x-openregister-*` keys (almost
-                    // always typos like `x-openregister-lifecycl`) so
-                    // SchemaMapper can log them via its structured
-                    // logger after save. The entity has no DI surface
-                    // for a logger and the ADR added in F06 bans the
-                    // `\OC::$server` static accessor — collecting on
-                    // the entity and bridging through the mapper is
-                    // the cleanest path that still surfaces a signal.
-                    $this->droppedAnnotationKeys[] = (string) $key;
-                }//end if
+                    continue;
+                }
+
+                // R07: track unknown `x-openregister-*` keys (almost
+                // always typos like `x-openregister-lifecycl`) so
+                // SchemaMapper can log them via its structured
+                // logger after save. The entity has no DI surface
+                // for a logger and the ADR added in F06 bans the
+                // `\OC::$server` static accessor — collecting on
+                // the entity and bridging through the mapper is
+                // the cleanest path that still surfaces a signal.
+                $this->droppedAnnotationKeys[] = (string) $key;
             }//end if
         }//end foreach
 

--- a/lib/Listener/NotifyPushListener.php
+++ b/lib/Listener/NotifyPushListener.php
@@ -157,7 +157,9 @@ class NotifyPushListener implements IEventListener
         } else if ($event instanceof ObjectDeletedEvent) {
             $action = 'delete';
             $object = $event->getObject();
-        } else {
+        }
+
+        if (isset($action) === false || isset($object) === false) {
             return;
         }
 
@@ -332,6 +334,8 @@ class NotifyPushListener implements IEventListener
      * @return void
      *
      * @spec openspec/changes/add-live-updates/tasks.md#task-4
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) Permission handler retained on the signature for upcoming per-user batch routing
      */
     public static function flushBatch(object $queue, PermissionHandler $permHandler): void
     {

--- a/lib/Service/Chat/ResponseGenerationHandler.php
+++ b/lib/Service/Chat/ResponseGenerationHandler.php
@@ -34,6 +34,7 @@ use Exception;
 use OCA\OpenRegister\Db\Agent;
 use OCA\OpenRegister\Service\SettingsService;
 use OCA\OpenRegister\Service\Chat\ToolManagementHandler;
+use OCA\OpenRegister\Tool\StreamingToolInstanceWrapper;
 use Psr\Log\LoggerInterface;
 use LLPhant\Chat\OpenAIChat;
 use LLPhant\Chat\OllamaChat;
@@ -42,6 +43,7 @@ use LLPhant\OpenAIConfig;
 use LLPhant\OllamaConfig;
 use LLPhant\Exception\MissingFeatureException;
 use Psr\Http\Message\StreamInterface;
+use ReflectionClass;
 
 /**
  * ResponseGenerationHandler
@@ -318,9 +320,10 @@ class ResponseGenerationHandler
                 foreach ($cnAiContext as $key => $value) {
                     if (is_scalar($value) === true) {
                         $systemPrompt .= "- {$key}: ".(string) $value."\n";
-                    } else {
-                        $systemPrompt .= "- {$key}: ".json_encode($value, JSON_UNESCAPED_SLASHES)."\n";
+                        continue;
                     }
+
+                    $systemPrompt .= "- {$key}: ".json_encode($value, JSON_UNESCAPED_SLASHES)."\n";
                 }
             }
 
@@ -506,7 +509,7 @@ class ResponseGenerationHandler
 
         foreach ($functionInfoObjects as $fi) {
             if (is_object($fi->instance) === true) {
-                $fi->instance = new \OCA\OpenRegister\Tool\StreamingToolInstanceWrapper(
+                $fi->instance = new StreamingToolInstanceWrapper(
                     wrapped: $fi->instance,
                     channel: $channel
                 );
@@ -583,7 +586,7 @@ class ResponseGenerationHandler
     private function chatHasTools(OpenAIChat|OllamaChat $chat): bool
     {
         try {
-            $refl = new \ReflectionClass($chat);
+            $refl = new ReflectionClass($chat);
             if ($refl->hasProperty(name: 'tools') === false) {
                 return false;
             }

--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -2695,7 +2695,9 @@ class ImportHandler
                     'unionSchemaIds' => $unionSchemaIds,
                 ]
             );
-        } else {
+        }//end if
+
+        if ($register === null) {
             // Fresh insert: derive a new Register entity.
             $register = $this->registerMapper->createFromArray(
                 object: [

--- a/lib/Service/Integration/BuiltinProviders/TasksProvider.php
+++ b/lib/Service/Integration/BuiltinProviders/TasksProvider.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Service\Integration\BuiltinProviders;
 
+use RuntimeException;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Exception\NotImplementedException;
@@ -219,7 +220,7 @@ class TasksProvider extends AbstractIntegrationProvider
         );
 
         if ($task === null) {
-            throw new \RuntimeException('TaskService::createTask returned null — calendar invalid or auth failure.');
+            throw new RuntimeException('TaskService::createTask returned null — calendar invalid or auth failure.');
         }
 
         return $task;
@@ -242,7 +243,7 @@ class TasksProvider extends AbstractIntegrationProvider
         $updated = $this->taskService->updateTask(calendarId: $calendarId, taskUri: $taskUri, data: $payload);
 
         if ($updated === null) {
-            throw new \RuntimeException('TaskService::updateTask returned null — entity may not exist.');
+            throw new RuntimeException('TaskService::updateTask returned null — entity may not exist.');
         }
 
         return $updated;

--- a/lib/Service/Integration/ExternalIntegrationRouter.php
+++ b/lib/Service/Integration/ExternalIntegrationRouter.php
@@ -35,10 +35,12 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Service\Integration;
 
+use LogicException;
 use OCA\OpenRegister\Exception\ProviderUnavailableException;
 use OCP\App\IAppManager;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Routes external integrations' CRUD calls through OpenConnector.
@@ -207,7 +209,7 @@ class ExternalIntegrationRouter
     private function assertProviderIsExternal(IntegrationProvider $provider): void
     {
         if ($provider->getStorageStrategy() !== 'external') {
-            throw new \LogicException(
+            throw new LogicException(
                 sprintf(
                     'ExternalIntegrationRouter::call() invoked with non-external provider %s (storage=%s)',
                     $provider->getId(),
@@ -293,7 +295,7 @@ class ExternalIntegrationRouter
             }
 
             if ($source === null) {
-                throw new \RuntimeException(sprintf('OpenConnector source "%s" not found', $sourceId));
+                throw new RuntimeException(sprintf('OpenConnector source "%s" not found', $sourceId));
             }
 
             return $source;
@@ -343,7 +345,7 @@ class ExternalIntegrationRouter
             return $this->decodeResponse(response: $response);
         }
 
-        throw new \RuntimeException(
+        throw new RuntimeException(
             'OpenConnector\\Service\\CallService does not expose a known call/request method.'
         );
     }//end invoke()
@@ -371,10 +373,9 @@ class ExternalIntegrationRouter
             return;
         }
 
+        $cause = ProviderUnavailableException::CAUSE_UPSTREAM_SERVICE_DOWN;
         if ($status === 401 || $status === 403) {
             $cause = ProviderUnavailableException::CAUSE_PROVIDER_AUTH;
-        } else {
-            $cause = ProviderUnavailableException::CAUSE_UPSTREAM_SERVICE_DOWN;
         }
 
         throw new ProviderUnavailableException(

--- a/lib/Service/Integration/Providers/BookmarksProvider.php
+++ b/lib/Service/Integration/Providers/BookmarksProvider.php
@@ -32,6 +32,7 @@ namespace OCA\OpenRegister\Service\Integration\Providers;
 
 // phpcs:disable PEAR.Commenting.FunctionComment.Missing -- self-documenting IntegrationProvider metadata getters mirror the contract in the interface.
 
+use OCA\Bookmarks\QueryParameters;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCP\App\IAppManager;
 use OCP\IL10N;
@@ -118,7 +119,7 @@ class BookmarksProvider extends AbstractIntegrationProvider
 
         try {
             $mapper          = $this->container->get('OCA\\Bookmarks\\Db\\BookmarkMapper');
-            $queryParameters = new \OCA\Bookmarks\QueryParameters();
+            $queryParameters = new QueryParameters();
             $queryParameters->setTags([$tag]);
             $bookmarks = $mapper->findAll($userId, $queryParameters);
         } catch (Throwable $e) {

--- a/lib/Service/Integration/Providers/CalendarProvider.php
+++ b/lib/Service/Integration/Providers/CalendarProvider.php
@@ -39,6 +39,7 @@ namespace OCA\OpenRegister\Service\Integration\Providers;
 
 // phpcs:disable PEAR.Commenting.FunctionComment.Missing -- self-documenting IntegrationProvider metadata getters mirror the contract in the interface.
 
+use InvalidArgumentException;
 use OCA\OpenRegister\Service\CalendarEventService;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCP\App\IAppManager;
@@ -152,7 +153,7 @@ class CalendarProvider extends AbstractIntegrationProvider
     {
         $parts = explode('/', $entityId, 2);
         if (count($parts) !== 2) {
-            throw new \InvalidArgumentException('Calendar entityId must be "calendarId/eventUri"');
+            throw new InvalidArgumentException('Calendar entityId must be "calendarId/eventUri"');
         }
 
         [$calendarId, $eventUri] = $parts;

--- a/lib/Service/Integration/Providers/OpenProjectProvider.php
+++ b/lib/Service/Integration/Providers/OpenProjectProvider.php
@@ -284,6 +284,8 @@ class OpenProjectProvider extends AbstractIntegrationProvider
      * @param bool $withBody Whether the request carries a JSON body.
      *
      * @return array<string,string>
+     *
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Body-vs-no-body is the natural toggle for HTTP request headers; a two-method split (requestHeaders / requestHeadersWithBody) would duplicate the static Accept header
      */
     private function requestHeaders(bool $withBody=false): array
     {

--- a/lib/Service/Integration/Providers/XwikiProvider.php
+++ b/lib/Service/Integration/Providers/XwikiProvider.php
@@ -381,6 +381,8 @@ class XwikiProvider extends AbstractIntegrationProvider
      * @param bool $withBody Whether the request carries a JSON body.
      *
      * @return array<string,string>
+     *
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Body-vs-no-body is the natural toggle for HTTP request headers; a two-method split would duplicate the static Accept header
      */
     private function requestHeaders(bool $withBody=false): array
     {

--- a/lib/Service/Notification/AnnotationNotificationDispatcher.php
+++ b/lib/Service/Notification/AnnotationNotificationDispatcher.php
@@ -818,10 +818,9 @@ class AnnotationNotificationDispatcher
             // dependency is preferred; the server container fallback
             // exists for callers that constructed the dispatcher with
             // the legacy (no-IConfig) signature.
+            $base = (string) $this->serverContainer->get(\OCP\IConfig::class)->getSystemValue('overwrite.cli.url', 'http://localhost');
             if ($this->config !== null) {
                 $base = (string) $this->config->getSystemValue('overwrite.cli.url', 'http://localhost');
-            } else {
-                $base = (string) $this->serverContainer->get(\OCP\IConfig::class)->getSystemValue('overwrite.cli.url', 'http://localhost');
             }
 
             $base = rtrim($base, '/');

--- a/lib/Service/Object/PermissionHandler.php
+++ b/lib/Service/Object/PermissionHandler.php
@@ -304,6 +304,8 @@ class PermissionHandler
      *
      * @return bool True when at least one authorization entry carries
      *              a non-empty `match` block.
+     *
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable) `$_` is the conventional ignore name for the unused foreach key
      */
     private function schemaHasMatchRule(Schema $schema): bool
     {
@@ -312,7 +314,7 @@ class PermissionHandler
             return false;
         }
 
-        foreach ($authorization as $action => $entries) {
+        foreach ($authorization as $_ => $entries) {
             if (is_array($entries) === false) {
                 continue;
             }

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -73,6 +73,7 @@ use OCA\OpenRegister\Service\Object\UtilityHandler;
 use OCA\OpenRegister\Service\Object\ValidationHandler;
 use OCA\OpenRegister\Service\Object\CascadingHandler;
 use OCA\OpenRegister\Service\Object\MigrationHandler;
+use OCA\OpenRegister\Exception\AppendOnlyException;
 use OCA\OpenRegister\Exception\ValidationException;
 use OCA\OpenRegister\Exception\CustomValidationException;
 use OCP\AppFramework\Db\DoesNotExistException as OcpDoesNotExistException;
@@ -1114,7 +1115,7 @@ class ObjectService
         // Reject UPDATE operations on append-only schemas (INSERT is still allowed).
         if ($uuid !== null && $this->currentSchema !== null && $this->currentSchema->isAppendOnly() === true) {
             $schemaSlug = $this->currentSchema->getSlug() ?? (string) $this->currentSchema->getId();
-            throw new \OCA\OpenRegister\Exception\AppendOnlyException(
+            throw new AppendOnlyException(
                 schemaIdentifier: $schemaSlug,
                 operation: 'update'
             );
@@ -1509,7 +1510,7 @@ class ObjectService
         // Reject DELETE operations on append-only schemas.
         if ($this->currentSchema !== null && $this->currentSchema->isAppendOnly() === true) {
             $schemaSlug = $this->currentSchema->getSlug() ?? (string) $this->currentSchema->getId();
-            throw new \OCA\OpenRegister\Exception\AppendOnlyException(
+            throw new AppendOnlyException(
                 schemaIdentifier: $schemaSlug,
                 operation: 'delete'
             );

--- a/lib/Service/RegisterService.php
+++ b/lib/Service/RegisterService.php
@@ -419,10 +419,9 @@ class RegisterService
                 }
 
                 $quotedTableName = $this->db->getQueryBuilder()->getTableName($tableName);
+                $schemaIdExpr    = "CAST({$schemaId} AS CHAR)";
                 if ($isPostgres === true) {
                     $schemaIdExpr = "{$schemaId}::text";
-                } else {
-                    $schemaIdExpr = "CAST({$schemaId} AS CHAR)";
                 }
 
                 $unionQueries[] = "

--- a/lib/Service/Reporting/PdfReportWriter.php
+++ b/lib/Service/Reporting/PdfReportWriter.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Service\Reporting;
 
 use Dompdf\Dompdf;
+use RuntimeException;
 use Dompdf\Options;
 
 /**
@@ -87,7 +88,7 @@ class PdfReportWriter
         // CVEs (CVE-2022-41343, CVE-2023-23924); these flags are the
         // primary mitigation and must stay false.
         if ($options->getIsRemoteEnabled() !== false || $options->getIsPhpEnabled() !== false) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 'PdfReportWriter sandbox configuration drifted; remote-fetch / PHP execution must remain disabled.'
             );
         }

--- a/lib/Service/Settings/ConfigurationSettingsHandler.php
+++ b/lib/Service/Settings/ConfigurationSettingsHandler.php
@@ -1158,13 +1158,13 @@ class ConfigurationSettingsHandler
                     ],
                     'ocrEnabled'               => false,
                     'maxFileSizeMB'            => 100,
-                // Text extraction settings (for FileConfiguration component).
+                    // Text extraction settings (for FileConfiguration component).
                     'extractionScope'          => 'objects',
-                // None, all, folders, objects.
+                    // None, all, folders, objects.
                     'textExtractor'            => 'llphant',
-                // Llphant, dolphin.
+                    // Llphant, dolphin.
                     'extractionMode'           => 'background',
-                // Background, immediate, manual.
+                    // Background, immediate, manual.
                     'maxFileSize'              => 100,
                     'batchSize'                => 10,
                     'dolphinApiEndpoint'       => '',
@@ -1228,13 +1228,13 @@ class ConfigurationSettingsHandler
                 ],
                 'ocrEnabled'               => $fileData['ocrEnabled'] ?? false,
                 'maxFileSizeMB'            => $fileData['maxFileSizeMB'] ?? 100,
-            // Text extraction settings (from FileConfiguration component).
+                // Text extraction settings (from FileConfiguration component).
                 'extractionScope'          => $fileData['extractionScope'] ?? 'objects',
-            // None, all, folders, objects.
+                // None, all, folders, objects.
                 'textExtractor'            => $fileData['textExtractor'] ?? 'llphant',
-            // Llphant, dolphin.
+                // Llphant, dolphin.
                 'extractionMode'           => $fileData['extractionMode'] ?? 'background',
-            // Background, immediate, manual.
+                // Background, immediate, manual.
                 'maxFileSize'              => $fileData['maxFileSize'] ?? 100,
                 'batchSize'                => $fileData['batchSize'] ?? 10,
                 'dolphinApiEndpoint'       => $fileData['dolphinApiEndpoint'] ?? '',

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -678,7 +678,8 @@ class SettingsService
      *
      * @return never Warmup result
      *
-     * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Boolean flag needed for error collection behavior
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)   Boolean flag needed for error collection behavior
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) Public facade signature kept while the deprecated delegate is refactored — see lib/Service/SettingsService.php TODO comment
      */
     public function warmupSolrIndex(
         array $schemas=[],

--- a/lib/Service/TextExtraction/EmlParser.php
+++ b/lib/Service/TextExtraction/EmlParser.php
@@ -171,12 +171,11 @@ class EmlParser
                 continue;
             }
 
+            $rendered = (string) $value;
             if ($key === 'date' && $value instanceof DateTimeImmutable) {
                 $rendered = $value->format(DateTimeImmutable::ATOM);
             } else if (is_array($value) === true) {
                 $rendered = implode(', ', $value);
-            } else {
-                $rendered = (string) $value;
             }
 
             $lines[] = ucfirst($key).': '.$rendered;
@@ -379,7 +378,9 @@ class EmlParser
         if (strtolower(string: $mimeType) === 'message/rfc822') {
             if ($depth < self::MAX_DEPTH) {
                 $nestedEml = $this->parseNestedEml(bytes: $bytes, depth: ($depth + 1));
-            } else {
+            }
+
+            if ($depth >= self::MAX_DEPTH) {
                 $this->logger->debug(
                     message: '[EmlParser] EML nesting depth limit reached',
                     context: [

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -1239,7 +1239,7 @@ class UserService
         if ($expiresIn !== null && $expiresIn !== '') {
             $expires = $this->parseExpiration(expiresIn: $expiresIn);
             if ($expires === null) {
-                throw new \InvalidArgumentException(
+                throw new InvalidArgumentException(
                     'Invalid expiresIn value "'.$expiresIn.'" — expected a number followed by d (days), h (hours), or m (minutes), e.g. "90d".'
                 );
             }

--- a/phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php
+++ b/phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php
@@ -1,0 +1,377 @@
+<?php
+/**
+ * Warn when a PHP class or public method lacks an @spec PHPDoc tag.
+ *
+ * ConductionNL ADR-003 (Backend rules) mandates that every class and public
+ * method MUST have one or more @spec PHPDoc tags linking back to the OpenSpec
+ * change that caused the code to exist:
+ *
+ *     @spec openspec/changes/{change-name}/tasks.md#task-N
+ *
+ * This sniff emits warnings (not errors) so that CI surfaces the gap without
+ * blocking merges while teams backfill coverage. Tests files and magic
+ * methods are skipped, as are private/protected methods — the ADR only
+ * mandates @spec for classes and public methods.
+ *
+ * @author  Conduction
+ * @package CustomSniffs
+ */
+
+namespace CustomSniffs\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * SpecTagSniff — warns when @spec PHPDoc tag is missing on classes / public methods.
+ */
+class SpecTagSniff implements Sniff
+{
+
+
+    /**
+     * PHP magic methods that are exempt from the @spec requirement.
+     *
+     * @var array<string>
+     */
+    private const MAGIC_METHODS = [
+        '__construct',
+        '__destruct',
+        '__get',
+        '__set',
+        '__call',
+        '__callstatic',
+        '__isset',
+        '__unset',
+        '__tostring',
+        '__invoke',
+        '__clone',
+        '__sleep',
+        '__wakeup',
+        '__serialize',
+        '__unserialize',
+        '__set_state',
+        '__debuginfo',
+    ];
+
+
+    /**
+     * Returns tokens this sniff listens for.
+     *
+     * @return array<int>
+     */
+    public function register(): array
+    {
+        return [T_CLASS, T_FUNCTION];
+
+    }//end register()
+
+
+    /**
+     * Process a T_CLASS or T_FUNCTION token.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the token.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        // Skip test files.
+        if ($this->isTestFile(phpcsFile: $phpcsFile) === true) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $code   = $tokens[$stackPtr]['code'];
+
+        if ($code === T_CLASS) {
+            $this->processClass(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+            return;
+        }
+
+        if ($code === T_FUNCTION) {
+            $this->processFunction(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+            return;
+        }
+
+    }//end process()
+
+
+    /**
+     * Check a class declaration for an @spec docblock tag.
+     *
+     * Skips anonymous classes (no name follows the T_CLASS keyword).
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_CLASS token.
+     *
+     * @return void
+     */
+    private function processClass(File $phpcsFile, int $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Anonymous classes — $var = new class { ... } — have no name; skip.
+        $namePtr = $phpcsFile->findNext(T_STRING, ($stackPtr + 1), null, false, null, true);
+        if ($namePtr === false) {
+            return;
+        }
+
+        // Sanity: name should be on the same line or within a short window.
+        $openBracePtr = $phpcsFile->findNext(T_OPEN_CURLY_BRACKET, ($stackPtr + 1));
+        if ($openBracePtr !== false && $namePtr > $openBracePtr) {
+            return;
+        }
+
+        $className = $tokens[$namePtr]['content'];
+
+        if ($this->hasSpecTag(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === true) {
+            return;
+        }
+
+        $message = 'Class %s is missing @spec PHPDoc tag — link back to openspec/changes/{name}/tasks.md#task-N';
+        $phpcsFile->addWarning($message, $stackPtr, 'MissingClassSpec', [$className]);
+
+    }//end processClass()
+
+
+    /**
+     * Check a function declaration for an @spec docblock tag.
+     *
+     * Only flags public methods declared inside a class. Global functions,
+     * private/protected methods, and magic methods are skipped.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_FUNCTION token.
+     *
+     * @return void
+     */
+    private function processFunction(File $phpcsFile, int $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Must be inside a class scope.
+        $className = $this->getEnclosingClassName(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+        if ($className === null) {
+            return;
+        }
+
+        // Get method name.
+        $namePtr = $phpcsFile->findNext(T_STRING, ($stackPtr + 1));
+        if ($namePtr === false) {
+            return;
+        }
+
+        $methodName = $tokens[$namePtr]['content'];
+
+        // Skip magic methods.
+        if (in_array(strtolower($methodName), self::MAGIC_METHODS, true) === true) {
+            return;
+        }
+
+        // Determine visibility: default is public when no modifier present.
+        if ($this->isPublicMethod(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === false) {
+            return;
+        }
+
+        if ($this->hasSpecTag(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === true) {
+            return;
+        }
+
+        $message = 'Public method %s::%s() is missing @spec PHPDoc tag';
+        $phpcsFile->addWarning($message, $stackPtr, 'MissingMethodSpec', [$className, $methodName]);
+
+    }//end processFunction()
+
+
+    /**
+     * Check whether the docblock directly preceding $stackPtr contains an @spec tag.
+     *
+     * Walks backwards from the token skipping whitespace, attribute tokens, and
+     * visibility/abstract/final/static modifiers. If the next non-skipped token
+     * is the close of a doc comment, scan the block for @spec.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the class/function token.
+     *
+     * @return bool True when an @spec tag is present.
+     */
+    private function hasSpecTag(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $skip = [
+            T_WHITESPACE,
+            T_ABSTRACT,
+            T_FINAL,
+            T_STATIC,
+            T_PUBLIC,
+            T_PROTECTED,
+            T_PRIVATE,
+            T_READONLY,
+            T_ATTRIBUTE,
+            T_ATTRIBUTE_END,
+        ];
+
+        $ptr = ($stackPtr - 1);
+        while ($ptr >= 0) {
+            $code = $tokens[$ptr]['code'];
+
+            // Skip over attribute blocks (PHP 8 #[Attribute]) in full.
+            if ($code === T_ATTRIBUTE_END && isset($tokens[$ptr]['attribute_opener']) === true) {
+                $ptr = ($tokens[$ptr]['attribute_opener'] - 1);
+                continue;
+            }
+
+            if (in_array($code, $skip, true) === true) {
+                $ptr--;
+                continue;
+            }
+
+            break;
+        }
+
+        if ($ptr < 0) {
+            return false;
+        }
+
+        if ($tokens[$ptr]['code'] !== T_DOC_COMMENT_CLOSE_TAG) {
+            return false;
+        }
+
+        if (isset($tokens[$ptr]['comment_opener']) === false) {
+            return false;
+        }
+
+        $opener = $tokens[$ptr]['comment_opener'];
+        for ($i = $opener; $i <= $ptr; $i++) {
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_TAG
+                && strtolower($tokens[$i]['content']) === '@spec'
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+
+    }//end hasSpecTag()
+
+
+    /**
+     * Determine if the function at $stackPtr is a public method.
+     *
+     * Methods default to public when no visibility modifier is present.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_FUNCTION token.
+     *
+     * @return bool True when the method is public (explicit or default).
+     */
+    private function isPublicMethod(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $ptr = ($stackPtr - 1);
+        while ($ptr >= 0) {
+            $code = $tokens[$ptr]['code'];
+            if ($code === T_PUBLIC) {
+                return true;
+            }
+
+            if ($code === T_PROTECTED || $code === T_PRIVATE) {
+                return false;
+            }
+
+            if ($code === T_WHITESPACE
+                || $code === T_ABSTRACT
+                || $code === T_FINAL
+                || $code === T_STATIC
+                || $code === T_READONLY
+            ) {
+                $ptr--;
+                continue;
+            }
+
+            // Skip attributes in full.
+            if ($code === T_ATTRIBUTE_END && isset($tokens[$ptr]['attribute_opener']) === true) {
+                $ptr = ($tokens[$ptr]['attribute_opener'] - 1);
+                continue;
+            }
+
+            if ($code === T_DOC_COMMENT_CLOSE_TAG
+                || $code === T_COMMENT
+                || $code === T_OPEN_CURLY_BRACKET
+                || $code === T_CLOSE_CURLY_BRACKET
+                || $code === T_SEMICOLON
+            ) {
+                // No visibility modifier found — default public.
+                return true;
+            }
+
+            $ptr--;
+        }
+
+        return true;
+
+    }//end isPublicMethod()
+
+
+    /**
+     * Return the name of the class/interface/trait/enum enclosing $stackPtr, or null.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the token to inspect.
+     *
+     * @return string|null The enclosing class name, or null when at file scope.
+     */
+    private function getEnclosingClassName(File $phpcsFile, int $stackPtr): ?string
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['conditions']) === false) {
+            return null;
+        }
+
+        // Walk the conditions chain looking for the innermost class-like scope.
+        $classLike = [T_CLASS, T_INTERFACE, T_TRAIT, T_ENUM, T_ANON_CLASS];
+
+        foreach (array_reverse($tokens[$stackPtr]['conditions'], true) as $scopePtr => $scopeCode) {
+            if (in_array($scopeCode, $classLike, true) === true) {
+                $namePtr = $phpcsFile->findNext(T_STRING, ($scopePtr + 1));
+                if ($namePtr === false) {
+                    return '{anonymous}';
+                }
+
+                // Sanity: ensure the name is before the opening brace for that class.
+                if (isset($tokens[$scopePtr]['scope_opener']) === true
+                    && $namePtr > $tokens[$scopePtr]['scope_opener']
+                ) {
+                    return '{anonymous}';
+                }
+
+                return $tokens[$namePtr]['content'];
+            }
+        }
+
+        return null;
+
+    }//end getEnclosingClassName()
+
+
+    /**
+     * Check whether the currently-scanned file is a test file.
+     *
+     * @param File $phpcsFile The file being scanned.
+     *
+     * @return bool True for files under /tests/ or /Tests/.
+     */
+    private function isTestFile(File $phpcsFile): bool
+    {
+        $path = str_replace('\\', '/', $phpcsFile->getFilename());
+        return (stripos($path, '/tests/') !== false);
+
+    }//end isTestFile()
+
+
+}//end class

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,17 +1,24 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
-    <description>The coding standard for PHP_CodeSniffer itself, for more config -> for https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options.</description>
+    <description>Coding standard for OpenRegister, based on the Conduction/OpenRegister standard.</description>
 
     <file>lib</file>
 
     <!-- Exclude external and vendor files -->
     <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/vendor-bin/*</exclude-pattern>
     <exclude-pattern>*/node_modules/*</exclude-pattern>
     <exclude-pattern>composer-setup.php</exclude-pattern>
+    <!-- Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt)
+         keep it out of lint scope; no-op for apps without the directory. -->
+    <exclude-pattern>lib/Resources/template/*</exclude-pattern>
+
+    <!-- Surface phpcs warnings (e.g. SpecTagSniff) in CI logs without failing the build. -->
+    <config name="ignore_warnings_on_exit" value="1"/>
 
     <arg name="basepath" value="."/>
     <arg name="colors"/>
-    <arg name="parallel" value="1"/>
+    <arg name="parallel" value="75"/>
     <arg name="extensions" value="php"/>
     <arg value="p"/>
 
@@ -46,22 +53,22 @@
     <rule ref="Squiz.Commenting.LongConditionClosingComment"/>
     <rule ref="Squiz.Commenting.PostStatementComment"/>
     <rule ref="Squiz.Commenting.VariableComment"/>
-    <!-- Removed the OperatorBracket rule to allow operations without brackets -->
     <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing"/>
     <rule ref="Squiz.Operators.ComparisonOperatorUsage"/>
-    <!-- Removed DisallowInlineIf to allow ternary operators for ElseExpression elimination -->
+    <rule ref="Squiz.PHP.DisallowInlineIf"/>
     <rule ref="Squiz.Scope.MethodScope"/>
-    <rule ref="Squiz.Strings.ConcatenationSpacing"/>
+    <rule ref="Squiz.Strings.ConcatenationSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
     <rule ref="Squiz.WhiteSpace.ControlStructureSpacing"/>
-    <!-- Disabled: Conflicts with Squiz.WhiteSpace.FunctionSpacing -->
-    <!-- <rule ref="Squiz.WhiteSpace.FunctionClosingBraceSpace"/> -->
     <rule ref="Squiz.WhiteSpace.FunctionSpacing">
         <properties>
             <property name="spacing" value="1"/>
             <property name="spacingAfterLast" value="0"/>
             <property name="spacingBeforeFirst" value="0"/>
         </properties>
-        <exclude-pattern>lib/Db/AuditTrailMapper\.php</exclude-pattern>
     </rule>
     <rule ref="Squiz.WhiteSpace.MemberVarSpacing"/>
     <rule ref="Squiz.WhiteSpace.OperatorSpacing"/>
@@ -76,14 +83,18 @@
     <rule ref="Generic.Formatting.SpaceAfterCast"/>
     <rule ref="Generic.Files.LineLength">
         <properties>
-            <property name="lineLimit" value="125"/>
+            <property name="lineLimit" value="150"/>
             <property name="absoluteLineLimit" value="150"/>
         </properties>
     </rule>
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Generic.PHP.LowerCaseKeyword"/>
-    <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
+    <rule ref="Generic.Strings.UnnecessaryStringConcat">
+        <properties>
+            <property name="allowMultiline" value="true"/>
+        </properties>
+    </rule>
     <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
     <rule ref="PSR2.Classes.PropertyDeclaration"/>
     <rule ref="PSR2.Methods.MethodDeclaration"/>
@@ -154,8 +165,6 @@
                 <element value="T_OPEN_SHORT_ARRAY"/>
             </property>
         </properties>
-        <exclude-pattern>lib/Service/Settings/ConfigurationSettingsHandler\.php</exclude-pattern>
-        <exclude-pattern>lib/Db/AuditTrailMapper\.php</exclude-pattern>
     </rule>
 
     <!-- Have 12 chars padding maximum and always show as errors -->
@@ -192,16 +201,6 @@
         <type>error</type>
     </rule>
 
-    <!-- The testing bootstrap file uses string concats to stop IDEs seeing the class aliases -->
-    <rule ref="Generic.Strings.UnnecessaryStringConcat">
-        <exclude-pattern>tests/bootstrap\.php</exclude-pattern>
-    </rule>
-
-    <!-- This test file specifically *needs* Windows line endings for testing purposes. -->
-    <rule ref="Generic.Files.LineEndings.InvalidEOLChar">
-        <exclude-pattern>tests/Core/Tokenizer/StableCommentWhitespaceWinTest\.php</exclude-pattern>
-    </rule>
-
     <!-- Explicitly exclude other rules that might conflict -->
     <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction">
         <severity>0</severity>
@@ -221,9 +220,15 @@
         <type>error</type>
     </rule>
 
-    <!-- Custom rule to forbid legacy \OC::$server->getX() accessors removed in Nextcloud 34 -->
+    <!-- Block calls to \OC::$server->getX() / \OC::$server->query() removed in Nextcloud 34. -->
     <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php">
         <type>error</type>
+    </rule>
+
+    <!-- Warn when a class or public method is missing the @spec PHPDoc tag (hydra ADR-003).
+         Emitted as warnings (not errors) so CI surfaces the gap but doesn't block merges. -->
+    <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php">
+        <type>warning</type>
     </rule>
 
 </ruleset>

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -6,7 +6,7 @@
                         http://pmd.sourceforge.net/ruleset_xml_schema.xsd">
 
     <description>
-        OpenRegister Nextcloud Rules
+        This is a custom ruleset for OpenRegister Nextcloud.
     </description>
 
     <!-- Clean Code Rules -->

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,5 +1,25 @@
+# Tracked phpstan debt entries surfaced when openregister synced to the fleet canonical.
+# All entries are tracked in https://github.com/ConductionNL/openregister/issues/1640
+# (Phase 2 fleet rollout lint-debt cleanup). Regenerate with:
+#     ./vendor/bin/phpstan analyse --generate-baseline=phpstan-baseline.neon
+# Entries removed as the underlying code is refactored.
 parameters:
 	ignoreErrors:
+		-
+			message: "#^Missing parameter \\$objectService \\(OCA\\\\OpenRegister\\\\Service\\\\ObjectService\\) in call to OCA\\\\OpenRegister\\\\Service\\\\Integration\\\\BuiltinProviders\\\\TasksProvider constructor\\.$#"
+			count: 1
+			path: lib/AppInfo/Application.php
+
+		-
+			message: "#^Missing parameter \\$registerMapper \\(OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\) in call to OCA\\\\OpenRegister\\\\Service\\\\Integration\\\\BuiltinProviders\\\\TasksProvider constructor\\.$#"
+			count: 1
+			path: lib/AppInfo/Application.php
+
+		-
+			message: "#^Missing parameter \\$schemaMapper \\(OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\) in call to OCA\\\\OpenRegister\\\\Service\\\\Integration\\\\BuiltinProviders\\\\TasksProvider constructor\\.$#"
+			count: 1
+			path: lib/AppInfo/Application.php
+
 		-
 			message: "#^Parameter \\$container of class OCA\\\\OpenRegister\\\\Service\\\\Object\\\\CacheHandler constructor expects OCP\\\\AppFramework\\\\IAppContainer\\|null, Psr\\\\Container\\\\ContainerInterface given\\.$#"
 			count: 1
@@ -14,6 +34,16 @@ parameters:
 			message: "#^Parameter \\$container of class OCA\\\\OpenRegister\\\\Service\\\\Settings\\\\ValidationOperationsHandler constructor expects OCP\\\\AppFramework\\\\IAppContainer, Psr\\\\Container\\\\ContainerInterface given\\.$#"
 			count: 1
 			path: lib/AppInfo/Application.php
+
+		-
+			message: "#^Call to method getNextRunDate\\(\\) on an unknown class Cron\\\\CronExpression\\.$#"
+			count: 1
+			path: lib/BackgroundJob/ActionScheduleJob.php
+
+		-
+			message: "#^Instantiated class Cron\\\\CronExpression not found\\.$#"
+			count: 1
+			path: lib/BackgroundJob/ActionScheduleJob.php
 
 		-
 			message: "#^Variable \\$fileId on left side of \\?\\? always exists and is not nullable\\.$#"
@@ -32,6 +62,26 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method OCP\\\\Files\\\\Node\\:\\:nodeExists\\(\\)\\.$#"
+			count: 1
+			path: lib/BackgroundJob/ReportRenderJob.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\MagicMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/BackgroundJob/ReportRenderJob.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/BackgroundJob/ReportRenderJob.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\MagicMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/BackgroundJob/ReportRenderJob.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
 			count: 1
 			path: lib/BackgroundJob/ReportRenderJob.php
 
@@ -61,6 +111,11 @@ parameters:
 			path: lib/Calendar/RegisterCalendarProvider.php
 
 		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Calendar/RegisterCalendarProvider.php
+
+		-
 			message: "#^Call to an undefined method OCA\\\\OpenRegister\\\\Db\\\\Register\\:\\:getName\\(\\)\\.$#"
 			count: 1
 			path: lib/Command/MigrateStorageCommand.php
@@ -69,6 +124,16 @@ parameters:
 			message: "#^Call to an undefined method OCA\\\\OpenRegister\\\\Db\\\\Schema\\:\\:getName\\(\\)\\.$#"
 			count: 1
 			path: lib/Command/MigrateStorageCommand.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Command/RematerialiseCalculationsCommand.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Command/RematerialiseCalculationsCommand.php
 
 		-
 			message: "#^Property OCA\\\\OpenRegister\\\\Command\\\\SolrDebugCommand\\:\\:\\$clientService is never read, only written\\.$#"
@@ -102,21 +167,6 @@ parameters:
 
 		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\AgentsController\\:\\:page\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\TemplateResponse\\<200, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\TemplateResponse\\<200, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/AgentsController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\AgentsController\\:\\:show\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<403\\|404, array\\{error\\: 'Access denied to…'\\|'Agent not found'\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, OCA\\\\OpenRegister\\\\Db\\\\Agent, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, OCA\\\\OpenRegister\\\\Db\\\\Agent, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/AgentsController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\AgentsController\\:\\:show\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<403\\|404, array\\{error\\: 'Access denied to…'\\|'Agent not found'\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, OCA\\\\OpenRegister\\\\Db\\\\Agent, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<403, array\\{error\\: string\\}, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/AgentsController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\AgentsController\\:\\:show\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<403\\|404, array\\{error\\: 'Access denied to…'\\|'Agent not found'\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, OCA\\\\OpenRegister\\\\Db\\\\Agent, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404, array\\{error\\: string\\}, array\\{\\}\\>\\.$#"
 			count: 1
 			path: lib/Controller/AgentsController.php
 
@@ -291,6 +341,11 @@ parameters:
 			path: lib/Controller/ChatController.php
 
 		-
+			message: "#^Offset 'context' does not exist on array\\{conversationUuid\\: string, agentUuid\\: string, message\\: non\\-falsy\\-string, selectedViews\\: array, selectedTools\\: array, ragSettings\\: array\\{includeObjects\\: mixed, includeFiles\\: mixed, numSourcesFiles\\: mixed, numSourcesObjects\\: mixed\\}\\}\\.$#"
+			count: 1
+			path: lib/Controller/ChatController.php
+
+		-
 			message: "#^Variable \\$conversationUuid on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 1
 			path: lib/Controller/ChatController.php
@@ -299,6 +354,26 @@ parameters:
 			message: "#^Variable \\$messageId on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 1
 			path: lib/Controller/ChatController.php
+
+		-
+			message: "#^Offset 'message' on array\\{message\\: string, messageId\\: string, sources\\: array\\<int, array\\>, timings\\: array\\{context\\: string, history\\: string, llm\\: string, total\\: string\\}\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Controller/ChatStreamController.php
+
+		-
+			message: "#^Offset 'messageId' on array\\{message\\: string, messageId\\: string, sources\\: array\\<int, array\\>, timings\\: array\\{context\\: string, history\\: string, llm\\: string, total\\: string\\}\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Controller/ChatStreamController.php
+
+		-
+			message: "#^Offset 'response' on array\\{message\\: string, messageId\\: string, sources\\: array\\<int, array\\>, timings\\: array\\{context\\: string, history\\: string, llm\\: string, total\\: string\\}\\} on left side of \\?\\? does not exist\\.$#"
+			count: 1
+			path: lib/Controller/ChatStreamController.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: lib/Controller/ChatStreamController.php
 
 		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\ConfigurationController\\:\\:destroy\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|404\\|500, array\\{error\\?\\: 'Configuration not…'\\|'Failed to delete…', success\\?\\: true\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, array\\{success\\: bool\\}, array\\{\\}\\>\\.$#"
@@ -472,6 +547,16 @@ parameters:
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between mixed and null will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Controller/ConfigurationsController.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\ConfigurationMapper\\:\\:find\\(\\)\\.$#"
+			count: 2
+			path: lib/Controller/ConfigurationsController.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\ConfigurationMapper\\:\\:findAll\\(\\)\\.$#"
 			count: 1
 			path: lib/Controller/ConfigurationsController.php
 
@@ -731,36 +816,6 @@ parameters:
 			path: lib/Controller/EndpointsController.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\EndpointsController\\:\\:logs\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|404\\|500, array\\{error\\?\\: 'Endpoint not found'\\|'Failed to retrieve…', results\\?\\: array\\<int, OCA\\\\OpenRegister\\\\Db\\\\EndpointLog\\>, total\\?\\: int\\<0, max\\>\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, array\\{results\\: array\\<int, OCA\\\\OpenRegister\\\\Db\\\\EndpointLog\\>, total\\: int\\}, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/EndpointsController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\EndpointsController\\:\\:logs\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|404\\|500, array\\{error\\?\\: 'Endpoint not found'\\|'Failed to retrieve…', results\\?\\: array\\<int, OCA\\\\OpenRegister\\\\Db\\\\EndpointLog\\>, total\\?\\: int\\<0, max\\>\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404, array\\{error\\: string\\}, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/EndpointsController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\EndpointsController\\:\\:logs\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|404\\|500, array\\{error\\?\\: 'Endpoint not found'\\|'Failed to retrieve…', results\\?\\: array\\<int, OCA\\\\OpenRegister\\\\Db\\\\EndpointLog\\>, total\\?\\: int\\<0, max\\>\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<500, array\\{error\\: string\\}, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/EndpointsController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\EndpointsController\\:\\:show\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404\\|500, array\\{error\\: 'Endpoint not found'\\|'Failed to retrieve…'\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, OCA\\\\OpenRegister\\\\Db\\\\Endpoint, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, OCA\\\\OpenRegister\\\\Db\\\\Endpoint, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/EndpointsController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\EndpointsController\\:\\:show\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404\\|500, array\\{error\\: 'Endpoint not found'\\|'Failed to retrieve…'\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, OCA\\\\OpenRegister\\\\Db\\\\Endpoint, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404, array\\{error\\: string\\}, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/EndpointsController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\EndpointsController\\:\\:show\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404\\|500, array\\{error\\: 'Endpoint not found'\\|'Failed to retrieve…'\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, OCA\\\\OpenRegister\\\\Db\\\\Endpoint, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<500, array\\{error\\: string\\}, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/EndpointsController.php
-
-		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\EndpointsController\\:\\:test\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<int, array\\{error\\?\\: string, success\\?\\: bool, message\\?\\: string, statusCode\\?\\: int, response\\?\\: mixed\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<100\\|101\\|102\\|200\\|201\\|202\\|203\\|204\\|205\\|206\\|207\\|208\\|226\\|300\\|301\\|302\\|303\\|304\\|305\\|306\\|307\\|400\\|401\\|402\\|403\\|404\\|405\\|406\\|407\\|408\\|409\\|410\\|411\\|412\\|413\\|414\\|415\\|416\\|417\\|418\\|422\\|423\\|424\\|426\\|428\\|429\\|431\\|500\\|501\\|502\\|503\\|504\\|505\\|506\\|507\\|508\\|509\\|510\\|511, array\\{success\\: bool, message\\: string, statusCode\\: int\\}, array\\{\\}\\>\\.$#"
 			count: 1
 			path: lib/Controller/EndpointsController.php
@@ -796,11 +851,6 @@ parameters:
 			path: lib/Controller/EndpointsController.php
 
 		-
-			message: "#^Parameter \\$statusCode of class OCP\\\\AppFramework\\\\Http\\\\JSONResponse constructor expects S of 100\\|101\\|102\\|200\\|201\\|202\\|203\\|204\\|205\\|206\\|207\\|208\\|226\\|300\\|301\\|302\\|303\\|304\\|305\\|306\\|307\\|400\\|401\\|402\\|403\\|404\\|405\\|406\\|407\\|408\\|409\\|410\\|411\\|412\\|413\\|414\\|415\\|416\\|417\\|418\\|422\\|423\\|424\\|426\\|428\\|429\\|431\\|500\\|501\\|502\\|503\\|504\\|505\\|506\\|507\\|508\\|509\\|510\\|511, int given\\.$#"
-			count: 1
-			path: lib/Controller/EndpointsController.php
-
-		-
 			message: "#^Type int in generic type OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<int, array\\<string, mixed\\>, array\\> in PHPDoc tag @return is not subtype of template type S of int of class OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\.$#"
 			count: 1
 			path: lib/Controller/EndpointsController.php
@@ -822,21 +872,6 @@ parameters:
 
 		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\FileExtractionController\\:\\:discover\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|500, array\\{success\\: bool, error\\?\\: 'File discovery…', message\\: string, data\\?\\: array\\{discovered\\: int\\<0, max\\>, failed\\: int\\<0, max\\>, total\\: int\\<0, max\\>, error\\?\\: string\\}\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<500, array\\{success\\: bool, error\\: string, message\\: string\\}, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/FileExtractionController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\FileExtractionController\\:\\:extract\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|404\\|500, array\\{success\\: bool, error\\?\\: 'Extraction failed'\\|'File not found in…', message\\: string\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, array\\{success\\: bool, message\\: string\\}, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/FileExtractionController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\FileExtractionController\\:\\:extract\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|404\\|500, array\\{success\\: bool, error\\?\\: 'Extraction failed'\\|'File not found in…', message\\: string\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404, array\\{success\\: bool, error\\: string, message\\: string\\}, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/FileExtractionController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\FileExtractionController\\:\\:extract\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|404\\|500, array\\{success\\: bool, error\\?\\: 'Extraction failed'\\|'File not found in…', message\\: string\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<500, array\\{success\\: bool, error\\: string, message\\: string\\}, array\\{\\}\\>\\.$#"
 			count: 1
 			path: lib/Controller/FileExtractionController.php
 
@@ -868,16 +903,6 @@ parameters:
 		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\FileExtractionController\\:\\:retryFailed\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|500, array\\{success\\: bool, error\\?\\: 'Retry failed', message\\: string, data\\?\\: array\\{retried\\: int\\<0, max\\>, failed\\: int\\<0, max\\>, total\\: int\\<0, max\\>\\}\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<500, array\\{success\\: bool, error\\: string, message\\: string\\}, array\\{\\}\\>\\.$#"
 			count: 1
-			path: lib/Controller/FileExtractionController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\FileExtractionController\\:\\:show\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|404, array\\{success\\: bool, error\\?\\: 'File not found in…', message\\?\\: string, data\\?\\: non\\-empty\\-array\\<int, array\\{checksum\\: string\\|null, chunkIndex\\: int, createdAt\\: string\\|null, embeddingProvider\\: string\\|null, endOffset\\: int, id\\: int, indexed\\: bool, language\\: string\\|null, \\.\\.\\.\\}\\>\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, array\\{success\\: bool, data\\: non\\-empty\\-array\\<int, array\\{id\\: int, uuid\\: string\\|null, sourceType\\: string\\|null, sourceId\\: int\\|null, chunkIndex\\: int, startOffset\\: int, endOffset\\: int, language\\: string\\|null, \\.\\.\\.\\}\\>\\}, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/FileExtractionController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\FileExtractionController\\:\\:show\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|404, array\\{success\\: bool, error\\?\\: 'File not found in…', message\\?\\: string, data\\?\\: non\\-empty\\-array\\<int, array\\{checksum\\: string\\|null, chunkIndex\\: int, createdAt\\: string\\|null, embeddingProvider\\: string\\|null, endOffset\\: int, id\\: int, indexed\\: bool, language\\: string\\|null, \\.\\.\\.\\}\\>\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404, array\\{success\\: bool, error\\: string, message\\: string\\}, array\\{\\}\\>\\.$#"
-			count: 2
 			path: lib/Controller/FileExtractionController.php
 
 		-
@@ -976,11 +1001,6 @@ parameters:
 			path: lib/Controller/FilesController.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\FilesController\\:\\:processUploadedFiles\\(\\) has invalid return type OCA\\\\OpenRegister\\\\Controller\\\\OCP\\\\Files\\\\File\\.$#"
-			count: 1
-			path: lib/Controller/FilesController.php
-
-		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\FilesController\\:\\:processUploadedFiles\\(\\) should return array\\<int, OCA\\\\OpenRegister\\\\Controller\\\\OCP\\\\Files\\\\File\\> but returns array\\<int\\<0, max\\>, OCP\\\\Files\\\\File\\>\\.$#"
 			count: 1
 			path: lib/Controller/FilesController.php
@@ -1054,11 +1074,6 @@ parameters:
 			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\HeartbeatController\\:\\:heartbeat\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, array\\{status\\: 'alive', timestamp\\: int\\<1, max\\>, message\\: 'Heartbeat…'\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, array\\{status\\: string, timestamp\\: int, message\\: string\\}, array\\{\\}\\>\\.$#"
 			count: 1
 			path: lib/Controller/HeartbeatController.php
-
-		-
-			message: "#^Call to method jsonSerialize\\(\\) on an unknown class OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\Mapping\\.$#"
-			count: 1
-			path: lib/Controller/MappingsController.php
 
 		-
 			message: "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\Mapping\\)\\: mixed\\)\\|null, Closure\\(OCA\\\\OpenRegister\\\\Db\\\\Mapping\\)\\: array\\<string, mixed\\> given\\.$#"
@@ -1296,6 +1311,16 @@ parameters:
 			path: lib/Controller/ObjectsController.php
 
 		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/ObjectsController.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/ObjectsController.php
+
+		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 4
 			path: lib/Controller/ObjectsController.php
@@ -1511,11 +1536,6 @@ parameters:
 			path: lib/Controller/RegistersController.php
 
 		-
-			message: "#^Parameter \\$statusCode of class OCP\\\\AppFramework\\\\Http\\\\JSONResponse constructor expects S of 100\\|101\\|102\\|200\\|201\\|202\\|203\\|204\\|205\\|206\\|207\\|208\\|226\\|300\\|301\\|302\\|303\\|304\\|305\\|306\\|307\\|400\\|401\\|402\\|403\\|404\\|405\\|406\\|407\\|408\\|409\\|410\\|411\\|412\\|413\\|414\\|415\\|416\\|417\\|418\\|422\\|423\\|424\\|426\\|428\\|429\\|431\\|500\\|501\\|502\\|503\\|504\\|505\\|506\\|507\\|508\\|509\\|510\\|511, int given\\.$#"
-			count: 4
-			path: lib/Controller/RegistersController.php
-
-		-
 			message: "#^Property OCA\\\\OpenRegister\\\\Controller\\\\RegistersController\\:\\:\\$appManager is never read, only written\\.$#"
 			count: 1
 			path: lib/Controller/RegistersController.php
@@ -1538,6 +1558,11 @@ parameters:
 		-
 			message: "#^Type int in generic type OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<int, array\\<string, string\\>, array\\> in PHPDoc tag @return is not subtype of template type S of int of class OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\.$#"
 			count: 4
+			path: lib/Controller/RegistersController.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
 			path: lib/Controller/RegistersController.php
 
 		-
@@ -1621,16 +1646,6 @@ parameters:
 			path: lib/Controller/SchemasController.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\SchemasController\\:\\:download\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404, array\\{error\\: 'Schema not found'\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, OCA\\\\OpenRegister\\\\Db\\\\Schema, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, OCA\\\\OpenRegister\\\\Db\\\\Schema, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/SchemasController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\SchemasController\\:\\:download\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404, array\\{error\\: 'Schema not found'\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, OCA\\\\OpenRegister\\\\Db\\\\Schema, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404, array\\{error\\: string\\}, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/SchemasController.php
-
-		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\SchemasController\\:\\:index\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, array\\{results\\: array\\<array\\{id\\: int, uuid\\: string\\|null, uri\\: string\\|null, slug\\: string\\|null, title\\: string\\|null, description\\: string\\|null, version\\: string\\|null, summary\\: string\\|null, \\.\\.\\.\\}\\>\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, array\\{results\\: array\\<array\\{id\\: int, uuid\\: string\\|null, uri\\: string\\|null, slug\\: string\\|null, title\\: string\\|null, description\\: string\\|null, version\\: string\\|null, summary\\: string\\|null, \\.\\.\\.\\}\\>\\}, array\\{\\}\\>\\.$#"
 			count: 1
 			path: lib/Controller/SchemasController.php
@@ -1691,11 +1706,6 @@ parameters:
 			path: lib/Controller/SchemasController.php
 
 		-
-			message: "#^Parameter \\$statusCode of class OCP\\\\AppFramework\\\\Http\\\\JSONResponse constructor expects S of 100\\|101\\|102\\|200\\|201\\|202\\|203\\|204\\|205\\|206\\|207\\|208\\|226\\|300\\|301\\|302\\|303\\|304\\|305\\|306\\|307\\|400\\|401\\|402\\|403\\|404\\|405\\|406\\|407\\|408\\|409\\|410\\|411\\|412\\|413\\|414\\|415\\|416\\|417\\|418\\|422\\|423\\|424\\|426\\|428\\|429\\|431\\|500\\|501\\|502\\|503\\|504\\|505\\|506\\|507\\|508\\|509\\|510\\|511, int given\\.$#"
-			count: 6
-			path: lib/Controller/SchemasController.php
-
-		-
 			message: "#^Property OCA\\\\OpenRegister\\\\Controller\\\\SchemasController\\:\\:\\$config is never read, only written\\.$#"
 			count: 1
 			path: lib/Controller/SchemasController.php
@@ -1736,6 +1746,16 @@ parameters:
 			path: lib/Controller/SchemasController.php
 
 		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/SchemasController.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/SchemasController.php
+
+		-
 			message: "#^Unknown parameter \\$filters in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
 			count: 1
 			path: lib/Controller/SchemasController.php
@@ -1757,6 +1777,26 @@ parameters:
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between OCA\\\\OpenRegister\\\\Db\\\\Schema and null will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Controller/ScopesController.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/ScopesController.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/ScopesController.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/ScopesController.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
 			count: 1
 			path: lib/Controller/ScopesController.php
 
@@ -2546,14 +2586,19 @@ parameters:
 			path: lib/Controller/TransitionController.php
 
 		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/TranslationController.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Controller/TranslationController.php
+
+		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\UiController\\:\\:makeSpaResponse\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\TemplateResponse but returns static\\(OCP\\\\AppFramework\\\\Http\\\\Response\\<int, array\\<string, mixed\\>\\>\\)\\.$#"
 			count: 1
 			path: lib/Controller/UiController.php
-
-		-
-			message: "#^Parameter \\$statusCode of class OCP\\\\AppFramework\\\\Http\\\\JSONResponse constructor expects S of 100\\|101\\|102\\|200\\|201\\|202\\|203\\|204\\|205\\|206\\|207\\|208\\|226\\|300\\|301\\|302\\|303\\|304\\|305\\|306\\|307\\|400\\|401\\|402\\|403\\|404\\|405\\|406\\|407\\|408\\|409\\|410\\|411\\|412\\|413\\|414\\|415\\|416\\|417\\|418\\|422\\|423\\|424\\|426\\|428\\|429\\|431\\|500\\|501\\|502\\|503\\|504\\|505\\|506\\|507\\|508\\|509\\|510\\|511, int given\\.$#"
-			count: 1
-			path: lib/Controller/UserController.php
 
 		-
 			message: "#^Property OCA\\\\OpenRegister\\\\Controller\\\\UserController\\:\\:\\$l10n is never read, only written\\.$#"
@@ -2616,57 +2661,12 @@ parameters:
 			path: lib/Controller/WebhooksController.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\WebhooksController\\:\\:destroy\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404\\|500, array\\{error\\: 'Failed to delete…'\\|'Webhook not found'\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<204, null, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<204, null, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/WebhooksController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\WebhooksController\\:\\:destroy\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404\\|500, array\\{error\\: 'Failed to delete…'\\|'Webhook not found'\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<204, null, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404, array\\{error\\: string\\}, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/WebhooksController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\WebhooksController\\:\\:destroy\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404\\|500, array\\{error\\: 'Failed to delete…'\\|'Webhook not found'\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<204, null, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<500, array\\{error\\: string\\}, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/WebhooksController.php
-
-		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\WebhooksController\\:\\:index\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|500, array\\{error\\?\\: 'Failed to list…', results\\?\\: array\\<array\\<string, mixed\\>\\>, total\\?\\: int\\<0, max\\>\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, array\\{results\\: array\\<array\\{id\\: int, uuid\\: string, name\\: string, url\\: string, method\\: string, events\\: array, headers\\: array, secret\\: string\\|null, \\.\\.\\.\\}\\>, total\\: int\\}, array\\{\\}\\>\\.$#"
 			count: 1
 			path: lib/Controller/WebhooksController.php
 
 		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\WebhooksController\\:\\:index\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|500, array\\{error\\?\\: 'Failed to list…', results\\?\\: array\\<array\\<string, mixed\\>\\>, total\\?\\: int\\<0, max\\>\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<500, array\\{error\\: string\\}, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/WebhooksController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\WebhooksController\\:\\:logs\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|404\\|500, array\\{error\\?\\: 'Failed to retrieve…'\\|'Webhook not found', results\\?\\: array\\<int, OCA\\\\OpenRegister\\\\Db\\\\WebhookLog\\>, total\\?\\: int\\<0, max\\>\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, array\\{results\\: array\\<int, OCA\\\\OpenRegister\\\\Db\\\\WebhookLog\\>, total\\: int\\}, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/WebhooksController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\WebhooksController\\:\\:logs\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|404\\|500, array\\{error\\?\\: 'Failed to retrieve…'\\|'Webhook not found', results\\?\\: array\\<int, OCA\\\\OpenRegister\\\\Db\\\\WebhookLog\\>, total\\?\\: int\\<0, max\\>\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404, array\\{error\\: string\\}, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/WebhooksController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\WebhooksController\\:\\:logs\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|404\\|500, array\\{error\\?\\: 'Failed to retrieve…'\\|'Webhook not found', results\\?\\: array\\<int, OCA\\\\OpenRegister\\\\Db\\\\WebhookLog\\>, total\\?\\: int\\<0, max\\>\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<500, array\\{error\\: string\\}, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/WebhooksController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\WebhooksController\\:\\:show\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404\\|500, array\\{error\\: 'Failed to retrieve…'\\|'Webhook not found'\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, OCA\\\\OpenRegister\\\\Db\\\\Webhook, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, OCA\\\\OpenRegister\\\\Db\\\\Webhook, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/WebhooksController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\WebhooksController\\:\\:show\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404\\|500, array\\{error\\: 'Failed to retrieve…'\\|'Webhook not found'\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, OCA\\\\OpenRegister\\\\Db\\\\Webhook, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404, array\\{error\\: string\\}, array\\{\\}\\>\\.$#"
-			count: 1
-			path: lib/Controller/WebhooksController.php
-
-		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\WebhooksController\\:\\:show\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404\\|500, array\\{error\\: 'Failed to retrieve…'\\|'Webhook not found'\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, OCA\\\\OpenRegister\\\\Db\\\\Webhook, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<500, array\\{error\\: string\\}, array\\{\\}\\>\\.$#"
 			count: 1
 			path: lib/Controller/WebhooksController.php
 
@@ -2691,6 +2691,16 @@ parameters:
 			path: lib/Db/ActionLogMapper.php
 
 		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:getOrganisation\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/ActionMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setOrganisation\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/ActionMapper.php
+
+		-
 			message: "#^Parameter \\$entity of method OCP\\\\AppFramework\\\\Db\\\\QBMapper\\<OCA\\\\OpenRegister\\\\Db\\\\Action\\>\\:\\:delete\\(\\) expects OCA\\\\OpenRegister\\\\Db\\\\Action, OCP\\\\AppFramework\\\\Db\\\\Entity given\\.$#"
 			count: 1
 			path: lib/Db/ActionMapper.php
@@ -2706,8 +2716,13 @@ parameters:
 			path: lib/Db/ActionMapper.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\AgentMapper\\:\\:findAll\\(\\) has invalid return type OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\Agent\\.$#"
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:getOrganisation\\(\\)\\.$#"
 			count: 1
+			path: lib/Db/AgentMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setOrganisation\\(\\)\\.$#"
+			count: 2
 			path: lib/Db/AgentMapper.php
 
 		-
@@ -2721,8 +2736,13 @@ parameters:
 			path: lib/Db/Application.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\ApplicationMapper\\:\\:findAll\\(\\) has invalid return type OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\Application\\.$#"
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:getOrganisation\\(\\)\\.$#"
 			count: 1
+			path: lib/Db/ApplicationMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setOrganisation\\(\\)\\.$#"
+			count: 2
 			path: lib/Db/ApplicationMapper.php
 
 		-
@@ -2776,7 +2796,7 @@ parameters:
 			path: lib/Db/AuditTrailMapper.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\AuditTrailMapper\\:\\:findAll\\(\\) has invalid return type OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\AuditTrail\\.$#"
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setSize\\(\\)\\.$#"
 			count: 1
 			path: lib/Db/AuditTrailMapper.php
 
@@ -2806,12 +2826,17 @@ parameters:
 			path: lib/Db/AuditTrailMapper.php
 
 		-
-			message: "#^Constant OCA\\\\OpenRegister\\\\Db\\\\ConfigurationMapper\\:\\:SESSION_KEY_PREFIX is unused\\.$#"
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:getOrganisation\\(\\)\\.$#"
 			count: 1
 			path: lib/Db/ConfigurationMapper.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\ConfigurationMapper\\:\\:findAll\\(\\) has invalid return type OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\Configuration\\.$#"
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setOrganisation\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/ConfigurationMapper.php
+
+		-
+			message: "#^Constant OCA\\\\OpenRegister\\\\Db\\\\ConfigurationMapper\\:\\:SESSION_KEY_PREFIX is unused\\.$#"
 			count: 1
 			path: lib/Db/ConfigurationMapper.php
 
@@ -2823,6 +2848,11 @@ parameters:
 		-
 			message: "#^Property OCA\\\\OpenRegister\\\\Db\\\\ConfigurationMapper\\:\\:\\$session is never read, only written\\.$#"
 			count: 1
+			path: lib/Db/ConfigurationMapper.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\ConfigurationMapper\\:\\:find\\(\\)\\.$#"
+			count: 2
 			path: lib/Db/ConfigurationMapper.php
 
 		-
@@ -2856,18 +2886,18 @@ parameters:
 			path: lib/Db/EndpointLog.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\EndpointLogMapper\\:\\:findAll\\(\\) has invalid return type OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\EndpointLog\\.$#"
-			count: 1
-			path: lib/Db/EndpointLogMapper.php
-
-		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\EndpointLogMapper\\:\\:findAll\\(\\) should return array\\<int, OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\EndpointLog\\> but returns array\\<int, OCA\\\\OpenRegister\\\\Db\\\\EndpointLog\\>\\.$#"
 			count: 1
 			path: lib/Db/EndpointLogMapper.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\EndpointMapper\\:\\:findAll\\(\\) has invalid return type OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\Endpoint\\.$#"
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:getOrganisation\\(\\)\\.$#"
 			count: 1
+			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setOrganisation\\(\\)\\.$#"
+			count: 2
 			path: lib/Db/EndpointMapper.php
 
 		-
@@ -2879,6 +2909,31 @@ parameters:
 			message: "#^Parameter \\$entity of method OCP\\\\AppFramework\\\\Db\\\\QBMapper\\<OCA\\\\OpenRegister\\\\Db\\\\Endpoint\\>\\:\\:delete\\(\\) expects OCA\\\\OpenRegister\\\\Db\\\\Endpoint, OCP\\\\AppFramework\\\\Db\\\\Entity given\\.$#"
 			count: 1
 			path: lib/Db/EndpointMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:getCreated\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/FeedbackMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:getUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/FeedbackMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setCreated\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/FeedbackMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setUpdated\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/FeedbackMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/FeedbackMapper.php
 
 		-
 			message: "#^Parameter \\$entity of method OCP\\\\AppFramework\\\\Db\\\\QBMapper\\<OCA\\\\OpenRegister\\\\Db\\\\Feedback\\>\\:\\:insert\\(\\) expects OCA\\\\OpenRegister\\\\Db\\\\Feedback, OCP\\\\AppFramework\\\\Db\\\\Entity given\\.$#"
@@ -3026,6 +3081,16 @@ parameters:
 			path: lib/Db/MagicMapper.php
 
 		-
+			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\) invoked with 5 parameters, 1 required\\.$#"
+			count: 1
+			path: lib/Db/MagicMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\) invoked with 5 parameters, 1 required\\.$#"
+			count: 1
+			path: lib/Db/MagicMapper.php
+
+		-
 			message: "#^Offset '\\$ref' on array\\{type\\: string, format\\?\\: string, items\\?\\: array, properties\\?\\: array, required\\?\\: array\\<string\\>, maxLength\\?\\: int, minLength\\?\\: int, maximum\\?\\: int, \\.\\.\\.\\} in isset\\(\\) does not exist\\.$#"
 			count: 1
 			path: lib/Db/MagicMapper.php
@@ -3081,6 +3146,26 @@ parameters:
 			path: lib/Db/MagicMapper.php
 
 		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 13
+			path: lib/Db/MagicMapper.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 15
+			path: lib/Db/MagicMapper.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 11
+			path: lib/Db/MagicMapper.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 13
+			path: lib/Db/MagicMapper.php
+
+		-
 			message: "#^Property OCA\\\\OpenRegister\\\\Db\\\\MagicMapper\\\\MagicBulkHandler\\:\\:\\$eventDispatcher is never read, only written\\.$#"
 			count: 1
 			path: lib/Db/MagicMapper/MagicBulkHandler.php
@@ -3121,6 +3206,26 @@ parameters:
 			path: lib/Db/MagicMapper/MagicSearchHandler.php
 
 		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 4
+			path: lib/Db/MagicMapper/MagicStatisticsHandler.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 4
+			path: lib/Db/MagicMapper/MagicStatisticsHandler.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 4
+			path: lib/Db/MagicMapper/MagicStatisticsHandler.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 4
+			path: lib/Db/MagicMapper/MagicStatisticsHandler.php
+
+		-
 			message: "#^Property OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:\\$id \\(int\\) in isset\\(\\) is not nullable\\.$#"
 			count: 1
 			path: lib/Db/Mapping.php
@@ -3141,8 +3246,13 @@ parameters:
 			path: lib/Db/Mapping.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\MappingMapper\\:\\:findAll\\(\\) has invalid return type OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\Mapping\\.$#"
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:getOrganisation\\(\\)\\.$#"
 			count: 1
+			path: lib/Db/MappingMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setOrganisation\\(\\)\\.$#"
+			count: 2
 			path: lib/Db/MappingMapper.php
 
 		-
@@ -3196,11 +3306,6 @@ parameters:
 			path: lib/Db/ObjectHandlers/HyperFacetHandler.php
 
 		-
-			message: "#^Function React\\\\Async\\\\await not found\\.$#"
-			count: 1
-			path: lib/Db/ObjectHandlers/HyperFacetHandler.php
-
-		-
 			message: "#^PHPDoc tag @return with type React\\\\Promise\\\\PromiseInterface is not subtype of native type React\\\\Promise\\\\Promise\\.$#"
 			count: 1
 			path: lib/Db/ObjectHandlers/HyperFacetHandler.php
@@ -3241,11 +3346,6 @@ parameters:
 			path: lib/Db/Organisation.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\OrganisationMapper\\:\\:findAll\\(\\) has invalid return type OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\Organisation\\.$#"
-			count: 1
-			path: lib/Db/OrganisationMapper.php
-
-		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\OrganisationMapper\\:\\:findAll\\(\\) should return array\\<int, OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\Organisation\\> but returns array\\<int, OCA\\\\OpenRegister\\\\Db\\\\Organisation\\>\\.$#"
 			count: 1
 			path: lib/Db/OrganisationMapper.php
@@ -3281,11 +3381,6 @@ parameters:
 			path: lib/Db/Register.php
 
 		-
-			message: "#^Caught class OCA\\\\OpenRegister\\\\Db\\\\Exception not found\\.$#"
-			count: 1
-			path: lib/Db/Register.php
-
-		-
 			message: "#^Property OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:\\$id \\(int\\) on left side of \\?\\? is not nullable\\.$#"
 			count: 1
 			path: lib/Db/Register.php
@@ -3296,12 +3391,27 @@ parameters:
 			path: lib/Db/Register.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:findAll\\(\\) has invalid return type OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\Register\\.$#"
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:getOrganisation\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/RegisterMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setOrganisation\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/RegisterMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\DB\\\\IResult\\:\\:fetchAllAssociative\\(\\)\\.$#"
 			count: 1
 			path: lib/Db/RegisterMapper.php
 
 		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:findAll\\(\\) should return array\\<int, OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\Register\\> but returns array\\<int, OCA\\\\OpenRegister\\\\Db\\\\Register\\>\\.$#"
+			count: 1
+			path: lib/Db/RegisterMapper.php
+
+		-
+			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\) invoked with 5 parameters, 1 required\\.$#"
 			count: 1
 			path: lib/Db/RegisterMapper.php
 
@@ -3326,6 +3436,16 @@ parameters:
 			path: lib/Db/RegisterMapper.php
 
 		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 3
+			path: lib/Db/RegisterMapper.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/RegisterMapper.php
+
+		-
 			message: "#^Unknown parameter \\$published in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
 			count: 2
 			path: lib/Db/RegisterMapper.php
@@ -3346,13 +3466,18 @@ parameters:
 			path: lib/Db/Schema.php
 
 		-
-			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
-			count: 4
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:getOrganisation\\(\\)\\.$#"
+			count: 1
 			path: lib/Db/SchemaMapper.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\) has invalid return type OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\Schema\\.$#"
-			count: 1
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setOrganisation\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/SchemaMapper.php
+
+		-
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 4
 			path: lib/Db/SchemaMapper.php
 
 		-
@@ -3397,6 +3522,16 @@ parameters:
 
 		-
 			message: "#^Unknown parameter \\$_extend in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/SchemaMapper.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/SchemaMapper.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
 			count: 1
 			path: lib/Db/SchemaMapper.php
 
@@ -3446,11 +3581,6 @@ parameters:
 			path: lib/Db/SearchTrailMapper.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\SearchTrailMapper\\:\\:findAll\\(\\) has invalid return type OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\SearchTrail\\.$#"
-			count: 1
-			path: lib/Db/SearchTrailMapper.php
-
-		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\SearchTrailMapper\\:\\:findAll\\(\\) should return array\\<int, OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\SearchTrail\\> but returns array\\<int, OCA\\\\OpenRegister\\\\Db\\\\SearchTrail\\>\\.$#"
 			count: 1
 			path: lib/Db/SearchTrailMapper.php
@@ -3466,8 +3596,13 @@ parameters:
 			path: lib/Db/SelectionListMapper.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\SourceMapper\\:\\:findAll\\(\\) has invalid return type OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\Source\\.$#"
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:getOrganisation\\(\\)\\.$#"
 			count: 1
+			path: lib/Db/SourceMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setOrganisation\\(\\)\\.$#"
+			count: 2
 			path: lib/Db/SourceMapper.php
 
 		-
@@ -3491,7 +3626,32 @@ parameters:
 			path: lib/Db/SourceMapper.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\ViewMapper\\:\\:findAll\\(\\) has invalid return type OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\View\\.$#"
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:getOrganisation\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/ViewMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:getUuid\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/ViewMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setCreated\\(\\)\\.$#"
+			count: 1
+			path: lib/Db/ViewMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setOrganisation\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/ViewMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setUpdated\\(\\)\\.$#"
+			count: 2
+			path: lib/Db/ViewMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setUuid\\(\\)\\.$#"
 			count: 1
 			path: lib/Db/ViewMapper.php
 
@@ -3516,11 +3676,6 @@ parameters:
 			path: lib/Db/ViewMapper.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\WebhookLogMapper\\:\\:findAll\\(\\) has invalid return type OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\WebhookLog\\.$#"
-			count: 1
-			path: lib/Db/WebhookLogMapper.php
-
-		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\WebhookLogMapper\\:\\:findAll\\(\\) should return array\\<int, OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\WebhookLog\\> but returns array\\<int, OCA\\\\OpenRegister\\\\Db\\\\WebhookLog\\>\\.$#"
 			count: 1
 			path: lib/Db/WebhookLogMapper.php
@@ -3531,8 +3686,13 @@ parameters:
 			path: lib/Db/WebhookLogMapper.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\WebhookMapper\\:\\:findAll\\(\\) has invalid return type OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\Webhook\\.$#"
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:getOrganisation\\(\\)\\.$#"
 			count: 1
+			path: lib/Db/WebhookMapper.php
+
+		-
+			message: "#^Call to an undefined method OCP\\\\AppFramework\\\\Db\\\\Entity\\:\\:setOrganisation\\(\\)\\.$#"
+			count: 2
 			path: lib/Db/WebhookMapper.php
 
 		-
@@ -3596,9 +3756,79 @@ parameters:
 			path: lib/EventListener/AbstractNodesFolderEventListener.php
 
 		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Listener/CalculationOnSaveListener.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Listener/LifecycleInitialStateListener.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Listener/LifecycleValidationListener.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Listener/MailAppScriptListener.php
+
+		-
+			message: "#^Property OCA\\\\OpenRegister\\\\Listener\\\\NotifyPushListener\\:\\:\\$appManager is never read, only written\\.$#"
+			count: 1
+			path: lib/Listener/NotifyPushListener.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Listener/NotifyPushListener.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Listener/NotifyPushListener.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Listener/NotifyPushListener.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Listener/NotifyPushListener.php
+
+		-
 			message: "#^Strict comparison using \\=\\=\\= between int and null will always evaluate to false\\.$#"
 			count: 1
 			path: lib/Listener/ObjectChangeListener.php
+
+		-
+			message: "#^Offset 'description' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Listener/ToolRegistrationListener.php
+
+		-
+			message: "#^Offset 'id' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Listener/ToolRegistrationListener.php
+
+		-
+			message: "#^Offset 'name' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Listener/ToolRegistrationListener.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Mcp/BuiltIn/SchemasToolProvider.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Mcp/BuiltIn/SchemasToolProvider.php
 
 		-
 			message: "#^Constant OCA\\\\OpenRegister\\\\Middleware\\\\TenantQuotaMiddleware\\:\\:ENV_BANDWIDTH_MULTIPLIER is unused\\.$#"
@@ -3607,11 +3837,6 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @throws with type OCP\\\\AppFramework\\\\Http\\\\TenantQuotaExceededException is not subtype of Throwable$#"
-			count: 1
-			path: lib/Middleware/TenantQuotaMiddleware.php
-
-		-
-			message: "#^Parameter \\#2 \\$statusCode of class OCP\\\\AppFramework\\\\Http\\\\JSONResponse constructor expects S of 100\\|101\\|102\\|200\\|201\\|202\\|203\\|204\\|205\\|206\\|207\\|208\\|226\\|300\\|301\\|302\\|303\\|304\\|305\\|306\\|307\\|400\\|401\\|402\\|403\\|404\\|405\\|406\\|407\\|408\\|409\\|410\\|411\\|412\\|413\\|414\\|415\\|416\\|417\\|418\\|422\\|423\\|424\\|426\\|428\\|429\\|431\\|500\\|501\\|502\\|503\\|504\\|505\\|506\\|507\\|508\\|509\\|510\\|511, int given\\.$#"
 			count: 1
 			path: lib/Middleware/TenantQuotaMiddleware.php
 
@@ -3687,6 +3912,11 @@ parameters:
 
 		-
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			count: 2
+			path: lib/Service/Aggregation/AggregationRunner.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between int and null will always evaluate to false\\.$#"
 			count: 1
 			path: lib/Service/Aggregation/AggregationRunner.php
 
@@ -3741,9 +3971,49 @@ parameters:
 			path: lib/Service/Archival/LegalHoldService.php
 
 		-
+			message: "#^Instantiated class OC\\\\AppFramework\\\\Middleware\\\\Security\\\\Exceptions\\\\SecurityException not found\\.$#"
+			count: 1
+			path: lib/Service/AuthorizationService.php
+
+		-
+			message: "#^PHPDoc tag @throws with type OC\\\\AppFramework\\\\Middleware\\\\Security\\\\Exceptions\\\\SecurityException is not subtype of Throwable$#"
+			count: 1
+			path: lib/Service/AuthorizationService.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/AvgComplianceService.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/AvgComplianceService.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/AvgComplianceService.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/AvgComplianceService.php
+
+		-
 			message: "#^Strict comparison using \\=\\=\\= between int\\<min, \\-1\\>\\|int\\<1, max\\>\\|non\\-empty\\-string and '' will always evaluate to false\\.$#"
 			count: 1
 			path: lib/Service/AvgRetentionService.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/BulkTranslationService.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/BulkTranslationService.php
 
 		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Service\\\\Calculation\\\\CalculationAnnotationValidator\\:\\:findCycle\\(\\) never returns array\\<int, string\\> so it can be removed from the return type\\.$#"
@@ -3761,9 +4031,19 @@ parameters:
 			path: lib/Service/Calculation/CalculationAnnotationValidator.php
 
 		-
+			message: "#^Match arm is unreachable because previous comparison is always true\\.$#"
+			count: 1
+			path: lib/Service/Calculation/CalculationEvaluator.php
+
+		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Service\\\\Calculation\\\\CalculationEvaluator\\:\\:modulo\\(\\) never returns int so it can be removed from the return type\\.$#"
 			count: 1
 			path: lib/Service/Calculation/CalculationEvaluator.php
+
+		-
+			message: "#^Call to static method read\\(\\) on an unknown class Sabre\\\\VObject\\\\Reader\\.$#"
+			count: 3
+			path: lib/Service/CalendarEventService.php
 
 		-
 			message: "#^Parameter \\$calDavBackend of method OCA\\\\OpenRegister\\\\Service\\\\CalendarEventService\\:\\:__construct\\(\\) has invalid type OCA\\\\DAV\\\\CalDAV\\\\CalDavBackend\\.$#"
@@ -3822,6 +4102,11 @@ parameters:
 
 		-
 			message: "#^Dead catch \\- Exception is never thrown in the try block\\.$#"
+			count: 1
+			path: lib/Service/ChatService.php
+
+		-
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
 			count: 1
 			path: lib/Service/ChatService.php
 
@@ -3991,6 +4276,36 @@ parameters:
 			path: lib/Service/Configuration/ImportHandler.php
 
 		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 6
+			path: lib/Service/Configuration/ImportHandler.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/Configuration/ImportHandler.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 5
+			path: lib/Service/Configuration/ImportHandler.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/Configuration/ImportHandler.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/Configuration/ImportHandler.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/Configuration/ImportHandler.php
+
+		-
 			message: "#^Unknown parameter \\$filters in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:findAll\\(\\)\\.$#"
 			count: 1
 			path: lib/Service/Configuration/ImportHandler.php
@@ -4146,6 +4461,11 @@ parameters:
 			path: lib/Service/ContactMatchingService.php
 
 		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/ContactMatchingService.php
+
+		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 2
 			path: lib/Service/ContactMatchingService.php
@@ -4153,6 +4473,11 @@ parameters:
 		-
 			message: "#^Call to an undefined method OCA\\\\OpenRegister\\\\Db\\\\ContactLinkMapper\\:\\:find\\(\\)\\.$#"
 			count: 2
+			path: lib/Service/ContactService.php
+
+		-
+			message: "#^Call to static method read\\(\\) on an unknown class Sabre\\\\VObject\\\\Reader\\.$#"
+			count: 4
 			path: lib/Service/ContactService.php
 
 		-
@@ -4252,6 +4577,11 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method OCA\\\\OpenRegister\\\\Db\\\\EmailLinkMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/EmailService.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
 			count: 1
 			path: lib/Service/EmailService.php
 
@@ -4556,6 +4886,11 @@ parameters:
 			path: lib/Service/File/FolderManagementHandler.php
 
 		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 3
+			path: lib/Service/File/FolderManagementHandler.php
+
+		-
 			message: "#^Cannot call method getCategory\\(\\) on array\\<string, int\\|string\\|null\\>\\.$#"
 			count: 1
 			path: lib/Service/File/ReadFileHandler.php
@@ -4649,6 +4984,31 @@ parameters:
 			message: "#^Call to an undefined method OCP\\\\IDBConnection\\:\\:getInner\\(\\)\\.$#"
 			count: 1
 			path: lib/Service/FileSidebarService.php
+
+		-
+			message: "#^Method OCA\\\\OpenRegister\\\\Db\\\\AuditTrailMapper\\:\\:findAll\\(\\) invoked with 4 parameters, 0\\-2 required\\.$#"
+			count: 1
+			path: lib/Service/GraphQL/GraphQLResolver.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/GraphQL/SchemaGenerator.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/GraphQL/SchemaGenerator.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/GraphQL/SchemaGenerator.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/GraphQL/SchemaGenerator.php
 
 		-
 			message: "#^Parameter \\$errors of method OCA\\\\OpenRegister\\\\Event\\\\ObjectCreatingEvent\\:\\:setErrors\\(\\) expects array\\<string, mixed\\>, array\\<int, array\\<string, string\\>\\> given\\.$#"
@@ -4851,6 +5211,101 @@ parameters:
 			path: lib/Service/Index/WarmupHandler.php
 
 		-
+			message: "#^Unknown parameter \\$filters in call to method OCA\\\\OpenRegister\\\\Db\\\\AuditTrailMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/Integration/BuiltinProviders/AuditTrailProvider.php
+
+		-
+			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			count: 1
+			path: lib/Service/Integration/PropertyReferenceTypeValidator.php
+
+		-
+			message: "#^Call to method setTags\\(\\) on an unknown class OCA\\\\Bookmarks\\\\QueryParameters\\.$#"
+			count: 1
+			path: lib/Service/Integration/Providers/BookmarksProvider.php
+
+		-
+			message: "#^Instantiated class OCA\\\\Bookmarks\\\\QueryParameters not found\\.$#"
+			count: 1
+			path: lib/Service/Integration/Providers/BookmarksProvider.php
+
+		-
+			message: "#^Offset 'results' on array\\{results\\: array, total\\: int\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/Integration/Providers/ContactsProvider.php
+
+		-
+			message: "#^Offset 'results' on array\\{results\\: array, total\\: int\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/Integration/Providers/DeckProvider.php
+
+		-
+			message: "#^Property OCA\\\\OpenRegister\\\\Service\\\\Integration\\\\Providers\\\\DeckProvider\\:\\:\\$appManager is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/Integration/Providers/DeckProvider.php
+
+		-
+			message: "#^Offset 'results' on array\\{results\\: array, total\\: int\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/Integration/Providers/EmailProvider.php
+
+		-
+			message: "#^Property OCA\\\\OpenRegister\\\\Service\\\\Integration\\\\Providers\\\\EmailProvider\\:\\:\\$appManager is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/Integration/Providers/EmailProvider.php
+
+		-
+			message: "#^Call to function array_is_list\\(\\) with array\\<string, mixed\\> will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/Integration/Providers/OpenProjectProvider.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: lib/Service/Integration/Providers/OpenProjectProvider.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between false and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/Integration/Providers/OpenProjectProvider.php
+
+		-
+			message: "#^Property OCA\\\\OpenRegister\\\\Service\\\\Integration\\\\Providers\\\\SharesProvider\\:\\:\\$appManager is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/Integration/Providers/SharesProvider.php
+
+		-
+			message: "#^Call to function array_is_list\\(\\) with array\\<string, mixed\\> will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/Integration/Providers/XwikiProvider.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: lib/Service/Integration/Providers/XwikiProvider.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between false and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/Integration/Providers/XwikiProvider.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/Lifecycle/TransitionEngine.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/LinkedEntityService.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/LinkedEntityService.php
+
+		-
 			message: "#^Unknown parameter \\$filters in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:findAll\\(\\)\\.$#"
 			count: 1
 			path: lib/Service/LinkedEntityService.php
@@ -4863,6 +5318,26 @@ parameters:
 		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Service\\\\LogService\\:\\:deleteLogs\\(\\) should return array\\{deleted\\: int\\<0, max\\>, failed\\: int\\<0, max\\>, total\\: int\\<0, max\\>\\} but returns array\\{success\\: true, deleted\\: int\\<0, max\\>, failed\\: int\\<0, max\\>\\}\\.$#"
 			count: 1
+			path: lib/Service/LogService.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/LogService.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/LogService.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/LogService.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 2
 			path: lib/Service/LogService.php
 
 		-
@@ -4879,6 +5354,11 @@ parameters:
 			message: "#^Unknown parameter \\$sort in call to method OCA\\\\OpenRegister\\\\Db\\\\AuditTrailMapper\\:\\:findAll\\(\\)\\.$#"
 			count: 3
 			path: lib/Service/LogService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/ManifestService.php
 
 		-
 			message: "#^Method OCA\\\\OpenRegister\\\\Service\\\\MappingService\\:\\:getMappings\\(\\) should return array\\<OCA\\\\OpenRegister\\\\Db\\\\Mapping\\> but returns array\\<int, OCA\\\\OpenRegister\\\\Db\\\\OCA\\\\OpenRegister\\\\Db\\\\Mapping\\>\\.$#"
@@ -4906,12 +5386,37 @@ parameters:
 			path: lib/Service/MappingService.php
 
 		-
+			message: "#^Offset 'id' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 2
+			path: lib/Service/Mcp/McpToolsService.php
+
+		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: lib/Service/MetricsService.php
 
 		-
 			message: "#^Property OCA\\\\OpenRegister\\\\Service\\\\MigrationService\\:\\:\\$db is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/MigrationService.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/MigrationService.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/MigrationService.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/MigrationService.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
 			count: 1
 			path: lib/Service/MigrationService.php
 
@@ -4928,6 +5433,11 @@ parameters:
 		-
 			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
 			count: 2
+			path: lib/Service/Notification/AnnotationNotificationDispatcher.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
 			path: lib/Service/Notification/AnnotationNotificationDispatcher.php
 
 		-
@@ -4972,6 +5482,26 @@ parameters:
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between 0\\|1\\|false and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/OasService.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/OasService.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/OasService.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/OasService.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:findAll\\(\\)\\.$#"
 			count: 1
 			path: lib/Service/OasService.php
 
@@ -5071,6 +5601,26 @@ parameters:
 			path: lib/Service/Object/FacetHandler.php
 
 		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/Object/FacetHandler.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/Object/FacetHandler.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/Object/FacetHandler.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/Object/FacetHandler.php
+
+		-
 			message: "#^Unknown parameter \\$filters in call to method OCA\\\\OpenRegister\\\\Db\\\\AuditTrailMapper\\:\\:findAll\\(\\)\\.$#"
 			count: 1
 			path: lib/Service/Object/GetObject.php
@@ -5111,6 +5661,16 @@ parameters:
 			path: lib/Service/Object/PerformanceHandler.php
 
 		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/Object/PermissionHandler.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/Object/PermissionHandler.php
+
+		-
 			message: "#^Property OCA\\\\OpenRegister\\\\Service\\\\Object\\\\QueryHandler\\:\\:\\$getHandler is never read, only written\\.$#"
 			count: 1
 			path: lib/Service/Object/QueryHandler.php
@@ -5124,6 +5684,26 @@ parameters:
 			message: "#^Property OCA\\\\OpenRegister\\\\Service\\\\Object\\\\QueryHandler\\:\\:\\$request is never read, only written\\.$#"
 			count: 1
 			path: lib/Service/Object/QueryHandler.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/Object/ReferentialIntegrityService.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/Object/ReferentialIntegrityService.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/Object/ReferentialIntegrityService.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/Object/ReferentialIntegrityService.php
 
 		-
 			message: "#^Anonymous function has an unused use \\$key\\.$#"
@@ -5148,6 +5728,16 @@ parameters:
 		-
 			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
 			count: 2
+			path: lib/Service/Object/RelationHandler.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 3
+			path: lib/Service/Object/RelationHandler.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 3
 			path: lib/Service/Object/RelationHandler.php
 
 		-
@@ -5201,6 +5791,21 @@ parameters:
 			path: lib/Service/Object/RenderObject.php
 
 		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/Object/RenderObject.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/Object/RenderObject.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/Object/RenderObject.php
+
+		-
 			message: "#^Unknown parameter \\$filters in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
 			count: 1
 			path: lib/Service/Object/RenderObject.php
@@ -5243,6 +5848,26 @@ parameters:
 		-
 			message: "#^Strict comparison using \\=\\=\\= between mixed and null will always evaluate to false\\.$#"
 			count: 4
+			path: lib/Service/Object/SaveObject.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 2
+			path: lib/Service/Object/SaveObject.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 3
+			path: lib/Service/Object/SaveObject.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/Object/SaveObject.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 2
 			path: lib/Service/Object/SaveObject.php
 
 		-
@@ -5446,6 +6071,16 @@ parameters:
 			path: lib/Service/Object/ValidationHandler.php
 
 		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method stdClass\\:\\:saveObjects\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/Object/ValidationHandler.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method stdClass\\:\\:saveObjects\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/Object/ValidationHandler.php
+
+		-
 			message: "#^Unknown parameter \\$deduplicateIds in call to method stdClass\\:\\:saveObjects\\(\\)\\.$#"
 			count: 1
 			path: lib/Service/Object/ValidationHandler.php
@@ -5482,11 +6117,6 @@ parameters:
 
 		-
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
-			count: 1
-			path: lib/Service/ObjectService.php
-
-		-
-			message: "#^Function React\\\\Async\\\\await not found\\.$#"
 			count: 1
 			path: lib/Service/ObjectService.php
 
@@ -5566,6 +6196,26 @@ parameters:
 			path: lib/Service/ObjectService.php
 
 		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/ObjectService.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/ObjectService.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/ObjectService.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 4
+			path: lib/Service/ObjectService.php
+
+		-
 			message: "#^Unknown parameter \\$published in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
 			count: 3
 			path: lib/Service/ObjectService.php
@@ -5597,6 +6247,16 @@ parameters:
 
 		-
 			message: "#^Unknown parameter \\$_extend in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/RegisterService.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/RegisterService.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:findAll\\(\\)\\.$#"
 			count: 1
 			path: lib/Service/RegisterService.php
 
@@ -5851,6 +6511,11 @@ parameters:
 			path: lib/Service/SettingsService.php
 
 		-
+			message: "#^Call to static method read\\(\\) on an unknown class Sabre\\\\VObject\\\\Reader\\.$#"
+			count: 2
+			path: lib/Service/TaskService.php
+
+		-
 			message: "#^Parameter \\$calDavBackend of method OCA\\\\OpenRegister\\\\Service\\\\TaskService\\:\\:__construct\\(\\) has invalid type OCA\\\\DAV\\\\CalDAV\\\\CalDavBackend\\.$#"
 			count: 2
 			path: lib/Service/TaskService.php
@@ -5921,6 +6586,16 @@ parameters:
 			path: lib/Service/TextExtractionService.php
 
 		-
+			message: "#^PHPDoc tag @param for parameter \\$emlParser with type OCA\\\\OpenRegister\\\\Service\\\\EmlParser is not subtype of native type OCA\\\\OpenRegister\\\\Service\\\\TextExtraction\\\\EmlParser\\.$#"
+			count: 1
+			path: lib/Service/TextExtractionService.php
+
+		-
+			message: "#^PHPDoc type for property OCA\\\\OpenRegister\\\\Service\\\\TextExtractionService\\:\\:\\$emlParser with type OCA\\\\OpenRegister\\\\Service\\\\EmlParser is not subtype of native type OCA\\\\OpenRegister\\\\Service\\\\TextExtraction\\\\EmlParser\\.$#"
+			count: 1
+			path: lib/Service/TextExtractionService.php
+
+		-
 			message: "#^Property OCA\\\\OpenRegister\\\\Service\\\\TextExtractionService\\:\\:\\$entityMapper is never read, only written\\.$#"
 			count: 1
 			path: lib/Service/TextExtractionService.php
@@ -5956,6 +6631,16 @@ parameters:
 			path: lib/Service/TranslationProjectionService.php
 
 		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/TranslationProjectionService.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/TranslationProjectionService.php
+
+		-
 			message: "#^Class OCA\\\\OpenRegister\\\\Service\\\\UploadService has an uninitialized readonly property \\$client\\. Assign it in the constructor\\.$#"
 			count: 1
 			path: lib/Service/UploadService.php
@@ -5977,6 +6662,26 @@ parameters:
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/UrnService.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/UrnService.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/UrnService.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Service/UrnService.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
 			count: 1
 			path: lib/Service/UrnService.php
 
@@ -6041,7 +6746,12 @@ parameters:
 			path: lib/Service/ViewService.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Settings\\\\OpenRegisterAdmin\\:\\:getForm\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\TemplateResponse\\<200, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\TemplateResponse\\<200, array\\{\\}\\>\\.$#"
+			message: "#^Property OCA\\\\OpenRegister\\\\Settings\\\\IntegrationsAdminSettings\\:\\:\\$l10n is never read, only written\\.$#"
+			count: 1
+			path: lib/Settings/IntegrationsAdminSettings.php
+
+		-
+			message: "#^Method OCA\\\\OpenRegister\\\\Settings\\\\OpenRegisterAdmin\\:\\:getForm\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\TemplateResponse\\<200, array\\<string, mixed\\>\\> but returns OCP\\\\AppFramework\\\\Http\\\\TemplateResponse\\<200, array\\{\\}\\>\\.$#"
 			count: 1
 			path: lib/Settings/OpenRegisterAdmin.php
 
@@ -6049,6 +6759,31 @@ parameters:
 			message: "#^Property OCA\\\\OpenRegister\\\\Settings\\\\OpenRegisterAdmin\\:\\:\\$l is never read, only written\\.$#"
 			count: 1
 			path: lib/Settings/OpenRegisterAdmin.php
+
+		-
+			message: "#^Offset 'description' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Tool/McpProviderBridge.php
+
+		-
+			message: "#^Offset 'id' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 2
+			path: lib/Tool/McpProviderBridge.php
+
+		-
+			message: "#^Offset 'inputSchema' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Tool/McpProviderBridge.php
+
+		-
+			message: "#^Offset 'name' on \\*NEVER\\* on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Tool/McpProviderBridge.php
+
+		-
+			message: "#^Property OCA\\\\OpenRegister\\\\Tool\\\\McpProviderBridge\\:\\:\\$agent is never read, only written\\.$#"
+			count: 1
+			path: lib/Tool/McpProviderBridge.php
 
 		-
 			message: "#^Unknown parameter \\$filters in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * PHPStan bootstrap file - registers OCP autoloader for static analysis.
+ */
+
+$autoloader = require __DIR__ . '/vendor/autoload.php';
+$autoloader->addPsr4('OCP\\', __DIR__ . '/vendor/nextcloud/ocp/OCP/');
+$autoloader->addPsr4('NCU\\', __DIR__ . '/vendor/nextcloud/ocp/NCU/');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,7 @@
 includes:
+    # Per-app tracked lint debt lives here (auto-generated via `phpstan --generate-baseline`).
+    # Apps without debt ship an empty baseline file; canonical includes are otherwise byte-identical
+    # across the fleet.
     - phpstan-baseline.neon
 
 parameters:
@@ -6,47 +9,51 @@ parameters:
     paths:
         - lib
     bootstrapFiles:
-        - vendor/autoload.php
+        - phpstan-bootstrap.php
+    excludePaths:
+        - vendor
+        - vendor-bin
+        # Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt).
+        - lib/Resources/template
     scanDirectories:
         - vendor/nextcloud/ocp
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:
-        # Nextcloud internals not covered by OCP stubs.
+        # Nextcloud server internals (\OC, OC_App, OC\) not stubbed in nextcloud/ocp
         - '#Call to an undefined method OC::#'
         - '#Class OC not found#'
         - '#Access to static property \$server on an unknown class OC#'
         - '#unknown class OC\\#'
-        - '#unknown class OCA\\DAV\\#'
-        - '#unknown class OC_App#'
-        - '#not found in catched class OC\\#'
         - '#Caught class OC\\#'
+        - '#unknown class OC_App#'
+        - '#Class OC_App not found#'
+        # OCA\DAV is server-internal and not in nextcloud/ocp stubs
+        - '#unknown class OCA\\DAV\\#'
         - '#Class OCA\\DAV\\#'
-        - '#Throwing object of an unknown class OC\\#'
-        - '#Instantiated class OC\\AppFramework\\Middleware\\Security\\Exceptions\\SecurityException not found#'
-        - '#PHPDoc tag @throws with type OC\\AppFramework\\Middleware\\Security\\Exceptions\\SecurityException#'
-        - '#unknown class OC\\AppFramework\\Middleware\\Security\\Exceptions\\SecurityException#'
-
-        # Doctrine\DBAL classes (used in migrations/mappers; not in vendor stubs).
+        # OCA classes from other apps (OpenRegister) not available during static analysis
+        - '#unknown class OCA\\OpenRegister\\#'
+        - '#OCA\\OpenRegister\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class OCA\\OpenRegister\\#'
+        - '#has invalid return type OCA\\OpenRegister\\#'
+        - '#has invalid type OCA\\OpenRegister\\#'
+        - '#implements unknown interface OCA\\OpenRegister\\#'
+        # GuzzleHttp is available at runtime via Nextcloud but not in composer require
+        - '#unknown class GuzzleHttp\\#'
+        - '#GuzzleHttp\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class GuzzleHttp\\#'
+        - '#invalid type GuzzleHttp\\#'
+        - '#Caught class GuzzleHttp\\#'
+        # Doctrine\DBAL is shipped by Nextcloud server but not stubbed in nextcloud/ocp
         - '#unknown class Doctrine\\DBAL\\#'
-        - '#class Doctrine\\DBAL\\#'
-        - '#Class Doctrine\\DBAL\\#'
-        - '#Doctrine\\DBAL\\Platforms\\#'
-
-        # Cron\CronExpression (mtdowling/cron-expression — not in stubs).
-        - '#class Cron\\CronExpression#'
-        - '#Cron\\CronExpression#'
-
-        # Sabre\VObject (sabre/vobject — not in scan stubs).
-        - '#Sabre\\VObject\\#'
-
-        # Multi-tenancy and RBAC stub parameters added at runtime by the QBMapper layer.
-        - '#Unknown parameter \$_multitenancy in call#'
-        - '#Unknown parameter \$_rbac in call#'
-        - '#Method OCA\\OpenRegister\\Db\\.+::find\(\) invoked with \d+ parameters#'
-        - '#Method OCA\\OpenRegister\\Db\\.+::findAll\(\) invoked with \d+ parameters#'
-
-        # Entity __call magic methods (setOrganisation/getOrganisation/etc.) — set
-        # at runtime by Nextcloud Entity, but the parent Entity class does not
-        # declare them. Per-property @method docblocks would be ideal but
-        # categorically suppressing here is honest about the framework pattern.
-        - '#Call to an undefined method OCP\\AppFramework\\Db\\Entity::#'
+        - '#Doctrine\\DBAL\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class Doctrine\\DBAL\\#'
+        # Dynamic HTTP status codes from business rule validation results
+        # (matches both `Parameter $statusCode` and `Parameter #N $statusCode` forms emitted by phpstan)
+        - '#Parameter (\#\d+ )?\$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor expects#'
+        # registerRepairStep exists on server; not yet in nextcloud/ocp stub used for analysis
+        - '#Call to an undefined method OCP\\AppFramework\\Bootstrap\\IRegistrationContext::registerRepairStep#'
+        # OCP stub gaps for methods that exist at runtime
+        - '#Call to an undefined method OCP\\IRequest::getContent\(\)#'
+        - '#Call to an undefined method OCP\\IRequest::setParameter\(\)#'
+        - '#Call to an undefined method OCP\\Mail\\IMessage::attachFile\(\)#'
+        - '#Call to an undefined method OCP\\AppFramework\\Db\\Entity::jsonSerialize#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <psalm
+    errorBaseline="psalm-baseline.xml"
     errorLevel="4"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -7,7 +8,6 @@
     findUnusedBaselineEntry="true"
     findUnusedCode="true"
     findUnusedVariablesAndParams="true"
-    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="lib" />
@@ -22,24 +22,6 @@
         <UndefinedDocblockClass errorLevel="suppress"/>
         <UndefinedClass>
             <errorLevel type="suppress">
-                <referencedClass name="OC"/>
-                <referencedClass name="Doctrine\DBAL\Types\Types"/>
-                <referencedClass name="Doctrine\DBAL\Types\Type"/>
-                <referencedClass name="Doctrine\DBAL\Connection"/>
-                <referencedClass name="Doctrine\DBAL\Schema\Schema"/>
-                <referencedClass name="Symfony\Component\HttpFoundation\Response"/>
-                <referencedClass name="Doctrine\DBAL\Platforms\AbstractPlatform"/>
-                <referencedClass name="Doctrine\DBAL\Platforms\MySQLPlatform"/>
-                <referencedClass name="Doctrine\DBAL\Platforms\AbstractMySQLPlatform"/>
-                <referencedClass name="Doctrine\DBAL\Platforms\SqlitePlatform"/>
-                <referencedClass name="Doctrine\DBAL\ParameterType"/>
-                <referencedClass name="APCUIterator"/>
-                <referencedClass name="React\Async\PromiseInterface"/>
-                <referencedClass name="Solarium\Client"/>
-                <referencedClass name="Solarium\Core\Client\Adapter\Curl"/>
-                <referencedClass name="Solarium\Exception\HttpException"/>
-                <referencedClass name="Symfony\Component\EventDispatcher\EventDispatcher"/>
-                <referencedClass name="Ramsey\Uuid\Uuid"/>
                 <!-- Nextcloud OCP Classes -->
                 <referencedClass name="OCP\AppFramework\App"/>
                 <referencedClass name="OCP\AppFramework\Bootstrap\IBootstrap"/>
@@ -58,7 +40,6 @@
                 <referencedClass name="OCP\IGroupManager"/>
                 <referencedClass name="OCP\IUserManager"/>
                 <referencedClass name="OCP\IUserSession"/>
-                <referencedClass name="OCP\Search\IFilteringProvider"/>
                 <referencedClass name="OCP\IMemcache"/>
                 <referencedClass name="OCP\IRequest"/>
                 <referencedClass name="OCP\EventDispatcher\IEventDispatcher"/>
@@ -77,20 +58,39 @@
                 <referencedClass name="OCP\IURLGenerator"/>
                 <referencedClass name="OCP\Http\Client\IClient"/>
                 <referencedClass name="OCP\Http\Client\IClientService"/>
-                <referencedClass name="OCP\SystemTag\ISystemTagManager"/>
                 <referencedClass name="OCP\Notification\IManager"/>
                 <referencedClass name="OCP\Share\IManager"/>
-                <referencedClass name="OC\Files\AppData\Factory"/>
-                <referencedClass name="OC\Security\CSP\ContentSecurityPolicyNonceManager"/>
-                <referencedClass name="OC\Security\CSRF\CsrfTokenManager"/>
-                <referencedClass name="Doctrine\DBAL\Platforms\PostgreSQLPlatform"/>
-                <referencedClass name="OCA\DAV\CalDAV\CalDavBackend"/>
-                <referencedClass name="Sabre\VObject\Reader"/>
-                <referencedClass name="OC\DB\Exceptions\DbalException"/>
-                <referencedClass name="OCA\OpenRegister\Db\Exception"/>
+                <!-- OpenRegister cross-app classes (loaded dynamically) -->
+                <referencedClass name="OCA\OpenRegister\Db\ObjectEntity"/>
+                <referencedClass name="OCA\OpenRegister\Db\RegisterMapper"/>
+                <referencedClass name="OCA\OpenRegister\Db\SchemaMapper"/>
+                <referencedClass name="OCA\OpenRegister\Event\DeepLinkRegistrationEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectCreatingEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectCreatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatingEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectDeletedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Service\ObjectService"/>
+                <referencedClass name="OCA\OpenRegister\Service\ConfigurationService"/>
+                <referencedClass name="OCA\OpenRegister\Service\RegisterService"/>
+                <referencedClass name="OCA\OpenRegister\Service\FileService"/>
+                <referencedClass name="OCA\OpenRegister\Service\CalendarEventService"/>
+                <referencedClass name="OCA\OpenRegister\Mcp\IMcpToolProvider"/>
+                <!-- Additional OCP infrastructure types used across the fleet -->
+                <referencedClass name="OCP\AppFramework\Bootstrap\IBootContext"/>
+                <referencedClass name="OCP\AppFramework\Bootstrap\IRegistrationContext"/>
+                <referencedClass name="OCP\AppFramework\Db\DoesNotExistException"/>
+                <referencedClass name="OCP\DB\Exception"/>
+                <referencedClass name="OCP\IGroup"/>
+                <referencedClass name="OCP\IUser"/>
+                <referencedClass name="OCP\Migration\IRepairStep"/>
+                <!-- Nextcloud server internals -->
+                <referencedClass name="OC"/>
+                <!-- GuzzleHttp (loaded via composer at runtime) -->
+                <referencedClass name="GuzzleHttp\Client"/>
+                <referencedClass name="GuzzleHttp\Exception\GuzzleException"/>
             </errorLevel>
         </UndefinedClass>
-        <InaccessibleMethod errorLevel="suppress"/>
         <UndefinedMagicMethod errorLevel="suppress"/>
         <UnusedClass errorLevel="suppress"/>
         <PossiblyUnusedMethod errorLevel="suppress"/>
@@ -103,80 +103,24 @@
         <RedundantCondition errorLevel="suppress"/>
         <RedundantFunctionCall errorLevel="suppress"/>
         <RedundantCast errorLevel="suppress"/>
-        <RedundantPropertyInitializationCheck errorLevel="suppress"/>
-        <StringIncrement errorLevel="suppress"/>
         <InvalidDocblock errorLevel="suppress"/>
         <MoreSpecificImplementedParamType errorLevel="suppress"/>
         <MissingDependency errorLevel="suppress"/>
         <UnevaluatedCode errorLevel="suppress"/>
-        <!-- Suppress external library/interface method issues -->
-        <UndefinedInterfaceMethod>
-            <errorLevel type="suppress">
-                <!-- Doctrine DBAL methods -->
-                <referencedMethod name="OCP\IDBConnection::getSchemaManager"/>
-                <!-- Nextcloud QueryBuilder methods -->
-                <referencedMethod name="OCP\DB\QueryBuilder\IQueryBuilder::escapeLikeParameter"/>
-                <!-- Nextcloud File methods -->
-                <referencedMethod name="OCP\Files\Node::fopen"/>
-                <referencedMethod name="OCP\Files\Node::getContent"/>
-                <!-- Search backend implementation methods -->
-                <referencedMethod name="OCA\OpenRegister\Service\Index\SearchBackendInterface::indexFiles"/>
-                <referencedMethod name="OCA\OpenRegister\Service\Index\SearchBackendInterface::getFileIndexStats"/>
-                <referencedMethod name="OCA\OpenRegister\Service\Index\SearchBackendInterface::fixMismatchedFields"/>
-            </errorLevel>
-        </UndefinedInterfaceMethod>
-        <!-- Suppress React library function calls -->
-        <UndefinedFunction>
-            <errorLevel type="suppress">
-                <referencedFunction name="React\Async\await"/>
-            </errorLevel>
-        </UndefinedFunction>
-        <!-- Suppress LLPhant dynamic property access -->
-        <UndefinedPropertyAssignment>
-            <errorLevel type="suppress">
-                <referencedProperty name="LLPhant\OpenAIConfig::$temperature"/>
-                <referencedProperty name="LLPhant\OpenAIConfig::$organizationId"/>
-            </errorLevel>
-        </UndefinedPropertyAssignment>
-        <UndefinedPropertyFetch>
-            <errorLevel type="suppress">
-                <referencedProperty name="LLPhant\OllamaConfig::$apiKey"/>
-                <referencedProperty name="LLPhant\OpenAIConfig::$apiKey"/>
-                <referencedProperty name="LLPhant\OpenAIConfig::$model"/>
-                <referencedProperty name="LLPhant\OpenAIConfig::$url"/>
-            </errorLevel>
-        </UndefinedPropertyFetch>
-        <!-- Suppress OrganisationMapper method calls from trait -->
-        <UndefinedMethod>
-            <errorLevel type="suppress">
-                <referencedMethod name="OCA\OpenRegister\Service\OrganisationService::getActiveOrganisationWithFallback"/>
-                <referencedMethod name="OCA\OpenRegister\Service\OrganisationService::getDefaultOrganisationFromConfig"/>
-                <referencedMethod name="OCA\OpenRegister\Service\OrganisationService::getOrganisationHierarchy"/>
-                <!-- Entity base class methods -->
-                <referencedMethod name="OCA\OpenRegister\Db\Register::getId"/>
-                <referencedMethod name="OCA\OpenRegister\Db\Schema::getId"/>
-                <referencedMethod name="OCA\OpenRegister\Db\Schema::getSlug"/>
-                <referencedMethod name="OCA\OpenRegister\Db\ObjectEntity::getRegister"/>
-                <referencedMethod name="OCA\OpenRegister\Db\ObjectEntity::getSchema"/>
-            </errorLevel>
-        </UndefinedMethod>
-        <!-- Suppress dead code warnings for defensive null checks -->
         <NoValue errorLevel="suppress"/>
         <TypeDoesNotContainNull errorLevel="suppress"/>
         <TypeDoesNotContainType errorLevel="suppress"/>
         <InvalidArrayOffset errorLevel="suppress"/>
         <InvalidCast errorLevel="suppress"/>
         <InvalidArgument errorLevel="suppress"/>
-        <InvalidTemplateParam errorLevel="suppress"/>
         <InvalidReturnType errorLevel="suppress"/>
         <InvalidReturnStatement errorLevel="suppress"/>
         <MismatchingDocblockReturnType errorLevel="suppress"/>
         <EmptyArrayAccess errorLevel="suppress"/>
         <ImplementedReturnTypeMismatch errorLevel="suppress"/>
         <InvalidMethodCall errorLevel="suppress"/>
-        <InvalidPropertyAssignmentValue errorLevel="suppress"/>
-        <InvalidThrow errorLevel="suppress"/>
-        <UnsupportedPropertyReferenceUsage errorLevel="suppress"/>
+        <UndefinedInterfaceMethod errorLevel="suppress"/>
+        <MissingTemplateParam errorLevel="suppress"/>
     </issueHandlers>
     <extraFiles>
         <directory name="vendor/nextcloud/ocp" />


### PR DESCRIPTION
## Summary

Phase 2 fleet rollout of the root-config consolidation for the **openregister** foundation app. Pattern adapted from [shillinq#300](https://github.com/ConductionNL/shillinq/pull/300) and [decidesk#243](https://github.com/ConductionNL/decidesk/pull/243).

openregister has the **largest follow-up scope of the fleet** — note that **phpmd / phpcs / psalm CI will be very red until [#1640](https://github.com/ConductionNL/openregister/issues/1640) is worked through**. Admin-merge authorised by the user.

## Config changes
- `phpcs.xml`: sync canonical, restore OpenRegister description.
- `phpmd.xml`: canonical, restore OpenRegister ruleset name.
- `psalm.xml`: sync canonical with `errorBaseline="psalm-baseline.xml"` attribute added back; **`psalm-baseline.xml` preserved untouched per fleet plan**.
- `phpstan.neon`: sync canonical (now uses `phpstan-bootstrap.php` instead of `vendor/autoload.php`; includes baseline).
- `phpstan-bootstrap.php`: NEW from canonical.
- `phpstan-baseline.neon`: regenerated with **1724 entries** baselined; header points to #1640.
- `phpcs-custom-sniffs/.../{SpecTagSniff,NoLegacyServerAccessorsSniff}.php`: sniffs the synced `phpcs.xml` references.

## Mechanical phpmd source cleanup (160 -> 59)
- **MissingImport** (57 -> 0): added 25+ `use` statements across `Application.php`, `BookmarksProvider`, `CalendarProvider`, `TasksProvider`, `ExternalIntegrationRouter`, `ResponseGenerationHandler`, `ObjectService`, `PdfReportWriter`, `UserService`.
- **ElseExpression** (15 -> 0): refactored to early-return / continue / default-then-override patterns.
- **UnusedFormalParameter** (7 -> 0): `@SuppressWarnings` on deprecated facade signatures with TODO comments.
- **UnusedLocalVariable** (2 -> 0): foreach key renamed to `$_` with suppression.
- **BooleanArgumentFlag** (2 -> 0): suppressed on `requestHeaders($withBody)` — body-vs-no-body is the natural HTTP-headers toggle.

Total mechanical fixes: ~80 violations cleared.

## Quality gate state
| Gate | Before sync | After sync (this PR) |
|---|---|---|
| phpcs errors | n/a (per-app rules) | 336 (SpecTag annotation debt + inline-if) |
| phpcs warnings | n/a | 3594 (SpecTag) |
| phpstan unmatched | 0 (per-app config) | 0 (1724 baselined) |
| psalm unbaselined | 0 (per-app suppressions) | 145 (stricter canonical config) |
| phpmd | 160 | 59 (architectural only) |

## Test plan
- [ ] CI quality workflow runs (will be red on phpcs / psalm / phpmd — expected).
- [ ] CI phpstan job is green (1724 baselined, 0 unmatched).
- [ ] Tracking issue #1640 captures the follow-up debt categorised by gate.
- [ ] Admin merge after spot-check.

Refs: #1640