### PR TITLE
chore(spdx): add EUPL-1.2 SPDX headers to 84 misc files (Bucket 4, 1/7)

### DIFF
--- a/lib/Activity/Filter.php
+++ b/lib/Activity/Filter.php
@@ -5,6 +5,9 @@
  *
  * Filter for OpenRegister activity events in the activity stream.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Activity
  * @package  OCA\OpenRegister\Activity
  *

--- a/lib/Activity/Provider.php
+++ b/lib/Activity/Provider.php
@@ -5,6 +5,9 @@
  *
  * Provider for parsing and rendering OpenRegister activity events.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Activity
  * @package  OCA\OpenRegister\Activity
  *

--- a/lib/Activity/ProviderSubjectHandler.php
+++ b/lib/Activity/ProviderSubjectHandler.php
@@ -5,6 +5,9 @@
  *
  * Handler for applying activity subject text and rich parameters to events.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Activity
  * @package  OCA\OpenRegister\Activity
  *

--- a/lib/Activity/Setting/ObjectSetting.php
+++ b/lib/Activity/Setting/ObjectSetting.php
@@ -5,6 +5,9 @@
  *
  * Activity setting for object CRUD notifications.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Activity
  * @package  OCA\OpenRegister\Activity\Setting
  *

--- a/lib/Activity/Setting/RegisterSetting.php
+++ b/lib/Activity/Setting/RegisterSetting.php
@@ -5,6 +5,9 @@
  *
  * Activity setting for register CRUD notifications.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Activity
  * @package  OCA\OpenRegister\Activity\Setting
  *

--- a/lib/Activity/Setting/SchemaSetting.php
+++ b/lib/Activity/Setting/SchemaSetting.php
@@ -5,6 +5,9 @@
  *
  * Activity setting for schema CRUD notifications.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Activity
  * @package  OCA\OpenRegister\Activity\Setting
  *

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -6,6 +6,9 @@
  * This file contains the controller for handling consumer related operations
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category AppInfo
  * @package  OCA\OpenRegister\AppInfo
  *

--- a/lib/BackgroundJob/ActionRetryJob.php
+++ b/lib/BackgroundJob/ActionRetryJob.php
@@ -5,6 +5,9 @@
  *
  * Background job for retrying failed action executions.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/ActionScheduleJob.php
+++ b/lib/BackgroundJob/ActionScheduleJob.php
@@ -5,6 +5,9 @@
  *
  * Background job for evaluating and executing scheduled actions.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/BatchNotificationJob.php
+++ b/lib/BackgroundJob/BatchNotificationJob.php
@@ -18,6 +18,9 @@
  * to enqueue a notification call `NotificationDigest::enqueue()`
  * instead of dispatching immediately; this job is the consumer side.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/BlobMigrationJob.php
+++ b/lib/BackgroundJob/BlobMigrationJob.php
@@ -7,6 +7,9 @@
  * (oc_openregister_objects) to schema-specific magic tables. Runs every 5 minutes
  * and processes up to 100 objects per execution, grouped by register+schema pair.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/BulkLegalHoldJob.php
+++ b/lib/BackgroundJob/BulkLegalHoldJob.php
@@ -5,6 +5,9 @@
  *
  * Queued background job that places legal holds on all objects in a schema.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/CacheWarmupJob.php
+++ b/lib/BackgroundJob/CacheWarmupJob.php
@@ -7,6 +7,9 @@
  * cold-start delays. Default interval: 1 hour, configurable via admin settings.
  * Set interval to 0 to disable.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/CronFileTextExtractionJob.php
+++ b/lib/BackgroundJob/CronFileTextExtractionJob.php
@@ -6,6 +6,9 @@
  * Recurring background job that periodically processes files for text extraction.
  * This job runs at configurable intervals to handle files when extraction mode is set to 'cron'.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/DestructionCheckJob.php
+++ b/lib/BackgroundJob/DestructionCheckJob.php
@@ -6,6 +6,9 @@
  * Periodic background job that scans for objects eligible for destruction
  * and generates destruction lists for archivist review.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/DestructionExecutionJob.php
+++ b/lib/BackgroundJob/DestructionExecutionJob.php
@@ -7,6 +7,9 @@
  * deleting objects in configurable batches, generating audit trails and
  * destruction certificates upon completion.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/ExecutionHistoryCleanupJob.php
+++ b/lib/BackgroundJob/ExecutionHistoryCleanupJob.php
@@ -5,6 +5,9 @@
  *
  * Background job for pruning old workflow execution history records.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/FileTextExtractionJob.php
