### PR TITLE
retrofit: reverse-spec saas-multi-tenant (3 new REQs)

### DIFF
--- a/lib/Service/TenantKeyService.php
+++ b/lib/Service/TenantKeyService.php
@@ -171,6 +171,8 @@ class TenantKeyService
      * @param string $tenantId Tenant identifier
      *
      * @return array<string,mixed>|null Database row or null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-saas-multi-tenant/tasks.md#task-1
      */
     private function fetchActiveRow(string $tenantId): ?array
     {
@@ -244,6 +246,8 @@ class TenantKeyService
      * @param string $rotatedAt ISO-8601 timestamp
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-saas-multi-tenant/tasks.md#task-2
      */
     private function insertKey(string $tenantId, string $rawKey, string $rotatedAt): void
     {

--- a/openspec/changes/retrofit-2026-05-24-saas-multi-tenant/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-saas-multi-tenant/proposal.md
@@ -1,0 +1,44 @@
+# retrofit-2026-05-24-saas-multi-tenant
+
+## Why
+
+`TenantKeyService` manages per-tenant HMAC signing keys that back the
+audit-trail hash chain (and any future per-tenant evidence-signing use
+case). It was originally annotated against `openspec/changes/scholiq-deps/
+tenant-key-api/tasks.md` — that change has since been archived, so the
+behaviour is undocumented in the spec library while the service is wired
+into the DI container in `Application.php` and exercised by
+`tests/Unit/Service/TenantKeyServiceTest.php`.
+
+Two private helpers (`fetchActiveRow`, `insertKey`) were observed in a
+Bucket 2 cluster ("saas-multi-tenant") during the OR coverage scan and
+were not coverable by any existing capability spec — they were triaged
+out of `actions#REQ-002` (workflow action execution) because their
+domain is HMAC tenant key persistence, not workflow execution.
+
+This change establishes the `saas-multi-tenant` capability spec by
+reverse-engineering the observed behaviour of those two helpers (and
+the public methods they support) into 3 new REQs. Behaviour described
+here is what the code does today, not aspirational.
+
+## What Changes
+
+- Create capability spec `openspec/specs/saas-multi-tenant/spec.md`
+  with 3 REQs covering:
+  - Per-tenant active-key lookup contract (single row, status=active,
+    most-recent-first)
+  - At-rest encryption + active-row insertion contract (ICrypto
+    wrapping, status=active, ISO-8601 timestamp)
+  - DI registration (TenantKeyService wired in `Application.php` so
+    audit-trail signing has a singleton key provider)
+- Annotate the two private helpers in
+  `lib/Service/TenantKeyService.php` with `@spec` tags pointing at
+  this change's `tasks.md`.
+
+## Impact
+
+- Affected specs: NEW capability `saas-multi-tenant`
+- Affected code: docblock-only changes in
+  `lib/Service/TenantKeyService.php` (no runtime behaviour change)
+- Retrofit: documents existing behaviour; closes the
+  `scholiq-deps/tenant-key-api` annotation gap left by that archive.

--- a/openspec/changes/retrofit-2026-05-24-saas-multi-tenant/specs/saas-multi-tenant/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-saas-multi-tenant/specs/saas-multi-tenant/spec.md
@@ -1,0 +1,129 @@
+# saas-multi-tenant Specification
+
+---
+retrofit: true
+capability: saas-multi-tenant
+status: retrofit-draft
+---
+
+## Purpose
+
+Define server-side primitives that make OpenRegister safe to operate as
+a shared-database multi-tenant SaaS. The first slice covered here is
+per-tenant HMAC key material used to sign audit-trail evidence: every
+tenant gets its own 256-bit key, generated lazily, encrypted at rest,
+and rotated without breaking historical verification.
+
+This capability is the home for primitives that (a) need to behave
+differently per tenant and (b) MUST NOT leak across tenant boundaries.
+Cross-tenant access auditing, isolation verification, and quota
+enforcement live in their sibling specs (`tenant-isolation-audit`,
+`tenant-lifecycle`, `tenant-quotas`).
+
+**Source**: BIO/ISO 27001 audit signing requirements; observed
+behaviour of `OCA\OpenRegister\Service\TenantKeyService`.
+
+## ADDED Requirements
+
+### Requirement: Per-tenant active HMAC key MUST be a single most-recent row
+
+The system SHALL expose, for each tenant, exactly one active key at a
+time. Lookup SHALL key on (`tenant_id`, `status = 'active'`) and SHALL
+return the most-recent row when more than one is matched (defensive
+against partial-rotation states). The active-key lookup MUST be the
+single read path used by both the get-current and rotate flows.
+
+#### Scenario: Active key exists for tenant
+
+- **GIVEN** the `openregister_tenant_keys` table contains exactly one
+  row for `tenant_id = "org-A"` with `status = "active"`
+- **WHEN** `TenantKeyService::getCurrentTenantKey("org-A")` runs
+- **THEN** the service SHALL `SELECT id, encrypted_key FROM
+  openregister_tenant_keys WHERE tenant_id = "org-A" AND status =
+  "active" ORDER BY id DESC LIMIT 1`
+- **AND** the service SHALL pass the resulting `encrypted_key` through
+  `ICrypto::decrypt()` and return the plaintext
+
+#### Scenario: No active key exists for tenant
+
+- **GIVEN** `openregister_tenant_keys` has zero rows for `tenant_id =
+  "org-B"`
+- **WHEN** `TenantKeyService::getCurrentTenantKey("org-B")` runs
+- **THEN** the active-row lookup SHALL return `null` and the service
+  SHALL bootstrap a fresh key (see Requirement 2)
+
+#### Scenario: Multiple active rows exist (defensive)
+
+- **GIVEN** `openregister_tenant_keys` has more than one row for
+  `tenant_id = "org-C"` with `status = "active"` (e.g. a partial
+  rotation left both rows active)
+- **WHEN** the active-row lookup runs
+- **THEN** the row with the highest `id` SHALL be returned
+- **AND** lower-`id` rows SHALL be ignored for this read (cleanup is
+  out of scope for this REQ)
+
+### Requirement: New active keys MUST be stored encrypted with status='active'
+
+The system SHALL insert new key rows through a single write path that
+encrypts the plaintext key material via `OCP\Security\ICrypto::encrypt`
+before persistence, sets `status = 'active'`, and stamps the row with
+an ISO-8601 timestamp. The plaintext key material MUST NOT be persisted
+to the row, the audit log, or any HTTP response.
+
+#### Scenario: Bootstrap insert on first access
+
+- **GIVEN** no active key exists for `tenant_id = "org-D"`
+- **WHEN** `TenantKeyService::getCurrentTenantKey("org-D")` is called
+- **THEN** the service SHALL generate 32 bytes of CSPRNG output via
+  `random_bytes(32)`, hex-encode it to a 64-character string, and
+  pass that string to `ICrypto::encrypt`
+- **AND** the service SHALL `INSERT INTO openregister_tenant_keys
+  (tenant_id, encrypted_key, status, created_at) VALUES ("org-D",
+  <ciphertext>, "active", <iso8601>)`
+- **AND** the service SHALL return the plaintext (caller-side use)
+  while the row stores only the ciphertext
+
+#### Scenario: Rotation insert after retiring previous active row
+
+- **GIVEN** an active key row already exists for `tenant_id = "org-E"`
+- **WHEN** `TenantKeyService::rotateTenantKey("org-E")` is called
+- **THEN** the existing row SHALL be flipped to `status = 'retired'`
+- **AND** a new row SHALL be inserted via the same encrypted-insert
+  path with `status = 'active'` and a fresh `created_at` timestamp
+- **AND** the rotation SHALL return metadata only (`tenant_id`,
+  `rotated_at`, `retired_key_id`) — never the plaintext key material
+
+#### Scenario: Encryption failure aborts the write
+
+- **GIVEN** `ICrypto::encrypt` throws a `RuntimeException` (e.g.
+  instance secret is missing)
+- **WHEN** an insert is attempted
+- **THEN** no row SHALL be written to `openregister_tenant_keys`
+- **AND** the exception SHALL propagate to the caller
+
+### Requirement: TenantKeyService MUST be DI-registered as a server-side internal API
+
+The `TenantKeyService` SHALL be registered in the Nextcloud DI
+container so it can be injected into audit-trail signers and future
+per-tenant evidence-signing call sites. The service MUST NOT be wired
+into any HTTP controller, OCS controller, or CLI command that exposes
+key material outside the server boundary.
+
+#### Scenario: Service is constructable via the DI container
+
+- **WHEN** the Nextcloud DI container resolves
+  `OCA\OpenRegister\Service\TenantKeyService`
+- **THEN** it SHALL receive `IDBConnection`, `ICrypto`, and
+  `LoggerInterface` constructor arguments
+- **AND** the resolved instance SHALL be the same singleton across
+  the request (standard Nextcloud DI behaviour)
+
+#### Scenario: No REST endpoint surfaces the plaintext key
+
+- **WHEN** the OpenRegister app's routes are loaded from
+  `appinfo/routes.php`
+- **THEN** no route SHALL map to a controller method that returns
+  `TenantKeyService::getCurrentTenantKey()` output in its HTTP
+  response body, headers, or logs
+- **AND** the rotation endpoint (if exposed) SHALL return only the
+  metadata array (`tenant_id`, `rotated_at`, `retired_key_id`)

--- a/openspec/changes/retrofit-2026-05-24-saas-multi-tenant/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-saas-multi-tenant/tasks.md
@@ -1,0 +1,16 @@
+# Tasks
+
+Retroactive annotation only — every task documents existing behaviour
+in `lib/Service/TenantKeyService.php`. No runtime changes.
+
+- [x] task-1: saas-multi-tenant#REQ-001 — Per-tenant active HMAC key MUST be a single most-recent row (retroactive annotation of `TenantKeyService::fetchActiveRow`)
+- [x] task-2: saas-multi-tenant#REQ-002 — New active keys MUST be stored encrypted with status='active' (retroactive annotation of `TenantKeyService::insertKey`)
+- [x] task-3: saas-multi-tenant#REQ-003 — TenantKeyService MUST be DI-registered as a server-side internal API (no new annotation — `Application.php` wiring observed but not in cluster scope)
+
+## REQ → method map
+
+| REQ | task | Methods tagged |
+|---|---|---|
+| REQ-001 | task-1 | `fetchActiveRow` (private; called by `getCurrentTenantKey` + `rotateTenantKey`) |
+| REQ-002 | task-2 | `insertKey` (private; called by `bootstrapKey` + `rotateTenantKey`) |
+| REQ-003 | task-3 | DI wiring in `lib/AppInfo/Application.php` (not annotated — documented in proposal) |


### PR DESCRIPTION
## Summary

Reverse-spec retrofit for the `saas-multi-tenant` capability. Bucket 2 cluster from the OR coverage scan — two private helpers in `TenantKeyService` that no existing capability spec covered. Their original `@spec` pointed at `scholiq-deps/tenant-key-api`, which has since been archived, leaving the behaviour undocumented.

This change establishes the `saas-multi-tenant` capability and documents what the service does today. No runtime behaviour change.

## Cluster

- **Capability**: `saas-multi-tenant` (NEW)
- **Methods** (2, both private):
  - `lib/Service/TenantKeyService.php::fetchActiveRow`
  - `lib/Service/TenantKeyService.php::insertKey`

Both methods inherit from public callers `getCurrentTenantKey` + `rotateTenantKey`; the private helpers are the ones that landed in the cluster, so they carry the `@spec` tags.

## REQs drafted

| REQ | Behaviour |
|---|---|
| REQ-001 | Per-tenant active HMAC key MUST be a single most-recent row (status='active', ORDER BY id DESC LIMIT 1) |
| REQ-002 | New active keys MUST be stored ICrypto-encrypted with `status='active'` and an ISO-8601 timestamp |
| REQ-003 | `TenantKeyService` MUST be DI-registered as a server-side internal API; never wired into a controller |

REQ-003 isn't annotated on a method in this PR — the cluster only included the two helpers. The DI wiring lives in `lib/AppInfo/Application.php`; documented in the proposal so it isn't lost.

## Files changed

- `openspec/changes/retrofit-2026-05-24-saas-multi-tenant/proposal.md` — new
- `openspec/changes/retrofit-2026-05-24-saas-multi-tenant/specs/saas-multi-tenant/spec.md` — new (3 REQs)
- `openspec/changes/retrofit-2026-05-24-saas-multi-tenant/tasks.md` — new (all `[x]`)
- `lib/Service/TenantKeyService.php` — docblock-only (added `@spec` tag to `fetchActiveRow` + `insertKey`)

## Test plan

- [ ] `composer check:strict` clean on `TenantKeyService.php` (docblock-only change, blank-line-before-tag preserved)
- [ ] `openspec validate retrofit-2026-05-24-saas-multi-tenant --strict` passes
- [ ] Existing `tests/Unit/Service/TenantKeyServiceTest.php` still green (no behaviour change)