### PR TITLE
retrofit: reverse-spec computed-fields (4 new REQs)

### DIFF
--- a/lib/Service/Object/SaveObject/ComputedFieldHandler.php
+++ b/lib/Service/Object/SaveObject/ComputedFieldHandler.php
@@ -488,6 +488,8 @@ class ComputedFieldHandler
      * @return array<int, array<int, string>> Detected cycles.
      *
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-computed-fields/tasks.md#task-2
      */
     public function detectCircularDependencies(Schema $schema): array
     {
@@ -574,6 +576,8 @@ class ComputedFieldHandler
      * @param string $expression The Twig expression source.
      *
      * @return array<int, string> Distinct top-level identifiers.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-computed-fields/tasks.md#task-1
      */
     private function extractTwigVariables(string $expression): array
     {
@@ -674,6 +678,8 @@ class ComputedFieldHandler
      *                                                 already emitted.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-computed-fields/tasks.md#task-3
      */
     private function dfsForCycles(
         string $node,
@@ -729,6 +735,8 @@ class ComputedFieldHandler
      *                                  node duplicated.
      *
      * @return string Canonical cycle signature.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-computed-fields/tasks.md#task-4
      */
     private function canonicaliseCycle(array $cycle): string
     {

--- a/openspec/changes/retrofit-2026-05-24-computed-fields/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-computed-fields/proposal.md
@@ -1,0 +1,20 @@
+# Retrofit — computed-fields (extend existing capability)
+
+Describes the observed behavior of the four static-analysis methods on `ComputedFieldHandler` that implement circular-dependency detection. The existing `computed-fields` spec specifies the **behavior** of cycle detection ("Circular Dependency Detection" requirement) but does not describe **how** the implementation derives the dependency graph or detects cycles. These four methods were originally triaged DROP from `object-lifecycle#REQ-004` (chunked bulk processing) because they belong to computed-fields, not bulk save. This change retroactively specifies them as 4 new REQs in the computed-fields capability.
+
+## Affected code units
+- lib/Service/Object/SaveObject/ComputedFieldHandler.php (4 methods)
+  - `detectCircularDependencies()` — public entry point; builds the computed-only dependency graph and walks it for cycles
+  - `extractTwigVariables()` — pulls candidate identifiers out of `{{ ... }}` / `{% ... %}` blocks via regex
+  - `dfsForCycles()` — depth-first traversal helper that records back-edges
+  - `canonicaliseCycle()` — rotates a detected cycle to a canonical signature for deduplication
+
+## Approach
+These methods are static-analysis helpers — they never evaluate a Twig template, only parse its source. They are the implementation side of the existing "Circular Dependency Detection" requirement. The existing requirement covers the **outcome** (cycles are detected, evaluation refuses to enter an infinite loop); the new REQs document the **algorithm** that produces that outcome:
+
+- Identifier extraction is **regex-based**, not AST-based, because a full Twig parser would require binding a sandbox environment just for static analysis.
+- The dependency graph **only contains edges between computed properties**. Non-computed inputs are inert leaves — they cannot close a cycle, so they are filtered out before DFS.
+- Cycle detection is **DFS-based** with an explicit traversal stack; a back-edge appears when the current node is already on the stack.
+- Cycle deduplication uses a **canonical signature** (rotate to the lexicographically smallest node) so that DFS-entering the same cycle from two starting nodes yields one report, not two.
+
+Source: rspec batch `/tmp/or-scan/rspec-cluster-computed-fields.json` (2026-05-24); triaged DROP from `object-lifecycle#REQ-004` cluster.

--- a/openspec/changes/retrofit-2026-05-24-computed-fields/specs/computed-fields/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-computed-fields/specs/computed-fields/spec.md
@@ -1,0 +1,116 @@
+---
+retrofit: true
+---
+
+# Computed Fields — Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Static Identifier Extraction From Twig Expression Source
+The system MUST extract candidate variable identifiers from a Twig expression by regex-scanning the source text of every `{{ ... }}` and `{% ... %}` block, without parsing the expression through a Twig AST or sandbox environment. The extractor MUST collect only the top-level word of dotted or array references (`foo`, `foo.bar`, `foo[0]` all yield `foo`). The extractor MUST skip a curated reserved-word set covering Twig keywords (`and`, `or`, `not`, `in`, `is`, `as`, `with`, `if`, `else`, `elseif`, `endif`, `for`, `endfor`, `set`, `do`, `block`, `endblock`), literals (`true`, `false`, `null`), and built-in helpers used inside expressions (`date`, `now`, `min`, `max`, `range`, `random`, `length`, `count`). The extractor MUST strip the cross-object reference prefix `_ref` from the result because `_ref.*` references are foreign-object lookups, not in-schema dependencies.
+
+#### Scenario: Identifier extracted from a simple expression
+- **GIVEN** the expression `{{ voornaam }} {{ achternaam }}`
+- **WHEN** `extractTwigVariables` runs
+- **THEN** the result MUST contain `voornaam` and `achternaam`
+- **AND** the result MUST NOT contain any Twig keyword
+
+#### Scenario: Top-level identifier of a dotted reference
+- **GIVEN** the expression `{{ klant.naam }}`
+- **WHEN** `extractTwigVariables` runs
+- **THEN** the result MUST contain `klant`
+- **AND** the result MUST NOT contain `naam` (it is a sub-property, not a top-level identifier)
+
+#### Scenario: Cross-object reference prefix is stripped
+- **GIVEN** the expression `{{ _ref.klant.naam }}`
+- **WHEN** `extractTwigVariables` runs
+- **THEN** the result MUST NOT contain `_ref`
+- **AND** the identifier `_ref` MUST be filtered out because cross-object references are not in-schema dependencies
+
+#### Scenario: Plain-text content outside Twig blocks is ignored
+- **GIVEN** the expression `Hello {{ name }} world`
+- **WHEN** `extractTwigVariables` runs
+- **THEN** the result MUST contain `name`
+- **AND** the result MUST NOT contain `Hello` or `world` (plain text outside `{{ }}` / `{% %}` is not scanned)
+
+#### Scenario: Empty expression yields empty result
+- **GIVEN** an expression with no `{{ }}` or `{% %}` blocks
+- **WHEN** `extractTwigVariables` runs
+- **THEN** the result MUST be an empty array
+
+### Requirement: Computed-Only Dependency Graph Construction
+The system MUST build the cycle-detection dependency graph using only edges between computed properties. Before extraction, the system MUST collect the set of property names whose definition contains a `computed` array attribute. For each computed property, after extracting candidate identifiers from its expression, the system MUST filter the identifiers down to those also in the computed-property set; references to non-computed properties MUST be discarded because non-computed inputs are inert leaves that cannot close a cycle. The resulting graph MUST be an adjacency list keyed by computed property name with deduplicated edge targets.
+
+#### Scenario: Non-computed property reference is filtered from graph
+- **GIVEN** computed field `totaal` with expression `{{ aantal * prijs - korting }}`
+- **AND** `aantal`, `prijs`, `korting` are non-computed (plain) properties
+- **WHEN** the dependency graph is built
+- **THEN** the graph entry for `totaal` MUST be an empty edge list
+- **AND** no graph entry MUST be created for `aantal`, `prijs`, or `korting` (they are not computed)
+
+#### Scenario: Computed-to-computed reference becomes a graph edge
+- **GIVEN** computed field `subtotaal` (expression `{{ aantal * prijs }}`)
+- **AND** computed field `totaal` (expression `{{ subtotaal - korting }}`)
+- **WHEN** the dependency graph is built
+- **THEN** the graph MUST contain an edge `totaal -> subtotaal`
+
+#### Scenario: Schema with no computed properties yields an empty graph
+- **GIVEN** a schema whose `properties` array contains no entry with a `computed` attribute
+- **WHEN** `detectCircularDependencies` runs
+- **THEN** the function MUST return an empty cycle list immediately without building the graph
+
+#### Scenario: Computed property with empty expression has empty edge list
+- **GIVEN** a computed property whose `computed.expression` is missing or the empty string
+- **WHEN** the dependency graph is built
+- **THEN** the graph entry for that property MUST be an empty edge list (the property is in the graph as a node but has no outgoing edges)
+
+### Requirement: DFS-Based Back-Edge Cycle Detection
+The system MUST detect cycles in the computed-field dependency graph by depth-first traversal. The traversal MUST maintain an explicit stack of nodes on the current path. When the traversal encounters a node that is already on the stack, that node is a back-edge target and the path from that node back to itself (the slice of the stack from the matched index plus the duplicated closing node) MUST be recorded as a cycle. The traversal MUST also maintain a globally-visited set so that subtrees already explored from another starting node are not re-walked. The traversal MUST be invoked once per node in the graph so cycles reachable only from non-root entry points are still detected.
+
+#### Scenario: Self-loop is detected as a length-1 cycle
+- **GIVEN** computed field `a` with expression `{{ a + 1 }}` (so `a -> a` is an edge)
+- **WHEN** `dfsForCycles` is called for node `a`
+- **THEN** the cycle `[a, a]` (start `a`, back-edge to `a`) MUST be recorded
+
+#### Scenario: Two-node cycle is detected from either starting node
+- **GIVEN** edges `a -> b` and `b -> a`
+- **WHEN** DFS runs from node `a`
+- **THEN** the cycle `[a, b, a]` MUST be recorded
+
+#### Scenario: Shared subtree not re-walked
+- **GIVEN** a graph with nodes `a`, `b`, `c` where both `a -> c` and `b -> c` exist and `c` is acyclic
+- **WHEN** DFS runs from `a` and then from `b`
+- **THEN** the subtree rooted at `c` MUST NOT be re-traversed during the second invocation (visited-set short-circuits the second walk)
+
+#### Scenario: Acyclic graph produces no cycles
+- **GIVEN** a graph `subtotaal -> []`, `totaal -> [subtotaal]` (no back-edges)
+- **WHEN** DFS runs from every node
+- **THEN** the returned cycle list MUST be empty
+
+### Requirement: Canonical Cycle Signature Deduplication
+The system MUST deduplicate detected cycles by canonical signature so that entering the same cycle from two different DFS starting nodes produces only one entry in the reported cycle list. The signature MUST be computed by dropping the duplicated closing node from the cycle path and then rotating the remaining sequence so the lexicographically smallest node leads. The rotated sequence MUST be joined by `->` to form the signature. The first time a signature is produced the cycle MUST be appended to the output and the signature recorded; subsequent re-discoveries with the same signature MUST be suppressed.
+
+#### Scenario: Same cycle entered from two starts yields one report
+- **GIVEN** the cycle `a -> b -> a` is reachable from both starting nodes `a` and `b`
+- **WHEN** DFS visits both starts in turn
+- **THEN** the cycle MUST appear exactly once in the returned cycle list
+- **AND** the canonical signature MUST be `a->b` (rotation starting at the lexicographically smallest node)
+
+#### Scenario: Cycle rotated to lexicographically smallest start
+- **GIVEN** the cycle path `[c, a, b, c]` (closing node duplicated)
+- **WHEN** `canonicaliseCycle` runs
+- **THEN** the duplicated closing `c` MUST be dropped
+- **AND** the body `[c, a, b]` MUST be rotated so `a` (smallest) leads
+- **AND** the returned signature MUST be `a->b->c`
+
+#### Scenario: Single-node self-loop produces a single-name signature
+- **GIVEN** the cycle path `[a, a]`
+- **WHEN** `canonicaliseCycle` runs
+- **THEN** the duplicated closing `a` MUST be dropped
+- **AND** the body `[a]` is already canonical
+- **AND** the returned signature MUST be `a`
+
+#### Scenario: Empty cycle returns empty signature
+- **GIVEN** an empty cycle path
+- **WHEN** `canonicaliseCycle` runs
+- **THEN** the returned signature MUST be the empty string

--- a/openspec/changes/retrofit-2026-05-24-computed-fields/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-computed-fields/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] task-1: computed-fields — Static Identifier Extraction From Twig Expression Source (retroactive annotation: `ComputedFieldHandler::extractTwigVariables`)
+- [x] task-2: computed-fields — Computed-Only Dependency Graph Construction (retroactive annotation: `ComputedFieldHandler::detectCircularDependencies`)
+- [x] task-3: computed-fields — DFS-Based Back-Edge Cycle Detection (retroactive annotation: `ComputedFieldHandler::dfsForCycles`)
+- [x] task-4: computed-fields — Canonical Cycle Signature Deduplication (retroactive annotation: `ComputedFieldHandler::canonicaliseCycle`)


### PR DESCRIPTION
## Summary

Reverse-spec retrofit for the **computed-fields** capability. Adds 4 new REQs describing the static-analysis algorithm used by `ComputedFieldHandler` to detect circular dependencies between computed fields. The existing `Circular Dependency Detection` requirement specifies the **outcome** (cycles detected, no infinite loops); these new REQs specify the **implementation**.

The 4 methods were originally triaged DROP from `object-lifecycle#REQ-004` (chunked bulk save) — they belong to computed-fields, not bulk save, and the rspec scanner re-clustered them here.

## New REQs (extend existing `computed-fields` spec)

| Task | Requirement | Method |
|------|-------------|--------|
| task-1 | Static Identifier Extraction From Twig Expression Source | `extractTwigVariables()` |
| task-2 | Computed-Only Dependency Graph Construction | `detectCircularDependencies()` |
| task-3 | DFS-Based Back-Edge Cycle Detection | `dfsForCycles()` |
| task-4 | Canonical Cycle Signature Deduplication | `canonicaliseCycle()` |

## Behavior captured

- Identifier extraction is **regex-based**, not AST-based (no Twig sandbox bound just for static analysis).
- Dependency graph contains **only computed-to-computed edges** — non-computed inputs are inert leaves that cannot close a cycle.
- Cycle detection uses **DFS with explicit traversal stack**; back-edges appear when the current node is already on the stack.
- Cycles are **deduplicated by canonical signature** (rotated to lexicographically smallest start) so entering the same cycle from two starts yields one report.

## Files

- `openspec/changes/retrofit-2026-05-24-computed-fields/proposal.md`
- `openspec/changes/retrofit-2026-05-24-computed-fields/specs/computed-fields/spec.md` (delta, 4 ADDED requirements)
- `openspec/changes/retrofit-2026-05-24-computed-fields/tasks.md` (4 tasks, all [x])
- `lib/Service/Object/SaveObject/ComputedFieldHandler.php` (4 @spec docblock annotations)

## Test plan

- [x] `openspec validate retrofit-2026-05-24-computed-fields --strict` passes
- [x] All 4 methods carry an @spec tag pointing back at the matching task
- [x] No behavior changes — annotations and spec only

Source: `/tmp/or-scan/rspec-cluster-computed-fields.json` (2026-05-24).