### PR TITLE
feat(occ): backfill __system__ owner on legacy empty-owner rows (closes #1648)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -130,6 +130,7 @@ Vrij en open source onder de EUPL-licentie.
 		<!-- <command>OCA\OpenRegister\Command\MigrateStorageCommand</command> -->
 		<!-- Annotation-related commands have light DI graphs (mappers + evaluator). -->
 		<command>OCA\OpenRegister\Command\RematerialiseCalculationsCommand</command>
+		<command>OCA\OpenRegister\Command\BackfillSystemOwnerCommand</command>
 	</commands>
 
 	<notification>

--- a/lib/Command/BackfillSystemOwnerCommand.php
+++ b/lib/Command/BackfillSystemOwnerCommand.php
@@ -1,0 +1,261 @@
+<?php
+
+/**
+ * OpenRegister backfill-system-owner command
+ *
+ * One-shot data backfill that updates magic-table rows with an empty
+ * `_owner` (legacy rows imported / created before #1645) to the
+ * `__system__` sentinel so admin RBAC filtering surfaces them. Idempotent
+ * by design: re-running on already-backfilled tables updates 0 rows.
+ *
+ * @category Command
+ * @package  OCA\OpenRegister\Command
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Command;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCP\IDBConnection;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Backfill the `__system__` sentinel on magic-table rows with empty `_owner`.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class BackfillSystemOwnerCommand extends Command
+{
+    /**
+     * Wire the mappers and database connection used by the command.
+     *
+     * @param RegisterMapper $registerMapper Register lookup mapper.
+     * @param SchemaMapper   $schemaMapper   Schema lookup mapper.
+     * @param MagicMapper    $magicMapper    Magic table resolver.
+     * @param IDBConnection  $db             Database connection for native UPDATE.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly RegisterMapper $registerMapper,
+        private readonly SchemaMapper $schemaMapper,
+        private readonly MagicMapper $magicMapper,
+        private readonly IDBConnection $db
+    ) {
+        parent::__construct();
+    }//end __construct()
+
+    /**
+     * Define command name, description, and options.
+     *
+     * @return void
+     */
+    protected function configure(): void
+    {
+        $this->setName(name: 'openregister:backfill-system-owner')
+            ->setDescription(
+                'Backfill _owner=\'__system__\' on magic-table rows with empty _owner (legacy rows from before #1645).'
+            )
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Report counts without writing to the database')
+            ->addOption('register', null, InputOption::VALUE_REQUIRED, 'Limit to a single register (slug, uuid or id)')
+            ->addOption('schema', null, InputOption::VALUE_REQUIRED, 'Limit to a single schema (slug, uuid or id)');
+    }//end configure()
+
+    /**
+     * Iterate every magic table and backfill the system owner sentinel.
+     *
+     * @param InputInterface  $input  Console input.
+     * @param OutputInterface $output Console output stream.
+     *
+     * @return int Symfony command exit code.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $dryRun      = (bool) $input->getOption('dry-run');
+        $registerRef = $input->getOption('register');
+        $schemaRef   = $input->getOption('schema');
+
+        try {
+            $registers = $this->resolveRegisters(registerRef: $registerRef);
+            $schemas   = $this->resolveSchemas(schemaRef: $schemaRef);
+        } catch (\Throwable $e) {
+            $output->writeln('<error>'.$e->getMessage().'</error>');
+            return Command::FAILURE;
+        }
+
+        if (count($registers) === 0 || count($schemas) === 0) {
+            $output->writeln('<comment>No registers or schemas resolved — nothing to do.</comment>');
+            return Command::SUCCESS;
+        }
+
+        $modeLabel = '';
+        if ($dryRun === true) {
+            $modeLabel = ' (dry run)';
+        }
+
+        $output->writeln(
+            sprintf(
+                '<info>Backfilling _owner=\'%s\' on rows with _owner=\'\'%s</info>',
+                OrganisationService::SYSTEM_USER_ID_DEFAULT,
+                $modeLabel
+            )
+        );
+
+        $grandScanned  = 0;
+        $grandUpdated  = 0;
+        $tablesTouched = 0;
+
+        $schemasById = [];
+        foreach ($schemas as $schema) {
+            $schemasById[(int) $schema->getId()] = $schema;
+        }
+
+        foreach ($registers as $register) {
+            $allowedSchemaIds = $register->getSchemas();
+            foreach ($allowedSchemaIds as $allowedSchemaId) {
+                $allowedId = (int) $allowedSchemaId;
+                if (isset($schemasById[$allowedId]) === false) {
+                    continue;
+                }
+
+                $schema = $schemasById[$allowedId];
+
+                if ($this->magicMapper->tableExistsForRegisterSchema(register: $register, schema: $schema) === false) {
+                    continue;
+                }
+
+                $tableName = $this->magicMapper->getTableNameForRegisterSchema(
+                    register: $register,
+                    schema: $schema
+                );
+
+                [$scanned, $updated] = $this->backfillTable(
+                    tableName: $tableName,
+                    dryRun: $dryRun
+                );
+
+                $grandScanned  += $scanned;
+                $grandUpdated  += $updated;
+                $tablesTouched += 1;
+
+                $output->writeln(
+                    sprintf(
+                        '  %s/%s (%s): scanned=%d updated=%d',
+                        $register->getSlug() ?? $register->getId(),
+                        $schema->getSlug() ?? $schema->getId(),
+                        $tableName,
+                        $scanned,
+                        $updated
+                    )
+                );
+            }//end foreach
+        }//end foreach
+
+        $summarySuffix = '';
+        if ($dryRun === true) {
+            $summarySuffix = ' (dry run — no writes performed)';
+        }
+
+        $output->writeln(
+            sprintf(
+                '<info>Done. Tables=%d scanned=%d updated=%d%s</info>',
+                $tablesTouched,
+                $grandScanned,
+                $grandUpdated,
+                $summarySuffix
+            )
+        );
+
+        return Command::SUCCESS;
+    }//end execute()
+
+    /**
+     * Resolve the list of registers to operate on.
+     *
+     * @param string|null $registerRef Optional register slug, uuid or id.
+     *
+     * @return Register[]
+     */
+    private function resolveRegisters(?string $registerRef): array
+    {
+        if ($registerRef !== null && $registerRef !== '') {
+            return [$this->registerMapper->find($registerRef, _multitenancy: false)];
+        }
+
+        return $this->registerMapper->findAll(_rbac: false, _multitenancy: false);
+    }//end resolveRegisters()
+
+    /**
+     * Resolve the list of schemas to operate on.
+     *
+     * @param string|null $schemaRef Optional schema slug, uuid or id.
+     *
+     * @return Schema[]
+     */
+    private function resolveSchemas(?string $schemaRef): array
+    {
+        if ($schemaRef !== null && $schemaRef !== '') {
+            return [$this->schemaMapper->find($schemaRef, _multitenancy: false)];
+        }
+
+        return $this->schemaMapper->findAll(_rbac: false, _multitenancy: false);
+    }//end resolveSchemas()
+
+    /**
+     * Count and (unless dry-run) update rows with empty `_owner` in a magic table.
+     *
+     * @param string $tableName Fully qualified magic table name (without `oc_` prefix).
+     * @param bool   $dryRun    When true, only count rows.
+     *
+     * @return array{0:int,1:int} Tuple of [scanned, updated].
+     */
+    private function backfillTable(string $tableName, bool $dryRun): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select($qb->func()->count('*', 'cnt'))
+            ->from($tableName)
+            ->where($qb->expr()->eq('_owner', $qb->createNamedParameter('')));
+
+        $result = $qb->executeQuery();
+        $row    = $result->fetch();
+        $result->closeCursor();
+        $scanned = (int) ($row['cnt'] ?? 0);
+
+        if ($scanned === 0 || $dryRun === true) {
+            return [$scanned, 0];
+        }
+
+        $update = $this->db->getQueryBuilder();
+        $update->update($tableName)
+            ->set('_owner', $update->createNamedParameter(OrganisationService::SYSTEM_USER_ID_DEFAULT))
+            ->where($update->expr()->eq('_owner', $update->createNamedParameter('')));
+
+        $updated = (int) $update->executeStatement();
+
+        return [$scanned, $updated];
+    }//end backfillTable()
+}//end class

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -136,6 +136,36 @@ parameters:
 			path: lib/Command/RematerialiseCalculationsCommand.php
 
 		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Command/BackfillSystemOwnerCommand.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Command/BackfillSystemOwnerCommand.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\RegisterMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Command/BackfillSystemOwnerCommand.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: lib/Command/BackfillSystemOwnerCommand.php
