### PR TITLE
feat(activity): Tier-2 — filtered + paginated feed with type/actor dropdowns

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -381,6 +381,19 @@ return [
         ['name' => 'flowLinks#link',      'url' => '/api/objects/{register}/{schema}/{id}/flow',              'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
         ['name' => 'flowLinks#destroy',   'url' => '/api/objects/{register}/{schema}/{id}/flow/{operationId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'operationId' => '[0-9]+']],
 
+        // Activity — Tier-2 read-only API. NC Activity entries are
+        // core-generated (no link/create/delete verbs); this surface
+        // only filters + cursor-paginates the entries linked to an OR
+        // object via the `[or:{uuid}]` marker in `activity.subject`
+        // (wave-5.3 MarkerLookupTrait carve-out, preserved). The
+        // app-global `types`/`actors` dropdown routes MUST precede the
+        // per-object wildcard route so they aren't grabbed as register
+        // slugs.
+        // @spec openspec/changes/integration-activity/tasks.md.
+        ['name' => 'activityLinks#types',  'url' => '/api/integrations/activity/types',                  'verb' => 'GET'],
+        ['name' => 'activityLinks#actors', 'url' => '/api/integrations/activity/actors',                 'verb' => 'GET'],
+        ['name' => 'activityLinks#index',  'url' => '/api/objects/{register}/{schema}/{id}/activity',    'verb' => 'GET', 'requirements' => ['id' => '[^/]+']],
+
         // Forms — Tier-2 link-table API. Specific routes (`/new`, `/submissions/{id}`)
         // MUST precede the wildcard `{formId}` route so they aren't grabbed as
         // formId='new' / formId='submissions'. Available-forms picker is app-global.

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1297,6 +1297,22 @@ class Application extends App implements IBootstrap
             }
         );
 
+        // ActivityFilterService — Tier-2 read-only filter/paginate
+        // service backing the ActivityLinksController. NC Activity
+        // entries are core-generated; this only wraps the wave-5.3
+        // MarkerLookupTrait carve-out query with type/actor/date
+        // filters + cursor pagination.
+        // @spec openspec/changes/integration-activity/tasks.md.
+        $context->registerService(
+            \OCA\OpenRegister\Service\ActivityFilterService::class,
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\Service\ActivityFilterService(
+                    db: $container->get('OCP\IDBConnection'),
+                    appManager: $container->get('OCP\App\IAppManager'),
+                );
+            }
+        );
+
         // FlowLinkService — Tier-2 admin-gated link/unlink/picker
         // service backing the FlowLinksController. NC Flow operations
         // are configured by admins only; the service enforces that

