### PR TITLE
retrofit: triage Bucket 2b small-misc bundle (9/9 DROP, 0 REQs)

### DIFF
--- a/openspec/changes/retrofit-2026-05-24-2b-small-misc/design.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-small-misc/design.md
@@ -1,0 +1,28 @@
+# Design — retrofit-2026-05-24-2b-small-misc
+
+**Retrofit change. Tasks describe retroactive triage outcomes, not new implementation work.**
+
+## Why an all-DROP retrofit still gets a change record
+
+The retrofit playbook's `--bundle` mode batches very-small directory clusters into a single triage pass. Bundling assumes most entries will DROP — that's the point: avoid creating one PR per trivial helper, but still leave a written justification so the coverage report doesn't keep re-surfacing the same plumbing.
+
+If a `--bundle` pass produces 0 REQs (as here), the change still exists as a paper trail: a future re-scan or spec audit can read `proposal.md` and see *why* each method was skipped, without having to re-derive the triage.
+
+## DROP categories used
+
+1. **Pure DTO** — value object whose public surface mirrors its fields by definition (`DeletionAnalysis::__construct`, `empty`, `toArray`).
+2. **Vue plumbing wrapper** — one-line `this.$router.push(path)` / `this.$root.$emit(...)` re-emit / `fetch().then(...)` style helpers (`handleNavigate`, `onConfigSetCreated`).
+3. **Static configuration data** — exported constant misclassified as a method by the symbol scanner (`routeKeyByPath`).
+4. **DI constructor** — Nextcloud autowiring boilerplate; the owning class's behavioral methods carry the spec (`AgentTool::__construct`).
+5. **Internal helper of an already-specced public method** — class-level `@spec` already covers the public behavior; the private helper is implementation detail (`StreamingToolInstanceWrapper::detectIsError`).
+6. **Suspected dead code** — flagged for cleanup follow-up rather than spec-locking unwanted behavior (`Configuration.vue::fetchData` — calls opencatalogi endpoint from openregister; component not registered in the current router).
+
+## Trade-offs
+
+- Could have minted a `dto-conventions` capability covering "every DTO has constructor / empty / toArray" — but that's a coding convention, not user-observable behavior. Belongs in an ADR if anywhere.
+- Could have minted a `vue-navigation-helpers` capability — same issue, it would just enumerate the wrapper pattern. The actual navigation behavior is the route table, already implicit in router-level specs.
+- Could have specified the suspected-dead-code `Configuration.vue` — explicitly rejected per the playbook's "Observed, not aspirational. Bugs stay bugs; TODO notes surface them" guardrail. Dead code is worse than bug code; specifying it would lock in an unwanted cross-app fetch.
+
+## Follow-ups
+
+- **Cleanup follow-up** (not part of this change): investigate whether `src/navigation/Configuration.vue` is reachable from any current route/menu. If not, delete the file. If yes, document what it's for and either fix the endpoint or migrate to an openregister-native equivalent.

--- a/openspec/changes/retrofit-2026-05-24-2b-small-misc/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-small-misc/proposal.md
@@ -1,0 +1,58 @@
+# Retrofit — Bucket 2b small-misc (all-DROP triage)
+
+Bundled triage of 9 methods across 5 tiny directory clusters (`lib/Dto/`, `src/navigation/`, `src/dialogs/`, `src/router/`, `lib/Tool/`). After sampling each method body, **all 9 entries DROP** — none warrants a new REQ.
+
+This change is a paper-trail-only retrofit: no spec delta, no tasks, no annotations. It exists so a future re-scan against the coverage report has a record of *why* these methods were not specced, rather than appearing un-triaged.
+
+## Triage results — 9 / 9 DROP
+
+### `lib/Dto/DeletionAnalysis.php` (3 methods) — DROP
+
+Pure DTO. The data class carries the result of `ReferentialIntegrityService::canDelete()`, which is the actual capability (already covered by the referential-integrity / archival-destruction-workflow specs).
+
+- `__construct` — promoted-property constructor for a readonly value object. Plumbing.
+- `empty` — static factory returning `new self(deletable: true)`. Plumbing.
+- `toArray` — mechanical key→value flattening for JSON serialization. Plumbing.
+
+A DTO is a data carrier; its public surface mirrors its fields by definition. Specifying the constructor/factory/serializer would just restate the field list.
+
+### `src/navigation/Configuration.vue::fetchData` — DROP (with observation)
+
+`fetchData(_newPage)` issues `GET /index.php/apps/opencatalogi/configuration` and assigns the response to `this.configuration`. The endpoint is in the **opencatalogi** app, not openregister — this looks like leftover scaffold from an early OR fork of opencatalogi. The component is also not referenced from the current router or MainMenu (router has `/configurations` → `ConfigurationsIndex`, not this `Configuration.vue`).
+
+**Observation**: this file may be dead code. Flagging for cleanup but not specifying — specifying dead code would lock in unwanted behavior. Track as a cleanup follow-up rather than a retrofit REQ.
+
+### `src/navigation/MainMenu.vue::handleNavigate` — DROP
+
+`handleNavigate(path) { this.$router.push(path) }` — one-line wrapper around the Vue Router. Pure plumbing. The actual navigation behavior is owned by `vue-router` + the route table in `src/router/index.js`.
+
+### `src/dialogs/Dialogs.vue::onConfigSetCreated` — DROP
+
+`onConfigSetCreated() { this.$root.$emit('configset-updated') }` — re-emits a child component's event up through the root bus. Plumbing for the existing CreateConfigSetDialog capability; not a new behavior.
+
+### `src/router/index.js::routeKeyByPath` — DROP
+
+Not actually a method — it's an exported `const` lookup table mapping route paths to `navigationStore` keys for backward-compatibility. Static configuration data, not behavior. The coverage scanner picked it up because it's an exported symbol.
+
+### `lib/Tool/AgentTool.php::__construct` — DROP (pre-triaged)
+
+DI constructor — pulls `AgentMapper`, `IUserSession`, `LoggerInterface`, delegates to parent. The AgentTool's actual behavior (`getName`, `getDescription`, `runWithUser`, etc.) is already annotated against `retrofit-2026-04-28-b2b-crossrefs/tasks.md#task-29`. Plumbing.
+
+### `lib/Tool/StreamingToolInstanceWrapper.php::detectIsError` — DROP (pre-triaged)
+
+Private helper. Three-line check for the MCP `{isError: true}` envelope. The wrapper's class-level `@spec` already points at `ai-chat-companion-streaming/specs/chat-ai/spec.md#tool-call-and-tool-result-sse-events` — that requirement *is* this behavior. The helper is an internal detail of an already-specced requirement.
+
+## Approach
+
+- Sampled each method body to confirm it was plumbing / internal detail / dead code, not new observable behavior
+- For methods already implicitly covered by an existing class-level `@spec` (the two `lib/Tool/` entries), confirmed the parent annotation suffices
+- For DTO methods, confirmed the owning service capability is already specced
+- For the suspicious Vue file (`Configuration.vue`), flagged as observation rather than spec-locking dead code
+
+## What this change does NOT do
+
+- No new REQs minted (cap was 5; DROPs hit 9/9).
+- No code annotations added — there is no `task-N` to point at.
+- No `.opsx-ignore` patches — leaving the matcher behavior unchanged so a future re-scan still surfaces these for review if their bodies change materially.
+
+Source: `/tmp/or-scan/rspec-2b-small-misc.json` (batch produced 2026-05-24). See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-2b-small-misc/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-small-misc/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+This is an all-DROP triage change. No REQs were minted, so there are no implementation tasks.
+
+The triage record itself is the deliverable — see `proposal.md` for the per-method DROP rationale.
+
+- [x] task-1: Triage 9 methods across 5 tiny directory clusters (dto, navigation, dialogs, router, tool) — outcome: 9/9 DROP, 0 REQs minted


