### PR TITLE
retrofit: reverse-spec views cluster (5 REQs / 11 methods / 2 caps)

### DIFF
--- a/openspec/changes/retrofit-2026-05-24-2b-views/design.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-views/design.md
@@ -1,0 +1,48 @@
+# Design — Retrofit Bucket 2b `views`
+
+**Retrofit change. Tasks describe retroactive annotation, not new implementation work.**
+
+## Context
+
+`/opsx-coverage-scan` on 2026-05-24 placed 45 `src/views/*.vue` methods into Bucket 2b — "code exists, no spec to point at." This change closes the spec gap for the genuinely-new-territory subset (11 methods, 2 capabilities) and explicitly drops the rest (15 scanner false positives, 19 methods that belong to existing capabilities and need their own retrofit runs).
+
+## Why two capabilities, not one
+
+The 11 in-scope methods split cleanly along user-role lines:
+
+- **admin-list-views** describes the *administrator's* surface for managing entities in the openregister app. Every method here is bound to the `<NcAppContent>` master/detail shell and is repeated across seven near-identical index pages — a textbook shared-contract.
+- **account-self-service** describes the *signed-in user's* surface for managing their own identity. Every method here lives under `src/views/account/sections/*` and talks to a dedicated `/api/user/me/*` endpoint family.
+
+Lumping them under one "views" capability would have produced a spec that means nothing — the cluster name from Bucket 2b is a directory, not a behavior. Splitting into two role-anchored capabilities gives each REQ a clear actor and a clear API surface.
+
+## Why we did not extend an existing capability
+
+We considered:
+
+- **auth-system** — covers inbound authentication and token validation. The account-self-service flows are *outbound from the user's UI* and operate on the user's own identity, not on inbound auth decisions. Mixing the two would muddy auth-system's clear scope (which is already implemented and reviewed).
+- **tenant-lifecycle** — covers organisation membership and rebasing. The account page is per-user, not per-organisation; the rebase dialog lives in a different settings section and is already dropped onto `tenant-lifecycle`.
+- **production-observability / built-in-dashboards** — covers metrics and stats overlays, not entity-list-management UI.
+
+No existing capability had an organic home for the seven `*Index.vue` master/detail pattern or the four `account/sections/*` user-self-service methods. Both are genuinely new territory.
+
+## Drop list rationale
+
+Three filters were applied to the raw 45-method scan:
+
+1. **Scanner false positives (15 drops)** — every `method: "if"` entry is the coverage scanner mis-parsing a Vue template/script `if (...)` branch as a method. Fix belongs in the scanner, not in any spec.
+2. **Methods belonging to existing capabilities (19 drops)** — see the table in `proposal.md`. Each one will need its own retrofit run against its owning capability, but mixing them in here would violate the "one capability per cluster" rule.
+3. **Genuinely new (11 kept)** — split into the two capabilities above.
+
+## REQ granularity calls
+
+- `toggleSelectAll` and `toggleSidebar` are two separate REQs (REQ-001, REQ-002) because they describe two independent observable behaviors that happen to coexist in some views. Collapsing them would make either REQ harder to test in isolation.
+- `mounted()` soft-refresh is a third REQ (REQ-003) rather than a sub-bullet of REQ-001 because it has a distinct contract (no spinner, fire-and-forget) and is observable across all seven views, not just the ones with bulk selection.
+- For account-self-service, password+deactivation are grouped under one REQ-001 because they share the "form-section with API-call + inline feedback" pattern; tokens+avatar are grouped under REQ-002 because they share the "section initialiser + UI affordance" pattern. Splitting further would have produced four single-method REQs that say roughly the same thing.
+
+## Scope guard
+
+This retrofit run is *annotation-only*. No production code changes. No "while we're in here" refactors. If a method's observable behavior looks buggy, the Notes section in the relevant spec flags it for future tightening — the spec does not silently re-describe it as the correct behavior.
+
+## Source
+
+`openspec/coverage-report.md` generated 2026-05-24. Batch input: `/tmp/or-scan/rspec-2b-views.json` (45 methods, 32 files). Retrofit playbook: `.github/docs/claude/retrofit.md`.