--- a/lib/Controller/ActivityLinksController.php
+++ b/lib/Controller/ActivityLinksController.php
@@ -1,0 +1,255 @@
+<?php
+
+/**
+ * ActivityLinksController — Tier-2 read-only REST controller for the
+ * `activity` integration leaf.
+ *
+ * NC Activity entries are core-generated and read-only; there is NO
+ * link, create, or delete verb. The Tier-2 surface is narrow:
+ *
+ *   - GET /api/objects/{r}/{s}/{id}/activity?type=&actor=&after=&limit=&cursor=
+ *         — filtered + cursor-paginated entry feed.
+ *   - GET /api/integrations/activity/types?object={r}/{s}/{id}
+ *         — distinct type values (filter dropdown source).
+ *   - GET /api/integrations/activity/actors?object={r}/{s}/{id}
+ *         — distinct actor values (filter dropdown source).
+ *
+ * Entries are linked to an OR object via the `[or:{objectUuid}]` marker
+ * in the `activity.subject` column (wave-5.3 MarkerLookupTrait carve-out,
+ * preserved). The backing ActivityFilterService wraps that marker query
+ * with type/actor/date filters and cursor pagination.
+ *
+ * @category  Controller
+ * @package   OCA\OpenRegister\Controller
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git-id>
+ * @link      https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use Exception;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\ActivityFilterService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Tier-2 Activity links controller (read-only).
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ */
+class ActivityLinksController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param string                $appName       App id.
+     * @param IRequest              $request       HTTP request.
+     * @param ActivityFilterService $filterService Backing service.
+     * @param ObjectService         $objectService OR object resolver.
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly ActivityFilterService $filterService,
+        private readonly ObjectService $objectService,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * List filtered + paginated activity entries for an object.
+     *
+     * Query params: `type`, `actor`, `after` (Unix ts), `limit`, `cursor`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function index(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->filterService->isActivityAvailable() === false) {
+            return $this->unavailable();
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $result = $this->filterService->getActivityEntries(
+                objectUuid: $object->getUuid(),
+                type: $this->nullableString(name: 'type'),
+                actor: $this->nullableString(name: 'actor'),
+                after: $this->nullableInt(name: 'after'),
+                limit: (int) $this->request->getParam('limit', 100),
+                cursor: $this->nullableInt(name: 'cursor')
+            );
+
+            return new JSONResponse(
+                    [
+                        'results'    => $result['results'],
+                        'total'      => $result['total'],
+                        'nextCursor' => $result['nextCursor'],
+                    ]
+                    );
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return new JSONResponse(['error' => $e->getMessage()], 500);
+        }//end try
+    }//end index()
+
+    /**
+     * Distinct activity types for the filter dropdown.
+     *
+     * Query param: `object` in the form `{register}/{schema}/{id}`.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function types(): JSONResponse
+    {
+        return $this->dropdown(fetch: fn (string $uuid): array => $this->filterService->getActivityTypes(objectUuid: $uuid));
+    }//end types()
+
+    /**
+     * Distinct activity actors for the filter dropdown.
+     *
+     * Query param: `object` in the form `{register}/{schema}/{id}`.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function actors(): JSONResponse
+    {
+        return $this->dropdown(fetch: fn (string $uuid): array => $this->filterService->getActivityActors(objectUuid: $uuid));
+    }//end actors()
+
+    /**
+     * Shared dropdown-source handler: resolve `object` param then run the
+     * supplied distinct-column fetcher.
+     *
+     * @param callable(string):array<int,string> $fetch Distinct-value fetcher keyed by object UUID.
+     *
+     * @return JSONResponse
+     */
+    private function dropdown(callable $fetch): JSONResponse
+    {
+        if ($this->filterService->isActivityAvailable() === false) {
+            return $this->unavailable();
+        }
+
+        $object = (string) $this->request->getParam('object', '');
+        $parts  = explode('/', $object);
+        if (count($parts) !== 3 || in_array('', $parts, true) === true) {
+            return new JSONResponse(
+                ['error' => 'object query param must be in the form {register}/{schema}/{id}'],
+                400
+            );
+        }
+
+        try {
+            $resolved = $this->validateObject(register: $parts[0], schema: $parts[1], id: $parts[2]);
+            if ($resolved === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $values = $fetch($resolved->getUuid());
+            return new JSONResponse(['results' => $values, 'total' => count($values)]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return new JSONResponse(['error' => $e->getMessage()], 500);
+        }//end try
+    }//end dropdown()
+
+    /**
+     * Standard "app not installed" 501 response.
+     *
+     * @return JSONResponse
+     */
+    private function unavailable(): JSONResponse
+    {
+        return new JSONResponse(
+            ['error' => 'NC Activity app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+            501
+        );
+    }//end unavailable()
+
+    /**
+     * Read a request param as a trimmed non-empty string, or null.
+     *
+     * @param string $name Param name.
+     *
+     * @return string|null
+     */
+    private function nullableString(string $name): ?string
+    {
+        $value = $this->request->getParam($name);
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+        if ($value === '') {
+            return null;
+        }
+
+        return $value;
+    }//end nullableString()
+
+    /**
+     * Read a request param as an int, or null when absent/empty.
+     *
+     * @param string $name Param name.
+     *
+     * @return int|null
+     */
+    private function nullableInt(string $name): ?int
+    {
+        $value = $this->request->getParam($name);
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return (int) $value;
+    }//end nullableInt()
+
+    /**
+     * Resolve an OR object from register/schema/id.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return ObjectEntity|null
+     */
+    private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
+    {
+        $this->objectService->setSchema($schema);
+        $this->objectService->setRegister($register);
+        $this->objectService->setObject($id);
+
+        return $this->objectService->getObject();
+    }//end validateObject()
+}//end class

--- a/lib/Service/ActivityFilterService.php
+++ b/lib/Service/ActivityFilterService.php
@@ -1,0 +1,407 @@
+<?php
+
+/**
+ * ActivityFilterService — Tier-2 read surface for the `activity`
+ * integration leaf.
+ *
+ * NC Activity entries are core-generated and read-only; the Tier-2
+ * surface is therefore narrow: filter (by type / actor / date) and
+ * paginate (cursor-based) the entries linked to an OpenRegister object
+ * via the `[or:{objectUuid}]` marker in the `activity.subject` column.
+ *
+ * This service deliberately preserves the wave-5.3 MarkerLookupTrait
+ * carve-out: NC Activity writes a single string `subject` column and
+ * that column is the marker target, so the marker-LIKE lookup remains
+ * the canonical link mechanism here (unlike the Tier-2 Flow leaf which
+ * moved to a dedicated link table). The filter/paginate logic wraps
+ * the same marker query; it never replaces it.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use OCP\App\IAppManager;
+use OCP\IDBConnection;
+use Throwable;
+
+/**
+ * Filtered + paginated read access to NC Activity entries linked to an
+ * OpenRegister object.
+ */
+class ActivityFilterService
+{
+    /**
+     * NC app id required for this leaf.
+     *
+     * @var string
+     */
+    private const REQUIRED_APP = 'activity';
+
+    /**
+     * Marker prefix written into `activity.subject`.
+     *
+     * @var string
+     */
+    private const MARKER_PREFIX = '[or:';
+
+    /**
+     * Default page size for entry listing.
+     *
+     * @var int
+     */
+    private const DEFAULT_LIMIT = 100;
+
+    /**
+     * Maximum page size to protect the upstream table.
+     *
+     * @var int
+     */
+    private const MAX_LIMIT = 200;
+
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $db         NC DB connection.
+     * @param IAppManager   $appManager NC app manager (availability check).
+     */
+    public function __construct(
+        private readonly IDBConnection $db,
+        private readonly IAppManager $appManager,
+    ) {
+    }//end __construct()
+
+    /**
+     * Whether the NC Activity app is installed/enabled.
+     *
+     * @return bool
+     */
+    public function isActivityAvailable(): bool
+    {
+        return $this->appManager->isInstalled(self::REQUIRED_APP);
+    }//end isActivityAvailable()
+
+    /**
+     * Fetch a filtered, cursor-paginated page of activity entries for an
+     * OR object.
+     *
+     * @param string      $objectUuid OR object UUID (marker target).
+     * @param string|null $type       Optional exact activity `type` filter.
+     * @param string|null $actor      Optional exact `affecteduser` filter.
+     * @param int|null    $after      Optional lower-bound Unix timestamp (date range).
+     * @param int         $limit      Page size (1..MAX_LIMIT, default DEFAULT_LIMIT).
+     * @param int|null    $cursor     Optional cursor — only rows with `timestamp` strictly
+     *                                less than this value are returned (DESC paging).
+     *
+     * @return array{results: array<int,array<string,mixed>>, total: int, nextCursor: ?int}
+     */
+    public function getActivityEntries(
+        string $objectUuid,
+        ?string $type=null,
+        ?string $actor=null,
+        ?int $after=null,
+        int $limit=self::DEFAULT_LIMIT,
+        ?int $cursor=null
+    ): array {
+        if ($this->isActivityAvailable() === false) {
+            return [
+                'results'    => [],
+                'total'      => 0,
+                'nextCursor' => null,
+            ];
+        }
+
+        $limit = $this->clampLimit(limit: $limit);
+        $rows  = $this->queryRows(
+            objectUuid: $objectUuid,
+            type: $type,
+            actor: $actor,
+            after: $after,
+            cursor: $cursor,
+            limit: ($limit + 1)
+        );
+
+        $hasMore = (count($rows) > $limit);
+        if ($hasMore === true) {
+            $rows = array_slice($rows, 0, $limit);
+        }
+
+        $results = [];
+        foreach ($rows as $row) {
+            $results[] = $this->normaliseRow(row: $row);
+        }
+
+        $nextCursor = null;
+        if ($hasMore === true && empty($results) === false) {
+            $nextCursor = (int) ($results[(count($results) - 1)]['timestamp'] ?? 0);
+        }
+
+        return [
+            'results'    => $results,
+            'total'      => $this->countRows(objectUuid: $objectUuid, type: $type, actor: $actor, after: $after),
+            'nextCursor' => $nextCursor,
+        ];
+    }//end getActivityEntries()
+
+    /**
+     * Distinct activity `type` values for the dropdown source.
+     *
+     * @param string $objectUuid OR object UUID.
+     *
+     * @return array<int,string>
+     */
+    public function getActivityTypes(string $objectUuid): array
+    {
+        return $this->distinctColumn(objectUuid: $objectUuid, column: 'type');
+    }//end getActivityTypes()
+
+    /**
+     * Distinct actor (`affecteduser`) values for the dropdown source.
+     *
+     * @param string $objectUuid OR object UUID.
+     *
+     * @return array<int,string>
+     */
+    public function getActivityActors(string $objectUuid): array
+    {
+        return $this->distinctColumn(objectUuid: $objectUuid, column: 'affecteduser');
+    }//end getActivityActors()
+
+    /**
+     * Clamp a requested limit into the allowed range.
+     *
+     * @param int $limit Requested limit.
+     *
+     * @return int
+     */
+    private function clampLimit(int $limit): int
+    {
+        if ($limit < 1) {
+            return self::DEFAULT_LIMIT;
+        }
+
+        if ($limit > self::MAX_LIMIT) {
+            return self::MAX_LIMIT;
+        }
+
+        return $limit;
+    }//end clampLimit()
+
+    /**
+     * Build the shared marker + filter WHERE clause onto a query builder.
+     *
+     * @param \OCP\DB\QueryBuilder\IQueryBuilder $qb         Query builder to mutate.
+     * @param string                             $objectUuid OR object UUID.
+     * @param string|null                        $type       Optional type filter.
+     * @param string|null                        $actor      Optional actor filter.
+     * @param int|null                           $after      Optional timestamp lower bound.
+     * @param int|null                           $cursor     Optional cursor upper bound.
+     *
+     * @return void
+     */
+    private function applyFilters(
+        \OCP\DB\QueryBuilder\IQueryBuilder $qb,
+        string $objectUuid,
+        ?string $type,
+        ?string $actor,
+        ?int $after,
+        ?int $cursor
+    ): void {
+        $marker = self::MARKER_PREFIX.$objectUuid.']';
+        $qb->where(
+            $qb->expr()->iLike('subject', $qb->createNamedParameter('%'.$marker.'%'))
+        );
+
+        if ($type !== null && $type !== '') {
+            $qb->andWhere($qb->expr()->eq('type', $qb->createNamedParameter($type)));
+        }
+
+        if ($actor !== null && $actor !== '') {
+            $qb->andWhere($qb->expr()->eq('affecteduser', $qb->createNamedParameter($actor)));
+        }
+
+        if ($after !== null) {
+            $qb->andWhere(
+                $qb->expr()->gte('timestamp', $qb->createNamedParameter($after, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT))
+            );
+        }
+
+        if ($cursor !== null) {
+            $qb->andWhere(
+                $qb->expr()->lt('timestamp', $qb->createNamedParameter($cursor, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT))
+            );
+        }
+    }//end applyFilters()
+
+    /**
+     * Run the filtered, ordered, limited row query.
+     *
+     * @param string      $objectUuid OR object UUID.
+     * @param string|null $type       Optional type filter.
+     * @param string|null $actor      Optional actor filter.
+     * @param int|null    $after      Optional timestamp lower bound.
+     * @param int|null    $cursor     Optional cursor upper bound.
+     * @param int         $limit      Row limit.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    private function queryRows(
+        string $objectUuid,
+        ?string $type,
+        ?string $actor,
+        ?int $after,
+        ?int $cursor,
+        int $limit
+    ): array {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('activity_id', 'subject', 'type', 'affecteduser', 'timestamp', 'object_id')
+                ->from('activity');
+            $this->applyFilters(qb: $qb, objectUuid: $objectUuid, type: $type, actor: $actor, after: $after, cursor: $cursor);
+            $qb->orderBy('timestamp', 'DESC')
+                ->addOrderBy('activity_id', 'DESC')
+                ->setMaxResults($limit);
+
+            $result = $qb->executeQuery();
+            $rows   = [];
+            $row    = $result->fetch();
+            while ($row !== false) {
+                $rows[] = $row;
+                $row    = $result->fetch();
+            }
+
+            $result->closeCursor();
+            return $rows;
+        } catch (Throwable $e) {
+            $this->logFailure(context: 'queryRows', e: $e);
+            return [];
+        }//end try
+    }//end queryRows()
+
+    /**
+     * Count total matching rows (ignoring cursor — total over the filter set).
+     *
+     * @param string      $objectUuid OR object UUID.
+     * @param string|null $type       Optional type filter.
+     * @param string|null $actor      Optional actor filter.
+     * @param int|null    $after      Optional timestamp lower bound.
+     *
+     * @return int
+     */
+    private function countRows(string $objectUuid, ?string $type, ?string $actor, ?int $after): int
+    {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select($qb->func()->count('*', 'cnt'))->from('activity');
+            $this->applyFilters(qb: $qb, objectUuid: $objectUuid, type: $type, actor: $actor, after: $after, cursor: null);
+
+            $result = $qb->executeQuery();
+            $row    = $result->fetch();
+            $result->closeCursor();
+
+            return (int) ($row['cnt'] ?? 0);
+        } catch (Throwable $e) {
+            $this->logFailure(context: 'countRows', e: $e);
+            return 0;
+        }//end try
+    }//end countRows()
+
+    /**
+     * Fetch distinct non-empty values of a column across the marker set.
+     *
+     * @param string $objectUuid OR object UUID.
+     * @param string $column     Column to distinct over.
+     *
+     * @return array<int,string>
+     */
+    private function distinctColumn(string $objectUuid, string $column): array
+    {
+        if ($this->isActivityAvailable() === false) {
+            return [];
+        }
+
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->selectDistinct($column)->from('activity');
+            $this->applyFilters(qb: $qb, objectUuid: $objectUuid, type: null, actor: null, after: null, cursor: null);
+            $qb->orderBy($column, 'ASC');
+
+            $result = $qb->executeQuery();
+            $values = [];
+            $row    = $result->fetch();
+            while ($row !== false) {
+                $value = (string) ($row[$column] ?? '');
+                if ($value !== '') {
+                    $values[] = $value;
+                }
+
+                $row = $result->fetch();
+            }
+
+            $result->closeCursor();
+            return array_values(array_unique($values));
+        } catch (Throwable $e) {
+            $this->logFailure(context: 'distinctColumn:'.$column, e: $e);
+            return [];
+        }//end try
+    }//end distinctColumn()
+
+    /**
+     * Normalise an upstream activity row into the registry leaf row shape.
+     *
+     * Mirrors ActivityProvider::list() flattening (Phase B-3) so the
+     * bespoke CnActivityTab reads type / timestamp / actor at the row
+     * root without hand-walking `data.*`.
+     *
+     * @param array<string,mixed> $row Raw upstream row.
+     *
+     * @return array<string,mixed>
+     */
+    private function normaliseRow(array $row): array
+    {
+        $activityId = (string) ($row['activity_id'] ?? '');
+
+        return [
+            'id'           => $activityId,
+            'title'        => (string) ($row['subject'] ?? ''),
+            'subject'      => (string) ($row['subject'] ?? ''),
+            'type'         => (string) ($row['type'] ?? ''),
+            'timestamp'    => (int) ($row['timestamp'] ?? 0),
+            'affecteduser' => (string) ($row['affecteduser'] ?? ''),
+            'actor_id'     => (string) ($row['affecteduser'] ?? ''),
+            'object_id'    => (string) ($row['object_id'] ?? ''),
+            'url'          => '/index.php/apps/activity/'.$activityId,
+            'data'         => $row,
+        ];
+    }//end normaliseRow()
+
+    /**
+     * Log a degraded-path failure (AD-23: any DB error → empty result).
+     *
+     * @param string    $context Call-site context label.
+     * @param Throwable $e       Caught throwable.
+     *
+     * @return void
+     */
+    private function logFailure(string $context, Throwable $e): void
+    {
+        \OCP\Server::get(\Psr\Log\LoggerInterface::class)->debug(
+            '[ActivityFilterService] '.$context.' failed: '.$e->getMessage(),
+            ['exception' => $e]
+        );
+    }//end logFailure()
+}//end class

