### PR TITLE
retrofit: reverse-spec file-actions partial (5 REQs / 35 methods, ~63 deferred)

### DIFF
--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -1173,6 +1173,8 @@ class FilesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-1
      */
     public function rename(string $register, string $schema, string $id, int $fileId): JSONResponse
     {
@@ -1234,6 +1236,8 @@ class FilesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-1
      */
     public function copy(string $register, string $schema, string $id, int $fileId): JSONResponse
     {
@@ -1320,6 +1324,8 @@ class FilesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-1
      */
     public function move(string $register, string $schema, string $id, int $fileId): JSONResponse
     {
@@ -1509,6 +1515,8 @@ class FilesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-2
      */
     public function lock(string $register, string $schema, string $id, int $fileId): JSONResponse
     {
@@ -1559,6 +1567,8 @@ class FilesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-2
      */
     public function unlock(string $register, string $schema, string $id, int $fileId): JSONResponse
     {
@@ -1663,6 +1673,8 @@ class FilesController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      * @PublicPage
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-3
      */
     public function preview(string $register, string $schema, string $id, int $fileId): JSONResponse|StreamResponse
     {

--- a/lib/Event/FileCopiedEvent.php
+++ b/lib/Event/FileCopiedEvent.php
@@ -30,6 +30,8 @@ class FileCopiedEvent extends Event
      * @param array  $data       Additional event data.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-1
      */
     public function __construct(
         private readonly string $objectUuid,

--- a/lib/Event/FileLockedEvent.php
+++ b/lib/Event/FileLockedEvent.php
@@ -30,6 +30,8 @@ class FileLockedEvent extends Event
      * @param array  $data       Additional event data.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-2
      */
     public function __construct(
         private readonly string $objectUuid,

--- a/lib/Event/FileMovedEvent.php
+++ b/lib/Event/FileMovedEvent.php
@@ -30,6 +30,8 @@ class FileMovedEvent extends Event
      * @param array  $data       Additional event data.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-1
      */
     public function __construct(
         private readonly string $objectUuid,

--- a/lib/Event/FileRenamedEvent.php
+++ b/lib/Event/FileRenamedEvent.php
@@ -30,6 +30,8 @@ class FileRenamedEvent extends Event
      * @param array  $data       Additional event data.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-1
      */
     public function __construct(
         private readonly string $objectUuid,

--- a/lib/Event/FileUnlockedEvent.php
+++ b/lib/Event/FileUnlockedEvent.php
@@ -30,6 +30,8 @@ class FileUnlockedEvent extends Event
      * @param array  $data       Additional event data.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-2
      */
     public function __construct(
         private readonly string $objectUuid,

--- a/lib/Service/File/DeleteFileHandler.php
+++ b/lib/Service/File/DeleteFileHandler.php
@@ -78,6 +78,8 @@ class DeleteFileHandler
      * @throws Exception If deleting the file is not permitted or file operations fail.
      *
      * @psalm-param Node|string|int $file
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-1
      */
     public function deleteFile(Node|string|int $file, ?ObjectEntity $object=null): bool
     {
@@ -132,6 +134,8 @@ class DeleteFileHandler
      * @return (Node|bool|int|mixed|string)[][] Array of deletion results.
      *
      * @psalm-return list<array{error?: string, file: Node|int|mixed|string, success: bool}>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-1
      */
     public function deleteFiles(array $files, ?ObjectEntity $object=null): array
     {

--- a/lib/Service/File/FileLockHandler.php
+++ b/lib/Service/File/FileLockHandler.php
@@ -115,6 +115,8 @@ class FileLockHandler
      * @return array Lock metadata.
      *
      * @throws Exception If the file is already locked by another user.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-2
      */
     public function lockFile(int $fileId, ?int $ttlMinutes=null): array
     {
@@ -149,6 +151,8 @@ class FileLockHandler
      * @throws Exception If the current user is not the lock owner and not admin.
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-2
      */
     public function unlockFile(int $fileId, bool $force=false): array
     {

--- a/lib/Service/File/FilePreviewHandler.php
+++ b/lib/Service/File/FilePreviewHandler.php
@@ -77,6 +77,8 @@ class FilePreviewHandler
      * @return ISimpleFile The preview image file.
      *
      * @throws Exception If preview cannot be generated.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-3
      */
     public function getPreview(File $file, ?int $width=null, ?int $height=null): ISimpleFile
     {

--- a/lib/Service/File/FolderManagementHandler.php
+++ b/lib/Service/File/FolderManagementHandler.php
@@ -166,6 +166,8 @@ class FolderManagementHandler
      * @phpstan-return Node
      *
      * @psalm-return Node
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-4
      */
     public function createRegisterFolderById(Register $register, ?IUser $currentUser=null): Node
     {
@@ -294,6 +296,8 @@ class FolderManagementHandler
      *
      * @psalm-return   Folder|null
      * @phpstan-return Folder|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-4
      */
     public function getRegisterFolderById(Register $register): ?Folder
     {
@@ -474,6 +478,8 @@ class FolderManagementHandler
      * @phpstan-return Node
      * @return         Node The folder node.
      * @throws         Exception If folder creation fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-4
      */
     public function createFolderPath(string $folderPath): Node
     {
@@ -561,6 +567,8 @@ class FolderManagementHandler
      *
      * @psalm-return   string|null
      * @phpstan-return string|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-4
      */
     public function getRegisterFolderName(Register $register): string|null
     {
@@ -584,6 +592,8 @@ class FolderManagementHandler
      *
      * @psalm-return   string
      * @phpstan-return string
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-4
      */
     public function getObjectFolderName(ObjectEntity|string $objectEntity): string
     {
@@ -612,6 +622,8 @@ class FolderManagementHandler
      *
      * @psalm-return   Folder
      * @phpstan-return Folder
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-4
      */
     public function getOpenRegisterUserFolder(): Folder
     {
@@ -637,6 +649,8 @@ class FolderManagementHandler
      *
      * @psalm-return   Node|null
      * @phpstan-return Node|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-4
      */
     public function getNodeById(int $nodeId): ?Node
     {

--- a/lib/Service/File/TaggingHandler.php
+++ b/lib/Service/File/TaggingHandler.php
@@ -238,6 +238,8 @@ class TaggingHandler
      * @param ObjectEntity|string $objectEntity Object entity or UUID.
      *
      * @return string The object tag (e.g., 'object:uuid').
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-5
      */
     public function generateObjectTag(ObjectEntity|string $objectEntity): string
     {
@@ -258,6 +260,8 @@ class TaggingHandler
      *
      * @phpstan-return array<int, string>
      * @psalm-return   list<string>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-5
      */
     public function getObjectTags(string $objectUuid): array
     {
@@ -295,6 +299,8 @@ class TaggingHandler
      * @param string $tagName    The tag name to add.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-5
      */
     public function addObjectTag(string $objectUuid, string $tagName): void
     {
@@ -315,6 +321,8 @@ class TaggingHandler
      * @return void
      *
      * @throws Exception If the tag is not found.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-5
      */
     public function removeObjectTag(string $objectUuid, string $tagName): void
     {
@@ -341,6 +349,8 @@ class TaggingHandler
      * @phpstan-return array<int, string>
      *
      * @psalm-return list<string>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-5
      */
     public function getAllTags(): array
     {

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -813,6 +813,8 @@ class FileService
      *
      * @psalm-return   Folder|null
      * @phpstan-return Folder|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-4
      */
     public function getObjectFolder(ObjectEntity|string $objectEntity, int|string|null $registerId=null): ?Folder
     {
@@ -1245,6 +1247,8 @@ class FileService
      *
      * @psalm-return   string
      * @phpstan-return string
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-5
      */
     public function generateObjectTag(ObjectEntity|string $objectEntity): string
     {
@@ -1345,6 +1349,8 @@ class FileService
      *
      * @psalm-return   list<string>
      * @phpstan-return array<int, string>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-5
      */
     public function getAllTags(): array
     {
@@ -1481,6 +1487,8 @@ class FileService
      * @phpstan-return \OCP\AppFramework\Http\StreamResponse
      *
      * @psalm-return \OCP\AppFramework\Http\StreamResponse<200, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-3
      */
     public function streamFile(File $file): \OCP\AppFramework\Http\StreamResponse
     {
@@ -1822,6 +1830,8 @@ class FileService
      * @return File The renamed file.
      *
      * @throws Exception If the rename fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-1
      */
     public function renameFile(ObjectEntity $object, int $fileId, string $newName): File
     {
@@ -1875,6 +1885,8 @@ class FileService
      * @return File The new file copy.
      *
      * @throws Exception If the copy fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-1
      */
     public function copyFile(ObjectEntity $sourceObject, int $fileId, ObjectEntity $targetObject): File
     {
@@ -1978,6 +1990,8 @@ class FileService
      * @return File The moved file.
      *
      * @throws Exception If the move fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-1
      */
     public function moveFile(ObjectEntity $sourceObject, int $fileId, ObjectEntity $targetObject): File
     {

--- a/openspec/changes/retrofit-2026-05-24-file-actions/design.md
+++ b/openspec/changes/retrofit-2026-05-24-file-actions/design.md
@@ -1,0 +1,67 @@
+# Design — retrofit-2026-05-24-file-actions
+
+**Retrofit change. Tasks describe retroactive annotation, not new implementation work.**
+
+This change retroactively annotates shipped OpenRegister code as the observed behavior of 5 REQs under a new `file-actions` capability. It does not modify behavior — every method covered by these REQs is already in production. The retrofit serves two purposes:
+
+1. **Make `coverage-report.json` honest.** The 30 methods covered here move from Bucket 2 (observed-but-unspecified) to Bucket 1 (specified) once this change archives and `/opsx-coverage-scan` re-runs.
+2. **Anchor future work.** Each REQ now has a stable address (`file-actions#REQ-NNN`) that future controller methods, refactors, and tests can reference.
+
+## Scope (5 REQs, this run)
+
+- **REQ-001**: File CRUD operations on objects (rename/copy/move/delete + audit + events)
+- **REQ-002**: Distributed file locking (lock/unlock + admin force-unlock + dispatched events + audit)
+- **REQ-003**: File preview & download streaming (auth + public-via-published-share gate)
+- **REQ-004**: Object & register folder management (idempotent folder creation + node-by-ID lookups)
+- **REQ-005**: Object tagging via Nextcloud system tags (generate/add/remove + facades on FileService)
+
+## Out of scope (this run — see tasks.md `## DROP — future-pass:next`)
+
+- Publish / depublish / generic file sharing (separate REQ)
+- File metadata enrichment — labels / description / category (separate REQ)
+- File upload pipeline (multipart, validation, normalisers) (separate REQ)
+- File versioning (list / restore / metadata GET/PUT) (separate REQ)
+- File chunking & Solr indexing (separate REQ)
+- File settings admin (Dolphin/Presidio/OpenAnonymiser) (separate REQ)
+- Document anonymisation (separate REQ)
+- File sidebar & UI (separate REQ — likely cross-capability)
+- File integration providers (separate REQ)
+
+## Coexistence with existing `file-actions` change
+
+There is an **unarchived `openspec/changes/file-actions/` change** (status: draft) that proposed the file-actions surface as forward-looking work. That change includes its own draft REQs for many of the same behaviors covered here, but in aspirational language ("MUST add", "SHALL register"). The two changes are not in conflict because:
+
+1. The existing change has not been archived — `openspec/specs/file-actions/spec.md` does not yet exist on `development`.
+2. This retrofit creates the canonical `openspec/specs/file-actions/spec.md` from observed behavior at archive time.
+3. When the original change is eventually archived, the maintainer should reconcile its REQs against the retrofit REQs and either merge (if the original draft is more precise) or supersede (if the retrofit is the canonical truth). The retrofit REQs are derived from the live code and should be treated as the source of truth for archive-merge conflicts.
+
+## Annotation conventions (per ADR-003)
+
+- Each covered method gets a `@spec` tag inside its existing PHPDoc block (or a new block if missing).
+- Tag format: `@spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-N`
+- Edits use the Edit tool only (per project rules — no sed/awk/python for code modification).
+- PHPCS blank-line-before-@spec rule honored: `@spec` tags go in the same docblock as existing `@param` / `@return` tags, with no leading or trailing blank tag lines.
+- The two `FileService` facade methods (`generateObjectTag`, `getAllTags`) get annotated alongside the handler methods — the facade is observable behavior too.
+
+## Observed-but-flagged
+
+See proposal.md "Notes" section. The most material observations:
+
+- **FileLockHandler cache fallback is volatile** when `ICacheFactory::createDistributed` throws — locks no longer survive between requests in that mode. The handler logs a warning but continues. REQ-002 captures this as observed behavior; tightening to fail-closed is a future change.
+- **`FilesController::preview` mixes response types** (`JSONResponse|StreamResponse`). The 404-with-fallback-icon shape is a deliberate UI contract — captured in REQ-003 as-is.
+- **Controller error-message-substring matching** (rename, lock, unlock) means localizing those strings would break the HTTP status mapping. REQ-001/REQ-002 capture the substrings literally; future i18n work will need to find an alternative dispatch (e.g., custom exception classes).
+
+## After archive
+
+Once this change archives:
+
+1. `openspec/specs/file-actions/spec.md` SHALL exist with the 5 REQs and `retrofit: true` frontmatter.
+2. `/opsx-coverage-scan openregister` SHOULD move the 30 covered methods from Bucket 2 to Bucket 1.
+3. A follow-up `retrofit-2026-05-NN-file-actions` change can be opened for the next batch of REQs from the deferred list.
+
+## References
+
+- Source coverage scan: `/tmp/or-scan/rspec-cluster-file-actions.json`
+- Coverage report: `openspec/coverage-report.json` (2026-05-24)
+- Retrofit playbook: `.github/docs/claude/retrofit.md`
+- Sibling change with overlapping draft REQs: `openspec/changes/file-actions/`

--- a/openspec/changes/retrofit-2026-05-24-file-actions/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-file-actions/proposal.md
@@ -1,0 +1,87 @@
+# Retrofit — file-actions (partial, 5 REQs)
+
+Describes the observed behavior of OpenRegister's shipped file-action surface (FilesController + FileService + the `lib/Service/File/*Handler` family) as 5 new REQs under a new `file-actions` capability. Code already exists and is in production — this change retroactively specifies it.
+
+## Why this is a partial pass
+
+The `file-actions` cluster from `coverage-report.json` has **268 methods across 41 files** — far beyond the 5-REQ-per-run cap. This run drafts the FIRST 5 highest-cohesion REQs, covering the most-implemented and highest-impact behaviors:
+
+1. File CRUD operations on objects (rename / copy / move / delete)
+2. Distributed file locking (acquire / release / admin force-unlock)
+3. File preview & download streaming (auth + public)
+4. Object & register folder management
+5. Object tagging via system tags
+
+The remaining ~63 in-scope methods (after subtracting the 191 pre-triaged DROPs) are listed in `tasks.md` under `## DROP — future-pass:next` with their behavioral grouping for follow-up runs.
+
+## Coexistence with the existing `file-actions` change
+
+There is an **unarchived `openspec/changes/file-actions/` change** (status: draft) that describes the same surface using forward-looking language. That change is the original implementation plan with phase-tracking and gap audits — many of its REQs were drafted before / during the build, so the verbs are aspirational ("MUST add", "SHALL register"). This retrofit captures **observed behavior of the shipped code as of 2026-05-24** so the spec accurately reflects the live system.
+
+When the original `file-actions` change is eventually archived (and finalised into a real spec), the maintainer should reconcile its REQs against the retrofit REQs here. Bias toward keeping the retrofit-derived REQs (they describe observed behavior); merge or supersede the original's draft REQs where they overlap.
+
+## Affected code units (5 REQs / 35 methods covered)
+
+### REQ-001 — File CRUD operations on objects
+- `lib/Controller/FilesController.php::rename()`
+- `lib/Controller/FilesController.php::copy()`
+- `lib/Controller/FilesController.php::move()`
+- `lib/Service/FileService.php::renameFile()` (orchestrator)
+- `lib/Service/FileService.php::copyFile()` (orchestrator)
+- `lib/Service/FileService.php::moveFile()` (orchestrator)
+- `lib/Service/File/DeleteFileHandler.php::deleteFile()`
+- `lib/Service/File/DeleteFileHandler.php::deleteFiles()`
+- `lib/Event/FileCopiedEvent.php::__construct()`
+- `lib/Event/FileMovedEvent.php::__construct()`
+- `lib/Event/FileRenamedEvent.php::__construct()`
+
+### REQ-002 — Distributed file locking
+- `lib/Controller/FilesController.php::lock()`
+- `lib/Controller/FilesController.php::unlock()`
+- `lib/Service/File/FileLockHandler.php::lockFile()`
+- `lib/Service/File/FileLockHandler.php::unlockFile()`
+- `lib/Event/FileLockedEvent.php::__construct()`
+- `lib/Event/FileUnlockedEvent.php::__construct()`
+
+### REQ-003 — File preview & download streaming
+- `lib/Controller/FilesController.php::preview()`
+- `lib/Service/File/FilePreviewHandler.php::getPreview()`
+- `lib/Service/FileService.php::streamFile()`
+
+### REQ-004 — Object & register folder management
+- `lib/Service/File/FolderManagementHandler.php::createRegisterFolderById()`
+- `lib/Service/File/FolderManagementHandler.php::getRegisterFolderById()`
+- `lib/Service/File/FolderManagementHandler.php::createFolderPath()`
+- `lib/Service/File/FolderManagementHandler.php::getRegisterFolderName()`
+- `lib/Service/File/FolderManagementHandler.php::getObjectFolderName()`
+- `lib/Service/File/FolderManagementHandler.php::getOpenRegisterUserFolder()`
+- `lib/Service/File/FolderManagementHandler.php::getNodeById()`
+- `lib/Service/FileService.php::getObjectFolder()`
+
+### REQ-005 — Object tagging via system tags
+- `lib/Service/File/TaggingHandler.php::generateObjectTag()`
+- `lib/Service/File/TaggingHandler.php::getObjectTags()`
+- `lib/Service/File/TaggingHandler.php::addObjectTag()`
+- `lib/Service/File/TaggingHandler.php::removeObjectTag()`
+- `lib/Service/File/TaggingHandler.php::getAllTags()`
+- `lib/Service/FileService.php::generateObjectTag()` (delegating facade)
+- `lib/Service/FileService.php::getAllTags()` (delegating facade)
+
+## Approach
+
+- One REQ per coherent behavioral surface, with WHEN/THEN scenarios drawn from the observed code paths.
+- Annotate the covered code units with `@spec openspec/changes/retrofit-2026-05-24-file-actions/tasks.md#task-N` tags using the same per-file single-pass approach as `/opsx-annotate`.
+- The `## DROP — future-pass:next` section in tasks.md lists methods deferred to subsequent retrofit runs, grouped by likely future REQ.
+
+## Notes (observed-but-flagged)
+
+These are observations from reading the code that the retrofit captures **as-is** rather than silently "fixing" via the spec:
+
+- **`FilesController::preview` mixed-result type.** Returns `JSONResponse|StreamResponse` — JSON on error, stream on success. The status-code-on-fallback returns 404 with a `fallbackIcon` key, which conflates "file not found" with "preview generation failed".
+- **`FilesController::unlock` swallows admin-check error messages.** The 403 trigger is regex-matched on substrings like `"Only the lock owner"` and `"administrators"`. Localising those strings would break the status-code mapping.
+- **`FileLockHandler::__construct` cache fallback is volatile.** When `ICacheFactory::createDistributed()` throws (e.g. no APCu / Redis), the handler falls back to a per-instance array, which means locks **do not survive between requests** under that configuration. The handler logs a warning but does not refuse to operate. Spec captures this as observed behavior; tightening it (e.g. fail-closed) is a future change.
+- **`DeleteFileHandler::deleteFile` returns false on most error paths.** Missing file, wrong instance type, or `delete()` exception all log + return `false` rather than throwing. The 207-partial-success pattern in `FilesController::batch` relies on this. The `assertCanModify` lock-guard call, however, **does throw** — so callers can see two failure modes (return false vs throw) from the same method.
+- **`TaggingHandler::generateObjectTag` falls back to numeric ID when UUID is missing.** The format is always `object:{uuid-or-id}`. Mixed-id-type tags can collide if UUID and numeric ID overlap (unlikely in practice but undefined).
+- **`FolderManagementHandler::createRegisterFolderById` writes the folder ID back into `$register->setFolder()` as a string.** Property is typed `?string` on the Register entity — the cast `(string) $folderNode->getId()` is intentional but stringifies an integer.
+
+Source: `coverage-report.json` generated 2026-05-24. See `/tmp/or-scan/rspec-cluster-file-actions.json` for the input batch.

--- a/openspec/changes/retrofit-2026-05-24-file-actions/specs/file-actions/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-file-actions/specs/file-actions/spec.md
@@ -1,0 +1,347 @@
+---
+retrofit: true
+---
+
+# file-actions Specification
+
+## Purpose
+
+OpenRegister extends Nextcloud's Files API with per-object file actions: CRUD operations (rename, copy, move, delete), distributed file locking, scoped previews + streaming, folder management for the per-Register / per-Object filesystem hierarchy, and object tagging via Nextcloud system tags. These actions back the file sidebar UI and are consumed by Procest / Pipelinq / ZaakAfhandelApp via the controller endpoints under `/apps/openregister/api/objects/{register}/{schema}/{id}/files/...`.
+
+This spec is a **partial retrofit** — it captures the observed behavior of 5 high-cohesion REQs covering 30 methods. Remaining file-actions surface (download / publish / batch / versioning / file metadata enrichment / vectorization indexing / file settings admin / sidebar UI) is deferred to follow-up retrofit passes; see `openspec/changes/retrofit-2026-05-24-file-actions/tasks.md` for the deferred list.
+
+## Requirements
+
+### REQ-001: File CRUD operations on objects
+
+The system SHALL expose per-object file CRUD endpoints — rename, copy, move, delete — through `FilesController` delegating to `FileService` orchestrators (`renameFile`, `copyFile`, `moveFile`) and the `DeleteFileHandler` family. Each mutation SHALL write an audit-trail entry via `FileAuditHandler::logFileAction()` and dispatch a typed CloudEvent (`FileRenamedEvent`, `FileCopiedEvent`, `FileMovedEvent`) when applicable. Copy and move operations SHALL support cross-register and cross-schema targets by accepting `targetRegister` and `targetSchema` request parameters that default to the source's register/schema. Copy SHALL emit a dual audit entry: one on the source object (`file.copied`) and one on the target object (`file.copied_in`); move SHALL emit `file.moved` / `file.moved_in`. Delete operations on a locked file SHALL throw via `FileLockHandler::assertCanModify()` before any filesystem write is attempted.
+
+#### Scenario: Rename a file under an object
+
+- **GIVEN** an authenticated user with write access to object `{register}/{schema}/{id}`
+- **AND** the object has an attached file with `fileId=42` and name `report.pdf`
+- **WHEN** the user calls `POST /api/objects/{register}/{schema}/{id}/files/42/rename` with body `{"name": "final-report.pdf"}`
+- **THEN** the controller SHALL load the object via `ObjectService::setObject($id)`
+- **AND** call `FileService::renameFile(object, fileId: 42, newName: "final-report.pdf")`
+- **AND** log an audit-trail entry `action: 'file.renamed'` with `data: {oldName, newName}`
+- **AND** dispatch `FileRenamedEvent` carrying the object UUID, fileId, and the same data payload
+- **AND** return HTTP 200 with the formatted file JSON via `FileService::formatFile($file)`
+
+#### Scenario: Rename produces structured HTTP status codes
+
+- **GIVEN** a rename request that fails inside `FileService::renameFile()` with an exception
+- **WHEN** the exception message contains one of the listed substrings
+- **THEN** the response status code SHALL be derived as follows:
+  - message contains `"already exists"` → HTTP 409
+  - message contains `"invalid characters"` → HTTP 400
+  - message contains `"required"` → HTTP 400
+  - message contains `"locked"` → HTTP 423
+  - any other exception → HTTP 400
+- **AND** the response body SHALL be `{"error": "<exception message>"}`
+
+#### Scenario: Copy a file between objects across registers
+
+- **GIVEN** a source object `{registerA}/{schemaA}/{sourceId}` with file `fileId=42`
+- **AND** a target object `{registerB}/{schemaB}/{targetId}`
+- **WHEN** the user calls `POST /api/objects/{registerA}/{schemaA}/{sourceId}/files/42/copy` with body `{"targetObjectId": "{targetId}", "targetRegister": "{registerB}", "targetSchema": "{schemaB}"}`
+- **THEN** the controller SHALL load the source object first, then switch ObjectService to the target's register/schema and load the target object
+- **AND** call `FileService::copyFile(sourceObject, fileId: 42, targetObject)` which delegates to a CRUD handler that copies the underlying NC Node
+- **AND** log a `file.copied` audit entry on the source object with `data: {targetObjectUuid, targetRegister, targetSchema}`
+- **AND** log a `file.copied_in` audit entry on the target object with `data: {sourceObjectUuid, sourceFileId}`
+- **AND** dispatch `FileCopiedEvent` with the source object UUID and target object UUID
+- **AND** return HTTP 201 with the formatted new file JSON
+
+#### Scenario: Move a file between objects with dual audit
+
+- **GIVEN** a source object with file `fileId=42`
+- **AND** a target object in any register/schema
+- **WHEN** the user calls `POST /api/objects/{register}/{schema}/{id}/files/42/move` with `{"targetObjectId", "targetRegister", "targetSchema"}`
+- **THEN** the controller SHALL behave identically to `copy` for object-loading and audit-dual-entry, but call `FileService::moveFile()` instead
+- **AND** emit `file.moved` + `file.moved_in` audit entries
+- **AND** dispatch `FileMovedEvent`
+- **AND** return HTTP 200 with the formatted moved file JSON
+
+#### Scenario: Missing target object returns 404
+
+- **GIVEN** a copy or move request where the target object cannot be resolved
+- **WHEN** `ObjectService::getObject()` returns `null` for the target
+- **THEN** the response SHALL be HTTP 404 with body `{"error": "Target object not found"}`
+
+#### Scenario: Delete a file via the DeleteFileHandler
+
+- **GIVEN** a file (as Node, path string, or numeric file ID) and an optional `ObjectEntity`
+- **WHEN** `DeleteFileHandler::deleteFile($file, $object)` is called
+- **THEN** the handler SHALL resolve a non-Node argument via `ReadFileHandler::getFile()`
+- **AND** call `FileLockHandler::assertCanModify($file->getId())` — if the file is locked by another user, this SHALL throw and abort the delete
+- **AND** call `FileValidationHandler::checkOwnership($file)` defensively before deletion
+- **AND** call `$file->delete()` and return `true` on success
+- **AND** return `false` (with a logger->error call) on any of these failure modes: file is null, file is not a `File` instance, or `delete()` throws
+
+#### Scenario: Batch delete returns per-file results
+
+- **GIVEN** an array of files (mix of Node / path / int) and an optional `ObjectEntity`
+- **WHEN** `DeleteFileHandler::deleteFiles($files, $object)` is called
+- **THEN** the handler SHALL iterate the array calling `deleteFile()` on each
+- **AND** return an array of result objects: `{file, success}` on success, `{file, success: false, error: <message>}` when `deleteFile` throws
+
+### REQ-002: Distributed file locking
+
+The system SHALL implement soft file locking via `FileLockHandler` to prevent concurrent edits. Locks SHALL be persisted in a Nextcloud distributed cache (`ICacheFactory::createDistributed('openregister_file_locks')`) so they survive across requests on the same Nextcloud instance; when the distributed cache is unavailable at construction time the handler SHALL fall back to a per-instance volatile map and emit a warning log line. Each lock entry SHALL carry a TTL (default 30 minutes) and is keyed by file ID. Only the lock owner SHALL be able to unlock a file; admin users SHALL be able to force-unlock via an explicit `force=true` parameter. Every lock and unlock SHALL write an audit-trail entry and dispatch a typed CloudEvent (`FileLockedEvent`, `FileUnlockedEvent`).
+
+#### Scenario: Acquire a lock on an unlocked file
+
+- **GIVEN** an authenticated user `alice` and a file `fileId=42` that is not currently locked
+- **WHEN** the user calls `POST /api/objects/{register}/{schema}/{id}/files/42/lock`
+- **THEN** the controller SHALL load the object and call `FileLockHandler::lockFile(42)`
+- **AND** `lockFile` SHALL persist a lock entry keyed by `42` with `lockedBy: 'alice'` and TTL 30 minutes
+- **AND** the controller SHALL log an audit-trail entry `action: 'file.locked'` and dispatch `FileLockedEvent`
+- **AND** return HTTP 200 with the lock metadata array
+
+#### Scenario: Lock owner refreshes own lock
+
+- **GIVEN** user `alice` already holds the lock on `fileId=42`
+- **WHEN** `alice` calls `lockFile(42)` again
+- **THEN** the existing lock SHALL be refreshed (new TTL written) rather than rejected
+- **AND** `lockFile` SHALL return the refreshed lock metadata
+
+#### Scenario: Lock contention from a different user
+
+- **GIVEN** `alice` holds the lock on `fileId=42`
+- **WHEN** user `bob` calls `lockFile(42)`
+- **THEN** `lockFile` SHALL throw `Exception('File is locked by alice')`
+- **AND** `FilesController::lock` SHALL catch the exception and return HTTP 423 (Locked) when the message contains `"locked"`, HTTP 400 otherwise
+
+#### Scenario: Lock owner unlocks their own file
+
+- **GIVEN** `alice` holds the lock on `fileId=42`
+- **WHEN** `alice` calls `POST .../files/42/unlock` (without `force`)
+- **THEN** `FileLockHandler::unlockFile(42, false)` SHALL verify the lock owner matches the current user
+- **AND** remove the lock entry from the distributed cache
+- **AND** the controller SHALL log audit `action: 'file.unlocked'` with `data: {force: false}` and dispatch `FileUnlockedEvent`
+- **AND** return HTTP 200 with `{"locked": false}`
+
+#### Scenario: Non-owner unlock attempt is rejected
+
+- **GIVEN** `alice` holds the lock; user `bob` (non-admin) attempts to unlock
+- **WHEN** `unlockFile(42, false)` is called
+- **THEN** the handler SHALL throw `Exception('Only the lock owner or an admin can unlock this file')`
+- **AND** the controller SHALL map the message substring `"Only the lock owner"` to HTTP 403
+
+#### Scenario: Admin force-unlock requires the force flag
+
+- **GIVEN** `alice` holds the lock; admin `root` attempts to force-unlock
+- **WHEN** the controller calls `unlockFile(42, force: true)`
+- **THEN** the handler SHALL accept the unlock and remove the lock entry
+- **AND** the controller SHALL log audit `action: 'file.force_unlocked'` (distinct from the standard `file.unlocked` action)
+- **AND** dispatch `FileUnlockedEvent` with `data: {force: true}`
+
+#### Scenario: Non-admin force-unlock is rejected
+
+- **GIVEN** non-admin user `bob` attempts to force-unlock
+- **WHEN** `unlockFile(42, force: true)` is called
+- **THEN** the handler SHALL throw `Exception('Only administrators can force-unlock files')`
+- **AND** the controller SHALL map `"administrators"` substring to HTTP 403
+
+#### Scenario: Unlock a file that is not locked is idempotent
+
+- **GIVEN** `fileId=42` is not currently locked
+- **WHEN** any user calls `unlockFile(42)`
+- **THEN** the handler SHALL return `['locked' => false]` without throwing
+- **AND** no audit / event SHALL be skipped at the handler layer — the controller still logs and dispatches normally
+
+#### Scenario: Distributed cache unavailable at construction
+
+- **GIVEN** `ICacheFactory::createDistributed('openregister_file_locks')` throws at handler construction
+- **WHEN** the handler is instantiated
+- **THEN** the handler SHALL set `$this->cache = null` and continue to operate
+- **AND** the handler SHALL emit a warning log line `'Distributed cache unavailable; falling back to per-instance map (volatile).'`
+- **AND** subsequent `lockFile()` / `unlockFile()` calls SHALL operate against the per-instance map (locks do NOT survive across requests in this mode — documented limitation, not a hard failure)
+
+#### Scenario: Expired lock is cleared lazily
+
+- **GIVEN** a lock entry whose `expiresAt` is in the past
+- **WHEN** `getLockInfo(42)` is called
+- **THEN** the handler SHALL parse `expiresAt` defensively (malformed → drop the entry and return null)
+- **AND** if `expiresAt <= now` the entry SHALL be removed and the method SHALL return `null`
+- **AND** an info log line SHALL be written: `'Lock on file {fileId} expired, auto-cleared'`
+
+### REQ-003: File preview & download streaming
+
+The system SHALL serve per-file preview thumbnails via `FilesController::preview()` and full-file downloads via `FileService::streamFile()`. The preview endpoint SHALL be marked `@PublicPage`, but anonymous callers SHALL be gated: only files explicitly published with a public share (`FileMapper::isFilePublished($fileId) === true`) SHALL be previewable without authentication. Preview generation SHALL delegate to `FilePreviewHandler::getPreview()`, which uses Nextcloud's `IPreview` manager; unavailable preview types SHALL throw a friendly `'Preview not available for this file type'` exception. Download streams SHALL set `Content-Disposition: attachment; filename="..."` for browser-initiated downloads.
+
+#### Scenario: Authenticated user retrieves a preview
+
+- **GIVEN** an authenticated user with read access to object `{register}/{schema}/{id}`
+- **AND** the object has a file `fileId=42` with a previewable MIME type
+- **WHEN** the user calls `GET /api/objects/{register}/{schema}/{id}/files/42/preview?width=512&height=512`
+- **THEN** the controller SHALL load the object, fetch the file via `FileService::getFile()`
+- **AND** call `FilePreviewHandler::getPreview($file, 512, 512)`
+- **AND** return a `StreamResponse` of the preview bytes
+- **AND** set headers `Content-Type: <preview mime>`, `Cache-Control: max-age=3600, public`, `Content-Length: <bytes>`
+
+#### Scenario: Default preview dimensions when omitted
+
+- **GIVEN** a preview request with no `width` / `height` query parameters
+- **WHEN** the controller calls `getPreview()`
+- **THEN** width and height SHALL default to 256 (per `FilePreviewHandler::DEFAULT_WIDTH` / `DEFAULT_HEIGHT`)
+
+#### Scenario: Anonymous preview for an unpublished file is blocked
+
+- **GIVEN** a request with no authenticated user (`userSession->getUser() === null`)
+- **AND** `FileMapper::isFilePublished($fileId)` returns `false` (or `$fileMapper` is null)
+- **WHEN** the controller calls `preview()`
+- **THEN** the response SHALL be HTTP 403 with body `{"error": "Preview not available for unpublished files"}`
+- **AND** no preview bytes SHALL be generated
+
+#### Scenario: Anonymous preview for a published file is allowed
+
+- **GIVEN** a request with no authenticated user
+- **AND** `FileMapper::isFilePublished($fileId)` returns `true`
+- **WHEN** the controller calls `preview()`
+- **THEN** the anonymous-caller gate SHALL pass and the standard preview path SHALL run
+
+#### Scenario: Preview generation failure returns a fallback icon hint
+
+- **GIVEN** a preview request where `FilePreviewHandler::getPreview()` throws (preview type not supported, or preview manager error)
+- **WHEN** the controller catches the exception
+- **THEN** the response SHALL be HTTP 404 with body `{"error": "<message>", "fallbackIcon": "/core/img/filetypes/file.svg"}`
+- **AND** the caller is expected to render the fallback icon
+
+#### Scenario: Stream a file as a download
+
+- **GIVEN** an authenticated request that resolves to a Nextcloud `OCP\Files\File` node
+- **WHEN** `FileService::streamFile($file)` is called
+- **THEN** a `StreamResponse` SHALL wrap `$file->fopen('r')`
+- **AND** the response headers SHALL include:
+  - `Content-Type: <file mime type>`
+  - `Content-Disposition: attachment; filename="<file name>"`
+  - `Content-Length: <file size>`
+
+### REQ-004: Object & register folder management
+
+The system SHALL maintain a per-Register / per-Object folder hierarchy under a single root folder (`self::ROOT_FOLDER`) within the OpenRegister system user's Files area. Each `Register` entity SHALL have at most one register folder, identified by a numeric NC node ID stored in `Register::getFolder()`. Each `ObjectEntity` SHALL have at most one object folder nested under its register's folder, identified similarly. `FolderManagementHandler` SHALL be idempotent: re-calling `createRegisterFolderById` / `createObjectFolderById` for an existing folder SHALL return the existing node rather than throwing or creating a duplicate. Folder lookups SHALL go through `getNodeById()` and degrade gracefully (return null) when the stored ID no longer resolves to a valid Folder.
+
+#### Scenario: Create register folder when none exists
+
+- **GIVEN** a `Register` entity whose `getFolder()` is null or does not resolve to an existing folder
+- **WHEN** `FolderManagementHandler::createRegisterFolderById($register, $currentUser)` is called
+- **THEN** the handler SHALL build the folder path as `self::ROOT_FOLDER . '/' . getRegisterFolderName($register)`
+- **AND** call `createFolderPath()` to materialise the path (creating each intermediate folder as needed)
+- **AND** persist the new folder's numeric node ID via `Register::setFolder((string) $folderNode->getId())` and `RegisterMapper::update($register)`
+- **AND** attempt to share the folder with `$currentUser` via the internal `shareFolderWithCurrentUser` helper
+- **AND** return the created Node
+
+#### Scenario: Register folder lookup is idempotent
+
+- **GIVEN** a `Register` whose `getFolder()` returns a numeric ID that resolves to an existing folder
+- **WHEN** `createRegisterFolderById($register)` is called
+- **THEN** the handler SHALL return the existing folder without creating a new one or re-sharing
+- **AND** an info log line `'Register folder already exists with ID: {id}'` SHALL be emitted
+
+#### Scenario: Retrieve register folder by ID
+
+- **GIVEN** a `Register` with `getFolder()` returning a stored numeric ID
+- **WHEN** `getRegisterFolderById($register)` is called
+- **THEN** the handler SHALL resolve the ID via `getNodeById()`
+- **AND** return the Folder if it exists and is of type folder, else return `null`
+
+#### Scenario: Get the OpenRegister user root folder
+
+- **GIVEN** the OpenRegister system user is initialised
+- **WHEN** `getOpenRegisterUserFolder()` is called
+- **THEN** the handler SHALL return the user's NC `Folder` root via `IRootFolder::getUserFolder()`
+
+#### Scenario: Create a multi-segment folder path
+
+- **GIVEN** a path string like `"Registers/MyRegister/sub-folder"`
+- **WHEN** `createFolderPath($folderPath)` is called
+- **THEN** the handler SHALL ensure each path segment exists, creating folders that are missing
+- **AND** return the Node at the terminal segment
+
+#### Scenario: Resolve a node by stored numeric ID
+
+- **GIVEN** a numeric node ID
+- **WHEN** `getNodeById($nodeId)` is called
+- **THEN** the handler SHALL look up the node in the OpenRegister user's Files area
+- **AND** return the Node if it exists, or `null` if not found / inaccessible
+
+#### Scenario: Generate register and object folder names
+
+- **GIVEN** a `Register` entity
+- **WHEN** `getRegisterFolderName($register)` is called
+- **THEN** a string SHALL be returned (or `null` if the register has no resolvable name) suitable for use as a single folder-name segment
+
+- **GIVEN** an `ObjectEntity` or its UUID/ID string
+- **WHEN** `getObjectFolderName($objectEntity)` is called
+- **THEN** a string SHALL be returned suitable for use as a single folder-name segment under the register folder
+
+#### Scenario: FileService delegates object-folder lookup
+
+- **GIVEN** an `ObjectEntity` or object UUID/ID string and optional register ID
+- **WHEN** `FileService::getObjectFolder($objectEntity, $registerId)` is called
+- **THEN** the call SHALL delegate to `FolderManagementHandler::getObjectFolder()`
+- **AND** return the Folder if present, or `null` if the object's stored folder ID does not resolve
+
+### REQ-005: Object tagging via Nextcloud system tags
+
+The system SHALL maintain a one-to-many relationship between OpenRegister `ObjectEntity` rows and Nextcloud `ISystemTag` entries via `TaggingHandler`. The handler SHALL use a constant `OBJECT_TAG_TYPE` for `objectType` in calls to `ISystemTagObjectMapper`, keeping OpenRegister object-tag mappings isolated from file-tag mappings. Object tags SHALL be addressable by the object's UUID. A standardised tag identifier of the form `object:{uuid-or-id}` SHALL be produced by `generateObjectTag()` for use as a stable tag name when attaching object metadata to NC nodes. Tag operations SHALL be exposed as facades on `FileService` (`generateObjectTag`, `getAllTags`) so consumers do not need to inject `TaggingHandler` directly.
+
+#### Scenario: Generate an object tag identifier
+
+- **GIVEN** an `ObjectEntity` whose `getUuid()` returns `"550e8400-e29b-41d4-a716-446655440000"`
+- **WHEN** `TaggingHandler::generateObjectTag($entity)` is called
+- **THEN** the return value SHALL be `"object:550e8400-e29b-41d4-a716-446655440000"`
+
+- **GIVEN** an `ObjectEntity` with no UUID (only a numeric `getId()` of `42`)
+- **WHEN** `generateObjectTag($entity)` is called
+- **THEN** the return value SHALL be `"object:42"` (fallback to numeric ID)
+
+- **GIVEN** a raw string identifier `"my-id"`
+- **WHEN** `generateObjectTag("my-id")` is called
+- **THEN** the return value SHALL be `"object:my-id"` (no UUID lookup)
+
+#### Scenario: List tags assigned to an object
+
+- **GIVEN** an object UUID and the object has 3 system tags assigned
+- **WHEN** `getObjectTags($objectUuid)` is called
+- **THEN** the handler SHALL call `ISystemTagObjectMapper::getTagIdsForObjects([$uuid], OBJECT_TAG_TYPE)`
+- **AND** resolve the tag IDs to tag names via `ISystemTagManager::getTagsByIds()`
+- **AND** return a `list<string>` of tag names sorted alphabetically
+- **AND** return `[]` if no tags are mapped or if any underlying call throws (with an error log)
+
+#### Scenario: Add a tag to an object
+
+- **GIVEN** an object UUID and a tag name (possibly not yet present in the system)
+- **WHEN** `addObjectTag($objectUuid, $tagName)` is called
+- **THEN** the handler SHALL call its internal `findOrCreateTag($tagName)` helper to ensure the tag exists
+- **AND** call `ISystemTagObjectMapper::assignTags($objectUuid, OBJECT_TAG_TYPE, [$tag->getId()])`
+- **AND** return `void`
+
+#### Scenario: Remove a tag from an object
+
+- **GIVEN** an object UUID and a tag name currently assigned to the object
+- **WHEN** `removeObjectTag($objectUuid, $tagName)` is called
+- **THEN** the handler SHALL query `getAllTags(nameSearchPattern: $tagName)` and find the exact-name match
+- **AND** call `ISystemTagObjectMapper::unassignTags($objectUuid, OBJECT_TAG_TYPE, [$tag->getId()])`
+- **AND** return `void`
+
+#### Scenario: Removing a non-existent tag throws
+
+- **GIVEN** a tag name that does not exist in the system tag manager
+- **WHEN** `removeObjectTag($objectUuid, $tagName)` is called
+- **THEN** the handler SHALL throw `Exception('Tag not found: ' . $tagName)`
+
+#### Scenario: List all system tags
+
+- **GIVEN** the NC system tag manager has N tags
+- **WHEN** `TaggingHandler::getAllTags()` (or its facade `FileService::getAllTags()`) is called
+- **THEN** the handler SHALL call `ISystemTagManager::getAllTags(visibilityFilter: null)`
+- **AND** return a `list<string>` of tag names (order matches the manager's native ordering)
+- **AND** return `[]` if the underlying call throws (with an error log)
+
+#### Scenario: FileService facade delegates to TaggingHandler
+
+- **GIVEN** a consumer that injects `FileService` but not `TaggingHandler`
+- **WHEN** the consumer calls `FileService::generateObjectTag($entity)` or `FileService::getAllTags()`
+- **THEN** the call SHALL delegate to the corresponding `TaggingHandler` method
+- **AND** the return value SHALL be identical to a direct handler call

--- a/openspec/changes/retrofit-2026-05-24-file-actions/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-file-actions/tasks.md
@@ -1,0 +1,117 @@
+# Tasks: retrofit-2026-05-24-file-actions (partial)
+
+This change retroactively annotates code that already exists in production. All covered tasks below are `[x]` because no new implementation work is required.
+
+This is a **partial pass** capping at 5 REQs out of an estimated 8–10 REQs needed for full file-actions coverage. The `## DROP — future-pass:next` section lists the methods deferred to subsequent retrofit runs.
+
+## Covered (annotated this run)
+
+- [x] task-1: file-actions#REQ-001 — File CRUD operations on objects (retroactive annotation; 11 methods)
+- [x] task-2: file-actions#REQ-002 — Distributed file locking (retroactive annotation; 6 methods)
+- [x] task-3: file-actions#REQ-003 — File preview & download streaming (retroactive annotation; 3 methods)
+- [x] task-4: file-actions#REQ-004 — Object & register folder management (retroactive annotation; 8 methods)
+- [x] task-5: file-actions#REQ-005 — Object tagging via Nextcloud system tags (retroactive annotation; 7 methods)
+
+## DROP — future-pass:next
+
+The following in-scope methods (i.e. not pre-triaged as DROP-to-other-capability) are deferred to follow-up retrofit runs. Grouped by likely future REQ. Numbers in parentheses are the file::method counts from the 2026-05-24 coverage scan.
+
+### Likely REQ — Publish / depublish / public sharing
+- `lib/Service/File/FilePublishingHandler.php::publishFile` — Generic public-share creation
+- `lib/Service/File/FilePublishingHandler.php::unpublishFile` — Remove public share
+- `lib/Service/File/FilePublishingHandler.php::createObjectFilesZip` — Object-files ZIP build
+- `lib/Service/File/FileSharingHandler.php::createShare` — Generic Nextcloud share creation
+- `lib/Service/File/FileSharingHandler.php::getShareLink` — Share URL builder
+- `lib/Service/File/FileSharingHandler.php::findShares` — Share lookup
+- `lib/Service/File/FileSharingHandler.php::shareFileWithUser` — User file share
+- `lib/Service/File/FileSharingHandler.php::shareFolderWithUser` — Folder share
+- `lib/Controller/FilesController.php::depublish` — File depublish endpoint
+
+### Likely REQ — File metadata & enrichment (labels, description, category)
+- `lib/Controller/FilesController.php::updateLabels` — Update file labels endpoint
+- `lib/Service/File/FileFormattingHandler.php::*` — Format file JSON output (10 methods)
+- `src/services/fileMetadata.js::buildFileUrl` / `updateFileLabels` / `updateFileMetadata` — Frontend metadata client (3 methods)
+
+### Likely REQ — File upload & creation pipeline
+- `lib/Controller/FilesController.php::save` — File save endpoint
+- `lib/Controller/FilesController.php::createMultipart` — Multipart upload helper
+- `lib/Controller/FilesController.php::processUploadedFiles` — Upload processor
+- `lib/Controller/FilesController.php::extractUploadedFiles` — Request-to-files extractor
+- `lib/Controller/FilesController.php::normalizeSingleFile` / `normalizeMultipleFiles` / `normalizeMultipartFiles` — Multipart normalisers
+- `lib/Controller/FilesController.php::validateUploadedFile` — Upload validator
+- `lib/Controller/FilesController.php::getUploadErrorMessage` — Upload-error string helper
+- `lib/Service/File/CreateFileHandler.php::*` — File creation (4 methods)
+- `src/modals/file/UploadFiles.vue::closeModal` — Upload modal close
+
+### Likely REQ — File versioning (list / restore / show)
+- `lib/Controller/FilesController.php::show` — File metadata GET
+- `lib/Controller/FilesController.php::update` — File metadata PUT
+- `lib/Controller/FilesController.php::batch` — Bulk file operations endpoint
+- `lib/Controller/FilesController.php::downloadById` — File download by ID
+- `lib/Controller/FilesController.php::recordDownloadEvent` — Download audit event
+- `lib/Service/File/UpdateFileHandler.php::*` — File update (4 methods)
+- `lib/Service/File/ReadFileHandler.php::*` — File reads (6 methods)
+- `lib/Service/File/FileBatchHandler.php::*` — Batch operations (4 methods)
+- `lib/Service/File/FileCrudHandler.php::*` — CRUD facade (the non-stub methods; ~5 methods)
+- `lib/Service/File/FileValidationHandler.php::*` — File validation (6 methods, 1 here-covered: ownFile)
+
+### Likely REQ — File locking internals (helpers)
+- `lib/Service/File/FileLockHandler.php::getLockInfo` / `readLockEntry` / `writeLockEntry` / `removeLockEntry` / `setLock` / `isLocked` / `assertCanModify` / `isCurrentUserAdmin` / `getCurrentUserId` — Lock cache layer + helpers (already covered indirectly by REQ-002; explicit REQs for the cache contract are deferred)
+
+### Likely REQ — File ownership (the OpenRegister system user)
+- `lib/Service/File/FileOwnershipHandler.php::*` — Ownership transfer (5 methods)
+- `lib/Service/File/FileValidationHandler.php::ownFile` — Ownership setter (1 method)
+
+### Likely REQ — File chunking + Solr indexing
+- `lib/Controller/FileTextController.php::getChunkingStats` — Chunking stats
+- `lib/Service/Index/FileHandler.php::indexFileChunks` / `getChunkingStats` / `getFileIndexStats` — Solr indexing (3 methods)
+- `lib/Service/Vectorization/Strategies/FileVectorizationStrategy.php::fetchEntities` — Vectorisation
+- `src/modals/settings/FileWarmupModal.vue::loadStats` — Warmup UI
+
+### Likely REQ — File settings admin (Dolphin / Presidio / OpenAnonymiser)
+- `lib/Controller/Settings/FileSettingsController.php::getFileSettings` / `updateFileSettings` — Settings CRUD
+- `lib/Controller/Settings/FileSettingsController.php::testDolphinConnection` / `testPresidioConnection` / `testOpenAnonymiserConnection` — Provider connection tests
+- `lib/Controller/Settings/FileSettingsController.php::reindexFiles` / `getFileIndexStats` — Re-indexing
+- `lib/Service/Settings/FileSettingsHandler.php::*` — Settings persistence (3 methods)
+- `src/modals/settings/FileManagementModal.vue::loadConfiguration` — Settings UI
+- `src/modals/settings/FileVectorizationModal.vue::loadFileTypes` — Vectorization settings UI
+- `src/views/settings/sections/FileConfiguration.vue::loadSettings` — Admin settings page
+
+### Likely REQ — Document anonymisation
+- `lib/Service/File/DocumentProcessingHandler.php::anonymizeDocument` — Document anonymisation orchestrator
+- `lib/Service/FileService.php::anonymizeDocument` — Facade (delegates to handler)
+- `lib/Service/File/DocumentProcessingHandler.php::*` — Other processing methods (5 methods)
+
+### Likely REQ — File sidebar & UI
+- `lib/Controller/FileSidebarController.php::__construct` — Sidebar controller
+- `lib/Service/FileSidebarService.php::__construct` — Sidebar service
+- `src/components/FilesSidebar.vue::handleSearchInput` — Sidebar search UI
+- `src/composables/UseFileSelection.js::useFileSelection` — File selection composable
+- `src/views/files/FilesIndex.vue::toggleSidebar` — Sidebar toggle
+
+### Likely REQ — File integrations / providers (built-in)
+- `lib/Service/Integration/BuiltinProviders/FilesProvider.php::getId` / `getLabel` / `getIcon` / `getStorageStrategy` — Files provider registration
+
+### Likely REQ — Trivial constructors / events (defer or skip)
+- Event constructors (`FileCopiedEvent::__construct`, `FileLockedEvent::__construct`, etc.) — Already covered by their parent REQs; explicit annotation low-value
+- `lib/Event/UserProfileUpdatedEvent.php::__construct` — Not file-actions (likely belongs to user-profile capability)
+
+### Pre-triaged DROP (NOT for future file-actions retrofit)
+
+The original coverage scan pre-triaged 191 methods as belonging to other capabilities. Those are not in scope for any future file-actions retrofit pass — they belong to their original target capability:
+
+- chat-ai (extractUploadedFiles)
+- content-versioning (show, update, batch, recordDownloadEvent, normalizers, FileCrudHandler::getFile / getFileById, FileLockHandler::__construct / assertCanModify / setLock / getCurrentUserId, FileSharingHandler::__construct / shareFileWithUser / getCurrentDomain, FilePublishingHandler::__construct / setFileService)
+- oas-generation (downloadById, getFileTags, FileCrudHandler::__construct / updateFile)
+- archival-destruction-workflow (depublish)
+- seed-related-items (getFileViaKnownUsers, save, createMultipart, normalizeTags, FileLockHandler::isCurrentUserAdmin / isLocked, FileSharingHandler::getShareLink / findShares / shareFolderWithUser, FilePublishingHandler::publishFile / unpublishFile, TaggingHandler::findOrCreateTag / attachTagsToFile, FileCrudHandler::addFile)
+- data-integrity-relations (getUploadErrorMessage)
+- text-extraction-eml (FileLockHandler::getLockInfo)
+- extended-field-types (FileLockHandler::writeLockEntry)
+- object-lifecycle (FileLockHandler::readLockEntry / removeLockEntry)
+- office-document-sanitization (FilePublishingHandler::createObjectFilesZip / getZipErrorMessage)
+- openregister-app-manifest (FilesController::page)
+- actions (FileCrudHandler::createFolder)
+- nextcloud-api-compat (FileCrudHandler::saveFile)
+
+See `/tmp/or-scan/rspec-cluster-file-actions.json` `observed_behavior` fields for the full DROP rationale per method.


### PR DESCRIPTION
## Retrofit — Reverse-Spec (partial pass)

Partial reverse-spec for the **file-actions** cluster. The full cluster has **268 methods across 41 files** — far beyond the 5-REQ-per-run cap. This PR drafts the FIRST 5 highest-cohesion REQs covering **35 methods**.

Ghost change: `openspec/changes/retrofit-2026-05-24-file-actions/` (to be archived).

### REQs drafted (5)

| REQ | Title | Methods | Tasks |
|-----|-------|---------|-------|
| REQ-001 | File CRUD operations on objects | 11 | task-1 |
| REQ-002 | Distributed file locking | 6 | task-2 |
| REQ-003 | File preview & download streaming | 3 | task-3 |
| REQ-004 | Object & register folder management | 8 | task-4 |
| REQ-005 | Object tagging via Nextcloud system tags | 7 | task-5 |

### What this PR does

- Creates `openspec/changes/retrofit-2026-05-24-file-actions/` with proposal.md, design.md, tasks.md, and the specs/file-actions/spec.md delta (frontmatter retrofit: true).
- Annotates **35 methods** across **14 files** with @spec PHPDoc tags pointing at tasks.md#task-N.
- Lists the **~63 remaining in-scope methods** under tasks.md \`## DROP — future-pass:next\`, grouped by likely future REQ (publish/depublish, upload pipeline, metadata enrichment, versioning, chunking/Solr, file settings admin, document anonymisation, sidebar UI, integration providers).
- Notes coexistence with the unarchived openspec/changes/file-actions/ draft — the retrofit captures observed behavior of shipped code; the draft still has forward-looking REQs to land/reconcile.

### What this PR does NOT do

- No code behavior changes — every covered method already exists and is in production. Only PHPDoc tags added.
- Does not silently fix observed-but-buggy behavior. proposal.md Notes section flags six observed-but-flagged items.
- Does not archive the change — that is a separate /opsx-archive step (run after review).

### Review focus

- REQ language matches observed behavior (not aspirational)
- Scenarios are testable (WHEN/THEN form)
- One REQ per distinct observable behavior

### Source

- Coverage report: openspec/coverage-report.json (2026-05-24)
- Batch JSON: /tmp/or-scan/rspec-cluster-file-actions.json (268 methods, 41 files)