### PR TITLE
retrofit: reverse-spec event bundle (6 sub-clusters)

### DIFF
--- a/lib/Event/ConfigurationUpdatedEvent.php
+++ b/lib/Event/ConfigurationUpdatedEvent.php
@@ -53,6 +53,8 @@ class ConfigurationUpdatedEvent extends Event
      * @param Configuration $oldConfiguration The configuration before update.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-4
      */
     public function __construct(Configuration $newConfiguration, Configuration $oldConfiguration)
     {

--- a/lib/Event/CustomScopeEvaluatedEvent.php
+++ b/lib/Event/CustomScopeEvaluatedEvent.php
@@ -66,6 +66,8 @@ class CustomScopeEvaluatedEvent extends Event
      * Schema that was evaluated.
      *
      * @return Schema The schema involved in the evaluation.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-8
      */
     public function getSchema(): Schema
     {
@@ -76,6 +78,8 @@ class CustomScopeEvaluatedEvent extends Event
      * Custom action verb that was evaluated.
      *
      * @return string The custom action verb.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-8
      */
     public function getAction(): string
     {
@@ -86,6 +90,8 @@ class CustomScopeEvaluatedEvent extends Event
      * User ID under evaluation (null for anonymous requests).
      *
      * @return string|null The user ID, or null when anonymous.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-8
      */
     public function getUserId(): ?string
     {
@@ -98,6 +104,8 @@ class CustomScopeEvaluatedEvent extends Event
      * @return bool The boolean verdict that the caller received.
      *
      * @SuppressWarnings(PHPMD.BooleanGetMethodName)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-8
      */
     public function getVerdict(): bool
     {
@@ -109,6 +117,8 @@ class CustomScopeEvaluatedEvent extends Event
      * standard rule chain after no listener voted (false).
      *
      * @return bool True when a listener decided the verdict.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-8
      */
     public function isFromListener(): bool
     {

--- a/lib/Event/CustomScopeEvaluatingEvent.php
+++ b/lib/Event/CustomScopeEvaluatingEvent.php
@@ -84,6 +84,8 @@ class CustomScopeEvaluatingEvent extends Event
      * Schema being checked.
      *
      * @return Schema The schema involved in this evaluation.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-7
      */
     public function getSchema(): Schema
     {
@@ -94,6 +96,8 @@ class CustomScopeEvaluatingEvent extends Event
      * The custom action verb being evaluated.
      *
      * @return string The custom action verb.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-7
      */
     public function getAction(): string
     {
@@ -104,6 +108,8 @@ class CustomScopeEvaluatingEvent extends Event
      * User ID under evaluation (null for anonymous requests).
      *
      * @return string|null The user ID, or null when anonymous.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-7
      */
     public function getUserId(): ?string
     {
@@ -114,6 +120,8 @@ class CustomScopeEvaluatingEvent extends Event
      * Group memberships of the user at evaluation time.
      *
      * @return string[]
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-7
      */
     public function getUserGroups(): array
     {
@@ -124,6 +132,8 @@ class CustomScopeEvaluatingEvent extends Event
      * Object the action is targeting, when one is supplied.
      *
      * @return ObjectEntity|null Target object, or null when none was supplied.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-7
      */
     public function getObject(): ?ObjectEntity
     {
@@ -136,6 +146,8 @@ class CustomScopeEvaluatingEvent extends Event
      * deterministic regardless of listener registration order.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-7
      */
     public function allow(): void
     {
@@ -148,6 +160,8 @@ class CustomScopeEvaluatingEvent extends Event
      * Vote deny. See `allow()` for verdict-order semantics.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-7
      */
     public function deny(): void
     {
@@ -160,6 +174,8 @@ class CustomScopeEvaluatingEvent extends Event
      * Resolved verdict, or null when no listener voted.
      *
      * @return bool|null The verdict, or null when no listener has voted.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-7
      */
     public function getVerdict(): ?bool
     {
@@ -170,6 +186,8 @@ class CustomScopeEvaluatingEvent extends Event
      * Whether any listener has cast a verdict.
      *
      * @return bool True when at least one listener has voted.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-7
      */
     public function hasVerdict(): bool
     {

--- a/lib/Event/DeepLinkRegistrationEvent.php
+++ b/lib/Event/DeepLinkRegistrationEvent.php
@@ -54,6 +54,8 @@ class DeepLinkRegistrationEvent extends Event
      * Get the deep link registry service to register URL patterns.
      *
      * @return DeepLinkRegistryService The registry service
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-9
      */
     public function getRegistry(): DeepLinkRegistryService
     {

--- a/lib/Event/ObjectTransitionedEvent.php
+++ b/lib/Event/ObjectTransitionedEvent.php
@@ -123,6 +123,8 @@ class ObjectTransitionedEvent extends Event
      * Read the object after the transition.
      *
      * @return ObjectEntity Object whose lifecycle just changed.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-2
      */
     public function getObject(): ObjectEntity
     {
@@ -133,6 +135,8 @@ class ObjectTransitionedEvent extends Event
      * Read the action name from the transition table.
      *
      * @return string Action name (e.g. "publish").
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-2
      */
     public function getAction(): string
     {
@@ -143,6 +147,8 @@ class ObjectTransitionedEvent extends Event
      * Read the lifecycle value before the transition.
      *
      * @return string Originating state value.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-2
      */
     public function getFrom(): string
     {
@@ -153,6 +159,8 @@ class ObjectTransitionedEvent extends Event
      * Read the lifecycle value after the transition.
      *
      * @return string Destination state value.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-2
      */
     public function getTo(): string
     {
@@ -163,6 +171,8 @@ class ObjectTransitionedEvent extends Event
      * Read the caller uid that triggered the transition.
      *
      * @return string|null Caller uid, or null for system transitions.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-2
      */
     public function getUserId(): ?string
     {
@@ -173,6 +183,8 @@ class ObjectTransitionedEvent extends Event
      * Read the register slug the object belongs to.
      *
      * @return string Register slug.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-2
      */
     public function getRegister(): string
     {
@@ -183,6 +195,8 @@ class ObjectTransitionedEvent extends Event
      * Read the schema slug the object belongs to.
      *
      * @return string Schema slug.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-2
      */
     public function getSchema(): string
     {

--- a/lib/Event/ObjectUnlockedEvent.php
+++ b/lib/Event/ObjectUnlockedEvent.php
@@ -58,6 +58,7 @@ class ObjectUnlockedEvent extends Event
      * @return ObjectEntity The object that has been unlocked
      *
      * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-27
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-3
      */
     public function getObject(): ObjectEntity
     {

--- a/lib/Event/ReferenceValidatedEvent.php
+++ b/lib/Event/ReferenceValidatedEvent.php
@@ -62,6 +62,8 @@ class ReferenceValidatedEvent extends Event
      * Schema property name that holds the validated reference.
      *
      * @return string Property name as declared on the schema.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-5
      */
     public function getPropertyName(): string
     {
@@ -73,6 +75,8 @@ class ReferenceValidatedEvent extends Event
      * UUID that successfully resolved during validation.
      *
      * @return string The resolved UUID.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-5
      */
     public function getReferencedUuid(): string
     {
@@ -84,6 +88,8 @@ class ReferenceValidatedEvent extends Event
      * Slug (or raw `$ref`) of the schema the reference targets.
      *
      * @return string Target schema slug or raw `$ref`.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-5
      */
     public function getTargetSchemaSlug(): string
     {
@@ -96,6 +102,8 @@ class ReferenceValidatedEvent extends Event
      *
      * @return string|null Register identifier or null when no register
      *                     context applied to the lookup.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-5
      */
     public function getTargetRegister(): ?string
     {

--- a/lib/Event/ReferenceValidationFailedEvent.php
+++ b/lib/Event/ReferenceValidationFailedEvent.php
@@ -65,6 +65,8 @@ class ReferenceValidationFailedEvent extends Event
      * Schema property name that holds the broken reference.
      *
      * @return string Property name as declared on the schema.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-6
      */
     public function getPropertyName(): string
     {
@@ -76,6 +78,8 @@ class ReferenceValidationFailedEvent extends Event
      * UUID that failed to resolve during validation.
      *
      * @return string The unresolved UUID.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-6
      */
     public function getReferencedUuid(): string
     {
@@ -87,6 +91,8 @@ class ReferenceValidationFailedEvent extends Event
      * Slug (or raw `$ref`) of the schema the reference targets.
      *
      * @return string Target schema slug or raw `$ref`.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-6
      */
     public function getTargetSchemaSlug(): string
     {
@@ -99,6 +105,8 @@ class ReferenceValidationFailedEvent extends Event
      *
      * @return string|null Register identifier or null when no register
      *                     context applied to the lookup.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-6
      */
     public function getTargetRegister(): ?string
     {

--- a/lib/Event/ViewUpdatedEvent.php
+++ b/lib/Event/ViewUpdatedEvent.php
@@ -53,6 +53,8 @@ class ViewUpdatedEvent extends Event
      * @param View $oldView The view before update.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md#task-4
      */
     public function __construct(View $newView, View $oldView)
     {

--- a/openspec/changes/retrofit-2026-05-24-b-event-all/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-b-event-all/proposal.md
@@ -1,0 +1,31 @@
+# Retrofit — event bundle (6 sub-clusters, all extend)
+
+Bundled reverse-spec of the OpenRegister event value-objects in `lib/Event/` (36 files). These are Nextcloud `OCP\EventDispatcher\Event` payload classes: a constructor that captures entity/context state plus getters that expose it to listeners. They ARE the published contract of pre-existing capabilities, so the architect classified all 6 sub-clusters as `--extend`. This change retroactively annotates the event methods against the capabilities they realise and mints REQs only where the existing spec genuinely lacks the contract.
+
+## Sub-clusters and extend decisions
+
+1. **event-object-lifecycle-crud** → `event-driven-architecture` — The canonical CRUD pre/post pair for `ObjectEntity` (ObjectCreating/Created, Updating/Updated, Deleting/Deleted). Already fully covered by the existing "All entity mutations MUST dispatch typed PHP events" and "Pre-mutation events MUST support rejection..." requirements (and the getters were annotated by `retrofit-2026-04-23-annotate-openregister`). **Annotate only — no new REQ.**
+
+2. **event-object-state-changes** → `event-driven-architecture` — Locked/Unlocked/Reverted/Transitioned. Lock + Reverted are covered by the existing "Lock and revert operations dispatch specialized events" scenario; ObjectUnlockedEvent's getter is already annotated. **ObjectTransitionedEvent has no spec coverage at all** (state-machine transitions fired after a lifecycle-field update, with a 7-arg constructor carrying action/from/to/userId/register/schema) — **mint 1 new REQ**. ObjectUnlockedEvent is the symmetric pair of the lock event and the existing scenario only asserts lock; **mint 1 new REQ** so the unlock half of the contract is explicit.
+
+3. **event-meta-entity-crud-non-object** → `event-driven-architecture` — 21 files for the seven non-Object meta-entities (Agent, Application, Configuration, Conversation, Organisation, Source, View). The existing "Non-object entity mutations dispatch corresponding typed events" scenario already enumerates exactly these entity types. **Annotate only — no new REQ.** Note: `ConfigurationUpdatedEvent` and `ViewUpdatedEvent` carry no getters (constructor-only), so only their constructors are brought into coverage; all other meta-entity getters were already annotated by the 2026-04-23 retrofit.
+
+4. **event-reference-existence-validation** → `reference-existence-validation` — ReferenceValidatedEvent + ReferenceValidationFailedEvent. The capability's existing "Validation events MUST be dispatched for notification and extensibility" requirement already names both events and their payload shape. **Annotate only — no new REQ.**
+
+5. **event-rbac-custom-scope** → `rbac-scopes` — CustomScopeEvaluatingEvent (voting allow()/deny(), first-vote-wins, hasVerdict()) + CustomScopeEvaluatedEvent (telemetry). Both carry a file-level `@spec openspec/changes/rbac-scopes/tasks.md` already. The custom-verb extension point is not yet a published requirement in the current `rbac-scopes/spec.md` (which documents the canonical five verbs). **Mint 1 new REQ** capturing the custom-scope event handshake, then annotate methods against it.
+
+6. **event-deep-link-registration** → `deep-link-registry` — DeepLinkRegistrationEvent. The capability's existing "Apps SHALL register deep link patterns via boot-time events" requirement already names this event and its `register()` convenience method (already annotated). The `getRegistry()` getter just exposes the wrapped service. **Annotate only — no new REQ.**
+
+## New REQs (3 total)
+
+- `event-driven-architecture` — Requirement: State-machine transitions MUST dispatch a typed ObjectTransitionedEvent
+- `event-driven-architecture` — Requirement: Object unlock MUST dispatch a typed ObjectUnlockedEvent
+- `rbac-scopes` — Requirement: Custom (non-canonical) action verbs MUST be resolvable via a voting event pair
+
+## Guardrails applied
+
+- Observed behaviour only; constructor signatures and getter return shapes taken directly from the source files.
+- No scanner false-positives included (these are real getter methods, not mis-parsed inline branches).
+- Heavy bias to `--extend`: 3 of 6 sub-clusters are annotation-only against existing requirements.
+
+Source: `/tmp/or-scan/bundle-event-all.json` (architect-bundled, 2026-05-24).

--- a/openspec/changes/retrofit-2026-05-24-b-event-all/specs/deep-link-registry/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-event-all/specs/deep-link-registry/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Apps SHALL register deep link patterns via boot-time events
+
+Consuming Nextcloud apps SHALL be able to register URL patterns for OpenRegister schema/register combinations via the `DeepLinkRegistryService`. A registration maps a (register, schema) pair to a URL template and optional icon, so that OpenRegister can generate URLs pointing to the consuming app's detail view instead of its own. Registration is event-driven: OpenRegister dispatches a `DeepLinkRegistrationEvent` during its `Application::boot()` phase. Consuming apps listen for this event and call `register()` on the provided `DeepLinkRegistryService` (or use the convenience `register()` method on the event itself). The event MUST expose the wrapped registry service via `getRegistry()` so listeners can interact with the registry directly.
+
+**Key classes:**
+- `OCA\OpenRegister\Service\DeepLinkRegistryService` -- In-memory registry with `register()`, `resolve()`, `resolveUrl()`, `resolveIcon()`, `hasRegistrations()`, `reset()` methods
+- `OCA\OpenRegister\Event\DeepLinkRegistrationEvent` -- Event dispatched during boot; wraps the registry service
+- `OCA\OpenRegister\Dto\DeepLinkRegistration` -- Value object storing a single registration (appId, registerSlug, schemaSlug, urlTemplate, icon)
+
+#### Scenario: Pipelinq registers deep link patterns for CRM schemas
+- **GIVEN** Pipelinq is installed alongside OpenRegister
+- **WHEN** OpenRegister dispatches `DeepLinkRegistrationEvent` during `Application::boot()`
+- **THEN** Pipelinq's `DeepLinkRegistrationListener` registers four patterns: `client`, `lead`, `request`, `contact` in the `pipelinq` register
+- **AND** each registration uses the URL template format `/apps/pipelinq/#/clients/{uuid}` (hash-based Vue Router routes)
+
+#### Scenario: Procest registers deep link patterns for case management schemas
+- **GIVEN** Procest is installed alongside OpenRegister
+- **WHEN** OpenRegister dispatches `DeepLinkRegistrationEvent` during `Application::boot()`
+- **THEN** Procest's `DeepLinkRegistrationListener` registers two patterns: `case` and `task` in the `case-management` register
+- **AND** each registration uses the URL template format `/apps/procest/#/cases/{uuid}` and `/apps/procest/#/tasks/{uuid}`
+
+#### Scenario: Multiple apps register for different schemas in the same register
+- **GIVEN** both Procest and a hypothetical audit app are installed
+- **WHEN** Procest registers for `case-management::case` and the audit app registers for `case-management::audit-log`
+- **THEN** both registrations coexist and the correct app is resolved per schema
+
+#### Scenario: Duplicate registration for same (register, schema) pair is silently ignored
+- **GIVEN** Procest has already registered a deep link for `case-management::case`
+- **WHEN** a second app attempts to register for the same `case-management::case` pair
+- **THEN** the duplicate registration is silently ignored (first-come-first-served)
+- **AND** a debug log message is emitted: `[DeepLinkRegistry] Ignoring duplicate registration for {key} from {appId} (already claimed by {existing})`
+
+#### Scenario: App that is disabled stops registering deep links
+- **GIVEN** Procest was previously registered for `case-management::case`
+- **WHEN** Procest is disabled by the admin
+- **THEN** on the next request, Procest's boot listener does not fire
+- **AND** the `case-management::case` pair has no registration, so search results fall back to OpenRegister's default URL
+
+#### Scenario: Listener obtains the registry service from the event
+- **GIVEN** a consuming app's `DeepLinkRegistrationListener` receives a `DeepLinkRegistrationEvent`
+- **WHEN** the listener calls `getRegistry()` on the event
+- **THEN** it MUST receive the live `DeepLinkRegistryService` instance
+- **AND** calling `register()` on that service MUST be equivalent to calling the event's convenience `register()` method

--- a/openspec/changes/retrofit-2026-05-24-b-event-all/specs/event-driven-architecture/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-event-all/specs/event-driven-architecture/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: State-machine transitions MUST dispatch a typed ObjectTransitionedEvent
+When an object's lifecycle field is changed through a declared transition (per `x-openregister-lifecycle`), the system MUST dispatch an `ObjectTransitionedEvent` carrying the post-transition `ObjectEntity` together with the transition metadata. This lets listeners (notifications, cascades, calculation re-materialisation, audit enrichment) react to the specific transition without inferring the action from the generic `ObjectUpdatedEvent`.
+
+#### Scenario: Transition event carries object and transition metadata
+- **GIVEN** schema `besluiten` declares a lifecycle transition `publish` from state `concept` to state `vastgesteld`
+- **WHEN** the `publish` transition is applied to an object and persisted
+- **THEN** an `ObjectTransitionedEvent` MUST be dispatched after the lifecycle-field update
+- **AND** `getObject()` MUST return the `ObjectEntity` in its post-transition state
+- **AND** `getAction()` MUST return `"publish"`, `getFrom()` MUST return `"concept"`, and `getTo()` MUST return `"vastgesteld"`
+- **AND** `getRegister()` and `getSchema()` MUST return the object's register and schema slugs
+
+#### Scenario: System-applied transition reports a null caller
+- **GIVEN** a transition is applied by a background process rather than an interactive user
+- **WHEN** the `ObjectTransitionedEvent` is constructed
+- **THEN** `getUserId()` MUST return `null`
+- **AND** when the transition was applied by an authenticated user, `getUserId()` MUST return that user's uid
+
+### Requirement: Object unlock MUST dispatch a typed ObjectUnlockedEvent
+Symmetric to the lock operation, releasing a lock on an object MUST dispatch an `ObjectUnlockedEvent` carrying the affected `ObjectEntity`. This completes the lock/unlock pair so listeners can observe both halves of the locking lifecycle.
+
+#### Scenario: Unlock dispatches the unlocked object
+- **GIVEN** object `obj-1` is currently locked
+- **WHEN** the lock on `obj-1` is released
+- **THEN** an `ObjectUnlockedEvent` MUST be dispatched
+- **AND** `getObject()` MUST return the `ObjectEntity` whose lock was released

--- a/openspec/changes/retrofit-2026-05-24-b-event-all/specs/rbac-scopes/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-event-all/specs/rbac-scopes/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Custom (non-canonical) action verbs MUST be resolvable via a voting event pair
+When `PermissionHandler` evaluates an action that is NOT one of the canonical five (`read`, `create`, `update`, `delete`, `list`), it MUST dispatch a `CustomScopeEvaluatingEvent` so consuming apps that declare custom action verbs on a register can contribute a verdict. The verdict is first-vote-wins: the first listener to call `allow()` OR `deny()` decides, and subsequent votes are ignored so the outcome is deterministic regardless of listener registration order. When no listener votes, the handler MUST fall through to the standard rule chain. After a listener-driven verdict, a paired telemetry `CustomScopeEvaluatedEvent` MUST be dispatched for observers (audit, dashboards, analytics) without participating in the decision.
+
+#### Scenario: Custom verb dispatches the evaluating event with full context
+- **GIVEN** a register declares a custom action verb `approve` and a user `jan` (groups `["behandelaars"]`) attempts it on schema `besluiten`
+- **WHEN** `PermissionHandler` evaluates the `approve` action
+- **THEN** a `CustomScopeEvaluatingEvent` MUST be dispatched
+- **AND** `getSchema()` MUST return the `besluiten` schema, `getAction()` MUST return `"approve"`, `getUserId()` MUST return `"jan"`, and `getUserGroups()` MUST return `["behandelaars"]`
+- **AND** `getObject()` MUST return the target `ObjectEntity` when one was supplied, otherwise `null`
+
+#### Scenario: First listener vote wins and short-circuits
+- **GIVEN** two listeners are registered for `CustomScopeEvaluatingEvent`
+- **WHEN** the first listener calls `allow()` and the second calls `deny()`
+- **THEN** `getVerdict()` MUST return `true` (the first vote)
+- **AND** `hasVerdict()` MUST return `true`
+- **AND** the second listener's `deny()` MUST be ignored
+
+#### Scenario: No listener votes falls through to the standard rule chain
+- **GIVEN** no listener casts a verdict on the `CustomScopeEvaluatingEvent`
+- **WHEN** evaluation completes
+- **THEN** `hasVerdict()` MUST return `false` and `getVerdict()` MUST return `null`
+- **AND** `PermissionHandler` MUST evaluate the action against the standard static rule chain
+- **AND** no `CustomScopeEvaluatedEvent` MUST be dispatched (the standard rule-chain audit paths capture that outcome)
+
+#### Scenario: Telemetry event reports the resolved verdict and its origin
+- **GIVEN** a listener resolved a custom-scope evaluation to `true`
+- **WHEN** the paired `CustomScopeEvaluatedEvent` is dispatched
+- **THEN** `getVerdict()` MUST return `true` and `isFromListener()` MUST return `true`
+- **AND** `getSchema()`, `getAction()`, and `getUserId()` MUST mirror the evaluating event's context

--- a/openspec/changes/retrofit-2026-05-24-b-event-all/specs/reference-existence-validation/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-event-all/specs/reference-existence-validation/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Validation events MUST be dispatched for notification and extensibility
+The reference validation pipeline MUST dispatch Nextcloud events via `IEventDispatcher` at key points, allowing other apps and listeners to react to validation outcomes. The dispatched event value-objects (`ReferenceValidatedEvent`, `ReferenceValidationFailedEvent`) MUST expose the validated reference context — property name, referenced UUID, target schema slug, and target register — via getters so listeners can route on it without re-deriving it from the object data.
+
+#### Scenario: Validation failure event dispatched
+- GIVEN a save that fails reference validation
+- WHEN the `ValidationException` is about to be thrown
+- THEN a `ReferenceValidationFailedEvent` MUST be dispatched with:
+  - The object data that was being saved
+  - The property name, invalid UUID, and target schema
+  - The register and schema context
+- AND other apps MAY listen to this event for custom notification or logging
+
+#### Scenario: Validation success event dispatched for monitored schemas
+- GIVEN a schema with `configuration.emitValidationEvents: true`
+- AND a save succeeds with all references validated
+- WHEN the save completes
+- THEN a `ReferenceValidationSucceededEvent` MUST be dispatched with the validated property names and UUIDs
+- AND this event MUST only be dispatched when `emitValidationEvents` is enabled (performance optimization)
+
+#### Scenario: Event listeners do not block the save pipeline
+- GIVEN a registered listener for `ReferenceValidationFailedEvent`
+- AND the listener throws an exception
+- WHEN the event is dispatched
+- THEN the exception MUST be caught and logged
+- AND the original validation error MUST still be returned to the client
+- AND the save pipeline MUST NOT be affected by listener failures
+
+#### Scenario: Validation event value-objects expose the reference context via getters
+- GIVEN a `ReferenceValidatedEvent` or `ReferenceValidationFailedEvent` is dispatched for property `assignee` referencing UUID `person-uuid` in target schema slug `person` within register `procest`
+- WHEN a listener reads the event
+- THEN `getPropertyName()` MUST return `"assignee"`
+- AND `getReferencedUuid()` MUST return `"person-uuid"`
+- AND `getTargetSchemaSlug()` MUST return `"person"` (the slug or raw `$ref`)
+- AND `getTargetRegister()` MUST return `"procest"`, or `null` when no register context applied to the lookup

--- a/openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-b-event-all/tasks.md
@@ -1,0 +1,22 @@
+# Tasks
+
+## event-driven-architecture (sub-clusters 1, 2, 3)
+
+- [x] task-1: event-driven-architecture#REQ — Object CRUD lifecycle events carry their entity payloads (ObjectCreatedEvent, ObjectDeletedEvent getters) (retroactive annotation; getters previously annotated under retrofit-2026-04-23-annotate-openregister, left as-is)
+- [x] task-2: event-driven-architecture — ObjectTransitionedEvent realises the new "State-machine transitions MUST dispatch a typed ObjectTransitionedEvent" requirement (constructor + getObject/getAction/getFrom/getTo/getUserId/getRegister/getSchema)
+- [x] task-3: event-driven-architecture — ObjectUnlockedEvent realises the new "Object unlock MUST dispatch a typed ObjectUnlockedEvent" requirement (getObject; previously annotated to 2026-04-23 retrofit, now re-anchored)
+- [x] task-4: event-driven-architecture#REQ — Non-object meta-entity mutation events carry their entity payloads — constructor-only events ConfigurationUpdatedEvent + ViewUpdatedEvent brought into coverage (no getters to annotate; all other meta-entity getters annotated under retrofit-2026-04-23-annotate-openregister)
+
+## reference-existence-validation (sub-cluster 4)
+
+- [x] task-5: reference-existence-validation — ReferenceValidatedEvent getters realise the existing "Validation events MUST be dispatched for notification and extensibility" requirement (getPropertyName/getReferencedUuid/getTargetSchemaSlug/getTargetRegister)
+- [x] task-6: reference-existence-validation — ReferenceValidationFailedEvent getters realise the same requirement (getPropertyName/getReferencedUuid/getTargetSchemaSlug/getTargetRegister)
+
+## rbac-scopes (sub-cluster 5)
+
+- [x] task-7: rbac-scopes — CustomScopeEvaluatingEvent realises the new "Custom action verbs MUST be resolvable via a voting event pair" requirement (getSchema/getAction/getUserId/getUserGroups/getObject + allow/deny/getVerdict/hasVerdict voting)
+- [x] task-8: rbac-scopes — CustomScopeEvaluatedEvent telemetry pair realises the same requirement (getSchema/getAction/getUserId/getVerdict/isFromListener)
+
+## deep-link-registry (sub-cluster 6)
+
+- [x] task-9: deep-link-registry — DeepLinkRegistrationEvent.getRegistry() realises the existing "Apps SHALL register deep link patterns via boot-time events" requirement (register() convenience method previously annotated under retrofit-2026-04-23-annotate-openregister)


### PR DESCRIPTION
## Summary

Bundled reverse-spec of the OpenRegister event value-objects in `lib/Event/`. Six architect-bundled sub-clusters, all classified `--extend` because these NC `Event` payload classes ARE the published contract of pre-existing capabilities. One ghost change (`openspec/changes/retrofit-2026-05-24-b-event-all/`) with spec deltas on four capabilities, one PR.

Heavy bias to annotation: 3 of 6 sub-clusters annotate against existing requirements; only 3 genuinely-new REQs minted.

### New REQs (3)
- `event-driven-architecture` — State-machine transitions MUST dispatch a typed `ObjectTransitionedEvent` (the spec had zero coverage of transition events; 7-arg ctor carrying action/from/to/userId/register/schema)
- `event-driven-architecture` — Object unlock MUST dispatch a typed `ObjectUnlockedEvent` (existing scenario only asserted the lock half of the lock/unlock pair)
- `rbac-scopes` — Custom (non-canonical) action verbs MUST be resolvable via a voting event pair (`CustomScopeEvaluatingEvent` allow()/deny() first-vote-wins + `CustomScopeEvaluatedEvent` telemetry)

### Annotate-only (extend against existing requirements)
- `reference-existence-validation` — `ReferenceValidatedEvent` / `ReferenceValidationFailedEvent` getters realise the existing "Validation events MUST be dispatched for notification and extensibility" requirement
- `deep-link-registry` — `DeepLinkRegistrationEvent::getRegistry()` realises the existing boot-time registration requirement
- CRUD/meta-entity events were already annotated under `retrofit-2026-04-23-annotate-openregister`; this bundle adds the two constructor-only events (`ConfigurationUpdatedEvent`, `ViewUpdatedEvent`) that the prior retrofit skipped for lack of getters

### Stats
- 33 methods annotated across 9 event files
- `php -l` clean on all touched files
- `openspec validate retrofit-2026-05-24-b-event-all --strict` passes

## Test plan
- [ ] `openspec validate retrofit-2026-05-24-b-event-all --strict`
- [ ] PHPCS/PHPStan on `lib/Event/*` touched files
- [ ] Spot-check `@spec` task refs resolve to `tasks.md#task-N`