### PR TITLE
retrofit: reverse-spec geo-metadata-kaart (2 new REQs)

### DIFF
--- a/lib/Service/Geo/GeoFilterApplier.php
+++ b/lib/Service/Geo/GeoFilterApplier.php
@@ -99,6 +99,8 @@ class GeoFilterApplier
      * @param ?string $property Property name; null = first GeoJSON-shaped value.
      *
      * @return ?array The GeoJSON geometry, or null when none found.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-geo-metadata-kaart/tasks.md#task-1
      */
     public function extractGeometry(array $row, ?string $property): ?array
     {

--- a/lib/Service/Geo/GeoSpatialEvaluator.php
+++ b/lib/Service/Geo/GeoSpatialEvaluator.php
@@ -381,6 +381,8 @@ class GeoSpatialEvaluator
      * @param array $geometry The geometry.
      *
      * @return array<int, array<int, array<int, array<int, float>>>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-geo-metadata-kaart/tasks.md#task-2
      */
     private function extractPolygons(array $geometry): array
     {

--- a/openspec/changes/retrofit-2026-05-24-geo-metadata-kaart/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-geo-metadata-kaart/proposal.md
@@ -1,0 +1,39 @@
+# Retrofit: reverse-spec geo-metadata-kaart helpers
+
+## Problem
+
+The `geo-metadata-kaart` capability has 15 existing REQs covering geospatial property types, GeoJSON storage, the four spatial-filter primitives, and spatial-query wiring. Two helper methods inside the spatial pipeline already ship and are exercised by the shipped REQ-GEO-004 / REQ-GEO-011 filter stack, but their behaviour is not separately specified:
+
+- `GeoFilterApplier::extractGeometry()` — pulls the geometry value out of a row, either at a named property or by first-found GeoJSON-shaped value (the "geometry hint vs. auto-detect" contract that callers like `rowMatchesAll()` and `GeoFilterApplierTest::testPropertyHint*` rely on).
+- `GeoSpatialEvaluator::extractPolygons()` — the private normaliser that flattens `Polygon` and `MultiPolygon` geometries to a single `polygon[]` shape so that `matchesIntersects()` / `pointInPolygonGeometry()` can iterate uniformly. The shape contract (Polygon → 1-element list, MultiPolygon → coordinates as-is, anything else → empty) is currently only documented by example in `GeoSpatialEvaluatorTest`.
+
+Both helpers were triaged as Bucket 2a (legacy code without a matching spec requirement) by the 2026-05-24 reverse-spec scan of the geo cluster.
+
+## Proposed Solution
+
+Add two new REQs to the `geo-metadata-kaart` capability that pin down the observed behaviour:
+
+1. **REQ-GEO-016** — Geometry extraction from filter rows, including the property-hint vs. first-found fallback semantics.
+2. **REQ-GEO-017** — Polygon normalisation: how `Polygon` and `MultiPolygon` are flattened to a list of polygons by the spatial evaluator, and how unsupported geometry types degrade silently.
+
+This is a documentation-only retrofit. No behaviour changes; the existing implementations stay as-is and gain `@spec` annotations.
+
+## Scope
+
+### In scope
+
+- 2 new REQs (REQ-GEO-016, REQ-GEO-017) under the `geo-metadata-kaart` capability spec
+- `@spec` annotations on `GeoFilterApplier::extractGeometry` and `GeoSpatialEvaluator::extractPolygons` pointing at the new tasks.md entries
+
+### Out of scope
+
+- Any code change beyond docblock annotations
+- The two Vue methods listed in the batch input (`MergeObject.initializeMerge`, `ManageOrganisationRoles.initializeOrganisationItem`) — these are unrelated to geo and were misclassified by the reverse-spec scanner; they belong to the merge-objects / organisation-roles capabilities instead
+- The two scanner false-positive entries named "if" (PHP `if` blocks parsed as methods)
+- Any change to the published `openspec/specs/geo-metadata-kaart/spec.md`; this retrofit's delta lives under the change folder and will be merged by the normal opsx sync process
+
+## Acceptance criteria
+
+- [x] Two new REQs drafted in `specs/geo-metadata-kaart/spec.md` (delta) describing observed behaviour
+- [x] `@spec` lines added to the docblocks of both helper methods
+- [x] PR opened with the `retrofit` label, base `development`

--- a/openspec/changes/retrofit-2026-05-24-geo-metadata-kaart/specs/geo-metadata-kaart/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-geo-metadata-kaart/specs/geo-metadata-kaart/spec.md
@@ -1,0 +1,84 @@
+---
+status: draft
+---
+
+# Geo Metadata en Kaart -- Retrofit 2026-05-24
+
+## Purpose
+
+Retrofit two helper methods inside the spatial-filter pipeline that already ship under REQ-GEO-004 (`GeoFilter` primitives + post-filter applier) but have observable contracts not separately specified. This delta adds REQ-GEO-016 (geometry extraction from filter rows) and REQ-GEO-017 (polygon normalisation in the spatial evaluator). No behaviour change; pure documentation.
+
+## ADDED Requirements
+
+### Requirement: REQ-GEO-016 -- Geometry extraction from filter rows
+
+`GeoFilterApplier` MUST expose a geometry-extraction helper that locates the GeoJSON geometry inside a filter row. The helper MUST support two modes:
+
+- **Property hint**: when the caller passes a non-null property name, the helper MUST return the geometry at that key in the row (coerced to a GeoJSON-shaped array) or null when the value at that key is not a valid GeoJSON geometry.
+- **First-found fallback**: when the property name is null, the helper MUST iterate over the row's values in insertion order and return the first value that coerces to a valid GeoJSON geometry. When no value in the row is a valid geometry, the helper MUST return null.
+
+A value is "GeoJSON-shaped" when it is an array containing a `type` field whose value is one of `Point`, `Polygon`, `MultiPolygon`, or `LineString`. The helper MUST NOT throw on malformed rows.
+
+#### Scenario: Property hint targets a specific row key
+
+- **GIVEN** a row `['locatie' => ['type' => 'Point', 'coordinates' => [5.12, 52.09]], 'name' => 'foo']`
+- **WHEN** `extractGeometry(row, property: 'locatie')` is called
+- **THEN** the helper MUST return the GeoJSON Point at `locatie`
+- **AND** the `name` field MUST NOT be inspected
+
+#### Scenario: Property hint points at a non-geometry value
+
+- **GIVEN** a row `['locatie' => 'not-a-geometry', 'extra' => ['type' => 'Point', 'coordinates' => [5.0, 52.0]]]`
+- **WHEN** `extractGeometry(row, property: 'locatie')` is called
+- **THEN** the helper MUST return null
+- **AND** the helper MUST NOT fall back to scanning other row values
+
+#### Scenario: First-found fallback when no property is hinted
+
+- **GIVEN** a row `['name' => 'foo', 'geo' => ['type' => 'Polygon', 'coordinates' => [[[0,0],[1,0],[1,1],[0,0]]]], 'extra' => ['type' => 'Point', 'coordinates' => [5, 52]]]`
+- **WHEN** `extractGeometry(row, property: null)` is called
+- **THEN** the helper MUST return the Polygon at `geo` (the first GeoJSON-shaped value in insertion order)
+- **AND** the helper MUST NOT continue scanning past the first match
+
+#### Scenario: Row contains no geometry
+
+- **GIVEN** a row `['name' => 'foo', 'count' => 3]`
+- **WHEN** `extractGeometry(row, property: null)` is called
+- **THEN** the helper MUST return null
+
+### Requirement: REQ-GEO-017 -- Polygon normalisation for spatial intersection
+
+`GeoSpatialEvaluator` MUST normalise input geometries to a uniform polygon list before iterating in `matchesIntersects()` and `pointInPolygonGeometry()`. The normalisation rules MUST be:
+
+- For a `Polygon` geometry, the helper MUST wrap the `coordinates` array as a single-element list (one polygon in the result).
+- For a `MultiPolygon` geometry, the helper MUST return the `coordinates` array as-is (each polygon already a separate entry).
+- For any other geometry type (including `Point`, `LineString`, missing `type`, or unsupported types), the helper MUST return an empty list. This MUST cause the calling intersection / containment test to return `false` without throwing.
+
+The shape of each polygon entry in the result MUST follow the GeoJSON Polygon `coordinates` convention: `array<int, array<int, array<int, float>>>` — a list of rings, each ring a list of `[lon, lat]` vertices.
+
+#### Scenario: Polygon input is wrapped as a single-element list
+
+- **GIVEN** a geometry `['type' => 'Polygon', 'coordinates' => [[[0,0],[2,0],[2,2],[0,2],[0,0]]]]`
+- **WHEN** the polygon normaliser is invoked
+- **THEN** the result MUST be a list of length 1
+- **AND** the single entry MUST equal the input `coordinates`
+
+#### Scenario: MultiPolygon input is passed through
+
+- **GIVEN** a geometry `['type' => 'MultiPolygon', 'coordinates' => [[[[0,0],[1,0],[1,1],[0,0]]], [[[5,5],[6,5],[6,6],[5,5]]]]]`
+- **WHEN** the polygon normaliser is invoked
+- **THEN** the result MUST be a list of length 2
+- **AND** each entry MUST be a polygon `coordinates` array drawn from the input
+
+#### Scenario: Unsupported geometry types yield an empty list
+
+- **GIVEN** a geometry `['type' => 'Point', 'coordinates' => [5, 52]]`
+- **WHEN** the polygon normaliser is invoked
+- **THEN** the result MUST be an empty list
+- **AND** the calling intersection test MUST therefore return `false`
+
+#### Scenario: Geometry without a type field yields an empty list
+
+- **GIVEN** a geometry `['coordinates' => [[[0,0],[1,0],[1,1],[0,0]]]]` (no `type`)
+- **WHEN** the polygon normaliser is invoked
+- **THEN** the result MUST be an empty list

--- a/openspec/changes/retrofit-2026-05-24-geo-metadata-kaart/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-geo-metadata-kaart/tasks.md
@@ -1,0 +1,18 @@
+# Tasks -- retrofit-2026-05-24-geo-metadata-kaart
+
+Reverse-spec retrofit: pin down two helper methods inside the `geo-metadata-kaart` spatial-filter pipeline. Documentation-only; both methods already ship.
+
+## Tasks
+
+- [x] **task-1 — REQ-GEO-016: Geometry extraction from filter rows.** Annotated `OCA\OpenRegister\Service\Geo\GeoFilterApplier::extractGeometry()`. The helper returns the GeoJSON geometry at a hinted property key, or — when no hint is given — the first GeoJSON-shaped value found by iterating the row in insertion order. Non-geometry values at a hinted key return null without falling back to scan; a row with no geometry returns null. A value is "GeoJSON-shaped" when it is an array with `type` in `{Point, Polygon, MultiPolygon, LineString}`. Method is `public` and called from `GeoFilterApplier::rowMatchesAll()` for every filter on every row.
+- [x] **task-2 — REQ-GEO-017: Polygon normalisation for spatial intersection.** Annotated `OCA\OpenRegister\Service\Geo\GeoSpatialEvaluator::extractPolygons()`. The helper normalises a GeoJSON geometry to a uniform `polygon[]` shape so `matchesIntersects()` and `pointInPolygonGeometry()` can iterate uniformly. `Polygon` → single-element list, `MultiPolygon` → coordinates as-is, anything else (including `Point`, `LineString`, missing `type`) → empty list, causing the calling test to return `false` without throwing. Method is `private` and called from three sites inside `GeoSpatialEvaluator`.
+
+## Excluded from this retrofit
+
+The reverse-spec batch input also listed four entries that are out of scope:
+
+- `src/modals/object/MergeObject.vue#initializeMerge` — object-merge initialiser, unrelated to geo; belongs to a different capability spec.
+- `src/modals/organisation/ManageOrganisationRoles.vue#initializeOrganisationItem` — organisation-role initialiser, unrelated to geo; belongs to the organisations capability.
+- Two entries named `if` — scanner false-positives (PHP `if` blocks parsed as methods).
+
+These should be re-routed to the correct capability clusters by a follow-up triage pass on the reverse-spec input.


### PR DESCRIPTION
## Summary

Reverse-spec retrofit for the `geo-metadata-kaart` capability. Two helper methods inside the spatial-filter pipeline already ship under REQ-GEO-004 / REQ-GEO-011 but their observable contracts were not separately specified. This ghost change adds them:

- **REQ-GEO-016** — `GeoFilterApplier::extractGeometry()`: geometry extraction from filter rows. Documents the property-hint vs. first-found-fallback semantics, what "GeoJSON-shaped" means, and the null-return contract.
- **REQ-GEO-017** — `GeoSpatialEvaluator::extractPolygons()`: Polygon/MultiPolygon normalisation. Documents the `Polygon -> [coords]`, `MultiPolygon -> coords`, anything-else -> empty-list contract that the intersection and containment tests depend on.

Both methods are annotated with `@spec` pointing at the new `tasks.md` entries.

## Scope

- **2 new REQs** (continuing REQ-GEO-NNN from existing max of 015 -> 016, 017)
- **2 methods annotated**: `GeoFilterApplier::extractGeometry`, `GeoSpatialEvaluator::extractPolygons`
- **Documentation-only**: no behaviour change

## Excluded from this retrofit (scanner noise)

The reverse-spec batch input listed four additional entries that are out of scope:

- `MergeObject.vue#initializeMerge` and `ManageOrganisationRoles.vue#initializeOrganisationItem` — unrelated to geo (object-merge and organisation-role initialisers); belong to other capabilities.
- Two `if` entries — scanner false-positives (PHP/JS `if` blocks parsed as methods).

These should be re-routed to their correct capability clusters in a follow-up triage pass on the reverse-spec input.

## Test plan

- [ ] CI green (PHPCS / PHPMD / PHPStan / Psalm — docblock-only change, should be no-op)
- [ ] `openspec validate retrofit-2026-05-24-geo-metadata-kaart --strict` (manual)
- [ ] Existing `GeoSpatialEvaluatorTest` and `GeoFilterApplierTest` still pass (no behaviour change)