+++ b/lib/BackgroundJob/FileTextExtractionJob.php
@@ -7,6 +7,9 @@
  * This job is queued automatically when files are created or modified to avoid
  * blocking user requests with potentially slow text extraction operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  BackgroundJob
  * @package   OCA\OpenRegister\BackgroundJob
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/BackgroundJob/HookRetryJob.php
+++ b/lib/BackgroundJob/HookRetryJob.php
@@ -5,6 +5,9 @@
  *
  * Background job for retrying schema hooks that failed due to engine unavailability.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/NameCacheWarmupJob.php
+++ b/lib/BackgroundJob/NameCacheWarmupJob.php
@@ -7,6 +7,9 @@
  * This ensures optimal facet label resolution performance by pre-populating the
  * distributed name cache with all object names.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/ObjectTextExtractionJob.php
+++ b/lib/BackgroundJob/ObjectTextExtractionJob.php
@@ -7,6 +7,9 @@
  * This job is queued automatically when objects are created or modified to avoid
  * blocking user requests with potentially slow text extraction operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  BackgroundJob
  * @package   OCA\OpenRegister\BackgroundJob
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/BackgroundJob/ScheduledNotificationJob.php
+++ b/lib/BackgroundJob/ScheduledNotificationJob.php
@@ -13,6 +13,9 @@
  * channel logic (nc-notification, email, activity, webhook, talk) is
  * reused unchanged.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/ScheduledWorkflowJob.php
+++ b/lib/BackgroundJob/ScheduledWorkflowJob.php
@@ -5,6 +5,9 @@
  *
  * Background job for executing scheduled workflows on their configured intervals.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/SolrNightlyWarmupJob.php
+++ b/lib/BackgroundJob/SolrNightlyWarmupJob.php
@@ -6,6 +6,9 @@
  * Recurring background job that runs every night at 00:00 to warm up the SOLR index.
  * This ensures optimal search performance by keeping the index warm and ready for queries.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/SolrWarmupJob.php
+++ b/lib/BackgroundJob/SolrWarmupJob.php
@@ -7,6 +7,9 @@
  * This job is scheduled automatically after import operations complete to
  * ensure optimal search performance without slowing down the import process.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/TenantDeprovisionJob.php
+++ b/lib/BackgroundJob/TenantDeprovisionJob.php
@@ -6,6 +6,9 @@
  * Processes organisations in 'deprovisioning' state by soft-deleting their
  * objects and transitioning them to 'archived' state.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/TenantPurgeJob.php
+++ b/lib/BackgroundJob/TenantPurgeJob.php
@@ -6,6 +6,9 @@
  * Permanently deletes archived organisations and their data after the
  * configured retention period (default: 90 days).
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/TenantUsageSyncJob.php
+++ b/lib/BackgroundJob/TenantUsageSyncJob.php
@@ -6,6 +6,9 @@
  * Flushes APCu-based quota counters to the openregister_tenant_usage database
  * table for persistence, dashboard display, and historical tracking.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/TransferExecutionJob.php
+++ b/lib/BackgroundJob/TransferExecutionJob.php
@@ -5,6 +5,9 @@
  *
  * Queued background job that executes e-Depot transfers for approved transfer lists.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/BackgroundJob/WebhookDeliveryJob.php
+++ b/lib/BackgroundJob/WebhookDeliveryJob.php
@@ -5,6 +5,9 @@
  *
  * Background job for webhook delivery with retries.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category BackgroundJob
  * @package  OCA\OpenRegister\BackgroundJob
  *

--- a/lib/Calendar/CalendarEventTransformer.php
+++ b/lib/Calendar/CalendarEventTransformer.php
@@ -6,6 +6,9 @@
  * Transforms ObjectEntity data into VEVENT-compatible arrays
  * for the Nextcloud Calendar app.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Calendar
  * @package  OCA\OpenRegister\Calendar
  *

--- a/lib/Calendar/RegisterCalendar.php
+++ b/lib/Calendar/RegisterCalendar.php
@@ -6,6 +6,9 @@
  * Implements ICalendar to provide a virtual calendar backed by
  * OpenRegister schema objects with date fields.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Calendar
  * @package  OCA\OpenRegister\Calendar
  *

--- a/lib/Calendar/RegisterCalendarProvider.php
+++ b/lib/Calendar/RegisterCalendarProvider.php
@@ -6,6 +6,9 @@
  * Implements ICalendarProvider to register virtual calendars
  * for OpenRegister schemas with calendar-enabled date fields.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Calendar
  * @package  OCA\OpenRegister\Calendar
  *

