### PR TITLE
retrofit: reverse-spec listener bundle (3 sub-clusters)

### DIFF
--- a/lib/Listener/CalculationOnSaveListener.php
+++ b/lib/Listener/CalculationOnSaveListener.php
@@ -58,6 +58,8 @@ class CalculationOnSaveListener implements IEventListener
      * @param LoggerInterface      $logger       PSR logger for warnings.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-listener-all/tasks.md#task-1
      */
     public function __construct(
         private readonly SchemaMapper $schemaMapper,
@@ -72,6 +74,8 @@ class CalculationOnSaveListener implements IEventListener
      * @param Event $event Inbound dispatcher event.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-listener-all/tasks.md#task-2
      */
     public function handle(Event $event): void
     {
@@ -98,6 +102,8 @@ class CalculationOnSaveListener implements IEventListener
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-listener-all/tasks.md#task-3
      */
     private function process(ObjectEntity $object, bool $isUpdate): void
     {
@@ -176,6 +182,8 @@ class CalculationOnSaveListener implements IEventListener
      * @param mixed $value Raw value returned by the evaluator.
      *
      * @return mixed JSON-serialisable representation of the value.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-listener-all/tasks.md#task-4
      */
     private function serialise(mixed $value): mixed
     {
@@ -192,6 +200,8 @@ class CalculationOnSaveListener implements IEventListener
      * @param ObjectEntity $object Object whose schema reference to resolve.
      *
      * @return Schema|null Resolved schema, or null on lookup failure.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-listener-all/tasks.md#task-5
      */
     private function loadSchema(ObjectEntity $object): ?Schema
     {
@@ -213,6 +223,8 @@ class CalculationOnSaveListener implements IEventListener
      * @param Schema $schema Schema to inspect.
      *
      * @return array<string, mixed>|null Calculations map, or null when absent.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-listener-all/tasks.md#task-6
      */
     private function getCalculations(Schema $schema): ?array
     {

--- a/lib/Listener/NotifyPushListener.php
+++ b/lib/Listener/NotifyPushListener.php
@@ -308,6 +308,8 @@ class NotifyPushListener implements IEventListener
      * @return void
      *
      * @internal For use in unit tests only.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-listener-all/tasks.md#task-7
      */
     public static function resetStaticState(): void
     {
@@ -381,6 +383,8 @@ class NotifyPushListener implements IEventListener
      * not installed or not reachable. Never logs WARNING/ERROR.
      *
      * @return object|null The IQueue instance, or null when unavailable.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-listener-all/tasks.md#task-8
      */
     private function resolveQueue(): ?object
     {
@@ -410,6 +414,8 @@ class NotifyPushListener implements IEventListener
      * @param string|null $registerUuid The register UUID from ObjectEntity::getRegister().
      *
      * @return string|null The register slug, or null when not resolvable.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-listener-all/tasks.md#task-9
      */
     private function resolveRegisterSlug(?string $registerUuid): ?string
     {
@@ -440,6 +446,8 @@ class NotifyPushListener implements IEventListener
      * @param string|null $schemaUuid The schema UUID from ObjectEntity::getSchema().
      *
      * @return string|null The schema slug, or null when not resolvable.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-listener-all/tasks.md#task-10
      */
     private function resolveSchemaSlug(?string $schemaUuid): ?string
     {

--- a/lib/Listener/RealtimeEventListener.php
+++ b/lib/Listener/RealtimeEventListener.php
@@ -47,6 +47,8 @@ class RealtimeEventListener implements IEventListener
      * @param RealtimeService $realtimeService Service that persists realtime events.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-listener-all/tasks.md#task-11
      */
     public function __construct(
         private readonly RealtimeService $realtimeService
@@ -59,6 +61,8 @@ class RealtimeEventListener implements IEventListener
      * @param Event $event Inbound dispatcher event.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-listener-all/tasks.md#task-12
      */
     public function handle(Event $event): void
     {

--- a/lib/Listener/TranslationProjectionListener.php
+++ b/lib/Listener/TranslationProjectionListener.php
@@ -49,6 +49,8 @@ class TranslationProjectionListener implements IEventListener
      * @param TranslationProjectionService $projection Projection service.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-listener-all/tasks.md#task-13
      */
     public function __construct(
         private readonly TranslationProjectionService $projection
@@ -61,6 +63,8 @@ class TranslationProjectionListener implements IEventListener
      * @param Event $event Inbound dispatcher event.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-listener-all/tasks.md#task-14
      */
     public function handle(Event $event): void
     {

--- a/openspec/changes/retrofit-2026-05-24-b-listener-all/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-b-listener-all/proposal.md
@@ -1,0 +1,70 @@
+# Retrofit — listener bundle (3 sub-clusters)
+
+Reverse-specs the `lib/Listener/` event-listener cluster: 4 files / 14 methods across 3 sub-clusters. All 3 are `--extend` of an existing capability — listeners are the reactive (event-driven) half of a pipeline whose synchronous half is already specced. Code already exists; this change retroactively specifies the observed behaviour and back-annotates the methods.
+
+Source: `/tmp/or-scan/bundle-listener-all.json` (parent cluster `listener`, generated 2026-05-24). See [retrofit playbook](../../../.github/docs/claude/retrofit.md).
+
+## Affected code units
+
+### Sub-cluster `computed-fields-on-save` → extend `computed-fields` (6 methods)
+- `lib/Listener/CalculationOnSaveListener.php::__construct`
+- `lib/Listener/CalculationOnSaveListener.php::handle`
+- `lib/Listener/CalculationOnSaveListener.php::process` (private)
+- `lib/Listener/CalculationOnSaveListener.php::serialise` (private)
+- `lib/Listener/CalculationOnSaveListener.php::loadSchema` (private)
+- `lib/Listener/CalculationOnSaveListener.php::getCalculations` (private)
+
+### Sub-cluster `realtime-updates-fanout` → extend `realtime-updates` (6 methods, 2 files)
+- `lib/Listener/NotifyPushListener.php::resetStaticState` (static)
+- `lib/Listener/NotifyPushListener.php::resolveQueue` (private)
+- `lib/Listener/NotifyPushListener.php::resolveRegisterSlug` (private)
+- `lib/Listener/NotifyPushListener.php::resolveSchemaSlug` (private)
+- `lib/Listener/RealtimeEventListener.php::__construct`
+- `lib/Listener/RealtimeEventListener.php::handle`
+
+### Sub-cluster `translation-projection-on-write` → extend `register-i18n` (2 methods)
+- `lib/Listener/TranslationProjectionListener.php::__construct`
+- `lib/Listener/TranslationProjectionListener.php::handle`
+
+## Approach
+
+### computed-fields-on-save
+`CalculationOnSaveListener` subscribes to `ObjectCreatingEvent` + `ObjectUpdatingEvent` and, for every `materialise: true` entry in the schema's `x-openregister-calculations` block, runs the `CalculationEvaluator` and **patches the result into the object payload before persistence**. This is the only listener in the bundle that mutates the persisted payload. The `computed-fields` spec already covers the equivalent declarative surface (`computed.expression` + `evaluateOn: save`, read-only on input, sandboxed evaluator, graceful per-field error handling) under "Save-Time Evaluation". The observed behaviours **not** yet captured there are the evaluator-context plumbing specific to this on-save listener:
+
+- a synthetic `@self` system-metadata block (`id`, `uuid`, `register`, `schema`, `owner`, ISO-8601 `created`/`updated`) is injected into the evaluation context so expressions can reference `@self.created` etc., then stripped before persist;
+- the payload is only re-set (`setObject()`) when at least one value actually changed (idempotent on no-op saves);
+- declaration-order iteration with a documented acyclic-graph guarantee from the validator's cycle check;
+- per-calculation `EvaluationException` is caught, logged at WARNING, and the field skipped without aborting the save.
+
+Drafted as one new REQ on `computed-fields`. The listener implements the JSON-AST `x-openregister-calculations` annotation (archived change `2026-04-29-calculations-annotation`, not yet promoted to its own capability spec) — but the on-save materialisation behaviour is the same derived-field capability and belongs in `computed-fields`.
+
+### realtime-updates-fanout
+Both listeners are reactive plumbing for `realtime-updates`. The in-flight `add-live-updates` change already specs `NotifyPushListener`'s per-object / per-collection fan-out, dedup, soft-fail, and batch mode (those methods — `handle`, `dispatchPushes`, `setBatchMode`, `flushBatch`, `__construct` — already carry `@spec add-live-updates/tasks.md#task-4`). The 4 NotifyPushListener methods in *this* bundle are the resolver / lifecycle helpers not covered by that delta:
+
+- `resetStaticState()` — test-isolation reset of all four static accumulators (`$batchMode`, `$batchedCollections`, `$seen`, `$queueUnavailable`); `@internal` for unit tests;
+- `resolveQueue()` — lazy `IQueue` resolution from the container with a per-request single-DEBUG soft-fail latch (`$queueUnavailable`), never WARNING/ERROR;
+- `resolveRegisterSlug()` / `resolveSchemaSlug()` — UUID→slug lookups that **bypass RBAC + multitenancy** (`_rbac: false, _multitenancy: false`) because the listener runs system-level, not user-scoped (issue #1454). Surfaced as a Notes item, not fixed.
+
+`RealtimeEventListener` records every `ObjectCreated/Updated/Deleted/Transitioned` as a CloudEvent in the realtime event log via `RealtimeService::record()` — it is the recorder that feeds the SSE controller's buffer. This recorder-listener was DROPPED from `nested-aggregations#NAG-005` and is not currently specced as a listener anywhere, so its behaviour is drafted here.
+
+Two new REQs on `realtime-updates`: one for the static-state / soft-fail / system-level-resolver semantics of `NotifyPushListener`, one for the `RealtimeEventListener` CloudEvent recorder.
+
+### translation-projection-on-write
+`TranslationProjectionListener` is the event-driven write-side of the `register-i18n` sidecar projection: on `ObjectCreated/Updated/Transitioned` it calls `TranslationProjectionService::project($object)`; on `ObjectDeleted` it calls `purge($object)`. The `register-i18n` spec currently covers the synchronous save/render path (`TranslationHandler::normalizeTranslationsForSave()` / `resolveTranslationsForRender()`) but does not specify the asynchronous projection of translatable content into the `openregister_translations` sidecar via lifecycle events. The service + sidecar table are named in the in-flight `i18n-source-of-truth` / `i18n-api-language-negotiation` changes. One new REQ on `register-i18n` for the event-driven projection/purge write-side.
+
+## New requirements
+
+- `computed-fields` — **Save-Time Materialisation of Declared Calculations** (1 REQ)
+- `realtime-updates` — **The system MUST manage NotifyPushListener static state and resolve slugs at system level** (1 REQ)
+- `realtime-updates` — **The system MUST record object lifecycle events as CloudEvents in the realtime log** (1 REQ)
+- `register-i18n` — **The system MUST project translatable content into the sidecar on object lifecycle events** (1 REQ)
+
+4 new REQs total. The remaining methods that map to already-specced behaviour (NotifyPushListener `handle`/`dispatchPushes`/`setBatchMode`/`flushBatch`/`__construct`) are out of scope here — they already carry their `add-live-updates` annotations.
+
+## Notes
+
+- **RBAC / multitenancy bypass (surfaced, not fixed)** — `NotifyPushListener::resolveRegisterSlug()` and `::resolveSchemaSlug()` call `RegisterMapper::find()` / `SchemaMapper::find()` with `_rbac: false, _multitenancy: false`. The in-code comment attributes this to issue #1454: without the bypass, cross-tenant lifecycle events leave the push payload's `register`/`schema` slug fields null because the request user's tenant does not own the register/schema. `CalculationOnSaveListener::loadSchema()` similarly passes `_multitenancy: false` to `SchemaMapper::find()`. This is observed behaviour and is documented in the REQ scenarios; it is a deliberate system-level-listener design choice but a multitenancy-boundary concern worth a follow-up review — not changed in this retrofit.
+- `serialise()`, `loadSchema()`, `getCalculations()`, `resolveQueue()`, `resolveRegisterSlug()`, `resolveSchemaSlug()` are private; `resetStaticState()` is static + `@internal`. Method-level annotations are added for completeness.
+- `RealtimeEventListener::handle` reads the new-state object from `getNewObject()` on update (and `getObject()` on create/delete/transition) — same accessor pattern as the other lifecycle listeners.
+
+Source: `/tmp/or-scan/bundle-listener-all.json`. See retrofit playbook.

--- a/openspec/changes/retrofit-2026-05-24-b-listener-all/specs/computed-fields/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-listener-all/specs/computed-fields/spec.md
@@ -1,0 +1,71 @@
+---
+status: proposed
+retrofit_extensions: [Save-Time Materialisation of Declared Calculations]
+---
+
+# Computed Fields — on-save calculation materialisation (delta)
+
+**Cross-references**: [computed-fields main spec](../../../../specs/computed-fields/spec.md), archived change `2026-04-29-calculations-annotation` (the `x-openregister-calculations` JSON-AST annotation this listener consumes).
+
+## Purpose of this delta
+
+The `computed-fields` capability already specifies save-time evaluation of `computed.expression` properties under "Save-Time Evaluation". This delta retroactively captures the observed behaviour of `CalculationOnSaveListener`, the event-driven component that materialises declared calculations into the persisted object payload. It runs from `ObjectCreatingEvent` / `ObjectUpdatingEvent` (the "creating"/"updating" pre-persist phase), implements the `x-openregister-calculations` annotation variant, and adds evaluator-context plumbing (synthetic `@self`, change-detection, declaration-order iteration) not described by the existing save-time scenarios.
+
+## ADDED Requirements
+
+### Requirement: Save-Time Materialisation of Declared Calculations
+
+When a schema declares an `x-openregister-calculations` configuration block, the system MUST materialise each calculation marked `materialise: true` into the object payload before the object is persisted, on both create and update. Materialisation MUST run during the `ObjectCreatingEvent` / `ObjectUpdatingEvent` (pre-persist) phase via `CalculationOnSaveListener`. The listener MUST iterate calculations in declaration order (a later calculation MAY reference an earlier one; the validator's cycle check guarantees the graph is acyclic), evaluate each expression through `CalculationEvaluator`, and write the serialised result back into the object data. The listener MUST NOT abort the save when an individual calculation fails.
+
+#### Scenario: Materialise a calculation into the payload on create
+- **GIVEN** a schema whose configuration declares `x-openregister-calculations` with an entry `total` having `materialise: true` and an expression over other fields
+- **WHEN** an object is created and `ObjectCreatingEvent` fires
+- **THEN** `CalculationOnSaveListener::handle()` MUST invoke `process()` with the new object
+- **AND** the evaluated value MUST be written into the object data under key `total`
+- **AND** the materialised value MUST be present in the persisted object
+
+#### Scenario: Re-materialise on update
+- **GIVEN** an existing object with a materialised calculation `total`
+- **WHEN** the object is updated and `ObjectUpdatingEvent` fires
+- **THEN** `CalculationOnSaveListener::handle()` MUST invoke `process()` with the new object state (`getNewObject()`)
+- **AND** `total` MUST be recomputed from the updated source data
+
+#### Scenario: Only `materialise: true` entries are written
+- **GIVEN** a calculations block containing one entry with `materialise: true` and one with `materialise` unset or false
+- **WHEN** the object is saved
+- **THEN** only the `materialise: true` entry MUST be written into the payload
+- **AND** the non-materialised entry MUST be skipped
+
+#### Scenario: Synthetic `@self` metadata is available during evaluation but stripped before persist
+- **GIVEN** a calculation expression that references `@self.created` or `@self.uuid`
+- **WHEN** `process()` builds the evaluation context
+- **THEN** it MUST inject a `@self` array containing `id`, `uuid`, `register`, `schema`, `owner`, and ISO-8601 `created` / `updated` (null when the entity timestamp is null)
+- **AND** the expression MUST resolve `@self.*` references against that block
+- **AND** the `@self` key MUST be removed from the data before the payload is persisted (it is a runtime aid, not user data)
+
+#### Scenario: No-op save does not rewrite the payload
+- **GIVEN** a materialised calculation whose recomputed value equals the value already stored
+- **WHEN** `process()` runs
+- **THEN** the listener MUST NOT call `setObject()` (the payload is only re-set when at least one materialised value actually changed)
+
+#### Scenario: Per-calculation evaluation error is logged and skipped
+- **GIVEN** one calculation whose expression raises an `EvaluationException`
+- **WHEN** `process()` evaluates the calculations in order
+- **THEN** the failing calculation MUST be skipped
+- **AND** a WARNING MUST be logged via `LoggerInterface` including the calculation name, the object UUID, and the error message
+- **AND** the remaining calculations MUST still be evaluated and the object MUST still be saved successfully
+
+#### Scenario: DateTime results are serialised to ATOM
+- **GIVEN** a calculation that returns a `DateTimeInterface` value
+- **WHEN** the result is written into the payload
+- **THEN** `serialise()` MUST format it as an ATOM (`DATE_ATOM`) string
+- **AND** non-DateTime values MUST be stored unchanged
+
+#### Scenario: Schema without a calculations block is a no-op
+- **GIVEN** a schema whose configuration does not contain `x-openregister-calculations` (or contains a non-array value)
+- **WHEN** an object of that schema is saved
+- **THEN** `getCalculations()` MUST return null and `process()` MUST return without modifying the payload
+
+#### Notes
+- `loadSchema()` resolves the object's schema via `SchemaMapper::find($ref, _multitenancy: false)`; an unresolvable or empty schema reference yields a null schema and the listener returns early. The `_multitenancy: false` flag is a system-level lookup (the listener is not user-scoped) — see the change Notes for the multitenancy-boundary follow-up.
+- This listener consumes the JSON-AST `x-openregister-calculations` annotation (archived change `2026-04-29-calculations-annotation`), which is the declarative sibling of the `computed.expression` form covered by the main spec's "Save-Time Evaluation" requirement. Both materialise derived values at save time.

--- a/openspec/changes/retrofit-2026-05-24-b-listener-all/specs/realtime-updates/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-listener-all/specs/realtime-updates/spec.md
@@ -1,0 +1,91 @@
+---
+status: proposed
+retrofit_extensions:
+  - The system MUST manage NotifyPushListener static state and resolve slugs at system level
+  - The system MUST record object lifecycle events as CloudEvents in the realtime log
+---
+
+# Realtime Updates — listener plumbing (delta)
+
+**Cross-references**: [realtime-updates main spec](../../../../specs/realtime-updates/spec.md), in-flight change `add-live-updates` (NotifyPushListener fan-out / dedup / soft-fail / batch mode — already specced there), `event-driven-architecture` (CloudEvents payload format).
+
+## Purpose of this delta
+
+The `add-live-updates` change already specifies `NotifyPushListener`'s per-object / per-collection fan-out, deduplication, soft-fail contract, and batch mode (`handle`, `dispatchPushes`, `setBatchMode`, `flushBatch`). This delta retroactively captures two pieces of reactive plumbing not covered there:
+
+1. `NotifyPushListener`'s static-state lifecycle (`resetStaticState()`), the queue-unavailable single-DEBUG latch (`resolveQueue()`), and the system-level UUID→slug resolvers (`resolveRegisterSlug()` / `resolveSchemaSlug()`) that deliberately bypass RBAC + multitenancy.
+2. `RealtimeEventListener`, the recorder that translates object lifecycle events into CloudEvent rows in the realtime event log consumed by the SSE controller. This recorder-listener was dropped from `nested-aggregations#NAG-005` and is not specced as a listener elsewhere.
+
+## ADDED Requirements
+
+### Requirement: The system MUST manage NotifyPushListener static state and resolve slugs at system level
+
+`NotifyPushListener` carries request-scoped static state (batch mode, batched-collection accumulator, per-request dedup set, queue-unavailable latch). The system MUST provide a reset entry point for test isolation, MUST soft-fail at most once per request when `IQueue` cannot be resolved, and MUST resolve register/schema slugs at the system level (bypassing RBAC and multitenancy) so push payloads carry correct slug fields even for cross-tenant lifecycle events.
+
+#### Scenario: Static-state reset for test isolation
+- **GIVEN** `NotifyPushListener` static state has been mutated (batch mode on, accumulated collections, seen dedup keys, queue-unavailable latched)
+- **WHEN** `NotifyPushListener::resetStaticState()` is called
+- **THEN** `$batchMode` MUST be reset to `false`
+- **AND** `$batchedCollections` MUST be cleared to an empty array
+- **AND** `$seen` (dedup set) MUST be cleared
+- **AND** `$queueUnavailable` MUST be reset to `false`
+- **AND** the method MUST be `@internal` (intended for unit-test isolation only)
+
+#### Scenario: IQueue unavailable logs at most one DEBUG per request
+- **GIVEN** the `OCA\NotifyPush\Queue\IQueue` service cannot be resolved from the container (notify_push not installed or config drift)
+- **WHEN** `resolveQueue()` is called for the first time in a request
+- **THEN** it MUST return null
+- **AND** it MUST emit exactly one DEBUG log entry (never WARNING or ERROR)
+- **AND** it MUST set the `$queueUnavailable` latch
+- **WHEN** `resolveQueue()` is called again within the same request
+- **THEN** it MUST return null immediately without emitting a further log entry
+
+#### Scenario: Register slug resolved at system level, bypassing RBAC + multitenancy
+- **GIVEN** a lifecycle event for an object whose register is owned by a tenant other than the request user's tenant
+- **WHEN** `resolveRegisterSlug($registerUuid)` is called
+- **THEN** it MUST call `RegisterMapper::find($registerUuid, _rbac: false, _multitenancy: false)`
+- **AND** it MUST return the register's slug
+- **AND** a null/empty UUID or a lookup failure MUST yield null (the listener degrades gracefully, leaving the slug field null)
+
+#### Scenario: Schema slug resolved at system level, bypassing RBAC + multitenancy
+- **GIVEN** a lifecycle event for an object whose schema is owned by another tenant
+- **WHEN** `resolveSchemaSlug($schemaUuid)` is called
+- **THEN** it MUST call `SchemaMapper::find($schemaUuid, _rbac: false, _multitenancy: false)`
+- **AND** it MUST return the schema's slug
+- **AND** a null/empty UUID or a lookup failure MUST yield null
+
+#### Notes
+- The RBAC + multitenancy bypass in the two slug resolvers is attributed in-code to issue #1454: without it, cross-tenant lifecycle events leave the push payload's `register` / `schema` slug fields null whenever the request user's tenant does not own the register/schema. This is a deliberate system-level-listener design choice but a multitenancy-boundary concern flagged for follow-up review — it is described here as observed behaviour, not changed in this retrofit.
+
+### Requirement: The system MUST record object lifecycle events as CloudEvents in the realtime log
+
+The system MUST record every object lifecycle event as a CloudEvent in the realtime event log that backs the SSE controller. `RealtimeEventListener` MUST subscribe to `ObjectCreatedEvent`, `ObjectUpdatedEvent`, `ObjectDeletedEvent`, and `ObjectTransitionedEvent` and forward each to `RealtimeService::record()` with the correct event type, the affected `ObjectEntity`, and (for transitions) the transition metadata.
+
+#### Scenario: Record a create event
+- **GIVEN** an `ObjectCreatedEvent` carrying an `ObjectEntity`
+- **WHEN** `RealtimeEventListener::handle()` processes it
+- **THEN** it MUST call `RealtimeService::record(RealtimeService::TYPE_OBJECT_CREATED, $object)`
+
+#### Scenario: Record an update event using the new object state
+- **GIVEN** an `ObjectUpdatedEvent`
+- **WHEN** `handle()` processes it
+- **THEN** it MUST read the new state via `getNewObject()`
+- **AND** call `RealtimeService::record(RealtimeService::TYPE_OBJECT_UPDATED, $object)`
+
+#### Scenario: Record a delete event
+- **GIVEN** an `ObjectDeletedEvent`
+- **WHEN** `handle()` processes it
+- **THEN** it MUST call `RealtimeService::record(RealtimeService::TYPE_OBJECT_DELETED, $object)`
+
+#### Scenario: Record a transition event with transition metadata
+- **GIVEN** an `ObjectTransitionedEvent` carrying `action`, `from`, and `to`
+- **WHEN** `handle()` processes it
+- **THEN** it MUST call `RealtimeService::record(RealtimeService::TYPE_OBJECT_TRANSITIONED, $object, ['action' => ..., 'from' => ..., 'to' => ...])`
+
+#### Scenario: Non-ObjectEntity payload is ignored
+- **GIVEN** a lifecycle event whose payload is not an `ObjectEntity`
+- **WHEN** `handle()` processes it
+- **THEN** no `record()` call MUST be made (the `instanceof ObjectEntity` guard short-circuits)
+
+#### Notes
+- This recorder feeds the same downstream consumer (the SSE controller's event buffer) as the GraphQL subscription path, in the CloudEvents payload format established by the `event-driven-architecture` spec. It was dropped from `nested-aggregations#NAG-005` and is specced here as the standalone realtime recorder listener.

--- a/openspec/changes/retrofit-2026-05-24-b-listener-all/specs/register-i18n/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-listener-all/specs/register-i18n/spec.md
@@ -1,0 +1,48 @@
+---
+status: proposed
+retrofit_extensions:
+  - The system MUST project translatable content into the sidecar on object lifecycle events
+---
+
+# Register Internationalization — sidecar projection write-side (delta)
+
+**Cross-references**: [register-i18n main spec](../../../../specs/register-i18n/spec.md), in-flight changes `i18n-source-of-truth` and `i18n-api-language-negotiation` (which name `TranslationProjectionService` and the `openregister_translations` sidecar table).
+
+## Purpose of this delta
+
+The `register-i18n` capability covers the synchronous save/render path for translatable properties (`TranslationHandler::normalizeTranslationsForSave()` / `resolveTranslationsForRender()`). This delta retroactively captures the event-driven write-side: `TranslationProjectionListener`, which keeps the `openregister_translations` sidecar in sync with the JSONB property data on each object lifecycle event. It is the projection sibling of the realtime recorder — derived-projection-by-event.
+
+## ADDED Requirements
+
+### Requirement: The system MUST project translatable content into the sidecar on object lifecycle events
+
+The system MUST keep the `openregister_translations` sidecar in sync with translatable object content by reacting to object lifecycle events. `TranslationProjectionListener` MUST subscribe to `ObjectCreatedEvent`, `ObjectUpdatedEvent`, `ObjectDeletedEvent`, and `ObjectTransitionedEvent`. On create, update, and transition it MUST project the object's translatable content into the sidecar via `TranslationProjectionService::project($object)`; on delete it MUST remove the object's sidecar rows via `TranslationProjectionService::purge($object)`.
+
+#### Scenario: Project on object creation
+- **GIVEN** an `ObjectCreatedEvent` carrying an `ObjectEntity`
+- **WHEN** `TranslationProjectionListener::handle()` processes it
+- **THEN** it MUST call `TranslationProjectionService::project($object)`
+
+#### Scenario: Re-project on update using the new object state
+- **GIVEN** an `ObjectUpdatedEvent`
+- **WHEN** `handle()` processes it
+- **THEN** it MUST read the new state via `getNewObject()`
+- **AND** call `TranslationProjectionService::project($object)`
+
+#### Scenario: Re-project on transition
+- **GIVEN** an `ObjectTransitionedEvent` carrying an `ObjectEntity`
+- **WHEN** `handle()` processes it
+- **THEN** it MUST call `TranslationProjectionService::project($object)`
+
+#### Scenario: Purge on deletion
+- **GIVEN** an `ObjectDeletedEvent` carrying an `ObjectEntity`
+- **WHEN** `handle()` processes it
+- **THEN** it MUST call `TranslationProjectionService::purge($object)` to remove the object's sidecar translation rows
+
+#### Scenario: Non-ObjectEntity payload is ignored
+- **GIVEN** a lifecycle event whose payload is not an `ObjectEntity`
+- **WHEN** `handle()` processes it
+- **THEN** neither `project()` nor `purge()` MUST be called (the `instanceof ObjectEntity` guard short-circuits)
+
+#### Notes
+- The projection sidecar (`openregister_translations`) and `TranslationProjectionService` are introduced by the in-flight `i18n-source-of-truth` / `i18n-api-language-negotiation` changes; this listener is the reactive write-side that those changes rely on.

--- a/openspec/changes/retrofit-2026-05-24-b-listener-all/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-b-listener-all/tasks.md
@@ -1,0 +1,26 @@
+# Tasks — listener bundle reverse-spec
+
+Each task back-annotates one listener method against its target REQ. Tasks 1–6 extend `computed-fields`; tasks 7–12 extend `realtime-updates`; tasks 13–14 extend `register-i18n`.
+
+## computed-fields-on-save → computed-fields
+
+- [x] task-1: computed-fields#Save-Time Materialisation of Declared Calculations — `CalculationOnSaveListener::__construct` wires SchemaMapper + CalculationEvaluator + LoggerInterface (retroactive annotation)
+- [x] task-2: computed-fields#Save-Time Materialisation of Declared Calculations — `CalculationOnSaveListener::handle` dispatches ObjectCreatingEvent / ObjectUpdatingEvent into the materialiser (retroactive annotation)
+- [x] task-3: computed-fields#Save-Time Materialisation of Declared Calculations — `CalculationOnSaveListener::process` injects synthetic `@self`, evaluates each `materialise: true` calc, patches changed values into the payload before persist (retroactive annotation)
+- [x] task-4: computed-fields#Save-Time Materialisation of Declared Calculations — `CalculationOnSaveListener::serialise` renders DateTimeInterface results to ATOM for JSON storage (retroactive annotation)
+- [x] task-5: computed-fields#Save-Time Materialisation of Declared Calculations — `CalculationOnSaveListener::loadSchema` resolves the object's schema (multitenancy-bypass lookup) (retroactive annotation)
+- [x] task-6: computed-fields#Save-Time Materialisation of Declared Calculations — `CalculationOnSaveListener::getCalculations` reads the `x-openregister-calculations` config block (retroactive annotation)
+
+## realtime-updates-fanout → realtime-updates
+
+- [x] task-7: realtime-updates#The system MUST manage NotifyPushListener static state and resolve slugs at system level — `NotifyPushListener::resetStaticState` resets all four static accumulators for test isolation (retroactive annotation)
+- [x] task-8: realtime-updates#The system MUST manage NotifyPushListener static state and resolve slugs at system level — `NotifyPushListener::resolveQueue` lazily resolves IQueue with a per-request single-DEBUG soft-fail latch (retroactive annotation)
+- [x] task-9: realtime-updates#The system MUST manage NotifyPushListener static state and resolve slugs at system level — `NotifyPushListener::resolveRegisterSlug` resolves register UUID→slug bypassing RBAC + multitenancy (issue #1454) (retroactive annotation)
+- [x] task-10: realtime-updates#The system MUST manage NotifyPushListener static state and resolve slugs at system level — `NotifyPushListener::resolveSchemaSlug` resolves schema UUID→slug bypassing RBAC + multitenancy (issue #1454) (retroactive annotation)
+- [x] task-11: realtime-updates#The system MUST record object lifecycle events as CloudEvents in the realtime log — `RealtimeEventListener::__construct` wires the RealtimeService recorder (retroactive annotation)
+- [x] task-12: realtime-updates#The system MUST record object lifecycle events as CloudEvents in the realtime log — `RealtimeEventListener::handle` records Created/Updated/Deleted/Transitioned events (with transition metadata) via RealtimeService::record() (retroactive annotation)
+
+## translation-projection-on-write → register-i18n
+
+- [x] task-13: register-i18n#The system MUST project translatable content into the sidecar on object lifecycle events — `TranslationProjectionListener::__construct` wires the TranslationProjectionService (retroactive annotation)
+- [x] task-14: register-i18n#The system MUST project translatable content into the sidecar on object lifecycle events — `TranslationProjectionListener::handle` projects on Created/Updated/Transitioned and purges on Deleted (retroactive annotation)


### PR DESCRIPTION
## Summary

Bundled reverse-spec of the `lib/Listener/` event-listener cluster: **4 files / 14 methods** across **3 `--extend` sub-clusters**, one ghost change (`retrofit-2026-05-24-b-listener-all`), one PR. No code logic changes — observed behaviour only; methods back-annotated with `@spec` pointers.

All 3 sub-clusters extend an existing capability (listeners are the reactive half of an already-specced pipeline):

- **computed-fields-on-save → `computed-fields`** (6 methods). `CalculationOnSaveListener` is the only listener that mutates the persisted payload — it materialises `materialise: true` entries from `x-openregister-calculations` before persist. New REQ captures the evaluator-context plumbing (synthetic `@self`, change-detection, declaration-order eval, per-calc error skip) not in the existing "Save-Time Evaluation" requirement.
- **realtime-updates-fanout → `realtime-updates`** (6 methods, 2 files). `NotifyPushListener`'s fan-out/dedup/soft-fail/batch are already specced in `add-live-updates`; the 4 methods here are the static-state reset, queue-unavailable single-DEBUG latch, and system-level slug resolvers. `RealtimeEventListener` is the CloudEvent recorder dropped from `nested-aggregations#NAG-005`. Two new REQs.
- **translation-projection-on-write → `register-i18n`** (2 methods). `TranslationProjectionListener` is the event-driven write-side of the `openregister_translations` sidecar (project on create/update/transition, purge on delete). One new REQ.

**4 new REQs / 14 methods annotated.** `openspec validate --strict` passes; `php -l` clean on all 4 files.

## Notes / follow-up

- Surfaced (not fixed): `NotifyPushListener::resolveRegisterSlug()` / `resolveSchemaSlug()` call `find(..., _rbac: false, _multitenancy: false)` — system-level lookups that bypass RBAC + multitenancy so cross-tenant lifecycle events still carry slug fields (issue #1454). `CalculationOnSaveListener::loadSchema()` similarly passes `_multitenancy: false`. Documented as observed behaviour in the REQ scenarios + change Notes; flagged as a multitenancy-boundary concern for follow-up review.

## Test plan

- [ ] Confirm `@spec` back-pointers resolve to the right tasks.md lines (no double-tagging of the already-annotated `add-live-updates#task-4` methods).
- [ ] Review the 4 drafted REQs against observed listener behaviour.
- [ ] `openspec validate retrofit-2026-05-24-b-listener-all --strict` (passes locally).