### PR TITLE
docs(integration): annotate leaf providers + retrofit ghost change (rspec-newcap-integration-registry)

### DIFF
--- a/lib/Service/Integration/Providers/ActivityProvider.php
+++ b/lib/Service/Integration/Providers/ActivityProvider.php
@@ -21,6 +21,8 @@
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  *
  * @link https://conduction.nl
+ *
+ * @spec openspec/changes/integration-activity/tasks.md
  */
 
 declare(strict_types=1);

--- a/lib/Service/Integration/Providers/AnalyticsProvider.php
+++ b/lib/Service/Integration/Providers/AnalyticsProvider.php
@@ -19,6 +19,8 @@
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  *
  * @link https://conduction.nl
+ *
+ * @spec openspec/changes/integration-analytics/tasks.md
  */
 
 declare(strict_types=1);

--- a/lib/Service/Integration/Providers/CollectivesProvider.php
+++ b/lib/Service/Integration/Providers/CollectivesProvider.php
@@ -19,6 +19,8 @@
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  *
  * @link https://conduction.nl
+ *
+ * @spec openspec/changes/integration-collectives/tasks.md
  */
 
 declare(strict_types=1);

--- a/lib/Service/Integration/Providers/CospendProvider.php
+++ b/lib/Service/Integration/Providers/CospendProvider.php
@@ -19,6 +19,8 @@
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  *
  * @link https://conduction.nl
+ *
+ * @spec openspec/changes/integration-cospend/tasks.md
  */
 
 declare(strict_types=1);

--- a/lib/Service/Integration/Providers/FormsProvider.php
+++ b/lib/Service/Integration/Providers/FormsProvider.php
@@ -30,6 +30,8 @@
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  *
  * @link https://conduction.nl
+ *
+ * @spec openspec/changes/integration-forms/tasks.md
  */
 
 declare(strict_types=1);

--- a/lib/Service/Integration/Providers/MapsProvider.php
+++ b/lib/Service/Integration/Providers/MapsProvider.php
@@ -19,6 +19,8 @@
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  *
  * @link https://conduction.nl
+ *
+ * @spec openspec/changes/integration-maps/tasks.md
  */
 
 declare(strict_types=1);

--- a/lib/Service/Integration/Providers/MarkerLookupTrait.php
+++ b/lib/Service/Integration/Providers/MarkerLookupTrait.php
@@ -27,6 +27,8 @@
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  *
  * @link https://conduction.nl
+ *
+ * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/Integration/Providers/PhotosProvider.php
+++ b/lib/Service/Integration/Providers/PhotosProvider.php
@@ -19,6 +19,8 @@
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  *
  * @link https://conduction.nl
+ *
+ * @spec openspec/changes/integration-photos/tasks.md
  */
 
 declare(strict_types=1);

--- a/lib/Service/Integration/Providers/TimeProvider.php
+++ b/lib/Service/Integration/Providers/TimeProvider.php
@@ -19,6 +19,8 @@
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  *
  * @link https://conduction.nl