### PR DESCRIPTION
## Retrofit — Reverse-Spec (all-DROP triage)

Bundled triage of **9 methods** across 5 tiny directory clusters: `lib/Dto/` (3), `src/navigation/` (2), `src/dialogs/` (1), `src/router/` (1), `lib/Tool/` (2). After sampling each method body, **all 9 entries DROP** — none warrants a new REQ.

Ghost change: `retrofit-2026-05-24-2b-small-misc` (paper-trail only — no spec delta to archive).

### What this PR does
- Records per-method DROP rationale in `proposal.md` so the coverage scanner has a written justification rather than re-triaging the same plumbing on every re-scan
- Documents the DROP taxonomy used (DTO, Vue plumbing wrapper, static config constant, DI constructor, internal helper of already-specced method, suspected dead code) in `design.md`

### What this PR does NOT do
- **No new REQs** — cap was 5, DROPs hit 9/9
- **No code annotations** — there is no `task-N` to point at
- **No spec delta** — nothing for `/opsx-archive` to merge into main specs (so this is a one-commit PR, not the usual two)
- **No `.opsx-ignore` patches** — leaving matcher behavior unchanged so future material changes still surface

### DROP categories

| Method | File | Category |
|---|---|---|
| `__construct` / `empty` / `toArray` | `lib/Dto/DeletionAnalysis.php` | Pure DTO — owning service capability already specced |
| `fetchData` | `src/navigation/Configuration.vue` | **Suspected dead code** — calls opencatalogi endpoint from openregister, component not in router. Flagged for cleanup follow-up |
| `handleNavigate` | `src/navigation/MainMenu.vue` | Vue plumbing — `this.\$router.push(path)` wrapper |
| `onConfigSetCreated` | `src/dialogs/Dialogs.vue` | Vue plumbing — re-emit child event up through root bus |
| `routeKeyByPath` | `src/router/index.js` | Not a method — exported static lookup table |
| `__construct` | `lib/Tool/AgentTool.php` | DI constructor — class methods already annotated to `retrofit-2026-04-28-b2b-crossrefs#task-29` |
| `detectIsError` | `lib/Tool/StreamingToolInstanceWrapper.php` | Private helper — class-level `@spec` covers behavior (`ai-chat-companion-streaming#tool-call-and-tool-result-sse-events`) |

### Observation — possible dead code

`src/navigation/Configuration.vue::fetchData` makes a `GET /index.php/apps/opencatalogi/configuration` request from inside the openregister app. The component does not appear in the current router (`/configurations` resolves to `ConfigurationsIndex`, not this file) or in `MainMenu.vue`. Looks like leftover scaffold from an early OR fork of opencatalogi. **Not specifying it** — would lock in unwanted cross-app behavior. Cleanup follow-up tracked in `design.md`.

### Review focus
- Confirm the DROP taxonomy reads correctly — would any of these 9 actually justify a REQ?
- Confirm the `Configuration.vue` dead-code hypothesis (or correct it)

Source: `/tmp/or-scan/rspec-2b-small-misc.json` (batch produced 2026-05-24) | Cluster: `small-misc` (bundle of 5)