### PR TITLE
retrofit: reverse-spec 4 REQs for calendar-integration cluster

### DIFF
--- a/lib/Calendar/CalendarEventTransformer.php
+++ b/lib/Calendar/CalendarEventTransformer.php
@@ -294,6 +294,8 @@ class CalendarEventTransformer
      * @param array $calendarConfig The calendar configuration
      *
      * @return string The VEVENT STATUS value (CONFIRMED, CANCELLED, TENTATIVE)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-3
      */
     private function resolveStatus(array $objectData, array $calendarConfig): string
     {

--- a/lib/Controller/CalendarEventsController.php
+++ b/lib/Controller/CalendarEventsController.php
@@ -112,6 +112,8 @@ class CalendarEventsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-1
      */
     public function create(string $register, string $schema, string $id): JSONResponse
     {
@@ -197,6 +199,8 @@ class CalendarEventsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-1
      */
     public function destroy(string $register, string $schema, string $id, string $eventId): JSONResponse
     {

--- a/lib/Service/CalendarEventService.php
+++ b/lib/Service/CalendarEventService.php
@@ -308,6 +308,8 @@ class CalendarEventService
      * @param string $objectUuid The object UUID.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-1
      */
     public function unlinkEventsForObject(string $objectUuid): void
     {

--- a/lib/Service/Integration/Providers/CalendarProvider.php
+++ b/lib/Service/Integration/Providers/CalendarProvider.php
@@ -75,36 +75,85 @@ class CalendarProvider extends AbstractIntegrationProvider
     ) {
     }//end __construct()
 
+    /**
+     * Provider identity used by the IntegrationProvider registry.
+     *
+     * @return string
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-2
+     */
     public function getId(): string
     {
         return 'calendar';
     }//end getId()
 
+    /**
+     * Localised label rendered on the sidebar tab.
+     *
+     * @return string
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-2
+     */
     public function getLabel(): string
     {
         return $this->l10n->t('Meetings');
     }//end getLabel()
 
+    /**
+     * Icon name resolved by the frontend icon registry.
+     *
+     * @return string
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-2
+     */
     public function getIcon(): string
     {
         return 'Calendar';
     }//end getIcon()
 
+    /**
+     * Sidebar grouping bucket.
+     *
+     * @return string|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-2
+     */
     public function getGroup(): ?string
     {
         return 'comms';
     }//end getGroup()
 
+    /**
+     * Nextcloud app that must be installed for this integration.
+     *
+     * @return string|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-2
+     */
     public function getRequiredApp(): ?string
     {
         return self::REQUIRED_APP;
     }//end getRequiredApp()
 
+    /**
+     * Registry routing classification (not literal physical storage — see class docblock).
+     *
+     * @return string
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-2
+     */
     public function getStorageStrategy(): string
     {
         return 'link-table';
     }//end getStorageStrategy()
 
+    /**
+     * Whether the required NC app is installed.
+     *
+     * @return bool
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-2
+     */
     public function isEnabled(): bool
     {
         return $this->appManager->isInstalled(self::REQUIRED_APP);
@@ -123,6 +172,8 @@ class CalendarProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $filters  Optional filters (currently ignored).
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-2
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -148,6 +199,8 @@ class CalendarProvider extends AbstractIntegrationProvider
      * @param string $entityId Composite `"calendarId/eventUri"`.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-2
      */
     public function delete(string $register, string $schema, string $objectId, string $entityId): void
     {
@@ -168,6 +221,8 @@ class CalendarProvider extends AbstractIntegrationProvider
      * useful runtime signal at registry resolution time.
      *
      * @return array<string,mixed>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-2
      */
     public function health(): array
     {

--- a/openspec/changes/retrofit-2026-05-24-calendar-integration/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-calendar-integration/proposal.md
@@ -1,0 +1,27 @@
+# Retrofit — calendar-integration (extend)
+
+Describes observed behavior of 15 methods across 6 files in the calendar cluster as 4 new REQs extending the existing `calendar-integration` capability. Code already exists — this change retroactively specifies it. Triaged drops from the batch (12 methods) are recorded in the batch JSON, not re-specified here.
+
+## Affected code units
+- lib/Calendar/CalendarEventTransformer.php::resolveStatus
+- lib/Controller/CalendarEventsController.php::create
+- lib/Controller/CalendarEventsController.php::destroy
+- lib/Service/CalendarEventService.php::unlinkEventsForObject
+- lib/Service/Integration/Providers/CalendarProvider.php (getId, getLabel, getIcon, getGroup, getRequiredApp, getStorageStrategy, isEnabled, list, delete, health) — 10 methods, 1 file (getStorageStrategy counted once)
+- src/views/schema/CalendarProviderTab.vue::loadConfig
+
+## Approach
+The existing capability covers two layers: REQ-001 the CalDAV provider (`RegisterCalendarProvider`) and REQ-002 the iCalendar transformer (`CalendarEventTransformer::transform()`). The kept methods in this cluster sit in four additional behavioural slices that are not yet specified:
+
+- **REQ-003** — REST link/unlink flow for users who want to attach a normal CalDAV VEVENT (in their own calendar) to an OR object. `CalendarEventsController::create` and `::destroy` plus the `CalendarEventService::unlinkEventsForObject` cleanup helper define a path that is independent of `RegisterCalendarProvider` (which is a read-only CalDAV exposure layer per REQ-001's notes).
+- **REQ-004** — `CalendarProvider` exposes that link/unlink flow through the unified `IntegrationProvider` registry so the `CnObjectSidebar` "Meetings" tab and dashboard widgets can render uniformly across integrations.
+- **REQ-005** — Resolving the VEVENT `STATUS` from object data via a configurable status mapping (the only transformer slice not covered by REQ-002, which is silent on status).
+- **REQ-006** — Schema-level admin UI for editing the calendar provider configuration that REQ-001/REQ-002/REQ-005 all read from.
+
+## Notes / observed drifts
+- `CalendarEventTransformer::formatDateValue()` always appends `Z` (UTC) to the DATE-TIME output regardless of the source string's timezone. REQ-002 does not call this out; flagged here as observed.
+- `CalendarProvider::list()` swallows all `Throwable` and returns `[]`. This matches AD-23 ("graceful degrade") as documented in the file but is worth surfacing in REQ-004 because a silent empty list is indistinguishable from "no events linked" at the UI layer.
+- `CalendarProvider::getStorageStrategy()` returns `'link-table'` even though events are physically stored as CalDAV custom properties — the file's own docblock acknowledges this is a registry-routing convention, not a literal description.
+- `CalendarEventService::createEvent()` and `linkEvent()` are triaged-DROP in the batch but are described indirectly by REQ-003 (controller→service contract); their detailed behaviour belongs to a separate retrofit if/when needed.
+
+Source: openspec/coverage-report.md — Bucket 2a (extend) for `calendar-integration`. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-calendar-integration/specs/calendar-integration/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-calendar-integration/specs/calendar-integration/spec.md
@@ -1,0 +1,132 @@
+---
+retrofit: true
+---
+
+# Calendar Integration
+
+## ADDED Requirements
+
+### REQ-003: The system MUST expose a REST link/unlink flow that ties CalDAV VEVENTs to OpenRegister objects
+
+`CalendarEventsController` MUST offer per-object endpoints that create a new VEVENT in the authenticated user's primary VEVENT-capable calendar and that remove the OR linkage from an existing VEVENT. The created event MUST carry `X-OPENREGISTER-REGISTER`, `X-OPENREGISTER-SCHEMA` and `X-OPENREGISTER-OBJECT` custom properties plus an RFC 9253 `LINK;LINKREL="related"` pointing back to the OR object so the link survives outside the OR UI. When an OR object is destroyed, `CalendarEventService::unlinkEventsForObject()` MUST iterate every linked VEVENT and remove the OR linkage without deleting the VEVENT itself (events are owned by the user, not by OR).
+
+This flow is distinct from REQ-001: REQ-001 surfaces objects read-only as a virtual CalDAV calendar; REQ-003 mutates the user's own calendar.
+
+#### Scenario: Create endpoint requires a summary
+- **GIVEN** an authenticated user calls `POST /apps/openregister/api/objects/{register}/{schema}/{id}/events` with body `{}`
+- **WHEN** `CalendarEventsController::create()` runs
+- **THEN** the response MUST be `400` with body `{"error": "Event summary is required"}`
+- **AND** no calendar object MUST be created
+
+#### Scenario: Create endpoint persists VEVENT with X-OPENREGISTER linking
+- **GIVEN** an authenticated user calls the create endpoint with `summary`, `dtstart`, `dtend`
+- **AND** the user has a VEVENT-capable calendar
+- **WHEN** `CalendarEventService::createEvent()` runs
+- **THEN** a new `.ics` file MUST be written to the user's calendar via `CalDavBackend::createCalendarObject()`
+- **AND** the VEVENT body MUST contain `X-OPENREGISTER-REGISTER`, `X-OPENREGISTER-SCHEMA`, `X-OPENREGISTER-OBJECT` lines
+- **AND** the response MUST be `201` with the event in JSON-friendly form (`id`, `uid`, `calendarId`, `summary`, `dtstart`, `dtend`, `objectUuid`)
+
+#### Scenario: Destroy endpoint requires the event to be currently linked to the object
+- **GIVEN** the user calls `DELETE /apps/openregister/api/objects/{register}/{schema}/{id}/events/{eventId}` for an `eventId` that is not in the per-object event list
+- **WHEN** `CalendarEventsController::destroy()` runs
+- **THEN** the response MUST be `404` with body `{"error": "Event not found"}`
+
+#### Scenario: Destroy endpoint removes X-OPENREGISTER linking but keeps the VEVENT
+- **GIVEN** the user destroys a linked event
+- **WHEN** `CalendarEventService::unlinkEvent()` runs (called from the controller)
+- **THEN** the VEVENT MUST remain in the user's calendar
+- **AND** `X-OPENREGISTER-REGISTER`, `X-OPENREGISTER-SCHEMA`, `X-OPENREGISTER-OBJECT` MUST be unset from the VEVENT
+- **AND** any `LINK` property whose value contains `openregister` MUST be removed
+
+#### Scenario: Object deletion sweeps all linked events
+- **GIVEN** an OR object UUID has three CalDAV events linked via X-OPENREGISTER-OBJECT
+- **WHEN** `CalendarEventService::unlinkEventsForObject($objectUuid)` runs
+- **THEN** each event MUST be passed to `unlinkEvent()`
+- **AND** a failure to unlink one event MUST be logged via `LoggerInterface::warning()` and MUST NOT abort the loop
+- **AND** the VEVENTs MUST remain in the user's calendars
+
+### REQ-004: The system MUST expose calendar links through the unified IntegrationProvider registry
+
+`CalendarProvider` MUST implement `AbstractIntegrationProvider` so the `CnObjectSidebar` "Meetings" tab and dashboard widgets can render calendar-linked events without per-app glue. The provider MUST declare its identity (`getId()` returns `'calendar'`, `getLabel()` returns the localised "Meetings", `getIcon()` returns `'Calendar'`, `getGroup()` returns `'comms'`), MUST declare `getRequiredApp()` as `'calendar'`, MUST declare `getStorageStrategy()` as `'link-table'` (a registry-routing convention, not a literal description — see Notes), and MUST gate `isEnabled()` on `IAppManager::isInstalled('calendar')`. The provider MUST surface the linked events via `list()` and MUST accept inline unlinks via `delete()` using the composite `"calendarId/eventUri"` entity id.
+
+#### Scenario: list() returns per-object events from CalendarEventService
+- **GIVEN** an OR object UUID with two linked VEVENTs
+- **WHEN** the registry calls `CalendarProvider::list($register, $schema, $objectUuid)`
+- **THEN** `CalendarEventService::getEventsForObject($objectUuid)` MUST be invoked
+- **AND** its return value MUST be returned unchanged
+
+#### Scenario: list() degrades to empty array on CalDAV failure (AD-23)
+- **GIVEN** the CalDAV backend throws (no user session, no VEVENT calendar, etc.)
+- **WHEN** `CalendarProvider::list()` runs
+- **THEN** the exception MUST be caught and `[]` MUST be returned
+- **AND** the registry consumer MUST NOT receive the failure
+
+#### Scenario: delete() rejects non-composite entityIds
+- **GIVEN** the registry calls `CalendarProvider::delete($register, $schema, $objectId, 'bad-id-no-slash')`
+- **WHEN** the method runs
+- **THEN** `InvalidArgumentException` MUST be thrown with message `'Calendar entityId must be "calendarId/eventUri"'`
+
+#### Scenario: delete() forwards to CalendarEventService::unlinkEvent
+- **GIVEN** `entityId = "42/event-uid-123.ics"`
+- **WHEN** `CalendarProvider::delete()` runs
+- **THEN** `CalendarEventService::unlinkEvent(calendarId: '42', eventUri: 'event-uid-123.ics')` MUST be called exactly once
+
+#### Scenario: health() reports installed/uninstalled
+- **GIVEN** the NC `calendar` app is installed
+- **WHEN** `CalendarProvider::health()` is called
+- **THEN** the result MUST be `['status' => 'ok', 'authStatus' => 'configured', 'message' => null]`
+- **AND** when the app is not installed the result MUST be `['status' => 'unavailable', 'authStatus' => 'configured', 'message' => 'NC Calendar app is not installed']`
+
+### REQ-005: The system MUST resolve VEVENT STATUS from object data via a configurable status mapping
+
+`CalendarEventTransformer::resolveStatus()` MUST translate an OR object's status field into one of the iCalendar VEVENT `STATUS` values (`CONFIRMED`, `CANCELLED`, `TENTATIVE`) using a `statusMapping` lookup from the calendar configuration. When mapping or status field is absent, when the object's status value is null, or when the value is not in the mapping, the result MUST default to `CONFIRMED`. This requirement extends REQ-002 which is otherwise silent on the STATUS property.
+
+#### Scenario: Default to CONFIRMED when statusField is unset
+- **GIVEN** `calendarConfig` has no `statusField` or no `statusMapping`
+- **WHEN** `resolveStatus()` runs
+- **THEN** the return MUST be `'CONFIRMED'`
+
+#### Scenario: Default to CONFIRMED when object data lacks the status field
+- **GIVEN** `calendarConfig = ['statusField' => 'state', 'statusMapping' => ['open' => 'CONFIRMED']]`
+- **AND** the object data has no `state` key (resolves to `null`)
+- **WHEN** `resolveStatus()` runs
+- **THEN** the return MUST be `'CONFIRMED'`
+
+#### Scenario: Map known status to VEVENT STATUS value
+- **GIVEN** `calendarConfig = ['statusField' => 'state', 'statusMapping' => ['cancelled' => 'CANCELLED', 'draft' => 'TENTATIVE']]`
+- **AND** the object has `state: 'cancelled'`
+- **WHEN** `resolveStatus()` runs
+- **THEN** the return MUST be `'CANCELLED'`
+
+#### Scenario: Unknown status falls back to CONFIRMED
+- **GIVEN** `calendarConfig = ['statusField' => 'state', 'statusMapping' => ['draft' => 'TENTATIVE']]`
+- **AND** the object has `state: 'reopened'` (not in the mapping)
+- **WHEN** `resolveStatus()` runs
+- **THEN** the return MUST be `'CONFIRMED'`
+
+### REQ-006: The system MUST provide a schema-level admin UI to edit calendar provider configuration
+
+The Schema editor MUST surface a "Calendar Provider" tab (`CalendarProviderTab.vue`) that reads and writes `schema.configuration.calendarProvider` — the same object shape REQ-001 (provider), REQ-002 (transformer) and REQ-005 (status) consume at runtime. The tab MUST hydrate its form from the schema on mount and on every schema prop change, MUST default missing keys to safe values (`enabled=false`, `color='#0082C9'`, `dtstart=null`, `dtend=null`, `titleTemplate=''`, `descriptionTemplate=''`, `locationField=null`, `allDay=null` for auto-detect), and MUST persist via `schemaStore.saveSchema()` so existing schema configuration is preserved.
+
+#### Scenario: Tab hydrates from schema.configuration.calendarProvider on mount
+- **GIVEN** a schema is loaded with `configuration.calendarProvider = { enabled: true, color: '#FF0000', dtstart: 'createdAt' }`
+- **WHEN** `CalendarProviderTab.loadConfig(schema)` runs (via the immediate watcher)
+- **THEN** `localConfig.enabled` MUST be `true`, `localConfig.color` MUST be `'#FF0000'`, `localConfig.dtstart` MUST be `'createdAt'`
+- **AND** every other field MUST take its default
+
+#### Scenario: Tab hydrates with safe defaults when configuration is missing
+- **GIVEN** a schema with no `configuration.calendarProvider`
+- **WHEN** `loadConfig()` runs
+- **THEN** `localConfig` MUST equal `{ enabled: false, displayName: '', color: '#0082C9', dtstart: null, dtend: null, titleTemplate: '', descriptionTemplate: '', locationField: null, allDay: null }`
+
+#### Scenario: Reloading the tab on schema change does not leak previous state
+- **GIVEN** the tab is mounted with schema A (calendarProvider.enabled = true)
+- **WHEN** the `schema` prop changes to schema B which has no `calendarProvider` block
+- **THEN** the `schema` watcher MUST call `loadConfig(schemaB)`
+- **AND** `localConfig.enabled` MUST be `false`
+
+#### Notes
+- `formatDateValue()` always emits a `Z` suffix on DATE-TIME values regardless of the source string's timezone (observed drift; REQ-002 is silent on tz handling — flagged for future REQ).
+- `CalendarProvider::getStorageStrategy()` returns `'link-table'` as a registry-routing classification only. The actual storage is CalDAV custom properties on a VEVENT (see REQ-003 and the file's class-level docblock).
+- `CalendarProvider::list()` swallows all `Throwable` per AD-23 (graceful degrade); the empty array is indistinguishable from "no events linked" at the UI layer (observed; REQ-004 documents this as the contract).
+- REQ-006's tab is read-write for the configuration document only — it does not create or delete CalDAV calendars; that remains the responsibility of REQ-001's provider.

--- a/openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] task-1: calendar-integration#REQ-003 — REST link/unlink flow for CalDAV VEVENTs tied to OR objects (retroactive annotation)
+- [x] task-2: calendar-integration#REQ-004 — CalendarProvider IntegrationProvider for the Meetings tab (retroactive annotation)
+- [x] task-3: calendar-integration#REQ-005 — VEVENT STATUS resolution from object data + statusMapping config (retroactive annotation)
+- [x] task-4: calendar-integration#REQ-006 — Schema-level admin UI for calendar provider configuration (retroactive annotation)

--- a/src/views/schema/CalendarProviderTab.vue
+++ b/src/views/schema/CalendarProviderTab.vue
@@ -241,6 +241,7 @@ export default {
 		/**
 		 * Load calendar provider config from schema configuration
 		 * @param {object} schema The schema object
+		 * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-4
 		 */
 		loadConfig(schema) {
 			const config = schema?.configuration?.calendarProvider || {}


### PR DESCRIPTION
## Summary

Ghost change `retrofit-2026-05-24-calendar-integration` extends the existing `calendar-integration` capability with **4 new REQs** describing observed behaviour of **15 kept methods** across **6 files**. Annotation-only — no behaviour changes.

Triaged-drop methods (12) from the batch are recorded in the batch JSON only; they belong to other capabilities or are already covered.

## New REQs

- **REQ-003** — REST link/unlink flow (`CalendarEventsController::create`/`destroy`, `CalendarEventService::unlinkEventsForObject`). Distinct from REQ-001's read-only CalDAV exposure: this mutates the user's own calendar.
- **REQ-004** — `CalendarProvider` IntegrationProvider for the Meetings sidebar tab (10 methods including the graceful-degrade `list()` per AD-23).
- **REQ-005** — VEVENT `STATUS` resolution via configurable `statusMapping` (extends REQ-002 which is silent on status).
- **REQ-006** — Schema-level admin UI (`CalendarProviderTab.vue::loadConfig`) for the configuration document the runtime layers read.

## Observed drifts (Notes)

- `CalendarEventTransformer::formatDateValue()` always emits the `Z` suffix on DATE-TIME values regardless of source-string timezone. Documented in spec Notes; not fixed here.
- `CalendarProvider::list()` swallows all `Throwable` per AD-23 (graceful degrade); the empty result is UI-indistinguishable from "no events linked". REQ-004 documents this as the contract.
- `CalendarProvider::getStorageStrategy()` returns `'link-table'` as a registry routing classification only — actual storage is CalDAV custom properties (file's own docblock already calls this out).

## Annotation count (`@spec` lines pointing at this ghost change)

- task-1: 3 methods (controller create/destroy + service sweep)
- task-2: 10 methods (CalendarProvider — all kept public methods)
- task-3: 1 method (resolveStatus)
- task-4: 1 method (Vue loadConfig)
- **Total: 15 = kept-method count, matches batch JSON.**

## Test plan

- [ ] `openspec validate retrofit-2026-05-24-calendar-integration --strict` passes
- [ ] `grep -rn "retrofit-2026-05-24-calendar-integration" lib/ src/` returns 15 hits
- [ ] PHPCS retrofit-annotation rule passes on the touched PHP files
- [ ] No behaviour changes — diff is `+229 insertions(+), 0 deletions(-)`