### PR TITLE
retrofit: reverse-spec avg-verwerkingsregister (1 new REQ)

### DIFF
--- a/lib/Service/AvgComplianceService.php
+++ b/lib/Service/AvgComplianceService.php
@@ -95,6 +95,8 @@ class AvgComplianceService
      * personal data, or accepts the gap with a documented rationale.
      *
      * @return array<int, array<string, mixed>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-avg-verwerkingsregister/tasks.md#task-1
      */
     public function findUnannotatedSchemasWithPii(): array
     {

--- a/openspec/changes/retrofit-2026-05-24-avg-verwerkingsregister/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-avg-verwerkingsregister/proposal.md
@@ -1,0 +1,22 @@
+# Retrofit — extend avg-verwerkingsregister with observed behaviors
+
+The 2026-05-24 coverage scan found 1 method in the avg-verwerkingsregister capability that doesn't match any existing requirement on the parent spec: `AvgComplianceService::findUnannotatedSchemasWithPii()`. This change adds 1 new REQ derived from the method's observed code behavior — a compliance scan surfacing schemas where PII has been detected but no `x-openregister-processing-activity` annotation exists on the schema or its enclosing register.
+
+No code logic changes. The annotation on the method points at this ghost change's task entry.
+
+## Affected code units
+
+- `lib/Service/AvgComplianceService.php` — `findUnannotatedSchemasWithPii()` (public, surfaced via `runAllChecks()`)
+
+## REQ map
+
+| Requirement | Methods |
+|-------------|---------|
+| "Surface schemas with detected PII but no processing-activity annotation" | AvgComplianceService::findUnannotatedSchemasWithPii |
+
+## Notes
+
+- The triage record (openregister-app-manifest#MAN-005) is unrelated — MAN-005 is the Vue main.js loader and was a false-positive cross-reference; this method is purely an AVG/PII compliance scanner.
+- The aggregator query in `aggregatePiiBySchema()` silently skips legacy `entity_relations` rows where either `register_id` or `schema_id` is empty (predating the disambiguation migration). This is observed behavior, not aspirational — the REQ documents it.
+
+See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-avg-verwerkingsregister/specs/avg-verwerkingsregister/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-avg-verwerkingsregister/specs/avg-verwerkingsregister/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: The system MUST surface schemas with detected PII but no processing-activity annotation
+
+The system MUST provide a compliance check that lists every `(register, schema)` pair where personal-data entities have been recorded in the GDPR entity store but neither the schema nor its enclosing register carries the `x-openregister-processing-activity` annotation key in its `configuration` column. Each row returned MUST be operator-actionable: annotate the schema or register with a processing-activity reference, remove the personal data, or document a rationale for the gap.
+
+`AvgComplianceService::findUnannotatedSchemasWithPii()` aggregates `oc_openregister_entities` joined against `oc_openregister_entity_relations` by `(register_id, schema_id)`, counts the distinct PII rows per pair, then filters out any pair where the schema OR the register carries a non-empty string value under the `x-openregister-processing-activity` key in its configuration. The check is also exposed via `AvgComplianceService::runAllChecks()` for a compliance-dashboard envelope.
+
+#### Scenario: Schema and register both lack the annotation, PII present
+- **GIVEN** schema `inwoners` and its enclosing register `brp` exist
+- **AND** 12 `GdprEntity` rows are linked via `entity_relations` to objects in `(brp, inwoners)`
+- **AND** neither `inwoners.configuration['x-openregister-processing-activity']` nor `brp.configuration['x-openregister-processing-activity']` is set to a non-empty string
+- **WHEN** `findUnannotatedSchemasWithPii()` is called
+- **THEN** the result MUST contain one envelope for `(brp, inwoners)` with `piiCount: 12`, `registerHasAnnotation: false`, `schemaHasAnnotation: false`, and `schemaTitle` populated from `SchemaMapper::find()` (or empty string on lookup failure)
+
+#### Scenario: Schema carries the annotation
+- **GIVEN** PII is detected for `(brp, inwoners)`
+- **AND** `inwoners.configuration['x-openregister-processing-activity']` equals `"verwerkings-act-uuid-abc"`
+- **WHEN** the check runs
+- **THEN** the `(brp, inwoners)` pair MUST be omitted from the result
+
+#### Scenario: Register carries the annotation (schema inherits)
+- **GIVEN** PII is detected for `(brp, inwoners)`
+- **AND** `inwoners.configuration` has no annotation key but `brp.configuration['x-openregister-processing-activity']` equals `"verwerkings-act-uuid-xyz"`
+- **WHEN** the check runs
+- **THEN** the `(brp, inwoners)` pair MUST be omitted (register-level annotation satisfies the check for all schemas in that register)
+
+#### Scenario: Legacy entity_relations row without register_id or schema_id
+- **GIVEN** an `entity_relations` row predates the disambiguation migration and has empty `register_id` or empty `schema_id`
+- **WHEN** the aggregation result is iterated
+- **THEN** the row MUST be skipped (it cannot be attributed to a `(register, schema)` pair) and MUST NOT contribute to the issues list
+
+#### Scenario: Aggregation query failure degrades gracefully
+- **GIVEN** the underlying database join throws (e.g., schema migration mid-flight)
+- **WHEN** `findUnannotatedSchemasWithPii()` is called
+- **THEN** the method MUST log a warning with message `[AVG compliance] Failed to aggregate PII by schema` and the exception message in context
+- **AND** the method MUST return an empty array (the dashboard treats this as "no issues this run")
+
+#### Scenario: Register or schema lookup failure during annotation check
+- **GIVEN** a `(register_id, schema_id)` pair appears in the aggregation result
+- **AND** `RegisterMapper::find()` throws `DoesNotExistException` or any other Throwable for that `register_id`
+- **WHEN** `registerHasAnnotation()` evaluates the register
+- **THEN** the method MUST treat the register as not annotated (return `false`) rather than propagating the exception
+- **AND** the same fallback MUST apply to `schemaHasAnnotation()` when `SchemaMapper::find()` throws
+- **AND** `resolveSchemaTitle()` MUST return an empty string on any lookup failure (best-effort title resolution)
+
+#### Notes
+- Both annotation checks call the mapper with `_rbac: false, _multitenancy: false` — the compliance scan deliberately bypasses tenant filtering so an organisation-scoped privacy officer sees gaps across all registers visible to the scan. The caller is responsible for restricting visibility of the result to authorised users.
+- The annotation key is exposed as the public constant `AvgComplianceService::ANNOTATION_KEY` so other services may reuse the same key when writing the annotation. The value is expected to be a non-empty string (e.g., a verwerkingsactiviteit UUID); empty strings or non-string values do NOT satisfy the check.

--- a/openspec/changes/retrofit-2026-05-24-avg-verwerkingsregister/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-avg-verwerkingsregister/tasks.md
@@ -1,0 +1,3 @@
+# Tasks
+
+- [x] task-1: avg-verwerkingsregister — Surface schemas with detected PII but no processing-activity annotation (retroactive annotation of `AvgComplianceService::findUnannotatedSchemasWithPii`)


### PR DESCRIPTION
## Summary

Retroactively specifies the observed behavior of `AvgComplianceService::findUnannotatedSchemasWithPii()` as a new requirement on the `avg-verwerkingsregister` capability spec. Annotation-only — no logic changes.

The 2026-05-24 coverage scan flagged this method as not matching any existing requirement in the parent spec. The triage record pointed at openregister-app-manifest#MAN-005, which turned out to be unrelated (MAN-005 is the Vue main.js loader); this method is a standalone AVG/PII compliance scan, hence the reverse-spec.

## Methods covered

- `lib/Service/AvgComplianceService.php` — `findUnannotatedSchemasWithPii()` (public, surfaced via `runAllChecks()` aggregator)

## REQ summary

**Surface schemas with detected PII but no processing-activity annotation** — joins `oc_openregister_entities` × `oc_openregister_entity_relations` aggregated by `(register_id, schema_id)`, filters out pairs where either the schema OR enclosing register carries a non-empty `x-openregister-processing-activity` value in its `configuration`. Returns operator-actionable envelopes with `piiCount`, `registerHasAnnotation`, `schemaHasAnnotation`, and a best-effort `schemaTitle`. Includes observed graceful-degradation behavior on aggregation failure, mapper lookup failure, and legacy `entity_relations` rows missing `register_id`/`schema_id`.

## Change artifacts

- `openspec/changes/retrofit-2026-05-24-avg-verwerkingsregister/proposal.md`
- `openspec/changes/retrofit-2026-05-24-avg-verwerkingsregister/specs/avg-verwerkingsregister/spec.md` — `## ADDED Requirements` delta with one requirement + 6 scenarios + notes
- `openspec/changes/retrofit-2026-05-24-avg-verwerkingsregister/tasks.md` — single completed task

`openspec validate --strict` passes.

## Annotations

`@spec openspec/changes/retrofit-2026-05-24-avg-verwerkingsregister/tasks.md#task-1` added to the method docblock.

## Notes

- Annotation-only PR. No code logic changes.
- Bypass of RBAC/multi-tenancy in mapper calls is documented in the spec as deliberate (compliance dashboard needs cross-tenant visibility); caller is responsible for restricting result visibility.