### PR TITLE
feat(photos): Tier-2 — link table + album picker + create

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -381,6 +381,15 @@ return [
         ['name' => 'flowLinks#link',      'url' => '/api/objects/{register}/{schema}/{id}/flow',              'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
         ['name' => 'flowLinks#destroy',   'url' => '/api/objects/{register}/{schema}/{id}/flow/{operationId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'operationId' => '[0-9]+']],
 
+        // Photos (NC Photos) — Tier-2 link-table API. User-scoped (no
+        // admin gate). The specific `/photos/new` (create + link) route
+        // MUST precede the wildcard `/photos/{albumId}` unlink route.
+        ['name' => 'photoLinks#available',    'url' => '/api/integrations/photos/available',                   'verb' => 'GET'],
+        ['name' => 'photoLinks#index',        'url' => '/api/objects/{register}/{schema}/{id}/photos',         'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
+        ['name' => 'photoLinks#createAndLink','url' => '/api/objects/{register}/{schema}/{id}/photos/new',     'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'photoLinks#link',         'url' => '/api/objects/{register}/{schema}/{id}/photos',         'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'photoLinks#destroy',      'url' => '/api/objects/{register}/{schema}/{id}/photos/{albumId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'albumId' => '[0-9]+']],
+
         // Forms — Tier-2 link-table API. Specific routes (`/new`, `/submissions/{id}`)
         // MUST precede the wildcard `{formId}` route so they aren't grabbed as
         // formId='new' / formId='submissions'. Available-forms picker is app-global.

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1155,8 +1155,8 @@ class Application extends App implements IBootstrap
             // takes a FlowLinkMapper. Registered separately below.
             // @spec openspec/changes/integration-maps/tasks.md.
             \OCA\OpenRegister\Service\Integration\Providers\MapsProvider::class,
-            // @spec openspec/changes/integration-photos/tasks.md.
-            \OCA\OpenRegister\Service\Integration\Providers\PhotosProvider::class,
+            // NB: PhotosProvider was Tier-1 greenfield until Tier-2; it now
+            // takes a PhotoLinkMapper. Registered separately below.
             // @spec openspec/changes/integration-time-tracker/tasks.md.
             \OCA\OpenRegister\Service\Integration\Providers\TimeProvider::class,
         ];
@@ -1312,6 +1312,42 @@ class Application extends App implements IBootstrap
                     appManager: $container->get('OCP\App\IAppManager'),
                     userSession: $container->get('OCP\IUserSession'),
                     groupManager: $container->get('OCP\IGroupManager'),
+                    logger: $container->get('Psr\Log\LoggerInterface'),
+                );
+            }
+        );
+
+        // PhotosProvider — Tier-2: backed by the PhotoLinkMapper. The
+        // provider still gracefully degrades to the legacy `[or:{uuid}]`
+        // album-name marker scan when the link table is empty (albums
+        // that pre-date the Tier-2 link table).
+        // @spec openspec/changes/integration-photos/tasks.md.
+        $context->registerService(
+            \OCA\OpenRegister\Service\Integration\Providers\PhotosProvider::class,
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\Service\Integration\Providers\PhotosProvider(
+                    db: $container->get('OCP\IDBConnection'),
+                    appManager: $container->get('OCP\App\IAppManager'),
+                    l10n: $container->get('OCP\IL10N'),
+                    photoLinkMapper: $container->get(\OCA\OpenRegister\Db\PhotoLinkMapper::class),
+                );
+            }
+        );
+
+        // PhotoLinkService — Tier-2 link/create/unlink/picker service
+        // backing the PhotoLinksController. NC Photos albums are
+        // user-scoped; the AlbumMapper is resolved lazily via the
+        // container so the service loads even when Photos is absent.
+        // @spec openspec/changes/integration-photos/tasks.md.
+        $context->registerService(
+            \OCA\OpenRegister\Service\PhotoLinkService::class,
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\Service\PhotoLinkService(
+                    photoLinkMapper: $container->get(\OCA\OpenRegister\Db\PhotoLinkMapper::class),
+                    container: $container,
+                    appManager: $container->get('OCP\App\IAppManager'),
+                    userSession: $container->get('OCP\IUserSession'),
+                    urlGenerator: $container->get('OCP\IURLGenerator'),
                     logger: $container->get('Psr\Log\LoggerInterface'),
                 );
             }
@@ -1539,7 +1575,11 @@ class Application extends App implements IBootstrap
                                     break;
                                 }
 
