### PR TITLE
retrofit: reverse-spec shared-ui-components (4 REQs / 4 methods)

### DIFF
--- a/openspec/changes/retrofit-2026-05-24-2b-components/design.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-components/design.md
@@ -1,0 +1,39 @@
+# Design — Retrofit shared-ui-components
+
+**Retrofit change.** Tasks describe retroactive annotation, not new implementation work. The code already exists in `src/components/`; this change adds the spec it should have been authored against.
+
+## Why a new capability instead of extending an existing one
+
+The four annotated methods belong to general-purpose UI building blocks (pagination, settings card, settings section, the universal configuration card). None of the existing OpenRegister capabilities — `register-i18n`, `zoeken-filteren`, `auth-system`, `audit-trail-immutable`, etc. — are about app-wide reusable widgets. Folding shared widgets into a feature capability (e.g. "put pagination inside zoeken-filteren") would couple the widget contract to a single consumer; every other consumer of `PaginationComponent` would then be reading a search-flavoured spec for a widget that knows nothing about search.
+
+Minting `shared-ui-components` as its own capability keeps the boundary clean: feature capabilities consume these widgets, and the widget contract evolves independently.
+
+## What was deliberately dropped
+
+The cluster JSON included 10 entries; the retrofit covers 4 of them. The remaining 6 were dropped:
+
+| Method | Reason |
+|---|---|
+| `AgentSelector.vue::t` | Translation-function placeholder (`return text`) — no observable behaviour. Plumbing. |
+| `PaginationComponent.vue::if` | False positive — the parser caught the `if`-statement inside `changePage`. |
+| `SettingsCard.vue::if` | False positive — the `if`-statement inside `toggleCollapsed`. |
+| `BulkTranslateDialog.vue::onSubmit` | Already covered by `register-i18n` (bulk-translate UI). Annotation will be added by a Bucket 1 sweep against the existing REQ. |
+| `TranslationCompletenessBadge.vue::ratioPercent` | Already covered by `register-i18n` (translation-completeness tracking). |
+| `TranslationFieldEditor.vue::getValue` | Already covered by `register-i18n` (language-tabbed editor). |
+
+This is in line with the playbook's no-inflate rule: do not mint REQs for plumbing, do not duplicate behaviour already specified elsewhere.
+
+## REQ granularity
+
+One REQ per distinct observable behaviour:
+
+- **REQ-001** captures pagination's bounded page-change emission (the safety check is the observable behaviour; the visiblePages calc is internal layout logic).
+- **REQ-002** captures the async backend round-trip that drives the imported/discovered presentation switch in `ConfigurationCard`. Scenarios cover the three observable branches (found, not-found, error).
+- **REQ-003** captures the collapsible-card toggle contract — opt-in via `collapsible`, with a `toggle` event payload that callers depend on.
+- **REQ-004** captures the XSS-safe rendering of `detailedDescription`. The "quick and dirty" implementation note is preserved verbatim in the spec's Notes section so it isn't lost when a future change replaces the textContent-roundtrip with DOMPurify.
+
+No REQ was split or merged beyond this rule.
+
+## Specter sync
+
+After archive, run `python3 concurrentie-analyse/scripts/sync_spec_content.py openregister` to register the new capability (and its `retrofit: true` frontmatter flag) in the retrofit cohort dashboards. Coverage report is regenerated on the next `/opsx-coverage-scan` cycle.

