### PR TITLE
chore(spdx): EUPL-1.2 SPDX headers — Events bundle (Event, EventListener, Listener, Exception) (Bucket 4, 7/7)

### DIFF
--- a/lib/Event/ActionCreatedEvent.php
+++ b/lib/Event/ActionCreatedEvent.php
@@ -5,6 +5,9 @@
  *
  * Event dispatched when an action is created in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ActionDeletedEvent.php
+++ b/lib/Event/ActionDeletedEvent.php
@@ -5,6 +5,9 @@
  *
  * Event dispatched when an action is deleted in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ActionUpdatedEvent.php
+++ b/lib/Event/ActionUpdatedEvent.php
@@ -5,6 +5,9 @@
  *
  * Event dispatched when an action is updated in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/AgentCreatedEvent.php
+++ b/lib/Event/AgentCreatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when an agent is created
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/AgentDeletedEvent.php
+++ b/lib/Event/AgentDeletedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when an agent is deleted
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/AgentUpdatedEvent.php
+++ b/lib/Event/AgentUpdatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when an agent is updated
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ApplicationCreatedEvent.php
+++ b/lib/Event/ApplicationCreatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when an application is created
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ApplicationDeletedEvent.php
+++ b/lib/Event/ApplicationDeletedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when an application is deleted
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ApplicationUpdatedEvent.php
+++ b/lib/Event/ApplicationUpdatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when an application is updated
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ConfigurationCreatedEvent.php
+++ b/lib/Event/ConfigurationCreatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a configuration is created
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ConfigurationDeletedEvent.php
+++ b/lib/Event/ConfigurationDeletedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a configuration is deleted
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ConfigurationUpdatedEvent.php
+++ b/lib/Event/ConfigurationUpdatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a configuration is updated
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ConversationCreatedEvent.php
+++ b/lib/Event/ConversationCreatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a conversation is created
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ConversationDeletedEvent.php
+++ b/lib/Event/ConversationDeletedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a conversation is deleted
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ConversationUpdatedEvent.php
+++ b/lib/Event/ConversationUpdatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a conversation is updated
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/DeepLinkRegistrationEvent.php
+++ b/lib/Event/DeepLinkRegistrationEvent.php
@@ -6,6 +6,9 @@
  * Event dispatched during OpenRegister boot to allow consuming apps
  * to register their deep link URL patterns.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/FileCopiedEvent.php
