### PR TITLE
retrofit: reverse-spec data-import-export (5 new REQs, Bucket 2a)

### DIFF
--- a/lib/Controller/UserController.php
+++ b/lib/Controller/UserController.php
@@ -518,6 +518,8 @@ class UserController extends Controller
     /**
      * Export personal data for the current user (GDPR)
      *
+     * @spec retrofit-2026-05-24-data-import-export#task-2
+     *
      * @NoAdminRequired
      *
      * @NoCSRFRequired

--- a/lib/Service/ExportService.php
+++ b/lib/Service/ExportService.php
@@ -262,6 +262,8 @@ class ExportService
      * schema's properties (the same headers `exportToExcel` would emit), with no
      * data rows. The returned spreadsheet can be written to either XLSX or CSV.
      *
+     * @spec retrofit-2026-05-24-data-import-export#task-1
+     *
      * @param Register|null $register    Optional register context (used for translation column expansion)
      * @param Schema        $schema      Schema whose property keys become the header row
      * @param IUser|null    $currentUser Current user (drives admin metadata column inclusion)
@@ -296,6 +298,8 @@ class ExportService
      * Emits a UTF-8 BOM-prefixed CSV string containing only the header row
      * derived from the schema's properties. Mirrors the BOM convention used
      * by the export pipeline so Excel opens the file with the correct encoding.
+     *
+     * @spec retrofit-2026-05-24-data-import-export#task-1
      *
      * @param Register|null $register    Optional register context
      * @param Schema        $schema      Schema whose property keys become the header row

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -1631,6 +1631,8 @@ class ImportService
     /**
      * Clear all internal caches to prevent issues between imports
      *
+     * @spec retrofit-2026-05-24-data-import-export#task-5
+     *
      * @return void
      */
     public function clearCaches(): void

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -1026,6 +1026,8 @@ class UserService
      * Assembles profile data, organisation memberships, and audit trail entries
      * into a downloadable JSON structure. Rate limited to once per hour.
      *
+     * @spec retrofit-2026-05-24-data-import-export#task-2
+     *
      * @param IUser $user The user requesting data export
      *
      * @return array The export data structure

