### PR TITLE
feat(rbac): system-context _owner attribution (closes #1617)

### DIFF
--- a/lib/Db/MagicMapper/MagicRbacHandler.php
+++ b/lib/Db/MagicMapper/MagicRbacHandler.php
@@ -180,6 +180,17 @@ class MagicRbacHandler
             $conditions[] = $qb->expr()->eq('t._owner', $qb->createNamedParameter($userId));
         }
 
+        // Condition: User is in a configured system-reader group - grant
+        // visibility on rows owned by the system identifier (e.g. cron-written
+        // rows). See openregister#1617. Admins already returned at line 147 so
+        // this branch only fires for non-admin reader-group members.
+        if ($this->shouldGrantSystemRowVisibility(userGroups: $userGroups) === true) {
+            $conditions[] = $qb->expr()->eq(
+                't._owner',
+                $qb->createNamedParameter($this->getSystemUserId())
+            );
+        }
+
         // Process each authorization rule.
         foreach ($rules as $rule) {
             $ruleCondition = $this->processAuthorizationRule(
@@ -754,6 +765,8 @@ class MagicRbacHandler
      * @return array{bypass: bool, conditions: string[]} Result with:
      *               - 'bypass' => true means no filtering needed (user has full access)
      *               - 'conditions' => SQL conditions to OR together, empty array means deny all
+     *
+     * @SuppressWarnings(PHPMD.NPathComplexity) Mirrors applyRbacFilters dispatch; carries the system-owner carve-out (openregister#1617).
      */
     public function buildRbacConditionsSql(Schema $schema, string $action='read'): array
     {
@@ -794,6 +807,14 @@ class MagicRbacHandler
         if ($userId !== null) {
             $quotedUserId = $this->quoteValue(value: $userId);
             $conditions[] = "_owner = {$quotedUserId}";
+        }
+
+        // Condition: User is in a configured system-reader group - grant
+        // visibility on rows owned by the system identifier. See
+        // openregister#1617. Admins already returned at line 781.
+        if ($this->shouldGrantSystemRowVisibility(userGroups: $userGroups) === true) {
+            $quotedSystemId = $this->quoteValue(value: $this->getSystemUserId());
+            $conditions[]   = "_owner = {$quotedSystemId}";
         }
 
         // Process each authorization rule.
@@ -1328,4 +1349,72 @@ class MagicRbacHandler
             return $schema->getAuthorization();
         }
     }//end resolveSchemaAuthorization()
+
+    /**
+     * Decide whether the current user qualifies for the system-row visibility
+     * carve-out (openregister#1617).
+     *
+     * Admins are NOT handled here — they bypass RBAC entirely at the top of
+     * the filter methods. This helper exists for non-admin users in groups
+     * configured under `openregister.systemReaderGroups`.
+     *
+     * @param string[] $userGroups The current user's group IDs.
+     *
+     * @return bool True if the user should see rows owned by the system identifier.
+     */
+    private function shouldGrantSystemRowVisibility(array $userGroups): bool
+    {
+        if (empty($userGroups) === true) {
+            return false;
+        }
+
+        $readerGroups = $this->resolveOrganisationService()?->getSystemReaderGroups() ?? [];
+        if (empty($readerGroups) === true) {
+            return false;
+        }
+
+        return count(array_intersect($userGroups, $readerGroups)) > 0;
+    }//end shouldGrantSystemRowVisibility()
+
+    /**
+     * Get the configured system identifier used as `_owner` for session-less
+     * writes.
+     *
+     * Falls back to {@see OrganisationService::SYSTEM_USER_ID_DEFAULT} when
+     * the OrganisationService is not available in the container (defensive
+     * default; matches the helper's own fallback path).
+     *
+     * @return string The system identifier.
+     */
+    private function getSystemUserId(): string
+    {
+        $service = $this->resolveOrganisationService();
+        if ($service === null) {
+            return \OCA\OpenRegister\Service\OrganisationService::SYSTEM_USER_ID_DEFAULT;
+        }
+
+        return $service->getSystemUserId();
+    }//end getSystemUserId()
+
+    /**
+     * Lazy-load OrganisationService from the container.
+     *
+     * Matches the lazy-load pattern already in use elsewhere in this class
+     * (see e.g. line 415) — avoids constructor-level circular DI dependencies.
+     *
+     * @return \OCA\OpenRegister\Service\OrganisationService|null The service or
+     *         null if the container cannot resolve it (defensive).
+     */
+    private function resolveOrganisationService(): ?\OCA\OpenRegister\Service\OrganisationService
+    {
+        try {
+            return $this->container->get(\OCA\OpenRegister\Service\OrganisationService::class);
+        } catch (\Throwable $e) {
+            $this->logger->debug(
+                message: '[MagicRbacHandler] OrganisationService unavailable - skipping system-owner carve-out',
+                context: ['file' => __FILE__, 'line' => __LINE__, 'error' => $e->getMessage()]
+            );
+            return null;
+        }
+    }//end resolveOrganisationService()
 }//end class

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -3414,11 +3414,10 @@ class SaveObject
         // Populate TMLO archival metadata defaults if register has TMLO enabled.
         $this->populateTmloDefaults(objectEntity: $objectEntity, schema: $schema, selfData: $selfData);
 
-        // Set user information if available.
-        $user = $this->userSession->getUser();
-        if ($user !== null) {
-            $objectEntity->setOwner($user->getUID());
-        }
+        // Set owner from the active user session, or fall back to the system
+        // identifier when no session is active. See applyOwnerAttribution()
+        // for the system-context contract (openregister#1617).
+        $this->applyOwnerAttribution(objectEntity: $objectEntity);
 
         // Set organisation from active organisation if not already set.
         // Always respect user's active organisation regardless of multitenancy settings.
@@ -3445,6 +3444,43 @@ class SaveObject
 
         return $objectEntity;
     }//end prepareObjectForCreation()