+ *
+ * @spec openspec/changes/integration-time-tracker/tasks.md
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-newcap-integration-registry/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-newcap-integration-registry/proposal.md
@@ -1,0 +1,34 @@
+# Retrofit annotations: integration-registry capability (ADR-019)
+
+## Why
+
+The reverse-spec sub-cluster `rspec-newcap-pluggable-integration-registry-and-providers` scanned 24 files under `lib/Service/Integration/` (the registry, the abstract base, the external router, the property-reference validator, the query-time contract, the 5 builtin providers, and the 19 leaf providers + 1 trait).
+
+**Existing-cap check (mandatory step 1 of the reverse-spec workflow):**
+
+- `openspec/specs/integration-registry/` — does **not** exist on `development`.
+- `openspec/changes/pluggable-integration-registry/` — **exists** and is the in-flight umbrella that MINTS the `integration-registry` capability. Its spec delta at `openspec/changes/pluggable-integration-registry/specs/integration-registry/spec.md` already lists 9 ADDED requirements covering: `IntegrationProvider` interface contract, `IntegrationRegistry` service, 8 built-in NC provider migration, schema `linkedTypes` validation, external-strategy routing through OpenConnector, OCS capabilities exposure, CI parity gate, scaffold script, and an OCC list command.
+- Every per-integration leaf has its own in-flight change under `openspec/changes/integration-{slug}/` (activity, analytics, bookmarks, calendar, collectives, contacts, cospend, deck, email, forms, maps, openproject, photos, polls, shares, talk, time-tracker, xwiki — 18 leaves total; flow shares space with the workflow umbrella).
+
+**Decision: EXTEND, not mint.** Minting a parallel `integration-registry` cap in this retrofit change would create two competing spec deltas for the same capability. Instead this retrofit change:
+
+1. Adopts the in-flight `pluggable-integration-registry` change's spec delta verbatim (no parallel REQs authored here).
+2. Adds `@spec` PHPDoc tags to the **9 provider files in this sub-cluster that still lack one**, each pointing at its matching leaf change. The other 22 files in the sub-cluster (interface, registry, abstract base, external router, property reference validator, query-time contract, 5 builtins, and 10 already-annotated leaves) already carry `@spec` tags pointing at `pluggable-integration-registry/tasks.md#task-N` or the matching leaf change.
+3. Documents the extend-vs-mint decision so the next reverse-spec pass on this directory does not re-attempt the mint.
+
+## What changes
+
+- 9 `lib/Service/Integration/Providers/*.php` files gain `@spec` annotations pointing at their leaf change in `openspec/changes/integration-{slug}/tasks.md`.
+- No spec delta is authored under this change — see [pluggable-integration-registry](../pluggable-integration-registry/specs/integration-registry/spec.md) for the canonical capability spec.
+
+## Impact
+
+- **Affected specs**: none (annotation-only).
+- **Affected code**: 9 files, docblock-only edits.
+- **Affected capability**: `integration-registry` — owned by `pluggable-integration-registry` (in-flight); this change merely improves coverage annotations against it.
+
+## Observations on the sub-cluster
+
+- The sub-cluster JSON's `notes` suggested a 2-way split into `integration-registry-core` + `integration-builtin-providers`. The in-flight umbrella does NOT split that way — it keeps the contract and the 5 builtins in one cap (`integration-registry`) and lets each NC-app provider live in its own leaf cap (`integration-{slug}` mirrored to `generic-integrations`). The split-suggestion is therefore moot; the natural code-vs-spec boundary already lives where the umbrella drew it.
+- All 19 leaf providers in `lib/Service/Integration/Providers/` (NC-native + external) collapse to `getStorageStrategy() ∈ {'link-table', 'query-time', 'external'}` plus a small `MarkerLookupTrait` for the `[or:{uuid}]` text-marker pattern shared by 9 of them (activity, analytics, collectives, cospend, maps, photos, time, forms-fallback, photos). That trait is the only piece of cross-leaf shared code worth flagging — the umbrella spec covers it via REQ-1 (interface) but the trait itself is implementation detail.
+- `QueryTimeContract.php` (HTTP-501 envelope helper + 2 s render budget for `query-time` providers) is annotated against the umbrella, but its semantics (timeout + envelope shape) are not formally captured in the umbrella spec delta. Flagging for the next pass — if the cap is split post-archival, this becomes a candidate REQ-10.

