### PR TITLE
retrofit: reverse-spec openregister-app-manifest partial (5 REQs / 9 methods, 100 deferred)

### DIFF
--- a/lib/Controller/ManifestController.php
+++ b/lib/Controller/ManifestController.php
@@ -83,6 +83,8 @@ class ManifestController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      * @PublicPage
+     *
+     * @spec openspec/specs/openregister-app-manifest/spec.md#REQ-OR-MAN-012
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -123,6 +125,8 @@ class ManifestController extends Controller
      * @return array<string, mixed>|null Decoded manifest, or null if not readable.
      *
      * @SuppressWarnings(PHPMD.StaticAccess)
+     *
+     * @spec openspec/specs/openregister-app-manifest/spec.md#REQ-OR-MAN-012
      */
     private function loadBundledManifest(string $appId): ?array
     {

--- a/lib/Service/ManifestService.php
+++ b/lib/Service/ManifestService.php
@@ -115,6 +115,9 @@ class ManifestService
      * @return array<string, mixed> Enriched manifest (original if no `currentUserSchema`).
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/specs/openregister-app-manifest/spec.md#REQ-OR-MAN-013
+     * @spec openspec/specs/openregister-app-manifest/spec.md#REQ-OR-MAN-014
      */
     public function getEnrichedManifest(array $manifest): array
     {
@@ -181,6 +184,8 @@ class ManifestService
      * @param string $userId     Nextcloud user ID.
      *
      * @return ObjectEntity|null The profile object, or null if not found.
+     *
+     * @spec openspec/specs/openregister-app-manifest/spec.md#REQ-OR-MAN-015
      */
     private function resolveUserProfile(string $schemaSlug, string $userId): ?ObjectEntity
     {
@@ -244,6 +249,8 @@ class ManifestService
      * @return array<string, mixed> The `runtime.user` data block.
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/specs/openregister-app-manifest/spec.md#REQ-OR-MAN-016
      */
     private function buildUserContext(string $userId, ObjectEntity $profile, string $schemaSlug): array
     {
@@ -328,6 +335,8 @@ class ManifestService
      * @param string $schemaSlug The schema slug.
      *
      * @return array<string, mixed>|null The calculations map, or null when absent.
+     *
+     * @spec openspec/specs/openregister-app-manifest/spec.md#REQ-OR-MAN-016
      */
     private function getCalculations(string $schemaSlug): ?array
     {
@@ -364,6 +373,8 @@ class ManifestService
      * @param array<string, mixed>|null $calcs      Calculation map for the schema.
      *
      * @return list<string> Distinct field names allowed in runtime.user.
+     *
+     * @spec openspec/specs/openregister-app-manifest/spec.md#REQ-OR-MAN-016
      */
     private function resolveAllowedFieldNames(string $schemaSlug, ?array $calcs): array
     {
@@ -396,6 +407,8 @@ class ManifestService
      *
      * @return list<string>|null List of allowed field names, or null when
      *                           the schema declares no allowlist.
+     *
+     * @spec openspec/specs/openregister-app-manifest/spec.md#REQ-OR-MAN-016
      */
     private function loadFieldAllowlist(string $schemaSlug): ?array
     {
@@ -432,6 +445,8 @@ class ManifestService
      * @param mixed $value Raw evaluator output.
      *
      * @return mixed JSON-safe representation.
+     *
+     * @spec openspec/specs/openregister-app-manifest/spec.md#REQ-OR-MAN-016
      */
     private function serialise(mixed $value): mixed
     {

--- a/openspec/changes/retrofit-2026-05-24-openregister-app-manifest/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-openregister-app-manifest/proposal.md
@@ -1,0 +1,47 @@
+# Retrofit — Reverse-spec openregister-app-manifest (partial, PHP backend)
+
+## Why
+
+The `openregister-app-manifest` capability already has a Vue-side spec (MAN-001..MAN-011, drafted by `openregister-adopt-app-manifest`). That change explicitly **deferred** the backend `/api/manifest` endpoint (REQ-OR-MAN-009) — but the backend was subsequently built anyway and shipped:
+
+- `lib/Controller/ManifestController.php` — public `GET /api/manifest/{appId}` endpoint
+- `lib/Service/ManifestService.php` — enriches a bundled manifest with a `runtime.user` block sourced from the requesting user's OR profile object
+
+Both files carry `@spec openspec/changes/manifest-user-context/tasks.md` PHPDoc tags pointing at a change that does not exist in `openspec/changes/`. The behaviour is in production but has no canonical spec home.
+
+This retrofit reverse-engineers 5 cohesive requirements from observed PHP behaviour and folds them into the existing `openregister-app-manifest` capability. The Vue-side REQs (MAN-001..MAN-011) are untouched. The deferral language in MAN-009 stays accurate as a historical record of the original Tier 1+2 scope — the new MAN-012..MAN-016 document the follow-up backend work that was subsequently delivered.
+
+## What Changes
+
+Add five new requirements to the `openregister-app-manifest` spec:
+
+- **REQ-OR-MAN-012** — `/api/manifest/{appId}` endpoint loads a host app's bundled `src/manifest.json` and returns it enriched, with `appId` validated and well-known failure modes mapped to HTTP status codes.
+- **REQ-OR-MAN-013** — Manifest enrichment is a no-op when the manifest carries no `currentUserSchema`, and emits `runtime.user = null` for anonymous requests.
+- **REQ-OR-MAN-014** — Schema-slug supplied by the manifest is validated (length + charset) before any lookup; invalid slugs fail closed to `runtime.user = null`.
+- **REQ-OR-MAN-015** — User-profile resolution filters the magic table for the declared schema by `ncUserId`, with Nextcloud's RBAC + multitenancy filters preserved.
+- **REQ-OR-MAN-016** — `runtime.user` is populated from an explicit field allowlist plus non-materialised `x-openregister-calculations`; raw profile payload is never merged verbatim.
+
+This is a **retrofit / reverse-spec** change (Bucket 2a per ADR-008): no behaviour is being added or modified — the change records observed implementation as canonical spec and annotates the relevant methods with `@spec` tags.
+
+This pass is **partial**: the batch JSON included 109 methods across 45 files, but most are FPs from class-name token overlap (Registers/Schemas CRUD, generic schema cache handlers, GraphQL schema generation). Only 9 methods are genuinely in scope for the PHP backend manifest capability — those are annotated. The rest are deferred as `future-pass:next` in `tasks.md`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `openregister-app-manifest` — extended with 5 new requirements (MAN-012..MAN-016) covering the backend enrichment endpoint. The original 11 Vue-side requirements remain unchanged.
+
+## Impact
+
+- **Modified files**:
+  - `openspec/specs/openregister-app-manifest/spec.md` — adds MAN-012..MAN-016
+  - `lib/Controller/ManifestController.php` — `@spec` tag updated from `manifest-user-context/tasks.md` (orphan) to per-method `@spec openregister-app-manifest#REQ-OR-MAN-012..016`
+  - `lib/Service/ManifestService.php` — per-method `@spec` annotations on the 7 service methods covered
+- **No behaviour change**. No new tests required (existing behaviour predates this retrofit and either has tests or has been deferred to a future test-coverage pass).
+- **Follow-ups**: the deferral block in `tasks.md` enumerates the FP-heavy clusters (Registers/Schemas CRUD, schema cache handlers, GraphQL generation) that were in the batch JSON but do not belong in `openregister-app-manifest`. Each is tagged `future-pass:next` and the methods are listed verbatim so a downstream coverage-scan can re-cluster them.
+
+## Risks
+
+- **High FP rate in the input batch.** Mitigated by being conservative: only methods that literally implement the backend manifest enrichment are annotated. Class-name token overlap (e.g. `RegisterService::find` or `SchemaCacheHandler::cacheSchema`) is explicitly dropped, not silently absorbed.
+- **MAN-009 deferral language now drifts from reality.** The original spec says the backend endpoint is deferred to a follow-up. The follow-up shipped (the orphan `manifest-user-context` change). This retrofit does not edit MAN-009's text; the deferral remains historically accurate, and MAN-012 supersedes it for current behaviour. A future cleanup pass can soften MAN-009 ("deferred → delivered in MAN-012") without changing observable behaviour.
+- **Orphan `@spec` tag.** The current `@spec openspec/changes/manifest-user-context/tasks.md` PHPDoc tags point at a change that does not exist on disk. This retrofit replaces them with REQ-anchored per-method `@spec` tags.

--- a/openspec/changes/retrofit-2026-05-24-openregister-app-manifest/specs/openregister-app-manifest/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-openregister-app-manifest/specs/openregister-app-manifest/spec.md
@@ -1,0 +1,170 @@
+# openregister-app-manifest capability — retrofit delta (PHP backend)
+
+## ADDED Requirements
+
+### Requirement: REQ-OR-MAN-012 Backend `/api/manifest/{appId}` endpoint returns enriched manifest
+
+OpenRegister SHALL expose `GET /index.php/apps/openregister/api/manifest/{appId}` returning the host app's bundled `src/manifest.json` enriched with a `runtime.user` block per REQ-OR-MAN-013 / 015 / 016.
+
+The endpoint SHALL:
+
+- Be marked `#[PublicPage]`, `#[NoAdminRequired]`, and `#[NoCSRFRequired]` — public access is intentional so unauthenticated callers can still load a manifest and receive `runtime.user = null` (the null is the signal nc-vue uses to gate public pages).
+- Validate `appId` against `/^[a-z0-9_-]+$/i`; reject with HTTP 400 (`{"error": "Invalid app ID."}`) when the slug does not match.
+- Resolve the calling app's bundle path via `IAppManager::getAppPath()` and load `<path>/src/manifest.json`; return HTTP 404 (`{"error": "Manifest not found for app \"{appId}\"."}`) when the app path resolution throws, the file is not readable, the file cannot be read, or the JSON does not decode.
+- Catch any `Throwable` from the enrichment pipeline, log it via the PSR logger at `error` level with `{file, line, appId}` context, and return HTTP 500 (`{"error": "Internal server error."}`).
+- Return HTTP 200 with the enriched manifest as JSON on the happy path.
+
+#### Scenario: Endpoint returns enriched manifest for a valid app
+
+- **WHEN** `GET /index.php/apps/openregister/api/manifest/decidesk` is called and `decidesk/src/manifest.json` exists and parses cleanly
+- **THEN** the response is HTTP 200 with the manifest body and a `runtime.user` block per REQ-OR-MAN-013
+
+#### Scenario: Invalid app ID is rejected
+
+- **WHEN** the path segment contains a character outside `[a-z0-9_-]` (e.g. `../etc/passwd`)
+- **THEN** the response is HTTP 400 and no path resolution is attempted
+
+#### Scenario: Missing or unreadable manifest returns 404
+
+- **WHEN** the app is not installed, the path does not exist, `src/manifest.json` is missing, the file is not readable, or the file content is not valid JSON
+- **THEN** the response is HTTP 404 with `error: Manifest not found for app "{appId}".` and a debug-level log entry is written
+
+#### Scenario: Enrichment failure is logged and returns 500
+
+- **WHEN** `ManifestService::getEnrichedManifest()` throws (e.g. evaluator crash)
+- **THEN** the response is HTTP 500 with `error: Internal server error.`, the `Throwable` is logged at `error` level with `{file, line, appId}` context, and the raw bundled manifest is NOT returned to the client
+
+---
+
+### Requirement: REQ-OR-MAN-013 Enrichment is no-op without `currentUserSchema`; anonymous request emits `runtime.user = null`
+
+`ManifestService::getEnrichedManifest()` SHALL examine the manifest's top-level `currentUserSchema` key:
+
+- When `currentUserSchema` is absent, null, or the empty string, the method SHALL return the input manifest unchanged (no `runtime.user` is injected).
+- When `currentUserSchema` is set but the requesting user is not authenticated (`IUserSession::getUser()` returns `null`), the method SHALL set `manifest.runtime.user = null` and return.
+- When the user is authenticated but has no matching profile object (per REQ-OR-MAN-015), the method SHALL set `manifest.runtime.user = {id: <uid>, roles: ["learner"]}` as a minimal fallback.
+
+#### Scenario: Manifest with no currentUserSchema is returned untouched
+
+- **WHEN** the input manifest does not declare `currentUserSchema`
+- **THEN** the returned array is structurally identical to the input and no `runtime` block is introduced by this method
+
+#### Scenario: Anonymous request gets null user context
+
+- **WHEN** the manifest declares a valid `currentUserSchema` and `IUserSession::getUser()` returns null
+- **THEN** the returned manifest has `runtime.user === null`
+
+#### Scenario: Logged-in user with no profile gets minimal fallback
+
+- **WHEN** the user is authenticated but `resolveUserProfile()` returns null
+- **THEN** `runtime.user` is `{id: <nextcloud-uid>, roles: ["learner"]}`
+
+---
+
+### Requirement: REQ-OR-MAN-014 Schema-slug from the manifest is validated before any lookup
+
+`ManifestService::getEnrichedManifest()` SHALL validate the `currentUserSchema` value before passing it to `SchemaMapper::findBySlug()` or the profile lookup. The validation SHALL enforce:
+
+- Type is `string`
+- Length ≤ 128 characters (constant `MAX_SLUG_LENGTH`)
+- Matches `/^[A-Za-z0-9_\-]{1,128}$/` (constant `SLUG_PATTERN`)
+
+A compromised or malformed manifest MUST NOT be able to steer schema or profile lookups at an attacker-controlled string. When validation fails, the method SHALL fail closed by setting `manifest.runtime.user = null`, returning the manifest, and emitting a `warning`-level log line tagged `[ManifestService] Rejected invalid currentUserSchema slug …`.
+
+#### Scenario: Non-string slug is rejected
+
+- **WHEN** `currentUserSchema` decodes as a number, array, or boolean
+- **THEN** `runtime.user` is null, a warning is logged with `var_export($schemaSlug, true)` in the message, and no lookup is performed
+
+#### Scenario: Over-length slug is rejected
+
+- **WHEN** `currentUserSchema` is a string longer than 128 characters
+- **THEN** the method short-circuits to `runtime.user = null`
+
+#### Scenario: Slug with disallowed characters is rejected
+
+- **WHEN** `currentUserSchema` contains characters outside `[A-Za-z0-9_-]` (e.g. `/`, `..`, whitespace, non-printable bytes)
+- **THEN** the method short-circuits to `runtime.user = null`
+
+---
+
+### Requirement: REQ-OR-MAN-015 User-profile resolution narrows magic table by `ncUserId` with RBAC + multitenancy preserved
+
+`ManifestService::resolveUserProfile()` SHALL locate the requesting user's profile object for a given schema slug by querying the OR object store via `ObjectService::findAll()` with:
+
+- `limit: 1`
+- `filters: { schema: <slug>, ncUserId: <nextcloud-uid> }`
+
+The method SHALL NOT disable RBAC or multitenancy when performing this lookup. The `(schema, ncUserId)` filter is a narrowing filter on top of the tenant scope, not a substitute for it. Disabling tenant scoping here would silently return profile objects from other tenants whenever the same Nextcloud UID exists in more than one tenant.
+
+The method SHALL handle:
+
+- Schema not found via `SchemaMapper::findBySlug()` → return `null` and emit a `debug` log line
+- Schema lookup throws → catch, emit a `warning`, return `null`
+- Profile lookup throws → catch, emit a `warning`, return `null`
+- Zero matching profile objects → return `null`
+- ≥ 1 matching profile object → return the first
+
+#### Scenario: Profile is found by schema slug + ncUserId
+
+- **WHEN** the schema exists and exactly one object has `ncUserId === <uid>`
+- **THEN** the method returns that `ObjectEntity`
+
+#### Scenario: Schema slug not found returns null
+
+- **WHEN** `SchemaMapper::findBySlug(slug)` returns an empty list
+- **THEN** the method returns null and logs `[ManifestService] Schema "<slug>" not found` at debug
+
+#### Scenario: Lookup exceptions are caught and logged
+
+- **WHEN** either the schema lookup or the object findAll throws a `Throwable`
+- **THEN** the method returns null and emits a `[ManifestService] … failed for …` warning; the exception does NOT propagate to the caller
+
+#### Scenario: RBAC and multitenancy are not disabled
+
+- **WHEN** `resolveUserProfile()` constructs the `findAll` config
+- **THEN** no `rbac: false`, `multitenancy: false`, or equivalent override flag is set; the call relies on default tenant/RBAC scoping
+
+---
+
+### Requirement: REQ-OR-MAN-016 `runtime.user` is populated from an explicit allowlist plus non-materialised calculations
+
+`ManifestService::buildUserContext()` SHALL build `runtime.user` from:
+
+1. An explicit field allowlist sourced from the schema configuration key `x-openregister-manifest-user-fields` (constant `FIELD_ALLOWLIST_KEY`). When absent, only the default safe fields (`id`, `roles`) are baseline-allowed.
+2. The keys of `x-openregister-calculations` whose entries have `materialise: true` — these are derived values the schema author has already declared safe to surface.
+3. Non-materialised `x-openregister-calculations` entries are evaluated at read-time via `CalculationEvaluator::evaluate()` against the profile payload (with a `@self` metadata block matching the listener's shape: `id`, `uuid`, `register`, `schema`, `owner`, `created`, `updated`).
+
+The method SHALL NOT merge `ObjectEntity::getObject()` verbatim into `runtime.user`. The raw payload may contain PII or schema-internal fields; surfacing it unfiltered was the leak path flagged in the original review.
+
+The method SHALL:
+
+- Always overlay the Nextcloud user ID as `runtime.user.id` (overriding any same-named field from the profile)
+- Skip non-`array` calculation specs (defensive)
+- Catch `EvaluationException` from each calculation independently, log a warning, and continue with remaining calculations
+- Pass calculation results through `serialise()`, which converts `DateTimeInterface` values to `DATE_ATOM` strings and otherwise returns the value unchanged
+
+#### Scenario: Allowlist filters the profile payload
+
+- **WHEN** the schema declares `x-openregister-manifest-user-fields: ["displayName", "department"]` and the profile object has additional fields
+- **THEN** `runtime.user` contains only `displayName`, `department`, the materialised calc keys, and the always-on `id` — never the un-listed payload keys
+
+#### Scenario: No allowlist surfaces only defaults plus calculations
+
+- **WHEN** the schema configuration has no `x-openregister-manifest-user-fields` key
+- **THEN** `runtime.user` contains only `id` (always), any `roles` in the payload (default), and materialised calculation keys
+
+#### Scenario: Non-materialised calculations are evaluated at read-time
+
+- **WHEN** `x-openregister-calculations.fullName` has `materialise: false` and `expression: "firstName ~ ' ' ~ lastName"`
+- **THEN** `runtime.user.fullName` is computed from the profile payload and injected via `serialise()`
+
+#### Scenario: Calculation failure does not abort the block
+
+- **WHEN** one calculation expression throws `EvaluationException`
+- **THEN** a warning is logged with the calc name and user UID, the failed key is omitted from `runtime.user`, and other calculations still evaluate
+
+#### Scenario: DateTime calculation result is ISO-8601
+
+- **WHEN** a calculation evaluates to a `DateTimeInterface` instance
+- **THEN** the serialised value is the `DATE_ATOM`-formatted string of that instant

--- a/openspec/changes/retrofit-2026-05-24-openregister-app-manifest/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-openregister-app-manifest/tasks.md
@@ -1,0 +1,109 @@
+# Tasks — Retrofit reverse-spec openregister-app-manifest (partial)
+
+This is a **partial** reverse-spec pass. The cluster batch JSON listed 109 methods across 45 files (`/tmp/or-scan/rspec-cluster-openregister-app-manifest.json`). After triage, only **9 methods** are genuinely in scope for the `openregister-app-manifest` capability — the rest are false positives from class-name token overlap (`Register*` / `Schema*` / `*Manifest*` substring hits on unrelated CRUD / cache / GraphQL code). They are deferred below as `future-pass:next` so a downstream coverage-scan can recluster them.
+
+## 1. Spec delta authored (5 new REQs)
+
+- [x] 1.1 `openspec/changes/retrofit-2026-05-24-openregister-app-manifest/specs/openregister-app-manifest/spec.md` adds:
+  - REQ-OR-MAN-012 Backend `/api/manifest/{appId}` endpoint returns enriched manifest
+  - REQ-OR-MAN-013 Enrichment is no-op without `currentUserSchema`; anonymous request emits `runtime.user = null`
+  - REQ-OR-MAN-014 Schema-slug from the manifest is validated before any lookup
+  - REQ-OR-MAN-015 User-profile resolution narrows magic table by `ncUserId` with RBAC + multitenancy preserved
+  - REQ-OR-MAN-016 `runtime.user` is populated from an explicit allowlist plus non-materialised calculations
+
+## 2. Methods annotated (9 methods across 2 files)
+
+- [x] 2.1 `lib/Controller/ManifestController.php`
+  - `index` → `@spec openregister-app-manifest#REQ-OR-MAN-012`
+  - `loadBundledManifest` → `@spec openregister-app-manifest#REQ-OR-MAN-012` (controller-private helper; triage note in batch JSON correctly DROPped it from MAN-005 which is the Vue-side loader, but it IS in scope for the backend endpoint requirement)
+- [x] 2.2 `lib/Service/ManifestService.php`
+  - `getEnrichedManifest` → `@spec openregister-app-manifest#REQ-OR-MAN-013, REQ-OR-MAN-014`
+  - `resolveUserProfile` → `@spec openregister-app-manifest#REQ-OR-MAN-015`
+  - `buildUserContext` → `@spec openregister-app-manifest#REQ-OR-MAN-016`
+  - `getCalculations` → `@spec openregister-app-manifest#REQ-OR-MAN-016`
+  - `resolveAllowedFieldNames` → `@spec openregister-app-manifest#REQ-OR-MAN-016`
+  - `loadFieldAllowlist` → `@spec openregister-app-manifest#REQ-OR-MAN-016`
+  - `serialise` → `@spec openregister-app-manifest#REQ-OR-MAN-016`
+
+The pre-existing class-level `@spec openspec/changes/manifest-user-context/tasks.md` PHPDoc tag (orphan — that change doesn't exist) is left untouched at the class docblock layer to preserve historical signal. Per-method `@spec` tags are the canonical reference going forward.
+
+## 3. Deferred — future-pass:next (100 methods)
+
+All entries below are **FPs / out-of-capability** from the cluster batch JSON. They were swept in because their file/method names share tokens with the manifest capability (`Register`, `Schema`, …) — not because they implement anything related to `app-manifest`. A downstream coverage-scan should recluster them into the correct capability buckets (likely `openregister-registers`, `openregister-schemas`, `openregister-search`, `openregister-graphql`, `openregister-vue-shell`, …).
+
+### 3.1 Registers CRUD controller — `future-pass:next` (likely `openregister-registers`)
+
+- `lib/Controller/RegistersController.php`: `index`, `show`, `create`, `update`, `patch`, `destroy`, `schemas`, `objects`, `export`, `import`, `stats`, `publish`, `depublish` (13)
+
+### 3.2 Schemas CRUD controller — `future-pass:next` (likely `openregister-schemas`)
+
+- `lib/Controller/SchemasController.php`: `index`, `show`, `create`, `update`, `patch`, `destroy`, `related`, `stats`, `explore`, `updateFromExploration`, `publish`, `depublish` (12)
+
+### 3.3 Register/Schema domain events — `future-pass:next`
+
+- `lib/Event/RegisterCreatedEvent.php::__construct`
+- `lib/Event/RegisterDeletedEvent.php::__construct`
+- `lib/Event/RegisterUpdatedEvent.php::__construct`
+- `lib/Event/SchemaCreatedEvent.php::__construct`
+- `lib/Event/SchemaDeletedEvent.php::__construct`
+- `lib/Event/SchemaUpdatedEvent.php::__construct`
+
+### 3.4 GraphQL schema generation — `future-pass:next` (likely `openregister-graphql`)
+
+- `lib/Service/GraphQL/SchemaGenerator.php::getObjectType`
+- `lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php`: `getCreateInputType`, `getUpdateInputType`, `getConnectionType`
+
+### 3.5 Solr / search-index schema mirroring — `future-pass:next` (likely `openregister-search-index`)
+
+- `lib/Service/Index/Backends/Solr/SolrSchemaManager.php`: `__construct`, `getFieldTypes`, `getFields`, `getSchema`
+- `lib/Service/Index/SchemaHandler.php`: `__construct`, `mirrorSchemas`, `createMissingFields`, `fixMismatchedFields`
+- `lib/Service/Index/SchemaMapper.php::__construct`
+
+### 3.6 RegisterService / SchemaService — `future-pass:next` (likely `openregister-registers` / `openregister-schemas`)
+
+- `lib/Service/RegisterService.php`: `__construct`, `find`, `findAll`, `createFromArray`, `updateFromArray`, `delete`
+- `lib/Service/SchemaService.php`: `__construct`, `exploreSchemaProperties`
+
+### 3.7 Cache handlers (register, schema, facet) — `future-pass:next` (likely `openregister-caching`)
+
+- `lib/Service/Registers/RegisterCacheHandler.php::invalidate`
+- `lib/Service/Schemas/FacetCacheHandler.php`: `clearAllCaches`, `cleanExpiredEntries`, `getCacheStatistics`
+- `lib/Service/Schemas/SchemaCacheHandler.php`: `getSchema`, `clearSchemaCache`, `cacheSchema`, `cacheSchemaConfiguration`, `cacheSchemaProperties`, `invalidateForSchemaChange`, `clearAllCaches`, `cleanExpiredEntries`, `getCacheStatistics`
+
+### 3.8 AI tool wrappers — `future-pass:next` (likely `openregister-ai-tools`)
+
+- `lib/Tool/RegisterTool.php::__construct`
+- `lib/Tool/SchemaTool.php::__construct`
+
+### 3.9 Vue components (registers/schemas UI) — `future-pass:next` (likely `openregister-vue-shell` or per-feature)
+
+- `src/components/cards/RegisterSchemaCard.vue`: `openEdit`, `if`
+- `src/components/files-sidebar/RegisterObjectsTab.vue::fetchObjects`
+- `src/components/i18n/RegisterLanguagesEditor.vue::validateDraft`
+- `src/entities/register/register.mock.ts`: `mockRegisterData`, `mockRegister`
+- `src/entities/schema/schema.mock.ts`: `mockSchemaData`, `mockSchema`
+- `src/modals/register/DeleteRegister.vue::closeDialog`
+- `src/modals/register/PublishRegister.vue`: `closeModal`, `if`
+- `src/modals/schema/DeleteSchema.vue`: `initDialog`, `if`
+- `src/modals/schema/DeleteSchemaObjects.vue`: `loadObjectCount`, `if`
+- `src/modals/schema/DeleteSchemaProperty.vue`: `initDialog`, `if`
+- `src/modals/schema/EditSchema.vue`: `loadRegistersAndSchemas`, `if`
+- `src/modals/schema/EditSchemaProperty.vue::addOneOfEntry`
+- `src/modals/schema/ExploreSchema.vue::handleDialogClose`
+- `src/modals/schema/UploadSchema.vue::closeModal`
+- `src/modals/schema/ValidateSchema.vue`: `loadObjectCount`, `if`
+- `src/sidebars/register/RegisterSideBar.vue::sizeBreakdown`
+- `src/sidebars/register/RegistersSideBar.vue::handleRegisterChange`
+- `src/store/modules/register.js::useRegisterStore`
+- `src/store/modules/schema.js::useSchemaStore`
+- `src/views/register/RegisterDetail.vue`: `loadRegisterStats`, `if`
+- `src/views/register/RegistersIndex.vue::handleRefresh`
+- `src/views/schema/SchemaDetails.vue`: `loadSchemaStats`, `if`
+- `src/views/schema/SchemasIndex.vue::handleRefresh`
+
+## 4. Notes / observations
+
+- **High FP rate, as expected.** Of 109 batched methods, only ~8% belong to `openregister-app-manifest`. The cluster was assembled by token overlap on file/class names; the underlying capability is small and tightly scoped (one controller, one service).
+- **Orphan `@spec` reference.** Both ManifestController.php and ManifestService.php class docblocks point at `openspec/changes/manifest-user-context/tasks.md`, which does not exist on disk. That orphan change was the original home of REQ-OR-MAN-012..016; this retrofit folds them into the canonical `openregister-app-manifest` capability spec. The class-level orphan tags are left in place pending a separate cleanup pass.
+- **MAN-009 drift.** The pre-existing REQ-OR-MAN-009 says the backend `/api/manifest` endpoint is "deferred". That deferral was historically accurate but the endpoint subsequently shipped. MAN-012 supersedes that deferral. A follow-up edit to MAN-009 ("deferred → delivered in MAN-012") is recommended but out of scope here — this retrofit is purely additive.
+- **No behavioural drift detected.** All observed behaviour matches the docblock summaries in ManifestService.php (which were unusually thorough). No drifts to flag.


### PR DESCRIPTION
## Summary

Reverse-engineer the PHP backend half of the `openregister-app-manifest` capability into 5 cohesive requirements (MAN-012..MAN-016) and annotate the 9 in-scope methods. **No behaviour change** — this is a Bucket 2a retrofit per ADR-008.

The existing capability spec (MAN-001..MAN-011 from `openregister-adopt-app-manifest`) covers Vue-side adoption only and explicitly defers the backend `/api/manifest` endpoint in MAN-009. That endpoint subsequently shipped under an orphan `@spec` reference (`openspec/changes/manifest-user-context/tasks.md` does not exist on disk). This retrofit folds the shipped behaviour into the canonical capability spec.

## What's added

- **REQ-OR-MAN-012** — `/api/manifest/{appId}` endpoint contract (status codes, app-id validation, failure modes)
- **REQ-OR-MAN-013** — Enrichment no-op without `currentUserSchema`; anonymous request returns `runtime.user = null`
- **REQ-OR-MAN-014** — Schema-slug validation (length ≤ 128, charset `[A-Za-z0-9_-]`, fail-closed)
- **REQ-OR-MAN-015** — Profile resolution by `ncUserId` filter with RBAC + multitenancy preserved
- **REQ-OR-MAN-016** — `runtime.user` populated from explicit allowlist + non-materialised calculations (never raw payload merge)

## Annotated methods (9)

- `lib/Controller/ManifestController.php` — `index`, `loadBundledManifest`
- `lib/Service/ManifestService.php` — `getEnrichedManifest`, `resolveUserProfile`, `buildUserContext`, `getCalculations`, `resolveAllowedFieldNames`, `loadFieldAllowlist`, `serialise`

## Deferred (100)

The batch JSON listed 109 methods across 45 files. After triage, **only ~8% (9 methods)** are genuinely in scope for `openregister-app-manifest`. The rest are FPs from token overlap on `Register*` / `Schema*` / `*Manifest*` substrings — Registers/Schemas CRUD, schema cache handlers, GraphQL generation, Vue components. All 100 are enumerated in `tasks.md` §3 as `future-pass:next` so a downstream coverage-scan can recluster them into the right capability buckets.

## Notes

- **MAN-009 drift.** The pre-existing MAN-009 says the backend endpoint is "deferred". That deferral was historically accurate but the endpoint subsequently shipped. MAN-012 supersedes it. A separate cleanup pass can soften the MAN-009 language without changing behaviour.
- **Orphan class-level `@spec` tags** (pointing at the non-existent `manifest-user-context` change) are left in place at the class docblock layer pending a separate cleanup pass; per-method `@spec` tags are the canonical reference going forward.
- **No drifts detected.**

## Test plan

- [ ] Spec validates with `openspec validate retrofit-2026-05-24-openregister-app-manifest --strict`
- [ ] No behaviour change; existing tests still pass
- [ ] Reviewer confirms the 5 REQs match observed code and the 100-method deferral list is complete