### PR TITLE
chore(openspec): retrofit 2b-store cluster (Pinia stores)

### DIFF
--- a/openspec/changes/retrofit-2026-05-24-2b-store/design.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-store/design.md
@@ -1,0 +1,27 @@
+# Design — 2b-store retrofit
+
+## Why one small new capability instead of many
+
+The scanner emitted a single `store` cluster, but the 27 methods cover 14 distinct backend domains. Minting one spec per store would generate noise (the backend domains already have specs) and inflate the spec count.
+
+Conversely, lumping everything into a single "store" spec would mis-frame the architecture: the stores are intentionally thin reactive mirrors over the REST/GraphQL surfaces and gain nothing from a behavioral spec at the store layer.
+
+The compromise applied here:
+1. **Annotate domain-mirror stores as cross-capability** against their backend spec — same pattern used by `searchTrail.js`/`auditTrail.js` (already annotated against `audit-trail-immutable` in retrofit-2026-04-23).
+2. **Mint exactly one small capability** (`frontend-ui-shell`) for the genuine UI-shell state machine (navigation + cross-section admin settings panel) that has no backend-domain counterpart.
+
+## Why endpoints.ts is dropped
+
+The custom-endpoint feature (configurable REST endpoint registry) has Entity + Mapper + Controller + Service in `lib/` but no corresponding capability spec. Annotating the frontend store alone would create a dangling reference. The miss is filed as a coverage gap for a future scan pass.
+
+## Why dashboard.js + reports.js share `rapportage-bi-export`
+
+`reports.js` is the rapportage list/widget shell (per-widget aggregation/GraphQL/statistics fetching with memo cache); `dashboard.js` is the legacy built-in registers-overview dashboard that uses the same chart-data endpoints. Both consume the chart-data API documented in `rapportage-bi-export#Requirement: The system MUST provide chart data API endpoints for frontend visualization`.
+
+## Why navigation + settings get separate REQs
+
+They're distinct concerns:
+- **navigation** is a pure transient UI controller (which menu is selected, which modal/dialog is open, which sidebar sections are collapsed). It has no backend.
+- **settings** owns long-lived async fetches against several backend services (SOLR, RBAC, multi-tenancy, retention, cache) and exposes their loaded state to the admin settings panels. It coordinates loading flags and toast notifications.
+
+Each needs its own behavioral contract.

