### PR TITLE
retrofit: reverse-spec archival-destruction-workflow (2 new REQs)

### DIFF
--- a/lib/Service/ArchivalService.php
+++ b/lib/Service/ArchivalService.php
@@ -89,6 +89,8 @@ class ArchivalService
      * @throws InvalidArgumentException If retention data is invalid
      *
      * @SuppressWarnings(PHPMD.StaticAccess)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-archival-destruction-workflow/tasks.md#task-1
      */
     public function setRetentionMetadata(ObjectEntity $object, array $retention): ObjectEntity
     {
@@ -419,6 +421,8 @@ class ArchivalService
      * @param string $uuid The object UUID
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-archival-destruction-workflow/tasks.md#task-2
      */
     private function extendRetentionForObject(string $uuid): void
     {

--- a/openspec/changes/retrofit-2026-05-24-archival-destruction-workflow/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-archival-destruction-workflow/proposal.md
@@ -1,0 +1,37 @@
+# Retrofit: reverse-spec archival-destruction-workflow
+
+## Why
+
+Two methods in `lib/Service/ArchivalService.php` (`setRetentionMetadata`,
+`extendRetentionForObject`) implement object-level retention behaviour that is
+genuinely owned by the `archival-destruction-workflow` capability but is not
+covered by REQ-001..REQ-009. This retrofit captures the observed behaviour as
+two new requirements (REQ-010, REQ-011) so the methods can be `@spec`-annotated
+and stay traceable.
+
+The other 8 methods in this cluster (DSL parser/comparator, hourly retention
+sweep cron, schema-save annotation validator, generic duration utility) were
+triaged out — they belong to the sibling `add-archival-annotation-support`
+capability (schema-level `x-openregister-archival` rules) rather than the
+per-object NEN 15489 destruction workflow tracked here. They are intentionally
+NOT annotated against this capability.
+
+## What Changes
+
+- Append REQ-010 (`setRetentionMetadata` write-path validation) to
+  `openspec/specs/archival-destruction-workflow/spec.md`.
+- Append REQ-011 (`extendRetentionForObject` selectionlist-driven extension)
+  to the same spec.
+- Annotate `ArchivalService::setRetentionMetadata()` with
+  `@spec ...#task-1`.
+- Annotate `ArchivalService::extendRetentionForObject()` with
+  `@spec ...#task-2`.
+
+No code is modified; this is annotation-only.
+
+## Impact
+
+- Affected specs: `archival-destruction-workflow` (+2 REQs).
+- Affected code: 2 docblocks in `lib/Service/ArchivalService.php` gain
+  `@spec` tags.
+- No runtime behaviour change.

--- a/openspec/changes/retrofit-2026-05-24-archival-destruction-workflow/specs/archival-destruction-workflow/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-archival-destruction-workflow/specs/archival-destruction-workflow/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### REQ-010: ArchivalService::setRetentionMetadata Validates and Merges Object Retention
+
+The `ArchivalService::setRetentionMetadata()` write-path MUST validate caller-supplied retention metadata against the `VALID_NOMINATIONS` and `VALID_STATUSES` enums, normalise `archiefactiedatum` to ISO-8601, default missing keys, and merge with the object's existing retention payload rather than replacing it. The method MUST return the mutated `ObjectEntity` without persisting it (the caller is responsible for the save).
+
+#### Scenario: Missing archiefnominatie defaults to nog_niet_bepaald
+- **GIVEN** an `ObjectEntity` with no existing `retention` field
+- **WHEN** `setRetentionMetadata($object, [])` is called
+- **THEN** the resulting `retention.archiefnominatie` MUST equal `nog_niet_bepaald`
+- **AND** `retention.archiefstatus` MUST equal `nog_te_archiveren`
+
+#### Scenario: Invalid archiefnominatie is rejected
+- **GIVEN** `retention.archiefnominatie` is set to `"weggooien"` (not in `VALID_NOMINATIONS = ['vernietigen', 'bewaren', 'nog_niet_bepaald']`)
+- **WHEN** `setRetentionMetadata()` is called
+- **THEN** the method MUST throw `InvalidArgumentException` whose message contains the invalid value and the allowed set
+- **AND** the object's existing retention MUST NOT be modified
+
+#### Scenario: Invalid archiefstatus is rejected
+- **GIVEN** `retention.archiefstatus` is set to `"klaar"` (not in `VALID_STATUSES = ['nog_te_archiveren', 'gearchiveerd', 'vernietigd', 'overgebracht']`)
+- **WHEN** `setRetentionMetadata()` is called
+- **THEN** the method MUST throw `InvalidArgumentException` whose message contains the invalid value and the allowed set
+
+#### Scenario: archiefactiedatum accepts Y-m-d and ISO 8601, normalises to ISO 8601
+- **GIVEN** `retention.archiefactiedatum` is `"2030-12-31"`
+- **WHEN** `setRetentionMetadata()` is called
+- **THEN** the stored `retention.archiefactiedatum` MUST be the ISO 8601 (`DateTime::format('c')`) representation of `2030-12-31T00:00:00`
+- **AND** an input already in ISO 8601 (`DateTime::ATOM`) format MUST round-trip unchanged
+
+#### Scenario: archiefactiedatum with unparseable format is rejected
+- **GIVEN** `retention.archiefactiedatum` is `"31-12-2030"` (neither `Y-m-d` nor ISO 8601 atomic)
+- **WHEN** `setRetentionMetadata()` is called
+- **THEN** the method MUST throw `InvalidArgumentException` whose message contains `"Invalid archiefactiedatum format"`
+
+#### Scenario: Existing retention fields outside the input payload are preserved
+- **GIVEN** an `ObjectEntity` with existing `retention = { archiefnominatie: "bewaren", legalHold: { active: true, reason: "WOO" } }`
+- **WHEN** `setRetentionMetadata($object, ['archiefactiedatum' => '2030-01-01'])` is called
+- **THEN** the resulting retention MUST still contain `legalHold.active = true` and `legalHold.reason = "WOO"`
+- **AND** `archiefnominatie` MUST remain `"bewaren"` (preserved from existing — the input only sets `archiefactiedatum`)
+- **AND** `archiefactiedatum` MUST be the ISO 8601 string for `2030-01-01`
+
+### REQ-011: extendRetentionForObject Recomputes archiefactiedatum from Classificatie's SelectionList
+
+When a destruction-list rejection requires extending an object's retention, `ArchivalService::extendRetentionForObject()` MUST look up the object's `retention.classificatie`, resolve the matching `SelectionList` entry via `SelectionListMapper::findByCategory()`, take its `retentionYears`, and add that many years to the current `retention.archiefactiedatum` (or to `now()` if no current date is set). The mutated retention MUST be persisted via a direct UPDATE on `openregister_objects.retention`. Failures MUST be caught and surface as a `logger->warning()` rather than propagating to the caller (so a single bad object does not abort a multi-object rejection batch).
+
+#### Scenario: Object with classificatie B1 extends by selection-list retentionYears
+- **GIVEN** an object with `retention = { classificatie: "B1", archiefactiedatum: "2026-01-01T00:00:00+00:00" }`
+- **AND** `SelectionListMapper::findByCategory("B1")` returns an entry with `retentionYears = 5`
+- **WHEN** `extendRetentionForObject($uuid)` is called
+- **THEN** the row's `retention.archiefactiedatum` in `openregister_objects` MUST be updated to the ISO 8601 string for `2031-01-01T00:00:00+00:00`
+
+#### Scenario: Object with no current archiefactiedatum extends from today
+- **GIVEN** an object with `retention = { classificatie: "B1" }` (no `archiefactiedatum`)
+- **AND** `SelectionListMapper::findByCategory("B1")` returns `retentionYears = 5`
+- **WHEN** `extendRetentionForObject($uuid)` is called on `2026-05-24`
+- **THEN** the row's `retention.archiefactiedatum` MUST be set to the ISO 8601 string for `2031-05-24` (today + 5 years)
+
+#### Scenario: Object without classificatie is silently skipped
+- **GIVEN** an object with `retention = { archiefnominatie: "vernietigen" }` (no `classificatie`)
+- **WHEN** `extendRetentionForObject($uuid)` is called
+- **THEN** the retention row MUST NOT be modified
+- **AND** no exception MUST propagate to the caller
+
+#### Scenario: Object UUID not in database is silently skipped
+- **GIVEN** no row in `openregister_objects` matches `$uuid`
+- **WHEN** `extendRetentionForObject($uuid)` is called
+- **THEN** the method MUST return without raising
+- **AND** no UPDATE statement MUST be executed
+
+#### Scenario: Mapper exceptions are logged, not propagated
+- **GIVEN** `SelectionListMapper::findByCategory()` throws a `\Exception`
+- **WHEN** `extendRetentionForObject($uuid)` is called
+- **THEN** the exception MUST be caught
+- **AND** a `LoggerInterface::warning()` entry MUST be emitted containing the UUID and the exception message
+- **AND** the method MUST return normally so a batch rejection of N objects continues processing the remaining N-1

--- a/openspec/changes/retrofit-2026-05-24-archival-destruction-workflow/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-archival-destruction-workflow/tasks.md
@@ -1,0 +1,43 @@
+# Tasks
+
+## 1. Annotate ArchivalService::setRetentionMetadata against REQ-010
+
+- [x] task-1: `lib/Service/ArchivalService.php::setRetentionMetadata()` —
+      validates archiefnominatie / archiefstatus enums, normalises
+      archiefactiedatum to ISO 8601, defaults missing keys, merges into
+      existing retention.
+
+## 2. Annotate ArchivalService::extendRetentionForObject against REQ-011
+
+- [x] task-2: `lib/Service/ArchivalService.php::extendRetentionForObject()` —
+      recomputes archiefactiedatum from the object's classificatie via
+      `SelectionListMapper::findByCategory()`, persists via direct UPDATE,
+      swallows exceptions with a warning log.
+
+## DROP (not annotated against this capability)
+
+The remaining 8 methods in the input cluster were triaged out — they belong to
+the sibling `add-archival-annotation-support` capability (schema-level
+`x-openregister-archival` rules), not the per-object NEN 15489 destruction
+workflow specified here:
+
+- `lib/Service/Archival/RetentionConditionEvaluator.php::parseLiteral` — DSL
+  literal parser (owned by `add-archival-annotation-support`).
+- `lib/Service/Archival/RetentionConditionEvaluator.php::compare` — DSL
+  operator comparator (owned by `add-archival-annotation-support`).
+- `lib/Cron/ArchivalRetentionTask.php::run` — hourly retention sweep cron
+  (owned by `add-archival-annotation-support`).
+- `lib/Cron/ArchivalRetentionTask.php::sweepSchema` — per-schema sweep helper
+  (owned by `add-archival-annotation-support`).
+- `lib/Cron/ArchivalRetentionTask.php::extractArchivalAnnotation` — reads
+  `x-openregister-archival` from schema config (owned by
+  `add-archival-annotation-support`).
+- `lib/Cron/ArchivalRetentionTask.php::stripMetadataColumns` — strips
+  magic-table metadata columns from a row before evaluation (owned by
+  `add-archival-annotation-support`).
+- `lib/Service/Archival/ArchivalAnnotationValidator.php::validateRule` —
+  schema-save validator for one rule entry (owned by
+  `add-archival-annotation-support`).
+- `lib/Service/Archival/RetentionEvaluator.php::addDuration` — generic
+  `DateInterval` addition utility used by the schema-level evaluator (owned
+  by `add-archival-annotation-support`).

--- a/openspec/specs/archival-destruction-workflow/spec.md
+++ b/openspec/specs/archival-destruction-workflow/spec.md
@@ -2,6 +2,8 @@
 status: implemented
 retrofit_extensions:
   - REQ-009
+  - REQ-010
+  - REQ-011
 ---
 
 # Archival Destruction Workflow
@@ -269,3 +271,77 @@ The `DestructionCheckJob` MUST scan for objects whose `archiefactiedatum` falls 
 - **GIVEN** object `zaak-333` has `archiefnominatie: bewaren` and `archiefactiedatum` within the lead window
 - **WHEN** the `DestructionCheckJob` runs
 - **THEN** the notification subject MUST be "Object requires e-Depot transfer" rather than "Object approaching destruction date"
+
+### REQ-010: ArchivalService::setRetentionMetadata Validates and Merges Object Retention
+
+The `ArchivalService::setRetentionMetadata()` write-path MUST validate caller-supplied retention metadata against the `VALID_NOMINATIONS` and `VALID_STATUSES` enums, normalise `archiefactiedatum` to ISO-8601, default missing keys, and merge with the object's existing retention payload rather than replacing it. The method MUST return the mutated `ObjectEntity` without persisting it (the caller is responsible for the save).
+
+#### Scenario: Missing archiefnominatie defaults to nog_niet_bepaald
+- **GIVEN** an `ObjectEntity` with no existing `retention` field
+- **WHEN** `setRetentionMetadata($object, [])` is called
+- **THEN** the resulting `retention.archiefnominatie` MUST equal `nog_niet_bepaald`
+- **AND** `retention.archiefstatus` MUST equal `nog_te_archiveren`
+
+#### Scenario: Invalid archiefnominatie is rejected
+- **GIVEN** `retention.archiefnominatie` is set to `"weggooien"` (not in `VALID_NOMINATIONS = ['vernietigen', 'bewaren', 'nog_niet_bepaald']`)
+- **WHEN** `setRetentionMetadata()` is called
+- **THEN** the method MUST throw `InvalidArgumentException` whose message contains the invalid value and the allowed set
+- **AND** the object's existing retention MUST NOT be modified
+
+#### Scenario: Invalid archiefstatus is rejected
+- **GIVEN** `retention.archiefstatus` is set to `"klaar"` (not in `VALID_STATUSES = ['nog_te_archiveren', 'gearchiveerd', 'vernietigd', 'overgebracht']`)
+- **WHEN** `setRetentionMetadata()` is called
+- **THEN** the method MUST throw `InvalidArgumentException` whose message contains the invalid value and the allowed set
+
+#### Scenario: archiefactiedatum accepts Y-m-d and ISO 8601, normalises to ISO 8601
+- **GIVEN** `retention.archiefactiedatum` is `"2030-12-31"`
+- **WHEN** `setRetentionMetadata()` is called
+- **THEN** the stored `retention.archiefactiedatum` MUST be the ISO 8601 (`DateTime::format('c')`) representation of `2030-12-31T00:00:00`
+- **AND** an input already in ISO 8601 (`DateTime::ATOM`) format MUST round-trip unchanged
+
+#### Scenario: archiefactiedatum with unparseable format is rejected
+- **GIVEN** `retention.archiefactiedatum` is `"31-12-2030"` (neither `Y-m-d` nor ISO 8601 atomic)
+- **WHEN** `setRetentionMetadata()` is called
+- **THEN** the method MUST throw `InvalidArgumentException` whose message contains `"Invalid archiefactiedatum format"`
+
+#### Scenario: Existing retention fields outside the input payload are preserved
+- **GIVEN** an `ObjectEntity` with existing `retention = { archiefnominatie: "bewaren", legalHold: { active: true, reason: "WOO" } }`
+- **WHEN** `setRetentionMetadata($object, ['archiefactiedatum' => '2030-01-01'])` is called
+- **THEN** the resulting retention MUST still contain `legalHold.active = true` and `legalHold.reason = "WOO"`
+- **AND** `archiefnominatie` MUST remain `"bewaren"` (preserved from existing — the input only sets `archiefactiedatum`)
+- **AND** `archiefactiedatum` MUST be the ISO 8601 string for `2030-01-01`
+
+### REQ-011: extendRetentionForObject Recomputes archiefactiedatum from Classificatie's SelectionList
+
+When a destruction-list rejection requires extending an object's retention, `ArchivalService::extendRetentionForObject()` MUST look up the object's `retention.classificatie`, resolve the matching `SelectionList` entry via `SelectionListMapper::findByCategory()`, take its `retentionYears`, and add that many years to the current `retention.archiefactiedatum` (or to `now()` if no current date is set). The mutated retention MUST be persisted via a direct UPDATE on `openregister_objects.retention`. Failures MUST be caught and surface as a `logger->warning()` rather than propagating to the caller (so a single bad object does not abort a multi-object rejection batch).
+
+#### Scenario: Object with classificatie B1 extends by selection-list retentionYears
+- **GIVEN** an object with `retention = { classificatie: "B1", archiefactiedatum: "2026-01-01T00:00:00+00:00" }`
+- **AND** `SelectionListMapper::findByCategory("B1")` returns an entry with `retentionYears = 5`
+- **WHEN** `extendRetentionForObject($uuid)` is called
+- **THEN** the row's `retention.archiefactiedatum` in `openregister_objects` MUST be updated to the ISO 8601 string for `2031-01-01T00:00:00+00:00`
+
+#### Scenario: Object with no current archiefactiedatum extends from today
+- **GIVEN** an object with `retention = { classificatie: "B1" }` (no `archiefactiedatum`)
+- **AND** `SelectionListMapper::findByCategory("B1")` returns `retentionYears = 5`
+- **WHEN** `extendRetentionForObject($uuid)` is called on `2026-05-24`
+- **THEN** the row's `retention.archiefactiedatum` MUST be set to the ISO 8601 string for `2031-05-24` (today + 5 years)
+
+#### Scenario: Object without classificatie is silently skipped
+- **GIVEN** an object with `retention = { archiefnominatie: "vernietigen" }` (no `classificatie`)
+- **WHEN** `extendRetentionForObject($uuid)` is called
+- **THEN** the retention row MUST NOT be modified
+- **AND** no exception MUST propagate to the caller
+
+#### Scenario: Object UUID not in database is silently skipped
+- **GIVEN** no row in `openregister_objects` matches `$uuid`
+- **WHEN** `extendRetentionForObject($uuid)` is called
+- **THEN** the method MUST return without raising
+- **AND** no UPDATE statement MUST be executed
+
+#### Scenario: Mapper exceptions are logged, not propagated
+- **GIVEN** `SelectionListMapper::findByCategory()` throws a `\Exception`
+- **WHEN** `extendRetentionForObject($uuid)` is called
+- **THEN** the exception MUST be caught
+- **AND** a `LoggerInterface::warning()` entry MUST be emitted containing the UUID and the exception message
+- **AND** the method MUST return normally so a batch rejection of N objects continues processing the remaining N-1


### PR DESCRIPTION
## Summary

Reverse-spec retrofit for the `archival-destruction-workflow` capability. Two
observed-behaviour requirements added; two methods annotated.

- **REQ-010** — `ArchivalService::setRetentionMetadata()` validates
  `archiefnominatie` / `archiefstatus` enums, normalises `archiefactiedatum`
  to ISO 8601, defaults missing keys, and merges with the object's existing
  retention payload (does not replace).
- **REQ-011** — `ArchivalService::extendRetentionForObject()` resolves the
  object's `retention.classificatie` via `SelectionListMapper::findByCategory()`
  and adds the selection-list's `retentionYears` to the current
  `archiefactiedatum` (or `now()` if unset). Failures are logged, never
  propagated, so a batch rejection of N objects keeps processing.

## Methods annotated (2/10)

- `lib/Service/ArchivalService.php::setRetentionMetadata` -> REQ-010 (task-1)
- `lib/Service/ArchivalService.php::extendRetentionForObject` -> REQ-011 (task-2)

## DROPs (8/10 - not annotated against this capability)

The remaining 8 methods in the input cluster belong to the sibling
`add-archival-annotation-support` capability (schema-level
`x-openregister-archival` rules) rather than the per-object NEN 15489
destruction workflow specified here. Annotating them against
`archival-destruction-workflow` would be inaccurate. They are explicitly listed
under the `## DROP` section of `tasks.md`:

- `RetentionConditionEvaluator::parseLiteral`, `compare`
- `ArchivalRetentionTask::run`, `sweepSchema`, `extractArchivalAnnotation`,
  `stripMetadataColumns`
- `ArchivalAnnotationValidator::validateRule`
- `RetentionEvaluator::addDuration`

A future reverse-spec run targeting `add-archival-annotation-support` would
pick those up.

## Test plan

- [ ] OpenSpec validate passes for the ghost change directory
- [ ] `archival-destruction-workflow/spec.md` retains REQ-001..REQ-009
      unchanged and gains REQ-010 + REQ-011
- [ ] Both annotated methods carry a single `@spec ...#task-N` tag