--- a/lib/Service/Integration/Providers/ActivityProvider.php
+++ b/lib/Service/Integration/Providers/ActivityProvider.php
@@ -91,12 +91,18 @@ class ActivityProvider extends AbstractIntegrationProvider
      * the marker `[or:{objectUuid}]`. The trait runs the LIKE query;
      * rows are normalised into the registry leaf row shape.
      *
+     * Tier-2 narrowing: optional `type` / `actor` / `after` filters may
+     * be passed in `$filters`. They are applied in PHP over the rows the
+     * MarkerLookupTrait returns — the marker LIKE query itself is left
+     * untouched so the wave-5.3 carve-out (NC Activity's single string
+     * `subject` column as the marker target) stays canonical.
+     *
      * @param string $register Register slug for the parent object.
      * @param string $schema   Schema slug for the parent object.
      * @param string $objectId UUID of the OR object whose rows we want.
-     * @param array  $filters  Optional registry filters (unused).
+     * @param array  $filters  Optional filters: `type`, `actor`, `after` (Unix ts).
      *
-     * @return array List of registry leaf rows.
+     * @return array<int,array<string,mixed>> List of registry leaf rows.
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -113,6 +119,8 @@ class ActivityProvider extends AbstractIntegrationProvider
             extraColumns: ['type', 'affecteduser', 'timestamp', 'object_id'],
             idColumn: 'activity_id',
         );
