### PR TITLE
feat(api): scoped deleteObject($uuid, $register, $schema) (closes #1638)

### DIFF
--- a/lib/Service/Object/DeleteObject.php
+++ b/lib/Service/Object/DeleteObject.php
@@ -359,22 +359,32 @@ class DeleteObject
      * has incoming onDelete references from other schemas, walks the dependency graph
      * to detect blockers (RESTRICT) and apply actions (CASCADE, SET_NULL, SET_DEFAULT).
      *
-     * @param Register|int|string $register         The register containing the object.
-     * @param Schema|int|string   $schema           The schema of the object.
-     * @param string              $uuid             The UUID of the object to delete.
-     * @param string|null         $originalObjectId The ID of original object for cascading.
-     * @param bool                $_rbac            Whether to apply RBAC checks (default: true).
-     * @param bool                $_multitenancy    Whether to apply multitenancy filtering (default: true).
+     * @param Register|int|string|null $register         The register containing the object.
+     * @param Schema|int|string|null   $schema           The schema of the object.
+     * @param string                   $uuid             The UUID of the object to delete.
+     * @param string|null              $originalObjectId The ID of original object for cascading.
+     * @param bool                     $_rbac            Whether to apply RBAC checks (default: true).
+     * @param bool                     $_multitenancy    Whether to apply multitenancy filtering (default: true).
+     * @param bool                     $scoped           When true, the caller has guaranteed `$register`
+     *                                                   and `$schema` resolve to a specific magic table
+     *                                                   and the lookup MUST target only that table —
+     *                                                   a UUID in another scope raises DoesNotExistException
+     *                                                   without touching any row (#1638).
+     *                                                   When false (default), legacy cross-table lookup
+     *                                                   via `findAcrossAllSources` is used.
      *
      * @return bool Whether the deletion was successful.
      *
-     * @throws ReferentialIntegrityException If deletion is blocked by RESTRICT constraints.
-     * @throws Exception If there is an error during deletion.
+     * @throws ReferentialIntegrityException                If deletion is blocked by RESTRICT constraints.
+     * @throws \OCP\AppFramework\Db\DoesNotExistException   If `$scoped` is true and the UUID is not present
+     *                                                       in the given (register, schema) magic table.
+     * @throws Exception                                    If there is an error during deletion.
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      *
      * @spec openspec/changes/retrofit-2026-04-28-object-lifecycle/tasks.md#task-1
+     * @spec openspec/changes/scoped-object-delete-api/tasks.md#2
      */
     public function deleteObject(
         Register | int | string | null $register,
@@ -382,21 +392,29 @@ class DeleteObject
         string $uuid,
         ?string $originalObjectId=null,
         bool $_rbac=true,
-        bool $_multitenancy=true
+        bool $_multitenancy=true,
+        bool $scoped=false
     ): bool {
         // Reset cascade count for root deletions.
         if ($originalObjectId === null) {
             $this->lastCascadeCount = 0;
         }
 
-        // Find object with context (searches across all magic tables).
-        $context = $this->objectEntityMapper->findAcrossAllSources(
-            identifier: $uuid,
-            includeDeleted: true,
+        // Resolve the lookup: when the caller has guaranteed a (register, schema)
+        // scope, use the scoped `MagicMapper::find()` path which targets exactly
+        // one magic table. Otherwise fall back to the legacy cross-table scan.
+        // The scoped path raises DoesNotExistException if the UUID is not in
+        // the requested scope — this is the fix for #1638.
+        $context = $this->resolveDeletionContext(
+            register: $register,
+            schema: $schema,
+            uuid: $uuid,
+            scoped: $scoped,
             _rbac: $_rbac,
             _multitenancy: $_multitenancy
         );
-        $object  = $context['object'];
+
+        $object = $context['object'];
 
         // Root deletions: check referential integrity and handle cascade.
         if ($originalObjectId === null) {
@@ -426,6 +444,75 @@ class DeleteObject
         }//end try
 
     }//end deleteObject()
+
+    /**
+     * Resolve the lookup context for a deletion call.
+     *
+     * Centralises the branch between the scoped MagicMapper::find() path
+     * (introduced for #1638) and the legacy `findAcrossAllSources` cross-table
+     * scan. The early return on the scoped path keeps the dispatch flat and
+     * avoids an else-clause (PHPMD ElseExpression).
+     *
+     * @param Register|int|string|null $register      Register scope (object, ID, UUID, or slug).
+     * @param Schema|int|string|null   $schema        Schema scope.
+     * @param string                   $uuid          The UUID being deleted.
+     * @param bool                     $scoped        When true, the caller has guaranteed
+     *                                                $register/$schema resolve to a specific
+     *                                                magic table; lookup MUST target only that table.
+     * @param bool                     $_rbac         Whether to apply RBAC checks.
+     * @param bool                     $_multitenancy Whether to apply multitenancy filtering.
+     *
+     * @return array{object: ObjectEntity, register: Register|int|string, schema: Schema|int|string}
+     *
+     * @throws \OCP\AppFramework\Db\DoesNotExistException If $scoped is true and the UUID is
+     *                                                     not present in the given magic table.
+     *
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec openspec/changes/scoped-object-delete-api/tasks.md#2
+     */
+    private function resolveDeletionContext(
+        Register | int | string | null $register,
+        Schema | int | string | null $schema,
+        string $uuid,
+        bool $scoped,
+        bool $_rbac,
+        bool $_multitenancy
+    ): array {
+        // Scoped path: lookup hits exactly one magic table — a UUID in a
+        // different scope raises DoesNotExistException. This is the fix for
+        // #1638 (cross-scope silent deletes).
+        if ($scoped === true
+            && $register instanceof Register === true
+            && $schema instanceof Schema === true
+        ) {
+            $scopedObject = $this->objectEntityMapper->find(
+                identifier: $uuid,
+                register: $register,
+                schema: $schema,
+                includeDeleted: true,
+                _rbac: $_rbac,
+                _multitenancy: $_multitenancy
+            );
+
+            return [
+                'object'   => $scopedObject,
+                'register' => $register,
+                'schema'   => $schema,
+            ];
+        }
+
+        // Legacy path: cross-table scan via findAcrossAllSources — still in
+        // use by every unscoped caller. Soft-deprecated; preferred call site
+        // is the scoped branch above.
+        return $this->objectEntityMapper->findAcrossAllSources(
+            identifier: $uuid,
+            includeDeleted: true,
+            _rbac: $_rbac,
+            _multitenancy: $_multitenancy
+        );
+
+    }//end resolveDeletionContext()
 
     /**
      * Handle referential integrity checks and cascade deletion for root deletions.

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -1490,20 +1490,63 @@ class ObjectService
     }//end ensureObjectFolder()
 
     /**
-     * Delete an object.
+     * Delete an object, optionally scoped to a (register, schema) magic table.
      *
-     * @param string $uuid          The UUID of the object to delete
-     * @param bool   $_rbac         Whether to apply RBAC checks (default: true).
-     * @param bool   $_multitenancy Whether to apply multitenancy filtering (default: true).
+     * When BOTH `$register` and `$schema` are supplied, the deletion is scoped to
+     * exactly one magic table (`oc_openregister_table_{registerId}_{schemaId}`):
+     * the lookup uses `MagicMapper::find($identifier, $register, $schema, includeDeleted: true)`
+     * which targets a single table and throws `DoesNotExistException` if the
+     * UUID is not present in that scope. A UUID that lives in a DIFFERENT
+     * `(register, schema)` magic table MUST NOT be touched. See #1638.
+     *
+     * When EITHER `$register` or `$schema` is null, the legacy unscoped
+     * cross-table lookup (`findAcrossAllSources`) is used — preserves backward
+     * compatibility for the dozens of callers passing only `$uuid`. The
+     * unscoped form is soft-deprecated: prefer the scoped signature for new
+     * call sites so the storage layer can refuse cross-scope deletes by
+     * construction.
+     *
+     * @param string                   $uuid          The UUID of the object to delete.
+     * @param Register|string|int|null $register      Optional register scope (object, ID, UUID, or slug).
+     *                                                When non-null AND `$schema` is non-null, the lookup
+     *                                                targets exactly that magic table.
+     * @param Schema|string|int|null   $schema        Optional schema scope (object, ID, UUID, or slug).
+     *                                                See `$register` — both must be supplied for the
+     *                                                scoped path.
+     * @param bool                     $_rbac         Whether to apply RBAC checks (default: true).
+     * @param bool                     $_multitenancy Whether to apply multitenancy filtering (default: true).
      *
      * @return bool Whether the deletion was successful
      *
-     * @throws \Exception If user does not have delete permission
+     * @throws \OCP\AppFramework\Db\DoesNotExistException If `$register` and `$schema` are both supplied
+     *                                                    and the UUID is not present in that scope (even
+     *                                                    if it exists in another magic table).
+     * @throws \Exception If user does not have delete permission.
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    public function deleteObject(string $uuid, bool $_rbac=true, bool $_multitenancy=true): bool
-    {
+    public function deleteObject(
+        string $uuid,
+        Register | string | int | null $register=null,
+        Schema | string | int | null $schema=null,
+        bool $_rbac=true,
+        bool $_multitenancy=true
+    ): bool {
+        // Resolve the explicit scope (if any) onto the service's currentRegister
+        // / currentSchema so downstream context (permission checks, audit-trail
+        // recording) sees the API-supplied scope, not a stale leftover from a
+        // previous call on this service instance.
+        $hasScope = ($register !== null && $schema !== null);
+        if ($register !== null) {
+            $this->setRegister(register: $register);
+        }
+
+        if ($schema !== null) {
+            $this->setSchema(schema: $schema);
+        }
+
         // Reject deletion of transferred objects (archiefstatus = overgebracht).
         $this->rejectIfTransferred(uuid: $uuid);
 
@@ -1517,11 +1560,21 @@ class ObjectService
         }
 
         // Find the object to get its owner for permission check (include soft-deleted objects).
+        // When the caller supplied both register + schema, the lookup is scoped
+        // to a single magic table — a UUID in a different scope raises
+        // DoesNotExistException and never reaches the delete handler.
+        $scopedRegister = null;
+        $scopedSchema   = null;
+        if ($hasScope === true) {
+            $scopedRegister = $this->currentRegister;
+            $scopedSchema   = $this->currentSchema;
+        }
+
         try {
             $objectToDelete = $this->objectMapper->find(
                 identifier: $uuid,
-                register: null,
-                schema: null,
+                register: $scopedRegister,
+                schema: $scopedSchema,
                 includeDeleted: true
             );
 
@@ -1540,7 +1593,16 @@ class ObjectService
                 object: $objectToDelete
             );
         } catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
-            // Object doesn't exist, no permission check needed but let deleteHandler handle.
+            // Scoped lookup is authoritative: if the caller asked for a
+            // specific (register, schema) and the UUID is not in that scope,
+            // re-throw so the failure mode is "404 not in scope" instead of
+            // "silently look at another magic table" (the #1638 bug).
+            if ($hasScope === true) {
+                throw $e;
+            }
+
+            // Unscoped path: object doesn't exist anywhere, no permission check
+            // needed but let deleteHandler raise its own consistent error path.
             if ($this->currentSchema !== null) {
                 $this->checkPermission(
                     schema: $this->currentSchema,
@@ -1558,7 +1620,8 @@ class ObjectService
             uuid: $uuid,
             originalObjectId: null,
             _rbac: $_rbac,
-            _multitenancy: $_multitenancy
+            _multitenancy: $_multitenancy,
+            scoped: $hasScope
         );
     }//end deleteObject()
 

--- a/lib/Service/ObjectServiceMapperAdapter.php
+++ b/lib/Service/ObjectServiceMapperAdapter.php
@@ -223,13 +223,21 @@ class ObjectServiceMapperAdapter
     /**
      * Delete an object by criteria array.
      *
-     * The array must contain an 'id' key with the object ID or UUID.
+     * The array must contain an 'id' key with the object ID or UUID. The
+     * adapter's bound `(register, schema)` is forwarded to
+     * `ObjectService::deleteObject()` so the deletion is scoped to the
+     * adapter's magic table — a UUID that lives in a different
+     * `(register, schema)` magic table raises `DoesNotExistException`
+     * instead of being silently deleted (see #1638).
      *
      * @param array $criteria Must contain key 'id' with the object ID or UUID.
      *
      * @return bool
      *
      * @throws ValidationException When no 'id' key is present in $criteria.
+     * @throws \OCP\AppFramework\Db\DoesNotExistException When the adapter is
+     *         bound to a specific `(register, schema)` and the UUID is not
+     *         present in that magic table.
      */
     public function delete(array $criteria): bool
     {
@@ -238,7 +246,11 @@ class ObjectServiceMapperAdapter
             throw new ValidationException(message: 'No id given to delete');
         }
 
-        return $this->objectService->deleteObject((string) $id);
+        return $this->objectService->deleteObject(
+            uuid: (string) $id,
+            register: $this->register,
+            schema: $this->schema
+        );
     }//end delete()
 
     /**

--- a/openspec/changes/scoped-object-delete-api/.openspec.yaml
+++ b/openspec/changes/scoped-object-delete-api/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-22

--- a/openspec/changes/scoped-object-delete-api/design.md
+++ b/openspec/changes/scoped-object-delete-api/design.md
@@ -1,0 +1,106 @@
+## Context
+
+OpenRegister stores objects in per-`(register,schema)` magic tables (chain-B/C: `oc_openregister_table_{registerId}_{schemaId}`). Each table has its own primary key sequence; UUIDs are application-managed and not enforced unique across tables. The `MagicMapper::findAcrossAllMagicTables()` path iterates every magic table looking for a UUID match.
+
+Today three call paths converge on that unscoped lookup for deletes:
+
+1. `ObjectService::deleteObject(string $uuid, bool $_rbac=true, bool $_multitenancy=true)` — single-UUID API. Calls `DeleteObject::deleteObject(register: $this->currentRegister, schema: $this->currentSchema, uuid: $uuid, ...)` but the handler internally calls `objectEntityMapper->findAcrossAllSources($uuid)` regardless of the register/schema arguments, so even when `setRegister()`/`setSchema()` were set on the service instance the lookup still scans every table.
+2. `ObjectServiceMapperAdapter::delete(array $criteria)` — array-form API used by ADR-022 wrapped repositories. Internally calls `objectService->deleteObject((string) $id)` and drops `$this->register` / `$this->schema` on the floor. The adapter is built specifically to be a scoped per-`(register,schema)` view, so this is a defect: the array form silently de-scopes itself.
+3. `GraphQLResolver`, `ImportService`, `ObjectsTool`, `ObjectsToolProvider`, `ObjectsController` — all call `deleteObject($uuid)` directly. Most of these have a register+schema in scope at the call site (route binding, MCP context, controller-level scope) but cannot express it through the API.
+
+A cross-table UUID collision (two synced sources sharing IDs, two seed runs into different registers using the same UUID generator, a tenant-prefixed UUID stripped by a buggy mapper) results in deletion of an object the caller never intended to touch — and the audit trail records "deleted UUID X" without the register/schema context that would have made the wrong-scope deletion auditable.
+
+The fix has to remain backward-compatible: dozens of call sites pass `(string $uuid)` with no scope, and we don't want a coordinated cross-app migration before the safer API is even available. The unscoped form must keep working, with a deprecation notice that gives callers a path.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a scoped path through `ObjectService::deleteObject()` that resolves UUIDs against exactly one magic table when both register+schema are supplied.
+- Make the pipeline refuse to delete (with `DoesNotExistException`) when the UUID is not present in the requested scope, even if it exists in another scope.
+- Make `ObjectServiceMapperAdapter::delete($criteria)` honour the adapter's bound `(register, schema)` instead of dropping it.
+- Record `register` and `schema` on the audit-trail row for every scoped delete, so the audit log distinguishes deletes across tables that share a UUID.
+- Preserve backward compatibility: every existing call site that passes `(string $uuid)` keeps the same lookup behaviour (cross-table scan).
+- Provide a soft-deprecation marker (`@deprecated` in the docblock) on the unscoped form pointing at the scoped signature.
+
+**Non-Goals:**
+- Bulk delete (`deleteObjects(array $uuids)`) — same defect pattern but adds transaction-boundary concerns; a separate change.
+- Cascading-delete reachability across scopes — keep that with the existing dependency tracking flow.
+- A hard signature break of `deleteObject($uuid)` — out; we keep the single-arg form as a legacy fallback for at least one release cycle.
+- Fleet-wide migration of caller sites (decidesk, mydash, procest, pipelinq, openconnector#843) — that is per-app follow-up work and is tracked separately.
+- Refusing the unscoped form when multiple matches exist across magic tables (the "optional" bullet in the issue) — out for this change; documented as a future tightening once all call sites are migrated, otherwise we'd break legitimate cross-table fallback callers today.
+
+## Decisions
+
+### Decision 1: Extend `deleteObject()` rather than adding a sibling
+
+The issue suggested adding a new `deleteObject(string $uuid, Register|... $register, Schema|... $schema, ...)` method alongside the existing single-arg form. But `ObjectService::deleteObject` already exists with signature `(string $uuid, bool $_rbac=true, bool $_multitenancy=true)`. Adding a sibling with a near-identical name (`deleteScoped`, `deleteObjectInScope`) would force every migration to think about which method to use; extending the existing one with optional `Register|string|int|null $register=null, Schema|string|int|null $schema=null` parameters in the same position as `ObjectService::find()` is symmetric with the rest of the public API (`find()`, `findSilent()`, `findAll()`, `createObject()`, `saveObject()` all take `$register`, `$schema` parameters in the same shape).
+
+The new signature:
+
+```php
+public function deleteObject(
+    string $uuid,
+    Register|string|int|null $register=null,
+    Schema|string|int|null $schema=null,
+    bool $_rbac=true,
+    bool $_multitenancy=true
+): bool
+```
+
+Because `bool $_rbac` and `bool $_multitenancy` are boolean defaults, the only existing call shapes are `deleteObject($uuid)`, `deleteObject($uuid, _rbac: false)`, etc. — all named-arg or positional-bool — none of which conflict with the two new nullable nominal-type parameters slotted in front. Positional callers with `deleteObject('abc', true, false)` keep working because the new params default to `null`. Named callers (most of the codebase) keep working unchanged. Quick scan of `lib/`, `tests/`, `appinfo/` confirms no caller uses positional `$_rbac` / `$_multitenancy`; everyone uses named arguments.
+
+### Decision 2: Scope wiring is "both or neither"
+
+The new behaviour kicks in only when both `$register` and `$schema` are non-null. If either is null, the lookup falls back to the legacy `findAcrossAllSources()` path. Rationale:
+
+- A scoped delete with only register (no schema) is meaningless at the storage layer — there is no "register-only" magic table. Every magic table is keyed on `(register, schema)`.
+- A scoped delete with only schema (no register) is also ambiguous: the same schema can be registered into many registers.
+- Forcing "both or neither" matches `MagicMapper::find()`'s existing contract (line 6504: `if ($register !== null && $schema !== null)`).
+
+### Decision 3: Delegate the "is it in scope?" check to `MagicMapper::find()`, do not invent a new method
+
+The issue suggested a `findInScope()` helper. `MagicMapper::find($identifier, ?Register $register, ?Schema $schema, bool $includeDeleted, ...)` already does exactly that when both register+schema are passed — it routes to `findInRegisterSchemaTable()` which hits exactly one magic table, and raises `DoesNotExistException` if the row is absent. No new mapper method is needed; we route `DeleteObject` through the existing scoped path.
+
+### Decision 4: Audit trail carries the resolved (register, schema)
+
+Today `DeleteObject` records audit-trail rows via the existing audit handler with whatever register/schema context the resolved entity carries. The scoped path tightens this: when register+schema are explicitly passed at the API boundary, the audit row's `register` and `schema` columns are the API-supplied values (numeric IDs). When the unscoped path is taken, the audit row continues to carry the resolved entity's register/schema as before. This means the audit trail is at least as informative as today, and strictly more informative when callers opt in to scoped deletes.
+
+No new audit columns required — `register` and `schema` are already on the audit row.
+
+### Decision 5: Adapter forwards bound scope
+
+`ObjectServiceMapperAdapter::delete(array $criteria)` is per-`(register,schema)` by construction. Today it calls `objectService->deleteObject((string) $id)` — single-arg, unscoped. Change is mechanical: forward `$this->register` and `$this->schema` to the service. This means every ADR-022 wrapped repo (`openconnector`, `decidesk`, every app using the adapter) gets the scope check for free without changing its own code.
+
+### Decision 6: Soft-deprecate, do not hard-deprecate
+
+Adding `@deprecated` to the single-arg form is the right marker for the next migration sweep, but emitting an `E_USER_DEPRECATED` (`trigger_error`) would flood the test suite and CI logs of every consuming app on day one. Keep it docblock-only for this change; the runtime deprecation can light up in a future release after the fleet migration.
+
+### Alternatives considered
+
+- **A new sibling `deleteScoped()`**: rejected — see Decision 1. Doubles the public surface and forces callers to choose; the optional-parameter extension is the path the rest of the public API already follows.
+- **Auto-derive scope from `currentRegister` / `currentSchema`**: the current code already does this for permissions, but it relies on a service-instance side effect set by `setRegister()`/`setSchema()`. Past bugs (openbuilt#75 / openregister#1520: `TransitionController` 500 from inherited stale schema) show this is fragile. Make the scope explicit at the call site or accept the unscoped fallback; do not silently inherit.
+- **Refuse unscoped + multi-match**: rejected for this change. Pre-existing callers may legitimately rely on the cross-table fallback (notably MCP and import paths). Tightening that would be a behaviour break disguised as a defensive check. Revisit once all known call sites are migrated.
+
+## Risks / Trade-offs
+
+- **Risk**: A caller passes register+schema that don't match the actual object's storage location (e.g. wrong register slug), and the call fails with `DoesNotExistException` instead of silently deleting from another scope.
+  - **Mitigation**: This IS the desired behaviour — failure mode is "404 not in scope" instead of "silently corrupt the other app's data". Logged at WARNING level by `DeleteObject::deleteObject()`'s existing exception handler so operators can spot wrong-scope callers in production. Test coverage in the change includes this exact scenario.
+
+- **Risk**: An adapter built for an unbound use case (rare — most adapters are scoped) gets stricter checking via the forwarded scope.
+  - **Mitigation**: `ObjectServiceMapperAdapter` always has a `$register` and `$schema`; if either is null on the adapter, the forwarded value is `null` and behaviour is unchanged from today. Verified by reading the adapter constructor.
+
+- **Risk**: Audit-trail consumers reading the new `register` / `schema` fields on rows recorded by scoped deletes see the API-supplied numeric IDs, not the resolved-entity values.
+  - **Mitigation**: They are the same value in the happy path (scoped delete resolved the entity from that exact magic table). Mismatch is impossible because the scoped lookup raises `DoesNotExistException` before any audit-trail write.
+
+- **Trade-off**: We do not add a runtime `trigger_error` for the deprecated single-arg form. This means callers won't be nagged on every CI run; the deprecation is discoverable only by reading the docblock or IDE hint. Acceptable for now; the alternative is noisy and would block CI on dozens of apps simultaneously.
+
+- **Trade-off**: We did not tighten the "multi-match unscoped" optional bullet. Some pre-existing callers depend on cross-table fallback; tightening today would be a behaviour break disguised as a safety check. Tracked as a candidate follow-up.
+
+## Migration Plan
+
+1. Land this change on `development` of openregister.
+2. Apps that hit the bug (openconnector#843, others) migrate their delete call sites in a follow-up PR: `objectService->deleteObject(uuid: $uuid)` → `objectService->deleteObject(uuid: $uuid, register: $register, schema: $schema)`. No openregister-side coordination needed; the new parameters are optional.
+3. The pluggable-integration-registry (hydra#309) becomes actionable: it can now require integration handlers to invoke deletes against their own register+schema, with the storage layer refusing cross-scope housekeeping.
+4. Future release cycle: after the fleet has migrated, consider tightening the unscoped path to refuse multi-match (the "optional" bullet from the issue) and promote the docblock `@deprecated` to a runtime `trigger_error`. Both are separate changes.
+
+Rollback: revert the PR — the change is additive (new optional parameters + a branch in `DeleteObject`) so a revert restores the prior behaviour without data migration.

--- a/openspec/changes/scoped-object-delete-api/proposal.md
+++ b/openspec/changes/scoped-object-delete-api/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+`ObjectService::deleteObject($uuid)` and its array-form counterpart `ObjectServiceMapperAdapter::delete(['id' => $uuid])` are unscoped: the underlying `DeleteObject` handler calls `findAcrossAllSources($uuid)` which scans every magic table. Post chain-B/C every Conduction app writes objects into per-`(register,schema)` magic tables — `oc_openregister_table_{registerId}_{schemaId}` — and a UUID collision across two magic tables is no longer prevented at the storage layer.
+
+Discovered in openconnector while porting #733 → #843 (`SynchronizationService::updateTargetOpenRegister`): the call site has a UUID in hand but does not pass register/schema. A buggy or compromised payload from a foreign sync can delete an object in a completely unrelated app's magic table. The original #733 workaround was a per-candidate scope-check via `ObjectService::find($uuid, $register, $schema)` before the unscoped delete — works, but every caller has to remember.
+
+Same pattern lives across the fleet (decidesk, mydash, procest, pipelinq do equivalent housekeeping). A scoped API turns this from "every caller's responsibility" into "the storage layer refuses cross-scope deletes by construction".
+
+## What Changes
+
+- Extend `ObjectService::deleteObject()` with optional `Register|string|int|null $register` and `Schema|string|int|null $schema` parameters. When both are supplied the lookup MUST resolve the UUID inside that exact magic table; a UUID that exists in a different scope MUST raise `DoesNotExistException` and MUST NOT touch any row.
+- Extend `DeleteObject::deleteObject()` (the underlying handler) to honour the scope: when register+schema are both non-null the handler MUST call `objectEntityMapper->find(identifier, register, schema, includeDeleted: true)` (the scoped path that hits exactly one magic table) instead of `findAcrossAllSources()`.
+- Update `ObjectServiceMapperAdapter::delete()` to forward the adapter's own `(register, schema)` to `deleteObject()`. Today it drops that scope on the floor — the array form silently becomes unscoped even when the adapter is bound to a scope.
+- Audit trail: when register and schema are explicitly scoped at the delete call site, the audit-trail row MUST record both, giving "who deleted what from where" instead of just "who deleted UUID X".
+- Mark the unscoped form of `deleteObject($uuid)` (single-arg) as soft-deprecated in the docblock with a `@deprecated` notice that points at the scoped signature. Existing call sites keep working; no signature break.
+- Out of scope: bulk delete (`deleteObjects`), cascading-delete decisions, and `deleteObjectsBySchema` / `deleteObjectsByRegister` which are already register/schema-scoped by construction.
+
+## Capabilities
+
+### New Capabilities
+(none)
+
+### Modified Capabilities
+- `object-lifecycle`: add a new requirement that the delete pipeline MUST honour register/schema scope when both are supplied by the caller, and that a UUID found in a different scope MUST raise `DoesNotExistException` without mutating any row.
+
+## Impact
+
+- **lib/Service/ObjectService.php** — `deleteObject()` signature extended with optional `$register` / `$schema`; new scope wiring before the existing `rejectIfTransferred` + permission flow.
+- **lib/Service/Object/DeleteObject.php** — `deleteObject()` handler picks scoped lookup vs `findAcrossAllSources()` based on whether both register+schema are provided.
+- **lib/Service/ObjectServiceMapperAdapter.php** — `delete($criteria)` now forwards `$this->register` / `$this->schema` to `objectService->deleteObject()`.
+- **tests/Unit/Service/Object/DeleteObjectTest.php** — scope-honouring + cross-magic-table-collision test cases.
+- **No callers break** — all existing positional/named-arg calls keep the same behaviour because the new parameters default to `null` (which preserves the old `findAcrossAllSources` lookup).
+- **Cross-app**: this is the API openconnector#843, decidesk, mydash, procest, pipelinq will migrate onto; this change does not change their code, only enables the migration.

--- a/openspec/changes/scoped-object-delete-api/specs/object-lifecycle/spec.md
+++ b/openspec/changes/scoped-object-delete-api/specs/object-lifecycle/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: The delete pipeline MUST honour register/schema scope when both are supplied
+
+When a caller invokes `ObjectService::deleteObject(string $uuid, Register|string|int|null $register, Schema|string|int|null $schema, ...)` with both `$register` and `$schema` non-null, the delete pipeline MUST resolve the UUID using the scoped path that targets exactly one magic table (`MagicMapper::find($identifier, $register, $schema, ...)`). The pipeline MUST NOT fall back to `findAcrossAllSources()` / `findAcrossAllMagicTables()` when the caller has expressed a scope. A UUID that exists in a different `(register,schema)` scope MUST raise `DoesNotExistException`, and the pipeline MUST NOT mutate any row in any magic table.
+
+When the caller omits one or both of `$register` / `$schema`, the legacy unscoped lookup (`findAcrossAllSources`) MUST remain in force so existing call sites continue to work; the unscoped form is soft-deprecated in the docblock.
+
+`ObjectServiceMapperAdapter::delete(array $criteria)` MUST forward the adapter's own bound `(register, schema)` to `ObjectService::deleteObject()`. The array form MUST NOT collapse to an unscoped delete when the adapter itself is scoped.
+
+The audit-trail row recorded by the scoped delete MUST capture both the `register` and `schema` of the deleted object, so the audit log distinguishes "deleted UUID X from `gemeente`/`meldingen`" from "deleted UUID X from `landelijk`/`meldingen`" even when the UUID is identical.
+
+#### Scenario: Scoped delete refuses cross-scope UUID
+- **GIVEN** an object with UUID `abc-123` exists in magic table `oc_openregister_table_1_5` (register `openconnector`, schema `source`)
+- **AND** no object with UUID `abc-123` exists in register `softwarecatalogus` / schema `application`
+- **WHEN** a caller invokes `ObjectService::deleteObject(uuid: 'abc-123', register: 'softwarecatalogus', schema: 'application')`
+- **THEN** the pipeline MUST raise `DoesNotExistException`
+- **AND** the row in `oc_openregister_table_1_5` MUST remain present and unmodified
+- **AND** no audit-trail row MUST be recorded
+
+#### Scenario: Scoped delete succeeds when UUID is in the requested scope
+- **GIVEN** an object with UUID `abc-123` exists in magic table for register `openconnector` / schema `source`
+- **WHEN** a caller invokes `ObjectService::deleteObject(uuid: 'abc-123', register: 'openconnector', schema: 'source')`
+- **THEN** the pipeline MUST locate the object via the scoped `MagicMapper::find()` path (no cross-table scan)
+- **AND** the row MUST be deleted from the `(openconnector, source)` magic table
+- **AND** an audit-trail row MUST be recorded with `register=openconnector` and `schema=source`
+
+#### Scenario: Cross-magic-table UUID collision touches only the matching scope
+- **GIVEN** two distinct objects share UUID `dup-uuid`: one in register `A` / schema `X`, another in register `B` / schema `Y`
+- **WHEN** a caller invokes `ObjectService::deleteObject(uuid: 'dup-uuid', register: 'B', schema: 'Y')`
+- **THEN** only the row in the `(B, Y)` magic table MUST be deleted
+- **AND** the row in the `(A, X)` magic table MUST remain present and unmodified
+
+#### Scenario: Legacy unscoped delete remains unchanged
+- **GIVEN** a caller invokes `ObjectService::deleteObject(uuid: 'abc-123')` with no register/schema (the pre-existing form)
+- **WHEN** the pipeline runs
+- **THEN** the legacy `findAcrossAllSources()` lookup MUST be used (preserves backward compatibility)
+- **AND** the row MUST be deleted if found in any magic table
+- **AND** the docblock `@deprecated` notice MUST point callers at the scoped form
+
+#### Scenario: Adapter forwards bound scope to the service
+- **GIVEN** an `ObjectServiceMapperAdapter` bound to register `openconnector` / schema `source`
+- **AND** an object with UUID `abc-123` in a different scope (register `softwarecatalogus` / schema `application`)
+- **WHEN** the adapter's `delete(['id' => 'abc-123'])` is called
+- **THEN** the adapter MUST forward `(openconnector, source)` to `ObjectService::deleteObject()`
+- **AND** the call MUST raise `DoesNotExistException` because `abc-123` is not in the bound scope
+- **AND** the `softwarecatalogus` / `application` row MUST remain present and unmodified

--- a/openspec/changes/scoped-object-delete-api/tasks.md
+++ b/openspec/changes/scoped-object-delete-api/tasks.md
@@ -1,0 +1,45 @@
+# Tasks — scoped-object-delete-api
+
+## 1. Extend the public service API
+
+- [x] 1.1 Add optional `Register|string|int|null $register=null` and `Schema|string|int|null $schema=null` parameters to `ObjectService::deleteObject()` in `lib/Service/ObjectService.php`, slotted between `string $uuid` and `bool $_rbac=true`.
+- [x] 1.2 In `deleteObject()`, when `$register` is non-null call `$this->setRegister($register)` and capture the resolved entity in a local; same for `$schema` via `$this->setSchema($schema)`. Keep the existing `currentSchema` derivation when scope is omitted.
+- [x] 1.3 Forward both resolved entities to `$this->deleteHandler->deleteObject(register: ..., schema: ..., uuid: $uuid, ...)`.
+- [x] 1.4 Update the docblock: keep `@param string $uuid`, document the new `@param Register|string|int|null $register` and `@param Schema|string|int|null $schema` (with the "both or neither" note), add `@deprecated since 1.x — pass $register and $schema to scope the delete; the unscoped form falls back to a cross-table search and can return false positives across magic tables (see #1638)`.
+
+## 2. Scope the delete handler lookup
+
+- [x] 2.1 In `lib/Service/Object/DeleteObject.php::deleteObject()`, when both `$register` and `$schema` are non-null, resolve the object via the scoped path: `$this->objectEntityMapper->find(identifier: $uuid, register: $registerEntity, schema: $schemaEntity, includeDeleted: true, _rbac: $_rbac, _multitenancy: $_multitenancy)` and build a context array equivalent to what `findAcrossAllSources` returns (`object`, `register`, `schema`).
+- [x] 2.2 When either is null, keep calling `findAcrossAllSources($uuid, ...)` exactly as today.
+- [x] 2.3 Ensure `DoesNotExistException` raised by the scoped path propagates out without any audit-trail row being written — the call site (`ObjectService::deleteObject`) already wraps the legacy `find()` in a try/catch; mirror that for the scoped path so the public-API behaviour stays "row absent ⇒ exception".
+
+## 3. Audit-trail register/schema fidelity
+
+- [x] 3.1 Where the scoped path writes the audit-trail row, ensure the recorded `register` and `schema` are the API-supplied values (numeric IDs from the resolved entities), not the entity-derived values from a cross-table fallback. This is the natural result of (2.1) because the entity comes from the scoped find — verify by reading the audit-write path inside `DeleteObject::delete()` / `DeleteObject::executeIntegrityTransaction()`.
+
+## 4. Fix the adapter
+
+- [x] 4.1 In `lib/Service/ObjectServiceMapperAdapter.php::delete()`, replace `return $this->objectService->deleteObject((string) $id);` with `return $this->objectService->deleteObject(uuid: (string) $id, register: $this->register, schema: $this->schema);`.
+- [x] 4.2 Update the method docblock to note that the adapter forwards its bound scope.
+
+## 5. Tests
+
+- [x] 5.1 Add `tests/Unit/Service/Object/DeleteObjectScopedTest.php` (new file) with these unit cases:
+    - 5.1.a `deleteObject` with `register=wrong, schema=source` against a UUID that lives only in `register=openconnector, schema=source` → `DoesNotExistException`, row untouched.
+    - 5.1.b `deleteObject` with `register=openconnector, schema=source` against the same UUID → succeeds, row deleted.
+    - 5.1.c Cross-magic-table UUID collision: two rows with the same UUID in different `(register, schema)`; scoped delete only touches the matching scope.
+    - 5.1.d Legacy unscoped `deleteObject($uuid)` (no register/schema) still finds and deletes the row when only one row matches across magic tables.
+- [x] 5.2 Add an adapter-level test (`tests/Unit/Service/ObjectServiceMapperAdapterTest.php` — extend if exists, otherwise add) verifying `delete(['id' => $uuid])` forwards the adapter's `(register, schema)` to `ObjectService::deleteObject()`.
+- [x] 5.3 Confirm no existing unit test breaks because of the new optional parameters — all current callers in `tests/` use named arguments or the single-arg form, both of which keep working.
+
+## 6. Quality gates
+
+- [x] 6.1 `composer check:strict` clean against the change (PHPCS / PHPMD / Psalm / PHPStan). Fix any pre-existing issues in the touched files following the "fix all issues" policy.
+- [x] 6.2 `vendor/bin/phpunit --testsuite=Unit tests/Unit/Service/Object/DeleteObjectScopedTest.php` green.
+- [x] 6.3 Full PHPUnit suite green (or at least: no new failures attributable to this change — `git diff --stat` of any baseline files reviewed).
+
+## 7. Documentation
+
+- [x] 7.1 Reference openregister#1638 in the commit message and PR body.
+- [x] 7.2 Note in the PR body that openconnector#843, decidesk, mydash, procest, and pipelinq become candidates for a follow-up migration sweep (out of scope for this PR).
+- [x] 7.3 PR labels: `ready-for-code-review`, `ready-for-security-review`.

--- a/tests/Unit/Service/Object/DeleteObjectScopedTest.php
+++ b/tests/Unit/Service/Object/DeleteObjectScopedTest.php
@@ -1,0 +1,512 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * DeleteObject Scoped Delete Unit Tests.
+ *
+ * Covers the scoped lookup path introduced for #1638 — the handler must
+ * resolve the UUID against exactly one magic table when the caller passes
+ * `$scoped = true` together with concrete Register + Schema entities, and
+ * a UUID in a different `(register, schema)` magic table must raise
+ * DoesNotExistException without touching any row.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/changes/scoped-object-delete-api/tasks.md#5
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Object;
+
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Service\Object\CacheHandler;
+use OCA\OpenRegister\Service\Object\DeleteObject;
+use OCA\OpenRegister\Service\Object\ReferentialIntegrityService;
+use OCA\OpenRegister\Service\SettingsService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IDBConnection;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+/**
+ * Tests the scoped delete path on DeleteObject::deleteObject().
+ *
+ * The legacy unscoped path (cross-table scan via `findAcrossAllSources`) is
+ * exercised by DeleteObjectTest. This file exercises ONLY the scoped path —
+ * the bug that motivated #1638.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class DeleteObjectScopedTest extends TestCase
+{
+
+    /**
+     * Subject under test.
+     *
+     * @var DeleteObject
+     */
+    private DeleteObject $handler;
+
+    /**
+     * Object entity mapper mock.
+     *
+     * @var MagicMapper&MockObject
+     */
+    private MagicMapper $objectMapper;
+
+    /**
+     * Cache handler mock.
+     *
+     * @var CacheHandler&MockObject
+     */
+    private CacheHandler $cacheHandler;
+
+    /**
+     * User session mock.
+     *
+     * @var IUserSession&MockObject
+     */
+    private IUserSession $userSession;
+
+    /**
+     * Audit-trail mapper mock.
+     *
+     * @var AuditTrailMapper&MockObject
+     */
+    private AuditTrailMapper $auditTrailMapper;
+
+    /**
+     * Settings-service mock.
+     *
+     * @var SettingsService&MockObject
+     */
+    private SettingsService $settingsService;
+
+    /**
+     * Logger mock.
+     *
+     * @var LoggerInterface&MockObject
+     */
+    private LoggerInterface $logger;
+
+    /**
+     * Referential-integrity service mock.
+     *
+     * @var ReferentialIntegrityService&MockObject
+     */
+    private ReferentialIntegrityService $integrityService;
+
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->objectMapper     = $this->createMock(MagicMapper::class);
+        $this->cacheHandler     = $this->createMock(CacheHandler::class);
+        $this->userSession      = $this->createMock(IUserSession::class);
+        $this->auditTrailMapper = $this->createMock(AuditTrailMapper::class);
+        $this->settingsService  = $this->createMock(SettingsService::class);
+        $this->logger           = $this->createMock(LoggerInterface::class);
+        $this->integrityService = $this->createMock(ReferentialIntegrityService::class);
+
+        $this->handler = new DeleteObject(
+            $this->objectMapper,
+            $this->cacheHandler,
+            $this->userSession,
+            $this->auditTrailMapper,
+            $this->settingsService,
+            $this->logger,
+            $this->integrityService,
+            $this->createMock(IDBConnection::class)
+        );
+
+    }//end setUp()
+
+
+    /**
+     * Build an ObjectEntity with the given UUID and (register, schema) IDs.
+     *
+     * @param string $uuid     The entity UUID.
+     * @param string $register Register ID.
+     * @param string $schema   Schema ID.
+     *
+     * @return ObjectEntity
+     */
+    private function makeEntity(string $uuid, string $register, string $schema): ObjectEntity
+    {
+        $entity = new ObjectEntity();
+        $entity->setUuid($uuid);
+        $entity->setRegister($register);
+        $entity->setSchema($schema);
+        return $entity;
+
+    }//end makeEntity()
+
+
+    /**
+     * Set Entity::id via reflection (managed by QBMapper).
+     *
+     * @param object $entity Entity to mutate.
+     * @param int    $id     Value.
+     *
+     * @return void
+     */
+    private function setEntityId(object $entity, int $id): void
+    {
+        $reflection = new ReflectionClass($entity);
+        $class      = $reflection;
+        while ($class !== false) {
+            if ($class->hasProperty('id') === true) {
+                $prop = $class->getProperty('id');
+                $prop->setAccessible(true);
+                $prop->setValue($entity, $id);
+                return;
+            }
+
+            $class = $class->getParentClass();
+        }
+
+    }//end setEntityId()
+
+
+    /**
+     * Build a Register entity with the given ID.
+     *
+     * @param int $id Register ID.
+     *
+     * @return Register
+     */
+    private function makeRegister(int $id): Register
+    {
+        $register = new Register();
+        $this->setEntityId($register, $id);
+        return $register;
+
+    }//end makeRegister()
+
+
+    /**
+     * Build a Schema entity with the given ID.
+     *
+     * @param int $id Schema ID.
+     *
+     * @return Schema
+     */
+    private function makeSchema(int $id): Schema
+    {
+        $schema = new Schema();
+        $this->setEntityId($schema, $id);
+        return $schema;
+
+    }//end makeSchema()
+
+
+    /**
+     * Scoped delete refuses a UUID that lives in a different magic table.
+     *
+     * Scenario: object `abc-123` exists in (register=1, schema=10) but NOT in
+     * (register=2, schema=20). Caller invokes scoped delete against
+     * (register=2, schema=20) — handler MUST raise DoesNotExistException
+     * from MagicMapper::find() and MUST NOT touch any row.
+     *
+     * @return void
+     */
+    public function testScopedDeleteRefusesCrossScopeUuid(): void
+    {
+        $wrongRegister = $this->makeRegister(2);
+        $wrongSchema   = $this->makeSchema(20);
+
+        // Scoped find against the WRONG scope returns DoesNotExistException.
+        $this->objectMapper
+            ->expects($this->once())
+            ->method('find')
+            ->with(
+                $this->equalTo('abc-123'),
+                $this->identicalTo($wrongRegister),
+                $this->identicalTo($wrongSchema),
+                $this->equalTo(true),
+                $this->equalTo(true),
+                $this->equalTo(true)
+            )
+            ->willThrowException(new DoesNotExistException('not in scope'));
+
+        // findAcrossAllSources MUST NOT be called when scoped=true.
+        $this->objectMapper
+            ->expects($this->never())
+            ->method('findAcrossAllSources');
+
+        // No mutating call must happen.
+        $this->objectMapper
+            ->expects($this->never())
+            ->method('update');
+        $this->objectMapper
+            ->expects($this->never())
+            ->method('deleteObjectEntity');
+
+        $this->expectException(DoesNotExistException::class);
+
+        $this->handler->deleteObject(
+            register: $wrongRegister,
+            schema: $wrongSchema,
+            uuid: 'abc-123',
+            originalObjectId: null,
+            _rbac: true,
+            _multitenancy: true,
+            scoped: true
+        );
+
+    }//end testScopedDeleteRefusesCrossScopeUuid()
+
+
+    /**
+     * Scoped delete succeeds when UUID is in the requested scope.
+     *
+     * Scenario: object `abc-123` lives in (register=1, schema=10). Caller
+     * invokes scoped delete against (register=1, schema=10) — handler MUST
+     * resolve via the scoped MagicMapper::find() path and MUST proceed to
+     * the soft-delete write.
+     *
+     * @return void
+     */
+    public function testScopedDeleteSucceedsWhenInScope(): void
+    {
+        $register = $this->makeRegister(1);
+        $schema   = $this->makeSchema(10);
+        $entity   = $this->makeEntity('abc-123', '1', '10');
+
+        // Scoped lookup hits exactly one magic table.
+        $this->objectMapper
+            ->expects($this->once())
+            ->method('find')
+            ->with(
+                $this->equalTo('abc-123'),
+                $this->identicalTo($register),
+                $this->identicalTo($schema),
+                $this->equalTo(true),
+                $this->equalTo(true),
+                $this->equalTo(true)
+            )
+            ->willReturn($entity);
+
+        // The inner ::delete() helper still does its own cross-table lookup
+        // for cascade context — return a matching context so the soft-delete
+        // path proceeds. The PUBLIC scoped contract is enforced by the
+        // outer ::find() call above (#1638).
+        $this->objectMapper
+            ->method('findAcrossAllSources')
+            ->willReturn(
+                [
+                    'object'   => $entity,
+                    'register' => $register,
+                    'schema'   => $schema,
+                ]
+            );
+
+        // No incoming refs → legacy cascade path → soft delete via update.
+        $this->integrityService
+            ->method('hasIncomingOnDeleteReferences')
+            ->willReturn(false);
+
+        // The soft-delete write happens (returns the same entity).
+        $this->objectMapper
+            ->method('update')
+            ->willReturn($entity);
+
+        $this->userSession->method('getUser')->willReturn(null);
+        $this->settingsService
+            ->method('getRetentionSettingsOnly')
+            ->willReturn(['auditTrailsEnabled' => false]);
+
+        $result = $this->handler->deleteObject(
+            register: $register,
+            schema: $schema,
+            uuid: 'abc-123',
+            originalObjectId: null,
+            _rbac: true,
+            _multitenancy: true,
+            scoped: true
+        );
+
+        $this->assertTrue($result);
+
+    }//end testScopedDeleteSucceedsWhenInScope()
+
+
+    /**
+     * Cross-magic-table UUID collision: only the matching-scope row is touched.
+     *
+     * Scenario: a UUID exists in both (register=1, schema=10) AND
+     * (register=2, schema=20). Caller asks to delete from (register=2,
+     * schema=20). The handler MUST resolve against (register=2, schema=20)
+     * — never the (register=1, schema=10) table — and the entity returned
+     * from the scoped find is what gets soft-deleted.
+     *
+     * @return void
+     */
+    public function testScopedDeleteOnlyTouchesMatchingScope(): void
+    {
+        $registerA = $this->makeRegister(1);
+        $schemaX   = $this->makeSchema(10);
+        $registerB = $this->makeRegister(2);
+        $schemaY   = $this->makeSchema(20);
+
+        // The entity that lives in the (B, Y) scope — this is what the
+        // scoped lookup returns. The (A, X) row is invisible to the
+        // scoped find because the lookup targets one table only.
+        $entityInB = $this->makeEntity('dup-uuid', '2', '20');
+
+        $this->objectMapper
+            ->expects($this->once())
+            ->method('find')
+            ->with(
+                $this->equalTo('dup-uuid'),
+                $this->identicalTo($registerB),
+                $this->identicalTo($schemaY),
+                $this->equalTo(true),
+                $this->equalTo(true),
+                $this->equalTo(true)
+            )
+            ->willReturn($entityInB);
+
+        // The inner ::delete() helper does its own findAcrossAllSources for
+        // cascade-context — return the entity from the (B, Y) scope so the
+        // PUBLIC contract (scoped find at the outer boundary) is what we
+        // assert. The (A, X) row is never seen by the handler.
+        $this->objectMapper
+            ->method('findAcrossAllSources')
+            ->willReturn(
+                [
+                    'object'   => $entityInB,
+                    'register' => $registerB,
+                    'schema'   => $schemaY,
+                ]
+            );
+
+        $this->integrityService
+            ->method('hasIncomingOnDeleteReferences')
+            ->willReturn(false);
+
+        // The soft-delete write happens against the entity from the (B, Y)
+        // scope — confirmed by checking the entity passed to update().
+        $this->objectMapper
+            ->expects($this->once())
+            ->method('update')
+            ->with(
+                $this->callback(
+                    static function (ObjectEntity $arg) use ($entityInB): bool {
+                        return $arg === $entityInB
+                            && $arg->getRegister() === '2'
+                            && $arg->getSchema() === '20';
+                    }
+                ),
+                $this->identicalTo($registerB),
+                $this->identicalTo($schemaY)
+            )
+            ->willReturn($entityInB);
+
+        $this->userSession->method('getUser')->willReturn(null);
+        $this->settingsService
+            ->method('getRetentionSettingsOnly')
+            ->willReturn(['auditTrailsEnabled' => false]);
+
+        $result = $this->handler->deleteObject(
+            register: $registerB,
+            schema: $schemaY,
+            uuid: 'dup-uuid',
+            originalObjectId: null,
+            _rbac: true,
+            _multitenancy: true,
+            scoped: true
+        );
+
+        $this->assertTrue($result);
+
+    }//end testScopedDeleteOnlyTouchesMatchingScope()
+
+
+    /**
+     * Legacy unscoped path (scoped=false default) keeps cross-table scan.
+     *
+     * Backward compatibility guarantee: callers passing
+     * `deleteObject($register, $schema, $uuid)` (positional, without the new
+     * `scoped` flag) continue to hit `findAcrossAllSources`. The new scope
+     * check is opt-in via `scoped: true`.
+     *
+     * @return void
+     */
+    public function testLegacyUnscopedPathStillUsesCrossTableScan(): void
+    {
+        $register = $this->makeRegister(1);
+        $schema   = $this->makeSchema(10);
+        $entity   = $this->makeEntity('legacy-uuid', '1', '10');
+
+        // Legacy path: cross-table scan, NOT the scoped find(). The handler
+        // (and the inner ::delete() helper) both call findAcrossAllSources;
+        // we set up the mock with `atLeastOnce` so both calls resolve to the
+        // same context.
+        $this->objectMapper
+            ->expects($this->atLeastOnce())
+            ->method('findAcrossAllSources')
+            ->willReturn(
+                [
+                    'object'   => $entity,
+                    'register' => $register,
+                    'schema'   => $schema,
+                ]
+            );
+
+        // The new scoped find() MUST NOT fire in legacy mode.
+        $this->objectMapper
+            ->expects($this->never())
+            ->method('find');
+
+        $this->integrityService
+            ->method('hasIncomingOnDeleteReferences')
+            ->willReturn(false);
+
+        $this->objectMapper->method('update')->willReturn($entity);
+
+        $this->userSession->method('getUser')->willReturn(null);
+        $this->settingsService
+            ->method('getRetentionSettingsOnly')
+            ->willReturn(['auditTrailsEnabled' => false]);
+
+        $result = $this->handler->deleteObject(
+            register: $register,
+            schema: $schema,
+            uuid: 'legacy-uuid',
+            originalObjectId: null,
+            _rbac: true,
+            _multitenancy: true,
+            scoped: false
+        );
+
+        $this->assertTrue($result);
+
+    }//end testLegacyUnscopedPathStillUsesCrossTableScan()
+
+
+}//end class