--- a/lib/Command/MigrateStorageCommand.php
+++ b/lib/Command/MigrateStorageCommand.php
@@ -5,6 +5,9 @@
  *
  * OCC command for migrating objects between blob storage and magic tables.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Command
  * @package   OCA\OpenRegister\Command
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Command/RematerialiseCalculationsCommand.php
+++ b/lib/Command/RematerialiseCalculationsCommand.php
@@ -8,6 +8,9 @@
  * expression changes so existing objects reflect the new shape without
  * waiting for the next user-driven save.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Command
  * @package  OCA\OpenRegister\Command
  *

--- a/lib/Command/SolrDebugCommand.php
+++ b/lib/Command/SolrDebugCommand.php
@@ -5,6 +5,9 @@
  *
  * SOLR Debug Command for testing SOLR functionality step by step.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Command
  * @package  OCA\OpenRegister\Command
  *

--- a/lib/Command/SolrManagementCommand.php
+++ b/lib/Command/SolrManagementCommand.php
@@ -8,6 +8,9 @@
  * This command provides comprehensive SOLR management operations including
  * setup, schema validation, optimization, warming, and maintenance tasks.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Command
  * @package  OCA\OpenRegister\Command
  *

--- a/lib/Contacts/ContactsMenuProvider.php
+++ b/lib/Contacts/ContactsMenuProvider.php
@@ -6,6 +6,9 @@
  * Nextcloud Contacts Menu provider that bridges Contacts/CardDAV
  * with OpenRegister entity data.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Contacts
  * @package  OCA\OpenRegister\Contacts
  *

--- a/lib/Cron/ArchivalRetentionTask.php
+++ b/lib/Cron/ArchivalRetentionTask.php
@@ -19,6 +19,9 @@
  *   5. Emit one structured log entry per schema:
  *      `{schemaSlug, scanned, expired, deleted}`.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Cron
  * @package  OCA\OpenRegister\Cron
  *

--- a/lib/Cron/ConfigurationCheckJob.php
+++ b/lib/Cron/ConfigurationCheckJob.php
@@ -6,6 +6,9 @@
  * This file contains the background job class for checking remote configurations
  * for updates in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Cron
  * @package   OCA\OpenRegister\Cron
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Cron/LogCleanUpTask.php
+++ b/lib/Cron/LogCleanUpTask.php
@@ -6,6 +6,9 @@
  * This file contains the background job for cleaning up expired audit trail logs
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Cron
  * @package   OCA\OpenRegister\Cron
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Cron/SyncConfigurationsJob.php
+++ b/lib/Cron/SyncConfigurationsJob.php
@@ -6,6 +6,9 @@
  * This file contains the background job class for synchronizing external configurations
  * from their source repositories (GitHub, GitLab, URL).
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Cron
  * @package  OCA\OpenRegister\Cron
  *

--- a/lib/Cron/TransferCheckJob.php
+++ b/lib/Cron/TransferCheckJob.php
@@ -6,6 +6,9 @@
  * Background job that scans for objects eligible for e-Depot transfer
  * and generates transfer lists for archivist review.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Cron
  * @package  OCA\OpenRegister\Cron
  *

--- a/lib/Cron/WebhookRetryJob.php
+++ b/lib/Cron/WebhookRetryJob.php
@@ -7,6 +7,9 @@
  * based on their next_retry_at timestamp. Uses exponential backoff
  * with increasing intervals between retries.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Cron
  * @package  OCA\OpenRegister\Cron
  *

--- a/lib/Dto/DeepLinkRegistration.php
+++ b/lib/Dto/DeepLinkRegistration.php
@@ -5,6 +5,9 @@
  *
  * Value object representing a deep link registration from a consuming app.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Dto
  * @package  OCA\OpenRegister\Dto
  *

--- a/lib/Dto/DeletionAnalysis.php
+++ b/lib/Dto/DeletionAnalysis.php
@@ -7,6 +7,9 @@
  * Contains information about what would happen if an object were deleted,
  * including cascade targets, nullification targets, and blockers.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Dto
  * @package  OCA\OpenRegister\Dto
  *

--- a/lib/Formats/BsnFormat.php
+++ b/lib/Formats/BsnFormat.php
@@ -5,6 +5,9 @@
  *
  * This file contains the format class for the Bsn format.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Format
  * @package  OCA\OpenRegister\Formats
  *