--- a/openspec/changes/retrofit-2026-05-24-data-import-export/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-data-import-export/proposal.md
@@ -1,0 +1,37 @@
+# Retrofit — data-import-export (extend)
+
+Describes observed behavior of 8 kept methods across 7 files in the data-import-export cluster as 5 new REQs extending the existing `data-import-export` capability. Code already exists — this change retroactively specifies it. Triaged drops from the batch (50 methods) are recorded in the batch JSON, not re-specified here.
+
+## Affected code units
+- lib/Service/ExportService.php::buildTemplateSpreadsheet
+- lib/Service/ExportService.php::buildTemplateCsv
+- lib/Service/ImportService.php::clearCaches
+- lib/Controller/UserController.php::exportData (backing endpoint for `ExportSection.vue::exportData`)
+- lib/Service/UserService.php::exportPersonalData (backing service for the same endpoint)
+- src/views/account/sections/ExportSection.vue::exportData
+- src/modals/configuration/ImportConfiguration.vue::checkTokenAvailability
+- src/modals/configuration/ImportConfiguration.vue::closeModal
+- src/modals/configuration/ExportConfiguration.vue::closeModal
+- src/modals/register/ExportRegister.vue::closeModal
+- src/modals/register/ImportRegister.vue::closeModal
+- src/modals/register/ImportRegister.vue::getFileExtension
+
+## Approach
+
+The existing canonical spec covers 17 REQs across the backend pipeline (CSV/Excel import, bulk API, validation, dedup, RBAC, scheduled imports, configuration portability, etc.). The 8 kept methods in this batch sit in five behavioral slices not yet specified:
+
+- **REQ-018** — Import templates (download CSV/XLSX for a schema). The existing spec lists this as a planned/not-implemented requirement, but `ExportService::buildTemplateSpreadsheet()` and `ExportService::buildTemplateCsv()` already implement the schema → empty-template pipeline. Documented here as observed implementation; this also corrects a drift in the existing spec's "NOT implemented" list (see Notes).
+- **REQ-019** — Personal data export endpoint (GDPR Article 20). The existing spec is entirely silent on per-user "give me my data" flows; only register/schema-level exports are covered. `UserController::exportData` + `UserService::exportPersonalData` + `ExportSection.vue` implement a hourly-rate-limited JSON download covering profile, organisation memberships, and audit trail.
+- **REQ-020** — Frontend file-type sniffing routes uploads to the correct importer based on extension. `ImportRegister.vue::getFileExtension()` is the single source of truth used by template gating, file-type display, upload validation, and per-format request building.
+- **REQ-021** — Configuration import-from-source pre-flight checks for GitHub/GitLab API tokens before discovery. `ImportConfiguration.vue::checkTokenAvailability` calls `/api/settings/api-tokens` on mount, drives the warning banner, and disables search buttons when tokens are missing.
+- **REQ-022** — Import/export modal lifecycle: each modal MUST reset its form state on close so the next open starts clean. Covers the four `closeModal` methods plus the backend `ImportService::clearCaches()` used to reset cross-import caches.
+
+## Notes / observed drifts
+
+- The canonical spec's "NOT implemented" list still includes "Import template generation (downloadable CSV/Excel with headers, example data, and documentation)". `buildTemplateSpreadsheet` and `buildTemplateCsv` provide the header-only path (no example row, no `instructies` sheet). REQ-018 retroactively specifies the implemented subset; the example-row / instructions-sheet variant remains unimplemented and is now flagged below the new REQ.
+- `UserService::exportPersonalData()` currently returns `'objects' => []` (placeholder). The exported envelope shape carries an `objects` key but the data is not populated — flagged in REQ-019.
+- `ImportConfiguration.vue::checkTokenAvailability` assumes any non-empty (masked) token from `/api/settings/api-tokens` means "configured". This means a revoked or expired GitHub/GitLab token still passes the pre-flight; failures only surface when the actual search call returns 401/403. Flagged in REQ-021.
+- `ImportService::clearCaches()` currently only clears `$schemaPropertiesCache`. Other internal caches inside ImportService (e.g. validation-result caches) are not reset by this method — flagged in REQ-022.
+- `closeModal` in `ImportConfiguration.vue` calls `resetForm()` which clears ~15 fields; the other three modals reset state inline (3-5 fields each). REQ-022 spec is on the contract (state MUST be reset), not the implementation shape.
+
+Source: openspec/coverage-report.md — Bucket 2a (extend) for `data-import-export`, batch JSON `/tmp/or-scan/rspec-cluster-data-import-export.json`. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-data-import-export/specs/data-import-export/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-data-import-export/specs/data-import-export/spec.md
@@ -1,0 +1,161 @@
+---
+retrofit: true
+---
+
+# Data Import and Export
+
+## ADDED Requirements
+
+### Requirement: Import templates MUST be downloadable as empty header-only files per schema (REQ-018)
+
+The `ExportService` MUST expose a `buildTemplateSpreadsheet()` method that returns a `PhpSpreadsheet\Spreadsheet` containing exactly one sheet titled `<schemaSlug>` (falling back to `'data'`) with a single header row derived from the same `getHeaders($schema, $currentUser)` call used by the regular export path. The headers SHALL include the same RBAC-filtered property columns, companion `_<relation>` columns for relation properties, and admin-only `@self.*` metadata columns that a full export would emit. The `ExportService` MUST also expose a `buildTemplateCsv()` method that wraps the spreadsheet output in `PhpSpreadsheet\Writer\Csv` with `setUseBOM(true)` so Excel detects the UTF-8 BOM correctly. The CSV writer MUST stream to `php://output` between `ob_start()` / `ob_get_clean()`.
+
+This REQ corrects a drift in the canonical spec's "NOT implemented" list — the header-only template path IS implemented. The richer variant (example data row, `instructies` documentation sheet) described in REQ "Import templates MUST be downloadable per schema" Scenario "Download Excel import template with documentation" remains unimplemented (see Notes).
+
+#### Scenario: Template spreadsheet has exactly one header row
+- **GIVEN** schema `meldingen` with three readable properties for the current user
+- **WHEN** `ExportService::buildTemplateSpreadsheet(register: $reg, schema: $meldingen, currentUser: $user)` is called
+- **THEN** the returned `Spreadsheet` MUST contain exactly one sheet
+- **AND** the sheet title MUST equal `$meldingen->getSlug()` (or `'data'` if the slug is null)
+- **AND** row 1 MUST contain the headers from `getHeaders($meldingen, $user)`
+- **AND** no further rows MUST be populated
+
+#### Scenario: Template CSV is BOM-prefixed
+- **GIVEN** the same inputs
+- **WHEN** `ExportService::buildTemplateCsv($reg, $meldingen, $user)` is called
+- **THEN** the returned string MUST start with the UTF-8 BOM `\xEF\xBB\xBF`
+- **AND** it MUST contain exactly one CSV row (the header) followed by a line terminator
+
+#### Scenario: Template inherits RBAC filtering from getHeaders
+- **GIVEN** schema `personen` has property `bsn` restricted to group `privacy-officers`
+- **AND** the current user is NOT in `privacy-officers`
+- **WHEN** the user requests a template
+- **THEN** the template header row MUST NOT include `bsn`
+- **AND** it MUST NOT include the companion `_bsn` column
+
+#### Scenario: Register context drives translatable column expansion
+- **GIVEN** schema `producten` has a translatable property `naam`
+- **AND** the register has languages `nl`, `en` configured
+- **WHEN** `buildTemplateSpreadsheet(register: $producten_register, ...)` runs
+- **THEN** the `$this->contextRegister` field MUST be set BEFORE `getHeaders` runs so per-language columns (`naam_nl`, `naam_en`) are emitted
+
+### Requirement: The system MUST expose a per-user personal data export endpoint (GDPR Art. 20) (REQ-019)
+
+OpenRegister MUST expose an authenticated `GET /apps/openregister/api/user/me/export` endpoint that returns a `DataDownloadResponse` containing a JSON document of all personal data held about the calling user. The endpoint MUST be implemented by `UserController::exportData()` and backed by `UserService::exportPersonalData()`. The endpoint MUST be marked `@NoAdminRequired` and `@NoCSRFRequired` (download-only). The export MUST be rate-limited to once per hour per user via the `last_export_time` user-value and `EXPORT_RATE_LIMIT` constant; exceeding the limit MUST return HTTP 429 with body `{"error":"...","retry_after":<seconds>}`. The JSON envelope MUST contain `exportDate` (ISO 8601), `profile`, `organisations`, `objects`, and `auditTrail` keys.
+
+#### Scenario: Authenticated user downloads their data
+- **GIVEN** an authenticated user calls `GET /apps/openregister/api/user/me/export`
+- **WHEN** `UserController::exportData()` runs
+- **THEN** the response MUST be a `DataDownloadResponse` with content type `application/json`
+- **AND** the filename MUST follow pattern `openregister-export-<uid>-<YYYY-MM-DD>.json`
+- **AND** the JSON body MUST be pretty-printed with `JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE`
+- **AND** the body MUST contain top-level keys `exportDate`, `profile`, `organisations`, `objects`, `auditTrail`
+
+#### Scenario: Unauthenticated request is rejected
+- **GIVEN** there is no current user (session expired)
+- **WHEN** the endpoint runs
+- **THEN** the response MUST be HTTP 401 with body `{"error":"Not authenticated"}`
+
+#### Scenario: Second export within an hour is rate limited
+- **GIVEN** the user successfully exported 30 minutes ago (`last_export_time` user-value set)
+- **WHEN** they call the endpoint again
+- **THEN** `UserService::exportPersonalData()` MUST throw a `RuntimeException` with code 429
+- **AND** the exception message MUST be a JSON string `{"error":"Data export is limited to once per hour","retry_after":<seconds>}`
+- **AND** the controller MUST return a 429 `JSONResponse` with the decoded payload
+- **AND** the response MUST go through `SecurityService::addSecurityHeaders()`
+
+#### Scenario: Audit trail is sliced to the last 1000 entries
+- **GIVEN** the user has 5000 audit trail entries authored by them
+- **WHEN** the export runs
+- **THEN** `AuditTrailMapper::findByActor($uid, 1000, 0)` MUST be called
+- **AND** the `auditTrail` array in the response MUST contain at most 1000 `jsonSerialize()`-d entries
+
+#### Scenario: Vue component triggers download with date-stamped filename
+- **GIVEN** the user clicks "Export my data" in `ExportSection.vue`
+- **WHEN** `exportData()` runs
+- **THEN** the component MUST `GET /apps/openregister/api/user/me/export` with `responseType: 'blob'`
+- **AND** on success it MUST trigger a browser download with filename `openregister-export-<YYYY-MM-DD>.json`
+- **AND** on HTTP 429 it MUST display the localized message "Export is rate limited. Please try again later."
+- **AND** on other errors it MUST display "Failed to export data"
+
+### Requirement: Frontend file-type sniffing MUST route uploads to the correct importer by extension (REQ-020)
+
+`ImportRegister.vue` MUST sniff the extension of any uploaded file via a single helper `getFileExtension(filename)` that lowercases the substring after the last dot. The result MUST drive: (a) the format-specific sub-form rendering (CSV column-mapping panel, Excel sheet selector), (b) the human-readable type label in the upload preview ("JSON Configuration", "Excel Spreadsheet", "CSV Data"), (c) the allow-list validation rejecting non-CSV/XLS/XLSX/JSON uploads with a translated error, and (d) the per-format request payload shape sent to the backend import endpoint.
+
+#### Scenario: Helper is case-insensitive and reads the last extension
+- **GIVEN** filename `Data.Backup.CSV`
+- **WHEN** `getFileExtension(filename)` runs
+- **THEN** the return value MUST be the lowercased string `"csv"`
+- **AND** intermediate dots MUST be ignored
+
+#### Scenario: Disallowed extension is rejected at upload time
+- **GIVEN** the user picks a file `archive.zip`
+- **AND** `allowedFileTypes` does not include `"zip"`
+- **WHEN** `handleFileUpload(event)` runs
+- **THEN** `this.error` MUST be set to a translated message naming the file and the allowed extensions
+- **AND** `this.selectedFile` MUST be cleared so the submit button stays disabled
+
+#### Scenario: Extension drives the import request shape
+- **GIVEN** the user submits a `.json` file
+- **WHEN** the import method runs
+- **THEN** the request body MUST be the JSON form payload (no `multipart/form-data`)
+- **GIVEN** the user submits a `.xlsx` or `.xls` file
+- **WHEN** the import method runs
+- **THEN** the request MUST use `multipart/form-data` with the Excel sheet selector value attached
+- **GIVEN** the user submits a `.csv` file
+- **WHEN** the import method runs
+- **THEN** the request MUST use `multipart/form-data` with the CSV column-mapping values attached
+
+### Requirement: Configuration import-from-source MUST pre-flight check API token availability (REQ-021)
+
+`ImportConfiguration.vue` MUST call `checkTokenAvailability()` from its mounted hook before the user can search GitHub or GitLab for shareable configurations. The method MUST `GET /apps/openregister/api/settings/api-tokens`, set `this.hasGithubToken` and `this.hasGitlabToken` based on whether the masked tokens are present and non-empty in the response, and silently fall back to `false` for both on any network/HTTP error. The token flags MUST gate (a) the warning banner above the search box, (b) the GitHub/GitLab search buttons (`:disabled="!hasGithubToken"` etc.), and (c) the warning title/message dynamically based on which tokens are missing.
+
+#### Scenario: Both tokens missing shows full warning
+- **GIVEN** `/api/settings/api-tokens` returns `{"github_token":"","gitlab_token":""}`
+- **WHEN** `checkTokenAvailability()` runs after mount
+- **THEN** `hasGithubToken` MUST be `false`
+- **AND** `hasGitlabToken` MUST be `false`
+- **AND** the warning banner MUST render with title "API Tokens Not Configured"
+- **AND** both search buttons MUST be disabled
+
+#### Scenario: Only GitHub token configured
+- **GIVEN** the API returns `{"github_token":"ghp_xxxxx****","gitlab_token":""}`
+- **WHEN** the check runs
+- **THEN** `hasGithubToken` MUST be `true`, `hasGitlabToken` MUST be `false`
+- **AND** the warning title MUST be "GitLab Token Not Configured"
+- **AND** the GitHub button MUST be enabled, the GitLab button MUST be disabled
+
+#### Scenario: API error degrades to "no tokens"
+- **GIVEN** the `/api/settings/api-tokens` request throws (network error, 500, etc.)
+- **WHEN** the catch block runs
+- **THEN** both flags MUST be set to `false`
+- **AND** no exception MUST propagate to the user
+- **AND** the warning banner MUST render as if no tokens were configured
+
+### Requirement: Import and export modals MUST reset all form state on close (REQ-022)
+
+Each modal under `src/modals/configuration/` and `src/modals/register/` that drives an import or export workflow MUST expose a `closeModal()` method that (a) sets `navigationStore.setModal(false)` to dismiss the modal, and (b) resets every locally-tracked form/result/error field to its initial value so reopening the modal starts from a clean slate. Modals MUST invoke `closeModal()` from: the close button click, the `@update:open` handler on the underlying `NcDialog`, and any success-path `setTimeout` after a successful submission. The backend cross-import cache state in `ImportService::clearCaches()` MUST clear `$schemaPropertiesCache` to prevent stale property metadata from leaking between consecutive imports in the same PHP process.
+
+#### Scenario: ImportConfiguration modal close resets the form
+- **GIVEN** the user filled the search query, picked a branch, and saw search results
+- **WHEN** they click the close button
+- **THEN** `closeModal()` MUST set the navigation modal to `false`
+- **AND** `resetForm()` MUST run, clearing `loading`, `success`, `error`, `searchQuery`, `searchResults`, `repoOwner`, `repoNamespace`, `repoName`, `branches`, `selectedBranch`, `configFiles`, `selectedFile`, `importUrl`, `urlError`
+- **AND** the next time the modal opens, the form MUST be empty
+
+#### Scenario: ExportConfiguration / ExportRegister close resets to defaults
+- **GIVEN** the user has changed the export format and toggled `includeObjects`
+- **WHEN** they close the modal
+- **THEN** `closeModal()` MUST reset `loading=false`, `error=null`, and the format/includeObjects fields to their defaults (`'excel'` and `false` respectively)
+
+#### Scenario: ImportRegister close clears the picked file and submit flags
+- **GIVEN** the user picked a CSV and toggled `validation=false`
+- **WHEN** they close the modal
+- **THEN** `closeModal()` MUST clear `selectedFile`, `loading`, `success`, `error`
+- **AND** it MUST reset the boolean toggles `includeObjects`, `validation`, `events` to their initial defaults
+
+#### Scenario: ImportService cross-import cache reset
+- **GIVEN** an import of register A has populated `$schemaPropertiesCache` with entries keyed by schema id
+- **WHEN** the caller invokes `ImportService::clearCaches()` before importing register B
+- **THEN** `$schemaPropertiesCache` MUST be reset to `[]`
+- **AND** the next call into the import pipeline MUST recompute property metadata from the source-of-truth schema mapper