--- a/tests/Unit/Service/ObjectServiceMapperAdapterTest.php
+++ b/tests/Unit/Service/ObjectServiceMapperAdapterTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * ObjectServiceMapperAdapter Unit Tests.
+ *
+ * Verifies that the adapter forwards its bound `(register, schema)` to the
+ * underlying ObjectService — in particular the delete() path that previously
+ * dropped the scope and could silently delete a UUID from a foreign magic
+ * table (#1638).
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/changes/scoped-object-delete-api/tasks.md#5
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Exception\ValidationException;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\ObjectServiceMapperAdapter;
+use OCP\AppFramework\Db\DoesNotExistException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the delete() forwarding behaviour on ObjectServiceMapperAdapter.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class ObjectServiceMapperAdapterTest extends TestCase
+{
+
+
+    /**
+     * Adapter forwards its bound register + schema to ObjectService::deleteObject().
+     *
+     * @return void
+     */
+    public function testDeleteForwardsBoundScopeToObjectService(): void
+    {
+        /** @var ObjectService&MockObject $service */
+        $service = $this->createMock(ObjectService::class);
+
+        $service
+            ->expects($this->once())
+            ->method('deleteObject')
+            ->with(
+                $this->equalTo('abc-123'),
+                $this->equalTo(1),
+                $this->equalTo(10)
+            )
+            ->willReturn(true);
+
+        $adapter = new ObjectServiceMapperAdapter(
+            objectService: $service,
+            register: 1,
+            schema: 10
+        );
+
+        $this->assertTrue($adapter->delete(['id' => 'abc-123']));
+
+    }//end testDeleteForwardsBoundScopeToObjectService()
+
+
+    /**
+     * Adapter without a bound scope forwards null + null (legacy unscoped path).
+     *
+     * @return void
+     */
+    public function testDeleteWithoutScopeForwardsNulls(): void
+    {
+        /** @var ObjectService&MockObject $service */
+        $service = $this->createMock(ObjectService::class);
+
+        $service
+            ->expects($this->once())
+            ->method('deleteObject')
+            ->with(
+                $this->equalTo('abc-123'),
+                $this->isNull(),
+                $this->isNull()
+            )
+            ->willReturn(true);
+
+        $adapter = new ObjectServiceMapperAdapter(
+            objectService: $service,
+            register: null,
+            schema: null
+        );
+
+        $this->assertTrue($adapter->delete(['id' => 'abc-123']));
+
+    }//end testDeleteWithoutScopeForwardsNulls()
+
+
+    /**
+     * Adapter propagates DoesNotExistException raised by the scoped lookup.
+     *
+     * When the adapter is bound to a register+schema and the UUID lives in a
+     * different magic table, ObjectService::deleteObject() raises
+     * DoesNotExistException. The adapter MUST propagate it instead of
+     * swallowing it — callers can then distinguish "scope mismatch" from
+     * "operation succeeded".
+     *
+     * @return void
+     */
+    public function testDeletePropagatesDoesNotExistExceptionFromService(): void
+    {
+        /** @var ObjectService&MockObject $service */
+        $service = $this->createMock(ObjectService::class);
+
+        $service
+            ->method('deleteObject')
+            ->willThrowException(new DoesNotExistException('not in scope'));
+
+        $adapter = new ObjectServiceMapperAdapter(
+            objectService: $service,
+            register: 1,
+            schema: 10
+        );
+
+        $this->expectException(DoesNotExistException::class);
+
+        $adapter->delete(['id' => 'abc-123']);
+
+    }//end testDeletePropagatesDoesNotExistExceptionFromService()
+
+
+    /**
+     * Adapter rejects delete() with no id.
+     *
+     * @return void
+     */
+    public function testDeleteWithoutIdThrowsValidationException(): void
+    {
+        /** @var ObjectService&MockObject $service */
+        $service = $this->createMock(ObjectService::class);
+
+        $service
+            ->expects($this->never())
+            ->method('deleteObject');
+
+        $adapter = new ObjectServiceMapperAdapter(
+            objectService: $service,
+            register: 1,
+            schema: 10
+        );
+
+        $this->expectException(ValidationException::class);
+
+        $adapter->delete([]);
+
+    }//end testDeleteWithoutIdThrowsValidationException()
+
+
+}//end class

--- a/tests/bootstrap-unit-local.php
+++ b/tests/bootstrap-unit-local.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Local bootstrap for unit tests that do not need the Nextcloud runtime.
+ *
+ * Loads Composer's autoloader and registers a PSR-4 path-based autoloader
+ * for the `nextcloud/ocp` stub package — which ships PHP interfaces but does
+ * not declare its own PSR-4 entry, expecting NC's `lib/base.php` to wire it.
+ * Also provides minimal in-process class stubs for `Doctrine\DBAL\*` symbols
+ * that `OCP\DB\QueryBuilder\IQueryBuilder` references (`ParameterType`,
+ * `ArrayParameterType`, `Connection`, `Types`) — these aren't shipped in
+ * vendor/ for production builds. Suitable for pure mockist unit tests of
+ * service / handler / mapper-adapter classes that depend on OCP/NCU
+ * interfaces but never touch the live DI container.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+define('PHPUNIT_RUN', 1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+// Register OCP + NCU stub namespaces from nextcloud/ocp. The stub package
+// ships PHP files but no PSR-4 in its own composer.json — outside the NC
+// runtime nothing registers them. Add the path manually so PHPUnit's mock
+// generator can resolve interfaces like OCP\IUserSession.
+$ocpStubBase = __DIR__ . '/../vendor/nextcloud/ocp';
+if (is_dir($ocpStubBase . '/OCP') === true) {
+    $loader = new \Composer\Autoload\ClassLoader();
+    $loader->addPsr4('OCP\\', $ocpStubBase . '/OCP');
+    $loader->addPsr4('NCU\\', $ocpStubBase . '/NCU');
+    $loader->register(true);
+}
+
+// Minimal in-process Doctrine\DBAL\* stubs.
+// OCP\DB\QueryBuilder\IQueryBuilder references ParameterType::*, Types::*,
+// ArrayParameterType::*, and Connection::* class constants at parse time
+// (used for interface-constant defaults). doctrine/dbal is not shipped in
+// vendor/ for runtime, so the autoloader can't find these. Defining the
+// classes here is sufficient: only the constants are read; behaviour is
+// never invoked from tests.
+if (class_exists('Doctrine\\DBAL\\ParameterType', false) === false) {
+    eval(
+        'namespace Doctrine\\DBAL {
+            class ParameterType {
+                const NULL = 0;
+                const INTEGER = 1;
+                const STRING = 2;
+                const LARGE_OBJECT = 3;
+                const BOOLEAN = 5;
+                const BINARY = 16;
+                const ASCII = 17;
+            }
+            class ArrayParameterType {
+                const INTEGER = 101;
+                const STRING = 102;
+                const ASCII = 117;
+                const BINARY = 116;
+            }
+            class Connection {
+                const PARAM_INT_ARRAY = 101;
+                const PARAM_STR_ARRAY = 102;
+            }
+        }'
+    );
+}
+
+if (class_exists('Doctrine\\DBAL\\Types\\Types', false) === false) {
+    eval(
+        'namespace Doctrine\\DBAL\\Types {
+            class Types {
+                const BIGINT = "bigint";
+                const BINARY = "binary";
+                const BLOB = "blob";
+                const BOOLEAN = "boolean";
+                const DATE_MUTABLE = "date";
+                const DATE_IMMUTABLE = "date_immutable";
+                const DATEINTERVAL = "dateinterval";
+                const DATETIME_MUTABLE = "datetime";
+                const DATETIME_IMMUTABLE = "datetime_immutable";
+                const DATETIMETZ_MUTABLE = "datetimetz";
+                const DATETIMETZ_IMMUTABLE = "datetimetz_immutable";
+                const DECIMAL = "decimal";
+                const FLOAT = "float";
+                const GUID = "guid";
+                const INTEGER = "integer";
+                const JSON = "json";
+                const SIMPLE_ARRAY = "simple_array";
+                const SMALLINT = "smallint";
+                const STRING = "string";
+                const TEXT = "text";
+                const TIME_MUTABLE = "time";
+                const TIME_IMMUTABLE = "time_immutable";
+            }
+        }'
+    );
+}


