### PR TITLE
retrofit(rspec-2b): reverse-spec BackgroundJob cluster (14 methods / 5 files)

### DIFF
--- a/lib/BackgroundJob/CacheWarmupJob.php
+++ b/lib/BackgroundJob/CacheWarmupJob.php
@@ -102,6 +102,8 @@ class CacheWarmupJob extends TimedJob
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-2b-backgroundjob/tasks.md#task-1
      */
     protected function run($argument): void
     {

--- a/lib/BackgroundJob/ExecutionHistoryCleanupJob.php
+++ b/lib/BackgroundJob/ExecutionHistoryCleanupJob.php
@@ -72,6 +72,8 @@ class ExecutionHistoryCleanupJob extends TimedJob
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-2b-backgroundjob/tasks.md#task-2
      */
     protected function run($argument): void
     {

--- a/lib/BackgroundJob/NameCacheWarmupJob.php
+++ b/lib/BackgroundJob/NameCacheWarmupJob.php
@@ -72,6 +72,8 @@ class NameCacheWarmupJob extends TimedJob
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-2b-backgroundjob/tasks.md#task-1
      */
     protected function run($argument): void
     {

--- a/lib/BackgroundJob/ReportRenderJob.php
+++ b/lib/BackgroundJob/ReportRenderJob.php
@@ -88,6 +88,8 @@ class ReportRenderJob extends TimedJob
      * @param MagicMapper         $objectMapper   Object loader.
      * @param IRootFolder         $rootFolder     Files root.
      * @param LoggerInterface     $logger         Logger.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-2b-backgroundjob/tasks.md#task-3
      */
     public function __construct(
         ITimeFactory $time,
@@ -111,6 +113,8 @@ class ReportRenderJob extends TimedJob
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-2b-backgroundjob/tasks.md#task-3
      */
     protected function run($argument): void
     {
@@ -187,6 +191,8 @@ class ReportRenderJob extends TimedJob
      * @param DateTime                  $now      Reference time.
      *
      * @return bool
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-2b-backgroundjob/tasks.md#task-3
      */
     private function shouldRender(array $payload, $schedule, DateTime $now): bool
     {
@@ -228,6 +234,8 @@ class ReportRenderJob extends TimedJob
      * @param array<string, mixed> $payload   Dashboard data.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-2b-backgroundjob/tasks.md#task-3
      */
     private function renderAndDeliver(ObjectEntity $dashboard, array $payload): void
     {
@@ -268,6 +276,8 @@ class ReportRenderJob extends TimedJob
      * @param array<string, mixed> $delivery  Delivery descriptor.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-2b-backgroundjob/tasks.md#task-3
      */
     private function writeToFiles(ObjectEntity $dashboard, array $payload, array $rendered, array $delivery): void
     {
@@ -337,6 +347,8 @@ class ReportRenderJob extends TimedJob
      * Resolve the `reports` register.
      *
      * @return Register
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-2b-backgroundjob/tasks.md#task-3
      */
     private function loadReportsRegister(): Register
     {
@@ -354,6 +366,8 @@ class ReportRenderJob extends TimedJob
      * @param Register $register Reports register.
      *
      * @return ObjectEntity[]
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-2b-backgroundjob/tasks.md#task-3
      */
     private function loadDashboards(Register $register): array
     {
@@ -384,6 +398,8 @@ class ReportRenderJob extends TimedJob
      * @param string $value Title.
      *
      * @return string Slug.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-2b-backgroundjob/tasks.md#task-3
      */
     private function slugify(string $value): string
     {

--- a/lib/BackgroundJob/SolrWarmupJob.php
+++ b/lib/BackgroundJob/SolrWarmupJob.php
@@ -98,6 +98,8 @@ class SolrWarmupJob extends QueuedJob
      * @throws \Exception If warmup fails critically (job will be marked as failed)
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-2b-backgroundjob/tasks.md#task-4
      */
     protected function run($argument): void
     {
@@ -246,6 +248,8 @@ class SolrWarmupJob extends QueuedJob
      * @param LoggerInterface $logger      Logger instance for debug messages
      *
      * @return bool True if SOLR is available and ready, false otherwise
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-2b-backgroundjob/tasks.md#task-4
      */
     private function isSolrAvailable(IndexService $solrService, LoggerInterface $logger): bool
     {
@@ -271,6 +275,8 @@ class SolrWarmupJob extends QueuedJob
      * @param float                $executionTime Total execution time in seconds
      *
      * @return float Objects indexed per second (rounded to 2 decimal places), or 0.0 if calculation not possible
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-2b-backgroundjob/tasks.md#task-4
      */
     private function calculateObjectsPerSecond(array $result, float $executionTime): float
     {

--- a/openspec/changes/retrofit-2026-05-24-2b-backgroundjob/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-backgroundjob/proposal.md
@@ -1,0 +1,43 @@
+# Retrofit — Bucket 2b BackgroundJob cluster
+
+Reverse-engineers specifications for 14 methods across 5 `lib/BackgroundJob/` classes that scanner couldn't cluster behaviorally (the namespace word `backgroundjob` is the only thing they share). Each class implements a **distinct task** that extends an existing capability — we describe what each one actually does and back-annotate.
+
+No new capability is minted. A generic `background-jobs` umbrella would be a namespace-word anti-pattern: TimedJob/QueuedJob is a Nextcloud framework hook, not a behavior. Splitting by what each job does keeps capabilities behavioral.
+
+## Affected code units (by class)
+
+- `lib/BackgroundJob/CacheWarmupJob.php::run` → faceting-configuration (REQ-NEW)
+- `lib/BackgroundJob/NameCacheWarmupJob.php::run` → faceting-configuration (REQ-NEW)
+- `lib/BackgroundJob/ExecutionHistoryCleanupJob.php::run` → workflow-operations (existing REQ — back-annotation only)
+- `lib/BackgroundJob/ReportRenderJob.php::__construct,run,shouldRender,renderAndDeliver,writeToFiles,loadReportsRegister,loadDashboards,slugify` → rapportage-bi-export (REQ-NEW for security hardening + dashboard-driven schedule)
+- `lib/BackgroundJob/SolrWarmupJob.php::run,isSolrAvailable,calculateObjectsPerSecond` → zoeken-filteren (REQ-NEW for post-import queued semantics + availability gate + throughput metrics)
+
+## Approach (per job)
+
+### CacheWarmupJob (configurable hourly) + NameCacheWarmupJob (nightly)
+Both classes call `CacheHandler::warmupNameCache()` to pre-populate the distributed UUID-to-name cache used by facet label resolution. `CacheWarmupJob` reads `cache_warmup_interval` from IAppConfig (default 3600s; `0` disables); writes `cache_warmup_last_run` timestamp. `NameCacheWarmupJob` is fixed-interval (24h). Both log execution time and number of names loaded.
+
+The `faceting-configuration` spec already mandates a 24-hour distributed label cache (`MagicFacetHandler::uuidLabelCache`, `openregister_facet_labels`) and an invalidation flow on schema change — but **does not specify the pre-warm lifecycle**. A facet-label cache that has to be warmed lazily on first request causes cold-start delays for the first facet query of the day. Both warmup jobs **extend** faceting-configuration with an explicit warm-up requirement.
+
+### ExecutionHistoryCleanupJob (daily)
+Reads `workflow_execution_retention_days` from IAppConfig (default 90), calls `WorkflowExecutionMapper::deleteOlderThan($cutoff)`, logs deleted count. **Already fully specified** at `workflow-operations` "Execution History Retention" (REQ-006). Back-annotation only — no new REQ.
+
+### ReportRenderJob (daily)
+Walks every dashboard object in the `reports` register, computes whether each is due based on `schedule.intervalSec` vs `lastRenderedAt`, renders via `ReportRenderService`, and writes the result to the dashboard owner's Files folder (default `Reports/<dashboard-slug>/`). The `rapportage-bi-export` spec already mentions scheduled rendering at REQ-002 ("scheduled report generation"), but the existing scenarios describe a notional `ScheduledReportJob` class with a different shape (per-report cron schedules, n8n SMTP delivery). The **actual** implementation uses dashboard-object iteration with `intervalSec` polling and includes two **security-relevant** behaviors not currently scenarized:
+
+- **Path traversal hardening**: `writeToFiles()` strips leading slashes and rejects any `..` segment in the user-controlled `delivery.filesFolder`.
+- **Owner-fallback refusal**: When the dashboard owner is null/empty, the job **skips delivery** rather than falling back to admin's Files share (which would be a phishing/redirect persistence vector — attacker-controlled bytes landing in admin's home on next login).
+- **Kill switch**: `rapportage_scheduled_renders_enabled` app-config flag (default `true`).
+
+These are real, observable security guards. They warrant their own REQ as **extension** to rapportage-bi-export so the next implementer cannot regress them.
+
+### SolrWarmupJob (queued, post-import)
+QueuedJob (not TimedJob) — scheduled imperatively after import operations to avoid blocking import completion. Reads `maxObjects` (default 5000), `mode` (`serial`/`parallel`/`hyper`), `collectErrors`, `triggeredBy` from job arguments. Calls `IndexService::isAvailable()` first and **skips** with a warning when Solr is not configured (not throwing). Records `objects_per_second` throughput metric. The `zoeken-filteren` spec already mentions index warmup at "Index warmup via background jobs", but the scenario doesn't cover the **post-import queued shape** or the availability gate or the mode-selection contract. New REQ extends zoeken-filteren with the queued/availability-gate/mode contract.
+
+## Observed gaps (advisory)
+
+- `ReportRenderJob` calls `RegisterMapper::find()` and `MagicMapper::findAll()` with `_rbac: false, _multitenancy: false` — the job runs as a system context and bypasses RBAC. The `rapportage-bi-export` spec REQ-13 ("Cross-register reporting respects RBAC boundaries") suggests RBAC should always apply; the job's bypass is justified for a cron context but isn't currently called out anywhere. Surfacing for reviewer attention.
+- `SolrWarmupJob` uses `\OC::$server->get(...)` service location instead of constructor injection for `IndexService` and `SchemaMapper`. Pre-existing pattern; not changed.
+- `CacheWarmupJob` and `NameCacheWarmupJob` both call `CacheHandler::warmupNameCache()` but use different invocation patterns (one via constructor-injected services, one via `\OC::$server->get()`). Consolidation candidate — surfacing as observation.
+
+Source: `/tmp/or-scan/rspec-2b-backgroundjob.json` (Bucket 2b BackgroundJob cluster, 14 methods / 5 files).

--- a/openspec/changes/retrofit-2026-05-24-2b-backgroundjob/specs/faceting-configuration/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-backgroundjob/specs/faceting-configuration/spec.md
@@ -1,0 +1,46 @@
+---
+retrofit_extensions: [REQ-cache-warmup-jobs]
+---
+
+### Requirement: UUID-to-name distributed cache MUST be pre-warmed via background jobs
+
+The system MUST pre-populate the distributed UUID-to-name label cache (used by `MagicFacetHandler` for facet label resolution) via two complementary `TimedJob` background jobs, to eliminate cold-start delays on the first facet query of the day. Cache warmup MUST be implemented as calls to `CacheHandler::warmupNameCache()`, which loads names from organisations, the objects table, and magic tables into the distributed cache.
+
+The two jobs MUST coexist with distinct cadences:
+
+1. A **configurable recurring** warmup (`CacheWarmupJob` extending `TimedJob`) that reads its interval from `IAppConfig` key `cache_warmup_interval` (default `3600` seconds; value `0` MUST disable the job by setting an effectively infinite interval). The job MUST write the last-run timestamp to `IAppConfig` key `cache_warmup_last_run` after a successful pass. The job MUST log execution time and number of names loaded.
+2. A **fixed nightly** warmup (`NameCacheWarmupJob` extending `TimedJob`) with a hard-coded interval of 24 hours. Not user-configurable; provides the daily floor.
+
+Both jobs MUST catch exceptions during warmup and log them as errors without crashing the cron worker. Neither job MUST throw — a failing warmup MUST NOT prevent the next interval's attempt.
+
+#### Scenario: Configurable warmup runs at the configured interval
+
+- **GIVEN** `cache_warmup_interval` is set to `3600` (1 hour) in `IAppConfig`
+- **WHEN** the Nextcloud cron triggers `CacheWarmupJob`
+- **THEN** the job MUST call `CacheHandler::warmupNameCache()` to populate the distributed cache
+- **AND** the job MUST write `cache_warmup_last_run` with the current timestamp on success
+- **AND** the job MUST log `[CacheWarmupJob] Cache warmup completed` with `names_loaded` and `execution_time` context
+
+#### Scenario: Configurable warmup is disabled when interval is zero
+
+- **GIVEN** `cache_warmup_interval` is set to `0`
+- **WHEN** the cron worker would normally invoke `CacheWarmupJob::run`
+- **THEN** the job MUST short-circuit with `[CacheWarmupJob] Cache warmup is disabled (interval set to 0), skipping`
+- **AND** MUST NOT call `CacheHandler::warmupNameCache()`
+- **AND** MUST NOT update `cache_warmup_last_run`
+
+#### Scenario: Nightly warmup runs unconditionally every 24 hours
+
+- **GIVEN** `NameCacheWarmupJob` is registered as a `TimedJob` with 86400-second interval
+- **WHEN** the Nextcloud cron triggers the job
+- **THEN** it MUST call `CacheHandler::warmupNameCache()` regardless of the `cache_warmup_interval` setting
+- **AND** MUST log `[NameCacheWarmupJob] 🌙 Name Cache Nightly Warmup Job Started` with `scheduled_time` and `timezone` context
+- **AND** on success MUST log `[NameCacheWarmupJob] ✅ Name Cache Nightly Warmup Job Completed` with `names_loaded`
+
+#### Scenario: Warmup failures do not crash the cron worker
+
+- **GIVEN** `CacheHandler::warmupNameCache()` throws an exception (e.g. database unavailable)
+- **WHEN** either warmup job runs
+- **THEN** the job MUST catch the exception and log it as an error with `error` and `execution_time` context
+- **AND** MUST NOT re-throw
+- **AND** the next scheduled invocation MUST proceed normally

--- a/openspec/changes/retrofit-2026-05-24-2b-backgroundjob/specs/rapportage-bi-export/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-backgroundjob/specs/rapportage-bi-export/spec.md
@@ -1,0 +1,107 @@
+---
+retrofit_extensions: [REQ-scheduled-report-render-job]
+---
+
+### Requirement: Scheduled-report rendering MUST be driven by dashboard objects and MUST harden delivery against missing-owner and path-traversal abuse
+
+The scheduled-report rendering pipeline MUST be implemented as a daily `TimedJob` (`ReportRenderJob`) that iterates every dashboard object in the operator-imported `reports` register and renders due dashboards via `ReportRenderService`. This requirement complements the existing "scheduled report generation" requirement by specifying the **observed** dispatch and delivery contract, including security guards.
+
+The job MUST run at a 24-hour interval. It MUST honour an operator kill switch via `IAppConfig` key `rapportage_scheduled_renders_enabled` (default `true`). When the kill switch is `false`, the job MUST log `[ReportRenderJob] Scheduled renders disabled (kill switch on), skipping` and return without enumerating dashboards.
+
+When the `reports` register is not present (e.g. the operator has not imported the bundle yet), the job MUST log `[ReportRenderJob] No 'reports' register found — bundle not imported, skipping` and return — it MUST NOT throw.
+
+For each dashboard, due-status MUST be computed against the dashboard payload's `schedule` subobject:
+
+- `schedule` MUST be an array; non-array (e.g. null) MUST be treated as "not due".
+- `schedule.active` MUST be a truthy value; otherwise "not due".
+- `schedule.intervalSec` MUST be a positive integer; zero or negative MUST be treated as "not due".
+- If `payload.lastRenderedAt` exists and parses as a `DateTime`, the dashboard MUST be considered due when `(now - lastRenderedAt) >= intervalSec`. A malformed `lastRenderedAt` MUST be treated as "due now" (not as a hard failure).
+- If `payload.lastRenderedAt` is absent or empty, the dashboard MUST be rendered.
+
+Delivery MUST be governed by the dashboard payload's `delivery` subobject:
+
+- `delivery.format` MUST be validated against `ReportRenderService::FORMATS`; an unknown format MUST fall back to `xlsx`.
+- `delivery.channel` `files` or `both` MUST trigger Files delivery; the `email` channel is deferred to Phase 2b.
+
+Files delivery MUST enforce the following security guards:
+
+- **Missing-owner refusal**: If `dashboard.getOwner()` is `null` or empty, the job MUST log `[ReportRenderJob] Dashboard owner missing — skipping Files delivery` and return — it MUST NOT fall back to `admin` or any other system identity. Rendered bytes are derived from user-writable JSON and dropping them into another user's home would be a phishing/redirect persistence vector.
+- **User-folder fallback**: If the owner's Files root is unavailable (`NotFoundException`), the job MUST log `[ReportRenderJob] User folder unavailable, skipping delivery` and return without throwing.
+- **Path-traversal rejection**: The folder path is taken from `delivery.filesFolder` (user-controlled JSON) or computed from `Reports/<slugified-titel>` when empty. The path MUST be normalised by stripping leading slashes. The job MUST reject any normalised path that is empty or contains `..` with `[ReportRenderJob] Rejected delivery folder containing path traversal`.
+
+The slugifier MUST lowercase the input, replace any run of non-alphanumeric characters with `-`, trim leading/trailing dashes, and fall back to literal `dashboard` when the result is empty.
+
+The job MUST resolve the `reports` register with `_rbac: false, _multitenancy: false` (system cron context, no acting user) and enumerate dashboards with the same flags via `MagicMapper::findAll(limit: 200, filters: ['register' => $register->getId()])`. Per-dashboard render failures MUST log `[ReportRenderJob] Render failed for dashboard` with the dashboard identifier and exception message, and MUST NOT halt the rest of the pass. The pass MUST end with `[ReportRenderJob] Scheduled-render pass complete` logging `candidates`, `rendered`, and `skipped` counts.
+
+#### Scenario: Kill switch short-circuits the job
+
+- **GIVEN** `IAppConfig` key `rapportage_scheduled_renders_enabled` is set to `false`
+- **WHEN** the Nextcloud cron triggers `ReportRenderJob::run`
+- **THEN** the job MUST log the kill-switch message and return
+- **AND** MUST NOT call `RegisterMapper::find` for the `reports` register
+- **AND** MUST NOT enumerate dashboards
+
+#### Scenario: Missing reports register is non-fatal
+
+- **GIVEN** the `reports` register has not been imported (no register with slug `reports` exists)
+- **WHEN** the job runs
+- **THEN** the job MUST log `[ReportRenderJob] No 'reports' register found — bundle not imported, skipping`
+- **AND** MUST return without throwing
+
+#### Scenario: Dashboard with `lastRenderedAt` older than `intervalSec` is rendered
+
+- **GIVEN** a dashboard with `schedule.active=true`, `schedule.intervalSec=86400`, and `lastRenderedAt` 25 hours ago
+- **WHEN** the job iterates the dashboard
+- **THEN** `shouldRender` MUST return `true`
+- **AND** the dashboard MUST be passed to `renderAndDeliver`
+
+#### Scenario: Dashboard never rendered before is rendered now
+
+- **GIVEN** a dashboard with `schedule.active=true`, `schedule.intervalSec=86400`, and no `lastRenderedAt`
+- **WHEN** the job iterates the dashboard
+- **THEN** `shouldRender` MUST return `true`
+
+#### Scenario: Dashboard with inactive schedule is skipped
+
+- **GIVEN** a dashboard with `schedule.active=false`
+- **WHEN** the job iterates the dashboard
+- **THEN** `shouldRender` MUST return `false`
+- **AND** the `skipped` counter MUST be incremented
+
+#### Scenario: Dashboard with missing owner is not delivered to admin
+
+- **GIVEN** a dashboard whose `owner` property is `null` (orphaned dashboard)
+- **WHEN** `renderAndDeliver` runs and `writeToFiles` is invoked
+- **THEN** the job MUST log `[ReportRenderJob] Dashboard owner missing — skipping Files delivery`
+- **AND** MUST NOT call `getUserFolder('admin')` or write any bytes anywhere
+- **AND** MUST return from `writeToFiles` without raising
+
+#### Scenario: Path-traversal in `delivery.filesFolder` is rejected
+
+- **GIVEN** a dashboard with `delivery.filesFolder` set to `../../../etc/passwd`
+- **WHEN** `writeToFiles` runs
+- **THEN** the normalised folder MUST contain `..`
+- **AND** the job MUST log `[ReportRenderJob] Rejected delivery folder containing path traversal`
+- **AND** MUST NOT create the folder or write any file
+
+#### Scenario: Default folder path follows `Reports/<slug>` convention
+
+- **GIVEN** a dashboard with `titel = "Weekly KPI Overview!"` and no `delivery.filesFolder`
+- **WHEN** `writeToFiles` runs
+- **THEN** the folder path MUST be `Reports/weekly-kpi-overview`
+- **AND** the folder MUST be created under the dashboard owner's home if absent
+
+#### Scenario: Existing report file is overwritten in place
+
+- **GIVEN** a dashboard whose delivery folder already contains a file with the rendered filename
+- **WHEN** `writeToFiles` runs
+- **THEN** the existing node MUST be updated via `putContent`
+- **AND** a new file MUST NOT be created alongside the old one
+
+#### Scenario: Per-dashboard render failure does not halt the pass
+
+- **GIVEN** five due dashboards, of which the third raises a `\Throwable` during `renderAndDeliver`
+- **WHEN** the job's main loop runs
+- **THEN** the failure MUST be logged at warning level with the dashboard identifier
+- **AND** the loop MUST continue with the remaining dashboards
+- **AND** the final summary MUST report the failed dashboard in the `candidates` count but not the `rendered` count

--- a/openspec/changes/retrofit-2026-05-24-2b-backgroundjob/specs/zoeken-filteren/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-backgroundjob/specs/zoeken-filteren/spec.md
@@ -1,0 +1,76 @@
+---
+retrofit_extensions: [REQ-solr-warmup-queued]
+---
+
+### Requirement: Post-import Solr index warmup MUST be a queued one-shot job with configurable scope and availability gating
+
+The system MUST expose a one-shot `QueuedJob` (`SolrWarmupJob`) that runs Solr index warmup after import operations complete, decoupling import latency from warmup latency. This requirement complements the existing nightly-warmup scenario by specifying the **post-import queued shape** observed in the codebase.
+
+The job MUST extend `OCP\BackgroundJob\QueuedJob` (one-shot, not recurring) so it executes once when the cron worker picks it up and is then discarded. The job MUST accept the following per-invocation arguments (all optional with defaults):
+
+- `maxObjects` (int, default `5000`) — upper bound on objects indexed during this warmup pass; prevents excessive resource use and overlong jobs.
+- `mode` (string, default `'serial'`) — one of `serial`, `parallel`, `hyper`. Selects the indexing strategy passed to `IndexService::warmupIndex`.
+- `collectErrors` (bool, default `false`) — whether to accumulate detailed per-object errors in the result.
+- `triggeredBy` (string, default `'unknown'`) — provenance label included in every log line (e.g. `import_completed`, `manual_admin`, `bulk_legal_hold`); used to trace warmup activity back to its initiator.
+
+Before invoking warmup, the job MUST gate on `IndexService::isAvailable()`. When Solr is not configured or unreachable, the job MUST log `[SolrWarmupJob] SOLR Warmup Job skipped - SOLR not available` (with `triggered_by` context) and return without raising. Skipping MUST NOT mark the job as failed — a missing Solr is an expected configuration state, not an error.
+
+When Solr is available, the job MUST enumerate all schemas via `SchemaMapper::findAll()` and pass them together with the bounds to `IndexService::warmupIndex(schemas, maxObjects, mode, collectErrors)`. The job MUST log a comprehensive summary on completion, including `execution_time_seconds`, `objects_indexed`, `schemas_processed`, `fields_created`, `triggered_by`, and a `performance_metrics` block containing:
+
+- `total_time_ms` — taken from the `IndexService` result envelope.
+- `objects_per_second` — computed locally as `objects_indexed / execution_time_seconds`, rounded to 2 decimal places. When either input is non-positive, the value MUST be `0.0` (no division-by-zero, no negative throughput).
+
+When `IndexService::warmupIndex` returns `success=false`, the job MUST log `[SolrWarmupJob] ❌ SOLR Warmup Job Failed` with the result's `error` field but MUST NOT re-throw (the result is the canonical failure surface).
+
+When the warmup body raises a `\Exception`, the job MUST log `[SolrWarmupJob] 🚨 SOLR Warmup Job Exception` with `exception`, `exception_file`, `exception_line`, `triggered_by`, and `trace` context, and MUST re-throw so the job is marked failed.
+
+#### Scenario: Post-import trigger queues warmup with provenance label
+
+- **GIVEN** an import workflow finishes and schedules `SolrWarmupJob` with `triggeredBy='import_completed'`, `maxObjects=10000`, `mode='parallel'`
+- **WHEN** the Nextcloud cron worker picks up the queued job
+- **THEN** the job MUST log `[SolrWarmupJob] 🔥 SOLR Warmup Job Started` with `triggered_by: import_completed`, `max_objects: 10000`, `mode: parallel`
+- **AND** the job MUST call `IndexService::warmupIndex(schemas, 10000, 'parallel', false)`
+
+#### Scenario: Defaults are applied when arguments are omitted
+
+- **GIVEN** `SolrWarmupJob` is queued with an empty `$argument` array
+- **WHEN** the job runs
+- **THEN** `maxObjects` MUST default to `5000`
+- **AND** `mode` MUST default to `'serial'`
+- **AND** `collectErrors` MUST default to `false`
+- **AND** `triggeredBy` MUST default to `'unknown'`
+
+#### Scenario: Job skips silently when Solr is not configured
+
+- **GIVEN** `IndexService::isAvailable()` returns `false` (Solr not configured)
+- **WHEN** `SolrWarmupJob::run` executes
+- **THEN** the job MUST log `[SolrWarmupJob] SOLR Warmup Job skipped - SOLR not available`
+- **AND** MUST return cleanly (job marked success, not failure)
+- **AND** MUST NOT call `SchemaMapper::findAll` or `IndexService::warmupIndex`
+
+#### Scenario: Throughput metric handles zero-objects-indexed gracefully
+
+- **GIVEN** a warmup result with `operations.objects_indexed = 0` and a positive `execution_time`
+- **WHEN** `calculateObjectsPerSecond` is invoked
+- **THEN** the return value MUST be exactly `0.0`
+- **AND** no division-by-zero or negative throughput MUST be logged
+
+#### Scenario: Throughput metric handles zero execution time gracefully
+
+- **GIVEN** a warmup result with `objects_indexed > 0` but `execution_time = 0.0` (instantaneous)
+- **WHEN** `calculateObjectsPerSecond` is invoked
+- **THEN** the return value MUST be `0.0`
+
+#### Scenario: Result envelope failure is logged but not re-thrown
+
+- **GIVEN** `IndexService::warmupIndex` returns `['success' => false, 'error' => 'collection unreachable']`
+- **WHEN** `SolrWarmupJob::run` evaluates the result
+- **THEN** the job MUST log `[SolrWarmupJob] ❌ SOLR Warmup Job Failed` with `error: collection unreachable`
+- **AND** MUST NOT re-throw (the result envelope is the failure surface)
+
+#### Scenario: Unhandled exception re-throws to mark job failed
+
+- **GIVEN** `IndexService::warmupIndex` raises `\RuntimeException('connection refused')`
+- **WHEN** `SolrWarmupJob::run` catches the exception
+- **THEN** the job MUST log `[SolrWarmupJob] 🚨 SOLR Warmup Job Exception` with full `trace` and `triggered_by` context
+- **AND** MUST re-throw so the Nextcloud job framework marks the job failed

--- a/openspec/changes/retrofit-2026-05-24-2b-backgroundjob/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-backgroundjob/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] task-1: faceting-configuration#REQ-NEW — UUID-to-name distributed cache MUST be pre-warmed via background jobs (covers `CacheWarmupJob::run` configurable hourly + `NameCacheWarmupJob::run` nightly) (retroactive specification)
+- [x] task-2: workflow-operations#REQ-006 — `ExecutionHistoryCleanupJob::run` already fully covered by existing "Execution History Retention" requirement (retroactive annotation)
+- [x] task-3: rapportage-bi-export#REQ-NEW — Scheduled-render job MUST iterate dashboard objects, gate on `schedule.intervalSec`/`lastRenderedAt`, refuse delivery on missing owner, and reject path-traversal in `delivery.filesFolder` (covers `ReportRenderJob` __construct/run/shouldRender/renderAndDeliver/writeToFiles/loadReportsRegister/loadDashboards/slugify) (retroactive specification)
+- [x] task-4: zoeken-filteren#REQ-NEW — Post-import Solr warmup MUST run as a `QueuedJob` with configurable `maxObjects`/`mode`/`collectErrors`/`triggeredBy`, MUST skip silently when Solr is unavailable, and MUST record `objects_per_second` throughput (covers `SolrWarmupJob::run` + `isSolrAvailable` + `calculateObjectsPerSecond`) (retroactive specification)


### PR DESCRIPTION
## Summary

Bucket 2b reverse-spec for the `backgroundjob` namespace-word cluster. Each of the 5 BackgroundJob classes implements a distinct task — split by **observed behavior** rather than minting a generic `background-jobs` umbrella capability (which would be a namespace-word anti-pattern).

## Capabilities touched (4 caps, 3 new REQs + 1 backfill)

| File | Capability | Disposition |
|------|------------|-------------|
| `CacheWarmupJob.php` + `NameCacheWarmupJob.php` | `faceting-configuration` | **NEW REQ** — UUID-to-name cache pre-warmup (configurable hourly + nightly) |
| `ExecutionHistoryCleanupJob.php` | `workflow-operations` | **Existing REQ-006** (Execution History Retention) — back-annotation only |
| `ReportRenderJob.php` (8 methods) | `rapportage-bi-export` | **NEW REQ** — dashboard-driven schedule, **missing-owner refusal** (no admin fallback), **path-traversal rejection** |
| `SolrWarmupJob.php` (3 methods) | `zoeken-filteren` | **NEW REQ** — post-import `QueuedJob` shape, availability gate, throughput metric |

## Why no `background-jobs` capability

`TimedJob` / `QueuedJob` is a Nextcloud framework hook, not a behavior. The 5 jobs do five different things:
- Two warm the facet label cache (distributed UUID-to-name)
- One prunes workflow execution history
- One renders scheduled dashboards to Files
- One warms Solr after imports

Naming a capability after the namespace would have hidden the actual contracts — including the **security guards** in `ReportRenderJob` (missing-owner refusal + path-traversal rejection) that are easy to regress without an explicit REQ.

## Methods annotated (14/14)

- `CacheWarmupJob::run` → task-1
- `NameCacheWarmupJob::run` → task-1
- `ExecutionHistoryCleanupJob::run` → task-2
- `ReportRenderJob::__construct,run,shouldRender,renderAndDeliver,writeToFiles,loadReportsRegister,loadDashboards,slugify` → task-3
- `SolrWarmupJob::run,isSolrAvailable,calculateObjectsPerSecond` → task-4

## Observed gaps (advisory, not fixed)

- `ReportRenderJob` calls mappers with `_rbac: false, _multitenancy: false` — system cron context, but worth highlighting against `rapportage-bi-export` REQ-13 ("cross-register reporting respects RBAC boundaries").
- `SolrWarmupJob` uses `\OC::$server->get(...)` instead of constructor injection.
- `CacheWarmupJob` (DI'd) and `NameCacheWarmupJob` (service-locator) use different patterns for the same dependency — consolidation candidate.

## Test plan

- [ ] Verify spec-driven coverage scanner picks up the 14 new `@spec` annotations
- [ ] Confirm 3 new REQs render correctly in their parent capability files
- [ ] Spot-check that `ReportRenderJob` security scenarios (missing owner, `..` path) match the code's `if ($owner === null)` and `if (str_contains($folderPath, '..'))` guards

Source: `/tmp/or-scan/rspec-2b-backgroundjob.json` (14 methods / 5 files, Bucket 2b).