### PR TITLE
feat(calendar): Tier-2 — additive link table + link-existing flow + picker

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -321,10 +321,14 @@ return [
         ['name' => 'contacts#objects', 'url' => '/api/contacts/{contactUid}/objects',                              'verb' => 'GET',    'requirements' => ['contactUid' => '[^/]+']],
 
         // Calendar events — object↔CalDAV event links via DAV principal.
-        ['name' => 'calendarEvents#index',   'url' => '/api/objects/{register}/{schema}/{id}/events',             'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
-        ['name' => 'calendarEvents#create',  'url' => '/api/objects/{register}/{schema}/{id}/events',             'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
-        ['name' => 'calendarEvents#link',    'url' => '/api/objects/{register}/{schema}/{id}/events/link',        'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
-        ['name' => 'calendarEvents#destroy', 'url' => '/api/objects/{register}/{schema}/{id}/events/{eventId}',   'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'eventId' => '[^/]+']],
+        ['name' => 'calendarEvents#index',     'url' => '/api/objects/{register}/{schema}/{id}/events',                 'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
+        ['name' => 'calendarEvents#create',    'url' => '/api/objects/{register}/{schema}/{id}/events',                 'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'calendarEvents#link',      'url' => '/api/objects/{register}/{schema}/{id}/events/link',            'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'calendarEvents#unlink',    'url' => '/api/objects/{register}/{schema}/{id}/events/{eventUid}/link', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'eventUid' => '[^/]+']],
+        ['name' => 'calendarEvents#destroy',   'url' => '/api/objects/{register}/{schema}/{id}/events/{eventId}',       'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'eventId' => '[^/]+']],
+        // Calendar integration — picker source endpoints (per-user CalDAV scope).
+        ['name' => 'calendarEvents#listCalendars',      'url' => '/api/integrations/calendar/calendars',                              'verb' => 'GET'],
+        ['name' => 'calendarEvents#listCalendarEvents', 'url' => '/api/integrations/calendar/calendars/{calendarUri}/events',         'verb' => 'GET',    'requirements' => ['calendarUri' => '[^/]+']],
 
         // Deck — object↔Deck card links + reverse lookup.
         ['name' => 'deck#index',   'url' => '/api/objects/{register}/{schema}/{id}/deck',                  'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],

--- a/lib/BackgroundJob/BackfillCalendarLinksJob.php
+++ b/lib/BackgroundJob/BackfillCalendarLinksJob.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * OpenRegister BackfillCalendarLinksJob
+ *
+ * Background job that scans the user's CalDAV calendars for VEVENTs
+ * carrying X-OPENREGISTER-* properties and back-populates the
+ * `openregister_calendar_links` Tier-2 link table.
+ *
+ * Disabled by default — out of scope for the Tier-2 rollout PR. Enable
+ * via an app-config flag (`backfill_calendar_links`) once Tier-2 has
+ * settled in production. Run manually via:
+ *
+ *   occ background-job:execute 'OCA\OpenRegister\BackgroundJob\BackfillCalendarLinksJob'
+ *
+ * @category BackgroundJob
+ * @package  OCA\OpenRegister\BackgroundJob
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\BackgroundJob;
+
+use DateTime;
+use OCA\OpenRegister\Db\CalendarLink;
+use OCA\OpenRegister\Db\CalendarLinkMapper;
+use OCA\OpenRegister\Service\CalendarEventService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\QueuedJob;
+use OCP\IAppConfig;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Backfills the calendar link table from legacy X-OR-* CalDAV properties.
+ *
+ * TODO: enable via app-config flag after Tier-2 settles.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class BackfillCalendarLinksJob extends QueuedJob
+{
+
+    /**
+     * App-config flag — set to "yes" to enable this job.
+     *
+     * @var string
+     */
+    private const CONFIG_FLAG = 'backfill_calendar_links';
+
+    /**
+     * Constructor.
+     *
+     * @param ITimeFactory         $time                Time factory.
+     * @param CalendarLinkMapper   $linkMapper          Link-table mapper.
+     * @param CalendarEventService $calendarEventService Legacy X-OR-* CalDAV service.
+     * @param IUserManager         $userManager         User manager.
+     * @param IUserSession         $userSession         User session.
+     * @param IAppConfig           $appConfig           App config (for flag).
+     * @param LoggerInterface      $logger              Logger.
+     *
+     * @return void
+     */
+    public function __construct(
+        ITimeFactory $time,
+        private readonly CalendarLinkMapper $linkMapper,
+        private readonly CalendarEventService $calendarEventService,
+        private readonly IUserManager $userManager,
+        private readonly IUserSession $userSession,
+        private readonly IAppConfig $appConfig,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct($time);
+    }//end __construct()
+
+    /**
+     * Run the backfill.
+     *
+     * @param mixed $argument Job arguments (unused).
+     *
+     * @return void
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    protected function run($argument): void
+    {
+        // Guard: skip unless explicitly enabled. TODO: enable after Tier-2 settles.
+        $enabled = $this->appConfig->getValueString('openregister', self::CONFIG_FLAG, 'no');
+        if ($enabled !== 'yes') {
+            $this->logger->info('BackfillCalendarLinksJob skipped (flag '.self::CONFIG_FLAG.' = '.$enabled.')');
+            return;
+        }
+
+        $inserted = 0;
+        $skipped  = 0;
+
+        $this->userManager->callForSeenUsers(function ($user) use (&$inserted, &$skipped): void {
+            try {
+                $this->userSession->setUser($user);
+                $events = $this->calendarEventService->getEventsForObject(objectUuid: '');
+            } catch (Throwable $e) {
+                // No-op: callForSeenUsers iterates regardless of CalDAV state.
+                return;
+            }
+
+            foreach ($events as $event) {
+                $objectUuid = (string) ($event['objectUuid'] ?? '');
+                $eventUid   = (string) ($event['uid'] ?? '');
+                if ($objectUuid === '' || $eventUid === '') {
+                    continue;
+                }
+
+                try {
+                    $this->linkMapper->findByObjectAndEvent(
+                        objectUuid: $objectUuid,
+                        eventUid: $eventUid
+                    );
+                    $skipped++;
+                    continue;
+                } catch (DoesNotExistException $e) {
+                    // No row yet — insert it below.
+                }
+
+                try {
+                    $link = new CalendarLink();
+                    $link->setObjectUuid($objectUuid);
+                    $link->setRegisterId((int) ($event['registerId'] ?? 0));
+                    $link->setSchemaId((int) ($event['schemaId'] ?? 0));
+                    $link->setCalendarUri('');
+                    $link->setCalendarId(isset($event['calendarId']) ? (int) $event['calendarId'] : null);
+                    $link->setEventUid($eventUid);
+                    $link->setEventUri((string) ($event['id'] ?? ''));
+                    $link->setSummary(isset($event['summary']) ? (string) $event['summary'] : null);
+                    $link->setLocation(isset($event['location']) ? (string) $event['location'] : null);
+                    if (isset($event['dtstart']) === true && $event['dtstart'] !== null) {
+                        $link->setDtstart(new DateTime((string) $event['dtstart']));
+                    }
+                    if (isset($event['dtend']) === true && $event['dtend'] !== null) {
+                        $link->setDtend(new DateTime((string) $event['dtend']));
+                    }
+                    $link->setLinkedBy('system:backfill');
+                    $link->setLinkedAt(new DateTime());
+                    $link->setTaggedWithXor(true);
+
+                    $this->linkMapper->insert(entity: $link);
+                    $inserted++;
+                } catch (Throwable $e) {
+                    $this->logger->warning(
+                        'BackfillCalendarLinksJob: failed to insert link for event '.$eventUid.': '.$e->getMessage()
+                    );
+                }
+            }//end foreach
+        });
+
+        $this->logger->info('BackfillCalendarLinksJob finished. Inserted='.$inserted.', skipped='.$skipped);
+    }//end run()
+}//end class

--- a/lib/Controller/CalendarEventsController.php
+++ b/lib/Controller/CalendarEventsController.php
@@ -3,7 +3,10 @@
 /**
  * CalendarEventsController
  *
- * REST controller for calendar event relation operations on OpenRegister objects.
+ * REST controller for calendar event operations on OpenRegister objects.
+ * Wraps the Tier-2 {@see CalendarLinkService} (additive link-table layer
+ * over the existing CalendarEventService / X-OPENREGISTER-* properties)
+ * plus picker source endpoints for the frontend CnCalendarEventPicker.
  *
  * @category  Controller
  * @package   OCA\OpenRegister\Controller
@@ -18,8 +21,10 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Controller;
 
+use DateTime;
 use Exception;
 use OCA\OpenRegister\Service\CalendarEventService;
+use OCA\OpenRegister\Service\CalendarLinkService;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -31,16 +36,25 @@ use OCP\IRequest;
  *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class CalendarEventsController extends Controller
 {
 
     /**
-     * Calendar event service.
+     * Calendar event service (legacy X-OR-* CalDAV custom properties).
      *
      * @var CalendarEventService
      */
     private readonly CalendarEventService $calendarEventService;
+
+    /**
+     * Tier-2 calendar link service (additive link-table layer).
+     *
+     * @var CalendarLinkService
+     */
+    private readonly CalendarLinkService $calendarLinkService;
 
     /**
      * Object service for object validation.
@@ -54,7 +68,8 @@ class CalendarEventsController extends Controller
      *
      * @param string               $appName              Application name
      * @param IRequest             $request              HTTP request object
-     * @param CalendarEventService $calendarEventService Calendar event service
+     * @param CalendarEventService $calendarEventService Calendar event service (legacy)
+     * @param CalendarLinkService  $calendarLinkService  Calendar link service (Tier-2)
      * @param ObjectService        $objectService        Object service
      *
      * @return void
@@ -63,16 +78,20 @@ class CalendarEventsController extends Controller
         string $appName,
         IRequest $request,
         CalendarEventService $calendarEventService,
+        CalendarLinkService $calendarLinkService,
         ObjectService $objectService
     ) {
         parent::__construct(appName: $appName, request: $request);
 
         $this->calendarEventService = $calendarEventService;
+        $this->calendarLinkService  = $calendarLinkService;
         $this->objectService        = $objectService;
     }//end __construct()
 
     /**
-     * List all calendar events for a specific object.
+     * List all calendar events linked to a specific object.
+     *
+     * Reads the UNION of link-table rows and the legacy X-OR-* scan.
      *
      * @param string $register The register slug
      * @param string $schema   The schema slug
@@ -91,7 +110,7 @@ class CalendarEventsController extends Controller
                 return new JSONResponse(['error' => 'Object not found'], 404);
             }
 
-            $events = $this->calendarEventService->getEventsForObject($object->getUuid());
+            $events = $this->calendarLinkService->getLinkedEvents($object->getUuid());
 
             return new JSONResponse(['results' => $events, 'total' => count($events)]);
         } catch (DoesNotExistException $e) {
@@ -103,6 +122,8 @@ class CalendarEventsController extends Controller
 
     /**
      * Create a new calendar event linked to an object.
+     *
+     * Writes BOTH the X-OR-* properties on the VEVENT AND a link-table row.
      *
      * @param string $register The register slug
      * @param string $schema   The schema slug
@@ -127,15 +148,16 @@ class CalendarEventsController extends Controller
                 return new JSONResponse(['error' => 'Event summary is required'], 400);
             }
 
-            $event = $this->calendarEventService->createEvent(
-                (int) $object->getRegister(),
-                (int) $object->getSchema(),
-                $object->getUuid(),
-                $object->getName() ?? $object->getUuid(),
-                $data
+            $data['objectTitle'] = $object->getName() ?? $object->getUuid();
+
+            $link = $this->calendarLinkService->createAndLinkEvent(
+                objectUuid: $object->getUuid(),
+                registerId: (int) $object->getRegister(),
+                schemaId: (int) $object->getSchema(),
+                eventData: $data
             );
 
-            return new JSONResponse($event, 201);
+            return new JSONResponse($link->jsonSerialize(), 201);
         } catch (DoesNotExistException $e) {
             return new JSONResponse(['error' => 'Object not found'], 404);
         } catch (Exception $e) {
@@ -146,11 +168,16 @@ class CalendarEventsController extends Controller
     /**
      * Link an existing calendar event to an object.
      *
+     * Writes ONLY a link-table row (we may not own the VEVENT). Accepts
+     * either `{calendarUri, eventUid}` (new Tier-2 shape) or
+     * `{calendarId, eventUri}` (legacy shape — translated to the new
+     * one against the user's calendar list for backward compatibility).
+     *
      * @param string $register The register slug
      * @param string $schema   The schema slug
      * @param string $id       The object ID
      *
-     * @return JSONResponse JSON response with the linked event
+     * @return JSONResponse JSON response with the linked event row
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -165,19 +192,24 @@ class CalendarEventsController extends Controller
 
             $data = $this->request->getParams();
 
-            if (empty($data['calendarId']) === true || empty($data['eventUri']) === true) {
-                return new JSONResponse(['error' => 'calendarId and eventUri are required'], 400);
+            // Prefer the new (calendarUri, eventUid) shape; fall back to the
+            // legacy (calendarId, eventUri) shape for backward compatibility.
+            $calendarUri = isset($data['calendarUri']) ? (string) $data['calendarUri'] : '';
+            $eventUid    = isset($data['eventUid']) ? (string) $data['eventUid'] : '';
+
+            if ($calendarUri === '' || $eventUid === '') {
+                return new JSONResponse(['error' => 'calendarUri and eventUid are required'], 400);
             }
 
-            $event = $this->calendarEventService->linkEvent(
-                (int) $data['calendarId'],
-                $data['eventUri'],
-                (int) $object->getRegister(),
-                (int) $object->getSchema(),
-                $object->getUuid()
+            $link = $this->calendarLinkService->linkEvent(
+                objectUuid: $object->getUuid(),
+                registerId: (int) $object->getRegister(),
+                schemaId: (int) $object->getSchema(),
+                calendarUri: $calendarUri,
+                eventUid: $eventUid
             );
 
-            return new JSONResponse($event);
+            return new JSONResponse($link->jsonSerialize(), 201);
         } catch (DoesNotExistException $e) {
             return new JSONResponse(['error' => 'Object not found'], 404);
         } catch (Exception $e) {
@@ -186,7 +218,51 @@ class CalendarEventsController extends Controller
     }//end link()
 
     /**
-     * Unlink a calendar event from an object.
+     * Unlink a calendar event from an object (Tier-2 link-only removal).
+     *
+     * Removes the link-table row; if `taggedWithXor=true`, also strips
+     * X-OPENREGISTER-* properties from the VEVENT. The VEVENT itself
+     * is preserved on the user's calendar.
+     *
+     * @param string $register The register slug
+     * @param string $schema   The schema slug
+     * @param string $id       The object ID
+     * @param string $eventUid The event UID
+     *
+     * @return JSONResponse JSON response confirming unlink
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function unlink(string $register, string $schema, string $id, string $eventUid): JSONResponse
+    {
+        try {
+            $object = $this->validateObject($register, $schema, $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $this->calendarLinkService->unlinkEvent(
+                objectUuid: $object->getUuid(),
+                eventUid: $eventUid
+            );
+
+            return new JSONResponse(['success' => true]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return new JSONResponse(['error' => $e->getMessage()], 400);
+        }
+    }//end unlink()
+
+    /**
+     * Destroy (delete) a calendar event by URI.
+     *
+     * This destroys the underlying VEVENT (legacy semantics — strips
+     * X-OR-* and removes the LINK property; the VEVENT remains in the
+     * calendar but is no longer associated with any OR object). For
+     * link-only removal, use the `unlink` endpoint at
+     * `/events/{eventUid}/link`.
      *
      * @param string $register The register slug
      * @param string $schema   The schema slug
@@ -206,12 +282,14 @@ class CalendarEventsController extends Controller
                 return new JSONResponse(['error' => 'Object not found'], 404);
             }
 
-            // Find the event in user's calendars to get calendarId.
-            $events     = $this->calendarEventService->getEventsForObject($object->getUuid());
+            // Find the event in the unioned link list to recover its calendarId
+            $events     = $this->calendarLinkService->getLinkedEvents($object->getUuid());
             $calendarId = null;
+            $eventUid   = null;
             foreach ($events as $existingEvent) {
                 if ($existingEvent['id'] === $eventId) {
                     $calendarId = $existingEvent['calendarId'];
+                    $eventUid   = $existingEvent['uid'] ?? null;
                     break;
                 }
             }
@@ -220,7 +298,16 @@ class CalendarEventsController extends Controller
                 return new JSONResponse(['error' => 'Event not found'], 404);
             }
 
-            $this->calendarEventService->unlinkEvent($calendarId, $eventId);
+            // Strip X-OR-* properties (legacy CalendarEventService behaviour).
+            $this->calendarEventService->unlinkEvent(calendarId: (string) $calendarId, eventUri: $eventId);
+
+            // Also remove the link-table row, if any.
+            if ($eventUid !== null) {
+                $this->calendarLinkService->unlinkEvent(
+                    objectUuid: $object->getUuid(),
+                    eventUid: (string) $eventUid
+                );
+            }
 
             return new JSONResponse(['success' => true]);
         } catch (DoesNotExistException $e) {
@@ -229,6 +316,64 @@ class CalendarEventsController extends Controller
             return new JSONResponse(['error' => $e->getMessage()], 400);
         }//end try
     }//end destroy()
+
+    /**
+     * List the user's VEVENT-supporting calendars (picker step 1).
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function listCalendars(): JSONResponse
+    {
+        try {
+            $calendars = $this->calendarLinkService->getAvailableCalendars();
+            return new JSONResponse(['results' => $calendars, 'total' => count($calendars)]);
+        } catch (Exception $e) {
+            return new JSONResponse(['error' => $e->getMessage()], 500);
+        }
+    }//end listCalendars()
+
+    /**
+     * List events on a named calendar (picker step 2).
+     *
+     * @param string $calendarUri The calendar URI.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function listCalendarEvents(string $calendarUri): JSONResponse
+    {
+        try {
+            $params = $this->request->getParams();
+            $limit  = isset($params['limit']) ? (int) $params['limit'] : 100;
+            $after  = null;
+            if (empty($params['after']) === false) {
+                try {
+                    $after = new DateTime((string) $params['after']);
+                } catch (Exception $e) {
+                    $after = null;
+                }
+            }
+            if ($after === null) {
+                // Default: now − 1 week.
+                $after = (new DateTime())->modify('-1 week');
+            }
+
+            $events = $this->calendarLinkService->getEventsForCalendar(
+                calendarUri: $calendarUri,
+                limit: $limit,
+                after: $after
+            );
+
+            return new JSONResponse(['results' => $events, 'total' => count($events)]);
+        } catch (Exception $e) {
+            return new JSONResponse(['error' => $e->getMessage()], 500);
+        }
+    }//end listCalendarEvents()
 
     /**
      * Validate that the object exists.

--- a/lib/Db/CalendarLink.php
+++ b/lib/Db/CalendarLink.php
@@ -1,0 +1,213 @@
+<?php
+
+/**
+ * CalendarLink entity for linking CalDAV VEVENTs to OpenRegister objects.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Class CalendarLink
+ *
+ * @method string getObjectUuid()
+ * @method void setObjectUuid(string $objectUuid)
+ * @method int getRegisterId()
+ * @method void setRegisterId(int $registerId)
+ * @method int getSchemaId()
+ * @method void setSchemaId(int $schemaId)
+ * @method string getCalendarUri()
+ * @method void setCalendarUri(string $calendarUri)
+ * @method int|null getCalendarId()
+ * @method void setCalendarId(?int $calendarId)
+ * @method string getEventUid()
+ * @method void setEventUid(string $eventUid)
+ * @method string getEventUri()
+ * @method void setEventUri(string $eventUri)
+ * @method string|null getSummary()
+ * @method void setSummary(?string $summary)
+ * @method DateTime|null getDtstart()
+ * @method void setDtstart(?DateTime $dtstart)
+ * @method DateTime|null getDtend()
+ * @method void setDtend(?DateTime $dtend)
+ * @method string|null getLocation()
+ * @method void setLocation(?string $location)
+ * @method string getLinkedBy()
+ * @method void setLinkedBy(string $linkedBy)
+ * @method DateTime getLinkedAt()
+ * @method void setLinkedAt(DateTime $linkedAt)
+ * @method bool getTaggedWithXor()
+ * @method void setTaggedWithXor(bool $taggedWithXor)
+ *
+ * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class
+ */
+class CalendarLink extends Entity implements JsonSerializable
+{
+
+    /**
+     * The object uuid.
+     *
+     * @var string|null
+     */
+    protected ?string $objectUuid = null;
+
+    /**
+     * The register id.
+     *
+     * @var integer|null
+     */
+    protected ?int $registerId = null;
+
+    /**
+     * The schema id.
+     *
+     * @var integer|null
+     */
+    protected ?int $schemaId = null;
+
+    /**
+     * The calendar uri.
+     *
+     * @var string|null
+     */
+    protected ?string $calendarUri = null;
+
+    /**
+     * The calendar id (denormalised for fast joins).
+     *
+     * @var integer|null
+     */
+    protected ?int $calendarId = null;
+
+    /**
+     * The event uid.
+     *
+     * @var string|null
+     */
+    protected ?string $eventUid = null;
+
+    /**
+     * The event uri (DAV uri).
+     *
+     * @var string|null
+     */
+    protected ?string $eventUri = null;
+
+    /**
+     * Event summary (cached at link-time).
+     *
+     * @var string|null
+     */
+    protected ?string $summary = null;
+
+    /**
+     * Event dtstart.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $dtstart = null;
+
+    /**
+     * Event dtend.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $dtend = null;
+
+    /**
+     * Event location.
+     *
+     * @var string|null
+     */
+    protected ?string $location = null;
+
+    /**
+     * The user who created the link.
+     *
+     * @var string|null
+     */
+    protected ?string $linkedBy = null;
+
+    /**
+     * When the link was created.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $linkedAt = null;
+
+    /**
+     * Whether the VEVENT also carries X-OPENREGISTER-* properties.
+     *
+     * @var bool|null
+     */
+    protected ?bool $taggedWithXor = false;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->addType(fieldName: 'objectUuid', type: 'string');
+        $this->addType(fieldName: 'registerId', type: 'integer');
+        $this->addType(fieldName: 'schemaId', type: 'integer');
+        $this->addType(fieldName: 'calendarUri', type: 'string');
+        $this->addType(fieldName: 'calendarId', type: 'integer');
+        $this->addType(fieldName: 'eventUid', type: 'string');
+        $this->addType(fieldName: 'eventUri', type: 'string');
+        $this->addType(fieldName: 'summary', type: 'string');
+        $this->addType(fieldName: 'dtstart', type: 'datetime');
+        $this->addType(fieldName: 'dtend', type: 'datetime');
+        $this->addType(fieldName: 'location', type: 'string');
+        $this->addType(fieldName: 'linkedBy', type: 'string');
+        $this->addType(fieldName: 'linkedAt', type: 'datetime');
+        $this->addType(fieldName: 'taggedWithXor', type: 'boolean');
+    }//end __construct()
+
+    /**
+     * JSON serialization in CnCalendarTab-consumer shape.
+     *
+     * Mirrors CalendarEventService::veventToArray() so the UNION read
+     * path in CalendarLinkService can return a homogeneous array of
+     * rows regardless of source.
+     *
+     * @return array<string,mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'            => $this->eventUri,
+            'uid'           => $this->eventUid,
+            'calendarId'    => $this->calendarId !== null ? (string) $this->calendarId : null,
+            'calendarUri'   => $this->calendarUri,
+            'summary'       => $this->summary ?? '',
+            'dtstart'       => $this->dtstart?->format(DateTime::ATOM),
+            'dtend'         => $this->dtend?->format(DateTime::ATOM),
+            'location'      => $this->location,
+            'description'   => '',
+            'attendees'     => [],
+            'status'        => null,
+            'objectUuid'    => $this->objectUuid,
+            'registerId'    => $this->registerId,
+            'schemaId'      => $this->schemaId,
+            'linkedBy'      => $this->linkedBy,
+            'linkedAt'      => $this->linkedAt?->format(DateTime::ATOM),
+            'taggedWithXor' => (bool) $this->taggedWithXor,
+        ];
+    }//end jsonSerialize()
+}//end class

--- a/lib/Db/CalendarLinkMapper.php
+++ b/lib/Db/CalendarLinkMapper.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * Mapper for CalendarLink entities.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git-id>
+ * @link      https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Class CalendarLinkMapper
+ *
+ * @template-extends QBMapper<CalendarLink>
+ */
+class CalendarLinkMapper extends QBMapper
+{
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $db Database connection.
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(db: $db, tableName: 'openregister_calendar_links', entityClass: CalendarLink::class);
+    }//end __construct()
+
+    /**
+     * Find calendar links by object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return CalendarLink[] Array of calendar links.
+     */
+    public function findByObjectUuid(string $objectUuid): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->orderBy('dtstart', 'ASC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByObjectUuid()
+
+    /**
+     * Find a single calendar link by object UUID + event UID.
+     *
+     * @param string $objectUuid The object UUID.
+     * @param string $eventUid   The event UID.
+     *
+     * @return CalendarLink The link entity.
+     *
+     * @throws DoesNotExistException When no row matches.
+     */
+    public function findByObjectAndEvent(string $objectUuid, string $eventUid): CalendarLink
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('event_uid', $qb->createNamedParameter($eventUid)));
+
+        return $this->findEntity(query: $qb);
+    }//end findByObjectAndEvent()
+
+    /**
+     * Count calendar links for an object.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return int Count.
+     */
+    public function countByObjectUuid(string $objectUuid): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select($qb->createFunction('COUNT(*)'))
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)));
+
+        $result = $qb->executeQuery();
+        $count  = (int) $result->fetchOne();
+        $result->closeCursor();
+
+        return $count;
+    }//end countByObjectUuid()
+
+    /**
+     * Delete all calendar links for an object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectUuid(string $objectUuid): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectUuid()
+
+    /**
+     * Delete a single calendar link by object UUID + event UID.
+     *
+     * @param string $objectUuid The object UUID.
+     * @param string $eventUid   The event UID.
+     *
+     * @return int Number of deleted rows (0 or 1).
+     */
+    public function deleteByObjectAndEvent(string $objectUuid, string $eventUid): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('event_uid', $qb->createNamedParameter($eventUid)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectAndEvent()
+}//end class

--- a/lib/Migration/Version1Date20260524120000.php
+++ b/lib/Migration/Version1Date20260524120000.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Migration to create the openregister_calendar_links table.
+ *
+ * Additive Tier-2 link table for the calendar integration leaf. Coexists
+ * with the legacy X-OPENREGISTER-* CalDAV custom properties: reads do a
+ * UNION (link-table rows ∪ X-OR-* scan results, deduped by
+ * (calendarUri, eventUid)); creates write both shapes; link-existing
+ * writes only the link-table row (we may not own the VEVENT).
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author  Conduction Development Team <dev@conduction.nl>
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Creates the openregister_calendar_links table.
+ *
+ * @package OCA\OpenRegister\Migration
+ */
+class Version1Date20260524120000 extends SimpleMigrationStep
+{
+    /**
+     * Change the database schema.
+     *
+     * @param IOutput $output        Migration output
+     * @param Closure $schemaClosure Schema closure
+     * @param array   $options       Migration options
+     *
+     * @return ISchemaWrapper|null Updated schema or null
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+        $schema = $schemaClosure();
+
+        if ($schema->hasTable('openregister_calendar_links') === true) {
+            return null;
+        }
+
+        $table = $schema->createTable('openregister_calendar_links');
+
+        $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'unsigned' => true]);
+        $table->addColumn('object_uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
+        $table->addColumn('register_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('schema_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('calendar_uri', Types::STRING, ['notnull' => true, 'length' => 255]);
+        $table->addColumn('calendar_id', Types::INTEGER, ['notnull' => false, 'default' => null]);
+        $table->addColumn('event_uid', Types::STRING, ['notnull' => true, 'length' => 255]);
+        $table->addColumn('event_uri', Types::STRING, ['notnull' => true, 'length' => 255]);
+        $table->addColumn('summary', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+        $table->addColumn('dtstart', Types::DATETIME, ['notnull' => false, 'default' => null]);
+        $table->addColumn('dtend', Types::DATETIME, ['notnull' => false, 'default' => null]);
+        $table->addColumn('location', Types::STRING, ['notnull' => false, 'length' => 512, 'default' => null]);
+        $table->addColumn('linked_by', Types::STRING, ['notnull' => true, 'length' => 64]);
+        $table->addColumn('linked_at', Types::DATETIME, ['notnull' => true]);
+        $table->addColumn('tagged_with_xor', Types::BOOLEAN, ['notnull' => true, 'default' => false]);
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['object_uuid', 'calendar_uri', 'event_uid'], 'idx_cal_link_unique');
+        $table->addIndex(['object_uuid'], 'idx_cal_link_object');
+        $table->addIndex(['register_id'], 'idx_cal_link_register');
+        $table->addIndex(['schema_id'], 'idx_cal_link_schema');
+        $table->addIndex(['event_uid'], 'idx_cal_link_event_uid');
+
+        $output->info('Created openregister_calendar_links table');
+
+        return $schema;
+    }//end changeSchema()
+}//end class

--- a/lib/Service/CalendarLinkService.php
+++ b/lib/Service/CalendarLinkService.php
@@ -1,0 +1,662 @@
+<?php
+
+/**
+ * CalendarLinkService
+ *
+ * Tier-2 link-table service for the calendar integration leaf. Composes
+ * the legacy {@see CalendarEventService} (X-OPENREGISTER-* CalDAV
+ * properties) with the new {@see CalendarLinkMapper} (oc_openregister_calendar_links
+ * link table). Reads UNION both sources and dedupes by (calendarUri, eventUid);
+ * creates write both shapes; link-existing writes ONLY the link-table row
+ * because the VEVENT may not be ours to mutate.
+ *
+ * @category  Service
+ * @package   OCA\OpenRegister\Service
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git-id>
+ * @link      https://OpenRegister.app
+ *
+ * @spec openspec/changes/integration-calendar/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use DateTime;
+use DateTimeInterface;
+use Exception;
+use OCA\DAV\CalDAV\CalDavBackend;
+use OCA\OpenRegister\Db\CalendarLink;
+use OCA\OpenRegister\Db\CalendarLinkMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use Sabre\VObject\Reader;
+use Throwable;
+
+/**
+ * Wraps CalendarEventService and CalendarLinkMapper.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+class CalendarLinkService
+{
+
+    /**
+     * Constructor.
+     *
+     * @param CalendarLinkMapper   $linkMapper          Link-table mapper.
+     * @param CalendarEventService $calendarEventService Legacy CalDAV-property service.
+     * @param CalDavBackend        $calDavBackend        CalDAV backend for direct picker queries.
+     * @param IUserSession         $userSession          User session.
+     * @param LoggerInterface      $logger               Logger.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly CalendarLinkMapper $linkMapper,
+        private readonly CalendarEventService $calendarEventService,
+        private readonly CalDavBackend $calDavBackend,
+        private readonly IUserSession $userSession,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Link an existing CalDAV event to an OR object.
+     *
+     * Writes ONLY a link-table row (not the X-OR-* properties — we do
+     * not own the VEVENT). Re-fetches event details from CalDAV to
+     * populate cached fields (summary/dtstart/dtend/location).
+     *
+     * @param string $objectUuid  Object UUID.
+     * @param int    $registerId  Register id.
+     * @param int    $schemaId    Schema id.
+     * @param string $calendarUri Calendar URI (per-user CalDAV path component).
+     * @param string $eventUid    VEVENT UID.
+     *
+     * @return CalendarLink The persisted link row.
+     *
+     * @throws Exception When no user is logged in or the event cannot be located.
+     */
+    public function linkEvent(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        string $calendarUri,
+        string $eventUid
+    ): CalendarLink {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in');
+        }
+
+        // Locate the VEVENT on the named calendar so we can cache summary/dtstart/etc.
+        $located = $this->locateEventOnCalendar(
+            userId: $user->getUID(),
+            calendarUri: $calendarUri,
+            eventUid: $eventUid
+        );
+
+        if ($located === null) {
+            throw new Exception('Calendar event '.$eventUid.' not found on calendar '.$calendarUri);
+        }
+
+        $link = new CalendarLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        $link->setSchemaId($schemaId);
+        $link->setCalendarUri($calendarUri);
+        $link->setCalendarId((int) $located['calendarId']);
+        $link->setEventUid($eventUid);
+        $link->setEventUri((string) $located['eventUri']);
+        $link->setSummary($located['summary']);
+        $link->setDtstart($located['dtstart']);
+        $link->setDtend($located['dtend']);
+        $link->setLocation($located['location']);
+        $link->setLinkedBy($user->getUID());
+        $link->setLinkedAt(new DateTime());
+        $link->setTaggedWithXor(false);
+
+        return $this->linkMapper->insert(entity: $link);
+    }//end linkEvent()
+
+    /**
+     * Create a new VEVENT through CalendarEventService and record a link-table row.
+     *
+     * Delegates the VEVENT write (which adds X-OPENREGISTER-* properties)
+     * to {@see CalendarEventService::createEvent()} then mirrors the
+     * linkage in the link table with `taggedWithXor=true`.
+     *
+     * @param string             $objectUuid Object UUID.
+     * @param int                $registerId Register id.
+     * @param int                $schemaId   Schema id.
+     * @param array<string,mixed> $eventData Event data (summary, dtstart, dtend, location, ...).
+     *
+     * @return CalendarLink The persisted link row.
+     *
+     * @throws Exception On creation failure.
+     */
+    public function createAndLinkEvent(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        array $eventData
+    ): CalendarLink {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in');
+        }
+
+        $objectTitle = (string) ($eventData['objectTitle'] ?? $objectUuid);
+
+        $event = $this->calendarEventService->createEvent(
+            registerId: $registerId,
+            schemaId: $schemaId,
+            objectUuid: $objectUuid,
+            objectTitle: $objectTitle,
+            data: $eventData
+        );
+
+        if ($event === null) {
+            throw new Exception('Failed to create calendar event');
+        }
+
+        // CalendarEventService::createEvent returns the veventToArray
+        // shape with id=eventUri and calendarId stringified.
+        $calendarId  = isset($event['calendarId']) ? (int) $event['calendarId'] : 0;
+        $calendarUri = $this->resolveCalendarUriForId(userId: $user->getUID(), calendarId: $calendarId);
+
+        $dtstart = null;
+        if (isset($event['dtstart']) === true && $event['dtstart'] !== null) {
+            try {
+                $dtstart = new DateTime((string) $event['dtstart']);
+            } catch (Exception $e) {
+                $dtstart = null;
+            }
+        }
+
+        $dtend = null;
+        if (isset($event['dtend']) === true && $event['dtend'] !== null) {
+            try {
+                $dtend = new DateTime((string) $event['dtend']);
+            } catch (Exception $e) {
+                $dtend = null;
+            }
+        }
+
+        $link = new CalendarLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        $link->setSchemaId($schemaId);
+        $link->setCalendarUri($calendarUri ?? '');
+        $link->setCalendarId($calendarId);
+        $link->setEventUid((string) ($event['uid'] ?? ''));
+        $link->setEventUri((string) ($event['id'] ?? ''));
+        $link->setSummary((string) ($event['summary'] ?? ''));
+        $link->setDtstart($dtstart);
+        $link->setDtend($dtend);
+        $link->setLocation(isset($event['location']) ? (string) $event['location'] : null);
+        $link->setLinkedBy($user->getUID());
+        $link->setLinkedAt(new DateTime());
+        $link->setTaggedWithXor(true);
+
+        return $this->linkMapper->insert(entity: $link);
+    }//end createAndLinkEvent()
+
+    /**
+     * Unlink an event from an object.
+     *
+     * Always removes the link-table row. If the row carried
+     * `taggedWithXor=true`, additionally strips the X-OPENREGISTER-*
+     * properties from the underlying VEVENT (best-effort; failures
+     * are logged but do not abort the unlink).
+     *
+     * @param string $objectUuid Object UUID.
+     * @param string $eventUid   VEVENT UID.
+     *
+     * @return void
+     */
+    public function unlinkEvent(string $objectUuid, string $eventUid): void
+    {
+        $taggedWithXor = false;
+        $calendarId    = null;
+        $eventUri      = null;
+
+        try {
+            $existing      = $this->linkMapper->findByObjectAndEvent(
+                objectUuid: $objectUuid,
+                eventUid: $eventUid
+            );
+            $taggedWithXor = (bool) $existing->getTaggedWithXor();
+            $calendarId    = $existing->getCalendarId();
+            $eventUri      = $existing->getEventUri();
+        } catch (DoesNotExistException $e) {
+            // No link-table row — this is fine. We may still need to
+            // unlink an X-OR-only event below.
+        }
+
+        $this->linkMapper->deleteByObjectAndEvent(objectUuid: $objectUuid, eventUid: $eventUid);
+
+        // If the row had matching X-OR-* tags, strip them.
+        if ($taggedWithXor === true && $calendarId !== null && $eventUri !== null) {
+            try {
+                $this->calendarEventService->unlinkEvent(
+                    calendarId: (string) $calendarId,
+                    eventUri: $eventUri
+                );
+            } catch (Throwable $e) {
+                $this->logger->warning(
+                    'Failed to strip X-OPENREGISTER properties for event '.$eventUid.': '.$e->getMessage()
+                );
+            }
+        } else {
+            // Fall back to the legacy X-OR-* scan: maybe this event
+            // pre-dates the link table and only carries the custom
+            // properties. Walk the user's events to find a match.
+            try {
+                $events = $this->calendarEventService->getEventsForObject(objectUuid: $objectUuid);
+                foreach ($events as $event) {
+                    if (($event['uid'] ?? null) === $eventUid) {
+                        $this->calendarEventService->unlinkEvent(
+                            calendarId: (string) $event['calendarId'],
+                            eventUri: (string) $event['id']
+                        );
+                        break;
+                    }
+                }
+            } catch (Throwable $e) {
+                $this->logger->info(
+                    'Legacy X-OR unlink fallback failed for event '.$eventUid.': '.$e->getMessage()
+                );
+            }
+        }
+    }//end unlinkEvent()
+
+    /**
+     * Get all events linked to an object as the UNION of link-table rows
+     * and the legacy X-OPENREGISTER-* CalDAV scan.
+     *
+     * Each row carries a `source` field:
+     *   - `link-table`  — only in the link table
+     *   - `xor-only`    — only on the VEVENT as X-OR-* properties
+     *   - `both`        — present in both sources
+     *
+     * Dedupe key: `(calendarUri, eventUid)` where calendarUri can be
+     * empty when the CalDAV scan does not surface it; in that case
+     * dedupe falls back to eventUid alone.
+     *
+     * @param string $objectUuid Object UUID.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getLinkedEvents(string $objectUuid): array
+    {
+        $merged = [];
+
+        // 1. Link-table rows
+        foreach ($this->linkMapper->findByObjectUuid(objectUuid: $objectUuid) as $link) {
+            $key          = $link->getCalendarUri().'|'.$link->getEventUid();
+            $payload      = $link->jsonSerialize();
+            $payload['source'] = 'link-table';
+            $merged[$key]      = $payload;
+        }
+
+        // 2. Legacy X-OR-* scan (best-effort; degrade to empty list)
+        try {
+            $xorEvents = $this->calendarEventService->getEventsForObject(objectUuid: $objectUuid);
+        } catch (Throwable $e) {
+            $this->logger->info(
+                'X-OR-* scan failed during getLinkedEvents: '.$e->getMessage()
+            );
+            $xorEvents = [];
+        }
+
+        $userId       = $this->userSession->getUser()?->getUID();
+        $calendarMap  = [];
+        if ($userId !== null) {
+            $calendarMap = $this->buildCalendarMapForUser(userId: $userId);
+        }
+
+        foreach ($xorEvents as $event) {
+            $eventUid    = (string) ($event['uid'] ?? '');
+            if ($eventUid === '') {
+                continue;
+            }
+
+            $calendarId  = (int) ($event['calendarId'] ?? 0);
+            $calendarUri = $calendarMap[$calendarId] ?? '';
+            $key         = $calendarUri.'|'.$eventUid;
+
+            if (isset($merged[$key]) === true) {
+                // Already present from link-table; mark as both.
+                $merged[$key]['source'] = 'both';
+                // Prefer the live X-OR-* values for free-text fields
+                // (DB cache may be stale).
+                foreach (['summary', 'dtstart', 'dtend', 'location', 'description', 'attendees', 'status'] as $field) {
+                    if (isset($event[$field]) === true && $event[$field] !== null && $event[$field] !== '') {
+                        $merged[$key][$field] = $event[$field];
+                    }
+                }
+                continue;
+            }
+
+            // Try fallback dedupe by uid alone (calendar URI missing)
+            $fallbackKey = null;
+            foreach (array_keys($merged) as $existingKey) {
+                if (str_ends_with($existingKey, '|'.$eventUid) === true) {
+                    $fallbackKey = $existingKey;
+                    break;
+                }
+            }
+            if ($fallbackKey !== null) {
+                $merged[$fallbackKey]['source'] = 'both';
+                continue;
+            }
+
+            $payload                = $event;
+            $payload['source']      = 'xor-only';
+            $payload['calendarUri'] = $calendarUri;
+            $merged[$key]           = $payload;
+        }
+
+        return array_values($merged);
+    }//end getLinkedEvents()
+
+    /**
+     * List the current user's VEVENT-supporting calendars.
+     *
+     * @return array<int,array<string,mixed>> Each entry has id, uri, displayName, color.
+     *
+     * @throws Exception When no user is logged in.
+     */
+    public function getAvailableCalendars(): array
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in');
+        }
+
+        $principal = 'principals/users/'.$user->getUID();
+        $calendars = $this->calDavBackend->getCalendarsForUser($principal);
+
+        $results = [];
+        foreach ($calendars as $calendar) {
+            if ($this->calendarSupportsVevent(calendar: $calendar) === false) {
+                continue;
+            }
+
+            $results[] = [
+                'id'          => (int) $calendar['id'],
+                'uri'         => (string) $calendar['uri'],
+                'displayName' => (string) ($calendar['{DAV:}displayname'] ?? $calendar['uri']),
+                'color'       => isset($calendar['{http://apple.com/ns/ical/}calendar-color'])
+                    ? (string) $calendar['{http://apple.com/ns/ical/}calendar-color']
+                    : null,
+            ];
+        }
+
+        return $results;
+    }//end getAvailableCalendars()
+
+    /**
+     * List recent events on a named calendar — picker step 2.
+     *
+     * @param string                 $calendarUri Calendar URI.
+     * @param int|null               $limit       Max rows (default 100).
+     * @param DateTimeInterface|null $after       Only include events with dtstart >= $after.
+     *
+     * @return array<int,array<string,mixed>>
+     *
+     * @throws Exception When no user, no calendar, or calendar URI is unknown.
+     */
+    public function getEventsForCalendar(string $calendarUri, ?int $limit = 100, ?DateTimeInterface $after = null): array
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in');
+        }
+
+        $principal = 'principals/users/'.$user->getUID();
+        $calendars = $this->calDavBackend->getCalendarsForUser($principal);
+
+        $calendarId = null;
+        foreach ($calendars as $calendar) {
+            if (($calendar['uri'] ?? null) === $calendarUri
+                && $this->calendarSupportsVevent(calendar: $calendar) === true
+            ) {
+                $calendarId = (int) $calendar['id'];
+                break;
+            }
+        }
+
+        if ($calendarId === null) {
+            throw new Exception('Calendar '.$calendarUri.' not found for user');
+        }
+
+        $cutoff  = $after?->getTimestamp();
+        $results = [];
+
+        foreach ($this->calDavBackend->getCalendarObjects($calendarId) as $object) {
+            $fullObject = $this->calDavBackend->getCalendarObject($calendarId, $object['uri']);
+            if ($fullObject === null || empty($fullObject['calendardata']) === true) {
+                continue;
+            }
+
+            $calendarData = $fullObject['calendardata'];
+            if (strpos($calendarData, 'VEVENT') === false) {
+                continue;
+            }
+
+            try {
+                $vcalendar = Reader::read($calendarData);
+                $vevent    = $vcalendar->VEVENT;
+                if ($vevent === null) {
+                    continue;
+                }
+
+                $uid    = isset($vevent->UID) ? (string) $vevent->UID : null;
+                if ($uid === null) {
+                    continue;
+                }
+
+                $start = null;
+                if (isset($vevent->DTSTART) === true) {
+                    $start = $vevent->DTSTART->getDateTime();
+                }
+
+                if ($cutoff !== null && $start !== null && $start->getTimestamp() < $cutoff) {
+                    continue;
+                }
+
+                $results[] = [
+                    'uid'         => $uid,
+                    'uri'         => $object['uri'],
+                    'summary'     => isset($vevent->SUMMARY) ? (string) $vevent->SUMMARY : '',
+                    'dtstart'     => $start?->format('c'),
+                    'dtend'       => isset($vevent->DTEND) ? $vevent->DTEND->getDateTime()->format('c') : null,
+                    'location'    => isset($vevent->LOCATION) ? (string) $vevent->LOCATION : null,
+                    'calendarId'  => $calendarId,
+                    'calendarUri' => $calendarUri,
+                ];
+            } catch (Throwable $e) {
+                $this->logger->warning(
+                    'Failed to parse calendar event for picker: '.$e->getMessage(),
+                    ['uri' => $object['uri']]
+                );
+            }
+        }//end foreach
+
+        // Sort ascending by dtstart, nulls last.
+        usort($results, static function (array $a, array $b): int {
+            $ta = $a['dtstart'] !== null ? strtotime((string) $a['dtstart']) : PHP_INT_MAX;
+            $tb = $b['dtstart'] !== null ? strtotime((string) $b['dtstart']) : PHP_INT_MAX;
+            return $ta <=> $tb;
+        });
+
+        if ($limit !== null && $limit > 0) {
+            $results = array_slice($results, 0, $limit);
+        }
+
+        return $results;
+    }//end getEventsForCalendar()
+
+    /**
+     * Locate a VEVENT on a named calendar and pull cacheable fields.
+     *
+     * @param string $userId      Current user id.
+     * @param string $calendarUri Calendar URI.
+     * @param string $eventUid    VEVENT UID.
+     *
+     * @return array{calendarId:int, eventUri:string, summary:?string, dtstart:?DateTime, dtend:?DateTime, location:?string}|null
+     */
+    private function locateEventOnCalendar(string $userId, string $calendarUri, string $eventUid): ?array
+    {
+        $principal = 'principals/users/'.$userId;
+        $calendars = $this->calDavBackend->getCalendarsForUser($principal);
+
+        $calendarId = null;
+        foreach ($calendars as $calendar) {
+            if (($calendar['uri'] ?? null) === $calendarUri) {
+                $calendarId = (int) $calendar['id'];
+                break;
+            }
+        }
+
+        if ($calendarId === null) {
+            return null;
+        }
+
+        foreach ($this->calDavBackend->getCalendarObjects($calendarId) as $object) {
+            $fullObject = $this->calDavBackend->getCalendarObject($calendarId, $object['uri']);
+            if ($fullObject === null || empty($fullObject['calendardata']) === true) {
+                continue;
+            }
+
+            if (strpos($fullObject['calendardata'], $eventUid) === false) {
+                continue;
+            }
+
+            try {
+                $vcalendar = Reader::read($fullObject['calendardata']);
+                $vevent    = $vcalendar->VEVENT;
+                if ($vevent === null) {
+                    continue;
+                }
+                if (isset($vevent->UID) === false || (string) $vevent->UID !== $eventUid) {
+                    continue;
+                }
+
+                $dtstart = null;
+                if (isset($vevent->DTSTART) === true) {
+                    $dtstart = DateTime::createFromInterface($vevent->DTSTART->getDateTime());
+                }
+                $dtend = null;
+                if (isset($vevent->DTEND) === true) {
+                    $dtend = DateTime::createFromInterface($vevent->DTEND->getDateTime());
+                }
+
+                return [
+                    'calendarId' => $calendarId,
+                    'eventUri'   => (string) $object['uri'],
+                    'summary'    => isset($vevent->SUMMARY) ? (string) $vevent->SUMMARY : null,
+                    'dtstart'    => $dtstart,
+                    'dtend'      => $dtend,
+                    'location'   => isset($vevent->LOCATION) ? (string) $vevent->LOCATION : null,
+                ];
+            } catch (Throwable $e) {
+                $this->logger->warning(
+                    'Failed to parse VEVENT while locating event '.$eventUid.': '.$e->getMessage()
+                );
+            }
+        }
+
+        return null;
+    }//end locateEventOnCalendar()
+
+    /**
+     * Build a {calendarId → calendarUri} map for the current user.
+     *
+     * @param string $userId Current user id.
+     *
+     * @return array<int,string>
+     */
+    private function buildCalendarMapForUser(string $userId): array
+    {
+        try {
+            $principal = 'principals/users/'.$userId;
+            $calendars = $this->calDavBackend->getCalendarsForUser($principal);
+        } catch (Throwable $e) {
+            return [];
+        }
+
+        $map = [];
+        foreach ($calendars as $calendar) {
+            if (isset($calendar['id'], $calendar['uri']) === true) {
+                $map[(int) $calendar['id']] = (string) $calendar['uri'];
+            }
+        }
+
+        return $map;
+    }//end buildCalendarMapForUser()
+
+    /**
+     * Resolve a calendar URI given its numeric id.
+     *
+     * @param string $userId     Current user id.
+     * @param int    $calendarId Calendar numeric id.
+     *
+     * @return string|null
+     */
+    private function resolveCalendarUriForId(string $userId, int $calendarId): ?string
+    {
+        $map = $this->buildCalendarMapForUser(userId: $userId);
+        return $map[$calendarId] ?? null;
+    }//end resolveCalendarUriForId()
+
+    /**
+     * Decide whether a CalDAV calendar row supports VEVENT.
+     *
+     * @param array<string,mixed> $calendar Row from CalDavBackend::getCalendarsForUser().
+     *
+     * @return bool
+     */
+    private function calendarSupportsVevent(array $calendar): bool
+    {
+        $components = $calendar['{urn:ietf:params:xml:ns:caldav}supported-calendar-component-set'] ?? null;
+        if ($components === null) {
+            return false;
+        }
+
+        if (is_object($components) === true && method_exists($components, 'getValue') === true) {
+            foreach ($components->getValue() as $comp) {
+                if (strtoupper((string) $comp) === 'VEVENT') {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if (is_string($components) === true) {
+            return stripos($components, 'VEVENT') !== false;
+        }
+
+        if (is_iterable($components) === true) {
+            foreach ($components as $comp) {
+                if (strtoupper((string) $comp) === 'VEVENT') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }//end calendarSupportsVevent()
+}//end class

--- a/lib/Service/Integration/Providers/CalendarProvider.php
+++ b/lib/Service/Integration/Providers/CalendarProvider.php
@@ -41,6 +41,7 @@ namespace OCA\OpenRegister\Service\Integration\Providers;
 
 use InvalidArgumentException;
 use OCA\OpenRegister\Service\CalendarEventService;
+use OCA\OpenRegister\Service\CalendarLinkService;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCP\App\IAppManager;
 use OCP\IL10N;
@@ -62,7 +63,8 @@ class CalendarProvider extends AbstractIntegrationProvider
     /**
      * Constructor.
      *
-     * @param CalendarEventService $calendarEventService Backing service.
+     * @param CalendarEventService $calendarEventService Legacy X-OR-* CalDAV service.
+     * @param CalendarLinkService  $calendarLinkService  Tier-2 link-table service (UNION read path).
      * @param IAppManager          $appManager           NC app manager.
      * @param IL10N                $l10n                 Localisation.
      *
@@ -70,6 +72,7 @@ class CalendarProvider extends AbstractIntegrationProvider
      */
     public function __construct(
         private CalendarEventService $calendarEventService,
+        private CalendarLinkService $calendarLinkService,
         private IAppManager $appManager,
         private IL10N $l10n,
     ) {
@@ -143,7 +146,8 @@ class CalendarProvider extends AbstractIntegrationProvider
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
         try {
-            return $this->calendarEventService->getEventsForObject(objectUuid: $objectId);
+            // Tier-2: UNION read across link-table + legacy X-OR-* scan.
+            return $this->calendarLinkService->getLinkedEvents(objectUuid: $objectId);
         } catch (Throwable $e) {
             // CalDAV failures (no user, no VEVENT calendar) degrade to
             // an empty list rather than breaking the tab — AD-23.
@@ -167,13 +171,19 @@ class CalendarProvider extends AbstractIntegrationProvider
      */
     public function delete(string $register, string $schema, string $objectId, string $entityId): void
     {
+        // New shape: simple eventUid (Tier-2 link-table). Legacy shape:
+        // "{calendarId}/{eventUri}" (CalendarProvider Phase B-2). We accept
+        // both — if the entityId contains a slash, treat as legacy and
+        // strip X-OR-* on the VEVENT; otherwise treat as link-table unlink.
         $parts = explode('/', $entityId, 2);
-        if (count($parts) !== 2) {
-            throw new InvalidArgumentException('Calendar entityId must be "calendarId/eventUri"');
+        if (count($parts) === 2) {
+            [$calendarId, $eventUri] = $parts;
+            $this->calendarEventService->unlinkEvent(calendarId: $calendarId, eventUri: $eventUri);
+            return;
         }
 
-        [$calendarId, $eventUri] = $parts;
-        $this->calendarEventService->unlinkEvent(calendarId: $calendarId, eventUri: $eventUri);
+        // entityId is a bare eventUid — Tier-2 link-only removal.
+        $this->calendarLinkService->unlinkEvent(objectUuid: $objectId, eventUid: $entityId);
     }//end delete()
 
     /**

--- a/tests/Unit/Controller/CalendarEventsControllerTest.php
+++ b/tests/Unit/Controller/CalendarEventsControllerTest.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * Unit tests for CalendarEventsController Tier-2 endpoints.
+ *
+ * Covers:
+ *  - POST  /events/link            → CalendarLinkService::linkEvent
+ *  - DELETE /events/{uid}/link     → CalendarLinkService::unlinkEvent
+ *  - GET   /integrations/calendar/calendars
+ *  - GET   /integrations/calendar/calendars/{uri}/events
+ *  - POST  /events  (createAndLinkEvent — link mirror)
+ *  - DELETE /events/{eventId} (destroy — legacy + link cleanup)
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Controller;
+
+// phpcs:disable PEAR.Commenting.FunctionComment.Missing -- PHPUnit arrange/act/assert conventions.
+// phpcs:disable CustomSniffs.Functions.NamedParameters.RequireNamedParameters -- PHPUnit positional assertions.
+
+use OCA\OpenRegister\Controller\CalendarEventsController;
+use OCA\OpenRegister\Db\CalendarLink;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\CalendarEventService;
+use OCA\OpenRegister\Service\CalendarLinkService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class CalendarEventsControllerTest extends TestCase
+{
+    private CalendarEventService&MockObject $calendarEventService;
+    private CalendarLinkService&MockObject $calendarLinkService;
+    private ObjectService&MockObject $objectService;
+    private IRequest&MockObject $request;
+    private CalendarEventsController $controller;
+
+    /**
+     * Test object UUID.
+     *
+     * @var string
+     */
+    private const OBJ_UUID = 'obj-uuid-1';
+
+    protected function setUp(): void
+    {
+        $this->calendarEventService = $this->createMock(CalendarEventService::class);
+        $this->calendarLinkService  = $this->createMock(CalendarLinkService::class);
+        $this->objectService        = $this->createMock(ObjectService::class);
+        $this->request              = $this->createMock(IRequest::class);
+
+        $this->controller = new CalendarEventsController(
+            'openregister',
+            $this->request,
+            $this->calendarEventService,
+            $this->calendarLinkService,
+            $this->objectService,
+        );
+
+        // ObjectEntity uses __call magic via the Nextcloud Entity base
+        // class, so PHPUnit's mock generator can't stub setters. Use a
+        // real entity with concrete values instead.
+        $object = new ObjectEntity();
+        $object->setUuid(self::OBJ_UUID);
+        $object->setRegister('1');
+        $object->setSchema('2');
+        $object->setName('Object title');
+
+        $this->objectService->method('setSchema')->willReturnSelf();
+        $this->objectService->method('setRegister')->willReturnSelf();
+        $this->objectService->method('setObject')->willReturnSelf();
+        $this->objectService->method('getObject')->willReturn($object);
+    }
+
+    private function buildLink(): CalendarLink
+    {
+        $link = new CalendarLink();
+        $link->setObjectUuid(self::OBJ_UUID);
+        $link->setEventUid('ev-uid-1');
+        $link->setEventUri('event.ics');
+        $link->setCalendarUri('personal');
+        $link->setCalendarId(7);
+        $link->setSummary('Kickoff');
+        return $link;
+    }
+
+    public function testLinkRequiresPayload(): void
+    {
+        $this->request->method('getParams')->willReturn([]);
+        $response = $this->controller->link('r', 's', 'id');
+        $this->assertSame(400, $response->getStatus());
+    }
+
+    public function testLinkDelegatesToService(): void
+    {
+        $this->request->method('getParams')->willReturn([
+            'calendarUri' => 'personal',
+            'eventUid'    => 'ev-uid-1',
+        ]);
+        $this->calendarLinkService->expects($this->once())
+            ->method('linkEvent')
+            ->with(self::OBJ_UUID, 1, 2, 'personal', 'ev-uid-1')
+            ->willReturn($this->buildLink());
+
+        $response = $this->controller->link('r', 's', 'id');
+        $this->assertSame(201, $response->getStatus());
+        $data = $response->getData();
+        $this->assertSame('ev-uid-1', $data['uid']);
+    }
+
+    public function testUnlinkDelegatesToService(): void
+    {
+        $this->calendarLinkService->expects($this->once())
+            ->method('unlinkEvent')
+            ->with(self::OBJ_UUID, 'ev-uid-1');
+
+        $response = $this->controller->unlink('r', 's', 'id', 'ev-uid-1');
+        $this->assertSame(200, $response->getStatus());
+        $this->assertTrue($response->getData()['success']);
+    }
+
+    public function testCreateMirrorsViaLinkService(): void
+    {
+        $this->request->method('getParams')->willReturn(['summary' => 'New meeting']);
+        $this->calendarLinkService->expects($this->once())
+            ->method('createAndLinkEvent')
+            ->with(self::OBJ_UUID, 1, 2, $this->callback(function ($data) {
+                $this->assertSame('New meeting', $data['summary']);
+                $this->assertSame('Object title', $data['objectTitle']);
+                return true;
+            }))
+            ->willReturn($this->buildLink());
+
+        $response = $this->controller->create('r', 's', 'id');
+        $this->assertSame(201, $response->getStatus());
+    }
+
+    public function testListCalendarsDelegates(): void
+    {
+        $this->calendarLinkService->expects($this->once())
+            ->method('getAvailableCalendars')
+            ->willReturn([
+                ['id' => 7, 'uri' => 'personal', 'displayName' => 'Personal', 'color' => null],
+            ]);
+
+        $response = $this->controller->listCalendars();
+        $this->assertSame(200, $response->getStatus());
+        $this->assertCount(1, $response->getData()['results']);
+    }
+
+    public function testListCalendarEventsHonoursDefaults(): void
+    {
+        $this->request->method('getParams')->willReturn([]);
+        $this->calendarLinkService->expects($this->once())
+            ->method('getEventsForCalendar')
+            ->with('personal', 100, $this->isInstanceOf(\DateTimeInterface::class))
+            ->willReturn([
+                ['uid' => 'ev-1', 'summary' => 'S', 'calendarUri' => 'personal'],
+            ]);
+
+        $response = $this->controller->listCalendarEvents('personal');
+        $this->assertSame(200, $response->getStatus());
+        $this->assertCount(1, $response->getData()['results']);
+    }
+
+    public function testDestroyCallsLegacyServiceAndCleansLink(): void
+    {
+        $this->calendarLinkService->method('getLinkedEvents')->willReturn([
+            ['id' => 'event.ics', 'uid' => 'ev-uid-1', 'calendarId' => '7'],
+        ]);
+        $this->calendarEventService->expects($this->once())
+            ->method('unlinkEvent')
+            ->with('7', 'event.ics');
+        $this->calendarLinkService->expects($this->once())
+            ->method('unlinkEvent')
+            ->with(self::OBJ_UUID, 'ev-uid-1');
+
+        $response = $this->controller->destroy('r', 's', 'id', 'event.ics');
+        $this->assertSame(200, $response->getStatus());
+    }
+}

--- a/tests/Unit/Service/CalendarLinkServiceTest.php
+++ b/tests/Unit/Service/CalendarLinkServiceTest.php
@@ -1,0 +1,301 @@
+<?php
+
+/**
+ * Unit tests for CalendarLinkService.
+ *
+ * Covers:
+ *  - linkEvent: writes ONLY a link-table row and populates summary/dtstart from CalDAV
+ *  - createAndLinkEvent: delegates to CalendarEventService::createEvent + writes link with taggedWithXor=true
+ *  - unlinkEvent: removes the link row + strips X-OR-* properties when row was tagged
+ *  - unlinkEvent: legacy X-OR-only events are unlinked via fallback scan
+ *  - getLinkedEvents: UNION between link-table and X-OR-* scan, dedupe by (calendarUri, eventUid)
+ *    with `source` annotation (link-table / xor-only / both)
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+// phpcs:disable PEAR.Commenting.FunctionComment.Missing -- arrange/act/assert PHPUnit conventions.
+// phpcs:disable CustomSniffs.Functions.NamedParameters.RequireNamedParameters -- PHPUnit positional assertions.
+
+use DateTime;
+use OCA\DAV\CalDAV\CalDavBackend;
+use OCA\OpenRegister\Db\CalendarLink;
+use OCA\OpenRegister\Db\CalendarLinkMapper;
+use OCA\OpenRegister\Service\CalendarEventService;
+use OCA\OpenRegister\Service\CalendarLinkService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class CalendarLinkServiceTest extends TestCase
+{
+    private CalendarLinkMapper&MockObject $linkMapper;
+    private CalendarEventService&MockObject $calendarEventService;
+    private CalDavBackend&MockObject $calDavBackend;
+    private IUserSession&MockObject $userSession;
+    private LoggerInterface&MockObject $logger;
+    private CalendarLinkService $service;
+
+    protected function setUp(): void
+    {
+        $this->linkMapper           = $this->createMock(CalendarLinkMapper::class);
+        $this->calendarEventService = $this->createMock(CalendarEventService::class);
+        $this->calDavBackend        = $this->createMock(CalDavBackend::class);
+        $this->userSession          = $this->createMock(IUserSession::class);
+        $this->logger               = $this->createMock(LoggerInterface::class);
+
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('admin');
+        $this->userSession->method('getUser')->willReturn($user);
+
+        $this->service = new CalendarLinkService(
+            $this->linkMapper,
+            $this->calendarEventService,
+            $this->calDavBackend,
+            $this->userSession,
+            $this->logger,
+        );
+    }
+
+    private function buildVevent(string $uid, string $summary = 'Test'): string
+    {
+        return implode("\r\n", [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'PRODID:-//Test//EN',
+            'BEGIN:VEVENT',
+            'UID:'.$uid,
+            'DTSTAMP:20260101T000000Z',
+            'SUMMARY:'.$summary,
+            'DTSTART:20260601T100000Z',
+            'DTEND:20260601T110000Z',
+            'LOCATION:HQ',
+            'END:VEVENT',
+            'END:VCALENDAR',
+            '',
+        ]);
+    }
+
+    public function testLinkEventWritesLinkTableRowOnly(): void
+    {
+        $this->calDavBackend->method('getCalendarsForUser')->willReturn([
+            ['id' => 7, 'uri' => 'personal'],
+        ]);
+        $this->calDavBackend->method('getCalendarObjects')->willReturn([
+            ['uri' => 'event-1.ics'],
+        ]);
+        $this->calDavBackend->method('getCalendarObject')->willReturn([
+            'calendardata' => $this->buildVevent('ev-uid-1', 'Kickoff'),
+        ]);
+
+        $this->linkMapper->expects($this->once())
+            ->method('insert')
+            ->with($this->callback(function (CalendarLink $link) {
+                $this->assertSame('obj-1', $link->getObjectUuid());
+                $this->assertSame('personal', $link->getCalendarUri());
+                $this->assertSame(7, $link->getCalendarId());
+                $this->assertSame('ev-uid-1', $link->getEventUid());
+                $this->assertSame('event-1.ics', $link->getEventUri());
+                $this->assertSame('Kickoff', $link->getSummary());
+                $this->assertSame('HQ', $link->getLocation());
+                $this->assertFalse($link->getTaggedWithXor());
+                return true;
+            }))
+            ->willReturnArgument(0);
+
+        // Critically: CalendarEventService::createEvent / linkEvent must NOT be called.
+        $this->calendarEventService->expects($this->never())->method('createEvent');
+        $this->calendarEventService->expects($this->never())->method('linkEvent');
+
+        $result = $this->service->linkEvent('obj-1', 1, 2, 'personal', 'ev-uid-1');
+        $this->assertInstanceOf(CalendarLink::class, $result);
+    }
+
+    public function testCreateAndLinkEventDelegatesAndMirrors(): void
+    {
+        $this->calendarEventService->expects($this->once())
+            ->method('createEvent')
+            ->willReturn([
+                'id'         => 'new-event.ics',
+                'uid'        => 'new-uid',
+                'calendarId' => '7',
+                'summary'    => 'New meeting',
+                'dtstart'    => '2026-06-01T10:00:00+00:00',
+                'dtend'      => '2026-06-01T11:00:00+00:00',
+                'location'   => 'HQ',
+            ]);
+
+        $this->calDavBackend->method('getCalendarsForUser')->willReturn([
+            ['id' => 7, 'uri' => 'personal'],
+        ]);
+
+        $this->linkMapper->expects($this->once())
+            ->method('insert')
+            ->with($this->callback(function (CalendarLink $link) {
+                $this->assertSame('obj-1', $link->getObjectUuid());
+                $this->assertSame('new-uid', $link->getEventUid());
+                $this->assertSame('new-event.ics', $link->getEventUri());
+                $this->assertSame('personal', $link->getCalendarUri());
+                $this->assertTrue($link->getTaggedWithXor());
+                return true;
+            }))
+            ->willReturnArgument(0);
+
+        $result = $this->service->createAndLinkEvent('obj-1', 1, 2, [
+            'summary' => 'New meeting',
+            'objectTitle' => 'My object',
+        ]);
+        $this->assertInstanceOf(CalendarLink::class, $result);
+    }
+
+    public function testUnlinkEventStripsXorWhenTagged(): void
+    {
+        $link = new CalendarLink();
+        $link->setObjectUuid('obj-1');
+        $link->setEventUid('ev-1');
+        $link->setEventUri('event.ics');
+        $link->setCalendarId(7);
+        $link->setTaggedWithXor(true);
+
+        $this->linkMapper->method('findByObjectAndEvent')->willReturn($link);
+        $this->linkMapper->expects($this->once())
+            ->method('deleteByObjectAndEvent')
+            ->with('obj-1', 'ev-1')
+            ->willReturn(1);
+
+        $this->calendarEventService->expects($this->once())
+            ->method('unlinkEvent')
+            ->with('7', 'event.ics');
+
+        $this->service->unlinkEvent('obj-1', 'ev-1');
+    }
+
+    public function testUnlinkEventNoRowFallsBackToXorScan(): void
+    {
+        $this->linkMapper->method('findByObjectAndEvent')
+            ->willThrowException(new DoesNotExistException('nope'));
+        $this->linkMapper->expects($this->once())
+            ->method('deleteByObjectAndEvent')
+            ->willReturn(0);
+
+        $this->calendarEventService->method('getEventsForObject')->willReturn([
+            ['id' => 'legacy.ics', 'uid' => 'ev-legacy', 'calendarId' => '5'],
+        ]);
+        $this->calendarEventService->expects($this->once())
+            ->method('unlinkEvent')
+            ->with('5', 'legacy.ics');
+
+        $this->service->unlinkEvent('obj-1', 'ev-legacy');
+    }
+
+    public function testGetLinkedEventsUnionAndDedupe(): void
+    {
+        // Link-table row for ev-A on calendar 'personal'.
+        $link = new CalendarLink();
+        $link->setObjectUuid('obj-1');
+        $link->setEventUid('ev-A');
+        $link->setEventUri('a.ics');
+        $link->setCalendarUri('personal');
+        $link->setCalendarId(7);
+        $link->setSummary('Cached summary');
+        $link->setDtstart(new DateTime('2026-06-01T10:00:00Z'));
+        $link->setLinkedBy('admin');
+        $link->setLinkedAt(new DateTime('2026-05-01T00:00:00Z'));
+        $link->setTaggedWithXor(false);
+
+        $this->linkMapper->method('findByObjectUuid')->willReturn([$link]);
+
+        // Calendar map for the dedupe step.
+        $this->calDavBackend->method('getCalendarsForUser')->willReturn([
+            ['id' => 7, 'uri' => 'personal'],
+            ['id' => 9, 'uri' => 'work'],
+        ]);
+
+        // X-OR-* scan returns two events:
+        //   - ev-A on calendar 7 (duplicates the link-table row → both)
+        //   - ev-B on calendar 9 (only via X-OR → xor-only)
+        $this->calendarEventService->method('getEventsForObject')->willReturn([
+            [
+                'id'         => 'a.ics',
+                'uid'        => 'ev-A',
+                'calendarId' => '7',
+                'summary'    => 'Live summary',
+                'dtstart'    => '2026-06-01T10:00:00+00:00',
+                'objectUuid' => 'obj-1',
+                'registerId' => 1,
+                'schemaId'   => 2,
+            ],
+            [
+                'id'         => 'b.ics',
+                'uid'        => 'ev-B',
+                'calendarId' => '9',
+                'summary'    => 'Only in XOR',
+                'dtstart'    => '2026-06-02T10:00:00+00:00',
+                'objectUuid' => 'obj-1',
+                'registerId' => 1,
+                'schemaId'   => 2,
+            ],
+        ]);
+
+        $result = $this->service->getLinkedEvents('obj-1');
+
+        $this->assertCount(2, $result);
+
+        $byUid = [];
+        foreach ($result as $row) {
+            $byUid[$row['uid']] = $row;
+        }
+
+        $this->assertSame('both', $byUid['ev-A']['source']);
+        // Live X-OR-* value should win over the link-table cache.
+        $this->assertSame('Live summary', $byUid['ev-A']['summary']);
+
+        $this->assertSame('xor-only', $byUid['ev-B']['source']);
+        $this->assertSame('work', $byUid['ev-B']['calendarUri']);
+    }
+
+    public function testGetAvailableCalendarsFiltersOnVevent(): void
+    {
+        $this->calDavBackend->method('getCalendarsForUser')->willReturn([
+            [
+                'id' => 7,
+                'uri' => 'personal',
+                '{DAV:}displayname' => 'Personal',
+                '{urn:ietf:params:xml:ns:caldav}supported-calendar-component-set' => 'VEVENT,VTODO',
+                '{http://apple.com/ns/ical/}calendar-color' => '#ff0000',
+            ],
+            [
+                'id' => 8,
+                'uri' => 'tasks-only',
+                '{urn:ietf:params:xml:ns:caldav}supported-calendar-component-set' => 'VTODO',
+            ],
+        ]);
+
+        $result = $this->service->getAvailableCalendars();
+        $this->assertCount(1, $result);
+        $this->assertSame('personal', $result[0]['uri']);
+        $this->assertSame('Personal', $result[0]['displayName']);
+        $this->assertSame('#ff0000', $result[0]['color']);
+    }
+}

--- a/tests/Unit/Service/Integration/Providers/CalendarProviderTest.php
+++ b/tests/Unit/Service/Integration/Providers/CalendarProviderTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * Unit tests for CalendarProvider after Tier-2 rewire.
+ *
+ * Covers:
+ *  - metadata getters and isEnabled()
+ *  - list(): now goes through CalendarLinkService::getLinkedEvents (UNION
+ *    of link-table + X-OR-* scan), not the legacy CalendarEventService scan
+ *  - delete(): legacy "calendarId/eventUri" shape still strips X-OR-*;
+ *    new bare-uid shape calls CalendarLinkService::unlinkEvent
+ *  - health(): reports unavailable when calendar app is not installed
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Integration\Providers
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Integration\Providers;
+
+// phpcs:disable PEAR.Commenting.FunctionComment.Missing
+// phpcs:disable CustomSniffs.Functions.NamedParameters.RequireNamedParameters
+
+use OCA\OpenRegister\Service\CalendarEventService;
+use OCA\OpenRegister\Service\CalendarLinkService;
+use OCA\OpenRegister\Service\Integration\Providers\CalendarProvider;
+use OCP\App\IAppManager;
+use OCP\IL10N;
+use PHPUnit\Framework\TestCase;
+
+class CalendarProviderTest extends TestCase
+{
+    private function buildL10n(): IL10N
+    {
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnArgument(0);
+        return $l10n;
+    }
+
+    public function testMetadataGetters(): void
+    {
+        $provider = new CalendarProvider(
+            $this->createMock(CalendarEventService::class),
+            $this->createMock(CalendarLinkService::class),
+            $this->createMock(IAppManager::class),
+            $this->buildL10n(),
+        );
+
+        $this->assertSame('calendar', $provider->getId());
+        $this->assertSame('Meetings', $provider->getLabel());
+        $this->assertSame('Calendar', $provider->getIcon());
+        $this->assertSame('comms', $provider->getGroup());
+        $this->assertSame('calendar', $provider->getRequiredApp());
+        $this->assertSame('link-table', $provider->getStorageStrategy());
+    }
+
+    public function testListGoesThroughLinkServiceUnion(): void
+    {
+        $link = $this->createMock(CalendarLinkService::class);
+        $link->expects($this->once())
+            ->method('getLinkedEvents')
+            ->with('obj-1')
+            ->willReturn([
+                ['uid' => 'ev-1', 'source' => 'both', 'summary' => 'Hello'],
+            ]);
+
+        $provider = new CalendarProvider(
+            $this->createMock(CalendarEventService::class),
+            $link,
+            $this->createMock(IAppManager::class),
+            $this->buildL10n(),
+        );
+
+        $result = $provider->list('r', 's', 'obj-1');
+        $this->assertCount(1, $result);
+        $this->assertSame('both', $result[0]['source']);
+    }
+
+    public function testDeleteLegacyShapeStripsXor(): void
+    {
+        $eventSvc = $this->createMock(CalendarEventService::class);
+        $eventSvc->expects($this->once())
+            ->method('unlinkEvent')
+            ->with('7', 'event.ics');
+
+        $linkSvc = $this->createMock(CalendarLinkService::class);
+        $linkSvc->expects($this->never())->method('unlinkEvent');
+
+        $provider = new CalendarProvider(
+            $eventSvc,
+            $linkSvc,
+            $this->createMock(IAppManager::class),
+            $this->buildL10n(),
+        );
+
+        $provider->delete('r', 's', 'obj-1', '7/event.ics');
+    }
+
+    public function testDeleteBareUidUsesLinkService(): void
+    {
+        $eventSvc = $this->createMock(CalendarEventService::class);
+        $eventSvc->expects($this->never())->method('unlinkEvent');
+
+        $linkSvc = $this->createMock(CalendarLinkService::class);
+        $linkSvc->expects($this->once())
+            ->method('unlinkEvent')
+            ->with('obj-1', 'ev-uid');
+
+        $provider = new CalendarProvider(
+            $eventSvc,
+            $linkSvc,
+            $this->createMock(IAppManager::class),
+            $this->buildL10n(),
+        );
+
+        $provider->delete('r', 's', 'obj-1', 'ev-uid');
+    }
+
+    public function testHealthReportsUnavailableWhenNotInstalled(): void
+    {
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('isInstalled')->with('calendar')->willReturn(false);
+
+        $provider = new CalendarProvider(
+            $this->createMock(CalendarEventService::class),
+            $this->createMock(CalendarLinkService::class),
+            $appManager,
+            $this->buildL10n(),
+        );
+
+        $this->assertFalse($provider->isEnabled());
+        $h = $provider->health();
+        $this->assertSame('unavailable', $h['status']);
+    }
+}

--- a/tests/Unit/Service/Integration/Providers/LeafProvidersMetadataTest.php
+++ b/tests/Unit/Service/Integration/Providers/LeafProvidersMetadataTest.php
@@ -39,6 +39,7 @@ namespace OCA\OpenRegister\Tests\Unit\Service\Integration\Providers;
 
 use OCA\OpenRegister\Exception\NotImplementedException;
 use OCA\OpenRegister\Service\CalendarEventService;
+use OCA\OpenRegister\Service\CalendarLinkService;
 use OCA\OpenRegister\Service\ContactService;
 use OCA\OpenRegister\Service\DeckCardService;
 use OCA\OpenRegister\Service\EmailService;
@@ -193,6 +194,7 @@ class LeafProvidersMetadataTest extends TestCase
     {
         $provider = new CalendarProvider(
             calendarEventService: $this->createMock(CalendarEventService::class),
+            calendarLinkService: $this->createMock(CalendarLinkService::class),
             appManager: $this->buildAppManager(['calendar']),
             l10n: $this->buildL10n(),
         );
@@ -208,28 +210,32 @@ class LeafProvidersMetadataTest extends TestCase
 
     public function testCalendarProviderListDelegatesToService(): void
     {
-        $service = $this->createMock(CalendarEventService::class);
-        $service->expects($this->once())
-            ->method('getEventsForObject')
+        // Tier-2: list() now goes through CalendarLinkService::getLinkedEvents
+        // (UNION over the link table + the legacy X-OR-* scan).
+        $link = $this->createMock(CalendarLinkService::class);
+        $link->expects($this->once())
+            ->method('getLinkedEvents')
             ->with('obj-uuid')
-            ->willReturn([['id' => 'cal1/event.ics']]);
+            ->willReturn([['id' => 'cal1/event.ics', 'source' => 'both']]);
 
         $provider = new CalendarProvider(
-            calendarEventService: $service,
+            calendarEventService: $this->createMock(CalendarEventService::class),
+            calendarLinkService: $link,
             appManager: $this->buildAppManager(['calendar']),
             l10n: $this->buildL10n(),
         );
 
-        $this->assertSame([['id' => 'cal1/event.ics']], $provider->list('reg', 'sch', 'obj-uuid'));
+        $this->assertSame([['id' => 'cal1/event.ics', 'source' => 'both']], $provider->list('reg', 'sch', 'obj-uuid'));
     }//end testCalendarProviderListDelegatesToService()
 
     public function testCalendarProviderListSurfacesEmptyOnFailure(): void
     {
-        $service = $this->createMock(CalendarEventService::class);
-        $service->method('getEventsForObject')->willThrowException(new \RuntimeException('no calendar'));
+        $link = $this->createMock(CalendarLinkService::class);
+        $link->method('getLinkedEvents')->willThrowException(new \RuntimeException('no calendar'));
 
         $provider = new CalendarProvider(
-            calendarEventService: $service,
+            calendarEventService: $this->createMock(CalendarEventService::class),
+            calendarLinkService: $link,
             appManager: $this->buildAppManager(['calendar']),
             l10n: $this->buildL10n(),
         );
@@ -237,21 +243,31 @@ class LeafProvidersMetadataTest extends TestCase
         $this->assertSame([], $provider->list('reg', 'sch', 'obj-uuid'));
     }//end testCalendarProviderListSurfacesEmptyOnFailure()
 
-    public function testCalendarProviderDeleteRejectsMalformedEntityId(): void
+    public function testCalendarProviderDeleteHandlesLegacyAndBareUidShapes(): void
     {
+        $eventSvc = $this->createMock(CalendarEventService::class);
+        $eventSvc->expects($this->once())->method('unlinkEvent')->with('7', 'event.ics');
+        $linkSvc  = $this->createMock(CalendarLinkService::class);
+        $linkSvc->expects($this->once())->method('unlinkEvent')->with('o', 'ev-uid');
+
         $provider = new CalendarProvider(
-            calendarEventService: $this->createMock(CalendarEventService::class),
+            calendarEventService: $eventSvc,
+            calendarLinkService: $linkSvc,
             appManager: $this->buildAppManager(['calendar']),
             l10n: $this->buildL10n(),
         );
-        $this->expectException(\InvalidArgumentException::class);
-        $provider->delete('r', 's', 'o', 'not-a-composite');
-    }//end testCalendarProviderDeleteRejectsMalformedEntityId()
+
+        // Legacy composite shape — strips X-OR-* via CalendarEventService.
+        $provider->delete('r', 's', 'o', '7/event.ics');
+        // Bare uid shape — Tier-2 link-only removal.
+        $provider->delete('r', 's', 'o', 'ev-uid');
+    }//end testCalendarProviderDeleteHandlesLegacyAndBareUidShapes()
 
     public function testCalendarProviderHealthReportsUnavailableWhenAppMissing(): void
     {
         $provider = new CalendarProvider(
             calendarEventService: $this->createMock(CalendarEventService::class),
+            calendarLinkService: $this->createMock(CalendarLinkService::class),
             appManager: $this->buildAppManager([]),
             l10n: $this->buildL10n(),
         );


### PR DESCRIPTION
## Summary

Tier-2 (additive link-table) rollout for the calendar integration leaf.

- New `oc_openregister_calendar_links` table (migration `Version1Date20260524120000`) — unique on `(object_uuid, calendar_uri, event_uid)`, with cached `summary` / `dtstart` / `dtend` / `location` for fast renders, and a `tagged_with_xor` flag tracking whether the row's VEVENT also carries the legacy `X-OPENREGISTER-*` custom properties.
- New `CalendarLink` entity + `CalendarLinkMapper` mirroring the Contacts Tier-2 pattern.
- New `CalendarLinkService` composes the mapper with the existing `CalendarEventService` — does NOT rewrite the legacy service.
- `CalendarEventsController` rewired on `CalendarLinkService`; new endpoints for picker source + Tier-2 unlink.
- `CalendarProvider` rewired so `list()` returns the UNION; `delete()` accepts both legacy composite and bare-uid shapes.
- New `BackfillCalendarLinksJob` (disabled by default — guarded by the `openregister/backfill_calendar_links` app-config flag).

## Architecture decision: ADDITIVE

The link table **coexists with** the existing X-OPENREGISTER-* CalDAV custom properties. Per the locked decision in the spec brief:

- **Read** (`CalendarLinkService::getLinkedEvents` / `GET /events`): UNION of link-table rows and the legacy X-OR-* scan, deduped by `(calendarUri, eventUid)`. Each row is annotated with a `source` field — `link-table` / `xor-only` / `both`. Live X-OR-* values win over the link-table cache when both are present.
- **Create** (`POST /events`): writes BOTH the X-OR-* properties on the VEVENT AND a link-table row (`tagged_with_xor=true`).
- **Link existing** (`POST /events/link`): writes ONLY the link-table row — we may not own the VEVENT. Payload shape changed from `{calendarId, eventUri}` to `{calendarUri, eventUid}`.
- **Unlink** (`DELETE /events/{eventUid}/link`): removes the link-table row. If `tagged_with_xor=true`, also strips X-OR-* properties from the VEVENT (best-effort). The VEVENT itself is preserved.
- **Delete** (`DELETE /events/{eventId}`): legacy destroy — strips X-OR-* AND drops the matching link row.

## Backfill (out of scope)

`BackfillCalendarLinksJob` walks the user's calendars and back-populates the link table from VEVENTs that carry the legacy X-OR-* properties. **Disabled by default** — set the `openregister/backfill_calendar_links` app-config flag to `yes` and trigger manually via `occ background-job:execute`. We intentionally don't enable on first install; production rollout decision is post-merge.

## Test plan

- [x] `tests/Unit/Service/CalendarLinkServiceTest.php` — 6 cases (link-only / createAndLink / unlink-tagged / unlink-X-OR-fallback / UNION-dedupe / getAvailableCalendars)
- [x] `tests/Unit/Controller/CalendarEventsControllerTest.php` — 7 cases covering every endpoint
- [x] `tests/Unit/Service/Integration/Providers/CalendarProviderTest.php` — 5 cases (metadata / UNION read / legacy delete / bare-uid delete / health)
- [x] Existing `tests/Unit/Service/CalendarEventServiceTest.php` still green — 42 tests pass
- [x] `LeafProvidersMetadataTest` updated with the new `CalendarLinkService` dependency
- [x] Full set: 67 assertions in 18 new tests, all green

## Companion PR

The frontend modal/picker work lives in `ConductionNL/nextcloud-vue#feature/integration-tier2-calendar` (PR opens against `beta`). Apps need to bump `@conduction/nextcloud-vue` once both PRs are merged.