### PR TITLE
feat(github-issues): owner allowlist replaces single-repo allowlist

### DIFF
--- a/lib/Service/Configuration/GitHubGuards.php
+++ b/lib/Service/Configuration/GitHubGuards.php
@@ -111,15 +111,28 @@ class GitHubGuards
     }//end enforceFeatureFlag()
 
     /**
-     * Enforce per-instance repo allowlist (task 1.14).
+     * Enforce per-instance owner allowlist (task 1.14, generalised).
      *
-     * Reads `openregister::github_repo` from IAppConfig:
-     *   - Unset → graceful degradation: 200 + `hint: github_repo_not_configured` on GET,
-     *     503 + `error: github_repo_not_configured` on POST.
-     *   - Set + mismatch with caller-supplied `repo` → 403 `repo_not_allowed`.
-     *   - Set + match → null (continue).
+     * Reads `openregister::github_allowed_owners` from IAppConfig as a
+     * comma-separated list of GitHub organisation / user names. The caller's
+     * `repo` is `<owner>/<name>`; only the owner segment is matched against
+     * the allowlist (case-insensitive). This lets one OR instance proxy
+     * issues for many sibling repos under the same orgs without per-repo
+     * configuration.
      *
-     * @param string $repo   Caller-supplied slug (already format-validated).
+     *   - Unset / empty after trimming → graceful degradation: 200 +
+     *     `hint: github_repo_not_configured` on GET, 503 +
+     *     `error: github_repo_not_configured` on POST.
+     *   - Owner not in list → 403 `repo_not_allowed`.
+     *   - Owner in list → null (continue).
+     *
+     * Default value: `ConductionNL,nextcloud` so fresh installs proxy the
+     * Conduction-fleet and core Nextcloud repos out of the box.
+     *
+     * Supersedes the old single-repo `openregister::github_repo` config key
+     * which used strict `owner/repo` equality (PR #1726).
+     *
+     * @param string $repo   Caller-supplied slug `<owner>/<name>` (already format-validated).
      * @param bool   $isRead Whether the call is the GET path (alters the unset-config response).
      *
      * @return JSONResponse|null Null on match, structured 403/200/503 otherwise.
@@ -128,8 +141,10 @@ class GitHubGuards
      */
     public function enforceRepoAllowlist(string $repo, bool $isRead): ?JSONResponse
     {
-        $allowed = $this->appConfig->getValueString('openregister', 'github_repo', '');
-        if ($allowed === '') {
+        $rawAllowed = $this->appConfig->getValueString('openregister', 'github_allowed_owners', 'ConductionNL,nextcloud');
+        $allowed    = array_values(array_filter(array_map('trim', explode(',', $rawAllowed)), static fn($o) => $o !== ''));
+
+        if ($allowed === []) {
             if ($isRead === true) {
                 return new JSONResponse(['items' => [], 'hint' => 'github_repo_not_configured']);
             }
@@ -137,7 +152,10 @@ class GitHubGuards
             return new JSONResponse(['error' => 'github_repo_not_configured'], Http::STATUS_SERVICE_UNAVAILABLE);
         }
 
-        if ($repo === $allowed) {
+        $owner          = explode('/', $repo, 2)[0];
+        $ownerLower     = strtolower($owner);
+        $allowedLower   = array_map('strtolower', $allowed);
+        if (in_array($ownerLower, $allowedLower, true) === true) {
             return null;
         }
 

--- a/tests/Unit/Service/Configuration/GitHubGuardsTest.php
+++ b/tests/Unit/Service/Configuration/GitHubGuardsTest.php
@@ -108,7 +108,7 @@ class GitHubGuardsTest extends TestCase
      */
     public function testRepoMismatchReturns403(): void
     {
-        $guards   = $this->buildGuards(repoConfig: 'ConductionNL/openregister', flagEnabled: true);
+        $guards   = $this->buildGuards(repoConfig: 'ConductionNL', flagEnabled: true);
         $response = $guards->enforceRepoAllowlist(repo: 'torvalds/linux', isRead: false);
 
         $this->assertEquals(403, $response->getStatus());
@@ -122,9 +122,39 @@ class GitHubGuardsTest extends TestCase
      */
     public function testRepoMatchPasses(): void
     {
-        $guards = $this->buildGuards(repoConfig: 'ConductionNL/openregister', flagEnabled: true);
+        $guards = $this->buildGuards(repoConfig: 'ConductionNL', flagEnabled: true);
         $this->assertNull($guards->enforceRepoAllowlist(repo: 'ConductionNL/openregister', isRead: true));
     }//end testRepoMatchPasses()
+
+    /**
+     * Owner allowlist matches any repo under the allowed organisation —
+     * the same OR instance can proxy issues for the whole Conduction fleet
+     * without per-repo configuration.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/add-features-roadmap-menu/tasks.md#task-14
+     */
+    public function testOwnerAllowlistMatchesAnyRepoUnderAllowedOrg(): void
+    {
+        $guards = $this->buildGuards(repoConfig: 'ConductionNL,nextcloud', flagEnabled: true);
+        $this->assertNull($guards->enforceRepoAllowlist(repo: 'ConductionNL/pipelinq', isRead: true));
+        $this->assertNull($guards->enforceRepoAllowlist(repo: 'ConductionNL/openregister', isRead: true));
+        $this->assertNull($guards->enforceRepoAllowlist(repo: 'nextcloud/server', isRead: true));
+    }//end testOwnerAllowlistMatchesAnyRepoUnderAllowedOrg()
+
+    /**
+     * Owner match is case-insensitive — GitHub org slugs are case-preserving
+     * but case-insensitive in URLs and API paths.
+     *
+     * @return void
+     */
+    public function testOwnerAllowlistIsCaseInsensitive(): void
+    {
+        $guards = $this->buildGuards(repoConfig: 'ConductionNL,nextcloud', flagEnabled: true);
+        $this->assertNull($guards->enforceRepoAllowlist(repo: 'conductionnl/anything', isRead: true));
+        $this->assertNull($guards->enforceRepoAllowlist(repo: 'NEXTCLOUD/server', isRead: true));
+    }//end testOwnerAllowlistIsCaseInsensitive()
 
     /**
      * @return void
@@ -203,8 +233,11 @@ class GitHubGuardsTest extends TestCase
     /**
      * Build a GitHubGuards with mocked deps. The user is "alice" by default.
      *
-     * @param string $repoConfig  Value returned by IAppConfig::getValueString for github_repo.
-     * @param bool   $flagEnabled Value returned by IAppConfig::getValueBool for features_roadmap_enabled.
+     * @param string $repoConfig  Value returned by IAppConfig for github_allowed_owners.
+     *                            Treated as the comma-separated allowlist when non-empty;
+     *                            empty string means "config explicitly unset" (the mock
+     *                            returns it as-is, including for the default-value branch).
+     * @param bool   $flagEnabled Value returned by IAppConfig for features_roadmap_enabled.
      *
      * @return GitHubGuards
      */
@@ -229,7 +262,9 @@ class GitHubGuardsTest extends TestCase
         $appConfig = $this->createMock(IAppConfig::class);
         $appConfig->method('getValueString')->willReturnCallback(
             function (string $app, string $key, string $default='') use ($repoConfig): string {
-                if ($key === 'github_repo') {
+                if ($key === 'github_allowed_owners') {
+                    // Empty string in the test fixture means "explicitly unset"
+                    // so the production default ("ConductionNL,nextcloud") is NOT applied.
                     return $repoConfig;
                 }
 


### PR DESCRIPTION
## Summary
- Replace `openregister::github_repo` (single `<owner>/<name>` exact match) with `openregister::github_allowed_owners` (comma-separated list of owners/orgs, case-insensitive match)
- Default value: `ConductionNL,nextcloud` — fresh installs work out of the box
- One OR instance can now serve the GitHub-issues proxy for every Conduction app + core Nextcloud repos without per-repo configuration

## Why
Builds on #1723 (unauthenticated reads). Once the proxy stopped requiring a PAT, the single-repo allowlist became the binding constraint — every app beyond the first hit `repo_not_allowed`. The owner-list shape solves the multi-app case directly.

## Migration
Existing `openregister::github_repo` keys are ignored by this change. Admins should delete the old key (`occ config:app:delete openregister github_repo`) and optionally set `openregister::github_allowed_owners` to override the default.

## Test plan
- [x] 49 GitHub tests pass (47 existing + 2 new: org-match for many repos + case-insensitive match)
- [x] `GET ?repo=ConductionNL/pipelinq` → 1 item
- [x] `GET ?repo=ConductionNL/openregister` → 24 items (same instance, no config change)
- [x] `GET ?repo=torvalds/linux` → 403 `repo_not_allowed`