### PR TITLE
feat(contacts): Tier-2 — link table + service + controller + picker

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -314,11 +314,15 @@ return [
         ['name' => 'emails#destroy',  'url' => '/api/objects/{register}/{schema}/{id}/emails/{emailId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'emailId' => '[0-9]+']],
 
         // Contacts — object↔NC contact links + reverse lookup. Match is app-global.
-        ['name' => 'contacts#index',   'url' => '/api/objects/{register}/{schema}/{id}/contacts',                 'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
-        ['name' => 'contacts#create',  'url' => '/api/objects/{register}/{schema}/{id}/contacts',                 'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
-        ['name' => 'contacts#update',  'url' => '/api/objects/{register}/{schema}/{id}/contacts/{contactUid}',    'verb' => 'PUT',    'requirements' => ['id' => '[^/]+', 'contactUid' => '[^/]+']],
-        ['name' => 'contacts#destroy', 'url' => '/api/objects/{register}/{schema}/{id}/contacts/{contactUid}',    'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'contactUid' => '[^/]+']],
-        ['name' => 'contacts#objects', 'url' => '/api/contacts/{contactUid}/objects',                              'verb' => 'GET',    'requirements' => ['contactUid' => '[^/]+']],
+        // The explicit `/contacts/new` route is the Tier-2 create-only path
+        // surfaced to the new `CnContactCreate` dialog; the bare POST still
+        // accepts both link- and create-shaped payloads for back-compat.
+        ['name' => 'contacts#index',     'url' => '/api/objects/{register}/{schema}/{id}/contacts',                 'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
+        ['name' => 'contacts#createNew', 'url' => '/api/objects/{register}/{schema}/{id}/contacts/new',             'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'contacts#create',    'url' => '/api/objects/{register}/{schema}/{id}/contacts',                 'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'contacts#update',    'url' => '/api/objects/{register}/{schema}/{id}/contacts/{contactUid}',    'verb' => 'PUT',    'requirements' => ['id' => '[^/]+', 'contactUid' => '[^/]+']],
+        ['name' => 'contacts#destroy',   'url' => '/api/objects/{register}/{schema}/{id}/contacts/{contactUid}',    'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'contactUid' => '[^/]+']],
+        ['name' => 'contacts#objects',   'url' => '/api/contacts/{contactUid}/objects',                              'verb' => 'GET',    'requirements' => ['contactUid' => '[^/]+']],
 
         // Calendar events — object↔CalDAV event links via DAV principal.
         ['name' => 'calendarEvents#index',   'url' => '/api/objects/{register}/{schema}/{id}/events',             'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],

--- a/lib/Controller/ContactsController.php
+++ b/lib/Controller/ContactsController.php
@@ -149,7 +149,12 @@ class ContactsController extends Controller
      * Link or create a contact for an object.
      *
      * If addressbookId and contactUri are provided, links an existing contact.
-     * If fullName is provided, creates a new contact and links it.
+     * If fullName or displayName is provided, creates a new contact and links
+     * it (back-compat path for callers that don't use `/contacts/new`).
+     *
+     * Tier-2 — both the link and create paths thread the object's
+     * register + schema ids into the link row so the consumer side can
+     * scope the picker by `schemaId` without extra round-trips.
      *
      * @param string $register The register slug
      * @param string $schema   The schema slug
@@ -173,14 +178,17 @@ class ContactsController extends Controller
             $data = $this->request->getParams();
 
             $hasLinkData   = (empty($data['addressbookId']) === false && empty($data['contactUri']) === false);
-            $hasCreateData = (empty($data['fullName']) === false);
+            // Accept `displayName` (Tier-2 dialog field) alongside `fullName`.
+            $hasCreateData = (empty($data['fullName']) === false || empty($data['displayName']) === false);
 
             if ($hasLinkData === false && $hasCreateData === false) {
                 return new JSONResponse(
-                    ['error' => 'Either addressbookId+contactUri or fullName is required'],
+                    ['error' => 'Either addressbookId+contactUri or fullName/displayName is required'],
                     400
                 );
             }
+
+            $schemaId = $this->resolveSchemaId(object: $object);
 
             if ($hasLinkData === true) {
                 // Link existing contact.
@@ -189,7 +197,8 @@ class ContactsController extends Controller
                     (int) $object->getRegister(),
                     (int) $data['addressbookId'],
                     $data['contactUri'],
-                    $data['role'] ?? null
+                    $data['role'] ?? null,
+                    $schemaId
                 );
             }
 
@@ -198,7 +207,8 @@ class ContactsController extends Controller
                 $link = $this->contactService->createAndLinkContact(
                     $object->getUuid(),
                     (int) $object->getRegister(),
-                    $data
+                    $data,
+                    $schemaId
                 );
             }
 
@@ -214,6 +224,100 @@ class ContactsController extends Controller
             return new JSONResponse(['error' => $e->getMessage()], 400);
         }//end try
     }//end create()
+
+    /**
+     * Create a new contact (only) and link it to an object.
+     *
+     * Tier-2 dedicated route — surfaced to the `CnContactCreate` dialog
+     * so the consumer can hit a single unambiguous endpoint for the
+     * create-only flow. Accepts `displayName` (or `fullName`), `email`,
+     * `phone`, `org`, `role`. Rejects payloads carrying `contactUri`
+     * (link-existing) with a 400 — those callers must use the bare
+     * POST endpoint instead.
+     *
+     * @param string $register The register slug
+     * @param string $schema   The schema slug
+     * @param string $id       The object ID
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function createNew(string $register, string $schema, string $id): JSONResponse
+    {
+        try {
+            $object = $this->validateObject($register, $schema, $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $data = $this->request->getParams();
+
+            // Refuse "link" payloads here — `/contacts/new` is create-only.
+            if (empty($data['contactUri']) === false) {
+                return new JSONResponse(
+                    ['error' => 'Use POST /contacts to link an existing contact'],
+                    400
+                );
+            }
+
+            $displayName = $data['displayName'] ?? $data['fullName'] ?? '';
+            if ($displayName === '' || trim($displayName) === '') {
+                return new JSONResponse(
+                    ['error' => 'displayName is required'],
+                    400
+                );
+            }
+
+            $schemaId = $this->resolveSchemaId(object: $object);
+
+            $link = $this->contactService->createAndLinkContact(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                $data,
+                $schemaId
+            );
+
+            return new JSONResponse($link, 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            $code = $e->getCode();
+            if ($code === 404) {
+                return new JSONResponse(['error' => $e->getMessage()], 404);
+            }
+
+            return new JSONResponse(['error' => $e->getMessage()], 400);
+        }//end try
+    }//end createNew()
+
+    /**
+     * Resolve the object's schema id as an int (or null).
+     *
+     * `ObjectEntity::getSchema()` returns the schema id as a string;
+     * the link table accepts a nullable int.
+     *
+     * @param \OCA\OpenRegister\Db\ObjectEntity $object The object entity.
+     *
+     * @return int|null
+     */
+    private function resolveSchemaId(\OCA\OpenRegister\Db\ObjectEntity $object): ?int
+    {
+        $schema = $object->getSchema();
+        if ($schema === null || $schema === '') {
+            return null;
+        }
+
+        // Non-numeric schema slugs map to null here — the link row keeps
+        // the register id only, and the consumer side falls back to
+        // resolving the schema from the URL.
+        if (is_numeric($schema) === false) {
+            return null;
+        }
+
+        return (int) $schema;
+    }//end resolveSchemaId()
 
     /**
      * Update a contact link (role change).
@@ -256,10 +360,17 @@ class ContactsController extends Controller
     /**
      * Remove a contact link.
      *
+     * `{contactUid}` may be either the vCard UID *or* a numeric link id
+     * — the route requirement is `[^/]+` and consumers historically
+     * passed both shapes. The service resolves the contact-uid form via
+     * the (objectUuid, contactUid) composite index, falling back to the
+     * id-based path when the param looks numeric. Both code paths
+     * tolerate a missing underlying vCard per Phase F-3.
+     *
      * @param string $register   The register slug
      * @param string $schema     The schema slug
      * @param string $id         The object ID
-     * @param string $contactUid The contact UID
+     * @param string $contactUid The contact UID (or numeric link id).
      *
      * @return JSONResponse
      *
@@ -274,7 +385,16 @@ class ContactsController extends Controller
                 return new JSONResponse(['error' => 'Object not found'], 404);
             }
 
-            $this->contactService->unlinkContact($object->getUuid(), $contactUid);
+            // Numeric param → legacy/link-id path. Otherwise resolve via
+            // the (objectUuid, contactUid) composite index.
+            if (ctype_digit($contactUid) === true) {
+                $this->contactService->unlinkContact((int) $contactUid);
+            } else {
+                $this->contactService->unlinkContactByUid(
+                    objectUuid: $object->getUuid(),
+                    contactUid: $contactUid
+                );
+            }
 
             return new JSONResponse(['success' => true]);
         } catch (DoesNotExistException $e) {

--- a/lib/Db/ContactLink.php
+++ b/lib/Db/ContactLink.php
@@ -30,6 +30,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setObjectUuid(string $objectUuid)
  * @method int getRegisterId()
  * @method void setRegisterId(int $registerId)
+ * @method int|null getSchemaId()
+ * @method void setSchemaId(?int $schemaId)
  * @method string getContactUid()
  * @method void setContactUid(string $contactUid)
  * @method int getAddressbookId()
@@ -40,8 +42,16 @@ use OCP\AppFramework\Db\Entity;
  * @method void setDisplayName(?string $displayName)
  * @method string|null getEmail()
  * @method void setEmail(?string $email)
+ * @method string|null getPhone()
+ * @method void setPhone(?string $phone)
+ * @method string|null getOrg()
+ * @method void setOrg(?string $org)
+ * @method string|null getAvatarUrl()
+ * @method void setAvatarUrl(?string $avatarUrl)
  * @method string|null getRole()
  * @method void setRole(?string $role)
+ * @method string|null getMetadata()
+ * @method void setMetadata(?string $metadata)
  * @method string getLinkedBy()
  * @method void setLinkedBy(string $linkedBy)
  * @method DateTime getLinkedAt()
@@ -65,6 +75,15 @@ class ContactLink extends Entity implements JsonSerializable
      * @var integer|null
      */
     protected ?int $registerId = null;
+
+    /**
+     * The schema id. Tier-2 addition — lets the consumer-side picker /
+     * Tab figure out which register/schema scope it's in without an
+     * extra round-trip.
+     *
+     * @var integer|null
+     */
+    protected ?int $schemaId = null;
 
     /**
      * The contact uid.
@@ -102,11 +121,43 @@ class ContactLink extends Entity implements JsonSerializable
     protected ?string $email = null;
 
     /**
+     * The cached primary phone number. Tier-2 — populated at link time
+     * + refreshed by `ContactService::getContactsForObject()` when the
+     * link is older than the 24h enrichment TTL.
+     *
+     * @var string|null
+     */
+    protected ?string $phone = null;
+
+    /**
+     * The cached primary organisation. Tier-2.
+     *
+     * @var string|null
+     */
+    protected ?string $org = null;
+
+    /**
+     * The cached avatar URL (PHOTO from the vCard, or the per-uid
+     * Contacts route as a fallback). Tier-2.
+     *
+     * @var string|null
+     */
+    protected ?string $avatarUrl = null;
+
+    /**
      * The role.
      *
      * @var string|null
      */
     protected ?string $role = null;
+
+    /**
+     * Free-form JSON-encoded extension bag for provider-specific
+     * payloads (per ADR-019 §AD-6). Tier-2.
+     *
+     * @var string|null
+     */
+    protected ?string $metadata = null;
 
     /**
      * The linked by.
@@ -129,12 +180,17 @@ class ContactLink extends Entity implements JsonSerializable
     {
         $this->addType(fieldName: 'objectUuid', type: 'string');
         $this->addType(fieldName: 'registerId', type: 'integer');
+        $this->addType(fieldName: 'schemaId', type: 'integer');
         $this->addType(fieldName: 'contactUid', type: 'string');
         $this->addType(fieldName: 'addressbookId', type: 'integer');
         $this->addType(fieldName: 'contactUri', type: 'string');
         $this->addType(fieldName: 'displayName', type: 'string');
         $this->addType(fieldName: 'email', type: 'string');
+        $this->addType(fieldName: 'phone', type: 'string');
+        $this->addType(fieldName: 'org', type: 'string');
+        $this->addType(fieldName: 'avatarUrl', type: 'string');
         $this->addType(fieldName: 'role', type: 'string');
+        $this->addType(fieldName: 'metadata', type: 'string');
         $this->addType(fieldName: 'linkedBy', type: 'string');
         $this->addType(fieldName: 'linkedAt', type: 'datetime');
     }//end __construct()
@@ -142,20 +198,45 @@ class ContactLink extends Entity implements JsonSerializable
     /**
      * JSON serialization.
      *
-     * @return array
+     * The Tier-2 widened payload (phone / org / avatarUrl) is emitted
+     * here directly; the `ContactService` keeps these fields fresh by
+     * re-enriching from the vCard when the cached row is older than
+     * 24 hours.
+     *
+     * @return array<string,mixed>
      */
     public function jsonSerialize(): array
     {
+        // `metadata` is stored as JSON-encoded text — decode it for the
+        // consumer so the registry / Tab can iterate keys naturally.
+        $metadata = null;
+        if ($this->metadata !== null && $this->metadata !== '') {
+            try {
+                $decoded = json_decode($this->metadata, true, 512, JSON_THROW_ON_ERROR);
+                if (is_array($decoded) === true) {
+                    $metadata = $decoded;
+                }
+            } catch (\JsonException $e) {
+                // Corrupt row — surface as null rather than blowing up.
+                $metadata = null;
+            }
+        }
+
         return [
             'id'            => $this->id,
             'objectUuid'    => $this->objectUuid,
             'registerId'    => $this->registerId,
+            'schemaId'      => $this->schemaId,
             'contactUid'    => $this->contactUid,
             'addressbookId' => $this->addressbookId,
             'contactUri'    => $this->contactUri,
             'displayName'   => $this->displayName,
             'email'         => $this->email,
+            'phone'         => $this->phone,
+            'org'           => $this->org,
+            'avatarUrl'     => $this->avatarUrl,
             'role'          => $this->role,
+            'metadata'      => $metadata,
             'linkedBy'      => $this->linkedBy,
             'linkedAt'      => $this->linkedAt?->format(DateTime::ATOM),
         ];

--- a/lib/Db/ContactLinkMapper.php
+++ b/lib/Db/ContactLinkMapper.php
@@ -110,4 +110,34 @@ class ContactLinkMapper extends QBMapper
 
         return $qb->executeStatement();
     }//end deleteByObjectUuid()
+
+    /**
+     * Find the single link for an (objectUuid, contactUid) pair.
+     *
+     * Backs the upsert path in `ContactService::linkContact()` — the DB
+     * already enforces uniqueness via the Tier-2 composite index
+     * `idx_contact_object_uid_uniq`, but reading first lets the service
+     * update the cached vCard fields (phone/org/avatar) and role
+     * in-place instead of failing on the duplicate-key.
+     *
+     * @param string $objectUuid The object UUID.
+     * @param string $contactUid The vCard UID.
+     *
+     * @return ContactLink|null The link, or null when no row exists.
+     */
+    public function findByObjectAndContact(string $objectUuid, string $contactUid): ?ContactLink
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('contact_uid', $qb->createNamedParameter($contactUid)))
+            ->setMaxResults(1);
+
+        try {
+            return $this->findEntity(query: $qb);
+        } catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
+            return null;
+        }
+    }//end findByObjectAndContact()
 }//end class

--- a/lib/Migration/Version1Date20260524100000.php
+++ b/lib/Migration/Version1Date20260524100000.php
@@ -1,0 +1,220 @@
+<?php
+
+/**
+ * Tier-2 migration: extend `openregister_contact_links` with the columns
+ * the dedicated ContactService + REST surface (and the new
+ * `CnContactPicker` / `CnContactCreate` consumer-side dialogs) need to
+ * cache and render a contact without having to round-trip CardDAV on
+ * every list call.
+ *
+ * Adds:
+ *   - schema_id     (int, indexed) — the OR schema the link belongs to
+ *   - phone         (varchar 64, nullable) — primary TEL from vCard
+ *   - org           (varchar 255, nullable) — primary ORG from vCard
+ *   - avatar_url    (varchar 512, nullable) — PHOTO URI or per-uid route
+ *   - metadata      (text/json, nullable) — extension bag for provider-
+ *     specific payloads (per ADR-019 §AD-6)
+ *
+ * Also adds a unique composite index on (object_uuid, contact_uid) so
+ * the upsert path in `ContactService::linkContact()` can rely on the DB
+ * for idempotency instead of an application-level read-modify-write.
+ *
+ * The migration is idempotent — re-running skips columns that already
+ * exist (so manual re-applies during development are safe).
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Version1Date20260524100000
+ *
+ * Extend the contact-links table with phone / org / avatar_url / metadata
+ * + the (object_uuid, contact_uid) unique composite index.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+class Version1Date20260524100000 extends SimpleMigrationStep
+{
+
+    /**
+     * Target table name (without `oc_` prefix).
+     *
+     * @var string
+     */
+    private const TABLE = 'openregister_contact_links';
+
+    /**
+     * Change the database schema.
+     *
+     * @param IOutput                 $output        Migration output stream
+     * @param Closure                 $schemaClosure Schema closure
+     * @param array<array-key, mixed> $options       Migration options
+     *
+     * @return ISchemaWrapper|null
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema = $schemaClosure();
+
+        if ($schema->hasTable(self::TABLE) === false) {
+            // Earlier consolidated migration may have been dropped on
+            // installs that moved to the magic-column pattern. Recreate
+            // the table here so the Tier-2 path always has a target.
+            $this->createTable(schema: $schema, output: $output);
+            return $schema;
+        }
+
+        $changed = false;
+        $table   = $schema->getTable(self::TABLE);
+
+        if ($table->hasColumn(name: 'schema_id') === false) {
+            $table->addColumn(
+                name: 'schema_id',
+                typeName: Types::BIGINT,
+                options: [
+                    'notnull'  => false,
+                    'default'  => null,
+                    'unsigned' => true,
+                ]
+            );
+            $output->info(message: 'Added schema_id column to '.self::TABLE);
+            $changed = true;
+        }
+
+        if ($table->hasColumn(name: 'phone') === false) {
+            $table->addColumn(
+                name: 'phone',
+                typeName: Types::STRING,
+                options: [
+                    'notnull' => false,
+                    'length'  => 64,
+                    'default' => null,
+                ]
+            );
+            $output->info(message: 'Added phone column to '.self::TABLE);
+            $changed = true;
+        }
+
+        if ($table->hasColumn(name: 'org') === false) {
+            $table->addColumn(
+                name: 'org',
+                typeName: Types::STRING,
+                options: [
+                    'notnull' => false,
+                    'length'  => 255,
+                    'default' => null,
+                ]
+            );
+            $output->info(message: 'Added org column to '.self::TABLE);
+            $changed = true;
+        }
+
+        if ($table->hasColumn(name: 'avatar_url') === false) {
+            $table->addColumn(
+                name: 'avatar_url',
+                typeName: Types::STRING,
+                options: [
+                    'notnull' => false,
+                    'length'  => 512,
+                    'default' => null,
+                ]
+            );
+            $output->info(message: 'Added avatar_url column to '.self::TABLE);
+            $changed = true;
+        }
+
+        if ($table->hasColumn(name: 'metadata') === false) {
+            $table->addColumn(
+                name: 'metadata',
+                typeName: Types::TEXT,
+                options: [
+                    'notnull' => false,
+                    'default' => null,
+                ]
+            );
+            $output->info(message: 'Added metadata column to '.self::TABLE);
+            $changed = true;
+        }
+
+        if ($table->hasIndex(name: 'idx_contact_object_uid_uniq') === false) {
+            $table->addUniqueIndex(
+                columnNames: ['object_uuid', 'contact_uid'],
+                indexName: 'idx_contact_object_uid_uniq'
+            );
+            $output->info(message: 'Added unique (object_uuid, contact_uid) index to '.self::TABLE);
+            $changed = true;
+        }
+
+        if ($changed === false) {
+            return null;
+        }
+
+        return $schema;
+
+    }//end changeSchema()
+
+    /**
+     * Recreate the table when an earlier migration dropped it.
+     *
+     * Mirrors the Tier-2 columns directly so a fresh install ends up
+     * with the same shape as a migrated existing install.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output stream
+     *
+     * @return void
+     */
+    private function createTable(ISchemaWrapper $schema, IOutput $output): void
+    {
+        $table = $schema->createTable(self::TABLE);
+
+        $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'unsigned' => true]);
+        $table->addColumn('object_uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
+        $table->addColumn('register_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('schema_id', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]);
+        $table->addColumn('contact_uid', Types::STRING, ['notnull' => true, 'length' => 255]);
+        $table->addColumn('addressbook_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('contact_uri', Types::STRING, ['notnull' => true, 'length' => 512]);
+        $table->addColumn('display_name', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+        $table->addColumn('email', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+        $table->addColumn('phone', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+        $table->addColumn('org', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+        $table->addColumn('avatar_url', Types::STRING, ['notnull' => false, 'length' => 512, 'default' => null]);
+        $table->addColumn('role', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+        $table->addColumn('metadata', Types::TEXT, ['notnull' => false, 'default' => null]);
+        $table->addColumn('linked_by', Types::STRING, ['notnull' => true, 'length' => 64]);
+        $table->addColumn('linked_at', Types::DATETIME, ['notnull' => true]);
+
+        $table->setPrimaryKey(['id']);
+        $table->addIndex(['object_uuid'], 'idx_contact_object');
+        $table->addIndex(['contact_uid'], 'idx_contact_uid');
+        $table->addIndex(['role'], 'idx_contact_role');
+        $table->addUniqueIndex(['object_uuid', 'contact_uid'], 'idx_contact_object_uid_uniq');
+
+        $output->info(message: 'Recreated '.self::TABLE.' with Tier-2 columns');
+
+    }//end createTable()
+}//end class

--- a/lib/Service/ContactService.php
+++ b/lib/Service/ContactService.php
@@ -92,6 +92,19 @@ class ContactService
     }//end __construct()
 
     /**
+     * Enrichment TTL for cached vCard fields.
+     *
+     * `getContactsForObject()` re-reads the vCard (phone/org/avatar)
+     * when the cached link row is older than this. The cached values
+     * still take precedence so the serialised payload remains stable
+     * on the hot path; the re-enrichment back-fills only when CardDAV
+     * disagrees with the cache, and the update is best-effort.
+     *
+     * @var int Seconds. Defaults to 24h.
+     */
+    private const ENRICHMENT_TTL_SECONDS = 86400;
+
+    /**
      * Get all contact links for an object.
      *
      * Each row is the canonical {@see ContactLink::jsonSerialize()} payload
@@ -106,6 +119,10 @@ class ContactService
      *     still returned but `phone` / `org` / `avatarUrl` are `null`.
      *   * If the vCard is present but lacks any of TEL / ORG / PHOTO,
      *     the corresponding field is `null`.
+     *   * The cached `phone` / `org` / `avatar_url` columns on the row
+     *     are used as long as the link is younger than
+     *     `ENRICHMENT_TTL_SECONDS`; older rows trigger a fresh vCard
+     *     read + a non-blocking persist of the re-enriched values.
      *
      * Idempotent: re-running the enrichment doesn't double-write — the
      * widened keys are computed fresh each call.
@@ -119,15 +136,54 @@ class ContactService
         $links = $this->contactLinkMapper->findByObjectUuid($objectUuid);
         $total = $this->contactLinkMapper->countByObjectUuid($objectUuid);
 
+        $now = new DateTime();
+
         $results = array_map(
-            function (ContactLink $link): array {
-                $row     = $link->jsonSerialize();
-                $vfields = $this->extractVcardFields(
-                    addressbookId: $link->getAddressbookId(),
-                    contactUri: $link->getContactUri(),
-                    contactUid: $link->getContactUid()
+            function (ContactLink $link) use ($now): array {
+                $row = $link->jsonSerialize();
+
+                // Decide whether to refresh the cached fields. A link
+                // without any cached values is always refreshed; a stale
+                // link (older than ENRICHMENT_TTL_SECONDS) is refreshed
+                // and the updated values are persisted opportunistically.
+                $linkedAt = $link->getLinkedAt();
+                $isStale  = (
+                    $linkedAt === null
+                    || ($now->getTimestamp() - $linkedAt->getTimestamp()) > self::ENRICHMENT_TTL_SECONDS
                 );
-                return $row + $vfields;
+                $hasCachedValues = (
+                    $link->getPhone() !== null
+                    || $link->getOrg() !== null
+                    || $link->getAvatarUrl() !== null
+                );
+
+                if ($hasCachedValues === false || $isStale === true) {
+                    $vfields = $this->extractVcardFields(
+                        addressbookId: $link->getAddressbookId(),
+                        contactUri: $link->getContactUri(),
+                        contactUid: $link->getContactUid()
+                    );
+
+                    // Persist the freshened values + bump linkedAt so
+                    // the next read can rely on the cache. Best-effort;
+                    // a DB failure here doesn't break the list call.
+                    try {
+                        $link->setPhone($vfields['phone']);
+                        $link->setOrg($vfields['org']);
+                        $link->setAvatarUrl($vfields['avatarUrl']);
+                        $this->contactLinkMapper->update($link);
+                    } catch (\Throwable $e) {
+                        $this->logger->debug(
+                            'Failed to persist re-enriched vCard fields: '.$e->getMessage()
+                        );
+                    }
+
+                    $row['phone']     = $vfields['phone'];
+                    $row['org']       = $vfields['org'];
+                    $row['avatarUrl'] = $vfields['avatarUrl'];
+                }
+
+                return $row;
             },
             $links
         );
@@ -280,22 +336,35 @@ class ContactService
     /**
      * Link an existing contact to an object.
      *
+     * Tier-2: the call is idempotent — if a link row already exists for
+     * `(objectUuid, contactUid)` (enforced by the
+     * `idx_contact_object_uid_uniq` index) the row is updated in-place
+     * with the freshened cached fields and the new role. Callers that
+     * relied on the previous "always-insert" semantics still get a
+     * persisted entity back.
+     *
      * @param string      $objectUuid    The object UUID.
      * @param int         $registerId    The register ID.
      * @param int         $addressbookId The addressbook ID.
      * @param string      $contactUri    The contact URI in the addressbook.
      * @param string|null $role          The role of this contact on the object.
+     * @param int|null    $schemaId      Optional schema id (Tier-2).
      *
-     * @return ContactLink The created link.
+     * @return ContactLink The created or updated link.
      *
      * @throws Exception If the contact does not exist.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Single switch on upsert state — extracting a sub-method
+     *                                                doesn't add clarity and would split the vCard hydration
+     *                                                from the DB write that consumes it.
      */
     public function linkContact(
         string $objectUuid,
         int $registerId,
         int $addressbookId,
         string $contactUri,
-        ?string $role=null
+        ?string $role=null,
+        ?int $schemaId=null
     ): ContactLink {
         // Verify the contact exists.
         $card = $this->cardDavBackend->getCard($addressbookId, $contactUri);
@@ -317,6 +386,15 @@ class ContactService
             $email = (string) $vcard->EMAIL;
         }
 
+        // Tier-2: extract the widened payload (phone / org / avatar) so
+        // the row can serve future list calls without round-tripping
+        // CardDAV.
+        $vfields = $this->extractVcardFields(
+            addressbookId: $addressbookId,
+            contactUri: $contactUri,
+            contactUid: $contactUid
+        );
+
         // Add X-OPENREGISTER-* properties to the vCard.
         $vcard->add('X-OPENREGISTER-OBJECT', $objectUuid);
         if ($role !== null) {
@@ -325,15 +403,52 @@ class ContactService
 
         $this->cardDavBackend->updateCard($addressbookId, $contactUri, $vcard->serialize());
 
+        // Upsert: if a row already exists for this (objectUuid, contactUid)
+        // pair, refresh its cached fields + role instead of inserting.
+        $existing = null;
+        if ($contactUid !== '') {
+            $existing = $this->contactLinkMapper->findByObjectAndContact(
+                objectUuid: $objectUuid,
+                contactUid: $contactUid
+            );
+        }
+
+        if ($existing !== null) {
+            $existing->setRegisterId($registerId);
+            if ($schemaId !== null) {
+                $existing->setSchemaId($schemaId);
+            }
+
+            $existing->setAddressbookId($addressbookId);
+            $existing->setContactUri($contactUri);
+            $existing->setDisplayName($displayName);
+            $existing->setEmail($email);
+            $existing->setPhone($vfields['phone']);
+            $existing->setOrg($vfields['org']);
+            $existing->setAvatarUrl($vfields['avatarUrl']);
+            $existing->setRole($role);
+            $existing->setLinkedBy($user->getUID());
+            $existing->setLinkedAt(new DateTime());
+
+            return $this->contactLinkMapper->update($existing);
+        }
+
         // Create DB record.
         $link = new ContactLink();
         $link->setObjectUuid($objectUuid);
         $link->setRegisterId($registerId);
+        if ($schemaId !== null) {
+            $link->setSchemaId($schemaId);
+        }
+
         $link->setContactUid($contactUid);
         $link->setAddressbookId($addressbookId);
         $link->setContactUri($contactUri);
         $link->setDisplayName($displayName);
         $link->setEmail($email);
+        $link->setPhone($vfields['phone']);
+        $link->setOrg($vfields['org']);
+        $link->setAvatarUrl($vfields['avatarUrl']);
         $link->setRole($role);
         $link->setLinkedBy($user->getUID());
         $link->setLinkedAt(new DateTime());
@@ -344,9 +459,17 @@ class ContactService
     /**
      * Create a new contact and link it to an object.
      *
-     * @param string $objectUuid The object UUID.
-     * @param int    $registerId The register ID.
-     * @param array  $data       Contact data: fullName, email, phone, role.
+     * Tier-2: extended to persist `phone` / `org` straight from the
+     * caller-supplied payload, and to accept an optional `schemaId`
+     * + free-form `org` field. The avatar URL falls back to the
+     * per-uid Contacts route (no PHOTO is set on freshly-created
+     * vCards yet).
+     *
+     * @param string   $objectUuid The object UUID.
+     * @param int      $registerId The register ID.
+     * @param array    $data       Contact data: `fullName` or `displayName`, `email`,
+     *                             `phone`, `org`, `role`.
+     * @param int|null $schemaId   Optional schema id (Tier-2).
      *
      * @return ContactLink The created link.
      *
@@ -355,7 +478,8 @@ class ContactService
     public function createAndLinkContact(
         string $objectUuid,
         int $registerId,
-        array $data
+        array $data,
+        ?int $schemaId=null
     ): ContactLink {
         $user = $this->userSession->getUser();
         if ($user === null) {
@@ -369,20 +493,30 @@ class ContactService
 
         $uid  = strtoupper(bin2hex(random_bytes(16)));
         $role = $data['role'] ?? null;
+        // Accept both `fullName` (existing) and `displayName` (spec /
+        // dialog form field) as the human-readable label.
+        $displayName = $data['displayName'] ?? $data['fullName'] ?? 'Unknown';
+        $phone       = $data['phone'] ?? null;
+        $email       = $data['email'] ?? null;
+        $org         = $data['org'] ?? null;
 
         // Build vCard.
         $lines   = [];
         $lines[] = 'BEGIN:VCARD';
         $lines[] = 'VERSION:3.0';
         $lines[] = 'UID:'.$uid;
-        $lines[] = 'FN:'.($data['fullName'] ?? 'Unknown');
+        $lines[] = 'FN:'.$displayName;
 
-        if (empty($data['email']) === false) {
-            $lines[] = 'EMAIL;TYPE=INTERNET:'.$data['email'];
+        if (empty($email) === false) {
+            $lines[] = 'EMAIL;TYPE=INTERNET:'.$email;
         }
 
-        if (empty($data['phone']) === false) {
-            $lines[] = 'TEL;TYPE=CELL:'.$data['phone'];
+        if (empty($phone) === false) {
+            $lines[] = 'TEL;TYPE=CELL:'.$phone;
+        }
+
+        if (empty($org) === false) {
+            $lines[] = 'ORG:'.$org;
         }
 
         $lines[] = 'X-OPENREGISTER-OBJECT:'.$objectUuid;
@@ -401,11 +535,19 @@ class ContactService
         $link = new ContactLink();
         $link->setObjectUuid($objectUuid);
         $link->setRegisterId($registerId);
+        if ($schemaId !== null) {
+            $link->setSchemaId($schemaId);
+        }
+
         $link->setContactUid($uid);
         $link->setAddressbookId($addressbook['id']);
         $link->setContactUri($contactUri);
-        $link->setDisplayName($data['fullName'] ?? null);
-        $link->setEmail($data['email'] ?? null);
+        $link->setDisplayName($displayName);
+        $link->setEmail($email);
+        $link->setPhone($phone);
+        $link->setOrg($org);
+        // PHOTO not set yet — fall back to the per-uid Contacts route.
+        $link->setAvatarUrl('/index.php/apps/contacts/photo/'.rawurlencode($uid));
         $link->setRole($role);
         $link->setLinkedBy($user->getUID());
         $link->setLinkedAt(new DateTime());
@@ -501,6 +643,37 @@ class ContactService
 
         $this->contactLinkMapper->delete($link);
     }//end unlinkContact()
+
+    /**
+     * Unlink a contact from a specific object by contact uid.
+     *
+     * Convenience overload of `unlinkContact(int $linkId)` for callers
+     * that hold the vCard's UID (e.g. the REST destroy endpoint, which
+     * routes on `{contactUid}` because the link id isn't visible in the
+     * URL). Resolves the link row via
+     * `ContactLinkMapper::findByObjectAndContact()` and delegates to the
+     * id-based path; tolerates missing rows + missing vCards exactly
+     * the same way.
+     *
+     * @param string $objectUuid The object UUID.
+     * @param string $contactUid The vCard UID.
+     *
+     * @return void
+     *
+     * @throws Exception If no row is found for the (objectUuid, contactUid) pair.
+     */
+    public function unlinkContactByUid(string $objectUuid, string $contactUid): void
+    {
+        $link = $this->contactLinkMapper->findByObjectAndContact(
+            objectUuid: $objectUuid,
+            contactUid: $contactUid
+        );
+        if ($link === null) {
+            throw new Exception('Contact link not found', 404);
+        }
+
+        $this->unlinkContact($link->getId());
+    }//end unlinkContactByUid()
 
     /**
      * Find all objects linked to a contact.

--- a/tests/Unit/Controller/ContactsControllerTest.php
+++ b/tests/Unit/Controller/ContactsControllerTest.php
@@ -168,6 +168,135 @@ class ContactsControllerTest extends TestCase
     // Email-only match
     // -------------------------------------------------------------------------
 
+    // -------------------------------------------------------------------------
+    // Tier-2: destroy by contact uid + create-new endpoint
+    // -------------------------------------------------------------------------
+
+    /**
+     * Tier-2: destroy with a non-numeric `{contactUid}` resolves through
+     * `unlinkContactByUid` (not the legacy id-based path).
+     */
+    public function testDestroyRoutesNonNumericUidThroughUnlinkByUid(): void
+    {
+        $object = new \OCA\OpenRegister\Db\ObjectEntity();
+        $object->setUuid('abc-123');
+
+        $this->objectService->method('getObject')->willReturn($object);
+
+        $this->contactService->expects($this->once())
+            ->method('unlinkContactByUid')
+            ->with('abc-123', 'jan-uid');
+
+        $response = $this->controller->destroy('reg', 'sch', 'oid', 'jan-uid');
+
+        $this->assertSame(200, $response->getStatus());
+        $this->assertSame(['success' => true], $response->getData());
+    }
+
+    /**
+     * Tier-2: destroy with a numeric `{contactUid}` falls back to the
+     * legacy id-based unlink path (back-compat).
+     */
+    public function testDestroyRoutesNumericIdThroughLegacyUnlink(): void
+    {
+        $object = new \OCA\OpenRegister\Db\ObjectEntity();
+        $object->setUuid('abc-123');
+
+        $this->objectService->method('getObject')->willReturn($object);
+
+        $this->contactService->expects($this->once())
+            ->method('unlinkContact')
+            ->with(42);
+
+        $response = $this->controller->destroy('reg', 'sch', 'oid', '42');
+
+        $this->assertSame(200, $response->getStatus());
+    }
+
+    /**
+     * Tier-2: createNew rejects payloads carrying a contactUri (link
+     * shape) with a 400.
+     */
+    public function testCreateNewRejectsLinkPayload(): void
+    {
+        $object = new \OCA\OpenRegister\Db\ObjectEntity();
+        $object->setUuid('abc-123');
+        $object->setRegister('5');
+        $object->setSchema('7');
+
+        $this->objectService->method('getObject')->willReturn($object);
+        $this->request->method('getParams')->willReturn([
+            'contactUri'    => 'jan.vcf',
+            'addressbookId' => 1,
+            'displayName'   => 'Jan',
+        ]);
+
+        $response = $this->controller->createNew('reg', 'sch', 'oid');
+
+        $this->assertSame(400, $response->getStatus());
+    }
+
+    /**
+     * Tier-2: createNew requires `displayName` (or back-compat
+     * `fullName`).
+     */
+    public function testCreateNewRequiresDisplayName(): void
+    {
+        $object = new \OCA\OpenRegister\Db\ObjectEntity();
+        $object->setUuid('abc-123');
+        $object->setRegister('5');
+        $object->setSchema('7');
+
+        $this->objectService->method('getObject')->willReturn($object);
+        $this->request->method('getParams')->willReturn([
+            'email' => 'jan@example.nl',
+        ]);
+
+        $response = $this->controller->createNew('reg', 'sch', 'oid');
+
+        $this->assertSame(400, $response->getStatus());
+    }
+
+    /**
+     * Tier-2: createNew passes the schema id through to
+     * `createAndLinkContact`.
+     */
+    public function testCreateNewThreadsSchemaId(): void
+    {
+        $object = new \OCA\OpenRegister\Db\ObjectEntity();
+        $object->setUuid('abc-123');
+        $object->setRegister('5');
+        $object->setSchema('7');
+
+        $this->objectService->method('getObject')->willReturn($object);
+        $this->request->method('getParams')->willReturn([
+            'displayName' => 'Jan de Vries',
+            'email'       => 'jan@example.nl',
+            'role'        => 'applicant',
+        ]);
+
+        $link = new \OCA\OpenRegister\Db\ContactLink();
+        $link->setObjectUuid('abc-123');
+
+        $this->contactService->expects($this->once())
+            ->method('createAndLinkContact')
+            ->with(
+                'abc-123',
+                5,
+                $this->callback(static function (array $data): bool {
+                    return $data['displayName'] === 'Jan de Vries'
+                        && $data['email'] === 'jan@example.nl'
+                        && $data['role'] === 'applicant';
+                }),
+                7
+            )
+            ->willReturn($link);
+
+        $response = $this->controller->createNew('reg', 'sch', 'oid');
+
+        $this->assertSame(201, $response->getStatus());
+    }
+
     public function testMatchWorksWithEmailOnly(): void
     {
         $this->request->method('getParam')

--- a/tests/Unit/Db/ContactLinkTest.php
+++ b/tests/Unit/Db/ContactLinkTest.php
@@ -52,4 +52,40 @@ class ContactLinkTest extends TestCase
         $this->assertSame('handler', $link->getRole());
         $this->assertSame('contact-123', $link->getContactUid());
     }
+
+    /**
+     * Tier-2: jsonSerialize emits the widened payload (phone / org /
+     * avatarUrl / schemaId / metadata) plus the original fields.
+     */
+    public function testJsonSerializeEmitsTier2Fields(): void
+    {
+        $link = new ContactLink();
+        $link->setObjectUuid('abc-123');
+        $link->setSchemaId(7);
+        $link->setPhone('+31 6 1234');
+        $link->setOrg('Acme B.V.');
+        $link->setAvatarUrl('https://example.com/jan.jpg');
+        $link->setMetadata(json_encode(['note' => 'hello']));
+
+        $json = $link->jsonSerialize();
+
+        $this->assertSame(7, $json['schemaId']);
+        $this->assertSame('+31 6 1234', $json['phone']);
+        $this->assertSame('Acme B.V.', $json['org']);
+        $this->assertSame('https://example.com/jan.jpg', $json['avatarUrl']);
+        $this->assertSame(['note' => 'hello'], $json['metadata']);
+    }
+
+    /**
+     * Tier-2: corrupt metadata JSON does not blow up the serialiser.
+     */
+    public function testJsonSerializeToleratesCorruptMetadata(): void
+    {
+        $link = new ContactLink();
+        $link->setMetadata('{ this is not json');
+
+        $json = $link->jsonSerialize();
+
+        $this->assertNull($json['metadata']);
+    }
 }

--- a/tests/Unit/Service/ContactServiceTest.php
+++ b/tests/Unit/Service/ContactServiceTest.php
@@ -26,7 +26,7 @@ class ContactServiceTest extends TestCase
     {
         $this->contactLinkMapper = $this->getMockBuilder(ContactLinkMapper::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['findByObjectUuid', 'findByContactUid', 'countByObjectUuid', 'deleteByObjectUuid', 'insert', 'delete'])
+            ->onlyMethods(['findByObjectUuid', 'findByContactUid', 'findByObjectAndContact', 'countByObjectUuid', 'deleteByObjectUuid', 'insert', 'update', 'delete'])
             ->addMethods(['find'])
             ->getMock();
         $this->cardDavBackend = $this->createMock(CardDavBackend::class);
@@ -236,12 +236,55 @@ class ContactServiceTest extends TestCase
         $this->cardDavBackend->method('getCard')->willReturn(['carddata' => $vcardData]);
         $this->cardDavBackend->expects($this->once())->method('updateCard');
 
+        // Tier-2: linkContact now consults findByObjectAndContact for
+        // idempotent upsert. Returning null means "no prior row" and
+        // the service falls through to the insert path.
+        $this->contactLinkMapper->method('findByObjectAndContact')->willReturn(null);
+
         $this->contactLinkMapper->expects($this->once())
             ->method('insert')
             ->willReturnCallback(function (ContactLink $link): ContactLink {
                 $this->assertSame('abc-123', $link->getObjectUuid());
                 $this->assertSame('Jan de Vries', $link->getDisplayName());
                 $this->assertSame('jan@example.nl', $link->getEmail());
+                $this->assertSame('applicant', $link->getRole());
+                return $link;
+            });
+
+        $this->service->linkContact('abc-123', 5, 1, 'jan.vcf', 'applicant');
+    }
+
+    /**
+     * Tier-2: when a row already exists for the (objectUuid, contactUid)
+     * pair, linkContact updates it in-place instead of inserting.
+     *
+     * @return void
+     */
+    public function testLinkContactUpsertsExistingRow(): void
+    {
+        $this->setupUser();
+
+        $vcardData = "BEGIN:VCARD\r\nVERSION:3.0\r\nUID:jan-uid\r\nFN:Jan de Vries\r\nEMAIL:jan@example.nl\r\nEND:VCARD\r\n";
+
+        $this->cardDavBackend->method('getCard')->willReturn(['carddata' => $vcardData]);
+        $this->cardDavBackend->expects($this->once())->method('updateCard');
+
+        $existing = new ContactLink();
+        $existing->setId(99);
+        $existing->setObjectUuid('abc-123');
+        $existing->setContactUid('jan-uid');
+        $existing->setRole('observer');
+
+        $this->contactLinkMapper->method('findByObjectAndContact')
+            ->with('abc-123', 'jan-uid')
+            ->willReturn($existing);
+
+        // Must update (not insert) and the role must be refreshed.
+        $this->contactLinkMapper->expects($this->never())->method('insert');
+        $this->contactLinkMapper->expects($this->once())
+            ->method('update')
+            ->willReturnCallback(function (ContactLink $link): ContactLink {
+                $this->assertSame(99, $link->getId());
                 $this->assertSame('applicant', $link->getRole());
                 return $link;
             });
@@ -324,6 +367,46 @@ class ContactServiceTest extends TestCase
             ->with($link);
 
         $this->service->unlinkContact(456);
+    }
+
+    /**
+     * Tier-2: unlinkContactByUid resolves the link row via the
+     * (objectUuid, contactUid) composite index, then delegates to the
+     * id-based unlinkContact path.
+     */
+    public function testUnlinkContactByUidResolvesAndDelegates(): void
+    {
+        $link = new ContactLink();
+        $link->setId(42);
+        $link->setObjectUuid('abc-123');
+        $link->setContactUid('jan-uid');
+        $link->setAddressbookId(1);
+        $link->setContactUri('jan.vcf');
+
+        $this->contactLinkMapper->method('findByObjectAndContact')
+            ->with('abc-123', 'jan-uid')
+            ->willReturn($link);
+        $this->contactLinkMapper->method('find')->with(42)->willReturn($link);
+        $this->cardDavBackend->method('getCard')->willReturn(false);
+
+        $this->contactLinkMapper->expects($this->once())
+            ->method('delete')
+            ->with($link);
+
+        $this->service->unlinkContactByUid('abc-123', 'jan-uid');
+    }
+
+    /**
+     * Tier-2: unlinkContactByUid raises 404 when no row matches.
+     */
+    public function testUnlinkContactByUidThrowsWhenMissing(): void
+    {
+        $this->contactLinkMapper->method('findByObjectAndContact')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Contact link not found');
+
+        $this->service->unlinkContactByUid('abc-123', 'missing-uid');
     }
 
     public function testGetObjectsForContactReturnsLinks(): void


### PR DESCRIPTION
## Summary

Brings the contacts integration leaf from Tier-1 (provider works + bespoke UI mounts) to Tier-2 (full feature set: explicit link table + dedicated service + REST controller + picker UX + inline create).

The backend ContactService + ContactsController already existed but had:
- a missing-columns gap on `oc_openregister_contact_links` (no `schema_id`, `phone`, `org`, `avatar_url`, `metadata`)
- a bug in `ContactsController::destroy()` — called `unlinkContact($objectUuid, $contactUid)` against a service signature of `unlinkContact(int $linkId)`, so the route silently 500-errored
- no upsert / idempotency for the link path
- no dedicated `/contacts/new` route for the create-only UX flow
- no 24h enrichment TTL on the cached vCard fields

## What changed

### Migration (`Version1Date20260524100000`)
- Adds `schema_id`, `phone`, `org`, `avatar_url`, `metadata` columns to `oc_openregister_contact_links`
- Adds unique composite index `(object_uuid, contact_uid)` so the ContactService upsert path can rely on the DB for idempotency
- Idempotent — re-runs skip columns/indexes that already exist
- Recreates the table when an earlier `26100001` drop migration removed it

### Entity + Mapper
- `ContactLink`: new getters/setters for `schemaId`, `phone`, `org`, `avatarUrl`, `metadata` — `jsonSerialize` emits Tier-2 payload + JSON-decodes the metadata bag
- `ContactLinkMapper`: new `findByObjectAndContact(objectUuid, contactUid)` for the upsert path

### Service
- `linkContact` — optional `schemaId`; idempotent upsert via `findByObjectAndContact` (refreshes phone/org/avatar/role on the existing row instead of duplicate-keying)
- `linkContact` + `createAndLinkContact` — persist phone/org/avatar at link time so the next list call serves from the DB cache
- `createAndLinkContact` — accepts `displayName` alongside `fullName`, plus `org` and `schemaId`
- `getContactsForObject` — 24h enrichment TTL re-reads + persists refreshed cached fields when stale; best-effort
- `unlinkContactByUid(objectUuid, contactUid)` — resolves via composite index, delegates to id-based unlink

### Controller + routes
- New `createNew()` action → `POST /api/objects/{r}/{s}/{id}/contacts/new` create-only path for the `CnContactCreate` dialog
- `create()` — accepts `displayName` alongside `fullName` and threads schemaId through
- `destroy()` — fixed: routes numeric `{contactUid}` through the legacy id-based path and non-numeric values through `unlinkContactByUid`

## Test plan

- [x] PHPUnit `ContactServiceTest`: 15/15 pass — including 2 new tests for upsert + unlinkByUid
- [x] PHPUnit `ContactsControllerTest`: 9/9 pass — including 4 new tests for destroy routing + createNew validation + schemaId threading
- [x] PHPUnit `ContactLinkTest`: 4/4 pass — including 2 new tests for Tier-2 payload + corrupt-metadata tolerance
- [x] Total: 63/63 contact-related unit tests green in the dev container
- [x] Full unit suite shows no new failures introduced by this PR (the pre-existing ZipStream / findJsonbColumnsNeedingRetype / findSchema failures are unrelated)
- [ ] Manual smoke: link existing contact via picker, create new contact, unlink — both code paths through the dev container

Refs: ADR-019, ADR-022, openregister#1311 — paired with nextcloud-vue PR for the picker + create dialogs.