--- a/openspec/changes/retrofit-2026-05-24-data-import-export/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-data-import-export/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: retrofit-2026-05-24-data-import-export
+
+## 1. Reverse-spec coverage
+
+- [x] task-1 — REQ-018 "Import templates MUST be downloadable as empty header-only files per schema": annotate `ExportService::buildTemplateSpreadsheet`, `ExportService::buildTemplateCsv`.
+- [x] task-2 — REQ-019 "The system MUST expose a per-user personal data export endpoint (GDPR Art. 20)": annotate `UserController::exportData`, `UserService::exportPersonalData`, `ExportSection.vue::exportData`.
+- [x] task-3 — REQ-020 "Frontend file-type sniffing MUST route uploads to the correct importer by extension": annotate `ImportRegister.vue::getFileExtension`.
+- [x] task-4 — REQ-021 "Configuration import-from-source MUST pre-flight check API token availability": annotate `ImportConfiguration.vue::checkTokenAvailability`.
+- [x] task-5 — REQ-022 "Import and export modals MUST reset all form state on close": annotate `ImportConfiguration.vue::closeModal`, `ExportConfiguration.vue::closeModal`, `ExportRegister.vue::closeModal`, `ImportRegister.vue::closeModal`, `ImportService::clearCaches`.

--- a/src/modals/configuration/ExportConfiguration.vue
+++ b/src/modals/configuration/ExportConfiguration.vue
@@ -97,6 +97,9 @@ export default {
 		},
 	},
 	methods: {
+		/**
+		 * @spec retrofit-2026-05-24-data-import-export#task-5
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 			this.loading = false

--- a/src/modals/configuration/ImportConfiguration.vue
+++ b/src/modals/configuration/ImportConfiguration.vue
@@ -437,6 +437,7 @@ export default {
 	methods: {
 		/**
 		 * Check if API tokens are configured
+		 * @spec retrofit-2026-05-24-data-import-export#task-4
 		 */
 		async checkTokenAvailability() {
 			try {
@@ -485,6 +486,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec retrofit-2026-05-24-data-import-export#task-5
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 			this.resetForm()

--- a/src/modals/register/ExportRegister.vue
+++ b/src/modals/register/ExportRegister.vue
@@ -95,6 +95,9 @@ export default {
 		},
 	},
 	methods: {
+		/**
+		 * @spec retrofit-2026-05-24-data-import-export#task-5
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 			this.loading = false

--- a/src/modals/register/ImportRegister.vue
+++ b/src/modals/register/ImportRegister.vue
@@ -503,6 +503,7 @@ export default {
 	methods: {
 		/**
 		 * Get the file extension from a filename
+		 * @spec retrofit-2026-05-24-data-import-export#task-3
 		 * @param {string} filename - The name of the file to get extension from
 		 * @return {string}
 		 */
@@ -552,6 +553,7 @@ export default {
 		},
 		/**
 		 * Close the import modal and reset state
+		 * @spec retrofit-2026-05-24-data-import-export#task-5
 		 */
 		closeModal() {
 			navigationStore.setModal(false)

--- a/src/views/account/sections/ExportSection.vue
+++ b/src/views/account/sections/ExportSection.vue
@@ -36,6 +36,9 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * @spec retrofit-2026-05-24-data-import-export#task-2
+		 */
 		async exportData() {
 			this.loading = true
 			this.message = ''


### PR DESCRIPTION
## Summary

Ghost change `retrofit-2026-05-24-data-import-export` extends the `data-import-export` capability with 5 new REQs reverse-engineered from observed code. 10 `@spec` annotations point methods back to the change's `tasks.md`. Docblock-only; no runtime behaviour changes.

- **REQ-018** — Import templates downloadable as empty header-only files per schema (`ExportService::buildTemplateSpreadsheet` / `buildTemplateCsv`)
- **REQ-019** — Per-user personal data export endpoint, GDPR Art. 20 (`UserController::exportData`, `UserService::exportPersonalData`, `ExportSection.vue::exportData`)
- **REQ-020** — Frontend file-type sniffing routes uploads to the correct importer by extension (`ImportRegister.vue::getFileExtension`)
- **REQ-021** — Configuration import-from-source pre-flight checks API token availability (`ImportConfiguration.vue::checkTokenAvailability`)
- **REQ-022** — Import/export modals reset all form state on close, plus `ImportService::clearCaches` resets cross-import schema-properties cache (4 closeModal Vue methods + `ImportService::clearCaches`)

## Observed drifts (flagged in spec Notes)

- Canonical spec's "NOT implemented" list still includes "Import template generation" — the header-only path IS implemented (REQ-018). Example-row + `instructies` documentation sheet remain unimplemented.
- `UserService::exportPersonalData` returns `'objects' => []` placeholder — owned objects aren't yet enumerated in the GDPR export envelope.
- `checkTokenAvailability` cannot distinguish revoked from configured tokens (only checks non-empty masked value) — failures only surface on actual search calls.
- `ImportService::clearCaches` only resets `\$schemaPropertiesCache`; other internal caches (validation results) are not currently cleared by this method.

## Coverage

- **Batch**: \`/tmp/or-scan/rspec-cluster-data-import-export.json\` (58 methods, 9 files)
- **Kept**: 8 methods → 5 REQs
- **Triaged drops**: 50 methods (recorded in batch JSON, not re-specified)
- **Deferred**: 0
- **Mode**: \`--extend\` (capability \`data-import-export\` already exists with 17 REQs)

## Validation

\`openspec validate --changes retrofit-2026-05-24-data-import-export --strict\` → pass

## Test plan

- [x] OpenSpec strict validation passes
- [ ] Reviewer confirms REQ titles match observed code behaviour
- [ ] Reviewer confirms triaged drops are correctly excluded