### PR TITLE
feat(talk): Tier-2 — link table + service + room picker + create

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -346,6 +346,16 @@ return [
         // Reverse lookup — keep on Tier-1 controller (not in Tier-2 scope).
         ['name' => 'deck#objects',        'url' => '/api/deck/boards/{boardId}/objects',                      'verb' => 'GET',    'requirements' => ['boardId' => '[^/]+']],
 
+        // Talk — Tier-2 link table + picker UX. Specific routes (`/new`)
+        // MUST precede the wildcard `{roomToken}` route so they aren't
+        // grabbed as roomToken='new'. The picker source endpoint is
+        // app-global (not per-object).
+        ['name' => 'talkLinks#index',     'url' => '/api/objects/{register}/{schema}/{id}/talk',              'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
+        ['name' => 'talkLinks#link',      'url' => '/api/objects/{register}/{schema}/{id}/talk',              'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'talkLinks#createNew', 'url' => '/api/objects/{register}/{schema}/{id}/talk/new',          'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'talkLinks#destroy',   'url' => '/api/objects/{register}/{schema}/{id}/talk/{roomToken}',  'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'roomToken' => '[A-Za-z0-9]+']],
+        ['name' => 'talkLinks#rooms',     'url' => '/api/integrations/talk/rooms',                            'verb' => 'GET'],
+
         // Forms — Tier-2 link-table API. Specific routes (`/new`, `/submissions/{id}`)
         // MUST precede the wildcard `{formId}` route so they aren't grabbed as
         // formId='new' / formId='submissions'. Available-forms picker is app-global.

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1223,7 +1223,9 @@ class Application extends App implements IBootstrap
 
         // TalkProvider — needs container for late-bound `OCA\Talk\Manager`
         // (only on the classpath with `spreed` installed) plus
-        // IUserSession to scope `getRoomsForUser`.
+        // IUserSession to scope `getRoomsForUser`. Tier-2: the
+        // TalkLinkMapper is injected so the provider can short-circuit
+        // the legacy marker scan when the link table is populated.
         // @spec openspec/changes/integration-talk/tasks.md.
         $context->registerService(
             TalkProvider::class,
@@ -1233,6 +1235,25 @@ class Application extends App implements IBootstrap
                     appManager: $container->get('OCP\App\IAppManager'),
                     userSession: $container->get('OCP\IUserSession'),
                     l10n: $container->get('OCP\IL10N'),
+                    talkLinkMapper: $container->get(\OCA\OpenRegister\Db\TalkLinkMapper::class),
+                );
+            }
+        );
+
+        // TalkLinkService — Tier-2 link/create/unlink service backing
+        // the TalkLinksController. Same late-bound Talk pattern as
+        // the provider (container for OCA\Talk\* lookups).
+        // @spec openspec/changes/integration-talk/tasks.md.
+        $context->registerService(
+            \OCA\OpenRegister\Service\TalkLinkService::class,
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\Service\TalkLinkService(
+                    talkLinkMapper: $container->get(\OCA\OpenRegister\Db\TalkLinkMapper::class),
+                    container: $container,
+                    appManager: $container->get('OCP\App\IAppManager'),
+                    userSession: $container->get('OCP\IUserSession'),
+                    l10n: $container->get('OCP\IL10N'),
+                    logger: $container->get('Psr\Log\LoggerInterface'),
                 );
             }
         );

--- a/lib/Controller/TalkLinksController.php
+++ b/lib/Controller/TalkLinksController.php
@@ -1,0 +1,315 @@
+<?php
+
+/**
+ * TalkLinksController — Tier-2 REST controller for Talk room links.
+ *
+ * Backs the bespoke CnTalkTab + picker UX (ADR-019 / ADR-022). Surfaces:
+ *   - GET    /api/objects/{register}/{schema}/{id}/talk            — list linked rooms
+ *   - POST   /api/objects/{register}/{schema}/{id}/talk            — link existing room
+ *   - POST   /api/objects/{register}/{schema}/{id}/talk/new        — create + link
+ *   - DELETE /api/objects/{register}/{schema}/{id}/talk/{roomToken}— unlink (does NOT destroy room)
+ *   - GET    /api/integrations/talk/rooms?search=                  — picker source
+ *
+ * @category  Controller
+ * @package   OCA\OpenRegister\Controller
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git-id>
+ * @link      https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use Exception;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\TalkLinkService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Tier-2 Talk links controller.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ */
+class TalkLinksController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param string          $appName         App id.
+     * @param IRequest        $request         HTTP request.
+     * @param TalkLinkService $talkLinkService Backing service.
+     * @param ObjectService   $objectService   OR object resolver.
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly TalkLinkService $talkLinkService,
+        private readonly ObjectService $objectService,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * List linked Talk rooms for an object.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function index(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->talkLinkService->isTalkAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Talk app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $results = $this->talkLinkService->getLinkedRooms($object->getUuid());
+
+            return new JSONResponse(['results' => $results, 'total' => count($results)]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return new JSONResponse(['error' => $e->getMessage()], 500);
+        }//end try
+    }//end index()
+
+    /**
+     * Link an existing Talk room.
+     *
+     * Body: `{ roomToken: string }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function link(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->talkLinkService->isTalkAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Talk app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $roomToken = (string) $this->request->getParam('roomToken', '');
+            if ($roomToken === '') {
+                return new JSONResponse(['error' => 'roomToken is required'], 400);
+            }
+
+            $link = $this->talkLinkService->linkRoom(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $roomToken
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end link()
+
+    /**
+     * Create a new Talk room and link it.
+     *
+     * Body: `{ name, description?, type? }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    public function createNew(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->talkLinkService->isTalkAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Talk app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $name = trim((string) $this->request->getParam('name', ''));
+            if ($name === '') {
+                return new JSONResponse(['error' => 'name is required'], 400);
+            }
+
+            $description = $this->request->getParam('description');
+            $typeParam   = $this->request->getParam('type');
+            $type        = $typeParam === null ? 2 : (int) $typeParam;
+
+            $link = $this->talkLinkService->createAndLinkRoom(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $name,
+                $description === null ? null : (string) $description,
+                $type
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end createNew()
+
+    /**
+     * Unlink a Talk room. Does NOT destroy the room in Talk.
+     *
+     * @param string $register  Register slug or id.
+     * @param string $schema    Schema slug or id.
+     * @param string $id        Object id.
+     * @param string $roomToken Talk room token.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function destroy(string $register, string $schema, string $id, string $roomToken): JSONResponse
+    {
+        if ($this->talkLinkService->isTalkAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Talk app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $this->talkLinkService->unlinkRoom($object->getUuid(), $roomToken);
+
+            return new JSONResponse(['success' => true]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end destroy()
+
+    /**
+     * List Talk rooms available to the current user (picker source).
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function rooms(): JSONResponse
+    {
+        if ($this->talkLinkService->isTalkAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Talk app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        $search = $this->request->getParam('search');
+        $rooms  = $this->talkLinkService->getAvailableRoomsForUser(
+            $search === null ? null : (string) $search
+        );
+
+        return new JSONResponse(['results' => $rooms, 'total' => count($rooms)]);
+    }//end rooms()
+
+    /**
+     * Resolve an OR object from register/schema/id.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return ObjectEntity|null
+     */
+    private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
+    {
+        $this->objectService->setSchema($schema);
+        $this->objectService->setRegister($register);
+        $this->objectService->setObject($id);
+
+        return $this->objectService->getObject();
+    }//end validateObject()
+
+    /**
+     * Map a service-layer Exception to a JSONResponse.
+     *
+     * Exception codes carry HTTP intent:
+     *   - 409 → conflict
+     *   - 404 → not found
+     *   - 503 → service unavailable
+     *   - 400 → bad request
+     *   - everything else → 400 bad request
+     *
+     * @param Exception $exception Source exception.
+     *
+     * @return JSONResponse
+     */
+    private function mapException(Exception $exception): JSONResponse
+    {
+        $code = $exception->getCode();
+        if ($code === 409) {
+            return new JSONResponse(['error' => $exception->getMessage()], 409);
+        }
+
+        if ($code === 404) {
+            return new JSONResponse(['error' => $exception->getMessage()], 404);
+        }
+
+        if ($code === 503) {
+            return new JSONResponse(['error' => $exception->getMessage()], 503);
+        }
+
+        return new JSONResponse(['error' => $exception->getMessage()], 400);
+    }//end mapException()
+}//end class