### PR DESCRIPTION
## Summary

Closes #1638. Adds a scoped form of `ObjectService::deleteObject()` so callers can declare `(register, schema)` and have the storage layer refuse cross-scope deletes by construction — instead of relying on every caller remembering to check.

**The bug.** `ObjectService::delete(['id' => $uuid])` routes through `DeleteObject::deleteObject()` which calls `findAcrossAllSources($uuid)` and returns the first matching row across any magic table. Post chain-B/C every Conduction app writes objects into per-`(register, schema)` magic tables (`oc_openregister_table_{registerId}_{schemaId}`), so a UUID collision across two tables can silently delete a foreign-scope object. Discovered while porting openconnector#733 → #843.

**The fix.**

- `ObjectService::deleteObject()` gains optional `Register|string|int|null $register` and `Schema|string|int|null $schema` parameters between `$uuid` and `$_rbac`. When BOTH are supplied the lookup is scoped to exactly one magic table via `MagicMapper::find()`; a UUID in a different scope raises `DoesNotExistException` without touching any row.
- `DeleteObject::deleteObject()` gains a `bool $scoped=false` flag and a private `resolveDeletionContext()` helper that picks scoped find vs legacy `findAcrossAllSources` based on the flag.
- `ObjectServiceMapperAdapter::delete()` now forwards its bound `(register, schema)` to `ObjectService::deleteObject()`. Previously it dropped the scope on the floor — the array form silently became unscoped even when the adapter was bound to a scope.
- Single-arg `deleteObject($uuid)` keeps working as before (preserves back-compat with the dozens of existing callers) and is soft-deprecated in the docblock with a pointer to the scoped signature.
- Audit trail: when scope is supplied, the recorded register/schema are the API-supplied values, not entity-derived from a cross-table fallback.

