### PR TITLE
chore(spdx): EUPL-1.2 SPDX headers — Service: pipelines + integrations (Bucket 4, 3/7)

### DIFF
--- a/lib/Service/Calculation/CalculationAnnotationValidator.php
+++ b/lib/Service/Calculation/CalculationAnnotationValidator.php
@@ -5,6 +5,9 @@
  *
  * Schema-save validation for the `x-openregister-calculations` annotation.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Calculation
  *

--- a/lib/Service/Calculation/CalculationEvaluator.php
+++ b/lib/Service/Calculation/CalculationEvaluator.php
@@ -7,6 +7,9 @@
  * DB access, no HTTP. Inputs: object payload + expression. Output:
  * typed value or EvaluationException.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Calculation
  *

--- a/lib/Service/Calculation/EvaluationException.php
+++ b/lib/Service/Calculation/EvaluationException.php
@@ -5,6 +5,9 @@
  *
  * Thrown by CalculationEvaluator when an expression cannot be reduced.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Calculation
  *

--- a/lib/Service/Chat/ContextRetrievalHandler.php
+++ b/lib/Service/Chat/ContextRetrievalHandler.php
@@ -6,6 +6,9 @@
  * Handler for RAG (Retrieval Augmented Generation) context retrieval.
  * Manages semantic search, keyword search, and source extraction for chat context.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Chat
  *

--- a/lib/Service/Chat/ConversationManagementHandler.php
+++ b/lib/Service/Chat/ConversationManagementHandler.php
@@ -6,6 +6,9 @@
  * Handler for conversation lifecycle management.
  * Manages conversation titles, summaries, and history management.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Chat
  *

--- a/lib/Service/Chat/MessageHistoryHandler.php
+++ b/lib/Service/Chat/MessageHistoryHandler.php
@@ -5,6 +5,9 @@
  *
  * Handler for message storage and history management.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Chat
  *

--- a/lib/Service/Chat/ResponseGenerationHandler.php
+++ b/lib/Service/Chat/ResponseGenerationHandler.php
@@ -16,6 +16,9 @@
  * exactly as before — that branch is load-bearing for the
  * non-streaming endpoint and must not regress.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Chat
  *

--- a/lib/Service/Chat/ToolManagementHandler.php
+++ b/lib/Service/Chat/ToolManagementHandler.php
@@ -5,6 +5,9 @@
  *
  * Handler for LLM tool/function calling management.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Chat
  *

--- a/lib/Service/Edepot/EdepotTransferService.php
+++ b/lib/Service/Edepot/EdepotTransferService.php
@@ -6,6 +6,9 @@
  * Orchestrates the full e-Depot transfer pipeline: SIP package building,
  * transport, object status tracking, and audit trail logging.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Edepot
  *

--- a/lib/Service/Edepot/MdtoXmlGenerator.php
+++ b/lib/Service/Edepot/MdtoXmlGenerator.php
@@ -7,6 +7,9 @@
  * Conforms to the MDTO (Metagegevens Duurzaam Toegankelijke Overheidsinformatie)
  * schema version 1.0 or later.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Edepot
  *

--- a/lib/Service/Edepot/SipPackageBuilder.php
+++ b/lib/Service/Edepot/SipPackageBuilder.php
@@ -6,6 +6,9 @@
  * Assembles SIP (Submission Information Package) archives conforming to the
  * OAIS reference model (ISO 14721) for e-Depot transfer.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Edepot
  *

--- a/lib/Service/Edepot/TransferListService.php
+++ b/lib/Service/Edepot/TransferListService.php
@@ -5,6 +5,9 @@
  *
  * Manages transfer lists for e-Depot overbrenging workflow.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Edepot
  *

--- a/lib/Service/Edepot/Transport/OpenConnectorTransport.php
+++ b/lib/Service/Edepot/Transport/OpenConnectorTransport.php
@@ -5,6 +5,9 @@
  *
  * Transmits SIP packages to e-Depot systems via OpenConnector synchronization.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Edepot\Transport
  *

--- a/lib/Service/Edepot/Transport/RestApiTransport.php
+++ b/lib/Service/Edepot/Transport/RestApiTransport.php
@@ -5,6 +5,9 @@
  *
  * Transmits SIP packages to e-Depot systems via REST API.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Edepot\Transport
  *