+
+		-
+			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Command/BackfillSystemOwnerCommand.php
+
+		-
+			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
+			count: 1
+			path: lib/Command/BackfillSystemOwnerCommand.php
+
+		-
 			message: "#^Property OCA\\\\OpenRegister\\\\Command\\\\SolrDebugCommand\\:\\:\\$clientService is never read, only written\\.$#"
 			count: 1
 			path: lib/Command/SolrDebugCommand.php


### PR DESCRIPTION
## Summary

Adds `occ openregister:backfill-system-owner`. PR #1645 introduced the `__system__` sentinel for system-context writes so they survive RBAC filtering, but rows imported / created before that fix still have `_owner=''` (empty string) and remain invisible to admins. This one-shot data backfill scans every (register x schema) magic table and rewrites those rows to `OrganisationService::SYSTEM_USER_ID_DEFAULT` via a native UPDATE on `IDBConnection` (faster than going through `ObjectService`).

## Command shape

```
occ openregister:backfill-system-owner
    [--dry-run]
    [--register=REGISTER]
    [--schema=SCHEMA]
```

- `--dry-run` — prints per-table scanned counts, no DB write
- `--register=<slug|uuid|id>` — limit to a single register
- `--schema=<slug|uuid|id>` — limit to a single schema
- Default scope: every register x schema combo with an existing magic table
- Per-table line: `register/schema (table): scanned=N updated=M`
- Final summary: `Done. Tables=N scanned=N updated=N`
- Idempotent: re-running on already-backfilled tables updates 0 rows

## Implementation notes

- Filters on `_owner = ''` (empty string), not `_owner IS NULL`, per the issue spec
- Uses `MagicMapper::getTableNameForRegisterSchema()` / `tableExistsForRegisterSchema()` to resolve table names — no hardcoded `oc_openregister_table_*` strings
- Skips register x schema pairs where the magic table doesn't exist yet
- Reuses `OrganisationService::SYSTEM_USER_ID_DEFAULT` constant — no re-definition
- Wired in `appinfo/info.xml` alongside `RematerialiseCalculationsCommand` (same light-DI bucket; the Solr/migrate-storage commands stay disabled per existing comment)
- PHPStan baselined the same `Unknown parameter $_multitenancy` / `$_rbac` notices that `RematerialiseCalculationsCommand` is already baselined for (mapper signatures vs. PHPStan inference quirk)

## Test plan

- [ ] `occ openregister:backfill-system-owner --dry-run` reports counts for legacy `_owner=''` rows, no DB writes
- [ ] `occ openregister:backfill-system-owner` rewrites them to `__system__`, second run shows `updated=0`
- [ ] `--register=<slug>` limits to one register; `--schema=<slug>` limits to one schema
- [ ] `composer check:strict` clean (PHPCS, PHPMD, Psalm, PHPStan)