### PR TITLE
feat(shares): Tier-2 — ShareLinkService wrapping IManager (no cache table)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -371,6 +371,17 @@ return [
         ['name' => 'pollLinks#createNew', 'url' => '/api/objects/{register}/{schema}/{id}/polls/new',         'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
         ['name' => 'pollLinks#destroy',   'url' => '/api/objects/{register}/{schema}/{id}/polls/{pollId}',    'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'pollId' => '[0-9]+']],
 
+        // Shares — Tier-2: NO link table, NO cache. Every endpoint wraps
+        // OCP\Share\IManager (NC core sharing is the single source of
+        // truth). The shareable-files picker source is app-global but
+        // object-scoped (it lists files inside the object's folder), so
+        // the specific `/api/integrations/shares/files/...` route is
+        // declared before the per-object wildcard `{shareId}` route.
+        ['name' => 'shareLinks#files',   'url' => '/api/integrations/shares/files/{register}/{schema}/{id}', 'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
+        ['name' => 'shareLinks#index',   'url' => '/api/objects/{register}/{schema}/{id}/shares',            'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
+        ['name' => 'shareLinks#create',  'url' => '/api/objects/{register}/{schema}/{id}/shares',            'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'shareLinks#destroy', 'url' => '/api/objects/{register}/{schema}/{id}/shares/{shareId}',  'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'shareId' => '[^/]+']],
+
         // Flow (workflowengine) — Tier-2 link-table API. Admin-gated:
         // POST/DELETE return 403 for non-admins; GET is read-only for
         // everyone. NC Flow operations are configured globally in the

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1194,8 +1194,8 @@ class Application extends App implements IBootstrap
             }
         );
 
-        // SharesProvider — NC core (no app gate); uses MarkerLookupTrait
-        // against the `share` table's `note` column.
+        // SharesProvider — NC core (no app gate); wraps OCP\Share\IManager
+        // (query-time, no link table — IShare is first-class NC state).
         // @spec openspec/changes/integration-shares/tasks.md.
         $context->registerService(
             SharesProvider::class,
@@ -1204,6 +1204,21 @@ class Application extends App implements IBootstrap
                     db: $container->get('OCP\IDBConnection'),
                     appManager: $container->get('OCP\App\IAppManager'),
                     l10n: $container->get('OCP\IL10N'),
+                );
+            }
+        );
+
+        // ShareLinkService — Tier-2 share create/revoke/list service
+        // backing the ShareLinksController. NO link table / NO cache:
+        // OCP\Share\IManager is the single source of truth, resolved
+        // lazily through the container (same pattern as SharesProvider).
+        // @spec openspec/changes/integration-shares/tasks.md.
+        $context->registerService(
+            \OCA\OpenRegister\Service\ShareLinkService::class,
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\Service\ShareLinkService(
+                    l10n: $container->get('OCP\IL10N'),
+                    logger: $container->get('Psr\Log\LoggerInterface'),
                 );
             }
         );

--- a/lib/Controller/ShareLinksController.php
+++ b/lib/Controller/ShareLinksController.php
@@ -1,0 +1,261 @@
+<?php
+
+/**
+ * ShareLinksController — Tier-2 REST controller for NC core shares
+ * linked to an OpenRegister object.
+ *
+ * NO LINK TABLE / NO CACHE: every endpoint delegates straight to
+ * `ShareLinkService`, which wraps `OCP\Share\IManager` (the single
+ * source of truth). See `ShareLinkService` for the rationale.
+ *
+ * Endpoints:
+ *   - GET    /api/objects/{register}/{schema}/{id}/shares          — list
+ *   - POST   /api/objects/{register}/{schema}/{id}/shares          — create
+ *   - DELETE /api/objects/{register}/{schema}/{id}/shares/{shareId} — revoke
+ *   - GET    /api/integrations/shares/files/{register}/{schema}/{id} — shareable files
+ *
+ * @category  Controller
+ * @package   OCA\OpenRegister\Controller
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/integration-shares/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use Exception;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\ShareLinkService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Tier-2 share links controller.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ */
+class ShareLinksController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param string           $appName          App id.
+     * @param IRequest         $request          HTTP request.
+     * @param ShareLinkService $shareLinkService Backing service.
+     * @param ObjectService    $objectService    OR object resolver.
+     *
+     * @return void
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly ShareLinkService $shareLinkService,
+        private readonly ObjectService $objectService,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * List shares linked to an object.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function index(string $register, string $schema, string $id): JSONResponse
+    {
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $results = $this->shareLinkService->getLinkedShares($object->getUuid());
+
+            return new JSONResponse(['results' => $results, 'total' => count($results)]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end index()
+
+    /**
+     * Create a share on a file inside the object's folder.
+     *
+     * Body:
+     *   `{ fileId: int, shareType: int, shareWith?: string,
+     *      permissions: int, password?: string, expiration?: ISO-8601 }`
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function create(string $register, string $schema, string $id): JSONResponse
+    {
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $fileId = (int) $this->request->getParam('fileId', 0);
+            if ($fileId === 0) {
+                return new JSONResponse(['error' => 'fileId is required'], 400);
+            }
+
+            $shareType   = (int) $this->request->getParam('shareType', -1);
+            $permissions = (int) $this->request->getParam('permissions', 1);
+            $shareWith   = $this->request->getParam('shareWith');
+            $password    = $this->request->getParam('password');
+            $expiration  = $this->request->getParam('expiration');
+
+            $share = $this->shareLinkService->createShare(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $fileId,
+                $shareType,
+                $shareWith !== null ? (string) $shareWith : null,
+                $permissions,
+                $password !== null ? (string) $password : null,
+                $expiration !== null ? (string) $expiration : null
+            );
+
+            return new JSONResponse(
+                [
+                    'shareId'   => (string) $share->getId(),
+                    'shareType' => (int) $share->getShareType(),
+                    'token'     => (string) ($share->getToken() ?? ''),
+                ],
+                201
+            );
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end create()
+
+    /**
+     * Revoke a share by id (ownership-checked).
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     * @param string $shareId  Share id to revoke.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function destroy(string $register, string $schema, string $id, string $shareId): JSONResponse
+    {
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $this->shareLinkService->revokeShare($object->getUuid(), $shareId);
+
+            return new JSONResponse(['success' => true]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end destroy()
+
+    /**
+     * List the files inside an object's folder that can be shared.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function files(string $register, string $schema, string $id): JSONResponse
+    {
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $results = $this->shareLinkService->getShareableFiles($object->getUuid());
+
+            return new JSONResponse(['results' => $results, 'total' => count($results)]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end files()
+
+    /**
+     * Resolve an OR object from register/schema/id.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return ObjectEntity|null
+     */
+    private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
+    {
+        $this->objectService->setSchema($schema);
+        $this->objectService->setRegister($register);
+        $this->objectService->setObject($id);
+
+        return $this->objectService->getObject();
+    }//end validateObject()
+
+    /**
+     * Map a service-layer Exception to a JSONResponse.
+     *
+     * Exception codes carry HTTP intent (401/403/404/503), everything
+     * else defaults to 400 bad request.
+     *
+     * @param Exception $exception Source exception.
+     *
+     * @return JSONResponse
+     */
+    private function mapException(Exception $exception): JSONResponse
+    {
+        $code = $exception->getCode();
+        if (in_array($code, [400, 401, 403, 404, 503], true) === true) {
+            return new JSONResponse(['error' => $exception->getMessage()], $code);
+        }
+
+        return new JSONResponse(['error' => $exception->getMessage()], 400);
+    }//end mapException()
+}//end class

--- a/lib/Service/Integration/Providers/SharesProvider.php
+++ b/lib/Service/Integration/Providers/SharesProvider.php
@@ -220,6 +220,24 @@ class SharesProvider extends AbstractIntegrationProvider
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
         try {
+            // Tier-2: delegate the IManager folder-walk to ShareLinkService
+            // so there is exactly ONE canonical implementation (and one
+            // copy of the Phase H-1 entity-input folder-resolve fix). The
+            // service returns the Tier-2 row contract; this provider
+            // re-maps it to the registry widget's contract (`id` / `url` /
+            // `data`) so existing consumers keep working. When the service
+            // is unavailable the original in-provider walk below is the
+            // fallback so the registry tab degrades gracefully per AD-23.
+            $service = $this->lookup(serviceName: 'OCA\\OpenRegister\\Service\\ShareLinkService');
+            if ($service !== null && method_exists($service, 'getLinkedShares') === true) {
+                try {
+                    $serviceRows = $service->getLinkedShares($objectId);
+                    return array_map([$this, 'mapServiceRow'], $serviceRows);
+                } catch (Throwable $e) {
+                    // Fall through to the local walk below.
+                }
+            }
+
             $shareManager = $this->lookup(serviceName: 'OCP\\Share\\IManager');
             $userId       = $this->resolveCurrentUserId();
             if ($shareManager === null || $userId === null) {
@@ -275,6 +293,44 @@ class SharesProvider extends AbstractIntegrationProvider
             return [];
         }
     }//end list()
+
+
+    /**
+     * Map a ShareLinkService row to the registry widget's row contract.
+     *
+     * The service exposes the Tier-2 shape (`shareId` / `fileId` /
+     * `shareWithDisplayName` / `createdAt`); the registry widget expects
+     * `id` / `url` / `data`. This adapter bridges the two without a
+     * second IManager walk.
+     *
+     * @param array<string,mixed> $row Service row.
+     *
+     * @return array<string,mixed> Widget row.
+     */
+    private function mapServiceRow(array $row): array
+    {
+        $fileId = (int) ($row['fileId'] ?? 0);
+
+        return [
+            'id'                   => (string) ($row['shareId'] ?? ''),
+            'shareType'            => (int) ($row['shareType'] ?? 0),
+            'shareWith'            => (string) ($row['shareWith'] ?? ''),
+            'shareWithDisplayname' => (string) ($row['shareWithDisplayName'] ?? ''),
+            'permissions'          => (int) ($row['permissions'] ?? 0),
+            'passwordProtected'    => (bool) ($row['passwordProtected'] ?? false),
+            'expiration'           => $row['expiration'] ?? null,
+            'stime'                => $row['createdAt'] ?? null,
+            'nodeName'             => (string) ($row['fileName'] ?? ''),
+            'canRevoke'            => (bool) ($row['canRevoke'] ?? false),
+            'url'                  => $fileId > 0
+                ? '/index.php/apps/files/?fileid='.$fileId
+                : '/index.php/apps/files',
+            'data'                 => [
+                'id'     => (string) ($row['shareId'] ?? ''),
+                'nodeId' => $fileId,
+            ],
+        ];
+    }//end mapServiceRow()
 
 
     /**

--- a/lib/Service/ShareLinkService.php
+++ b/lib/Service/ShareLinkService.php
@@ -1,0 +1,634 @@
+<?php
+
+/**
+ * ShareLinkService — Tier-2 shares integration service.
+ *
+ * Composes `OCP\Share\IManager` (NC core sharing — the single source of
+ * truth) with the OR `ObjectEntityMapper` + `FolderManagementHandler`
+ * so the registry "Shares" leaf can list, create and revoke shares on
+ * the files inside an object's NC folder.
+ *
+ * NO CACHE / NO LINK TABLE: `IShare` is first-class NC core state and
+ * mutates outside OpenRegister (users open the Files share panel
+ * directly). Any OR-side snapshot table would desync immediately, so
+ * every read/write goes straight through `IManager`. This is the
+ * deliberate divergence from the polls/flow/talk Tier-2 services, which
+ * own a private link table because their upstream apps expose no
+ * per-object query surface.
+ *
+ * Surface:
+ *   - getLinkedShares(objectUuid)                       — list (H-1 folder-resolve)
+ *   - createShare(objectUuid, registerId, schemaId,
+ *                 fileId, shareType, shareWith?,
+ *                 permissions, password?, expiration?)  — IManager::createShare
+ *   - revokeShare(objectUuid, shareId)                  — IManager::deleteShare (ownership-checked)
+ *   - getShareableFiles(objectUuid)                     — files in the object's folder
+ *
+ * Lazy-resolution policy mirrors {@see SharesProvider}: `IManager`,
+ * `FolderManagementHandler`, `ObjectEntityMapper` and `IUserSession`
+ * are pulled from the server container on demand so the ctor stays a
+ * plain `(IL10N, LoggerInterface, ?ContainerInterface)` and unit tests
+ * inject a mock container.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/integration-shares/tasks.md
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use DateTime;
+use DateTimeInterface;
+use Exception;
+use OCP\Files\Folder;
+use OCP\Files\Node;
+use OCP\IL10N;
+use OCP\Server;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * ShareLinkService.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ */
+class ShareLinkService
+{
+
+    /**
+     * Share types the service surfaces when listing. Mirrors
+     * {@see SharesProvider::SHARE_TYPES} so the registry tab and this
+     * service agree on which shares belong to the object.
+     *
+     * @var int[]
+     */
+    private const SHARE_TYPES = [
+        IShare::TYPE_USER,
+        IShare::TYPE_GROUP,
+        IShare::TYPE_LINK,
+        IShare::TYPE_EMAIL,
+        IShare::TYPE_REMOTE,
+        IShare::TYPE_REMOTE_GROUP,
+    ];
+
+    /**
+     * Maximum nodes inside the object's folder to walk when listing or
+     * collecting shareable files. Matches the provider's bound so deep
+     * object folders don't hammer the share manager.
+     *
+     * @var int
+     */
+    private const MAX_NODES = 50;
+
+    /**
+     * Optional server-container override (tests only). Production uses
+     * NC's global `\OCP\Server` container via {@see resolveContainer()}.
+     *
+     * @var ContainerInterface|null
+     */
+    private ?ContainerInterface $container;
+
+    /**
+     * Constructor.
+     *
+     * @param IL10N                   $l10n      Localisation.
+     * @param LoggerInterface         $logger    Logger.
+     * @param ContainerInterface|null $container Optional server-container override (tests only).
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly IL10N $l10n,
+        private readonly LoggerInterface $logger,
+        ?ContainerInterface $container=null,
+    ) {
+        $this->container = $container;
+    }//end __construct()
+
+    /**
+     * List shares linked to an OR object.
+     *
+     * Walks the object's NC folder (resolved via the H-1 entity-input
+     * branch of {@see FolderManagementHandler::getObjectFolder()}) and
+     * unions shares across the object's files for every relevant share
+     * type, deduplicated by share id.
+     *
+     * @param string $objectUuid Owning object uuid.
+     *
+     * @return array<int,array<string,mixed>> Normalised share rows.
+     *
+     * @throws Exception When the share subsystem is unreachable (503).
+     */
+    public function getLinkedShares(string $objectUuid): array
+    {
+        $shareManager = $this->getShareManager();
+        $userId       = $this->resolveCurrentUserId();
+        if ($userId === null) {
+            throw new Exception('No user logged in', 401);
+        }
+
+        $folder = $this->resolveObjectFolder(objectUuid: $objectUuid);
+        if ($folder === null) {
+            return [];
+        }
+
+        $rows  = [];
+        $seen  = [];
+        $count = 0;
+        foreach ($folder->getDirectoryListing() as $node) {
+            if ($count >= self::MAX_NODES) {
+                break;
+            }
+
+            $count++;
+
+            foreach (self::SHARE_TYPES as $type) {
+                try {
+                    $shares = $shareManager->getSharesBy($userId, $type, $node);
+                } catch (Throwable $e) {
+                    continue;
+                }
+
+                foreach ($shares as $share) {
+                    $row = $this->normaliseShare(share: $share, userId: $userId);
+                    if ($row === null) {
+                        continue;
+                    }
+
+                    $id = $row['shareId'];
+                    if (isset($seen[$id]) === true) {
+                        continue;
+                    }
+
+                    $seen[$id] = true;
+                    $rows[]    = $row;
+                }
+            }//end foreach
+        }//end foreach
+
+        return $rows;
+    }//end getLinkedShares()
+
+    /**
+     * Create a share on a file inside the object's folder.
+     *
+     * The target `fileId` MUST resolve to a node within the object's
+     * folder — this is the ownership boundary that keeps OR from
+     * minting shares on arbitrary files. `IManager::newShare()` builds
+     * the prototype, which is then populated and handed to
+     * `IManager::createShare()`.
+     *
+     * @param string      $objectUuid  Owning object uuid.
+     * @param int         $registerId  OR register id (reserved — folder is per-object).
+     * @param int         $schemaId    OR schema id (reserved).
+     * @param int         $fileId      Target file node id (must be in the object's folder).
+     * @param int         $shareType   IShare::TYPE_* (user/group/link/email).
+     * @param string|null $shareWith   Recipient uid/gid/email; null for public link.
+     * @param int         $permissions Permission bitmask.
+     * @param string|null $password    Optional password (public/email shares).
+     * @param string|null $expiration  Optional ISO-8601 expiration date.
+     *
+     * @return IShare The created share.
+     *
+     * @throws Exception On missing user (401), file-not-in-folder (404),
+     *                   invalid recipient (400) or share-manager failure.
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
+    public function createShare(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        int $fileId,
+        int $shareType,
+        ?string $shareWith,
+        int $permissions,
+        ?string $password=null,
+        ?string $expiration=null,
+    ): IShare {
+        $shareManager = $this->getShareManager();
+        $userId       = $this->resolveCurrentUserId();
+        if ($userId === null) {
+            throw new Exception('No user logged in', 401);
+        }
+
+        $node = $this->resolveNodeInFolder(objectUuid: $objectUuid, fileId: $fileId);
+        if ($node === null) {
+            throw new Exception('File does not belong to this object', 404);
+        }
+
+        if (in_array($shareType, self::SHARE_TYPES, true) === false) {
+            throw new Exception('Unsupported share type', 400);
+        }
+
+        if (($shareType === IShare::TYPE_USER
+            || $shareType === IShare::TYPE_GROUP
+            || $shareType === IShare::TYPE_EMAIL)
+            && ($shareWith === null || trim($shareWith) === '')
+        ) {
+            throw new Exception('shareWith is required for this share type', 400);
+        }
+
+        $share = $shareManager->newShare();
+        $share->setNode($node);
+        $share->setShareType($shareType);
+        $share->setSharedBy($userId);
+        $share->setPermissions($permissions);
+
+        if ($shareWith !== null && trim($shareWith) !== '') {
+            $share->setSharedWith(trim($shareWith));
+        }
+
+        if ($password !== null && trim($password) !== '') {
+            $share->setPassword($password);
+        }
+
+        if ($expiration !== null && trim($expiration) !== '') {
+            try {
+                $share->setExpirationDate(new DateTime($expiration));
+            } catch (Throwable $e) {
+                throw new Exception('Invalid expiration date', 400);
+            }
+        }
+
+        try {
+            return $shareManager->createShare($share);
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                'ShareLinkService::createShare failed: '.$e->getMessage(),
+                ['app' => 'openregister']
+            );
+            throw new Exception($e->getMessage(), 400);
+        }
+    }//end createShare()
+
+    /**
+     * Revoke a share by id, ownership-checked.
+     *
+     * The share's backing node MUST live inside the object's folder,
+     * otherwise the request is rejected with 404 — this prevents
+     * revoking a share through an unrelated object's endpoint.
+     *
+     * @param string $objectUuid Owning object uuid.
+     * @param string $shareId    Share id to revoke.
+     *
+     * @return void
+     *
+     * @throws Exception On missing user (401), share-not-found (404),
+     *                   ownership mismatch (403).
+     */
+    public function revokeShare(string $objectUuid, string $shareId): void
+    {
+        $shareManager = $this->getShareManager();
+        $userId       = $this->resolveCurrentUserId();
+        if ($userId === null) {
+            throw new Exception('No user logged in', 401);
+        }
+
+        try {
+            $share = $shareManager->getShareById($shareId);
+        } catch (Throwable $e) {
+            throw new Exception('Share not found', 404);
+        }
+
+        $folder = $this->resolveObjectFolder(objectUuid: $objectUuid);
+        if ($folder === null || $this->shareIsInFolder(share: $share, folder: $folder) === false) {
+            throw new Exception('Share does not belong to this object', 403);
+        }
+
+        $shareManager->deleteShare($share);
+    }//end revokeShare()
+
+    /**
+     * List the files inside an object's folder that can be shared.
+     *
+     * @param string $objectUuid Owning object uuid.
+     *
+     * @return array<int,array<string,mixed>> File descriptors `{fileId, fileName, mimetype, size}`.
+     */
+    public function getShareableFiles(string $objectUuid): array
+    {
+        $folder = $this->resolveObjectFolder(objectUuid: $objectUuid);
+        if ($folder === null) {
+            return [];
+        }
+
+        $files = [];
+        $count = 0;
+        foreach ($folder->getDirectoryListing() as $node) {
+            if ($count >= self::MAX_NODES) {
+                break;
+            }
+
+            $count++;
+
+            if ($node->getType() !== \OCP\Files\FileInfo::TYPE_FILE) {
+                continue;
+            }
+
+            $files[] = [
+                'fileId'   => (int) $node->getId(),
+                'fileName' => (string) $node->getName(),
+                'mimetype' => (string) $node->getMimetype(),
+                'size'     => (int) $node->getSize(),
+            ];
+        }
+
+        return $files;
+    }//end getShareableFiles()
+
+    /**
+     * Resolve the NC share manager or throw a 503.
+     *
+     * @return IManager
+     *
+     * @throws Exception When the share subsystem is unreachable (503).
+     */
+    private function getShareManager(): IManager
+    {
+        $manager = $this->lookup(serviceName: 'OCP\\Share\\IManager');
+        if (($manager instanceof IManager) === false) {
+            throw new Exception('NC share manager is unreachable', 503);
+        }
+
+        return $manager;
+    }//end getShareManager()
+
+    /**
+     * Resolve the object's NC folder via FolderManagementHandler,
+     * passing the resolved ObjectEntity so the handler uses its
+     * entity-input branch (the H-1 fix — string input throws "no
+     * objectEntity or registerId given").
+     *
+     * @param string $objectUuid Owning object uuid.
+     *
+     * @return Folder|null
+     */
+    private function resolveObjectFolder(string $objectUuid): ?Folder
+    {
+        try {
+            $handler = $this->lookup(
+                serviceName: 'OCA\\OpenRegister\\Service\\File\\FolderManagementHandler'
+            );
+            if ($handler === null) {
+                return null;
+            }
+
+            $entity = $this->resolveObjectEntity(objectUuid: $objectUuid);
+            $folder = $handler->getObjectFolder($entity ?? $objectUuid);
+            return ($folder instanceof Folder) === true ? $folder : null;
+        } catch (Throwable $e) {
+            return null;
+        }
+    }//end resolveObjectFolder()
+
+    /**
+     * Resolve a file node inside the object's folder by file id.
+     *
+     * @param string $objectUuid Owning object uuid.
+     * @param int    $fileId     Target file node id.
+     *
+     * @return Node|null Node when present in the folder, else null.
+     */
+    private function resolveNodeInFolder(string $objectUuid, int $fileId): ?Node
+    {
+        $folder = $this->resolveObjectFolder(objectUuid: $objectUuid);
+        if ($folder === null) {
+            return null;
+        }
+
+        $count = 0;
+        foreach ($folder->getDirectoryListing() as $node) {
+            if ($count >= self::MAX_NODES) {
+                break;
+            }
+
+            $count++;
+
+            if ((int) $node->getId() === $fileId) {
+                return $node;
+            }
+        }
+
+        return null;
+    }//end resolveNodeInFolder()
+
+    /**
+     * Whether a share's backing node lives inside the given folder.
+     *
+     * @param IShare $share  Share to check.
+     * @param Folder $folder Object folder.
+     *
+     * @return bool
+     */
+    private function shareIsInFolder(IShare $share, Folder $folder): bool
+    {
+        try {
+            $node = $share->getNode();
+        } catch (Throwable $e) {
+            return false;
+        }
+
+        if ($node === null) {
+            return false;
+        }
+
+        $nodeId = (int) $node->getId();
+        $count  = 0;
+        foreach ($folder->getDirectoryListing() as $child) {
+            if ($count >= self::MAX_NODES) {
+                break;
+            }
+
+            $count++;
+
+            if ((int) $child->getId() === $nodeId) {
+                return true;
+            }
+        }
+
+        return false;
+    }//end shareIsInFolder()
+
+    /**
+     * Look up an ObjectEntity by uuid via the lazy container.
+     *
+     * @param string $objectUuid Object uuid.
+     *
+     * @return object|null
+     */
+    private function resolveObjectEntity(string $objectUuid): ?object
+    {
+        try {
+            $mapper = $this->lookup(
+                serviceName: 'OCA\\OpenRegister\\Db\\ObjectEntityMapper'
+            );
+            if ($mapper === null) {
+                return null;
+            }
+
+            $entity = $mapper->find($objectUuid);
+            return is_object($entity) === true ? $entity : null;
+        } catch (Throwable $e) {
+            return null;
+        }
+    }//end resolveObjectEntity()
+
+    /**
+     * Resolve the current user's UID via IUserSession.
+     *
+     * @return string|null
+     */
+    private function resolveCurrentUserId(): ?string
+    {
+        try {
+            $session = $this->lookup(serviceName: 'OCP\\IUserSession');
+            if ($session === null) {
+                return null;
+            }
+
+            $user = $session->getUser();
+            if ($user === null) {
+                return null;
+            }
+
+            return $user->getUID();
+        } catch (Throwable $e) {
+            return null;
+        }
+    }//end resolveCurrentUserId()
+
+    /**
+     * Normalise an `IShare` into the leaf-row contract.
+     *
+     * @param IShare $share  Share to normalise.
+     * @param string $userId Current user uid (drives `canRevoke`).
+     *
+     * @return array<string,mixed>|null
+     */
+    private function normaliseShare(IShare $share, string $userId): ?array
+    {
+        try {
+            $shareId     = (string) $share->getId();
+            $shareType   = (int) $share->getShareType();
+            $sharedWith  = (string) ($share->getSharedWith() ?? '');
+            $displayName = (string) ($share->getSharedWithDisplayName() ?? $sharedWith);
+            $permissions = (int) $share->getPermissions();
+            $hasPassword = $share->getPassword() !== null && $share->getPassword() !== '';
+            $expiration  = null;
+            $expDate     = $share->getExpirationDate();
+            if ($expDate !== null) {
+                $expiration = $expDate->format(DateTimeInterface::ATOM);
+            }
+
+            $stime     = $share->getShareTime();
+            $createdAt = $stime !== null ? $stime->format(DateTimeInterface::ATOM) : null;
+            $owner     = (string) ($share->getSharedBy() ?? '');
+            $node      = $share->getNode();
+            $fileName  = $node !== null ? (string) $node->getName() : '';
+            $fileId    = $node !== null ? (int) $node->getId() : 0;
+
+            return [
+                'shareId'              => $shareId,
+                'shareType'            => $shareType,
+                'shareWith'            => $sharedWith,
+                'shareWithDisplayName' => $displayName,
+                'permissions'          => $permissions,
+                'passwordProtected'    => $hasPassword,
+                'expiration'           => $expiration,
+                'createdAt'            => $createdAt,
+                'fileId'               => $fileId,
+                'fileName'             => $fileName,
+                'canRevoke'            => $owner === $userId,
+            ];
+        } catch (Throwable $e) {
+            return null;
+        }//end try
+    }//end normaliseShare()
+
+    /**
+     * Resolve a service from the container.
+     *
+     * @param string $serviceName Fully qualified class name to resolve.
+     *
+     * @return object|null
+     */
+    private function lookup(string $serviceName): ?object
+    {
+        try {
+            $container = $this->resolveContainer();
+            $service   = $container->get($serviceName);
+            return is_object($service) === true ? $service : null;
+        } catch (Throwable $e) {
+            return null;
+        }
+    }//end lookup()
+
+    /**
+     * Resolve the active container — the test override if injected,
+     * otherwise NC's global server container.
+     *
+     * @return ContainerInterface
+     */
+    private function resolveContainer(): ContainerInterface
+    {
+        if ($this->container !== null) {
+            return $this->container;
+        }
+
+        // Thin PSR-11 adapter around `\OCP\Server::get()` so the rest
+        // of the service can treat container lookups uniformly.
+        return new class implements ContainerInterface {
+            /**
+             * Resolve a service from the NC server container.
+             *
+             * @param string $id Service id.
+             *
+             * @return object
+             */
+            public function get(string $id): object
+            {
+                return Server::get($id);
+            }//end get()
+
+            /**
+             * Whether the NC server container can resolve a service.
+             *
+             * @param string $id Service id.
+             *
+             * @return bool
+             */
+            public function has(string $id): bool
+            {
+                try {
+                    Server::get($id);
+                    return true;
+                } catch (Throwable $e) {
+                    return false;
+                }
+            }//end has()
+        };
+    }//end resolveContainer()
+}//end class

--- a/tests/Unit/Service/ShareLinkServiceTest.php
+++ b/tests/Unit/Service/ShareLinkServiceTest.php
@@ -1,0 +1,393 @@
+<?php
+
+/**
+ * Unit tests for ShareLinkService (Tier-2 shares — OCP\Share\IManager,
+ * NO link table / NO cache).
+ *
+ * Covers:
+ *   - getLinkedShares() happy-path: walks the object's folder, calls
+ *     `IManager::getSharesBy()` per child × per share type, normalises
+ *     rows and dedupes by share id
+ *   - getLinkedShares() no-folder: returns []
+ *   - createShare() happy-path: builds + persists via IManager::newShare()
+ *     / createShare(), file must live in the object's folder
+ *   - createShare() file-not-in-folder: 404
+ *   - createShare() missing recipient for user share: 400
+ *   - revokeShare() happy-path: IManager::deleteShare()
+ *   - revokeShare() ownership 403 when the share's node is outside the
+ *     object's folder
+ *   - getShareableFiles() lists only file nodes
+ *
+ * NC's `OCP\Share\IManager`, `OCP\Share\IShare`, and the OR
+ * `FolderManagementHandler` are pulled lazily through a `ContainerInterface`
+ * the test injects, so the service's runtime path is exercisable without
+ * the full NC server container.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/integration-shares/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+// phpcs:disable PEAR.Commenting.FunctionComment.Missing -- arrange/act/assert PHPUnit conventions.
+// phpcs:disable CustomSniffs.Functions.NamedParameters.RequireNamedParameters -- PHPUnit assertion helpers take positional args by convention.
+
+use Exception;
+use OCA\OpenRegister\Service\ShareLinkService;
+use OCP\Files\FileInfo;
+use OCP\Files\Folder;
+use OCP\Files\Node;
+use OCP\IL10N;
+use OCP\IUser;
+use OCP\IUserSession;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Unit tests for ShareLinkService.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class ShareLinkServiceTest extends TestCase
+{
+    private function buildL10n(): IL10N
+    {
+        $mock = $this->createMock(IL10N::class);
+        $mock->method('t')->willReturnArgument(0);
+        return $mock;
+    }//end buildL10n()
+
+    private function buildLogger(): LoggerInterface
+    {
+        return $this->createMock(LoggerInterface::class);
+    }//end buildLogger()
+
+    private function buildUserSession(?string $uid): IUserSession
+    {
+        $session = $this->createMock(IUserSession::class);
+        if ($uid === null) {
+            $session->method('getUser')->willReturn(null);
+            return $session;
+        }
+
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $session->method('getUser')->willReturn($user);
+        return $session;
+    }//end buildUserSession()
+
+    private function buildNode(int $id, string $name, string $type=FileInfo::TYPE_FILE): Node
+    {
+        $node = $this->createMock(Node::class);
+        $node->method('getId')->willReturn($id);
+        $node->method('getName')->willReturn($name);
+        $node->method('getType')->willReturn($type);
+        $node->method('getMimetype')->willReturn('text/plain');
+        $node->method('getSize')->willReturn(123);
+        return $node;
+    }//end buildNode()
+
+    private function buildFolder(array $children): Folder
+    {
+        $folder = $this->createMock(Folder::class);
+        $folder->method('getDirectoryListing')->willReturn($children);
+        return $folder;
+    }//end buildFolder()
+
+    private function buildShare(
+        string $id,
+        int $type,
+        string $with,
+        int $perms,
+        string $owner,
+        Node $node
+    ): IShare {
+        $share = $this->createMock(IShare::class);
+        $share->method('getId')->willReturn($id);
+        $share->method('getShareType')->willReturn($type);
+        $share->method('getSharedWith')->willReturn($with);
+        $share->method('getSharedWithDisplayName')->willReturn($with);
+        $share->method('getPermissions')->willReturn($perms);
+        $share->method('getSharedBy')->willReturn($owner);
+        $share->method('getNode')->willReturn($node);
+        $share->method('getPassword')->willReturn(null);
+        $share->method('getExpirationDate')->willReturn(null);
+        $share->method('getShareTime')->willReturn(null);
+        $share->method('getToken')->willReturn(null);
+        return $share;
+    }//end buildShare()
+
+    private function buildFolderHandler(?Folder $folder): object
+    {
+        return new class($folder) {
+            public function __construct(private ?Folder $folder)
+            {
+            }//end __construct()
+
+            public function getObjectFolder(mixed $objectEntityOrId): ?Folder
+            {
+                return $this->folder;
+            }//end getObjectFolder()
+        };
+    }//end buildFolderHandler()
+
+    private function buildObjectMapper(): object
+    {
+        return new class {
+            public function find(string $uuid): object
+            {
+                return new \stdClass();
+            }//end find()
+        };
+    }//end buildObjectMapper()
+
+    /**
+     * Build a container that resolves the named services from a map. A
+     * missing key throws a NotFoundExceptionInterface so the service's
+     * lazy lookups behave like the real NC container.
+     *
+     * @param array<string,object> $services Service-id → instance.
+     *
+     * @return ContainerInterface
+     */
+    private function buildContainer(array $services): ContainerInterface
+    {
+        return new class($services) implements ContainerInterface {
+            public function __construct(private array $services)
+            {
+            }//end __construct()
+
+            public function get(string $id): object
+            {
+                if (isset($this->services[$id]) === true) {
+                    return $this->services[$id];
+                }
+
+                throw new class extends RuntimeException implements NotFoundExceptionInterface {
+                };
+            }//end get()
+
+            public function has(string $id): bool
+            {
+                return isset($this->services[$id]);
+            }//end has()
+        };
+    }//end buildContainer()
+
+    public function testGetLinkedSharesHappyPath(): void
+    {
+        $node   = $this->buildNode(10, 'doc.txt');
+        $folder = $this->buildFolder([$node]);
+        $share  = $this->buildShare('s1', IShare::TYPE_USER, 'bob', 1, 'alice', $node);
+
+        $manager = $this->createMock(IManager::class);
+        $manager->method('getSharesBy')->willReturnCallback(
+            function ($uid, $type, $n) use ($share) {
+                return $type === IShare::TYPE_USER ? [$share] : [];
+            }
+        );
+
+        $container = $this->buildContainer(
+            [
+                'OCP\\Share\\IManager'                                      => $manager,
+                'OCP\\IUserSession'                                         => $this->buildUserSession('alice'),
+                'OCA\\OpenRegister\\Service\\File\\FolderManagementHandler' => $this->buildFolderHandler($folder),
+                'OCA\\OpenRegister\\Db\\ObjectEntityMapper'                 => $this->buildObjectMapper(),
+            ]
+        );
+
+        $service = new ShareLinkService($this->buildL10n(), $this->buildLogger(), $container);
+        $rows    = $service->getLinkedShares('uuid-1');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('s1', $rows[0]['shareId']);
+        $this->assertSame(IShare::TYPE_USER, $rows[0]['shareType']);
+        $this->assertSame('bob', $rows[0]['shareWith']);
+        $this->assertTrue($rows[0]['canRevoke']);
+        $this->assertSame(10, $rows[0]['fileId']);
+    }//end testGetLinkedSharesHappyPath()
+
+    public function testGetLinkedSharesNoFolderReturnsEmpty(): void
+    {
+        $container = $this->buildContainer(
+            [
+                'OCP\\Share\\IManager'                                      => $this->createMock(IManager::class),
+                'OCP\\IUserSession'                                         => $this->buildUserSession('alice'),
+                'OCA\\OpenRegister\\Service\\File\\FolderManagementHandler' => $this->buildFolderHandler(null),
+                'OCA\\OpenRegister\\Db\\ObjectEntityMapper'                 => $this->buildObjectMapper(),
+            ]
+        );
+
+        $service = new ShareLinkService($this->buildL10n(), $this->buildLogger(), $container);
+        $this->assertSame([], $service->getLinkedShares('uuid-1'));
+    }//end testGetLinkedSharesNoFolderReturnsEmpty()
+
+    public function testCreateShareHappyPath(): void
+    {
+        $node   = $this->buildNode(10, 'doc.txt');
+        $folder = $this->buildFolder([$node]);
+
+        $newShare = $this->createMock(IShare::class);
+        $newShare->method('getId')->willReturn('s99');
+        $newShare->method('getShareType')->willReturn(IShare::TYPE_USER);
+        $newShare->method('getToken')->willReturn(null);
+
+        $manager = $this->createMock(IManager::class);
+        $manager->method('newShare')->willReturn($newShare);
+        $manager->expects($this->once())->method('createShare')->with($newShare)->willReturn($newShare);
+
+        $container = $this->buildContainer(
+            [
+                'OCP\\Share\\IManager'                                      => $manager,
+                'OCP\\IUserSession'                                         => $this->buildUserSession('alice'),
+                'OCA\\OpenRegister\\Service\\File\\FolderManagementHandler' => $this->buildFolderHandler($folder),
+                'OCA\\OpenRegister\\Db\\ObjectEntityMapper'                 => $this->buildObjectMapper(),
+            ]
+        );
+
+        $service = new ShareLinkService($this->buildL10n(), $this->buildLogger(), $container);
+        $result  = $service->createShare('uuid-1', 1, 1, 10, IShare::TYPE_USER, 'bob', 1, null, null);
+
+        $this->assertSame('s99', $result->getId());
+    }//end testCreateShareHappyPath()
+
+    public function testCreateShareFileNotInFolderThrows404(): void
+    {
+        $node   = $this->buildNode(10, 'doc.txt');
+        $folder = $this->buildFolder([$node]);
+
+        $container = $this->buildContainer(
+            [
+                'OCP\\Share\\IManager'                                      => $this->createMock(IManager::class),
+                'OCP\\IUserSession'                                         => $this->buildUserSession('alice'),
+                'OCA\\OpenRegister\\Service\\File\\FolderManagementHandler' => $this->buildFolderHandler($folder),
+                'OCA\\OpenRegister\\Db\\ObjectEntityMapper'                 => $this->buildObjectMapper(),
+            ]
+        );
+
+        $service = new ShareLinkService($this->buildL10n(), $this->buildLogger(), $container);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(404);
+        $service->createShare('uuid-1', 1, 1, 999, IShare::TYPE_USER, 'bob', 1, null, null);
+    }//end testCreateShareFileNotInFolderThrows404()
+
+    public function testCreateShareMissingRecipientThrows400(): void
+    {
+        $node   = $this->buildNode(10, 'doc.txt');
+        $folder = $this->buildFolder([$node]);
+
+        $manager = $this->createMock(IManager::class);
+        $manager->method('newShare')->willReturn($this->createMock(IShare::class));
+
+        $container = $this->buildContainer(
+            [
+                'OCP\\Share\\IManager'                                      => $manager,
+                'OCP\\IUserSession'                                         => $this->buildUserSession('alice'),
+                'OCA\\OpenRegister\\Service\\File\\FolderManagementHandler' => $this->buildFolderHandler($folder),
+                'OCA\\OpenRegister\\Db\\ObjectEntityMapper'                 => $this->buildObjectMapper(),
+            ]
+        );
+
+        $service = new ShareLinkService($this->buildL10n(), $this->buildLogger(), $container);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+        $service->createShare('uuid-1', 1, 1, 10, IShare::TYPE_USER, null, 1, null, null);
+    }//end testCreateShareMissingRecipientThrows400()
+
+    public function testRevokeShareHappyPath(): void
+    {
+        $node   = $this->buildNode(10, 'doc.txt');
+        $folder = $this->buildFolder([$node]);
+        $share  = $this->buildShare('s1', IShare::TYPE_USER, 'bob', 1, 'alice', $node);
+
+        $manager = $this->createMock(IManager::class);
+        $manager->method('getShareById')->with('s1')->willReturn($share);
+        $manager->expects($this->once())->method('deleteShare')->with($share);
+
+        $container = $this->buildContainer(
+            [
+                'OCP\\Share\\IManager'                                      => $manager,
+                'OCP\\IUserSession'                                         => $this->buildUserSession('alice'),
+                'OCA\\OpenRegister\\Service\\File\\FolderManagementHandler' => $this->buildFolderHandler($folder),
+                'OCA\\OpenRegister\\Db\\ObjectEntityMapper'                 => $this->buildObjectMapper(),
+            ]
+        );
+
+        $service = new ShareLinkService($this->buildL10n(), $this->buildLogger(), $container);
+        $service->revokeShare('uuid-1', 's1');
+        // No exception == pass; deleteShare expectation asserts the call.
+        $this->addToAssertionCount(1);
+    }//end testRevokeShareHappyPath()
+
+    public function testRevokeShareOutsideFolderThrows403(): void
+    {
+        $folderNode = $this->buildNode(10, 'doc.txt');
+        $folder     = $this->buildFolder([$folderNode]);
+        // Share backed by a node id (999) NOT present in the folder.
+        $alienNode = $this->buildNode(999, 'other.txt');
+        $share     = $this->buildShare('s7', IShare::TYPE_USER, 'bob', 1, 'alice', $alienNode);
+
+        $manager = $this->createMock(IManager::class);
+        $manager->method('getShareById')->with('s7')->willReturn($share);
+        $manager->expects($this->never())->method('deleteShare');
+
+        $container = $this->buildContainer(
+            [
+                'OCP\\Share\\IManager'                                      => $manager,
+                'OCP\\IUserSession'                                         => $this->buildUserSession('alice'),
+                'OCA\\OpenRegister\\Service\\File\\FolderManagementHandler' => $this->buildFolderHandler($folder),
+                'OCA\\OpenRegister\\Db\\ObjectEntityMapper'                 => $this->buildObjectMapper(),
+            ]
+        );
+
+        $service = new ShareLinkService($this->buildL10n(), $this->buildLogger(), $container);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(403);
+        $service->revokeShare('uuid-1', 's7');
+    }//end testRevokeShareOutsideFolderThrows403()
+
+    public function testGetShareableFilesListsOnlyFiles(): void
+    {
+        $file   = $this->buildNode(10, 'doc.txt', FileInfo::TYPE_FILE);
+        $subdir = $this->buildNode(11, 'subdir', FileInfo::TYPE_FOLDER);
+        $folder = $this->buildFolder([$file, $subdir]);
+
+        $container = $this->buildContainer(
+            [
+                'OCP\\Share\\IManager'                                      => $this->createMock(IManager::class),
+                'OCP\\IUserSession'                                         => $this->buildUserSession('alice'),
+                'OCA\\OpenRegister\\Service\\File\\FolderManagementHandler' => $this->buildFolderHandler($folder),
+                'OCA\\OpenRegister\\Db\\ObjectEntityMapper'                 => $this->buildObjectMapper(),
+            ]
+        );
+
+        $service = new ShareLinkService($this->buildL10n(), $this->buildLogger(), $container);
+        $files   = $service->getShareableFiles('uuid-1');
+
+        $this->assertCount(1, $files);
+        $this->assertSame(10, $files[0]['fileId']);
+        $this->assertSame('doc.txt', $files[0]['fileName']);
+    }//end testGetShareableFilesListsOnlyFiles()
+}//end class


### PR DESCRIPTION
## Summary

Tier-2 for the **shares** integration leaf. Adds a service + REST endpoints + create/revoke surface on top of NC core sharing.

- **`ShareLinkService`** wraps `OCP\Share\IManager` (lazy-resolved via the container, same pattern as `SharesProvider`). Composes `ObjectEntityMapper` + `FolderManagementHandler` so listing/creating/revoking is scoped to the files inside an object's NC folder (preserves the Phase H-1 entity-input folder-resolve fix). Methods: `getLinkedShares`, `createShare`, `revokeShare` (ownership-checked), `getShareableFiles`.
- **`ShareLinksController`** — `GET/POST /api/objects/{r}/{s}/{id}/shares`, `DELETE .../shares/{shareId}`, `GET /api/integrations/shares/files/{r}/{s}/{id}`. Routes declared specific-before-wildcard.
- **`SharesProvider::list()`** now delegates to `ShareLinkService::getLinkedShares` (re-mapped to the widget row contract), so there is one canonical IManager walk; the in-provider walk remains as a graceful-degradation fallback.
- PHPUnit: 8 tests (list / create / file-not-in-folder 404 / missing-recipient 400 / revoke / ownership 403 / shareable-files). Existing `SharesProviderTest` (8) still green.

## NO CACHE TABLE — rationale

`IShare` is **first-class Nextcloud core state**. Shares mutate outside OpenRegister (users open the Files share panel directly), so any OR-side snapshot/link table would desync immediately and serve stale data. Every read and write therefore goes straight through `IManager` — this is the deliberate divergence from the polls/flow/talk Tier-2 services, which own a private link table only because their upstream apps expose no per-object query surface. NC core sharing already does.

## Test plan

- [ ] `composer test:unit` (ShareLinkServiceTest + SharesProviderTest green)
- [ ] Create a user/group/public-link/email share on an object's file via the sidebar dialog
- [ ] Revoke a share; confirm a share on a file outside the object's folder is rejected (403)
- [ ] List reflects shares created directly in the Files app (no staleness)

Refs: openregister#1323, ADR-019, ADR-022.