-                                $resolvedClass = is_object($appProvider) === true ? get_class($appProvider) : gettype($appProvider);
+                                $resolvedClass = gettype($appProvider);
+                                if (is_object($appProvider) === true) {
+                                    $resolvedClass = get_class($appProvider);
+                                }
+
                                 $logger->warning(
                                     '[McpToolsService] Resolved but not IMcpToolProvider',
                                     ['appId' => $appId, 'via' => $key, 'class' => $resolvedClass]

--- a/lib/Controller/PhotoLinksController.php
+++ b/lib/Controller/PhotoLinksController.php
@@ -1,0 +1,318 @@
+<?php
+
+/**
+ * PhotoLinksController — Tier-2 REST controller for NC Photos album
+ * links.
+ *
+ * Surface:
+ *
+ *   - GET    /api/objects/{r}/{s}/{id}/photos             — list linked albums
+ *   - POST   /api/objects/{r}/{s}/{id}/photos             — link existing album `{albumId}`
+ *   - POST   /api/objects/{r}/{s}/{id}/photos/new         — create + link album `{name}`
+ *   - DELETE /api/objects/{r}/{s}/{id}/photos/{albumId}   — unlink album
+ *   - GET    /api/integrations/photos/available?search=   — picker source
+ *
+ * NC Photos albums are user-scoped, so (unlike Flow) there is no admin
+ * gate — the active session's user owns the albums it can link/create.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use Exception;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\PhotoLinkService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Tier-2 Photos links controller.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ */
+class PhotoLinksController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param string           $appName          App id.
+     * @param IRequest         $request          HTTP request.
+     * @param PhotoLinkService $photoLinkService Backing service.
+     * @param ObjectService    $objectService    OR object resolver.
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly PhotoLinkService $photoLinkService,
+        private readonly ObjectService $objectService,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * List linked Photos albums for an object.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function index(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->photoLinkService->isPhotosAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Photos app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $results = $this->photoLinkService->getLinkedAlbums($object->getUuid());
+
+            return new JSONResponse(
+                    [
+                        'results' => $results,
+                        'total'   => count($results),
+                    ]
+                    );
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return new JSONResponse(['error' => $e->getMessage()], 500);
+        }//end try
+    }//end index()
+
+    /**
+     * Link an existing Photos album.
+     *
+     * Body: `{ albumId: int }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function link(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->photoLinkService->isPhotosAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Photos app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $albumId = (int) $this->request->getParam('albumId', 0);
+            if ($albumId === 0) {
+                return new JSONResponse(['error' => 'albumId is required'], 400);
+            }
+
+            $link = $this->photoLinkService->linkAlbum(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $albumId
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end link()
+
+    /**
+     * Create a new Photos album and link it.
+     *
+     * Body: `{ name: string }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function createAndLink(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->photoLinkService->isPhotosAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Photos app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $name = (string) $this->request->getParam('name', '');
+            if (trim($name) === '') {
+                return new JSONResponse(['error' => 'name is required'], 400);
+            }
+
+            $link = $this->photoLinkService->createAndLinkAlbum(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $name
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end createAndLink()
+
+    /**
+     * Unlink a Photos album.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     * @param string $albumId  Album id (numeric).
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function destroy(string $register, string $schema, string $id, string $albumId): JSONResponse
+    {
+        if ($this->photoLinkService->isPhotosAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Photos app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $this->photoLinkService->unlinkAlbum($object->getUuid(), (int) $albumId);
+
+            return new JSONResponse(['success' => true]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end destroy()
+
+    /**
+     * List the current user's Photos albums (picker source).
+     *
+     * Query param: `search` — optional name substring.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function available(): JSONResponse
+    {
+        if ($this->photoLinkService->isPhotosAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Photos app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        $search = $this->request->getParam('search');
+        if ($search !== null) {
+            $search = (string) $search;
+        }
+
+        $albums = $this->photoLinkService->getAvailableAlbums($search);
+        return new JSONResponse(['results' => $albums, 'total' => count($albums)]);
+    }//end available()
+
+    /**
+     * Resolve an OR object from register/schema/id.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return ObjectEntity|null
+     */
+    private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
+    {
+        $this->objectService->setSchema($schema);
+        $this->objectService->setRegister($register);
+        $this->objectService->setObject($id);
+
+        return $this->objectService->getObject();
+    }//end validateObject()
+
+    /**
+     * Map a service-layer Exception to a JSONResponse.
+     *
+     * Exception codes carry HTTP intent:
+     *   - 400 → bad request
+     *   - 401 → unauthorized (no user)
+     *   - 404 → not found
+     *   - 409 → conflict (duplicate link)
+     *   - 503 → service unavailable
+     *   - everything else → 400 bad request
+     *
+     * @param Exception $exception Source exception.
+     *
+     * @return JSONResponse
+     */
+    private function mapException(Exception $exception): JSONResponse
+    {
+        $code = $exception->getCode();
+        if (in_array($code, [400, 401, 404, 409, 503], true) === true) {
+            return new JSONResponse(['error' => $exception->getMessage()], $code);
+        }
+
+        return new JSONResponse(['error' => $exception->getMessage()], 400);
+    }//end mapException()
+}//end class