--- a/lib/Service/Edepot/Transport/SftpTransport.php
+++ b/lib/Service/Edepot/Transport/SftpTransport.php
@@ -5,6 +5,9 @@
  *
  * Transmits SIP packages to e-Depot systems via SFTP.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Edepot\Transport
  *

--- a/lib/Service/Edepot/Transport/TransportInterface.php
+++ b/lib/Service/Edepot/Transport/TransportInterface.php
@@ -5,6 +5,9 @@
  *
  * Defines the contract for SIP package transport implementations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Edepot\Transport
  *

--- a/lib/Service/Edepot/Transport/TransportResult.php
+++ b/lib/Service/Edepot/Transport/TransportResult.php
@@ -5,6 +5,9 @@
  *
  * Value object representing the result of a SIP transport operation.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Edepot\Transport
  *

--- a/lib/Service/Handler/AgentHandler.php
+++ b/lib/Service/Handler/AgentHandler.php
@@ -5,6 +5,9 @@
  *
  * This file contains the handler class for Agent entity import/export operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Handler
  *

--- a/lib/Service/Handler/ApplicationHandler.php
+++ b/lib/Service/Handler/ApplicationHandler.php
@@ -5,6 +5,9 @@
  *
  * This file contains the handler class for Application entity import/export operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Handler
  *

--- a/lib/Service/Handler/OrganisationHandler.php
+++ b/lib/Service/Handler/OrganisationHandler.php
@@ -5,6 +5,9 @@
  *
  * This file contains the handler class for Organisation entity import/export operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Handler
  *

--- a/lib/Service/Handler/SourceHandler.php
+++ b/lib/Service/Handler/SourceHandler.php
@@ -5,6 +5,9 @@
  *
  * This file contains the handler class for Source entity import/export operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Handler
  *

--- a/lib/Service/Handler/ViewHandler.php
+++ b/lib/Service/Handler/ViewHandler.php
@@ -5,6 +5,9 @@
  *
  * This file contains the handler class for View entity import/export operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Handler
  *

