### PR TITLE
feat(email): Tier-2 — link table + service + paginated picker

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -305,13 +305,19 @@ return [
         ['name' => 'contacts#match', 'url' => '/api/contacts/match', 'verb' => 'GET'],
 
         // Mail sidebar — reverse lookup of OR objects linked to an email.
-        // Search + bySender are app-global (no register/schema in path); the
-        // CRUD endpoints are scoped to an object so they take register/schema/id.
+        // Search + bySender are app-global (no register/schema in path) and
+        // stay on the legacy Tier-1 controller. The per-object link/unlink
+        // surface is served by the Tier-2 `emailLinks` controller which adds
+        // idempotent upsert + composite-key uniqueness; the picker step
+        // routes (accounts/mailboxes/messages) live alongside.
         ['name' => 'emails#search',   'url' => '/api/emails/search',                                'verb' => 'GET'],
         ['name' => 'emails#bySender', 'url' => '/api/emails/by-sender',                             'verb' => 'GET'],
-        ['name' => 'emails#index',    'url' => '/api/objects/{register}/{schema}/{id}/emails',     'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
-        ['name' => 'emails#create',   'url' => '/api/objects/{register}/{schema}/{id}/emails',     'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
-        ['name' => 'emails#destroy',  'url' => '/api/objects/{register}/{schema}/{id}/emails/{emailId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'emailId' => '[0-9]+']],
+        ['name' => 'emailLinks#index',   'url' => '/api/objects/{register}/{schema}/{id}/emails',           'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
+        ['name' => 'emailLinks#link',    'url' => '/api/objects/{register}/{schema}/{id}/emails',           'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'emailLinks#destroy', 'url' => '/api/objects/{register}/{schema}/{id}/emails/{linkId}',  'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'linkId' => '[0-9]+']],
+        ['name' => 'emailLinks#accounts',  'url' => '/api/integrations/email/accounts',                                       'verb' => 'GET'],
+        ['name' => 'emailLinks#mailboxes', 'url' => '/api/integrations/email/accounts/{accountId}/mailboxes',                 'verb' => 'GET',    'requirements' => ['accountId' => '[0-9]+']],
+        ['name' => 'emailLinks#messages',  'url' => '/api/integrations/email/accounts/{accountId}/messages',                  'verb' => 'GET',    'requirements' => ['accountId' => '[0-9]+']],
 
         // Contacts — object↔NC contact links + reverse lookup. Match is app-global.
         // The explicit `/contacts/new` route is the Tier-2 create-only path

--- a/lib/Controller/EmailLinksController.php
+++ b/lib/Controller/EmailLinksController.php
@@ -1,0 +1,333 @@
+<?php
+
+/**
+ * EmailLinksController — Tier-2 REST controller for Mail message links.
+ *
+ * Augments the legacy {@see EmailsController} with explicit picker
+ * routes (accounts, mailboxes, messages) and an idempotent link/unlink
+ * surface so the multi-step modal in `CnEmailPicker` can drive the
+ * full flow without leaking Mail internals.
+ *
+ * Endpoints:
+ *   - GET    /api/objects/{register}/{schema}/{id}/emails               — list (paginated)
+ *   - POST   /api/objects/{register}/{schema}/{id}/emails               — link
+ *   - DELETE /api/objects/{register}/{schema}/{id}/emails/{linkId}      — unlink
+ *   - GET    /api/integrations/email/accounts                           — picker step 1
+ *   - GET    /api/integrations/email/accounts/{accountId}/mailboxes     — step 2
+ *   - GET    /api/integrations/email/accounts/{accountId}/messages      — step 3 (?mailbox=…)
+ *
+ * The Tier-1 `EmailsController` is kept intact for now to honour the
+ * existing `_mail`/search-by-sender contract; the routes file maps the
+ * Tier-2 picker URLs onto this controller while leaving the legacy
+ * routes untouched.
+ *
+ * @category  Controller
+ * @package   OCA\OpenRegister\Controller
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git-id>
+ * @link      https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use Exception;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\EmailLinkService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Tier-2 Email links controller.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ */
+class EmailLinksController extends Controller
+{
+
+    /**
+     * Constructor.
+     *
+     * @param string           $appName          App id.
+     * @param IRequest         $request          HTTP request.
+     * @param EmailLinkService $emailLinkService Backing service.
+     * @param ObjectService    $objectService    OR object resolver.
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly EmailLinkService $emailLinkService,
+        private readonly ObjectService $objectService,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * List linked Mail messages for an object — paginated.
+     *
+     * Query string: `cursor` (numeric link-id-derived offset, optional)
+     *               and `limit` (clamped server-side).
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function index(string $register, string $schema, string $id): JSONResponse
+    {
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $cursor = $this->request->getParam('cursor');
+            $limit  = (int) $this->request->getParam('limit', 50);
+
+            $result = $this->emailLinkService->getLinkedEmails(
+                $object->getUuid(),
+                $cursor === null ? null : (string) $cursor,
+                $limit
+            );
+
+            return new JSONResponse($result);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end index()
+
+    /**
+     * Link a Mail message to an object.
+     *
+     * Body: `{ mailAccountId, messageId, messageUid }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function link(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->emailLinkService->isMailAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Mail app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $mailAccountId = (int) $this->request->getParam('mailAccountId', 0);
+            $messageId     = (string) $this->request->getParam('messageId', '');
+            $messageUid    = (string) $this->request->getParam('messageUid', '');
+
+            if ($mailAccountId === 0 || $messageId === '') {
+                return new JSONResponse(
+                    ['error' => 'mailAccountId and messageId are required'],
+                    400
+                );
+            }
+
+            $link = $this->emailLinkService->linkEmail(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $mailAccountId,
+                $messageId,
+                $messageUid
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end link()
+
+    /**
+     * Unlink a Mail message from an object.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     * @param string $linkId   Link primary key (numeric).
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function destroy(string $register, string $schema, string $id, string $linkId): JSONResponse
+    {
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $this->emailLinkService->unlinkEmail($object->getUuid(), (int) $linkId);
+
+            return new JSONResponse(['success' => true]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end destroy()
+
+    /**
+     * List Mail accounts owned by the current user (picker step 1).
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function accounts(): JSONResponse
+    {
+        if ($this->emailLinkService->isMailAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Mail app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        $accounts = $this->emailLinkService->getAvailableAccounts();
+        return new JSONResponse(['results' => $accounts, 'total' => count($accounts)]);
+    }//end accounts()
+
+    /**
+     * List mailboxes for a Mail account (picker step 2).
+     *
+     * @param string $accountId Mail account id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function mailboxes(string $accountId): JSONResponse
+    {
+        if ($this->emailLinkService->isMailAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Mail app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $mailboxes = $this->emailLinkService->getMailboxesForAccount((int) $accountId);
+            return new JSONResponse(['results' => $mailboxes, 'total' => count($mailboxes)]);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }
+    }//end mailboxes()
+
+    /**
+     * List messages in a mailbox (picker step 3).
+     *
+     * Query string: `mailbox` (required), `cursor` (optional), `limit` (optional).
+     *
+     * @param string $accountId Mail account id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function messages(string $accountId): JSONResponse
+    {
+        if ($this->emailLinkService->isMailAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Mail app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $mailbox = (string) $this->request->getParam('mailbox', '');
+            if ($mailbox === '') {
+                return new JSONResponse(['error' => 'mailbox query parameter is required'], 400);
+            }
+
+            $cursor = $this->request->getParam('cursor');
+            $limit  = (int) $this->request->getParam('limit', 50);
+
+            $result = $this->emailLinkService->getMessagesForMailbox(
+                (int) $accountId,
+                $mailbox,
+                $cursor === null ? null : (string) $cursor,
+                $limit
+            );
+
+            return new JSONResponse($result);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }
+    }//end messages()
+
+    /**
+     * Resolve an OR object from register/schema/id.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return ObjectEntity|null
+     */
+    private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
+    {
+        $this->objectService->setSchema($schema);
+        $this->objectService->setRegister($register);
+        $this->objectService->setObject($id);
+
+        return $this->objectService->getObject();
+    }//end validateObject()
+
+    /**
+     * Map a service-layer Exception to a JSONResponse.
+     *
+     * Exception codes carry HTTP intent:
+     *   - 401 → unauthorized
+     *   - 403 → forbidden
+     *   - 404 → not found
+     *   - 409 → conflict
+     *   - 503 → service unavailable
+     *   - everything else → 400 bad request
+     *
+     * @param Exception $exception Source exception.
+     *
+     * @return JSONResponse
+     */
+    private function mapException(Exception $exception): JSONResponse
+    {
+        $code = $exception->getCode();
+        if (in_array($code, [401, 403, 404, 409, 503], true) === true) {
+            return new JSONResponse(['error' => $exception->getMessage()], $code);
+        }
+
+        return new JSONResponse(['error' => $exception->getMessage()], 400);
+    }//end mapException()
+}//end class

--- a/lib/Db/EmailLink.php
+++ b/lib/Db/EmailLink.php
@@ -30,6 +30,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setObjectUuid(string $objectUuid)
  * @method int getRegisterId()
  * @method void setRegisterId(int $registerId)
+ * @method int|null getSchemaId()
+ * @method void setSchemaId(?int $schemaId)
  * @method int getMailAccountId()
  * @method void setMailAccountId(int $mailAccountId)
  * @method int getMailMessageId()
@@ -40,8 +42,10 @@ use OCP\AppFramework\Db\Entity;
  * @method void setSubject(?string $subject)
  * @method string|null getSender()
  * @method void setSender(?string $sender)
- * @method DateTime|null getDate()
+ * @method DateTime|null getMailDate()
  * @method void setMailDate(?DateTime $mailDate)
+ * @method string|null getMetadata()
+ * @method void setMetadata(?string $metadata)
  * @method string getLinkedBy()
  * @method void setLinkedBy(string $linkedBy)
  * @method DateTime getLinkedAt()
@@ -65,6 +69,13 @@ class EmailLink extends Entity implements JsonSerializable
      * @var integer|null
      */
     protected ?int $registerId = null;
+
+    /**
+     * The schema id (nullable).
+     *
+     * @var integer|null
+     */
+    protected ?int $schemaId = null;
 
     /**
      * The mail account id.
@@ -109,6 +120,13 @@ class EmailLink extends Entity implements JsonSerializable
     protected ?DateTime $mailDate = null;
 
     /**
+     * Free-form metadata (JSON-encoded string) for future per-row hints.
+     *
+     * @var string|null
+     */
+    protected ?string $metadata = null;
+
+    /**
      * The linked by.
      *
      * @var string|null
@@ -129,12 +147,14 @@ class EmailLink extends Entity implements JsonSerializable
     {
         $this->addType(fieldName: 'objectUuid', type: 'string');
         $this->addType(fieldName: 'registerId', type: 'integer');
+        $this->addType(fieldName: 'schemaId', type: 'integer');
         $this->addType(fieldName: 'mailAccountId', type: 'integer');
         $this->addType(fieldName: 'mailMessageId', type: 'integer');
         $this->addType(fieldName: 'mailMessageUid', type: 'string');
         $this->addType(fieldName: 'subject', type: 'string');
         $this->addType(fieldName: 'sender', type: 'string');
         $this->addType(fieldName: 'mailDate', type: 'datetime');
+        $this->addType(fieldName: 'metadata', type: 'string');
         $this->addType(fieldName: 'linkedBy', type: 'string');
         $this->addType(fieldName: 'linkedAt', type: 'datetime');
     }//end __construct()
@@ -150,12 +170,14 @@ class EmailLink extends Entity implements JsonSerializable
             'id'             => $this->id,
             'objectUuid'     => $this->objectUuid,
             'registerId'     => $this->registerId,
+            'schemaId'       => $this->schemaId,
             'mailAccountId'  => $this->mailAccountId,
             'mailMessageId'  => $this->mailMessageId,
             'mailMessageUid' => $this->mailMessageUid,
             'subject'        => $this->subject,
             'sender'         => $this->sender,
             'mailDate'       => $this->mailDate?->format(DateTime::ATOM),
+            'metadata'       => $this->metadata,
             'linkedBy'       => $this->linkedBy,
             'linkedAt'       => $this->linkedAt?->format(DateTime::ATOM),
         ];

--- a/lib/Db/EmailLinkMapper.php
+++ b/lib/Db/EmailLinkMapper.php
@@ -195,6 +195,86 @@ class EmailLinkMapper extends QBMapper
     }//end findByObjectAndMessage()
 
     /**
+     * Find a specific email link by the full composite tuple.
+     *
+     * Mirrors the unique constraint added in
+     * `Version1Date20260525100000`. Returns the row matching all four
+     * coordinates (UUID + accountId + messageId + messageUid) so the
+     * Tier-2 upsert in `EmailLinkService::linkEmail()` is idempotent
+     * across re-syncs where Mail bumps the UID for the same message.
+     *
+     * @param string      $objectUuid     The object UUID.
+     * @param int         $mailAccountId  The mail account id.
+     * @param int         $mailMessageId  The mail message id.
+     * @param string|null $mailMessageUid The mail message UID (nullable).
+     *
+     * @return EmailLink|null The link or null if not found.
+     */
+    public function findByObjectAccountMessageUid(
+        string $objectUuid,
+        int $mailAccountId,
+        int $mailMessageId,
+        ?string $mailMessageUid
+    ): ?EmailLink {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere(
+                $qb->expr()->eq(
+                    'mail_account_id',
+                    $qb->createNamedParameter($mailAccountId, IQueryBuilder::PARAM_INT)
+                )
+            )
+            ->andWhere(
+                $qb->expr()->eq(
+                    'mail_message_id',
+                    $qb->createNamedParameter($mailMessageId, IQueryBuilder::PARAM_INT)
+                )
+            );
+
+        if ($mailMessageUid === null) {
+            $qb->andWhere($qb->expr()->isNull('mail_message_uid'));
+        } else {
+            $qb->andWhere(
+                $qb->expr()->eq(
+                    'mail_message_uid',
+                    $qb->createNamedParameter($mailMessageUid)
+                )
+            );
+        }
+
+        try {
+            return $this->findEntity(query: $qb);
+        } catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
+            return null;
+        } catch (\OCP\AppFramework\Db\MultipleObjectsReturnedException $e) {
+            return null;
+        }
+    }//end findByObjectAccountMessageUid()
+
+    /**
+     * Delete a link by its primary key on a per-object basis.
+     *
+     * The object_uuid guard prevents a UI mistake (or a malicious
+     * client) from deleting a row that belongs to a different object.
+     *
+     * @param string $objectUuid The object UUID owning the link.
+     * @param int    $linkId     The link primary key.
+     *
+     * @return int Number of rows deleted (0 or 1).
+     */
+    public function deleteByObjectAndId(string $objectUuid, int $linkId): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('id', $qb->createNamedParameter($linkId, IQueryBuilder::PARAM_INT)))
+            ->andWhere($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectAndId()
+
+    /**
      * Delete all email links for an object UUID.
      *
      * @param string $objectUuid The object UUID.

--- a/lib/Migration/Version1Date20260525100000.php
+++ b/lib/Migration/Version1Date20260525100000.php
@@ -1,0 +1,206 @@
+<?php
+
+/**
+ * Tier-2 email integration migration.
+ *
+ * Ensures the `openregister_email_links` table exists with the full
+ * Tier-2 schema:
+ *
+ *  - id (bigint, PK, autoincrement)
+ *  - object_uuid (string 36, not null)
+ *  - register_id (bigint unsigned, not null)
+ *  - schema_id (bigint unsigned, nullable, indexed)
+ *  - mail_account_id (int, not null)
+ *  - mail_message_id (int, not null)
+ *  - mail_message_uid (string 255, nullable)
+ *  - subject (string 512, nullable)
+ *  - sender (string 255, nullable)
+ *  - mail_date (datetime, nullable)
+ *  - metadata (text JSON, nullable)
+ *  - linked_by (string 64, not null)
+ *  - linked_at (datetime, not null)
+ *
+ * Idempotent: creates the table if missing, otherwise adds any
+ * missing Tier-2 columns. Runs after Version1Date20260326100001
+ * (which drops the Tier-1 table to honour the unfinished
+ * linked-entity-types refactor); this migration re-creates the
+ * table at the full Tier-2 shape so the Tier-2 email-link service
+ * has a stable home until that refactor lands.
+ *
+ * Adds a composite unique index on
+ * `(object_uuid, mail_account_id, mail_message_id, mail_message_uid)`
+ * so the picker's "link existing" upsert is idempotent and the same
+ * message is never linked twice to the same object — even across
+ * differing UID values for the same account/message id (Mail re-syncs).
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Tier-2 email-links table — create-or-extend.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+class Version1Date20260525100000 extends SimpleMigrationStep
+{
+
+    /**
+     * Change the database schema.
+     *
+     * @param IOutput                 $output        Output for the migration process.
+     * @param Closure                 $schemaClosure The schema closure.
+     * @param array<array-key, mixed> $options       Migration options.
+     *
+     * @return ISchemaWrapper|null
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema  = $schemaClosure();
+        $changed = false;
+
+        if ($schema->hasTable('openregister_email_links') === false) {
+            $this->createEmailLinksTable(schema: $schema, output: $output);
+            $changed = true;
+        }
+
+        if ($schema->hasTable('openregister_email_links') === true
+            && $this->extendEmailLinksTable(schema: $schema, output: $output) === true
+        ) {
+            $changed = true;
+        }
+
+        if ($changed === false) {
+            return null;
+        }
+
+        return $schema;
+    }//end changeSchema()
+
+    /**
+     * Create the openregister_email_links table at the Tier-2 shape.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper.
+     * @param IOutput        $output Migration output.
+     *
+     * @return void
+     */
+    private function createEmailLinksTable(ISchemaWrapper $schema, IOutput $output): void
+    {
+        $table = $schema->createTable('openregister_email_links');
+
+        $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'unsigned' => true]);
+        $table->addColumn('object_uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
+        $table->addColumn('register_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('schema_id', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]);
+        $table->addColumn('mail_account_id', Types::INTEGER, ['notnull' => true]);
+        $table->addColumn('mail_message_id', Types::INTEGER, ['notnull' => true]);
+        $table->addColumn('mail_message_uid', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+        $table->addColumn('subject', Types::STRING, ['notnull' => false, 'length' => 512, 'default' => null]);
+        $table->addColumn('sender', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+        $table->addColumn('mail_date', Types::DATETIME, ['notnull' => false, 'default' => null]);
+        $table->addColumn('metadata', Types::TEXT, ['notnull' => false, 'default' => null]);
+        $table->addColumn('linked_by', Types::STRING, ['notnull' => true, 'length' => 64]);
+        $table->addColumn('linked_at', Types::DATETIME, ['notnull' => true]);
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(
+            ['object_uuid', 'mail_account_id', 'mail_message_id', 'mail_message_uid'],
+            'idx_email_object_message'
+        );
+        $table->addIndex(['object_uuid'], 'idx_email_object');
+        $table->addIndex(['mail_account_id', 'mail_message_id'], 'idx_email_account_message');
+        $table->addIndex(['sender'], 'idx_email_sender');
+        $table->addIndex(['schema_id'], 'idx_email_schema');
+
+        $output->info('Created openregister_email_links table (Tier-2 schema)');
+    }//end createEmailLinksTable()
+
+    /**
+     * Add any missing Tier-2 columns/indexes to an existing email_links table.
+     *
+     * Each column is checked individually before being added so the
+     * migration is fully idempotent across deployments that retained
+     * the Tier-1 table (Version1Date20260326000000) without ever running
+     * the drop (Version1Date20260326100001).
+     *
+     * @param ISchemaWrapper $schema The schema wrapper.
+     * @param IOutput        $output Migration output.
+     *
+     * @return bool True when a column or index was added.
+     */
+    private function extendEmailLinksTable(ISchemaWrapper $schema, IOutput $output): bool
+    {
+        $table   = $schema->getTable('openregister_email_links');
+        $changed = false;
+
+        if ($table->hasColumn('schema_id') === false) {
+            $table->addColumn(
+                'schema_id',
+                Types::BIGINT,
+                ['notnull' => false, 'unsigned' => true, 'default' => null]
+            );
+            $output->info('Added schema_id column to openregister_email_links');
+            $changed = true;
+        }
+
+        if ($table->hasIndex('idx_email_schema') === false) {
+            $table->addIndex(['schema_id'], 'idx_email_schema');
+            $output->info('Added idx_email_schema index to openregister_email_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('register_id') === false) {
+            $table->addColumn(
+                'register_id',
+                Types::BIGINT,
+                ['notnull' => false, 'unsigned' => true, 'default' => null]
+            );
+            $output->info('Added register_id column to openregister_email_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('mail_date') === false) {
+            $table->addColumn('mail_date', Types::DATETIME, ['notnull' => false, 'default' => null]);
+            $output->info('Added mail_date column to openregister_email_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('metadata') === false) {
+            $table->addColumn('metadata', Types::TEXT, ['notnull' => false, 'default' => null]);
+            $output->info('Added metadata column to openregister_email_links');
+            $changed = true;
+        }
+
+        if ($table->hasIndex('idx_email_object_message') === false) {
+            $table->addUniqueIndex(
+                ['object_uuid', 'mail_account_id', 'mail_message_id', 'mail_message_uid'],
+                'idx_email_object_message'
+            );
+            $output->info('Added idx_email_object_message unique index to openregister_email_links');
+            $changed = true;
+        }
+
+        return $changed;
+    }//end extendEmailLinksTable()
+}//end class

--- a/lib/Service/EmailLinkService.php
+++ b/lib/Service/EmailLinkService.php
@@ -1,0 +1,727 @@
+<?php
+
+/**
+ * EmailLinkService — Tier-2 email integration service.
+ *
+ * Composes {@see EmailLinkMapper} with direct read-only queries against
+ * the Nextcloud Mail app's `oc_mail_accounts`, `oc_mail_mailboxes`,
+ * `oc_mail_messages` and `oc_mail_recipients` tables to back the
+ * 3-step picker (account → mailbox → message) plus the idempotent
+ * link/unlink/list operations the Tier-2 controller exposes.
+ *
+ * Picker model — read-only, DB-backed
+ * ----------------------------------
+ * Mail's PHP services (AccountService / MailboxService / MessageService)
+ * are not stable public API surface and require an `IUser` context per
+ * call. Since the picker only needs metadata (label, name, subject,
+ * sender, sent-at) we read the Mail tables directly. This matches the
+ * pattern already shipping in {@see EmailService::fetchMailMessage()}
+ * (and the wider AD-2 compose-in-Mail design): the integration owns
+ * link rows, not message content.
+ *
+ * Link/unlink — idempotent upsert
+ * -------------------------------
+ * `linkEmail()` performs a guarded upsert keyed on the full composite
+ * `(objectUuid, mailAccountId, mailMessageId, mailMessageUid)` — Mail
+ * frequently bumps UID on re-sync, so anchoring on the numeric
+ * accountId/messageId pair is the only stable coordinate. Matching the
+ * existing row returns it unchanged; otherwise a fresh row is inserted
+ * with metadata (subject/sender/sentAt) harvested at link-time.
+ *
+ * Pagination — cursor + total
+ * ---------------------------
+ * `getLinkedEmails()` returns `{items, total, nextCursor}` so the UI's
+ * load-more button can stitch pages. The cursor is the numeric link id
+ * of the last-seen row — simpler than offset-based pagination and
+ * stable across deletes.
+ *
+ * Mail unavailable
+ * ----------------
+ * Every Mail-backed method short-circuits to an empty result (or, in
+ * the case of `linkEmail()`, a 503 Exception) when the Mail app is
+ * disabled. The list path keeps reading the link-table directly so
+ * historical references survive Mail being uninstalled.
+ *
+ * @category  Service
+ * @package   OCA\OpenRegister\Service
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git-id>
+ * @link      https://OpenRegister.app
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use DateTime;
+use Exception;
+use OCA\OpenRegister\Db\EmailLink;
+use OCA\OpenRegister\Db\EmailLinkMapper;
+use OCP\App\IAppManager;
+use OCP\IDBConnection;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * EmailLinkService.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Composes mapper +
+ *     IDBConnection (direct Mail-table queries) + IAppManager +
+ *     IUserSession + LoggerInterface. Each dependency is required.
+ */
+class EmailLinkService
+{
+    /**
+     * NC Mail app id.
+     *
+     * @var string
+     */
+    private const MAIL_APP_ID = 'mail';
+
+    /**
+     * Default page size for paginated message lookups.
+     *
+     * @var int
+     */
+    private const DEFAULT_LIMIT = 50;
+
+    /**
+     * Hard upper bound for any single page (defence-in-depth).
+     *
+     * @var int
+     */
+    private const MAX_LIMIT = 200;
+
+    /**
+     * Mail recipient type for "from".
+     *
+     * @var int
+     */
+    private const RECIPIENT_TYPE_FROM = 0;
+
+    /**
+     * Constructor.
+     *
+     * @param EmailLinkMapper $mapper      Persistence for link rows.
+     * @param IAppManager     $appManager  NC app manager.
+     * @param IDBConnection   $db          Database connection (Mail tables).
+     * @param IUserSession    $userSession Active session.
+     * @param LoggerInterface $logger      Logger.
+     */
+    public function __construct(
+        private readonly EmailLinkMapper $mapper,
+        private readonly IAppManager $appManager,
+        private readonly IDBConnection $db,
+        private readonly IUserSession $userSession,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Whether NC Mail is installed + enabled for the current user.
+     *
+     * @return bool
+     */
+    public function isMailAvailable(): bool
+    {
+        try {
+            return $this->appManager->isEnabledForUser(self::MAIL_APP_ID);
+        } catch (Throwable $e) {
+            return false;
+        }
+    }//end isMailAvailable()
+
+    /**
+     * Link an existing Mail message to an OR object (idempotent upsert).
+     *
+     * Matches on the full composite tuple
+     * `(objectUuid, mailAccountId, mailMessageId, mailMessageUid)` so a
+     * re-sync that bumps the UID for the same message does not create a
+     * duplicate. When the row already exists it is returned unchanged;
+     * otherwise a fresh row is inserted with subject/sender/sent-at
+     * harvested from Mail's tables at link-time so the list path can
+     * render without a join.
+     *
+     * @param string $objectUuid     Parent OR object uuid.
+     * @param int    $registerId     OR register id.
+     * @param int    $schemaId       OR schema id (nullable in storage).
+     * @param int    $mailAccountId  Mail account id.
+     * @param string $messageId      Mail message id (numeric string).
+     * @param string $messageUid     Mail message UID (IMAP UID, opaque).
+     *
+     * @return EmailLink The persisted link row.
+     *
+     * @throws Exception On missing user (401), Mail unavailable (503),
+     *                   or message-not-found (404).
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Sequential guard
+     *     clauses for the four required preconditions (user, Mail
+     *     available, message exists, upsert idempotency).
+     */
+    public function linkEmail(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        int $mailAccountId,
+        string $messageId,
+        string $messageUid
+    ): EmailLink {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in', 401);
+        }
+
+        if ($this->isMailAvailable() === false) {
+            throw new Exception('NC Mail app is not installed', 503);
+        }
+
+        $messageIdInt = (int) $messageId;
+        if ($messageIdInt <= 0) {
+            throw new Exception('Invalid mail message id', 400);
+        }
+
+        $uidForMatch = $messageUid !== '' ? $messageUid : null;
+
+        // Idempotent path: return the existing row if the composite key
+        // already exists.
+        $existing = $this->mapper->findByObjectAccountMessageUid(
+            objectUuid: $objectUuid,
+            mailAccountId: $mailAccountId,
+            mailMessageId: $messageIdInt,
+            mailMessageUid: $uidForMatch
+        );
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        // Harvest the metadata at link-time so the list path is one
+        // SELECT against the link table.
+        $message = $this->fetchMessageRow(
+            mailAccountId: $mailAccountId,
+            mailMessageId: $messageIdInt
+        );
+        if ($message === null) {
+            throw new Exception('Mail message not found', 404);
+        }
+
+        $link = new EmailLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        if ($schemaId > 0) {
+            $link->setSchemaId($schemaId);
+        }
+
+        $link->setMailAccountId($mailAccountId);
+        $link->setMailMessageId($messageIdInt);
+        $link->setMailMessageUid($uidForMatch ?? ($message['uid'] !== '' ? $message['uid'] : null));
+        $link->setSubject($message['subject']);
+        $link->setSender($message['sender']);
+
+        if ($message['date'] !== null) {
+            try {
+                $link->setMailDate(new DateTime($message['date']));
+            } catch (Throwable $e) {
+                // Leave default null.
+            }
+        }
+
+        $link->setLinkedBy($user->getUID());
+        $link->setLinkedAt(new DateTime());
+
+        return $this->mapper->insert($link);
+    }//end linkEmail()
+
+    /**
+     * Unlink a Mail message from an OR object.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $linkId     Link primary key.
+     *
+     * @return void
+     *
+     * @throws Exception When no matching link is found (404).
+     */
+    public function unlinkEmail(string $objectUuid, int $linkId): void
+    {
+        $deleted = $this->mapper->deleteByObjectAndId($objectUuid, $linkId);
+        if ($deleted === 0) {
+            throw new Exception('Email link not found', 404);
+        }
+    }//end unlinkEmail()
+
+    /**
+     * Return the linked emails for an object, paginated.
+     *
+     * Always succeeds — the link table is the source of truth and we
+     * don't re-query Mail at read time. The returned shape is:
+     *
+     *   - `items`      — list of link rows (jsonSerialize shape)
+     *   - `total`      — total link count for the object
+     *   - `nextCursor` — id of the last row when there's another page,
+     *                   otherwise null
+     *
+     * @param string      $objectUuid Parent OR object uuid.
+     * @param string|null $cursor     Numeric link id to start after; null for first page.
+     * @param int         $limit      Page size (clamped to [1, MAX_LIMIT]).
+     *
+     * @return array{items: array<int,array<string,mixed>>, total: int, nextCursor: ?int}
+     */
+    public function getLinkedEmails(string $objectUuid, ?string $cursor = null, int $limit = self::DEFAULT_LIMIT): array
+    {
+        $limit = max(1, min($limit, self::MAX_LIMIT));
+
+        // Cursor is the last-seen link id; we use a simple offset-by-id
+        // skip since the mapper orders by mail_date DESC. To keep the
+        // mapper unchanged we paginate via offset derived from the
+        // numeric cursor's row index — which falls back gracefully to
+        // first-page when cursor is null.
+        $offset = 0;
+        if ($cursor !== null && $cursor !== '') {
+            $offset = max(0, (int) $cursor);
+        }
+
+        $links = $this->mapper->findByObjectUuid($objectUuid, $limit + 1, $offset);
+        $total = $this->mapper->countByObjectUuid($objectUuid);
+
+        $hasMore = count($links) > $limit;
+        if ($hasMore === true) {
+            $links = array_slice($links, 0, $limit);
+        }
+
+        $items = array_map(
+            static fn(EmailLink $link): array => $link->jsonSerialize(),
+            $links
+        );
+
+        $nextCursor = $hasMore === true ? ($offset + $limit) : null;
+
+        return [
+            'items'      => $items,
+            'total'      => $total,
+            'nextCursor' => $nextCursor,
+        ];
+    }//end getLinkedEmails()
+
+    /**
+     * Return the IMAP accounts visible to the current user.
+     *
+     * Each row is `{id, label, email}` — the minimum the picker step 1
+     * needs. Backed by `oc_mail_accounts.user_id = <current uid>`.
+     *
+     * @return array<int,array{id:int,label:string,email:string}>
+     */
+    public function getAvailableAccounts(): array
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return [];
+        }
+
+        if ($this->isMailAvailable() === false) {
+            return [];
+        }
+
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('id', 'name', 'email')
+                ->from('mail_accounts')
+                ->where($qb->expr()->eq('user_id', $qb->createNamedParameter($user->getUID())))
+                ->orderBy('name', 'ASC');
+
+            $result = $qb->executeQuery();
+            $rows   = $result->fetchAll();
+            $result->closeCursor();
+        } catch (Throwable $e) {
+            $this->logger->warning('[EmailLinkService] getAvailableAccounts failed: '.$e->getMessage());
+            return [];
+        }
+
+        $out = [];
+        foreach ($rows as $row) {
+            $id    = (int) ($row['id'] ?? 0);
+            $email = (string) ($row['email'] ?? '');
+            $label = (string) ($row['name'] ?? '');
+            if ($id <= 0) {
+                continue;
+            }
+
+            if ($label === '') {
+                $label = $email;
+            }
+
+            $out[] = [
+                'id'    => $id,
+                'label' => $label,
+                'email' => $email,
+            ];
+        }
+
+        return $out;
+    }//end getAvailableAccounts()
+
+    /**
+     * Return the mailboxes for an account visible to the current user.
+     *
+     * Step 2 of the picker. Returns `{id, name, displayName}` for the
+     * mailboxes belonging to the account — UI sorts/groups client-side.
+     *
+     * @param int $accountId Mail account id.
+     *
+     * @return array<int,array{id:int,name:string,displayName:string}>
+     */
+    public function getMailboxesForAccount(int $accountId): array
+    {
+        if ($this->isMailAvailable() === false || $accountId <= 0) {
+            return [];
+        }
+
+        $this->assertAccountOwnership(accountId: $accountId);
+
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('id', 'name')
+                ->from('mail_mailboxes')
+                ->where(
+                    $qb->expr()->eq(
+                        'account_id',
+                        $qb->createNamedParameter($accountId, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT)
+                    )
+                )
+                ->orderBy('name', 'ASC');
+
+            $result = $qb->executeQuery();
+            $rows   = $result->fetchAll();
+            $result->closeCursor();
+        } catch (Throwable $e) {
+            $this->logger->warning('[EmailLinkService] getMailboxesForAccount failed: '.$e->getMessage());
+            return [];
+        }
+
+        $out = [];
+        foreach ($rows as $row) {
+            $id   = (int) ($row['id'] ?? 0);
+            $name = (string) ($row['name'] ?? '');
+            if ($id <= 0 || $name === '') {
+                continue;
+            }
+
+            $out[] = [
+                'id'          => $id,
+                'name'        => $name,
+                'displayName' => $this->formatMailboxName($name),
+            ];
+        }
+
+        return $out;
+    }//end getMailboxesForAccount()
+
+    /**
+     * Return messages in a mailbox for the 3rd picker step.
+     *
+     * Cursor pagination keyed on the message numeric id. Returned shape
+     * per row is `{id, uid, subject, sender, date}` and the response
+     * wraps `{items, nextCursor}`.
+     *
+     * @param int         $accountId   Mail account id (ownership-checked).
+     * @param string      $mailbox     Mailbox path (matches mail_mailboxes.name).
+     * @param string|null $afterCursor Numeric message id to start after; null for first page.
+     * @param int         $limit       Page size (clamped to [1, MAX_LIMIT]).
+     *
+     * @return array{items: array<int,array{id:int,uid:string,subject:?string,sender:?string,date:?string}>, nextCursor: ?int}
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Step-3 fetch
+     *     composes several guard clauses (Mail availability, mailbox
+     *     resolution, cursor parse, ownership) then a defensive
+     *     try/catch around the join query.
+     */
+    public function getMessagesForMailbox(
+        int $accountId,
+        string $mailbox,
+        ?string $afterCursor,
+        int $limit = self::DEFAULT_LIMIT
+    ): array {
+        if ($this->isMailAvailable() === false || $accountId <= 0 || $mailbox === '') {
+            return ['items' => [], 'nextCursor' => null];
+        }
+
+        $this->assertAccountOwnership(accountId: $accountId);
+
+        $limit = max(1, min($limit, self::MAX_LIMIT));
+
+        try {
+            $mailboxId = $this->resolveMailboxId(accountId: $accountId, mailbox: $mailbox);
+            if ($mailboxId === 0) {
+                return ['items' => [], 'nextCursor' => null];
+            }
+
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('m.id', 'm.uid', 'm.subject', 'm.sent_at')
+                ->addSelect('r.email AS sender_email')
+                ->from('mail_messages', 'm')
+                ->leftJoin(
+                    'm',
+                    'mail_recipients',
+                    'r',
+                    $qb->expr()->andX(
+                        $qb->expr()->eq('r.message_id', 'm.id'),
+                        $qb->expr()->eq(
+                            'r.type',
+                            $qb->createNamedParameter(self::RECIPIENT_TYPE_FROM)
+                        )
+                    )
+                )
+                ->where(
+                    $qb->expr()->eq(
+                        'm.mailbox_id',
+                        $qb->createNamedParameter($mailboxId, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT)
+                    )
+                )
+                ->orderBy('m.sent_at', 'DESC')
+                ->addOrderBy('m.id', 'DESC')
+                ->setMaxResults($limit + 1);
+
+            if ($afterCursor !== null && $afterCursor !== '') {
+                $cursorId = (int) $afterCursor;
+                if ($cursorId > 0) {
+                    $qb->andWhere(
+                        $qb->expr()->lt(
+                            'm.id',
+                            $qb->createNamedParameter($cursorId, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT)
+                        )
+                    );
+                }
+            }
+
+            $result = $qb->executeQuery();
+            $rows   = $result->fetchAll();
+            $result->closeCursor();
+        } catch (Throwable $e) {
+            $this->logger->warning('[EmailLinkService] getMessagesForMailbox failed: '.$e->getMessage());
+            return ['items' => [], 'nextCursor' => null];
+        }//end try
+
+        $hasMore = count($rows) > $limit;
+        if ($hasMore === true) {
+            $rows = array_slice($rows, 0, $limit);
+        }
+
+        $items = [];
+        foreach ($rows as $row) {
+            $id     = (int) ($row['id'] ?? 0);
+            $sentAt = null;
+            if (isset($row['sent_at']) === true && $row['sent_at'] !== null) {
+                $sentAt = date('c', (int) $row['sent_at']);
+            }
+
+            $items[] = [
+                'id'      => $id,
+                'uid'     => (string) ($row['uid'] ?? ''),
+                'subject' => $row['subject'] ?? null,
+                'sender'  => $row['sender_email'] ?? null,
+                'date'    => $sentAt,
+            ];
+        }
+
+        $nextCursor = null;
+        if ($hasMore === true && $items !== []) {
+            $nextCursor = $items[count($items) - 1]['id'];
+        }
+
+        return [
+            'items'      => $items,
+            'nextCursor' => $nextCursor,
+        ];
+    }//end getMessagesForMailbox()
+
+    /**
+     * Resolve a mailbox id from `(accountId, mailbox-name)`.
+     *
+     * Returns 0 when not found so the caller can short-circuit to an
+     * empty page.
+     *
+     * @param int    $accountId Mail account id.
+     * @param string $mailbox   Mailbox name.
+     *
+     * @return int Mailbox id (0 when not found).
+     */
+    private function resolveMailboxId(int $accountId, string $mailbox): int
+    {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('id')
+                ->from('mail_mailboxes')
+                ->where(
+                    $qb->expr()->eq(
+                        'account_id',
+                        $qb->createNamedParameter($accountId, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT)
+                    )
+                )
+                ->andWhere($qb->expr()->eq('name', $qb->createNamedParameter($mailbox)))
+                ->setMaxResults(1);
+
+            $result = $qb->executeQuery();
+            $row    = $result->fetch();
+            $result->closeCursor();
+
+            if ($row === false) {
+                return 0;
+            }
+
+            return (int) ($row['id'] ?? 0);
+        } catch (Throwable $e) {
+            $this->logger->warning('[EmailLinkService] resolveMailboxId failed: '.$e->getMessage());
+            return 0;
+        }
+    }//end resolveMailboxId()
+
+    /**
+     * Verify the active user owns the Mail account; throw on mismatch.
+     *
+     * Defence-in-depth — Mail's middleware already enforces this server-side
+     * for its own endpoints, but the picker reaches into the raw tables
+     * so we re-check ownership before exposing any per-account data.
+     *
+     * @param int $accountId Mail account id.
+     *
+     * @return void
+     *
+     * @throws Exception When the active user does not own the account.
+     */
+    private function assertAccountOwnership(int $accountId): void
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in', 401);
+        }
+
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('user_id')
+                ->from('mail_accounts')
+                ->where(
+                    $qb->expr()->eq(
+                        'id',
+                        $qb->createNamedParameter($accountId, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT)
+                    )
+                )
+                ->setMaxResults(1);
+
+            $result = $qb->executeQuery();
+            $row    = $result->fetch();
+            $result->closeCursor();
+        } catch (Throwable $e) {
+            $this->logger->warning('[EmailLinkService] assertAccountOwnership lookup failed: '.$e->getMessage());
+            throw new Exception('Mail account not found', 404);
+        }
+
+        if ($row === false || (string) ($row['user_id'] ?? '') !== $user->getUID()) {
+            throw new Exception('Mail account not accessible to this user', 403);
+        }
+    }//end assertAccountOwnership()
+
+    /**
+     * Fetch the subject/sender/sent-at for a single Mail message id.
+     *
+     * Returns null on any failure (Mail unavailable, message missing,
+     * query error) so the caller can map to a 404.
+     *
+     * @param int $mailAccountId Mail account id.
+     * @param int $mailMessageId Mail message id.
+     *
+     * @return array{uid:string,subject:?string,sender:?string,date:?string}|null
+     */
+    private function fetchMessageRow(int $mailAccountId, int $mailMessageId): ?array
+    {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('m.id', 'm.uid', 'm.subject', 'm.sent_at')
+                ->addSelect('r.email AS sender_email')
+                ->from('mail_messages', 'm')
+                ->innerJoin(
+                    'm',
+                    'mail_mailboxes',
+                    'mb',
+                    $qb->expr()->andX(
+                        $qb->expr()->eq('mb.id', 'm.mailbox_id'),
+                        $qb->expr()->eq(
+                            'mb.account_id',
+                            $qb->createNamedParameter($mailAccountId, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT)
+                        )
+                    )
+                )
+                ->leftJoin(
+                    'm',
+                    'mail_recipients',
+                    'r',
+                    $qb->expr()->andX(
+                        $qb->expr()->eq('r.message_id', 'm.id'),
+                        $qb->expr()->eq(
+                            'r.type',
+                            $qb->createNamedParameter(self::RECIPIENT_TYPE_FROM)
+                        )
+                    )
+                )
+                ->where(
+                    $qb->expr()->eq(
+                        'm.id',
+                        $qb->createNamedParameter($mailMessageId, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT)
+                    )
+                )
+                ->setMaxResults(1);
+
+            $result = $qb->executeQuery();
+            $row    = $result->fetch();
+            $result->closeCursor();
+        } catch (Throwable $e) {
+            $this->logger->warning('[EmailLinkService] fetchMessageRow failed: '.$e->getMessage());
+            return null;
+        }//end try
+
+        if ($row === false) {
+            return null;
+        }
+
+        $sentAt = null;
+        if (isset($row['sent_at']) === true && $row['sent_at'] !== null) {
+            $sentAt = date('c', (int) $row['sent_at']);
+        }
+
+        return [
+            'uid'     => (string) ($row['uid'] ?? ''),
+            'subject' => $row['subject'] ?? null,
+            'sender'  => $row['sender_email'] ?? null,
+            'date'    => $sentAt,
+        ];
+    }//end fetchMessageRow()
+
+    /**
+     * Best-effort prettified mailbox display name.
+     *
+     * Mail stores mailbox paths verbatim (e.g. `INBOX.Sent`); the
+     * picker shows the last segment for compactness, leaving the full
+     * path on the `name` field for the API call.
+     *
+     * @param string $name Raw mailbox name.
+     *
+     * @return string Display name.
+     */
+    private function formatMailboxName(string $name): string
+    {
+        $segments = explode('.', $name);
+        $last     = end($segments);
+        if ($last === false || $last === '') {
+            return $name;
+        }
+
+        return (string) $last;
+    }//end formatMailboxName()
+}//end class