--- a/lib/Db/TalkLink.php
+++ b/lib/Db/TalkLink.php
@@ -1,0 +1,221 @@
+<?php
+
+/**
+ * TalkLink entity for linking Nextcloud Talk (spreed) rooms to
+ * OpenRegister objects.
+ *
+ * Tier-2 schema: also carries schema_id + cached room metadata
+ * (subtitle, participantCount, lastMessageData, lastActivity) so the
+ * link row alone can hydrate the sidebar tab + picker UX without a
+ * per-row roundtrip to Talk's Manager. Caches are refreshed by
+ * TalkLinkService on read (>5min staleness).
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Class TalkLink
+ *
+ * @method string getObjectUuid()
+ * @method void setObjectUuid(string $objectUuid)
+ * @method int getRegisterId()
+ * @method void setRegisterId(int $registerId)
+ * @method int|null getSchemaId()
+ * @method void setSchemaId(?int $schemaId)
+ * @method string getRoomToken()
+ * @method void setRoomToken(string $roomToken)
+ * @method int|null getRoomId()
+ * @method void setRoomId(?int $roomId)
+ * @method string|null getRoomName()
+ * @method void setRoomName(?string $roomName)
+ * @method int|null getRoomType()
+ * @method void setRoomType(?int $roomType)
+ * @method string|null getSubtitle()
+ * @method void setSubtitle(?string $subtitle)
+ * @method int|null getParticipantCount()
+ * @method void setParticipantCount(?int $participantCount)
+ * @method string|null getLastMessageData()
+ * @method void setLastMessageData(?string $lastMessageData)
+ * @method DateTime|null getLastActivity()
+ * @method void setLastActivity(?DateTime $lastActivity)
+ * @method string getLinkedBy()
+ * @method void setLinkedBy(string $linkedBy)
+ * @method DateTime getLinkedAt()
+ * @method void setLinkedAt(DateTime $linkedAt)
+ *
+ * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class
+ */
+class TalkLink extends Entity implements JsonSerializable
+{
+
+    /**
+     * The object uuid.
+     *
+     * @var string|null
+     */
+    protected ?string $objectUuid = null;
+
+    /**
+     * The register id.
+     *
+     * @var integer|null
+     */
+    protected ?int $registerId = null;
+
+    /**
+     * The schema id.
+     *
+     * @var integer|null
+     */
+    protected ?int $schemaId = null;
+
+    /**
+     * The Talk room token (canonical id).
+     *
+     * @var string|null
+     */
+    protected ?string $roomToken = null;
+
+    /**
+     * The Talk room internal id (legacy numeric Room::id).
+     *
+     * @var integer|null
+     */
+    protected ?int $roomId = null;
+
+    /**
+     * The cached Talk room display name.
+     *
+     * @var string|null
+     */
+    protected ?string $roomName = null;
+
+    /**
+     * The Talk room type (Talk Room::TYPE_*: 1=one2one, 2=group,
+     * 3=public, 4=changelog, 6=note-to-self).
+     *
+     * @var integer|null
+     */
+    protected ?int $roomType = null;
+
+    /**
+     * Human-readable subtitle (cached translation of room type or
+     * description).
+     *
+     * @var string|null
+     */
+    protected ?string $subtitle = null;
+
+    /**
+     * Cached participant count from ParticipantService::getNumberOfActors.
+     *
+     * @var integer|null
+     */
+    protected ?int $participantCount = null;
+
+    /**
+     * JSON-encoded last-message payload, shape:
+     *   { actor: {type, id}, text, timestamp }
+     *
+     * @var string|null
+     */
+    protected ?string $lastMessageData = null;
+
+    /**
+     * Cached Talk Room::getLastActivity() timestamp.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $lastActivity = null;
+
+    /**
+     * The user UID that linked the room.
+     *
+     * @var string|null
+     */
+    protected ?string $linkedBy = null;
+
+    /**
+     * When the link was created.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $linkedAt = null;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->addType(fieldName: 'objectUuid', type: 'string');
+        $this->addType(fieldName: 'registerId', type: 'integer');
+        $this->addType(fieldName: 'schemaId', type: 'integer');
+        $this->addType(fieldName: 'roomToken', type: 'string');
+        $this->addType(fieldName: 'roomId', type: 'integer');
+        $this->addType(fieldName: 'roomName', type: 'string');
+        $this->addType(fieldName: 'roomType', type: 'integer');
+        $this->addType(fieldName: 'subtitle', type: 'string');
+        $this->addType(fieldName: 'participantCount', type: 'integer');
+        $this->addType(fieldName: 'lastMessageData', type: 'string');
+        $this->addType(fieldName: 'lastActivity', type: 'datetime');
+        $this->addType(fieldName: 'linkedBy', type: 'string');
+        $this->addType(fieldName: 'linkedAt', type: 'datetime');
+    }//end __construct()
+
+    /**
+     * JSON serialization.
+     *
+     * Decodes the JSON `lastMessageData` column into an associative
+     * array so the leaf row is directly consumable by the sidebar tab
+     * and picker UX. Returns `null` for `lastMessage` on malformed
+     * JSON.
+     *
+     * @return array<string,mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        $lastMessage = null;
+        if ($this->lastMessageData !== null && $this->lastMessageData !== '') {
+            $decoded = json_decode($this->lastMessageData, true);
+            if (is_array($decoded) === true) {
+                $lastMessage = $decoded;
+            }
+        }
+
+        return [
+            'id'               => $this->id,
+            'objectUuid'       => $this->objectUuid,
+            'registerId'       => $this->registerId,
+            'schemaId'         => $this->schemaId,
+            'roomToken'        => $this->roomToken,
+            'roomId'           => $this->roomId,
+            'roomName'         => $this->roomName,
+            'roomType'         => $this->roomType,
+            'subtitle'         => $this->subtitle,
+            'participantCount' => $this->participantCount,
+            'lastMessage'      => $lastMessage,
+            'lastActivity'     => $this->lastActivity?->format(DateTime::ATOM),
+            'linkedBy'         => $this->linkedBy,
+            'linkedAt'         => $this->linkedAt?->format(DateTime::ATOM),
+            // Convenience deep-link for the UI.
+            'url'              => $this->roomToken !== null ? '/index.php/call/'.$this->roomToken : null,
+        ];
+    }//end jsonSerialize()
+}//end class

--- a/lib/Db/TalkLinkMapper.php
+++ b/lib/Db/TalkLinkMapper.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * Mapper for talk link entities.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git-id>
+ * @link      https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\IDBConnection;
+
+/**
+ * Class TalkLinkMapper
+ *
+ * @template-extends QBMapper<TalkLink>
+ */
+class TalkLinkMapper extends QBMapper
+{
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $db Database connection.
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(db: $db, tableName: 'openregister_talk_links', entityClass: TalkLink::class);
+    }//end __construct()
+
+    /**
+     * Find talk links by object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return TalkLink[] Array of talk links.
+     */
+    public function findByObjectUuid(string $objectUuid): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByObjectUuid()
+
+    /**
+     * Find talk links by room token (reverse lookup — which objects is
+     * this room linked to?).
+     *
+     * @param string $roomToken The Talk room token.
+     *
+     * @return TalkLink[] Array of talk links.
+     */
+    public function findByRoomToken(string $roomToken): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('room_token', $qb->createNamedParameter($roomToken)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByRoomToken()
+
+    /**
+     * Find a specific talk link by object UUID and room token.
+     *
+     * @param string $objectUuid The object UUID.
+     * @param string $roomToken  The Talk room token.
+     *
+     * @return TalkLink|null The link or null if not found.
+     */
+    public function findByObjectAndRoom(string $objectUuid, string $roomToken): ?TalkLink
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('room_token', $qb->createNamedParameter($roomToken)));
+
+        try {
+            return $this->findEntity(query: $qb);
+        } catch (DoesNotExistException $e) {
+            return null;
+        }
+    }//end findByObjectAndRoom()
+
+    /**
+     * Delete all talk links for an object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectUuid(string $objectUuid): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectUuid()
+
+    /**
+     * Delete a talk link by object UUID + room token (Tier-2 unlink
+     * path — does NOT destroy the Talk room itself).
+     *
+     * Returns the number of rows actually deleted so callers can
+     * distinguish "no such link" (0) from "ok" (>=1).
+     *
+     * @param string $objectUuid The object UUID.
+     * @param string $roomToken  The Talk room token.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectAndRoom(string $objectUuid, string $roomToken): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('room_token', $qb->createNamedParameter($roomToken)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectAndRoom()
+}//end class

--- a/lib/Migration/Version1Date20260525110000.php
+++ b/lib/Migration/Version1Date20260525110000.php
@@ -1,0 +1,182 @@
+<?php
+
+/**
+ * Tier-2 talk integration migration.
+ *
+ * Ensures the `openregister_talk_links` table exists with the full
+ * Tier-2 schema:
+ *
+ *  - id (bigint, PK, autoincrement)
+ *  - object_uuid (string 36, not null)
+ *  - register_id (bigint unsigned, not null)
+ *  - schema_id (bigint unsigned, nullable)
+ *  - room_token (string 64, not null) — Talk room token (canonical id)
+ *  - room_id (bigint, nullable) — Talk Room::id (legacy numeric id)
+ *  - room_name (string 255, nullable) — cached display name
+ *  - room_type (int, nullable) — Talk Room::TYPE_* (1..6)
+ *  - subtitle (string 255, nullable) — cached human-readable type label
+ *  - participant_count (int, nullable) — cached participant count
+ *  - last_message_data (text JSON, nullable) — cached {actor,text,timestamp}
+ *  - last_activity (datetime, nullable) — cached last-activity timestamp
+ *  - linked_by (string 64, not null)
+ *  - linked_at (datetime, not null)
+ *
+ * Composite unique `(object_uuid, room_token)` so a single Talk room can be
+ * linked to multiple OR objects but only once per object.
+ *
+ * Idempotent: creates the table if missing, otherwise adds any
+ * missing Tier-2 columns. Cached fields are best-effort — they're
+ * refreshed by TalkLinkService on read (>5min staleness) so a
+ * persistent link row alone surfaces a usable sidebar tab even when
+ * Talk is briefly unavailable.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Tier-2 talk-links table — create-or-extend.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+class Version1Date20260525110000 extends SimpleMigrationStep
+{
+    /**
+     * Change the database schema.
+     *
+     * @param IOutput                 $output        Output for the migration process
+     * @param Closure                 $schemaClosure The schema closure
+     * @param array<array-key, mixed> $options       Migration options
+     *
+     * @return ISchemaWrapper|null
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema  = $schemaClosure();
+        $changed = false;
+
+        if ($schema->hasTable('openregister_talk_links') === false) {
+            $this->createTalkLinksTable(schema: $schema, output: $output);
+            $changed = true;
+        }
+
+        if ($schema->hasTable('openregister_talk_links') === true
+            && $this->extendTalkLinksTable(schema: $schema, output: $output) === true
+        ) {
+            $changed = true;
+        }
+
+        if ($changed === false) {
+            return null;
+        }
+
+        return $schema;
+    }//end changeSchema()
+
+    /**
+     * Create the openregister_talk_links table at the Tier-2 shape.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return void
+     */
+    private function createTalkLinksTable(ISchemaWrapper $schema, IOutput $output): void
+    {
+        $table = $schema->createTable('openregister_talk_links');
+
+        $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'unsigned' => true]);
+        $table->addColumn('object_uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
+        $table->addColumn('register_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('schema_id', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]);
+        $table->addColumn('room_token', Types::STRING, ['notnull' => true, 'length' => 64]);
+        $table->addColumn('room_id', Types::BIGINT, ['notnull' => false, 'default' => null]);
+        $table->addColumn('room_name', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+        $table->addColumn('room_type', Types::INTEGER, ['notnull' => false, 'default' => null]);
+        $table->addColumn('subtitle', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+        $table->addColumn('participant_count', Types::INTEGER, ['notnull' => false, 'default' => null]);
+        $table->addColumn('last_message_data', Types::TEXT, ['notnull' => false, 'default' => null]);
+        $table->addColumn('last_activity', Types::DATETIME, ['notnull' => false, 'default' => null]);
+        $table->addColumn('linked_by', Types::STRING, ['notnull' => true, 'length' => 64]);
+        $table->addColumn('linked_at', Types::DATETIME, ['notnull' => true]);
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['object_uuid', 'room_token'], 'idx_talk_object_room');
+        $table->addIndex(['object_uuid'], 'idx_talk_object');
+        $table->addIndex(['room_token'], 'idx_talk_room_token');
+        $table->addIndex(['schema_id'], 'idx_talk_schema');
+
+        $output->info('Created openregister_talk_links table (Tier-2 schema)');
+    }//end createTalkLinksTable()
+
+    /**
+     * Add any missing Tier-2 columns to an existing talk_links table.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return bool True when a column was added.
+     */
+    private function extendTalkLinksTable(ISchemaWrapper $schema, IOutput $output): bool
+    {
+        $table   = $schema->getTable('openregister_talk_links');
+        $changed = false;
+
+        if ($table->hasColumn('schema_id') === false) {
+            $table->addColumn(
+                'schema_id',
+                Types::BIGINT,
+                ['notnull' => false, 'unsigned' => true, 'default' => null]
+            );
+            $table->addIndex(['schema_id'], 'idx_talk_schema');
+            $output->info('Added schema_id column to openregister_talk_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('subtitle') === false) {
+            $table->addColumn('subtitle', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+            $output->info('Added subtitle column to openregister_talk_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('participant_count') === false) {
+            $table->addColumn('participant_count', Types::INTEGER, ['notnull' => false, 'default' => null]);
+            $output->info('Added participant_count column to openregister_talk_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('last_message_data') === false) {
+            $table->addColumn('last_message_data', Types::TEXT, ['notnull' => false, 'default' => null]);
+            $output->info('Added last_message_data column to openregister_talk_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('last_activity') === false) {
+            $table->addColumn('last_activity', Types::DATETIME, ['notnull' => false, 'default' => null]);
+            $output->info('Added last_activity column to openregister_talk_links');
+            $changed = true;
+        }
+
+        return $changed;
+    }//end extendTalkLinksTable()
+}//end class

--- a/lib/Service/Integration/Providers/TalkProvider.php
+++ b/lib/Service/Integration/Providers/TalkProvider.php
@@ -4,9 +4,13 @@
  * TalkProvider — exposes NC Talk (spreed) conversations linked to an OR
  * object via the IntegrationProvider contract.
  *
- * `link-table` storage (a future `openregister_talk_links` pairs
- * object ↔ conversation token); the wrapping TalkService lands in a
- * follow-up — this provider registers the registry surface today.
+ * Tier-2 storage: the `openregister_talk_links` table pairs
+ * object ↔ room token. When the table contains rows for the object
+ * we return them via the {@see TalkLinkMapper} (cheap, no Talk API
+ * roundtrip needed for the leaf-row shape — the cache already has
+ * subtitle/participantCount/lastMessage). When it's empty we fall
+ * back to the legacy marker scan (`[or:{uuid}]` substring in the
+ * room display name) so rooms linked before Tier-2 still surface.
  *
  * NB: NC Talk's internal app id is `spreed`, not `talk` — that's what
  * IAppManager resolves against.
@@ -29,6 +33,7 @@ namespace OCA\OpenRegister\Service\Integration\Providers;
 
 // phpcs:disable PEAR.Commenting.FunctionComment.Missing -- self-documenting IntegrationProvider metadata getters mirror the contract in the interface.
 
+use OCA\OpenRegister\Db\TalkLinkMapper;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCP\App\IAppManager;
 use OCP\IL10N;
@@ -47,6 +52,7 @@ class TalkProvider extends AbstractIntegrationProvider
         private IAppManager $appManager,
         private IUserSession $userSession,
         private IL10N $l10n,
+        private ?TalkLinkMapper $talkLinkMapper = null,
     ) {
     }//end __construct()
 
@@ -130,6 +136,21 @@ class TalkProvider extends AbstractIntegrationProvider
         $user = $this->userSession->getUser();
         if ($user === null) {
             return [];
+        }
+
+        // Tier-2 preferred path — query the link table directly. Each row
+        // already carries the widened Phase B-1 payload (subtitle,
+        // participantCount, lastMessage, lastActivity) so we don't need
+        // to hit Talk for the leaf-row shape.
+        if ($this->talkLinkMapper !== null) {
+            try {
+                $links = $this->talkLinkMapper->findByObjectUuid($objectId);
+                if (count($links) > 0) {
+                    return $this->mapLinks($links);
+                }
+            } catch (Throwable $e) {
+                // Fall through to legacy marker scan.
+            }
         }
 
         $marker = self::ROOM_TAG.$objectId.']';
@@ -336,6 +357,51 @@ class TalkProvider extends AbstractIntegrationProvider
             'timestamp' => $timestamp,
         ];
     }//end buildLastMessage()
+
+    /**
+     * Map a list of {@see \OCA\OpenRegister\Db\TalkLink} entities to the
+     * registry leaf-row contract (same shape as the legacy marker-scan
+     * path so callers don't see a regression).
+     *
+     * @param array<int, \OCA\OpenRegister\Db\TalkLink> $links Persisted rows.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    private function mapLinks(array $links): array
+    {
+        $out = [];
+        foreach ($links as $link) {
+            $serialized = $link->jsonSerialize();
+
+            $lastMessage = $serialized['lastMessage'] ?? null;
+            $lastActivityIso = $serialized['lastActivity'] ?? null;
+            $lastActivityTs  = null;
+            if ($lastActivityIso !== null) {
+                try {
+                    $lastActivityTs = (new \DateTime($lastActivityIso))->getTimestamp();
+                } catch (Throwable $e) {
+                    $lastActivityTs = null;
+                }
+            }
+
+            $token = (string) ($serialized['roomToken'] ?? '');
+
+            $out[] = [
+                'id'               => $token,
+                'title'            => $serialized['roomName'] ?? $token,
+                'type'             => $serialized['roomType'] ?? null,
+                'subtitle'         => $serialized['subtitle'] ?? null,
+                'participantCount' => $serialized['participantCount'] ?? null,
+                'lastMessage'      => $lastMessage,
+                // `unreadMessages` left null — see legacy list() docblock.
+                'unreadMessages'   => null,
+                'lastActivity'     => $lastActivityTs,
+                'url'              => $serialized['url'] ?? ($token !== '' ? '/index.php/call/'.$token : null),
+            ];
+        }
+
+        return $out;
+    }//end mapLinks()
 
     public function health(): array
     {

--- a/lib/Service/TalkLinkService.php
+++ b/lib/Service/TalkLinkService.php
@@ -1,0 +1,812 @@
+<?php
+
+/**
+ * TalkLinkService — Tier-2 talk integration service.
+ *
+ * Composes the {@see TalkLinkMapper} with Nextcloud Talk's internal
+ * `Manager` / `RoomService` / `ParticipantService` to provide the
+ * picker + inline-create UX surface area:
+ *
+ *   - linkRoom(uuid, registerId, schemaId, roomToken)
+ *   - createAndLinkRoom(uuid, ..., name, ?description, type=2)
+ *   - unlinkRoom(uuid, roomToken)
+ *   - getLinkedRooms(uuid)              — refreshes stale cache (>5min)
+ *   - getAvailableRoomsForUser(?search)
+ *
+ * Talk is reached via the server container ("OCA\\Talk\\Manager") with
+ * graceful degradation: when Talk is unavailable or a Manager call
+ * throws, the stored link row is returned as-is so historical
+ * references survive even after Talk is uninstalled (ADR-019 AD-23).
+ *
+ * Linking convention preserved: the Tier-1 {@see TalkProvider} relied
+ * on a `[or:{uuid}]` marker substring in the room name. Tier-2 uses
+ * the explicit link table — but `createAndLinkRoom` still tags the
+ * description with the marker so the legacy reverse-marker code path
+ * stays consistent until that lookup is removed.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git-id>
+ * @link      https://OpenRegister.app
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use DateTime;
+use Exception;
+use OCA\OpenRegister\Db\TalkLink;
+use OCA\OpenRegister\Db\TalkLinkMapper;
+use OCP\App\IAppManager;
+use OCP\IL10N;
+use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * TalkLinkService.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Composes mapper +
+ *     Talk's Manager/RoomService/ParticipantService + user session +
+ *     l10n + container. Each dependency is required for one of the
+ *     Tier-2 flows (link, create, refresh, subtitle).
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) Defensive
+ *     method_exists + try/catch guards around every getter on Talk's
+ *     Room entity (which uses Entity::__call magic) inflate the
+ *     cyclomatic score; splitting into helper classes would scatter
+ *     the leaf-row contract.
+ */
+class TalkLinkService
+{
+    private const REQUIRED_APP = 'spreed';
+    private const ROOM_TAG     = '[or:';
+    private const STALE_AFTER  = 300; // 5 minutes in seconds.
+
+    /**
+     * Constructor.
+     *
+     * @param TalkLinkMapper     $talkLinkMapper Persistence for link rows.
+     * @param ContainerInterface $container      Container for late-bound Talk classes.
+     * @param IAppManager        $appManager     NC app manager.
+     * @param IUserSession       $userSession    Active session.
+     * @param IL10N              $l10n           Translation service.
+     * @param LoggerInterface    $logger         Logger.
+     */
+    public function __construct(
+        private readonly TalkLinkMapper $talkLinkMapper,
+        private readonly ContainerInterface $container,
+        private readonly IAppManager $appManager,
+        private readonly IUserSession $userSession,
+        private readonly IL10N $l10n,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Whether NC Talk (spreed) is installed + enabled for the current
+     * user.
+     *
+     * @return bool
+     */
+    public function isTalkAvailable(): bool
+    {
+        return $this->appManager->isEnabledForUser(self::REQUIRED_APP);
+    }//end isTalkAvailable()
+
+    /**
+     * Link an existing Talk room to an OR object.
+     *
+     * The link row carries room_id/room_name/room_type/subtitle/
+     * participantCount/lastMessageData/lastActivity harvested from the
+     * Talk room so subsequent reads don't need to hit Talk. Idempotent:
+     * a duplicate link raises a 409 Exception.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $registerId OR register id.
+     * @param int    $schemaId   OR schema id (Tier-2 column).
+     * @param string $roomToken  Talk room token.
+     *
+     * @return TalkLink The persisted link row.
+     *
+     * @throws Exception On missing user, missing room (404), duplicate (409),
+     *                   Talk unavailable (503).
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Sequential guard
+     *     clauses (no user, duplicate, Talk unavailable, find failure,
+     *     null room) followed by best-effort cache extraction.
+     */
+    public function linkRoom(string $objectUuid, int $registerId, int $schemaId, string $roomToken): TalkLink
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in');
+        }
+
+        $existing = $this->talkLinkMapper->findByObjectAndRoom($objectUuid, $roomToken);
+        if ($existing !== null) {
+            throw new Exception('Room already linked to this object', 409);
+        }
+
+        $manager = $this->resolveManager();
+        if ($manager === null) {
+            throw new Exception('Talk is not available', 503);
+        }
+
+        $room = $this->findRoom($manager, $roomToken, $user->getUID());
+        if ($room === null) {
+            throw new Exception('Talk room not found', 404);
+        }
+
+        $cache = $this->extractRoomFields(room: $room, userUid: $user->getUID());
+
+        $link = new TalkLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        $link->setSchemaId($schemaId);
+        $link->setRoomToken($roomToken);
+        $link->setRoomId($cache['roomId']);
+        $link->setRoomName($cache['roomName']);
+        $link->setRoomType($cache['roomType']);
+        $link->setSubtitle($cache['subtitle']);
+        $link->setParticipantCount($cache['participantCount']);
+        $link->setLastMessageData(
+            $cache['lastMessage'] !== null ? json_encode($cache['lastMessage']) : null
+        );
+        $link->setLastActivity($cache['lastActivity']);
+        $link->setLinkedBy($user->getUID());
+        $link->setLinkedAt(new DateTime());
+
+        return $this->talkLinkMapper->insert($link);
+    }//end linkRoom()
+
+    /**
+     * Unlink a Talk room from an object. Does NOT destroy the room
+     * itself — it remains in Talk for other linked objects (or the
+     * users who joined it directly).
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param string $roomToken  Talk room token.
+     *
+     * @return void
+     *
+     * @throws Exception When no matching link is found (404).
+     */
+    public function unlinkRoom(string $objectUuid, string $roomToken): void
+    {
+        $deleted = $this->talkLinkMapper->deleteByObjectAndRoom($objectUuid, $roomToken);
+        if ($deleted === 0) {
+            throw new Exception('Talk link not found', 404);
+        }
+    }//end unlinkRoom()
+
+    /**
+     * Return the linked rooms for an object, refreshing cached fields
+     * for rows older than {@see self::STALE_AFTER}.
+     *
+     * Always succeeds: when Talk's `Manager` is missing or `getRoom`
+     * throws for a stale link, the stored row is returned with its
+     * cached fields as-is.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getLinkedRooms(string $objectUuid): array
+    {
+        $links   = $this->talkLinkMapper->findByObjectUuid($objectUuid);
+        $manager = $this->resolveManager();
+        $user    = $this->userSession->getUser();
+
+        $results = [];
+        foreach ($links as $link) {
+            $row = $link->jsonSerialize();
+
+            if ($manager !== null && $user !== null && $this->isStale($link) === true) {
+                try {
+                    $room = $this->findRoom($manager, $link->getRoomToken(), $user->getUID());
+                    if ($room !== null) {
+                        $refreshed = $this->extractRoomFields(room: $room, userUid: $user->getUID());
+                        $link->setRoomId($refreshed['roomId']);
+                        $link->setRoomName($refreshed['roomName']);
+                        $link->setRoomType($refreshed['roomType']);
+                        $link->setSubtitle($refreshed['subtitle']);
+                        $link->setParticipantCount($refreshed['participantCount']);
+                        $link->setLastMessageData(
+                            $refreshed['lastMessage'] !== null ? json_encode($refreshed['lastMessage']) : null
+                        );
+                        $link->setLastActivity($refreshed['lastActivity']);
+                        $this->talkLinkMapper->update($link);
+                        $row = $link->jsonSerialize();
+                    }
+                } catch (Throwable $e) {
+                    // Stale link — keep cached row as-is.
+                    $this->logger->debug('Stale talk link for room '.$link->getRoomToken().': '.$e->getMessage());
+                }
+            }
+
+            $results[] = $row;
+        }
+
+        return $results;
+    }//end getLinkedRooms()
+
+    /**
+     * Create a new Talk room and link it to an object in one
+     * transaction.
+     *
+     * Uses Talk's `Manager::createRoom` for the create then invites
+     * the current user as participant (so the room is visible in
+     * Talk's UI). The link row carries the new room's token + cached
+     * metadata.
+     *
+     * Room type maps to Talk Room::TYPE_*:
+     *   1 → one2one  (rejected — pickers exclude it)
+     *   2 → group    (default)
+     *   3 → public
+     *
+     * @param string      $objectUuid  Parent OR object uuid.
+     * @param int         $registerId  OR register id.
+     * @param int         $schemaId    OR schema id.
+     * @param string      $roomName    Room display name (required).
+     * @param string|null $description Room description (optional).
+     * @param int         $roomType    Talk room type (default 2 = group).
+     *
+     * @return TalkLink The persisted link row.
+     *
+     * @throws Exception On missing user, Talk unavailable, invalid
+     *                   type, or create failure.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    public function createAndLinkRoom(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        string $roomName,
+        ?string $description,
+        int $roomType = 2
+    ): TalkLink {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in');
+        }
+
+        if (in_array($roomType, [2, 3], true) === false) {
+            throw new Exception('Invalid room type (must be 2=group or 3=public)', 400);
+        }
+
+        $manager = $this->resolveManager();
+        if ($manager === null) {
+            throw new Exception('Talk is not available', 503);
+        }
+
+        // Tag with the OR marker so the legacy `[or:{uuid}]` reverse
+        // lookup still finds it until that code path is removed.
+        $taggedName = $roomName.' '.self::ROOM_TAG.$objectUuid.']';
+        $userUid    = $user->getUID();
+
+        try {
+            // Talk Manager::createRoom(type, name, owner) — exact
+            // signature varies across Talk releases. We pass the
+            // three canonical args and trust the manager to ignore
+            // extras.
+            $room = $manager->createRoom($roomType, $taggedName, $userUid);
+        } catch (Throwable $e) {
+            $this->logger->warning('Failed to create Talk room: '.$e->getMessage());
+            throw new Exception('Failed to create Talk room: '.$e->getMessage(), 500);
+        }
+
+        if (is_object($room) === false) {
+            throw new Exception('Talk createRoom returned no room', 500);
+        }
+
+        // Set the description (best-effort; older Talk versions may
+        // not support it).
+        if ($description !== null && $description !== '') {
+            try {
+                $roomService = $this->resolveRoomService();
+                if ($roomService !== null && method_exists($roomService, 'setDescription') === true) {
+                    $roomService->setDescription($room, $description);
+                }
+            } catch (Throwable $e) {
+                $this->logger->debug('Failed to set Talk room description: '.$e->getMessage());
+            }
+        }
+
+        // Invite the current user so the room appears in their UI.
+        try {
+            $participantService = $this->resolveParticipantService();
+            if ($participantService !== null && method_exists($participantService, 'addUsers') === true) {
+                $participantService->addUsers($room, [['actorType' => 'users', 'actorId' => $userUid]]);
+            }
+        } catch (Throwable $e) {
+            // Best-effort — the owner is implicitly a participant in
+            // many Talk versions, so a failure here is non-fatal.
+            $this->logger->debug('Failed to add owner as Talk participant: '.$e->getMessage());
+        }
+
+        $roomToken = '';
+        try {
+            $roomToken = (string) $room->getToken();
+        } catch (Throwable $e) {
+            throw new Exception('Talk room has no token after create', 500);
+        }
+
+        if ($roomToken === '') {
+            throw new Exception('Talk room has no token after create', 500);
+        }
+
+        $cache = $this->extractRoomFields(room: $room, userUid: $userUid);
+
+        $link = new TalkLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        $link->setSchemaId($schemaId);
+        $link->setRoomToken($roomToken);
+        $link->setRoomId($cache['roomId']);
+        $link->setRoomName($cache['roomName'] !== null && $cache['roomName'] !== '' ? $cache['roomName'] : $roomName);
+        $link->setRoomType($cache['roomType'] !== null ? $cache['roomType'] : $roomType);
+        $link->setSubtitle($cache['subtitle']);
+        $link->setParticipantCount($cache['participantCount']);
+        $link->setLastMessageData(
+            $cache['lastMessage'] !== null ? json_encode($cache['lastMessage']) : null
+        );
+        $link->setLastActivity($cache['lastActivity']);
+        $link->setLinkedBy($userUid);
+        $link->setLinkedAt(new DateTime());
+
+        return $this->talkLinkMapper->insert($link);
+    }//end createAndLinkRoom()
+
+    /**
+     * Return Talk rooms available to the current user for the picker.
+     *
+     * Each row is `{token, name, type, participantCount}`. The optional
+     * `$search` filter does a case-insensitive substring match on the
+     * room name client-side (Talk's getRoomsForUser doesn't accept a
+     * search param across all versions).
+     *
+     * Returns an empty array when Talk is unavailable or the manager
+     * throws.
+     *
+     * @param string|null $search Optional case-insensitive name filter.
+     *
+     * @return array<int,array{token:string,name:string,type:?int,participantCount:?int}>
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     */
+    public function getAvailableRoomsForUser(?string $search = null): array
+    {
+        if ($this->isTalkAvailable() === false) {
+            return [];
+        }
+
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return [];
+        }
+
+        $manager = $this->resolveManager();
+        if ($manager === null) {
+            return [];
+        }
+
+        try {
+            $rooms = $manager->getRoomsForUser($user->getUID(), [], true);
+        } catch (Throwable $e) {
+            $this->logger->debug('Talk Manager::getRoomsForUser failed: '.$e->getMessage());
+            return [];
+        }
+
+        if (is_array($rooms) === false) {
+            return [];
+        }
+
+        $participantService = $this->resolveParticipantService();
+        $needle             = $search !== null ? mb_strtolower(trim($search)) : null;
+
+        $out = [];
+        foreach ($rooms as $room) {
+            $token = '';
+            try {
+                $token = (string) $room->getToken();
+            } catch (Throwable $e) {
+                continue;
+            }
+
+            if ($token === '') {
+                continue;
+            }
+
+            $name = '';
+            try {
+                $name = (string) $room->getName();
+            } catch (Throwable $e) {
+                // Leave default empty.
+            }
+
+            if (method_exists($room, 'getDisplayName') === true) {
+                try {
+                    $displayName = (string) $room->getDisplayName($user->getUID());
+                    if ($displayName !== '') {
+                        $name = $displayName;
+                    }
+                } catch (Throwable $e) {
+                    // Keep existing $name.
+                }
+            }
+
+            $cleanName = $this->stripMarker($name);
+
+            if ($needle !== null && $needle !== '' && mb_strpos(mb_strtolower($cleanName), $needle) === false) {
+                continue;
+            }
+
+            $type = null;
+            try {
+                $type = (int) $room->getType();
+            } catch (Throwable $e) {
+                // Leave null.
+            }
+
+            // Exclude changelog / note-to-self / one2one auto-rooms
+            // from the picker — the user can't usefully link those.
+            if ($type === 4 || $type === 6) {
+                continue;
+            }
+
+            $count = null;
+            if ($participantService !== null && method_exists($participantService, 'getNumberOfActors') === true) {
+                try {
+                    $count = (int) $participantService->getNumberOfActors($room);
+                } catch (Throwable $e) {
+                    $count = null;
+                }
+            }
+
+            $out[] = [
+                'token'            => $token,
+                'name'             => $cleanName,
+                'type'             => $type,
+                'participantCount' => $count,
+            ];
+        }//end foreach
+
+        return $out;
+    }//end getAvailableRoomsForUser()
+
+    /**
+     * Resolve Talk's `Manager` from the server container.
+     *
+     * @return object|null Returns null when Talk is unavailable.
+     */
+    private function resolveManager(): ?object
+    {
+        if ($this->isTalkAvailable() === false) {
+            return null;
+        }
+
+        if (class_exists('OCA\\Talk\\Manager') === false) {
+            return null;
+        }
+
+        try {
+            return $this->container->get('OCA\\Talk\\Manager');
+        } catch (Throwable $e) {
+            $this->logger->debug('Talk Manager not resolvable: '.$e->getMessage());
+            return null;
+        }
+    }//end resolveManager()
+
+    /**
+     * Resolve Talk's `RoomService`.
+     *
+     * @return object|null Returns null when Talk is unavailable.
+     */
+    private function resolveRoomService(): ?object
+    {
+        if (class_exists('OCA\\Talk\\Service\\RoomService') === false) {
+            return null;
+        }
+
+        try {
+            return $this->container->get('OCA\\Talk\\Service\\RoomService');
+        } catch (Throwable $e) {
+            $this->logger->debug('Talk RoomService not resolvable: '.$e->getMessage());
+            return null;
+        }
+    }//end resolveRoomService()
+
+    /**
+     * Resolve Talk's `ParticipantService`.
+     *
+     * @return object|null Returns null when Talk is unavailable.
+     */
+    private function resolveParticipantService(): ?object
+    {
+        if (class_exists('OCA\\Talk\\Service\\ParticipantService') === false) {
+            return null;
+        }
+
+        try {
+            return $this->container->get('OCA\\Talk\\Service\\ParticipantService');
+        } catch (Throwable $e) {
+            $this->logger->debug('Talk ParticipantService not resolvable: '.$e->getMessage());
+            return null;
+        }
+    }//end resolveParticipantService()
+
+    /**
+     * Look up a Talk Room by token via the Manager.
+     *
+     * Tries `getRoomForUserByToken(token, userUid)` first (the
+     * user-scoped variant), then `getRoomByToken(token)` (raw).
+     * Returns null when both throw or are missing.
+     *
+     * @param object $manager   Talk Manager.
+     * @param string $roomToken Talk room token.
+     * @param string $userUid   User UID.
+     *
+     * @return object|null Talk Room or null.
+     */
+    private function findRoom(object $manager, string $roomToken, string $userUid): ?object
+    {
+        if (method_exists($manager, 'getRoomForUserByToken') === true) {
+            try {
+                return $manager->getRoomForUserByToken($roomToken, $userUid);
+            } catch (Throwable $e) {
+                // Fall through.
+            }
+        }
+
+        if (method_exists($manager, 'getRoomByToken') === true) {
+            try {
+                return $manager->getRoomByToken($roomToken);
+            } catch (Throwable $e) {
+                return null;
+            }
+        }
+
+        return null;
+    }//end findRoom()
+
+    /**
+     * Whether a link row's cache is older than {@see self::STALE_AFTER}.
+     *
+     * Note: we treat `lastActivity` as the cache-age proxy because Talk
+     * updates it on every message; if it's missing we fall back to
+     * `linkedAt`. A row with no cache yet (lastActivity null) is
+     * considered stale.
+     *
+     * @param TalkLink $link The link row.
+     *
+     * @return bool
+     */
+    private function isStale(TalkLink $link): bool
+    {
+        $proxy = $link->getLastActivity() ?? $link->getLinkedAt();
+        if ($proxy === null) {
+            return true;
+        }
+
+        return ((new DateTime())->getTimestamp() - $proxy->getTimestamp()) > self::STALE_AFTER;
+    }//end isStale()
+
+    /**
+     * Strip the OR linking marker `[or:{uuid}]` from a room name.
+     *
+     * @param string $name Raw room name.
+     *
+     * @return string
+     */
+    private function stripMarker(string $name): string
+    {
+        // Match [or:<uuid>] anywhere in the string.
+        $stripped = preg_replace('/\s*\[or:[^\]]+\]\s*/', ' ', $name) ?? $name;
+        return trim($stripped);
+    }//end stripMarker()
+
+    /**
+     * Extract cached fields from a Talk Room entity.
+     *
+     * Returns:
+     *   - `roomId`           — Talk Room::id (legacy numeric id)
+     *   - `roomName`         — display name (or fallback raw name)
+     *   - `roomType`         — Talk Room::TYPE_*
+     *   - `subtitle`         — human-readable type label
+     *   - `participantCount` — ParticipantService::getNumberOfActors
+     *   - `lastMessage`      — {actor:{type,id},text,timestamp} or null
+     *   - `lastActivity`     — DateTime or null
+     *
+     * Each accessor is wrapped in try/catch so a missing getter on an
+     * older Talk release degrades to null rather than crashing.
+     *
+     * @param object $room    Talk Room entity.
+     * @param string $userUid User UID (for getDisplayName).
+     *
+     * @return array{roomId:?int,roomName:?string,roomType:?int,subtitle:?string,participantCount:?int,lastMessage:?array,lastActivity:?DateTime}
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     */
+    private function extractRoomFields(object $room, string $userUid): array
+    {
+        $roomId = null;
+        try {
+            $roomId = (int) $room->getId();
+        } catch (Throwable $e) {
+            // Leave null.
+        }
+
+        $name = '';
+        try {
+            $name = (string) $room->getName();
+        } catch (Throwable $e) {
+            // Leave default empty.
+        }
+
+        if (method_exists($room, 'getDisplayName') === true) {
+            try {
+                $displayName = (string) $room->getDisplayName($userUid);
+                if ($displayName !== '') {
+                    $name = $displayName;
+                }
+            } catch (Throwable $e) {
+                // Keep $name as-is.
+            }
+        }
+
+        $cleanName = $this->stripMarker($name);
+
+        $type = null;
+        try {
+            $type = (int) $room->getType();
+        } catch (Throwable $e) {
+            // Leave null.
+        }
+
+        $subtitle = $this->buildSubtitle($room, $type);
+
+        $participantCount = null;
+        $participantService = $this->resolveParticipantService();
+        if ($participantService !== null && method_exists($participantService, 'getNumberOfActors') === true) {
+            try {
+                $participantCount = (int) $participantService->getNumberOfActors($room);
+            } catch (Throwable $e) {
+                $participantCount = null;
+            }
+        }
+
+        $lastActivity = null;
+        try {
+            $rawActivity = method_exists($room, 'getLastActivity') === true ? $room->getLastActivity() : null;
+            if ($rawActivity instanceof \DateTimeInterface) {
+                $lastActivity = new DateTime($rawActivity->format(DateTime::ATOM));
+            }
+        } catch (Throwable $e) {
+            // Leave null.
+        }
+
+        $lastMessage = $this->buildLastMessage($room);
+
+        return [
+            'roomId'           => $roomId,
+            'roomName'         => $cleanName !== '' ? $cleanName : null,
+            'roomType'         => $type,
+            'subtitle'         => $subtitle,
+            'participantCount' => $participantCount,
+            'lastMessage'      => $lastMessage,
+            'lastActivity'     => $lastActivity,
+        ];
+    }//end extractRoomFields()
+
+    /**
+     * Build a human-readable subtitle from the room type.
+     *
+     * Prefers the room description when set, falling back to the
+     * translated Talk room-type label.
+     *
+     * @param object   $room Talk Room.
+     * @param int|null $type Numeric room type.
+     *
+     * @return string|null
+     */
+    private function buildSubtitle(object $room, ?int $type): ?string
+    {
+        $description = '';
+        if (method_exists($room, 'getDescription') === true) {
+            try {
+                $description = trim((string) $room->getDescription());
+            } catch (Throwable $e) {
+                $description = '';
+            }
+        }
+
+        if ($description !== '') {
+            return $description;
+        }
+
+        switch ($type) {
+            case 1:
+                return $this->l10n->t('Direct message');
+
+            case 2:
+                return $this->l10n->t('Group');
+
+            case 3:
+                return $this->l10n->t('Public');
+
+            case 4:
+                return $this->l10n->t('System');
+
+            case 6:
+                return $this->l10n->t('Note to self');
+
+            default:
+                return null;
+        }
+    }//end buildSubtitle()
+
+    /**
+     * Build the `{actor, text, timestamp}` shape from a Talk Room's
+     * last comment.
+     *
+     * Returns `null` when the room has no last message yet, or when
+     * the lookup throws (federated rooms return null by design).
+     *
+     * @param object $room Talk Room.
+     *
+     * @return array{actor:array{type:string,id:string},text:string,timestamp:?int}|null
+     */
+    private function buildLastMessage(object $room): ?array
+    {
+        if (method_exists($room, 'getLastMessage') === false) {
+            return null;
+        }
+
+        try {
+            $comment = $room->getLastMessage();
+        } catch (Throwable $e) {
+            return null;
+        }
+
+        if (is_object($comment) === false) {
+            return null;
+        }
+
+        $text      = method_exists($comment, 'getMessage') === true ? (string) $comment->getMessage() : '';
+        $actorType = method_exists($comment, 'getActorType') === true ? (string) $comment->getActorType() : '';
+        $actorId   = method_exists($comment, 'getActorId') === true ? (string) $comment->getActorId() : '';
+
+        $timestamp = null;
+        if (method_exists($comment, 'getCreationDateTime') === true) {
+            try {
+                $created = $comment->getCreationDateTime();
+                if ($created instanceof \DateTimeInterface) {
+                    $timestamp = $created->getTimestamp();
+                }
+            } catch (Throwable $e) {
+                $timestamp = null;
+            }
+        }
+
+        return [
+            'actor'     => ['type' => $actorType, 'id' => $actorId],
+            'text'      => $text,
+            'timestamp' => $timestamp,
+        ];
+    }//end buildLastMessage()
+}//end class

--- a/tests/Unit/Db/TalkLinkTest.php
+++ b/tests/Unit/Db/TalkLinkTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Db\TalkLink}.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/integration-talk/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Db;
+
+use DateTime;
+use OCA\OpenRegister\Db\TalkLink;
+use PHPUnit\Framework\TestCase;
+
+class TalkLinkTest extends TestCase
+{
+    public function testJsonSerializeReturnsAllFields(): void
+    {
+        $link = new TalkLink();
+        $link->setObjectUuid('abc-123');
+        $link->setRegisterId(5);
+        $link->setSchemaId(7);
+        $link->setRoomToken('room-tok');
+        $link->setRoomId(42);
+        $link->setRoomName('Test Room');
+        $link->setRoomType(2);
+        $link->setSubtitle('Group');
+        $link->setParticipantCount(3);
+        $link->setLastActivity(new DateTime('2026-05-25T11:00:00+00:00'));
+        $link->setLinkedBy('admin');
+        $link->setLinkedAt(new DateTime('2026-05-25T11:00:00+00:00'));
+
+        $json = $link->jsonSerialize();
+
+        $this->assertSame('abc-123', $json['objectUuid']);
+        $this->assertSame(5, $json['registerId']);
+        $this->assertSame(7, $json['schemaId']);
+        $this->assertSame('room-tok', $json['roomToken']);
+        $this->assertSame(42, $json['roomId']);
+        $this->assertSame('Test Room', $json['roomName']);
+        $this->assertSame(2, $json['roomType']);
+        $this->assertSame('Group', $json['subtitle']);
+        $this->assertSame(3, $json['participantCount']);
+        $this->assertSame('/index.php/call/room-tok', $json['url']);
+    }
+
+    public function testJsonSerializeHandlesNulls(): void
+    {
+        $link = new TalkLink();
+
+        $json = $link->jsonSerialize();
+
+        $this->assertNull($json['roomToken']);
+        $this->assertNull($json['roomName']);
+        $this->assertNull($json['lastMessage']);
+        $this->assertNull($json['lastActivity']);
+        $this->assertNull($json['linkedAt']);
+        $this->assertNull($json['url']);
+    }
+
+    public function testJsonSerializeDecodesLastMessageData(): void
+    {
+        $link = new TalkLink();
+        $link->setLastMessageData(json_encode([
+            'actor'     => ['type' => 'users', 'id' => 'admin'],
+            'text'      => 'Hello',
+            'timestamp' => 1716640000,
+        ]));
+
+        $json = $link->jsonSerialize();
+
+        $this->assertIsArray($json['lastMessage']);
+        $this->assertSame('Hello', $json['lastMessage']['text']);
+        $this->assertSame('admin', $json['lastMessage']['actor']['id']);
+    }
+
+    public function testJsonSerializeReturnsNullOnMalformedLastMessageData(): void
+    {
+        $link = new TalkLink();
+        $link->setLastMessageData('not-json{');
+
+        $json = $link->jsonSerialize();
+
+        $this->assertNull($json['lastMessage']);
+    }
+
+    public function testSettersAndGetters(): void
+    {
+        $link = new TalkLink();
+        $link->setRoomToken('xyz');
+        $link->setRoomType(3);
+
+        $this->assertSame('xyz', $link->getRoomToken());
+        $this->assertSame(3, $link->getRoomType());
+    }
+}