--- a/lib/Service/Index/Backends/Elasticsearch/ElasticsearchDocumentIndexer.php
+++ b/lib/Service/Index/Backends/Elasticsearch/ElasticsearchDocumentIndexer.php
@@ -5,6 +5,9 @@
  *
  * Handles document indexing operations to Elasticsearch.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Index\Backends\Elasticsearch
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/Index/Backends/Elasticsearch/ElasticsearchHttpClient.php
+++ b/lib/Service/Index/Backends/Elasticsearch/ElasticsearchHttpClient.php
@@ -5,6 +5,9 @@
  *
  * Handles HTTP client configuration and basic HTTP operations for Elasticsearch.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Index\Backends\Elasticsearch
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/Index/Backends/Elasticsearch/ElasticsearchIndexManager.php
+++ b/lib/Service/Index/Backends/Elasticsearch/ElasticsearchIndexManager.php
@@ -5,6 +5,9 @@
  *
  * Manages Elasticsearch indices.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Index\Backends\Elasticsearch
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/Index/Backends/Elasticsearch/ElasticsearchQueryExecutor.php
+++ b/lib/Service/Index/Backends/Elasticsearch/ElasticsearchQueryExecutor.php
@@ -5,6 +5,9 @@
  *
  * Manages search queries and execution for Elasticsearch.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Index\Backends\Elasticsearch
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/Index/Backends/ElasticsearchBackend.php
+++ b/lib/Service/Index/Backends/ElasticsearchBackend.php
@@ -5,6 +5,9 @@
  *
  * Elasticsearch backend implementation for OpenRegister search operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Index\Backends
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/Index/Backends/Solr/SolrCollectionManager.php
+++ b/lib/Service/Index/Backends/Solr/SolrCollectionManager.php
@@ -6,6 +6,9 @@
  * Manages Solr collections and ConfigSets.
  * Handles creation, deletion, and existence checks for collections.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Index\Backends\Solr
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/Index/Backends/Solr/SolrDocumentIndexer.php
+++ b/lib/Service/Index/Backends/Solr/SolrDocumentIndexer.php
@@ -6,6 +6,9 @@
  * Handles document indexing operations to Solr.
  * Manages single and bulk indexing, deletions, and commits.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Index\Backends\Solr
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/Index/Backends/Solr/SolrFacetProcessor.php
+++ b/lib/Service/Index/Backends/Solr/SolrFacetProcessor.php
@@ -6,6 +6,9 @@
  * Handles facet processing operations for Solr.
  * Manages facet discovery, building, and formatting.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Index\Backends\Solr
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/Index/Backends/Solr/SolrHttpClient.php
+++ b/lib/Service/Index/Backends/Solr/SolrHttpClient.php
@@ -6,6 +6,9 @@
  * Handles HTTP client configuration and basic HTTP operations for Solr.
  * Responsible for building URLs, managing HTTP client, and making requests.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Index\Backends\Solr
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/Index/Backends/Solr/SolrQueryExecutor.php
+++ b/lib/Service/Index/Backends/Solr/SolrQueryExecutor.php
@@ -6,6 +6,9 @@
  * Handles query execution and search operations for Solr.
  * Manages query building, execution, and result parsing.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Index\Backends\Solr
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/Index/Backends/Solr/SolrSchemaManager.php
+++ b/lib/Service/Index/Backends/Solr/SolrSchemaManager.php
@@ -6,6 +6,9 @@
  * Manages Solr schema operations.
  * Handles field types, field management, and schema synchronization.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Index\Backends\Solr
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/Index/Backends/SolrBackend.php
+++ b/lib/Service/Index/Backends/SolrBackend.php
@@ -6,6 +6,9 @@
  * Solr backend implementation for OpenRegister search operations.
  * Coordinates specialized Solr service classes to provide SearchBackendInterface.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Index\Backends
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/Index/BulkIndexer.php
+++ b/lib/Service/Index/BulkIndexer.php
@@ -6,6 +6,9 @@
  * Handles bulk indexing business logic (batching, parallel processing, optimization).
  * Does NOT contain backend-specific I/O - delegates to SearchBackendInterface.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Index
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/Index/ConfigurationHandler.php
+++ b/lib/Service/Index/ConfigurationHandler.php
@@ -5,6 +5,9 @@
  *
  * Handles Solr configuration initialization, validation, and management.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service\Index
  *

--- a/lib/Service/Index/DocumentBuilder.php
+++ b/lib/Service/Index/DocumentBuilder.php
@@ -6,6 +6,9 @@
  * Handles building Solr documents from ObjectEntity instances.
  * Extracted from SolrBackend to separate document creation logic.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Index
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/Index/FacetBuilder.php
+++ b/lib/Service/Index/FacetBuilder.php
@@ -6,6 +6,9 @@
  * Handles Solr facet building operations.
  * Extracted from GuzzleSolrService to separate facet logic.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Index
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/Index/FileHandler.php
+++ b/lib/Service/Index/FileHandler.php
@@ -6,6 +6,9 @@
  * Handles file chunk indexing to Solr/Elasticsearch.
  * Reads chunks from database (created by TextExtractionService) and indexes them.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Index
  *

--- a/lib/Service/Index/ObjectHandler.php
+++ b/lib/Service/Index/ObjectHandler.php
@@ -6,6 +6,9 @@
  * Handles object indexing and search in Solr/Elasticsearch.
  * Reads objects from database and indexes them - does NOT extract text or vectorize.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Index
  *

--- a/lib/Service/Index/SchemaHandler.php
+++ b/lib/Service/Index/SchemaHandler.php
@@ -6,6 +6,9 @@
  * Handles schema management operations for Solr collections.
  * Manages field types, schema mirroring, and collection field status.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Index
  *

--- a/lib/Service/Index/SchemaMapper.php
+++ b/lib/Service/Index/SchemaMapper.php
@@ -5,6 +5,9 @@
  *
  * Handles mapping between OpenRegister schemas and search backend schemas.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Index
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Service/Index/SearchBackendInterface.php
+++ b/lib/Service/Index/SearchBackendInterface.php
@@ -9,6 +9,9 @@
  * allowing the IndexService to be backend-agnostic and support multiple search
  * technologies without code changes.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Interface
  * @package  OCA\OpenRegister\Service\Index
  *

