### PR TITLE
chore(spdx): EUPL-1.2 SPDX headers — Service: data layer (Object, File, Aggregation, Geo, Schemas, Search) (Bucket 4, 2/7)

### DIFF
--- a/lib/Service/Aggregation/AggregationAnnotationValidator.php
+++ b/lib/Service/Aggregation/AggregationAnnotationValidator.php
@@ -6,6 +6,9 @@
  * Schema-save validation for the `x-openregister-aggregations` annotation.
  * Returns a list of errors; empty = valid.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Aggregation
  *

--- a/lib/Service/Aggregation/AggregationCache.php
+++ b/lib/Service/Aggregation/AggregationCache.php
@@ -7,6 +7,9 @@
  * schema + name + resolved-filters hash + RBAC scope hash. Evicted
  * by the existing object-write event listeners.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Aggregation
  *

--- a/lib/Service/Aggregation/AggregationQuery.php
+++ b/lib/Service/Aggregation/AggregationQuery.php
@@ -13,6 +13,9 @@
  * gte / lt / lte / ne (mirrors the inline magic-table SQL path that
  * lived in `AggregationRunner::tryNativeAggregation`).
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Aggregation
  *

--- a/lib/Service/Aggregation/AggregationRunner.php
+++ b/lib/Service/Aggregation/AggregationRunner.php
@@ -10,6 +10,9 @@
  * v1 trades performance for simplicity: backend-native aggregation
  * (Postgres GROUP BY / Solr facets / ES aggs) ships in a follow-up.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Aggregation
  *

--- a/lib/Service/Aggregation/ElasticsearchAggregationQueryBuilder.php
+++ b/lib/Service/Aggregation/ElasticsearchAggregationQueryBuilder.php
@@ -15,6 +15,9 @@
  * Pure-PHP translation. The ES backend wraps a thin HTTP client around
  * this builder. Unit-testable independently.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Aggregation
  *

--- a/lib/Service/Aggregation/SolrAggregationQueryBuilder.php
+++ b/lib/Service/Aggregation/SolrAggregationQueryBuilder.php
@@ -15,6 +15,9 @@
  * Pure-PHP translation — no HTTP. The Solr backend wraps a thin HTTP
  * client around this builder. Unit-testable independently.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Aggregation
  *

--- a/lib/Service/Aggregation/WidgetAnnotationValidator.php
+++ b/lib/Service/Aggregation/WidgetAnnotationValidator.php
@@ -6,6 +6,9 @@
  * Schema-save validation for the `x-openregister-widgets` annotation.
  * Returns a list of errors; empty = valid.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Aggregation
  *

--- a/lib/Service/File/CreateFileHandler.php
+++ b/lib/Service/File/CreateFileHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/File/DeleteFileHandler.php
+++ b/lib/Service/File/DeleteFileHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/File/DocumentProcessingHandler.php
+++ b/lib/Service/File/DocumentProcessingHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/File/FileAuditHandler.php
+++ b/lib/Service/File/FileAuditHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/File/FileBatchHandler.php
+++ b/lib/Service/File/FileBatchHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/File/FileCrudHandler.php
+++ b/lib/Service/File/FileCrudHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/File/FileFormattingHandler.php
+++ b/lib/Service/File/FileFormattingHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/File/FileLockHandler.php
+++ b/lib/Service/File/FileLockHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/File/FileOwnershipHandler.php
+++ b/lib/Service/File/FileOwnershipHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/File/FilePreviewHandler.php
+++ b/lib/Service/File/FilePreviewHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/File/FilePublishingHandler.php
+++ b/lib/Service/File/FilePublishingHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/File/FileSharingHandler.php
+++ b/lib/Service/File/FileSharingHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/File/FileValidationHandler.php
+++ b/lib/Service/File/FileValidationHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/File/FileVersioningHandler.php
+++ b/lib/Service/File/FileVersioningHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/File/FolderManagementHandler.php
+++ b/lib/Service/File/FolderManagementHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/File/ReadFileHandler.php
+++ b/lib/Service/File/ReadFileHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/File/TaggingHandler.php
+++ b/lib/Service/File/TaggingHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/File/UpdateFileHandler.php
+++ b/lib/Service/File/UpdateFileHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/Geo/GeoFilter.php
+++ b/lib/Service/Geo/GeoFilter.php
@@ -15,6 +15,9 @@
  * Filters are immutable and constructed via static factory methods so
  * invalid input fails fast at parse time.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Geo
  *