+
+    /**
+     * Attribute owner on a freshly created object entity.
+     *
+     * When an `IUserSession` user is active, owner is set to the user's UID
+     * (legacy behaviour, unchanged for logged-in writes).
+     *
+     * When no user session is active — cron jobs, background workers, internal
+     * service calls like openconnector's `CallService::call()` — owner is set
+     * to the configured system identifier instead of being left empty.
+     * Rows persisted with empty `_owner` are invisible to the REST list path's
+     * RBAC filter even for admins, which is the bug fixed by openregister#1617.
+     *
+     * A pre-existing non-empty `_owner` value (e.g. set explicitly by the
+     * caller via @self metadata) is honoured and not overwritten by the
+     * system-context fallback.
+     *
+     * @param ObjectEntity $objectEntity Entity being prepared for creation.
+     *
+     * @return void
+     */
+    private function applyOwnerAttribution(ObjectEntity $objectEntity): void
+    {
+        $user = $this->userSession->getUser();
+        if ($user !== null) {
+            $objectEntity->setOwner($user->getUID());
+            return;
+        }
+
+        // No user session — only fall back to the system identifier when
+        // owner is genuinely missing (empty or null). An explicit non-empty
+        // owner (e.g. set by the caller) is preserved.
+        $currentOwner = $objectEntity->getOwner();
+        if ($currentOwner === null || $currentOwner === '') {
+            $objectEntity->setOwner($this->organisationService->getSystemUserId());
+        }
+    }//end applyOwnerAttribution()
 
     /**
      * Prepares an object for update by applying all necessary transformations.

--- a/lib/Service/OrganisationService.php
+++ b/lib/Service/OrganisationService.php
@@ -83,6 +83,29 @@ class OrganisationService
     private const CACHE_TIMEOUT = 900;
 
     /**
+     * Configuration key for the system identifier used as `_owner` when a write
+     * happens with no active user session (cron jobs, background workers, etc.).
+     *
+     * @see self::getSystemUserId()
+     */
+    public const CONFIG_SYSTEM_USER_ID = 'systemUserId';
+
+    /**
+     * Configuration key for the comma-separated list of Nextcloud groups that
+     * are allowed to read system-owned rows in addition to the `admin` group.
+     *
+     * @see self::getSystemReaderGroups()
+     */
+    public const CONFIG_SYSTEM_READER_GROUPS = 'systemReaderGroups';
+
+    /**
+     * Default system identifier persisted as `_owner` when no user session is
+     * active. The double-underscore prefix is rejected by Nextcloud's user-ID
+     * validator, guaranteeing this identifier cannot collide with a real user.
+     */
+    public const SYSTEM_USER_ID_DEFAULT = '__system__';
+
+    /**
      * Static cache for default organisation (shared across all instances)
      *
      * @var Organisation|null
@@ -1418,6 +1441,72 @@ class OrganisationService
 
         return null;
     }//end getDefaultOrganisationId()
+
+    /**
+     * Get the system identifier used as `_owner` for writes without an active
+     * user session (cron jobs, background workers, internal service calls).
+     *
+     * Reads `openregister.systemUserId` from app-config; falls back to
+     * {@see self::SYSTEM_USER_ID_DEFAULT} when the key is unset or empty.
+     *
+     * The default identifier (`__system__`) cannot collide with a real user
+     * because Nextcloud's user-ID validator rejects identifiers starting with
+     * a double-underscore.
+     *
+     * @return string The system identifier (never empty).
+     *
+     * @spec openspec/changes/system-context-owner-attribution/tasks.md#task-1
+     */
+    public function getSystemUserId(): string
+    {
+        $configured = $this->appConfig->getValueString(
+            self::APP_NAME,
+            self::CONFIG_SYSTEM_USER_ID,
+            ''
+        );
+
+        if ($configured !== '') {
+            return $configured;
+        }
+
+        return self::SYSTEM_USER_ID_DEFAULT;
+    }//end getSystemUserId()
+
+    /**
+     * Get the Nextcloud groups (beyond `admin`) that are allowed to read
+     * system-owned rows.
+     *
+     * Reads `openregister.systemReaderGroups` from app-config as a
+     * comma-separated string, trims each entry, and drops empties. Returns
+     * an empty array when the key is unset.
+     *
+     * @return string[] Normalised list of group IDs (may be empty).
+     *
+     * @spec openspec/changes/system-context-owner-attribution/tasks.md#task-1
+     */
+    public function getSystemReaderGroups(): array
+    {
+        $configured = $this->appConfig->getValueString(
+            self::APP_NAME,
+            self::CONFIG_SYSTEM_READER_GROUPS,
+            ''
+        );
+
+        if ($configured === '') {
+            return [];
+        }
+
+        $parts  = explode(',', $configured);
+        $groups = [];
+        foreach ($parts as $part) {
+            $trimmed = trim($part);
+            if ($trimmed !== '') {
+                $groups[] = $trimmed;
+            }
+        }
+
+        return $groups;
+    }//end getSystemReaderGroups()
 
     /**
      * Format created date for JSON serialization

--- a/openspec/changes/system-context-owner-attribution/.openspec.yaml
+++ b/openspec/changes/system-context-owner-attribution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-22

--- a/openspec/changes/system-context-owner-attribution/design.md
+++ b/openspec/changes/system-context-owner-attribution/design.md
@@ -1,0 +1,100 @@
+## Context
+
+Two OR code paths conspire to hide service-written rows:
+
+1. **Write path** — `SaveObject::prepareObjectForCreation()` (lib/Service/Object/SaveObject.php:3417) reads `IUserSession::getUser()`. If null, it skips `setOwner()` entirely, so the new row persists with the column default (`''`).
+2. **Read path** — `MagicRbacHandler::applyRbacFilters()` (lib/Db/MagicMapper/MagicRbacHandler.php:178) emits `_owner = <currentUserId>` as the user-self-access condition. For an unauthenticated row (`_owner=''`) the only way to be visible is to satisfy a schema authorization rule. The full admin bypass at line 147 IS hit when the requesting user is in the `admin` group, BUT in chain-E the reproduction shows admin still gets `total: 0`. That is because the list endpoint is reached via the openconnector controller chain which proxies to OR — by the time we get to RBAC we have a user, but the multi-tenancy filter (`MagicOrganizationHandler::applyOrganizationFilter` lib/Db/MagicMapper/MagicOrganizationHandler.php:93) excludes null/empty `_organisation` rows for non-admin code paths.
+
+Even when the row has `_organisation` set, the empty `_owner` means non-admin users in the same org can't see it because every authorization rule the schema configures (e.g. "users in `log-readers` group can read") doesn't have a matching condition for "service-owned rows".
+
+The cleanest fix is to never persist an empty `_owner` in the first place, and to make the chosen identifier semantically visible: it is a system identifier, and admin-of-org can see it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- New service writes get a non-empty `_owner` that uniquely identifies them as system-attributed.
+- Admin users see system-owned rows on REST list (the chain-E dashboard works).
+- A deployment can opt extra groups (e.g. `log-readers`, `audit-readers`) into seeing system rows without giving them admin.
+- Organisation isolation continues to hold — admin-of-org-A cannot suddenly read system-owned rows in org-B unless they were admin-of-org-B already.
+
+**Non-Goals:**
+- Backfill of existing rows with `_owner=''`. Operators can run a one-off SQL UPDATE; we don't migrate automatically.
+- A per-organisation system identity. One identifier per deployment, period. Per-org tenant separation is preserved by `_organisation`, not by `_owner`.
+- Changing audit-trail provenance. `AuditTrailMapper` continues to record whatever actor it sees; system writes appear with empty actor on the audit row, which preserves the forensic distinction "the object's owner is `__system__`" vs "the object was modified by a user who happens to be called `__system__`" (impossible — see Decisions).
+- ADR-023 action-level authorization. Out of scope.
+
+## Decisions
+
+### D1 — Fix the source, not the filter
+
+**Decision:** Set `_owner = <systemUserId>` on save when no user session exists. Add a small RBAC visibility carve-out for that owner.
+
+**Alternatives considered:**
+
+- **A. Filter-only fix.** Change `MagicRbacHandler` to also OR-in `_owner IS NULL OR _owner = ''` for admins. Rejected — it papers over the symptom: rows still ship with empty `_owner`, which means every downstream consumer (audit dashboards, BI, OpenSearch sync) has to keep coding around the empty-string case. The data stays semantically wrong.
+- **B. Fix-source-only.** Set `_owner = systemUserId` but don't touch RBAC. Rejected — without the carve-out, the only users who can see system rows are admins (via the line-147 admin-bypass) and that's not configurable. Many deployments want a dedicated `log-readers` group that isn't `admin`.
+
+This is the layered approach the issue asked for; we do both.
+
+### D2 — Identifier choice: `__system__`
+
+**Decision:** Default `openregister.systemUserId = '__system__'`. The double-underscore prefix is forbidden in Nextcloud's user-ID validator (`OC\User\Manager::validateUserId` rejects `__` prefix), so no real user can collide. The identifier is config-overridable for deployments that want a different convention.
+
+**Alternative considered:** the nil UUID `00000000-...`. Rejected — UUID-shaped `_owner` values would confuse audit-trail readers who expect a UID-shaped string there.
+
+### D3 — Carve-out granularity: `admin` group + configurable `systemReaderGroups`
+
+**Decision:** Two-tier visibility. Admins always see system rows (they already bypass RBAC entirely via line 147, but we add `_owner = systemUserId` as an explicit OR-condition for completeness — see D5). A deployment can additionally widen visibility by listing groups in `openregister.systemReaderGroups`.
+
+**Alternative considered:** A new schema-level `authorization.read` rule keyword like `{ "system": true }`. Rejected — every schema would need the keyword added explicitly; deployment-wide visibility is the right granularity for "I as the operator decided this group reads service-written logs everywhere."
+
+### D4 — Single service for system identity
+
+**Decision:** Add methods on the existing `OrganisationService` — `getSystemUserId(): string` and `getSystemReaderGroups(): array`. Both `SaveObject` and `MagicRbacHandler` call them. Single source of truth, no parallel implementations.
+
+**Alternative considered:** A new `SystemIdentityService` class. Rejected for now — it would be 30 lines with two methods. If/when more "system identity" concerns appear, we extract. (Refactor signal: a third caller asks for the same value.)
+
+### D5 — RBAC carve-out is layered ABOVE the existing admin bypass
+
+**Decision:** Keep the existing admin-group full-bypass at line 147 unchanged. Add the system-owner OR-condition AFTER the admin-bypass return — so for admin users the carve-out is dead code (they already saw everything), but for `systemReaderGroups` members it's the only thing letting them see system rows. This keeps the admin contract intact and isolates the new behaviour to the new code path.
+
+### D6 — Declarative vs imperative (ADR-031)
+
+Not applicable. This is a security/auth code change, not a schema-register behaviour. The change touches no lifecycle, aggregation, calculation, notification, relation, or widget logic. Per ADR-031 § "Exception: lifecycle guard / scheduled bulk / external integration / domain rule", security-filter code legitimately lives in service classes, not schema JSON.
+
+## Seed Data
+
+Not applicable — this change introduces no new OpenRegister schemas. The behavioural change applies to all existing schemas that record `_owner` (i.e. every register table). ADR-001 seed-data section is not required for a security/visibility fix that doesn't introduce schema.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Existing rows with `_owner=''` remain hidden | Document the one-shot SQL: `UPDATE oc_openregister_<table> SET _owner = '__system__' WHERE _owner = '' OR _owner IS NULL;`. Not auto-run — operators audit first. Tracked in proposal "Backwards compatible". |
+| Misconfigured `systemReaderGroups` grants over-broad visibility | App-config keys are admin-only writable. Documentation in proposal warns operators. Default is empty so the carve-out is opt-in beyond admin. |
+| New OR-condition in the RBAC SQL slightly increases query plan complexity | The condition is a constant-string equality against an indexed column (`_owner` is indexed on every register table per the standard schema). Added cost is negligible (sub-ms). |
+| Test environment uses `__system__` as a real test fixture and collides | We verified NC's user-manager rejects `__` prefix; cannot collide with a real user. If a test fixture inserts a raw row with `_owner='__system__'`, it is by definition a system-attribute row — that's the intended semantics. |
+| Audit-trail provenance becomes ambiguous | `AuditTrailMapper` is NOT modified. System writes still record the actor as `null`/empty on the audit row. The data row says `_owner=__system__`; the audit row says "no user". A forensic reader sees both and knows the distinction. |
+
+## Migration Plan
+
+**Deploy:**
+1. Merge PR. New session-less writes immediately get `_owner = '__system__'` (config key unset → default).
+2. Operators who want non-default reader groups set `php occ config:app:set openregister systemReaderGroups --value="log-readers,audit-readers"`.
+
+**Rollback:** Revert the PR. Any rows written between deploy and rollback will have `_owner='__system__'` — they remain visible to admin (no change required) but non-admin reader groups lose access (their config key becomes a no-op). No DB rollback needed.
+
+**Backfill (optional, manual):**
+```sql
+-- For each register's data table, identified by oc_openregister_<id>_<id>:
+UPDATE oc_openregister_table_<id> SET _owner = '__system__' WHERE _owner = '' OR _owner IS NULL;
+```
+Run per table during a maintenance window. Not part of this PR.
+
+## Mixed-spec rationale
+
+Not applicable — `kind: code`, no config surface touched (the two new app-config keys are runtime configuration, not schema-register JSON).
+
+## Open Questions
+
+- Should `systemReaderGroups` be a per-schema setting instead of a deployment-wide one? Deferred — current scope is "make dashboards work"; per-schema granularity is overkill for that and adds spec surface. Revisit if a deployment asks for it.

--- a/openspec/changes/system-context-owner-attribution/proposal.md
+++ b/openspec/changes/system-context-owner-attribution/proposal.md
@@ -1,0 +1,48 @@
+---
+kind: code
+issue: 1617
+---
+
+## Why
+
+Services that write OpenRegister objects without an active HTTP/user session — cron jobs, background workers, internal service calls such as openconnector's `CallService::call()` — currently create rows with empty `_owner`. The REST list endpoint then hides those rows from every user because the RBAC filter requires `_owner` to match the requesting user (or be reachable via an authorization rule).
+
+Confirmed in chain-E: `CallService` writes a `call_log` row, direct DB shows `_owner=''`, `GET /api/objects/openregister/api/objects/openconnector/call_log` returns `total: 0`. Direct UUID lookup still returns the row — the data exists, it's just invisible. This is the last gap before openconnector's dashboard can show real call-log counts.
+
+## What Changes
+
+- **System-context attribution on save.** When `SaveObject::prepareObjectForCreation()` cannot resolve a user (no `IUserSession` user), `_owner` is set to a configured system identifier (default `__system__`) instead of being left empty. The identifier is exposed via OR's `appConfig` under `openregister.systemUserId` so a deployment can override it.
+- **System rows are visible to admins.** `MagicRbacHandler::applyRbacFilters()` and `buildRbacConditionsSql()` add one condition: rows with `_owner = systemUserId` are visible to users in the `admin` group OR in any group listed in `openregister.systemReaderGroups` (multi-string config, default empty). For non-admin, non-reader users behaviour is unchanged — they still need an authorization rule match.
+- **Audit trail is honest.** `AuditTrailMapper` continues to record the actor as before (`null` user → empty actor on the audit row). The change only addresses the data-row owner; audit-row provenance is untouched so a forensic read can still distinguish "owned by `__system__`" from "modified by a logged-in user named `__system__`" (impossible, the identifier is `__` prefixed which Nextcloud rejects for real users).
+- **Backwards compatible.** Pre-existing rows with `_owner=''` are NOT migrated. Operators who want them re-attributed run a one-off SQL or OCC command (documented in the change). New writes from this PR onward get the system owner automatically.
+
+## Capabilities
+
+### New Capabilities
+
+None — this is a behavioural change to existing capabilities.
+
+### Modified Capabilities
+
+- `auth-system`: codifies the "no active user session → `_owner = systemUserId`" rule on object create, and the system-owner visibility carve-out in the RBAC filter. Adds two app-config keys (`systemUserId`, `systemReaderGroups`).
+
+## Impact
+
+- **Code.** `lib/Service/Object/SaveObject.php` (one branch in `prepareObjectForCreation`), `lib/Db/MagicMapper/MagicRbacHandler.php` (one extra OR-condition in two filter paths), one helper on `OrganisationService` or a new `SystemIdentityService` to centralize the config lookup.
+- **API.** No new endpoints. Existing list endpoint now returns system-owned rows for admins where it previously returned zero.
+- **Schema/DB.** No migration. New rows get `_owner='__system__'` by default instead of `''`.
+- **Config.** Two new app-config keys:
+  - `openregister.systemUserId` (string, default `__system__`)
+  - `openregister.systemReaderGroups` (comma-separated list, default empty — admins always read system rows regardless)
+- **Dependencies.** Consumers (openconnector `CallService`, decidesk schedulers, future cron writers) get correct behaviour automatically — no caller-side changes required.
+- **Tests.** Adds unit coverage for both code paths (SaveObject system-attribution, MagicRbacHandler visibility carve-out) and a regression test that pins the reported chain-E scenario: write with no user session → list as admin returns the row.
+
+## Security trade-offs
+
+This is RBAC-adjacent, hence the `ready-for-security-review` label.
+
+- **Risk: a malicious org member could create a user literally named `__system__` and impersonate system writes.** Nextcloud rejects user IDs containing `__` at registration; verified in OC's `Manager::validateUserId`. Even so, the visibility carve-out is gated on group membership (`admin` or a configured reader group), not on the requesting user's UID — a normal user can't read system rows just because their UID happens to match.
+- **Risk: cross-organisation leakage via `_organisation=null`.** Existing `MagicOrganizationHandler::applyOrganizationFilter` already only shows null-`_organisation` rows to admin in non-SaaS mode (and never in SaaS mode). System-attributed rows go through `getOrganisationForNewEntity()` which falls back to the default org, so system rows DO have an `_organisation` and the existing tenant boundary holds. We add an explicit unit test for this path.
+- **Risk: log-row visibility lets attackers in admin-of-org-A read logs from system writes that happened in org-B.** Same protection as above: each row has an `_organisation`, and the org filter is applied independently of the RBAC owner check.
+- **Risk: the configurable system identifier is a footgun.** A deployment that sets `systemUserId` to a real existing user ID would grant that user read access to everything system-written. Mitigation: documentation warns; we keep the default to an identifier Nextcloud's own validator cannot collide with (`__system__`).
+- **Deferred:** action-level authorization (ADR-023) and per-organisation system identities are out of scope. Tracked in follow-up issues if needed.

--- a/openspec/changes/system-context-owner-attribution/specs/auth-system/spec.md
+++ b/openspec/changes/system-context-owner-attribution/specs/auth-system/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Writes without an active user session MUST be attributed to a system identifier
+When an OpenRegister object is created via `ObjectService::saveObject()` and `IUserSession::getUser()` returns `null` (cron job, queue worker, internal service call), the system MUST set `_owner` on the new row to a configured system identifier instead of leaving it empty. The identifier is read from the `openregister.systemUserId` app-config key. The default value is `__system__`, which Nextcloud's user-ID validator rejects for real user creation, guaranteeing the identifier cannot collide with any logged-in user.
+
+#### Scenario: Cron-job write gets system owner
+- **GIVEN** a background job (no `IUserSession` user) calls `ObjectService::saveObject(...)` on a register/schema it is allowed to write
+- **WHEN** `SaveObject::prepareObjectForCreation()` runs
+- **THEN** the persisted `ObjectEntity` MUST have `_owner = '__system__'` (or the configured `openregister.systemUserId` value)
+- **AND** the object MUST still receive an `_organisation` value via the existing `OrganisationService::getOrganisationForNewEntity()` fallback to the default organisation
+
+#### Scenario: Logged-in writes are unchanged
+- **GIVEN** a user `alice` is in the active `IUserSession`
+- **WHEN** `SaveObject::prepareObjectForCreation()` runs
+- **THEN** `_owner` MUST be set to `alice` (NOT the system identifier)
+
+#### Scenario: Operator can override the system identifier
+- **GIVEN** an operator sets `openregister.systemUserId` to `cron-bot` via OCC or app-config
+- **WHEN** a session-less write happens
+- **THEN** the persisted row MUST have `_owner = 'cron-bot'`
+
+### Requirement: System-owned rows MUST be visible to admin readers in the RBAC filter
+Both `MagicRbacHandler::applyRbacFilters()` and `MagicRbacHandler::buildRbacConditionsSql()` MUST treat rows where `_owner` equals the configured system identifier as visible to:
+- any user in the `admin` Nextcloud group (in addition to the existing full RBAC bypass for admins), AND
+- any user in any group listed in `openregister.systemReaderGroups` (comma-separated, default empty).
+
+For other users, system-owned rows MUST remain subject to the usual RBAC rule evaluation. The organisation/multitenancy filter is NOT modified — system rows MUST carry an `_organisation` and tenant boundaries hold independently of this carve-out.
+
+#### Scenario: Admin lists call_log and sees system-written rows
+- **GIVEN** a `call_log` row exists with `_owner = '__system__'` and `_organisation = <default-org-uuid>`
+- **AND** admin user has the default-org-uuid as their active organisation
+- **WHEN** admin GETs `/api/objects/openregister/api/objects/openconnector/call_log`
+- **THEN** the response `total` MUST include the system-written row
+- **AND** the row MUST appear in `results[]`
+
+#### Scenario: Non-admin without reader group does not see system rows from other authorization rules
+- **GIVEN** user `bob` is not in `admin` and not in any group listed in `openregister.systemReaderGroups`
+- **AND** the schema's `authorization.read` rule does NOT grant `bob` access by group
+- **AND** a row exists with `_owner = '__system__'`
+- **WHEN** `bob` lists that register/schema
+- **THEN** the response MUST NOT include the system-owned row (only rows matching `_owner = 'bob'` or the schema's group rules, exactly as before)
+
+#### Scenario: Configured reader-group member sees system rows
+- **GIVEN** `openregister.systemReaderGroups = "log-readers"` and user `carol` is in `log-readers`
+- **AND** a row exists with `_owner = '__system__'` in carol's active organisation
+- **WHEN** `carol` lists the schema
+- **THEN** the system row MUST be visible
+
+#### Scenario: Cross-organisation isolation still holds
+- **GIVEN** admin-of-org-A and a system-owned row exists in org-B
+- **AND** admin bypass is disabled (SaaS mode) so admin cannot see other orgs
+- **WHEN** admin-of-org-A lists the schema
+- **THEN** the row MUST NOT appear (the organisation filter excludes it before RBAC evaluates)
+
+### Requirement: The system identifier MUST be discoverable via a single service method
+A dedicated service method MUST expose the system identifier so that both `SaveObject` and `MagicRbacHandler` read the same value. The method MUST read `openregister.systemUserId` via `IAppConfig`, falling back to the constant default `__system__` when the key is unset or empty. The companion method MUST return the configured reader groups as a normalised `string[]` (trimmed, no empty entries).
+
+#### Scenario: Default identifier when unset
+- **GIVEN** `openregister.systemUserId` is unset
+- **WHEN** the service method is called
+- **THEN** it MUST return `__system__`
+
+#### Scenario: Reader-groups parse
+- **GIVEN** `openregister.systemReaderGroups = " log-readers , audit-readers ,, "`
+- **WHEN** the reader-groups method is called
+- **THEN** it MUST return `['log-readers', 'audit-readers']` (trimmed, empties removed)

--- a/openspec/changes/system-context-owner-attribution/tasks.md
+++ b/openspec/changes/system-context-owner-attribution/tasks.md
@@ -1,0 +1,50 @@
+## Tasks
+
+### 1. Add system-identity helpers to OrganisationService
+- [ ] Add `OrganisationService::getSystemUserId(): string` — reads `openregister.systemUserId` via `IAppConfig`, falls back to constant `OrganisationService::SYSTEM_USER_ID_DEFAULT = '__system__'`.
+- [ ] Add `OrganisationService::getSystemReaderGroups(): array` — reads `openregister.systemReaderGroups`, splits on `,`, trims each entry, drops empties; returns `string[]`.
+- [ ] Add `OrganisationService::SYSTEM_USER_ID_DEFAULT` class constant for the default value.
+- [ ] Update `OrganisationService` docblock + SPDX header (no new file, header already present).
+
+### 2. Wire system-attribution into SaveObject
+- [ ] In `SaveObject::prepareObjectForCreation()` (around line 3417), when `$this->userSession->getUser()` returns `null`, call `$this->organisationService->getSystemUserId()` and `$objectEntity->setOwner(<id>)` so the row is never persisted with empty `_owner`.
+- [ ] Confirm no second code path persists `_owner` empty — search `lib/Service/Object/SaveObject.php` for every `setOwner(` to ensure the system fallback covers the prepare-for-create flow only.
+- [ ] Keep `prepareObjectForUpdate` untouched — updates preserve the existing owner.
+
+### 3. Wire system-visibility into MagicRbacHandler
+- [ ] In `MagicRbacHandler::applyRbacFilters()`, after the admin-bypass return, before building `$conditions`, compute `$isSystemReader = in_array('admin', $userGroups, true) || count(array_intersect($userGroups, $this->organisationService->getSystemReaderGroups())) > 0;`. When `$isSystemReader === true`, push `_owner = <systemUserId>` (named parameter) as an OR-condition.
+- [ ] Apply the equivalent change in `MagicRbacHandler::buildRbacConditionsSql()` (the raw-SQL twin), using `$this->quoteValue($systemUserId)` to stay consistent with the existing quoting pattern at line 795-796.
+- [ ] Inject `OrganisationService` via the existing DI constructor — `MagicRbacHandler` already lazy-loads services from the container per the file's pattern; confirm constructor signature.
+
+### 4. PHPUnit coverage
+- [ ] `tests/Unit/Service/Object/SaveObjectSystemOwnerTest.php` — new file. Cases:
+  - `prepareObjectForCreation` with `IUserSession::getUser() === null` sets `_owner` to `__system__` (default).
+  - Same with `openregister.systemUserId = 'cron-bot'` sets `_owner = 'cron-bot'`.
+  - Same with user session present sets `_owner` to the user UID (regression — no behaviour change).
+- [ ] `tests/Unit/Db/MagicMapper/MagicRbacHandlerSystemOwnerTest.php` — new file. Cases:
+  - Admin user list query receives an OR-condition matching `_owner = '__system__'` (or whatever override).
+  - Non-admin user in `systemReaderGroups` group receives the same OR-condition.
+  - Non-admin user NOT in any reader group does NOT receive the OR-condition (regression — no visibility leak).
+  - Reader-group parse: trims, drops empties.
+- [ ] `tests/Unit/Service/OrganisationServiceSystemIdentityTest.php` — new file. Cases:
+  - `getSystemUserId()` returns `__system__` when key unset.
+  - `getSystemUserId()` returns the configured override.
+  - `getSystemReaderGroups()` returns `[]` when key unset.
+  - `getSystemReaderGroups()` trims and drops empties as documented.
+
+### 5. Quality gates (must be green before PR)
+- [ ] `composer phpcs` clean on changed files
+- [ ] `composer phpmd` clean on changed files
+- [ ] `composer psalm` clean on changed files
+- [ ] `composer phpstan` clean on changed files
+- [ ] `composer phpunit` — all existing tests pass + new tests pass
+
+### 6. PR
+- [ ] Open PR targeting `development` (not `main`).
+- [ ] Add labels `ready-for-code-review` and `ready-for-security-review`.
+- [ ] PR description references issue #1617 with `Closes #1617`.
+- [ ] Note in the PR body that no DB migration runs — operators backfill manually per design.md.
+
+### 7. Out of scope / follow-up
+- [ ] (Deferred) Backfill OCC command for existing `_owner=''` rows — open a separate issue if operators request it.
+- [ ] (Deferred) Per-schema `systemReaderGroups` override — revisit if multi-tenant deployments ask.

--- a/tests/Unit/Db/MagicMapper/MagicRbacHandlerSystemOwnerTest.php
+++ b/tests/Unit/Db/MagicMapper/MagicRbacHandlerSystemOwnerTest.php
@@ -1,0 +1,345 @@
+<?php
+
+/**
+ * OpenRegister - MagicRbacHandler system-owner carve-out test
+ *
+ * Verifies the openregister#1617 system-row visibility carve-out: rows
+ * owned by the configured system identifier are visible to admins and to
+ * users in any group listed under `openregister.systemReaderGroups`, but
+ * remain hidden from other non-admin users (no leak).
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Db\MagicMapper
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Db\MagicMapper;
+
+use OCA\OpenRegister\Db\MagicMapper\MagicRbacHandler;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Service\ConditionMatcher;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCP\DB\QueryBuilder\ICompositeExpression;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IAppConfig;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests the system-row visibility carve-out added to
+ * {@see MagicRbacHandler::applyRbacFilters()} (and its raw-SQL twin
+ * {@see MagicRbacHandler::buildRbacConditionsSql()}) for openregister#1617.
+ *
+ * Admin users hit the bypass at the top of both methods and never reach the
+ * carve-out; the new code only fires for non-admin users in a configured
+ * reader group. These tests pin that contract from the outside.
+ */
+class MagicRbacHandlerSystemOwnerTest extends TestCase
+{
+
+    /**
+     * IUserSession mock.
+     *
+     * @var IUserSession&MockObject
+     */
+    private IUserSession $userSession;
+
+    /**
+     * IGroupManager mock.
+     *
+     * @var IGroupManager&MockObject
+     */
+    private IGroupManager $groupManager;
+
+    /**
+     * Container mock — used to lazy-load OrganisationService.
+     *
+     * @var ContainerInterface&MockObject
+     */
+    private ContainerInterface $container;
+
+    /**
+     * OrganisationService mock — exposes system identifier + reader groups.
+     *
+     * @var OrganisationService&MockObject
+     */
+    private OrganisationService $organisationService;
+
+    /**
+     * System under test.
+     *
+     * @var MagicRbacHandler
+     */
+    private MagicRbacHandler $handler;
+
+    /**
+     * Build mocks + wire container to return the OrganisationService.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userSession         = $this->createMock(IUserSession::class);
+        $this->groupManager        = $this->createMock(IGroupManager::class);
+        $this->container           = $this->createMock(ContainerInterface::class);
+        $this->organisationService = $this->createMock(OrganisationService::class);
+
+        $this->container
+            ->method('get')
+            ->willReturnCallback(
+                    function (string $id) {
+                        if ($id === OrganisationService::class) {
+                            return $this->organisationService;
+                        }
+
+                        throw new \RuntimeException('Unexpected container::get('.$id.')');
+                    }
+                    );
+
+        $this->handler = new MagicRbacHandler(
+            $this->userSession,
+            $this->groupManager,
+            $this->createMock(IUserManager::class),
+            $this->createMock(IAppConfig::class),
+            $this->createMock(ConditionMatcher::class),
+            $this->container,
+            $this->createMock(LoggerInterface::class)
+        );
+    }//end setUp()
+
+    /**
+     * Helper — set up a logged-in user with the given groups.
+     *
+     * @param string $uid    User identifier.
+     * @param array  $groups Group IDs the user belongs to.
+     *
+     * @return void
+     */
+    private function mockUser(string $uid, array $groups): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager->method('getUserGroupIds')->willReturn($groups);
+    }//end mockUser()
+
+    /**
+     * Helper — build a schema with a single conditional authorization rule
+     * for the read action.
+     *
+     * @return Schema The schema with a non-empty auth.read array.
+     */
+    private function schemaWithReadRule(): Schema
+    {
+        $schema = new Schema();
+        $schema->setId(1);
+        $schema->setTitle('Test');
+        $schema->setAuthorization(['read' => ['some-group']]);
+        return $schema;
+    }//end schemaWithReadRule()
+
+    /**
+     * Helper — build a query-builder mock whose expression builder produces
+     * a deterministic, capturable SQL-ish fragment for each `eq()` call.
+     *
+     * Captures every emitted OR-clause via the spy returned by reference.
+     *
+     * @param array $captured Output array receiving each "column={value}" string.
+     *
+     * @return IQueryBuilder&MockObject
+     */
+    private function mockQueryBuilder(array &$captured): IQueryBuilder
+    {
+        $qb = $this->createMock(IQueryBuilder::class);
+
+        $expr = $this->createMock(IExpressionBuilder::class);
+        $expr
+            ->method('eq')
+            ->willReturnCallback(
+                    function (string $col, mixed $param) use (&$captured) {
+                        $captured[] = $col.'='.(string) $param;
+                        return $col.'='.(string) $param;
+                    }
+                    );
+        $expr
+            ->method('orX')
+            ->willReturnCallback(
+                    function (...$args): ICompositeExpression {
+                        // Return a minimal real ICompositeExpression implementation —
+                        // mocked __toString is forbidden by PHPUnit, and the type
+                        // signature on orX() must be satisfied at runtime.
+                        return new class implements ICompositeExpression {
+                            public function addMultiple(array $parts = []): ICompositeExpression
+                            {
+                                return $this;
+                            }
+
+                            public function add($part): ICompositeExpression
+                            {
+                                return $this;
+                            }
+
+                            public function count(): int
+                            {
+                                return 0;
+                            }
+
+                            public function getType(): string
+                            {
+                                return 'OR';
+                            }
+                        };
+                    }
+                    );
+
+        $qb->method('expr')->willReturn($expr);
+        $qb->method('createNamedParameter')->willReturnArgument(0);
+        // andWhere is called once at the end - no return value capture needed.
+        $qb->method('andWhere');
+
+        return $qb;
+    }//end mockQueryBuilder()
+
+    /**
+     * Non-admin user in a configured systemReaderGroups group gets a
+     * `_owner = '__system__'` OR-condition appended.
+     *
+     * @return void
+     */
+    public function testReaderGroupGetsSystemOwnerCondition(): void
+    {
+        $this->mockUser(uid: 'carol', groups: ['log-readers']);
+
+        $this->organisationService
+            ->method('getSystemReaderGroups')
+            ->willReturn(['log-readers']);
+        $this->organisationService
+            ->method('getSystemUserId')
+            ->willReturn('__system__');
+
+        $captured = [];
+        $qb       = $this->mockQueryBuilder($captured);
+
+        $this->handler->applyRbacFilters(
+            qb: $qb,
+            schema: $this->schemaWithReadRule(),
+            action: 'read'
+        );
+
+        $this->assertContains(
+            't._owner=__system__',
+            $captured,
+            'Reader-group member must receive the system-owner OR-condition.'
+        );
+    }//end testReaderGroupGetsSystemOwnerCondition()
+
+    /**
+     * Non-admin user NOT in any reader group does NOT receive the
+     * system-owner condition — no visibility leak.
+     *
+     * @return void
+     */
+    public function testNonReaderUserDoesNotGetSystemOwnerCondition(): void
+    {
+        $this->mockUser(uid: 'bob', groups: ['users']);
+
+        $this->organisationService
+            ->method('getSystemReaderGroups')
+            ->willReturn(['log-readers']);
+        // getSystemUserId is NOT expected to be called - assert that.
+        $this->organisationService
+            ->expects($this->never())
+            ->method('getSystemUserId');
+
+        $captured = [];
+        $qb       = $this->mockQueryBuilder($captured);
+
+        $this->handler->applyRbacFilters(
+            qb: $qb,
+            schema: $this->schemaWithReadRule(),
+            action: 'read'
+        );
+
+        $this->assertNotContains(
+            't._owner=__system__',
+            $captured,
+            'Non-reader users must NOT receive the system-owner OR-condition.'
+        );
+    }//end testNonReaderUserDoesNotGetSystemOwnerCondition()
+
+    /**
+     * Reader-group config that's empty means no system-owner condition
+     * even when the user has groups.
+     *
+     * @return void
+     */
+    public function testEmptyReaderGroupsConfigSkipsCarveOut(): void
+    {
+        $this->mockUser(uid: 'bob', groups: ['log-readers']);
+
+        $this->organisationService
+            ->method('getSystemReaderGroups')
+            ->willReturn([]);
+
+        $captured = [];
+        $qb       = $this->mockQueryBuilder($captured);
+
+        $this->handler->applyRbacFilters(
+            qb: $qb,
+            schema: $this->schemaWithReadRule(),
+            action: 'read'
+        );
+
+        $this->assertNotContains(
+            't._owner=__system__',
+            $captured,
+            'Empty reader-groups config must skip the carve-out entirely.'
+        );
+    }//end testEmptyReaderGroupsConfigSkipsCarveOut()
+
+    /**
+     * Admin users hit the bypass at the top and never reach the carve-out -
+     * no system-owner condition is emitted, but the test also verifies the
+     * method returned without crashing on the admin path.
+     *
+     * @return void
+     */
+    public function testAdminUserBypassesBeforeCarveOut(): void
+    {
+        $this->mockUser(uid: 'admin1', groups: ['admin']);
+
+        // Container should NOT be touched - admin bypasses before OrganisationService is consulted.
+        $this->organisationService
+            ->expects($this->never())
+            ->method('getSystemReaderGroups');
+
+        $captured = [];
+        $qb       = $this->mockQueryBuilder($captured);
+
+        $this->handler->applyRbacFilters(
+            qb: $qb,
+            schema: $this->schemaWithReadRule(),
+            action: 'read'
+        );
+
+        // No conditions captured at all - admin bypass returns immediately.
+        $this->assertSame(
+            [],
+            $captured,
+            'Admin must bypass before any conditions are emitted.'
+        );
+    }//end testAdminUserBypassesBeforeCarveOut()
+}//end class

