### PR TITLE
docs(retention-management): retrofit AVG pass + realtime-event prune + settings handler

### DIFF
--- a/lib/BackgroundJob/AvgRetentionJob.php
+++ b/lib/BackgroundJob/AvgRetentionJob.php
@@ -79,6 +79,8 @@ class AvgRetentionJob extends TimedJob
      * @param IAppConfig          $appConfig        App-config reader.
      * @param AvgRetentionService $retentionService Domain service.
      * @param LoggerInterface     $logger           Logger.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-retention-management/tasks.md#task-1
      */
     public function __construct(
         ITimeFactory $time,
@@ -99,6 +101,8 @@ class AvgRetentionJob extends TimedJob
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-retention-management/tasks.md#task-1
      */
     protected function run($argument): void
     {

--- a/lib/BackgroundJob/RealtimeEventRetentionJob.php
+++ b/lib/BackgroundJob/RealtimeEventRetentionJob.php
@@ -79,6 +79,8 @@ class RealtimeEventRetentionJob extends TimedJob
      * @param RealtimeEventMapper $eventMapper Mapper exposing
      *                                         `deleteOlderThan()`.
      * @param LoggerInterface     $logger      Logger for telemetry.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-retention-management/tasks.md#task-2
      */
     public function __construct(
         ITimeFactory $time,
@@ -99,6 +101,8 @@ class RealtimeEventRetentionJob extends TimedJob
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-retention-management/tasks.md#task-2
      */
     protected function run($argument): void
     {

--- a/lib/Service/AvgRetentionService.php
+++ b/lib/Service/AvgRetentionService.php
@@ -60,6 +60,8 @@ class AvgRetentionService
      * @param VerwerkingsactiviteitMapper $vrwMapper    Catalog reader.
      * @param MagicMapper                 $objectMapper Object loader.
      * @param LoggerInterface             $logger       Logger.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-retention-management/tasks.md#task-1
      */
     public function __construct(
         private readonly IDBConnection $db,
@@ -98,6 +100,8 @@ class AvgRetentionService
      * @return array<string, mixed>
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-retention-management/tasks.md#task-1
      */
     public function runRetentionPass(bool $dryRun=false): array
     {
@@ -140,6 +144,8 @@ class AvgRetentionService
      * @param bool                  $dryRun   Pass-through dry-run flag.
      *
      * @return array<string, mixed>|null Per-activity result or null skip.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-retention-management/tasks.md#task-1
      */
     private function processActivity(Verwerkingsactiviteit $activity, DateTime $now, bool $dryRun): ?array
     {
@@ -195,6 +201,8 @@ class AvgRetentionService
      * @param string   $duration ISO-8601 duration string.
      *
      * @return DateTime|null Cutoff timestamp or null on parse error.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-retention-management/tasks.md#task-1
      */
     private function computeCutoff(DateTime $now, string $duration): ?DateTime
     {
@@ -221,6 +229,8 @@ class AvgRetentionService
      * @param DateTime $cutoff       Cut-off timestamp.
      *
      * @return array<int, array{object: int, object_uuid: string|null, register: int|null, schema: int|null}>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-retention-management/tasks.md#task-1
      */
     private function findOverdueObjectsForActivity(string $activityUuid, DateTime $cutoff): array
     {
@@ -284,6 +294,8 @@ class AvgRetentionService
      * @param Verwerkingsactiviteit            $activity   Owning activity.
      *
      * @return int
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-retention-management/tasks.md#task-1
      */
     private function erasePastRetention(array $candidates, Verwerkingsactiviteit $activity): int
     {
@@ -327,6 +339,8 @@ class AvgRetentionService
      * @param array<string, mixed> $candidate Single candidate row.
      *
      * @return ObjectEntity|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-retention-management/tasks.md#task-1
      */
     private function loadCandidate(array $candidate): ?ObjectEntity
     {

--- a/lib/Service/Settings/ObjectRetentionHandler.php
+++ b/lib/Service/Settings/ObjectRetentionHandler.php
@@ -360,6 +360,8 @@ class ObjectRetentionHandler
      * @throws \RuntimeException If version information retrieval fails
      *
      * @psalm-return array{appName: 'Open Register', appVersion: '0.2.3'}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-retention-management/tasks.md#task-3
      */
     public function getVersionInfoOnly(): array
     {
@@ -379,6 +381,8 @@ class ObjectRetentionHandler
      * @param mixed $value The value to convert to boolean
      *
      * @return bool The boolean representation
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-retention-management/tasks.md#task-3
      */
     private function convertToBoolean($value): bool
     {

--- a/openspec/changes/retrofit-2026-05-24-retention-management/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-retention-management/proposal.md
@@ -1,0 +1,40 @@
+# Retrofit — retention-management
+
+Describes observed behavior of 7 methods across 4 files under `retention-management` as 3 new REQs. Code already exists — this change retroactively specifies it. The remaining 11 methods in the original batch were either DROPped because they implement requirements already present in `openspec/specs/retention-management/spec.md` (private helpers behind public REQ-bearing methods) or were FPs from a prior triage pass against other capabilities.
+
+## Affected code units
+
+- `lib/Service/AvgRetentionService.php` — `__construct`, `runRetentionPass`, `processActivity` (private), `computeCutoff` (private), `findOverdueObjectsForActivity` (private), `erasePastRetention` (private), `loadCandidate` (private)
+- `lib/BackgroundJob/AvgRetentionJob.php` — `__construct`, `run` (protected)
+- `lib/BackgroundJob/RealtimeEventRetentionJob.php` — `__construct`, `run` (protected)
+- `lib/Service/Settings/ObjectRetentionHandler.php` — `getVersionInfoOnly`, `convertToBoolean` (private)
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes.
+- Draft REQs that match behavior (not aspirational).
+- DROPs documented in the Notes section below.
+
+## REQ map
+
+| REQ | Methods |
+|-----|---------|
+| REQ-AVG-RETENTION | `AvgRetentionService::__construct/runRetentionPass/processActivity/computeCutoff/findOverdueObjectsForActivity/erasePastRetention/loadCandidate`, `AvgRetentionJob::__construct/run` |
+| REQ-REALTIME-EVENT-RETENTION | `RealtimeEventRetentionJob::__construct/run` |
+| REQ-RETENTION-SETTINGS-VERSION-AND-BOOLEANS | `ObjectRetentionHandler::getVersionInfoOnly/convertToBoolean` |
+
+## Notes — DROPs
+
+The original batch JSON contained 11 additional methods that this retrofit does NOT annotate:
+
+- `RetentionService::determineBrondatum` (private) — helper of `calculateArchiefactiedatum`; already covered by the existing _"The system MUST calculate archiefactiedatum using configurable afleidingswijzen"_ requirement (Scenarios "Calculate from afgehandeld" / "Calculate from eigenschap" / "Calculate from termijn").
+- `RetentionService::validateNotImmutable` (public) — powers the existing _"Destroyed objects cannot be modified"_ and _"Transferred objects become read-only"_ Scenarios under the MDTO retention metadata requirement.
+- `RetentionService::extractSelectielijstBron` (private) — helper of `generateDestructionCertificate`; covered by the existing _"The system MUST generate destruction certificates"_ requirement.
+- `RetentionController::checkDualApprovalRequired` (private) — helper invoked from the approve endpoint; covered by the existing _"Two-step approval for sensitive schemas"_ Scenario under the multi-step approval workflow requirement.
+- `src/views/settings/sections/RetentionConfiguration.vue::showRebaseDialog` — trivial UI dispatch (one-liner that delegates to the settings store); no distinct backend behavior to specify.
+
+DROPs from earlier coverage triage that landed in this batch (FP carry-overs, not actually retention-management new behavior):
+
+- `AvgRetentionJob::__construct/run`, `AvgRetentionService::runRetentionPass/processActivity/computeCutoff/findOverdueObjectsForActivity/erasePastRetention/loadCandidate` were earlier triaged as DROPs of `archival-destruction-workflow#REQ-001/REQ-003/REQ-006/REQ-008` and `actions#REQ-001`. They WERE correctly DROPped from those capabilities — they belong to retention-management AVG/GDPR enforcement, NOT to Archiefwet destruction-list workflow nor actions CRUD. They are picked up here as a new dedicated REQ.
+
+Source: `/tmp/or-scan/rspec-cluster-retention-management.json` (capability `retention-management`, 18 methods, 7 files).

--- a/openspec/changes/retrofit-2026-05-24-retention-management/specs/retention-management/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-retention-management/specs/retention-management/spec.md
@@ -1,0 +1,188 @@
+---
+retrofit: true
+---
+
+# Retention Management — Retrofit Delta 2026-05-24
+
+This delta adds three new requirements to the `retention-management` capability covering observed behavior that the existing spec does not yet describe:
+
+1. AVG / GDPR retention enforcement driven by `processing_activity_id` from the audit-trail ledger (parallel to the Archiefwet 1995 destruction-list workflow already specified).
+2. Daily prune of the `openregister_realtime_events` log table.
+3. Retention/Object/Archival settings handler utility behavior (version reporting and boolean coercion of mixed-type config values).
+
+Code already exists — requirements describe what the code does, not what it should do.
+
+## ADDED Requirements
+
+### Requirement: The system MUST run a daily AVG / GDPR retention pass driven by per-activity bewaartermijn
+
+A `TimedJob` (`AvgRetentionJob`, 24-hour interval) MUST invoke `AvgRetentionService::runRetentionPass()` which walks every published `Verwerkingsactiviteit` catalog row, computes a bewaartermijn cut-off per activity, finds audit-trail objects whose **latest** `created` timestamp predates the cut-off, and soft-deletes them. This is distinct from the Archiefwet destruction-list workflow: it operates on the audit-trail's `processing_activity_id` column, not on `archiefactiedatum`, and serves GDPR Article 5(1)(e) (storage limitation).
+
+#### Scenario: Daily job runs the retention pass unless disabled
+
+- **GIVEN** the app-config key `avg_retention_enabled` is unset or `true`
+- **WHEN** the `AvgRetentionJob` (24-hour `TimedJob`) fires
+- **THEN** it MUST call `AvgRetentionService::runRetentionPass()` with the `dryRun` flag read from app-config key `avg_retention_dry_run` (default `false`)
+- **AND** it MUST log an info entry with `evaluatedActivities`, `skippedActivities`, `objectsErased`, and the resolved `dryRun` flag
+- **AND** any `\Throwable` raised by the service MUST be caught and logged at `error` level without re-throwing
+
+#### Scenario: Disable toggle short-circuits the job
+
+- **GIVEN** the app-config key `avg_retention_enabled` is the string `"false"` (or any value parsed as boolean `false` by `FILTER_VALIDATE_BOOLEAN`)
+- **WHEN** the `AvgRetentionJob` fires
+- **THEN** the job MUST log an info entry indicating retention is disabled
+- **AND** it MUST return without invoking the service
+
+#### Scenario: Pass evaluates only published activities
+
+- **GIVEN** the catalog contains two `Verwerkingsactiviteit` rows with `status='published'` and one with `status='draft'`
+- **WHEN** `runRetentionPass(dryRun: false)` is invoked
+- **THEN** the service MUST iterate exactly the two published activities (via `VerwerkingsactiviteitMapper::findAll(status: 'published')`)
+- **AND** the summary's `evaluatedActivities` MUST equal the number of activities that produced a per-activity result, and `skippedActivities` MUST equal the number that returned `null`
+
+#### Scenario: Activity without bewaartermijn is skipped
+
+- **GIVEN** a published activity whose `bewaartermijn` is null or the empty string
+- **WHEN** `processActivity()` is invoked for that activity
+- **THEN** the method MUST return `null` and the activity MUST NOT contribute to `perActivity`
+- **AND** the summary's `skippedActivities` counter MUST be incremented by 1
+
+#### Scenario: Activity with unparseable bewaartermijn is skipped with a warning
+
+- **GIVEN** a published activity whose `bewaartermijn` is a string that is not a valid ISO-8601 duration (e.g. `"10 years"` instead of `"P10Y"`)
+- **WHEN** `computeCutoff()` attempts `new DateInterval($duration)` and catches the resulting `\Exception`
+- **THEN** `computeCutoff()` MUST return `null`
+- **AND** `processActivity()` MUST log a warning `[AVG retention] Unparseable bewaartermijn — skipping activity` carrying the activity uuid and the offending value
+- **AND** the activity MUST be reported under `skippedActivities`
+
+#### Scenario: Cut-off is computed as now-minus-bewaartermijn
+
+- **GIVEN** the current reference time is `2026-05-24T00:00:00Z` and bewaartermijn is `"P10Y"`
+- **WHEN** `computeCutoff()` runs
+- **THEN** the returned cut-off `DateTime` MUST equal `2016-05-24T00:00:00Z`
+- **AND** it MUST be returned in ISO-8601 form (`format('c')`) within the per-activity summary's `cutoff` field
+
+#### Scenario: Overdue candidates are those whose newest audit row predates the cut-off
+
+- **GIVEN** an activity uuid `act-1` with cut-off `2016-05-24`
+- **AND** the `openregister_audit_trails` table contains rows for object A (latest `created` = `2015-12-01`) and object B (latest `created` = `2020-03-15`), both tagged `processing_activity_id='act-1'`
+- **WHEN** `findOverdueObjectsForActivity('act-1', cutoff)` runs
+- **THEN** the SQL MUST `GROUP BY object, object_uuid, register, schema` and apply `HAVING MAX(created) < :cutoff`
+- **AND** object A MUST be returned and object B MUST NOT
+- **AND** each returned row MUST carry `object` (int), `object_uuid` (string|null), `register` (int|null), `schema` (int|null)
+
+#### Scenario: SQL failure during enumeration is contained per activity
+
+- **GIVEN** the query builder for an activity uuid throws a `\Throwable`
+- **WHEN** `findOverdueObjectsForActivity()` catches it
+- **THEN** the method MUST log a warning `[AVG retention] Failed to enumerate overdue objects for activity` with the activity uuid and the error message
+- **AND** the method MUST return `[]` so the retention pass continues with the next activity
+
+#### Scenario: Erasure is a soft-delete carrying the activity attribution
+
+- **GIVEN** `processActivity()` resolves three candidate rows and `dryRun=false`
+- **WHEN** `erasePastRetention()` runs
+- **THEN** for each candidate the loader MUST call `MagicMapper::find($uuidOrIntId, _rbac: false, _multitenancy: false)`
+- **AND** each loaded `ObjectEntity` MUST have its `deleted` field set to an array `{ deletedBy: 'system', deletedAt: <ISO 8601 ATOM>, reason: 'avg-bewaartermijn', activityUuid: <activity uuid>, bewaartermijn: <activity bewaartermijn> }`
+- **AND** the same `ObjectEntity` MUST have its `processingActivityId` set to the owning activity's uuid before being passed to `objectMapper->update()`
+- **AND** the per-activity `erased` count MUST equal the number of successful `update()` calls; failures MUST be logged at warning level and MUST NOT abort the loop
+
+#### Scenario: Dry run reports candidates without writing
+
+- **GIVEN** `runRetentionPass(dryRun: true)` is invoked with two overdue candidates for an activity
+- **WHEN** `processActivity()` runs
+- **THEN** `erasePastRetention()` MUST NOT be called
+- **AND** the per-activity entry MUST report `matchedObjects=2`, `erased=0`
+- **AND** the summary's `dryRun` field MUST be `true`
+
+#### Scenario: Candidate loader prefers UUID over int id
+
+- **GIVEN** a candidate row with both `object_uuid='abc-123'` and `object=42`
+- **WHEN** `loadCandidate()` runs
+- **THEN** it MUST call `objectMapper->find('abc-123', ...)` (uuid wins)
+
+#### Scenario: Candidate loader falls back to int id when uuid is empty
+
+- **GIVEN** a candidate row with `object_uuid=null` and `object=42`
+- **WHEN** `loadCandidate()` runs
+- **THEN** it MUST call `objectMapper->find(42, ...)`
+
+#### Scenario: Candidate that no longer exists is skipped silently
+
+- **GIVEN** `objectMapper->find()` raises `DoesNotExistException` for a candidate (e.g. already hard-deleted)
+- **WHEN** `loadCandidate()` catches it
+- **THEN** the method MUST return `null` without logging
+- **AND** the candidate MUST NOT count toward `erased`
+
+### Requirement: The system MUST prune the realtime events log daily
+
+A separate `TimedJob` (`RealtimeEventRetentionJob`, 24-hour interval) MUST bound the size of the `openregister_realtime_events` table by deleting rows older than a configurable retention window. This is independent of the AVG retention pass and of the Archiefwet destruction workflow — it manages the SSE event ledger used by the realtime-updates feature.
+
+#### Scenario: Default retention window is 7 days
+
+- **GIVEN** the app-config key `realtime_event_retention_seconds` is unset
+- **WHEN** the job runs
+- **THEN** it MUST call `RealtimeEventMapper::deleteOlderThan(retentionSeconds: 604800)` (7 × 86400)
+- **AND** it MUST log an info entry with `retentionSeconds=604800` and `deletedRows=<count returned by mapper>`
+
+#### Scenario: Configurable retention window override
+
+- **GIVEN** the app-config key `realtime_event_retention_seconds` is set to `"259200"` (3 days)
+- **WHEN** the job runs
+- **THEN** it MUST pass `259200` as the `retentionSeconds` argument to `deleteOlderThan()`
+
+#### Scenario: Setting retention to zero or negative disables the prune
+
+- **GIVEN** the app-config key `realtime_event_retention_seconds` is `"0"` (or any string parsed as int ≤ 0)
+- **WHEN** the job fires on its scheduled tick
+- **THEN** the job MUST log an info entry `[RealtimeEventRetentionJob] Retention disabled (value <= 0), skipping prune`
+- **AND** it MUST return without touching the `openregister_realtime_events` table
+
+#### Scenario: Mapper failure is logged and swallowed
+
+- **GIVEN** `deleteOlderThan()` raises a `\Throwable` (e.g. DB connection error)
+- **WHEN** the job's `run()` catches it
+- **THEN** the job MUST log the error at `error` level with the message prefix `[RealtimeEventRetentionJob] Prune failed:`
+- **AND** the job MUST NOT re-throw — the next scheduled tick will retry
+
+#### Scenario: Job interval is fixed at 24 hours
+
+- **GIVEN** the constructor builds a new `RealtimeEventRetentionJob`
+- **WHEN** the parent `TimedJob` is configured
+- **THEN** `setInterval(seconds: 86400)` MUST be called (running more often than daily is intentionally rejected per the implementation contract)
+
+### Requirement: The retention settings handler MUST expose app metadata and normalise mixed-type toggle values
+
+`ObjectRetentionHandler` is the back-end handler for the Retention/Object/Archival settings sections. Beyond the read/write methods already covered by the settings retrofit, it MUST provide a version-info endpoint backing the settings UI's "About" panel and MUST coerce mixed-type boolean inputs from stored JSON (strings, ints, native booleans) to PHP `bool`.
+
+#### Scenario: Version info reports app name and version
+
+- **WHEN** `ObjectRetentionHandler::getVersionInfoOnly()` is called
+- **THEN** the method MUST return an array containing exactly `appName` = `"Open Register"` and `appVersion` = `"0.2.3"`
+- **AND** any thrown `Exception` MUST be re-thrown as `\RuntimeException` with the prefix `Failed to retrieve version information:`
+
+#### Scenario: Native booleans pass through unchanged
+
+- **GIVEN** the input value is the PHP boolean `true` (resp. `false`)
+- **WHEN** `convertToBoolean()` is called
+- **THEN** it MUST return `true` (resp. `false`) without further processing
+
+#### Scenario: Truthy strings normalise to true
+
+- **GIVEN** the input value is the string `"true"`, `"1"`, `"yes"`, or `"on"` (case-insensitive)
+- **WHEN** `convertToBoolean()` is called
+- **THEN** it MUST return `true`
+- **AND** any other string (e.g. `"false"`, `"no"`, `"random"`) MUST return `false`
+
+#### Scenario: Numeric values use C-style zero/non-zero semantics
+
+- **GIVEN** the input value is the int `0`, `1`, `42`, or the float `0.0`
+- **WHEN** `convertToBoolean()` is called
+- **THEN** the method MUST return `false` for `0` / `0.0` and `true` for any non-zero numeric value
+- **AND** the comparison MUST use `(int) $value !== 0` (so the float `0.5` casts to int `0` and returns `false`)
+
+#### Scenario: convertToBoolean drives audit/search-trail toggle parsing
+
+- **GIVEN** the stored `retention` JSON blob contains `auditTrailsEnabled: "true"` and `searchTrailsEnabled: 1`
+- **WHEN** `getRetentionSettingsOnly()` decodes the blob
+- **THEN** both flags MUST be returned as PHP boolean `true` (via `convertToBoolean()`), not as the raw string/int — so downstream callers can rely on strict `=== true` checks

--- a/openspec/changes/retrofit-2026-05-24-retention-management/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-retention-management/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] task-1: retention-management#REQ-AVG-RETENTION — AVG/GDPR processing-activity-driven retention pass (retroactive annotation)
+- [x] task-2: retention-management#REQ-REALTIME-EVENT-RETENTION — Realtime event log daily prune (retroactive annotation)
+- [x] task-3: retention-management#REQ-RETENTION-SETTINGS-VERSION-AND-BOOLEANS — Retention settings handler version reporting and boolean normalisation (retroactive annotation)


### PR DESCRIPTION
## Summary

Retrofit ghost change `retrofit-2026-05-24-retention-management` adds **3 ADDED requirements** to `openspec/specs/retention-management/spec.md` describing observed-but-unspecified behavior in 4 files / 11 methods.

| REQ | Behaviour | Methods annotated |
|-----|-----------|-------------------|
| REQ-AVG-RETENTION | Daily GDPR Article 5(1)(e) storage-limitation pass driven by `processing_activity_id` on audit-trail rows; soft-deletes objects whose newest audit row predates the per-activity bewaartermijn cut-off. Distinct from the Archiefwet destruction-list workflow already in spec. | `AvgRetentionService::{__construct, runRetentionPass, processActivity, computeCutoff, findOverdueObjectsForActivity, erasePastRetention, loadCandidate}`, `AvgRetentionJob::{__construct, run}` |
| REQ-REALTIME-EVENT-RETENTION | Daily prune of `openregister_realtime_events` table (default 7-day window, configurable via `realtime_event_retention_seconds`, `0` disables). | `RealtimeEventRetentionJob::{__construct, run}` |
| REQ-RETENTION-SETTINGS-VERSION-AND-BOOLEANS | Version-info endpoint + mixed-type boolean coercion driving the `auditTrailsEnabled` / `searchTrailsEnabled` flags. | `ObjectRetentionHandler::{getVersionInfoOnly, convertToBoolean}` |

## DROPs (11 methods)

Documented in `proposal.md`. Two reasons:

1. **Already covered by existing REQs** — `RetentionService::determineBrondatum` (afleidingswijze REQ), `RetentionService::validateNotImmutable` (MDTO metadata immutability scenarios), `RetentionService::extractSelectielijstBron` (destruction certificate REQ), `RetentionController::checkDualApprovalRequired` (two-step approval scenario), `RetentionConfiguration.vue::showRebaseDialog` (trivial UI dispatcher).
2. **Triage carry-over from other capabilities** — the AVG service/job methods were earlier triaged out of `archival-destruction-workflow#REQ-001/003/006/008` and `actions#REQ-001`; they're correctly DROPped from those, and are now picked up here under the new REQ-AVG-RETENTION.

## Test plan

- [ ] CI green on `development`.
- [ ] OpenSpec validate (`openspec validate retrofit-2026-05-24-retention-management --strict`).
- [ ] Spot-check the 11 `@spec` annotations point to the right task IDs.