### PR TITLE
fix(calendar-provider): log Throwable from list() instead of swallowing silently

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1088,6 +1088,7 @@ class Application extends App implements IBootstrap
                     calendarEventService: $container->get(\OCA\OpenRegister\Service\CalendarEventService::class),
                     appManager: $container->get('OCP\App\IAppManager'),
                     l10n: $container->get('OCP\IL10N'),
+                    logger: $container->get(\Psr\Log\LoggerInterface::class),
                 );
             }
         );

--- a/lib/Service/Integration/Providers/CalendarProvider.php
+++ b/lib/Service/Integration/Providers/CalendarProvider.php
@@ -44,6 +44,7 @@ use OCA\OpenRegister\Service\CalendarEventService;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCP\App\IAppManager;
 use OCP\IL10N;
+use Psr\Log\LoggerInterface;
 use Throwable;
 
 /**
@@ -65,6 +66,7 @@ class CalendarProvider extends AbstractIntegrationProvider
      * @param CalendarEventService $calendarEventService Backing service.
      * @param IAppManager          $appManager           NC app manager.
      * @param IL10N                $l10n                 Localisation.
+     * @param LoggerInterface      $logger               PSR-3 logger for surfacing CalDAV failures.
      *
      * @return void
      */
@@ -72,6 +74,7 @@ class CalendarProvider extends AbstractIntegrationProvider
         private CalendarEventService $calendarEventService,
         private IAppManager $appManager,
         private IL10N $l10n,
+        private LoggerInterface $logger,
     ) {
     }//end __construct()
 
@@ -146,7 +149,23 @@ class CalendarProvider extends AbstractIntegrationProvider
             return $this->calendarEventService->getEventsForObject(objectUuid: $objectId);
         } catch (Throwable $e) {
             // CalDAV failures (no user, no VEVENT calendar) degrade to
-            // an empty list rather than breaking the tab — AD-23.
+            // an empty list rather than breaking the tab — AD-23 covers
+            // the user-facing contract (empty list, no thrown exception
+            // for link-table providers) but does NOT mandate silent
+            // failure: surface the cause so an empty Meetings tab can
+            // be diagnosed from nextcloud.log instead of guessing.
+            $this->logger->warning(
+                'CalendarProvider::list() failed; degrading to empty list',
+                [
+                    'app'       => 'openregister',
+                    'provider'  => self::class,
+                    'method'    => 'list',
+                    'objectId'  => $objectId,
+                    'register'  => $register,
+                    'schema'    => $schema,
+                    'exception' => $e,
+                ]
+            );
             return [];
         }
     }//end list()

--- a/tests/Unit/Service/Integration/Providers/LeafProvidersMetadataTest.php
+++ b/tests/Unit/Service/Integration/Providers/LeafProvidersMetadataTest.php
@@ -67,6 +67,7 @@ use OCP\IL10N;
 use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Contract + delegation tests for all 16 leaf integration providers.
@@ -104,6 +105,17 @@ class LeafProvidersMetadataTest extends TestCase
         );
         return $mock;
     }//end buildAppManager()