--- a/lib/Db/PhotoLink.php
+++ b/lib/Db/PhotoLink.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * PhotoLink entity for linking NC Photos albums to OpenRegister objects.
+ *
+ * Tier-2 schema: carries register_id, schema_id, album_name,
+ * cover_photo_url, photo_count and last_edited so the link row alone can
+ * hydrate the sidebar tab + picker UX without a per-album roundtrip to
+ * NC Photos. Replaces the Tier-1 `PhotosProvider`'s `[or:{uuid}]`
+ * album-name marker convention with a proper persistence layer that
+ * survives album renames.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Class PhotoLink
+ *
+ * @method string getObjectUuid()
+ * @method void setObjectUuid(string $objectUuid)
+ * @method int getRegisterId()
+ * @method void setRegisterId(int $registerId)
+ * @method int|null getSchemaId()
+ * @method void setSchemaId(?int $schemaId)
+ * @method int getAlbumId()
+ * @method void setAlbumId(int $albumId)
+ * @method string getAlbumName()
+ * @method void setAlbumName(string $albumName)
+ * @method string|null getCoverPhotoUrl()
+ * @method void setCoverPhotoUrl(?string $coverPhotoUrl)
+ * @method int|null getPhotoCount()
+ * @method void setPhotoCount(?int $photoCount)
+ * @method DateTime|null getLastEdited()
+ * @method void setLastEdited(?DateTime $lastEdited)
+ * @method string|null getLinkedBy()
+ * @method void setLinkedBy(string $linkedBy)
+ * @method DateTime|null getLinkedAt()
+ * @method void setLinkedAt(DateTime $linkedAt)
+ *
+ * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class
+ */
+class PhotoLink extends Entity implements JsonSerializable
+{
+
+    /**
+     * The object uuid.
+     *
+     * @var string|null
+     */
+    protected ?string $objectUuid = null;
+
+    /**
+     * The register id.
+     *
+     * @var integer|null
+     */
+    protected ?int $registerId = null;
+
+    /**
+     * The schema id.
+     *
+     * @var integer|null
+     */
+    protected ?int $schemaId = null;
+
+    /**
+     * The NC Photos album id (primary key in `oc_photos_albums`).
+     *
+     * @var integer|null
+     */
+    protected ?int $albumId = null;
+
+    /**
+     * The album display name (cached at link time).
+     *
+     * @var string|null
+     */
+    protected ?string $albumName = null;
+
+    /**
+     * The cached cover photo thumbnail href.
+     *
+     * @var string|null
+     */
+    protected ?string $coverPhotoUrl = null;
+
+    /**
+     * The cached photo count.
+     *
+     * @var integer|null
+     */
+    protected ?int $photoCount = null;
+
+    /**
+     * The cached album last-edited (last-added-photo) timestamp.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $lastEdited = null;
+
+    /**
+     * The linked by uid.
+     *
+     * @var string|null
+     */
+    protected ?string $linkedBy = null;
+
+    /**
+     * The linked at timestamp.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $linkedAt = null;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->addType(fieldName: 'objectUuid', type: 'string');
+        $this->addType(fieldName: 'registerId', type: 'integer');
+        $this->addType(fieldName: 'schemaId', type: 'integer');
+        $this->addType(fieldName: 'albumId', type: 'integer');
+        $this->addType(fieldName: 'albumName', type: 'string');
+        $this->addType(fieldName: 'coverPhotoUrl', type: 'string');
+        $this->addType(fieldName: 'photoCount', type: 'integer');
+        $this->addType(fieldName: 'lastEdited', type: 'datetime');
+        $this->addType(fieldName: 'linkedBy', type: 'string');
+        $this->addType(fieldName: 'linkedAt', type: 'datetime');
+    }//end __construct()
+
+    /**
+     * JSON serialization.
+     *
+     * @return array<string,mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'            => $this->id,
+            'objectUuid'    => $this->objectUuid,
+            'registerId'    => $this->registerId,
+            'schemaId'      => $this->schemaId,
+            'albumId'       => $this->albumId,
+            'albumName'     => $this->albumName,
+            'coverPhotoUrl' => $this->coverPhotoUrl,
+            'photoCount'    => $this->photoCount,
+            'lastEdited'    => $this->lastEdited?->format(DateTime::ATOM),
+            'linkedBy'      => $this->linkedBy,
+            'linkedAt'      => $this->linkedAt?->format(DateTime::ATOM),
+        ];
+    }//end jsonSerialize()
+}//end class

--- a/lib/Db/PhotoLinkMapper.php
+++ b/lib/Db/PhotoLinkMapper.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * Mapper for photo link entities.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Class PhotoLinkMapper
+ *
+ * @template-extends QBMapper<PhotoLink>
+ */
+class PhotoLinkMapper extends QBMapper
+{
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $db Database connection.
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(db: $db, tableName: 'openregister_photo_links', entityClass: PhotoLink::class);
+    }//end __construct()
+
+    /**
+     * Find photo links by object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return PhotoLink[] Array of photo links.
+     */
+    public function findByObjectUuid(string $objectUuid): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByObjectUuid()
+
+    /**
+     * Find photo links by album id.
+     *
+     * @param int $albumId The album id.
+     *
+     * @return PhotoLink[] Array of photo links.
+     */
+    public function findByAlbumId(int $albumId): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('album_id', $qb->createNamedParameter($albumId, IQueryBuilder::PARAM_INT)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByAlbumId()
+
+    /**
+     * Find a specific photo link by object UUID and album id.
+     *
+     * @param string $objectUuid The object UUID.
+     * @param int    $albumId    The album id.
+     *
+     * @return PhotoLink|null The link or null if not found.
+     */
+    public function findByObjectAndAlbum(string $objectUuid, int $albumId): ?PhotoLink
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('album_id', $qb->createNamedParameter($albumId, IQueryBuilder::PARAM_INT)));
+
+        try {
+            return $this->findEntity(query: $qb);
+        } catch (DoesNotExistException $e) {
+            return null;
+        }
+    }//end findByObjectAndAlbum()
+
+    /**
+     * Delete all photo links for an object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectUuid(string $objectUuid): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectUuid()
+
+    /**
+     * Delete a photo link by object UUID + album id (Tier-2 unlink path).
+     *
+     * Returns the number of rows actually deleted so callers can
+     * distinguish "no such link" (0) from "ok" (>=1).
+     *
+     * @param string $objectUuid The object UUID.
+     * @param int    $albumId    The album id.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectAndAlbum(string $objectUuid, int $albumId): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('album_id', $qb->createNamedParameter($albumId, IQueryBuilder::PARAM_INT)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectAndAlbum()
+}//end class

--- a/lib/Migration/Version1Date20260525170000.php
+++ b/lib/Migration/Version1Date20260525170000.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * Tier-2 photos (NC Photos) integration migration.
+ *
+ * Ensures the `openregister_photo_links` table exists with the full
+ * Tier-2 schema:
+ *
+ *  - id (bigint, PK, autoincrement)
+ *  - object_uuid (string 36, not null, indexed)
+ *  - register_id (bigint unsigned, not null, indexed)
+ *  - schema_id (bigint unsigned, nullable, indexed)
+ *  - album_id (bigint unsigned, not null) — `photos_albums` row id
+ *  - album_name (string 255, not null) — cached album title
+ *  - cover_photo_url (string 512, nullable) — cached cover thumbnail href
+ *  - photo_count (integer, nullable) — cached photo count
+ *  - last_edited (datetime, nullable) — cached album last-added timestamp
+ *  - linked_by (string 64, not null)
+ *  - linked_at (datetime, not null)
+ *
+ * Idempotent: creates the table if missing, otherwise adds any missing
+ * Tier-2 columns. Companion to the Tier-2 talk/polls/email/forms/deck/flow
+ * link tables; the wrapping `PhotoLinkService` replaces the `[or:{uuid}]`
+ * album-name marker convention used by the Tier-1 `PhotosProvider` with a
+ * proper persistence layer so links survive album renames.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Tier-2 photo-links table — create-or-extend.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+class Version1Date20260525170000 extends SimpleMigrationStep
+{
+    /**
+     * Change the database schema.
+     *
+     * @param IOutput                 $output        Output for the migration process
+     * @param Closure                 $schemaClosure The schema closure
+     * @param array<array-key, mixed> $options       Migration options
+     *
+     * @return ISchemaWrapper|null
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema  = $schemaClosure();
+        $changed = false;
+
+        if ($schema->hasTable('openregister_photo_links') === false) {
+            $this->createPhotoLinksTable(schema: $schema, output: $output);
+            $changed = true;
+        }
+
+        if ($schema->hasTable('openregister_photo_links') === true
+            && $this->extendPhotoLinksTable(schema: $schema, output: $output) === true
+        ) {
+            $changed = true;
+        }
+
+        if ($changed === false) {
+            return null;
+        }
+
+        return $schema;
+    }//end changeSchema()
+
+    /**
+     * Create the openregister_photo_links table at the Tier-2 shape.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return void
+     */
+    private function createPhotoLinksTable(ISchemaWrapper $schema, IOutput $output): void
+    {
+        $table = $schema->createTable('openregister_photo_links');
+
+        $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'unsigned' => true]);
+        $table->addColumn('object_uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
+        $table->addColumn('register_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('schema_id', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]);
+        $table->addColumn('album_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('album_name', Types::STRING, ['notnull' => true, 'length' => 255]);
+        $table->addColumn('cover_photo_url', Types::STRING, ['notnull' => false, 'length' => 512, 'default' => null]);
+        $table->addColumn('photo_count', Types::INTEGER, ['notnull' => false, 'default' => null]);
+        $table->addColumn('last_edited', Types::DATETIME, ['notnull' => false, 'default' => null]);
+        $table->addColumn('linked_by', Types::STRING, ['notnull' => true, 'length' => 64]);
+        $table->addColumn('linked_at', Types::DATETIME, ['notnull' => true]);
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['object_uuid', 'album_id'], 'idx_photo_object_album');
+        $table->addIndex(['object_uuid'], 'idx_photo_object');
+        $table->addIndex(['register_id'], 'idx_photo_register');
+        $table->addIndex(['schema_id'], 'idx_photo_schema');
+
+        $output->info('Created openregister_photo_links table (Tier-2 schema)');
+    }//end createPhotoLinksTable()
+
+    /**
+     * Add any missing Tier-2 columns to an existing photo_links table.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return bool True when a column was added.
+     */
+    private function extendPhotoLinksTable(ISchemaWrapper $schema, IOutput $output): bool
+    {
+        $table   = $schema->getTable('openregister_photo_links');
+        $changed = false;
+
+        if ($table->hasColumn('schema_id') === false) {
+            $table->addColumn(
+                'schema_id',
+                Types::BIGINT,
+                ['notnull' => false, 'unsigned' => true, 'default' => null]
+            );
+            $table->addIndex(['schema_id'], 'idx_photo_schema');
+            $output->info('Added schema_id column to openregister_photo_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('cover_photo_url') === false) {
+            $table->addColumn('cover_photo_url', Types::STRING, ['notnull' => false, 'length' => 512, 'default' => null]);
+            $output->info('Added cover_photo_url column to openregister_photo_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('photo_count') === false) {
+            $table->addColumn('photo_count', Types::INTEGER, ['notnull' => false, 'default' => null]);
+            $output->info('Added photo_count column to openregister_photo_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('last_edited') === false) {
+            $table->addColumn('last_edited', Types::DATETIME, ['notnull' => false, 'default' => null]);
+            $output->info('Added last_edited column to openregister_photo_links');
+            $changed = true;
+        }
+
+        return $changed;
+    }//end extendPhotoLinksTable()
+}//end class

--- a/lib/Service/Integration/Providers/PhotosProvider.php
+++ b/lib/Service/Integration/Providers/PhotosProvider.php
@@ -1,12 +1,17 @@
 <?php
 
 /**
- * PhotosProvider — exposes NC Photos entities linked to an OpenRegister
- * object via a `[or:{objectUuid}]` marker in the entity's `name`
- * field.
+ * PhotosProvider — exposes NC Photos albums linked to an OpenRegister
+ * object via the Tier-2 `openregister_photo_links` table.
  *
- * Storage strategy is `link-table` — the marker lives in the upstream
- * app's own table (`photos_albums`), not in OR.
+ * Pre-Tier-2 the provider matched a `[or:{objectUuid}]` marker embedded
+ * in the album's `name` field. Tier-2 (this file) reads the dedicated
+ * link table instead — the marker convention is retained as a
+ * backwards-compat fallback for albums that pre-date the link table.
+ *
+ * Storage strategy is `link-table` — the link rows live in OR; the
+ * upstream `photos_albums` table is only read for live cover / count
+ * data via the wrapping {@see \OCA\OpenRegister\Service\PhotoLinkService}.
  *
  * @category Service
  * @package  OCA\OpenRegister\Service\Integration\Providers
@@ -27,10 +32,13 @@ namespace OCA\OpenRegister\Service\Integration\Providers;
 
 // phpcs:disable PEAR.Commenting.FunctionComment.Missing
 
+use OCA\OpenRegister\Db\PhotoLink;
+use OCA\OpenRegister\Db\PhotoLinkMapper;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCP\App\IAppManager;
 use OCP\IDBConnection;
 use OCP\IL10N;
+use Throwable;
 
 class PhotosProvider extends AbstractIntegrationProvider
 {
@@ -40,10 +48,19 @@ class PhotosProvider extends AbstractIntegrationProvider
 
     private const MARKER_PREFIX = '[or:';
 
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection   $db              NC DB connection.
+     * @param IAppManager     $appManager      NC app manager.
+     * @param IL10N           $l10n            Localisation.
+     * @param PhotoLinkMapper $photoLinkMapper Photo-link mapper (Tier-2 link table).
+     */
     public function __construct(
         private IDBConnection $db,
         private IAppManager $appManager,
         private IL10N $l10n,
+        private PhotoLinkMapper $photoLinkMapper,
     ) {
     }//end __construct()
 
@@ -83,18 +100,18 @@ class PhotosProvider extends AbstractIntegrationProvider
     }//end isEnabled()
 
     /**
-     * List linked Photos entities for an OR object.
+     * List linked Photos albums for an OR object.
      *
-     * Linking convention: the entity's `name` field contains
-     * the marker `[or:{objectUuid}]`. The trait runs the LIKE query;
-     * rows are normalised into the registry leaf row shape.
+     * Reads the Tier-2 link table first; if no link rows exist it falls
+     * back to the legacy `[or:{uuid}]` marker scan in `photos_albums.name`
+     * so albums that pre-date the link table still surface.
      *
      * @param string $register Register slug for the parent object.
      * @param string $schema   Schema slug for the parent object.
      * @param string $objectId UUID of the OR object whose rows we want.
      * @param array  $filters  Optional registry filters (unused).
      *
-     * @return array List of registry leaf rows.
+     * @return array<int,array<string,mixed>> List of registry leaf rows.
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -102,6 +119,22 @@ class PhotosProvider extends AbstractIntegrationProvider
             return [];
         }
 
+        // Tier-2 path: read from the link table.
+        try {
+            $linkRows = $this->photoLinkMapper->findByObjectUuid($objectId);
+        } catch (Throwable $e) {
+            $linkRows = [];
+        }
+
+        if (count($linkRows) > 0) {
+            return array_map(
+                fn (PhotoLink $link): array => $this->rowFromLink(link: $link),
+                $linkRows
+            );
+        }
+
+        // Backwards-compat fallback: scan the legacy `[or:{uuid}]`
+        // marker in `photos_albums.name`.
         $marker = self::MARKER_PREFIX.$objectId.']';
         $rows   = $this->findByMarker(
             db: $this->db,
@@ -113,25 +146,54 @@ class PhotosProvider extends AbstractIntegrationProvider
         );
 
         return array_map(
-                static function (array $row): array {
-                    return [
-                        'id'    => (string) ($row['album_id'] ?? ''),
-                        'title' => (string) ($row['name'] ?? ''),
-                        'url'   => '/index.php/apps/photos/albums/'.(string) ($row['album_id'] ?? ''),
-                        'data'  => $row,
-                    ];
-                },
-                $rows
-                );
+            static function (array $row): array {
+                return [
+                    'id'    => (string) ($row['album_id'] ?? ''),
+                    'title' => (string) ($row['name'] ?? ''),
+                    'url'   => '/index.php/apps/photos/albums/'.(string) ($row['album_id'] ?? ''),
+                    'data'  => $row,
+                ];
+            },
+            $rows
+        );
     }//end list()
+
+    /**
+     * Convert a PhotoLink row into the registry leaf-row shape.
+     *
+     * @param PhotoLink $link Link row from the mapper.
+     *
+     * @return array<string,mixed>
+     */
+    private function rowFromLink(PhotoLink $link): array
+    {
+        $albumId = (int) $link->getAlbumId();
+        $data    = $link->jsonSerialize();
+
+        return [
+            'id'            => (string) $albumId,
+            'title'         => (string) $link->getAlbumName(),
+            'url'           => '/index.php/apps/photos/albums/'.$albumId,
+            'coverPhotoUrl' => $link->getCoverPhotoUrl(),
+            'photoCount'    => $link->getPhotoCount(),
+            'data'          => $data,
+        ];
+    }//end rowFromLink()
 
     public function health(): array
     {
         $available = $this->isEnabled();
+        $status    = 'unavailable';
+        $message   = 'NC Photos app is not installed';
+        if ($available === true) {
+            $status  = 'ok';
+            $message = null;
+        }
+
         return [
-            'status'     => $available === true ? 'ok' : 'unavailable',
+            'status'     => $status,
             'authStatus' => 'configured',
-            'message'    => $available === true ? null : 'NC Photos app is not installed',
+            'message'    => $message,
         ];
     }//end health()
 }//end class

--- a/lib/Service/PhotoLinkService.php
+++ b/lib/Service/PhotoLinkService.php
@@ -1,0 +1,502 @@
+<?php
+
+/**
+ * PhotoLinkService — Tier-2 photos (NC Photos) integration service.
+ *
+ * Composes the {@see PhotoLinkMapper} with NC Photos'
+ * `OCA\Photos\Album\AlbumMapper` to expose the Tier-2 surface:
+ *
+ *   - linkAlbum(uuid, registerId, schemaId, albumId)
+ *       — link an existing album
+ *   - createAndLinkAlbum(uuid, registerId, schemaId, name)
+ *       — create a new NC Photos album and link it
+ *   - unlinkAlbum(uuid, albumId)
+ *       — remove a link (the album itself stays in NC Photos)
+ *   - getLinkedAlbums(uuid)
+ *       — list linked albums, refreshing cached cover/count/last_edited
+ *       when the row is older than 24h
+ *   - getAvailableAlbums(?search)
+ *       — picker source listing the current user's albums
+ *
+ * NC Photos exposes its album persistence as `OCA\Photos\Album\AlbumMapper`
+ * (NOT `OCA\Photos\Service\AlbumService` — that class does not exist;
+ * wave-2.1 correction). The mapper is resolved lazily through the server
+ * container behind a `Throwable` guard so this service loads even when the
+ * Photos app is not installed (ADR-019 AD-23 graceful degradation): when
+ * Photos is missing or a mapper call throws, the stored link row is
+ * returned as-is so historical references survive.
+ *
+ * Albums are user-scoped: NC Photos albums belong to a user, so every
+ * mutating + picker call is scoped to the active session's UID.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://OpenRegister.app
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use DateTime;
+use Exception;
+use OCA\OpenRegister\Db\PhotoLink;
+use OCA\OpenRegister\Db\PhotoLinkMapper;
+use OCP\App\IAppManager;
+use OCP\IURLGenerator;
+use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * PhotoLinkService.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Composes mapper +
+ *     NC Photos AlbumMapper (late-bound) + user session + app manager +
+ *     url generator + container + logger. Each dependency is required
+ *     for one of the Tier-2 flows (link, create, unlink, list, picker,
+ *     cache refresh, graceful degradation).
+ */
+class PhotoLinkService
+{
+    private const REQUIRED_APP = 'photos';
+
+    private const ALBUM_MAPPER = 'OCA\\Photos\\Album\\AlbumMapper';
+
+    private const STALE_AFTER = 86400;
+    // 24 hours in seconds.
+
+    /**
+     * Constructor.
+     *
+     * @param PhotoLinkMapper    $photoLinkMapper Persistence for link rows.
+     * @param ContainerInterface $container       Container for late-bound Photos classes.
+     * @param IAppManager        $appManager      NC app manager.
+     * @param IUserSession       $userSession     Active session.
+     * @param IURLGenerator      $urlGenerator    URL generator for deep links / thumbnails.
+     * @param LoggerInterface    $logger          Logger.
+     */
+    public function __construct(
+        private readonly PhotoLinkMapper $photoLinkMapper,
+        private readonly ContainerInterface $container,
+        private readonly IAppManager $appManager,
+        private readonly IUserSession $userSession,
+        private readonly IURLGenerator $urlGenerator,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Whether NC Photos is installed + enabled for the current user.
+     *
+     * @return bool
+     */
+    public function isPhotosAvailable(): bool
+    {
+        return $this->appManager->isEnabledForUser(self::REQUIRED_APP);
+    }//end isPhotosAvailable()
+
+    /**
+     * Resolve NC Photos' AlbumMapper lazily.
+     *
+     * Returns null when Photos is absent or the class can't be
+     * resolved, so callers degrade gracefully (ADR-019 AD-23).
+     *
+     * @return object|null The AlbumMapper instance or null.
+     */
+    private function getAlbumMapper(): ?object
+    {
+        if ($this->isPhotosAvailable() === false) {
+            return null;
+        }
+
+        try {
+            return $this->container->get(self::ALBUM_MAPPER);
+        } catch (Throwable $e) {
+            $this->logger->debug('PhotoLinkService: AlbumMapper unavailable: '.$e->getMessage());
+            return null;
+        }
+    }//end getAlbumMapper()
+
+    /**
+     * Active session UID, or throw if no user is logged in.
+     *
+     * @return string The user id.
+     *
+     * @throws Exception When there is no active user.
+     */
+    private function requireUid(): string
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in', 401);
+        }
+
+        return $user->getUID();
+    }//end requireUid()
+
+    /**
+     * Link an existing NC Photos album to an OR object.
+     *
+     * Idempotent: a duplicate link raises a 409 Exception. Album
+     * metadata (name/cover/count/last_edited) is cached at link time.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $registerId OR register id.
+     * @param int    $schemaId   OR schema id.
+     * @param int    $albumId    NC Photos album id.
+     *
+     * @return PhotoLink The persisted link row.
+     *
+     * @throws Exception On missing user (401), missing album (404),
+     *                   duplicate (409), Photos unavailable (503).
+     */
+    public function linkAlbum(string $objectUuid, int $registerId, int $schemaId, int $albumId): PhotoLink
+    {
+        $uid = $this->requireUid();
+
+        if ($this->isPhotosAvailable() === false) {
+            throw new Exception('NC Photos is not available', 503);
+        }
+
+        $existing = $this->photoLinkMapper->findByObjectAndAlbum($objectUuid, $albumId);
+        if ($existing !== null) {
+            throw new Exception('Album already linked to this object', 409);
+        }
+
+        $info = $this->fetchAlbumInfo(albumId: $albumId, uid: $uid);
+        if ($info === null) {
+            throw new Exception('Photos album not found', 404);
+        }
+
+        $link = new PhotoLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        $link->setSchemaId($schemaId);
+        $link->setAlbumId($albumId);
+        $link->setAlbumName($info['name']);
+        $link->setCoverPhotoUrl($info['coverPhotoUrl']);
+        $link->setPhotoCount($info['photoCount']);
+        $link->setLastEdited($info['lastEdited']);
+        $link->setLinkedBy($uid);
+        $link->setLinkedAt(new DateTime());
+
+        return $this->photoLinkMapper->insert($link);
+    }//end linkAlbum()
+
+    /**
+     * Create a new NC Photos album and link it to an OR object.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $registerId OR register id.
+     * @param int    $schemaId   OR schema id.
+     * @param string $name       New album name.
+     *
+     * @return PhotoLink The persisted link row.
+     *
+     * @throws Exception On missing user (401), empty name (400),
+     *                   Photos unavailable (503).
+     */
+    public function createAndLinkAlbum(string $objectUuid, int $registerId, int $schemaId, string $name): PhotoLink
+    {
+        $uid = $this->requireUid();
+
+        $name = trim($name);
+        if ($name === '') {
+            throw new Exception('Album name is required', 400);
+        }
+
+        $mapper = $this->getAlbumMapper();
+        if ($mapper === null) {
+            throw new Exception('NC Photos is not available', 503);
+        }
+
+        try {
+            $albumInfo = $mapper->create($uid, $name);
+            $albumId   = (int) $albumInfo->getId();
+        } catch (Throwable $e) {
+            $this->logger->warning('PhotoLinkService::createAndLinkAlbum failed: '.$e->getMessage());
+            throw new Exception('Failed to create Photos album', 500);
+        }
+
+        $link = new PhotoLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        $link->setSchemaId($schemaId);
+        $link->setAlbumId($albumId);
+        $link->setAlbumName($name);
+        $link->setCoverPhotoUrl(null);
+        $link->setPhotoCount(0);
+        $link->setLastEdited(new DateTime());
+        $link->setLinkedBy($uid);
+        $link->setLinkedAt(new DateTime());
+
+        return $this->photoLinkMapper->insert($link);
+    }//end createAndLinkAlbum()
+
+    /**
+     * Unlink an album from an object.
+     *
+     * Does NOT delete the album itself — it stays in NC Photos for the
+     * user and for any other linked objects.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $albumId    NC Photos album id.
+     *
+     * @return void
+     *
+     * @throws Exception On missing user (401) or no matching link (404).
+     */
+    public function unlinkAlbum(string $objectUuid, int $albumId): void
+    {
+        $this->requireUid();
+
+        $deleted = $this->photoLinkMapper->deleteByObjectAndAlbum($objectUuid, $albumId);
+        if ($deleted === 0) {
+            throw new Exception('Photo link not found', 404);
+        }
+    }//end unlinkAlbum()
+
+    /**
+     * Return the linked albums for an object, refreshing the cached
+     * cover/count/last_edited columns when a row is older than 24h.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getLinkedAlbums(string $objectUuid): array
+    {
+        $links     = $this->photoLinkMapper->findByObjectUuid($objectUuid);
+        $available = $this->isPhotosAvailable();
+        $uid       = $this->userSession->getUser()?->getUID();
+
+        $results = [];
+        foreach ($links as $link) {
+            if ($available === true && $uid !== null && $this->isStale(link: $link) === true) {
+                $link = $this->refreshLink(link: $link, uid: $uid);
+            }
+
+            $row        = $link->jsonSerialize();
+            $row['url'] = $this->albumDeepLink(albumId: (int) ($row['albumId'] ?? 0));
+            $results[]  = $row;
+        }
+
+        return $results;
+    }//end getLinkedAlbums()
+
+    /**
+     * Return the current user's NC Photos albums (picker source).
+     *
+     * Optional substring search against the album name. Returns an empty
+     * array when Photos is unavailable.
+     *
+     * @param string|null $search Optional name-substring filter.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getAvailableAlbums(?string $search=null): array
+    {
+        $mapper = $this->getAlbumMapper();
+        $uid    = $this->userSession->getUser()?->getUID();
+        if ($mapper === null || $uid === null) {
+            return [];
+        }
+
+        try {
+            $albums = $mapper->getForUser($uid);
+        } catch (Throwable $e) {
+            $this->logger->warning('PhotoLinkService::getAvailableAlbums failed: '.$e->getMessage());
+            return [];
+        }
+
+        $needle = null;
+        if ($search !== null && $search !== '') {
+            $needle = mb_strtolower($search);
+        }
+
+        $out = [];
+        foreach ($albums as $album) {
+            $row = $this->pickerRowFromAlbum(album: $album, needle: $needle);
+            if ($row !== null) {
+                $out[] = $row;
+            }
+        }
+
+        return $out;
+    }//end getAvailableAlbums()
+
+    /**
+     * Map a single NC Photos album into a picker row, applying the
+     * optional name filter.
+     *
+     * @param object      $album  An NC Photos `AlbumInfo` instance.
+     * @param string|null $needle Lower-cased name-substring filter, or null.
+     *
+     * @return array<string,mixed>|null The picker row, or null when the
+     *                                  album is unreadable or filtered out.
+     */
+    private function pickerRowFromAlbum(object $album, ?string $needle): ?array
+    {
+        try {
+            $name    = (string) $album->getTitle();
+            $albumId = (int) $album->getId();
+        } catch (Throwable $e) {
+            return null;
+        }
+
+        if ($needle !== null && str_contains(mb_strtolower($name), $needle) === false) {
+            return null;
+        }
+
+        return [
+            'id'            => $albumId,
+            'name'          => $name,
+            'coverPhotoUrl' => $this->albumDeepLink(albumId: $albumId),
+            'photoCount'    => null,
+            'url'           => $this->albumDeepLink(albumId: $albumId),
+        ];
+    }//end pickerRowFromAlbum()
+
+    /**
+     * Whether a link row's cache is older than the stale window.
+     *
+     * @param PhotoLink $link The link row.
+     *
+     * @return bool
+     */
+    private function isStale(PhotoLink $link): bool
+    {
+        $linkedAt = $link->getLinkedAt();
+        if ($linkedAt === null) {
+            return true;
+        }
+
+        return (time() - $linkedAt->getTimestamp()) > self::STALE_AFTER;
+    }//end isStale()
+
+    /**
+     * Refresh a link row's cached album metadata in place.
+     *
+     * Best-effort: when the album can't be resolved the link is left
+     * untouched (the album may have been deleted in NC Photos).
+     *
+     * @param PhotoLink $link The link row.
+     * @param string    $uid  The owning user id.
+     *
+     * @return PhotoLink The (possibly updated) link row.
+     */
+    private function refreshLink(PhotoLink $link, string $uid): PhotoLink
+    {
+        $info = $this->fetchAlbumInfo(albumId: (int) $link->getAlbumId(), uid: $uid);
+        if ($info === null) {
+            return $link;
+        }
+
+        $link->setAlbumName($info['name']);
+        $link->setCoverPhotoUrl($info['coverPhotoUrl']);
+        $link->setPhotoCount($info['photoCount']);
+        $link->setLastEdited($info['lastEdited']);
+        $link->setLinkedAt(new DateTime());
+
+        try {
+            return $this->photoLinkMapper->update($link);
+        } catch (Throwable $e) {
+            $this->logger->debug('PhotoLinkService::refreshLink update failed: '.$e->getMessage());
+            return $link;
+        }
+    }//end refreshLink()
+
+    /**
+     * Fetch normalised album metadata from NC Photos.
+     *
+     * @param int    $albumId The album id.
+     * @param string $uid     The owning user id.
+     *
+     * @return array{name:string,coverPhotoUrl:?string,photoCount:?int,lastEdited:?DateTime}|null
+     */
+    private function fetchAlbumInfo(int $albumId, string $uid): ?array
+    {
+        $mapper = $this->getAlbumMapper();
+        if ($mapper === null) {
+            return null;
+        }
+
+        try {
+            $album = $mapper->get($albumId);
+        } catch (Throwable $e) {
+            $this->logger->debug('PhotoLinkService::fetchAlbumInfo get failed: '.$e->getMessage());
+            return null;
+        }
+
+        if ($album === null) {
+            return null;
+        }
+
+        $lastEdited = null;
+        try {
+            $lastAdded = (int) $album->getLastAddedPhoto();
+            if ($lastAdded > 0) {
+                $lastEdited = (new DateTime())->setTimestamp($lastAdded);
+            }
+        } catch (Throwable $e) {
+            $lastEdited = null;
+        }
+
+        $photoCount = $this->countPhotos(mapper: $mapper, albumId: $albumId, uid: $uid);
+
+        return [
+            'name'          => (string) $album->getTitle(),
+            'coverPhotoUrl' => $this->albumDeepLink(albumId: $albumId),
+            'photoCount'    => $photoCount,
+            'lastEdited'    => $lastEdited,
+        ];
+    }//end fetchAlbumInfo()
+
+    /**
+     * Best-effort photo count for an album.
+     *
+     * @param object $mapper  The AlbumMapper instance.
+     * @param int    $albumId The album id.
+     * @param string $uid     The owning user id.
+     *
+     * @return int|null The count, or null when it can't be resolved.
+     */
+    private function countPhotos(object $mapper, int $albumId, string $uid): ?int
+    {
+        try {
+            $withFiles = $mapper->getForAlbumIdAndUserWithFiles($albumId, $uid, []);
+            return count($withFiles);
+        } catch (Throwable $e) {
+            $this->logger->debug('PhotoLinkService::countPhotos failed: '.$e->getMessage());
+            return null;
+        }
+    }//end countPhotos()
+
+    /**
+     * Build the NC Photos deep link for an album.
+     *
+     * @param int $albumId The album id.
+     *
+     * @return string
+     */
+    private function albumDeepLink(int $albumId): string
+    {
+        return $this->urlGenerator->linkToRoute('photos.page.index').'albums/'.$albumId;
+    }//end albumDeepLink()
+}//end class