--- a/lib/Formats/SemVerFormat.php
+++ b/lib/Formats/SemVerFormat.php
@@ -5,6 +5,9 @@
  *
  * Validates semantic version strings according to SemVer specification.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Formats
  * @package  OCA\OpenRegister\Formats
  *

--- a/lib/Lifecycle/GuardResult.php
+++ b/lib/Lifecycle/GuardResult.php
@@ -6,6 +6,9 @@
  * Value object returned by `LifecycleGuardInterface::check`. Two factory
  * constructors (`allow` and `deny`) plus read-only inspectors.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Lifecycle
  * @package  OCA\OpenRegister\Lifecycle
  *

--- a/lib/Lifecycle/LifecycleGuardInterface.php
+++ b/lib/Lifecycle/LifecycleGuardInterface.php
@@ -8,6 +8,9 @@
  * via DI tag; the schema's `x-openregister-lifecycle.transitions[*].requires`
  * field names the tag.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Lifecycle
  * @package  OCA\OpenRegister\Lifecycle
  *

--- a/lib/Mcp/BuiltIn/ObjectsToolProvider.php
+++ b/lib/Mcp/BuiltIn/ObjectsToolProvider.php
@@ -6,6 +6,9 @@
  * Exposes CRUD operations on OpenRegister objects as an MCP tool
  * under the namespaced id `openregister.objects`.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Mcp
  * @package  OCA\OpenRegister\Mcp\BuiltIn
  *

--- a/lib/Mcp/BuiltIn/RegistersToolProvider.php
+++ b/lib/Mcp/BuiltIn/RegistersToolProvider.php
@@ -6,6 +6,9 @@
  * Exposes CRUD operations on OpenRegister registers as an MCP tool
  * under the namespaced id `openregister.registers`.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Mcp
  * @package  OCA\OpenRegister\Mcp\BuiltIn
  *

--- a/lib/Mcp/BuiltIn/SchemasToolProvider.php
+++ b/lib/Mcp/BuiltIn/SchemasToolProvider.php
@@ -6,6 +6,9 @@
  * Exposes CRUD operations on OpenRegister schemas as an MCP tool
  * under the namespaced id `openregister.schemas`.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Mcp
  * @package  OCA\OpenRegister\Mcp\BuiltIn
  *

--- a/lib/Mcp/IMcpToolProvider.php
+++ b/lib/Mcp/IMcpToolProvider.php
@@ -8,6 +8,9 @@
  * container. OpenRegister's McpToolsService enumerates every registered
  * implementation in-process per turn without issuing extra HTTP requests.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Mcp
  * @package  OCA\OpenRegister\Mcp
  *

--- a/lib/Middleware/LanguageMiddleware.php
+++ b/lib/Middleware/LanguageMiddleware.php
@@ -7,6 +7,9 @@
  * and store the preferred language in the LanguageService. Also checks for
  * the _translations=all query parameter.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Middleware
  * @package  OCA\OpenRegister\Middleware
  *

--- a/lib/Middleware/OasValidationFailureException.php
+++ b/lib/Middleware/OasValidationFailureException.php
@@ -7,6 +7,9 @@
  * body fails OAS schema validation. Caught by the same middleware's
  * `afterException` method and translated into an RFC 7807 422 response.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Middleware
  * @package  OCA\OpenRegister\Middleware
  *

--- a/lib/Middleware/OasValidationMiddleware.php
+++ b/lib/Middleware/OasValidationMiddleware.php
@@ -15,6 +15,9 @@
  * callers without the annotation skip validation, preserving the old
  * behaviour for clients that don't yet send strictly-typed bodies).
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Middleware
  * @package  OCA\OpenRegister\Middleware
  *

--- a/lib/Middleware/TenantQuotaExceededException.php
+++ b/lib/Middleware/TenantQuotaExceededException.php
@@ -5,6 +5,9 @@
  *
  * Thrown when an organisation exceeds its request or bandwidth quota.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Exception
  * @package  OCA\OpenRegister\Middleware
  *

--- a/lib/Middleware/TenantQuotaMiddleware.php
+++ b/lib/Middleware/TenantQuotaMiddleware.php
@@ -7,6 +7,9 @@
  * status checks before controller execution. Uses APCu for high-performance
  * counter management.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Middleware
  * @package  OCA\OpenRegister\Middleware
  *

