### PR TITLE
fix(tmlo): correct MDTO element name typo (waarpinaering → waardering)

### DIFF
--- a/lib/Service/TmloService.php
+++ b/lib/Service/TmloService.php
@@ -473,7 +473,7 @@ class TmloService
             $root->appendChild(
                 $dom->createElementNS(
                     self::MDTO_NAMESPACE,
-                    'mdto:waarpinaering',
+                    'mdto:waardering',
                     $this->mapArchiefnominatie(nominatie: $tmlo['archiefnominatie'])
                 )
             );


### PR DESCRIPTION
## Summary

`lib/Service/TmloService.php` (around line 476) emitted the malformed element name `<mdto:waarpinaering>` instead of the canonical MDTO element `<mdto:waardering>`. Exports therefore failed schema validation at any receiving e-depot.

## Context

MDTO — **Metadata voor Duurzaam Toegankelijke Overheidsinformatie** (Metadata for Sustainably Accessible Government Information) — is the Dutch government records-management metadata standard. The element `waardering` ("appraisal" / "valuation") is mandatory in an MDTO record and carries the archival disposition decision (mapped from TMLO's `archiefnominatie`, e.g. `blijvend_bewaren` → `bewaren`).

The correct spelling is used everywhere else in this codebase:
- `lib/Service/Edepot/MdtoXmlGenerator.php` (canonical generator)
- `openspec/specs/edepot-transfer/spec.md`
- `openspec/specs/archivering-vernietiging/spec.md`
- `docs/features/archiving.md`
- `tests/Unit/Service/TmloExportTest.php` (docblock)

Only `TmloService::generateMdtoXml` had the typo. The unit test `testGenerateMdtoXmlMapsArchiefnominatie` only asserted the mapped *value* (`bewaren`) was present, not the element *name*, so the bug went undetected.

## Fix

One-character cluster fix: `mdto:waarpinaering` → `mdto:waardering`. Verified there are no other occurrences of `waarpinaering` anywhere in the tree (`grep -r 'waarpinaering' .`).

## Notes

Surfaced by the 2026-05-24 reverse-spec retrofit of the `tmlo-metadata` bucket — see PR #1759 spec Notes.

## Test plan

- [ ] CI green (PHPUnit, PHPCS, Psalm, PHPStan)
- [ ] Manual: generate MDTO XML for an object with `tmlo.archiefnominatie` set; assert the output contains `<mdto:waardering>` (not `<mdto:waarpinaering>`)
- [ ] Optional follow-up: tighten `testGenerateMdtoXmlMapsArchiefnominatie` to assert the element name as well as the value