### PR TITLE
retrofit: reverse-spec files-sidebar-tabs (3 new REQs)

### DIFF
--- a/openspec/changes/retrofit-2026-05-24-files-sidebar-tabs/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-files-sidebar-tabs/proposal.md
@@ -1,0 +1,19 @@
+# Retrofit: Filter Sidebar Tabs (reverse-spec)
+
+## Why
+
+The OpenRegister frontend ships four filter-sidebar components (`EntitiesSidebar`, `WebhooksSidebar`, `DashboardSideBar`, `DeletedSideBar`) that share a common UX vocabulary (debounced search, register/schema cascade, URL-as-state) but were never documented in `openspec/specs/`. The Bucket 2a coverage scan (2026-05-24) surfaced four public methods (`handleSearchInput` x2, `handleRegisterChange`, `applyFilters`) with no docblocks and no `@spec` annotations.
+
+This ghost change reverse-engineers a new `files-sidebar-tabs` capability spec from the observed code, captures three REQs describing the shared behaviour, and annotates the four methods with `@spec` pointers back to this change's tasks. No production code changes; this is an annotation-only retrofit so future edits to these methods can be reviewed against an explicit contract.
+
+## What changes
+
+- Add new capability spec `openspec/specs/files-sidebar-tabs/spec.md` (3 REQs, all extracted from observed behaviour).
+- Add ghost change `retrofit-2026-05-24-files-sidebar-tabs/` with delta + tasks.
+- Annotate 4 methods with `@spec` pointers to this change's tasks file.
+
+## Impact
+
+- **Specs**: new capability `files-sidebar-tabs`.
+- **Code**: docblock-only edits in 4 Vue SFCs; no runtime behaviour changes.
+- **Risk**: none — annotation retrofit.

--- a/openspec/changes/retrofit-2026-05-24-files-sidebar-tabs/specs/files-sidebar-tabs/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-files-sidebar-tabs/specs/files-sidebar-tabs/spec.md
@@ -1,0 +1,82 @@
+# files-sidebar-tabs — Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Debounced search input emits update:search after 500ms
+
+Filter sidebars that own a free-text search field (currently `EntitiesSidebar` and `WebhooksSidebar`) SHALL implement `handleSearchInput(value)` which debounces keystrokes through a single `searchTimeout` handle and emits `update:search` to the parent component 500ms after the last keystroke. Each invocation MUST clear the previous timeout so that only the final value is emitted.
+
+#### Scenario: Single keystroke emits after 500ms
+
+- **GIVEN** the user types one character `f` into the sidebar's search input
+- **WHEN** `handleSearchInput("f")` fires
+- **THEN** a `setTimeout` is registered with a 500ms delay
+- **AND** after 500ms the parent receives `update:search` with payload `"f"`
+
+#### Scenario: Rapid keystrokes only emit the final value
+
+- **GIVEN** the user types `foo` quickly (within 500ms)
+- **WHEN** `handleSearchInput` fires three times in succession (`f`, `fo`, `foo`)
+- **THEN** the first two timeouts MUST be cleared by `clearTimeout(this.searchTimeout)` before the next is set
+- **AND** only one `update:search` event MUST fire 500ms after the last keystroke, with payload `"foo"`
+
+#### Scenario: Component owns a single search timeout handle
+
+- **GIVEN** the sidebar component is mounted
+- **WHEN** any debounced method runs
+- **THEN** the timeout handle MUST be stored on `this.searchTimeout` (not a module-level variable)
+- **AND** the same handle MUST be reused so that `clearTimeout` correctly cancels the pending emission
+
+### Requirement: Register selection cascade resets dependent schema state
+
+Filter sidebars that expose a register picker (currently `DashboardSideBar` and `DeletedSideBar`) SHALL implement `handleRegisterChange(register)` which sets the new register on `registerStore` via `setRegisterItem(option)` AND immediately clears the schema selection by calling `schemaStore.setSchemaItem(null)`. The cascade ensures stale schema state from a previous register does not leak into the new register's filter context.
+
+#### Scenario: Switching register clears the active schema
+
+- **GIVEN** the user has register `R1` and schema `S1` (which belongs to `R1`) selected
+- **WHEN** the user picks register `R2` from the register picker and `handleRegisterChange(R2)` runs
+- **THEN** `registerStore.setRegisterItem(R2)` MUST be called
+- **AND** `schemaStore.setSchemaItem(null)` MUST be called in the same handler, before any other action
+
+#### Scenario: Clearing the register also clears the schema
+
+- **GIVEN** a register is currently selected
+- **WHEN** the user clears the register selection (`handleRegisterChange(null)`)
+- **THEN** `registerStore.setRegisterItem(null)` MUST be called
+- **AND** `schemaStore.setSchemaItem(null)` MUST be called
+
+#### Scenario: DeletedSideBar additionally re-applies filters after the cascade
+
+- **GIVEN** the DeletedSideBar variant of `handleRegisterChange`
+- **WHEN** the cascade completes
+- **THEN** `this.applyFilters()` MUST be called so that the new register selection is immediately reflected in the route query string and the parent list
+
+### Requirement: Deleted sidebar serialises filter state into the route query
+
+`DeletedSideBar` SHALL implement `applyFilters()` as a thin wrapper that delegates to `updateRouteQueryFromState()`. The route-query function MUST:
+
+1. No-op when `this.$route.path` is not `/deleted` (to avoid mutating unrelated routes during teardown or hot-reload).
+2. Build a fresh query object from the current sidebar state via `buildQueryFromState()` (including `register`, `schema`, `deletedBy`, `dateFrom`, `dateTo`).
+3. Compare the new query to the current `$route.query` via `queriesEqual()` and skip the navigation if they match (prevents redundant router pushes that would re-trigger watchers).
+4. Otherwise call `this.$router.replace({ path: this.$route.path, query: nextQuery })`.
+
+#### Scenario: applyFilters writes filter state to the URL
+
+- **GIVEN** the user is on `/deleted` with no query string
+- **AND** the sidebar has register `5`, schema `12`, and `dateFrom = 2026-05-01` selected
+- **WHEN** any filter change triggers `applyFilters()`
+- **THEN** `updateRouteQueryFromState()` MUST call `$router.replace` with query `{ register: "5", schema: "12", dateFrom: "2026-05-01T00:00:00.000Z" }`
+
+#### Scenario: applyFilters is a no-op outside /deleted
+
+- **GIVEN** the user has navigated away to `/dashboard` but the DeletedSideBar component is still mounted (or being torn down)
+- **WHEN** a residual watcher fires `applyFilters()`
+- **THEN** `updateRouteQueryFromState()` MUST detect `this.$route.path !== '/deleted'` and return immediately
+- **AND** no `$router.replace` call MUST be issued
+
+#### Scenario: applyFilters skips redundant navigation
+
+- **GIVEN** the current `$route.query` already equals the query built from sidebar state
+- **WHEN** `applyFilters()` runs (for example after `applyQueryParamsFromRoute` already synchronised both directions)
+- **THEN** `queriesEqual` MUST return true
+- **AND** `$router.replace` MUST NOT be called

