### PR TITLE
retrofit: reverse-spec approval-workflow (2 REQs / 2 methods)

### DIFF
--- a/openspec/changes/retrofit-2026-05-24-approval-workflow/design.md
+++ b/openspec/changes/retrofit-2026-05-24-approval-workflow/design.md
@@ -1,0 +1,25 @@
+# Design — Retrofit approval-workflow (frontend surface)
+
+> Retrofit change. Tasks describe retroactive annotation, not new implementation work.
+
+## Context
+
+The `approval-workflow` spec covered the backend HTTP surface (REQ-001..REQ-005) and was missing any description of the Vue surface that drives it. This retrofit captures the **observed** frontend behavior — what the panels actually do today — as REQ-006 and REQ-007.
+
+## What is being annotated, not built
+
+- `ApprovalChainPanel.vue` mounts under the schema-detail workflow tab and is the canonical UI for listing/creating approval-chain configurations for a single schema.
+- `ApprovalStepList.vue` is mounted on object-detail surfaces to show the step ledger and expose decide controls.
+
+Both components were authored well before the retrofit playbook existed; they are now reverse-spec'd so the dashboard reports them as covered.
+
+## Drift observations (carried forward)
+
+The coverage batch suggested 27 methods belonged to this capability. On inspection, only 2 of those 27 are actually approval-workflow behavior; the other 25 belong to `workflow-engine-abstraction`, `workflow-integration`, and `schema-hooks` (already specified). The proposal lists each off-capability method explicitly so they can be picked up by the correct retrofit run rather than re-surfaced as "uncovered" in the next scan.
+
+## Decisions
+
+- **REQs added: 2** (well under the 5-REQ cap).
+- **No new capability minted** — this is a `--extend` of `approval-workflow`.
+- **No code changes** — only annotation tags applied to the two methods listed.
+- Suspicious behaviors (always-true `canDecide`, console-only error handling, client-side filtering instead of server query) are flagged in REQ Notes as observed-but-suspicious; they are NOT silently "fixed" by the spec language.

