### PR TITLE
retrofit(chat-ai): REQ-006 LLPhant FunctionInfo conversion (Bucket 2a 2026-05-24)

### DIFF
--- a/lib/Service/Chat/ToolManagementHandler.php
+++ b/lib/Service/Chat/ToolManagementHandler.php
@@ -215,6 +215,8 @@ class ToolManagementHandler
      *
      * @psalm-return list<FunctionInfo>
      *
+     * @spec openspec/changes/retrofit-2026-05-24-chat-ai/tasks.md#task-1
+     *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Function conversion requires handling multiple parameter types
      * @SuppressWarnings(PHPMD.NPathComplexity)      Function conversion requires handling multiple parameter types
      */

--- a/openspec/changes/retrofit-2026-05-24-chat-ai/design.md
+++ b/openspec/changes/retrofit-2026-05-24-chat-ai/design.md
@@ -1,0 +1,16 @@
+# Design: Chat AI (2026-05-24 retrofit)
+
+Retrofit change. Tasks describe retroactive annotation + a Notes update; no implementation work.
+
+## Approach
+A Bucket 2a coverage scan flagged 19 chat-related methods as unspecced. Triage against existing class-level `@spec` annotations and the in-flight `ai-chat-companion-orchestrator` / `ai-chat-companion-streaming` changes reduces this to one real gap (`ToolManagementHandler::convertFunctionsToFunctionInfo`), which this change retroactively links to a new `REQ-006`.
+
+## Files affected
+- `openspec/specs/chat-ai/spec.md` — adds REQ-006, extends Notes
+- `lib/Service/Chat/ToolManagementHandler.php` — adds `@spec` tag on `convertFunctionsToFunctionInfo`
+
+## What this change deliberately does NOT cover
+- **In-flight-covered methods** (`ChatHealthController::health`, all `StreamYieldChannel` emit/on* methods, all `ChatStreamController` SSE helpers): their containing classes already carry class-level `@spec` annotations pointing to the in-flight `ai-chat-companion-orchestrator` / `ai-chat-companion-streaming` change directories. When those changes archive, their REQs merge into `chat-ai/spec.md` and these methods inherit canonical coverage. Retroactively annotating them now would create duplicate `@spec` paths.
+- **Stubs already documented in spec Notes** (`ChatService::testChat`): the existing spec already explicitly states this method is a facade stub awaiting the original implementation.
+- **Dead code** (`ChatController::page`): not registered in `appinfo/routes.php`; unreachable. Flagged in Notes; cleanup belongs in a separate change, not a spec retrofit.
+- **Vue UI helpers** (`ChatSideBar::isActive`, `ChatIndex::showAgentSelector`): pure presentational logic — CSS class binding and dialog open-toggle — with no server-observable behaviour worth specifying.