--- a/openspec/changes/retrofit-2026-05-24-files-sidebar-tabs/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-files-sidebar-tabs/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: retrofit-2026-05-24-files-sidebar-tabs
+
+## 1. Reverse-spec coverage
+
+- [x] task-1 — REQ "Debounced search input emits update:search after 500ms": annotate `EntitiesSidebar.handleSearchInput` and `WebhooksSidebar.handleSearchInput`.
+- [x] task-2 — REQ "Register selection cascade resets dependent schema state": annotate `DashboardSideBar.handleRegisterChange` (and document the DeletedSideBar variant via the same REQ in the canonical spec).
+- [x] task-3 — REQ "Deleted sidebar serialises filter state into the route query": annotate `DeletedSideBar.applyFilters`.

--- a/openspec/specs/files-sidebar-tabs/spec.md
+++ b/openspec/specs/files-sidebar-tabs/spec.md
@@ -1,0 +1,114 @@
+---
+status: implemented
+retrofit: true
+---
+
+# Filter Sidebar Tabs
+
+## Purpose
+
+Provide a consistent filter-sidebar UX across OpenRegister's main list views (Entities, Webhooks, Dashboard, Deleted). Each filter sidebar is a Vue single-file component that owns a small set of filter controls (search input, register/schema pickers, status pickers, date ranges) and communicates its state either through `update:*` events to a parent list view (Entities, Webhooks) or through the global Pinia register/schema/deleted stores plus the router query string (Dashboard, Deleted).
+
+This spec documents the observed behavior of the four sidebar components as retroactively introduced by the `retrofit-2026-05-24-files-sidebar-tabs` ghost change. Code already exists — requirements describe what the code does, not what it should do.
+
+**Standards**: Vue 2 single-file components, Pinia stores, Vue Router, Nextcloud `@nextcloud/l10n` for i18n
+**Cross-references**: list views consuming the sidebars live under `src/views/`
+
+## Requirements
+
+### Requirement: Debounced search input emits update:search after 500ms
+
+Filter sidebars that own a free-text search field (currently `EntitiesSidebar` and `WebhooksSidebar`) SHALL implement `handleSearchInput(value)` which debounces keystrokes through a single `searchTimeout` handle and emits `update:search` to the parent component 500ms after the last keystroke. Each invocation MUST clear the previous timeout so that only the final value is emitted.
+
+#### Rationale
+
+Without debouncing every keystroke would trigger a network round-trip on the parent list view. 500ms is the project's standard search-input debounce interval (also used by the mail sidebar's link dialog).
+
+#### Scenario: Single keystroke emits after 500ms
+
+- **GIVEN** the user types one character `f` into the sidebar's search input
+- **WHEN** `handleSearchInput("f")` fires
+- **THEN** a `setTimeout` is registered with a 500ms delay
+- **AND** after 500ms the parent receives `update:search` with payload `"f"`
+
+#### Scenario: Rapid keystrokes only emit the final value
+
+- **GIVEN** the user types `foo` quickly (within 500ms)
+- **WHEN** `handleSearchInput` fires three times in succession (`f`, `fo`, `foo`)
+- **THEN** the first two timeouts MUST be cleared by `clearTimeout(this.searchTimeout)` before the next is set
+- **AND** only one `update:search` event MUST fire 500ms after the last keystroke, with payload `"foo"`
+
+#### Scenario: Component owns a single search timeout handle
+
+- **GIVEN** the sidebar component is mounted
+- **WHEN** any debounced method runs
+- **THEN** the timeout handle MUST be stored on `this.searchTimeout` (not a module-level variable)
+- **AND** the same handle MUST be reused so that `clearTimeout` correctly cancels the pending emission
+
+---
+
+### Requirement: Register selection cascade resets dependent schema state
+
+Filter sidebars that expose a register picker (currently `DashboardSideBar` and `DeletedSideBar`) SHALL implement `handleRegisterChange(register)` which sets the new register on `registerStore` via `setRegisterItem(option)` AND immediately clears the schema selection by calling `schemaStore.setSchemaItem(null)`. The cascade ensures stale schema state from a previous register does not leak into the new register's filter context.
+
+#### Rationale
+
+Schemas belong to a register; selecting a different register makes any previously selected schema meaningless. Clearing the schema in the same handler keeps the two stores consistent without requiring the parent list view to coordinate the reset.
+
+#### Scenario: Switching register clears the active schema
+
+- **GIVEN** the user has register `R1` and schema `S1` (which belongs to `R1`) selected
+- **WHEN** the user picks register `R2` from the register picker and `handleRegisterChange(R2)` runs
+- **THEN** `registerStore.setRegisterItem(R2)` MUST be called
+- **AND** `schemaStore.setSchemaItem(null)` MUST be called in the same handler, before any other action
+
+#### Scenario: Clearing the register also clears the schema
+
+- **GIVEN** a register is currently selected
+- **WHEN** the user clears the register selection (`handleRegisterChange(null)`)
+- **THEN** `registerStore.setRegisterItem(null)` MUST be called
+- **AND** `schemaStore.setSchemaItem(null)` MUST be called
+
+#### Scenario: DeletedSideBar additionally re-applies filters after the cascade
+
+- **GIVEN** the DeletedSideBar variant of `handleRegisterChange`
+- **WHEN** the cascade completes
+- **THEN** `this.applyFilters()` MUST be called so that the new register selection is immediately reflected in the route query string and the parent list
+
+---
+
+### Requirement: Deleted sidebar serialises filter state into the route query
+
+`DeletedSideBar` SHALL implement `applyFilters()` as a thin wrapper that delegates to `updateRouteQueryFromState()`. The route-query function MUST:
+
+1. No-op when `this.$route.path` is not `/deleted` (to avoid mutating unrelated routes during teardown or hot-reload).
+2. Build a fresh query object from the current sidebar state via `buildQueryFromState()` (including `register`, `schema`, `deletedBy`, `dateFrom`, `dateTo`).
+3. Compare the new query to the current `$route.query` via `queriesEqual()` and skip the navigation if they match (prevents redundant router pushes that would re-trigger watchers).
+4. Otherwise call `this.$router.replace({ path: this.$route.path, query: nextQuery })`.
+
+#### Rationale
+
+Using the route query as the canonical filter store makes the filter state shareable (URLs can be bookmarked / sent to colleagues) and survives page reloads. Using `replace` (not `push`) avoids polluting browser history with every filter tweak. The path guard and equality guard prevent reactive loops between the sidebar watchers and the route-watcher that re-applies query params on navigation.
+
+#### Scenario: applyFilters writes filter state to the URL
+
+- **GIVEN** the user is on `/deleted` with no query string
+- **AND** the sidebar has register `5`, schema `12`, and `dateFrom = 2026-05-01` selected
+- **WHEN** any filter change triggers `applyFilters()`
+- **THEN** `updateRouteQueryFromState()` MUST call `$router.replace` with query `{ register: "5", schema: "12", dateFrom: "2026-05-01T00:00:00.000Z" }`
+
+#### Scenario: applyFilters is a no-op outside /deleted
+
+- **GIVEN** the user has navigated away to `/dashboard` but the DeletedSideBar component is still mounted (or being torn down)
+- **WHEN** a residual watcher fires `applyFilters()`
+- **THEN** `updateRouteQueryFromState()` MUST detect `this.$route.path !== '/deleted'` and return immediately
+- **AND** no `$router.replace` call MUST be issued
+
+#### Scenario: applyFilters skips redundant navigation
+
+- **GIVEN** the current `$route.query` already equals the query built from sidebar state
+- **WHEN** `applyFilters()` runs (for example after `applyQueryParamsFromRoute` already synchronised both directions)
+- **THEN** `queriesEqual` MUST return true
+- **AND** `$router.replace` MUST NOT be called
+
+---