--- a/openspec/changes/retrofit-2026-05-24-approval-workflow/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-approval-workflow/proposal.md
@@ -1,0 +1,29 @@
+# Retrofit — approval-workflow
+
+Describes observed frontend behavior of 2 Vue surfaces under the `approval-workflow` capability as 2 new REQs. Code already exists — this change retroactively specifies it.
+
+The existing `approval-workflow` spec (REQ-001..REQ-005) describes the backend HTTP surface and state machine. The Vue components in `src/components/workflow/` are the canonical frontend for that surface and are not yet specified. This retrofit closes that gap.
+
+## Affected code units
+
+- `src/components/workflow/ApprovalChainPanel.vue::fetchChains()` — lists chains, filters by `schemaId` on the client.
+- `src/components/workflow/ApprovalStepList.vue::fetchSteps()` — lists steps for one `objectUuid`, with inline approve/reject controls.
+
+## Approach
+
+- Treat the Vue panels as the documented UI surface for REQ-001 (chain CRUD) and REQ-005 (decide a step).
+- Describe observed inputs, outputs, and side effects of `fetchChains` / `fetchSteps` (HTTP requests issued, client-side filtering, post-decide refresh).
+- Leave the (currently broken) `canDecide()` always-true stub flagged in Notes — observed behavior is "client does not enforce", server enforces.
+
+## Out of scope (drift from coverage batch)
+
+The coverage batch for `approval-workflow` lumped in 25 additional methods that, on inspection, belong to **other** capabilities — they are not approval-workflow behavior. They are already covered by sibling specs and should NOT be retrofitted here:
+
+- `ScheduledWorkflowController::*` + `BackgroundJob/ScheduledWorkflowJob::*` → belong under `workflow-integration` (scheduled-workflow surface).
+- `WorkflowEngineController::*` (update, destroy, testHook, available, health) → covered by `workflow-engine-abstraction` REQs and `workflow-integration` engine-CRUD scenarios.
+- `WorkflowEngineRegistry::*` (resolveAdapterById, getEngines, getEnginesByType, getEngine, createEngine, updateEngine, deleteEngine, discoverEngines) → covered by `workflow-engine-abstraction` (registry + adapter resolution + auto-discovery REQs).
+- `HookForm`, `TestHookDialog`, `WorkflowExecutionPanel`, `SchemaWorkflowTab::editHook` → belong under `schema-hooks` and `workflow-integration` UI scenarios.
+
+These should be picked up by separate retrofit runs targeting the correct capabilities. Forcing them into `approval-workflow` would inflate REQs and drift the capability boundary.
+
+Source: `openspec/coverage-report.json` generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-approval-workflow/specs/approval-workflow/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-approval-workflow/specs/approval-workflow/spec.md
@@ -1,0 +1,66 @@
+---
+retrofit_extensions:
+  - REQ-006
+  - REQ-007
+---
+# Approval Workflow (delta)
+
+## Requirements
+
+### REQ-006: Frontend lists approval chains per schema
+
+The system SHALL provide a Vue panel (`ApprovalChainPanel`) mounted in the schema-detail workflow tab that lists configured approval chains. On mount the panel issues `GET /api/approval-chains` and, when a `schemaId` prop is supplied, filters the response to chains whose `schemaId` matches. The panel displays each chain's `name`, `statusField`, and ordered steps (with each step's `order`, `role`, `statusOnApprove`, and `statusOnReject`), and exposes a "Create Chain" form that issues `POST /api/approval-chains` with the schema's ID attached and re-fetches on success.
+
+#### Scenario: Panel lists chains for the current schema
+
+- **GIVEN** the schema-detail workflow tab is open for a schema with ID `42`
+- **AND** the user is authenticated
+- **WHEN** `ApprovalChainPanel` mounts with `schemaId=42`
+- **THEN** `GET /api/approval-chains` is issued
+- **AND** the response is filtered client-side to entries where `chain.schemaId === 42`
+- **AND** each remaining chain is rendered with its name, statusField, and step list
+
+#### Scenario: Panel creates a chain bound to the current schema
+
+- **GIVEN** the create form is open with a `name` filled in
+- **WHEN** the user clicks "Save Chain"
+- **THEN** `POST /api/approval-chains` is issued with the form body merged with `{ schemaId: <current schemaId> }`
+- **AND** on success the form closes and `fetchChains` is re-invoked
+
+#### Notes
+
+- The panel filters by `schemaId` **client-side**, not via a server query parameter. With many chains this is wasteful; a server-side `?schemaId=` filter would be more efficient but is not currently implemented.
+- Error handling is a `console.error` only — failed requests do not surface to the user. This is observed behavior, not desired behavior. A future change should introduce toast notifications via `@nextcloud/dialogs` (`showError`).
+
+---
+
+### REQ-007: Frontend renders approval-step progress with inline decide controls
+
+The system SHALL provide a Vue component (`ApprovalStepList`) that lists approval steps for one object and renders inline approve/reject controls for steps the current user can decide. On mount, the component issues `GET /api/approval-steps?objectUuid={objectUuid}` and renders each returned step's order, role, status, and (when present) the deciding user. For each step with `status: pending`, an inline action row exposes a comment input plus "Approve" and "Reject" buttons that issue `POST /api/approval-steps/{id}/approve` and `/reject` respectively with the comment in the body. After any decide call the component re-fetches the step list.
+
+#### Scenario: Component lists steps for an object
+
+- **GIVEN** an object with UUID `abc-123` has two approval steps in two chains
+- **WHEN** `ApprovalStepList` mounts with `objectUuid="abc-123"`
+- **THEN** `GET /api/approval-steps?objectUuid=abc-123` is issued
+- **AND** all returned steps are rendered in order with their `stepOrder`, `role`, status badge, and (if set) `decidedBy`
+
+#### Scenario: User approves a pending step inline
+
+- **GIVEN** a step with `status: pending` is rendered with a comment input
+- **WHEN** the user types a comment and clicks "Approve"
+- **THEN** `POST /api/approval-steps/{step.id}/approve` is issued with `{ comment: "<entered text>" }`
+- **AND** on success `fetchSteps` is re-invoked so the now-decided step's badge updates and any newly-advanced step appears as `pending`
+
+#### Scenario: User rejects a pending step inline
+
+- **GIVEN** a step with `status: pending` is rendered
+- **WHEN** the user clicks "Reject" (with or without a comment)
+- **THEN** `POST /api/approval-steps/{step.id}/reject` is issued with `{ comment: "<entered text or empty string>" }`
+- **AND** on success `fetchSteps` is re-invoked
+
+#### Notes
+
+- `canDecide()` in the component currently `return true` — i.e., the client renders approve/reject buttons for **every** pending step regardless of the viewing user's group membership. Authorisation is enforced server-side per REQ-005 (the server returns 403 for non-group members), so the buttons "work" only in the sense that unauthorised clicks fail. A future change should fetch the current user's groups and gate the buttons client-side to avoid showing actions the user cannot perform. Flagged as observed-but-suspicious.
+- The component does not paginate. With many steps per object this is acceptable today, but if approval chains grow long (>50 steps) pagination should be added.
+- Error handling is `console.error` only (same caveat as REQ-006).