+
+        $rows = $this->applyFilters(rows: $rows, filters: $filters);
 
         return array_map(
                 static function (array $row): array {
@@ -137,13 +145,78 @@ class ActivityProvider extends AbstractIntegrationProvider
                 );
     }//end list()
 
+    /**
+     * Apply Tier-2 type/actor/after filters over marker-matched rows.
+     *
+     * Filtering is done in PHP (not in the marker query) to preserve the
+     * wave-5.3 MarkerLookupTrait carve-out intact.
+     *
+     * @param array $rows    Rows returned by the marker lookup.
+     * @param array $filters Optional `type` / `actor` / `after` filters.
+     *
+     * @return array Filtered rows.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) — three independent
+     * predicate filters short-circuit; splitting them would only add
+     * indirection.
+     */
+    private function applyFilters(array $rows, array $filters): array
+    {
+        $type  = '';
+        $actor = '';
+        $after = 0;
+        if (isset($filters['type']) === true) {
+            $type = (string) $filters['type'];
+        }
+
+        if (isset($filters['actor']) === true) {
+            $actor = (string) $filters['actor'];
+        }
+
+        if (isset($filters['after']) === true) {
+            $after = (int) $filters['after'];
+        }
+
+        if ($type === '' && $actor === '' && $after === 0) {
+            return $rows;
+        }
+
+        return array_values(
+            array_filter(
+                $rows,
+                static function (array $row) use ($type, $actor, $after): bool {
+                    if ($type !== '' && (string) ($row['type'] ?? '') !== $type) {
+                        return false;
+                    }
+
+                    if ($actor !== '' && (string) ($row['affecteduser'] ?? '') !== $actor) {
+                        return false;
+                    }
+
+                    if ($after > 0 && (int) ($row['timestamp'] ?? 0) < $after) {
+                        return false;
+                    }
+
+                    return true;
+                }
+            )
+        );
+    }//end applyFilters()
+
     public function health(): array
     {
         $available = $this->isEnabled();
+        $status    = 'unavailable';
+        $message   = 'NC Activity app is not installed';
+        if ($available === true) {
+            $status  = 'ok';
+            $message = null;
+        }
+
         return [
-            'status'     => $available === true ? 'ok' : 'unavailable',
+            'status'     => $status,
             'authStatus' => 'configured',
-            'message'    => $available === true ? null : 'NC Activity app is not installed',
+            'message'    => $message,
         ];
     }//end health()
 }//end class