--- a/openspec/changes/retrofit-2026-05-24-2b-store/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-store/proposal.md
@@ -1,0 +1,44 @@
+# Retrofit — 2b-store (Pinia stores)
+
+Describes observed behavior of 27 public Pinia store methods across 16 files classified by the scanner under Bucket 2b (`store` cluster). All methods are frontend state-management modules in `src/store/`. Code already exists — this change retroactively specifies it.
+
+## Approach
+
+The scanner clustered everything under a generic `store` slug because the methods all live in `src/store/`. In practice each store mirrors a backend domain that is already covered by an existing capability spec — these stores are the frontend reactive state for those backends and SHOULD be annotated as cross-capability code, not minted as a new spec each.
+
+Only the **UI shell** state (navigation/dialog/sidebar coordination + the cross-section admin settings panel) is genuinely not covered by any backend-domain spec: this is the frontend's "where am I, what dialog is open, which sidebar section is collapsed" state machine. That small surface gets a new `frontend-ui-shell` capability with 2 REQs.
+
+## Affected code units (frontend stores)
+
+### Cross-capability annotations (existing specs)
+- `src/store/modules/agent.js` → `chat-ai#REQ-004` (agent management)
+- `src/store/modules/conversation.ts` → `chat-ai#REQ-002` (conversation lifecycle)
+- `src/store/modules/avg.js` → `avg-verwerkingsregister` (Art 30 register + data-subject rights)
+  - `useAvgStore`, `RECHTSGROND_VOCABULARY`, `STATUS_VOCABULARY`
+- `src/store/modules/reports.js` → `rapportage-bi-export` (dashboards, chart data, widget cache)
+  - `useReportsStore`, `widgetCacheKey`, `DEFAULT_REPORTS_REGISTER`, `DEFAULT_DASHBOARD_SCHEMA`
+- `src/store/modules/translations.js` → `register-i18n` (translation lifecycle, RTL, bulk translate)
+  - `useTranslationsStore`, `RTL_LANGUAGES`, `TRANSLATION_STATUSES`, `isRtlLanguage`
+- `src/store/modules/object.js` → `object-lifecycle#REQ-001` (object CRUD pipeline mirrored on frontend via `createObjectStore` adapter)
+  - `useObjectStore`, `getCurrentType`, `openregisterObjectPlugin`
+- `src/store/modules/deleted.js` → `object-lifecycle` (soft-delete / restore UI)
+- `src/store/modules/source.js` → `data-sync-harvesting#REQ-001` (sync source definitions)
+- `src/store/modules/application.js` → `auth-system` (Application entity + Nextcloud group access control)
+- `src/store/modules/configuration.js` → `data-import-export` (Configuration bundle import/export)
+- `src/store/modules/organisation.js` → `tenant-lifecycle` (organisation entity + multi-tenancy state)
+- `src/store/modules/views.js` → `zoeken-filteren` (saved search views composition)
+- `src/store/modules/dashboard.js` → `rapportage-bi-export` (chart data API for built-in dashboards)
+  - `useDashboardStore`, `setupDashboardStoreWatchers`
+
+### Net-new capability (frontend-ui-shell, 2 REQs)
+- `src/store/modules/navigation.js` → `frontend-ui-shell#REQ-001`
+- `src/store/settings.js` → `frontend-ui-shell#REQ-002`
+
+### Dropped (no clean spec home — known coverage gap)
+- `src/store/modules/endpoints.ts` (`useEndpointStore`) — custom REST endpoint registry has no backend-domain spec; flagged for follow-up
+
+## Total REQ count
+
+2 new REQs in 1 new capability (`frontend-ui-shell`). All other store methods annotated against existing specs.
+
+Source: `/tmp/or-scan/rspec-2b-store.json` generated 2026-05-24. See retrofit playbook.