--- a/openspec/changes/retrofit-2026-05-24-approval-workflow/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-approval-workflow/tasks.md
@@ -1,0 +1,4 @@
+# Tasks
+
+- [x] task-1: approval-workflow#REQ-006 — Frontend lists approval chains per schema (retroactive annotation)
+- [x] task-2: approval-workflow#REQ-007 — Frontend renders approval-step progress with inline decide controls (retroactive annotation)

--- a/src/components/workflow/ApprovalChainPanel.vue
+++ b/src/components/workflow/ApprovalChainPanel.vue
@@ -38,6 +38,9 @@ import { NcButton } from '@nextcloud/vue'
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 
+/**
+ * @spec openspec/changes/retrofit-2026-05-24-approval-workflow/tasks.md#task-1
+ */
 export default {
 	name: 'ApprovalChainPanel',
 	components: { NcButton },
@@ -55,6 +58,9 @@ export default {
 		this.fetchChains()
 	},
 	methods: {
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-24-approval-workflow/tasks.md#task-1
+		 */
 		async fetchChains() {
 			try {
 				const url = generateUrl('/apps/openregister/api/approval-chains')

--- a/src/components/workflow/ApprovalStepList.vue
+++ b/src/components/workflow/ApprovalStepList.vue
@@ -30,6 +30,9 @@ import { generateUrl } from '@nextcloud/router'
 </template>
 
 <script>
+/**
+ * @spec openspec/changes/retrofit-2026-05-24-approval-workflow/tasks.md#task-2
+ */
 export default {
 	name: 'ApprovalStepList',
 	components: { NcButton },
@@ -46,6 +49,9 @@ export default {
 		this.fetchSteps()
 	},
 	methods: {
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-24-approval-workflow/tasks.md#task-2
+		 */
 		async fetchSteps() {
 			try {
 				const url = generateUrl('/apps/openregister/api/approval-steps')


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed frontend behavior of 2 Vue surfaces under `approval-workflow` as 2 new REQs.

Ghost change: `retrofit-2026-05-24-approval-workflow` (not yet archived — review-merge first, then archive merges delta into main spec).

### What this PR does

- Drafts **REQ-006** (ApprovalChainPanel) and **REQ-007** (ApprovalStepList) as a spec delta with `retrofit_extensions: [REQ-006, REQ-007]` block YAML frontmatter
- Creates `tasks.md` with one `[x]` task per REQ
- Annotates the two in-scope methods (`fetchChains()`, `fetchSteps()`) with `@spec openspec/changes/retrofit-2026-05-24-approval-workflow/tasks.md#task-N`
- Documents drift in `proposal.md` "Out of scope" — 25 of 27 batch methods belong to other capabilities (`workflow-engine-abstraction`, `workflow-integration`, `schema-hooks`) and are already specified there

### What this PR does NOT do

- No code behavior changes — annotation tags only
- Does not silently "fix" observed-but-buggy behaviors. Notes flag:
  - `canDecide()` always returns `true` — client renders approve/reject for every pending step regardless of group membership (server still enforces 403)
  - Error handling is `console.error` only — failures don't surface to the user
  - Client-side `schemaId` filter rather than a server query parameter

### Review focus

- REQ language matches observed behavior (not aspirational)
- Scenarios are testable
- Drift list in proposal correctly punts the off-capability methods to future runs

Source: `openspec/coverage-report.json` generated 2026-05-24 | Cluster: `approval-workflow` (27 methods in batch → 2 in-scope, 25 drift)