--- a/tests/Unit/Service/ActivityFilterServiceTest.php
+++ b/tests/Unit/Service/ActivityFilterServiceTest.php
@@ -1,0 +1,216 @@
+<?php
+
+/**
+ * Unit tests for ActivityFilterService — the Tier-2 read surface for the
+ * `activity` integration leaf.
+ *
+ * Covers the availability gate, cursor-based pagination (limit+1 probe,
+ * slicing, nextCursor derivation), row normalisation, and the distinct
+ * type/actor dropdown helpers. The DB layer is exercised through a
+ * fluent IQueryBuilder mock that returns staged rows.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/integration-activity/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+// phpcs:disable PEAR.Commenting.FunctionComment.Missing -- arrange/act/assert PHPUnit conventions.
+// phpcs:disable CustomSniffs.Functions.NamedParameters.RequireNamedParameters -- PHPUnit positional assertions.
+
+use OCA\OpenRegister\Service\ActivityFilterService;
+use OCP\App\IAppManager;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\QueryBuilder\IQueryFunction;
+use OCP\IDBConnection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for ActivityFilterService.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class ActivityFilterServiceTest extends TestCase
+{
+    /**
+     * Build a service whose DB connection yields a query builder that
+     * returns the supplied rows from executeQuery()->fetch().
+     *
+     * @param array<int,array<string,mixed>> $rows      Rows to stage.
+     * @param bool                           $installed App availability.
+     *
+     * @return ActivityFilterService
+     */
+    private function buildService(array $rows, bool $installed=true): ActivityFilterService
+    {
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('isInstalled')->willReturn($installed);
+
+        $db = $this->createMock(IDBConnection::class);
+        if ($installed === true) {
+            $db->method('getQueryBuilder')->willReturnCallback(
+                function () use ($rows): IQueryBuilder {
+                    return $this->makeQueryBuilder($rows);
+                }
+            );
+        }
+
+        return new ActivityFilterService(db: $db, appManager: $appManager);
+    }//end buildService()
+
+    /**
+     * Build a fluent IQueryBuilder mock returning the staged rows.
+     *
+     * @param array<int,array<string,mixed>> $rows Rows to stage.
+     *
+     * @return IQueryBuilder
+     */
+    private function makeQueryBuilder(array $rows): IQueryBuilder
+    {
+        $expr = $this->createMock(IExpressionBuilder::class);
+        $expr->method('iLike')->willReturn('ilike');
+        $expr->method('eq')->willReturn('eq');
+        $expr->method('gte')->willReturn('gte');
+        $expr->method('lt')->willReturn('lt');
+
+        $result = $this->createMock(\OCP\DB\IResult::class);
+        $queue  = $rows;
+        $result->method('fetch')->willReturnCallback(
+            function () use (&$queue) {
+                if (empty($queue) === true) {
+                    return false;
+                }
+
+                return array_shift($queue);
+            }
+        );
+        $result->method('closeCursor')->willReturn(true);
+
+        $qb = $this->createMock(IQueryBuilder::class);
+        $qb->method('expr')->willReturn($expr);
+        $qb->method('func')->willReturn($this->makeFunc());
+        $qb->method('select')->willReturnSelf();
+        $qb->method('selectDistinct')->willReturnSelf();
+        $qb->method('from')->willReturnSelf();
+        $qb->method('where')->willReturnSelf();
+        $qb->method('andWhere')->willReturnSelf();
+        $qb->method('orderBy')->willReturnSelf();
+        $qb->method('addOrderBy')->willReturnSelf();
+        $qb->method('setMaxResults')->willReturnSelf();
+        $qb->method('createNamedParameter')->willReturn('?');
+        $qb->method('executeQuery')->willReturn($result);
+
+        return $qb;
+    }//end makeQueryBuilder()
+
+    /**
+     * Build a func() stub whose count() returns a placeholder.
+     *
+     * @return \OCP\DB\QueryBuilder\IFunctionBuilder
+     */
+    private function makeFunc(): \OCP\DB\QueryBuilder\IFunctionBuilder
+    {
+        $func = $this->createMock(\OCP\DB\QueryBuilder\IFunctionBuilder::class);
+        $func->method('count')->willReturn($this->createMock(IQueryFunction::class));
+        return $func;
+    }//end makeFunc()
+
+    public function testReturnsEmptyWhenAppMissing(): void
+    {
+        $service = $this->buildService(rows: [], installed: false);
+        self::assertFalse($service->isActivityAvailable());
+
+        $result = $service->getActivityEntries(objectUuid: 'u');
+        self::assertSame([], $result['results']);
+        self::assertSame(0, $result['total']);
+        self::assertNull($result['nextCursor']);
+    }//end testReturnsEmptyWhenAppMissing()
+
+    public function testNormalisesAndReturnsRows(): void
+    {
+        $rows    = [
+            [
+                'activity_id'  => 5,
+                'subject'      => 'Alice changed X [or:u]',
+                'type'         => 'files',
+                'timestamp'    => 1779002099,
+                'affecteduser' => 'alice',
+                'object_id'    => 'u',
+            ],
+        ];
+        $service = $this->buildService(rows: $rows);
+
+        $result = $service->getActivityEntries(objectUuid: 'u', limit: 10);
+        self::assertCount(1, $result['results']);
+        $row = $result['results'][0];
+        self::assertSame('5', $row['id']);
+        self::assertSame('files', $row['type']);
+        self::assertSame(1779002099, $row['timestamp']);
+        self::assertSame('alice', $row['actor_id']);
+        self::assertSame('/index.php/apps/activity/5', $row['url']);
+        // Limit not exceeded, so there is no further page.
+        self::assertNull($result['nextCursor']);
+    }//end testNormalisesAndReturnsRows()
+
+    public function testCursorPaginationSlicesAndSetsNextCursor(): void
+    {
+        // Stage limit+1 (=3) rows for a limit of 2; service must slice to
+        // 2 and surface the last kept row's timestamp as the next cursor.
+        $rows    = [
+            ['activity_id' => 3, 'subject' => 'c [or:u]', 'type' => 'files', 'timestamp' => 300, 'affecteduser' => 'a', 'object_id' => 'u'],
+            ['activity_id' => 2, 'subject' => 'b [or:u]', 'type' => 'files', 'timestamp' => 200, 'affecteduser' => 'a', 'object_id' => 'u'],
+            ['activity_id' => 1, 'subject' => 'a [or:u]', 'type' => 'files', 'timestamp' => 100, 'affecteduser' => 'a', 'object_id' => 'u'],
+        ];
+        $service = $this->buildService(rows: $rows);
+
+        $result = $service->getActivityEntries(objectUuid: 'u', limit: 2);
+        self::assertCount(2, $result['results']);
+        self::assertSame(200, $result['nextCursor']);
+    }//end testCursorPaginationSlicesAndSetsNextCursor()
+
+    public function testGetActivityTypesReturnsDistinctValues(): void
+    {
+        $rows    = [
+            ['type' => 'files'],
+            ['type' => 'or:decision'],
+            ['type' => ''],
+        ];
+        $service = $this->buildService(rows: $rows);
+
+        $types = $service->getActivityTypes(objectUuid: 'u');
+        self::assertSame(['files', 'or:decision'], $types);
+    }//end testGetActivityTypesReturnsDistinctValues()
+
+    public function testGetActivityActorsReturnsDistinctValues(): void
+    {
+        $rows    = [
+            ['affecteduser' => 'alice'],
+            ['affecteduser' => 'bob'],
+        ];
+        $service = $this->buildService(rows: $rows);
+
+        $actors = $service->getActivityActors(objectUuid: 'u');
+        self::assertSame(['alice', 'bob'], $actors);
+    }//end testGetActivityActorsReturnsDistinctValues()
+
+    public function testTypesEmptyWhenAppMissing(): void
+    {
+        $service = $this->buildService(rows: [], installed: false);
+        self::assertSame([], $service->getActivityTypes(objectUuid: 'u'));
+        self::assertSame([], $service->getActivityActors(objectUuid: 'u'));
+    }//end testTypesEmptyWhenAppMissing()
+}//end class

