### PR TITLE
chore(chat): remove unreachable ChatController::page() dead code

### DIFF
--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -34,7 +34,6 @@ use OCA\OpenRegister\Db\Conversation;
 use OCA\OpenRegister\Db\Feedback;
 use OCA\OpenRegister\Db\FeedbackMapper;
 use OCP\AppFramework\Controller;
-use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -389,30 +388,6 @@ class ChatController extends Controller
             throw new Exception('You do not have access to this conversation', 403);
         }
     }//end verifyConversationAccess()
-
-    /**
-     * Returns the template of the main chat page
-     *
-     * Renders the Single Page Application template for the chat interface.
-     * All routing is handled client-side by the SPA.
-     *
-     * @NoAdminRequired
-     *
-     * @NoCSRFRequired
-     *
-     * @return TemplateResponse Template response for chat SPA
-     *
-     * @psalm-return TemplateResponse<200, array<never, never>>
-     */
-    public function page(): TemplateResponse
-    {
-        // Return SPA template response (routing handled client-side).
-        return new TemplateResponse(
-            appName: 'openregister',
-            templateName: 'index',
-            params: []
-        );
-    }//end page()
 
     /**
      * Send a chat message in a conversation and get AI response

--- a/tests/Service/ControllersIntegrationTest2.php
+++ b/tests/Service/ControllersIntegrationTest2.php
@@ -169,19 +169,6 @@ class ControllersIntegrationTest2 extends TestCase
     // ─── ChatController ──────────────────────────────────────────────────
 
     /**
-     * Test ChatController::page returns TemplateResponse
-     *
-     * @return void
-     */
-    public function testChatControllerPage(): void
-    {
-        $controller = $this->buildChatController();
-        $response   = $controller->page();
-
-        $this->assertSame(200, $response->getStatus());
-    }//end testChatControllerPage()
-
-    /**
      * Test ChatController::sendMessage with empty message
      *
      * @return void


### PR DESCRIPTION
## Summary

`ChatController::page()` returns a SPA `TemplateResponse` but **no `chat#page` route is registered in `appinfo/routes.php`** — the method is unreachable. The `/chat` URL is actually served by `ui#chat` (`UiController::chat()` at `appinfo/routes.php:655`).

Surfaced by the 2026-05-24 reverse-spec retrofit of `chat-ai` (PR #1764 spec Notes). Previously flagged in `docs/development-notes/AUDIT_2026-05-01.md` (Pattern A table) as Tier 2 dead code with "no replacement — `chat#page` template render legacy".

## Changes

- Remove `ChatController::page()` and its now-unused `OCP\AppFramework\Http\TemplateResponse` import (`lib/Controller/ChatController.php`).
- Remove `ControllersIntegrationTest2::testChatControllerPage()` which exercised the dead method (`tests/Service/ControllersIntegrationTest2.php`).

Net: **38 lines deleted, 0 added** across 2 files.

## Verification

```
grep -rn 'chat#page\|ChatController::page\|ChatController->page' lib/ tests/ src/ appinfo/
# → no hits after the change
```

`docs/development/deeplinking-spot.md` still lists `chat#page` as part of an aspirational deeplinking design snippet — that doc has multiple pre-existing inconsistencies with `appinfo/routes.php` (most routes there are `ui#<x>`, not `<x>#page`) and is out of scope for this PR.

## Test plan

- [ ] CI: PHPCS/PHPMD/Psalm/PHPStan green
- [ ] CI: PHPUnit green (no test references the removed method)
- [ ] Manual: hit `/index.php/apps/openregister/chat` in browser — still loads the SPA via `ui#chat`