--- a/src/components/EntitiesSidebar.vue
+++ b/src/components/EntitiesSidebar.vue
@@ -151,6 +151,13 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * Handle search input with 500ms debounce; emits `update:search` once typing pauses.
+		 *
+		 * @param {string} value - The search value
+		 * @return {void}
+		 * @spec openspec/changes/retrofit-2026-05-24-files-sidebar-tabs/tasks.md#task-1
+		 */
 		handleSearchInput(value) {
 			clearTimeout(this.searchTimeout)
 			this.searchTimeout = setTimeout(() => {

--- a/src/components/WebhooksSidebar.vue
+++ b/src/components/WebhooksSidebar.vue
@@ -115,6 +115,7 @@ export default {
 		 *
 		 * @param {string} value - The search value
 		 * @return {void}
+		 * @spec openspec/changes/retrofit-2026-05-24-files-sidebar-tabs/tasks.md#task-1
 		 */
 		handleSearchInput(value) {
 			clearTimeout(this.searchTimeout)

--- a/src/sidebars/dashboard/DashboardSideBar.vue
+++ b/src/sidebars/dashboard/DashboardSideBar.vue
@@ -341,6 +341,13 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * Apply a new register selection and reset the dependent schema state.
+		 *
+		 * @param {object|null} option - The selected register (or null to clear)
+		 * @return {void}
+		 * @spec openspec/changes/retrofit-2026-05-24-files-sidebar-tabs/tasks.md#task-2
+		 */
 		handleRegisterChange(option) {
 			registerStore.setRegisterItem(option)
 			schemaStore.setSchemaItem(null)

--- a/src/sidebars/deleted/DeletedSideBar.vue
+++ b/src/sidebars/deleted/DeletedSideBar.vue
@@ -318,8 +318,13 @@ export default {
 	},
 	methods: {
 		/**
-		 * Apply filters and emit to parent components
+		 * Apply filters and emit to parent components.
+		 *
+		 * Delegates to {@link updateRouteQueryFromState} which serialises the current
+		 * sidebar state into the `/deleted` route query (with path + equality guards).
+		 *
 		 * @return {void}
+		 * @spec openspec/changes/retrofit-2026-05-24-files-sidebar-tabs/tasks.md#task-3
 		 */
 		applyFilters() {
 			this.updateRouteQueryFromState()


### PR DESCRIPTION
## Summary

Reverse-engineers the **filter-sidebar** capability from observed code in four Vue SFCs that share a common UX vocabulary but were never specced.

- Adds new capability spec `openspec/specs/files-sidebar-tabs/spec.md` (`status: implemented`, `retrofit: true`).
- Adds ghost change `retrofit-2026-05-24-files-sidebar-tabs/` with proposal, spec delta (3 ADDED REQs), and tasks (all `[x]`).
- Annotates 4 public methods with `@spec` pointers to the ghost change's `tasks.md`.

## New REQs (extracted from observed behaviour)

1. **Debounced search input emits `update:search` after 500ms** — `EntitiesSidebar.handleSearchInput`, `WebhooksSidebar.handleSearchInput`.
2. **Register selection cascade resets dependent schema state** — `DashboardSideBar.handleRegisterChange` (with note on the DeletedSideBar variant that additionally calls `applyFilters()`).
3. **Deleted sidebar serialises filter state into the route query** — `DeletedSideBar.applyFilters` -> `updateRouteQueryFromState` with `path !== '/deleted'` guard and `queriesEqual` equality guard.

## Impact

- **Specs**: new capability `files-sidebar-tabs`.
- **Code**: docblock-only edits in 4 Vue SFCs; no runtime behaviour changes.
- **Risk**: none — annotation retrofit.

## Test plan

- [ ] CI lint passes (the JSDoc additions follow the existing convention already used by `WebhooksSidebar.handleSearchInput`).
- [ ] `openspec validate retrofit-2026-05-24-files-sidebar-tabs --strict` (optional — ghost-change validation).