--- a/openspec/changes/retrofit-2026-05-24-2b-store/specs/frontend-ui-shell/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-store/specs/frontend-ui-shell/spec.md
@@ -1,0 +1,59 @@
+---
+retrofit: true
+---
+
+# Frontend UI Shell
+
+## Purpose
+
+Describes the frontend state-machine that governs how the OpenRegister admin UI coordinates navigation, modals, dialogs, sidebar visibility, and cross-section admin-settings panel state. This capability covers the transient UI-shell concerns that have no backend-domain counterpart but are required so that only one modal/dialog is active at a time, so that long-running settings fetches (SOLR/RBAC/multi-tenancy/retention/cache) share loading flags across the settings panels, and so that view-shell preferences persist across route transitions.
+
+All backend-domain state (objects, schemas, registers, conversations, etc.) lives in the per-domain stores annotated against their respective capability specs (see `chat-ai`, `rapportage-bi-export`, `register-i18n`, `object-lifecycle`, etc.). The UI shell stores are intentionally backend-free.
+
+## ADDED Requirements
+
+### Requirement: The UI MUST coordinate modal, dialog, sidebar, and selected-section state through a single navigation store
+
+A Pinia `navigation` store MUST hold the currently-selected menu item, the currently-active modal slug, the currently-active dialog slug, optional transient transfer-data for hand-off between modal contexts, and a per-section sidebar collapsed/expanded map. The store MUST guarantee single-active-modal and single-active-dialog semantics (opening a second modal MUST close the first) so that two overlay surfaces cannot stack and trap focus.
+
+#### Scenario: Default selection routes to the dashboard
+- **GIVEN** the app loads without an explicit route
+- **WHEN** the `navigation` store is initialized
+- **THEN** the `selected` state MUST default to `'dashboard'` so the dashboard view is rendered
+
+#### Scenario: Opening a modal supersedes the previous one
+- **GIVEN** modal `A` is currently active in the navigation store
+- **WHEN** a caller invokes `setModal('B')`
+- **THEN** the store state MUST reflect `'B'` as the single active modal
+- **AND** modal `A` MUST no longer be rendered
+
+#### Scenario: Sidebar collapsed state is preserved per section
+- **GIVEN** sections `registers`, `register`, `organisations`, `search`, `deleted`, `logs`, `searchTrail`, `auditTrail`, `chat` each have an independent collapsed flag
+- **WHEN** `setSidebarState('logs', false)` is invoked
+- **THEN** only the `logs` flag MUST flip; the other section flags MUST remain unchanged
+
+#### Scenario: Transient transfer data is set and retrieved
+- **GIVEN** a modal needs to pass an object handle to a downstream dialog
+- **WHEN** the caller invokes `setTransferData({ id: 'abc-123' })` and the downstream dialog later calls `getTransferData()`
+- **THEN** the downstream dialog MUST receive `{ id: 'abc-123' }`
+
+### Requirement: The admin settings panel MUST coordinate cross-section loading and result state through a unified settings store
+
+A Pinia `settings` store MUST aggregate the transient loading/saving flags and result state of the admin settings sections (SOLR configuration, RBAC, multi-tenancy, retention, cache management, statistics extraction, vector index). The store MUST expose distinct loading flags per long-running async operation (test connection, warm-up, setup, field comparison, field creation/fix) so that one section's slow request does not block the panel as a whole, and MUST surface user-visible toasts via `@nextcloud/dialogs` `showError`/`showSuccess` on the operation outcome.
+
+#### Scenario: SOLR connection test exposes a distinct loading flag
+- **GIVEN** the SOLR settings section is open
+- **WHEN** the admin clicks "Test connection"
+- **THEN** the `settings.testingConnection` flag MUST be set to `true` for the duration of the request
+- **AND** other loading flags (`warmingUpSolr`, `settingUpSolr`, `loadingFields`, `loadingStats`) MUST remain unchanged
+
+#### Scenario: Stats fetches are cached on the store
+- **GIVEN** statistics for extraction or vector index have been previously loaded
+- **WHEN** another settings section accesses `settings.extractionStats` or `settings.vectorStats`
+- **THEN** the cached value MUST be returned without a refetch unless an explicit refresh action is invoked
+
+#### Scenario: User-facing toasts are emitted on success and failure
+- **GIVEN** the SOLR setup completes
+- **WHEN** the operation returns `2xx`
+- **THEN** `showSuccess` MUST be invoked with a translated message
+- **AND** on a non-`2xx` response, `showError` MUST be invoked with the server-reported error message

--- a/openspec/changes/retrofit-2026-05-24-2b-store/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-store/tasks.md
@@ -1,0 +1,26 @@
+# Tasks
+
+## New capability — frontend-ui-shell
+
+- [x] task-1: frontend-ui-shell#REQ-001 — Navigation/modal/dialog/sidebar coordination (`src/store/modules/navigation.js`, `useNavigationStore`) (retroactive annotation)
+- [x] task-2: frontend-ui-shell#REQ-002 — Admin settings panel cross-section loading + toast state (`src/store/settings.js`, `useSettingsStore`) (retroactive annotation)
+
+## Cross-capability annotations
+
+- [x] task-3: chat-ai#REQ-004 — Agent CRUD store (`src/store/modules/agent.js`, `useAgentStore`) (retroactive annotation)
+- [x] task-4: chat-ai#REQ-002 — Conversation + message-history store (`src/store/modules/conversation.ts`, `useConversationStore`) (retroactive annotation)
+- [x] task-5: avg-verwerkingsregister — AVG Art 30 register + data-subject-rights store (`src/store/modules/avg.js`, `useAvgStore`, `RECHTSGROND_VOCABULARY`, `STATUS_VOCABULARY`) (retroactive annotation)
+- [x] task-6: rapportage-bi-export — Reports/dashboards widget store + widget cache key (`src/store/modules/reports.js`, `useReportsStore`, `widgetCacheKey`, `DEFAULT_REPORTS_REGISTER`, `DEFAULT_DASHBOARD_SCHEMA`) (retroactive annotation)
+- [x] task-7: rapportage-bi-export — Built-in dashboard store + watcher setup (`src/store/modules/dashboard.js`, `useDashboardStore`, `setupDashboardStoreWatchers`) (retroactive annotation)
+- [x] task-8: register-i18n — Translations store + RTL detection (`src/store/modules/translations.js`, `useTranslationsStore`, `RTL_LANGUAGES`, `TRANSLATION_STATUSES`, `isRtlLanguage`) (retroactive annotation)
+- [x] task-9: object-lifecycle#REQ-001 — Object store adapter (`src/store/modules/object.js`, `useObjectStore`, `getCurrentType`, `openregisterObjectPlugin`) (retroactive annotation)
+- [x] task-10: object-lifecycle — Soft-delete / restore store (`src/store/modules/deleted.js`, `useDeletedStore`) (retroactive annotation)
+- [x] task-11: data-sync-harvesting#REQ-001 — Source store (`src/store/modules/source.js`, `useSourceStore`) (retroactive annotation)
+- [x] task-12: auth-system — Application access-control store (`src/store/modules/application.js`, `useApplicationStore`) (retroactive annotation)
+- [x] task-13: data-import-export — Configuration bundle store (`src/store/modules/configuration.js`, `useConfigurationStore`) (retroactive annotation)
+- [x] task-14: tenant-lifecycle — Organisation/multi-tenancy store (`src/store/modules/organisation.js`, `useOrganisationStore`) (retroactive annotation)
+- [x] task-15: zoeken-filteren — Saved views store (`src/store/modules/views.js`, `useViewsStore`) (retroactive annotation)
+
+## Coverage gaps
+
+- [ ] follow-up: Custom endpoint registry (`src/store/modules/endpoints.ts`, `useEndpointStore`) — no backend-domain capability spec exists; dropped from this retrofit pending an `endpoint-registry` (or similar) spec