--- a/tests/Unit/Service/Integration/Providers/ActivityProviderTest.php
+++ b/tests/Unit/Service/Integration/Providers/ActivityProviderTest.php
@@ -47,7 +47,12 @@ use PHPUnit\Framework\TestCase;
  */
 class TestableActivityProvider extends ActivityProvider
 {
-    /** @var array<int,array<string,mixed>> */
+
+    /**
+     * Pre-baked rows returned in place of the trait DB call.
+     *
+     * @var array<int,array<string,mixed>>
+     */
     public array $stubRows = [];
 
     protected function findByMarker(
@@ -59,8 +64,8 @@ class TestableActivityProvider extends ActivityProvider
         string $idColumn='id'
     ): array {
         return $this->stubRows;
-    }
-}
+    }//end findByMarker()
+}//end class
 
 /**
  * Unit tests for ActivityProvider.
@@ -69,8 +74,7 @@ class TestableActivityProvider extends ActivityProvider
  */
 class ActivityProviderTest extends TestCase
 {
-
-    private function buildProvider(bool $installed = true): TestableActivityProvider
+    private function buildProvider(bool $installed=true): TestableActivityProvider
     {
         $db   = $this->createMock(IDBConnection::class);
         $apps = $this->createMock(IAppManager::class);
@@ -78,22 +82,20 @@ class ActivityProviderTest extends TestCase
         $l10n = $this->createMock(IL10N::class);
         $l10n->method('t')->willReturnArgument(0);
         return new TestableActivityProvider(db: $db, appManager: $apps, l10n: $l10n);
-    }
-
+    }//end buildProvider()
 
     public function testListEmptyWhenAppMissing(): void
     {
-        $provider = $this->buildProvider(installed: false);
+        $provider           = $this->buildProvider(installed: false);
         $provider->stubRows = [
             ['activity_id' => 1, 'subject' => 'x [or:uuid]', 'type' => 'files', 'timestamp' => 100, 'affecteduser' => 'a', 'object_id' => 'uuid'],
         ];
         self::assertSame([], $provider->list(register: 'r', schema: 's', objectId: 'uuid'));
-    }
-
+    }//end testListEmptyWhenAppMissing()
 
     public function testListWidenedPayloadFlattensFields(): void
     {
-        $provider = $this->buildProvider();
+        $provider           = $this->buildProvider();
         $provider->stubRows = [
             [
                 'activity_id'  => 17,
@@ -134,32 +136,68 @@ class ActivityProviderTest extends TestCase
         $r1 = $rows[1];
         self::assertSame('or:decision', $r1['type']);
         self::assertSame('bob', $r1['actor_id']);
-    }
+    }//end testListWidenedPayloadFlattensFields()
 
+    public function testListFiltersByType(): void
+    {
+        $provider           = $this->buildProvider();
+        $provider->stubRows = [
+            ['activity_id' => 1, 'subject' => 'a [or:u]', 'type' => 'files', 'timestamp' => 100, 'affecteduser' => 'alice', 'object_id' => 'u'],
+            ['activity_id' => 2, 'subject' => 'b [or:u]', 'type' => 'or:decision', 'timestamp' => 200, 'affecteduser' => 'bob', 'object_id' => 'u'],
+        ];
+
+        $rows = $provider->list(register: 'r', schema: 's', objectId: 'u', filters: ['type' => 'or:decision']);
+        self::assertCount(1, $rows);
+        self::assertSame('or:decision', $rows[0]['type']);
+    }//end testListFiltersByType()
+
+    public function testListFiltersByActor(): void
+    {
+        $provider           = $this->buildProvider();
+        $provider->stubRows = [
+            ['activity_id' => 1, 'subject' => 'a [or:u]', 'type' => 'files', 'timestamp' => 100, 'affecteduser' => 'alice', 'object_id' => 'u'],
+            ['activity_id' => 2, 'subject' => 'b [or:u]', 'type' => 'files', 'timestamp' => 200, 'affecteduser' => 'bob', 'object_id' => 'u'],
+        ];
+
+        $rows = $provider->list(register: 'r', schema: 's', objectId: 'u', filters: ['actor' => 'bob']);
+        self::assertCount(1, $rows);
+        self::assertSame('bob', $rows[0]['actor_id']);
+    }//end testListFiltersByActor()
+
+    public function testListFiltersByAfterTimestamp(): void
+    {
+        $provider           = $this->buildProvider();
+        $provider->stubRows = [
+            ['activity_id' => 1, 'subject' => 'old [or:u]', 'type' => 'files', 'timestamp' => 100, 'affecteduser' => 'alice', 'object_id' => 'u'],
+            ['activity_id' => 2, 'subject' => 'new [or:u]', 'type' => 'files', 'timestamp' => 500, 'affecteduser' => 'bob', 'object_id' => 'u'],
+        ];
+
+        $rows = $provider->list(register: 'r', schema: 's', objectId: 'u', filters: ['after' => 300]);
+        self::assertCount(1, $rows);
+        self::assertSame(500, $rows[0]['timestamp']);
+    }//end testListFiltersByAfterTimestamp()
 
     public function testListHandlesEmptyResult(): void
     {
-        $provider = $this->buildProvider();
+        $provider           = $this->buildProvider();
         $provider->stubRows = [];
         self::assertSame([], $provider->list(register: 'r', schema: 's', objectId: 'uuid'));
-    }
-
+    }//end testListHandlesEmptyResult()
 
     public function testHealthReportsOk(): void
     {
         $provider = $this->buildProvider();
-        $h = $provider->health();
+        $h        = $provider->health();
         self::assertSame('ok', $h['status']);
         self::assertSame('configured', $h['authStatus']);
         self::assertNull($h['message']);
-    }
-
+    }//end testHealthReportsOk()
 
     public function testHealthReportsUnavailable(): void
     {
         $provider = $this->buildProvider(installed: false);
-        $h = $provider->health();
+        $h        = $provider->health();
         self::assertSame('unavailable', $h['status']);
         self::assertNotNull($h['message']);
-    }
-}
+    }//end testHealthReportsUnavailable()
+}//end class