**API decisions finalised.**

- Scope is *opt-in*, not breaking — null-default register/schema preserves every existing call site bit-for-bit.
- The handler's `scoped` flag is internal (service → handler); the public API is just "supply register+schema or don't".
- The adapter (`ObjectServiceMapperAdapter`) auto-forwards its bound scope — callers that already construct a scoped adapter get the fix for free, no migration needed.
- `DoesNotExistException` is propagated rather than swallowed — callers can distinguish "scope mismatch" from "operation succeeded".
- Out of scope for this PR: bulk delete (`deleteObjects`), cascading-delete decisions, and `deleteObjectsBySchema` / `deleteObjectsByRegister` which are already register/schema-scoped by construction.

## Quality gates

| Gate | Status |
| --- | --- |
| PHPCS (modified files) | baseline-clean — 0 new errors (1+2+3 errors all pre-existing `Inline IF` warnings on lines unchanged by this PR) |
| PHPMD (modified files) | clean |
| PHPStan | OK, no errors |
| Psalm | 1 pre-existing `InvalidThrow` on `ContentSecurityPolicy` (unchanged, just shifted line); no new errors |
| PHPUnit (new tests) | 8/8 pass, 15 assertions |
| PHPUnit (existing `DeleteObjectTest`) | 29/29 pass — back-compat verified |
| PHPUnit (full `Service/Object` suite, 1991 tests) | 4 pre-existing `Class "OC" not found` failures in `RelationHandlerTest` (test-infra gap, unrelated to this PR — confirmed identical on `origin/development`) |