--- a/tests/Unit/Service/PhotoLinkServiceTest.php
+++ b/tests/Unit/Service/PhotoLinkServiceTest.php
@@ -1,0 +1,263 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Service\PhotoLinkService}.
+ *
+ * Exercises the Tier-2 service contract (link / createAndLink / unlink /
+ * list + available picker) against a mocked PhotoLinkMapper. Tests that
+ * touch NC Photos' `AlbumMapper` use the "Photos unavailable" path
+ * because that class is resolved from the container and isn't injectable
+ * into this unit test scope without the `photos` app on the classpath.
+ * Real-AlbumMapper round-trips are gated by `@group requires-app-photos`.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/integration-photos/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use Exception;
+use OCA\OpenRegister\Db\PhotoLink;
+use OCA\OpenRegister\Db\PhotoLinkMapper;
+use OCA\OpenRegister\Service\PhotoLinkService;
+use OCP\App\IAppManager;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * PhotoLinkServiceTest.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ *
+ * @group requires-app-photos
+ */
+class PhotoLinkServiceTest extends TestCase
+{
+
+    private PhotoLinkMapper&MockObject $mapper;
+
+    private ContainerInterface&MockObject $container;
+
+    private IAppManager&MockObject $appManager;
+
+    private IUserSession&MockObject $userSession;
+
+    private IURLGenerator&MockObject $urlGenerator;
+
+    private LoggerInterface&MockObject $logger;
+
+    private PhotoLinkService $service;
+
+    protected function setUp(): void
+    {
+        $this->mapper = $this->getMockBuilder(PhotoLinkMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(
+                    [
+                        'findByObjectUuid',
+                        'findByObjectAndAlbum',
+                        'deleteByObjectAndAlbum',
+                        'insert',
+                        'update',
+                    ]
+                    )
+            ->getMock();
+
+        $this->container    = $this->createMock(ContainerInterface::class);
+        $this->appManager   = $this->createMock(IAppManager::class);
+        $this->userSession  = $this->createMock(IUserSession::class);
+        $this->urlGenerator = $this->createMock(IURLGenerator::class);
+        $this->logger       = $this->createMock(LoggerInterface::class);
+
+        $this->urlGenerator->method('linkToRoute')->willReturn('/index.php/apps/photos/');
+
+        $this->service = new PhotoLinkService(
+            $this->mapper,
+            $this->container,
+            $this->appManager,
+            $this->userSession,
+            $this->urlGenerator,
+            $this->logger
+        );
+    }//end setUp()
+
+    private function setupUser(string $uid='alice'): IUser&MockObject
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $this->userSession->method('getUser')->willReturn($user);
+        return $user;
+    }//end setupUser()
+
+    public function testIsPhotosAvailableTrue(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('photos')->willReturn(true);
+        $this->assertTrue($this->service->isPhotosAvailable());
+    }//end testIsPhotosAvailableTrue()
+
+    public function testIsPhotosAvailableFalse(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('photos')->willReturn(false);
+        $this->assertFalse($this->service->isPhotosAvailable());
+    }//end testIsPhotosAvailableFalse()
+
+    public function testLinkAlbumThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->linkAlbum('abc-123', 1, 2, 99);
+    }//end testLinkAlbumThrowsWhenNoUser()
+
+    public function testLinkAlbumThrowsWhenPhotosUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('photos')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+
+        $this->service->linkAlbum('abc-123', 1, 2, 99);
+    }//end testLinkAlbumThrowsWhenPhotosUnavailable()
+
+    public function testLinkAlbumThrowsOnDuplicate(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->willReturn(true);
+        $this->mapper->method('findByObjectAndAlbum')->with('abc-123', 99)->willReturn(new PhotoLink());
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(409);
+        $this->expectExceptionMessage('Album already linked to this object');
+
+        $this->service->linkAlbum('abc-123', 1, 2, 99);
+    }//end testLinkAlbumThrowsOnDuplicate()
+
+    public function testCreateAndLinkAlbumThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->createAndLinkAlbum('abc-123', 1, 2, 'Holiday');
+    }//end testCreateAndLinkAlbumThrowsWhenNoUser()
+
+    public function testCreateAndLinkAlbumThrowsOnEmptyName(): void
+    {
+        $this->setupUser();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+
+        $this->service->createAndLinkAlbum('abc-123', 1, 2, '   ');
+    }//end testCreateAndLinkAlbumThrowsOnEmptyName()
+
+    public function testCreateAndLinkAlbumThrowsWhenPhotosUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('photos')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+
+        $this->service->createAndLinkAlbum('abc-123', 1, 2, 'Holiday');
+    }//end testCreateAndLinkAlbumThrowsWhenPhotosUnavailable()
+
+    public function testUnlinkAlbumThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->unlinkAlbum('abc-123', 99);
+    }//end testUnlinkAlbumThrowsWhenNoUser()
+
+    public function testUnlinkAlbumThrowsWhenLinkMissing(): void
+    {
+        $this->setupUser();
+        $this->mapper->method('deleteByObjectAndAlbum')->with('abc-123', 99)->willReturn(0);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(404);
+
+        $this->service->unlinkAlbum('abc-123', 99);
+    }//end testUnlinkAlbumThrowsWhenLinkMissing()
+
+    public function testUnlinkAlbumSucceeds(): void
+    {
+        $this->setupUser();
+        $this->mapper->expects($this->once())
+            ->method('deleteByObjectAndAlbum')
+            ->with('abc-123', 99)
+            ->willReturn(1);
+
+        $this->service->unlinkAlbum('abc-123', 99);
+    }//end testUnlinkAlbumSucceeds()
+
+    public function testGetLinkedAlbumsReturnsRowsWithDeepLink(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->willReturn(false);
+
+        $link = new PhotoLink();
+        $link->setObjectUuid('abc-123');
+        $link->setAlbumId(42);
+        $link->setAlbumName('Holiday');
+
+        $this->mapper->method('findByObjectUuid')->with('abc-123')->willReturn([$link]);
+
+        $rows = $this->service->getLinkedAlbums('abc-123');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame(42, $rows[0]['albumId']);
+        $this->assertSame('Holiday', $rows[0]['albumName']);
+        $this->assertStringContainsString('albums/42', $rows[0]['url']);
+    }//end testGetLinkedAlbumsReturnsRowsWithDeepLink()
+
+    public function testGetLinkedAlbumsEmpty(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->willReturn(false);
+        $this->mapper->method('findByObjectUuid')->with('abc-123')->willReturn([]);
+
+        $this->assertSame([], $this->service->getLinkedAlbums('abc-123'));
+    }//end testGetLinkedAlbumsEmpty()
+
+    public function testGetAvailableAlbumsEmptyWhenPhotosUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('photos')->willReturn(false);
+
+        $this->assertSame([], $this->service->getAvailableAlbums());
+    }//end testGetAvailableAlbumsEmptyWhenPhotosUnavailable()
+
+    public function testGetAvailableAlbumsEmptyWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+        $this->appManager->method('isEnabledForUser')->with('photos')->willReturn(true);
+
+        $this->assertSame([], $this->service->getAvailableAlbums());
+    }//end testGetAvailableAlbumsEmptyWhenNoUser()
+}//end class


