### PR TITLE
retrofit: reverse-spec actions partial (5 REQs / 7 methods, 78 deferred)

### DIFF
--- a/lib/Controller/ActionsController.php
+++ b/lib/Controller/ActionsController.php
@@ -119,6 +119,8 @@ class ActionsController extends Controller
      * silently re-adds `@NoAdminRequired` does not open the surface.
      *
      * @return JSONResponse|null 403 response when not admin, null when allowed.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-actions/tasks.md#task-1
      */
     private function requireAdmin(): ?JSONResponse
     {
@@ -154,6 +156,7 @@ class ActionsController extends Controller
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      *
      * @spec openspec/changes/retrofit-2026-05-01-actions/tasks.md#task-1
+     * @spec openspec/changes/retrofit-2026-05-24-actions/tasks.md#task-5
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -445,6 +448,8 @@ class ActionsController extends Controller
      * @return JSONResponse
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-actions/tasks.md#task-2
      */
     #[NoCSRFRequired]
     public function test(int $id): JSONResponse
@@ -488,6 +493,8 @@ class ActionsController extends Controller
      * @NoAdminRequired
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-actions/tasks.md#task-4
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -539,6 +546,8 @@ class ActionsController extends Controller
      * @return JSONResponse
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-actions/tasks.md#task-3
      */
     #[NoCSRFRequired]
     public function migrateFromHooks(int $schemaId): JSONResponse

--- a/lib/Service/ActionService.php
+++ b/lib/Service/ActionService.php
@@ -209,6 +209,8 @@ class ActionService
      * @return array Test result with match info and payload
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-actions/tasks.md#task-2
      */
     public function testAction(int $id, array $samplePayload): array
     {
@@ -274,6 +276,8 @@ class ActionService
      * @return array Migration report
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-actions/tasks.md#task-3
      */
     public function migrateFromHooks(int $schemaId): array
     {

--- a/openspec/changes/retrofit-2026-05-24-actions/design.md
+++ b/openspec/changes/retrofit-2026-05-24-actions/design.md
@@ -1,0 +1,45 @@
+# Design — retrofit-2026-05-24-actions
+
+**Retrofit change. Tasks describe retroactive annotation, not new implementation work.**
+
+## Why a second retrofit pass on the same capability?
+
+The first pass (`retrofit-2026-05-01-actions`) explicitly deferred two follow-ups in its Notes section:
+- The dry-run **test endpoint** (`ActionService::testAction()` + `ActionsController::test()`)
+- The **hook-migration utility** (`ActionService::migrateFromHooks()` + `ActionsController::migrateFromHooks()`)
+
+The Phase-2 coverage scan additionally surfaced three uncovered sub-behaviors that the first pass touched only obliquely:
+- `requireAdmin()` body (defence-in-depth admin gate)
+- `logs()` endpoint (paginated log retrieval + statistics aggregation)
+- `index()` pagination/filter/search semantics (REQ-001 references the endpoint but does not pin down `_page`/`_limit`/`_offset`/`_search` behavior, the whitelisted `filterableFields` set, or the dual-query `total` count)
+
+The cluster has 96 entries; this pass picks the 10 most-cohesive method bodies inside the actual `actions` capability and DROPs the 78+ `TextExtraction/*` siblings (most of which were already DROP-triaged in the JSON).
+
+## Granularity choices
+
+- **5 REQs, 6 methods directly annotated**. `testAction` + `test`, and `migrateFromHooks` (service) + `migrateFromHooks` (controller) each pair up under one REQ — the controller is a thin pass-through.
+- One REQ per **observable behavior**, not per method. REQ-006 (admin gating) covers the gate helper; the per-method-level admin enforcement is documented in the REQ text rather than minted as separate REQs.
+- REQ-010 splits OFF from REQ-001. REQ-001 already covers "list with filters and pagination" at the surface level; REQ-010 pins down the exact field whitelist, the `_page` vs `_offset` precedence, the post-page search ordering quirk, and the dual-query total-count strategy.
+
+## Observed-but-flagged behavior (notes, not fixes)
+
+- **REQ-007/008 do not invoke the workflow engine** — confirmed by reading the bodies; the dry-run is genuinely side-effect-free.
+- **REQ-008 duplicate-check is O(N) across all active actions** per hook — fine for one-shot, suspect for hot-loop use.
+- **REQ-009 does not 404 on unknown action IDs** — returns empty results with `total=0` instead. Minor quirk; surfaced not fixed.
+- **REQ-010 search applied after pagination** — early pages may be sparser than `_limit` suggests; could mislead a client that expects exactly `_limit` rows.
+- **REQ-010 dual-query total** — two mapper calls per list request; would be replaced by a `countAll(filters:)` mapper method.
+
+## Why not extend REQ-001 vs minting REQ-010?
+
+REQ-001's title is *"The system SHALL provide a CRUD API for schema-attached workflow actions"* — covers the surface contract. REQ-010 is about the **observable side effects of the list endpoint**: which fields filter, which don't, how `_page`/`_offset` interact, and the search-after-paginate quirk. Distinct enough to mint its own REQ.
+
+## Annotation strategy
+
+`@spec` tags are appended to the **method-level docblock** (not the file-level docblock — file-level already carries the previous pass's tag for `requireAdmin` indirectly). Where a method already carries an `@spec` tag from the previous pass (e.g. `index`, `requireAdmin` via file-level), a second `@spec` tag is added alongside — multi-tag is supported by the convention.
+
+## Out of scope
+
+- Does NOT touch any TextExtraction/* file — those are sibling capabilities.
+- Does NOT modify `actions/spec.md` directly — delta only; archive step merges.
+- Does NOT renumber existing REQ-001..REQ-005.
+- Does NOT enforce, fix, or reorganise the observed quirks — they are flagged in Notes.

--- a/openspec/changes/retrofit-2026-05-24-actions/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-actions/proposal.md
@@ -1,0 +1,56 @@
+# Retrofit — actions (partial pass 2 of N)
+
+Describes observed behavior of 10 method bodies under the `actions` capability that the first retrofit pass (`retrofit-2026-05-01-actions`) explicitly deferred or did not cover. Drafts 5 new REQs (REQ-006..REQ-010). Code already exists — this change retroactively specifies it.
+
+## Context
+
+The first retrofit pass on actions covered the core CRUD + execution lifecycle (REQ-001..REQ-005). It explicitly listed two follow-ups in its Notes section that this pass now picks up:
+
+- The dry-run **test endpoint** (`ActionsController::test()` + `ActionService::testAction()`)
+- The **hook-migration utility** (`ActionsController::migrateFromHooks()` + `ActionService::migrateFromHooks()`)
+
+The Phase-2 coverage scan additionally surfaced three uncovered sub-behaviors of methods already touched by REQ-001..REQ-005:
+
+- **Admin-only gating** (`ActionsController::requireAdmin()`) — a defence-in-depth helper with a long security comment block but no spec coverage.
+- **Per-action execution log retrieval** (`ActionsController::logs()`) — a sibling of the CRUD endpoints, never specced.
+- **List endpoint pagination/filtering/search semantics** (`ActionsController::index()`) — REQ-001 references it but does not pin down `_page`/`_limit`/`_offset`/`_search` semantics, the supported `filterableFields` set, or the dual-query total-count behavior.
+
+## Affected code units
+
+- `lib/Controller/ActionsController.php::requireAdmin` → REQ-006
+- `lib/Controller/ActionsController.php::test` → REQ-007
+- `lib/Service/ActionService.php::testAction` → REQ-007
+- `lib/Controller/ActionsController.php::migrateFromHooks` → REQ-008
+- `lib/Service/ActionService.php::migrateFromHooks` → REQ-008
+- `lib/Controller/ActionsController.php::logs` → REQ-009
+- `lib/Controller/ActionsController.php::index` → REQ-010 (existing REQ-001 link retained)
+
+## Out-of-scope (deferred to `future-pass:next`)
+
+- `ActionService::updateStatistics` — observable side effects of execution counters; deferred for its own REQ in a later pass.
+- `ActionService::HOOK_EVENT_MAP` semantics — observable but cross-cutting with REQ-008's normalisation.
+- `getNestedValue` dot-notation accessor — internal helper, covered transitively by REQ-007's filter-condition scenario.
+
+## Out-of-cluster (DROP, sibling capability)
+
+The Phase-2 cluster scan name-matched 78 additional methods because they sit under `lib/Service/TextExtraction/*` and `lib/Service/TextExtractionService.php`; these are **not** workflow Actions:
+
+- `TextExtraction/EmlParser`, `EmlAttachment`, `EmlBody`, `EmlStructure` → belong to capability **text-extraction-eml**
+- `TextExtraction/EntityRecognitionHandler` (Presidio / OpenAnonymiser / hybrid PII detection) → belongs to a future **pii-entity-recognition** capability (currently uncovered)
+- `TextExtraction/FileHandler`, `ObjectHandler`, `TextExtractionService` → belong to capability **text-extraction-vectorization** (currently uncovered)
+- `BackgroundJob/FileTextExtractionJob` → belongs to capability **text-extraction-vectorization** (background-job sub-behavior)
+- `src/components/files-sidebar/ExtractionTab.vue` → frontend tab for text-extraction status; sibling
+- `src/mail-sidebar/components/ActionsTab.vue::objectName` → mail-sidebar UI tab, not workflow actions; sibling capability **mail-sidebar**
+
+The previous pass already triaged most of these as DROPs; this proposal carries that triage forward without re-litigation. The right home for each is flagged in the per-method DROP notes inside `tasks.md`.
+
+## Approach
+
+For each in-scope method:
+- Read the body, capture observed inputs, outputs, side effects, failure modes, preconditions.
+- Draft a REQ that pins down only the observed behavior.
+- Surface any observed-but-suspicious behavior in a Notes section (per first-pass convention).
+
+Bias: observed, not aspirational. Bugs stay bugs — surfaced, not silently spec-fixed.
+
+Source: `/tmp/or-scan/rspec-cluster-actions.json` (96 methods, 17 files). See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-actions/specs/actions/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-actions/specs/actions/spec.md
@@ -1,0 +1,209 @@
+---
+retrofit_extensions:
+  - REQ-006
+  - REQ-007
+  - REQ-008
+  - REQ-009
+  - REQ-010
+---
+# Actions Specification — Delta (retrofit-2026-05-24-actions)
+
+This delta appends five REQs to the `actions` capability covering behaviors that the first retrofit pass (`retrofit-2026-05-01-actions`) deferred or left uncovered. The archive step will merge these into the main spec under the same `## Requirements` section.
+
+## Requirements
+
+### REQ-006: The system SHALL restrict Actions mutation endpoints to administrator group members
+
+`ActionsController::requireAdmin()` is invoked from every Actions write surface (`create`, `update`, `patch` (via `update`), `destroy`, `test`, `migrateFromHooks`). It checks the active `IUserSession` user and returns a `JSONResponse` denial:
+
+- **No active user** → HTTP 401 with `{ "error": "Authentication required" }`
+- **User not in admin group** (per `IGroupManager::isAdmin($uid)`) → HTTP 403 with `{ "error": "Forbidden: Actions management is admin-only" }`
+- **Admin user** → returns `null`, allowing the calling controller method to continue.
+
+The list (`index`), show (`show`), and `logs` endpoints carry `#[NoAdminRequired]` and intentionally do NOT call `requireAdmin()` — read access to action definitions and their execution logs is available to any authenticated user.
+
+The admin check is enforced **in the controller body**, not via a route-level `@AuthorizedAdminSetting` or middleware. The mutation methods carry no `#[NoAdminRequired]` attribute, so Nextcloud's framework also denies non-admin access — `requireAdmin()` is intentional defence-in-depth so a future refactor that silently re-adds `#[NoAdminRequired]` does not open the surface.
+
+#### Scenario: Unauthenticated mutation attempt
+
+- **GIVEN** an unauthenticated client
+- **WHEN** they POST to `/api/actions`
+- **THEN** the framework rejects the request before reaching the controller (no `#[NoAdminRequired]`) and returns 401 / redirect to login
+
+#### Scenario: Authenticated non-admin mutation attempt
+
+- **GIVEN** an authenticated user who is not in the admin group
+- **WHEN** they POST to `/api/actions`
+- **THEN** the framework rejects with 403; if reached, `requireAdmin()` would also return HTTP 403 with `{ "error": "Forbidden: Actions management is admin-only" }`
+
+#### Scenario: Admin reads action list
+
+- **GIVEN** an authenticated non-admin user
+- **WHEN** they GET `/api/actions`
+- **THEN** the request succeeds (200) because `index` carries `#[NoAdminRequired]` and never calls `requireAdmin()`
+
+### REQ-007: The system SHALL provide a dry-run test endpoint that reports event/schema/register/filter match without executing the workflow
+
+`ActionsController::test()` (POST `/api/actions/{id}/test`) is admin-only (REQ-006). It accepts a JSON body with at minimum `eventType`, optional `schemaUuid`, `registerUuid`, and arbitrary payload fields used by `filterConditions`. It delegates to `ActionService::testAction()` which:
+
+1. Loads the action via `ActionMapper::find($id)`.
+2. Evaluates four independent match predicates on the supplied sample payload:
+   - `eventMatch` = `$action->matchesEvent($eventType)`
+   - `schemaMatch` = `$action->matchesSchema($schemaUuid)`
+   - `registerMatch` = `$action->matchesRegister($registerUuid)`
+   - `filterMatch` — for each entry in the action's `filterConditions` array, the value at the dot-notation key in `samplePayload` (via `getNestedValue`) is compared against the expected value. Array-typed `expected` is treated as "one of"; scalar `expected` is treated as strict equality.
+3. Computes overall `matched = eventMatch && schemaMatch && registerMatch && filterMatch`.
+4. Returns an array (NOT a `JSONResponse` — the controller wraps it) with: `matched`, `action` (serialised), the four match booleans, `filterReasons` (human-readable strings for any failing filter conditions), and `builtPayload` (the original sample payload when matched, `null` otherwise).
+
+The dry-run **does not** invoke the workflow engine, **does not** create an `ActionLog`, and **does not** update statistics. Failures return: 404 if the action does not exist; 500 with the exception message on any other error.
+
+#### Scenario: Successful dry-run on a matching event
+
+- **GIVEN** an active action scoped to schema `schema-abc` with `eventType='ObjectCreatedEvent'` and no filter conditions
+- **WHEN** an admin POSTs to `/api/actions/7/test` with body `{ "eventType": "ObjectCreatedEvent", "schemaUuid": "schema-abc", "registerUuid": null }`
+- **THEN** the response is HTTP 200 with `{ "matched": true, "eventMatch": true, "schemaMatch": true, "registerMatch": true, "filterMatch": true, "filterReasons": [], "builtPayload": <the sample> }`
+- **AND** no `ActionLog` row is created and the workflow engine is never called
+
+#### Scenario: Filter condition mismatch surfaces reason
+
+- **GIVEN** an action with `filterConditions: { "object.status": "published" }`
+- **WHEN** an admin POSTs to `/api/actions/{id}/test` with body where `object.status = "draft"`
+- **THEN** the response contains `filterMatch: false`, `matched: false`, and `filterReasons: ["filter_condition mismatch: object.status expected 'published', got 'draft'"]`
+- **AND** `builtPayload: null`
+
+#### Scenario: Array-typed expected value
+
+- **GIVEN** an action with `filterConditions: { "object.priority": ["high", "critical"] }`
+- **WHEN** an admin POSTs `/api/actions/{id}/test` with `object.priority = "normal"`
+- **THEN** `filterMatch` is `false` and `filterReasons` contains `"filter_condition mismatch: object.priority expected one of [high, critical], got 'normal'"`
+
+### REQ-008: The system SHALL migrate inline schema hooks to Action entities idempotently
+
+`ActionsController::migrateFromHooks($schemaId)` (POST `/api/actions/migrate-hooks/{schemaId}`) is admin-only (REQ-006). It delegates to `ActionService::migrateFromHooks($schemaId)` which:
+
+1. Loads the schema via `SchemaMapper::find($schemaId)`. Returns 404 on `DoesNotExistException`.
+2. Reads `$schema->getHooks()` (a `?array`). If null or empty, returns `{ "created": [], "skipped": [], "errors": [] }`.
+3. For each hook entry, resolves:
+   - `name` from `hook['id']` or falls back to `"Hook {$index} for {$schemaName}"`
+   - `eventKey` from `hook['event']` (defaulting to `'creating'`)
+   - `eventType` from `self::HOOK_EVENT_MAP[$eventKey]` (a class-constant mapping legacy hook event keys like `creating` → `ObjectCreatingEvent`); falls back to the raw `eventKey` when not mapped
+4. Performs a **duplicate check**: lists all `status='active'` actions and skips when any existing action has the same `name`, matches the resolved `eventType` (`matchesEvent`), and contains the target schema's UUID in its `schemasArray`.
+5. On non-duplicate: calls `createAction()` (REQ-001) with the hook's fields mapped to the Action contract — including `status='active'` (NOT the default `'draft'`).
+6. Records each outcome in the report: `created[]` (the serialised new Action), `skipped[]` (`{ name, reason: 'duplicate' }`), or `errors[]` (`{ hook: <original>, error: <exception message> }`).
+
+Returns the report as the response body (HTTP 200). Per-hook exceptions are caught and logged in `errors[]`; the loop continues. Other exceptions (e.g. schema load failure) bubble to the controller which returns 404 or 500.
+
+**Note**: The migration is intended to be **idempotent** — re-running it yields the same created/skipped report given the same schema state. Idempotency relies on the duplicate-detection triple (name + eventType match + schema UUID in scope). Renaming a hook after migration would create a duplicate — surfaced here, not enforced.
+
+**Note**: The duplicate-check `findAll(filters: ['status' => 'active'])` returns every active action across all schemas, not just the migrated schema. For large action sets the check is O(N) per hook; acceptable for the one-shot migration use case, would be a problem if called in a loop.
+
+#### Scenario: First migration creates actions
+
+- **GIVEN** schema `42` with two inline hooks `{ id: "notify", event: "creating", engine: "n8n", workflowId: "wf-1" }` and `{ id: "audit", event: "deleted", engine: "n8n", workflowId: "wf-2" }`
+- **WHEN** an admin POSTs to `/api/actions/migrate-hooks/42`
+- **THEN** the response is HTTP 200 with `{ "created": [<notify-action>, <audit-action>], "skipped": [], "errors": [] }`
+- **AND** both new actions have `status='active'` and `schemas: ["<schema-42-uuid>"]`
+
+#### Scenario: Re-running the migration is idempotent
+
+- **GIVEN** schema `42` whose hooks were already migrated by a previous run
+- **WHEN** an admin POSTs `/api/actions/migrate-hooks/42` a second time
+- **THEN** the response is `{ "created": [], "skipped": [{ name: "notify", reason: "duplicate" }, { name: "audit", reason: "duplicate" }], "errors": [] }`
+
+#### Scenario: Unknown schema
+
+- **GIVEN** schema id `99999` does not exist
+- **WHEN** an admin POSTs `/api/actions/migrate-hooks/99999`
+- **THEN** the response is HTTP 404 with `{ "error": "Schema not found" }`
+
+### REQ-009: The system SHALL expose paginated execution logs and per-action statistics
+
+`ActionsController::logs($id)` (GET `/api/actions/{id}/logs`) carries `#[NoAdminRequired]` — log retrieval is available to any authenticated user. It accepts optional query parameters `_limit` (default 25) and `_offset` (default 0).
+
+It calls `ActionLogMapper::findByActionId($id, $limit, $offset)` for the page of log rows and `ActionLogMapper::getStatsByActionId($id)` for aggregate counts, then returns:
+
+```json
+{
+  "results":   [<serialized ActionLog>, ...],
+  "total":     <stats.total>,
+  "statistics": { "total": ..., ... }
+}
+```
+
+The `statistics` object is the full mapper-supplied aggregate (count by status, etc. — exact shape is defined by `ActionLogMapper::getStatsByActionId()`, not by the controller). `total` is duplicated at the top level for client convenience.
+
+Exceptions return HTTP 500 with `{ "error": "Failed to retrieve action logs" }`. The endpoint does **not** validate that the action ID exists before querying logs — a non-existent action ID returns an empty `results` and a zero `statistics`, not 404. Surfaced as a minor observable quirk, not fixed.
+
+#### Scenario: Paginated log retrieval
+
+- **GIVEN** action `7` has 60 execution log rows
+- **WHEN** an authenticated user GETs `/api/actions/7/logs?_limit=10&_offset=20`
+- **THEN** the response contains 10 log rows, `total=60`, and `statistics.total=60`
+
+#### Scenario: Defaults when limit/offset are omitted
+
+- **GIVEN** a GET to `/api/actions/7/logs` with no `_limit` or `_offset`
+- **WHEN** the controller handles the request
+- **THEN** it calls `findByActionId(actionId: 7, limit: 25, offset: 0)`
+
+#### Scenario: Action ID with no logs
+
+- **GIVEN** action id `99999` has no log rows (whether the action exists or not)
+- **WHEN** a GET to `/api/actions/99999/logs` is made
+- **THEN** the response is HTTP 200 with `{ "results": [], "total": 0, "statistics": { ... } }` — NOT 404
+
+### REQ-010: The system SHALL support pagination, field-based filtering, and substring search on the list endpoint
+
+`ActionsController::index()` (GET `/api/actions`) accepts these query parameters:
+
+- **Pagination**: `_limit` (int, no default), `_offset` (int, no default), `_page` (int, 1-based). When `_page` and `_limit` are both set, `_offset` is computed as `($_page - 1) * $_limit` — taking precedence over any explicit `_offset`.
+- **Filters**: only the whitelisted field names `status`, `event_type`, `engine`, `enabled`, `mode` are forwarded to `ActionMapper::findAll(filters: …)`. Any other query parameter is ignored at the filter level (still reaches `$params` but is dropped).
+- **Search**: `_search` is **NOT** delegated to the mapper — it is applied in PHP after the page is loaded. A non-empty `_search` value (case-insensitive) is matched against each action's `name` and `slug` via `str_contains`. Matches across both fields are unioned.
+
+The controller computes `total` by re-querying `findAll(filters: $filters)` (no limit/offset) and applying the same search filter in PHP, then `count()`-ing. This means a single list call issues **two** mapper queries — one for the page, one for the unfiltered count. Surfaced as observable behavior, not optimised.
+
+Each returned action is `jsonSerialize()`-ed. The response envelope is `{ "results": [...], "total": <int> }` (HTTP 200) or `{ "error": "Failed to list actions" }` (HTTP 500 on `\Exception`).
+
+**Note**: `_search` being applied in PHP after pagination means a `_limit=10` request that page-loads 10 actions and filters out 7 of them via search will return only 3 results despite there being more matches on later pages. The mapper does not yet support full-text search on `name`/`slug`. Surfaced here, not fixed.
+
+#### Scenario: Page-based pagination
+
+- **GIVEN** 100 actions exist
+- **WHEN** an authenticated user GETs `/api/actions?_page=3&_limit=10`
+- **THEN** the controller calls `findAll(limit: 10, offset: 20, filters: [])`
+- **AND** returns `{ "results": [<10 actions>], "total": 100 }`
+
+#### Scenario: Whitelisted filters reach the mapper
+
+- **GIVEN** a GET to `/api/actions?status=active&event_type=ObjectCreatedEvent&unknown_field=foo`
+- **WHEN** the controller builds the filter map
+- **THEN** it calls `findAll(filters: { "status": "active", "event_type": "ObjectCreatedEvent" })` — `unknown_field` is dropped
+
+#### Scenario: Substring search on name and slug
+
+- **GIVEN** four actions: `name="Notify CRM"`, `name="Notify Slack"`, `name="Audit Log"`, `name="Cleanup", slug="notify-cleanup"`
+- **WHEN** a GET to `/api/actions?_search=notify` is made
+- **THEN** the response includes three actions: `Notify CRM`, `Notify Slack`, and `Cleanup` (matched on slug)
+
+#### Scenario: Page-then-filter ordering quirk
+
+- **GIVEN** 50 actions named `Cleanup-1`..`Cleanup-50` and a search for `cleanup-49`
+- **WHEN** a GET to `/api/actions?_search=cleanup-49&_limit=10&_page=1` is made
+- **THEN** the response is `{ "results": [], "total": 1 }` — the mapper returns the first 10 actions (`Cleanup-1`..`Cleanup-10`), none match the search, but the unfiltered `total` count correctly reports 1 match
+
+## Acceptance Criteria
+
+- [ ] Mutation endpoints reject non-admin authenticated users with HTTP 403 (REQ-006)
+- [ ] `POST /api/actions/{id}/test` returns match booleans, filter reasons, and built payload without invoking the workflow engine (REQ-007)
+- [ ] `POST /api/actions/migrate-hooks/{schemaId}` is idempotent — re-running yields all `skipped[]` entries (REQ-008)
+- [ ] `GET /api/actions/{id}/logs` returns paginated logs plus aggregate `statistics` (REQ-009)
+- [ ] `GET /api/actions?_page=N&_limit=M` computes offset as `(N-1)*M` (REQ-010)
+- [ ] `GET /api/actions?_search=…` matches against `name` and `slug` case-insensitively, applied in PHP after the mapper page (REQ-010)
+
+## Notes
+
+- **Two-query total**: `index()` issues two mapper queries to compute `total` (one for the page, one for the unfiltered count). Acceptable for current scale; would be replaced by a `countAll(filters:)` mapper method in future.
+- **Post-page search filter**: `_search` is applied in PHP after pagination — results may be sparser than `_limit` suggests on early pages of large result sets.
+- **Defence-in-depth admin check**: `requireAdmin()` duplicates the framework-level admin gate. The duplication is intentional — see REQ-006.
+- **Logs endpoint does not validate action existence**: a non-existent action ID returns an empty result set with `total=0`, not 404. REQ-009 notes.
+- **Hook duplicate-check scope**: REQ-008 lists ALL active actions to detect duplicates, not just actions targeting the migrated schema. O(N) per hook; acceptable for one-shot migration.

--- a/openspec/changes/retrofit-2026-05-24-actions/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-actions/tasks.md
@@ -1,0 +1,58 @@
+# Tasks
+
+## In-scope REQs (annotated this pass)
+
+- [x] task-1: actions#REQ-006 — Admin-only gating for Actions mutation endpoints (retroactive annotation)
+- [x] task-2: actions#REQ-007 — Dry-run test endpoint with match diagnostics (retroactive annotation)
+- [x] task-3: actions#REQ-008 — Idempotent migration from inline schema hooks (retroactive annotation)
+- [x] task-4: actions#REQ-009 — Per-action execution log retrieval with statistics (retroactive annotation)
+- [x] task-5: actions#REQ-010 — Pagination, field-filter, and substring search on list endpoint (retroactive annotation)
+
+## Method → task map (for annotation step)
+
+- task-1 → `lib/Controller/ActionsController.php::requireAdmin`
+- task-2 → `lib/Controller/ActionsController.php::test`
+- task-2 → `lib/Service/ActionService.php::testAction`
+- task-3 → `lib/Controller/ActionsController.php::migrateFromHooks`
+- task-3 → `lib/Service/ActionService.php::migrateFromHooks`
+- task-4 → `lib/Controller/ActionsController.php::logs`
+- task-5 → `lib/Controller/ActionsController.php::index` (carries REQ-001 link from previous pass; this pass adds REQ-010)
+
+## Deferred to `future-pass:next`
+
+These behaviors are observable and worth pinning down, but defer to a subsequent retrofit pass to keep this PR ≤ 5 REQs:
+
+- `future-pass:next` — `ActionService::updateStatistics` per-execution counter side effects (success vs failure vs abandoned) — currently bundled into REQ-001 mention only
+- `future-pass:next` — `ActionService::HOOK_EVENT_MAP` legacy-key→event-class normalisation table (referenced by REQ-008 but not enumerated)
+- `future-pass:next` — `ActionService::getNestedValue` dot-notation accessor contract (used by REQ-007 filter matching)
+- `future-pass:next` — `ActionsController::index` exception-path observability (logger.error message format, error envelope shape) — REQ-010 only covers happy path
+- `future-pass:next` — Soft-delete + re-create with same name interaction with REQ-008 idempotency
+
+## DROP (out-of-cluster — sibling capability owns these)
+
+The Phase-2 scan name-matched 78 methods that live under `lib/Service/TextExtraction/*`, `lib/Service/TextExtractionService.php`, `lib/Service/TextExtraction/EntityRecognitionHandler.php`, `lib/BackgroundJob/FileTextExtractionJob.php`, and two frontend files. None of these are workflow Actions. Most were already DROP-triaged by the coverage scan; this pass confirms and notes the proper owner:
+
+### text-extraction-eml (existing capability)
+- `lib/Service/TextExtraction/EmlAttachment.php::jsonSerialize`
+- `lib/Service/TextExtraction/EmlBody.php::jsonSerialize`
+- `lib/Service/TextExtraction/EmlStructure.php::jsonSerialize`
+- `lib/Service/TextExtraction/EmlParser.php::stripAngleBrackets`, `splitAddressList`, `resolveFilename`, `sanitiseFilename`, `getParser`
+
+### text-extraction-vectorization (uncovered — future cluster)
+- `lib/Service/TextExtraction/FileHandler.php::__construct`, `extractText`, `needsExtraction`, `getSourceMetadata`, `getSourceTimestamp`, `performTextExtraction`, `detectLanguage`, `getSourceType`
+- `lib/Service/TextExtraction/ObjectHandler.php::__construct`, `extractText`, `needsExtraction`, `extractTextFromArray`, `getSourceMetadata`, `getSourceTimestamp`, `getSourceType`
+- `lib/Service/TextExtraction/TextExtractionHandlerInterface.php::extractText`, `getSourceMetadata`
+- `lib/Service/TextExtractionService.php::__construct`, `extractFile`, `extractObject`, `extractSourceText`, `textToChunks`, `summarizeMetadataPayload`, `performTextExtraction`, `discoverUntrackedFiles`, `extractPendingFiles`, `retryFailedExtractions`, `getTableCountSafe`, `sanitizeText`, `extractPdf`, `extractWord`, `extractSpreadsheet`, `isWordDocument`, `isSpreadsheet`, `isSourceUpToDate`, `hydrateChunkEntity`, `persistMetadataChunk`, `chunkDocument`, `chunkFixedSize`, `recursiveSplit`, `getDetectionMethod`, `calculateAvgChunkSize`, `detectLanguageSignals`, `buildPositionReference`, `persistChunksForSource`, `cleanText`, `chunkRecursive`, `getStats`
+- `lib/BackgroundJob/FileTextExtractionJob.php::__construct`, `run`
+- `src/components/files-sidebar/ExtractionTab.vue::fetchExtractionStatus`
+
+### pii-entity-recognition (uncovered — future capability, GDPR-adjacent)
+- `lib/Service/TextExtraction/EntityRecognitionHandler.php::__construct`, `processSourceChunks`, `extractFromChunk`, `storeDetectedEntities`, `detectEntities`, `getRegexPatterns`, `buildAnalyzeRequestBody`, `postAnalyzeRequest`, `convertApiResultsToEntities`, `mapToPresidioEntityTypes`, `mapFromPresidioEntityType`, `populateObjectContextOnRelation`, `detectWithLLM`, `extractContext`, `detectWithRegex`, `detectWithPresidio`, `detectWithOpenAnonymiser`, `detectWithHybrid`, `findOrCreateEntity`, `getCategoryForType`
+
+### mail-sidebar (frontend, sibling)
+- `src/mail-sidebar/components/ActionsTab.vue::objectName`
+
+### Plain DTO constructors (covered transitively by actions#REQ-001)
+- `lib/Event/ActionCreatedEvent.php::__construct`
+- `lib/Event/ActionDeletedEvent.php::__construct`
+- `lib/Event/ActionUpdatedEvent.php::__construct`

--- a/openspec/specs/actions/spec.md
+++ b/openspec/specs/actions/spec.md
@@ -1,5 +1,11 @@
 ---
 retrofit: true
+retrofit_extensions:
+  - REQ-006
+  - REQ-007
+  - REQ-008
+  - REQ-009
+  - REQ-010
 ---
 # Actions Specification
 
@@ -7,6 +13,7 @@ retrofit: true
 **Scope**: openregister
 **OpenSpec changes**:
 - [retrofit-2026-05-01-actions](../../changes/retrofit-2026-05-01-actions/) _(archived 2026-05-01)_
+- [retrofit-2026-05-24-actions](../../changes/retrofit-2026-05-24-actions/) _(pending archive)_
 
 ## Purpose
 


### PR DESCRIPTION
## Retrofit — Reverse-Spec (partial pass 2)

Second retrofit pass on the `actions` capability. The first pass (`retrofit-2026-05-01-actions`, archived 2026-05-01) covered REQ-001..REQ-005 (the core CRUD + execution lifecycle) and explicitly deferred two follow-ups in its Notes section; this pass picks them up plus three sub-behaviors surfaced by the Phase-2 coverage scan.

Ghost change: `retrofit-2026-05-24-actions` (pending archive).

### What this PR does

- Drafts 5 new REQs as a delta under `openspec/changes/retrofit-2026-05-24-actions/specs/actions/spec.md`.
- Adds `retrofit_extensions: [REQ-006..REQ-010]` to `openspec/specs/actions/spec.md` frontmatter so Specter can flag the cohort.
- Annotates 7 method bodies with `@spec` tags pointing at the new tasks.
- Records 78 sibling-capability methods as DROPs with proper-owner hints.
- Records 5 deferred behaviors as `future-pass:next` for the next retrofit pass.

### New REQs (delta)

| REQ | Title | Methods |
| --- | --- | --- |
| REQ-006 | Admin-only gating for Actions mutation endpoints | `ActionsController::requireAdmin` |
| REQ-007 | Dry-run test endpoint with match diagnostics | `ActionsController::test`, `ActionService::testAction` |
| REQ-008 | Idempotent migration from inline schema hooks | `ActionsController::migrateFromHooks`, `ActionService::migrateFromHooks` |
| REQ-009 | Per-action paginated log retrieval + statistics | `ActionsController::logs` |
| REQ-010 | List endpoint pagination/filter/search semantics | `ActionsController::index` |

### What this PR does NOT do

- No code behavior changes — annotations and spec only.
- Does NOT silently fix observed quirks. Surfaced in REQ Notes:
  - `index()` issues two mapper queries per list to compute `total`.
  - `_search` is applied in PHP after pagination — early pages can be sparser than `_limit` suggests.
  - `logs()` does NOT 404 on unknown action IDs (returns empty + `total=0`).
  - `migrateFromHooks()` duplicate-check is O(N) across all active actions per hook.

### Deferred to `future-pass:next` (5)

- `ActionService::updateStatistics` observable counter side effects
- `HOOK_EVENT_MAP` normalisation table enumeration
- `getNestedValue` dot-notation accessor contract
- `ActionsController::index` exception-path observability
- Soft-delete + re-create with same name vs REQ-008 idempotency

### DROP — sibling capabilities (78 methods, 13 files)

Phase-2 scan name-matched these because they live under `lib/Service/TextExtraction/*` etc., but they are not workflow Actions. Proper-owner hints recorded in `tasks.md`:

- **text-extraction-eml** (existing capability) — EmlParser/EmlAttachment/EmlBody/EmlStructure
- **text-extraction-vectorization** (uncovered, future cluster) — FileHandler/ObjectHandler/TextExtractionService + FileTextExtractionJob
- **pii-entity-recognition** (uncovered, future capability) — EntityRecognitionHandler (Presidio, OpenAnonymiser, regex, LLM, hybrid)
- **mail-sidebar** (frontend sibling) — `ActionsTab.vue::objectName`
- Plain DTO constructors covered transitively by REQ-001 — `ActionCreatedEvent`/`ActionUpdatedEvent`/`ActionDeletedEvent::__construct`

### Review focus

- REQ language matches **observed** behavior (not aspirational).
- Scenarios are testable.
- One REQ per distinct observable behavior (no inflation).
- Notes sections call out suspect-but-shipping quirks rather than silently spec-fixing them.

Source: `/tmp/or-scan/rspec-cluster-actions.json` (96 methods, 17 files). Cluster: `actions` (partial — 5/N REQs this pass).