--- a/tests/Unit/Service/TalkLinkServiceTest.php
+++ b/tests/Unit/Service/TalkLinkServiceTest.php
@@ -1,0 +1,264 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Service\TalkLinkService}.
+ *
+ * Exercises the Tier-2 service contract (link/create/list/unlink +
+ * room discovery) against a mocked TalkLinkMapper. Tests that touch
+ * Talk's internal services (Manager / RoomService / ParticipantService)
+ * use the "Talk unavailable" path because those classes are resolved
+ * from the container and aren't injectable into this unit test scope
+ * without the `spreed` app on the classpath. Tests that exercise the
+ * real Manager are gated by `@group requires-app-spreed`.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/integration-talk/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use Exception;
+use OCA\OpenRegister\Db\TalkLink;
+use OCA\OpenRegister\Db\TalkLinkMapper;
+use OCA\OpenRegister\Service\TalkLinkService;
+use OCP\App\IAppManager;
+use OCP\IL10N;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * TalkLinkServiceTest.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class TalkLinkServiceTest extends TestCase
+{
+    private TalkLinkMapper&MockObject $mapper;
+    private ContainerInterface&MockObject $container;
+    private IAppManager&MockObject $appManager;
+    private IUserSession&MockObject $userSession;
+    private IL10N&MockObject $l10n;
+    private LoggerInterface&MockObject $logger;
+    private TalkLinkService $service;
+
+    protected function setUp(): void
+    {
+        $this->mapper = $this->getMockBuilder(TalkLinkMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'findByObjectUuid',
+                'findByObjectAndRoom',
+                'deleteByObjectAndRoom',
+                'insert',
+                'update',
+            ])
+            ->getMock();
+        $this->container   = $this->createMock(ContainerInterface::class);
+        $this->appManager  = $this->createMock(IAppManager::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->l10n        = $this->createMock(IL10N::class);
+        $this->logger      = $this->createMock(LoggerInterface::class);
+
+        // l10n->t() is called from extractRoomFields → buildSubtitle.
+        // Return the input verbatim so the test doesn't depend on the
+        // translation cache.
+        $this->l10n->method('t')->willReturnArgument(0);
+
+        $this->service = new TalkLinkService(
+            $this->mapper,
+            $this->container,
+            $this->appManager,
+            $this->userSession,
+            $this->l10n,
+            $this->logger
+        );
+    }
+
+    private function setupUser(string $uid = 'admin'): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $this->userSession->method('getUser')->willReturn($user);
+    }
+
+    public function testIsTalkAvailableTrue(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('spreed')->willReturn(true);
+        $this->assertTrue($this->service->isTalkAvailable());
+    }
+
+    public function testIsTalkAvailableFalse(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('spreed')->willReturn(false);
+        $this->assertFalse($this->service->isTalkAvailable());
+    }
+
+    public function testLinkRoomThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No user logged in');
+
+        $this->service->linkRoom('abc-123', 1, 2, 'room-tok');
+    }
+
+    public function testLinkRoomThrowsOnDuplicate(): void
+    {
+        $this->setupUser();
+        $existing = new TalkLink();
+        $this->mapper->method('findByObjectAndRoom')->with('abc-123', 'room-tok')->willReturn($existing);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(409);
+        $this->expectExceptionMessage('Room already linked to this object');
+
+        $this->service->linkRoom('abc-123', 1, 2, 'room-tok');
+    }
+
+    public function testLinkRoomThrowsWhenTalkUnavailable(): void
+    {
+        $this->setupUser();
+        $this->mapper->method('findByObjectAndRoom')->willReturn(null);
+        // appManager->isEnabledForUser('spreed') defaults to false here.
+
+        // Either Talk isn't installed (→ 503 from the null Manager
+        // guard) or the Manager throws when looking up the room
+        // (→ 404). Both are valid "cannot link this room" outcomes.
+        $this->expectException(Exception::class);
+
+        try {
+            $this->service->linkRoom('abc-123', 1, 2, 'room-tok');
+            $this->fail('Expected exception was not thrown');
+        } catch (Exception $exception) {
+            $this->assertContains($exception->getCode(), [404, 503]);
+            throw $exception;
+        }
+    }
+
+    public function testUnlinkRoomSucceeds(): void
+    {
+        $this->mapper->expects($this->once())
+            ->method('deleteByObjectAndRoom')
+            ->with('abc-123', 'room-tok')
+            ->willReturn(1);
+
+        $this->service->unlinkRoom('abc-123', 'room-tok');
+    }
+
+    public function testUnlinkRoomNotFound(): void
+    {
+        $this->mapper->method('deleteByObjectAndRoom')->willReturn(0);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(404);
+        $this->expectExceptionMessage('Talk link not found');
+
+        $this->service->unlinkRoom('abc-123', 'room-tok');
+    }
+
+    public function testGetLinkedRoomsReturnsSerialisedRows(): void
+    {
+        $link = new TalkLink();
+        $link->setObjectUuid('abc-123');
+        $link->setRoomToken('room-tok');
+        $link->setRoomName('Stub Room');
+        $link->setRoomType(2);
+
+        $this->mapper->method('findByObjectUuid')->with('abc-123')->willReturn([$link]);
+
+        $rows = $this->service->getLinkedRooms('abc-123');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('abc-123', $rows[0]['objectUuid']);
+        $this->assertSame('room-tok', $rows[0]['roomToken']);
+        $this->assertSame('Stub Room', $rows[0]['roomName']);
+        $this->assertSame(2, $rows[0]['roomType']);
+        // Tier-2 widened keys always present even with Talk unavailable.
+        $this->assertArrayHasKey('subtitle', $rows[0]);
+        $this->assertArrayHasKey('participantCount', $rows[0]);
+        $this->assertArrayHasKey('lastMessage', $rows[0]);
+        $this->assertArrayHasKey('lastActivity', $rows[0]);
+        $this->assertArrayHasKey('url', $rows[0]);
+        $this->assertSame('/index.php/call/room-tok', $rows[0]['url']);
+    }
+
+    public function testGetLinkedRoomsEmpty(): void
+    {
+        $this->mapper->method('findByObjectUuid')->willReturn([]);
+
+        $this->assertSame([], $this->service->getLinkedRooms('nonexistent'));
+    }
+
+    public function testCreateAndLinkRoomThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No user logged in');
+
+        $this->service->createAndLinkRoom('abc-123', 1, 2, 'Test', null, 2);
+    }
+
+    public function testCreateAndLinkRoomRejectsOneToOneType(): void
+    {
+        $this->setupUser();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+        $this->expectExceptionMessage('Invalid room type');
+
+        $this->service->createAndLinkRoom('abc-123', 1, 2, 'Test', null, 1);
+    }
+
+    public function testCreateAndLinkRoomThrowsWhenTalkUnavailable(): void
+    {
+        $this->setupUser();
+
+        // Talk unavailable → resolveManager returns null → 503.
+        $this->expectException(Exception::class);
+
+        try {
+            $this->service->createAndLinkRoom('abc-123', 1, 2, 'Test', null, 2);
+            $this->fail('Expected exception was not thrown');
+        } catch (Exception $exception) {
+            $this->assertContains($exception->getCode(), [500, 503]);
+            throw $exception;
+        }
+    }
+
+    public function testGetAvailableRoomsForUserReturnsEmptyWhenTalkUnavailable(): void
+    {
+        // appManager default false → isTalkAvailable false → empty.
+        $this->assertSame([], $this->service->getAvailableRoomsForUser());
+        $this->assertSame([], $this->service->getAvailableRoomsForUser('search'));
+    }
+
+    /**
+     * Real Talk Manager round-trip — only runs when `spreed` is loaded.
+     *
+     * @group requires-app-spreed
+     */
+    public function testLinkRoomEndToEndWithRealTalk(): void
+    {
+        if (class_exists('OCA\\Talk\\Manager') === false) {
+            $this->markTestSkipped('NC Talk (spreed) is not installed');
+        }
+
+        $this->markTestSkipped('Integration test — exercised manually with a seeded Talk room');
+    }
+}


