### PR TITLE
docs(spec): retrofit object-lifecycle Bucket 2a (lifecycle annotation surface)

### DIFF
--- a/lib/Lifecycle/GuardResult.php
+++ b/lib/Lifecycle/GuardResult.php
@@ -58,6 +58,8 @@ final class GuardResult
      * Allow the transition.
      *
      * @return self Allow verdict instance.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-lifecycle/tasks.md#task-4
      */
     public static function allow(): self
     {
@@ -70,6 +72,8 @@ final class GuardResult
      * @param string $message Human-readable reason. Surfaced to the caller in the 403 response.
      *
      * @return self Deny verdict instance.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-lifecycle/tasks.md#task-4
      */
     public static function deny(string $message): self
     {
@@ -80,6 +84,8 @@ final class GuardResult
      * Read whether the verdict allows the transition.
      *
      * @return bool True when allowed, false when denied.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-lifecycle/tasks.md#task-4
      */
     public function isAllowed(): bool
     {

--- a/lib/Lifecycle/LifecycleGuardInterface.php
+++ b/lib/Lifecycle/LifecycleGuardInterface.php
@@ -41,6 +41,8 @@ interface LifecycleGuardInterface
      * @param string               $userId The uid of the caller.
      *
      * @return GuardResult Allow or deny + optional message.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-lifecycle/tasks.md#task-4
      */
     public function check(array $object, string $action, string $userId): GuardResult;
 }//end interface

--- a/lib/Service/Lifecycle/LifecycleAnnotationValidator.php
+++ b/lib/Service/Lifecycle/LifecycleAnnotationValidator.php
@@ -43,6 +43,8 @@ final class LifecycleAnnotationValidator
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-lifecycle/tasks.md#task-1
      */
     public function validate(array $schema): array
     {

--- a/lib/Service/Lifecycle/LifecycleGuardRegistry.php
+++ b/lib/Service/Lifecycle/LifecycleGuardRegistry.php
@@ -56,6 +56,8 @@ final class LifecycleGuardRegistry
      * @param ContainerInterface $container       OR app container used to resolve guard services first.
      * @param IServerContainer   $serverContainer NC server container used as fallback for FQCN-tagged guards (F06).
      * @param LoggerInterface    $logger          Logger for guard resolution diagnostics.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-lifecycle/tasks.md#task-3
      */
     public function __construct(
         private readonly ContainerInterface $container,
@@ -72,6 +74,8 @@ final class LifecycleGuardRegistry
      * @return LifecycleGuardInterface
      *
      * @throws RuntimeException When the tag is not registered or the resolved service does not implement the interface.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-lifecycle/tasks.md#task-3
      */
     public function resolve(string $tag): LifecycleGuardInterface
     {

--- a/lib/Service/Lifecycle/TransitionEngine.php
+++ b/lib/Service/Lifecycle/TransitionEngine.php
@@ -54,6 +54,8 @@ class TransitionEngine
      * @param IEventDispatcher  $eventDispatcher   Dispatcher used to fire ObjectTransitionedEvent.
      * @param IUserSession      $userSession       Current user session, for actor attribution.
      * @param PermissionHandler $permissionHandler RBAC verdict on the object's `update`/`read` actions (F03).
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-lifecycle/tasks.md#task-2
      */
     public function __construct(
         private readonly ObjectService $objectService,
@@ -75,6 +77,8 @@ class TransitionEngine
      * @throws RuntimeException When the object/schema/transition is missing,
      *                          the action is not allowed from the current
      *                          state, or the underlying save is rejected.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-lifecycle/tasks.md#task-2
      */
     public function transition(string $objectId, string $action): ObjectEntity
     {

--- a/openspec/changes/retrofit-2026-05-24-object-lifecycle/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-object-lifecycle/proposal.md
@@ -1,0 +1,54 @@
+# Retrofit — object-lifecycle (Bucket 2a extras)
+
+Describes observed behavior of 9 methods (Bucket 2a) across 5 keeper files that
+implement the schema-declared state-machine layer added by the
+`2026-04-29-lifecycle-annotation` change. The original retrofit
+(`retrofit-2026-04-28-object-lifecycle`) anchored REQ-001..005 on the layered
+save pipeline. Those REQs do not cover the lifecycle annotation / guard /
+transition surface — this change extends `object-lifecycle` with four new REQs
+(REQ-006..009) for that surface. Code already exists — this change
+retroactively specifies it.
+
+## Affected code units (keepers, 9 methods / 5 files)
+- lib/Lifecycle/GuardResult.php (`allow`, `deny`, `isAllowed`) — verdict VO
+- lib/Lifecycle/LifecycleGuardInterface.php (`check`) — guard contract
+- lib/Service/Lifecycle/LifecycleAnnotationValidator.php (`validate`) — schema-save annotation shape check
+- lib/Service/Lifecycle/LifecycleGuardRegistry.php (`__construct`, `resolve`) — DI tag → guard resolver with NC server fallback
+- lib/Service/Lifecycle/TransitionEngine.php (`__construct`, `transition`) — apply named transition, fire `ObjectTransitionedEvent`
+
+## Triaged DROPs (16 methods, recorded for audit only)
+The Bucket 2a batch carried 16 methods triaged as drops. Reasons in the batch
+JSON (`/tmp/or-scan/rspec-cluster-object-lifecycle.json`):
+- `GuardResult::__construct`, `GuardResult::getMessage` — internal VO plumbing already implied by allow/deny/isAllowed contract
+- `LifecycleGuardRegistry` constructor was already a keeper; nothing dropped there
+- `TransitionEngine::availableActions`, `TransitionEngine::loadSchema`, `TransitionEngine::getLifecycleAnnotation` — `availableActions` is read-only enumeration over the same annotation surface and is adequately implied by REQ-007's transition lookup; the two private helpers are pure resolvers
+- `LifecycleInitialStateListener::*` (4 methods) — initial-state forcer on create; arguably belongs to schema-hooks or a separate event-driven REQ. Out of scope for this retrofit pass; will be picked up by a future retrofit if it shows up under a different bucket
+- `LifecycleValidationListener::*` (5 methods) — pre-save state-machine enforcement at the `ObjectUpdatingEvent` hook. The listener is the on-save twin of `TransitionEngine` (which provides the API-level path). REQ-007 covers the API-level guarantee; the listener's pre-save enforcement is observable through REQ-007's "transition is rejected from disallowed `from` state" scenario, so a separate REQ would be duplicative
+- `TenantLifecycleService::isValidStatus` — tenant-lifecycle capability, not object-lifecycle
+
+## Approach
+The 9 keeper methods break into four behaviours not covered by REQ-001..005:
+
+1. **Schema-save annotation validation** (REQ-006) — `LifecycleAnnotationValidator::validate()` shape-checks `x-openregister-lifecycle` and returns a structured error list (empty = valid). Required top-level keys, field/initial/final/from/to enum-membership, transitions must be a non-empty map, `requires` (when present) must be a non-empty string.
+2. **Named transition application** (REQ-007) — `TransitionEngine::transition()` loads an object, gates with `PermissionHandler` (`update`), resolves the schema's lifecycle annotation, validates the requested action is declared and the current state is in `from`, mutates the lifecycle field, saves through `ObjectService::saveObject()`, and dispatches a typed `ObjectTransitionedEvent`.
+3. **Guard DI tag resolution** (REQ-008) — `LifecycleGuardRegistry::resolve()` resolves a `requires` tag against the OR app container first then falls back to NC's `IServerContainer` (covers FQCN-referenced guards in other apps that NC can autowire). Fail-closed: unresolved tag throws `RuntimeException`; per-request cache prevents repeat resolution within one request.
+4. **Guard verdict value object** (REQ-009) — `GuardResult::allow()` / `GuardResult::deny(string $message)` factories and `isAllowed()` inspector form the contract returned by `LifecycleGuardInterface::check()`. Guards are read-only — must not mutate the object — side effects belong on `ObjectTransitionedEvent` listeners.
+
+## Mode
+`--extend` — adds REQ-006..009 to the existing `object-lifecycle` spec. Existing
+REQ-001..005 (layered save pipeline, validation, cache, bulk, hydration) are
+unchanged.
+
+## Notes
+- The keeper list contains both `__construct` methods of services; constructors
+  carry the DI contract (which collaborators are injected) that the REQs depend
+  on, so they are annotated under the same REQ as their service's primary
+  method.
+- `LifecycleValidationListener` (the on-save twin of `TransitionEngine`) was
+  triaged out — it is the event-driven enforcement path. A future retrofit can
+  promote it to its own REQ when the `event-driven-architecture` capability is
+  extended; for now its behavior is covered indirectly by REQ-007.
+- The 16 DROPs are listed above so the next coverage scan does not re-surface
+  them as gaps.
+
+Source: `/tmp/or-scan/rspec-cluster-object-lifecycle.json` (25 methods, 8 files).

--- a/openspec/changes/retrofit-2026-05-24-object-lifecycle/specs/object-lifecycle/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-object-lifecycle/specs/object-lifecycle/spec.md
@@ -1,0 +1,183 @@
+# Object Lifecycle
+
+## ADDED Requirements
+
+### Requirement: REQ-006 — Schema lifecycle annotations MUST be shape-validated at schema-save time
+
+`LifecycleAnnotationValidator::validate()` MUST check the `x-openregister-lifecycle`
+annotation on a schema and return a structured list of error entries (each with
+a `code` and `message`). An empty list MUST be returned when the annotation is
+absent or fully valid. Validation MUST NOT throw on malformed input; errors are
+collected and returned, mapped to HTTP 422 by the caller. The validator MUST
+enforce:
+
+- the required top-level keys `field`, `initial`, and `transitions` are present;
+- the `field` name resolves to a declared property of type `string` with a
+  non-empty `enum`;
+- the `initial` value and every declared `final` value is a member of the
+  enum;
+- the `transitions` map is non-empty;
+- each transition object declares a non-empty `from` array whose every member
+  is in the enum, and a non-empty `to` string that is in the enum;
+- when a transition declares `requires`, the value is a non-empty string
+  (DI-tag shape only — the validator does NOT attempt to resolve the tag).
+
+#### Scenario: Annotation absent — no errors
+- **GIVEN** a schema definition without an `x-openregister-lifecycle` key
+- **WHEN** `LifecycleAnnotationValidator::validate()` is invoked
+- **THEN** the method MUST return an empty array
+
+#### Scenario: Missing required top-level key
+- **GIVEN** an annotation `{"field": "status", "initial": "draft"}` (no `transitions`)
+- **WHEN** the annotation is validated
+- **THEN** the result MUST contain an entry with code `lifecycle-missing-key`
+  and a message naming `transitions` as the missing key
+
+#### Scenario: Initial state not in field enum
+- **GIVEN** a schema with `properties.status.enum = ["draft", "open"]` and an
+  annotation whose `initial` is `"closed"`
+- **WHEN** the annotation is validated
+- **THEN** the result MUST contain an entry with code
+  `lifecycle-initial-not-in-enum` referencing the offending value
+
+#### Scenario: Transition `to` not in enum
+- **GIVEN** a schema with `properties.status.enum = ["draft", "open"]` and a
+  transition `{"open": {"from": ["draft"], "to": "closed"}}`
+- **WHEN** the annotation is validated
+- **THEN** the result MUST contain an entry with code
+  `lifecycle-to-not-in-enum`
+
+#### Scenario: `requires` shape check only
+- **GIVEN** a transition declaring `"requires": "decidesk.meeting.openGuard"`
+- **WHEN** the annotation is validated
+- **THEN** the result MUST NOT contain a tag-resolution error — the validator
+  does not attempt DI resolution at schema-save time
+
+### Requirement: REQ-007 — Named transitions MUST be applied through the central engine
+
+`TransitionEngine::transition($objectId, $action)` MUST be the entry point for
+state-machine transitions and MUST, in order:
+
+1. Load the object via `ObjectService::find()`; throw `RuntimeException` if not found.
+2. Resolve the object's schema; throw `RuntimeException` if unresolvable.
+3. Gate on per-object RBAC via `PermissionHandler::hasPermission(action: 'update')`;
+   throw `NotAuthorizedException` on denial.
+4. Read the schema's `x-openregister-lifecycle` annotation; throw
+   `RuntimeException` if the schema does not declare lifecycle.
+5. Look up the requested action in `transitions`; throw `RuntimeException` if
+   the action is not declared.
+6. Reject the transition if the object's current lifecycle field value is not
+   in the action's `from` array.
+7. Mutate the lifecycle field to the action's `to` value and persist through
+   `ObjectService::saveObject()` (so all standard validation/eventing/audit
+   machinery runs unchanged).
+8. Dispatch a typed `ObjectTransitionedEvent` carrying object, action, from,
+   to, userId, register, and schema.
+
+The engine MUST NOT bypass the standard save pipeline; transitions inherit
+validation, audit, and event behaviour from REQ-001..005.
+
+#### Scenario: Successful transition
+- **GIVEN** an object in state `"draft"` and a transition `open` with
+  `from: ["draft"], to: "open"`
+- **AND** the caller has `update` permission on the object
+- **WHEN** `TransitionEngine::transition($objectId, "open")` is invoked
+- **THEN** the saved object MUST have lifecycle field `"open"`
+- **AND** an `ObjectTransitionedEvent(from: "draft", to: "open", action: "open")`
+  MUST be dispatched
+
+#### Scenario: Transition rejected when current state not in `from`
+- **GIVEN** an object in state `"closed"` and a transition `open` declaring
+  `from: ["draft"]`
+- **WHEN** `TransitionEngine::transition($objectId, "open")` is invoked
+- **THEN** a `RuntimeException` MUST be thrown with a message naming the
+  current state and the action
+- **AND** no save MUST occur and no `ObjectTransitionedEvent` MUST be dispatched
+
+#### Scenario: Transition denied by RBAC
+- **GIVEN** a caller without `update` permission on the target object
+- **WHEN** `TransitionEngine::transition()` is invoked
+- **THEN** a `NotAuthorizedException` MUST be thrown before the annotation is
+  read or the object is saved
+
+#### Scenario: Schema does not declare lifecycle
+- **GIVEN** an object whose schema has no `x-openregister-lifecycle` annotation
+- **WHEN** `TransitionEngine::transition()` is invoked
+- **THEN** a `RuntimeException` MUST be thrown naming the schema slug
+
+### Requirement: REQ-008 — Guard DI tags MUST resolve through the registry with NC server fallback
+
+`LifecycleGuardRegistry::resolve($tag)` MUST resolve a transition's `requires`
+DI tag to a `LifecycleGuardInterface` instance. Resolution MUST:
+
+- try the OpenRegister app container first (covers OR-internal guards);
+- fall back to the injected `IServerContainer` (covers FQCN-referenced guards
+  in cooperating apps that Nextcloud can autowire);
+- fail closed: when neither container resolves the tag, log the collected
+  resolution errors at error level and throw `RuntimeException` whose message
+  names the tag;
+- type-check the resolved service: if it does not implement
+  `LifecycleGuardInterface`, throw `RuntimeException` naming the offending
+  service and the required interface;
+- cache successful resolutions per request so repeat transitions on the same
+  tag within one request reuse the resolved instance.
+
+The registry MUST NOT reach `\OC::$server` directly; the server container is
+injected via constructor (`IServerContainer`) to keep `lib/` free of static
+server accessors.
+
+#### Scenario: Tag resolves from OR app container
+- **GIVEN** a guard service `my.guard` registered in the OR app container
+- **WHEN** `LifecycleGuardRegistry::resolve("my.guard")` is invoked
+- **THEN** the registered `LifecycleGuardInterface` instance MUST be returned
+- **AND** a second invocation with the same tag MUST return the cached instance
+
+#### Scenario: Tag falls back to server container
+- **GIVEN** a guard FQCN `Acme\\Guard\\OpenGuard` autowirable by Nextcloud
+  but not registered in the OR app container
+- **WHEN** `LifecycleGuardRegistry::resolve("Acme\\\\Guard\\\\OpenGuard")` is invoked
+- **THEN** the server container MUST be consulted and its instance MUST be
+  returned
+
+#### Scenario: Unresolvable tag fails closed
+- **GIVEN** a tag that neither container can resolve
+- **WHEN** `resolve()` is invoked
+- **THEN** a `RuntimeException` MUST be thrown whose message names the tag
+- **AND** the logger MUST receive an error-level entry containing the
+  resolution errors from each container
+
+#### Scenario: Resolved service does not implement the interface
+- **GIVEN** a service registered under a tag that does NOT implement
+  `LifecycleGuardInterface`
+- **WHEN** `resolve()` is invoked with that tag
+- **THEN** a `RuntimeException` MUST be thrown naming the service and the
+  required interface
+
+### Requirement: REQ-009 — Guard verdicts MUST use the immutable GuardResult contract
+
+Guards (implementations of `LifecycleGuardInterface::check()`) MUST return a
+`GuardResult` value object constructed via the static factories
+`GuardResult::allow()` or `GuardResult::deny(string $message)`. The
+constructor MUST be private; callers MUST NOT instantiate `GuardResult`
+directly. The verdict MUST be inspectable via `isAllowed(): bool`, and a deny
+verdict MUST carry a human-readable message that is surfaced to the caller in
+the 403 response. Guards MUST be read-only: implementations MUST NOT mutate
+the inbound `$object` payload; side effects (notifications, cascades,
+derived-field maintenance) belong on `ObjectTransitionedEvent` listeners.
+
+#### Scenario: Allow factory
+- **WHEN** `GuardResult::allow()` is called
+- **THEN** the returned instance MUST report `isAllowed() === true`
+
+#### Scenario: Deny factory carries message
+- **WHEN** `GuardResult::deny("Meeting is not in draft state")` is called
+- **THEN** the returned instance MUST report `isAllowed() === false`
+- **AND** the deny message MUST be retrievable for surfacing in the response
+
+#### Scenario: Guard contract receives loaded object, action, and userId
+- **GIVEN** a guard implementing `LifecycleGuardInterface::check()`
+- **WHEN** invoked from a transition flow
+- **THEN** the guard MUST receive the loaded object payload, the action name,
+  and the caller's uid as parameters
+- **AND** the guard MUST return a `GuardResult` without having mutated the
+  inbound object array

--- a/openspec/changes/retrofit-2026-05-24-object-lifecycle/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-object-lifecycle/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] task-1: object-lifecycle#REQ-006 — Schema lifecycle annotation validation (`LifecycleAnnotationValidator::validate`) (retroactive annotation)
+- [x] task-2: object-lifecycle#REQ-007 — Named transition application (`TransitionEngine::transition`, `TransitionEngine::__construct`) (retroactive annotation)
+- [x] task-3: object-lifecycle#REQ-008 — Guard DI tag resolution (`LifecycleGuardRegistry::resolve`, `LifecycleGuardRegistry::__construct`) (retroactive annotation)
+- [x] task-4: object-lifecycle#REQ-009 — Guard verdict value object and contract (`GuardResult::allow`, `GuardResult::deny`, `GuardResult::isAllowed`, `LifecycleGuardInterface::check`) (retroactive annotation)


### PR DESCRIPTION
## Summary

Retrofit pass over the schema-declared state-machine layer (Bucket 2a) added by
`2026-04-29-lifecycle-annotation`. Extends `object-lifecycle` with four new
REQs (REQ-006..009) and back-annotates the 9 keeper methods with `@spec` tags.

The original `retrofit-2026-04-28-object-lifecycle` (REQ-001..005) anchored the
layered save pipeline. The lifecycle annotation / guard / transition surface
shipped after that retrofit and had not yet been retrofitted — this pass closes
the gap.

## What changed

- **Ghost change:** `openspec/changes/retrofit-2026-05-24-object-lifecycle/`
  - `proposal.md` — keepers, triaged drops with rationale, approach
  - `tasks.md` — 4 retroactive annotation tasks
  - `specs/object-lifecycle/spec.md` — `## ADDED Requirements` delta
- **4 new REQs:**
  - **REQ-006** — `LifecycleAnnotationValidator::validate` schema-save shape check
  - **REQ-007** — `TransitionEngine::transition` named transition application (load → RBAC → annotation → from-state check → save → event)
  - **REQ-008** — `LifecycleGuardRegistry::resolve` DI-tag resolution with `IServerContainer` fallback, fail-closed semantics, per-request cache
  - **REQ-009** — `GuardResult` immutable verdict contract + `LifecycleGuardInterface::check` read-only guarantee
- **9 methods annotated** with `@spec` across 5 files:
  - `lib/Lifecycle/GuardResult.php` (`allow`, `deny`, `isAllowed`)
  - `lib/Lifecycle/LifecycleGuardInterface.php` (`check`)
  - `lib/Service/Lifecycle/LifecycleAnnotationValidator.php` (`validate`)
  - `lib/Service/Lifecycle/LifecycleGuardRegistry.php` (`__construct`, `resolve`)
  - `lib/Service/Lifecycle/TransitionEngine.php` (`__construct`, `transition`)

## Triaged drops (16 methods)

Recorded in proposal.md Notes; reasoning per method:

- Internal VO plumbing (`GuardResult::__construct`, `getMessage`) implied by the allow/deny/isAllowed contract.
- `TransitionEngine::availableActions` + private resolvers (`loadSchema`, `getLifecycleAnnotation`) — `availableActions` is the read-only twin of `transition`, indirectly covered.
- `LifecycleInitialStateListener::*` (4 methods) — initial-state-on-create; arguably schema-hooks territory, not retrofitted here.
- `LifecycleValidationListener::*` (5 methods) — pre-save state-machine enforcement; same surface as REQ-007 via the on-save event path. Could promote to its own REQ in a future retrofit.
- `TenantLifecycleService::isValidStatus` — `tenant-lifecycle` capability, not `object-lifecycle`.

## Test plan

- [x] `openspec validate retrofit-2026-05-24-object-lifecycle --strict` passes
- [ ] Behavior is observation-only — no functional changes; CI run confirms
- [ ] Coverage scanner next-run: 9 keepers should resolve to REQ-006..009; 16 drops should not re-surface under object-lifecycle

## Notes

- Mode is `--extend`: REQ-001..005 are unchanged.
- All annotations use the same `@spec openspec/changes/<change>/tasks.md#task-N` form as the previous retrofit batch (TenantUsageSyncJob etc.).
- PHPCS blank-line-before-`@spec` rule observed throughout.