### PR TITLE
feat(polls): Tier-2 — link table + service + picker + create

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -346,6 +346,15 @@ return [
         // Reverse lookup — keep on Tier-1 controller (not in Tier-2 scope).
         ['name' => 'deck#objects',        'url' => '/api/deck/boards/{boardId}/objects',                      'verb' => 'GET',    'requirements' => ['boardId' => '[^/]+']],
 
+        // Polls — Tier-2 link table + picker UX. Specific routes (`/new`)
+        // MUST precede the wildcard `{pollId}` route so they aren't grabbed
+        // as pollId='new'. Available-polls picker is app-global.
+        ['name' => 'pollLinks#available', 'url' => '/api/integrations/polls/available',                       'verb' => 'GET'],
+        ['name' => 'pollLinks#index',     'url' => '/api/objects/{register}/{schema}/{id}/polls',             'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
+        ['name' => 'pollLinks#link',      'url' => '/api/objects/{register}/{schema}/{id}/polls',             'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'pollLinks#createNew', 'url' => '/api/objects/{register}/{schema}/{id}/polls/new',         'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'pollLinks#destroy',   'url' => '/api/objects/{register}/{schema}/{id}/polls/{pollId}',    'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'pollId' => '[0-9]+']],
+
         // Forms — Tier-2 link-table API. Specific routes (`/new`, `/submissions/{id}`)
         // MUST precede the wildcard `{formId}` route so they aren't grabbed as
         // formId='new' / formId='submissions'. Available-forms picker is app-global.

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1237,16 +1237,17 @@ class Application extends App implements IBootstrap
             }
         );
 
-        // PollsProvider — late-bound `OCA\Polls\Service\PollService`
-        // (only on classpath with the `polls` app installed) + user
-        // session for scoping. Links via the `[or:{objectUuid}]`
-        // marker in the poll title.
+        // PollsProvider — Tier-2: backed by the PollLinkMapper +
+        // direct queries against `oc_polls_*` tables. Replaces the
+        // original title-marker convention with a proper persistence
+        // layer.
         // @spec openspec/changes/integration-polls/tasks.md.
         $context->registerService(
             PollsProvider::class,
             function (ContainerInterface $container) {
                 return new PollsProvider(
-                    container: $container,
+                    pollLinkMapper: $container->get(\OCA\OpenRegister\Db\PollLinkMapper::class),
+                    db: $container->get('OCP\IDBConnection'),
                     appManager: $container->get('OCP\App\IAppManager'),
                     userSession: $container->get('OCP\IUserSession'),
                     l10n: $container->get('OCP\IL10N'),

--- a/lib/Controller/PollLinksController.php
+++ b/lib/Controller/PollLinksController.php
@@ -1,0 +1,352 @@
+<?php
+
+/**
+ * PollLinksController — Tier-2 REST controller for Polls poll links.
+ *
+ * Adds explicit link/create endpoints and an available-polls picker
+ * source so the picker UX can drive its modal without leaking Polls
+ * internals.
+ *
+ * Endpoints:
+ *   - GET    /api/objects/{register}/{schema}/{id}/polls          — list
+ *   - POST   /api/objects/{register}/{schema}/{id}/polls          — link existing poll
+ *   - POST   /api/objects/{register}/{schema}/{id}/polls/new      — create + link
+ *   - DELETE /api/objects/{register}/{schema}/{id}/polls/{pollId} — unlink
+ *   - GET    /api/integrations/polls/available                    — picker source
+ *
+ * @category  Controller
+ * @package   OCA\OpenRegister\Controller
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git-id>
+ * @link      https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use DateTime;
+use Exception;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\PollLinkService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use Throwable;
+
+/**
+ * Tier-2 Poll links controller.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ */
+class PollLinksController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param string          $appName         App id.
+     * @param IRequest        $request         HTTP request.
+     * @param PollLinkService $pollLinkService Backing service.
+     * @param ObjectService   $objectService   OR object resolver.
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly PollLinkService $pollLinkService,
+        private readonly ObjectService $objectService,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * List linked polls for an object.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function index(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->pollLinkService->isPollsAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Polls app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $results = $this->pollLinkService->getLinkedPolls($object->getUuid());
+
+            return new JSONResponse(['results' => $results, 'total' => count($results)]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return new JSONResponse(['error' => $e->getMessage()], 500);
+        }//end try
+    }//end index()
+
+    /**
+     * Link an existing poll.
+     *
+     * Body: `{ pollId: int }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function link(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->pollLinkService->isPollsAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Polls app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $pollId = (int) $this->request->getParam('pollId', 0);
+            if ($pollId === 0) {
+                return new JSONResponse(['error' => 'pollId is required'], 400);
+            }
+
+            $link = $this->pollLinkService->linkPoll(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $pollId
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end link()
+
+    /**
+     * Create a new poll and link it.
+     *
+     * Body:
+     *   `{ title, description?, type?, options: [string], deadline?: ISO-8601 }`
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    public function createNew(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->pollLinkService->isPollsAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Polls app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $title       = (string) $this->request->getParam('title', '');
+            $description = (string) $this->request->getParam('description', '');
+            $type        = (string) $this->request->getParam('type', 'textPoll');
+            $rawOptions  = $this->request->getParam('options', []);
+            $deadline    = $this->request->getParam('deadline');
+
+            if (trim($title) === '') {
+                return new JSONResponse(['error' => 'title is required'], 400);
+            }
+
+            $options = [];
+            if (is_array($rawOptions) === true) {
+                foreach ($rawOptions as $option) {
+                    if (is_string($option) === true) {
+                        $options[] = $option;
+                    } elseif (is_array($option) === true) {
+                        $options[] = (string) ($option['text'] ?? $option['label'] ?? '');
+                    }
+                }
+            }
+
+            $deadlineObj = null;
+            if ($deadline !== null && $deadline !== '') {
+                try {
+                    $deadlineObj = new DateTime((string) $deadline);
+                } catch (Throwable $e) {
+                    $deadlineObj = null;
+                }
+            }
+
+            $link = $this->pollLinkService->createAndLinkPoll(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $title,
+                $description,
+                $type,
+                $options,
+                $deadlineObj
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end createNew()
+
+    /**
+     * Unlink a poll.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     * @param string $pollId   Polls poll id (numeric).
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function destroy(string $register, string $schema, string $id, string $pollId): JSONResponse
+    {
+        if ($this->pollLinkService->isPollsAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Polls app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $this->pollLinkService->unlinkPoll($object->getUuid(), (int) $pollId);
+
+            return new JSONResponse(['success' => true]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end destroy()
+
+    /**
+     * List polls visible to the current user (picker source).
+     *
+     * Query param: `search` — optional title substring.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function available(): JSONResponse
+    {
+        if ($this->pollLinkService->isPollsAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Polls app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        $search = $this->request->getParam('search');
+        if ($search !== null) {
+            $search = (string) $search;
+        }
+
+        $polls = $this->pollLinkService->getAvailablePolls($search);
+        return new JSONResponse(['results' => $polls, 'total' => count($polls)]);
+    }//end available()
+
+    /**
+     * Resolve an OR object from register/schema/id.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return ObjectEntity|null
+     */
+    private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
+    {
+        $this->objectService->setSchema($schema);
+        $this->objectService->setRegister($register);
+        $this->objectService->setObject($id);
+
+        return $this->objectService->getObject();
+    }//end validateObject()
+
+    /**
+     * Map a service-layer Exception to a JSONResponse.
+     *
+     * Exception codes carry HTTP intent:
+     *   - 409 → conflict
+     *   - 404 → not found
+     *   - 503 → service unavailable
+     *   - 400 → bad request
+     *   - everything else → 400 bad request
+     *
+     * @param Exception $exception Source exception.
+     *
+     * @return JSONResponse
+     */
+    private function mapException(Exception $exception): JSONResponse
+    {
+        $code = $exception->getCode();
+        if ($code === 409) {
+            return new JSONResponse(['error' => $exception->getMessage()], 409);
+        }
+
+        if ($code === 404) {
+            return new JSONResponse(['error' => $exception->getMessage()], 404);
+        }
+
+        if ($code === 503) {
+            return new JSONResponse(['error' => $exception->getMessage()], 503);
+        }
+
+        if ($code === 400) {
+            return new JSONResponse(['error' => $exception->getMessage()], 400);
+        }
+
+        return new JSONResponse(['error' => $exception->getMessage()], 400);
+    }//end mapException()
+}//end class

--- a/lib/Db/PollLink.php
+++ b/lib/Db/PollLink.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * PollLink entity for linking Nextcloud Polls polls to OpenRegister objects.
+ *
+ * Tier-2 schema: carries register_id, schema_id, poll_title, poll_type,
+ * deadline, voter_count, option_count, closed so the link row alone can
+ * hydrate the sidebar tab + picker UX without a per-poll roundtrip to
+ * Polls. Replaces the original PollsProvider's title-marker convention
+ * (`[or:{uuid}]` embedded in the poll title) with a proper persistence
+ * layer.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Class PollLink
+ *
+ * @method string getObjectUuid()
+ * @method void setObjectUuid(string $objectUuid)
+ * @method int getRegisterId()
+ * @method void setRegisterId(int $registerId)
+ * @method int|null getSchemaId()
+ * @method void setSchemaId(?int $schemaId)
+ * @method int getPollId()
+ * @method void setPollId(int $pollId)
+ * @method string|null getPollTitle()
+ * @method void setPollTitle(?string $pollTitle)
+ * @method string|null getPollType()
+ * @method void setPollType(?string $pollType)
+ * @method DateTime|null getDeadline()
+ * @method void setDeadline(?DateTime $deadline)
+ * @method int|null getVoterCount()
+ * @method void setVoterCount(?int $voterCount)
+ * @method int|null getOptionCount()
+ * @method void setOptionCount(?int $optionCount)
+ * @method bool getClosed()
+ * @method void setClosed(bool $closed)
+ * @method string getLinkedBy()
+ * @method void setLinkedBy(string $linkedBy)
+ * @method DateTime getLinkedAt()
+ * @method void setLinkedAt(DateTime $linkedAt)
+ *
+ * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class
+ */
+class PollLink extends Entity implements JsonSerializable
+{
+
+    /**
+     * The object uuid.
+     *
+     * @var string|null
+     */
+    protected ?string $objectUuid = null;
+
+    /**
+     * The register id.
+     *
+     * @var integer|null
+     */
+    protected ?int $registerId = null;
+
+    /**
+     * The schema id.
+     *
+     * @var integer|null
+     */
+    protected ?int $schemaId = null;
+
+    /**
+     * The Polls poll id (primary key in `oc_polls_polls`).
+     *
+     * @var integer|null
+     */
+    protected ?int $pollId = null;
+
+    /**
+     * The poll title (cached at link time).
+     *
+     * @var string|null
+     */
+    protected ?string $pollTitle = null;
+
+    /**
+     * The poll type (e.g. `textPoll` / `datePoll`).
+     *
+     * @var string|null
+     */
+    protected ?string $pollType = null;
+
+    /**
+     * The poll deadline (cached at link time).
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $deadline = null;
+
+    /**
+     * Cached voter count (distinct users who voted at least once).
+     *
+     * @var integer|null
+     */
+    protected ?int $voterCount = null;
+
+    /**
+     * Cached option count.
+     *
+     * @var integer|null
+     */
+    protected ?int $optionCount = null;
+
+    /**
+     * Whether the poll is closed (deadline elapsed).
+     *
+     * @var boolean|null
+     */
+    protected ?bool $closed = false;
+
+    /**
+     * The linked by uid.
+     *
+     * @var string|null
+     */
+    protected ?string $linkedBy = null;
+
+    /**
+     * The linked at timestamp.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $linkedAt = null;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->addType(fieldName: 'objectUuid', type: 'string');
+        $this->addType(fieldName: 'registerId', type: 'integer');
+        $this->addType(fieldName: 'schemaId', type: 'integer');
+        $this->addType(fieldName: 'pollId', type: 'integer');
+        $this->addType(fieldName: 'pollTitle', type: 'string');
+        $this->addType(fieldName: 'pollType', type: 'string');
+        $this->addType(fieldName: 'deadline', type: 'datetime');
+        $this->addType(fieldName: 'voterCount', type: 'integer');
+        $this->addType(fieldName: 'optionCount', type: 'integer');
+        $this->addType(fieldName: 'closed', type: 'boolean');
+        $this->addType(fieldName: 'linkedBy', type: 'string');
+        $this->addType(fieldName: 'linkedAt', type: 'datetime');
+    }//end __construct()
+
+    /**
+     * JSON serialization.
+     *
+     * @return array<string,mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'          => $this->id,
+            'objectUuid'  => $this->objectUuid,
+            'registerId'  => $this->registerId,
+            'schemaId'    => $this->schemaId,
+            'pollId'      => $this->pollId,
+            'pollTitle'   => $this->pollTitle,
+            'pollType'    => $this->pollType,
+            'deadline'    => $this->deadline?->format(DateTime::ATOM),
+            'voterCount'  => $this->voterCount,
+            'optionCount' => $this->optionCount,
+            'closed'      => (bool) $this->closed,
+            'linkedBy'    => $this->linkedBy,
+            'linkedAt'    => $this->linkedAt?->format(DateTime::ATOM),
+        ];
+    }//end jsonSerialize()
+}//end class

--- a/lib/Db/PollLinkMapper.php
+++ b/lib/Db/PollLinkMapper.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Mapper for poll link entities.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git-id>
+ * @link      https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Class PollLinkMapper
+ *
+ * @template-extends QBMapper<PollLink>
+ */
+class PollLinkMapper extends QBMapper
+{
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $db Database connection.
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(db: $db, tableName: 'openregister_poll_links', entityClass: PollLink::class);
+    }//end __construct()
+
+    /**
+     * Find poll links by object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return PollLink[] Array of poll links.
+     */
+    public function findByObjectUuid(string $objectUuid): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByObjectUuid()
+
+    /**
+     * Find poll links by poll id.
+     *
+     * @param int $pollId The poll id.
+     *
+     * @return PollLink[] Array of poll links.
+     */
+    public function findByPollId(int $pollId): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('poll_id', $qb->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByPollId()
+
+    /**
+     * Find a specific poll link by object UUID and poll id.
+     *
+     * @param string $objectUuid The object UUID.
+     * @param int    $pollId     The poll id.
+     *
+     * @return PollLink|null The link or null if not found.
+     */
+    public function findByObjectAndPoll(string $objectUuid, int $pollId): ?PollLink
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('poll_id', $qb->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)));
+
+        try {
+            return $this->findEntity(query: $qb);
+        } catch (DoesNotExistException $e) {
+            return null;
+        }
+    }//end findByObjectAndPoll()
+
+    /**
+     * Delete all poll links for an object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectUuid(string $objectUuid): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectUuid()
+
+    /**
+     * Delete a poll link by object UUID + poll id (Tier-2 unlink path).
+     *
+     * Returns the number of rows actually deleted so callers can
+     * distinguish "no such link" (0) from "ok" (>=1).
+     *
+     * @param string $objectUuid The object UUID.
+     * @param int    $pollId     The poll id.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectAndPoll(string $objectUuid, int $pollId): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('poll_id', $qb->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectAndPoll()
+}//end class

--- a/lib/Migration/Version1Date20260525130000.php
+++ b/lib/Migration/Version1Date20260525130000.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * Tier-2 polls integration migration.
+ *
+ * Ensures the `openregister_poll_links` table exists with the full
+ * Tier-2 schema:
+ *
+ *  - id (bigint, PK, autoincrement)
+ *  - object_uuid (string 36, not null)
+ *  - register_id (bigint unsigned, not null)
+ *  - schema_id (bigint unsigned, nullable)
+ *  - poll_id (bigint unsigned, not null)
+ *  - poll_title (string 255, nullable)
+ *  - poll_type (string 64, nullable)
+ *  - deadline (datetime, nullable)
+ *  - voter_count (bigint unsigned, nullable — cached tally)
+ *  - option_count (bigint unsigned, nullable — cached tally)
+ *  - closed (boolean, default false)
+ *  - linked_by (string 64, not null)
+ *  - linked_at (datetime, not null)
+ *
+ * Idempotent: creates the table if missing, otherwise adds any
+ * missing Tier-2 columns.  Companion to the Tier-2 deck/forms/email
+ * link tables; the wrapping `PollLinkService` replaces the title-marker
+ * convention from the original PollsProvider with a proper persistence
+ * layer so links survive title edits + don't pollute Polls' UX.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Tier-2 poll-links table — create-or-extend.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+class Version1Date20260525130000 extends SimpleMigrationStep
+{
+    /**
+     * Change the database schema.
+     *
+     * @param IOutput                 $output        Output for the migration process
+     * @param Closure                 $schemaClosure The schema closure
+     * @param array<array-key, mixed> $options       Migration options
+     *
+     * @return ISchemaWrapper|null
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema  = $schemaClosure();
+        $changed = false;
+
+        if ($schema->hasTable('openregister_poll_links') === false) {
+            $this->createPollLinksTable(schema: $schema, output: $output);
+            $changed = true;
+        }
+
+        if ($schema->hasTable('openregister_poll_links') === true
+            && $this->extendPollLinksTable(schema: $schema, output: $output) === true
+        ) {
+            $changed = true;
+        }
+
+        if ($changed === false) {
+            return null;
+        }
+
+        return $schema;
+    }//end changeSchema()
+
+    /**
+     * Create the openregister_poll_links table at the Tier-2 shape.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return void
+     */
+    private function createPollLinksTable(ISchemaWrapper $schema, IOutput $output): void
+    {
+        $table = $schema->createTable('openregister_poll_links');
+
+        $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'unsigned' => true]);
+        $table->addColumn('object_uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
+        $table->addColumn('register_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('schema_id', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]);
+        $table->addColumn('poll_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('poll_title', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+        $table->addColumn('poll_type', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+        $table->addColumn('deadline', Types::DATETIME, ['notnull' => false, 'default' => null]);
+        $table->addColumn('voter_count', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]);
+        $table->addColumn('option_count', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]);
+        $table->addColumn('closed', Types::BOOLEAN, ['notnull' => true, 'default' => false]);
+        $table->addColumn('linked_by', Types::STRING, ['notnull' => true, 'length' => 64]);
+        $table->addColumn('linked_at', Types::DATETIME, ['notnull' => true]);
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['object_uuid', 'poll_id'], 'idx_poll_object_poll');
+        $table->addIndex(['object_uuid'], 'idx_poll_object');
+        $table->addIndex(['poll_id'], 'idx_poll_poll');
+        $table->addIndex(['schema_id'], 'idx_poll_schema');
+
+        $output->info('Created openregister_poll_links table (Tier-2 schema)');
+    }//end createPollLinksTable()
+
+    /**
+     * Add any missing Tier-2 columns to an existing poll_links table.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return bool True when a column was added.
+     */
+    private function extendPollLinksTable(ISchemaWrapper $schema, IOutput $output): bool
+    {
+        $table   = $schema->getTable('openregister_poll_links');
+        $changed = false;
+
+        if ($table->hasColumn('schema_id') === false) {
+            $table->addColumn(
+                'schema_id',
+                Types::BIGINT,
+                ['notnull' => false, 'unsigned' => true, 'default' => null]
+            );
+            $table->addIndex(['schema_id'], 'idx_poll_schema');
+            $output->info('Added schema_id column to openregister_poll_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('poll_title') === false) {
+            $table->addColumn('poll_title', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+            $output->info('Added poll_title column to openregister_poll_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('poll_type') === false) {
+            $table->addColumn('poll_type', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+            $output->info('Added poll_type column to openregister_poll_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('deadline') === false) {
+            $table->addColumn('deadline', Types::DATETIME, ['notnull' => false, 'default' => null]);
+            $output->info('Added deadline column to openregister_poll_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('voter_count') === false) {
+            $table->addColumn('voter_count', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]);
+            $output->info('Added voter_count column to openregister_poll_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('option_count') === false) {
+            $table->addColumn('option_count', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]);
+            $output->info('Added option_count column to openregister_poll_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('closed') === false) {
+            $table->addColumn('closed', Types::BOOLEAN, ['notnull' => true, 'default' => false]);
+            $output->info('Added closed column to openregister_poll_links');
+            $changed = true;
+        }
+
+        return $changed;
+    }//end extendPollLinksTable()
+}//end class

--- a/lib/Service/Integration/Providers/PollsProvider.php
+++ b/lib/Service/Integration/Providers/PollsProvider.php
@@ -4,9 +4,16 @@
  * PollsProvider — exposes NC Polls linked to an OR object via the
  * IntegrationProvider contract.
  *
- * `link-table` storage (a future `openregister_poll_links` pairs
- * object ↔ poll); the wrapping PollsService lands in a follow-up —
- * this provider registers the registry surface today.
+ * Tier-2: backed by the `openregister_poll_links` table via
+ * {@see PollLinkMapper}. Replaces the original title-marker convention
+ * (`[or:{uuid}]` embedded in poll title) with a proper persistence
+ * layer so links survive title edits and don't pollute Polls' UX.
+ *
+ * Reads each linked poll's current title/type/expire/voter count/option
+ * tallies directly from `oc_polls_polls` / `oc_polls_options` /
+ * `oc_polls_votes` (Phase B-3 session-workaround pattern: Polls' own
+ * services need Polls' UserSession populated, which it isn't when OR
+ * serves the sub-resource).
  *
  * @category Service
  * @package  OCA\OpenRegister\Service\Integration\Providers
@@ -26,21 +33,23 @@ namespace OCA\OpenRegister\Service\Integration\Providers;
 
 // phpcs:disable PEAR.Commenting.FunctionComment.Missing -- self-documenting IntegrationProvider metadata getters mirror the contract in the interface.
 
+use OCA\OpenRegister\Db\PollLinkMapper;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCP\App\IAppManager;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
 use Throwable;
 
 class PollsProvider extends AbstractIntegrationProvider
 {
 
     private const REQUIRED_APP = 'polls';
-    private const TITLE_TAG    = '[or:';
 
     public function __construct(
-        private ContainerInterface $container,
+        private PollLinkMapper $pollLinkMapper,
+        private IDBConnection $db,
         private IAppManager $appManager,
         private IUserSession $userSession,
         private IL10N $l10n,
@@ -85,10 +94,10 @@ class PollsProvider extends AbstractIntegrationProvider
     /**
      * List polls linked to an OR object.
      *
-     * Linking convention: polls whose title contains the marker
-     * `[or:{objectUuid}]`. The provider asks Polls' PollService for
-     * the current user's polls, filters by marker, and normalises the
-     * rows into the registry's leaf row shape.
+     * Reads link rows from `openregister_poll_links`, then hydrates
+     * each row with current title/type/deadline + the per-option vote
+     * tallies (used by CnPollsTab to render progress bars). Returns
+     * an empty array when Polls is uninstalled.
      *
      * @param string              $register Register slug or numeric id (unused).
      * @param string              $schema   Schema slug or numeric id (unused).
@@ -103,54 +112,36 @@ class PollsProvider extends AbstractIntegrationProvider
             return [];
         }
 
-        $marker = self::TITLE_TAG.$objectId.']';
-
-        $user = $this->userSession->getUser();
-        if ($user === null) {
-            return [];
-        }
-
-        // Query the polls table directly. Polls' PollMapper::buildQuery
-        // depends on Polls' own UserSession service for joins / detail
-        // expansion; when OR's controller serves the sub-resource with
-        // Basic auth the Polls session isn't populated, so listByOwner
-        // returns Poll entities with empty title/description fields.
-        // Going through the raw DB row sidesteps that and is sufficient
-        // for the marker-based link filter.
-        try {
-            $db = $this->container->get('OCP\\IDBConnection');
-            $qb = $db->getQueryBuilder();
-            $qb->select('*')->from('polls_polls')->where(
-                $qb->expr()->eq('owner', $qb->createNamedParameter($user->getUID()))
-            );
-            $rows = $qb->executeQuery()->fetchAll();
-        } catch (Throwable $e) {
+        $links = $this->pollLinkMapper->findByObjectUuid($objectId);
+        if ($links === []) {
             return [];
         }
 
         $out = [];
-        foreach ($rows as $row) {
-            $title = (string) ($row['title'] ?? '');
-            if (str_contains($title, $marker) === false) {
-                continue;
-            }
+        foreach ($links as $link) {
+            $pollId  = (int) $link->getPollId();
+            $pollRow = $this->fetchPollRow($pollId);
 
-            $id      = (string) ($row['id'] ?? '');
-            $pollId  = (int) ($row['id'] ?? 0);
-            $expire  = (int) ($row['expire'] ?? 0);
-            $options = $this->fetchOptionsWithCounts($db, $pollId);
-            $voters  = $this->fetchVoterCount($db, $pollId);
+            $title       = (string) ($pollRow['title'] ?? $link->getPollTitle() ?? '');
+            $description = (string) ($pollRow['description'] ?? '');
+            $type        = (string) ($pollRow['type'] ?? $link->getPollType() ?? '');
+            $expire      = (int) ($pollRow['expire'] ?? 0);
+
+            $options = $this->fetchOptionsWithCounts($pollId);
+            $voters  = $this->fetchVoterCount($pollId);
 
             $out[] = [
-                'id'          => $id,
+                'id'          => (string) $pollId,
+                'pollId'      => $pollId,
                 'title'       => $title,
-                'description' => (string) ($row['description'] ?? ''),
-                'type'        => (string) ($row['type'] ?? ''),
-                'url'         => '/index.php/apps/polls/vote/'.$id,
+                'description' => $description,
+                'type'        => $type,
+                'url'         => '/index.php/apps/polls/vote/'.$pollId,
                 'deadline'    => $expire > 0 ? $expire : null,
                 'closed'      => ($expire > 0 && $expire <= time()),
                 'voterCount'  => $voters,
                 'options'     => $options,
+                'linkId'      => $link->getId(),
             ];
         }
 
@@ -158,27 +149,51 @@ class PollsProvider extends AbstractIntegrationProvider
     }//end list()
 
     /**
+     * Fetch a poll row from `oc_polls_polls`.
+     *
+     * @param int $pollId Poll id.
+     *
+     * @return array<string,mixed>|null
+     */
+    private function fetchPollRow(int $pollId): ?array
+    {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('id', 'title', 'description', 'type', 'expire')
+                ->from('polls_polls')
+                ->where($qb->expr()->eq('id', $qb->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)))
+                ->andWhere($qb->expr()->eq('deleted', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
+
+            $row = $qb->executeQuery()->fetch();
+            if ($row === false) {
+                return null;
+            }
+
+            return $row;
+        } catch (Throwable $e) {
+            return null;
+        }
+    }//end fetchPollRow()
+
+    /**
      * Fetch poll options with their yes-vote tallies.
      *
-     * Returns a list of `{id, text, votes}` rows, ordered by the poll's
-     * stored option order. Vote counts only include rows where
-     * `vote_answer = 'yes'` and the option/vote are not soft-deleted —
-     * mirrors Polls' own tally surface. Returns an empty array on any
-     * DB failure to keep the leaf row degradation-safe.
+     * Returns `[{id, text, votes}, ...]`, ordered by stored option
+     * order. Vote counts only include `vote_answer = 'yes'` /
+     * non-deleted rows. Returns an empty array on any DB failure.
      *
-     * @param \OCP\IDBConnection $db     OR's lazy-resolved DB handle.
-     * @param int                $pollId Poll primary key.
+     * @param int $pollId Poll primary key.
      *
      * @return array<int,array{id:int,text:string,votes:int}>
      */
-    private function fetchOptionsWithCounts(\OCP\IDBConnection $db, int $pollId): array
+    private function fetchOptionsWithCounts(int $pollId): array
     {
         try {
-            $qb = $db->getQueryBuilder();
+            $qb = $this->db->getQueryBuilder();
             $qb->select('id', 'poll_option_text', 'poll_option_hash')
                 ->from('polls_options')
-                ->where($qb->expr()->eq('poll_id', $qb->createNamedParameter($pollId, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT)))
-                ->andWhere($qb->expr()->eq('deleted', $qb->createNamedParameter(0, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT)))
+                ->where($qb->expr()->eq('poll_id', $qb->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)))
+                ->andWhere($qb->expr()->eq('deleted', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
                 ->orderBy('order', 'ASC');
             $optionRows = $qb->executeQuery()->fetchAll();
         } catch (Throwable $e) {
@@ -187,16 +202,16 @@ class PollsProvider extends AbstractIntegrationProvider
 
         $out = [];
         foreach ($optionRows as $opt) {
-            $hash = (string) ($opt['poll_option_hash'] ?? '');
+            $hash  = (string) ($opt['poll_option_hash'] ?? '');
             $votes = 0;
             try {
-                $vq = $db->getQueryBuilder();
+                $vq = $this->db->getQueryBuilder();
                 $vq->select($vq->func()->count('*', 'cnt'))
                     ->from('polls_votes')
-                    ->where($vq->expr()->eq('poll_id', $vq->createNamedParameter($pollId, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT)))
+                    ->where($vq->expr()->eq('poll_id', $vq->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)))
                     ->andWhere($vq->expr()->eq('vote_option_hash', $vq->createNamedParameter($hash)))
                     ->andWhere($vq->expr()->eq('vote_answer', $vq->createNamedParameter('yes')))
-                    ->andWhere($vq->expr()->eq('deleted', $vq->createNamedParameter(0, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT)));
+                    ->andWhere($vq->expr()->eq('deleted', $vq->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
                 $votes = (int) ($vq->executeQuery()->fetchOne() ?: 0);
             } catch (Throwable $e) {
                 $votes = 0;
@@ -207,7 +222,7 @@ class PollsProvider extends AbstractIntegrationProvider
                 'text'  => (string) ($opt['poll_option_text'] ?? ''),
                 'votes' => $votes,
             ];
-        }
+        }//end foreach
 
         return $out;
     }//end fetchOptionsWithCounts()
@@ -215,19 +230,18 @@ class PollsProvider extends AbstractIntegrationProvider
     /**
      * Distinct user count that has cast at least one non-deleted vote.
      *
-     * @param \OCP\IDBConnection $db     OR's lazy-resolved DB handle.
-     * @param int                $pollId Poll primary key.
+     * @param int $pollId Poll primary key.
      *
      * @return int
      */
-    private function fetchVoterCount(\OCP\IDBConnection $db, int $pollId): int
+    private function fetchVoterCount(int $pollId): int
     {
         try {
-            $qb = $db->getQueryBuilder();
+            $qb = $this->db->getQueryBuilder();
             $qb->selectDistinct('user_id')
                 ->from('polls_votes')
-                ->where($qb->expr()->eq('poll_id', $qb->createNamedParameter($pollId, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT)))
-                ->andWhere($qb->expr()->eq('deleted', $qb->createNamedParameter(0, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT)));
+                ->where($qb->expr()->eq('poll_id', $qb->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)))
+                ->andWhere($qb->expr()->eq('deleted', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
             $rows = $qb->executeQuery()->fetchAll();
             return count($rows);
         } catch (Throwable $e) {

--- a/lib/Service/PollLinkService.php
+++ b/lib/Service/PollLinkService.php
@@ -1,0 +1,565 @@
+<?php
+
+/**
+ * PollLinkService — Tier-2 polls integration service.
+ *
+ * Composes the {@see PollLinkMapper} with direct queries into NC Polls'
+ * own tables (`oc_polls_polls`, `oc_polls_options`, `oc_polls_votes`)
+ * to provide the picker + inline-create UX surface area:
+ *
+ *   - linkPoll(uuid, registerId, schemaId, pollId)          — link existing poll
+ *   - createAndLinkPoll(uuid, ..., title, description,
+ *                       type, options, deadline)            — create + link new
+ *   - unlinkPoll(uuid, pollId)
+ *   - getLinkedPolls(uuid)                                  — list, enriched
+ *   - getAvailablePolls(search?)                            — picker source
+ *
+ * Polls' own `PollService::list` requires Polls' UserSession to be
+ * populated (which it isn't when OR serves the sub-resource), so this
+ * service uses the same DB-direct pattern as Phase B-3 PollsProvider:
+ * raw queries against `oc_polls_*` tables. When Polls is unavailable,
+ * `getLinkedPolls` still returns the persisted link row so historical
+ * references survive even after Polls is uninstalled.
+ *
+ * The `createAndLinkPoll` path INSERTs directly into `oc_polls_polls` +
+ * `oc_polls_options` because Polls' `PollService::add` also depends on
+ * Polls' UserSession + `requestAccessControl`, and the create flow runs
+ * inside an OR controller where that session isn't bootstrapped.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git-id>
+ * @link      https://OpenRegister.app
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use DateTime;
+use DateTimeInterface;
+use Exception;
+use OCA\OpenRegister\Db\PollLink;
+use OCA\OpenRegister\Db\PollLinkMapper;
+use OCP\App\IAppManager;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * PollLinkService.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Composes mapper + DB
+ *     + IAppManager + IUserSession + logger. Each dependency is
+ *     required.
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) Direct table writes
+ *     for the create+link path inflate the count; the alternative
+ *     (re-implementing Polls' UserSession) would be worse.
+ */
+class PollLinkService
+{
+    /**
+     * Constructor.
+     *
+     * @param PollLinkMapper  $pollLinkMapper Persistence for link rows.
+     * @param IDBConnection   $db             Database connection.
+     * @param IAppManager     $appManager     NC app manager.
+     * @param IUserSession    $userSession    Active session.
+     * @param LoggerInterface $logger         Logger.
+     */
+    public function __construct(
+        private readonly PollLinkMapper $pollLinkMapper,
+        private readonly IDBConnection $db,
+        private readonly IAppManager $appManager,
+        private readonly IUserSession $userSession,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Whether NC Polls is installed + enabled for the current user.
+     *
+     * @return bool
+     */
+    public function isPollsAvailable(): bool
+    {
+        return $this->appManager->isEnabledForUser('polls');
+    }//end isPollsAvailable()
+
+    /**
+     * Link an existing Polls poll to an OR object.
+     *
+     * Idempotent: a duplicate link raises a 409 Exception (callers
+     * should surface as HTTP 409 to the UI).
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $registerId OR register id.
+     * @param int    $schemaId   OR schema id.
+     * @param int    $pollId     Polls poll id.
+     *
+     * @return PollLink The persisted link row.
+     *
+     * @throws Exception On missing user, missing poll (404), duplicate (409).
+     */
+    public function linkPoll(string $objectUuid, int $registerId, int $schemaId, int $pollId): PollLink
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in');
+        }
+
+        $existing = $this->pollLinkMapper->findByObjectAndPoll($objectUuid, $pollId);
+        if ($existing !== null) {
+            throw new Exception('Poll already linked to this object', 409);
+        }
+
+        if ($this->isPollsAvailable() === false) {
+            throw new Exception('Polls is not available', 503);
+        }
+
+        $pollRow = $this->fetchPollRow($pollId);
+        if ($pollRow === null) {
+            throw new Exception('Poll not found', 404);
+        }
+
+        $deadline    = $this->expireToDateTime((int) ($pollRow['expire'] ?? 0));
+        $closed      = ($deadline !== null && $deadline->getTimestamp() <= time());
+        $voterCount  = $this->fetchVoterCount($pollId);
+        $optionCount = $this->fetchOptionCount($pollId);
+
+        $link = new PollLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        $link->setSchemaId($schemaId);
+        $link->setPollId($pollId);
+        $link->setPollTitle((string) ($pollRow['title'] ?? ''));
+        $link->setPollType((string) ($pollRow['type'] ?? ''));
+        $link->setDeadline($deadline);
+        $link->setVoterCount($voterCount);
+        $link->setOptionCount($optionCount);
+        $link->setClosed($closed);
+        $link->setLinkedBy($user->getUID());
+        $link->setLinkedAt(new DateTime());
+
+        return $this->pollLinkMapper->insert($link);
+    }//end linkPoll()
+
+    /**
+     * Unlink a poll from an object.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $pollId     Polls poll id.
+     *
+     * @return void
+     *
+     * @throws Exception When no matching link is found (404).
+     */
+    public function unlinkPoll(string $objectUuid, int $pollId): void
+    {
+        $deleted = $this->pollLinkMapper->deleteByObjectAndPoll($objectUuid, $pollId);
+        if ($deleted === 0) {
+            throw new Exception('Poll link not found', 404);
+        }
+    }//end unlinkPoll()
+
+    /**
+     * Return the linked polls for an object, with the tally counts and
+     * `closed` flag refreshed from `oc_polls_polls` on every call.
+     *
+     * Session-workaround pattern (Phase B-3 commit 73b49f3ad): Polls'
+     * own PollService can't run inside an OR controller because Polls'
+     * UserSession isn't populated, so we read directly from
+     * `oc_polls_polls` / `oc_polls_votes`. When Polls is unavailable
+     * the cached link-row values are returned unchanged.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     *
+     * @return array<int,array<string,mixed>>
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    public function getLinkedPolls(string $objectUuid): array
+    {
+        $links     = $this->pollLinkMapper->findByObjectUuid($objectUuid);
+        $available = $this->isPollsAvailable();
+
+        $results = [];
+        foreach ($links as $link) {
+            $row = $link->jsonSerialize();
+
+            if ($available === true) {
+                $pollId  = (int) $link->getPollId();
+                $pollRow = $this->fetchPollRow($pollId);
+
+                if ($pollRow !== null) {
+                    $deadline = $this->expireToDateTime((int) ($pollRow['expire'] ?? 0));
+                    $row['pollTitle']   = (string) ($pollRow['title'] ?? $row['pollTitle']);
+                    $row['pollType']    = (string) ($pollRow['type'] ?? $row['pollType']);
+                    $row['deadline']    = $deadline?->format(DateTime::ATOM);
+                    $row['voterCount']  = $this->fetchVoterCount($pollId);
+                    $row['optionCount'] = $this->fetchOptionCount($pollId);
+                    $row['closed']      = ($deadline !== null && $deadline->getTimestamp() <= time());
+                }
+            }
+
+            $row['url'] = '/index.php/apps/polls/vote/'.($row['pollId'] ?? '');
+            $results[] = $row;
+        }//end foreach
+
+        return $results;
+    }//end getLinkedPolls()
+
+    /**
+     * Return polls visible to the current user (picker source).
+     *
+     * Filters out polls already deleted in Polls. Optional substring
+     * search against the poll title.
+     *
+     * @param string|null $search Optional title-substring filter.
+     *
+     * @return array<int,array{id:int,title:string,type:string,deadline:?string,closed:bool,voterCount:int,optionCount:int}>
+     */
+    public function getAvailablePolls(?string $search = null): array
+    {
+        if ($this->isPollsAvailable() === false) {
+            return [];
+        }
+
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return [];
+        }
+
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('id', 'title', 'type', 'expire')
+                ->from('polls_polls')
+                ->where($qb->expr()->eq('owner', $qb->createNamedParameter($user->getUID())))
+                ->andWhere($qb->expr()->eq('deleted', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
+                ->orderBy('id', 'DESC');
+
+            if ($search !== null && $search !== '') {
+                $qb->andWhere(
+                    $qb->expr()->iLike('title', $qb->createNamedParameter('%'.$search.'%'))
+                );
+            }
+
+            $rows = $qb->executeQuery()->fetchAll();
+        } catch (Throwable $e) {
+            $this->logger->warning('PollLinkService::getAvailablePolls failed: '.$e->getMessage());
+            return [];
+        }
+
+        $out = [];
+        foreach ($rows as $row) {
+            $pollId   = (int) ($row['id'] ?? 0);
+            $deadline = $this->expireToDateTime((int) ($row['expire'] ?? 0));
+            $out[]    = [
+                'id'          => $pollId,
+                'title'       => (string) ($row['title'] ?? ''),
+                'type'        => (string) ($row['type'] ?? ''),
+                'deadline'    => $deadline?->format(DateTime::ATOM),
+                'closed'      => ($deadline !== null && $deadline->getTimestamp() <= time()),
+                'voterCount'  => $this->fetchVoterCount($pollId),
+                'optionCount' => $this->fetchOptionCount($pollId),
+            ];
+        }
+
+        return $out;
+    }//end getAvailablePolls()
+
+    /**
+     * Create a new Polls poll and link it to an OR object in one operation.
+     *
+     * Direct INSERT into `oc_polls_polls` + `oc_polls_options` (session
+     * workaround, see class docblock). The new poll is owned by the
+     * current user and uses the default access setting.
+     *
+     * @param string                 $objectUuid  Parent OR object uuid.
+     * @param int                    $registerId  OR register id.
+     * @param int                    $schemaId    OR schema id.
+     * @param string                 $title       Poll title (required).
+     * @param string                 $description Poll description (optional).
+     * @param string                 $type        Poll type: `textPoll` / `datePoll`.
+     * @param array<int,string>      $options     Option labels.
+     * @param DateTimeInterface|null $deadline    Optional deadline.
+     *
+     * @return PollLink The persisted link row.
+     *
+     * @throws Exception On missing user, Polls unavailable, or create failure.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
+    public function createAndLinkPoll(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        string $title,
+        string $description,
+        string $type,
+        array $options,
+        ?DateTimeInterface $deadline
+    ): PollLink {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in');
+        }
+
+        if ($this->isPollsAvailable() === false) {
+            throw new Exception('Polls is not available', 503);
+        }
+
+        if (trim($title) === '') {
+            throw new Exception('Title is required', 400);
+        }
+
+        // Normalise the type — accept legacy short forms.
+        $normalisedType = $this->normalisePollType($type);
+
+        $uid     = $user->getUID();
+        $now     = time();
+        $expire  = ($deadline !== null) ? $deadline->getTimestamp() : 0;
+
+        try {
+            $insert = $this->db->getQueryBuilder();
+            $insert->insert('polls_polls')
+                ->values([
+                    'type'            => $insert->createNamedParameter($normalisedType),
+                    'title'           => $insert->createNamedParameter(mb_substr($title, 0, 128)),
+                    'description'     => $insert->createNamedParameter($description),
+                    'owner'           => $insert->createNamedParameter($uid),
+                    'created'         => $insert->createNamedParameter($now, IQueryBuilder::PARAM_INT),
+                    'expire'          => $insert->createNamedParameter($expire, IQueryBuilder::PARAM_INT),
+                    'deleted'         => $insert->createNamedParameter(0, IQueryBuilder::PARAM_INT),
+                    'access'          => $insert->createNamedParameter('private'),
+                    'anonymous'       => $insert->createNamedParameter(0, IQueryBuilder::PARAM_INT),
+                    'allow_maybe'     => $insert->createNamedParameter(1, IQueryBuilder::PARAM_INT),
+                    'allow_proposals' => $insert->createNamedParameter('disallow'),
+                    'show_results'    => $insert->createNamedParameter('always'),
+                    'admin_access'    => $insert->createNamedParameter(0, IQueryBuilder::PARAM_INT),
+                    'allow_comment'   => $insert->createNamedParameter(1, IQueryBuilder::PARAM_INT),
+                    'hide_booked_up'  => $insert->createNamedParameter(1, IQueryBuilder::PARAM_INT),
+                    'use_no'          => $insert->createNamedParameter(1, IQueryBuilder::PARAM_INT),
+                    'voting_variant'  => $insert->createNamedParameter('simple'),
+                ]);
+            $insert->executeStatement();
+
+            $pollId = (int) $this->db->lastInsertId('oc_polls_polls_id_seq');
+            if ($pollId === 0) {
+                // Fallback for drivers without sequence support.
+                $pollId = (int) $this->db->lastInsertId();
+            }
+
+            if ($pollId === 0) {
+                throw new Exception('Failed to retrieve created poll id', 500);
+            }
+
+            $this->insertPollOptions($pollId, $uid, $normalisedType, $options, $now);
+        } catch (Throwable $e) {
+            $this->logger->warning('Failed to create poll: '.$e->getMessage());
+            throw new Exception('Failed to create poll: '.$e->getMessage(), 500);
+        }//end try
+
+        $deadlineDateTime = null;
+        if ($deadline !== null) {
+            try {
+                $deadlineDateTime = new DateTime('@'.$deadline->getTimestamp());
+            } catch (Throwable $e) {
+                $deadlineDateTime = null;
+            }
+        }
+
+        $link = new PollLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        $link->setSchemaId($schemaId);
+        $link->setPollId($pollId);
+        $link->setPollTitle(mb_substr($title, 0, 128));
+        $link->setPollType($normalisedType);
+        $link->setDeadline($deadlineDateTime);
+        $link->setVoterCount(0);
+        $link->setOptionCount(count($options));
+        $link->setClosed(false);
+        $link->setLinkedBy($uid);
+        $link->setLinkedAt(new DateTime());
+
+        return $this->pollLinkMapper->insert($link);
+    }//end createAndLinkPoll()
+
+    /**
+     * Insert poll options.
+     *
+     * @param int               $pollId  Created poll id.
+     * @param string            $owner   Owner uid.
+     * @param string            $type    Normalised poll type.
+     * @param array<int,string> $options Option labels.
+     * @param int               $now     Created timestamp.
+     *
+     * @return void
+     */
+    private function insertPollOptions(int $pollId, string $owner, string $type, array $options, int $now): void
+    {
+        $order = 0;
+        foreach ($options as $option) {
+            $text = trim((string) $option);
+            if ($text === '') {
+                continue;
+            }
+
+            $order++;
+
+            $hash      = substr(hash('sha256', $pollId.'-'.$text.'-'.$order), 0, 32);
+            $timestamp = ($type === 'datePoll' ? strtotime($text) ?: 0 : 0);
+
+            $qb = $this->db->getQueryBuilder();
+            $qb->insert('polls_options')->values([
+                'poll_id'          => $qb->createNamedParameter($pollId, IQueryBuilder::PARAM_INT),
+                'poll_option_text' => $qb->createNamedParameter(mb_substr($text, 0, 1024)),
+                'poll_option_hash' => $qb->createNamedParameter($hash),
+                'order'            => $qb->createNamedParameter($order, IQueryBuilder::PARAM_INT),
+                'timestamp'        => $qb->createNamedParameter($timestamp, IQueryBuilder::PARAM_INT),
+                'duration'         => $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT),
+                'confirmed'        => $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT),
+                'owner'            => $qb->createNamedParameter($owner),
+                'released'         => $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT),
+                'deleted'          => $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT),
+                'created'          => $qb->createNamedParameter($now, IQueryBuilder::PARAM_INT),
+            ]);
+            $qb->executeStatement();
+        }//end foreach
+    }//end insertPollOptions()
+
+    /**
+     * Fetch a poll row from `oc_polls_polls`.
+     *
+     * @param int $pollId Poll id.
+     *
+     * @return array<string,mixed>|null
+     */
+    private function fetchPollRow(int $pollId): ?array
+    {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('id', 'title', 'type', 'expire', 'owner', 'deleted')
+                ->from('polls_polls')
+                ->where($qb->expr()->eq('id', $qb->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)))
+                ->andWhere($qb->expr()->eq('deleted', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
+
+            $row = $qb->executeQuery()->fetch();
+            if ($row === false) {
+                return null;
+            }
+
+            return $row;
+        } catch (Throwable $e) {
+            $this->logger->debug('fetchPollRow failed: '.$e->getMessage());
+            return null;
+        }
+    }//end fetchPollRow()
+
+    /**
+     * Distinct user count that has cast at least one non-deleted vote.
+     *
+     * @param int $pollId Poll id.
+     *
+     * @return int
+     */
+    private function fetchVoterCount(int $pollId): int
+    {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->selectDistinct('user_id')
+                ->from('polls_votes')
+                ->where($qb->expr()->eq('poll_id', $qb->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)))
+                ->andWhere($qb->expr()->eq('deleted', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
+            $rows = $qb->executeQuery()->fetchAll();
+            return count($rows);
+        } catch (Throwable $e) {
+            return 0;
+        }
+    }//end fetchVoterCount()
+
+    /**
+     * Count of non-deleted options on a poll.
+     *
+     * @param int $pollId Poll id.
+     *
+     * @return int
+     */
+    private function fetchOptionCount(int $pollId): int
+    {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select($qb->func()->count('*', 'cnt'))
+                ->from('polls_options')
+                ->where($qb->expr()->eq('poll_id', $qb->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)))
+                ->andWhere($qb->expr()->eq('deleted', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
+            return (int) ($qb->executeQuery()->fetchOne() ?: 0);
+        } catch (Throwable $e) {
+            return 0;
+        }
+    }//end fetchOptionCount()
+
+    /**
+     * Convert a Polls `expire` epoch column to a DateTime.
+     *
+     * Polls treats 0 as "no deadline".
+     *
+     * @param int $expire Epoch seconds or zero.
+     *
+     * @return DateTime|null
+     */
+    private function expireToDateTime(int $expire): ?DateTime
+    {
+        if ($expire <= 0) {
+            return null;
+        }
+
+        try {
+            return new DateTime('@'.$expire);
+        } catch (Throwable $e) {
+            return null;
+        }
+    }//end expireToDateTime()
+
+    /**
+     * Normalise short-form poll types to Polls' canonical strings.
+     *
+     * Accepted aliases:
+     *  - `text` / `textPoll` → `textPoll`
+     *  - `date` / `datePoll` → `datePoll`
+     *
+     * Anything else falls through unchanged so future Polls types
+     * don't need a code change here.
+     *
+     * @param string $type Caller-supplied type.
+     *
+     * @return string
+     */
+    private function normalisePollType(string $type): string
+    {
+        $lower = strtolower(trim($type));
+        if ($lower === 'text' || $lower === 'textpoll') {
+            return 'textPoll';
+        }
+
+        if ($lower === 'date' || $lower === 'datepoll') {
+            return 'datePoll';
+        }
+
+        return $type === '' ? 'textPoll' : $type;
+    }//end normalisePollType()
+}//end class

--- a/tests/Unit/Controller/PollLinksControllerTest.php
+++ b/tests/Unit/Controller/PollLinksControllerTest.php
@@ -1,0 +1,255 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Controller\PollLinksController}.
+ *
+ * Exercises the Tier-2 controller surface: HTTP status mapping
+ * (200/201/400/404/409/501/503), payload routing (link existing vs.
+ * create new), and graceful degradation when Polls is unavailable.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/integration-polls/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use Exception;
+use OCA\OpenRegister\Controller\PollLinksController;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\PollLink;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\PollLinkService;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * PollLinksControllerTest.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class PollLinksControllerTest extends TestCase
+{
+    private IRequest&MockObject $request;
+    private PollLinkService&MockObject $service;
+    private ObjectService&MockObject $objectService;
+    private PollLinksController $controller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request       = $this->createMock(IRequest::class);
+        $this->service       = $this->createMock(PollLinkService::class);
+        $this->objectService = $this->createMock(ObjectService::class);
+
+        $this->controller = new PollLinksController(
+            'openregister',
+            $this->request,
+            $this->service,
+            $this->objectService,
+        );
+    }
+
+    private function mockObject(string $uuid = 'abc-123', int $registerId = 1, int $schemaId = 2): ObjectEntity
+    {
+        $object = new ObjectEntity();
+        $object->setUuid($uuid);
+        $object->setRegister($registerId);
+        $object->setSchema($schemaId);
+        $this->objectService->method('setSchema')->willReturnSelf();
+        $this->objectService->method('setRegister')->willReturnSelf();
+        $this->objectService->method('setObject')->willReturnSelf();
+        $this->objectService->method('getObject')->willReturn($object);
+        return $object;
+    }
+
+    public function testIndexReturns501WhenPollsUnavailable(): void
+    {
+        $this->service->method('isPollsAvailable')->willReturn(false);
+
+        $response = $this->controller->index('reg', 'sch', 'obj');
+
+        $this->assertSame(501, $response->getStatus());
+    }
+
+    public function testIndexReturnsResults(): void
+    {
+        $this->service->method('isPollsAvailable')->willReturn(true);
+        $this->mockObject();
+        $this->service->method('getLinkedPolls')->with('abc-123')->willReturn([
+            ['pollId' => 99, 'pollTitle' => 'Test'],
+        ]);
+
+        $response = $this->controller->index('reg', 'sch', 'obj');
+        $data     = $response->getData();
+
+        $this->assertSame(200, $response->getStatus());
+        $this->assertSame(1, $data['total']);
+        $this->assertSame(99, $data['results'][0]['pollId']);
+    }
+
+    public function testIndexReturns404WhenObjectMissing(): void
+    {
+        $this->service->method('isPollsAvailable')->willReturn(true);
+        $this->objectService->method('getObject')->willReturn(null);
+
+        $response = $this->controller->index('reg', 'sch', 'missing');
+
+        $this->assertSame(404, $response->getStatus());
+    }
+
+    public function testLinkReturns400WhenPollIdMissing(): void
+    {
+        $this->service->method('isPollsAvailable')->willReturn(true);
+        $this->mockObject();
+        $this->request->method('getParam')->willReturnMap([['pollId', 0, 0]]);
+
+        $response = $this->controller->link('reg', 'sch', 'obj');
+
+        $this->assertSame(400, $response->getStatus());
+    }
+
+    public function testLinkReturns201OnSuccess(): void
+    {
+        $this->service->method('isPollsAvailable')->willReturn(true);
+        $this->mockObject();
+        $this->request->method('getParam')->willReturn(99);
+
+        $link = new PollLink();
+        $link->setObjectUuid('abc-123');
+        $link->setPollId(99);
+
+        $this->service->method('linkPoll')
+            ->with('abc-123', 1, 2, 99)
+            ->willReturn($link);
+
+        $response = $this->controller->link('reg', 'sch', 'obj');
+
+        $this->assertSame(201, $response->getStatus());
+        $this->assertSame(99, $response->getData()['pollId']);
+    }
+
+    public function testLinkReturns409OnDuplicate(): void
+    {
+        $this->service->method('isPollsAvailable')->willReturn(true);
+        $this->mockObject();
+        $this->request->method('getParam')->willReturn(99);
+
+        $this->service->method('linkPoll')
+            ->willThrowException(new Exception('Poll already linked to this object', 409));
+
+        $response = $this->controller->link('reg', 'sch', 'obj');
+
+        $this->assertSame(409, $response->getStatus());
+    }
+
+    public function testCreateNewReturns400WhenTitleMissing(): void
+    {
+        $this->service->method('isPollsAvailable')->willReturn(true);
+        $this->mockObject();
+        $this->request->method('getParam')->willReturnCallback(
+            static function (string $key, $default = null) {
+                return match ($key) {
+                    'title'   => '',
+                    'options' => ['A'],
+                    default   => $default,
+                };
+            }
+        );
+
+        $response = $this->controller->createNew('reg', 'sch', 'obj');
+
+        $this->assertSame(400, $response->getStatus());
+    }
+
+    public function testCreateNewReturns201OnSuccess(): void
+    {
+        $this->service->method('isPollsAvailable')->willReturn(true);
+        $this->mockObject();
+        $this->request->method('getParam')->willReturnCallback(
+            static function (string $key, $default = null) {
+                return match ($key) {
+                    'title'       => 'Lunch',
+                    'description' => 'Pick a day',
+                    'type'        => 'textPoll',
+                    'options'     => ['Mon', 'Tue'],
+                    'deadline'    => null,
+                    default       => $default,
+                };
+            }
+        );
+
+        $link = new PollLink();
+        $link->setObjectUuid('abc-123');
+        $link->setPollId(456);
+        $link->setPollTitle('Lunch');
+
+        $this->service->expects($this->once())
+            ->method('createAndLinkPoll')
+            ->willReturn($link);
+
+        $response = $this->controller->createNew('reg', 'sch', 'obj');
+
+        $this->assertSame(201, $response->getStatus());
+        $this->assertSame(456, $response->getData()['pollId']);
+    }
+
+    public function testDestroyReturns200OnSuccess(): void
+    {
+        $this->service->method('isPollsAvailable')->willReturn(true);
+        $this->mockObject();
+        $this->service->expects($this->once())
+            ->method('unlinkPoll')
+            ->with('abc-123', 42);
+
+        $response = $this->controller->destroy('reg', 'sch', 'obj', '42');
+
+        $this->assertSame(200, $response->getStatus());
+        $this->assertTrue($response->getData()['success']);
+    }
+
+    public function testDestroyReturns404WhenLinkMissing(): void
+    {
+        $this->service->method('isPollsAvailable')->willReturn(true);
+        $this->mockObject();
+        $this->service->method('unlinkPoll')
+            ->willThrowException(new Exception('Poll link not found', 404));
+
+        $response = $this->controller->destroy('reg', 'sch', 'obj', '42');
+
+        $this->assertSame(404, $response->getStatus());
+    }
+
+    public function testAvailableReturnsList(): void
+    {
+        $this->service->method('isPollsAvailable')->willReturn(true);
+        $this->service->method('getAvailablePolls')->willReturn([
+            ['id' => 1, 'title' => 'Lunch', 'type' => 'textPoll', 'deadline' => null, 'closed' => false, 'voterCount' => 0, 'optionCount' => 2],
+        ]);
+
+        $response = $this->controller->available();
+
+        $this->assertSame(200, $response->getStatus());
+        $this->assertSame(1, $response->getData()['total']);
+    }
+
+    public function testAvailableReturns501WhenPollsUnavailable(): void
+    {
+        $this->service->method('isPollsAvailable')->willReturn(false);
+
+        $response = $this->controller->available();
+
+        $this->assertSame(501, $response->getStatus());
+    }
+}

--- a/tests/Unit/Db/PollLinkTest.php
+++ b/tests/Unit/Db/PollLinkTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Db;
+
+use DateTime;
+use OCA\OpenRegister\Db\PollLink;
+use PHPUnit\Framework\TestCase;
+
+class PollLinkTest extends TestCase
+{
+    public function testJsonSerializeReturnsAllFields(): void
+    {
+        $link = new PollLink();
+        $link->setObjectUuid('abc-123');
+        $link->setRegisterId(5);
+        $link->setSchemaId(7);
+        $link->setPollId(42);
+        $link->setPollTitle('Lunch');
+        $link->setPollType('datePoll');
+        $link->setDeadline(new DateTime('2026-06-01T12:00:00+00:00'));
+        $link->setVoterCount(3);
+        $link->setOptionCount(2);
+        $link->setClosed(false);
+        $link->setLinkedBy('admin');
+        $link->setLinkedAt(new DateTime('2026-03-25T11:00:00+00:00'));
+
+        $json = $link->jsonSerialize();
+
+        $this->assertSame('abc-123', $json['objectUuid']);
+        $this->assertSame(5, $json['registerId']);
+        $this->assertSame(7, $json['schemaId']);
+        $this->assertSame(42, $json['pollId']);
+        $this->assertSame('Lunch', $json['pollTitle']);
+        $this->assertSame('datePoll', $json['pollType']);
+        $this->assertSame(3, $json['voterCount']);
+        $this->assertSame(2, $json['optionCount']);
+        $this->assertFalse($json['closed']);
+        $this->assertSame('admin', $json['linkedBy']);
+        $this->assertNotNull($json['deadline']);
+        $this->assertNotNull($json['linkedAt']);
+    }
+
+    public function testJsonSerializeHandlesNulls(): void
+    {
+        $link = new PollLink();
+
+        $json = $link->jsonSerialize();
+
+        $this->assertNull($json['pollTitle']);
+        $this->assertNull($json['pollType']);
+        $this->assertNull($json['deadline']);
+        $this->assertNull($json['voterCount']);
+        $this->assertNull($json['optionCount']);
+        $this->assertNull($json['linkedAt']);
+        $this->assertFalse($json['closed']);
+    }
+
+    public function testSettersAndGetters(): void
+    {
+        $link = new PollLink();
+        $link->setPollId(99);
+        $link->setVoterCount(5);
+
+        $this->assertSame(99, $link->getPollId());
+        $this->assertSame(5, $link->getVoterCount());
+    }
+}

--- a/tests/Unit/Service/Integration/Providers/PollsProviderTest.php
+++ b/tests/Unit/Service/Integration/Providers/PollsProviderTest.php
@@ -1,23 +1,17 @@
 <?php
 
 /**
- * Unit tests for PollsProvider after Phase B-3 payload widening.
+ * Unit tests for PollsProvider after Tier-2 migration to PollLinkMapper.
  *
  * Covers:
  *  - metadata getters (id / label / icon / group / requiredApp / storage)
  *  - `isEnabled()` honours `IAppManager::isInstalled()`
- *  - `list()` happy-path: walks `polls_polls`, filters by `[or:{uuid}]`
- *    marker, attaches `options[]` from `polls_options` joined with
- *    `polls_votes` yes-tallies, and `voterCount` (distinct users), plus
- *    `deadline` + `closed` derived from the poll's `expire` field
- *  - `list()` no-user: returns `[]` cleanly when no session user
- *  - `list()` no-marker-match: a poll without the marker is excluded
+ *  - `list()` returns empty when Polls is uninstalled
+ *  - `list()` returns empty when no link rows exist
+ *  - `list()` happy-path: walks `openregister_poll_links`, hydrates each
+ *    row from `polls_polls` + per-option vote tallies, returns
+ *    `{id,title,type,url,deadline,closed,voterCount,options[],linkId}`
  *  - `health()` reports `'unavailable'` when Polls is not installed
- *
- * The provider talks to `polls_polls` / `polls_options` / `polls_votes`
- * via OR's lazy-resolved `IDBConnection`; the test injects a mock
- * `ContainerInterface` so the DB plumbing is exercisable without
- * spinning up the full NC server container.
  *
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Integration\Providers
@@ -39,22 +33,21 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Tests\Unit\Service\Integration\Providers;
 
 // phpcs:disable PEAR.Commenting.FunctionComment.Missing -- arrange/act/assert PHPUnit conventions.
-// phpcs:disable CustomSniffs.Functions.NamedParameters.RequireNamedParameters -- PHPUnit positional assertions.
 
+use OCA\OpenRegister\Db\PollLink;
+use OCA\OpenRegister\Db\PollLinkMapper;
 use OCA\OpenRegister\Service\Integration\Providers\PollsProvider;
 use OCP\App\IAppManager;
-use OCP\DB\QueryBuilder\IExpressionBuilder;
 use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
 use OCP\DB\QueryBuilder\IFunctionBuilder;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\DB\QueryBuilder\IQueryFunction;
-use OCP\DB\QueryBuilder\ILiteral;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 
 /**
  * Unit tests for PollsProvider.
@@ -65,11 +58,6 @@ use Psr\Container\ContainerInterface;
 class PollsProviderTest extends TestCase
 {
 
-    /**
-     * Build an IL10N pass-through.
-     *
-     * @return IL10N
-     */
     private function buildL10n(): IL10N
     {
         $mock = $this->createMock(IL10N::class);
@@ -78,13 +66,6 @@ class PollsProviderTest extends TestCase
     }//end buildL10n()
 
 
-    /**
-     * Build an IAppManager mock that reports Polls as installed (or not).
-     *
-     * @param bool $installed Whether the Polls app reports installed.
-     *
-     * @return IAppManager
-     */
     private function buildAppManager(bool $installed): IAppManager
     {
         $mock = $this->createMock(IAppManager::class);
@@ -93,13 +74,6 @@ class PollsProviderTest extends TestCase
     }//end buildAppManager()
 
 
-    /**
-     * Build an IUserSession that returns a user with the given UID.
-     *
-     * @param string|null $uid Uid or null for no user.
-     *
-     * @return IUserSession
-     */
     private function buildUserSession(?string $uid): IUserSession
     {
         $session = $this->createMock(IUserSession::class);
@@ -115,16 +89,9 @@ class PollsProviderTest extends TestCase
 
 
     /**
-     * Build a query-builder mock that returns the supplied rows when
-     * `executeQuery()->fetchAll()` is called, or `$singleValue` when
-     * `executeQuery()->fetchOne()` is called.
+     * Build a query-builder mock that returns the supplied rows.
      *
-     * The fluent setters (`select`, `selectDistinct`, `from`, `where`,
-     * `andWhere`, `orderBy`, `createNamedParameter`, `expr`, `func`)
-     * all return self / safe stub values, mirroring how the provider
-     * threads them.
-     *
-     * @param array $rows        Rows for `fetchAll()`.
+     * @param array $rows        Rows for `fetchAll()` / `fetch()` (first row).
      * @param mixed $singleValue Value for `fetchOne()`.
      *
      * @return IQueryBuilder
@@ -135,7 +102,7 @@ class PollsProviderTest extends TestCase
         $expr->method('eq')->willReturn('eq');
 
         $literal = $this->createMock(IQueryFunction::class);
-        $func = $this->createMock(IFunctionBuilder::class);
+        $func    = $this->createMock(IFunctionBuilder::class);
         $func->method('count')->willReturn($literal);
 
         $qb = $this->createMock(IQueryBuilder::class);
@@ -151,16 +118,29 @@ class PollsProviderTest extends TestCase
 
         $result = $this->createMock(IResult::class);
         $result->method('fetchAll')->willReturn($rows);
+        $result->method('fetch')->willReturn($rows === [] ? false : $rows[0]);
         $result->method('fetchOne')->willReturn($singleValue);
         $qb->method('executeQuery')->willReturn($result);
         return $qb;
     }//end buildQb()
 
 
+    private function buildMapper(array $links): PollLinkMapper
+    {
+        $mapper = $this->getMockBuilder(PollLinkMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['findByObjectUuid'])
+            ->getMock();
+        $mapper->method('findByObjectUuid')->willReturn($links);
+        return $mapper;
+    }//end buildMapper()
+
+
     public function testMetadata(): void
     {
         $provider = new PollsProvider(
-            container: $this->createMock(ContainerInterface::class),
+            pollLinkMapper: $this->buildMapper([]),
+            db: $this->createMock(IDBConnection::class),
             appManager: $this->buildAppManager(true),
             userSession: $this->buildUserSession('admin'),
             l10n: $this->buildL10n()
@@ -178,7 +158,8 @@ class PollsProviderTest extends TestCase
     public function testIsEnabledFalseWhenPollsMissing(): void
     {
         $provider = new PollsProvider(
-            container: $this->createMock(ContainerInterface::class),
+            pollLinkMapper: $this->buildMapper([]),
+            db: $this->createMock(IDBConnection::class),
             appManager: $this->buildAppManager(false),
             userSession: $this->buildUserSession('admin'),
             l10n: $this->buildL10n()
@@ -188,32 +169,36 @@ class PollsProviderTest extends TestCase
     }//end testIsEnabledFalseWhenPollsMissing()
 
 
-    public function testListEmptyWhenNoUser(): void
+    public function testListEmptyWhenNoLinks(): void
     {
         $provider = new PollsProvider(
-            container: $this->createMock(ContainerInterface::class),
+            pollLinkMapper: $this->buildMapper([]),
+            db: $this->createMock(IDBConnection::class),
             appManager: $this->buildAppManager(true),
-            userSession: $this->buildUserSession(null),
+            userSession: $this->buildUserSession('admin'),
             l10n: $this->buildL10n()
         );
 
         self::assertSame([], $provider->list(register: 'r', schema: 's', objectId: 'uuid'));
-    }//end testListEmptyWhenNoUser()
+    }//end testListEmptyWhenNoLinks()
 
 
-    public function testListWidenedPayloadHappyPath(): void
+    public function testListHappyPath(): void
     {
-        $uuid = 'abc-123';
-        $marker = '[or:'.$uuid.']';
-        $now = time();
+        $uuid         = 'abc-123';
+        $now          = time();
         $futureExpire = $now + 86400;
 
-        // Three QB hops per matched poll: polls, options, votes-count.
-        // Plus the distinct-users voterCount QB.
-        $pollsRows = [
+        $link = new PollLink();
+        $link->setPollId(42);
+        $link->setPollTitle('Lunch');
+        $link->setPollType('datePoll');
+        $link->setObjectUuid($uuid);
+
+        $pollRows = [
             [
                 'id'          => 42,
-                'title'       => 'Lunch ' . $marker,
+                'title'       => 'Lunch',
                 'description' => 'Pick a day',
                 'type'        => 'datePoll',
                 'expire'      => $futureExpire,
@@ -229,26 +214,24 @@ class PollsProviderTest extends TestCase
             ['user_id' => 'carol'],
         ];
 
-        $qbPolls    = $this->buildQb($pollsRows);
+        $qbPoll     = $this->buildQb($pollRows);
         $qbOptions  = $this->buildQb($optionRows);
-        $qbVotesMon = $this->buildQb([], 3); // 3 yes votes for Mon
-        $qbVotesTue = $this->buildQb([], 1); // 1 yes vote for Tue
+        $qbVotesMon = $this->buildQb([], 3);
+        $qbVotesTue = $this->buildQb([], 1);
         $qbVoters   = $this->buildQb($voteRowsForVoters);
 
         $db = $this->createMock(IDBConnection::class);
         $db->method('getQueryBuilder')->willReturnOnConsecutiveCalls(
-            $qbPolls,
+            $qbPoll,
             $qbOptions,
             $qbVotesMon,
             $qbVotesTue,
             $qbVoters
         );
 
-        $container = $this->createMock(ContainerInterface::class);
-        $container->method('get')->with('OCP\\IDBConnection')->willReturn($db);
-
         $provider = new PollsProvider(
-            container: $container,
+            pollLinkMapper: $this->buildMapper([$link]),
+            db: $db,
             appManager: $this->buildAppManager(true),
             userSession: $this->buildUserSession('admin'),
             l10n: $this->buildL10n()
@@ -259,6 +242,8 @@ class PollsProviderTest extends TestCase
 
         $row = $rows[0];
         self::assertSame('42', $row['id']);
+        self::assertSame(42, $row['pollId']);
+        self::assertSame('Lunch', $row['title']);
         self::assertSame('datePoll', $row['type']);
         self::assertSame('/index.php/apps/polls/vote/42', $row['url']);
         self::assertSame($futureExpire, $row['deadline']);
@@ -269,37 +254,14 @@ class PollsProviderTest extends TestCase
         self::assertSame(3, $row['options'][0]['votes']);
         self::assertSame('Tue', $row['options'][1]['text']);
         self::assertSame(1, $row['options'][1]['votes']);
-    }//end testListWidenedPayloadHappyPath()
-
-
-    public function testListMarkerMismatchExcluded(): void
-    {
-        $pollsRows = [
-            ['id' => 7, 'title' => 'Unrelated poll', 'description' => '', 'type' => 'textPoll', 'expire' => 0],
-        ];
-        $qb = $this->buildQb($pollsRows);
-
-        $db = $this->createMock(IDBConnection::class);
-        $db->method('getQueryBuilder')->willReturn($qb);
-        $container = $this->createMock(ContainerInterface::class);
-        $container->method('get')->willReturn($db);
-
-        $provider = new PollsProvider(
-            container: $container,
-            appManager: $this->buildAppManager(true),
-            userSession: $this->buildUserSession('admin'),
-            l10n: $this->buildL10n()
-        );
-
-        $rows = $provider->list(register: 'r', schema: 's', objectId: 'no-match');
-        self::assertSame([], $rows);
-    }//end testListMarkerMismatchExcluded()
+    }//end testListHappyPath()
 
 
     public function testHealthOk(): void
     {
         $provider = new PollsProvider(
-            container: $this->createMock(ContainerInterface::class),
+            pollLinkMapper: $this->buildMapper([]),
+            db: $this->createMock(IDBConnection::class),
             appManager: $this->buildAppManager(true),
             userSession: $this->buildUserSession('admin'),
             l10n: $this->buildL10n()
@@ -314,7 +276,8 @@ class PollsProviderTest extends TestCase
     public function testHealthUnavailable(): void
     {
         $provider = new PollsProvider(
-            container: $this->createMock(ContainerInterface::class),
+            pollLinkMapper: $this->buildMapper([]),
+            db: $this->createMock(IDBConnection::class),
             appManager: $this->buildAppManager(false),
             userSession: $this->buildUserSession('admin'),
             l10n: $this->buildL10n()

--- a/tests/Unit/Service/PollLinkServiceTest.php
+++ b/tests/Unit/Service/PollLinkServiceTest.php
@@ -1,0 +1,229 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Service\PollLinkService}.
+ *
+ * Exercises the Tier-2 service contract (link/create/list/unlink +
+ * available-polls picker) against mocked PollLinkMapper + IDBConnection.
+ * Tests requiring real Polls table data are kept in integration tests;
+ * unit scope here is the service's branch coverage.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/integration-polls/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use Exception;
+use OCA\OpenRegister\Db\PollLink;
+use OCA\OpenRegister\Db\PollLinkMapper;
+use OCA\OpenRegister\Service\PollLinkService;
+use OCP\App\IAppManager;
+use OCP\IDBConnection;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * PollLinkServiceTest.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class PollLinkServiceTest extends TestCase
+{
+    private PollLinkMapper&MockObject $mapper;
+    private IDBConnection&MockObject $db;
+    private IAppManager&MockObject $appManager;
+    private IUserSession&MockObject $userSession;
+    private LoggerInterface&MockObject $logger;
+    private PollLinkService $service;
+
+    protected function setUp(): void
+    {
+        $this->mapper = $this->getMockBuilder(PollLinkMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'findByObjectUuid',
+                'findByObjectAndPoll',
+                'deleteByObjectAndPoll',
+                'insert',
+            ])
+            ->getMock();
+        $this->db          = $this->createMock(IDBConnection::class);
+        $this->appManager  = $this->createMock(IAppManager::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->logger      = $this->createMock(LoggerInterface::class);
+
+        $this->service = new PollLinkService(
+            $this->mapper,
+            $this->db,
+            $this->appManager,
+            $this->userSession,
+            $this->logger
+        );
+    }
+
+    private function setupUser(string $uid = 'admin'): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $this->userSession->method('getUser')->willReturn($user);
+    }
+
+    public function testIsPollsAvailableTrue(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('polls')->willReturn(true);
+        $this->assertTrue($this->service->isPollsAvailable());
+    }
+
+    public function testIsPollsAvailableFalse(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('polls')->willReturn(false);
+        $this->assertFalse($this->service->isPollsAvailable());
+    }
+
+    public function testLinkPollThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No user logged in');
+
+        $this->service->linkPoll('abc-123', 1, 2, 5);
+    }
+
+    public function testLinkPollThrowsOnDuplicate(): void
+    {
+        $this->setupUser();
+        $existing = new PollLink();
+        $this->mapper->method('findByObjectAndPoll')->with('abc-123', 5)->willReturn($existing);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(409);
+        $this->expectExceptionMessage('Poll already linked to this object');
+
+        $this->service->linkPoll('abc-123', 1, 2, 5);
+    }
+
+    public function testLinkPollThrowsWhenPollsUnavailable(): void
+    {
+        $this->setupUser();
+        $this->mapper->method('findByObjectAndPoll')->willReturn(null);
+        $this->appManager->method('isEnabledForUser')->with('polls')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+        $this->expectExceptionMessage('Polls is not available');
+
+        $this->service->linkPoll('abc-123', 1, 2, 5);
+    }
+
+    public function testUnlinkPollSucceeds(): void
+    {
+        $this->mapper->expects($this->once())
+            ->method('deleteByObjectAndPoll')
+            ->with('abc-123', 5)
+            ->willReturn(1);
+
+        $this->service->unlinkPoll('abc-123', 5);
+    }
+
+    public function testUnlinkPollNotFound(): void
+    {
+        $this->mapper->method('deleteByObjectAndPoll')->willReturn(0);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(404);
+        $this->expectExceptionMessage('Poll link not found');
+
+        $this->service->unlinkPoll('abc-123', 5);
+    }
+
+    public function testGetLinkedPollsEmpty(): void
+    {
+        $this->mapper->method('findByObjectUuid')->willReturn([]);
+
+        $this->assertSame([], $this->service->getLinkedPolls('nonexistent'));
+    }
+
+    public function testGetLinkedPollsReturnsSerialisedRowsWhenPollsUnavailable(): void
+    {
+        $link = new PollLink();
+        $link->setObjectUuid('abc-123');
+        $link->setPollId(99);
+        $link->setPollTitle('Stub Poll');
+        $link->setPollType('textPoll');
+
+        $this->mapper->method('findByObjectUuid')->with('abc-123')->willReturn([$link]);
+        // Polls uninstalled — cached link row used as-is, no DB hop.
+        $this->appManager->method('isEnabledForUser')->with('polls')->willReturn(false);
+
+        $rows = $this->service->getLinkedPolls('abc-123');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('abc-123', $rows[0]['objectUuid']);
+        $this->assertSame(99, $rows[0]['pollId']);
+        $this->assertSame('Stub Poll', $rows[0]['pollTitle']);
+        $this->assertSame('textPoll', $rows[0]['pollType']);
+        $this->assertSame('/index.php/apps/polls/vote/99', $rows[0]['url']);
+    }
+
+    public function testCreateAndLinkPollThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No user logged in');
+
+        $this->service->createAndLinkPoll('abc-123', 1, 2, 'Lunch', '', 'textPoll', ['A'], null);
+    }
+
+    public function testCreateAndLinkPollThrowsWhenPollsUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('polls')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+        $this->expectExceptionMessage('Polls is not available');
+
+        $this->service->createAndLinkPoll('abc-123', 1, 2, 'Lunch', '', 'textPoll', ['A'], null);
+    }
+
+    public function testCreateAndLinkPollThrowsWhenTitleEmpty(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('polls')->willReturn(true);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+        $this->expectExceptionMessage('Title is required');
+
+        $this->service->createAndLinkPoll('abc-123', 1, 2, '   ', '', 'textPoll', ['A'], null);
+    }
+
+    public function testGetAvailablePollsReturnsEmptyWhenPollsUnavailable(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('polls')->willReturn(false);
+        $this->assertSame([], $this->service->getAvailablePolls());
+    }
+
+    public function testGetAvailablePollsReturnsEmptyWhenNoUser(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('polls')->willReturn(true);
+        $this->userSession->method('getUser')->willReturn(null);
+        $this->assertSame([], $this->service->getAvailablePolls());
+    }
+}


### PR DESCRIPTION
## Summary

Tier-2 for the polls integration leaf. Replaces the legacy title-marker convention (\`[or:{uuid}]\` embedded in poll title) with a proper link table.

- New \`openregister_poll_links\` table (Version1Date20260525130000) — composite unique \`(object_uuid, poll_id)\`, carries register_id, schema_id, poll_title, poll_type, deadline, voter_count, option_count, closed.
- \`PollLink\` entity + \`PollLinkMapper\`.
- \`PollLinkService\` with linkPoll / unlinkPoll / getLinkedPolls (refreshes counts + closed from \`oc_polls_polls\` per call — Phase B-3 session-workaround pattern) / getAvailablePolls (picker source) / createAndLinkPoll (direct INSERT into polls_polls + polls_options because Polls' own services need Polls' UserSession populated which OR doesn't).
- \`PollLinksController\` Tier-2 REST surface (GET/POST/DELETE \`…/polls\` + GET \`/api/integrations/polls/available\`).
- \`PollsProvider\` rewritten to read from the link table; DI updated.

## Test plan

- [ ] \`composer phpunit\` passes (PollLink entity, PollLinkService, PollLinksController, PollsProvider rewrites)
- [ ] \`composer check:strict\` clean on new files
- [ ] Migration creates table cleanly on fresh DB and adds columns idempotently on existing
- [ ] Manual: linking → row appears in CnPollsTab; create-new → poll in NC Polls + link instant; unlink removes link only

Refs: openregister#1314, ADR-019, ADR-022. Pairs with nextcloud-vue feature/integration-tier2-polls.