### PR TITLE
docs(activity-provider): fix storage-strategy mismatch — docblock says link-table, code returns query-time

### DIFF
--- a/lib/Service/Integration/Providers/ActivityProvider.php
+++ b/lib/Service/Integration/Providers/ActivityProvider.php
@@ -5,8 +5,10 @@
  * object via a `[or:{objectUuid}]` marker in the entity's `subject`
  * field.
  *
- * Storage strategy is `link-table` — the marker lives in the upstream
- * app's own table (`activity`), not in OR.
+ * Storage strategy is `query-time` — the marker lives in the upstream
+ * app's own table (`activity`), not in OR. Every `list()` call runs a
+ * live LIKE query against the upstream `activity` table; OpenRegister
+ * persists nothing about the link itself.
  *
  * @category Service
  * @package  OCA\OpenRegister\Service\Integration\Providers


### PR DESCRIPTION
## Summary

Fix a docblock/code mismatch in `lib/Service/Integration/Providers/ActivityProvider.php`.

The class-level file docblock declared the storage strategy as `link-table`, but `getStorageStrategy()` returns `'query-time'`. **The code is correct; the docblock was stale.**

## Why the code is the source of truth

Per the `IntegrationProvider` interface contract (`lib/Service/Integration/IntegrationProvider.php`):

- `link-table` — link stored in a dedicated `openregister_*_links` table.
- `query-time` — no local persistence; source system queried live on every `list()` call.

`ActivityProvider::list()` uses `MarkerLookupTrait::findByMarker()` to run a live LIKE query against the upstream `activity` table's `subject` column (looking for `[or:{objectUuid}]`). OpenRegister persists nothing about the link itself — there is no `openregister_activity_links` table — so `query-time` is the only correct strategy per the interface contract.

This matches the pattern of `SharesProvider`, which also returns `'query-time'` for the same reason (marker lives in upstream `share.note`, not in OR).

## What changed

Updated the docblock prose to match `getStorageStrategy()` and clarified the runtime behavior so the drift doesn't recur:

```diff
- * Storage strategy is `link-table` — the marker lives in the upstream
- * app's own table (`activity`), not in OR.
+ * Storage strategy is `query-time` — the marker lives in the upstream
+ * app's own table (`activity`), not in OR. Every `list()` call runs a
+ * live LIKE query against the upstream `activity` table; OpenRegister
+ * persists nothing about the link itself.
```

No code changes; doc-only.

## Provenance

Surfaced by the 2026-05-24 reverse-spec retrofit of activity-provider (PR #1755 spec Notes).

## Test plan

- [x] Docblock change only — no runtime behavior affected.
- [ ] CI green on the branch.