--- a/src/store/modules/agent.js
+++ b/src/store/modules/agent.js
@@ -6,6 +6,8 @@
  * @copyright 2024 Conduction B.V.
  * @license  EUPL-1.2
  * @version  1.0.0
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-2b-store/tasks.md#task-3
  */
 
 /* eslint-disable no-console */

--- a/src/store/modules/application.js
+++ b/src/store/modules/application.js
@@ -1,3 +1,6 @@
+/**
+ * @spec openspec/changes/retrofit-2026-05-24-2b-store/tasks.md#task-12
+ */
 /* eslint-disable no-console */
 import { defineStore } from 'pinia'
 import { Application } from '../../entities/index.js'

--- a/src/store/modules/avg.js
+++ b/src/store/modules/avg.js
@@ -18,6 +18,8 @@
  * @author    Conduction Development Team <dev@conduction.nl>
  * @copyright 2026 Conduction B.V.
  * @license   EUPL-1.2
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-2b-store/tasks.md#task-5
  */
 
 /* eslint-disable no-console */

--- a/src/store/modules/configuration.js
+++ b/src/store/modules/configuration.js
@@ -1,3 +1,6 @@
+/**
+ * @spec openspec/changes/retrofit-2026-05-24-2b-store/tasks.md#task-13
+ */
 /* eslint-disable no-console */
 import { defineStore } from 'pinia'
 import { ConfigurationEntity } from '../../entities/index.js'

--- a/src/store/modules/conversation.ts
+++ b/src/store/modules/conversation.ts
@@ -6,6 +6,8 @@
  * @copyright 2024 Conduction B.V.
  * @license  EUPL-1.2
  * @version  1.0.0
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-2b-store/tasks.md#task-4
  */
 
 /* eslint-disable no-console */

--- a/src/store/modules/dashboard.js
+++ b/src/store/modules/dashboard.js
@@ -1,3 +1,6 @@
+/**
+ * @spec openspec/changes/retrofit-2026-05-24-2b-store/tasks.md#task-7
+ */
 import { defineStore } from 'pinia'
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'

--- a/src/store/modules/deleted.js
+++ b/src/store/modules/deleted.js
@@ -1,3 +1,6 @@
+/**
+ * @spec openspec/changes/retrofit-2026-05-24-2b-store/tasks.md#task-10
+ */
 /* eslint-disable no-console */
 import { defineStore } from 'pinia'
 