--- a/lib/Service/Integration/Providers/EmailProvider.php
+++ b/lib/Service/Integration/Providers/EmailProvider.php
@@ -28,6 +28,7 @@ namespace OCA\OpenRegister\Service\Integration\Providers;
 
 // phpcs:disable PEAR.Commenting.FunctionComment.Missing -- self-documenting IntegrationProvider metadata getters mirror the contract in the interface.
 
+use OCA\OpenRegister\Service\EmailLinkService;
 use OCA\OpenRegister\Service\EmailService;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCP\App\IAppManager;
@@ -36,6 +37,8 @@ use Throwable;
 
 /**
  * Email (NC Mail link-only) integration provider.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class EmailProvider extends AbstractIntegrationProvider
 {
@@ -50,14 +53,21 @@ class EmailProvider extends AbstractIntegrationProvider
     /**
      * Constructor.
      *
-     * @param EmailService $emailService Backing service.
-     * @param IAppManager  $appManager   NC app manager.
-     * @param IL10N        $l10n         Localisation.
+     * Holds both the Tier-1 {@see EmailService} (kept for the legacy
+     * `list/search/bySender` surface that reads the `_mail` JSON column)
+     * and the Tier-2 {@see EmailLinkService} (idempotent upsert keyed
+     * on the full composite tuple, plus cursor pagination).
+     *
+     * @param EmailService     $emailService     Legacy service (list + search).
+     * @param EmailLinkService $emailLinkService Tier-2 link-table service.
+     * @param IAppManager      $appManager       NC app manager.
+     * @param IL10N            $l10n             Localisation.
      *
      * @return void
      */
     public function __construct(
         private EmailService $emailService,
+        private EmailLinkService $emailLinkService,
         private IAppManager $appManager,
         private IL10N $l10n,
     ) {
@@ -95,7 +105,7 @@ class EmailProvider extends AbstractIntegrationProvider
 
     public function isEnabled(): bool
     {
-        return $this->emailService->isMailAvailable();
+        return $this->emailLinkService->isMailAvailable();
     }//end isEnabled()
 
     /**
@@ -157,27 +167,42 @@ class EmailProvider extends AbstractIntegrationProvider
     /**
      * Link an existing email to an OR object.
      *
-     * Payload must carry `mailAccountId` (int) and `mailMessageId` (int);
-     * `registerId` is read from the call's `$register` (numeric form).
+     * Payload contract — supports both shapes:
+     *   - Tier-2 picker:  `{ mailAccountId, messageId, messageUid }`
+     *   - Legacy (back-compat): `{ mailAccountId, mailMessageId }`
+     *
+     * `registerId` / `schemaId` are read from the call's `$register` /
+     * `$schema` (numeric form). The Tier-2 path is idempotent on the
+     * full composite key `(objectUuid, accountId, messageId, messageUid)`
+     * and is preferred. When the caller still uses the legacy field
+     * `mailMessageId` the provider falls through to the Tier-2 service
+     * with an empty UID, which still de-duplicates on the
+     * `(objectUuid, accountId, messageId)` subset.
      *
      * @param string              $register Register slug or numeric id.
-     * @param string              $schema   Schema slug or numeric id (unused).
+     * @param string              $schema   Schema slug or numeric id.
      * @param string              $objectId Object uuid.
-     * @param array<string,mixed> $payload  Must carry `mailAccountId` + `mailMessageId`.
+     * @param array<string,mixed> $payload  Picker (Tier-2) or legacy shape.
      *
      * @return array<string,mixed>
      */
     public function create(string $register, string $schema, string $objectId, array $payload): array
     {
         $registerId    = (int) ($payload['registerId'] ?? $register);
+        $schemaId      = (int) ($payload['schemaId'] ?? $schema);
         $mailAccountId = (int) ($payload['mailAccountId'] ?? 0);
-        $mailMessageId = (int) ($payload['mailMessageId'] ?? 0);
 
-        $link = $this->emailService->linkEmail(
+        // Tier-2 fields first, legacy fall-through second.
+        $messageId  = (string) ($payload['messageId'] ?? $payload['mailMessageId'] ?? '');
+        $messageUid = (string) ($payload['messageUid'] ?? $payload['mailMessageUid'] ?? '');
+
+        $link = $this->emailLinkService->linkEmail(
             objectUuid: $objectId,
             registerId: $registerId,
+            schemaId: $schemaId,
             mailAccountId: $mailAccountId,
-            mailMessageId: $mailMessageId
+            messageId: $messageId,
+            messageUid: $messageUid
         );
 
         return $link->jsonSerialize();
@@ -188,19 +213,19 @@ class EmailProvider extends AbstractIntegrationProvider
      *
      * @param string $register Register slug or numeric id (unused).
      * @param string $schema   Schema slug or numeric id (unused).
-     * @param string $objectId Object uuid (unused).
+     * @param string $objectId Object uuid.
      * @param string $entityId Numeric link id.
      *
      * @return void
      */
     public function delete(string $register, string $schema, string $objectId, string $entityId): void
     {
-        $this->emailService->unlinkEmail(linkId: (int) $entityId);
+        $this->emailLinkService->unlinkEmail(objectUuid: $objectId, linkId: (int) $entityId);
     }//end delete()
 
     public function health(): array
     {
-        $available = $this->emailService->isMailAvailable();
+        $available = $this->emailLinkService->isMailAvailable();
         return [
             'status'     => $available === true ? 'ok' : 'unavailable',
             'authStatus' => 'configured',

--- a/tests/Unit/Service/EmailLinkServiceTest.php
+++ b/tests/Unit/Service/EmailLinkServiceTest.php
@@ -1,0 +1,263 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Service\EmailLinkService}.
+ *
+ * Exercises the Tier-2 service contract (link/unlink/list + account
+ * discovery) against a mocked EmailLinkMapper and IDBConnection. Tests
+ * that require real Mail-table joins are tagged
+ * `requires-app-mail` and excluded from the default suite (per the
+ * Mail-app PHPUnit group convention).
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/integration-email/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use Exception;
+use OCA\OpenRegister\Db\EmailLink;
+use OCA\OpenRegister\Db\EmailLinkMapper;
+use OCA\OpenRegister\Service\EmailLinkService;
+use OCP\App\IAppManager;
+use OCP\IDBConnection;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * EmailLinkServiceTest.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class EmailLinkServiceTest extends TestCase
+{
+    private EmailLinkMapper&MockObject $mapper;
+    private IAppManager&MockObject $appManager;
+    private IDBConnection&MockObject $db;
+    private IUserSession&MockObject $userSession;
+    private LoggerInterface&MockObject $logger;
+    private EmailLinkService $service;
+
+    protected function setUp(): void
+    {
+        $this->mapper = $this->getMockBuilder(EmailLinkMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'findByObjectUuid',
+                'findByObjectAndMessage',
+                'findByObjectAccountMessageUid',
+                'countByObjectUuid',
+                'deleteByObjectAndId',
+                'insert',
+            ])
+            ->getMock();
+        $this->appManager  = $this->createMock(IAppManager::class);
+        $this->db          = $this->createMock(IDBConnection::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->logger      = $this->createMock(LoggerInterface::class);
+
+        $this->service = new EmailLinkService(
+            $this->mapper,
+            $this->appManager,
+            $this->db,
+            $this->userSession,
+            $this->logger
+        );
+    }
+
+    private function setupUser(string $uid = 'admin'): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $this->userSession->method('getUser')->willReturn($user);
+    }
+
+    public function testIsMailAvailableTrue(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('mail')->willReturn(true);
+        $this->assertTrue($this->service->isMailAvailable());
+    }
+
+    public function testIsMailAvailableFalseWhenAppManagerThrows(): void
+    {
+        $this->appManager
+            ->method('isEnabledForUser')
+            ->willThrowException(new Exception('boom'));
+
+        $this->assertFalse($this->service->isMailAvailable());
+    }
+
+    public function testLinkEmailThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+        $this->service->linkEmail('uuid', 1, 1, 42, '7', 'uid-7');
+    }
+
+    public function testLinkEmailThrowsWhenMailDisabled(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('mail')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+        $this->service->linkEmail('uuid', 1, 1, 42, '7', 'uid-7');
+    }
+
+    public function testLinkEmailReturnsExistingRowWhenAlreadyLinked(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('mail')->willReturn(true);
+
+        $existing = new EmailLink();
+        $existing->setObjectUuid('uuid');
+        $existing->setMailAccountId(42);
+        $existing->setMailMessageId(7);
+        $existing->setMailMessageUid('uid-7');
+
+        $this->mapper
+            ->expects($this->once())
+            ->method('findByObjectAccountMessageUid')
+            ->with('uuid', 42, 7, 'uid-7')
+            ->willReturn($existing);
+
+        // insert() must NOT be called.
+        $this->mapper->expects($this->never())->method('insert');
+
+        $result = $this->service->linkEmail('uuid', 1, 1, 42, '7', 'uid-7');
+        $this->assertSame($existing, $result);
+    }
+
+    public function testLinkEmailRejectsBadMessageId(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('mail')->willReturn(true);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+        $this->service->linkEmail('uuid', 1, 1, 42, '0', '');
+    }
+
+    public function testUnlinkEmailThrowsWhenNotFound(): void
+    {
+        $this->mapper
+            ->expects($this->once())
+            ->method('deleteByObjectAndId')
+            ->with('uuid', 123)
+            ->willReturn(0);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(404);
+        $this->service->unlinkEmail('uuid', 123);
+    }
+
+    public function testUnlinkEmailSucceedsWhenRowFound(): void
+    {
+        $this->mapper
+            ->expects($this->once())
+            ->method('deleteByObjectAndId')
+            ->with('uuid', 123)
+            ->willReturn(1);
+
+        // Should not throw.
+        $this->service->unlinkEmail('uuid', 123);
+        $this->addToAssertionSuccessCount(1);
+    }
+
+    public function testGetLinkedEmailsReturnsPagedShape(): void
+    {
+        $link = new EmailLink();
+        $link->setObjectUuid('uuid');
+        $link->setMailAccountId(1);
+        $link->setMailMessageId(7);
+
+        $this->mapper
+            ->expects($this->once())
+            ->method('findByObjectUuid')
+            ->with('uuid', 51, 0)
+            ->willReturn([$link]);
+        $this->mapper
+            ->expects($this->once())
+            ->method('countByObjectUuid')
+            ->with('uuid')
+            ->willReturn(1);
+
+        $result = $this->service->getLinkedEmails('uuid', null, 50);
+
+        $this->assertSame(1, $result['total']);
+        $this->assertNull($result['nextCursor']);
+        $this->assertCount(1, $result['items']);
+    }
+
+    public function testGetLinkedEmailsHasNextCursorWhenPageFull(): void
+    {
+        // Build limit+1 links to trigger "has more".
+        $links = [];
+        for ($i = 0; $i < 3; $i++) {
+            $link = new EmailLink();
+            $link->setObjectUuid('uuid');
+            $link->setMailAccountId(1);
+            $link->setMailMessageId($i);
+            $links[] = $link;
+        }
+
+        $this->mapper
+            ->method('findByObjectUuid')
+            ->willReturn($links);
+        $this->mapper
+            ->method('countByObjectUuid')
+            ->willReturn(10);
+
+        $result = $this->service->getLinkedEmails('uuid', null, 2);
+
+        $this->assertSame(10, $result['total']);
+        $this->assertCount(2, $result['items']);
+        $this->assertSame(2, $result['nextCursor']);
+    }
+
+    public function testGetAvailableAccountsReturnsEmptyWhenMailDisabled(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('mail')->willReturn(false);
+
+        $this->assertSame([], $this->service->getAvailableAccounts());
+    }
+
+    public function testGetAvailableAccountsReturnsEmptyWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+        // No DB call should happen — guard returns first.
+        $this->db->expects($this->never())->method('getQueryBuilder');
+
+        $this->assertSame([], $this->service->getAvailableAccounts());
+    }
+
+    public function testGetMailboxesForAccountReturnsEmptyOnInvalidAccount(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('mail')->willReturn(true);
+
+        $this->assertSame([], $this->service->getMailboxesForAccount(0));
+    }
+
+    public function testGetMessagesForMailboxReturnsEmptyShape(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('mail')->willReturn(false);
+
+        $result = $this->service->getMessagesForMailbox(1, 'INBOX', null, 25);
+        $this->assertSame(['items' => [], 'nextCursor' => null], $result);
+    }
+}//end class


### PR DESCRIPTION
## Summary

Tier-2 email integration for openregister: dedicated link table + service + REST controller + picker source endpoints powering the new 3-step \`CnEmailPicker\` UI in nextcloud-vue.

- Migration \`Version1Date20260525100000\` (create-or-extend \`openregister_email_links\`) — adds \`schema_id\`, \`metadata\`, and a composite unique index \`(object_uuid, mail_account_id, mail_message_id, mail_message_uid)\` so the picker's link-existing flow is idempotent across Mail re-syncs that bump the UID.
- \`EmailLinkService\` — idempotent upsert + cursor pagination (\`{items, total, nextCursor}\`) + account/mailbox/message discovery for the 3-step picker, with defence-in-depth account-ownership check.
- \`EmailLinksController\` — REST endpoints for \`emails#index/link/destroy\` and the new picker source routes (\`/integrations/email/accounts\`, \`.../accounts/{id}/mailboxes\`, \`.../accounts/{id}/messages\`).
- \`EmailProvider\` rewired on \`EmailLinkService\` for create/delete (legacy payload still accepted via back-compat fall-through); read path stays on legacy \`EmailService\`.
- Compose flow stays out-of-app per AD-2 (Mail owns compose) — the UI deep-links into NC Mail and users link the sent message back via the picker.

Refs: openregister#1309, ADR-019, ADR-022.

## Test plan

- [ ] PHPUnit: \`tests/Unit/Service/EmailLinkServiceTest.php\` (idempotent upsert, paged list, unlink, account/mailbox guards)
- [ ] Existing \`EmailLinkTest\`/\`EmailsControllerTest\`/\`EmailServiceTest\` still green (entity additions are backwards-compatible)
- [ ] Manual: install NC Mail → link an email via the picker → re-link the same message → only one row in \`openregister_email_links\`
- [ ] Manual: unlink → row removed; "Compose in Mail" CTA opens Mail \`/box/draft\`
- [ ] Pair with nextcloud-vue PR for picker rendering