### PR TITLE
chore(spdx): EUPL-1.2 SPDX headers — Service: config, archival, OAS + flat files (Bucket 4, 4/7)

### DIFF
--- a/lib/Service/ActionExecutor.php
+++ b/lib/Service/ActionExecutor.php
@@ -5,6 +5,9 @@
  *
  * Orchestrates action execution for lifecycle events.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/ActionService.php
+++ b/lib/Service/ActionService.php
@@ -5,6 +5,9 @@
  *
  * Business logic for Action entity management.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/ActivityService.php
+++ b/lib/Service/ActivityService.php
@@ -5,6 +5,9 @@
  *
  * Service for publishing OpenRegister activity events to the Nextcloud activity stream.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/ApplicationService.php
+++ b/lib/Service/ApplicationService.php
@@ -5,6 +5,9 @@
  *
  * This file contains the service class for managing applications.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/ApprovalService.php
+++ b/lib/Service/ApprovalService.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister ApprovalService
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/Archival/ArchiefactiedatumCalculator.php
+++ b/lib/Service/Archival/ArchiefactiedatumCalculator.php
@@ -6,6 +6,9 @@
  * Calculates the archive action date (archiefactiedatum) using configurable
  * derivation methods (afleidingswijzen) as defined by the ZGW API standard.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Archival
  *

--- a/lib/Service/Archival/ArchivalAnnotationValidator.php
+++ b/lib/Service/Archival/ArchivalAnnotationValidator.php
@@ -12,6 +12,9 @@
  * row matches the rule's `condition`. Validation is shape-only at save
  * time; the runtime condition grammar lives in `RetentionConditionEvaluator`.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Archival
  *

--- a/lib/Service/Archival/DestructionService.php
+++ b/lib/Service/Archival/DestructionService.php
@@ -7,6 +7,9 @@
  * creating destruction lists, handling approvals/rejections, executing
  * destruction, and generating destruction certificates.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Archival
  *

--- a/lib/Service/Archival/LegalHoldService.php
+++ b/lib/Service/Archival/LegalHoldService.php
@@ -6,6 +6,9 @@
  * Manages legal holds (bevriezing) on register objects, preventing destruction
  * regardless of archival dates. Supports WOB/WOO requests and regulatory investigations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Archival
  *

--- a/lib/Service/Archival/RetentionConditionEvaluator.php
+++ b/lib/Service/Archival/RetentionConditionEvaluator.php
@@ -19,6 +19,9 @@
  * is intentionally out of scope. A future change can layer a real
  * expression engine on top if the fleet ever needs it.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Archival
  *

--- a/lib/Service/Archival/RetentionEvaluator.php
+++ b/lib/Service/Archival/RetentionEvaluator.php
@@ -14,6 +14,9 @@
  *   - `ObjectEntity::jsonSerialize()` (via the renderer) to surface the
  *     `_retention` block on read so the UI can show *why* a row is kept.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Archival
  *

--- a/lib/Service/ArchivalService.php
+++ b/lib/Service/ArchivalService.php
@@ -6,6 +6,9 @@
  * Core business logic for archiving and destruction workflows conforming
  * to Dutch archival standards (MDTO, NEN 2082, Archiefwet 1995).
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/AuditHashService.php
+++ b/lib/Service/AuditHashService.php
@@ -6,6 +6,9 @@
  * Provides SHA-256 hash computation, chain verification, and genesis hash management
  * for the immutable audit trail system.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/AuthenticationService.php