--- a/lib/Service/Index/SetupHandler.php
+++ b/lib/Service/Index/SetupHandler.php
@@ -5,6 +5,9 @@
  *
  * Setup class for SOLR configuration in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Index
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/Index/WarmupHandler.php
+++ b/lib/Service/Index/WarmupHandler.php
@@ -6,6 +6,9 @@
  * Handles Solr index warmup operations.
  * Extracted from GuzzleSolrService to separate warmup logic.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Index
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/Integration/Providers/CalendarProvider.php
+++ b/lib/Service/Integration/Providers/CalendarProvider.php
@@ -21,6 +21,9 @@
  * registry-driven sidebar uses for rendering, with `delete()` wired so
  * the unified inline unlink works out of the box.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Integration\Providers
  *

--- a/lib/Service/Integration/Providers/ContactsProvider.php
+++ b/lib/Service/Integration/Providers/ContactsProvider.php
@@ -18,6 +18,9 @@
  * ContactsController routes; the registry's generic create() would lose
  * that distinction.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Integration\Providers
  *

--- a/lib/Service/Integration/Providers/DeckProvider.php
+++ b/lib/Service/Integration/Providers/DeckProvider.php
@@ -12,6 +12,9 @@
  * either `cardId` (link existing) or `boardId + stackId + title`
  * (create new), matching DeckCardService::linkOrCreateCard.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Integration\Providers
  *

--- a/lib/Service/Integration/Providers/EmailProvider.php
+++ b/lib/Service/Integration/Providers/EmailProvider.php
@@ -10,6 +10,9 @@
  * offers "link existing message" via account/folder picker (the UI
  * concern), and the provider exposes that link path through `create()`.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Integration\Providers
  *

--- a/lib/Service/Integration/Providers/OpenProjectProvider.php
+++ b/lib/Service/Integration/Providers/OpenProjectProvider.php
@@ -16,6 +16,9 @@
  * No NC app is required — OpenProject is external; the only install
  * dependency is OpenConnector (which carries the source + credentials).
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Integration\Providers
  *

--- a/lib/Service/Integration/Providers/PollsProvider.php
+++ b/lib/Service/Integration/Providers/PollsProvider.php
@@ -8,6 +8,9 @@
  * object ↔ poll); the wrapping PollsService lands in a follow-up —
  * this provider registers the registry surface today.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Integration\Providers
  *

--- a/lib/Service/Integration/Providers/TalkProvider.php
+++ b/lib/Service/Integration/Providers/TalkProvider.php
@@ -11,6 +11,9 @@
  * NB: NC Talk's internal app id is `spreed`, not `talk` — that's what
  * IAppManager resolves against.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Integration\Providers
  *

--- a/lib/Service/Mcp/McpProtocolService.php
+++ b/lib/Service/Mcp/McpProtocolService.php
@@ -6,6 +6,9 @@
  * Handles Model Context Protocol (MCP) standard handshake, session management,
  * and protocol-level operations for the OpenRegister MCP server.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Mcp
  *

--- a/lib/Service/Mcp/McpResourcesService.php
+++ b/lib/Service/Mcp/McpResourcesService.php
@@ -6,6 +6,9 @@
  * Handles MCP standard resource listing, reading, and URI template
  * operations for the OpenRegister MCP server.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Mcp
  *

--- a/lib/Service/Mcp/McpToolsService.php
+++ b/lib/Service/Mcp/McpToolsService.php
@@ -9,6 +9,9 @@
  * their tool descriptors. Namespace enforcement (ADR-034 D5) rejects any
  * descriptor whose id does not start with `{provider->getAppId()}.`.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Mcp
  *

--- a/lib/Service/Notification/AnnotationNotificationDispatcher.php
+++ b/lib/Service/Notification/AnnotationNotificationDispatcher.php
@@ -8,6 +8,9 @@
  * matches. v1 supports trigger types created/updated/transition,
  * recipient kinds users/field, channel `nc-notification`.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Notification
  *

