### PR TITLE
chore(spdx): EUPL-1.2 SPDX headers — Controller (Bucket 4, 5/7)

### DIFF
--- a/lib/Controller/ActionsController.php
+++ b/lib/Controller/ActionsController.php
@@ -5,6 +5,9 @@
  *
  * Controller for handling action management operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/AgentsController.php
+++ b/lib/Controller/AgentsController.php
@@ -5,6 +5,9 @@
  *
  * This file contains the controller for managing AI agents.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/ApplicationsController.php
+++ b/lib/Controller/ApplicationsController.php
@@ -5,6 +5,9 @@
  *
  * This file contains the controller for managing applications.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/ApprovalController.php
+++ b/lib/Controller/ApprovalController.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister ApprovalController
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/ArchivalController.php
+++ b/lib/Controller/ArchivalController.php
@@ -6,6 +6,9 @@
  * Controller for managing archival destruction workflows including
  * destruction lists, legal holds, and destruction certificates.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/AuditTrailController.php
+++ b/lib/Controller/AuditTrailController.php
@@ -7,6 +7,9 @@
  * Provides functionality to retrieve audit trails related to objects within registers and schemas.
  * Includes hash chain verification, verwerkingsregister, and immutability enforcement.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\AppInfo
  *

--- a/lib/Controller/BulkController.php
+++ b/lib/Controller/BulkController.php
@@ -6,6 +6,9 @@
  * Controller for handling bulk operations on objects in the OpenRegister app.
  * Provides endpoints for bulk delete and save operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/CalendarEventsController.php
+++ b/lib/Controller/CalendarEventsController.php
@@ -5,6 +5,9 @@
  *
  * REST controller for calendar event relation operations on OpenRegister objects.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -5,6 +5,9 @@
  *
  * Controller for handling AI chat API endpoints.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/ChatHealthController.php
+++ b/lib/Controller/ChatHealthController.php
@@ -8,6 +8,9 @@
  * the chat backend is configured and reachable — without requiring a
  * Nextcloud session (PublicPage).
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/ChatStreamController.php
+++ b/lib/Controller/ChatStreamController.php
@@ -15,6 +15,9 @@
  * already accommodates this degradation, so no client change is needed
  * when token streaming lands later.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/ConfigurationController.php
+++ b/lib/Controller/ConfigurationController.php
@@ -5,6 +5,9 @@
  *
  * This file contains the controller class for handling configuration-related API requests.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/ConfigurationsController.php
