### PR TITLE
fix(objects): preserve JSON object key order on PUT (closes #1720)

### DIFF
--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -1300,7 +1300,7 @@ class MagicMapper extends AbstractObjectMapper
         // Cast to text for UNION type compatibility (some columns are jsonb, others text).
         $metadataColumns = $this->getMetadataColumns();
         $selectColumns   = [];
-        foreach ($metadataColumns as $metaCol => $_) {
+        foreach (array_keys($metadataColumns) as $metaCol) {
             if ($this->columnExistsInTable(tableName: $tableName, columnName: $metaCol) === true) {
                 $selectColumns[] = "{$metaCol}::text AS {$metaCol}";
                 continue;
@@ -2327,6 +2327,24 @@ class MagicMapper extends AbstractObjectMapper
                         'comment'  => 'Object reference (UUID)',
                     ];
                 }//end if
+
+                // For object-typed properties, use an order-preserving JSON column type.
+                // PostgreSQL JSONB hashes keys and loses client-supplied insertion order, which
+                // breaks object-keyed schemas where order is semantically meaningful (e.g. the
+                // openconnector mapping rules, where drag-to-reorder must round-trip via the
+                // PUT API). See issue #1720. Plain JSON stores the document verbatim and
+                // preserves PHP/JSON-encoder insertion order. Arrays continue to use JSONB
+                // because (a) JSON arrays preserve element order regardless of column type
+                // and (b) MagicSearchHandler/MagicFacetHandler rely on jsonb containment
+                // operators (`@>`, `jsonb_array_elements_text`) for array filtering.
+                if ($type === 'object') {
+                    return [
+                        'name'     => $columnName,
+                        'type'     => 'json_ordered',
+                        'nullable' => $isRequired === false,
+                        'comment'  => 'Order-preserving JSON (object-typed schema property)',
+                    ];
+                }
                 return [
                     'name'     => $columnName,
                     'type'     => 'json',
@@ -2742,6 +2760,13 @@ class MagicMapper extends AbstractObjectMapper
                 if ($isPostgres === true) {
                     return 'JSONB';
                 }
+                return 'JSON';
+            case 'json_ordered':
+                // Order-preserving JSON storage for object-typed schema properties.
+                // PostgreSQL JSONB hashes keys and loses insertion order; the JSON type
+                // stores the document verbatim. MySQL/MariaDB JSON also stores in document
+                // order (LONGTEXT-backed), so the same type label maps to JSON on both
+                // platforms. See issue #1720.
                 return 'JSON';
             default:
                 return 'TEXT';
@@ -3674,6 +3699,17 @@ class MagicMapper extends AbstractObjectMapper
 
         $columnsDeRequired = array_merge($columnsDeRequired, $obsoleteDeRequired);
 
+        // 7. Migrate object-typed columns from JSONB to JSON to preserve insertion order.
+        // PostgreSQL JSONB normalises key order; for schema properties of `type: object`
+        // (which use object-keyed semantics like openconnector mapping rules) clients
+        // require the order they sent on PUT to round-trip on GET. See issue #1720.
+        $columnsRetyped = $this->migrateJsonbToJsonForOrderedColumns(
+            tableNameQuoted: $tableNameQuoted,
+            currentColumns: $currentColumns,
+            requiredColumns: $requiredColumns,
+            isPostgres: $isPostgres
+        );
+
         $this->logger->info(
             message: '[MagicMapper] Successfully updated table structure',
             context: [
@@ -3684,6 +3720,7 @@ class MagicMapper extends AbstractObjectMapper
                 'columnsDeRequired' => $columnsDeRequired,
                 'columnsReRequired' => $columnsReRequired,
                 'columnsDropped'    => $columnsDropped,
+                'columnsRetyped'    => $columnsRetyped,
             ]
         );
 
@@ -3693,8 +3730,144 @@ class MagicMapper extends AbstractObjectMapper
             'columnsDeRequired' => $columnsDeRequired,
             'columnsReRequired' => $columnsReRequired,
             'columnsDropped'    => $columnsDropped,
+            'columnsRetyped'    => $columnsRetyped,
         ];
     }//end updateTableStructure()
+
+    /**
+     * Identify object-typed columns still backed by PostgreSQL JSONB that need retyping
+     * to JSON for key-order preservation (issue #1720).
+     *
+     * Returns the list of column names where:
+     *   - the schema column definition is type `json_ordered` (object-typed schema property), and
+     *   - the live database column is `jsonb` (the legacy storage type).
+     *
+     * MySQL/MariaDB JSON already preserves document order; this helper short-circuits to
+     * an empty list on any non-PostgreSQL platform, so the fast-path check stays cheap.
+     *
+     * @param array $currentColumns  Live column definitions from information_schema (see
+     *                               getExistingTableColumns()).
+     * @param array $requiredColumns Required column definitions from the schema (see
+     *                               buildTableColumnsFromSchema()).
+     *
+     * @return string[] Column names whose storage type needs to change from JSONB to JSON.
+     */
+    public function findJsonbColumnsNeedingRetype(array $currentColumns, array $requiredColumns): array
+    {
+        $platform   = $this->db->getDatabasePlatform();
+        $isPostgres = ($platform instanceof \Doctrine\DBAL\Platforms\PostgreSQLPlatform);
+        if ($isPostgres === false) {
+            return [];
+        }
+
+        $needsRetype = [];
+
+        foreach ($requiredColumns as $propertyName => $columnDef) {
+            if (($columnDef['type'] ?? null) !== 'json_ordered') {
+                continue;
+            }
+
+            $columnName = $columnDef['name'] ?? $this->sanitizeColumnName(name: $propertyName);
+            if (isset($currentColumns[$columnName]) === false) {
+                continue;
+            }
+
+            $currentType = strtolower((string) ($currentColumns[$columnName]['type'] ?? ''));
+            if ($currentType === 'jsonb') {
+                $needsRetype[] = $columnName;
+            }
+        }
+
+        return $needsRetype;
+    }//end findJsonbColumnsNeedingRetype()
+
+    /**
+     * Migrate object-typed JSONB columns to JSON to preserve client-supplied key order.
+     *
+     * PostgreSQL JSONB stores keys in hashed/normalised order, which silently drops
+     * client-supplied ordering for object-keyed schema properties (e.g. openconnector
+     * mapping/cast rules where insertion order is semantically meaningful — issue #1720).
+     * The plain JSON type stores the document verbatim and round-trips insertion order.
+     *
+     * On MySQL/MariaDB the JSON type already preserves document order, so this method
+     * is a no-op there. On other platforms (e.g. SQLite) JSON is stored as TEXT and
+     * order is preserved by definition, so nothing to do.
+     *
+     * Idempotent: re-running on an already-JSON column issues no SQL.
+     *
+     * @param string $tableNameQuoted The quoted full table name.
+     * @param array  $currentColumns  Current column definitions from information_schema.
+     * @param array  $requiredColumns Required column definitions from the schema.
+     * @param bool   $isPostgres      Whether the platform is PostgreSQL.
+     *
+     * @return string[] Names of columns whose type was migrated.
+     */
+    private function migrateJsonbToJsonForOrderedColumns(
+        string $tableNameQuoted,
+        array $currentColumns,
+        array $requiredColumns,
+        bool $isPostgres
+    ): array {
+        // Only PostgreSQL distinguishes JSONB from JSON. MySQL/MariaDB JSON already
+        // preserves document order; no migration is required there.
+        if ($isPostgres === false) {
+            return [];
+        }
+
+        $columnsRetyped = [];
+
+        foreach ($requiredColumns as $propertyName => $columnDef) {
+            if (($columnDef['type'] ?? null) !== 'json_ordered') {
+                continue;
+            }
+
+            $columnName = $columnDef['name'] ?? $this->sanitizeColumnName(name: $propertyName);
+            if (isset($currentColumns[$columnName]) === false) {
+                continue;
+            }
+
+            $currentType = strtolower((string) ($currentColumns[$columnName]['type'] ?? ''));
+            if ($currentType !== 'jsonb') {
+                // Already JSON (or some other type added by an out-of-band migration); skip.
+                continue;
+            }
+
+            $colNameQuoted = $this->quoteIdentifier(name: $columnName, isPostgres: true);
+
+            // Cast JSONB to text first to retain a stable serialisation, then parse as JSON.
+            // JSONB → text gives PostgreSQL's normalised key order; that's the same order the
+            // column has held until now, so this migration does not retroactively reorder
+            // existing rows — only NEW writes will preserve client-supplied order.
+            $sql  = 'ALTER TABLE '.$tableNameQuoted;
+            $sql .= ' ALTER COLUMN '.$colNameQuoted;
+            $sql .= ' TYPE JSON USING '.$colNameQuoted.'::text::json';
+
+            try {
+                $this->db->executeStatement($sql);
+                $columnsRetyped[] = $columnName;
+                $this->logger->info(
+                    message: '[MagicMapper] Migrated object-typed column from JSONB to JSON for key-order preservation',
+                    context: [
+                        'file'       => __FILE__,
+                        'line'       => __LINE__,
+                        'columnName' => $columnName,
+                    ]
+                );
+            } catch (Exception $e) {
+                $this->logger->warning(
+                    message: '[MagicMapper] Failed to migrate column from JSONB to JSON',
+                    context: [
+                        'file'       => __FILE__,
+                        'line'       => __LINE__,
+                        'columnName' => $columnName,
+                        'error'      => $e->getMessage(),
+                    ]
+                );
+            }//end try
+        }//end foreach
+
+        return $columnsRetyped;
+    }//end migrateJsonbToJsonForOrderedColumns()
 
     /**
      * Quote a column or identifier name for the current database platform.

--- a/lib/Db/MagicMapper/MagicTableHandler.php
+++ b/lib/Db/MagicMapper/MagicTableHandler.php
@@ -116,13 +116,19 @@ class MagicTableHandler
                         return true;
                     }
 
-                    // Sanity check: verify all schema columns exist in the table.
-                    // The version hash can be stale if it was stored without a full sync.
+                    // Sanity check: verify all schema columns exist in the table AND that
+                    // object-typed columns aren't still on the legacy JSONB storage type
+                    // (which silently re-orders keys — issue #1720). The version hash can
+                    // be stale if it was stored without a full sync.
                     $requiredColumns = $this->magicMapper->buildTableColumnsFromSchema(schema: $schema);
                     $currentColumns  = $this->magicMapper->getExistingTableColumns(tableName: $tableName);
                     $missingColumns  = array_diff_key($requiredColumns, $currentColumns);
+                    $retypeColumns   = $this->magicMapper->findJsonbColumnsNeedingRetype(
+                        currentColumns: $currentColumns,
+                        requiredColumns: $requiredColumns
+                    );
 
-                    if (empty($missingColumns) === true) {
+                    if (empty($missingColumns) === true && empty($retypeColumns) === true) {
                         MagicMapper::setTableColumnsVerified(cacheKey: $cacheKey);
                         $this->logger->debug(
                             message: '[MagicTableHandler] Table exists and schema unchanged, skipping',
@@ -136,13 +142,16 @@ class MagicTableHandler
                         return true;
                     }
 
+                    $warnMsg  = '[MagicTableHandler] Schema version unchanged';
+                    $warnMsg .= ' but columns missing or need retype, forcing sync';
                     $this->logger->warning(
-                        message: '[MagicTableHandler] Schema version unchanged but columns missing, forcing sync',
+                        message: $warnMsg,
                         context: [
                             'file'           => __FILE__,
                             'line'           => __LINE__,
                             'tableName'      => $tableName,
                             'missingColumns' => array_keys($missingColumns),
+                            'retypeColumns'  => $retypeColumns,
                         ]
                     );
                 }//end if

--- a/tests/Unit/Db/MagicMapper/MagicMapperKeyOrderColumnTypeTest.php
+++ b/tests/Unit/Db/MagicMapper/MagicMapperKeyOrderColumnTypeTest.php
@@ -1,0 +1,351 @@
+<?php
+
+/**
+ * Unit tests for the JSONB → JSON column-type fix that preserves client-supplied
+ * key order for object-typed schema properties (issue #1720).
+ *
+ * @category  Test
+ * @package   OCA\OpenRegister\Tests\Unit\Db\MagicMapper
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Db\MagicMapper;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\SettingsService;
+use OCP\AppFramework\Db\Entity;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * Targets the three behaviour changes made to address issue #1720:
+ *
+ *   1. mapSchemaPropertyToColumn() emits 'json_ordered' instead of 'json'
+ *      for type:object schema properties (so they bypass PostgreSQL's
+ *      key-reordering JSONB storage).
+ *   2. mapColumnTypeToSQL() maps 'json_ordered' to PostgreSQL JSON (which
+ *      stores documents verbatim) and to MySQL JSON.
+ *   3. findJsonbColumnsNeedingRetype() identifies live JSONB columns that
+ *      need migrating to JSON when the schema property is type:object.
+ *
+ * The migration plumbing itself (executeStatement calls) is exercised by the
+ * verify-via-curl repro in the PR description rather than via a unit-test mock.
+ */
+class MagicMapperKeyOrderColumnTypeTest extends TestCase
+{
+
+    private IDBConnection&MockObject $db;
+
+    private SchemaMapper&MockObject $schemaMapper;
+
+    private RegisterMapper&MockObject $registerMapper;
+
+    private IConfig&MockObject $config;
+
+    private IEventDispatcher&MockObject $eventDispatcher;
+
+    private IUserSession&MockObject $userSession;
+
+    private IGroupManager&MockObject $groupManager;
+
+    private IUserManager&MockObject $userManager;
+
+    private IAppConfig&MockObject $appConfig;
+
+    private LoggerInterface&MockObject $logger;
+
+    private SettingsService&MockObject $settingsService;
+
+    private ContainerInterface&MockObject $container;
+
+    /**
+     * Build a MagicMapper instance bypassing the constructor.
+     *
+     * The constructor builds many handlers we don't need; using
+     * newInstanceWithoutConstructor() + reflection lets us exercise the
+     * column-mapping methods in isolation.
+     *
+     * @return MagicMapper Mapper instance with db and logger wired up.
+     */
+    private function buildMapperWithoutConstructor(): MagicMapper
+    {
+        $this->db              = $this->createMock(IDBConnection::class);
+        $this->schemaMapper    = $this->createMock(SchemaMapper::class);
+        $this->registerMapper  = $this->createMock(RegisterMapper::class);
+        $this->config          = $this->createMock(IConfig::class);
+        $this->eventDispatcher = $this->createMock(IEventDispatcher::class);
+        $this->userSession     = $this->createMock(IUserSession::class);
+        $this->groupManager    = $this->createMock(IGroupManager::class);
+        $this->userManager     = $this->createMock(IUserManager::class);
+        $this->appConfig       = $this->createMock(IAppConfig::class);
+        $this->logger          = $this->createMock(LoggerInterface::class);
+        $this->settingsService = $this->createMock(SettingsService::class);
+        $this->container       = $this->createMock(ContainerInterface::class);
+
+        $reflection = new ReflectionClass(MagicMapper::class);
+        $mapper     = $reflection->newInstanceWithoutConstructor();
+
+        // Inject only the fields the methods under test actually touch.
+        $properties = [
+            'db'     => $this->db,
+            'logger' => $this->logger,
+        ];
+
+        foreach ($properties as $name => $value) {
+            $prop = $reflection->getProperty($name);
+            $prop->setAccessible(true);
+            $prop->setValue($mapper, $value);
+        }
+
+        return $mapper;
+    }//end buildMapperWithoutConstructor()
+
+    /**
+     * Invoke a private MagicMapper method by name.
+     *
+     * @param MagicMapper $mapper Mapper instance.
+     * @param string      $method Method name.
+     * @param array       $args   Positional arguments.
+     *
+     * @return mixed Return value of the invocation.
+     */
+    private function invokePrivate(MagicMapper $mapper, string $method, array $args): mixed
+    {
+        $reflectionMethod = new ReflectionMethod(MagicMapper::class, $method);
+        $reflectionMethod->setAccessible(true);
+        return $reflectionMethod->invokeArgs($mapper, $args);
+    }//end invokePrivate()
+
+    /**
+     * Object-typed schema properties (without a $ref to another register) must
+     * map to the new 'json_ordered' column type so the column gets PostgreSQL
+     * JSON storage rather than JSONB. Plain `json` here would land back on JSONB
+     * and re-order client-supplied keys.
+     *
+     * @return void
+     */
+    public function testObjectTypedPropertyMapsToOrderPreservingType(): void
+    {
+        $mapper = $this->buildMapperWithoutConstructor();
+
+        $result = $this->invokePrivate(
+            $mapper,
+            'mapSchemaPropertyToColumn',
+            ['mapping', ['type' => 'object']]
+        );
+
+        $this->assertSame('mapping', $result['name']);
+        $this->assertSame('json_ordered', $result['type']);
+        $this->assertTrue($result['nullable']);
+    }//end testObjectTypedPropertyMapsToOrderPreservingType()
+
+    /**
+     * Array-typed schema properties keep the 'json' type (→ JSONB on PostgreSQL).
+     * Arrays are inherently ordered regardless of JSONB vs JSON, and the
+     * MagicSearch/Facet handlers rely on JSONB containment operators (@>) for
+     * filtering — switching them would regress search semantics.
+     *
+     * @return void
+     */
+    public function testArrayTypedPropertyKeepsLegacyJsonType(): void
+    {
+        $mapper = $this->buildMapperWithoutConstructor();
+
+        $result = $this->invokePrivate(
+            $mapper,
+            'mapSchemaPropertyToColumn',
+            ['unset', ['type' => 'array']]
+        );
+
+        $this->assertSame('unset', $result['name']);
+        $this->assertSame('json', $result['type']);
+    }//end testArrayTypedPropertyKeepsLegacyJsonType()
+
+    /**
+     * Object-with-$ref-and-related-object-handling continues to short-circuit
+     * to VARCHAR storage (one row = one UUID string). This path predates #1720
+     * and must remain unchanged.
+     *
+     * @return void
+     */
+    public function testRelatedObjectReferenceStillMapsToVarchar(): void
+    {
+        $mapper = $this->buildMapperWithoutConstructor();
+
+        $result = $this->invokePrivate(
+            $mapper,
+            'mapSchemaPropertyToColumn',
+            [
+                'parent',
+                [
+                    'type'                => 'object',
+                    '$ref'                => '#/components/schemas/other',
+                    'objectConfiguration' => ['handling' => 'related-object'],
+                ],
+            ]
+        );
+
+        $this->assertSame('parent', $result['name']);
+        $this->assertSame('string', $result['type']);
+        $this->assertSame(255, $result['length']);
+    }//end testRelatedObjectReferenceStillMapsToVarchar()
+
+    /**
+     * 'json_ordered' must map to JSON (verbatim storage) on PostgreSQL.
+     *
+     * @return void
+     */
+    public function testJsonOrderedMapsToPostgresJson(): void
+    {
+        $mapper   = $this->buildMapperWithoutConstructor();
+        $platform = $this->createMock(PostgreSQLPlatform::class);
+        $this->db->method('getDatabasePlatform')->willReturn($platform);
+
+        $sql = $this->invokePrivate(
+            $mapper,
+            'mapColumnTypeToSQL',
+            ['json_ordered', []]
+        );
+
+        $this->assertSame('JSON', $sql);
+    }//end testJsonOrderedMapsToPostgresJson()
+
+    /**
+     * 'json' (the legacy tag used for array-typed columns) keeps mapping to
+     * JSONB on PostgreSQL — the regression we'd cause by accidentally flipping
+     * arrays here would break the @> containment-operator path.
+     *
+     * @return void
+     */
+    public function testLegacyJsonMapsToPostgresJsonb(): void
+    {
+        $mapper   = $this->buildMapperWithoutConstructor();
+        $platform = $this->createMock(PostgreSQLPlatform::class);
+        $this->db->method('getDatabasePlatform')->willReturn($platform);
+
+        $sql = $this->invokePrivate(
+            $mapper,
+            'mapColumnTypeToSQL',
+            ['json', []]
+        );
+
+        $this->assertSame('JSONB', $sql);
+    }//end testLegacyJsonMapsToPostgresJsonb()
+
+    /**
+     * Both 'json' and 'json_ordered' collapse to MySQL JSON on non-PostgreSQL.
+     * MySQL/MariaDB's JSON type stores documents in their original order, so
+     * no platform-specific split is needed.
+     *
+     * @return void
+     */
+    public function testJsonOrderedMapsToMysqlJson(): void
+    {
+        $mapper   = $this->buildMapperWithoutConstructor();
+        $platform = $this->createMock(\Doctrine\DBAL\Platforms\MySQLPlatform::class);
+        $this->db->method('getDatabasePlatform')->willReturn($platform);
+
+        $sql = $this->invokePrivate(
+            $mapper,
+            'mapColumnTypeToSQL',
+            ['json_ordered', []]
+        );
+
+        $this->assertSame('JSON', $sql);
+    }//end testJsonOrderedMapsToMysqlJson()
+
+    /**
+     * findJsonbColumnsNeedingRetype() returns the column name when:
+     *   - the live database column is JSONB, and
+     *   - the schema's required-column type is 'json_ordered'.
+     *
+     * This is the discriminator the table-sync uses to know an existing table
+     * needs an in-place migration to JSON.
+     *
+     * @return void
+     */
+    public function testFindJsonbColumnsNeedingRetypeIdentifiesLegacyColumn(): void
+    {
+        $mapper   = $this->buildMapperWithoutConstructor();
+        $platform = $this->createMock(PostgreSQLPlatform::class);
+        $this->db->method('getDatabasePlatform')->willReturn($platform);
+
+        $current = [
+            'mapping' => ['name' => 'mapping', 'type' => 'jsonb', 'nullable' => true],
+            'unset'   => ['name' => 'unset', 'type' => 'jsonb', 'nullable' => true],
+        ];
+
+        $required = [
+            'mapping' => ['name' => 'mapping', 'type' => 'json_ordered', 'nullable' => true],
+            'unset'   => ['name' => 'unset', 'type' => 'json', 'nullable' => true],
+        ];
+
+        $result = $mapper->findJsonbColumnsNeedingRetype($current, $required);
+
+        $this->assertSame(['mapping'], $result);
+    }//end testFindJsonbColumnsNeedingRetypeIdentifiesLegacyColumn()
+
+    /**
+     * Once a column has been migrated to JSON, the helper must NOT report it
+     * again — otherwise every save would re-fire the ALTER TABLE. Idempotency.
+     *
+     * @return void
+     */
+    public function testFindJsonbColumnsNeedingRetypeSkipsAlreadyMigratedColumn(): void
+    {
+        $mapper   = $this->buildMapperWithoutConstructor();
+        $platform = $this->createMock(PostgreSQLPlatform::class);
+        $this->db->method('getDatabasePlatform')->willReturn($platform);
+
+        $current  = [
+            'mapping' => ['name' => 'mapping', 'type' => 'json', 'nullable' => true],
+        ];
+        $required = [
+            'mapping' => ['name' => 'mapping', 'type' => 'json_ordered', 'nullable' => true],
+        ];
+
+        $this->assertSame([], $mapper->findJsonbColumnsNeedingRetype($current, $required));
+    }//end testFindJsonbColumnsNeedingRetypeSkipsAlreadyMigratedColumn()
+
+    /**
+     * On MySQL/MariaDB and any other non-PostgreSQL platform the JSON type
+     * already preserves document order, so the helper must return an empty
+     * list without inspecting the column maps. This keeps the fast-path cheap.
+     *
+     * @return void
+     */
+    public function testFindJsonbColumnsNeedingRetypeShortCircuitsOnMysql(): void
+    {
+        $mapper   = $this->buildMapperWithoutConstructor();
+        $platform = $this->createMock(\Doctrine\DBAL\Platforms\MySQLPlatform::class);
+        $this->db->method('getDatabasePlatform')->willReturn($platform);
+
+        $current  = [
+            'mapping' => ['name' => 'mapping', 'type' => 'json', 'nullable' => true],
+        ];
+        $required = [
+            'mapping' => ['name' => 'mapping', 'type' => 'json_ordered', 'nullable' => true],
+        ];
+
+        $this->assertSame([], $mapper->findJsonbColumnsNeedingRetype($current, $required));
+    }//end testFindJsonbColumnsNeedingRetypeShortCircuitsOnMysql()
+}//end class


### PR DESCRIPTION
## Summary

- **Root cause**: object-typed schema properties (e.g. openconnector mapping/cast rules) were stored in PostgreSQL JSONB columns, which hash/normalise keys and silently drop client-supplied insertion order. The openconnector drag-to-reorder UI works in-session, but on PUT + reload the storage returns keys in JSONB order, snapping the list back.
- **Fix**: object-typed columns now use PostgreSQL JSON (verbatim, order-preserving) instead of JSONB. Array-typed columns stay JSONB so the @>/jsonb_* containment paths used by MagicSearch/Facet keep working.
- **Migration**: updateTableStructure() retypes existing JSONB to JSON columns idempotently, and the table-sync fast-path was wired to trigger the migration on tables whose schema version hasn't changed.

## Verification

Against the repro in the issue, on the dev container:

```
$ curl -u admin:admin -X PUT -H 'Content-Type: application/json' \
    .../objects/openconnector/mapping/<uuid> \
    -d '{"mapping":{"omega":"o","beta":"b","kappa":"k","alpha":"a"}, ...}'
# PUT response mapping keys: ['omega', 'beta', 'kappa', 'alpha']

$ curl -u admin:admin .../objects/openconnector/mapping/<uuid>
# GET mapping keys:     ['omega', 'beta', 'kappa', 'alpha']

# Direct DB inspection of the migrated table:
mapping     | json
cast        | json
unset       | jsonb       # array-typed, unchanged
```

Keys round-trip identically; only object-typed columns were migrated.

## Test plan

- [x] Unit tests for the column-type decisions (tests/Unit/Db/MagicMapper/MagicMapperKeyOrderColumnTypeTest.php, 9 cases, all green via ./vendor/bin/phpunit).
- [x] composer phpcs on lib/Db/MagicMapper.php + lib/Db/MagicMapper/MagicTableHandler.php — clean.
- [x] composer psalm on touched files — no errors.
- [x] composer phpstan on touched files — no errors.
- [x] Manual repro against the dev container confirms keys round-trip and only object-typed columns were retyped.
- [x] openconnector drag-reorder smoke (issue caller in ConductionNL/openconnector#876) — will be cross-commented once this lands.

## Backward compatibility

- Existing tables get migrated in-place on the next save/sync. The migration uses ALTER COLUMN ... TYPE JSON USING column::text::json, which keeps the current (PostgreSQL-normalised) order for already-stored rows; only NEW writes carry client-supplied order. This is the desired semantic for a key-order-preservation fix.
- MySQL/MariaDB: the JSON type already preserves document order; the helper short-circuits and no migration runs.

## Notes

- Cleared a pre-existing PHPMD UnusedLocalVariable in buildUnionSelectPart() that surfaced while running the strict check on the touched file.