--- a/lib/Service/Geo/GeoFilterApplier.php
+++ b/lib/Service/Geo/GeoFilterApplier.php
@@ -11,6 +11,9 @@
  * Filter list semantics: AND. A row passes only when every filter
  * matches. Empty filter list = pass-through.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Geo
  *

--- a/lib/Service/Geo/GeoFilterParser.php
+++ b/lib/Service/Geo/GeoFilterParser.php
@@ -11,6 +11,9 @@
  *
  * Either entry returns a list of GeoFilter; the caller AND-composes.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Geo
  *

--- a/lib/Service/Geo/GeoSpatialEvaluator.php
+++ b/lib/Service/Geo/GeoSpatialEvaluator.php
@@ -21,6 +21,9 @@
  *   - Polygon-polygon overlap is approximated as "any vertex of A is in
  *     B, OR any vertex of B is in A".
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Geo
  *

--- a/lib/Service/Object/AuditHandler.php
+++ b/lib/Service/Object/AuditHandler.php
@@ -6,6 +6,9 @@
  * Handles audit trail and logging operations for objects.
  * Tracks all changes and access to objects for compliance and debugging.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Objects\Handlers
  *

--- a/lib/Service/Object/CacheHandler.php
+++ b/lib/Service/Object/CacheHandler.php
@@ -10,6 +10,9 @@
  * - Cache warming strategies
  * - Memory-efficient cache management
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/Object/CascadingHandler.php
+++ b/lib/Service/Object/CascadingHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/Object/CrudHandler.php
+++ b/lib/Service/Object/CrudHandler.php
@@ -6,6 +6,9 @@
  * Handles core CRUD (Create, Read, Update, Delete) operations for objects.
  * Coordinates between controller and ObjectService for data operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Objects\Handlers
  *

--- a/lib/Service/Object/DataManipulationHandler.php
+++ b/lib/Service/Object/DataManipulationHandler.php
@@ -7,6 +7,9 @@
  * This handler consolidates utility functions for manipulating object data,
  * making these operations more testable and maintainable.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service\Objects
  *

--- a/lib/Service/Object/DeleteObject.php
+++ b/lib/Service/Object/DeleteObject.php
@@ -12,6 +12,9 @@
  * - Maintaining referential integrity
  * - Tracking deletion operations
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/Object/ExportHandler.php
+++ b/lib/Service/Object/ExportHandler.php
@@ -6,6 +6,9 @@
  * Handles object export, import, and file download operations.
  * Coordinates between controller and specialized export/import services.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Objects\Handlers
  *

