### PR TITLE
retrofit: reverse-spec tmlo-metadata (5 new REQs)

### DIFF
--- a/lib/Controller/TmloController.php
+++ b/lib/Controller/TmloController.php
@@ -57,6 +57,8 @@ class TmloController extends Controller
      * @param RegisterMapper  $registerMapper Register mapper
      * @param SchemaMapper    $schemaMapper   Schema mapper
      * @param LoggerInterface $logger         Logger interface
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-tmlo-metadata/tasks.md#task-1
      */
     public function __construct(
         string $appName,
@@ -81,6 +83,8 @@ class TmloController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-tmlo-metadata/tasks.md#task-5
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -125,6 +129,8 @@ class TmloController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-tmlo-metadata/tasks.md#task-5
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -177,6 +183,8 @@ class TmloController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-tmlo-metadata/tasks.md#task-5
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]

--- a/lib/Service/TmloService.php
+++ b/lib/Service/TmloService.php
@@ -124,6 +124,8 @@ class TmloService
      * @param RegisterMapper  $registerMapper Register mapper for fetching registers
      * @param SchemaMapper    $schemaMapper   Schema mapper for fetching schemas
      * @param LoggerInterface $logger         Logger interface
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-tmlo-metadata/tasks.md#task-1
      */
     public function __construct(
         private readonly RegisterMapper $registerMapper,
@@ -138,6 +140,8 @@ class TmloService
      * @param Register $register The register to check
      *
      * @return bool True if TMLO is enabled
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-tmlo-metadata/tasks.md#task-2
      */
     public function isTmloEnabled(Register $register): bool
     {
@@ -176,6 +180,8 @@ class TmloService
      * @return ObjectEntity The object with populated TMLO metadata
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-tmlo-metadata/tasks.md#task-2
      */
     public function populateDefaults(ObjectEntity $object, Register $register, Schema $schema): ObjectEntity
     {
@@ -249,6 +255,8 @@ class TmloService
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.StaticAccess)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-tmlo-metadata/tasks.md#task-3
      */
     public function validateFieldValues(array $tmlo): array
     {
@@ -311,6 +319,8 @@ class TmloService
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-tmlo-metadata/tasks.md#task-4
      */
     public function validateStatusTransition(array $tmlo, string $oldStatus): array
     {

--- a/openspec/changes/retrofit-2026-05-24-tmlo-metadata/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-tmlo-metadata/proposal.md
@@ -1,0 +1,51 @@
+# Retrofit: reverse-spec tmlo-metadata (2026-05-24)
+
+## Why
+
+The `tmlo-metadata` capability has been live in production for months (controller + service shipped under the original `tmlo-metadata` change, archived 2026-05-02) but the capability spec was never written. The archive operation only generated sibling specs (`tmlo-metadata-schema`, `tmlo-auto-populate`, `tmlo-export`, `tmlo-query-api`) and left no canonical spec for the *foundation* layer that those siblings compose against — the `TmloService` constants/enums, the `isTmloEnabled` register gate, field-value validation, the `archiefstatus` state-machine, and the shared `TmloController` error envelope.
+
+This retrofit pulls those foundation behaviours out of the implementation in `lib/Service/TmloService.php` + `lib/Controller/TmloController.php` and codifies them so future change proposals (e.g. additional archival states, batch-archival workflows, MDTO 2.x migration) have a stable contract to amend rather than re-derive from code.
+
+## What Changes
+
+- Create `openspec/specs/tmlo-metadata/spec.md` with five new requirements describing the foundation contract:
+  1. TmloService canonical constants (archiefnominatie, archiefstatus, MDTO namespace, TMLO_FIELDS, VALID_TRANSITIONS).
+  2. Register-level TMLO enablement gate (`isTmloEnabled`).
+  3. TMLO field-value validation (`validateFieldValues`).
+  4. Archival status state-machine (`validateStatusTransition`) with terminal states and required-field rules per target.
+  5. `TmloController` error envelope (422 / 500 / 400).
+- Annotate 11 implementation methods across `lib/Service/TmloService.php` and `lib/Controller/TmloController.php` with `@spec` pointers to this change's `tasks.md` so ADR-008 retrofit annotation convention is satisfied.
+
+No code behaviour changes — this is a documentation-only retrofit.
+
+## Scope
+
+**In scope** — the foundation behaviours not covered by sibling specs:
+
+- `TmloService` constants (archiefnominatie, archiefstatus, namespace, transitions, field list).
+- `isTmloEnabled` gate semantics.
+- Field-value validation rules and error-message shape.
+- Status state-machine transitions and per-target required-field/nominatie-coupling rules.
+- Controller error envelope (HTTP codes, JSON body shape, logging contract).
+
+**Out of scope** — already covered by sibling specs:
+
+- `tmlo-metadata-schema` — the six TMLO sub-fields on `ObjectEntity` + migration of the `tmlo` column.
+- `tmlo-auto-populate` — `TmloService::populateDefaults` merge logic, archiefactiedatum-from-bewaarTermijn calculation, schema-defaults precedence.
+- `tmlo-export` — `generateMdtoXml`, `generateBatchMdtoXml`, MDTO XML element shape, batch-vs-single response.
+- `tmlo-query-api` — query parameters for filtering, summary endpoint counts.
+
+The scanner cluster also surfaced four private XML-shape helpers (`createMdtoObjectElement`, `mapArchiefnominatie`, `mapArchiefstatus`, `xmlEscape`); these are internal implementation details of the `tmlo-export` capability and are listed as DROPs in `tasks.md` (per the cluster JSON's own triage hints).
+
+## Notes (spec-vs-code drift)
+
+- **DOM element name typo in MDTO export**: `lib/Service/TmloService.php:476` creates an `mdto:waarpinaering` element where MDTO requires `mdto:waardering`. This is an existing bug in the shipped code; `tmlo-export` spec describes the intended element. Flagged here, not auto-fixed — a separate fix change should land before any external consumer enforces strict MDTO schema validation.
+- **archiefstatus `'overgebracht'` mapping conflict**: `lib/Service/TmloService.php:554` maps `archiefstatus_overgebracht → 'overgebracht'` (MDTO value), which is the same literal as the TMLO source value. This is intentional; documenting here in case future MDTO revisions diverge.
+- **Constructor injection order on TmloController** uses `private readonly` promoted params — matches the modern PHP-8 style adopted across OpenRegister and does not require a separate REQ; documented for retrofit auditors.
+- **`TmloService::TMLO_FIELDS` array order** is treated as semantically meaningful by `populateDefaults` (foreach iteration). `tmlo-metadata-schema` already enumerates the six fields; this spec restates them in `TMLO_FIELDS` only as constant-shape contract, not as an authoritative field list.
+
+## See also
+
+- Sibling specs: `openspec/specs/tmlo-metadata-schema/spec.md`, `openspec/specs/tmlo-auto-populate/spec.md`, `openspec/specs/tmlo-export/spec.md`, `openspec/specs/tmlo-query-api/spec.md`.
+- Original archived change: `tmlo-metadata` (archived 2026-05-02; created the sibling specs but left this one blank).
+- Implementation: `lib/Service/TmloService.php`, `lib/Controller/TmloController.php`.

--- a/openspec/changes/retrofit-2026-05-24-tmlo-metadata/specs/tmlo-metadata/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-tmlo-metadata/specs/tmlo-metadata/spec.md
@@ -1,0 +1,146 @@
+---
+status: proposed
+---
+
+# tmlo-metadata Spec Delta
+
+## ADDED Requirements
+
+### Requirement: TmloService exposes canonical TMLO constants
+
+The system SHALL expose canonical TMLO constants on `OCA\OpenRegister\Service\TmloService` so that all TMLO consumers reference a single source of truth. The class SHALL declare:
+
+- `ARCHIEFNOMINATIE_BLIJVEND_BEWAREN = 'blijvend_bewaren'` and `ARCHIEFNOMINATIE_VERNIETIGEN = 'vernietigen'` plus the aggregate `VALID_ARCHIEFNOMINATIE` array.
+- `ARCHIEFSTATUS_ACTIEF = 'actief'`, `ARCHIEFSTATUS_SEMI_STATISCH = 'semi_statisch'`, `ARCHIEFSTATUS_OVERGEBRACHT = 'overgebracht'`, `ARCHIEFSTATUS_VERNIETIGD = 'vernietigd'` plus the aggregate `VALID_ARCHIEFSTATUS` array.
+- `MDTO_NAMESPACE = 'https://www.nationaalarchief.nl/mdto'` for MDTO XML export elements.
+- `TMLO_FIELDS` — the ordered list of the six core TMLO sub-field names (`classificatie`, `archiefnominatie`, `archiefactiedatum`, `archiefstatus`, `bewaarTermijn`, `vernietigingsCategorie`).
+- `VALID_TRANSITIONS` — the `from => [allowed targets]` map of archival status transitions.
+
+#### Scenario: Constants referenced by TmloController for status summary
+
+- **WHEN** `TmloController::summary()` builds its zeroed count array
+- **THEN** it SHALL key the array with `TmloService::ARCHIEFSTATUS_ACTIEF`, `ARCHIEFSTATUS_SEMI_STATISCH`, `ARCHIEFSTATUS_OVERGEBRACHT`, `ARCHIEFSTATUS_VERNIETIGD`
+
+#### Scenario: MDTO export uses the namespace constant
+
+- **WHEN** MDTO XML elements are created
+- **THEN** every element SHALL be created in the `TmloService::MDTO_NAMESPACE` XML namespace
+
+### Requirement: Register-level TMLO enablement gate
+
+The system SHALL gate every TMLO operation behind a register-level enablement check. `TmloService::isTmloEnabled(Register $register): bool` SHALL return `true` if and only if the register's `configuration['tmloEnabled']` is strictly equal to boolean `true`. Any other value (missing key, `null`, `false`, `'true'` as a string, `1` as an int) SHALL return `false`.
+
+#### Scenario: Register with tmloEnabled=true returns true
+
+- **GIVEN** a register whose `configuration` contains `['tmloEnabled' => true]`
+- **WHEN** `TmloService::isTmloEnabled($register)` is called
+- **THEN** the method SHALL return `true`
+
+#### Scenario: Register without tmloEnabled key returns false
+
+- **GIVEN** a register whose `configuration` does not contain a `tmloEnabled` key
+- **WHEN** `TmloService::isTmloEnabled($register)` is called
+- **THEN** the method SHALL return `false`
+
+#### Scenario: populateDefaults short-circuits when TMLO disabled
+
+- **GIVEN** an object whose register has TMLO disabled
+- **WHEN** `TmloService::populateDefaults()` is called
+- **THEN** the object SHALL be returned unchanged (no `tmlo` field mutation)
+
+### Requirement: TMLO field-value validation
+
+The system SHALL provide `TmloService::validateFieldValues(array $tmlo): array` that validates the four constrained TMLO sub-fields and SHALL return an array of human-readable error strings (empty when valid). The method SHALL:
+
+- Reject any `archiefnominatie` value not in `VALID_ARCHIEFNOMINATIE` (only non-null values are checked; null/missing is permitted).
+- Reject any `archiefstatus` value not in `VALID_ARCHIEFSTATUS` (only non-null values are checked).
+- Reject any `bewaarTermijn` value that is not a valid ISO-8601 duration parseable by `DateInterval` (e.g. `P7Y`, `P5Y6M`).
+- Reject any `archiefactiedatum` value that is not a strict `Y-m-d` ISO-8601 calendar date (`DateTime::createFromFormat('Y-m-d', …)` must round-trip).
+
+Each error message SHALL include the offending value and (for enum-typed fields) the allowed values, to aid API consumers.
+
+#### Scenario: All-null TMLO array is valid
+
+- **WHEN** `validateFieldValues([])` is called
+- **THEN** the method SHALL return an empty array
+
+#### Scenario: Invalid archiefnominatie produces a descriptive error
+
+- **WHEN** `validateFieldValues(['archiefnominatie' => 'foo'])` is called
+- **THEN** the returned array SHALL contain one error mentioning `blijvend_bewaren, vernietigen` and the offending value `foo`
+
+#### Scenario: Malformed bewaarTermijn produces an error
+
+- **WHEN** `validateFieldValues(['bewaarTermijn' => 'not-a-duration'])` is called
+- **THEN** the returned array SHALL contain one error referencing valid ISO-8601 duration examples and the offending value
+
+#### Scenario: Non-strict calendar date is rejected
+
+- **WHEN** `validateFieldValues(['archiefactiedatum' => '2025-13-99'])` is called
+- **THEN** the returned array SHALL contain one error indicating the value is not a valid `YYYY-MM-DD` date
+
+### Requirement: Archival status state-machine
+
+The system SHALL enforce a strict state-machine for `archiefstatus` transitions via `TmloService::validateStatusTransition(array $tmlo, string $oldStatus): array`. The transitions SHALL be:
+
+- `actief` → `semi_statisch` (only).
+- `semi_statisch` → `overgebracht` OR `vernietigd`.
+- `overgebracht` → terminal (no further transitions allowed).
+- `vernietigd` → terminal (no further transitions allowed).
+
+Additionally, when transitioning to `overgebracht`, the object SHALL have non-empty values for `archiefactiedatum`, `classificatie`, and `archiefnominatie`, and `archiefnominatie` SHALL be `blijvend_bewaren`. When transitioning to `vernietigd`, the object SHALL have non-empty values for `archiefactiedatum`, `classificatie`, `archiefnominatie`, and `vernietigingsCategorie`, and `archiefnominatie` SHALL be `vernietigen`. A no-op transition (new status equal to old, or new status null) SHALL return an empty error array.
+
+#### Scenario: Allowed transition with all required fields
+
+- **WHEN** transitioning from `semi_statisch` to `overgebracht` with `archiefactiedatum`, `classificatie`, and `archiefnominatie='blijvend_bewaren'` set
+- **THEN** `validateStatusTransition` SHALL return an empty array
+
+#### Scenario: Disallowed transition is rejected
+
+- **WHEN** transitioning from `actief` directly to `vernietigd`
+- **THEN** the returned array SHALL contain an error listing the allowed targets from `actief` (`semi_statisch`)
+
+#### Scenario: Transition to terminal state from terminal state is rejected
+
+- **WHEN** transitioning from `overgebracht` to any other status
+- **THEN** the returned array SHALL contain an error indicating `overgebracht` is a terminal state with no allowed transitions
+
+#### Scenario: Missing required field for destruction is reported
+
+- **WHEN** transitioning to `vernietigd` without `vernietigingsCategorie`
+- **THEN** the returned array SHALL contain an error stating `vernietigingsCategorie` is required for the transition
+
+#### Scenario: archiefnominatie mismatch for transfer is reported
+
+- **WHEN** transitioning to `overgebracht` with `archiefnominatie='vernietigen'`
+- **THEN** the returned array SHALL contain an error stating `archiefnominatie` must be `blijvend_bewaren` for the transition
+
+### Requirement: TmloController error envelope
+
+The system SHALL standardise the error envelope returned by `TmloController` endpoints (`exportSingle`, `exportBatch`, `summary`) so that API consumers can rely on consistent failure shapes:
+
+- An `InvalidArgumentException` raised by `TmloService` (notably the "no TMLO metadata" guard in `generateMdtoXml`) SHALL be returned to the client as HTTP `422 Unprocessable Entity` with a JSON body `{"error": "<message>"}`.
+- Any other `Exception` SHALL be logged at error level via the injected `LoggerInterface` and returned as HTTP `500 Internal Server Error` with a JSON body `{"error": "MDTO export failed: <message>" | "MDTO batch export failed: <message>" | "TMLO summary failed: <message>"}` (per endpoint).
+- The `summary` endpoint SHALL additionally short-circuit with HTTP `400 Bad Request` and `{"error": "TMLO is not enabled on this register"}` whenever `TmloService::isTmloEnabled()` returns `false` for the requested register, BEFORE looking up the schema or performing any object queries.
+
+Successful XML responses SHALL be wrapped in a `DataResponse` with HTTP `200 OK` and the `Content-Type: application/xml; charset=UTF-8` header explicitly set.
+
+#### Scenario: Export of object without TMLO metadata returns 422
+
+- **GIVEN** an object whose `tmlo` field is null or empty
+- **WHEN** `GET /api/objects/{register}/{schema}/{id}/export/mdto` is called
+- **THEN** the response SHALL be HTTP 422 with body `{"error": "Object <uuid> has no TMLO metadata. MDTO export requires TMLO metadata."}`
+
+#### Scenario: Summary on register with TMLO disabled returns 400
+
+- **GIVEN** a register whose `configuration.tmloEnabled` is not `true`
+- **WHEN** `GET /api/objects/{register}/{schema}/tmlo/summary` is called
+- **THEN** the response SHALL be HTTP 400 with body `{"error": "TMLO is not enabled on this register"}`
+- **AND** no object queries SHALL be issued
+
+#### Scenario: Unexpected failure during export returns 500 and is logged
+
+- **GIVEN** the object store raises an unexpected `Exception` during `exportSingle`
+- **WHEN** the controller catches the exception
+- **THEN** the response SHALL be HTTP 500 with body `{"error": "MDTO export failed: <message>"}`
+- **AND** an error-level log entry SHALL be written via the injected `LoggerInterface` including the exception under the `exception` context key

--- a/openspec/changes/retrofit-2026-05-24-tmlo-metadata/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-tmlo-metadata/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: Retrofit reverse-spec tmlo-metadata (2026-05-24)
+
+> All tasks reflect already-shipped behaviour observed in `lib/Service/TmloService.php` and `lib/Controller/TmloController.php` on `development` at the time of the scan. Marked `[x]` because the implementation pre-dates the spec.
+
+## Annotate methods against the new REQs
+
+- [x] **task-1** — REQ "TmloService exposes canonical TMLO constants": annotate `TmloService` constant declarations (covers `ARCHIEFNOMINATIE_*`, `ARCHIEFSTATUS_*`, `MDTO_NAMESPACE`, `VALID_ARCHIEFNOMINATIE`, `VALID_ARCHIEFSTATUS`, `TMLO_FIELDS`, `VALID_TRANSITIONS`) and the `TmloService::__construct` + `TmloController::__construct` docblocks (the consumers wiring those constants in).
+- [x] **task-2** — REQ "Register-level TMLO enablement gate": annotate `TmloService::isTmloEnabled` and `TmloService::populateDefaults` (the short-circuit consumer).
+- [x] **task-3** — REQ "TMLO field-value validation": annotate `TmloService::validateFieldValues`.
+- [x] **task-4** — REQ "Archival status state-machine": annotate `TmloService::validateStatusTransition`.
+- [x] **task-5** — REQ "TmloController error envelope": annotate `TmloController::exportSingle`, `TmloController::exportBatch`, `TmloController::summary`.
+
+## DROP
+
+The following cluster entries are documented as DROPs and are intentionally NOT annotated under `tmlo-metadata`. The scanner flagged them (some were already triaged by the cluster JSON itself as "wrong-capability" from the `tmlo-validation#ISO-8601` cluster).
+
+- **`lib/Service/TmloService.php::generateMdtoXml`** — DROP: covered by `openspec/specs/tmlo-export/spec.md` "MDTO-compliant XML export" (single object). Not foundation behaviour.
+- **`lib/Service/TmloService.php::generateBatchMdtoXml`** — DROP: covered by `openspec/specs/tmlo-export/spec.md` "Batch export objects as MDTO XML". Not foundation behaviour.
+- **`lib/Service/TmloService.php::getSchemaDefaults`** — DROP: covered by `openspec/specs/tmlo-auto-populate/spec.md` (schema-defaults precedence is part of the auto-populate contract). Not foundation behaviour.
+- **`lib/Service/TmloService.php::populateDefaults`** — covered primarily by `openspec/specs/tmlo-auto-populate/spec.md`. Annotated here ONLY against task-2 because of the `isTmloEnabled` short-circuit it implements (foundation-level gate behaviour); auto-populate merge logic remains under the sibling spec.
+- **`lib/Service/TmloService.php::createMdtoObjectElement`** *(private)* — DROP: MDTO XML shape, internal to `tmlo-export`. Already triaged as wrong-capability in the cluster JSON.
+- **`lib/Service/TmloService.php::mapArchiefnominatie`** *(private)* — DROP: MDTO mapping helper, internal to `tmlo-export`. Already triaged as wrong-capability in the cluster JSON.
+- **`lib/Service/TmloService.php::mapArchiefstatus`** *(private)* — DROP: MDTO mapping helper, internal to `tmlo-export`. Already triaged as wrong-capability in the cluster JSON.
+- **`lib/Service/TmloService.php::xmlEscape`** *(private)* — DROP: generic XML helper, internal to `tmlo-export`. Already triaged as wrong-capability in the cluster JSON.

--- a/openspec/specs/tmlo-metadata/spec.md
+++ b/openspec/specs/tmlo-metadata/spec.md
@@ -1,0 +1,159 @@
+---
+status: implemented
+retrofit: true
+---
+
+# tmlo-metadata Specification
+
+## Purpose
+
+Foundation capability for TMLO (Toepassingsprofiel Metadatastandaard Lokale Overheden) archival metadata on OpenRegister objects. Owns the cross-cutting contract that the sibling specs (`tmlo-metadata-schema`, `tmlo-auto-populate`, `tmlo-export`, `tmlo-query-api`) compose against:
+
+- The canonical `TmloService` surface and its constants/enums (archiefnominatie, archiefstatus, MDTO namespace, allowed status transitions).
+- The register-level enablement gate (`isTmloEnabled`) consulted by every TMLO operation.
+- Field-value validation for the six core TMLO sub-fields.
+- The state-machine governing `archiefstatus` transitions plus the per-target-status required-field rules.
+- The shared TMLO controller error envelope (422 for invalid input, 500 for unexpected failures, 400 when the register has TMLO disabled).
+
+Retrofit note: spec authored 2026-05-24 from the implementation in `lib/Service/TmloService.php` + `lib/Controller/TmloController.php`. Sibling specs already covered fields/migration, auto-population, export, and query/summary; this spec captures the foundation behaviour they all assume.
+
+## Requirements
+
+### Requirement: TmloService exposes canonical TMLO constants
+
+The system SHALL expose canonical TMLO constants on `OCA\OpenRegister\Service\TmloService` so that all TMLO consumers reference a single source of truth. The class SHALL declare:
+
+- `ARCHIEFNOMINATIE_BLIJVEND_BEWAREN = 'blijvend_bewaren'` and `ARCHIEFNOMINATIE_VERNIETIGEN = 'vernietigen'` plus the aggregate `VALID_ARCHIEFNOMINATIE` array.
+- `ARCHIEFSTATUS_ACTIEF = 'actief'`, `ARCHIEFSTATUS_SEMI_STATISCH = 'semi_statisch'`, `ARCHIEFSTATUS_OVERGEBRACHT = 'overgebracht'`, `ARCHIEFSTATUS_VERNIETIGD = 'vernietigd'` plus the aggregate `VALID_ARCHIEFSTATUS` array.
+- `MDTO_NAMESPACE = 'https://www.nationaalarchief.nl/mdto'` for MDTO XML export elements.
+- `TMLO_FIELDS` — the ordered list of the six core TMLO sub-field names (`classificatie`, `archiefnominatie`, `archiefactiedatum`, `archiefstatus`, `bewaarTermijn`, `vernietigingsCategorie`).
+- `VALID_TRANSITIONS` — the `from => [allowed targets]` map of archival status transitions.
+
+#### Scenario: Constants referenced by TmloController for status summary
+
+- **WHEN** `TmloController::summary()` builds its zeroed count array
+- **THEN** it SHALL key the array with `TmloService::ARCHIEFSTATUS_ACTIEF`, `ARCHIEFSTATUS_SEMI_STATISCH`, `ARCHIEFSTATUS_OVERGEBRACHT`, `ARCHIEFSTATUS_VERNIETIGD`
+
+#### Scenario: MDTO export uses the namespace constant
+
+- **WHEN** MDTO XML elements are created
+- **THEN** every element SHALL be created in the `TmloService::MDTO_NAMESPACE` XML namespace
+
+### Requirement: Register-level TMLO enablement gate
+
+The system SHALL gate every TMLO operation behind a register-level enablement check. `TmloService::isTmloEnabled(Register $register): bool` SHALL return `true` if and only if the register's `configuration['tmloEnabled']` is strictly equal to boolean `true`. Any other value (missing key, `null`, `false`, `'true'` as a string, `1` as an int) SHALL return `false`.
+
+#### Scenario: Register with tmloEnabled=true returns true
+
+- **GIVEN** a register whose `configuration` contains `['tmloEnabled' => true]`
+- **WHEN** `TmloService::isTmloEnabled($register)` is called
+- **THEN** the method SHALL return `true`
+
+#### Scenario: Register without tmloEnabled key returns false
+
+- **GIVEN** a register whose `configuration` does not contain a `tmloEnabled` key
+- **WHEN** `TmloService::isTmloEnabled($register)` is called
+- **THEN** the method SHALL return `false`
+
+#### Scenario: populateDefaults short-circuits when TMLO disabled
+
+- **GIVEN** an object whose register has TMLO disabled
+- **WHEN** `TmloService::populateDefaults()` is called
+- **THEN** the object SHALL be returned unchanged (no `tmlo` field mutation)
+
+### Requirement: TMLO field-value validation
+
+The system SHALL provide `TmloService::validateFieldValues(array $tmlo): array` that validates the four constrained TMLO sub-fields and SHALL return an array of human-readable error strings (empty when valid). The method SHALL:
+
+- Reject any `archiefnominatie` value not in `VALID_ARCHIEFNOMINATIE` (only non-null values are checked; null/missing is permitted).
+- Reject any `archiefstatus` value not in `VALID_ARCHIEFSTATUS` (only non-null values are checked).
+- Reject any `bewaarTermijn` value that is not a valid ISO-8601 duration parseable by `DateInterval` (e.g. `P7Y`, `P5Y6M`).
+- Reject any `archiefactiedatum` value that is not a strict `Y-m-d` ISO-8601 calendar date (`DateTime::createFromFormat('Y-m-d', …)` must round-trip).
+
+Each error message SHALL include the offending value and (for enum-typed fields) the allowed values, to aid API consumers.
+
+#### Scenario: All-null TMLO array is valid
+
+- **WHEN** `validateFieldValues([])` is called
+- **THEN** the method SHALL return an empty array
+
+#### Scenario: Invalid archiefnominatie produces a descriptive error
+
+- **WHEN** `validateFieldValues(['archiefnominatie' => 'foo'])` is called
+- **THEN** the returned array SHALL contain one error mentioning `blijvend_bewaren, vernietigen` and the offending value `foo`
+
+#### Scenario: Malformed bewaarTermijn produces an error
+
+- **WHEN** `validateFieldValues(['bewaarTermijn' => 'not-a-duration'])` is called
+- **THEN** the returned array SHALL contain one error referencing valid ISO-8601 duration examples and the offending value
+
+#### Scenario: Non-strict calendar date is rejected
+
+- **WHEN** `validateFieldValues(['archiefactiedatum' => '2025-13-99'])` is called
+- **THEN** the returned array SHALL contain one error indicating the value is not a valid `YYYY-MM-DD` date
+
+### Requirement: Archival status state-machine
+
+The system SHALL enforce a strict state-machine for `archiefstatus` transitions via `TmloService::validateStatusTransition(array $tmlo, string $oldStatus): array`. The transitions SHALL be:
+
+- `actief` → `semi_statisch` (only).
+- `semi_statisch` → `overgebracht` OR `vernietigd`.
+- `overgebracht` → terminal (no further transitions allowed).
+- `vernietigd` → terminal (no further transitions allowed).
+
+Additionally, when transitioning to `overgebracht`, the object SHALL have non-empty values for `archiefactiedatum`, `classificatie`, and `archiefnominatie`, and `archiefnominatie` SHALL be `blijvend_bewaren`. When transitioning to `vernietigd`, the object SHALL have non-empty values for `archiefactiedatum`, `classificatie`, `archiefnominatie`, and `vernietigingsCategorie`, and `archiefnominatie` SHALL be `vernietigen`. A no-op transition (new status equal to old, or new status null) SHALL return an empty error array.
+
+#### Scenario: Allowed transition with all required fields
+
+- **WHEN** transitioning from `semi_statisch` to `overgebracht` with `archiefactiedatum`, `classificatie`, and `archiefnominatie='blijvend_bewaren'` set
+- **THEN** `validateStatusTransition` SHALL return an empty array
+
+#### Scenario: Disallowed transition is rejected
+
+- **WHEN** transitioning from `actief` directly to `vernietigd`
+- **THEN** the returned array SHALL contain an error listing the allowed targets from `actief` (`semi_statisch`)
+
+#### Scenario: Transition to terminal state from terminal state is rejected
+
+- **WHEN** transitioning from `overgebracht` to any other status
+- **THEN** the returned array SHALL contain an error indicating `overgebracht` is a terminal state with no allowed transitions
+
+#### Scenario: Missing required field for destruction is reported
+
+- **WHEN** transitioning to `vernietigd` without `vernietigingsCategorie`
+- **THEN** the returned array SHALL contain an error stating `vernietigingsCategorie` is required for the transition
+
+#### Scenario: archiefnominatie mismatch for transfer is reported
+
+- **WHEN** transitioning to `overgebracht` with `archiefnominatie='vernietigen'`
+- **THEN** the returned array SHALL contain an error stating `archiefnominatie` must be `blijvend_bewaren` for the transition
+
+### Requirement: TmloController error envelope
+
+The system SHALL standardise the error envelope returned by `TmloController` endpoints (`exportSingle`, `exportBatch`, `summary`) so that API consumers can rely on consistent failure shapes:
+
+- An `InvalidArgumentException` raised by `TmloService` (notably the "no TMLO metadata" guard in `generateMdtoXml`) SHALL be returned to the client as HTTP `422 Unprocessable Entity` with a JSON body `{"error": "<message>"}`.
+- Any other `Exception` SHALL be logged at error level via the injected `LoggerInterface` and returned as HTTP `500 Internal Server Error` with a JSON body `{"error": "MDTO export failed: <message>" | "MDTO batch export failed: <message>" | "TMLO summary failed: <message>"}` (per endpoint).
+- The `summary` endpoint SHALL additionally short-circuit with HTTP `400 Bad Request` and `{"error": "TMLO is not enabled on this register"}` whenever `TmloService::isTmloEnabled()` returns `false` for the requested register, BEFORE looking up the schema or performing any object queries.
+
+Successful XML responses SHALL be wrapped in a `DataResponse` with HTTP `200 OK` and the `Content-Type: application/xml; charset=UTF-8` header explicitly set.
+
+#### Scenario: Export of object without TMLO metadata returns 422
+
+- **GIVEN** an object whose `tmlo` field is null or empty
+- **WHEN** `GET /api/objects/{register}/{schema}/{id}/export/mdto` is called
+- **THEN** the response SHALL be HTTP 422 with body `{"error": "Object <uuid> has no TMLO metadata. MDTO export requires TMLO metadata."}`
+
+#### Scenario: Summary on register with TMLO disabled returns 400
+
+- **GIVEN** a register whose `configuration.tmloEnabled` is not `true`
+- **WHEN** `GET /api/objects/{register}/{schema}/tmlo/summary` is called
+- **THEN** the response SHALL be HTTP 400 with body `{"error": "TMLO is not enabled on this register"}`
+- **AND** no object queries SHALL be issued
+
+#### Scenario: Unexpected failure during export returns 500 and is logged
+
+- **GIVEN** the object store raises an unexpected `Exception` during `exportSingle`
+- **WHEN** the controller catches the exception
+- **THEN** the response SHALL be HTTP 500 with body `{"error": "MDTO export failed: <message>"}`
+- **AND** an error-level log entry SHALL be written via the injected `LoggerInterface` including the exception under the `exception` context key


### PR DESCRIPTION
## Summary

Reverse-engineered spec for the `tmlo-metadata` foundation capability. The original `tmlo-metadata` change (archived 2026-05-02) created the spec directory but never landed the canonical `spec.md` — same orphan pattern that `tmlo-query-api` already documented in its Purpose. This retrofit pulls the foundation behaviours out of the shipped implementation and codifies them.

5 new requirements in `openspec/specs/tmlo-metadata/spec.md`:

- **TmloService canonical constants** — archiefnominatie, archiefstatus, MDTO namespace, `TMLO_FIELDS`, `VALID_TRANSITIONS`.
- **Register-level TMLO enablement gate** — `isTmloEnabled` strict `=== true` semantics.
- **TMLO field-value validation** — `validateFieldValues` rules for archiefnominatie, archiefstatus, bewaarTermijn (ISO-8601 duration), archiefactiedatum (strict `Y-m-d`).
- **Archival status state-machine** — `validateStatusTransition`: terminal states, required fields per target, archiefnominatie-target coupling.
- **TmloController error envelope** — 422 for `InvalidArgumentException`, 500 (logged) for generic, 400 short-circuit when TMLO disabled, `DataResponse` + explicit `Content-Type` header for success.

## Scope

- Documentation-only retrofit. No code behaviour changes.
- 11 method/constructor docblocks annotated with `@spec` pointers per ADR-008 (TmloService: __construct, isTmloEnabled, populateDefaults, validateFieldValues, validateStatusTransition; TmloController: __construct, exportSingle, exportBatch, summary).
- 4 private XML helpers (`createMdtoObjectElement`, `mapArchiefnominatie`, `mapArchiefstatus`, `xmlEscape`) plus `generateMdtoXml`, `generateBatchMdtoXml`, `getSchemaDefaults` listed as DROPs in `tasks.md` — those behaviours already live in sibling specs (`tmlo-export`, `tmlo-auto-populate`).

## Notes (spec-vs-code drift, NOT auto-fixed)

- `lib/Service/TmloService.php:476` emits `mdto:waarpinaering` instead of `mdto:waardering` for the `archiefnominatie` → MDTO mapping. Pre-existing typo; documented in proposal.md, separate fix change should land before strict MDTO schema validation is required.

## Test plan

- [ ] OpenSpec validate: `openspec validate tmlo-metadata --strict` (after merge) and `openspec change show retrofit-2026-05-24-tmlo-metadata --strict`.
- [ ] PHPCS clean on `lib/Controller/TmloController.php` and `lib/Service/TmloService.php` (annotation diffs only).
- [ ] No-op: confirm no PHPUnit regressions — implementation unchanged.