### PR TITLE
retrofit: reverse-spec exception bundle (3 extends + 1 drop)

### DIFF
--- a/lib/Exception/AppendOnlyException.php
+++ b/lib/Exception/AppendOnlyException.php
@@ -71,6 +71,8 @@ class AppendOnlyException extends \Exception
      * @param string         $schemaIdentifier The schema slug, UUID, or ID
      * @param string         $operation        The rejected operation ('update' or 'delete')
      * @param Throwable|null $previous         Previous exception
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md#task-3
      */
     public function __construct(
         string $schemaIdentifier,
@@ -93,6 +95,8 @@ class AppendOnlyException extends \Exception
      * Get the schema identifier that triggered this exception.
      *
      * @return string The schema slug, UUID, or ID
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md#task-3
      */
     public function getSchemaIdentifier(): string
     {
@@ -103,6 +107,8 @@ class AppendOnlyException extends \Exception
      * Get the mutating operation that was rejected.
      *
      * @return string 'update' or 'delete'
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md#task-3
      */
     public function getOperation(): string
     {
@@ -113,6 +119,8 @@ class AppendOnlyException extends \Exception
      * Build the structured JSON error body for HTTP 405 responses.
      *
      * @return array{error: string, message: string, schema: string, operation: string}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md#task-3
      */
     public function toResponseBody(): array
     {

--- a/lib/Exception/CircularReferenceException.php
+++ b/lib/Exception/CircularReferenceException.php
@@ -48,6 +48,8 @@ class CircularReferenceException extends ValidationException
      * @param string|null    $message          Optional override for the human-readable message.
      * @param int            $code             HTTP status code (default 422).
      * @param Throwable|null $previous         Previous exception in the chain.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md#task-1
      */
     public function __construct(
         private readonly string $referencedUuid,
@@ -77,6 +79,8 @@ class CircularReferenceException extends ValidationException
      * The UUID whose re-entry triggered the cycle detection.
      *
      * @return string The UUID at the closing edge of the cycle.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md#task-1
      */
     public function getReferencedUuid(): string
     {
@@ -88,6 +92,8 @@ class CircularReferenceException extends ValidationException
      * Slug (or raw `$ref`) of the schema involved in the cycle.
      *
      * @return string Target schema slug or raw `$ref`.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md#task-1
      */
     public function getTargetSchemaSlug(): string
     {
@@ -99,6 +105,8 @@ class CircularReferenceException extends ValidationException
      * The cycle chain that triggered the detection.
      *
      * @return array<int, array{register?:string|null,schema:string,uuid:string}> Visited stack.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md#task-1
      */
     public function getCycle(): array
     {
@@ -116,6 +124,8 @@ class CircularReferenceException extends ValidationException
      *     message: string,
      *     code: int
      * }
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md#task-1
      */
     public function toArray(): array
     {

--- a/lib/Exception/ProviderUnavailableException.php
+++ b/lib/Exception/ProviderUnavailableException.php
@@ -58,6 +58,8 @@ class ProviderUnavailableException extends \RuntimeException
      * @param \Throwable|null $previous Optional wrapped throwable.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md#task-2
      */
     public function __construct(string $message, string $cause, ?\Throwable $previous=null)
     {
@@ -70,6 +72,8 @@ class ProviderUnavailableException extends \RuntimeException
      *
      * @return string One of openconnector-down |
      *                openconnector-source-missing | upstream-service-down.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md#task-2
      */
     public function getCause(): string
     {
@@ -81,6 +85,8 @@ class ProviderUnavailableException extends \RuntimeException
      * the UI renders (per AD-23: `details.cause`).
      *
      * @return array{cause: string}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md#task-2
      */
     public function getDetails(): array
     {

--- a/lib/Exception/ReferenceValidationException.php
+++ b/lib/Exception/ReferenceValidationException.php
@@ -63,6 +63,8 @@ class ReferenceValidationException extends ValidationException
      * @param Throwable|null $previous         The previous exception
      *                                         that triggered this
      *                                         one.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md#task-1
      */
     public function __construct(
         private readonly string $propertyName,
@@ -94,6 +96,8 @@ class ReferenceValidationException extends ValidationException
      * Schema property name that holds the broken reference.
      *
      * @return string Property name as declared on the schema.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md#task-1
      */
     public function getPropertyName(): string
     {
@@ -105,6 +109,8 @@ class ReferenceValidationException extends ValidationException
      * The UUID value that failed to resolve.
      *
      * @return string The unresolved UUID.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md#task-1
      */
     public function getReferencedUuid(): string
     {
@@ -116,6 +122,8 @@ class ReferenceValidationException extends ValidationException
      * Slug (or raw `$ref`) of the schema the reference targets.
      *
      * @return string Target schema slug or raw `$ref`.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md#task-1
      */
     public function getTargetSchemaSlug(): string
     {
@@ -128,6 +136,8 @@ class ReferenceValidationException extends ValidationException
      *
      * @return string|null Register identifier or null when no register
      *                     context applied to the lookup.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md#task-1
      */
     public function getTargetRegister(): ?string
     {
@@ -150,6 +160,8 @@ class ReferenceValidationException extends ValidationException
      *     message: string,
      *     code: int
      * }
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md#task-1
      */
     public function toArray(): array
     {

--- a/openspec/changes/retrofit-2026-05-24-b-exception-all/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-b-exception-all/proposal.md
@@ -1,0 +1,106 @@
+# retrofit-2026-05-24-b-exception-all
+
+## Why
+
+The `lib/Exception/` directory contains a family of exception classes whose
+constructor/getter plumbing is already implicitly covered by host-capability
+scenarios, but a subset of them carry a *structured payload contract* that
+downstream consumers (UI error rendering, API clients, audit-log clients)
+depend on. Those payload shapes are not pinned by any current spec.
+
+This is a reverse-spec retrofit (observed behavior, no code changes beyond
+`@spec` annotations). It bundles four sub-clusters over 8 files / 21 methods
+into ONE ghost change: three `--extend` clusters that pin payload contracts
+onto existing host capabilities, and one explicit DROP cluster.
+
+The bias is to **extend** the host capability rather than create a parallel
+"exception" sub-capability — the exception's behavior *is* the host spec's
+diagnostic/envelope requirement, so the new REQs only pin the concrete key
+shape where the host spec is silent on it.
+
+## What Changes
+
+### Cluster 1 — `exception-reference-validation` → extend `reference-existence-validation`
+
+`CircularReferenceException` and `ReferenceValidationException` both subclass
+`ValidationException` and expose structured getters plus a `toArray()`
+diagnostic payload. The host spec already requires "structured diagnostic
+information" (l.219) and "circular reference chains MUST be detected" (l.248),
+and it pins the *HTTP 422 `details` envelope* shape (`property`,
+`referenceUuid`, `targetSchema`, `targetRegister`, `validationType`).
+
+It does **not** pin the *exception-level* `toArray()` keys, which use a
+distinct internal naming (`propertyName`, `referencedUuid`, `targetSchemaSlug`,
+`targetRegister`, `message`, `code`) and — for the circular variant — a `cycle`
+array. Those are the keys the controller maps from, so they are a real
+contract. ONE new REQ pins both `toArray()` shapes and the structured getters.
+
+Annotated: `CircularReferenceException` (__construct, getReferencedUuid,
+getTargetSchemaSlug, getCycle, toArray) + `ReferenceValidationException`
+(__construct, getPropertyName, getReferencedUuid, getTargetSchemaSlug,
+getTargetRegister, toArray) — 11 methods.
+
+### Cluster 2 — `exception-provider-unavailable` → extend `generic-integrations`
+
+`ProviderUnavailableException` carries the AD-23 actionable-error contract: the
+four `CAUSE_*` classification constants drive the UI's "Reconfigure connector"
+vs "Service offline" rendering, and `getDetails()` returns the `{cause: ...}`
+payload the frontend consumes. The host spec's "Graceful Degradation"
+requirement specifies the *trigger* (subsystem unreachable → degraded health)
+but not the cause vocabulary or the `details.cause` payload. ONE new REQ pins
+the four permitted cause values and the getCause()/getDetails() shape.
+
+Annotated: `ProviderUnavailableException` (__construct, getCause, getDetails) —
+3 methods.
+
+Note: the active `pluggable-integration-registry` change is still pre-archive
+and the class docblock already points at its task-4. The bundle guidance was to
+route this delta there if it were the canonical home; however this retrofit is
+scoped as ONE ghost change against the merged host capability
+(`generic-integrations`, created by archiving `integration-shares`). The new
+REQ is additive and does not conflict with the active change.
+
+### Cluster 3 — `exception-append-only` → extend `audit-trail-immutable`
+
+`AppendOnlyException::toResponseBody()` returns the structured HTTP 405 body
+`{error: "SCHEMA_APPEND_ONLY", message, schema, operation}` raised when an
+UPDATE/DELETE is attempted on an `appendOnly: true` schema. The host spec's
+"Audit trail entries MUST NOT be deletable" requirement pins a *different*
+405 envelope (`{"error": "Audit trail entries cannot be deleted"}`, prose-only)
+for the audit-trail *API endpoints*. The append-only *schema-write* refusal is
+a separate, machine-readable code-based envelope that audit-log clients use to
+distinguish "append-only refusal" from "lock" from "not-found". ONE new REQ
+pins the four envelope keys plus the canonical `SCHEMA_APPEND_ONLY` error code.
+
+Annotated: `AppendOnlyException` (__construct, getSchemaIdentifier,
+getOperation, toResponseBody) — 4 methods.
+
+### Cluster 4 — `exception-plumbing-drop` → DROP (no spec, no annotation)
+
+These five methods across four files are pure signaling exceptions:
+constructor formats a message + sets an HTTP code; the single getter (where
+present) exposes the ctor arg. There is no testable behavior independent of the
+host spec that *throws* them.
+
+- `LockedException::__construct` — "write on a locked object yields 423" belongs
+  to the lock/concurrency requirement in `object-lifecycle`, not the exception.
+- `RegisterNotFoundException::__construct` / `SchemaNotFoundException::__construct`
+  — the "missing register/schema yields 404" behavior is covered by
+  `object-lifecycle` lookup scenarios.
+- `HookStoppedException::__construct` / `HookStoppedException::getErrors` — the
+  "a hook may stop the operation and surface its errors" behavior is covered by
+  the `schema-hooks` capability in scenario form.
+
+Annotating these would add `@spec` noise without bucketing any new contract.
+They are dropped explicitly per the architect decision.
+
+## Impact
+
+- Specs: `reference-existence-validation`, `generic-integrations`,
+  `audit-trail-immutable` each gain ONE new ADDED requirement (3 new REQs total).
+- Code: `@spec` annotations only on the 18 non-dropped methods across 4 files
+  (`CircularReferenceException`, `ReferenceValidationException`,
+  `ProviderUnavailableException`, `AppendOnlyException`). No behavior changes.
+- Dropped: 5 plumbing methods across 4 files
+  (`LockedException`, `RegisterNotFoundException`, `SchemaNotFoundException`,
+  `HookStoppedException`) — documented above, not annotated.

--- a/openspec/changes/retrofit-2026-05-24-b-exception-all/specs/audit-trail-immutable/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-exception-all/specs/audit-trail-immutable/spec.md
@@ -1,0 +1,37 @@
+# audit-trail-immutable (delta)
+
+## ADDED Requirements
+
+### Requirement: Append-only schema-write refusals MUST return a structured 405 envelope
+The system MUST raise `AppendOnlyException` carrying HTTP code 405 and a machine-readable response body when an UPDATE or DELETE is attempted on an object whose schema is declared `appendOnly: true` (used for audit logs, xAPI statements, compliance attestations where past-record immutability is required). The body MUST let audit-log clients distinguish an "append-only refusal" from a lock (423) or a not-found (404) without parsing the human-readable message.
+
+This is distinct from the audit-trail *API endpoint* 405 (see "Audit trail
+entries MUST NOT be deletable or modifiable"), which returns a prose-only
+`{"error": "..."}` body; the append-only schema-write refusal carries a stable
+error *code* plus schema/operation context.
+
+#### Scenario: toResponseBody envelope shape
+
+- GIVEN an `AppendOnlyException` constructed with
+  `schemaIdentifier = "xapi-statements"` and `operation = "delete"`
+- WHEN `toResponseBody()` is called
+- THEN it MUST return exactly the keys `error`, `message`, `schema`, `operation`
+- AND `error` MUST be the canonical code `"SCHEMA_APPEND_ONLY"`
+- AND `schema` MUST be `"xapi-statements"`
+- AND `operation` MUST be `"delete"`
+
+#### Scenario: HTTP code and default operation
+
+- GIVEN an `AppendOnlyException` constructed with only a `schemaIdentifier`
+- WHEN the exception is inspected
+- THEN `getCode()` MUST be `405`
+- AND `getOperation()` MUST default to `"update"`
+- AND `getMessage()` MUST be
+  `"SCHEMA_APPEND_ONLY: Schema \"<schema>\" is append-only; <operation> operations are not permitted."`
+
+#### Scenario: Getters expose constructor args
+
+- GIVEN an `AppendOnlyException` constructed with
+  `schemaIdentifier = "attestations"` and `operation = "update"`
+- WHEN `getSchemaIdentifier()` and `getOperation()` are called
+- THEN they MUST return `"attestations"` and `"update"` unchanged

--- a/openspec/changes/retrofit-2026-05-24-b-exception-all/specs/generic-integrations/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-exception-all/specs/generic-integrations/spec.md
@@ -1,0 +1,31 @@
+# generic-integrations (delta)
+
+## ADDED Requirements
+
+### Requirement: Provider-unavailable errors MUST carry an AD-23 cause classification
+A raised `ProviderUnavailableException` MUST classify the failure with one of a fixed set of cause values so the UI can render the correct actionable message (per AD-23) when an external-integration call fails because the upstream service or the OpenConnector source itself is unreachable: connector-down ("Reconfigure connector") vs upstream-down ("Service offline") vs source-missing vs provider-auth. The cause MUST be exposed both directly and inside a structured `details` payload that the frontend consumes.
+
+#### Scenario: Permitted cause vocabulary
+
+- GIVEN the `ProviderUnavailableException` class
+- THEN it MUST define exactly these four cause constants and string values:
+  - `CAUSE_OPENCONNECTOR_DOWN` = `"openconnector-down"`
+  - `CAUSE_OPENCONNECTOR_SOURCE_MISSING` = `"openconnector-source-missing"`
+  - `CAUSE_UPSTREAM_SERVICE_DOWN` = `"upstream-service-down"`
+  - `CAUSE_PROVIDER_AUTH` = `"provider-auth"`
+
+#### Scenario: getCause returns the constructor cause
+
+- GIVEN a `ProviderUnavailableException` constructed with
+  `cause = ProviderUnavailableException::CAUSE_OPENCONNECTOR_DOWN`
+- WHEN `getCause()` is called
+- THEN it MUST return `"openconnector-down"` unchanged
+
+#### Scenario: getDetails returns the cause payload
+
+- GIVEN a `ProviderUnavailableException` constructed with
+  `cause = "upstream-service-down"`
+- WHEN `getDetails()` is called
+- THEN it MUST return `{"cause": "upstream-service-down"}`
+- AND this payload MUST be the `details.cause` shape the UI renders for the
+  actionable error

--- a/openspec/changes/retrofit-2026-05-24-b-exception-all/specs/reference-existence-validation/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-exception-all/specs/reference-existence-validation/spec.md
@@ -1,0 +1,47 @@
+# reference-existence-validation (delta)
+
+## ADDED Requirements
+
+### Requirement: Reference-validation exceptions MUST expose a structured diagnostic payload
+The two `ValidationException` subclasses raised on the reference-existence path (`ReferenceValidationException`, `CircularReferenceException`) MUST expose their diagnostic data as a structured `toArray()` payload and via individual getters, so that controllers can surface a machine-readable error without re-parsing the human-readable message. Both subclasses MUST default the HTTP code to 422 and MUST build a structured default message from their fields when no explicit message is supplied.
+
+This is the exception-level contract that the HTTP 422 `details` envelope (see
+"Validation error reporting MUST include structured diagnostic information") is
+mapped from; the key names differ deliberately because `toArray()` is the
+internal diagnostic shape and `details` is the public API envelope.
+
+#### Scenario: ReferenceValidationException toArray shape
+
+- GIVEN a `ReferenceValidationException` constructed with
+  `propertyName = "assignee"`, `referencedUuid = "nonexistent-uuid"`,
+  `targetSchemaSlug = "person"`, `targetRegister = "procest"`
+- WHEN `toArray()` is called
+- THEN it MUST return exactly the keys `propertyName`, `referencedUuid`,
+  `targetSchemaSlug`, `targetRegister`, `message`, `code`
+- AND `code` MUST be `422`
+- AND `message` MUST be
+  `"Referenced object 'nonexistent-uuid' not found in schema 'person' for property 'assignee'"`
+  when no explicit message was supplied
+- AND `getPropertyName()`, `getReferencedUuid()`, `getTargetSchemaSlug()`, and
+  `getTargetRegister()` MUST each return the corresponding constructor value
+  unchanged
+
+#### Scenario: CircularReferenceException toArray shape
+
+- GIVEN a `CircularReferenceException` constructed with
+  `referencedUuid = "obj-a"`, `targetSchemaSlug = "incident"`, and a non-empty
+  `cycle` array of `(register, schema, uuid)` entries
+- WHEN `toArray()` is called
+- THEN it MUST return exactly the keys `referencedUuid`, `targetSchemaSlug`,
+  `cycle`, `message`, `code`
+- AND `code` MUST be `422`
+- AND `cycle` MUST contain the visited chain that triggered detection
+- AND `getReferencedUuid()`, `getTargetSchemaSlug()`, and `getCycle()` MUST each
+  return the corresponding constructor value unchanged
+
+#### Scenario: Default message built from fields
+
+- GIVEN a `CircularReferenceException` constructed with no `message` argument
+- WHEN the exception is inspected
+- THEN `getMessage()` MUST be
+  `"Circular reference detected for object '<referencedUuid>' in schema '<targetSchemaSlug>'"`

--- a/openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-b-exception-all/tasks.md
@@ -1,0 +1,67 @@
+# Tasks — retrofit-2026-05-24-b-exception-all
+
+Reverse-spec retrofit. Tasks below describe the observed behavior each
+annotated method group already satisfies. No code changes other than `@spec`
+annotations.
+
+## task-1 — Reference-validation diagnostic payload shape
+
+Extend `reference-existence-validation`. Pin the exception-level structured
+diagnostic contract for the two `ValidationException` subclasses on the
+reference-existence path:
+
+- `ReferenceValidationException::toArray()` MUST return keys `propertyName`,
+  `referencedUuid`, `targetSchemaSlug`, `targetRegister`, `message`, `code`.
+- `CircularReferenceException::toArray()` MUST return keys `referencedUuid`,
+  `targetSchemaSlug`, `cycle`, `message`, `code`.
+- The structured getters (`getPropertyName`, `getReferencedUuid`,
+  `getTargetSchemaSlug`, `getTargetRegister`, `getCycle`) MUST expose the
+  constructor-supplied values unchanged.
+- Both subclasses MUST default `code` to 422 and build a structured default
+  message when none is supplied.
+
+Methods annotated: `CircularReferenceException::__construct`,
+`::getReferencedUuid`, `::getTargetSchemaSlug`, `::getCycle`, `::toArray`;
+`ReferenceValidationException::__construct`, `::getPropertyName`,
+`::getReferencedUuid`, `::getTargetSchemaSlug`, `::getTargetRegister`,
+`::toArray`.
+
+## task-2 — Provider-unavailable cause classification (AD-23)
+
+Extend `generic-integrations`. Pin the actionable-error contract for
+`ProviderUnavailableException`:
+
+- The class MUST expose exactly four cause constants:
+  `CAUSE_OPENCONNECTOR_DOWN = "openconnector-down"`,
+  `CAUSE_OPENCONNECTOR_SOURCE_MISSING = "openconnector-source-missing"`,
+  `CAUSE_UPSTREAM_SERVICE_DOWN = "upstream-service-down"`,
+  `CAUSE_PROVIDER_AUTH = "provider-auth"`.
+- `getCause()` MUST return the constructor-supplied cause unchanged.
+- `getDetails()` MUST return `{cause: <cause>}` for the UI's `details.cause`
+  rendering.
+
+Methods annotated: `ProviderUnavailableException::__construct`, `::getCause`,
+`::getDetails`.
+
+## task-3 — Append-only refusal response envelope
+
+Extend `audit-trail-immutable`. Pin the structured HTTP 405 body for
+append-only schema-write refusals:
+
+- `AppendOnlyException::toResponseBody()` MUST return keys `error`, `message`,
+  `schema`, `operation`.
+- The `error` value MUST be the canonical code `SCHEMA_APPEND_ONLY`.
+- The constructor MUST set HTTP code 405 and default `operation` to `update`.
+- `getSchemaIdentifier()` / `getOperation()` MUST expose the constructor args
+  unchanged.
+
+Methods annotated: `AppendOnlyException::__construct`, `::getSchemaIdentifier`,
+`::getOperation`, `::toResponseBody`.
+
+## DROP — exception plumbing (not annotated)
+
+`LockedException::__construct`, `RegisterNotFoundException::__construct`,
+`SchemaNotFoundException::__construct`, `HookStoppedException::__construct`,
+`HookStoppedException::getErrors` — pure ctor/getter plumbing; throwing
+behavior is covered by `object-lifecycle` / `schema-hooks` host scenarios. See
+proposal.md for rationale. No `@spec` annotation added.


### PR DESCRIPTION
## Summary

Reverse-spec retrofit bundling four `lib/Exception/` sub-clusters into ONE ghost change `retrofit-2026-05-24-b-exception-all` (3 `--extend` clusters + 1 explicit DROP). Observed behavior only; no behavior changes beyond `@spec` annotations.

- **exception-reference-validation -> extend `reference-existence-validation`**: pins the `toArray()` diagnostic payload + structured getters of `ReferenceValidationException` (`propertyName`/`referencedUuid`/`targetSchemaSlug`/`targetRegister`) and `CircularReferenceException` (`referencedUuid`/`targetSchemaSlug`/`cycle`). The host spec already pins the public HTTP-422 `details` envelope; this pins the distinct internal exception-level `toArray()` shape the controller maps from. 11 methods.
- **exception-provider-unavailable -> extend `generic-integrations`**: pins the AD-23 actionable-error contract of `ProviderUnavailableException` — the four `CAUSE_*` constants and the `getCause()`/`getDetails()` (`{cause}`) shape. 3 methods.
- **exception-append-only -> extend `audit-trail-immutable`**: pins the `AppendOnlyException::toResponseBody()` 405 envelope `{error: SCHEMA_APPEND_ONLY, message, schema, operation}` — distinct from the prose-only audit-API 405. 4 methods.
- **DROP cluster** (documented in proposal.md, NOT specced/annotated): 5 plumbing methods across `LockedException`, `RegisterNotFoundException`, `SchemaNotFoundException`, `HookStoppedException`. Pure ctor/getter plumbing; throwing behavior is already covered by `object-lifecycle` / `schema-hooks` host scenarios.

**Net: 3 new ADDED requirements / 18 methods annotated / 5 dropped.**

`openspec validate --strict` passes; `php -l` clean on all 4 touched files.

## Test plan

- [ ] `openspec validate retrofit-2026-05-24-b-exception-all --strict` passes
- [ ] PHPCS clean on the 4 touched exception files (blank-line-before-`@spec` rule)
- [ ] Reviewer confirms the 3 new REQs pin payload shapes not already specced by the host capabilities, and the DROP rationale holds