+
+    /**
+     * Build a PSR-3 logger mock — providers log failure paths through
+     * this; in unit tests we only care that the type contract is met.
+     *
+     * @return LoggerInterface
+     */
+    private function buildLogger(): LoggerInterface
+    {
+        return $this->createMock(LoggerInterface::class);
+    }//end buildLogger()
 
     /**
      * Build a greenfield provider instance. The provider's constructor
@@ -195,6 +207,7 @@ class LeafProvidersMetadataTest extends TestCase
             calendarEventService: $this->createMock(CalendarEventService::class),
             appManager: $this->buildAppManager(['calendar']),
             l10n: $this->buildL10n(),
+            logger: $this->buildLogger(),
         );
 
         $this->assertSame('calendar', $provider->getId());
@@ -218,6 +231,7 @@ class LeafProvidersMetadataTest extends TestCase
             calendarEventService: $service,
             appManager: $this->buildAppManager(['calendar']),
             l10n: $this->buildL10n(),
+            logger: $this->buildLogger(),
         );
 
         $this->assertSame([['id' => 'cal1/event.ics']], $provider->list('reg', 'sch', 'obj-uuid'));
@@ -228,10 +242,25 @@ class LeafProvidersMetadataTest extends TestCase
         $service = $this->createMock(CalendarEventService::class);
         $service->method('getEventsForObject')->willThrowException(new \RuntimeException('no calendar'));
 
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with(
+                $this->stringContains('CalendarProvider::list()'),
+                $this->callback(static function (array $ctx): bool {
+                    return ($ctx['provider'] ?? null) === CalendarProvider::class
+                        && ($ctx['method'] ?? null) === 'list'
+                        && ($ctx['objectId'] ?? null) === 'obj-uuid'
+                        && isset($ctx['exception'])
+                        && $ctx['exception'] instanceof \Throwable;
+                })
+            );
+
         $provider = new CalendarProvider(
             calendarEventService: $service,
             appManager: $this->buildAppManager(['calendar']),
             l10n: $this->buildL10n(),
+            logger: $logger,
         );
 
         $this->assertSame([], $provider->list('reg', 'sch', 'obj-uuid'));
@@ -243,6 +272,7 @@ class LeafProvidersMetadataTest extends TestCase
             calendarEventService: $this->createMock(CalendarEventService::class),
             appManager: $this->buildAppManager(['calendar']),
             l10n: $this->buildL10n(),
+            logger: $this->buildLogger(),
         );
         $this->expectException(\InvalidArgumentException::class);
         $provider->delete('r', 's', 'o', 'not-a-composite');
@@ -254,6 +284,7 @@ class LeafProvidersMetadataTest extends TestCase
             calendarEventService: $this->createMock(CalendarEventService::class),
             appManager: $this->buildAppManager([]),
             l10n: $this->buildL10n(),
+            logger: $this->buildLogger(),
         );
 
         $health = $provider->health();


### PR DESCRIPTION
## Summary

`lib/Service/Integration/Providers/CalendarProvider.php::list()` catches `\Throwable` and returns an empty array with only an `AD-23` comment. Result: an empty **Meetings** tab whenever the underlying CalDAV lookup fails (no user, no VEVENT calendar, schema mismatch, runtime error, etc.) with **zero breadcrumb** in `nextcloud.log` — impossible to diagnose without attaching a debugger.

## The AD-23 question

AD-23 (`openspec/changes/pluggable-integration-registry/design.md`) — "OpenConnector failure-path contract" — sets the user-facing contract for **external / OpenConnector** providers:

> 1. Auth check is lazy ... providers throw `ProviderAuthException`
> 2. Token refresh is OpenConnector-managed
> 3. OpenConnector unavailability is distinct from upstream unavailability ... providers throw `ProviderUnavailableException`

`CalendarProvider` is `storage='link-table'` (CalDAV custom property), **not `external`**. AD-23 governs the *external* path. It says nothing about whether link-table providers should log or silently swallow on the degrade path. "Degrade to empty list" is the right *user-facing* answer; "leave no breadcrumb in `nextcloud.log`" is not — it just hides the bug.

## Fix

- Inject `Psr\Log\LoggerInterface` into `CalendarProvider`
- Inside the existing `catch (\Throwable $e)` block, log at `warning` with context: provider class, method, register, schema, objectId, and the exception (the standard NC log enrichment will surface stack-trace + file/line)
- Keep the `return []` degrade contract — same user-facing behaviour, no breaking change
- Wire the logger through `Application::register()` DI
- Tighten the existing `testCalendarProviderListSurfacesEmptyOnFailure` unit test to assert the warning is emitted with the right context shape

## Background

Surfaced by the 2026-05-24 reverse-spec retrofit of calendar-integration (PR #1761 — see spec Notes). The retrofit walked every line of `CalendarProvider` against ADR coverage and flagged this catch block as the only `AD-23` reference that wasn't actually about AD-23 (link-table vs external mix-up).

## Test plan

- [ ] `vendor/bin/phpunit --filter CalendarProvider tests/Unit/Service/Integration/Providers/LeafProvidersMetadataTest.php` — both `testCalendarProviderListDelegatesToService` and `testCalendarProviderListSurfacesEmptyOnFailure` pass
- [ ] Manual: open an object detail in an env where the user has no VEVENT calendar; Meetings tab still renders empty; `nextcloud.log` now shows a `warning` from `OCA\OpenRegister\Service\Integration\Providers\CalendarProvider`
- [ ] CI green