--- a/lib/Middleware/TenantStatusException.php
+++ b/lib/Middleware/TenantStatusException.php
@@ -5,6 +5,9 @@
  *
  * Thrown when an organisation is in a non-active state that prevents API access.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Exception
  * @package  OCA\OpenRegister\Middleware
  *

--- a/lib/Notification/AnnotationNotifier.php
+++ b/lib/Notification/AnnotationNotifier.php
@@ -7,6 +7,9 @@
  * already-interpolated subject under the `_text` parameter; this notifier
  * surfaces it as the notification's parsed subject.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Notification
  * @package  OCA\OpenRegister\Notification
  *

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -6,6 +6,9 @@
  * This file contains the notifier class for displaying notifications
  * in the Nextcloud notification center.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Notification
  * @package  OCA\OpenRegister\Notification
  *

--- a/lib/Push/PushEvents.php
+++ b/lib/Push/PushEvents.php
@@ -11,6 +11,9 @@
  *   - OR_OBJECT     → `or-object`     — base string; append `-{uuid}` to target a single object.
  *   - OR_COLLECTION → `or-collection` — base string; append `-{register-slug}-{schema-slug}` to target a collection.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Push
  * @package  OCA\OpenRegister\Push
  *

--- a/lib/Reference/ObjectReferenceProvider.php
+++ b/lib/Reference/ObjectReferenceProvider.php
@@ -7,6 +7,9 @@
  * to search for and insert rich references to register objects in Mail,
  * Text, Talk, Collectives, and any Nextcloud app supporting the Smart Picker.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Reference
  * @package  OCA\OpenRegister\Reference
  *