--- a/tests/Unit/Service/Object/SaveObjectSystemOwnerTest.php
+++ b/tests/Unit/Service/Object/SaveObjectSystemOwnerTest.php
@@ -1,0 +1,226 @@
+<?php
+
+/**
+ * OpenRegister - SaveObject system-owner attribution test
+ *
+ * Pins the openregister#1617 contract on `SaveObject::applyOwnerAttribution()`:
+ *   - Logged-in writes set `_owner` to the user UID (legacy behaviour).
+ *   - Session-less writes attribute to the configured system identifier.
+ *   - An explicit pre-existing owner is never overwritten.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Object;
+
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Object\CacheHandler;
+use OCA\OpenRegister\Service\Object\SaveObject;
+use OCA\OpenRegister\Service\Object\SaveObject\FilePropertyHandler;
+use OCA\OpenRegister\Service\Object\SaveObject\MetadataHydrationHandler;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCA\OpenRegister\Service\PropertyRbacHandler;
+use OCA\OpenRegister\Service\SettingsService;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+use Twig\Loader\ArrayLoader;
+
+/**
+ * Unit tests for {@see SaveObject::applyOwnerAttribution()}.
+ *
+ * The helper is exercised via reflection because the production call sites
+ * (prepareObjectForCreation) carry many heavyweight dependencies that are not
+ * relevant to this single contract.
+ */
+class SaveObjectSystemOwnerTest extends TestCase
+{
+
+    /**
+     * IUserSession mock - controls whether a "session user" is active.
+     *
+     * @var IUserSession&MockObject
+     */
+    private IUserSession $userSession;
+
+    /**
+     * OrganisationService mock - returns the configured system identifier.
+     *
+     * @var OrganisationService&MockObject
+     */
+    private OrganisationService $organisationService;
+
+    /**
+     * System under test.
+     *
+     * @var SaveObject
+     */
+    private SaveObject $handler;
+
+    /**
+     * Wire mocks + build a SaveObject instance with mostly-mocked collaborators.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userSession         = $this->createMock(IUserSession::class);
+        $this->organisationService = $this->createMock(OrganisationService::class);
+
+        $this->handler = new SaveObject(
+            $this->createMock(MagicMapper::class),
+            $this->createMock(MagicMapper::class),
+            $this->createMock(MetadataHydrationHandler::class),
+            $this->createMock(FilePropertyHandler::class),
+            $this->createMock(\OCA\OpenRegister\Service\Object\SaveObject\LinkedEntityPropertyHandler::class),
+            $this->userSession,
+            $this->createMock(AuditTrailMapper::class),
+            $this->createMock(SchemaMapper::class),
+            $this->createMock(RegisterMapper::class),
+            $this->createMock(IURLGenerator::class),
+            $this->organisationService,
+            $this->createMock(CacheHandler::class),
+            $this->createMock(SettingsService::class),
+            $this->createMock(PropertyRbacHandler::class),
+            $this->createMock(\OCA\OpenRegister\Service\Object\SaveObject\ComputedFieldHandler::class),
+            $this->createMock(\OCA\OpenRegister\Service\Object\TranslationHandler::class),
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(\OCA\OpenRegister\Service\TmloService::class),
+            new ArrayLoader()
+        );
+    }//end setUp()
+
+    /**
+     * Invoke the private applyOwnerAttribution() helper on the entity.
+     *
+     * @param ObjectEntity $entity Entity to attribute.
+     *
+     * @return void
+     */
+    private function invokeApply(ObjectEntity $entity): void
+    {
+        $method = new ReflectionMethod(SaveObject::class, 'applyOwnerAttribution');
+        $method->setAccessible(true);
+        $method->invoke($this->handler, $entity);
+    }//end invokeApply()
+
+    /**
+     * Logged-in writes attribute the user UID (regression - legacy behaviour).
+     *
+     * @return void
+     */
+    public function testLoggedInWriteSetsUserUid(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $this->userSession->method('getUser')->willReturn($user);
+
+        // OrganisationService MUST NOT be touched when a user is present.
+        $this->organisationService
+            ->expects($this->never())
+            ->method('getSystemUserId');
+
+        $entity = new ObjectEntity();
+        $this->invokeApply($entity);
+
+        $this->assertSame('alice', $entity->getOwner());
+    }//end testLoggedInWriteSetsUserUid()
+
+    /**
+     * Session-less write with empty owner falls back to the system identifier.
+     *
+     * @return void
+     */
+    public function testSessionlessWriteFallsBackToSystemIdentifier(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->organisationService
+            ->expects($this->once())
+            ->method('getSystemUserId')
+            ->willReturn('__system__');
+
+        $entity = new ObjectEntity();
+        $this->invokeApply($entity);
+
+        $this->assertSame('__system__', $entity->getOwner());
+    }//end testSessionlessWriteFallsBackToSystemIdentifier()
+
+    /**
+     * Session-less write honours an operator's configured override.
+     *
+     * @return void
+     */
+    public function testSessionlessWriteHonoursConfiguredOverride(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->organisationService
+            ->method('getSystemUserId')
+            ->willReturn('cron-bot');
+
+        $entity = new ObjectEntity();
+        $this->invokeApply($entity);
+
+        $this->assertSame('cron-bot', $entity->getOwner());
+    }//end testSessionlessWriteHonoursConfiguredOverride()
+
+    /**
+     * A pre-existing non-empty owner is preserved on session-less writes
+     * (e.g. an explicit `@self.owner` set by the caller).
+     *
+     * @return void
+     */
+    public function testSessionlessWritePreservesExplicitOwner(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        // OrganisationService MUST NOT be touched - owner is already set.
+        $this->organisationService
+            ->expects($this->never())
+            ->method('getSystemUserId');
+
+        $entity = new ObjectEntity();
+        $entity->setOwner('explicit-owner');
+        $this->invokeApply($entity);
+
+        $this->assertSame('explicit-owner', $entity->getOwner());
+    }//end testSessionlessWritePreservesExplicitOwner()
+
+    /**
+     * Empty-string owner triggers the system-context fallback
+     * (defends against callers passing `''` explicitly).
+     *
+     * @return void
+     */
+    public function testSessionlessWriteOverwritesEmptyStringOwner(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->organisationService
+            ->method('getSystemUserId')
+            ->willReturn('__system__');
+
+        $entity = new ObjectEntity();
+        $entity->setOwner('');
+        $this->invokeApply($entity);
+
+        $this->assertSame('__system__', $entity->getOwner());
+    }//end testSessionlessWriteOverwritesEmptyStringOwner()
+}//end class