--- a/lib/Service/Object/FacetHandler.php
+++ b/lib/Service/Object/FacetHandler.php
@@ -7,6 +7,9 @@
  * with intelligent fallback strategies, response caching, and performance optimization.
  * Solves the fundamental pagination vs faceting architectural conflict.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Handler
  * @package   OCA\OpenRegister\Service\Object
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/Object/GetObject.php
+++ b/lib/Service/Object/GetObject.php
@@ -12,6 +12,9 @@
  * - Handling search operations
  * - Managing object extensions
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/Object/LinkedEntityEnricher.php
+++ b/lib/Service/Object/LinkedEntityEnricher.php
@@ -3,6 +3,9 @@
 /**
  * LinkedEntityEnricher
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/Object/LockHandler.php
+++ b/lib/Service/Object/LockHandler.php
@@ -6,6 +6,9 @@
  * Handles object locking and unlocking operations.
  * Locks prevent concurrent modifications to objects.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Objects\Handlers
  *

--- a/lib/Service/Object/MergeHandler.php
+++ b/lib/Service/Object/MergeHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/Object/MetadataHandler.php
+++ b/lib/Service/Object/MetadataHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/Object/MigrationHandler.php
+++ b/lib/Service/Object/MigrationHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/Object/NewFacetingExample.php
+++ b/lib/Service/Object/NewFacetingExample.php
@@ -6,6 +6,9 @@
  * This file contains examples demonstrating the new faceting system
  * that has replaced the legacy getFacets approach.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Example
  * @package  OCA\OpenRegister\Service\Objects
  *

--- a/lib/Service/Object/ObjectServiceFacetExample.php
+++ b/lib/Service/Object/ObjectServiceFacetExample.php
@@ -6,6 +6,9 @@
  * This file contains comprehensive examples demonstrating the new faceting
  * capabilities integrated into the ObjectService, showing both new and legacy approaches.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Example
  * @package  OCA\OpenRegister\Service\Objects
  *

--- a/lib/Service/Object/PerformanceHandler.php
+++ b/lib/Service/Object/PerformanceHandler.php
@@ -7,6 +7,9 @@
  * This handler consolidates performance-related operations from ObjectService,
  * improving code organization and making optimization logic more maintainable.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service\Objects
  *

--- a/lib/Service/Object/PerformanceOptimizationHandler.php
+++ b/lib/Service/Object/PerformanceOptimizationHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/Object/PermissionHandler.php
+++ b/lib/Service/Object/PermissionHandler.php
@@ -7,6 +7,9 @@
  * This handler centralizes authorization logic that was previously scattered
  * throughout ObjectService, making security policies more maintainable.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service\Objects
  *

--- a/lib/Service/Object/QueryHandler.php
+++ b/lib/Service/Object/QueryHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/Object/ReferentialIntegrityService.php
+++ b/lib/Service/Object/ReferentialIntegrityService.php
@@ -8,6 +8,9 @@
  * blockers (RESTRICT) and cascade targets, and applies mutations (CASCADE, SET_NULL,
  * SET_DEFAULT) when deletion proceeds.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Object
  *

--- a/lib/Service/Object/RelationHandler.php
+++ b/lib/Service/Object/RelationHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/Object/RelationshipOptimizationHandler.php
+++ b/lib/Service/Object/RelationshipOptimizationHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/Object/RenderObject.php
+++ b/lib/Service/Object/RenderObject.php
@@ -11,6 +11,9 @@
  * - Applying field filtering and selection
  * - Formatting object properties for display
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/Object/RevertHandler.php
+++ b/lib/Service/Object/RevertHandler.php
@@ -5,6 +5,9 @@
  *
  * Service class for handling object reversion in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -12,6 +12,9 @@
  * - Maintaining audit trails (user tracking)
  * - Setting default values and properties
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/Object/SaveObject/ComputedFieldHandler.php
+++ b/lib/Service/Object/SaveObject/ComputedFieldHandler.php
@@ -7,6 +7,9 @@
  * Supports save-time and read-time evaluation of Twig expressions
  * defined in schema property `computed` attributes.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service\Objects\SaveObject
  *

--- a/lib/Service/Object/SaveObject/FilePropertyHandler.php
+++ b/lib/Service/Object/SaveObject/FilePropertyHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/Object/SaveObject/LinkedEntityPropertyHandler.php
+++ b/lib/Service/Object/SaveObject/LinkedEntityPropertyHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/Object/SaveObject/MetadataHydrationHandler.php
+++ b/lib/Service/Object/SaveObject/MetadataHydrationHandler.php
@@ -6,6 +6,9 @@
  * Handler for extracting and hydrating object metadata.
  * Handles name, description, summary, image extraction, and slug generation.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service\Objects\SaveObject
  *

--- a/lib/Service/Object/SaveObject/RelationCascadeHandler.php
+++ b/lib/Service/Object/SaveObject/RelationCascadeHandler.php
@@ -6,6 +6,9 @@
  * Handler for managing object relations and cascading operations.
  * Handles schema resolution, relation scanning, and cascading object creation.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service\Objects\SaveObject
  *

--- a/lib/Service/Object/SaveObjects.php
+++ b/lib/Service/Object/SaveObjects.php
@@ -43,6 +43,9 @@
  * - Time complexity: O(N*M*P) → O(N*M)
  * - Processing speed: 2-3x faster for large datasets
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Handler
  * @package   OCA\OpenRegister\Service\ObjectHandlers
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Service/Object/SaveObjects/BulkRelationHandler.php
+++ b/lib/Service/Object/SaveObjects/BulkRelationHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/Object/SaveObjects/BulkValidationHandler.php
+++ b/lib/Service/Object/SaveObjects/BulkValidationHandler.php
@@ -6,6 +6,9 @@
  * Handler for bulk validation operations and schema analysis.
  * Optimizes validation for bulk object operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service\Objects\SaveObjects
  *

--- a/lib/Service/Object/SaveObjects/ChunkProcessingHandler.php
+++ b/lib/Service/Object/SaveObjects/ChunkProcessingHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/Object/SaveObjects/PreparationHandler.php
+++ b/lib/Service/Object/SaveObjects/PreparationHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/Object/SaveObjects/TransformationHandler.php
+++ b/lib/Service/Object/SaveObjects/TransformationHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/Object/SchemaTypeConverter.php
+++ b/lib/Service/Object/SchemaTypeConverter.php
@@ -9,6 +9,9 @@
  *
  * Contract spec: openspec/specs/schema-driven-read-coercion/spec.md
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Object
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Service/Object/SearchQueryHandler.php
+++ b/lib/Service/Object/SearchQueryHandler.php
@@ -7,6 +7,9 @@
  * This handler separates search-related business logic from the main ObjectService,
  * improving code organization and maintainability.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service\Objects
  *

--- a/lib/Service/Object/TranslationHandler.php
+++ b/lib/Service/Object/TranslationHandler.php
@@ -7,6 +7,9 @@
  * Supports both reading (selecting the correct language variant) and writing
  * (normalizing input to language-keyed objects) for translatable properties.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service\Object
  *

--- a/lib/Service/Object/UtilityHandler.php
+++ b/lib/Service/Object/UtilityHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/Object/ValidateObject.php
+++ b/lib/Service/Object/ValidateObject.php
@@ -12,6 +12,9 @@
  * - Support for external schema references
  * - Format validation (e.g., BSN numbers)
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/Object/ValidationHandler.php
+++ b/lib/Service/Object/ValidationHandler.php
@@ -5,6 +5,9 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/Object/VectorizationHandler.php
+++ b/lib/Service/Object/VectorizationHandler.php
@@ -6,6 +6,9 @@
  * Handles vectorization operations for objects.
  * Acts as a bridge between ObjectsController and VectorizationService.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Objects\Handlers
  *

--- a/lib/Service/Schemas/FacetCacheHandler.php
+++ b/lib/Service/Schemas/FacetCacheHandler.php
@@ -9,6 +9,9 @@
  * Since facets are determined by schema properties, they can be cached and
  * invalidated when schemas change, providing significant performance benefits.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/Schemas/PropertyValidatorHandler.php
+++ b/lib/Service/Schemas/PropertyValidatorHandler.php
@@ -6,6 +6,9 @@
  * This file contains the class for validating schema properties
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/Schemas/SchemaCacheHandler.php
+++ b/lib/Service/Schemas/SchemaCacheHandler.php
@@ -9,6 +9,9 @@
  * computed properties like facetable fields, validation rules, and configuration.
  * It automatically invalidates cache when schemas are updated.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Schemas
  *

--- a/lib/Service/Search/PlaceholderResolver.php
+++ b/lib/Service/Search/PlaceholderResolver.php
@@ -7,6 +7,9 @@
  * annotation values. Shared by the parallel `aggregations-annotation`
  * and `calculations-annotation` changes so both write the same DSL.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Search
  *


### PR DESCRIPTION
Mechanical SPDX header sweep — part **2 of 7** from the openregister coverage-scan retrofit (2026-05-24).

Adds the two SPDX lines to the existing file docblock of every file in scope:

```
 * SPDX-License-Identifier: EUPL-1.2
 * SPDX-FileCopyrightText: 2026 Conduction B.V.
```

Per ADR-014 and the convention in existing files (e.g. `lib/Service/AvgComplianceService.php`) — SPDX lives inside the docblock, not as line comments before/after.

## Scope (77 files)

lib/Service/Object/ (44), lib/Service/File/ (18), lib/Service/Aggregation/ (7), lib/Service/Geo/ (4), lib/Service/Schemas/ (3), lib/Service/Search/ (1)

## Companion PRs

- #1737 — 1/7 (misc bundle, 84 files)
- the other 5 in this series are in flight alongside this one

## Test plan

- [ ] CI green (PHPCS / PHPMD / PHPStan / Psalm)
- [ ] No functional change — every diff hunk is comment-only