--- a/lib/Repair/RegisterRiskLevelMetadata.php
+++ b/lib/Repair/RegisterRiskLevelMetadata.php
@@ -3,6 +3,9 @@
 /**
  * Repair step to register the risk level metadata key.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Repair
  * @package  OCA\OpenRegister\Repair
  *

--- a/lib/Search/ObjectsProvider.php
+++ b/lib/Search/ObjectsProvider.php
@@ -5,6 +5,9 @@
  *
  * This file contains the provider class for the objects search.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Search
  * @package  OCA\OpenRegister\Search
  *

--- a/lib/Sections/OpenRegisterAdmin.php
+++ b/lib/Sections/OpenRegisterAdmin.php
@@ -5,6 +5,9 @@
  *
  * Provides admin settings section for OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Section
  * @package  OCA\OpenRegister\Sections
  *

--- a/lib/Settings/OpenRegisterAdmin.php
+++ b/lib/Settings/OpenRegisterAdmin.php
@@ -5,6 +5,9 @@
  *
  * Admin settings page for OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Settings
  * @package  OCA\OpenRegister\Settings
  *

--- a/lib/Tool/AbstractTool.php
+++ b/lib/Tool/AbstractTool.php
@@ -6,6 +6,9 @@
  * Base class for LLphant function tools providing common functionality
  * for user context management, view filtering, and error handling.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Tool
  * @package  OCA\OpenRegister\Tool
  *

--- a/lib/Tool/AgentTool.php
+++ b/lib/Tool/AgentTool.php
@@ -6,6 +6,9 @@
  * LLphant function tool for AI agents to manage other agents.
  * Provides CRUD operations for agents with RBAC enforcement.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Tool
  * @package  OCA\OpenRegister\Tool
  *

--- a/lib/Tool/ApplicationTool.php
+++ b/lib/Tool/ApplicationTool.php
@@ -6,6 +6,9 @@
  * LLphant function tool for AI agents to manage applications.
  * Provides CRUD operations for applications with RBAC enforcement.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Tool
  * @package  OCA\OpenRegister\Tool
  *

--- a/lib/Tool/ObjectsTool.php
+++ b/lib/Tool/ObjectsTool.php
@@ -6,6 +6,9 @@
  * LLphant function tool for managing objects through natural language.
  * Provides CRUD operations on objects with RBAC and multi-tenancy support.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Tool
  * @package  OCA\OpenRegister\Tool
  *

--- a/lib/Tool/RegisterTool.php
+++ b/lib/Tool/RegisterTool.php
@@ -6,6 +6,9 @@
  * LLphant function tool for managing registers through natural language.
  * Provides CRUD operations on registers with RBAC and multi-tenancy support.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Tool
  * @package  OCA\OpenRegister\Tool
  *

--- a/lib/Tool/SchemaTool.php
+++ b/lib/Tool/SchemaTool.php
@@ -6,6 +6,9 @@
  * LLphant function tool for managing schemas through natural language.
  * Provides CRUD operations on schemas with RBAC and multi-tenancy support.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Tool
  * @package  OCA\OpenRegister\Tool
  *

--- a/lib/Tool/ToolInterface.php
+++ b/lib/Tool/ToolInterface.php
@@ -6,6 +6,9 @@
  * Interface for LLphant function tools that agents can use to interact
  * with OpenRegister data.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Tool
  * @package  OCA\OpenRegister\Tool
  *

--- a/lib/Twig/AuthenticationExtension.php
+++ b/lib/Twig/AuthenticationExtension.php
@@ -3,6 +3,9 @@
 /**
  * Twig extension for authentication token functions.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Twig
  * @package  OCA\OpenRegister\Twig
  *

--- a/lib/Twig/AuthenticationRuntime.php
+++ b/lib/Twig/AuthenticationRuntime.php
@@ -3,6 +3,9 @@
 /**
  * Twig runtime for authentication token functions.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Twig
  * @package  OCA\OpenRegister\Twig
  *

--- a/lib/Twig/MappingExtension.php
+++ b/lib/Twig/MappingExtension.php
@@ -5,6 +5,9 @@
  *
  * Registers Twig functions and filters for the mapping engine.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Twig
  * @package  OCA\OpenRegister\Twig
  *

--- a/lib/Twig/MappingRuntime.php
+++ b/lib/Twig/MappingRuntime.php
@@ -6,6 +6,9 @@
  * Twig runtime extension providing mapping functions and filters
  * for use within Twig mapping templates.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Twig
  * @package  OCA\OpenRegister\Twig
  *

--- a/lib/Twig/MappingRuntimeLoader.php
+++ b/lib/Twig/MappingRuntimeLoader.php
@@ -5,6 +5,9 @@
  *
  * Loader that provides the MappingRuntime to Twig's extension system.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Twig
  * @package  OCA\OpenRegister\Twig
  *

--- a/lib/WorkflowEngine/N8nAdapter.php
+++ b/lib/WorkflowEngine/N8nAdapter.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister N8nAdapter
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category WorkflowEngine
  * @package  OCA\OpenRegister\WorkflowEngine
  *

--- a/lib/WorkflowEngine/WindmillAdapter.php
+++ b/lib/WorkflowEngine/WindmillAdapter.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister WindmillAdapter
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category WorkflowEngine
  * @package  OCA\OpenRegister\WorkflowEngine
  *

--- a/lib/WorkflowEngine/WorkflowEngineInterface.php
+++ b/lib/WorkflowEngine/WorkflowEngineInterface.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister WorkflowEngine Interface
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category WorkflowEngine
  * @package  OCA\OpenRegister\WorkflowEngine
  *

--- a/lib/WorkflowEngine/WorkflowResult.php
+++ b/lib/WorkflowEngine/WorkflowResult.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister WorkflowResult Value Object
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category WorkflowEngine
  * @package  OCA\OpenRegister\WorkflowEngine
  *


### PR DESCRIPTION
Mechanical SPDX header sweep — part **1 of 7** from the openregister coverage-scan retrofit (2026-05-24).

Adds the two SPDX lines to the existing file docblock of every file in scope:

```
 * SPDX-License-Identifier: EUPL-1.2
 * SPDX-FileCopyrightText: 2026 Conduction B.V.
```

Per ADR-014 and the convention used in existing files (e.g. `lib/Service/AvgComplianceService.php`) — SPDX lives inside the docblock, not as line comments.

## Scope
84 files across BackgroundJob (23), Cron (6), Middleware (6), Tool (7), Activity (6), Twig (5), Mcp/WorkflowEngine/Command (4 each), Calendar (3), Dto/Formats/Lifecycle/Notification (2 each), and single-file dirs AppInfo/Contacts/Push/Reference/Repair/Search/Sections/Settings/Capabilities/Resources.

## Companion PRs (in flight)
- 2/7 — Db
- 3/7 — Controller
- 4/7 — Event + EventListener + Listener + Exception
- 5/7 — Service: data layer (Object/File/Aggregation/Geo/Schemas/Search)
- 6/7 — Service: pipelines/integrations (Index/Vectorization/Chat/Notification/Mcp/Webhook/Edepot/TextExtraction/Translation/Calculation/Handler/Integration)
- 7/7 — Service: config/archival/oas + flat files

## Test plan
- [ ] CI green (PHPCS / PHPMD / PHPStan / Psalm)
- [ ] No functional change — every hunk is comment-only