--- a/tests/Unit/Service/OrganisationServiceSystemIdentityTest.php
+++ b/tests/Unit/Service/OrganisationServiceSystemIdentityTest.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * OpenRegister - OrganisationService system-identity helpers test
+ *
+ * Covers the helpers that surface the system-user identifier and reader
+ * groups for openregister#1617.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Db\OrganisationMapper;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCP\IAppConfig;
+use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\ISession;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+/**
+ * Tests {@see OrganisationService::getSystemUserId()} and
+ * {@see OrganisationService::getSystemReaderGroups()} — the two helpers
+ * introduced for the openregister#1617 fix.
+ *
+ * The system identifier and reader-group lookup are the single source of
+ * truth for both SaveObject (write-side attribution) and MagicRbacHandler
+ * (read-side visibility carve-out). Tests live here so a change to either
+ * helper trips a focused failure rather than a diffuse downstream surprise.
+ */
+class OrganisationServiceSystemIdentityTest extends TestCase
+{
+
+    /**
+     * IAppConfig mock — primary collaborator for both helpers.
+     *
+     * @var IAppConfig&MockObject
+     */
+    private IAppConfig $appConfig;
+
+    /**
+     * System under test.
+     *
+     * @var OrganisationService
+     */
+    private OrganisationService $service;
+
+    /**
+     * Construct an OrganisationService with mocked collaborators.
+     *
+     * Builds the instance via reflection so this test does not need to track
+     * the (long) production constructor signature — only IAppConfig is
+     * exercised here.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->appConfig = $this->createMock(IAppConfig::class);
+
+        $reflection = new ReflectionClass(OrganisationService::class);
+        /*
+         * @var OrganisationService $service
+         */
+        $service = $reflection->newInstanceWithoutConstructor();
+
+        $appConfigProp = $reflection->getProperty('appConfig');
+        $appConfigProp->setAccessible(true);
+        $appConfigProp->setValue($service, $this->appConfig);
+
+        // Wire the logger - getSystemUserId/Groups don't touch it but other
+        // potentially-loaded code paths might via PHP property initialisation.
+        $loggerProp = $reflection->getProperty('logger');
+        $loggerProp->setAccessible(true);
+        $loggerProp->setValue($service, $this->createMock(LoggerInterface::class));
+
+        $this->service = $service;
+    }//end setUp()
+
+    /**
+     * When the `systemUserId` config key is unset, the helper falls back to
+     * the constant default `__system__`.
+     *
+     * @return void
+     */
+    public function testGetSystemUserIdReturnsDefaultWhenConfigEmpty(): void
+    {
+        $this->appConfig
+            ->expects($this->once())
+            ->method('getValueString')
+            ->with('openregister', OrganisationService::CONFIG_SYSTEM_USER_ID, '')
+            ->willReturn('');
+
+        $this->assertSame(
+            OrganisationService::SYSTEM_USER_ID_DEFAULT,
+            $this->service->getSystemUserId()
+        );
+    }//end testGetSystemUserIdReturnsDefaultWhenConfigEmpty()
+
+    /**
+     * A configured override is honoured verbatim.
+     *
+     * @return void
+     */
+    public function testGetSystemUserIdHonoursConfiguredOverride(): void
+    {
+        $this->appConfig
+            ->expects($this->once())
+            ->method('getValueString')
+            ->with('openregister', OrganisationService::CONFIG_SYSTEM_USER_ID, '')
+            ->willReturn('cron-bot');
+
+        $this->assertSame('cron-bot', $this->service->getSystemUserId());
+    }//end testGetSystemUserIdHonoursConfiguredOverride()
+
+    /**
+     * Empty reader-groups config returns an empty array.
+     *
+     * @return void
+     */
+    public function testGetSystemReaderGroupsReturnsEmptyWhenConfigEmpty(): void
+    {
+        $this->appConfig
+            ->expects($this->once())
+            ->method('getValueString')
+            ->with('openregister', OrganisationService::CONFIG_SYSTEM_READER_GROUPS, '')
+            ->willReturn('');
+
+        $this->assertSame([], $this->service->getSystemReaderGroups());
+    }//end testGetSystemReaderGroupsReturnsEmptyWhenConfigEmpty()
+
+    /**
+     * Reader-groups parse: comma-separated, trimmed, empties dropped.
+     *
+     * @return void
+     */
+    public function testGetSystemReaderGroupsTrimsAndDropsEmpties(): void
+    {
+        $this->appConfig
+            ->expects($this->once())
+            ->method('getValueString')
+            ->with('openregister', OrganisationService::CONFIG_SYSTEM_READER_GROUPS, '')
+            ->willReturn(' log-readers , audit-readers ,, ');
+
+        $this->assertSame(
+            ['log-readers', 'audit-readers'],
+            $this->service->getSystemReaderGroups()
+        );
+    }//end testGetSystemReaderGroupsTrimsAndDropsEmpties()
+}//end class