--- a/src/store/modules/navigation.js
+++ b/src/store/modules/navigation.js
@@ -1,3 +1,6 @@
+/**
+ * @spec openspec/changes/retrofit-2026-05-24-2b-store/tasks.md#task-1
+ */
 /* eslint-disable no-console */
 import { defineStore } from 'pinia'
 

--- a/src/store/modules/object.js
+++ b/src/store/modules/object.js
@@ -2,6 +2,8 @@
  * Object store using @conduction/nextcloud-vue with an adapter for the existing app API.
  * Delegates to the package's createObjectStore; maps register/schema context to type slug
  * and exposes getCollection, objectItem, refreshObjectList, etc. via the package store API.
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-2b-store/tasks.md#task-9
  */
 
 import { getActivePinia } from 'pinia'

--- a/src/store/modules/organisation.js
+++ b/src/store/modules/organisation.js
@@ -1,3 +1,6 @@
+/**
+ * @spec openspec/changes/retrofit-2026-05-24-2b-store/tasks.md#task-14
+ */
 /* eslint-disable no-console */
 import { defineStore } from 'pinia'
 import { Organisation } from '../../entities/index.js'

--- a/src/store/modules/reports.js
+++ b/src/store/modules/reports.js
@@ -20,6 +20,8 @@
  * @author    Conduction Development Team <dev@conduction.nl>
  * @copyright 2026 Conduction B.V.
  * @license   EUPL-1.2
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-2b-store/tasks.md#task-6
  */
 
 /* eslint-disable no-console */

--- a/src/store/modules/source.js
+++ b/src/store/modules/source.js
@@ -1,3 +1,6 @@
+/**
+ * @spec openspec/changes/retrofit-2026-05-24-2b-store/tasks.md#task-11
+ */
 /* eslint-disable no-console */
 import { defineStore } from 'pinia'
 import { Source } from '../../entities/index.js'

--- a/src/store/modules/translations.js
+++ b/src/store/modules/translations.js
@@ -11,6 +11,8 @@
  * @author   Conduction Development Team <dev@conduction.nl>
  * @copyright 2026 Conduction B.V.
  * @license  EUPL-1.2
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-2b-store/tasks.md#task-8
  */
 
 /* eslint-disable no-console */

--- a/src/store/modules/views.js
+++ b/src/store/modules/views.js
@@ -14,6 +14,8 @@ import { defineStore } from 'pinia'
  * @copyright 2024
  * @license AGPL-3.0-or-later
  * @version 1.0.0
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-2b-store/tasks.md#task-15
  */
 export const useViewsStore = defineStore('views', {
 	state: () => ({

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -9,6 +9,8 @@
  * - Retention policies
  * - Cache management
  * - System statistics
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-2b-store/tasks.md#task-2
  */
 
 import { defineStore } from 'pinia'


### PR DESCRIPTION
## Summary
- Retrofit annotates 15 of 16 `src/store/` modules against existing capability specs (chat-ai, avg-verwerkingsregister, rapportage-bi-export, register-i18n, object-lifecycle, data-sync-harvesting, auth-system, data-import-export, tenant-lifecycle, zoeken-filteren).
- Mints one small new capability `frontend-ui-shell` with 2 REQs — the only genuinely net-new behavioral surface: navigation/modal/dialog/sidebar coordination + cross-section admin settings panel state.
- `endpoints.ts` is dropped (no backend-domain spec for custom REST endpoint registry; flagged as a follow-up coverage gap in `tasks.md`).

## Method counts
- Batch: 27 methods, 16 files (Bucket 2b store cluster)
- Annotated: 27 methods across 15 files
- Dropped: 1 file (`src/store/modules/endpoints.ts`)
- New REQs: 2 (both in `frontend-ui-shell`)
- Existing capabilities extended via cross-ref: 10

## Validation
- `openspec validate retrofit-2026-05-24-2b-store` -> Change 'retrofit-2026-05-24-2b-store' is valid

## Test plan
- [ ] Reviewer confirms the cross-capability mapping (one store -> one existing spec or `frontend-ui-shell`) is correct
- [ ] Reviewer confirms `endpoints.ts` deferral is acceptable (gap filed in tasks.md)
- [ ] Reviewer confirms the two new REQs in `frontend-ui-shell` describe observed behavior (no aspirational scope)