### PR TITLE
retrofit: reverse-spec content-versioning (1 new REQ)

### DIFF
--- a/lib/Event/FileVersionRestoredEvent.php
+++ b/lib/Event/FileVersionRestoredEvent.php
@@ -30,6 +30,8 @@ class FileVersionRestoredEvent extends Event
      * @param array  $data       Additional event data.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-content-versioning/tasks.md#task-1
      */
     public function __construct(
         private readonly string $objectUuid,

--- a/openspec/changes/retrofit-2026-05-24-content-versioning/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-content-versioning/proposal.md
@@ -1,0 +1,28 @@
+# Retrofit — content-versioning (rspec 2026-05-24)
+
+Describes observed behavior of 1 method in 1 file under `content-versioning` as 1 new REQ. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+
+- `lib/Event/FileVersionRestoredEvent.php` — `__construct` (DTO carrying objectUuid, fileId, data for the typed event dispatched by `FilesController::restoreVersion()`)
+
+## Cluster scan notes (rspec-cluster-content-versioning.json)
+
+The 2026-05-24 reverse-spec scanner clustered 3 methods into `content-versioning`. Triage on read:
+
+- `src/components/shared/VersionInfoCard.vue::handleUpdateClick` — **not in scope**. This is a generic Vue component that displays the **app's own version** (used by `Settings.vue` to show "Open Register vX.Y.Z" and a self-update button); it does not version register-object content. Cluster match was a false positive on the word "version".
+- `src/components/shared/VersionInfoCard.vue::if` — **false positive**. The scanner picked up a Vue template `v-if` directive as a method name; no method exists.
+- `lib/Event/FileVersionRestoredEvent.php::__construct` — **in scope but originally triaged DROP from REQ-017** (REQ-017 covers the restore *operation* in `FileVersioningHandler::restoreVersion()`, not the typed-event-dispatch contract the controller layer uses). On second read this is a genuine observed integration behavior worth specifying as a new REQ — the event is the integration point n8n / external listeners hook into, and REQ-017's scenarios stop at "return true on success" without mentioning the event payload contract.
+
+## Approach
+
+- Add one new REQ describing the observed event-dispatch contract for file-version restore. Scenarios describe what `FilesController::restoreVersion()` dispatches and what listeners observe in the event DTO.
+- Do not add aspirational REQs for the UI app-version card or the parser-induced `if` false positive.
+
+## REQ map
+
+| REQ | Methods |
+|-----|---------|
+| REQ-018 | `FileVersionRestoredEvent::__construct` (DTO) + dispatch call in `FilesController::restoreVersion()` (already annotated via files capability) |
+
+Source: `/tmp/or-scan/rspec-cluster-content-versioning.json`. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-content-versioning/specs/content-versioning/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-content-versioning/specs/content-versioning/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Successful file-version restore MUST dispatch a typed FileVersionRestoredEvent for integration listeners
+
+When a file version is restored via `FilesController::restoreVersion()` (after `FileVersioningHandler::restoreVersion()` returns successfully and the audit-trail entry has been written), the controller MUST construct and dispatch a typed `FileVersionRestoredEvent` via `IEventDispatcher::dispatchTyped()`. The event DTO carries the parent object UUID, the restored file ID, and an arbitrary `data` array. The event is the integration hook that n8n webhook triggers, registered Nextcloud event listeners, and downstream activity-stream providers consume; without it, file-version restores are observable only via the audit trail (best-effort) and not via the event bus.
+
+This requirement (tracked as REQ-018) documents the observed event-dispatch contract — REQ-017 specifies the operation in `FileVersioningHandler::restoreVersion()` but stops at "return true on success" without mentioning the controller-level event side effect.
+
+#### Scenario: Event is dispatched after successful restore
+
+- **GIVEN** an authenticated user invokes `POST /api/objects/{register}/{schema}/{id}/files/{fileId}/versions/{versionId}/restore`
+- **AND** the parent object resolves, the file resolves, and `FileVersioningHandler::restoreVersion()` returns `true`
+- **WHEN** the controller continues past the audit-trail call
+- **THEN** the controller MUST call `IEventDispatcher::dispatchTyped()` with a `FileVersionRestoredEvent` instance
+- **AND** the event MUST carry `objectUuid = $object->getUuid()`, `fileId = <the restored file id>`, and `data = ["versionId" => <the restored version id>]`
+
+#### Scenario: Event carries the version identifier so listeners can correlate with audit-trail entries
+
+- **GIVEN** the controller has just dispatched `FileVersionRestoredEvent` with `data = ["versionId" => "v-1710892800"]`
+- **WHEN** a registered listener receives the event and calls `$event->getData()`
+- **THEN** the returned array MUST equal `["versionId" => "v-1710892800"]`
+- **AND** `$event->getObjectUuid()` MUST return the parent object UUID exactly as it appears on the audit-trail entry's `object` column for the same restore operation
+- **AND** `$event->getFileId()` MUST return the restored file ID as an `int`
+
+#### Scenario: Event is NOT dispatched when the underlying restore fails
+
+- **GIVEN** `FileVersioningHandler::restoreVersion()` throws `Exception("Version not found")` (per REQ-017 graceful-degradation contract)
+- **WHEN** the controller's try/catch block handles the exception and returns a 4xx `JSONResponse`
+- **THEN** no `FileVersionRestoredEvent` MUST be dispatched
+- **AND** no audit-trail `file.version_restored` entry MUST be written for this request
+
+#### Notes
+
+- `FileVersionRestoredEvent` extends `OCP\EventDispatcher\Event`. Its constructor declares the three carried fields as `private readonly` promoted properties, exposed via `getObjectUuid()`, `getFileId()`, and `getData()`. Listeners MUST NOT mutate the event payload — there is no setter API.
+- The `data` array is intentionally untyped: REQ-017 currently only writes `versionId` into it, but the open-ended shape lets future restore-related metadata (e.g. `restoredBy`, `previousVersionId`) be added without breaking the event signature.
+- This requirement is paired with the audit-trail `file.version_restored` entry and REQ-017 (the `FileVersioningHandler::restoreVersion()` operation itself). All three fire on the same successful restore; only this requirement governs the typed-event side effect.

--- a/openspec/changes/retrofit-2026-05-24-content-versioning/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-content-versioning/tasks.md
@@ -1,0 +1,3 @@
+# Tasks
+
+- [x] task-1: content-versioning#REQ-018 — Typed `FileVersionRestoredEvent` is dispatched on successful file-version restore (retroactive annotation)


### PR DESCRIPTION
## Summary

Reverse-specs one observed behavior from the 2026-05-24 rspec scan into the `content-versioning` capability:

- **REQ-018**: Successful file-version restore MUST dispatch a typed `FileVersionRestoredEvent` for integration listeners.

REQ-017 already covers the `FileVersioningHandler::restoreVersion()` operation, but stops at "return true on success" — it does not specify the controller-level event side effect that n8n webhook triggers, registered NC event listeners, and downstream activity providers depend on. REQ-018 closes that gap.

## Cluster triage

The scanner clustered 3 methods into `content-versioning`. Triage on read:

| Method | Verdict |
|---|---|
| `VersionInfoCard.vue::handleUpdateClick` | **False positive** — generic Vue component for the **app's own** version display (used by Settings.vue to show "Open Register vX.Y.Z" + self-update button). Not register-object versioning. |
| `VersionInfoCard.vue::if` | **Parser false positive** — Vue template `v-if` directive picked up as a method name. |
| `FileVersionRestoredEvent::__construct` | **Promoted to REQ-018** — originally triaged DROP from REQ-017, but the event-dispatch contract is a genuine observed behavior worth specifying separately from the handler operation. |

## Changes

- `openspec/changes/retrofit-2026-05-24-content-versioning/` — proposal, tasks, and content-versioning spec delta (1 new REQ, 3 scenarios).
- `lib/Event/FileVersionRestoredEvent.php` — `__construct` docblock annotated with `@spec` task tag.

`openspec validate retrofit-2026-05-24-content-versioning --strict` passes.

## Test plan

- [ ] Reviewer confirms REQ-018 describes observed behavior (not aspiration) — see `lib/Controller/FilesController.php::restoreVersion()` lines 1485-1491 for the dispatch call.
- [ ] Reviewer confirms the cluster triage notes in `proposal.md` are accurate (VersionInfoCard is admin-settings UI, not content-versioning).
- [ ] `openspec validate retrofit-2026-05-24-content-versioning --strict` continues to pass on CI.