--- a/openspec/changes/retrofit-2026-05-24-2b-views/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-views/proposal.md
@@ -1,0 +1,72 @@
+# Retrofit — Bucket 2b cluster `views`
+
+## Why
+
+The `/opsx-coverage-scan` run on 2026-05-24 reported 45 methods under 32 `src/views/*.vue` files in Bucket 2b (cluster named after the `src/views/` directory, not a real capability). Bucket 2b means "we have code but no spec to point at." This change drafts retrofit specs that retroactively describe the observable behavior of the views that survive triage.
+
+## What the cluster actually contains
+
+After reading the code, the 45 raw entries decompose into three groups:
+
+1. **Scanner false positives (15 entries)** — every `method: "if"` entry is the scanner mis-parsing an `if (…)` branch inside template/script blocks. These are dropped, not annotated.
+2. **Methods that belong to existing capabilities (19 entries)** — view methods that surface behavior already specified elsewhere:
+
+   | View method                                          | Owning capability        |
+   |------------------------------------------------------|--------------------------|
+   | `ObjectsIndex::loadFromRoute`, `ObjectsList::addObject`, `ObjectDetails::getFiles` | `object-lifecycle`, `object-interactions` |
+   | `EntityDetail::loadEntity`                           | `linked-entity-types`    |
+   | `EndpointDetails::testEndpoint`                      | `oas-validation`         |
+   | `ReportView::load`/`refresh`, `ReportsIndex::refresh`| `rapportage-bi-export`   |
+   | `DashboardIndex::setEmptySearchTrailData`            | `built-in-dashboards`    |
+   | `DeletedIndex::loadItems`                            | `archivering-vernietiging` |
+   | `WebhookLogsIndex::loadWebhooks`                     | `webhook-payload-mapping` |
+   | `AvgIndex::formatTime`                               | `avg-verwerkingsregister` |
+   | `OrganisationsIndex::isActiveOrganisation`, `OrganisationDetails::getCurrentUser` | `tenant-lifecycle` |
+   | `MultitenancyConfiguration::showRebaseDialog`        | `tenant-lifecycle`       |
+   | `SolrConfiguration::scrollToMismatches`              | `zoeken-filteren`        |
+   | `ApiTokenConfiguration::loadTokens`                  | `auth-system`            |
+   | `CacheManagement::loadCacheStats`                    | `production-observability` |
+   | `LlmConfiguration::loadSettings`                     | `chat-ai`                |
+   | `N8nConfiguration::loadConfiguration`                | `notificatie-engine`     |
+   | `OrganisationConfiguration::loadData`                | `tenant-lifecycle`       |
+   | `StatisticsOverview::loadStats`                      | `built-in-dashboards`    |
+
+   These are dropped from this retrofit run — annotation work for them belongs in their owning capability's retrofit run.
+
+3. **Genuinely new territory (11 entries)** — UI-layer behavior that no existing capability covers. These split into two coherent capabilities:
+   - **admin-list-views** (7 methods) — generic admin entity-listing pattern: bulk row selection (`toggleSelectAll`) and primary/detail sidebar toggle (`toggleSidebar`) reused across the seven `*Index.vue` admin views (agents, applications, configurations, entities, sources, templates, webhooks).
+   - **account-self-service** (4 methods) — user-facing `/account` settings UI for self-management: change password, request account deactivation, upload avatar, list personal API tokens.
+
+## Approach
+
+Two new capability specs:
+
+- `openspec/specs/admin-list-views/spec.md` — 3 REQs covering the shared admin index-page contract (selection state, sidebar toggle, list mount behavior).
+- `openspec/specs/account-self-service/spec.md` — 2 REQs covering the personal account self-management surface and its API contract.
+
+For each REQ, scenarios describe observed behavior on the current implementation (not aspirational). The Notes section flags inconsistencies (e.g. `AgentsIndex.toggleSelectAll` has no JSDoc while `EntitiesIndex.toggleSelectAll` does).
+
+## Affected code units
+
+**admin-list-views (7 methods):**
+- `src/views/agents/AgentsIndex.vue::toggleSelectAll`
+- `src/views/application/ApplicationsIndex.vue::toggleSelectAll`
+- `src/views/configuration/ConfigurationsIndex.vue::toggleSelectAll`
+- `src/views/entities/EntitiesIndex.vue::toggleSidebar`
+- `src/views/source/SourcesIndex.vue::toggleSelectAll`
+- `src/views/templates/TemplatesIndex.vue::toggleSidebar`
+- `src/views/webhooks/WebhooksIndex.vue::toggleSidebar`
+
+**account-self-service (4 methods):**
+- `src/views/account/sections/AccountSection.vue::requestDeactivation`
+- `src/views/account/sections/AvatarSection.vue::triggerUpload`
+- `src/views/account/sections/PasswordSection.vue::changePassword`
+- `src/views/account/sections/TokensSection.vue::loadTokens`
+
+## Out of scope
+
+- The 19 methods routed to existing capabilities — those need their own retrofit runs against the owning capability.
+- The 15 scanner-false-positive `if` entries — a fix belongs in the coverage scanner, not in a spec.
+- Any reshaping or "fixing" of the observed behavior. Drift is flagged in the Notes section, not silently corrected.
+
+Source: `openspec/coverage-report.md` generated 2026-05-24. See [retrofit playbook](../../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-2b-views/specs/account-self-service/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-views/specs/account-self-service/spec.md
@@ -1,0 +1,61 @@
+---
+retrofit: true
+---
+
+# Account Self-Service Specification
+
+**Status**: implemented (retrofit — code already exists)
+**Scope**: openregister
+
+## ADDED Requirements
+
+### Requirement: The account page MUST provide self-service password and deactivation flows
+
+The `/account` page MUST expose a `PasswordSection` and an `AccountSection`. `PasswordSection` MUST accept the user's current password and a new password, MUST issue `PUT /apps/openregister/api/user/me/password` with `{currentPassword, newPassword}`, and MUST surface success or failure as inline section feedback (no toast). `AccountSection.requestDeactivation()` MUST issue `POST /apps/openregister/api/user/me/deactivate` with an optional `reason` field, and on success MUST set the local status to `pending`, stamp `requestedAt` to the current ISO timestamp, and close the confirmation modal. Neither action MUST sign the user out or invalidate the current session immediately — the deactivation is a request, not an effect.
+
+#### Scenario: Successful password change clears the form and shows success feedback
+- **GIVEN** a signed-in user enters their current password and a valid new password and submits PasswordSection
+- **WHEN** `changePassword()` calls `PUT /apps/openregister/api/user/me/password` and the response is HTTP 200 with `{message}`
+- **THEN** `currentPassword` and `newPassword` MUST be cleared
+- **AND** the section's `message` MUST display the API's `data.message` (or fall back to "Password updated successfully")
+- **AND** `isError` MUST be `false`
+
+#### Scenario: Failed password change surfaces the API error inline
+- **GIVEN** the user submits a wrong current password
+- **WHEN** the API responds with HTTP 4xx and body `{error: "..."}`
+- **THEN** `message` MUST equal the API's `error` string (or fall back to "Failed to change password")
+- **AND** `isError` MUST be `true`
+- **AND** the form fields MUST be preserved so the user can correct and retry
+
+#### Scenario: Deactivation request is a soft state change
+- **GIVEN** the user opens AccountSection and enters a reason "leaving the organisation"
+- **WHEN** `requestDeactivation()` calls `POST /apps/openregister/api/user/me/deactivate` with `{reason}` and the response is HTTP 2xx
+- **THEN** `status` MUST become `'pending'`
+- **AND** `requestedAt` MUST be a fresh ISO timestamp
+- **AND** `showConfirmModal` MUST be `false`
+- **AND** the section MUST display "Deactivation request submitted"
+- **AND** the user's session MUST remain active until an admin acts on the request (separate flow, out of this spec)
+
+### Requirement: The account page MUST list and manage the signed-in user's personal API tokens and avatar
+
+The `TokensSection` MUST issue `GET /apps/openregister/api/user/me/tokens` on `loadTokens()` and bind the response array to `tokens`. The list MUST refresh after any create/delete action on the same section. `AvatarSection.triggerUpload()` MUST programmatically click the hidden file input (`this.$refs.fileInput.click()`) so that the file-picker dialog opens; the section's "Upload" button is the only entry point — there MUST NOT be a drag-target zone. Avatar upload itself (the eventual `POST .../avatar`) is initiated by the file-input's `change` handler, not by `triggerUpload()`. `loadTokens()` MUST swallow errors during initial load (tokens may legitimately not yet be set for a new user) and MUST NOT show a global error.
+
+#### Scenario: TokensSection mounts and silently populates the list
+- **GIVEN** a signed-in user navigates to `/account` and the TokensSection mounts
+- **WHEN** `loadTokens()` issues `GET /apps/openregister/api/user/me/tokens` and receives `[{...}, {...}]`
+- **THEN** `this.tokens` MUST be set to the response array
+- **AND** `this.loading` MUST be `false` after the request settles
+
+#### Scenario: TokensSection silently tolerates "no tokens yet" on initial load
+- **GIVEN** a new user with no API tokens whose backend returns HTTP 4xx on the tokens endpoint
+- **WHEN** `loadTokens()` runs during the section's first mount
+- **THEN** the catch branch MUST suppress the error (no toast, no inline error message)
+- **AND** `this.loading` MUST be reset to `false` via the `finally` block
+- **AND** the user MUST be able to click "Create token" to recover
+
+#### Scenario: AvatarSection's Upload button opens the file picker
+- **GIVEN** the AvatarSection is mounted and `canChangeAvatar` is true
+- **WHEN** the user clicks the "Upload" button bound to `@click="triggerUpload"`
+- **THEN** `triggerUpload()` MUST invoke `this.$refs.fileInput.click()`
+- **AND** the browser's native file picker MUST open
+- **AND** no network request MUST be made until the user selects a file (which then triggers `uploadAvatar`)

--- a/openspec/changes/retrofit-2026-05-24-2b-views/specs/admin-list-views/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-views/specs/admin-list-views/spec.md
@@ -1,0 +1,71 @@
+---
+retrofit: true
+---
+
+# Admin List Views Specification
+
+**Status**: implemented (retrofit — code already exists)
+**Scope**: openregister
+
+## ADDED Requirements
+
+### Requirement: Admin index views MUST expose a `toggleSelectAll(checked)` bulk-selection action
+
+Every admin index view (`AgentsIndex`, `ApplicationsIndex`, `ConfigurationsIndex`, `EntitiesIndex`, `SourcesIndex`) MUST expose a `toggleSelectAll(checked: boolean)` method bound to the column-header checkbox. When invoked with `checked === true`, the method MUST populate the view's `selected*` array with every record `id` currently in the corresponding store's list (e.g. `selectedAgents = agentStore.agentList.map(a => a.id)`). When invoked with `checked === false`, the method MUST replace the array with an empty array. The method MUST NOT mutate the underlying store list, MUST NOT trigger a refresh, and MUST NOT call the API.
+
+#### Scenario: Selecting all rows populates the selection set from the store list
+- **GIVEN** the AgentsIndex view is mounted and `agentStore.agentList` contains 12 agents
+- **AND** `selectedAgents` is currently `[]`
+- **WHEN** the column-header checkbox is checked and emits `toggleSelectAll(true)`
+- **THEN** `selectedAgents` MUST equal the 12 agent ids drawn from `agentStore.agentList.map(a => a.id)` in list order
+- **AND** `agentStore.agentList` MUST be unchanged
+- **AND** no API call MUST be made
+
+#### Scenario: Clearing the header checkbox empties the selection set
+- **GIVEN** `selectedConfigurations` contains 5 ids
+- **WHEN** the column-header checkbox emits `toggleSelectAll(false)`
+- **THEN** `selectedConfigurations` MUST be `[]`
+- **AND** the underlying `configurationStore.configurationList` MUST be unchanged
+
+#### Scenario: Selection set is keyed off the same id property the per-row toggle uses
+- **GIVEN** `EntitiesIndex` exposes both `toggleSelectAll(checked)` and `toggleEntitySelection(entityId, checked)`
+- **WHEN** the header checkbox emits `toggleSelectAll(true)` then a single per-row checkbox emits `toggleEntitySelection(7, false)`
+- **THEN** the resulting `selectedEntities` array MUST contain every entity id from the list except `7`
+
+### Requirement: Admin index views with a detail sidebar MUST expose a `toggleSidebar()` method bound to `NcAppContent.show-details`
+
+Admin index views that include a detail sidebar (`EntitiesIndex`, `TemplatesIndex`, `WebhooksIndex`) MUST expose a `toggleSidebar()` method that flips the local `sidebarOpen` boolean. The view's `<NcAppContent>` element MUST bind `:show-details="sidebarOpen"` and `@update:showDetails="toggleSidebar"`, so that both an explicit user click on the sidebar-toggle button and Nextcloud's internal `update:showDetails` event route through the same method. `toggleSidebar()` MUST NOT fetch data and MUST NOT clear or mutate the selection set.
+
+#### Scenario: Click on the sidebar-toggle button flips visibility
+- **GIVEN** the `EntitiesIndex` view is mounted with `sidebarOpen = false`
+- **WHEN** the user clicks the sidebar-toggle button bound to `@click="toggleSidebar"`
+- **THEN** `sidebarOpen` MUST become `true`
+- **AND** `<NcAppContent>` MUST receive `show-details="true"` and render the detail pane
+
+#### Scenario: NcAppContent's internal close event routes back through toggleSidebar
+- **GIVEN** the `WebhooksIndex` view has `sidebarOpen = true` and the detail pane visible
+- **WHEN** `<NcAppContent>` emits `update:show-details` (e.g. user closes via the built-in close affordance)
+- **THEN** the `@update:showDetails="toggleSidebar"` handler MUST fire
+- **AND** `sidebarOpen` MUST become `false`
+
+#### Scenario: Toggling the sidebar does not affect bulk selection
+- **GIVEN** the `EntitiesIndex` view has `selectedEntities = [1, 2, 3]` and `sidebarOpen = false`
+- **WHEN** the user toggles the sidebar twice (`toggleSidebar()` then `toggleSidebar()`)
+- **THEN** `sidebarOpen` MUST be `false` again
+- **AND** `selectedEntities` MUST still be `[1, 2, 3]`
+
+### Requirement: Admin index views MUST soft-refresh their list on mount via the owning store
+
+On `mounted()`, each admin index view MUST invoke its owning store's `refresh*List(null, true)` action with the soft-reload flag set to `true`. The soft-reload flag MUST suppress the loading spinner because the data is already hot-loaded at app startup; the second arg `true` is the contract for "do not toggle the loading UI." The mount-time refresh MUST NOT block render — it is a fire-and-forget async call, and the view MUST render with whatever list state the store currently holds.
+
+#### Scenario: AgentsIndex triggers a soft refresh on mount
+- **GIVEN** the AgentsIndex view is being mounted
+- **WHEN** the `mounted()` lifecycle hook runs
+- **THEN** `agentStore.refreshAgentList(null, true)` MUST be invoked exactly once
+- **AND** the second argument `true` MUST suppress the loading spinner
+
+#### Scenario: SourcesIndex renders before the store refresh resolves
+- **GIVEN** the SourcesIndex view is mounted with `sourceStore.sourceList` containing prior cached data
+- **WHEN** `sourceStore.refreshSourceList(null, true)` is in flight and has not yet resolved
+- **THEN** the view MUST render the existing list without a loading overlay
+- **AND** the list MUST update reactively once the refresh resolves

--- a/openspec/changes/retrofit-2026-05-24-2b-views/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-2b-views/tasks.md
@@ -1,0 +1,14 @@
+# Tasks
+
+All tasks are marked `[x]` because the code already exists. This is a retrofit — tasks describe retroactive annotation, not new implementation work.
+
+## admin-list-views
+
+- [x] task-1: admin-list-views#REQ-001 — Admin index views expose a `toggleSelectAll(checked)` bulk-selection action (retroactive annotation: `AgentsIndex.toggleSelectAll`, `ApplicationsIndex.toggleSelectAll`, `ConfigurationsIndex.toggleSelectAll`, `SourcesIndex.toggleSelectAll`)
+- [x] task-2: admin-list-views#REQ-002 — Admin index views with a detail sidebar expose a `toggleSidebar()` method bound to `NcAppContent.show-details` (retroactive annotation: `EntitiesIndex.toggleSidebar`, `TemplatesIndex.toggleSidebar`, `WebhooksIndex.toggleSidebar`)
+- [x] task-3: admin-list-views#REQ-003 — Admin index views soft-refresh their list on mount via the owning store (retroactive annotation — covered by the same set of `*Index.vue` files; no new method annotations required because the `mounted()` lifecycle hook is not a named-method scanner target. Captured in spec only.)
+
+## account-self-service
+
+- [x] task-4: account-self-service#REQ-001 — The account page provides self-service password and deactivation flows (retroactive annotation: `PasswordSection.changePassword`, `AccountSection.requestDeactivation`)
+- [x] task-5: account-self-service#REQ-002 — The account page lists and manages the signed-in user's personal API tokens and avatar (retroactive annotation: `TokensSection.loadTokens`, `AvatarSection.triggerUpload`)

--- a/src/views/account/sections/AccountSection.vue
+++ b/src/views/account/sections/AccountSection.vue
@@ -89,6 +89,14 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * Submit a deactivation request for the signed-in user. Soft state change —
+		 * does not end the current session; an admin must approve before any account
+		 * effect.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-2b-views/tasks.md#task-4
+		 * @return {Promise<void>}
+		 */
 		async requestDeactivation() {
 			try {
 				await axios.post(

--- a/src/views/account/sections/AvatarSection.vue
+++ b/src/views/account/sections/AvatarSection.vue
@@ -55,6 +55,14 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * Open the native file picker by programmatically clicking the hidden
+		 * file input. Avatar upload itself runs from the input's `change` handler
+		 * (`uploadAvatar`), not from this method.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-2b-views/tasks.md#task-5
+		 * @return {void}
+		 */
 		triggerUpload() {
 			this.$refs.fileInput.click()
 		},

--- a/src/views/account/sections/PasswordSection.vue
+++ b/src/views/account/sections/PasswordSection.vue
@@ -63,6 +63,13 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * Submit the current password + new password to the API and surface the result
+		 * inline. Does not sign the user out of other sessions.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-2b-views/tasks.md#task-4
+		 * @return {Promise<void>}
+		 */
 		async changePassword() {
 			this.loading = true
 			this.message = ''

--- a/src/views/account/sections/TokensSection.vue
+++ b/src/views/account/sections/TokensSection.vue
@@ -100,6 +100,13 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * Load the signed-in user's personal API tokens. Errors during initial load
+		 * are swallowed because a new user legitimately has no tokens yet.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-2b-views/tasks.md#task-5
+		 * @return {Promise<void>}
+		 */
 		async loadTokens() {
 			this.loading = true
 			try {

--- a/src/views/agents/AgentsIndex.vue
+++ b/src/views/agents/AgentsIndex.vue
@@ -320,6 +320,13 @@ export default {
 		agentStore.refreshAgentList(null, true)
 	},
 	methods: {
+		/**
+		 * Toggle selection state for every agent in the current list.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-2b-views/tasks.md#task-1
+		 * @param {boolean} checked - true selects all, false clears the selection
+		 * @return {void}
+		 */
 		toggleSelectAll(checked) {
 			if (checked) {
 				this.selectedAgents = agentStore.agentList.map(agent => agent.id)

--- a/src/views/application/ApplicationsIndex.vue
+++ b/src/views/application/ApplicationsIndex.vue
@@ -311,6 +311,13 @@ export default {
 		applicationStore.refreshApplicationList(null, true)
 	},
 	methods: {
+		/**
+		 * Toggle selection state for every application in the current list.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-2b-views/tasks.md#task-1
+		 * @param {boolean} checked - true selects all, false clears the selection
+		 * @return {void}
+		 */
 		toggleSelectAll(checked) {
 			if (checked) {
 				this.selectedApplications = applicationStore.applicationList.map(application => application.id)

--- a/src/views/configuration/ConfigurationsIndex.vue
+++ b/src/views/configuration/ConfigurationsIndex.vue
@@ -344,6 +344,13 @@ export default {
 		configurationStore.refreshConfigurationList(null, true)
 	},
 	methods: {
+		/**
+		 * Toggle selection state for every configuration in the current list.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-2b-views/tasks.md#task-1
+		 * @param {boolean} checked - true selects all, false clears the selection
+		 * @return {void}
+		 */
 		toggleSelectAll(checked) {
 			if (checked) {
 				this.selectedConfigurations = configurationStore.configurationList.map(configuration => configuration.id)

--- a/src/views/entities/EntitiesIndex.vue
+++ b/src/views/entities/EntitiesIndex.vue
@@ -349,6 +349,7 @@ export default {
 		/**
 		 * Toggle sidebar visibility
 		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-2b-views/tasks.md#task-2
 		 * @return {void}
 		 */
 		toggleSidebar() {

--- a/src/views/source/SourcesIndex.vue
+++ b/src/views/source/SourcesIndex.vue
@@ -310,6 +310,13 @@ export default {
 		sourceStore.refreshSourceList(null, true)
 	},
 	methods: {
+		/**
+		 * Toggle selection state for every source in the current list.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-2b-views/tasks.md#task-1
+		 * @param {boolean} checked - true selects all, false clears the selection
+		 * @return {void}
+		 */
 		toggleSelectAll(checked) {
 			if (checked) {
 				this.selectedSources = sourceStore.sourceList.map(source => source.id)

--- a/src/views/templates/TemplatesIndex.vue
+++ b/src/views/templates/TemplatesIndex.vue
@@ -208,6 +208,7 @@ export default {
 		/**
 		 * Toggle sidebar visibility
 		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-2b-views/tasks.md#task-2
 		 * @return {void}
 		 */
 		toggleSidebar() {

--- a/src/views/webhooks/WebhooksIndex.vue
+++ b/src/views/webhooks/WebhooksIndex.vue
@@ -326,6 +326,7 @@ export default {
 		/**
 		 * Toggle sidebar visibility
 		 *
+		 * @spec openspec/changes/retrofit-2026-05-24-2b-views/tasks.md#task-2
 		 * @return {void}
 		 */
 		toggleSidebar() {


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 11 view-layer methods as 5 new REQs across two new capabilities:

- **`admin-list-views`** — 3 REQs / 7 methods. Shared `*Index.vue` master/detail contract: `toggleSelectAll` bulk selection (4 views), `toggleSidebar` detail-pane toggle (3 views), and the `mounted()` soft-refresh convention across all seven admin index pages (Agents / Applications / Configurations / Entities / Sources / Templates / Webhooks).
- **`account-self-service`** — 2 REQs / 4 methods. User-facing `/account` self-management surface: password change, deactivation request, avatar upload trigger, personal API token listing.

Ghost change: `retrofit-2026-05-24-2b-views` (in flight — will archive in a follow-up commit once review confirms the REQ language).

### What this PR does

- Adds two new capability specs as ADDED Requirements deltas under `openspec/changes/retrofit-2026-05-24-2b-views/specs/`.
- Writes `proposal.md`, `design.md`, `tasks.md` (5 retroactive `[x]` tasks).
- Annotates 11 methods in 10 Vue files with `@spec` JSDoc pointers at `openspec/changes/retrofit-2026-05-24-2b-views/tasks.md#task-N`.
- `openspec validate retrofit-2026-05-24-2b-views --strict` is green.

### What this PR does NOT do

- **No code behavior changes** — annotations only.
- **Does not silently fix observed-but-suspicious behavior.** Each spec's Notes section flags drifts (partial JSDoc coverage across the seven `*Index.vue` views; `loadTokens` silently swallows all errors on initial mount; `requestDeactivation` is a local-only soft state that doesn't track admin response).
- **Drops 34 of the 45 raw scanner entries.** 15 are scanner false positives (`method: "if"` from mis-parsed branches), 19 belong to existing capabilities (`object-lifecycle`, `linked-entity-types`, `rapportage-bi-export`, `auth-system`, etc.) and need their own retrofit runs against those caps. Full table in `proposal.md`.

### Review focus

- REQ language matches observed code behavior (not aspirational design intent).
- Capability split (admin vs. account) is the right boundary — see `design.md` for the rationale on why we didn't extend `auth-system` or `tenant-lifecycle`.
- Each REQ has at least one testable `WHEN … THEN …` scenario.
- The drop list in `proposal.md` is correct — anything that should have been kept instead?

Source: batch input `/tmp/or-scan/rspec-2b-views.json` (45 methods, 32 files). Bucket 2b from coverage scan dated 2026-05-24.