--- a/lib/Service/Notification/NotificationAnnotationValidator.php
+++ b/lib/Service/Notification/NotificationAnnotationValidator.php
@@ -5,6 +5,9 @@
  *
  * Schema-save validation for the `x-openregister-notifications` annotation.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Notification
  *

--- a/lib/Service/Notification/NotificationCoalescer.php
+++ b/lib/Service/Notification/NotificationCoalescer.php
@@ -19,6 +19,9 @@
  * window state survives across requests + (with Redis) across
  * cluster nodes.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Notification
  *

--- a/lib/Service/Notification/NotificationDigest.php
+++ b/lib/Service/Notification/NotificationDigest.php
@@ -14,6 +14,9 @@
  * NotificationCoalescer (already in the codebase) for content-side
  * deduplication.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Notification
  *

--- a/lib/Service/Notification/NotificationReadState.php
+++ b/lib/Service/Notification/NotificationReadState.php
@@ -19,6 +19,9 @@
  * (`oc_openregister_notification_readstate` table with a unique
  * `(user_id, notification_id)` index) follows exactly these semantics.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Notification
  *

--- a/lib/Service/Notification/NotificationsAnnotationInstaller.php
+++ b/lib/Service/Notification/NotificationsAnnotationInstaller.php
@@ -9,6 +9,9 @@
  * pipeline (retry, HMAC, dead-letter, multi-tenancy) handles
  * dispatch instead of the inline fire-and-forget POST.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Notification
  *

--- a/lib/Service/Notification/RateLimiter.php
+++ b/lib/Service/Notification/RateLimiter.php
@@ -10,6 +10,9 @@
  * size. When a token isn't available the dispatch is dropped and
  * logged at info level — operators who care can grep for it.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Notification
  *

--- a/lib/Service/Notification/RecipientResolverInterface.php
+++ b/lib/Service/Notification/RecipientResolverInterface.php
@@ -8,6 +8,9 @@
  * implementation under a DI tag; the schema's notification annotation
  * references the tag via `{kind: "expression", resolver: "<tag>"}`.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Notification
  *

--- a/lib/Service/Notification/VngNotificatiesEnvelope.php
+++ b/lib/Service/Notification/VngNotificatiesEnvelope.php
@@ -24,6 +24,9 @@
  *   2. the algorithmic correctness has unit-test coverage independent of
  *      the Twig stack.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Notification
  *

--- a/lib/Service/TextExtraction/EntityRecognitionHandler.php
+++ b/lib/Service/TextExtraction/EntityRecognitionHandler.php
@@ -7,6 +7,9 @@
  * from text chunks for GDPR compliance and data classification.
  * This handler is invoked after chunks are created to detect and store entities.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\TextExtraction
  *

--- a/lib/Service/TextExtraction/FileHandler.php
+++ b/lib/Service/TextExtraction/FileHandler.php
@@ -5,6 +5,9 @@
  *
  * Handles text extraction from Nextcloud files.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\TextExtraction
  *

--- a/lib/Service/TextExtraction/ObjectHandler.php
+++ b/lib/Service/TextExtraction/ObjectHandler.php
@@ -5,6 +5,9 @@
  *
  * Handles text extraction from OpenRegister objects.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\TextExtraction
  *

--- a/lib/Service/TextExtraction/TextExtractionHandlerInterface.php
+++ b/lib/Service/TextExtraction/TextExtractionHandlerInterface.php
@@ -7,6 +7,9 @@
  * This allows the TextExtractionService to be generic and extensible
  * for future source types (agenda, email, etc.).
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\TextExtraction
  *

--- a/lib/Service/Translation/IdentityTranslationProvider.php
+++ b/lib/Service/Translation/IdentityTranslationProvider.php
@@ -9,6 +9,9 @@
  * (LibreTranslate / DeepL / Google) in `Application.php` to get
  * actual machine translations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Translation
  *

--- a/lib/Service/Translation/TranslationCsvCodec.php
+++ b/lib/Service/Translation/TranslationCsvCodec.php
@@ -9,6 +9,9 @@
  * `ExportService::exportToCsv` once they're updated to be
  * translation-aware (Phase 2.3 wire-in).
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Translation
  *