+++ b/lib/Controller/ConfigurationsController.php
@@ -6,6 +6,9 @@
  * This file contains the controller class for handling configuration operations
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/ConsumersController.php
+++ b/lib/Controller/ConsumersController.php
@@ -3,6 +3,9 @@
 /**
  * ConsumersController handles REST API endpoints for consumer management.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/ContactsController.php
+++ b/lib/Controller/ContactsController.php
@@ -5,6 +5,9 @@
  *
  * REST controller for contact relation operations on OpenRegister objects.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Controller/ConversationController.php
+++ b/lib/Controller/ConversationController.php
@@ -5,6 +5,9 @@
  *
  * Controller for handling AI conversation API endpoints.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -6,6 +6,9 @@
  * This file contains the controller for handling dashboard related operations
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Controller/DeckController.php
+++ b/lib/Controller/DeckController.php
@@ -5,6 +5,9 @@
  *
  * REST controller for Deck card relation operations on OpenRegister objects.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Controller/DeletedController.php
+++ b/lib/Controller/DeletedController.php
@@ -6,6 +6,9 @@
  * Controller for managing soft deleted objects in the OpenRegister app.
  * Provides functionality for listing, filtering, restoring, and permanently deleting objects.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/EmailsController.php
+++ b/lib/Controller/EmailsController.php
@@ -5,6 +5,9 @@
  *
  * REST controller for email relation operations on OpenRegister objects.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Controller/EndpointsController.php
+++ b/lib/Controller/EndpointsController.php
@@ -5,6 +5,9 @@
  *
  * Controller for handling endpoint management operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/FileExtractionController.php
+++ b/lib/Controller/FileExtractionController.php
@@ -6,6 +6,9 @@
  * This controller handles file operations and text extraction endpoints.
  * Provides core file extraction functionality accessible via API.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/FileSearchController.php
+++ b/lib/Controller/FileSearchController.php
@@ -5,6 +5,9 @@
  *
  * Controller for file search operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Controller/FileSidebarController.php
+++ b/lib/Controller/FileSidebarController.php
@@ -7,6 +7,9 @@
  * Returns OpenRegister object references and extraction metadata
  * for a given Nextcloud file ID.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/FileTextController.php
+++ b/lib/Controller/FileTextController.php
@@ -5,6 +5,9 @@
  *
  * Controller for file text management operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -5,6 +5,9 @@
  *
  * Controller for file operations in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Controller/GdprEntitiesController.php
+++ b/lib/Controller/GdprEntitiesController.php
@@ -7,6 +7,9 @@
  * Provides endpoints for listing, viewing, and managing detected entities
  * from text extraction and entity recognition.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/GitHubIssuesController.php
+++ b/lib/Controller/GitHubIssuesController.php
@@ -13,6 +13,9 @@
  * by tasks 1.14 – 1.22 and lands in a follow-up commit. This file implements the core
  * proxy shape only (tasks 1.3, 1.5, 1.6, 1.7, 1.8, 1.9).
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/GraphQLController.php
+++ b/lib/Controller/GraphQLController.php
@@ -6,6 +6,9 @@
  * Provides a GraphQL endpoint at /api/graphql and an interactive
  * GraphiQL explorer at /api/graphql/explorer.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/GraphQLSubscriptionController.php
+++ b/lib/Controller/GraphQLSubscriptionController.php
@@ -6,6 +6,9 @@
  * Provides a Server-Sent Events endpoint for GraphQL subscriptions.
  * Clients connect via GET and receive real-time object change events.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -5,6 +5,9 @@
  *
  * Exposes health check endpoint for container orchestration and monitoring.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/HeartbeatController.php
+++ b/lib/Controller/HeartbeatController.php
@@ -6,6 +6,9 @@
  * This file contains the controller class for handling heartbeat requests in the OpenRegister application.
  * Used to keep connections alive during long-running operations to prevent gateway timeouts.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/LinkedEntityController.php
+++ b/lib/Controller/LinkedEntityController.php
@@ -3,6 +3,9 @@
 /**
  * LinkedEntityController
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>

--- a/lib/Controller/ManifestController.php
+++ b/lib/Controller/ManifestController.php
@@ -7,6 +7,9 @@
  * app's bundled manifest.json enriched with a `runtime.user` block built
  * from the authenticated user's OpenRegister profile object.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/MappingsController.php
+++ b/lib/Controller/MappingsController.php
@@ -6,6 +6,9 @@
  * Controller for managing mapping operations in the OpenRegister app.
  * Provides endpoints for CRUD operations on mappings used for data transformation.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/McpController.php
+++ b/lib/Controller/McpController.php
@@ -6,6 +6,9 @@
  * Controller for MCP (Model Context Protocol) discovery endpoints.
  * Provides AI agents with tiered API discovery for OpenRegister.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\AppInfo
  *

--- a/lib/Controller/McpServerController.php
+++ b/lib/Controller/McpServerController.php
@@ -6,6 +6,9 @@
  * Handles the MCP (Model Context Protocol) standard JSON-RPC 2.0 endpoint
  * for the OpenRegister MCP server. Provides Streamable HTTP transport.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -5,6 +5,9 @@
  *
  * Exposes application metrics in Prometheus text exposition format.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/MigrationController.php
+++ b/lib/Controller/MigrationController.php
@@ -5,6 +5,9 @@
  *
  * Controller for storage migration between blob and magic tables.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/NamesController.php
+++ b/lib/Controller/NamesController.php
@@ -11,6 +11,9 @@
  * Utilizes aggressive caching for sub-10ms response times to enable
  * seamless frontend rendering of object names instead of UUIDs.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -6,6 +6,9 @@
  * REST controller for note operations on OpenRegister objects.
  * Follows the FilesController pattern for sub-resource endpoints.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Controller/NotificationHistoryController.php
+++ b/lib/Controller/NotificationHistoryController.php
@@ -9,6 +9,9 @@
  * `Version1Date20260501100000` migration + the `NotificationHistory`
  * entity + the `NotificationHistoryMapper` query API.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/NotificationSubscriptionsController.php
+++ b/lib/Controller/NotificationSubscriptionsController.php
@@ -17,6 +17,9 @@
  *          query: ?registerId=X&schemaId=Y (either may be omitted)
  *          → unsubscribe by tuple
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/OasController.php
+++ b/lib/Controller/OasController.php
@@ -10,6 +10,9 @@
  * response) and `?strict=true` (returns HTTP 422 with the validation report when
  * any validation error is detected, instead of auto-correcting).
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\AppInfo
  *

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -6,6 +6,9 @@
  * Controller for managing object operations in the OpenRegister app.
  * Provides CRUD functionality for objects within registers and schemas.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/OrganisationController.php
+++ b/lib/Controller/OrganisationController.php
@@ -7,6 +7,9 @@
  * Provides API endpoints for organisation management, user-organisation relationships,
  * and session management for active organisations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/RealtimeController.php
+++ b/lib/Controller/RealtimeController.php
@@ -7,6 +7,9 @@
  *   GET /apps/openregister/api/realtime/events?since={cursor}&limit=100
  *     &register=...&schema=...&objectUuid=...&eventType=...
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/RegistersController.php
+++ b/lib/Controller/RegistersController.php
@@ -7,6 +7,9 @@
  * Provides endpoints for CRUD operations, import/export, GitHub publishing,
  * and OpenAPI specification generation.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/RelationsController.php
+++ b/lib/Controller/RelationsController.php
@@ -5,6 +5,9 @@
  *
  * Unified REST controller that aggregates all relation types for an object.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Controller/RetentionController.php
+++ b/lib/Controller/RetentionController.php
@@ -6,6 +6,9 @@
  * Handles API endpoints for destruction list management, legal holds,
  * and archival workflow operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/RevertController.php
+++ b/lib/Controller/RevertController.php
@@ -6,6 +6,9 @@
  * Controller for managing object reversion operations in the OpenRegister app.
  * Provides functionality to revert objects to previous states based on different criteria.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\AppInfo
  *

--- a/lib/Controller/ScheduledWorkflowController.php
+++ b/lib/Controller/ScheduledWorkflowController.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister ScheduledWorkflowController
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/SchemasController.php
+++ b/lib/Controller/SchemasController.php
@@ -7,6 +7,9 @@
  * Provides endpoints for CRUD operations, schema exploration, caching,
  * import/export, and statistics.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/ScopesController.php
+++ b/lib/Controller/ScopesController.php
@@ -11,6 +11,9 @@
  * (register, schema, action) tuples the current user is permitted to
  * perform without having to probe every endpoint.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/SearchController.php
+++ b/lib/Controller/SearchController.php
@@ -5,6 +5,9 @@
  *
  * Controller for handling search operations in the OpenRegister app.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\AppInfo
  *

--- a/lib/Controller/SearchTrailController.php
+++ b/lib/Controller/SearchTrailController.php
@@ -6,6 +6,9 @@
  * Controller for managing search trail operations and analytics in the OpenRegister app.
  * Provides functionality to retrieve search statistics, popular search terms, and search logs.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/Settings/ApiTokenSettingsController.php
+++ b/lib/Controller/Settings/ApiTokenSettingsController.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister API Token Settings Controller
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller\Settings
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Controller/Settings/CacheSettingsController.php
+++ b/lib/Controller/Settings/CacheSettingsController.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister Cache Settings Controller
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller\Settings
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Controller/Settings/ConfigurationSettingsController.php
+++ b/lib/Controller/Settings/ConfigurationSettingsController.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister Configuration Settings Controller
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller\Settings
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Controller/Settings/EdepotSettingsController.php
+++ b/lib/Controller/Settings/EdepotSettingsController.php
@@ -5,6 +5,9 @@
  *
  * Handles e-Depot endpoint configuration and connection testing.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller\Settings
  *

--- a/lib/Controller/Settings/FileSettingsController.php
+++ b/lib/Controller/Settings/FileSettingsController.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister File Settings Controller
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller\Settings
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Controller/Settings/LlmSettingsController.php
+++ b/lib/Controller/Settings/LlmSettingsController.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister LLM Settings Controller
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller\Settings
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Controller/Settings/N8nSettingsController.php
+++ b/lib/Controller/Settings/N8nSettingsController.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister n8n Settings Controller
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller\Settings
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Controller/Settings/SecuritySettingsController.php
+++ b/lib/Controller/Settings/SecuritySettingsController.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister Security Settings Controller
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller\Settings
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Controller/Settings/SolrManagementController.php
+++ b/lib/Controller/Settings/SolrManagementController.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister SOLR Management Controller
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller\Settings
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Controller/Settings/SolrOperationsController.php
+++ b/lib/Controller/Settings/SolrOperationsController.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister SOLR Operations Controller
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller\Settings
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Controller/Settings/SolrSettingsController.php
+++ b/lib/Controller/Settings/SolrSettingsController.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister SOLR Settings Controller
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller\Settings
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Controller/Settings/ValidationSettingsController.php
+++ b/lib/Controller/Settings/ValidationSettingsController.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister Validation Settings Controller
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller\Settings
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Controller/Settings/VectorSettingsController.php
+++ b/lib/Controller/Settings/VectorSettingsController.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister Vector Settings Controller
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller\Settings
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -5,6 +5,9 @@
  *
  * This file contains the controller class for handling settings in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Controller/SourcesController.php
+++ b/lib/Controller/SourcesController.php
@@ -5,6 +5,9 @@
  *
  * Controller for managing source operations in the OpenRegister app.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Controller/TablesController.php
+++ b/lib/Controller/TablesController.php
@@ -5,6 +5,9 @@
  *
  * Controller for managing database tables view and magic table operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/TagsController.php
+++ b/lib/Controller/TagsController.php
@@ -7,6 +7,9 @@
  * Provides endpoints for retrieving and managing tags used for categorizing
  * objects and files.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/TasksController.php
+++ b/lib/Controller/TasksController.php
@@ -6,6 +6,9 @@
  * REST controller for CalDAV task operations on OpenRegister objects.
  * Follows the FilesController pattern for sub-resource endpoints.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Controller/TmloController.php
+++ b/lib/Controller/TmloController.php
@@ -6,6 +6,9 @@
  * Controller for TMLO (Toepassingsprofiel Metadatastandaard Lokale Overheden)
  * metadata operations including MDTO XML export and archival status summary.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/TransferController.php
+++ b/lib/Controller/TransferController.php
@@ -5,6 +5,9 @@
  *
  * Handles e-Depot transfer list operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/TransitionController.php
+++ b/lib/Controller/TransitionController.php
@@ -7,6 +7,9 @@
  * x-openregister-lifecycle annotation no longer need to write their
  * own action endpoint per schema.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/TranslationController.php
+++ b/lib/Controller/TranslationController.php
@@ -9,6 +9,9 @@
  *   GET  /api/translations/object/{uuid}      — list slots + completeness
  *   POST /api/translations/object/{uuid}/{property}/{language}/status
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/UiController.php
+++ b/lib/Controller/UiController.php
@@ -3,6 +3,9 @@
 /**
  * UiController
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  OpenRegister
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction b.v. <info@conduction.nl>

--- a/lib/Controller/UrnController.php
+++ b/lib/Controller/UrnController.php
@@ -8,6 +8,9 @@
  *   - GET /api/urn/lookup?url=...   → URN for the URL
  *   - POST /api/urn/bulk            → batch resolve { urns: [...] }
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/UserController.php
+++ b/lib/Controller/UserController.php
@@ -6,6 +6,9 @@
  * Controller for user management operations including profile retrieval
  * and update operations for the currently authenticated user.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/UserSettingsController.php
+++ b/lib/Controller/UserSettingsController.php
@@ -6,6 +6,9 @@
  * This file contains the controller class for handling user-specific settings,
  * particularly GitHub token management.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Controller/ViewsController.php
+++ b/lib/Controller/ViewsController.php
@@ -6,6 +6,9 @@
  * Controller for managing saved search views across multiple registers and schemas.
  * Provides CRUD operations for views that store search configurations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Controller/WebhooksController.php
+++ b/lib/Controller/WebhooksController.php
@@ -5,6 +5,9 @@
  *
  * Controller for handling webhook management operations.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/WorkflowEngineController.php
+++ b/lib/Controller/WorkflowEngineController.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister WorkflowEngineController
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *

--- a/lib/Controller/WorkflowExecutionController.php
+++ b/lib/Controller/WorkflowExecutionController.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister WorkflowExecutionController
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  *


### PR DESCRIPTION
Mechanical SPDX header sweep — part **5 of 7** from the openregister coverage-scan retrofit (2026-05-24).

Adds the two SPDX lines to the existing file docblock of every file in scope:

```
 * SPDX-License-Identifier: EUPL-1.2
 * SPDX-FileCopyrightText: 2026 Conduction B.V.
```

Per ADR-014 and the convention in existing files (e.g. `lib/Service/AvgComplianceService.php`) — SPDX lives inside the docblock, not as line comments before/after.

## Scope (86 files)

lib/Controller/ (86)

## Companion PRs

- #1737 — 1/7 (misc bundle, 84 files)
- the other 5 in this series are in flight alongside this one

## Test plan

- [ ] CI green (PHPCS / PHPMD / PHPStan / Psalm)
- [ ] No functional change — every diff hunk is comment-only