### PR TITLE
retrofit: reverse-spec oas-generation (5 new REQs / 19 methods annotated)

### DIFF
--- a/lib/Controller/OasController.php
+++ b/lib/Controller/OasController.php
@@ -177,6 +177,8 @@ class OasController extends Controller
      * @param string $name Query parameter name.
      *
      * @return bool
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md#task-5
      */
     private function boolQueryParam(string $name): bool
     {

--- a/lib/Middleware/OasValidationMiddleware.php
+++ b/lib/Middleware/OasValidationMiddleware.php
@@ -70,6 +70,8 @@ class OasValidationMiddleware extends Middleware
      * @return void
      *
      * @throws OasValidationFailureException When the body fails validation.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md#task-4
      */
     public function beforeController(mixed $controller, string $methodName): void
     {
@@ -113,6 +115,8 @@ class OasValidationMiddleware extends Middleware
      * @throws \Throwable When the exception is not ours; rethrown for upstream handling.
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter) NC Middleware interface requires $controller + $methodName.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md#task-4
      */
     public function afterException(
         mixed $controller,

--- a/lib/Service/Oas/OasETagComputer.php
+++ b/lib/Service/Oas/OasETagComputer.php
@@ -53,6 +53,8 @@ class OasETagComputer
      * @param array $spec The OAS payload.
      *
      * @return string The hex-encoded SHA-256 hash.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md#task-1
      */
     public function hash(array $spec): string
     {
@@ -72,6 +74,8 @@ class OasETagComputer
      * @param string $currentETag The currently computed ETag (quoted).
      *
      * @return bool True when a 304 response can be returned.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md#task-1
      */
     public function matches(string $ifNoneMatch, string $currentETag): bool
     {
@@ -106,6 +110,8 @@ class OasETagComputer
      * @param mixed $value The value to canonicalise.
      *
      * @return mixed Canonical-shape value.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md#task-1
      */
     private function canonicalise(mixed $value): mixed
     {

--- a/lib/Service/Oas/OasRequestValidator.php
+++ b/lib/Service/Oas/OasRequestValidator.php
@@ -43,6 +43,8 @@ class OasRequestValidator
      * @param array $schema The JSON-Schema to validate against (decoded).
      *
      * @return array<int, array{path: string, message: string}>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md#task-4
      */
     public function validate(mixed $body, array $schema): array
     {
@@ -78,6 +80,8 @@ class OasRequestValidator
      * @param array $schema The JSON-Schema.
      *
      * @return bool
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md#task-4
      */
     public function isValid(mixed $body, array $schema): bool
     {
@@ -99,6 +103,8 @@ class OasRequestValidator
      *                                               across versions; each method_exists
      *                                               branch is one independent fallback.
      * @SuppressWarnings(PHPMD.NPathComplexity)      Same: each fallback is one branch.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md#task-4
      */
     private function collectErrors(mixed $error, array &$errors): void
     {

--- a/lib/Service/Oas/OasValidationReport.php
+++ b/lib/Service/Oas/OasValidationReport.php
@@ -80,6 +80,8 @@ final class OasValidationReport
      * @param string $code    Stable machine code (one of the CODE_* constants).
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md#task-3
      */
     public function addError(string $path, string $message, string $code): void
     {
@@ -100,6 +102,8 @@ final class OasValidationReport
      * @param string $code    Stable machine code (one of the CODE_* constants).
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md#task-3
      */
     public function addWarning(string $path, string $message, string $code): void
     {
@@ -120,6 +124,8 @@ final class OasValidationReport
      * @param string $code    Stable machine code (one of the CODE_* constants).
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md#task-3
      */
     public function addAutoCorrection(string $path, string $message, string $code): void
     {

--- a/lib/Service/Oas/ProblemDetailsBuilder.php
+++ b/lib/Service/Oas/ProblemDetailsBuilder.php
@@ -101,6 +101,8 @@ class ProblemDetailsBuilder
      * @param string $instance Instance URI, '' = omit.
      *
      * @return array<string, mixed>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md#task-2
      */
     public function validationFailed(array $errors, string $detail='', string $instance=''): array
     {
@@ -122,6 +124,8 @@ class ProblemDetailsBuilder
      * @param string $instance Instance URI, '' = omit.
      *
      * @return array<string, mixed>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md#task-2
      */
     public function notFound(string $detail='', string $instance=''): array
     {
@@ -141,6 +145,8 @@ class ProblemDetailsBuilder
      * @param string $instance Instance URI, '' = omit.
      *
      * @return array<string, mixed>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md#task-2
      */
     public function conflict(string $detail='', string $instance=''): array
     {

--- a/lib/Service/OasService.php
+++ b/lib/Service/OasService.php
@@ -666,6 +666,8 @@ class OasService
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Many OpenAPI schema keywords require individual validation
      * @SuppressWarnings(PHPMD.NPathComplexity)       Multiple conditional paths for schema keyword processing
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Comprehensive OpenAPI schema validation logic
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md#task-5
      */
     private function sanitizePropertyDefinition($propertyDefinition): array
     {
@@ -1842,6 +1844,8 @@ class OasService
      * meta-schema. Closes oas-validation issue #1378.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md#task-5
      */
     private function validateAgainstMetaSchema(): void
     {
@@ -2043,6 +2047,8 @@ class OasService
      * - API-03: only standard HTTP status codes on responses.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md#task-5
      */
     private function validateNlGovRules(): void
     {

--- a/openspec/changes/retrofit-2026-05-24-oas-generation/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-oas-generation/proposal.md
@@ -1,0 +1,53 @@
+# Retrofit — Reverse-Spec `oas-generation` (sub-behaviors)
+
+## Why
+
+The `oas-generation` capability spec (`openspec/specs/oas-generation/spec.md`) covers REQ-001 (all-register OAS) and REQ-002 (single-register OAS) — the user-facing HTTP surface. The Bucket 2a scan flagged 33 methods across 9 files as not matching either REQ; on closer reading those methods implement **sub-behaviors** of the same capability that the spec never pins down:
+
+- `OasETagComputer` — deterministic SHA-256 over canonicalised JSON, RFC 7232 `If-None-Match` short-circuit returning `304 Not Modified`. The controller already wires this in but no REQ describes the contract.
+- `ProblemDetailsBuilder` — RFC 7807 `application/problem+json` shape used for `404`, `409`, and `422` responses from the OAS endpoint and its validation middleware.
+- `OasValidationReport` value object — structured collection of error/warning/auto-correction issues with stable machine codes (`dangling_ref`, `duplicate_operation_id`, `relative_server_url`, ...) and a summary serializer that drives both the `x-validation-summary` extension field (when `?validate=true`) and the `422` response body (when `?strict=true`).
+- `OasRequestValidator` + `OasValidationMiddleware` — opt-in JSON-Schema validation of incoming request bodies against per-operation schemas, gated by `?_validate=true` on POST/PUT/PATCH. The middleware's resolver is currently a stub returning `null`; the spec needs to document the contract so the future resolver implementation has a target.
+- Internal validation passes inside `OasService` — meta-schema (OpenAPI 3.1) check, NLGov API-01 (allowed HTTP methods) + API-03 (allowed status codes) rules, property-definition sanitization (whitelist of OpenAPI 3.1 keywords with auto-coercion of malformed inputs).
+- The controller's `?strict=` / `?validate=` boolean query-parameter parser (accepts `true|1|yes|on`, case-insensitive).
+
+This retrofit lifts these observed sub-behaviors into the `oas-generation` spec and annotates the 19 backing methods that have substance. Pure DTO accessors and trivial wiring (`OasService::__construct`, `OasService::getLastValidationReport`, the exception getters, the middleware stub) are dropped as false positives.
+
+## What Changes
+
+- ADD 5 new requirements to `openspec/specs/oas-generation/spec.md`:
+  1. ETag computation + `If-None-Match` short-circuit on the OAS endpoint.
+  2. RFC 7807 problem-details shape for error responses.
+  3. `OasValidationReport` issue collection, severity model, and summary serialization.
+  4. Per-operation request-body validation middleware (opt-in via `?_validate=true`).
+  5. Internal validation pipeline — meta-schema, NLGov API-01/API-03, property-definition sanitization.
+- ADD a note on the controller-level boolean query-param parser (folded into REQ-001 since it's shared by `?strict=` and `?validate=`).
+- ANNOTATE 19 substantive methods across 7 files with `@spec` tags pointing at the new tasks. 14 of the 33 cluster methods are DTO accessors, trivial constructors, exception getters, or a stub middleware resolver — those are dropped as false positives (see Notes).
+
+## Impact
+
+- `openspec/specs/oas-generation/spec.md` — gains 5 requirements.
+- `lib/Service/Oas/OasETagComputer.php` — 3 method docblocks annotated (`hash`, `matches`, `canonicalise`).
+- `lib/Service/Oas/ProblemDetailsBuilder.php` — 3 method docblocks annotated (`validationFailed`, `notFound`, `conflict`).
+- `lib/Service/Oas/OasValidationReport.php` — 3 method docblocks annotated (`addError`, `addWarning`, `addAutoCorrection`) covering the contract surface; pure getters left unannotated.
+- `lib/Service/Oas/OasRequestValidator.php` — 3 method docblocks annotated (`validate`, `isValid`, `collectErrors`).
+- `lib/Middleware/OasValidationMiddleware.php` — 2 method docblocks annotated (`beforeController`, `afterException`).
+- `lib/Service/OasService.php` — 3 method docblocks annotated (`sanitizePropertyDefinition`, `validateAgainstMetaSchema`, `validateNlGovRules`).
+- `lib/Controller/OasController.php` — 1 method docblock annotated (`boolQueryParam`); other methods already carry `@spec` tags from the 2026-05-01 retrofit.
+- **No behavior change.** Documentation/coverage only.
+
+## Notes
+
+**Dropped as false positives (14 methods):**
+
+- `OasController::boolQueryParam` — KEPT (annotated; small but its semantics are load-bearing for `?strict=` and `?validate=`).
+- `OasValidationReport` accessors (`getIssues`, `getErrors`, `getWarnings`, `getAutoCorrections`, `hasErrors`, `passed`, `isEmpty`, `toSummary`, `filterBySeverity`) — DTO read API. The setters (`addError`/`addWarning`/`addAutoCorrection`) are annotated because they define the issue shape; the readers are pure consequences and would clutter the spec with no signal.
+- `OasValidationException::__construct`, `OasValidationException::getReport` — exception wiring.
+- `OasValidationFailureException::__construct`, `OasValidationFailureException::getErrors` — internal carrier between middleware phases.
+- `OasService::__construct`, `OasService::getLastValidationReport` — DI plumbing + trivial accessor.
+- `OasValidationMiddleware::resolveOperationSchema` — explicit stub returning `null`; new REQ-006 documents the *contract* the future implementation must satisfy, but the stub itself is not part of the implemented surface.
+
+**Drift flagged:**
+
+- `OasValidationMiddleware::resolveOperationSchema` is a stub. The middleware therefore never validates today even when `?_validate=true` is set. REQ-006 documents the eventual contract; until the resolver is wired the middleware is a no-op. This is a known gap, not a regression.
+- `INCLUDED_EXTENDED_ENDPOINTS` is empty (already noted in the existing REQ-001 Notes).

--- a/openspec/changes/retrofit-2026-05-24-oas-generation/specs/oas-generation/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-oas-generation/specs/oas-generation/spec.md
@@ -1,0 +1,209 @@
+---
+status: draft
+---
+
+# OAS Generation — Retrofit Delta (2026-05-24)
+
+## ADDED Requirements
+
+### Requirement: OAS responses MUST carry a deterministic ETag and short-circuit matching `If-None-Match` requests with 304
+
+The OAS endpoint MUST compute a strong `ETag` per RFC 7232 over a canonical-JSON representation of the generated spec, return it in the response header, and respond with `304 Not Modified` (no body) when the client sends an `If-None-Match` header containing a matching ETag. Canonicalisation sorts object keys recursively so two structurally-equivalent specs differing only in key order produce the same ETag. The 304 short-circuit MUST be skipped when `?validate=true` is set so the validation summary is always fresh.
+
+#### Scenario: First request returns the spec with an ETag header
+
+- **GIVEN** an OAS endpoint configured with an `OasETagComputer`
+- **WHEN** `GET /api/oas` (or `/api/oas/{id}`) is requested without `If-None-Match`
+- **THEN** the response is `200 OK` with the OAS body
+- **AND** the response carries an `ETag` header whose value is a strong tag of the form `"<sha256-hex>"`
+- **AND** the ETag is the SHA-256 of `json_encode($canonicalised)` where `$canonicalised` recursively sorts associative-array keys and preserves list order
+
+#### Scenario: Subsequent request with matching `If-None-Match` returns 304
+
+- **GIVEN** a previously-returned ETag value `"abc123..."`
+- **WHEN** `GET /api/oas` is requested with `If-None-Match: "abc123..."`
+- **THEN** the response is `304 Not Modified`
+- **AND** the response body is `null` / empty
+- **AND** the response carries the same `ETag` header
+
+#### Scenario: `If-None-Match: *` always short-circuits
+
+- **WHEN** `If-None-Match: *` is sent
+- **THEN** the endpoint SHALL return `304 Not Modified`
+
+#### Scenario: Weak-tag prefix is stripped per RFC 7232
+
+- **GIVEN** a current ETag `"abc"`
+- **WHEN** the client sends `If-None-Match: W/"abc"`
+- **THEN** the comparison strips the `W/` prefix and SHALL match
+
+#### Scenario: Validation mode bypasses the 304 short-circuit
+
+- **WHEN** `GET /api/oas?validate=true` is requested with a matching `If-None-Match`
+- **THEN** the endpoint SHALL still compute and return the full body so the `x-validation-summary` extension is fresh
+
+#### Notes
+
+- The ETag computer is wired optionally on `OasController` — when not present the controller MUST fall back to a plain `200 OK` response without ETag handling.
+- The boolean query parameter parser shared by `?strict=` and `?validate=` accepts `true|1|yes|on` (case-insensitive); everything else (including missing) is `false`.
+
+---
+
+### Requirement: Error responses from the OAS endpoint MUST follow RFC 7807 `application/problem+json`
+
+Error responses produced by the OAS endpoint and its validation middleware MUST conform to RFC 7807. Every problem document carries `type` (default `about:blank`), `title`, `status`, plus optional `detail`, `instance`, and free-form extension fields. Custom extensions MUST NOT overwrite the standard fields. The HTTP response MUST advertise `Content-Type: application/problem+json`.
+
+#### Scenario: Validation failure returns a 422 problem document
+
+- **GIVEN** OAS request-body validation produced a list of `{path, message}` errors
+- **WHEN** the middleware emits the failure response
+- **THEN** the body SHALL be `{type: 'about:blank', title: 'Validation failed', status: 422, detail: <reason>, instance: <request URI>, errors: [...] }`
+- **AND** the `Content-Type` header SHALL be `application/problem+json`
+
+#### Scenario: Not-found problem document shape
+
+- **WHEN** a `notFound(detail, instance)` problem is built
+- **THEN** the document SHALL be `{type: 'about:blank', title: 'Not found', status: 404, ...}` with `detail` and `instance` omitted when empty
+
+#### Scenario: Conflict problem document shape
+
+- **WHEN** a `conflict(detail, instance)` problem is built (e.g. lock conflict, ETag mismatch)
+- **THEN** the document SHALL be `{type: 'about:blank', title: 'Conflict', status: 409, ...}`
+
+#### Scenario: Custom extensions cannot overwrite standard fields
+
+- **GIVEN** a caller passes `extensions: ['title' => 'Spoof', 'errors' => [...]]`
+- **WHEN** the problem document is built
+- **THEN** the `title` SHALL remain the builder-controlled value
+- **AND** the `errors` extension SHALL be added to the document
+
+---
+
+### Requirement: Validation issues MUST be collected in an `OasValidationReport` with stable severity and machine codes
+
+Internal OAS validation passes MUST record findings in an `OasValidationReport` value object that distinguishes three severity levels (`error`, `warning`, `auto_corrected`) and carries stable machine codes so downstream consumers (CI, dashboards, the `x-validation-summary` extension) can filter and aggregate without parsing free-form text. The report MUST expose a compact summary shape suitable for embedding in the OAS document.
+
+#### Scenario: Recorded issue shape
+
+- **GIVEN** `addError(path, message, code)`, `addWarning(path, message, code)`, or `addAutoCorrection(path, message, code)` is called
+- **THEN** the report SHALL store an entry `{path, message, code, severity}` where `severity` is one of `'error' | 'warning' | 'auto_corrected'`
+- **AND** `path` is a JSON Pointer (RFC 6901) identifying the location in the OAS document
+- **AND** `code` is one of the stable `CODE_*` constants (e.g. `dangling_ref`, `invalid_allof`, `duplicate_operation_id`, `orphan_tag`, `unused_tag`, `invalid_http_method`, `invalid_status_code`, `invalid_property_type`, `missing_array_items`, `relative_server_url`)
+
+#### Scenario: Summary shape embedded as `x-validation-summary`
+
+- **WHEN** `toSummary()` is called on a report
+- **THEN** the return SHALL be `{passed: bool, errors: int, warnings: int, autoCorrected: int, issues: [...] }`
+- **AND** `passed` SHALL be `true` iff no error-severity issues were recorded
+- **AND** the per-severity counts SHALL equal the counts when filtered by `getErrors()` / `getWarnings()` / `getAutoCorrections()`
+
+#### Scenario: Strict mode surfaces the report on the exception
+
+- **GIVEN** `OasService::createOas(registerId, strict: true)` is called
+- **WHEN** the validation pass records one or more error-severity issues
+- **THEN** the service SHALL throw `OasValidationException` carrying the report
+- **AND** the controller SHALL translate the exception into a `422` response with body `{error, summary}` where `summary` is the report's `toSummary()` output
+
+---
+
+### Requirement: An opt-in middleware MUST validate JSON request bodies against per-operation OAS schemas
+
+OpenRegister MUST provide a `before-controller` middleware that, when opted in via the `?_validate=true` query parameter on POST/PUT/PATCH requests, looks up the operation's request-body schema and validates the decoded body against it. On a validation miss the middleware MUST short-circuit with an RFC 7807 `422` problem-json response carrying the flat `{path, message}` error list. GET/HEAD/DELETE/OPTIONS requests SHALL bypass validation. When the resolver returns `null` (no schema known for the operation) the middleware SHALL pass the request through unmodified.
+
+#### Scenario: Non-write verb bypasses validation
+
+- **GIVEN** a `GET` / `HEAD` / `DELETE` / `OPTIONS` request
+- **WHEN** the middleware's `beforeController` runs
+- **THEN** the request SHALL pass through with no validation
+
+#### Scenario: Missing opt-in bypasses validation
+
+- **GIVEN** a `POST` request without `?_validate=true`
+- **WHEN** the middleware runs
+- **THEN** the request SHALL pass through with no validation
+
+#### Scenario: Opt-in truthy values
+
+- **GIVEN** `?_validate=` is set to one of `true | 1 | yes | on` (case-insensitive)
+- **THEN** validation SHALL be enabled
+
+#### Scenario: No resolver schema means pass-through
+
+- **GIVEN** validation is opted in
+- **AND** the per-operation schema resolver returns `null`
+- **WHEN** the middleware runs
+- **THEN** the request SHALL pass through unmodified
+
+#### Scenario: Validation failure becomes a 422 problem-json response
+
+- **GIVEN** the resolver returns a schema and the request body fails validation
+- **WHEN** the middleware runs
+- **THEN** it SHALL throw an internal `OasValidationFailureException` carrying the flat `{path, message}[]` error list
+- **AND** its `afterException` handler SHALL convert that exception into a `422 JSONResponse` whose body is built by `ProblemDetailsBuilder::validationFailed()` and whose `Content-Type` header is `application/problem+json`
+
+#### Scenario: opis/json-schema errors are flattened
+
+- **GIVEN** the body validator wraps `opis/json-schema`
+- **WHEN** validation fails with a tree of `ValidationError` instances
+- **THEN** the validator SHALL flatten the tree into a list of `{path, message}` entries where `path` is the JSON Pointer of the offending field (or `/` when unknown) and `message` is the opis message (or the keyword name when no message is available)
+
+#### Notes
+
+- The resolver `OasValidationMiddleware::resolveOperationSchema()` is currently a stub returning `null` — when `OasService` exposes a per-operation schema lookup the resolver will use that. Until then this middleware is effectively a no-op; consumers needing validation can still call `OasRequestValidator::validate()` directly with a schema in hand.
+
+---
+
+### Requirement: The OAS generator MUST run an internal validation pipeline producing structured issues
+
+Inside `OasService::createOas()` the generator MUST run a multi-pass validation pipeline that records issues on the `OasValidationReport`. The pipeline covers (1) OpenAPI 3.1 meta-schema conformance, (2) NLGov API-01 (allowed HTTP methods) and API-03 (allowed status codes) rules, and (3) property-definition sanitization that strips non-OpenAPI keywords and coerces malformed inputs to valid shapes. Validation MUST NOT block generation in the default mode; issues are auto-corrected where possible and surfaced via the report. Strict mode (`strict: true`) MUST throw `OasValidationException` when any error-severity issue is recorded.
+
+#### Scenario: Property definitions are stripped to the OpenAPI 3.1 keyword whitelist
+
+- **GIVEN** a raw schema property definition containing OR-internal fields (`objectConfiguration`, `inversedBy`, `authorization`, `defaultBehavior`, ...) alongside OpenAPI keywords
+- **WHEN** the generator sanitizes the definition
+- **THEN** only the OpenAPI 3.1 keyword whitelist SHALL survive: `type`, `format`, `description`, `example(s)`, `default`, `enum`, `const`, `multipleOf`, `maximum`/`minimum` (+`exclusive*`), `maxLength`/`minLength`, `pattern`, `maxItems`/`minItems`, `uniqueItems`, `maxProperties`/`minProperties`, `required`, `properties`, `items`, `additionalProperties`, `allOf`/`anyOf`/`oneOf`/`not`, `$ref`, `nullable`, `readOnly`/`writeOnly`, `title`
+- **AND** non-array values for the `items`, `properties`, and composition keywords SHALL recurse and be sanitized too
+- **AND** empty `oneOf`/`anyOf`/`allOf`/`enum` SHALL be removed
+- **AND** an empty `$ref` SHALL be removed; a bare `$ref` value (no leading `#/`) SHALL be normalised to `#/components/schemas/<sanitized-name>`
+- **AND** property-level `required: true` (a boolean) SHALL be removed because OpenAPI 3.1 requires `required` to be an array of property names
+- **AND** an unrecognised `type` value SHALL be coerced to `"string"`
+- **AND** an `items` value that is a sequential list SHALL be collapsed to its first element (or `{type: "string"}` when the list is empty)
+- **AND** a property with `type: "array"` SHALL gain a default `items: {type: "string"}` when none is set
+- **AND** a property with neither `type` nor `$ref` SHALL gain `type: "string"`
+
+#### Scenario: NLGov API-01 — only standard HTTP methods are allowed
+
+- **GIVEN** an operation under `paths` with a method outside `{get, post, put, delete, parameters}`
+- **WHEN** the NLGov-rules pass runs
+- **THEN** the report SHALL record an error with code `CODE_INVALID_HTTP_METHOD` at path `paths.<path>.<method>`
+
+#### Scenario: NLGov API-03 — only the allowed status-code set may appear
+
+- **GIVEN** an operation declaring a response with a status code outside `{200, 201, 204, 400, 401, 403, 404, 422, 500, default}`
+- **WHEN** the NLGov-rules pass runs
+- **THEN** the report SHALL record a warning with code `CODE_INVALID_STATUS_CODE` at path `paths.<path>.<method>.responses.<code>`
+
+#### Scenario: OpenAPI 3.1 meta-schema validation surfaces errors via the report
+
+- **GIVEN** an `OasRequestValidator` is wired as the meta-validator
+- **AND** `lib/Service/Oas/Resources/meta/openapi-3.1.0.json` exists
+- **WHEN** the generated OAS document fails the OpenAPI 3.1 meta-schema
+- **THEN** every opis-reported violation SHALL be recorded on the report with code `'meta-schema-violation'` and a message prefixed `OpenAPI 3.1 meta-schema violation: `
+
+#### Scenario: Meta-schema validator errors MUST NOT block generation
+
+- **GIVEN** the meta-validator itself throws (e.g. a `Throwable` while validating)
+- **WHEN** generation runs
+- **THEN** the exception SHALL be logged at warning level on the OAS service's logger
+- **AND** generation SHALL continue without recording the failure on the report
+
+#### Scenario: Strict mode converts error-severity issues into a 422 response
+
+- **GIVEN** the pipeline records at least one error-severity issue
+- **WHEN** `createOas(strict: true)` is invoked
+- **THEN** the service SHALL throw `OasValidationException`
+- **AND** the controller SHALL respond `422` with body `{error, summary}` where `summary` is the report's `toSummary()` output
+
+#### Notes
+
+- The validation pipeline also runs `validateServerUrls`, `validateOperationIdUniqueness` (auto-suffixes collisions), `validateTagConsistency`, and `validateSchemaReferences` (recursively fixes empty/invalid `allOf`/`$ref`). Those passes are existing implementation details supporting this requirement; only the property-definition sanitization, NLGov rules, and meta-schema check are described here because they encode policy decisions (the OpenAPI keyword whitelist; the NLGov allowed-method/status-code sets) rather than mechanical clean-up.

--- a/openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-oas-generation/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: Retrofit — Reverse-Spec `oas-generation` (sub-behaviors)
+
+All tasks are observation-only retrofit annotations. No behavior change.
+
+## Task 1 — ETag computation and `If-None-Match` short-circuit
+
+- [x] Document `OasETagComputer::hash($spec)` — recursive key-sort canonicalisation followed by SHA-256 of `json_encode($canonical)`; output is hex without quotes (the quoted strong tag is produced by `computeETag()` which wraps `hash()` in `"…"`).
+- [x] Document `OasETagComputer::matches($ifNoneMatch, $currentETag)` — RFC 7232 weak comparison: `*` always matches, comma-separated list of candidates, leading `W/` stripped, whitespace trimmed.
+- [x] Document `OasETagComputer::canonicalise($value)` — recursively sorts associative-array keys ascending (`sort($keys)`) and preserves list order (`array_is_list()` returns true → keep order); scalars pass through unchanged.
+- [x] Document the `OasController` integration: `If-None-Match` short-circuit returns `JSONResponse(null, 304)` with the `ETag` header; the short-circuit is skipped when `?validate=true` so the `x-validation-summary` is always fresh.
+
+## Task 2 — RFC 7807 problem-details builder
+
+- [x] Document `ProblemDetailsBuilder::validationFailed($errors, $detail, $instance)` — returns the 422-shaped problem with title `"Validation failed"`, `type: about:blank`, and the validator's flat `{path, message}[]` list under `errors`.
+- [x] Document `ProblemDetailsBuilder::notFound($detail, $instance)` — returns a 404 problem with title `"Not found"`; empty `detail`/`instance` are omitted from the body.
+- [x] Document `ProblemDetailsBuilder::conflict($detail, $instance)` — returns a 409 problem with title `"Conflict"` (used for lock conflicts and ETag mismatches).
+- [x] Document the global rule: custom extensions passed to `build()` MUST NOT overwrite the standard `type/title/status/detail/instance` fields (they're filtered out before merging); response `Content-Type` is always `application/problem+json` (constant `ProblemDetailsBuilder::CONTENT_TYPE`).
+
+## Task 3 — `OasValidationReport` issue collection and severity model
+
+- [x] Document `OasValidationReport::addError($path, $message, $code)` — appends `{path, message, code, severity: 'error'}` where `code` is one of the `CODE_*` constants (`dangling_ref`, `invalid_allof`, `duplicate_operation_id`, `orphan_tag`, `unused_tag`, `invalid_http_method`, `invalid_status_code`, `invalid_property_type`, `missing_array_items`, `relative_server_url`).
+- [x] Document `OasValidationReport::addWarning($path, $message, $code)` — same shape with `severity: 'warning'`.
+- [x] Document `OasValidationReport::addAutoCorrection($path, $message, $code)` — same shape with `severity: 'auto_corrected'`; used by passes that mutate the OAS in place (e.g. `validateOperationIdUniqueness` appending `_2`/`_3` suffixes).
+- [x] Document the summary contract: `toSummary()` returns `{passed, errors, warnings, autoCorrected, issues}` where `passed = !hasErrors()`. `passed`/`hasErrors` are driven exclusively by error-severity issues; warnings and auto-corrections do not fail the pass.
+
+## Task 4 — Opt-in OAS request-body validation middleware
+
+- [x] Document `OasRequestValidator::validate($body, $schema)` — JSON round-trip to convert PHP arrays into the `stdClass` shape opis expects, run opis, return `[]` on success or a flat `{path, message}[]` list on failure.
+- [x] Document `OasRequestValidator::isValid($body, $schema)` — convenience boolean wrapper around `validate()`.
+- [x] Document `OasRequestValidator::collectErrors($error, &$errors)` — recursive flattener over opis `ValidationError` trees: uses defensive `method_exists` guards for shape stability across opis versions, extracts `path` from `$error->data()->fullPath()` (joined with `/`), prefers `$error->message()` over `$error->keyword()`, and falls back to `'/'` + `'value does not validate'`.
+- [x] Document `OasValidationMiddleware::beforeController($controller, $methodName)` — opt-in gating: bypass unless verb is POST/PUT/PATCH AND `?_validate=` is `true|1|yes|on` (case-insensitive); resolver lookup returns `null` → pass-through; resolver returns a schema → validate `$request->getParams()` and throw `OasValidationFailureException` on a non-empty error list.
+- [x] Document `OasValidationMiddleware::afterException()` — only handles `OasValidationFailureException`; builds `ProblemDetailsBuilder::validationFailed(errors, detail, instance)` and emits a `422 JSONResponse` with `Content-Type: application/problem+json`; rethrows any other exception.
+
+## Task 5 — Internal validation pipeline (sanitization, NLGov rules, meta-schema)
+
+- [x] Document `OasService::sanitizePropertyDefinition($propertyDefinition)` — full OpenAPI 3.1 keyword whitelist enforcement: non-array input becomes `{type: 'string', description: 'Property value'}`; copy only the 23 allowed keywords; recurse into `items`/`properties`/`oneOf`/`anyOf`/`allOf`; remove empty composition arrays and empty `enum`/`$ref`; normalise bare `$ref` to `#/components/schemas/<sanitized>`; coerce property-level `required: bool` (drop), unrecognised `type` (→`"string"`), `items` as sequential list (→ first element), missing `items` on array types (→ `{type: 'string'}`), missing `type`/`$ref` (→ `type: 'string'`), missing `description` (→ `'Property value'`).
+- [x] Document `OasService::validateAgainstMetaSchema()` — when the optional `OasRequestValidator` is wired AND `Resources/meta/openapi-3.1.0.json` exists, runs the generated OAS document through it; opis errors are added with code `'meta-schema-violation'`; a `Throwable` from the validator is logged at warning level and swallowed (validation MUST NOT block generation).
+- [x] Document `OasService::validateNlGovRules()` — NLGov API-01 (allowed methods: `get/post/put/delete/parameters`) records `CODE_INVALID_HTTP_METHOD` errors; NLGov API-03 (allowed status codes: `200/201/204/400/401/403/404/422/500/default`) records `CODE_INVALID_STATUS_CODE` warnings.
+- [x] Document `OasController::boolQueryParam($name)` — boolean query-param parser shared by `?strict=` and `?validate=`: accepts `true|1|yes|on` (case-insensitive) as truthy; everything else (including missing/empty) is `false`.


### PR DESCRIPTION
## Summary

Reverse-spec retrofit for the `oas-generation` capability — lifts five observed sub-behaviors into the spec and annotates the 19 substantive methods with `@spec` tags. Generated from the Bucket 2a scan (`/tmp/or-scan/rspec-cluster-oas-generation.json`, 33 methods / 9 files); 14 of the 33 are DTO accessors, trivial constructors, exception getters, or a stub resolver and were dropped as false positives.

## New REQs (5)

1. **ETag computation + `If-None-Match` short-circuit** — deterministic SHA-256 over canonicalised JSON; RFC 7232 weak comparison; `304 Not Modified` skip-on-`?validate=true`.
2. **RFC 7807 problem-details shape** — `application/problem+json` for the OAS endpoint's 404/409/422 responses; custom extensions cannot overwrite standard fields.
3. **`OasValidationReport` contract** — issue collection with `error`/`warning`/`auto_corrected` severity and 10 stable `CODE_*` machine codes; `toSummary()` shape drives `x-validation-summary` extension and strict-mode 422 body.
4. **Opt-in request-body validation middleware** — `?_validate=true` gates JSON-Schema validation on POST/PUT/PATCH; failure → 422 problem-json via `OasValidationFailureException → afterException`. Resolver is currently a stub; the REQ documents the contract the future implementation must satisfy.
5. **Internal validation pipeline** — `sanitizePropertyDefinition` (23-keyword OpenAPI 3.1 whitelist + auto-coercion), NLGov API-01 (allowed HTTP methods → error), NLGov API-03 (allowed status codes → warning), OpenAPI 3.1 meta-schema validation (best-effort; validator errors logged but swallowed).

## Annotated methods (19)

- `lib/Service/Oas/OasETagComputer.php` — `hash`, `matches`, `canonicalise` (task-1)
- `lib/Service/Oas/ProblemDetailsBuilder.php` — `validationFailed`, `notFound`, `conflict` (task-2)
- `lib/Service/Oas/OasValidationReport.php` — `addError`, `addWarning`, `addAutoCorrection` (task-3)
- `lib/Service/Oas/OasRequestValidator.php` — `validate`, `isValid`, `collectErrors` (task-4)
- `lib/Middleware/OasValidationMiddleware.php` — `beforeController`, `afterException` (task-4)
- `lib/Service/OasService.php` — `sanitizePropertyDefinition`, `validateAgainstMetaSchema`, `validateNlGovRules` (task-5)
- `lib/Controller/OasController.php` — `boolQueryParam` (task-5)

## Dropped as false positives (14)

- `OasValidationReport` read-accessors (`getIssues`, `getErrors`, `getWarnings`, `getAutoCorrections`, `hasErrors`, `passed`, `isEmpty`, `toSummary`, `filterBySeverity`) — pure consequence of the setters; annotating them would clutter the spec.
- `OasValidationException` / `OasValidationFailureException` `__construct` + getters — exception wiring.
- `OasService::__construct`, `OasService::getLastValidationReport` — DI plumbing + trivial accessor.
- `OasValidationMiddleware::resolveOperationSchema` — explicit stub returning `null`; REQ documents the contract for the future implementation, not the stub.

## Drift flagged

`OasValidationMiddleware::resolveOperationSchema` is a stub returning `null`, so the validation middleware is effectively a no-op today — even when `?_validate=true` is set. REQ-006 documents the eventual contract so the future implementation has a target. This is a known gap, not a regression. Consumers needing validation can still call `OasRequestValidator::validate()` directly.

## Test plan

- [ ] OpenSpec validate: `openspec validate retrofit-2026-05-24-oas-generation --strict`
- [ ] PHPCS check on the 7 modified files (annotations follow the format used elsewhere on this branch — see `OasController` existing `@spec` tags).
- [ ] No behavior change — documentation/coverage only.