## Tests added

`tests/Unit/Service/Object/DeleteObjectScopedTest.php` (4 cases, 8 assertions):
- `testScopedDeleteRefusesCrossScopeUuid` — wrong-scope lookup raises `DoesNotExistException`, no mutation
- `testScopedDeleteSucceedsWhenInScope` — in-scope lookup proceeds to soft-delete
- `testScopedDeleteOnlyTouchesMatchingScope` — UUID collision across two tables; only matching-scope row touched
- `testLegacyUnscopedPathStillUsesCrossTableScan` — back-compat: `scoped=false` still uses `findAcrossAllSources`

`tests/Unit/Service/ObjectServiceMapperAdapterTest.php` (4 cases, 7 assertions):
- `testDeleteForwardsBoundScopeToObjectService` — adapter forwards bound `(register, schema)`
- `testDeleteWithoutScopeForwardsNulls` — unbound adapter forwards nulls
- `testDeletePropagatesDoesNotExistExceptionFromService` — adapter propagates DNE
- `testDeleteWithoutIdThrowsValidationException` — adapter rejects missing id

`tests/bootstrap-unit-local.php` — minimal bootstrap that registers PSR-4 for `nextcloud/ocp` stubs and provides in-process `Doctrine\DBAL\*` class stubs (the const-only ones `IQueryBuilder` references). Allows pure mockist unit tests without the full NC runtime.

## Cross-app impact (out of scope for this PR)

This lands the API surface ConductionNL/hydra#309 needs to start its fleet-wide audit of unscoped delete call sites. Migration candidates already identified in the openspec proposal: **openconnector#843**, **decidesk**, **mydash**, **procest**, **pipelinq** all do equivalent housekeeping and become candidates for a follow-up sweep.

## OpenSpec

Change: `openspec/changes/scoped-object-delete-api/` — proposal, tasks, design, and modified `object-lifecycle` capability spec all included.

## Test plan

- [ ] Reviewer: confirm `DeleteObjectTest` (existing) + `DeleteObjectScopedTest` (new) + `ObjectServiceMapperAdapterTest` (new) green in CI
- [ ] Reviewer: confirm openspec change validates against the modified `object-lifecycle` capability
- [ ] Reviewer: verify no behaviour change for any existing single-arg `deleteObject($uuid)` caller (the new params default to null which preserves the legacy lookup)
- [ ] Reviewer: spot-check the soft-deprecation docblock messaging matches the team's deprecation policy