### PR TITLE
chore(ci): add missing canonical workflows

### DIFF
--- a/.github/workflows/openspec-sync.yml
+++ b/.github/workflows/openspec-sync.yml
@@ -1,0 +1,15 @@
+name: OpenSpec Sync
+
+on:
+  push:
+    branches: [development]
+    paths: ['openspec/**']
+  workflow_dispatch:
+
+jobs:
+  sync:
+    uses: ConductionNL/.github/.github/workflows/openspec-sync.yml@main
+    with:
+      app-name: openregister
+    secrets:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/pull-request-lint-check.yaml
+++ b/.github/workflows/pull-request-lint-check.yaml
@@ -1,0 +1,22 @@
+name: Lint Check
+
+on:
+  pull_request:
+    branches:
+      - development
+      - main
+      - beta
+
+jobs:
+  lint-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Linting
+        run: npm run lint

--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -1,0 +1,40 @@
+name: Spec Validation
+
+# Validates the OpenRegister register seed (lib/Settings/*_register.json) and the
+# CnAppRoot manifest (src/manifest.json) on every push and PR:
+#   - check:json-strict — strict JSON parse, rejects duplicate keys + appendOnly
+#     nested in x-openregister (the silent-data-loss class of bug a bad JSON merge
+#     produces — see the scholiq Wave-2 incident)
+#   - check:manifest     — Ajv validation against @conduction/nextcloud-vue's
+#     app-manifest.schema.json (catches invented page/widget/action shapes)
+#   - check:register     — structural checks: schema shape, slug uniqueness,
+#     lifecycle `requires:` → PHP class exists, "schema looks clobbered" heuristic
+#
+# To make these BLOCK a merge, add the "Spec Validation / validate" check to the
+# branch-protection ruleset's required-status-checks list (org settings).
+
+on:
+  push:
+    branches: [main, master, development, beta, 'feature/**', 'bugfix/**', 'hotfix/**', 'chore/**', 'fix/**', 'spec/**']
+  pull_request:
+    branches: [main, master, development, beta]
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Validate specs (json-strict + manifest + register)
+        run: npm run check:specs

--- a/.github/workflows/sync-to-beta.yml
+++ b/.github/workflows/sync-to-beta.yml
@@ -1,0 +1,10 @@
+name: Sync to Beta
+
+on:
+  push:
+    branches: [development]
+
+jobs:
+  sync:
+    uses: ConductionNL/.github/.github/workflows/sync-to-beta.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adding canonical workflows from `nextcloud-app-template` — `openregister` was missing 4 of 10 (release-* deferred).

See [fleet-drift-deeper.md §3](https://github.com/ConductionNL/nextcloud-app-template/blob/development/docs/fleet-drift-deeper.md#3-ci-workflows-githubworkflowsyml) for full context. Commit message lists the specific workflows added (and any deferred for legacy-conflict reasons).

## Test plan

- [x] Verify all added workflows have `app-name: openregister` (not `app-template`)
- [x] Verify no `app-template` references remain
- [ ] CI runs on this PR exercise the new canonical workflow set