--- a/lib/Service/Translation/TranslationProviderInterface.php
+++ b/lib/Service/Translation/TranslationProviderInterface.php
@@ -9,6 +9,9 @@
  * the source text verbatim) so the bulk-translate UI works for testing
  * without provisioning external API keys.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Translation
  *

--- a/lib/Service/Vectorization/Handlers/EmbeddingGeneratorHandler.php
+++ b/lib/Service/Vectorization/Handlers/EmbeddingGeneratorHandler.php
@@ -5,6 +5,9 @@
  *
  * Manages creation and caching of embedding generators for different LLM providers.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Vectorization\Handlers
  *

--- a/lib/Service/Vectorization/Handlers/VectorSearchHandler.php
+++ b/lib/Service/Vectorization/Handlers/VectorSearchHandler.php
@@ -5,6 +5,9 @@
  *
  * Handles semantic and hybrid search operations using vectors.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Vectorization\Handlers
  *

--- a/lib/Service/Vectorization/Handlers/VectorStatsHandler.php
+++ b/lib/Service/Vectorization/Handlers/VectorStatsHandler.php
@@ -5,6 +5,9 @@
  *
  * Handles gathering statistics about stored vectors from database and Solr.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Vectorization\Handlers
  *

--- a/lib/Service/Vectorization/Handlers/VectorStorageHandler.php
+++ b/lib/Service/Vectorization/Handlers/VectorStorageHandler.php
@@ -5,6 +5,9 @@
  *
  * Handles storing vector embeddings in database and Solr.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Vectorization\Handlers
  *

--- a/lib/Service/Vectorization/Strategies/FileVectorizationStrategy.php
+++ b/lib/Service/Vectorization/Strategies/FileVectorizationStrategy.php
@@ -5,6 +5,9 @@
  *
  * Strategy for vectorizing file chunks.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Vectorization
  *

--- a/lib/Service/Vectorization/Strategies/ObjectVectorizationStrategy.php
+++ b/lib/Service/Vectorization/Strategies/ObjectVectorizationStrategy.php
@@ -5,6 +5,9 @@
  *
  * Strategy for vectorizing OpenRegister objects.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Vectorization
  *

--- a/lib/Service/Vectorization/Strategies/VectorizationStrategyInterface.php
+++ b/lib/Service/Vectorization/Strategies/VectorizationStrategyInterface.php
@@ -5,6 +5,9 @@
  *
  * Defines contract for entity-specific vectorization logic.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Vectorization
  *

--- a/lib/Service/Vectorization/VectorEmbeddings.php
+++ b/lib/Service/Vectorization/VectorEmbeddings.php
@@ -6,6 +6,9 @@
  * Main entry point for all vector embedding operations.
  * Coordinates handlers for generation, storage, search, and statistics.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Vectorization
  *

--- a/lib/Service/Webhook/CloudEventFormatter.php
+++ b/lib/Service/Webhook/CloudEventFormatter.php
@@ -5,6 +5,9 @@
  *
  * Formatter for creating CloudEvents specification compliant webhook payloads.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Webhook
  *


### PR DESCRIPTION
Mechanical SPDX header sweep — part **3 of 7** from the openregister coverage-scan retrofit (2026-05-24).

Adds the two SPDX lines to the existing file docblock of every file in scope:

```
 * SPDX-License-Identifier: EUPL-1.2
 * SPDX-FileCopyrightText: 2026 Conduction B.V.
```

Per ADR-014 and the convention in existing files (e.g. `lib/Service/AvgComplianceService.php`) — SPDX lives inside the docblock, not as line comments before/after.

## Scope (80 files)

lib/Service/Index/ (23), lib/Service/Vectorization/ (8), lib/Service/Notification/ (9), lib/Service/Edepot/ (9), lib/Service/Integration/ (7), lib/Service/Chat/ (5), lib/Service/Handler/ (5), lib/Service/TextExtraction/ (4), lib/Service/Calculation/ (3), lib/Service/Mcp/ (3), lib/Service/Translation/ (3), lib/Service/Webhook/ (1)

## Companion PRs

- #1737 — 1/7 (misc bundle, 84 files)
- the other 5 in this series are in flight alongside this one

## Test plan

- [ ] CI green (PHPCS / PHPMD / PHPStan / Psalm)
- [ ] No functional change — every diff hunk is comment-only