### PR TITLE
retrofit: reverse-spec edepot-transfer (2 new REQs)

### DIFF
--- a/lib/BackgroundJob/TransferExecutionJob.php
+++ b/lib/BackgroundJob/TransferExecutionJob.php
@@ -117,6 +117,8 @@ class TransferExecutionJob extends QueuedJob
      * Resolve the configured transport implementation.
      *
      * @return TransportInterface The transport to use.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-edepot-transfer/tasks.md#task-1
      */
     private function resolveTransport(): TransportInterface
     {

--- a/lib/Controller/Settings/EdepotSettingsController.php
+++ b/lib/Controller/Settings/EdepotSettingsController.php
@@ -186,6 +186,8 @@ class EdepotSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse The connection test result.
+     *
+     * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-23
      */
     public function testEdepotConnection(): JSONResponse
     {
@@ -218,6 +220,8 @@ class EdepotSettingsController extends Controller
      * @param string $type The transport type.
      *
      * @return TransportInterface The transport.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-edepot-transfer/tasks.md#task-1
      */
     private function resolveTransport(string $type): TransportInterface
     {

--- a/lib/Service/Edepot/Transport/OpenConnectorTransport.php
+++ b/lib/Service/Edepot/Transport/OpenConnectorTransport.php
@@ -40,6 +40,8 @@ class OpenConnectorTransport implements TransportInterface
      *
      * @param Client          $httpClient The HTTP client.
      * @param LoggerInterface $logger     Logger.
+     *
+     * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-21
      */
     public function __construct(
         private readonly Client $httpClient,

--- a/lib/Service/Edepot/Transport/TransportResult.php
+++ b/lib/Service/Edepot/Transport/TransportResult.php
@@ -69,6 +69,8 @@ class TransportResult
      * @param string|null                                                                      $transferReference Transfer reference.
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-edepot-transfer/tasks.md#task-2
      */
     public function __construct(
         bool $success=false,
@@ -149,6 +151,8 @@ class TransportResult
      * Get the transfer reference.
      *
      * @return string|null The e-Depot transfer reference.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-edepot-transfer/tasks.md#task-2
      */
     public function getTransferReference(): ?string
     {

--- a/openspec/changes/retrofit-2026-05-24-edepot-transfer/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-edepot-transfer/proposal.md
@@ -1,0 +1,22 @@
+# Retrofit — edepot-transfer
+
+Describes observed behavior of 2 methods under `edepot-transfer` as 2 new REQs. Code already exists — this change retroactively specifies it.
+
+## Affected code units
+- lib/BackgroundJob/TransferExecutionJob.php::resolveTransport (REQ-009)
+- lib/Controller/Settings/EdepotSettingsController.php::resolveTransport (REQ-009)
+- lib/Service/Edepot/Transport/TransportResult.php::getTransferReference (REQ-010)
+
+## Additional methods annotated with existing REQs
+- lib/Controller/Settings/EdepotSettingsController.php::testEdepotConnection — covered by existing "Test e-Depot connection" scenario under the configurable endpoint settings requirement
+- lib/Service/Edepot/Transport/OpenConnectorTransport.php::__construct — covered by the existing OpenConnector transport requirement (transport dependency injection)
+- lib/Service/Edepot/Transport/TransportResult.php::__construct — covered by REQ-010 (TransportResult value object contract)
+
+## Approach
+- Observed: Both `resolveTransport` implementations read `edepot_transport` from `IAppConfig` (with `rest_api` as default) and dispatch via a `switch` on `sftp` / `openconnector` / `rest_api` — `rest_api` is also the `default` arm, so any unknown/missing value silently falls back to REST.
+- Observed: `TransportResult` is a constructor-only value object exposing the e-Depot's transfer reference (the call-log id for OpenConnector, the upload identifier for REST/SFTP) alongside per-object accept/reject results and an optional top-level error message. `OpenConnectorTransport::send()` returns it with `transferReference: $callLogId`.
+- The existing spec already covers the high-level transport-protocol selection (SFTP, REST, OpenConnector) but does NOT specify (a) the default-fallback behavior when the configured transport type is unknown, nor (b) the TransportResult contract callers rely on to record `retention.eDepotReferentie`.
+- REQ-009 captures the resolver default-fallback rule.
+- REQ-010 captures the TransportResult value-object shape, in particular `getTransferReference()` and the partial-success classification.
+
+Source: bucket 2a coverage scan. See retrofit playbook.

--- a/openspec/changes/retrofit-2026-05-24-edepot-transfer/specs/edepot-transfer/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-edepot-transfer/specs/edepot-transfer/spec.md
@@ -1,0 +1,67 @@
+---
+retrofit_extensions:
+  - REQ-009
+  - REQ-010
+---
+
+### REQ-009: The system MUST resolve the e-Depot transport implementation from app config with `rest_api` as the default fallback
+
+Both the `TransferExecutionJob` (background path) and the `EdepotSettingsController` (admin connection-test path) MUST resolve the active transport implementation by reading the `edepot_transport` app-config value from the `openregister` namespace. Recognised values are `sftp`, `openconnector`, and `rest_api`. Any unset, empty, or unrecognised value MUST silently fall back to the `rest_api` transport — the resolver MUST NOT throw on unknown transport types.
+
+#### Scenario: Resolver returns SFTP transport when configured
+- **GIVEN** the app config `openregister.edepot_transport` is set to `sftp`
+- **WHEN** `TransferExecutionJob::resolveTransport` runs
+- **THEN** it MUST return the `SftpTransport` instance injected via the constructor
+
+#### Scenario: Resolver returns OpenConnector transport when configured
+- **GIVEN** the app config `openregister.edepot_transport` is set to `openconnector`
+- **WHEN** the resolver runs
+- **THEN** it MUST return the `OpenConnectorTransport` instance
+
+#### Scenario: Resolver returns REST transport when configured
+- **GIVEN** the app config `openregister.edepot_transport` is set to `rest_api`
+- **WHEN** the resolver runs
+- **THEN** it MUST return the `RestApiTransport` instance
+
+#### Scenario: Resolver falls back to REST when app config is missing or unknown
+- **GIVEN** the app config `openregister.edepot_transport` is unset, empty, or set to an unrecognised value (e.g. `s3`, `ftp`, `null`)
+- **WHEN** the resolver runs
+- **THEN** it MUST return the `RestApiTransport` instance without throwing
+- **AND** the fallback MUST NOT log an error — REST is the documented default
+
+#### Scenario: Settings controller resolver accepts an explicit type override
+- **GIVEN** an admin posts a connection test with body `{"transport": "openconnector"}`
+- **WHEN** `EdepotSettingsController::resolveTransport($type)` runs with `$type = "openconnector"`
+- **THEN** it MUST return the `OpenConnectorTransport` instance regardless of the stored `edepot_transport` config value
+- **AND** an unknown `$type` value MUST fall back to `RestApiTransport`
+
+### REQ-010: The TransportResult value object MUST expose overall success, partial-success classification, per-object accept/reject results, an optional error message, and the e-Depot transfer reference
+
+Every transport implementation (`SftpTransport`, `RestApiTransport`, `OpenConnectorTransport`) MUST return a `TransportResult` from its `send()` method. The result MUST be constructible with `success`, `objectResults`, `errorMessage`, and `transferReference` parameters and MUST expose the following query methods used by `EdepotTransferService` to update `retention.archiefstatus`, `retention.eDepotReferentie`, and `retention.transferErrors[]`.
+
+#### Scenario: TransportResult exposes the transfer reference set by the transport
+- **GIVEN** `OpenConnectorTransport::send()` succeeds and the OpenConnector API responds with `{"callLogId": "ocl-abc-123"}`
+- **WHEN** the transport returns a `TransportResult` constructed with `transferReference: "ocl-abc-123"`
+- **THEN** `TransportResult::getTransferReference()` MUST return the string `"ocl-abc-123"`
+- **AND** when no reference is supplied the method MUST return `null`
+- **AND** callers MUST use this value to populate `retention.eDepotReferentie` on accepted objects
+
+#### Scenario: TransportResult classifies a partial success
+- **GIVEN** a `TransportResult` is constructed with `success: false` and `objectResults` containing 3 entries where 2 have `accepted: true` and 1 has `accepted: false`
+- **WHEN** `isPartialSuccess()` is called
+- **THEN** it MUST return `true`
+- **AND** `getAcceptedUuids()` MUST return the 2 accepted UUIDs
+- **AND** `getRejectedUuids()` MUST return the 1 rejected UUID
+
+#### Scenario: TransportResult reports overall failure with an error message
+- **GIVEN** a transport catches a network exception and returns `new TransportResult(success: false, errorMessage: "Connection refused")`
+- **WHEN** the caller queries the result
+- **THEN** `isSuccess()` MUST return `false`
+- **AND** `isPartialSuccess()` MUST return `false` (no per-object results)
+- **AND** `getErrorMessage()` MUST return `"Connection refused"`
+- **AND** `toArray()` MUST include all four fields: `success`, `objectResults`, `errorMessage`, `transferReference`
+
+#### Scenario: TransportResult overall-success short-circuits partial-success
+- **GIVEN** a `TransportResult` is constructed with `success: true`
+- **WHEN** `isPartialSuccess()` is called
+- **THEN** it MUST return `false` regardless of the contents of `objectResults` — overall success is mutually exclusive with partial success

--- a/openspec/changes/retrofit-2026-05-24-edepot-transfer/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-edepot-transfer/tasks.md
@@ -1,0 +1,4 @@
+# Tasks
+
+- [x] task-1: edepot-transfer#REQ-009 — The system MUST resolve the e-Depot transport implementation from app config with `rest_api` as the default fallback (retroactive annotation)
+- [x] task-2: edepot-transfer#REQ-010 — The TransportResult value object MUST expose overall success, partial-success classification, per-object accept/reject results, an optional error message, and the e-Depot transfer reference (retroactive annotation)


### PR DESCRIPTION
## Summary

Reverse-spec retrofit for the `edepot-transfer` capability. Adds two new REQs to the existing spec describing observed behavior of 6 Bucket 2a methods across 4 files. No code changes — annotation-only.

## New requirements

- **REQ-009**: The system MUST resolve the e-Depot transport implementation from app config with `rest_api` as the default fallback. Both `TransferExecutionJob::resolveTransport` and `EdepotSettingsController::resolveTransport` switch on the configured transport type (`sftp` / `openconnector` / `rest_api`), with `rest_api` doubling as the `default` arm — so any unknown/missing value silently falls back to REST.
- **REQ-010**: The `TransportResult` value object MUST expose overall success, partial-success classification, per-object accept/reject results, an optional error message, and the e-Depot transfer reference. `OpenConnectorTransport::send()` populates `transferReference` from the OpenConnector call-log id; `EdepotTransferService` uses `getTransferReference()` to set `retention.eDepotReferentie`.

## Methods annotated

| File | Method | Tag |
|------|--------|-----|
| `lib/BackgroundJob/TransferExecutionJob.php` | `resolveTransport` | new task-1 (REQ-009) |
| `lib/Controller/Settings/EdepotSettingsController.php` | `resolveTransport` | new task-1 (REQ-009) |
| `lib/Controller/Settings/EdepotSettingsController.php` | `testEdepotConnection` | existing annotate-openregister task-23 |
| `lib/Service/Edepot/Transport/OpenConnectorTransport.php` | `__construct` | existing annotate-openregister task-21 |
| `lib/Service/Edepot/Transport/TransportResult.php` | `__construct` | new task-2 (REQ-010) |
| `lib/Service/Edepot/Transport/TransportResult.php` | `getTransferReference` | new task-2 (REQ-010) |

## Test plan

- [ ] `openspec validate` clean on the ghost change
- [ ] Spec delta accurately reflects observed behavior in the four files (no aspirational scenarios)
- [ ] All 6 listed methods carry a `@spec` annotation pointing to the right task

Source: bucket 2a coverage scan / retrofit playbook.