+++ b/lib/Service/AuthenticationService.php
@@ -3,6 +3,9 @@
 /**
  * Authentication Service for generating outbound tokens.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/AuthorizationAuditService.php
+++ b/lib/Service/AuthorizationAuditService.php
@@ -6,6 +6,9 @@
  * Logs all changes to authorization configuration on registers and schemas.
  * Provides structured audit entries for compliance and debugging.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Service/AuthorizationService.php
+++ b/lib/Service/AuthorizationService.php
@@ -3,6 +3,9 @@
 /**
  * Authorization Service for validating incoming API requests.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/BulkTranslationService.php
+++ b/lib/Service/BulkTranslationService.php
@@ -14,6 +14,9 @@
  * The actual saveObject path is left to the caller — this service is
  * a pure translation step that returns the patch the caller applies.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/CalendarEventService.php
+++ b/lib/Service/CalendarEventService.php
@@ -7,6 +7,9 @@
  * Events are stored as standard VEVENT items in the user's Nextcloud calendar with
  * X-OPENREGISTER-* properties for linking and an RFC 9253 LINK property.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/ChatService.php
+++ b/lib/Service/ChatService.php
@@ -6,6 +6,9 @@
  * Service for managing AI chat conversations with RAG (Retrieval Augmented Generation).
  * This is a thin facade that orchestrates specialized handlers.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/ConditionMatcher.php
+++ b/lib/Service/ConditionMatcher.php
@@ -9,6 +9,9 @@
  *
  * Extracted from PropertyRbacHandler to keep class complexity manageable.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Service/Configuration/AttributionFormatter.php
+++ b/lib/Service/Configuration/AttributionFormatter.php
@@ -13,6 +13,9 @@
  * URL) is scoped to task 1.15 (follow-up); this skeleton implementation builds the
  * prefix from the raw values returned by IUserManager + IURLGenerator.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Configuration
  *

--- a/lib/Service/Configuration/CacheHandler.php
+++ b/lib/Service/Configuration/CacheHandler.php
@@ -6,6 +6,9 @@
  * This file contains the handler for caching configurations in the user session
  * to avoid excessive database queries when checking if entities are managed by configurations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Configuration
  *

--- a/lib/Service/Configuration/ExportHandler.php
+++ b/lib/Service/Configuration/ExportHandler.php
@@ -6,6 +6,9 @@
  * This file contains the handler class for exporting configurations
  * in OpenAPI format from the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service\Configuration
  *

--- a/lib/Service/Configuration/FetchHandler.php
+++ b/lib/Service/Configuration/FetchHandler.php
@@ -6,6 +6,9 @@
  * This file contains the handler class for fetching configuration data
  * from remote sources (URLs, GitHub, GitLab).
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service\Configuration
  *

--- a/lib/Service/Configuration/GitHubGuards.php
+++ b/lib/Service/Configuration/GitHubGuards.php
@@ -17,6 +17,9 @@
  * Each public guard returns either `null` (continue) or a `JSONResponse` (short-circuit
  * with a structured error). The controller invokes them via the shared `runGuards` pipeline.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Configuration
  *

--- a/lib/Service/Configuration/GitHubHandler.php
+++ b/lib/Service/Configuration/GitHubHandler.php
@@ -6,6 +6,9 @@
  * This file contains the GitHubHandler class for interacting with the GitHub API
  * to discover, fetch, and manage OpenRegister configurations stored in GitHub repositories.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service\Configuration
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Service/Configuration/GitHubRequestValidator.php
+++ b/lib/Service/Configuration/GitHubRequestValidator.php
@@ -13,6 +13,9 @@
  * threshold and the two responsibilities (input validation vs. policy enforcement) stay
  * clearly distinct.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Configuration
  *

--- a/lib/Service/Configuration/GitLabHandler.php
+++ b/lib/Service/Configuration/GitLabHandler.php
@@ -6,6 +6,9 @@
  * This file contains the GitLabHandler class for interacting with the GitLab API
  * to discover, fetch, and manage OpenRegister configurations stored in GitLab repositories.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Configuration
  *

--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -6,6 +6,9 @@
  * This file contains the handler class for importing configurations
  * from various sources in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service\Configuration
  *

--- a/lib/Service/Configuration/PreviewHandler.php
+++ b/lib/Service/Configuration/PreviewHandler.php
@@ -6,6 +6,9 @@
  * This file contains the handler class for previewing configuration changes
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service\Configuration
  *

--- a/lib/Service/Configuration/RateLimiterService.php
+++ b/lib/Service/Configuration/RateLimiterService.php
@@ -20,6 +20,9 @@
  * Both return `null` when within budget and an `int` (whole seconds until the window
  * resets) when the budget is exhausted.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Configuration
  *

--- a/lib/Service/Configuration/UploadHandler.php
+++ b/lib/Service/Configuration/UploadHandler.php
@@ -6,6 +6,9 @@
  * This file contains the handler class for processing file uploads
  * and parsing JSON/YAML data in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service\Configuration
  *

--- a/lib/Service/ConfigurationService.php
+++ b/lib/Service/ConfigurationService.php
@@ -6,6 +6,9 @@
  * This file contains the service class for handling configuration imports and exports
  * in the OpenRegister application, supporting various formats including OpenAPI.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/ContactMatchingService.php
+++ b/lib/Service/ContactMatchingService.php
@@ -6,6 +6,9 @@
  * Shared service for matching contact metadata (email, name, organization)
  * to OpenRegister entities with APCu caching.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/ContactService.php
+++ b/lib/Service/ContactService.php
@@ -6,6 +6,9 @@
  * Service that wraps CardDAV vCard operations for linking contacts to OpenRegister objects.
  * Uses dual storage: X-OPENREGISTER-* vCard properties + openregister_contact_links table.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/DashboardService.php
+++ b/lib/Service/DashboardService.php
@@ -6,6 +6,9 @@
  * This file contains the service class for handling dashboard related operations
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/DateTimeNormalizer.php
+++ b/lib/Service/DateTimeNormalizer.php
@@ -12,6 +12,9 @@
  * delegate to this class. Direct use of `new DateTime($value)` on user data
  * is forbidden — see OpenSpec change `fix-empty-string-date-conversion`.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Service/DeckCardService.php
+++ b/lib/Service/DeckCardService.php
@@ -6,6 +6,9 @@
  * Service that wraps Nextcloud Deck card operations for linking cards to OpenRegister objects.
  * Uses the Deck app's internal PHP service classes when available.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/DeepLinkRegistryService.php
+++ b/lib/Service/DeepLinkRegistryService.php
@@ -5,6 +5,9 @@
  *
  * Registry service for deep link registrations from consuming apps.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/DownloadService.php
+++ b/lib/Service/DownloadService.php
@@ -8,6 +8,9 @@
  * This service provides methods for:
  * - Downloading objects as files.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/EmailService.php
+++ b/lib/Service/EmailService.php
@@ -6,6 +6,9 @@
  * Service that wraps Nextcloud Mail message lookups and manages email-to-object links.
  * Emails are immutable; this service only creates/removes link references.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/EndpointService.php
+++ b/lib/Service/EndpointService.php
@@ -5,6 +5,9 @@
  *
  * Service for handling endpoint execution and management.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/ExportService.php
+++ b/lib/Service/ExportService.php
@@ -5,6 +5,9 @@
  *
  * This file contains the class for handling data export operations in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -15,6 +15,9 @@
  * - Object-specific file operations
  * - Audit trails and data aggregation
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/FileSidebarService.php
+++ b/lib/Service/FileSidebarService.php
@@ -7,6 +7,9 @@
  * OpenRegister objects that reference a given file ID and aggregating
  * extraction / entity-recognition metadata for the Extraction tab.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/GraphQL/GraphQLErrorFormatter.php
+++ b/lib/Service/GraphQL/GraphQLErrorFormatter.php
@@ -5,6 +5,9 @@
  *
  * Formats GraphQL errors into structured responses with extension codes.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\GraphQL
  *

--- a/lib/Service/GraphQL/GraphQLResolver.php
+++ b/lib/Service/GraphQL/GraphQLResolver.php
@@ -6,6 +6,9 @@
  * Resolves GraphQL queries, mutations, and fields by delegating
  * to OpenRegister services with RBAC enforcement and DataLoader batching.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\GraphQL
  * @author   Conduction B.V. <info@conduction.nl>

--- a/lib/Service/GraphQL/GraphQLService.php
+++ b/lib/Service/GraphQL/GraphQLService.php
@@ -5,6 +5,9 @@
  *
  * Main service for executing GraphQL queries with schema caching and complexity analysis.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\GraphQL
  *

--- a/lib/Service/GraphQL/QueryComplexityAnalyzer.php
+++ b/lib/Service/GraphQL/QueryComplexityAnalyzer.php
@@ -5,6 +5,9 @@
  *
  * Analyzes GraphQL query complexity and enforces limits to prevent resource abuse.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\GraphQL
  *

--- a/lib/Service/GraphQL/Scalar/DateTimeType.php
+++ b/lib/Service/GraphQL/Scalar/DateTimeType.php
@@ -5,6 +5,9 @@
  *
  * Handles serialization and parsing of ISO 8601 date-time strings.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\GraphQL\Scalar
  *

--- a/lib/Service/GraphQL/Scalar/EmailType.php
+++ b/lib/Service/GraphQL/Scalar/EmailType.php
@@ -5,6 +5,9 @@
  *
  * Validates and handles RFC 5321 email address strings.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\GraphQL\Scalar
  *

--- a/lib/Service/GraphQL/Scalar/JsonType.php
+++ b/lib/Service/GraphQL/Scalar/JsonType.php
@@ -5,6 +5,9 @@
  *
  * Handles arbitrary JSON values including objects, arrays, and scalars.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\GraphQL\Scalar
  *

--- a/lib/Service/GraphQL/Scalar/UploadType.php
+++ b/lib/Service/GraphQL/Scalar/UploadType.php
@@ -5,6 +5,9 @@
  *
  * Follows the GraphQL multipart request specification for file uploads.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\GraphQL\Scalar
  *

--- a/lib/Service/GraphQL/Scalar/UriType.php
+++ b/lib/Service/GraphQL/Scalar/UriType.php
@@ -5,6 +5,9 @@
  *
  * Validates and handles RFC 3986 URI strings.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\GraphQL\Scalar
  *

--- a/lib/Service/GraphQL/Scalar/UuidType.php
+++ b/lib/Service/GraphQL/Scalar/UuidType.php
@@ -5,6 +5,9 @@
  *
  * Validates and handles UUID v4 format strings.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\GraphQL\Scalar
  *

--- a/lib/Service/GraphQL/SchemaGenerator.php
+++ b/lib/Service/GraphQL/SchemaGenerator.php
@@ -10,6 +10,9 @@
  * Delegates type mapping to TypeMapperHandler and composition logic to
  * CompositionHandler to keep class complexity manageable.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\GraphQL
  * @author   Conduction B.V. <info@conduction.nl>

--- a/lib/Service/GraphQL/SchemaGenerator/CompositionHandler.php
+++ b/lib/Service/GraphQL/SchemaGenerator/CompositionHandler.php
@@ -5,6 +5,9 @@
  *
  * Extracted from SchemaGenerator to reduce class complexity.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\GraphQL\SchemaGenerator
  * @author   Conduction B.V. <info@conduction.nl>

--- a/lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php
+++ b/lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php
@@ -5,6 +5,9 @@
  *
  * Extracted from SchemaGenerator to reduce class complexity.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\GraphQL\SchemaGenerator
  * @author   Conduction B.V. <info@conduction.nl>

--- a/lib/Service/GraphQL/SubscriptionService.php
+++ b/lib/Service/GraphQL/SubscriptionService.php
@@ -6,6 +6,9 @@
  * Manages server-sent event (SSE) subscriptions for GraphQL real-time updates.
  * Bridges OpenRegister's event system to GraphQL subscription delivery.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\GraphQL
  *

--- a/lib/Service/HookExecutor.php
+++ b/lib/Service/HookExecutor.php
@@ -5,6 +5,9 @@
  *
  * Orchestrates schema hook execution for object lifecycle events.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -5,6 +5,9 @@
  *
  * This file contains the class for handling data import operations in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/IndexService.php
+++ b/lib/Service/IndexService.php
@@ -6,6 +6,9 @@
  * Main service for search indexing operations.
  * Acts as a facade coordinating FileHandler, ObjectHandler, and SchemaHandler.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/LanguageService.php
+++ b/lib/Service/LanguageService.php
@@ -6,6 +6,9 @@
  * Request-scoped service that stores the resolved language from the Accept-Language header.
  * Used by RenderObject and SaveObject to determine which translation variant to serve or store.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/Lifecycle/LifecycleAnnotationValidator.php
+++ b/lib/Service/Lifecycle/LifecycleAnnotationValidator.php
@@ -9,6 +9,9 @@
  * Per ADR-024 (hydra#202), schemas declare state machines via this annotation;
  * the implementation is in `lifecycle-annotation` change directory.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Lifecycle
  *

--- a/lib/Service/Lifecycle/LifecycleGuardRegistry.php
+++ b/lib/Service/Lifecycle/LifecycleGuardRegistry.php
@@ -10,6 +10,9 @@
  * Cache per request — multiple transitions on the same object during one
  * request reuse the resolved instance.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Lifecycle
  *

--- a/lib/Service/Lifecycle/TransitionEngine.php
+++ b/lib/Service/Lifecycle/TransitionEngine.php
@@ -9,6 +9,9 @@
  * eventing, and audit machinery runs unchanged), and dispatches the
  * typed ObjectTransitionedEvent.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Lifecycle
  *

--- a/lib/Service/LinkedEntityService.php
+++ b/lib/Service/LinkedEntityService.php
@@ -3,6 +3,9 @@
 /**
  * LinkedEntityService
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Service/LogService.php
+++ b/lib/Service/LogService.php
@@ -5,6 +5,9 @@
  *
  * Service class for handling audit trail logs in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/ManifestService.php
+++ b/lib/Service/ManifestService.php
@@ -14,6 +14,9 @@
  * 4. Logged-in user, profile found → `runtime.user` populated with every
  *    `x-openregister-calculations.*` field evaluated against the profile object.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/MappingService.php
+++ b/lib/Service/MappingService.php
@@ -6,6 +6,9 @@
  * Service for executing data mappings using Twig templating and dot notation.
  * Provides data transformation capabilities between different formats.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/McpDiscoveryService.php
+++ b/lib/Service/McpDiscoveryService.php
@@ -5,6 +5,9 @@
  *
  * Provides AI agents with tiered discovery of OpenRegister's API capabilities.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/MetricsService.php
+++ b/lib/Service/MetricsService.php
@@ -5,6 +5,9 @@
  *
  * Service for tracking and retrieving operational metrics.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/MigrationService.php
+++ b/lib/Service/MigrationService.php
@@ -2,6 +2,9 @@
 /**
  * MigrationService for OpenRegister.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Service/NoteService.php
+++ b/lib/Service/NoteService.php
@@ -6,6 +6,9 @@
  * Service that wraps Nextcloud's ICommentsManager for adding notes to OpenRegister objects.
  * Notes are stored as standard Nextcloud comments with objectType "openregister".
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -6,6 +6,9 @@
  * This file contains the service class for sending notifications
  * about configuration updates in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/Oas/OasETagComputer.php
+++ b/lib/Service/Oas/OasETagComputer.php
@@ -13,6 +13,9 @@
  * `304 Not Modified` when the client sends an `If-None-Match` matching
  * the current ETag.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Oas
  *

--- a/lib/Service/Oas/OasRequestValidator.php
+++ b/lib/Service/Oas/OasRequestValidator.php
@@ -12,6 +12,9 @@
  * Validation errors are emitted in a flat list of `{ path, message }`
  * tuples ready to be wrapped by `ProblemDetailsBuilder::validationFailed`.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Oas
  *

--- a/lib/Service/Oas/ProblemDetailsBuilder.php
+++ b/lib/Service/Oas/ProblemDetailsBuilder.php
@@ -19,6 +19,9 @@
  * HTTP error response carries the same machine-readable shape and the
  * `Content-Type: application/problem+json` header.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Oas
  *

--- a/lib/Service/OasService.php
+++ b/lib/Service/OasService.php
@@ -5,6 +5,9 @@
  *
  * This service generates OpenAPI Specification (OAS) documentation for registers and schemas.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -8,6 +8,9 @@
  * This service acts as a facade for the various object handlers,
  * coordinating operations between them and maintaining state.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service\Objects
  *

--- a/lib/Service/ObjectServiceMapperAdapter.php
+++ b/lib/Service/ObjectServiceMapperAdapter.php
@@ -2,6 +2,9 @@
 /**
  * Adapter that exposes a mapper-like API over ObjectService.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Service/OperatorEvaluator.php
+++ b/lib/Service/OperatorEvaluator.php
@@ -9,6 +9,9 @@
  * Extracted from PropertyRbacHandler / ConditionMatcher to keep class
  * complexity manageable.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Service/OrganisationService.php
+++ b/lib/Service/OrganisationService.php
@@ -6,6 +6,9 @@
  * This file contains the service class for managing organisations and multi-tenancy.
  * Handles user-organisation relationships, session management, and organisational context.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/PropertyRbacHandler.php
+++ b/lib/Service/PropertyRbacHandler.php
@@ -27,6 +27,9 @@
  *   }
  * }
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Service/RealtimeService.php
+++ b/lib/Service/RealtimeService.php
@@ -21,6 +21,9 @@
  *   - debounce / batch coalescing
  *   - frontend reactive store wiring
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/RegisterService.php
+++ b/lib/Service/RegisterService.php
@@ -8,6 +8,9 @@
  * This service acts as a facade for register operations,
  * coordinating between RegisterMapper and FileService.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/Registers/RegisterCacheHandler.php
+++ b/lib/Service/Registers/RegisterCacheHandler.php
@@ -10,6 +10,9 @@
  * cache window on {@see \OCA\OpenRegister\Db\RegisterMapper} so that follow-up
  * reads in the same PHP worker observe a fresh state.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Registers
  *

--- a/lib/Service/RequestScopedCache.php
+++ b/lib/Service/RequestScopedCache.php
@@ -7,6 +7,9 @@
  * HTTP request. Nextcloud DI registers services as shared by default, so all
  * service injections within one request receive the same instance.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/RetentionService.php
+++ b/lib/Service/RetentionService.php
@@ -6,6 +6,9 @@
  * Orchestrates archival lifecycle operations: metadata population, archiefactiedatum
  * calculation, selectielijst lookup, legal hold management, and destruction coordination.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/RiskLevelService.php
+++ b/lib/Service/RiskLevelService.php
@@ -20,6 +20,9 @@
  * If the total entity count exceeds 50, the risk level is escalated by one tier
  * (capped at very_high).
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/SchemaService.php
+++ b/lib/Service/SchemaService.php
@@ -6,6 +6,9 @@
  * This file contains the service class for handling schema exploration and analysis
  * operations in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/SearchTrailService.php
+++ b/lib/Service/SearchTrailService.php
@@ -9,6 +9,9 @@
  *
  * This service also supports self-clearing (automatic cleanup) of old search trails.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/SecurityService.php
+++ b/lib/Service/SecurityService.php
@@ -5,6 +5,9 @@
  *
  * Service for handling security measures including rate limiting and XSS protection.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/Settings/CacheSettingsHandler.php
+++ b/lib/Service/Settings/CacheSettingsHandler.php
@@ -5,6 +5,9 @@
  *
  * This file contains the handler class for managing cache operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Settings
  *

--- a/lib/Service/Settings/ConfigurationSettingsHandler.php
+++ b/lib/Service/Settings/ConfigurationSettingsHandler.php
@@ -5,6 +5,9 @@
  *
  * This file contains the handler class for managing general configuration settings.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Settings
  *

--- a/lib/Service/Settings/FileSettingsHandler.php
+++ b/lib/Service/Settings/FileSettingsHandler.php
@@ -5,6 +5,9 @@
  *
  * This file contains the handler class for managing file management configuration.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Settings
  *

--- a/lib/Service/Settings/LlmSettingsHandler.php
+++ b/lib/Service/Settings/LlmSettingsHandler.php
@@ -5,6 +5,9 @@
  *
  * This file contains the handler class for managing LLM provider configuration.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Settings
  *

--- a/lib/Service/Settings/ObjectRetentionHandler.php
+++ b/lib/Service/Settings/ObjectRetentionHandler.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister Object and Retention Settings Handler
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Settings
  *

--- a/lib/Service/Settings/SearchBackendHandler.php
+++ b/lib/Service/Settings/SearchBackendHandler.php
@@ -5,6 +5,9 @@
  *
  * This file contains the handler class for managing search backend configuration.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Settings
  *

--- a/lib/Service/Settings/SolrSettingsHandler.php
+++ b/lib/Service/Settings/SolrSettingsHandler.php
@@ -5,6 +5,9 @@
  *
  * This file contains the handler class for managing SOLR configuration and operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service\Settings
  *

--- a/lib/Service/Settings/ValidationOperationsHandler.php
+++ b/lib/Service/Settings/ValidationOperationsHandler.php
@@ -5,6 +5,9 @@
  *
  * Handles administrative validation operations for all objects in the system.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Handler
  * @package  OCA\OpenRegister\Service\Settings
  *

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -5,6 +5,9 @@
  *
  * This file contains the service class for handling settings in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/TaskService.php
+++ b/lib/Service/TaskService.php
@@ -7,6 +7,9 @@
  * Tasks are stored as standard VTODO items in the user's Nextcloud calendar with
  * X-OPENREGISTER-* properties for linking and an RFC 9253 LINK property.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Service
  * @package   OCA\OpenRegister\Service
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Service/TenantKeyService.php
+++ b/lib/Service/TenantKeyService.php
@@ -16,6 +16,9 @@
  * - This service is an internal server-side API only; it is not wired
  *   into any HTTP controller.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/TenantLifecycleService.php
+++ b/lib/Service/TenantLifecycleService.php
@@ -7,6 +7,9 @@
  * provisioning -> active -> suspended -> deprovisioning -> archived.
  * Also handles reactivation from suspended back to active.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/TextExtractionService.php
+++ b/lib/Service/TextExtractionService.php
@@ -6,6 +6,9 @@
  * This service handles all text extraction logic for files in the system.
  * It consolidates extraction workflows, file tracking, and re-extraction detection.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/TmloService.php
+++ b/lib/Service/TmloService.php
@@ -12,6 +12,9 @@
  * - TMLO field value validation
  * - MDTO-compliant XML export generation
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/ToolRegistry.php
+++ b/lib/Service/ToolRegistry.php
@@ -6,6 +6,9 @@
  * Central registry for managing LLphant function tools from all apps.
  * Allows other Nextcloud apps to register their own tools for agents to use.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/TranslationProjectionService.php
+++ b/lib/Service/TranslationProjectionService.php
@@ -11,6 +11,9 @@
  * is a derived projection optimised for per-language search,
  * completeness queries, and workflow status tracking.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/TranslationStatusService.php
+++ b/lib/Service/TranslationStatusService.php
@@ -7,6 +7,9 @@
  * per-object completeness queries, search, and bulk discovery
  * ("find objects missing X translation").
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/UploadService.php
+++ b/lib/Service/UploadService.php
@@ -14,6 +14,9 @@
  * - CRUD operations on objects
  * - Audit trails and data aggregation
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/UrnService.php
+++ b/lib/Service/UrnService.php
@@ -8,6 +8,9 @@
  * across instance migrations: `urn:nl-or:{instance}:{register}:{schema}:{uuid}`.
  * Resolution is bidirectional — URN → API URL and URL → URN.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -7,6 +7,9 @@
  * updates, and profile management. It centralizes user operations and provides
  * a clean interface for controllers and other services.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/VectorizationService.php
+++ b/lib/Service/VectorizationService.php
@@ -6,6 +6,9 @@
  * Generic service for vectorizing any entity type (objects, files, etc).
  * Uses strategy pattern for entity-specific logic.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/ViewService.php
+++ b/lib/Service/ViewService.php
@@ -8,6 +8,9 @@
  * This service acts as a facade for view operations,
  * coordinating between ViewMapper and business logic.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/WebhookService.php
+++ b/lib/Service/WebhookService.php
@@ -5,6 +5,9 @@
  *
  * Service for handling webhook delivery.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *

--- a/lib/Service/WorkflowEngineRegistry.php
+++ b/lib/Service/WorkflowEngineRegistry.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister WorkflowEngineRegistry
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Service
  * @package  OCA\OpenRegister\Service
  *


### PR DESCRIPTION
Mechanical SPDX header sweep — part **4 of 7** from the openregister coverage-scan retrofit (2026-05-24).

Adds the two SPDX lines to the existing file docblock of every file in scope:

```
 * SPDX-License-Identifier: EUPL-1.2
 * SPDX-FileCopyrightText: 2026 Conduction B.V.
```

Per ADR-014 and the convention in existing files (e.g. `lib/Service/AvgComplianceService.php`) — SPDX lives inside the docblock, not as line comments before/after.

## Scope (117 files)

lib/Service/GraphQL/ (14), lib/Service/Configuration/ (12), lib/Service/Settings/ (8), lib/Service/Archival/ (6), lib/Service/Lifecycle/ (3), lib/Service/Oas/ (3), lib/Service/Registers/ (1) + 70 flat lib/Service/*.php files

## Companion PRs

- #1737 — 1/7 (misc bundle, 84 files)
- the other 5 in this series are in flight alongside this one

## Test plan

- [ ] CI green (PHPCS / PHPMD / PHPStan / Psalm)
- [ ] No functional change — every diff hunk is comment-only