--- a/openspec/changes/retrofit-2026-05-24-chat-ai/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-chat-ai/proposal.md
@@ -1,0 +1,21 @@
+# Retrofit — chat-ai (2026-05-24 follow-up)
+
+Second-pass retrofit on the `chat-ai` capability. The 2026-04-30 retrofit covered the user-facing pipeline (REQ-001..005). The Bucket 2a scan on 2026-05-24 re-surfaced 19 chat-related methods that the heuristic flagged as "unspecced". Triaging them against observed behaviour, the in-flight `ai-chat-companion-orchestrator` and `ai-chat-companion-streaming` changes, plus the existing chat-ai spec Notes:
+
+- **15 methods are already covered** by class-level `@spec` annotations pointing to the two in-flight changes (orchestrator's `health-probe-endpoint`, `sse-streaming-endpoint`, streaming's three SSE-event REQs). Those REQs land naturally when the in-flight changes archive.
+- **1 method is documented in the existing spec Notes** as an unimplemented stub (`ChatService::testChat`).
+- **1 method is dead code** — `ChatController::page` is not registered in `appinfo/routes.php` and is unreachable. Flagged in Notes; should be removed in a separate cleanup, not retrofit-specced.
+- **2 methods are pure Vue UI helpers** (`ChatSideBar::isActive`, `ChatIndex::showAgentSelector`) — presentational logic without server-observable behaviour. Out of scope for backend spec retrofit.
+- **1 method is a genuine unspecced backend behaviour** — `ToolManagementHandler::convertFunctionsToFunctionInfo` converts internal tool-array descriptors into the `FunctionInfo` objects LLPhant expects for `setTools()`. This is part of the agent tool-calling pipeline (`REQ-001` describes the LLM call; this method is the adapter that makes tool-equipped agents work).
+
+This change retrofits the one real gap and documents the rest in the spec Notes section.
+
+## Affected code units
+- lib/Service/Chat/ToolManagementHandler.php::convertFunctionsToFunctionInfo
+
+## Approach
+- For the one in-scope method: describe inputs, output shape, parameter-type handling, and the cross-tool lookup performed to bind each `FunctionInfo` to its source `ToolInterface`.
+- Extend `chat-ai/spec.md` with `REQ-006`.
+- Update the spec Notes to record the FP triage above (`page` dead code, in-flight orchestrator/streaming coverage, Vue UI scope), so a third-pass scan does not re-surface them.
+
+Source: `/tmp/or-scan/rspec-cluster-chat-ai.json` (Bucket 2a, generated 2026-05-24). See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-chat-ai/specs/chat-ai/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-chat-ai/specs/chat-ai/spec.md
@@ -1,0 +1,32 @@
+---
+retrofit_extensions: [REQ-006]
+---
+
+## ADDED Requirements
+
+### Requirement: The system MUST convert tool definitions to LLPhant FunctionInfo objects for LLM function calling
+
+When an agent has tools configured (via the agent's `tools` field listing tool IDs the agent may invoke), the system MUST translate each tool's array-shaped function definition into a `LLPhant\Chat\FunctionInfo\FunctionInfo` instance that LLPhant accepts via `setTools()`. `ToolManagementHandler::convertFunctionsToFunctionInfo($functions, $tools)` performs this translation, MUST preserve `name` / `description` / parameters / required fields, MUST resolve each function's source `ToolInterface` instance by scanning the supplied tools (so LLPhant can invoke `$toolInstance->{$func['name']}(...)`), and MUST handle nested `object` and `array` parameter types by carrying their `properties` / `items` schemas through to the `Parameter` constructor's `itemsOrProperties` argument.
+
+#### Scenario: Scalar parameter is converted to a Parameter
+
+- **GIVEN** a function definition `{ name: 'searchObjects', description: 'Search', parameters: { properties: { query: { type: 'string', description: 'q' } }, required: ['query'] } }`
+- **AND** a tool instance whose `getFunctions()` returns a function with `name === 'searchObjects'`
+- **WHEN** `convertFunctionsToFunctionInfo($functions, $tools)` is called
+- **THEN** the returned `FunctionInfo` MUST have `name === 'searchObjects'`, `description === 'Search'`, exactly one `Parameter` (`name: 'query'`, `type: 'string'`, `description: 'q'`, `enum: []`, `format: null`), `required === ['query']`
+- **AND** the `FunctionInfo`'s instance target MUST be the supplied tool, so LLPhant can call `$tool->searchObjects(...)` directly
+
+#### Scenario: Object and array parameter types carry their nested schemas
+
+- **GIVEN** a function definition whose `parameters.properties` includes `filters: { type: 'object', properties: { tag: { type: 'string' } } }` and `ids: { type: 'array', items: { type: 'integer' } }`
+- **WHEN** `convertFunctionsToFunctionInfo` is called
+- **THEN** the `filters` `Parameter` MUST be constructed with `itemsOrProperties` equal to the `properties` map `{ tag: { type: 'string' } }`
+- **AND** the `ids` `Parameter` MUST be constructed with `itemsOrProperties` equal to the `items` schema `{ type: 'integer' }`
+- **AND** when an `object` parameter omits `properties`, or an `array` parameter omits `items`, `itemsOrProperties` MUST default to `[]` rather than `null`
+
+#### Scenario: Tool instance bound by name match across all supplied tools
+
+- **GIVEN** three tools are supplied, and only tool B's `getFunctions()` contains a function named `runReport`
+- **WHEN** `convertFunctionsToFunctionInfo` converts a function definition with `name === 'runReport'`
+- **THEN** the produced `FunctionInfo`'s instance target MUST be tool B
+- **AND** if no supplied tool exposes a function with that name, the `FunctionInfo` MUST still be created with a `null` tool instance (LLPhant will surface the resulting invocation failure at call time rather than at conversion time)

--- a/openspec/changes/retrofit-2026-05-24-chat-ai/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-chat-ai/tasks.md
@@ -1,0 +1,4 @@
+# Tasks
+
+- [x] task-1: chat-ai#REQ-006 — Tool definition conversion for LLM function calling (retroactive annotation)
+- [x] task-2: chat-ai Notes — record FP triage for in-flight-covered methods, dead `page()` route, and Vue UI helpers (spec edit only)

--- a/openspec/specs/chat-ai/spec.md
+++ b/openspec/specs/chat-ai/spec.md
@@ -131,8 +131,39 @@ An agent is a named AI entity with a prompt persona, model configuration, tool a
 - **WHEN** `sendFeedback` checks conversation ownership
 - **THEN** HTTP 403 MUST be returned without persisting any feedback
 
+### REQ-006: The system MUST convert tool definitions to LLPhant FunctionInfo objects for LLM function calling
+
+When an agent has tools configured (via the agent's `tools` field listing tool IDs the agent may invoke), the system MUST translate each tool's array-shaped function definition into a `LLPhant\Chat\FunctionInfo\FunctionInfo` instance that LLPhant accepts via `setTools()`. `ToolManagementHandler::convertFunctionsToFunctionInfo($functions, $tools)` performs this translation, MUST preserve `name` / `description` / parameters / required fields, MUST resolve each function's source `ToolInterface` instance by scanning the supplied tools (so LLPhant can invoke `$toolInstance->{$func['name']}(...)`), and MUST handle nested `object` and `array` parameter types by carrying their `properties` / `items` schemas through to the `Parameter` constructor's `itemsOrProperties` argument.
+
+#### Scenario: Scalar parameter is converted to a Parameter
+
+- **GIVEN** a function definition `{ name: 'searchObjects', description: 'Search', parameters: { properties: { query: { type: 'string', description: 'q' } }, required: ['query'] } }`
+- **AND** a tool instance whose `getFunctions()` returns a function with `name === 'searchObjects'`
+- **WHEN** `convertFunctionsToFunctionInfo($functions, $tools)` is called
+- **THEN** the returned `FunctionInfo` MUST have `name === 'searchObjects'`, `description === 'Search'`, exactly one `Parameter` (`name: 'query'`, `type: 'string'`, `description: 'q'`, `enum: []`, `format: null`), `required === ['query']`
+- **AND** the `FunctionInfo`'s instance target MUST be the supplied tool, so LLPhant can call `$tool->searchObjects(...)` directly
+
+#### Scenario: Object and array parameter types carry their nested schemas
+
+- **GIVEN** a function definition whose `parameters.properties` includes `filters: { type: 'object', properties: { tag: { type: 'string' } } }` and `ids: { type: 'array', items: { type: 'integer' } }`
+- **WHEN** `convertFunctionsToFunctionInfo` is called
+- **THEN** the `filters` `Parameter` MUST be constructed with `itemsOrProperties` equal to the `properties` map `{ tag: { type: 'string' } }`
+- **AND** the `ids` `Parameter` MUST be constructed with `itemsOrProperties` equal to the `items` schema `{ type: 'integer' }`
+- **AND** when an `object` parameter omits `properties`, or an `array` parameter omits `items`, `itemsOrProperties` MUST default to `[]` rather than `null`
+
+#### Scenario: Tool instance bound by name match across all supplied tools
+
+- **GIVEN** three tools are supplied, and only tool B's `getFunctions()` contains a function named `runReport`
+- **WHEN** `convertFunctionsToFunctionInfo` converts a function definition with `name === 'runReport'`
+- **THEN** the produced `FunctionInfo`'s instance target MUST be tool B
+- **AND** if no supplied tool exposes a function with that name, the `FunctionInfo` MUST still be created with a `null` tool instance (LLPhant will surface the resulting invocation failure at call time rather than at conversion time)
+
 ## Notes
 
 - `ChatController::getChatStats` queries all rows globally (no user/org filter). This may expose aggregate counts across organisations in a multi-tenant deployment. Worth reviewing against ADR-022 (OpenRegister RBAC on data).
 - `ChatService::testChat` is a stub returning a static success message. The real implementation was preserved in `ChatService_ORIGINAL_2156.php` backup. This method is not covered by these REQs until the stub is replaced.
 - `ConversationController::destroyPermanent` does not delete feedback (only messages + conversation), while the two-stage `destroy` path does delete feedback on the second call. This asymmetry may be unintentional.
+- REQ-006: the optional `format` field on a function-parameter definition is passed through verbatim to the `Parameter` constructor (e.g. OpenAI's `format: 'date-time'`); default `null`. `enum` is passed through verbatim; default `[]`. `required` defaults to `[]` when absent. The method is annotated `@SuppressWarnings(PHPMD.CyclomaticComplexity)` / `(NPathComplexity)` because the parameter-type fan-out is irreducible without restructuring LLPhant's `Parameter` API.
+- `ChatController::page` returns a `TemplateResponse` for the chat SPA but is NOT registered in `appinfo/routes.php` and is unreachable. Surfaced by a 2026-05-24 Bucket 2a scan; should be deleted in a cleanup change rather than retrofit-specced.
+- The following methods were surfaced by the 2026-05-24 Bucket 2a scan but are covered by class-level `@spec` annotations pointing to the in-flight `ai-chat-companion-orchestrator` (`health-probe-endpoint`, `sse-streaming-endpoint`) and `ai-chat-companion-streaming` (token, tool-call, heartbeat events) changes: `ChatHealthController::health`; all `ChatStreamController` helpers (`clearOutputBuffers`, `emitSseHeaders`, `emitAndExit`, `safeShutdown`, `emitSseEvent`, `now`, `forwardWithHeartbeat`, `pickFallbackAgentForUser`); all `StreamYieldChannel::on*` and `emit*` methods. Their REQs land in this spec when those changes archive.
+- Vue UI helpers (`ChatSideBar::isActive`, `ChatIndex::showAgentSelector`) are out of scope for backend spec retrofit — they are presentational logic (CSS class binding, dialog open-toggle) with no server-observable behaviour.


### PR DESCRIPTION
## Summary

Second-pass retrofit on the `chat-ai` capability. A Bucket 2a coverage scan on 2026-05-24 surfaced 19 chat-related methods as "unspecced". After triage:

- **15 are already covered** by class-level `@spec` annotations pointing to the in-flight `ai-chat-companion-orchestrator` and `ai-chat-companion-streaming` changes (health probe, SSE streaming endpoint, token / tool-call / heartbeat events). Their REQs land in `chat-ai/spec.md` when those changes archive.
- **1 already documented** in the existing spec Notes as a stub (`ChatService::testChat`).
- **1 is dead code** — `ChatController::page` is not registered in `appinfo/routes.php` and is unreachable. Flagged in Notes; should be removed in a separate cleanup change, not retrofit-specced.
- **2 are pure Vue UI helpers** (`ChatSideBar::isActive`, `ChatIndex::showAgentSelector`) — out of scope for backend retrofit.
- **1 is a real gap** — `ToolManagementHandler::convertFunctionsToFunctionInfo` converts array-shaped tool descriptors into the `LLPhant\Chat\FunctionInfo\FunctionInfo` objects LLPhant expects via `setTools()`. This is the adapter that makes tool-equipped agents work in REQ-001's LLM call.

## Changes

- Adds `chat-ai#REQ-006` covering the LLPhant `FunctionInfo` conversion with three scenarios (scalar parameter, nested object/array, tool-instance lookup).
- Adds `@spec openspec/changes/retrofit-2026-05-24-chat-ai/tasks.md#task-1` to `ToolManagementHandler::convertFunctionsToFunctionInfo`.
- Extends `chat-ai/spec.md` Notes with the FP triage so a third-pass scan does not re-surface the same 18 methods.

## Validation

- `openspec validate retrofit-2026-05-24-chat-ai --strict` → valid.
- `php -l lib/Service/Chat/ToolManagementHandler.php` → no syntax errors.

## Notes

- Real-vs-FP ratio in this Bucket 2a cluster: 1 / 19 (~5%). The high FP rate matches the guardrail expectation — the heuristic does not see class-level `@spec` annotations pointing to in-flight changes, so anything in an SSE / health controller surfaces as a gap.
- The dead-code finding on `ChatController::page` is a useful by-product. Worth opening a follow-up cleanup issue (this PR keeps it as a Notes flag rather than expanding scope).

Source: `/tmp/or-scan/rspec-cluster-chat-ai.json`. Retrofit playbook: `.github/docs/claude/retrofit.md`.