### PR DESCRIPTION
## Summary
- Tier-2 read-only surface for the `activity` integration leaf: NC Activity entries are core-generated, so this is narrow — filter (type / actor / date) + cursor pagination, **no picker, no inline create**.
- New `ActivityFilterService` (`getActivityEntries` cursor-paginated + filtered, `getActivityTypes`, `getActivityActors`) and read-only `ActivityLinksController` (`GET .../activity`, `GET /integrations/activity/types`, `GET /integrations/activity/actors`).
- `ActivityProvider.list()` now honours `type`/`actor`/`after` filters in PHP over the marker-matched rows — the **wave-5.3 `MarkerLookupTrait` carve-out** (`activity.subject` as the `[or:{uuid}]` marker target) is intentionally preserved.
- No pin feature shipped (optional) → no migration.

## Test plan
- [ ] `composer check:strict` (PHPCS 0 errors, PHPMD only pre-existing `$register`/`$schema` unused-param baseline, PHPStan + Psalm clean)
- [ ] PHPUnit: `ActivityFilterServiceTest` (7) + `ActivityProviderTest` filter cases + existing `ActivityServiceTest` green
- [ ] Manual: open an object's Activity tab, filter by type/actor, switch 24h/7d/30d/all, click Load more

Refs openregister#1318, ADR-019, ADR-022.