### PR TITLE
fix(github-issues): allow unauthenticated reads on public repos

### DIFF
--- a/lib/Service/Configuration/GitHubHandler.php
+++ b/lib/Service/Configuration/GitHubHandler.php
@@ -1399,10 +1399,11 @@ class GitHubHandler
         int $perPage=30,
         ?array $labels=null
     ): array {
+        // PAT is optional for reads — GitHub's public Issues API serves anonymous
+        // requests at a lower rate limit (60/hr unauth vs 5000/hr authenticated).
+        // Supersedes the original D23 (add-features-roadmap-menu) decision to gate
+        // reads on a configured PAT.
         $token = $this->appConfig->getValueString('openregister', 'github_api_token', '');
-        if ($token === '') {
-            return ['items' => [], 'hint' => 'github_pat_not_configured'];
-        }
 
         $effectiveLabels = is_array($labels) === true ? array_values(array_filter($labels, static fn($l) => $l !== '')) : [];
         $labelCount      = count($effectiveLabels);
@@ -1799,17 +1800,21 @@ class GitHubHandler
             $query['labels'] = $label;
         }
 
-        $url      = self::API_BASE.'/repos/'.rawurlencode($owner).'/'.rawurlencode($repo).'/issues';
+        $url     = self::API_BASE.'/repos/'.rawurlencode($owner).'/'.rawurlencode($repo).'/issues';
+        $headers = [
+            'Accept'               => 'application/vnd.github+json',
+            'X-GitHub-Api-Version' => '2022-11-28',
+        ];
+        if ($token !== '') {
+            $headers['Authorization'] = 'Bearer '.$token;
+        }
+
         $response = $this->client->request(
             'GET',
             $url,
             [
                 'query'   => $query,
-                'headers' => [
-                    'Accept'               => 'application/vnd.github+json',
-                    'X-GitHub-Api-Version' => '2022-11-28',
-                    'Authorization'        => 'Bearer '.$token,
-                ],
+                'headers' => $headers,
             ]
         );
 


### PR DESCRIPTION
## Summary
- Drop the early-return on empty `openregister::github_api_token` in `GitHubHandler::listIssues()` so anonymous GitHub Issues reads work for public repos
- Make `Authorization` header conditional in `fetchIssuesPage()` — only added when a PAT is configured
- POST (suggest-feature) path unchanged; still requires a PAT for authoring

## Why
GitHub's REST Issues API serves anonymous requests at a lower rate limit (60/hr unauth vs 5000/hr authenticated). The previous gate returned `{"items":[],"hint":"github_pat_not_configured"}` even for public repos GitHub would happily serve, breaking the in-product roadmap surface on every fresh dev/test install. Supersedes D23 in `add-features-roadmap-menu`.

## Test plan
- [x] All 47 existing GitHub tests (Controller/Handler/Guards) pass against the patched file
- [x] Manual: `curl -s -u admin:admin "http://localhost:8080/index.php/apps/openregister/api/github/issues?repo=ConductionNL/pipelinq&labels=enhancement,feature"` returns real issues instead of the `github_pat_not_configured` hint
- [ ] Reviewer: confirm POST (suggest-feature) still 503s without a PAT