### PR DESCRIPTION
## Summary

Promotes the **talk** integration leaf from Tier-1 (marker-scan only) to Tier-2 (explicit link table backing a picker / inline-create UX). Mirrors the Deck Tier-2 shape (openregister#1799).

## Backend changes

- New migration `Version1Date20260525110000` creates `openregister_talk_links` with composite-unique `(object_uuid, room_token)` plus cached fields: `room_id`, `room_name`, `room_type`, `subtitle`, `participant_count`, `last_message_data` (JSON), `last_activity`.
- `TalkLink` entity + `TalkLinkMapper` for persistence; serialised JSON shape mirrors the Phase B-1 widened payload (subtitle / participantCount / lastMessage / lastActivity) the bespoke `CnTalkTab` already consumes.
- `TalkLinkService` — `linkRoom`, `unlinkRoom`, `getLinkedRooms` (refreshes cached fields when stale > 5 minutes), `createAndLinkRoom` (rejects type 1 / one2one), `getAvailableRoomsForUser(?search)`. Late-bound Talk classes via the server container so the service degrades gracefully when `spreed` is missing (AD-23).
- `TalkLinksController` exposes:
  - `GET /api/objects/{r}/{s}/{id}/talk` — list
  - `POST /api/objects/{r}/{s}/{id}/talk` — link `{roomToken}`
  - `POST /api/objects/{r}/{s}/{id}/talk/new` — create + link `{name, description?, type=2|3}`
  - `DELETE /api/objects/{r}/{s}/{id}/talk/{roomToken}` — unlink (does **NOT** destroy the room)
  - `GET /api/integrations/talk/rooms?search=` — picker source
- `TalkProvider` now consults `TalkLinkMapper` first, falling back to the legacy `[or:{uuid}]` marker scan when the table is empty. Both code paths emit the same leaf-row contract (no regression for rooms linked before Tier-2).
- DI wiring: `TalkLinkService` registered; `TalkProvider` gets `TalkLinkMapper` injected.

## Tests

- `tests/Unit/Db/TalkLinkTest.php` — entity JSON shape (incl. malformed `lastMessageData` falls back to `null`).
- `tests/Unit/Service/TalkLinkServiceTest.php` — guard clauses (no user / duplicate / Talk unavailable / one2one rejected) + degradation-on-unavailable-Talk paths. Real-Manager round-trip gated by `@group requires-app-spreed`.

## Test plan

- [ ] `composer test:unit -- --filter TalkLink` passes
- [ ] `composer check:strict` clean on changed files
- [ ] Manual: with Talk installed, link an existing room → row appears in sidebar; unlink → row removed, room still in Talk
- [ ] Manual: create a new room from the sidebar → opens correctly in Talk with the OR marker

Refs: openregister#1312, ADR-019, ADR-022.