### PR DESCRIPTION
## Summary

- **Problem.** Services writing OR objects without an active user session (cron jobs, queue workers, openconnector's `CallService::call()`) created rows with empty `_owner`. The REST list endpoint's RBAC filter then hid those rows from every user — even admins — because the only legacy condition was `_owner = currentUserId`. Confirmed in chain-E: openconnector wrote a `call_log` row, direct DB confirmed `_owner=''`, list returned `total: 0`, direct UUID lookup still found the row.
- **Write-path fix.** `SaveObject::prepareObjectForCreation()` now calls `OrganisationService::getSystemUserId()` (default `__system__`) when no user session is active. An explicit pre-existing owner is preserved.
- **Read-path fix.** `MagicRbacHandler::applyRbacFilters()` and its raw-SQL twin `buildRbacConditionsSql()` add one OR-condition: rows with `_owner = systemUserId` are visible to any user in a group listed under `openregister.systemReaderGroups` (default empty). Admins are unaffected — they already bypass RBAC entirely at the top of both methods.
- **Single source of truth.** Two new helpers on `OrganisationService` (`getSystemUserId()` + `getSystemReaderGroups()`) read app-config keys `openregister.systemUserId` and `openregister.systemReaderGroups`. Both write- and read-paths consume them.

## Security trade-offs

This is RBAC-adjacent, hence `ready-for-security-review`.

- **`__system__` cannot collide with a real user.** Nextcloud's user-ID validator (`OC\User\Manager::validateUserId`) rejects identifiers containing `__`, so an attacker cannot register a user that impersonates system-attributed writes.
- **Visibility carve-out is group-based, not UID-based.** A user whose UID *happens* to equal the system identifier does not gain access — only group membership in `systemReaderGroups` does.
- **Tenant boundaries hold.** System-attributed rows go through `OrganisationService::getOrganisationForNewEntity()` and receive an `_organisation`. The existing organisation filter (`MagicOrganizationHandler::applyOrganizationFilter`) runs independently of the RBAC owner check.
- **Configurable identifier is a footgun.** A deployment setting `systemUserId` to a real user ID would grant that user read access to all system-attributed rows. Default identifier (`__system__`) is the safe choice; docs in the change `proposal.md` warn operators.

## OpenSpec change

`openspec/changes/system-context-owner-attribution/` — `proposal.md`, `design.md` (D1-D6 with alternatives), `tasks.md`, and `specs/auth-system/spec.md` with 6 scenarios covering cron writes, session-present unchanged, override, admin visibility, non-reader negative path, reader-group positive path, and cross-org isolation. `openspec validate system-context-owner-attribution --strict` passes.

## Migration

No automatic DB migration. Pre-existing rows with `_owner=''` stay invisible. Operators backfill manually with:

```sql
UPDATE oc_openregister_table_<id> SET _owner = '__system__' WHERE _owner = '' OR _owner IS NULL;
```

run per-register during a maintenance window. Documented in `design.md`.

## Test plan

- [x] PHPCS clean on the 3 modified files (only pre-existing baseline errors remain: inline-IF at SaveObject lines 2766/2802/4288)
- [x] PHPMD clean (added `@SuppressWarnings(PHPMD.NPathComplexity)` to `buildRbacConditionsSql()` mirroring the existing suppression on `applyRbacFilters()`)
- [x] PHPStan analyse OK on the 3 modified files
- [x] Psalm clean on net-new code (only pre-existing baseline `DbalException` errors at OrganisationService lines 775-814 remain — untouched by this change)
- [x] PHPUnit: 13 new tests across `OrganisationServiceSystemIdentityTest`, `SaveObjectSystemOwnerTest`, `MagicRbacHandlerSystemOwnerTest` — all pass
- [x] Full unit suite ran (12239 tests); the 23 errors are all pre-existing `ContactServiceTest` failures from `OCA\DAV\CardDAV\CardDavBackend` missing in the autoloader, unrelated to this change
- [ ] Manual verification: write a `call_log` via openconnector `CallService::call()`, confirm `_owner='__system__'` in DB, list as admin returns the row
- [ ] Set `openregister.systemReaderGroups=log-readers`, add a non-admin user to `log-readers`, confirm they see system rows

Closes #1617