--- a/openspec/changes/retrofit-2026-05-24-2b-components/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-components/proposal.md
@@ -1,0 +1,57 @@
+# Retrofit — Shared UI Components Cluster
+
+## Why
+
+Coverage scan on 2026-05-24 surfaced 10 public methods across 8 `src/components/` Vue files that have no `@spec` annotation linking them to a capability. This change retroactively specifies four of those methods as a new `shared-ui-components` capability (pagination, configuration card import detection, settings card collapse, HTML sanitisation in settings sections). Code already exists — this change describes observed behavior, not new work.
+
+## What Changes
+
+- Mint a new `shared-ui-components` capability spec that captures the observable contracts of four shared Vue components: `PaginationComponent`, `ConfigurationCard`, `SettingsCard`, and `SettingsSection`.
+- Add four numbered requirements (REQ-001..REQ-004) describing the observed behaviour — page-change bounds-checking, async detection of already-imported discovered configurations, opt-in collapsible section toggle, and HTML-entity escaping for the detailed-description slot.
+- Annotate the four implementing methods with `@spec` pointers so the coverage matcher resolves them on the next scan.
+
+This is a retroactive specification — code already exists. No code behaviour changes.
+
+## Scope of this batch
+
+**Cluster source**: `/tmp/or-scan/rspec-2b-components.json` — 10 methods / 8 files.
+
+After triage:
+
+- **4 methods → 4 REQs** in the new `shared-ui-components` capability:
+  - `src/components/PaginationComponent.vue::changePage` (REQ-001)
+  - `src/components/cards/ConfigurationCard.vue::checkIfImported` (REQ-002)
+  - `src/components/shared/SettingsCard.vue::toggleCollapsed` (REQ-003)
+  - `src/components/shared/SettingsSection.vue::sanitizeHtml` (REQ-004)
+
+- **3 methods dropped** — behaviour is already covered by the existing `register-i18n` capability spec (the coverage matcher missed them only because they lack `@spec` annotation; a separate Bucket 1 sweep will add the pointers):
+  - `src/components/i18n/BulkTranslateDialog.vue::onSubmit` — covered by register-i18n bulk-translate UI requirements.
+  - `src/components/i18n/TranslationCompletenessBadge.vue::ratioPercent` — covered by register-i18n translation-completeness tracking.
+  - `src/components/i18n/TranslationFieldEditor.vue::getValue` — covered by register-i18n language-tabbed editor requirements.
+
+- **3 methods dropped as plumbing / false positives**:
+  - `src/components/AgentSelector.vue::t` — translation function placeholder (`return text`), no observable behaviour.
+  - `src/components/PaginationComponent.vue::if` — false positive; matches the `if`-statement inside `changePage`.
+  - `src/components/shared/SettingsCard.vue::if` — false positive; matches the `if`-statement inside `toggleCollapsed`.
+
+## Affected code units
+
+- `src/components/PaginationComponent.vue::changePage`
+- `src/components/cards/ConfigurationCard.vue::checkIfImported`
+- `src/components/shared/SettingsCard.vue::toggleCollapsed`
+- `src/components/shared/SettingsSection.vue::sanitizeHtml`
+
+## Approach
+
+For each method:
+1. Read the file and capture observed inputs, outputs, side effects, preconditions, failure modes.
+2. Draft one REQ per distinct observable behaviour, using imperative MUST/SHALL language.
+3. Add at least one `WHEN … THEN …` scenario per REQ, testable against the existing implementation.
+4. Surface observed-but-suspicious behaviour in a Notes section — do not silently "fix" it via the spec.
+
+## Notes (carried into spec)
+
+- `SettingsSection::sanitizeHtml` uses a `document.createElement('div').textContent = html; return div.innerHTML` roundtrip. The method's own inline comment flags this as "quick and dirty" and "@TODO: Implement production ready sanitisation". The retrofit REQ captures the observed behaviour (text-escape, not HTML-allowlist) and the Notes preserve the TODO.
+- `ConfigurationCard::checkIfImported` swallows fetch errors (`catch (error) { this.importedConfigId = null }`) — observed behaviour is "on any error, treat as not-imported". The REQ captures this; tightening to retry / surface error is left as future work.
+
+Source: `openspec/coverage-report.md` generated 2026-05-24. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-2b-components/specs/shared-ui-components/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-components/specs/shared-ui-components/spec.md
@@ -1,0 +1,125 @@
+---
+retrofit: true
+---
+
+# Shared UI Components Specification
+
+**Status**: in-progress
+**Scope**: openregister
+
+## Purpose
+
+Specifies the observable behaviour of OpenRegister's shared, reusable Vue components that are not tied to a specific register-data feature (search, i18n, audit, etc.). These components are consumed across many views — pagination controls on every list view, settings cards/sections across all settings panels, and the universal configuration card used by both imported and discovered configurations. This spec captures behaviour that already exists in `src/components/` so the coverage matcher can resolve `@spec` annotations on those methods. Future enhancements to these components — additional events, accessibility tightening, HTML-allowlist sanitisation — extend this capability via new REQs rather than reinventing parallel widgets.
+
+## ADDED Requirements
+
+### Requirement: REQ-001 — Pagination component MUST clamp page-change requests to the valid range
+
+The reusable pagination component (`src/components/PaginationComponent.vue`) MUST validate every page-change request before emitting it to the parent. The component MUST NOT emit a `page-changed` event when the requested page equals the current page, is less than 1, or is greater than the total page count. Page-change requests originate from First/Previous/Next/Last buttons, ellipsis-aware numbered buttons, and any external caller that mounts the component.
+
+#### Scenario: Out-of-range page request is rejected
+
+- **GIVEN** a `PaginationComponent` mounted with `currentPage = 3` and `totalPages = 10`
+- **WHEN** `changePage(0)` is called (e.g. underflow from a hand-crafted prop)
+- **THEN** no `page-changed` event SHALL be emitted
+- **AND** the parent's `currentPage` SHALL remain unchanged
+
+#### Scenario: Same-page request is a no-op
+
+- **GIVEN** the same component with `currentPage = 3`
+- **WHEN** the user clicks the numbered button for page 3 (the active page)
+- **THEN** no `page-changed` event SHALL be emitted
+- **AND** the parent SHALL NOT receive a redundant request
+
+#### Scenario: Valid page-change emits the new page number
+
+- **GIVEN** the same component with `currentPage = 3` and `totalPages = 10`
+- **WHEN** the user clicks "Next" (request for page 4)
+- **THEN** the component SHALL emit `page-changed` with payload `4`
+- **AND** the parent SHALL update its `currentPage` prop, re-rendering the component on page 4
+
+### Requirement: REQ-002 — ConfigurationCard MUST detect already-imported discovered configurations via backend lookup
+
+The universal `ConfigurationCard` (`src/components/cards/ConfigurationCard.vue`) renders both locally-imported configurations and remotely-discovered ones (from `ImportConfiguration` flows). For discovered configurations (those with a `config.app` field), the component MUST query the backend on mount to check whether a configuration with the same `app` identifier already exists locally. On a positive match, the card MUST switch from the "Discovered" presentation (Import button) to the "Imported" presentation (View/Edit/Export/Delete actions, status badges) without requiring the user to refresh the page or re-open the discover dialog.
+
+#### Scenario: Discovered configuration is already imported
+
+- **GIVEN** a discovered configuration with `config.app = "decidesk"` and a local configuration already exists with `app = "decidesk"`
+- **WHEN** the card is mounted
+- **THEN** the component SHALL call `GET /index.php/apps/openregister/api/configurations?app=decidesk`
+- **AND** when the response contains a non-empty `results` array, the component SHALL store the first result's `id` in `importedConfigId`
+- **AND** the rendered card SHALL show the "Local" or "External" badge (per `isLocalConfiguration`) instead of "Discovered"
+- **AND** the action menu SHALL show View/Edit/Export/Delete instead of Import
+
+#### Scenario: Discovered configuration is not imported
+
+- **GIVEN** a discovered configuration whose `config.app` has no matching local row
+- **WHEN** the card is mounted
+- **THEN** the backend call returns an empty `results` array
+- **AND** `importedConfigId` SHALL remain `null`
+- **AND** the card SHALL render the "Discovered" badge and the Import action
+
+#### Scenario: Backend lookup fails
+
+- **GIVEN** a discovered configuration whose backend lookup throws (network error, 5xx response, malformed JSON)
+- **WHEN** the card is mounted
+- **THEN** the thrown error SHALL be caught
+- **AND** `importedConfigId` SHALL be set to `null` (assume "not imported")
+- **AND** the card SHALL render as Discovered with an Import action
+
+### Requirement: REQ-003 — Collapsible settings card MUST toggle on header click and emit a toggle event
+
+The `SettingsCard` component (`src/components/shared/SettingsCard.vue`) MAY be configured as collapsible via the `collapsible` prop. When collapsible, clicks on the header MUST toggle the section's expanded/collapsed state and MUST emit a `toggle` event carrying the new collapsed state (`true` = now collapsed, `false` = now expanded). The default expanded/collapsed state on mount is controlled by the `defaultCollapsed` prop. When `collapsible` is `false`, header clicks SHALL have no effect and no `toggle` event SHALL be emitted.
+
+#### Scenario: Toggling a collapsible section
+
+- **GIVEN** a `SettingsCard` rendered with `collapsible = true` and `defaultCollapsed = false`
+- **WHEN** the user clicks the section header
+- **THEN** the section's content SHALL collapse (transition-driven `v-show="!isCollapsed"`)
+- **AND** the component SHALL emit `toggle` with payload `true`
+- **WHEN** the user clicks the header again
+- **THEN** the content SHALL re-expand
+- **AND** the component SHALL emit `toggle` with payload `false`
+
+#### Scenario: Non-collapsible card ignores header clicks
+
+- **GIVEN** a `SettingsCard` rendered with `collapsible = false`
+- **WHEN** the user clicks the header
+- **THEN** no state change SHALL occur and no `toggle` event SHALL be emitted
+
+### Requirement: REQ-004 — SettingsSection MUST escape HTML in detailed descriptions before rendering
+
+The `SettingsSection` wrapper (`src/components/shared/SettingsSection.vue`) accepts a `detailedDescription` prop that is rendered via `v-html` inside the main description box. To prevent XSS, the component MUST escape the supplied string before rendering. The `sanitizeHtml` method MUST guarantee that no HTML tags or attributes from the input are interpreted by the browser as markup — the visible output SHALL be the input rendered as plain text (special characters replaced by their HTML entity equivalents).
+
+#### Scenario: Script tag is escaped
+
+- **GIVEN** a `SettingsSection` rendered with `detailedDescription = "<script>alert(1)</script>"`
+- **WHEN** the component renders the description box
+- **THEN** the DOM SHALL contain the text `&lt;script&gt;alert(1)&lt;/script&gt;` (or equivalent encoding)
+- **AND** no `script` element SHALL be present in the rendered tree
+- **AND** no JavaScript from the input SHALL execute
+
+#### Scenario: Plain text passes through visibly unchanged
+
+- **GIVEN** a `SettingsSection` with `detailedDescription = "Quotas are enforced per organisation."`
+- **WHEN** the component renders
+- **THEN** the description box SHALL display "Quotas are enforced per organisation." verbatim
+- **AND** no characters SHALL be added or removed beyond the entity-escape pass
+
+## Non-Functional Requirements
+
+- **Accessibility:** Collapsible headers (REQ-003) and pagination buttons (REQ-001) MUST remain keyboard-operable; pagination buttons MUST receive a discernible name (the page label or "First"/"Previous"/"Next"/"Last"). WCAG 2.1 AA SC 2.1.1 and 4.1.2.
+- **Security:** REQ-004 closes one XSS vector. The current implementation is a `textContent` round-trip, not an HTML-allowlist; richer formatting (bold, links) is out of scope.
+- **Internationalisation:** Visible strings inside these components are translated via `t('openregister', ...)`; component-level behaviour does not vary by locale (ADR-007).
+
+## Acceptance Criteria
+
+- [ ] `@spec` annotations exist on every method listed in this spec's REQ map, pointing at `openspec/changes/retrofit-2026-05-24-2b-components/tasks.md#task-N`.
+- [ ] `npm run lint -- src/components/PaginationComponent.vue src/components/cards/ConfigurationCard.vue src/components/shared/SettingsCard.vue src/components/shared/SettingsSection.vue` passes.
+- [ ] Coverage scan re-run after archive resolves each method to its REQ (no longer in Bucket 2b).
+
+## Notes
+
+- `SettingsSection.sanitizeHtml` is the project's current "quick and dirty" sanitiser (per the inline comment); a follow-up should replace it with an allowlist-based sanitiser such as DOMPurify if richer description content is ever needed. Tracked as a TODO inside the method body — this retrofit does not enlarge scope.
+- `ConfigurationCard.checkIfImported` silently swallows fetch errors and falls back to "not imported". This is the observed behaviour and is captured as such; surfacing the error to the user is out of scope for this retrofit.
+- The pagination component already has a JSDoc docblock (REQ-001's implementation is well-commented); the coverage matcher flagged it only because no `@spec` link existed. Annotation closes that gap.

--- a/openspec/changes/retrofit-2026-05-24-2b-components/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-components/tasks.md
@@ -1,0 +1,8 @@
+# Tasks — Retrofit shared-ui-components
+
+All tasks are retroactive annotations of behaviour that already exists in `src/components/`. The code already implements the REQ; the only work captured here is the `@spec` pointer.
+
+- [x] task-1: shared-ui-components#REQ-001 — Pagination component clamps page-change requests to the valid range (retroactive annotation of `src/components/PaginationComponent.vue::changePage`)
+- [x] task-2: shared-ui-components#REQ-002 — ConfigurationCard detects already-imported discovered configurations via backend lookup (retroactive annotation of `src/components/cards/ConfigurationCard.vue::checkIfImported`)
+- [x] task-3: shared-ui-components#REQ-003 — Collapsible settings card toggles on header click and emits a toggle event (retroactive annotation of `src/components/shared/SettingsCard.vue::toggleCollapsed`)
+- [x] task-4: shared-ui-components#REQ-004 — SettingsSection escapes HTML in detailed descriptions before rendering (retroactive annotation of `src/components/shared/SettingsSection.vue::sanitizeHtml`)

--- a/src/components/PaginationComponent.vue
+++ b/src/components/PaginationComponent.vue
@@ -208,6 +208,7 @@ export default {
 		 * Change to a specific page
 		 * @param {number} page - The page number to change to
 		 * @return {void}
+		 * @spec openspec/changes/retrofit-2026-05-24-2b-components/tasks.md#task-1
 		 */
 		changePage(page) {
 			if (page !== this.currentPage && page >= 1 && page <= this.totalPages) {

--- a/src/components/cards/ConfigurationCard.vue
+++ b/src/components/cards/ConfigurationCard.vue
@@ -546,6 +546,8 @@ export default {
 		/**
 		 * Check if this discovered configuration is already imported in the backend
 		 * Makes an API call to check by appId and stores the full config
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-2b-components/tasks.md#task-2
 		 */
 		async checkIfImported() {
 			if (!this.appId || this.checkingImportStatus) return

--- a/src/components/shared/SettingsCard.vue
+++ b/src/components/shared/SettingsCard.vue
@@ -67,6 +67,13 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * Toggle the collapsed state when the section is configured as collapsible
+		 * and emit a `toggle` event carrying the new collapsed state.
+		 *
+		 * @return {void}
+		 * @spec openspec/changes/retrofit-2026-05-24-2b-components/tasks.md#task-3
+		 */
 		toggleCollapsed() {
 			if (this.collapsible) {
 				this.isCollapsed = !this.isCollapsed

--- a/src/components/shared/SettingsSection.vue
+++ b/src/components/shared/SettingsSection.vue
@@ -197,9 +197,20 @@ export default {
 	},
 
 	methods: {
-		// quick and dirty way to sanitize HTML.
-		// this guarantees that no dangerous HTML is rendered, though it'll make the output ugly.
-		// @TODO: Implement production ready sanitization.
+		/**
+		 * Quick and dirty way to sanitize HTML for the detailedDescription slot.
+		 *
+		 * Guarantees no dangerous HTML is rendered by round-tripping through
+		 * `textContent` (escapes every tag/entity); cost is that the output is
+		 * plain text, not formatted HTML.
+		 *
+		 * @TODO Replace with an allowlist-based sanitiser (e.g. DOMPurify) once
+		 * formatted descriptions are needed.
+		 *
+		 * @param {string} html Untrusted markup
+		 * @return {string} HTML-entity-escaped string safe for v-html
+		 * @spec openspec/changes/retrofit-2026-05-24-2b-components/tasks.md#task-4
+		 */
 		sanitizeHtml(html) {
 			const div = document.createElement('div')
 			div.textContent = html


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Draft 4 REQs in a new `shared-ui-components` capability describing the observable behaviour of 4 shared Vue components in `src/components/`, and annotate the implementing methods with `@spec` pointers.

Ghost change: `retrofit-2026-05-24-2b-components`.

### What this PR does

- Mints a new `shared-ui-components` capability spec (`retrofit: true` marker; archive will land it under `openspec/specs/shared-ui-components/spec.md`).
- Adds 4 numbered REQs covering:
  - **REQ-001** — `PaginationComponent.changePage`: page-change bounds-checking + same-page no-op + emit `page-changed`.
  - **REQ-002** — `ConfigurationCard.checkIfImported`: async backend lookup for discovered configurations, switches the card from Discovered to Imported on positive match, swallows fetch errors as not-imported.
  - **REQ-003** — `SettingsCard.toggleCollapsed`: opt-in collapsible toggle + `toggle` event payload (true/false).
  - **REQ-004** — `SettingsSection.sanitizeHtml`: HTML-entity-escape pass for the detailedDescription slot (textContent round-trip; XSS-safe but not formatting-preserving).
- Annotates the 4 implementing methods with `@spec openspec/changes/retrofit-2026-05-24-2b-components/tasks.md#task-N`.
- Adds tasks.md (all checked) and design.md (justifies the new capability vs extending an existing one).

### What this PR does NOT do

- No code-behaviour changes — `@spec` annotations only.
- Does not silently fix observed-but-buggy behaviour. The "quick and dirty" `sanitizeHtml` implementation is captured with its TODO in the spec's Notes section, not replaced.
- Does not retrofit the 3 i18n component methods in the batch (BulkTranslateDialog.onSubmit, TranslationCompletenessBadge.ratioPercent, TranslationFieldEditor.getValue). Their behaviour is already covered by `register-i18n`; a separate Bucket 1 sweep will add `@spec` pointers to the existing REQs.
- Does not draft REQs for plumbing or false positives (AgentSelector.t placeholder, two if-statement parser false-matches).

### Cluster sizing

Batch: 10 methods / 8 files. After triage: 4 REQs / 4 methods / 1 new capability. Bias was toward fewer REQs — one REQ per observable behaviour, no inflation.

### Review focus

- REQ language matches observed behaviour (not aspirational).
- Scenarios are testable against the existing implementations without code changes.
- One REQ per distinct observable behaviour; no merges or splits beyond that rule.

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: 2b-components | Batch JSON: `/tmp/or-scan/rspec-2b-components.json`