### PR DESCRIPTION
## Summary
Promotes the **photos** integration leaf to Tier-2: replaces the Tier-1 `PhotosProvider` `[or:{uuid}]` album-name marker convention with a dedicated `openregister_photo_links` persistence layer so links survive album renames.

- **Migration** `Version1Date20260525170000` — idempotent create-or-extend of `openregister_photo_links` (`object_uuid`/`register_id`/`schema_id` indexed, `album_id`/`album_name`/`cover_photo_url`/`photo_count`/`last_edited`/`linked_by`/`linked_at`; composite unique `(object_uuid, album_id)`).
- **PhotoLink** entity + **PhotoLinkMapper**.
- **PhotoLinkService** composes the mapper with a lazily-resolved `OCA\Photos\Album\AlbumMapper` (graceful degradation when Photos is absent, ADR-019 AD-23); caches album metadata with a 24h refresh window; user-scoped link / create+link / unlink / list / picker.
- **PhotoLinksController** — `GET/POST /photos`, `POST /photos/new`, `DELETE /photos/{albumId}`, `GET /integrations/photos/available`; routes specific-before-wildcard.
- **PhotosProvider** reads the link table first, falls back to the legacy marker scan; promoted out of the greenfield DI list to its own factory injecting `PhotoLinkMapper`.

## Test plan
- [x] 15 PHPUnit tests in `tests/Unit/Service/PhotoLinkServiceTest.php` (`@group requires-app-photos`), all green
- [x] PHPCS strict, PHPStan (level 5), PHPMD all clean on the new/changed `lib/` files
- [ ] Manual: link/create/unlink an album from an OR object's Photos tab with NC Photos installed

Refs: openregister#1319, ADR-019, ADR-022, ADR-004.