+++ b/lib/Event/FileCopiedEvent.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister FileCopiedEvent
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/FileLockedEvent.php
+++ b/lib/Event/FileLockedEvent.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister FileLockedEvent
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/FileMovedEvent.php
+++ b/lib/Event/FileMovedEvent.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister FileMovedEvent
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/FileRenamedEvent.php
+++ b/lib/Event/FileRenamedEvent.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister FileRenamedEvent
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/FileUnlockedEvent.php
+++ b/lib/Event/FileUnlockedEvent.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister FileUnlockedEvent
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/FileVersionRestoredEvent.php
+++ b/lib/Event/FileVersionRestoredEvent.php
@@ -3,6 +3,9 @@
 /**
  * OpenRegister FileVersionRestoredEvent
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ObjectCreatedEvent.php
+++ b/lib/Event/ObjectCreatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when an object is created
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ObjectCreatingEvent.php
+++ b/lib/Event/ObjectCreatingEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when an object is being created
  * in the OpenRegister application. Supports hook-based rejection via StoppableEventInterface.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ObjectDeletedEvent.php
+++ b/lib/Event/ObjectDeletedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when an object is deleted
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ObjectDeletingEvent.php
+++ b/lib/Event/ObjectDeletingEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when an object is being deleted
  * in the OpenRegister application. Supports hook-based rejection via StoppableEventInterface.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ObjectLockedEvent.php
+++ b/lib/Event/ObjectLockedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when an object is locked
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ObjectRevertedEvent.php
+++ b/lib/Event/ObjectRevertedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when an object is reverted
  * to a previous state in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ObjectTransitionedEvent.php
+++ b/lib/Event/ObjectTransitionedEvent.php
@@ -7,6 +7,9 @@
  * the existing event-driven-architecture family — listeners subscribe via
  * `IEventDispatcher` like every other Object*Event in OpenRegister.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ObjectUnlockedEvent.php
+++ b/lib/Event/ObjectUnlockedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when an object is unlocked
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ObjectUpdatedEvent.php
+++ b/lib/Event/ObjectUpdatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when an object is updated
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ObjectUpdatingEvent.php
+++ b/lib/Event/ObjectUpdatingEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when an object is being updated
  * in the OpenRegister application. Supports hook-based rejection via StoppableEventInterface.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/OrganisationCreatedEvent.php
+++ b/lib/Event/OrganisationCreatedEvent.php
@@ -5,6 +5,9 @@
  *
  * This file contains the event class that is dispatched when an organisation entity is created.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Event
  * @package   OCA\OpenRegister\Event
  * @author    Conduction b.v. <info@conduction.nl>

--- a/lib/Event/OrganisationDeletedEvent.php
+++ b/lib/Event/OrganisationDeletedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when an organisation is deleted
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/OrganisationUpdatedEvent.php
+++ b/lib/Event/OrganisationUpdatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when an organisation is updated
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/RegisterCreatedEvent.php
+++ b/lib/Event/RegisterCreatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a register is created
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/RegisterDeletedEvent.php
+++ b/lib/Event/RegisterDeletedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a register is deleted
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/RegisterUpdatedEvent.php
+++ b/lib/Event/RegisterUpdatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a register is updated
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/SchemaCreatedEvent.php
+++ b/lib/Event/SchemaCreatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a schema is created
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/SchemaDeletedEvent.php
+++ b/lib/Event/SchemaDeletedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a schema is deleted
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/SchemaUpdatedEvent.php
+++ b/lib/Event/SchemaUpdatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a schema is updated
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/SourceCreatedEvent.php
+++ b/lib/Event/SourceCreatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a source is created
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/SourceDeletedEvent.php
+++ b/lib/Event/SourceDeletedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a source is deleted
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/SourceUpdatedEvent.php
+++ b/lib/Event/SourceUpdatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a source is updated
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ToolRegistrationEvent.php
+++ b/lib/Event/ToolRegistrationEvent.php
@@ -5,6 +5,9 @@
  *
  * Event dispatched to allow apps to register their tools with the ToolRegistry.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/UserProfileUpdatedEvent.php
+++ b/lib/Event/UserProfileUpdatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a user profile is updated
  * via the OpenRegister /me endpoint.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ViewCreatedEvent.php
+++ b/lib/Event/ViewCreatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a view is created
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ViewDeletedEvent.php
+++ b/lib/Event/ViewDeletedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a view is deleted
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/Event/ViewUpdatedEvent.php
+++ b/lib/Event/ViewUpdatedEvent.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a view is updated
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Event
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/EventListener/AbstractNodeFolderEventListener.php
+++ b/lib/EventListener/AbstractNodeFolderEventListener.php
@@ -6,6 +6,9 @@
  * This file contains the event class dispatched when a schema is updated
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category EventListener
  * @package  OCA\OpenRegister\Event
  *

--- a/lib/EventListener/AbstractNodesFolderEventListener.php
+++ b/lib/EventListener/AbstractNodesFolderEventListener.php
@@ -6,6 +6,9 @@
  * This file contains the event listener for node folder events
  * in the OpenRegister application.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category EventListener
  * @package  OCA\OpenRegister\EventListener
  *

--- a/lib/EventListener/SolrEventListener.php
+++ b/lib/EventListener/SolrEventListener.php
@@ -7,6 +7,9 @@
  * This listener responds to object creation, update, and deletion events by
  * maintaining the corresponding Solr index entries.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category EventListener
  * @package  OCA\OpenRegister\EventListener
  *

--- a/lib/Exception/AppendOnlyException.php
+++ b/lib/Exception/AppendOnlyException.php
@@ -6,6 +6,9 @@
  * Exception thrown when a mutating operation (UPDATE or DELETE) is attempted
  * on an object whose schema is declared append-only.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Exception
  * @package  OCA\OpenRegister\Exception
  *

--- a/lib/Exception/ArchivalImmutableException.php
+++ b/lib/Exception/ArchivalImmutableException.php
@@ -9,6 +9,9 @@
  * sets a private `_retentionSweep: true` flag on the delete call so the
  * gate is bypassed.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Exception
  * @package  OCA\OpenRegister\Exception
  *

--- a/lib/Exception/AuthenticationException.php
+++ b/lib/Exception/AuthenticationException.php
@@ -3,6 +3,9 @@
 /**
  * Authentication Exception.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Exception
  * @package  OCA\OpenRegister\Exception
  *

--- a/lib/Exception/CustomValidationException.php
+++ b/lib/Exception/CustomValidationException.php
@@ -5,6 +5,9 @@
  *
  * This file contains the exception class for custom validation errors.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Exception
  * @package  OCA\OpenRegister\Exception
  *

--- a/lib/Exception/DatabaseConstraintException.php
+++ b/lib/Exception/DatabaseConstraintException.php
@@ -6,6 +6,9 @@
  * This file contains the custom exception class for handling database constraint violations
  * with user-friendly error messages.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Exception
  * @package  OCA\OpenRegister\Exception
  *

--- a/lib/Exception/HookStoppedException.php
+++ b/lib/Exception/HookStoppedException.php
@@ -5,6 +5,9 @@
  *
  * Exception thrown when a schema hook stops event propagation.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Exception
  * @package  OCA\OpenRegister\Exception
  *

--- a/lib/Exception/LockedException.php
+++ b/lib/Exception/LockedException.php
@@ -5,6 +5,9 @@
  *
  * This file contains the exception class for object lock errors.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Exception
  * @package  OCA\OpenRegister\Exception
  *

--- a/lib/Exception/NoVtodoCalendarException.php
+++ b/lib/Exception/NoVtodoCalendarException.php
@@ -5,6 +5,9 @@
  *
  * Exception thrown when no VTODO-supporting calendar is found for a user.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Exception
  * @package   OCA\OpenRegister\Exception
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Exception/NotAuthorizedException.php
+++ b/lib/Exception/NotAuthorizedException.php
@@ -5,6 +5,9 @@
  *
  * This file contains the exception class for authorization errors.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Exception
  * @package  OCA\OpenRegister\Exception
  *

--- a/lib/Exception/ReferentialIntegrityException.php
+++ b/lib/Exception/ReferentialIntegrityException.php
@@ -6,6 +6,9 @@
  * Exception thrown when an object deletion is blocked by referential integrity constraints.
  * Contains the full DeletionAnalysis with blocker details for structured API error responses.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Exception
  * @package  OCA\OpenRegister\Exception
  *

--- a/lib/Exception/RegisterNotFoundException.php
+++ b/lib/Exception/RegisterNotFoundException.php
@@ -5,6 +5,9 @@
  *
  * Exception thrown when a register cannot be found by slug or ID.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Exception
  * @package   OCA\OpenRegister\Exception
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Exception/SchemaNotFoundException.php
+++ b/lib/Exception/SchemaNotFoundException.php
@@ -5,6 +5,9 @@
  *
  * Exception thrown when a schema cannot be found by slug or ID.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Exception
  * @package   OCA\OpenRegister\Exception
  * @author    Conduction Development Team <info@conduction.nl>

--- a/lib/Exception/ValidationException.php
+++ b/lib/Exception/ValidationException.php
@@ -5,6 +5,9 @@
  *
  * This file contains the exception class for validation errors.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Exception
  * @package  OCA\OpenRegister\Exception
  *

--- a/lib/Listener/ActionListener.php
+++ b/lib/Listener/ActionListener.php
@@ -5,6 +5,9 @@
  *
  * Listener that delegates event handling to ActionExecutor for matching actions.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *

--- a/lib/Listener/ActivityEventListener.php
+++ b/lib/Listener/ActivityEventListener.php
@@ -5,6 +5,9 @@
  *
  * Listens to OpenRegister entity events and publishes corresponding activity events.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *

--- a/lib/Listener/AggregationCacheInvalidationListener.php
+++ b/lib/Listener/AggregationCacheInvalidationListener.php
@@ -8,6 +8,9 @@
  * AggregationCache so the next aggregation read recomputes against
  * fresh data. The 60s TTL bounds staleness even when an evict is missed.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *

--- a/lib/Listener/AggregationThresholdListener.php
+++ b/lib/Listener/AggregationThresholdListener.php
@@ -13,6 +13,9 @@
  * fires once on breach, not on every subsequent write while still over
  * the threshold.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *

--- a/lib/Listener/AnnotationNotificationListener.php
+++ b/lib/Listener/AnnotationNotificationListener.php
@@ -7,6 +7,9 @@
  * ObjectTransitionedEvent and asks the dispatcher to fire any matching
  * notifications declared on the schema.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *

--- a/lib/Listener/CalculationOnSaveListener.php
+++ b/lib/Listener/CalculationOnSaveListener.php
@@ -8,6 +8,9 @@
  * evaluator and patches the field into the object payload before
  * persistence.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *

--- a/lib/Listener/CommentsEntityListener.php
+++ b/lib/Listener/CommentsEntityListener.php
@@ -6,6 +6,9 @@
  * Registers the "openregister" objectType with Nextcloud's Comments system.
  * This allows comments to be stored against OpenRegister object UUIDs.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Listener
  * @package   OCA\OpenRegister\Listener
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Listener/FileChangeListener.php
+++ b/lib/Listener/FileChangeListener.php
@@ -5,6 +5,9 @@
  *
  * Listens for file creation and update events to queue asynchronous text extraction.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *

--- a/lib/Listener/FilesSidebarListener.php
+++ b/lib/Listener/FilesSidebarListener.php
@@ -7,6 +7,9 @@
  * This listener uses the standard Nextcloud pattern for loading scripts
  * into the Files app context via LoadAdditionalScriptsEvent.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *

--- a/lib/Listener/GraphQLSubscriptionListener.php
+++ b/lib/Listener/GraphQLSubscriptionListener.php
@@ -6,6 +6,9 @@
  * Listens for object CRUD events and pushes them to the
  * GraphQL subscription buffer for SSE delivery.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *

--- a/lib/Listener/HookListener.php
+++ b/lib/Listener/HookListener.php
@@ -5,6 +5,9 @@
  *
  * Listener that delegates schema hook execution to HookExecutor.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *

--- a/lib/Listener/LifecycleInitialStateListener.php
+++ b/lib/Listener/LifecycleInitialStateListener.php
@@ -7,6 +7,9 @@
  * to the schema's declared `initial` value when the caller did not
  * supply a value. Apps don't need to remember to set it.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *

--- a/lib/Listener/LifecycleValidationListener.php
+++ b/lib/Listener/LifecycleValidationListener.php
@@ -7,6 +7,9 @@
  * lifecycle field to a value that no declared transition allows from the
  * current value. Uses the existing StoppableEventInterface contract.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *

--- a/lib/Listener/MailAppScriptListener.php
+++ b/lib/Listener/MailAppScriptListener.php
@@ -3,6 +3,9 @@
 /**
  * Listener that injects the mail sidebar script into the Nextcloud Mail app.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *

--- a/lib/Listener/NotifyPushListener.php
+++ b/lib/Listener/NotifyPushListener.php
@@ -26,6 +26,9 @@
  *  - IAppConfig key `openregister.push_available` is set to '1' on the first
  *    successful IQueue::push() call (consumed by OpenRegisterAdmin::getPushStatus()).
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *

--- a/lib/Listener/ObjectChangeListener.php
+++ b/lib/Listener/ObjectChangeListener.php
@@ -5,6 +5,9 @@
  *
  * Listens for object creation and update events to queue asynchronous text extraction.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *

--- a/lib/Listener/ObjectCleanupListener.php
+++ b/lib/Listener/ObjectCleanupListener.php
@@ -6,6 +6,9 @@
  * Listens for ObjectDeletedEvent and cleans up associated notes, tasks,
  * email links, calendar event links, contact links, and deck card links.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category  Listener
  * @package   OCA\OpenRegister\Listener
  * @author    Conduction Development Team <dev@conduction.nl>

--- a/lib/Listener/RealtimeEventListener.php
+++ b/lib/Listener/RealtimeEventListener.php
@@ -6,6 +6,9 @@
  * Subscribes to ObjectCreated/Updated/Deleted/Transitioned events and
  * records each one as a CloudEvent in the realtime event log.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *

--- a/lib/Listener/ToolRegistrationListener.php
+++ b/lib/Listener/ToolRegistrationListener.php
@@ -5,6 +5,9 @@
  *
  * Listens to ToolRegistrationEvent and registers OpenRegister's built-in tools.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *

--- a/lib/Listener/TranslationProjectionListener.php
+++ b/lib/Listener/TranslationProjectionListener.php
@@ -8,6 +8,9 @@
  * JSONB property data on the object. Same pattern as the realtime
  * event listener — derived-projection-by-event.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *

--- a/lib/Listener/WebhookEventListener.php
+++ b/lib/Listener/WebhookEventListener.php
@@ -5,6 +5,9 @@
  *
  * Listener for webhook events.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  *


### PR DESCRIPTION
Mechanical SPDX header sweep — part **7 of 7** from the openregister coverage-scan retrofit (2026-05-24).

Adds the two SPDX lines to the existing file docblock of every file in scope:

```
 * SPDX-License-Identifier: EUPL-1.2
 * SPDX-FileCopyrightText: 2026 Conduction B.V.
```

Per ADR-014 and the convention in existing files (e.g. `lib/Service/AvgComplianceService.php`) — SPDX lives inside the docblock, not as line comments before/after.

## Scope (86 files)

lib/Event/ (49), lib/Listener/ (21), lib/Exception/ (13), lib/EventListener/ (3)

## Companion PRs

- #1737 — 1/7 (misc bundle, 84 files)
- the other 5 in this series are in flight alongside this one

## Test plan

- [ ] CI green (PHPCS / PHPMD / PHPStan / Psalm)
- [ ] No functional change — every diff hunk is comment-only