### PR TITLE
retrofit(audit-trail-immutable): file-event audit + clear-all drift

### DIFF
--- a/lib/Controller/AuditTrailController.php
+++ b/lib/Controller/AuditTrailController.php
@@ -494,6 +494,7 @@ class AuditTrailController extends Controller
      * @return JSONResponse JSON response confirming clear or error
      *
      * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-8
+     * @spec openspec/changes/retrofit-2026-05-24-audit-trail-immutable/tasks.md#task-2
      */
     public function clearAll(): JSONResponse
     {

--- a/lib/Service/File/FileAuditHandler.php
+++ b/lib/Service/File/FileAuditHandler.php
@@ -123,6 +123,8 @@ class FileAuditHandler
      * @return AuditTrail|null The persisted audit row, or null on failure.
      *
      * @SuppressWarnings(PHPMD.StaticAccess)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-audit-trail-immutable/tasks.md#task-4
      */
     public function logBulkDownload(
         ObjectEntity $object,
@@ -200,6 +202,8 @@ class FileAuditHandler
      * @return AuditTrail|null The persisted audit row, or null on failure.
      *
      * @SuppressWarnings(PHPMD.StaticAccess)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-audit-trail-immutable/tasks.md#task-4
      */
     public function logFileAction(
         ObjectEntity $object,

--- a/openspec/changes/retrofit-2026-05-24-audit-trail-immutable/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-audit-trail-immutable/proposal.md
@@ -1,0 +1,36 @@
+# Retrofit — audit-trail-immutable
+
+Describes observed behavior of methods clustered under `audit-trail-immutable` and adds two new REQs:
+
+1. File-attachment audit events (`logBulkDownload`, `logFileAction`) MUST flow through the same hash-chained `AuditTrail` entity.
+2. An admin-only `clearAll` surface is exposed at `DELETE /api/audit-trails/clear-all` that wipes the entire audit table. This is a documented operational escape hatch and a known drift from the spec's "Audit trail entries MUST NOT be deletable or modifiable" requirement; the retrofit captures observed behavior and flags it as drift.
+
+Also retroactively annotates the `ClearAuditTrails.vue` admin UI methods.
+
+## Affected code units (in-scope, retained)
+
+- `src/modals/logs/ClearAuditTrails.vue::closeDialog` — admin UI to close the clear-all confirmation dialog.
+- `src/modals/logs/ClearAuditTrails.vue::clearAuditTrails` — admin UI submitting `DELETE /api/audit-trails` with active filters; surfaces the immutability drift to operators.
+- `lib/Service/File/FileAuditHandler.php::logBulkDownload` — persists a single `AuditTrail` row for ZIP bulk downloads, inheriting hash-chain integrity from `AuditTrailMapper::insert`.
+- `lib/Service/File/FileAuditHandler.php::logFileAction` — persists `AuditTrail` rows for namespaced file events (`file.renamed`, `file.locked`, `file.version_restored`, …), inheriting hash-chain integrity from `AuditTrailMapper::insert`.
+
+## DROPs (mis-clustered — owning capability noted)
+
+- `lib/Service/Integration/BuiltinProviders/AuditTrailProvider.php::{getId,getLabel,getIcon,getRequiredApp,getStorageStrategy,getGroup,isEnabled,list,normalize}` — owned by **pluggable-integration-registry** (already annotated `@spec openspec/changes/pluggable-integration-registry/tasks.md#task-16`); IntegrationProvider contract surface, not the immutable-trail engine.
+- `src/modals/logs/AuditTrailChanges.vue::closeDialog`, `src/modals/logs/AuditTrailDetails.vue::closeDialog`, `src/modals/logs/DeleteAuditTrail.vue::closeDialog`, `src/modals/objectAuditTrail/ViewObjectAuditTrail.vue::closeDialog`, `src/views/logs/AuditTrailIndex.vue::loadAuditTrails` — already annotated under `retrofit-2026-04-23-annotate-openregister`; generic UI dialog plumbing, not the immutable-trail engine.
+- `lib/Service/AuthorizationAuditService.php::logSchemaAuthorizationChange` — writes to NC `LoggerInterface`, NOT the `AuditTrail` entity / hash chain; owned by **auth-system** (authorization-config audit, separate surface).
+- `src/sidebars/logs/AuditTrailSideBar.vue::loadAuditTrailData` — UI consumer of the trail API; owned by **audit-trail-immutable** UI surface but is generic data-fetch plumbing (no new behavior to spec).
+- `src/entities/auditTrail/auditTrail.mock.ts::{mockAuditTrailData,mockAuditTrail}` — test fixtures; no production behavior.
+- `src/store/modules/auditTrail.js::useAuditTrailStore` — Pinia store factory; UI state, not the trail engine.
+- `lib/Service/File/FileAuditHandler.php::__construct`, `getCurrentUserId` — constructor / generic user-id getter helpers, no spec-relevant behavior.
+- `lib/Controller/AuditTrailController.php::requireAdmin` — generic admin gate helper already annotated under `retrofit-2026-04-23-annotate-openregister/task-8`.
+
+## Drift (flagged, not fixed)
+
+- **D-1**: `AuditTrailMapper::clearAllLogs()` (called from `AuditTrailController::clearAll` → `DELETE /api/audit-trails/clear-all`) wipes the entire audit table. The mapper's docblock explicitly says "not just expired ones." This contradicts the spec's REQ "Audit trail entries MUST NOT be deletable or modifiable." It is admin-only and defense-in-depth-gated by `requireAdmin()`, but a privileged user can still destroy the chain of trust required for AVG/GDPR Art 30 reviews. Captured here as observed behavior (REQ-IMMU-002); fixing is a future spec change, not a retrofit.
+
+## Approach
+
+Source: `/tmp/or-scan/rspec-cluster-audit-trail-immutable.json` (26 methods, 13 files).
+
+The retrofit follows the playbook for `--extend` mode: two new REQs (REQ-IMMU-001 for file-attachment audit events, REQ-IMMU-002 to acknowledge the admin clear-all drift), plus `@spec` annotations on the four in-scope methods listed above. The drift on `clearAll` is intentionally captured rather than ignored — the spec must reflect what the code does, even when that's a known compliance gap.

--- a/openspec/changes/retrofit-2026-05-24-audit-trail-immutable/specs/audit-trail-immutable/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-audit-trail-immutable/specs/audit-trail-immutable/spec.md
@@ -1,0 +1,85 @@
+---
+retrofit_extensions: [REQ-IMMU-001, REQ-IMMU-002]
+---
+
+## ADDED Requirements
+
+### Requirement: File-attachment audit events MUST persist via the same hash-chained AuditTrail entity (REQ-IMMU-001)
+
+File-attachment lifecycle events (bulk downloads as ZIP archives, and namespaced single-file actions such as `file.renamed`, `file.locked`, `file.version_restored`) MUST produce `AuditTrail` rows persisted via `AuditTrailMapper::insert`, so they inherit the same hash-chain integrity, immutability, and verification guarantees as object mutations. File-event audit rows MUST be keyed to the parent `ObjectEntity` (object id, objectUuid, register, schema) so they surface in the same audit timeline as object updates. Audit-logging failures MUST NOT break the underlying file operation — the audit write is best-effort and any exception MUST be swallowed and logged at warning level.
+
+#### Scenario: Bulk download produces a single audit row for the ZIP
+
+- **GIVEN** an authenticated user downloads files `[42, 43, 44]` from object `obj-uuid-1` as a single ZIP archive named `bundle.zip`
+- **WHEN** `FileAuditHandler::logBulkDownload($object, [42,43,44], ['a.pdf','b.pdf','c.pdf'], 'bundle.zip', 3200)` is called
+- **THEN** exactly ONE `AuditTrail` row MUST be persisted (not three)
+- **AND** the row's `action` MUST equal `file.bulk_downloaded`
+- **AND** the row's `changed` payload MUST include `fileIds: [42,43,44]`, `fileNames: ['a.pdf','b.pdf','c.pdf']`, `fileCount: 3`, `zipName: 'bundle.zip'`, `totalBytes: 3200`
+- **AND** the row MUST inherit the active hash-chain via `AuditTrailMapper::insert`
+
+#### Scenario: Anonymous bulk download is attributed by IP
+
+- **GIVEN** an anonymous (no session) bulk-download request from remote address `203.0.113.7`
+- **WHEN** `FileAuditHandler::logBulkDownload` is called with no active user session
+- **THEN** the persisted row's `user` MUST equal `Anonymous`
+- **AND** the row's `userName` MUST contain the remote address (e.g. `Anonymous (203.0.113.7)`)
+
+#### Scenario: Namespaced file action produces an audit row
+
+- **GIVEN** a file `42` attached to object `obj-uuid-1` is renamed
+- **WHEN** `FileAuditHandler::logFileAction($object, 42, 'file.renamed', ['newName' => 'report-final.pdf'])` is called
+- **THEN** an `AuditTrail` row MUST be persisted with `action: 'file.renamed'`
+- **AND** the row's `changed` payload MUST include `fileId: 42` and `data: {newName: 'report-final.pdf'}`
+- **AND** the row MUST be keyed to the parent object (object id, objectUuid, register, schema columns set from the `ObjectEntity`)
+
+#### Scenario: Audit-write failure does not break the file operation
+
+- **GIVEN** the database is unavailable mid-request
+- **WHEN** `FileAuditHandler::logFileAction` or `logBulkDownload` is called
+- **THEN** the method MUST return `null` (not throw)
+- **AND** the failure MUST be logged via `LoggerInterface::warning`
+
+#### Notes
+
+- File-action audit rows currently set `expires` to `+30 days`. This is shorter than the spec's 10-year retention REQ; either the retention REQ does not apply uniformly to file events, or the 30-day default is incorrect. Flagged as a follow-up clarification, not a retrofit blocker.
+- The bulk-download `size` field is hardcoded to `14` (matching the default in `AuditTrailMapper::createAuditTrail`). This is observed behavior, not a calculated payload size.
+
+### Requirement: Admin-only `DELETE /api/audit-trails/clear-all` MUST wipe the entire audit table (REQ-IMMU-002 — drift from immutability REQ)
+
+The system exposes an admin-only operational escape hatch at `DELETE /api/audit-trails/clear-all` (route `auditTrail#clearAll`) that calls `AuditTrailMapper::clearAllLogs()` and deletes ALL rows from the `openregister_audit_trails` table — not just expired ones. The endpoint MUST be gated at two layers: (1) framework-level (no `@NoAdminRequired`, so NC's middleware blocks non-admins) and (2) body-level (`AuditTrailController::requireAdmin()` returns 401 for unauthenticated and 403 for non-admin callers as defense-in-depth). The admin UI at `src/modals/logs/ClearAuditTrails.vue` is the documented consumer of this endpoint (POSTing `DELETE /api/audit-trails` with active filters; the broader `clearAll` variant has no filter set).
+
+**DRIFT**: This requirement contradicts the existing REQ "Audit trail entries MUST NOT be deletable or modifiable". An authenticated admin can destroy the chain of trust required for AVG/GDPR Art 30 reviews. Captured here as observed behavior; resolving the contradiction is a future spec change, not a retrofit.
+
+#### Scenario: Admin clears all audit trails
+
+- **GIVEN** an authenticated admin user
+- **WHEN** the admin issues `DELETE /api/audit-trails/clear-all`
+- **THEN** `AuditTrailMapper::clearAllLogs()` MUST execute `DELETE FROM openregister_audit_trails` (no WHERE clause)
+- **AND** the response MUST be HTTP 200 with `{success: true, message: 'All audit trails cleared successfully'}`
+- **AND** the response body's `deleted` field MUST be set (true value indicates at least one row was deleted)
+
+#### Scenario: Non-admin caller is rejected at the body-level gate
+
+- **GIVEN** an authenticated non-admin user `user-1`
+- **WHEN** the user issues `DELETE /api/audit-trails/clear-all`
+- **THEN** the response MUST be HTTP 403 with `{error: 'Forbidden: this audit-trail operation is admin-only'}`
+- **AND** no rows MUST be deleted
+
+#### Scenario: Unauthenticated caller is rejected at the body-level gate
+
+- **GIVEN** no active user session
+- **WHEN** the request reaches `AuditTrailController::clearAll`
+- **THEN** the response MUST be HTTP 401 with `{error: 'Authentication required'}`
+
+#### Scenario: Admin clears filtered audit trails via the UI
+
+- **GIVEN** the admin opens the `ClearAuditTrails` dialog with active filters in `auditTrailStore.filters`
+- **WHEN** the admin confirms "Clear Entries"
+- **THEN** the UI MUST issue `DELETE /index.php/apps/openregister/api/audit-trails?<filters as query params>`
+- **AND** on success the UI MUST display `{count} audit trails cleared successfully` and auto-close the dialog after 3 seconds
+- **AND** on failure the UI MUST display the error message and keep the dialog open
+
+#### Notes
+
+- The `ClearAuditTrails.vue` dialog defaults to deleting ALL entries when no filters are active and surfaces a warning note-card to that effect; the UI flow tries to dissuade but does not block.
+- The companion routes `auditTrail#destroy` (DELETE `/api/audit-trails/{id}`) and `auditTrail#destroyMultiple` (DELETE `/api/audit-trails`) DO return HTTP 405 per the existing immutability REQ, which makes the `clear-all` carve-out inconsistent. Flagged as part of the drift in D-1 of the proposal.

--- a/openspec/changes/retrofit-2026-05-24-audit-trail-immutable/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-audit-trail-immutable/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] task-1: audit-trail-immutable#REQ-IMMU-001 — File-attachment audit events (bulk download, file action) MUST persist via the same hash-chained AuditTrail entity (retroactive annotation)
+- [x] task-2: audit-trail-immutable#REQ-IMMU-002 — Admin-only `DELETE /api/audit-trails/clear-all` exists and wipes the entire audit table (retroactive annotation; flagged as drift from existing "MUST NOT be deletable" requirement)
+- [x] task-3: Annotate `ClearAuditTrails.vue::closeDialog` and `ClearAuditTrails.vue::clearAuditTrails` under task-2 (admin clear-all UI surface)
+- [x] task-4: Annotate `FileAuditHandler.php::logBulkDownload` and `FileAuditHandler.php::logFileAction` under task-1 (file-event audit producers)

--- a/src/modals/logs/ClearAuditTrails.vue
+++ b/src/modals/logs/ClearAuditTrails.vue
@@ -120,6 +120,8 @@ export default {
 		/**
 		 * Close the dialog and reset state
 		 * @return {void}
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-audit-trail-immutable/tasks.md#task-3
 		 */
 		closeDialog() {
 			navigationStore.setDialog(false)
@@ -133,6 +135,8 @@ export default {
 		/**
 		 * Clear the filtered audit trails
 		 * @return {Promise<void>}
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-audit-trail-immutable/tasks.md#task-3
 		 */
 		async clearAuditTrails() {
 			this.loading = true


### PR DESCRIPTION
## Summary

Reverse-engineers spec coverage for the `audit-trail-immutable` capability from the Bucket 2a cluster scan. Adds two REQs and annotates 4 methods; documents 22 DROPs from the original 26-method cluster.

- **REQ-IMMU-001** — `FileAuditHandler::logBulkDownload` and `logFileAction` persist `AuditTrail` rows via `AuditTrailMapper::insert`, inheriting the hash chain. Failures are swallowed so audit-logging never breaks the underlying file operation.
- **REQ-IMMU-002** — `DELETE /api/audit-trails/clear-all` is an admin-only operational escape hatch that wipes the entire `openregister_audit_trails` table. Captured as observed behavior and flagged as **drift** from the existing "Audit trail entries MUST NOT be deletable or modifiable" REQ.

### Drift surfaced (not fixed here)

`AuditTrailMapper::clearAllLogs()` executes `DELETE FROM openregister_audit_trails` with no WHERE clause. Mapper docblock says "not just expired ones." The companion routes `auditTrail#destroy` and `auditTrail#destroyMultiple` return HTTP 405 per the immutability REQ — the `clear-all` carve-out is inconsistent. An authenticated admin can destroy the chain of trust required for AVG/GDPR Art 30 reviews. Resolution is a future spec change, not this retrofit.

### DROPs

22 of 26 cluster methods are mis-grouped. The proposal documents the owning capability for each:

- `AuditTrailProvider` methods → `pluggable-integration-registry` (already annotated)
- `AuthorizationAuditService::logSchemaAuthorizationChange` → `auth-system` (logs via NC `LoggerInterface`, not the AuditTrail entity)
- Vue `closeDialog` methods + `loadAuditTrails` + `AuditTrailController::requireAdmin` → already annotated under `retrofit-2026-04-23-annotate-openregister`
- Test fixtures + Pinia store + private helpers → no spec-relevant behavior

## Test plan

- [x] `openspec validate retrofit-2026-05-24-audit-trail-immutable --strict` — clean
- [ ] Spot-check that each `@spec` link resolves to the right task
- [ ] Decide whether to address the REQ-IMMU-002 drift (either make `clear-all` 405 too, or relax the immutability REQ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)