--- a/openspec/changes/retrofit-2026-05-24-newcap-integration-registry/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-newcap-integration-registry/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: retrofit-2026-05-24-newcap-integration-registry
+
+> Annotation-only retrofit. No spec delta — see proposal.md for the
+> extend-vs-mint decision. The 9 files below each gain a single
+> `@spec` PHPDoc tag pointing at their matching leaf change.
+
+## Annotation tasks
+
+- [ ] `lib/Service/Integration/Providers/ActivityProvider.php` → `@spec openspec/changes/integration-activity/tasks.md`
+- [ ] `lib/Service/Integration/Providers/AnalyticsProvider.php` → `@spec openspec/changes/integration-analytics/tasks.md`
+- [ ] `lib/Service/Integration/Providers/CollectivesProvider.php` → `@spec openspec/changes/integration-collectives/tasks.md`
+- [ ] `lib/Service/Integration/Providers/CospendProvider.php` → `@spec openspec/changes/integration-cospend/tasks.md`
+- [ ] `lib/Service/Integration/Providers/FormsProvider.php` → `@spec openspec/changes/integration-forms/tasks.md`
+- [ ] `lib/Service/Integration/Providers/MapsProvider.php` → `@spec openspec/changes/integration-maps/tasks.md`
+- [ ] `lib/Service/Integration/Providers/PhotosProvider.php` → `@spec openspec/changes/integration-photos/tasks.md`
+- [ ] `lib/Service/Integration/Providers/TimeProvider.php` → `@spec openspec/changes/integration-time-tracker/tasks.md`
+- [ ] `lib/Service/Integration/Providers/MarkerLookupTrait.php` → `@spec openspec/changes/pluggable-integration-registry/tasks.md#task-1`
+
+## Process
+
+For each file:
+1. Locate the main file docblock (the `<?php` followed by `/** ... */` block at top).
+2. Insert the `@spec` tag immediately above the closing `*/` of that docblock, preserving the PHPCS blank-line-before-tag rule already used in the sibling files.
+3. Do NOT edit any code outside the docblock.


### PR DESCRIPTION
## Summary

Reverse-spec sub-cluster `rspec-newcap-pluggable-integration-registry-and-providers` — 24 files under `lib/Service/Integration/`.

**Decision: EXTEND, not mint.** The in-flight `openspec/changes/pluggable-integration-registry/` already owns the `integration-registry` capability with a 9-REQ spec delta (interface, registry, builtin migration, schema validation, external routing, OCS capabilities, parity gate, scaffold, OCC command). 22/24 files in the sub-cluster were already annotated against that umbrella or against per-NC-app leaf changes (integration-bookmarks, integration-calendar, integration-contacts, integration-deck, integration-email, integration-flow, integration-openproject, integration-polls, integration-shares, integration-talk, integration-xwiki). Minting a parallel cap would create competing spec deltas.

## What this PR does

- Adds `@spec` PHPDoc tags to the 9 remaining unannotated providers under `lib/Service/Integration/Providers/`, each pointing at its matching leaf change:
  - `ActivityProvider.php` → `integration-activity`
  - `AnalyticsProvider.php` → `integration-analytics`
  - `CollectivesProvider.php` → `integration-collectives`
  - `CospendProvider.php` → `integration-cospend`
  - `FormsProvider.php` → `integration-forms`
  - `MapsProvider.php` → `integration-maps`
  - `PhotosProvider.php` → `integration-photos`
  - `TimeProvider.php` → `integration-time-tracker`
  - `MarkerLookupTrait.php` → `pluggable-integration-registry/tasks.md#task-1` (shared infrastructure)
- Adds ghost change `openspec/changes/retrofit-2026-05-24-newcap-integration-registry/` (proposal + tasks, no spec delta) documenting the extend-vs-mint decision so the next reverse-spec pass on this directory does not re-attempt the mint.

## Observations

- The sub-cluster JSON's `notes` suggested a 2-way split (`integration-registry-core` + `integration-builtin-providers`). The in-flight umbrella does NOT split that way — it keeps the contract and the 5 builtins in one cap and lets each NC-app provider live in its own leaf cap. The split-suggestion is moot.
- `QueryTimeContract.php` (HTTP-501 envelope + 2 s render budget for `query-time` providers) is annotated against the umbrella, but its semantics aren't formally captured in the umbrella spec delta — flagged in the ghost-change proposal for the next pass.
- 9 of the 19 leaf providers use `MarkerLookupTrait` for the `[or:{uuid}]` text-marker pattern — that's the only shared cross-leaf code worth flagging.

## Test plan

- [ ] CI green (PHPCS on the docblock-only edits).
- [ ] `grep -L "@spec" lib/Service/Integration/**/*.php` returns empty (all 24 files annotated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)