### PR TITLE
feat(bookmarks): Tier-2 — link table + service + picker + create

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -371,6 +371,16 @@ return [
         ['name' => 'pollLinks#createNew', 'url' => '/api/objects/{register}/{schema}/{id}/polls/new',         'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
         ['name' => 'pollLinks#destroy',   'url' => '/api/objects/{register}/{schema}/{id}/polls/{pollId}',    'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'pollId' => '[0-9]+']],
 
+        // Bookmarks — Tier-2 link table + picker UX. Specific routes
+        // (`/new`) MUST precede the wildcard `{bookmarkId}` route so they
+        // aren't grabbed as bookmarkId='new'. Available-bookmarks picker
+        // is app-global.
+        ['name' => 'bookmarkLinks#available', 'url' => '/api/integrations/bookmarks/available',                       'verb' => 'GET'],
+        ['name' => 'bookmarkLinks#index',     'url' => '/api/objects/{register}/{schema}/{id}/bookmarks',             'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
+        ['name' => 'bookmarkLinks#link',      'url' => '/api/objects/{register}/{schema}/{id}/bookmarks',             'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'bookmarkLinks#createNew', 'url' => '/api/objects/{register}/{schema}/{id}/bookmarks/new',         'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'bookmarkLinks#destroy',   'url' => '/api/objects/{register}/{schema}/{id}/bookmarks/{bookmarkId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'bookmarkId' => '[0-9]+']],
+
         // Flow (workflowengine) — Tier-2 link-table API. Admin-gated:
         // POST/DELETE return 403 for non-admins; GET is read-only for
         // everyone. NC Flow operations are configured globally in the

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1208,18 +1208,17 @@ class Application extends App implements IBootstrap
             }
         );
 
-        // BookmarksProvider needs the container (for late-bound NC
-        // Bookmarks classes — they're only on the classpath when the
-        // Bookmarks app is installed) plus IUserSession to scope the
-        // bookmark query to the current user.
+        // BookmarksProvider — Tier-2: backed by the BookmarkLinkMapper.
+        // Replaces the original `or:{uuid}` tag-marker convention with a
+        // proper persistence layer; the wrapping BookmarkLinkService
+        // owns the late-bound NC Bookmarks reads/writes.
         // @spec openspec/changes/integration-bookmarks/tasks.md.
         $context->registerService(
             BookmarksProvider::class,
             function (ContainerInterface $container) {
                 return new BookmarksProvider(
-                    container: $container,
+                    bookmarkLinkMapper: $container->get(\OCA\OpenRegister\Db\BookmarkLinkMapper::class),
                     appManager: $container->get('OCP\App\IAppManager'),
-                    userSession: $container->get('OCP\IUserSession'),
                     l10n: $container->get('OCP\IL10N'),
                 );
             }

--- a/lib/Controller/BookmarkLinksController.php
+++ b/lib/Controller/BookmarkLinksController.php
@@ -1,0 +1,356 @@
+<?php
+
+/**
+ * BookmarkLinksController — Tier-2 REST controller for Bookmarks links.
+ *
+ * Adds explicit link/create endpoints and an available-bookmarks picker
+ * source so the picker UX can drive its modal without leaking NC
+ * Bookmarks internals.
+ *
+ * Endpoints:
+ *   - GET    /api/objects/{register}/{schema}/{id}/bookmarks              — list
+ *   - POST   /api/objects/{register}/{schema}/{id}/bookmarks              — link existing
+ *   - POST   /api/objects/{register}/{schema}/{id}/bookmarks/new          — create + link
+ *   - DELETE /api/objects/{register}/{schema}/{id}/bookmarks/{bookmarkId} — unlink
+ *   - GET    /api/integrations/bookmarks/available                        — picker source
+ *
+ * @category  Controller
+ * @package   OCA\OpenRegister\Controller
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git-id>
+ * @link      https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use Exception;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\BookmarkLinkService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Tier-2 Bookmark links controller.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ */
+class BookmarkLinksController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param string              $appName             App id.
+     * @param IRequest            $request             HTTP request.
+     * @param BookmarkLinkService $bookmarkLinkService Backing service.
+     * @param ObjectService       $objectService       OR object resolver.
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly BookmarkLinkService $bookmarkLinkService,
+        private readonly ObjectService $objectService,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * List linked bookmarks for an object.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function index(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->bookmarkLinkService->isBookmarksAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Bookmarks app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $results = $this->bookmarkLinkService->getLinkedBookmarks($object->getUuid());
+
+            return new JSONResponse(['results' => $results, 'total' => count($results)]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return new JSONResponse(['error' => $e->getMessage()], 500);
+        }//end try
+    }//end index()
+
+    /**
+     * Link an existing bookmark.
+     *
+     * Body: `{ bookmarkId: int }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function link(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->bookmarkLinkService->isBookmarksAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Bookmarks app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $bookmarkId = (int) $this->request->getParam('bookmarkId', 0);
+            if ($bookmarkId === 0) {
+                return new JSONResponse(['error' => 'bookmarkId is required'], 400);
+            }
+
+            $link = $this->bookmarkLinkService->linkBookmark(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $bookmarkId
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end link()
+
+    /**
+     * Create a new bookmark and link it.
+     *
+     * Body: `{ title, url, description?, tags?: [string] }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    public function createNew(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->bookmarkLinkService->isBookmarksAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Bookmarks app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $title       = (string) $this->request->getParam('title', '');
+            $url         = (string) $this->request->getParam('url', '');
+            $description = (string) $this->request->getParam('description', '');
+            $rawTags     = $this->request->getParam('tags', []);
+
+            if (trim($title) === '') {
+                return new JSONResponse(['error' => 'title is required'], 400);
+            }
+
+            if (trim($url) === '') {
+                return new JSONResponse(['error' => 'url is required'], 400);
+            }
+
+            $tags = [];
+            if (is_array($rawTags) === true) {
+                foreach ($rawTags as $tag) {
+                    if (is_string($tag) === true) {
+                        $tags[] = $tag;
+                    }
+                }
+            }
+
+            $link = $this->bookmarkLinkService->createAndLinkBookmark(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $title,
+                $url,
+                $description,
+                $tags
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end createNew()
+
+    /**
+     * Unlink a bookmark.
+     *
+     * @param string $register   Register slug or id.
+     * @param string $schema     Schema slug or id.
+     * @param string $id         Object id.
+     * @param string $bookmarkId NC Bookmarks bookmark id (numeric).
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function destroy(string $register, string $schema, string $id, string $bookmarkId): JSONResponse
+    {
+        if ($this->bookmarkLinkService->isBookmarksAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Bookmarks app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $this->bookmarkLinkService->unlinkBookmark($object->getUuid(), (int) $bookmarkId);
+
+            return new JSONResponse(['success' => true]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end destroy()
+
+    /**
+     * List bookmarks visible to the current user (picker source).
+     *
+     * Query params: `search` — optional title/url substring;
+     * `tags` — optional comma-separated tag filter.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function available(): JSONResponse
+    {
+        if ($this->bookmarkLinkService->isBookmarksAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'Nextcloud Bookmarks app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        $search = $this->request->getParam('search');
+        if ($search !== null) {
+            $search = (string) $search;
+        }
+
+        $tags    = null;
+        $rawTags = $this->request->getParam('tags');
+        if (is_string($rawTags) === true && $rawTags !== '') {
+            $tags = array_values(
+                array_filter(
+                    array_map('trim', explode(',', $rawTags)),
+                    static function (string $tag): bool {
+                        return $tag !== '';
+                    }
+                )
+            );
+        } else if (is_array($rawTags) === true) {
+            $tags = array_values(array_filter($rawTags, 'is_string'));
+        }
+
+        $bookmarks = $this->bookmarkLinkService->getAvailableBookmarks($search, $tags);
+        return new JSONResponse(['results' => $bookmarks, 'total' => count($bookmarks)]);
+    }//end available()
+
+    /**
+     * Resolve an OR object from register/schema/id.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return ObjectEntity|null
+     */
+    private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
+    {
+        $this->objectService->setSchema($schema);
+        $this->objectService->setRegister($register);
+        $this->objectService->setObject($id);
+
+        return $this->objectService->getObject();
+    }//end validateObject()
+
+    /**
+     * Map a service-layer Exception to a JSONResponse.
+     *
+     * Exception codes carry HTTP intent:
+     *   - 409 → conflict
+     *   - 404 → not found
+     *   - 503 → service unavailable
+     *   - 400 → bad request
+     *   - everything else → 400 bad request
+     *
+     * @param Exception $exception Source exception.
+     *
+     * @return JSONResponse
+     */
+    private function mapException(Exception $exception): JSONResponse
+    {
+        $code = $exception->getCode();
+        if ($code === 409) {
+            return new JSONResponse(['error' => $exception->getMessage()], 409);
+        }
+
+        if ($code === 404) {
+            return new JSONResponse(['error' => $exception->getMessage()], 404);
+        }
+
+        if ($code === 503) {
+            return new JSONResponse(['error' => $exception->getMessage()], 503);
+        }
+
+        if ($code === 400) {
+            return new JSONResponse(['error' => $exception->getMessage()], 400);
+        }
+
+        return new JSONResponse(['error' => $exception->getMessage()], 400);
+    }//end mapException()
+}//end class

--- a/lib/Db/BookmarkLink.php
+++ b/lib/Db/BookmarkLink.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * BookmarkLink entity for linking Nextcloud Bookmarks to OpenRegister
+ * objects.
+ *
+ * Tier-2 schema: carries register_id, schema_id, title, url, description,
+ * tags, added_at so the link row alone can hydrate the sidebar tab +
+ * picker UX without a per-bookmark roundtrip to NC Bookmarks. Replaces
+ * the original BookmarksProvider's tag-marker convention
+ * (`or:{uuid}` tag on the bookmark) with a proper persistence layer.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Class BookmarkLink
+ *
+ * @method string getObjectUuid()
+ * @method void setObjectUuid(string $objectUuid)
+ * @method int getRegisterId()
+ * @method void setRegisterId(int $registerId)
+ * @method int|null getSchemaId()
+ * @method void setSchemaId(?int $schemaId)
+ * @method int getBookmarkId()
+ * @method void setBookmarkId(int $bookmarkId)
+ * @method string|null getTitle()
+ * @method void setTitle(?string $title)
+ * @method string|null getUrl()
+ * @method void setUrl(?string $url)
+ * @method string|null getDescription()
+ * @method void setDescription(?string $description)
+ * @method array|null getTags()
+ * @method void setTags(?array $tags)
+ * @method DateTime|null getAddedAt()
+ * @method void setAddedAt(?DateTime $addedAt)
+ * @method string getLinkedBy()
+ * @method void setLinkedBy(string $linkedBy)
+ * @method DateTime|null getLinkedAt()
+ * @method void setLinkedAt(DateTime $linkedAt)
+ *
+ * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class
+ */
+class BookmarkLink extends Entity implements JsonSerializable
+{
+
+    /**
+     * The object uuid.
+     *
+     * @var string|null
+     */
+    protected ?string $objectUuid = null;
+
+    /**
+     * The register id.
+     *
+     * @var integer|null
+     */
+    protected ?int $registerId = null;
+
+    /**
+     * The schema id.
+     *
+     * @var integer|null
+     */
+    protected ?int $schemaId = null;
+
+    /**
+     * The NC Bookmarks bookmark id (primary key in `oc_bookmarks`).
+     *
+     * @var integer|null
+     */
+    protected ?int $bookmarkId = null;
+
+    /**
+     * The bookmark title (cached at link time).
+     *
+     * @var string|null
+     */
+    protected ?string $title = null;
+
+    /**
+     * The bookmark URL (cached at link time).
+     *
+     * @var string|null
+     */
+    protected ?string $url = null;
+
+    /**
+     * The bookmark description (cached at link time).
+     *
+     * @var string|null
+     */
+    protected ?string $description = null;
+
+    /**
+     * Bookmarks-side tags (cached at link time, `or:*` markers stripped).
+     *
+     * @var array<int,string>|null
+     */
+    protected ?array $tags = null;
+
+    /**
+     * When the bookmark was originally saved in NC Bookmarks.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $addedAt = null;
+
+    /**
+     * The linked by uid.
+     *
+     * @var string|null
+     */
+    protected ?string $linkedBy = null;
+
+    /**
+     * The linked at timestamp.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $linkedAt = null;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->addType(fieldName: 'objectUuid', type: 'string');
+        $this->addType(fieldName: 'registerId', type: 'integer');
+        $this->addType(fieldName: 'schemaId', type: 'integer');
+        $this->addType(fieldName: 'bookmarkId', type: 'integer');
+        $this->addType(fieldName: 'title', type: 'string');
+        $this->addType(fieldName: 'url', type: 'string');
+        $this->addType(fieldName: 'description', type: 'string');
+        $this->addType(fieldName: 'tags', type: 'json');
+        $this->addType(fieldName: 'addedAt', type: 'datetime');
+        $this->addType(fieldName: 'linkedBy', type: 'string');
+        $this->addType(fieldName: 'linkedAt', type: 'datetime');
+    }//end __construct()
+
+    /**
+     * JSON serialization.
+     *
+     * @return array<string,mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'          => $this->id,
+            'objectUuid'  => $this->objectUuid,
+            'registerId'  => $this->registerId,
+            'schemaId'    => $this->schemaId,
+            'bookmarkId'  => $this->bookmarkId,
+            'title'       => $this->title,
+            'url'         => $this->url,
+            'description' => $this->description,
+            'tags'        => ($this->tags ?? []),
+            'addedAt'     => $this->addedAt?->format(DateTime::ATOM),
+            'linkedBy'    => $this->linkedBy,
+            'linkedAt'    => $this->linkedAt?->format(DateTime::ATOM),
+        ];
+    }//end jsonSerialize()
+}//end class

--- a/lib/Db/BookmarkLinkMapper.php
+++ b/lib/Db/BookmarkLinkMapper.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * Mapper for bookmark link entities.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git-id>
+ * @link      https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Class BookmarkLinkMapper
+ *
+ * @template-extends QBMapper<BookmarkLink>
+ */
+class BookmarkLinkMapper extends QBMapper
+{
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $db Database connection.
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(db: $db, tableName: 'openregister_bookmark_links', entityClass: BookmarkLink::class);
+    }//end __construct()
+
+    /**
+     * Find bookmark links by object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return BookmarkLink[] Array of bookmark links.
+     */
+    public function findByObjectUuid(string $objectUuid): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByObjectUuid()
+
+    /**
+     * Find bookmark links by bookmark id.
+     *
+     * @param int $bookmarkId The bookmark id.
+     *
+     * @return BookmarkLink[] Array of bookmark links.
+     */
+    public function findByBookmarkId(int $bookmarkId): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('bookmark_id', $qb->createNamedParameter($bookmarkId, IQueryBuilder::PARAM_INT)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByBookmarkId()
+
+    /**
+     * Find a specific bookmark link by object UUID and bookmark id.
+     *
+     * @param string $objectUuid The object UUID.
+     * @param int    $bookmarkId The bookmark id.
+     *
+     * @return BookmarkLink|null The link or null if not found.
+     */
+    public function findByObjectAndBookmark(string $objectUuid, int $bookmarkId): ?BookmarkLink
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere(
+                $qb->expr()->eq('bookmark_id', $qb->createNamedParameter($bookmarkId, IQueryBuilder::PARAM_INT))
+            );
+
+        try {
+            return $this->findEntity(query: $qb);
+        } catch (DoesNotExistException $e) {
+            return null;
+        }
+    }//end findByObjectAndBookmark()
+
+    /**
+     * Delete all bookmark links for an object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectUuid(string $objectUuid): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectUuid()
+
+    /**
+     * Delete a bookmark link by object UUID + bookmark id (Tier-2 unlink).
+     *
+     * Returns the number of rows actually deleted so callers can
+     * distinguish "no such link" (0) from "ok" (>=1).
+     *
+     * @param string $objectUuid The object UUID.
+     * @param int    $bookmarkId The bookmark id.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectAndBookmark(string $objectUuid, int $bookmarkId): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere(
+                $qb->expr()->eq('bookmark_id', $qb->createNamedParameter($bookmarkId, IQueryBuilder::PARAM_INT))
+            );
+
+        return $qb->executeStatement();
+    }//end deleteByObjectAndBookmark()
+}//end class

--- a/lib/Migration/Version1Date20260525140000.php
+++ b/lib/Migration/Version1Date20260525140000.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * Tier-2 bookmarks integration migration.
+ *
+ * Ensures the `openregister_bookmark_links` table exists with the full
+ * Tier-2 schema:
+ *
+ *  - id (bigint, PK, autoincrement)
+ *  - object_uuid (string 36, not null)
+ *  - register_id (bigint unsigned, not null)
+ *  - schema_id (bigint unsigned, nullable)
+ *  - bookmark_id (bigint unsigned, not null)
+ *  - title (string 512, nullable)
+ *  - url (text, nullable)
+ *  - description (text, nullable)
+ *  - tags (json, nullable)
+ *  - added_at (datetime, nullable)
+ *  - linked_by (string 64, not null)
+ *  - linked_at (datetime, not null)
+ *
+ * Composite unique on (object_uuid, bookmark_id). Idempotent: creates the
+ * table if missing, otherwise adds any missing Tier-2 columns. Companion
+ * to the Tier-2 deck/forms/poll link tables; the wrapping
+ * `BookmarkLinkService` replaces the `or:{uuid}` tag-marker convention
+ * from the original BookmarksProvider with a proper persistence layer so
+ * links survive Bookmarks tag edits and don't pollute Bookmarks' UX.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Tier-2 bookmark-links table — create-or-extend.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+class Version1Date20260525140000 extends SimpleMigrationStep
+{
+    /**
+     * Change the database schema.
+     *
+     * @param IOutput                 $output        Output for the migration process
+     * @param Closure                 $schemaClosure The schema closure
+     * @param array<array-key, mixed> $options       Migration options
+     *
+     * @return ISchemaWrapper|null
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema  = $schemaClosure();
+        $changed = false;
+
+        if ($schema->hasTable('openregister_bookmark_links') === false) {
+            $this->createBookmarkLinksTable(schema: $schema, output: $output);
+            $changed = true;
+        }
+
+        if ($schema->hasTable('openregister_bookmark_links') === true
+            && $this->extendBookmarkLinksTable(schema: $schema, output: $output) === true
+        ) {
+            $changed = true;
+        }
+
+        if ($changed === false) {
+            return null;
+        }
+
+        return $schema;
+    }//end changeSchema()
+
+    /**
+     * Create the openregister_bookmark_links table at the Tier-2 shape.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return void
+     */
+    private function createBookmarkLinksTable(ISchemaWrapper $schema, IOutput $output): void
+    {
+        $table = $schema->createTable('openregister_bookmark_links');
+
+        $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'unsigned' => true]);
+        $table->addColumn('object_uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
+        $table->addColumn('register_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('schema_id', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]);
+        $table->addColumn('bookmark_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('title', Types::STRING, ['notnull' => false, 'length' => 512, 'default' => null]);
+        $table->addColumn('url', Types::TEXT, ['notnull' => false, 'default' => null]);
+        $table->addColumn('description', Types::TEXT, ['notnull' => false, 'default' => null]);
+        $table->addColumn('tags', Types::JSON, ['notnull' => false, 'default' => null]);
+        $table->addColumn('added_at', Types::DATETIME, ['notnull' => false, 'default' => null]);
+        $table->addColumn('linked_by', Types::STRING, ['notnull' => true, 'length' => 64]);
+        $table->addColumn('linked_at', Types::DATETIME, ['notnull' => true]);
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['object_uuid', 'bookmark_id'], 'idx_bm_object_bm');
+        $table->addIndex(['object_uuid'], 'idx_bm_object');
+        $table->addIndex(['register_id'], 'idx_bm_register');
+        $table->addIndex(['schema_id'], 'idx_bm_schema');
+        $table->addIndex(['bookmark_id'], 'idx_bm_bookmark');
+
+        $output->info('Created openregister_bookmark_links table (Tier-2 schema)');
+    }//end createBookmarkLinksTable()
+
+    /**
+     * Add any missing Tier-2 columns to an existing bookmark_links table.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return bool True when a column was added.
+     */
+    private function extendBookmarkLinksTable(ISchemaWrapper $schema, IOutput $output): bool
+    {
+        $table   = $schema->getTable('openregister_bookmark_links');
+        $changed = false;
+
+        if ($table->hasColumn('schema_id') === false) {
+            $table->addColumn(
+                'schema_id',
+                Types::BIGINT,
+                ['notnull' => false, 'unsigned' => true, 'default' => null]
+            );
+            $table->addIndex(['schema_id'], 'idx_bm_schema');
+            $output->info('Added schema_id column to openregister_bookmark_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('title') === false) {
+            $table->addColumn('title', Types::STRING, ['notnull' => false, 'length' => 512, 'default' => null]);
+            $output->info('Added title column to openregister_bookmark_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('url') === false) {
+            $table->addColumn('url', Types::TEXT, ['notnull' => false, 'default' => null]);
+            $output->info('Added url column to openregister_bookmark_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('description') === false) {
+            $table->addColumn('description', Types::TEXT, ['notnull' => false, 'default' => null]);
+            $output->info('Added description column to openregister_bookmark_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('tags') === false) {
+            $table->addColumn('tags', Types::JSON, ['notnull' => false, 'default' => null]);
+            $output->info('Added tags column to openregister_bookmark_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('added_at') === false) {
+            $table->addColumn('added_at', Types::DATETIME, ['notnull' => false, 'default' => null]);
+            $output->info('Added added_at column to openregister_bookmark_links');
+            $changed = true;
+        }
+
+        return $changed;
+    }//end extendBookmarkLinksTable()
+}//end class

--- a/lib/Service/BookmarkLinkService.php
+++ b/lib/Service/BookmarkLinkService.php
@@ -1,0 +1,574 @@
+<?php
+
+/**
+ * BookmarkLinkService — Tier-2 bookmarks integration service.
+ *
+ * Composes the {@see BookmarkLinkMapper} with NC Bookmarks' own
+ * `BookmarkMapper` + `TagMapper` (lazy-resolved via `\OCP\Server::get()`
+ * behind a `class_exists` guard so OR boots cleanly when Bookmarks is not
+ * installed) to provide the picker + inline-create UX surface area:
+ *
+ *   - linkBookmark(uuid, registerId, schemaId, bookmarkId)     — link existing
+ *   - createAndLinkBookmark(uuid, ..., title, url,
+ *                           description?, tags)                — create + link
+ *   - unlinkBookmark(uuid, bookmarkId)
+ *   - getLinkedBookmarks(uuid)                                 — list, cache-refresh
+ *   - getAvailableBookmarks(search?, tags?)                    — picker source
+ *
+ * Replaces the original BookmarksProvider's `or:{uuid}` tag-marker
+ * convention with a proper persistence layer so links survive Bookmarks
+ * tag edits + don't pollute Bookmarks' UX. The cached title/url/
+ * description/tags on each link row are refreshed from NC Bookmarks when
+ * the row is older than 24h; when Bookmarks is unavailable, the cached
+ * link-row values are returned unchanged so historical references survive
+ * even after Bookmarks is uninstalled.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git-id>
+ * @link      https://OpenRegister.app
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use DateTime;
+use Exception;
+use OCA\OpenRegister\Db\BookmarkLink;
+use OCA\OpenRegister\Db\BookmarkLinkMapper;
+use OCP\App\IAppManager;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * BookmarkLinkService.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)   Composes mapper +
+ *     IAppManager + IUserSession + logger + lazily-resolved Bookmarks
+ *     mappers. Each dependency is required.
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) The create+link path
+ *     and cache-refresh hydration inflate the count; the alternative
+ *     (re-implementing NC Bookmarks' write path) would be worse.
+ * @SuppressWarnings(PHPMD.StaticAccess)             `\OCP\Server::get()`
+ *     is the documented way to late-resolve an optional peer app's
+ *     services behind a class_exists guard (ADR-019).
+ * @SuppressWarnings(PHPMD.MissingImport)            NC Bookmarks classes
+ *     are referenced FQN-only on purpose — importing them would break
+ *     autoloading when Bookmarks is not installed.
+ */
+class BookmarkLinkService
+{
+    /**
+     * NC Bookmarks app id.
+     *
+     * @var string
+     */
+    private const REQUIRED_APP = 'bookmarks';
+
+    /**
+     * Marker tag prefix kept off the bookmark's user-visible tag set.
+     *
+     * @var string
+     */
+    private const TAG_PREFIX = 'or:';
+
+    /**
+     * Cache-refresh staleness threshold in seconds (24h).
+     *
+     * @var int
+     */
+    private const CACHE_TTL = 86400;
+
+    /**
+     * Constructor.
+     *
+     * @param BookmarkLinkMapper $bookmarkLinkMapper Persistence for link rows.
+     * @param IAppManager        $appManager         NC app manager.
+     * @param IUserSession       $userSession        Active session.
+     * @param LoggerInterface    $logger             Logger.
+     */
+    public function __construct(
+        private readonly BookmarkLinkMapper $bookmarkLinkMapper,
+        private readonly IAppManager $appManager,
+        private readonly IUserSession $userSession,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Whether NC Bookmarks is installed + enabled for the current user.
+     *
+     * @return bool
+     */
+    public function isBookmarksAvailable(): bool
+    {
+        return $this->appManager->isEnabledForUser(self::REQUIRED_APP);
+    }//end isBookmarksAvailable()
+
+    /**
+     * Link an existing NC Bookmarks bookmark to an OR object.
+     *
+     * Idempotent: a duplicate link raises a 409 Exception (callers should
+     * surface as HTTP 409 to the UI).
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $registerId OR register id.
+     * @param int    $schemaId   OR schema id.
+     * @param int    $bookmarkId NC Bookmarks bookmark id.
+     *
+     * @return BookmarkLink The persisted link row.
+     *
+     * @throws Exception On missing user, missing bookmark (404), duplicate (409).
+     */
+    public function linkBookmark(string $objectUuid, int $registerId, int $schemaId, int $bookmarkId): BookmarkLink
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in');
+        }
+
+        $existing = $this->bookmarkLinkMapper->findByObjectAndBookmark($objectUuid, $bookmarkId);
+        if ($existing !== null) {
+            throw new Exception('Bookmark already linked to this object', 409);
+        }
+
+        if ($this->isBookmarksAvailable() === false) {
+            throw new Exception('Bookmarks is not available', 503);
+        }
+
+        $details = $this->fetchBookmarkDetails($bookmarkId, $user->getUID());
+        if ($details === null) {
+            throw new Exception('Bookmark not found', 404);
+        }
+
+        $link = new BookmarkLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        $link->setSchemaId($schemaId);
+        $link->setBookmarkId($bookmarkId);
+        $link->setTitle($details['title']);
+        $link->setUrl($details['url']);
+        $link->setDescription($details['description']);
+        $link->setTags($details['tags']);
+        $link->setAddedAt($details['addedAt']);
+        $link->setLinkedBy($user->getUID());
+        $link->setLinkedAt(new DateTime());
+
+        return $this->bookmarkLinkMapper->insert($link);
+    }//end linkBookmark()
+
+    /**
+     * Unlink a bookmark from an object.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $bookmarkId NC Bookmarks bookmark id.
+     *
+     * @return void
+     *
+     * @throws Exception When no matching link is found (404).
+     */
+    public function unlinkBookmark(string $objectUuid, int $bookmarkId): void
+    {
+        $deleted = $this->bookmarkLinkMapper->deleteByObjectAndBookmark($objectUuid, $bookmarkId);
+        if ($deleted === 0) {
+            throw new Exception('Bookmark link not found', 404);
+        }
+    }//end unlinkBookmark()
+
+    /**
+     * Return the linked bookmarks for an object, refreshing each cached
+     * row from NC Bookmarks when the link row is older than 24h.
+     *
+     * When Bookmarks is unavailable the cached link-row values are
+     * returned unchanged.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     *
+     * @return array<int,array<string,mixed>>
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    public function getLinkedBookmarks(string $objectUuid): array
+    {
+        $links = $this->bookmarkLinkMapper->findByObjectUuid($objectUuid);
+        if ($links === []) {
+            return [];
+        }
+
+        $available = $this->isBookmarksAvailable();
+        $user      = $this->userSession->getUser();
+        $userId    = $user?->getUID();
+        $now       = time();
+
+        $results = [];
+        foreach ($links as $link) {
+            if ($available === true && $userId !== null && $this->isStale($link, $now) === true) {
+                $details = $this->fetchBookmarkDetails((int) $link->getBookmarkId(), $userId);
+                if ($details !== null) {
+                    $link->setTitle($details['title']);
+                    $link->setUrl($details['url']);
+                    $link->setDescription($details['description']);
+                    $link->setTags($details['tags']);
+                    $link->setAddedAt($details['addedAt']);
+                    $link->setLinkedAt(new DateTime());
+
+                    try {
+                        $this->bookmarkLinkMapper->update($link);
+                    } catch (Throwable $e) {
+                        $this->logger->debug('BookmarkLinkService cache refresh failed: '.$e->getMessage());
+                    }
+                }
+            }
+
+            $results[] = $link->jsonSerialize();
+        }//end foreach
+
+        return $results;
+    }//end getLinkedBookmarks()
+
+    /**
+     * Return bookmarks visible to the current user (picker source).
+     *
+     * Optional substring search against title/url and optional tag
+     * filter. Returns an empty list when Bookmarks is unavailable.
+     *
+     * @param string|null            $search Optional title/url substring filter.
+     * @param array<int,string>|null $tags   Optional tag filter.
+     *
+     * @return array<int,array{id:int,title:string,url:string,description:string,tags:array<int,string>,added:?int}>
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    public function getAvailableBookmarks(?string $search=null, ?array $tags=null): array
+    {
+        if ($this->isBookmarksAvailable() === false) {
+            return [];
+        }
+
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return [];
+        }
+
+        $mapper = $this->resolveBookmarkMapper();
+        if ($mapper === null) {
+            return [];
+        }
+
+        try {
+            $queryParameters = new \OCA\Bookmarks\QueryParameters();
+            if ($search !== null && $search !== '') {
+                $queryParameters->setSearch([$search]);
+            }
+
+            if ($tags !== null && count($tags) > 0) {
+                $queryParameters->setTags(array_values($tags));
+            }
+
+            $bookmarks = $mapper->findAll($user->getUID(), $queryParameters);
+        } catch (Throwable $e) {
+            $this->logger->warning('BookmarkLinkService::getAvailableBookmarks failed: '.$e->getMessage());
+            return [];
+        }
+
+        $out = [];
+        foreach ($bookmarks as $bookmark) {
+            $out[] = $this->normaliseBookmark($bookmark);
+        }
+
+        return $out;
+    }//end getAvailableBookmarks()
+
+    /**
+     * Create a new NC Bookmarks bookmark and link it to an OR object in
+     * one operation.
+     *
+     * The new bookmark is owned by the current user. Tags supplied here
+     * are applied to the bookmark via NC Bookmarks' TagMapper.
+     *
+     * @param string            $objectUuid  Parent OR object uuid.
+     * @param int               $registerId  OR register id.
+     * @param int               $schemaId    OR schema id.
+     * @param string            $title       Bookmark title (required).
+     * @param string            $url         Bookmark URL (required).
+     * @param string|null       $description Optional description.
+     * @param array<int,string> $tags        Optional tags.
+     *
+     * @return BookmarkLink The persisted link row.
+     *
+     * @throws Exception On missing user, Bookmarks unavailable, or create failure.
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     */
+    public function createAndLinkBookmark(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        string $title,
+        string $url,
+        ?string $description=null,
+        array $tags=[]
+    ): BookmarkLink {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in');
+        }
+
+        if ($this->isBookmarksAvailable() === false) {
+            throw new Exception('Bookmarks is not available', 503);
+        }
+
+        if (trim($title) === '') {
+            throw new Exception('Title is required', 400);
+        }
+
+        if (trim($url) === '') {
+            throw new Exception('URL is required', 400);
+        }
+
+        $mapper = $this->resolveBookmarkMapper();
+        if ($mapper === null) {
+            throw new Exception('Bookmarks is not available', 503);
+        }
+
+        $cleanTags = $this->cleanTags($tags);
+
+        try {
+            $bookmark = new \OCA\Bookmarks\Db\Bookmark();
+            $bookmark->setUserId($user->getUID());
+            $bookmark->setUrl(trim($url));
+            $bookmark->setTitle(mb_substr(trim($title), 0, 512));
+            $bookmark->setDescription((string) ($description ?? ''));
+
+            $saved      = $mapper->insertOrUpdate($bookmark);
+            $bookmarkId = (int) $saved->getId();
+
+            if ($bookmarkId === 0) {
+                throw new Exception('Failed to retrieve created bookmark id', 500);
+            }
+
+            if (count($cleanTags) > 0) {
+                $tagMapper = $this->resolveTagMapper();
+                if ($tagMapper !== null) {
+                    $tagMapper->addTo($cleanTags, $bookmarkId);
+                }
+            }
+        } catch (Exception $e) {
+            throw $e;
+        } catch (Throwable $e) {
+            $this->logger->warning('Failed to create bookmark: '.$e->getMessage());
+            throw new Exception('Failed to create bookmark: '.$e->getMessage(), 500);
+        }//end try
+
+        $existing = $this->bookmarkLinkMapper->findByObjectAndBookmark($objectUuid, $bookmarkId);
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        $link = new BookmarkLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        $link->setSchemaId($schemaId);
+        $link->setBookmarkId($bookmarkId);
+        $link->setTitle(mb_substr(trim($title), 0, 512));
+        $link->setUrl(trim($url));
+        $link->setDescription((string) ($description ?? ''));
+        $link->setTags($cleanTags);
+        $link->setAddedAt(new DateTime());
+        $link->setLinkedBy($user->getUID());
+        $link->setLinkedAt(new DateTime());
+
+        return $this->bookmarkLinkMapper->insert($link);
+    }//end createAndLinkBookmark()
+
+    /**
+     * Whether a link row is stale enough to warrant a cache refresh.
+     *
+     * @param BookmarkLink $link The link row.
+     * @param int          $now  Current epoch seconds.
+     *
+     * @return bool
+     */
+    private function isStale(BookmarkLink $link, int $now): bool
+    {
+        $linkedAt = $link->getLinkedAt();
+        if ($linkedAt === null) {
+            return true;
+        }
+
+        return ($now - $linkedAt->getTimestamp()) > self::CACHE_TTL;
+    }//end isStale()
+
+    /**
+     * Fetch a single bookmark's normalised details for caching at link
+     * time / cache-refresh.
+     *
+     * @param int    $bookmarkId NC Bookmarks bookmark id.
+     * @param string $userId     Owning user id (for tag scoping).
+     *
+     * @return array{title:string,url:string,description:string,tags:array<int,string>,addedAt:?DateTime}|null
+     */
+    private function fetchBookmarkDetails(int $bookmarkId, string $userId): ?array
+    {
+        $mapper = $this->resolveBookmarkMapper();
+        if ($mapper === null) {
+            return null;
+        }
+
+        try {
+            $bookmark = $mapper->find($bookmarkId);
+        } catch (Throwable $e) {
+            $this->logger->debug('fetchBookmarkDetails find failed: '.$e->getMessage());
+            return null;
+        }
+
+        if ((string) $bookmark->getUserId() !== $userId) {
+            return null;
+        }
+
+        $normalised = $this->normaliseBookmark($bookmark);
+
+        $addedAt = null;
+        if ($normalised['added'] !== null && $normalised['added'] > 0) {
+            try {
+                $addedAt = new DateTime('@'.$normalised['added']);
+            } catch (Throwable $e) {
+                $addedAt = null;
+            }
+        }
+
+        return [
+            'title'       => $normalised['title'],
+            'url'         => $normalised['url'],
+            'description' => $normalised['description'],
+            'tags'        => $normalised['tags'],
+            'addedAt'     => $addedAt,
+        ];
+    }//end fetchBookmarkDetails()
+
+    /**
+     * Normalise a NC Bookmarks bookmark entity into the picker/leaf row
+     * shape. Tags are read via TagMapper when not already joined on the
+     * entity, and `or:*` markers are stripped.
+     *
+     * @param object $bookmark NC Bookmarks Bookmark entity.
+     *
+     * @return array{id:int,title:string,url:string,description:string,tags:array<int,string>,added:?int}
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    private function normaliseBookmark(object $bookmark): array
+    {
+        $arr = (method_exists($bookmark, 'toArray') === true) ? $bookmark->toArray() : (array) $bookmark;
+
+        $id  = (int) ($arr['id'] ?? (method_exists($bookmark, 'getId') === true ? $bookmark->getId() : 0));
+        $url = (string) ($arr['url'] ?? '');
+
+        $tags = [];
+        if (method_exists($bookmark, 'getTags') === true) {
+            $rawTags = $bookmark->getTags();
+            if (is_array($rawTags) === true) {
+                $tags = $rawTags;
+            }
+        }
+
+        if (count($tags) === 0 && $id > 0) {
+            $tagMapper = $this->resolveTagMapper();
+            if ($tagMapper !== null) {
+                try {
+                    $tags = $tagMapper->findByBookmark($id);
+                } catch (Throwable $e) {
+                    $tags = [];
+                }
+            }
+        }
+
+        return [
+            'id'          => $id,
+            'title'       => (string) ($arr['title'] ?? $url),
+            'url'         => $url,
+            'description' => (string) ($arr['description'] ?? ''),
+            'tags'        => $this->cleanTags($tags),
+            'added'       => (isset($arr['added']) === true) ? (int) $arr['added'] : null,
+        ];
+    }//end normaliseBookmark()
+
+    /**
+     * Strip empty + `or:*` marker tags and re-index.
+     *
+     * @param array<int,mixed> $tags Raw tags.
+     *
+     * @return array<int,string>
+     */
+    private function cleanTags(array $tags): array
+    {
+        $out = [];
+        foreach ($tags as $tag) {
+            if (is_string($tag) === false) {
+                continue;
+            }
+
+            $trimmed = trim($tag);
+            if ($trimmed === '' || str_starts_with($trimmed, self::TAG_PREFIX) === true) {
+                continue;
+            }
+
+            $out[] = $trimmed;
+        }
+
+        return array_values(array_unique($out));
+    }//end cleanTags()
+
+    /**
+     * Lazily resolve NC Bookmarks' BookmarkMapper behind a class_exists
+     * guard so OR boots cleanly without the Bookmarks app.
+     *
+     * @return \OCA\Bookmarks\Db\BookmarkMapper|null
+     */
+    private function resolveBookmarkMapper(): ?object
+    {
+        if (class_exists('\OCA\Bookmarks\Db\BookmarkMapper') === false) {
+            return null;
+        }
+
+        try {
+            return \OCP\Server::get('\OCA\Bookmarks\Db\BookmarkMapper');
+        } catch (Throwable $e) {
+            $this->logger->debug('resolveBookmarkMapper failed: '.$e->getMessage());
+            return null;
+        }
+    }//end resolveBookmarkMapper()
+
+    /**
+     * Lazily resolve NC Bookmarks' TagMapper behind a class_exists guard.
+     *
+     * @return \OCA\Bookmarks\Db\TagMapper|null
+     */
+    private function resolveTagMapper(): ?object
+    {
+        if (class_exists('\OCA\Bookmarks\Db\TagMapper') === false) {
+            return null;
+        }
+
+        try {
+            return \OCP\Server::get('\OCA\Bookmarks\Db\TagMapper');
+        } catch (Throwable $e) {
+            $this->logger->debug('resolveTagMapper failed: '.$e->getMessage());
+            return null;
+        }
+    }//end resolveTagMapper()
+}//end class

--- a/lib/Service/Integration/Providers/BookmarksProvider.php
+++ b/lib/Service/Integration/Providers/BookmarksProvider.php
@@ -2,14 +2,23 @@
 
 /**
  * BookmarksProvider — exposes NC Bookmarks linked to an OpenRegister
- * object via a tag convention.
+ * object via the IntegrationProvider contract.
  *
- * Bookmarks are linked by tagging them `or:{objectUuid}` in NC
- * Bookmarks. The provider queries BookmarkMapper::findAll filtered by
- * that tag; rows are normalised into the shared leaf row contract.
+ * Tier-2: backed by the `openregister_bookmark_links` table via
+ * {@see BookmarkLinkMapper}. Replaces the original tag-marker convention
+ * (`or:{objectUuid}` tag on the bookmark in NC Bookmarks) with a proper
+ * persistence layer so links survive Bookmarks tag edits and don't
+ * pollute Bookmarks' UX.
  *
- * `link-table` storage strategy — the link lives in NC Bookmarks' own
- * tag table, not in OR.
+ * Each link row caches title/url/description/tags/added so the sidebar
+ * tab can render without a per-bookmark roundtrip to NC Bookmarks; the
+ * wrapping `BookmarkLinkService` refreshes the cache lazily. Returns an
+ * empty list when Bookmarks is uninstalled.
+ *
+ * `link-table` storage strategy — the link lives in OR's own table.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  *
  * @category Service
  * @package  OCA\OpenRegister\Service\Integration\Providers
@@ -17,9 +26,6 @@
  * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- *
- * SPDX-License-Identifier: EUPL-1.2
- * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  *
  * @link https://conduction.nl
  *
@@ -32,24 +38,20 @@ namespace OCA\OpenRegister\Service\Integration\Providers;
 
 // phpcs:disable PEAR.Commenting.FunctionComment.Missing -- self-documenting IntegrationProvider metadata getters mirror the contract in the interface.
 
-use OCA\Bookmarks\QueryParameters;
+use DateTime;
+use OCA\OpenRegister\Db\BookmarkLinkMapper;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCP\App\IAppManager;
 use OCP\IL10N;
-use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
-use Throwable;
 
 class BookmarksProvider extends AbstractIntegrationProvider
 {
 
     private const REQUIRED_APP = 'bookmarks';
-    private const TAG_PREFIX   = 'or:';
 
     public function __construct(
-        private ContainerInterface $container,
+        private BookmarkLinkMapper $bookmarkLinkMapper,
         private IAppManager $appManager,
-        private IUserSession $userSession,
         private IL10N $l10n,
     ) {
     }//end __construct()
@@ -90,35 +92,22 @@ class BookmarksProvider extends AbstractIntegrationProvider
     }//end isEnabled()
 
     /**
-     * List bookmarks tagged with `or:{objectId}` for the current user.
+     * List bookmarks linked to an OR object.
      *
-     * BookmarkMapper::findAll honours QueryParameters::setTags; we
-     * inject the per-object tag and normalise the response rows into
-     * the registry leaf row shape (id, title, description, url, tags,
-     * added).
+     * Reads link rows from `openregister_bookmark_links` and normalises
+     * each into the registry leaf row shape consumed by CnBookmarksTab +
+     * CnBookmarksCard. Returns an empty array when Bookmarks is
+     * uninstalled.
      *
      * Payload contract per row:
-     *   id    : string — NC Bookmarks numeric id, cast to string
-     *   title : string — bookmark title (falls back to url)
+     *   id          : string — NC Bookmarks numeric id, cast to string
+     *   bookmarkId  : int    — NC Bookmarks numeric id
+     *   title       : string — bookmark title (falls back to url)
      *   description : string — user-entered description
-     *   url   : string — canonical URL
-     *   tags  : string[] — Bookmarks-side tags including the `or:*`
-     *           marker (UI filters out `or:*` prefix client-side)
-     *   added : int|null — unix timestamp (seconds) the bookmark was
-     *           saved; used by `CnBookmarksCard` for "most recent"
-     *           sort
-     *
-     * This shape matches every field `CnBookmarksTab` (favicon, title,
-     * url, description, tag chips, tag filter) and `CnBookmarksCard`
-     * (all four surfaces, including "added at" sort) consume. No
-     * widening required for Phase B-2.
-     *
-     * Favicon strategy: the UI derives the favicon URL from the
-     * bookmark's URL origin (`{origin}/favicon.ico`) and falls back
-     * to a generic Bookmark icon on load error. Bookmarks does store
-     * a `last_preview` ID for archived previews but that's not a
-     * public-facing favicon — keeping discovery client-side avoids
-     * an extra API hop per row.
+     *   url         : string — canonical URL
+     *   tags        : string[] — Bookmarks-side tags (`or:*` stripped)
+     *   added       : int|null — unix timestamp the bookmark was saved
+     *   linkId      : int    — OR link-row id
      *
      * @param string              $register Register slug or numeric id (unused).
      * @param string              $schema   Schema slug or numeric id (unused).
@@ -126,6 +115,9 @@ class BookmarksProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $filters  Optional filters (unused).
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) register/schema/filters
+     *     are part of the IntegrationProvider::list() contract.
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -133,39 +125,29 @@ class BookmarksProvider extends AbstractIntegrationProvider
             return [];
         }
 
-        $user = $this->userSession->getUser();
-        if ($user === null) {
+        $links = $this->bookmarkLinkMapper->findByObjectUuid($objectId);
+        if ($links === []) {
             return [];
         }
 
-        $userId = $user->getUID();
-        $tag    = self::TAG_PREFIX.$objectId;
+        $out = [];
+        foreach ($links as $link) {
+            $bookmarkId = (int) $link->getBookmarkId();
+            $addedAt    = $link->getAddedAt();
 
-        try {
-            $mapper          = $this->container->get('OCA\\Bookmarks\\Db\\BookmarkMapper');
-            $queryParameters = new QueryParameters();
-            $queryParameters->setTags([$tag]);
-            $bookmarks = $mapper->findAll($userId, $queryParameters);
-        } catch (Throwable $e) {
-            // Bookmarks app schema mismatch or missing tag column on
-            // older installs degrades to an empty list — AD-23.
-            return [];
+            $out[] = [
+                'id'          => (string) $bookmarkId,
+                'bookmarkId'  => $bookmarkId,
+                'title'       => (string) ($link->getTitle() ?? ($link->getUrl() ?? '')),
+                'description' => (string) ($link->getDescription() ?? ''),
+                'url'         => (string) ($link->getUrl() ?? ''),
+                'tags'        => ($link->getTags() ?? []),
+                'added'       => ($addedAt instanceof DateTime) ? $addedAt->getTimestamp() : null,
+                'linkId'      => $link->getId(),
+            ];
         }
 
-        return array_map(
-                static function ($bookmark): array {
-                    $arr = method_exists($bookmark, 'toArray') === true ? $bookmark->toArray() : (array) $bookmark;
-                    return [
-                        'id'          => (string) ($arr['id'] ?? ''),
-                        'title'       => (string) ($arr['title'] ?? ($arr['url'] ?? '')),
-                        'description' => (string) ($arr['description'] ?? ''),
-                        'url'         => (string) ($arr['url'] ?? ''),
-                        'tags'        => $arr['tags'] ?? [],
-                        'added'       => isset($arr['added']) === true ? (int) $arr['added'] : null,
-                    ];
-                },
-                $bookmarks
-                );
+        return $out;
     }//end list()
 
     public function health(): array

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -30,6 +30,14 @@ parameters:
         # OCA\DAV is server-internal and not in nextcloud/ocp stubs
         - '#unknown class OCA\\DAV\\#'
         - '#Class OCA\\DAV\\#'
+        # OCA\Bookmarks is an optional peer app (lazy-resolved via
+        # \OCP\Server::get() behind a class_exists guard) — not a
+        # composer dependency, so its classes are absent during analysis.
+        - '#unknown class OCA\\Bookmarks\\#'
+        - '#OCA\\Bookmarks\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class OCA\\Bookmarks\\#'
+        - '#has invalid return type OCA\\Bookmarks\\#'
+        - '#Instantiated class OCA\\Bookmarks\\#'
         # OCA classes from other apps (OpenRegister) not available during static analysis
         - '#unknown class OCA\\OpenRegister\\#'
         - '#OCA\\OpenRegister\\[a-zA-Z\\]+.*not found#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -76,6 +76,11 @@
                 <referencedClass name="OCA\OpenRegister\Service\FileService"/>
                 <referencedClass name="OCA\OpenRegister\Service\CalendarEventService"/>
                 <referencedClass name="OCA\OpenRegister\Mcp\IMcpToolProvider"/>
+                <!-- OCA\Bookmarks optional peer app (lazy-resolved at runtime) -->
+                <referencedClass name="OCA\Bookmarks\QueryParameters"/>
+                <referencedClass name="OCA\Bookmarks\Db\Bookmark"/>
+                <referencedClass name="OCA\Bookmarks\Db\BookmarkMapper"/>
+                <referencedClass name="OCA\Bookmarks\Db\TagMapper"/>
                 <!-- Additional OCP infrastructure types used across the fleet -->
                 <referencedClass name="OCP\AppFramework\Bootstrap\IBootContext"/>
                 <referencedClass name="OCP\AppFramework\Bootstrap\IRegistrationContext"/>

--- a/tests/Unit/Controller/BookmarkLinksControllerTest.php
+++ b/tests/Unit/Controller/BookmarkLinksControllerTest.php
@@ -1,0 +1,275 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Controller\BookmarkLinksController}.
+ *
+ * Exercises the Tier-2 controller surface: HTTP status mapping
+ * (200/201/400/404/409/501/503), payload routing (link existing vs.
+ * create new), and graceful degradation when NC Bookmarks is unavailable.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/integration-bookmarks/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use Exception;
+use OCA\OpenRegister\Controller\BookmarkLinksController;
+use OCA\OpenRegister\Db\BookmarkLink;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\BookmarkLinkService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * BookmarkLinksControllerTest.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class BookmarkLinksControllerTest extends TestCase
+{
+    private IRequest&MockObject $request;
+    private BookmarkLinkService&MockObject $service;
+    private ObjectService&MockObject $objectService;
+    private BookmarkLinksController $controller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request       = $this->createMock(IRequest::class);
+        $this->service       = $this->createMock(BookmarkLinkService::class);
+        $this->objectService = $this->createMock(ObjectService::class);
+
+        $this->controller = new BookmarkLinksController(
+            'openregister',
+            $this->request,
+            $this->service,
+            $this->objectService,
+        );
+    }
+
+    private function mockObject(string $uuid = 'abc-123', int $registerId = 1, int $schemaId = 2): ObjectEntity
+    {
+        $object = new ObjectEntity();
+        $object->setUuid($uuid);
+        $object->setRegister($registerId);
+        $object->setSchema($schemaId);
+        $this->objectService->method('setSchema')->willReturnSelf();
+        $this->objectService->method('setRegister')->willReturnSelf();
+        $this->objectService->method('setObject')->willReturnSelf();
+        $this->objectService->method('getObject')->willReturn($object);
+        return $object;
+    }
+
+    public function testIndexReturns501WhenBookmarksUnavailable(): void
+    {
+        $this->service->method('isBookmarksAvailable')->willReturn(false);
+
+        $response = $this->controller->index('reg', 'sch', 'obj');
+
+        $this->assertSame(501, $response->getStatus());
+    }
+
+    public function testIndexReturnsResults(): void
+    {
+        $this->service->method('isBookmarksAvailable')->willReturn(true);
+        $this->mockObject();
+        $this->service->method('getLinkedBookmarks')->with('abc-123')->willReturn([
+            ['bookmarkId' => 99, 'title' => 'Test'],
+        ]);
+
+        $response = $this->controller->index('reg', 'sch', 'obj');
+        $data     = $response->getData();
+
+        $this->assertSame(200, $response->getStatus());
+        $this->assertSame(1, $data['total']);
+        $this->assertSame(99, $data['results'][0]['bookmarkId']);
+    }
+
+    public function testIndexReturns404WhenObjectMissing(): void
+    {
+        $this->service->method('isBookmarksAvailable')->willReturn(true);
+        $this->objectService->method('getObject')->willReturn(null);
+
+        $response = $this->controller->index('reg', 'sch', 'missing');
+
+        $this->assertSame(404, $response->getStatus());
+    }
+
+    public function testLinkReturns400WhenBookmarkIdMissing(): void
+    {
+        $this->service->method('isBookmarksAvailable')->willReturn(true);
+        $this->mockObject();
+        $this->request->method('getParam')->willReturnMap([['bookmarkId', 0, 0]]);
+
+        $response = $this->controller->link('reg', 'sch', 'obj');
+
+        $this->assertSame(400, $response->getStatus());
+    }
+
+    public function testLinkReturns201OnSuccess(): void
+    {
+        $this->service->method('isBookmarksAvailable')->willReturn(true);
+        $this->mockObject();
+        $this->request->method('getParam')->willReturn(99);
+
+        $link = new BookmarkLink();
+        $link->setObjectUuid('abc-123');
+        $link->setBookmarkId(99);
+
+        $this->service->method('linkBookmark')
+            ->with('abc-123', 1, 2, 99)
+            ->willReturn($link);
+
+        $response = $this->controller->link('reg', 'sch', 'obj');
+
+        $this->assertSame(201, $response->getStatus());
+        $this->assertSame(99, $response->getData()['bookmarkId']);
+    }
+
+    public function testLinkReturns409OnDuplicate(): void
+    {
+        $this->service->method('isBookmarksAvailable')->willReturn(true);
+        $this->mockObject();
+        $this->request->method('getParam')->willReturn(99);
+
+        $this->service->method('linkBookmark')
+            ->willThrowException(new Exception('Bookmark already linked to this object', 409));
+
+        $response = $this->controller->link('reg', 'sch', 'obj');
+
+        $this->assertSame(409, $response->getStatus());
+    }
+
+    public function testCreateNewReturns400WhenTitleMissing(): void
+    {
+        $this->service->method('isBookmarksAvailable')->willReturn(true);
+        $this->mockObject();
+        $this->request->method('getParam')->willReturnCallback(
+            static function (string $key, $default = null) {
+                return match ($key) {
+                    'title' => '',
+                    'url'   => 'https://x.nl',
+                    'tags'  => [],
+                    default => $default,
+                };
+            }
+        );
+
+        $response = $this->controller->createNew('reg', 'sch', 'obj');
+
+        $this->assertSame(400, $response->getStatus());
+    }
+
+    public function testCreateNewReturns400WhenUrlMissing(): void
+    {
+        $this->service->method('isBookmarksAvailable')->willReturn(true);
+        $this->mockObject();
+        $this->request->method('getParam')->willReturnCallback(
+            static function (string $key, $default = null) {
+                return match ($key) {
+                    'title' => 'Conduction',
+                    'url'   => '',
+                    'tags'  => [],
+                    default => $default,
+                };
+            }
+        );
+
+        $response = $this->controller->createNew('reg', 'sch', 'obj');
+
+        $this->assertSame(400, $response->getStatus());
+    }
+
+    public function testCreateNewReturns201OnSuccess(): void
+    {
+        $this->service->method('isBookmarksAvailable')->willReturn(true);
+        $this->mockObject();
+        $this->request->method('getParam')->willReturnCallback(
+            static function (string $key, $default = null) {
+                return match ($key) {
+                    'title'       => 'Conduction',
+                    'url'         => 'https://conduction.nl',
+                    'description' => 'Company',
+                    'tags'        => ['vendor'],
+                    default       => $default,
+                };
+            }
+        );
+
+        $link = new BookmarkLink();
+        $link->setObjectUuid('abc-123');
+        $link->setBookmarkId(456);
+        $link->setTitle('Conduction');
+
+        $this->service->expects($this->once())
+            ->method('createAndLinkBookmark')
+            ->willReturn($link);
+
+        $response = $this->controller->createNew('reg', 'sch', 'obj');
+
+        $this->assertSame(201, $response->getStatus());
+        $this->assertSame(456, $response->getData()['bookmarkId']);
+    }
+
+    public function testDestroyReturns200OnSuccess(): void
+    {
+        $this->service->method('isBookmarksAvailable')->willReturn(true);
+        $this->mockObject();
+        $this->service->expects($this->once())
+            ->method('unlinkBookmark')
+            ->with('abc-123', 42);
+
+        $response = $this->controller->destroy('reg', 'sch', 'obj', '42');
+
+        $this->assertSame(200, $response->getStatus());
+        $this->assertTrue($response->getData()['success']);
+    }
+
+    public function testDestroyReturns404WhenLinkMissing(): void
+    {
+        $this->service->method('isBookmarksAvailable')->willReturn(true);
+        $this->mockObject();
+        $this->service->method('unlinkBookmark')
+            ->willThrowException(new Exception('Bookmark link not found', 404));
+
+        $response = $this->controller->destroy('reg', 'sch', 'obj', '42');
+
+        $this->assertSame(404, $response->getStatus());
+    }
+
+    public function testAvailableReturnsList(): void
+    {
+        $this->service->method('isBookmarksAvailable')->willReturn(true);
+        $this->service->method('getAvailableBookmarks')->willReturn([
+            ['id' => 1, 'title' => 'Conduction', 'url' => 'https://conduction.nl', 'description' => '', 'tags' => [], 'added' => null],
+        ]);
+
+        $response = $this->controller->available();
+
+        $this->assertSame(200, $response->getStatus());
+        $this->assertSame(1, $response->getData()['total']);
+    }
+
+    public function testAvailableReturns501WhenBookmarksUnavailable(): void
+    {
+        $this->service->method('isBookmarksAvailable')->willReturn(false);
+
+        $response = $this->controller->available();
+
+        $this->assertSame(501, $response->getStatus());
+    }
+}

--- a/tests/Unit/Db/BookmarkLinkTest.php
+++ b/tests/Unit/Db/BookmarkLinkTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Db;
+
+use DateTime;
+use OCA\OpenRegister\Db\BookmarkLink;
+use PHPUnit\Framework\TestCase;
+
+class BookmarkLinkTest extends TestCase
+{
+    public function testJsonSerializeReturnsAllFields(): void
+    {
+        $link = new BookmarkLink();
+        $link->setObjectUuid('abc-123');
+        $link->setRegisterId(5);
+        $link->setSchemaId(7);
+        $link->setBookmarkId(42);
+        $link->setTitle('Conduction');
+        $link->setUrl('https://conduction.nl');
+        $link->setDescription('Company site');
+        $link->setTags(['reference', 'vendor']);
+        $link->setAddedAt(new DateTime('2026-06-01T12:00:00+00:00'));
+        $link->setLinkedBy('admin');
+        $link->setLinkedAt(new DateTime('2026-03-25T11:00:00+00:00'));
+
+        $json = $link->jsonSerialize();
+
+        $this->assertSame('abc-123', $json['objectUuid']);
+        $this->assertSame(5, $json['registerId']);
+        $this->assertSame(7, $json['schemaId']);
+        $this->assertSame(42, $json['bookmarkId']);
+        $this->assertSame('Conduction', $json['title']);
+        $this->assertSame('https://conduction.nl', $json['url']);
+        $this->assertSame('Company site', $json['description']);
+        $this->assertSame(['reference', 'vendor'], $json['tags']);
+        $this->assertSame('admin', $json['linkedBy']);
+        $this->assertNotNull($json['addedAt']);
+        $this->assertNotNull($json['linkedAt']);
+    }
+
+    public function testJsonSerializeHandlesNulls(): void
+    {
+        $link = new BookmarkLink();
+
+        $json = $link->jsonSerialize();
+
+        $this->assertNull($json['title']);
+        $this->assertNull($json['url']);
+        $this->assertNull($json['description']);
+        $this->assertSame([], $json['tags']);
+        $this->assertNull($json['addedAt']);
+        $this->assertNull($json['linkedAt']);
+    }
+
+    public function testSettersAndGetters(): void
+    {
+        $link = new BookmarkLink();
+        $link->setBookmarkId(99);
+        $link->setTitle('Docs');
+
+        $this->assertSame(99, $link->getBookmarkId());
+        $this->assertSame('Docs', $link->getTitle());
+    }
+}

--- a/tests/Unit/Service/BookmarkLinkServiceTest.php
+++ b/tests/Unit/Service/BookmarkLinkServiceTest.php
@@ -1,0 +1,240 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Service\BookmarkLinkService}.
+ *
+ * Exercises the Tier-2 service contract (link/create/list/unlink +
+ * available-bookmarks picker) against a mocked BookmarkLinkMapper.
+ * Tests requiring real NC Bookmarks table data are kept in integration
+ * tests (`@group requires-app-bookmarks`); unit scope here is the
+ * service's branch coverage when Bookmarks is unavailable.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/integration-bookmarks/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use Exception;
+use OCA\OpenRegister\Db\BookmarkLink;
+use OCA\OpenRegister\Db\BookmarkLinkMapper;
+use OCA\OpenRegister\Service\BookmarkLinkService;
+use OCP\App\IAppManager;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * BookmarkLinkServiceTest.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class BookmarkLinkServiceTest extends TestCase
+{
+    private BookmarkLinkMapper&MockObject $mapper;
+    private IAppManager&MockObject $appManager;
+    private IUserSession&MockObject $userSession;
+    private LoggerInterface&MockObject $logger;
+    private BookmarkLinkService $service;
+
+    protected function setUp(): void
+    {
+        $this->mapper = $this->getMockBuilder(BookmarkLinkMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'findByObjectUuid',
+                'findByObjectAndBookmark',
+                'deleteByObjectAndBookmark',
+                'insert',
+                'update',
+            ])
+            ->getMock();
+        $this->appManager  = $this->createMock(IAppManager::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->logger      = $this->createMock(LoggerInterface::class);
+
+        $this->service = new BookmarkLinkService(
+            $this->mapper,
+            $this->appManager,
+            $this->userSession,
+            $this->logger
+        );
+    }
+
+    private function setupUser(string $uid = 'admin'): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $this->userSession->method('getUser')->willReturn($user);
+    }
+
+    public function testIsBookmarksAvailableTrue(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('bookmarks')->willReturn(true);
+        $this->assertTrue($this->service->isBookmarksAvailable());
+    }
+
+    public function testIsBookmarksAvailableFalse(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('bookmarks')->willReturn(false);
+        $this->assertFalse($this->service->isBookmarksAvailable());
+    }
+
+    public function testLinkBookmarkThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No user logged in');
+
+        $this->service->linkBookmark('abc-123', 1, 2, 5);
+    }
+
+    public function testLinkBookmarkThrowsOnDuplicate(): void
+    {
+        $this->setupUser();
+        $existing = new BookmarkLink();
+        $this->mapper->method('findByObjectAndBookmark')->with('abc-123', 5)->willReturn($existing);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(409);
+        $this->expectExceptionMessage('Bookmark already linked to this object');
+
+        $this->service->linkBookmark('abc-123', 1, 2, 5);
+    }
+
+    public function testLinkBookmarkThrowsWhenBookmarksUnavailable(): void
+    {
+        $this->setupUser();
+        $this->mapper->method('findByObjectAndBookmark')->willReturn(null);
+        $this->appManager->method('isEnabledForUser')->with('bookmarks')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+        $this->expectExceptionMessage('Bookmarks is not available');
+
+        $this->service->linkBookmark('abc-123', 1, 2, 5);
+    }
+
+    public function testUnlinkBookmarkSucceeds(): void
+    {
+        $this->mapper->expects($this->once())
+            ->method('deleteByObjectAndBookmark')
+            ->with('abc-123', 5)
+            ->willReturn(1);
+
+        $this->service->unlinkBookmark('abc-123', 5);
+    }
+
+    public function testUnlinkBookmarkNotFound(): void
+    {
+        $this->mapper->method('deleteByObjectAndBookmark')->willReturn(0);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(404);
+        $this->expectExceptionMessage('Bookmark link not found');
+
+        $this->service->unlinkBookmark('abc-123', 5);
+    }
+
+    public function testGetLinkedBookmarksEmpty(): void
+    {
+        $this->mapper->method('findByObjectUuid')->willReturn([]);
+
+        $this->assertSame([], $this->service->getLinkedBookmarks('nonexistent'));
+    }
+
+    public function testGetLinkedBookmarksReturnsCachedRowsWhenBookmarksUnavailable(): void
+    {
+        $link = new BookmarkLink();
+        $link->setObjectUuid('abc-123');
+        $link->setBookmarkId(99);
+        $link->setTitle('Conduction');
+        $link->setUrl('https://conduction.nl');
+        $link->setTags(['vendor']);
+
+        $this->mapper->method('findByObjectUuid')->with('abc-123')->willReturn([$link]);
+        // Bookmarks uninstalled — cached link row used as-is, no refresh.
+        $this->appManager->method('isEnabledForUser')->with('bookmarks')->willReturn(false);
+
+        $rows = $this->service->getLinkedBookmarks('abc-123');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('abc-123', $rows[0]['objectUuid']);
+        $this->assertSame(99, $rows[0]['bookmarkId']);
+        $this->assertSame('Conduction', $rows[0]['title']);
+        $this->assertSame('https://conduction.nl', $rows[0]['url']);
+        $this->assertSame(['vendor'], $rows[0]['tags']);
+    }
+
+    public function testCreateAndLinkBookmarkThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No user logged in');
+
+        $this->service->createAndLinkBookmark('abc-123', 1, 2, 'T', 'https://x.nl', null, []);
+    }
+
+    public function testCreateAndLinkBookmarkThrowsWhenBookmarksUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('bookmarks')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+        $this->expectExceptionMessage('Bookmarks is not available');
+
+        $this->service->createAndLinkBookmark('abc-123', 1, 2, 'T', 'https://x.nl', null, []);
+    }
+
+    public function testCreateAndLinkBookmarkThrowsWhenTitleEmpty(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('bookmarks')->willReturn(true);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+        $this->expectExceptionMessage('Title is required');
+
+        $this->service->createAndLinkBookmark('abc-123', 1, 2, '   ', 'https://x.nl', null, []);
+    }
+
+    public function testCreateAndLinkBookmarkThrowsWhenUrlEmpty(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('bookmarks')->willReturn(true);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+        $this->expectExceptionMessage('URL is required');
+
+        $this->service->createAndLinkBookmark('abc-123', 1, 2, 'Title', '   ', null, []);
+    }
+
+    public function testGetAvailableBookmarksReturnsEmptyWhenBookmarksUnavailable(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('bookmarks')->willReturn(false);
+        $this->assertSame([], $this->service->getAvailableBookmarks());
+    }
+
+    public function testGetAvailableBookmarksReturnsEmptyWhenNoUser(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('bookmarks')->willReturn(true);
+        $this->userSession->method('getUser')->willReturn(null);
+        $this->assertSame([], $this->service->getAvailableBookmarks());
+    }
+}

--- a/tests/Unit/Service/Integration/Providers/BookmarksProviderTest.php
+++ b/tests/Unit/Service/Integration/Providers/BookmarksProviderTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * Unit tests for BookmarksProvider after Tier-2 migration to
+ * BookmarkLinkMapper.
+ *
+ * Covers:
+ *  - metadata getters (id / label / icon / group / requiredApp / storage)
+ *  - `isEnabled()` honours `IAppManager::isInstalled()`
+ *  - `list()` returns empty when Bookmarks is uninstalled
+ *  - `list()` returns empty when no link rows exist
+ *  - `list()` happy-path: walks `openregister_bookmark_links` and
+ *    normalises each row to
+ *    `{id,bookmarkId,title,description,url,tags,added,linkId}`
+ *  - `health()` reports `'unavailable'` when Bookmarks is not installed
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Integration\Providers
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/integration-bookmarks/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Integration\Providers;
+
+// phpcs:disable PEAR.Commenting.FunctionComment.Missing -- arrange/act/assert PHPUnit conventions.
+
+use DateTime;
+use OCA\OpenRegister\Db\BookmarkLink;
+use OCA\OpenRegister\Db\BookmarkLinkMapper;
+use OCA\OpenRegister\Service\Integration\Providers\BookmarksProvider;
+use OCP\App\IAppManager;
+use OCP\IL10N;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for BookmarksProvider.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class BookmarksProviderTest extends TestCase
+{
+
+    private function buildL10n(): IL10N
+    {
+        $mock = $this->createMock(IL10N::class);
+        $mock->method('t')->willReturnArgument(0);
+        return $mock;
+    }//end buildL10n()
+
+
+    private function buildAppManager(bool $installed): IAppManager
+    {
+        $mock = $this->createMock(IAppManager::class);
+        $mock->method('isInstalled')->willReturn($installed);
+        return $mock;
+    }//end buildAppManager()
+
+
+    public function testMetadataGetters(): void
+    {
+        $mapper   = $this->createMock(BookmarkLinkMapper::class);
+        $provider = new BookmarksProvider($mapper, $this->buildAppManager(true), $this->buildL10n());
+
+        $this->assertSame('bookmarks', $provider->getId());
+        $this->assertSame('Bookmarks', $provider->getLabel());
+        $this->assertSame('Bookmark', $provider->getIcon());
+        $this->assertSame('docs', $provider->getGroup());
+        $this->assertSame('bookmarks', $provider->getRequiredApp());
+        $this->assertSame('link-table', $provider->getStorageStrategy());
+        $this->assertTrue($provider->isEnabled());
+    }//end testMetadataGetters()
+
+
+    public function testListReturnsEmptyWhenBookmarksUninstalled(): void
+    {
+        $mapper = $this->createMock(BookmarkLinkMapper::class);
+        $mapper->expects($this->never())->method('findByObjectUuid');
+
+        $provider = new BookmarksProvider($mapper, $this->buildAppManager(false), $this->buildL10n());
+
+        $this->assertSame([], $provider->list('reg', 'sch', 'obj-uuid'));
+    }//end testListReturnsEmptyWhenBookmarksUninstalled()
+
+
+    public function testListReturnsEmptyWhenNoLinks(): void
+    {
+        $mapper = $this->createMock(BookmarkLinkMapper::class);
+        $mapper->method('findByObjectUuid')->with('obj-uuid')->willReturn([]);
+
+        $provider = new BookmarksProvider($mapper, $this->buildAppManager(true), $this->buildL10n());
+
+        $this->assertSame([], $provider->list('reg', 'sch', 'obj-uuid'));
+    }//end testListReturnsEmptyWhenNoLinks()
+
+
+    public function testListNormalisesLinkRows(): void
+    {
+        $link = new BookmarkLink();
+        $link->setObjectUuid('obj-uuid');
+        $link->setBookmarkId(42);
+        $link->setTitle('Conduction');
+        $link->setUrl('https://conduction.nl');
+        $link->setDescription('Company site');
+        $link->setTags(['vendor', 'reference']);
+        $link->setAddedAt(new DateTime('2026-06-01T12:00:00+00:00'));
+
+        $mapper = $this->createMock(BookmarkLinkMapper::class);
+        $mapper->method('findByObjectUuid')->with('obj-uuid')->willReturn([$link]);
+
+        $provider = new BookmarksProvider($mapper, $this->buildAppManager(true), $this->buildL10n());
+
+        $rows = $provider->list('reg', 'sch', 'obj-uuid');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('42', $rows[0]['id']);
+        $this->assertSame(42, $rows[0]['bookmarkId']);
+        $this->assertSame('Conduction', $rows[0]['title']);
+        $this->assertSame('https://conduction.nl', $rows[0]['url']);
+        $this->assertSame('Company site', $rows[0]['description']);
+        $this->assertSame(['vendor', 'reference'], $rows[0]['tags']);
+        $this->assertNotNull($rows[0]['added']);
+    }//end testListNormalisesLinkRows()
+
+
+    public function testHealthReportsUnavailableWhenUninstalled(): void
+    {
+        $mapper   = $this->createMock(BookmarkLinkMapper::class);
+        $provider = new BookmarksProvider($mapper, $this->buildAppManager(false), $this->buildL10n());
+
+        $health = $provider->health();
+
+        $this->assertSame('unavailable', $health['status']);
+    }//end testHealthReportsUnavailableWhenUninstalled()
+}//end class

--- a/tests/Unit/Service/Integration/Providers/LeafProvidersMetadataTest.php
+++ b/tests/Unit/Service/Integration/Providers/LeafProvidersMetadataTest.php
@@ -133,20 +133,42 @@ class LeafProvidersMetadataTest extends TestCase
         $appManager = $this->buildAppManager([$requiredApp]);
         $l10n       = $this->buildL10n();
 
-        // Container/session-backed providers (Bookmarks, Polls, Talk).
-        if (in_array(
-            $class,
-            [
-                BookmarksProvider::class,
-                PollsProvider::class,
-                TalkProvider::class,
-            ],
-            true
-        ) === true) {
+        // Container/session-backed provider (Talk).
+        if ($class === TalkProvider::class) {
             return new $class(
                 container: $this->createMock(ContainerInterface::class),
                 appManager: $appManager,
                 userSession: $this->createMock(IUserSession::class),
+                l10n: $l10n,
+            );
+        }
+
+        // PollsProvider — Tier-2 link-table backed (PollLinkMapper + db).
+        if ($class === PollsProvider::class) {
+            $pollLinkMapper = $this->getMockBuilder(\OCA\OpenRegister\Db\PollLinkMapper::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['findByObjectUuid'])
+                ->getMock();
+            $pollLinkMapper->method('findByObjectUuid')->willReturn([]);
+            return new $class(
+                pollLinkMapper: $pollLinkMapper,
+                db: $this->createMock(IDBConnection::class),
+                appManager: $appManager,
+                userSession: $this->createMock(IUserSession::class),
+                l10n: $l10n,
+            );
+        }
+
+        // BookmarksProvider — Tier-2 link-table backed (BookmarkLinkMapper).
+        if ($class === BookmarksProvider::class) {
+            $bookmarkLinkMapper = $this->getMockBuilder(\OCA\OpenRegister\Db\BookmarkLinkMapper::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['findByObjectUuid'])
+                ->getMock();
+            $bookmarkLinkMapper->method('findByObjectUuid')->willReturn([]);
+            return new $class(
+                bookmarkLinkMapper: $bookmarkLinkMapper,
+                appManager: $appManager,
                 l10n: $l10n,
             );
         }
@@ -187,19 +209,33 @@ class LeafProvidersMetadataTest extends TestCase
         $appManager = $this->buildAppManager([]);
         $l10n       = $this->buildL10n();
 
-        if (in_array(
-            $class,
-            [
-                BookmarksProvider::class,
-                PollsProvider::class,
-                TalkProvider::class,
-            ],
-            true
-        ) === true) {
+        if ($class === TalkProvider::class) {
             return new $class(
                 container: $this->createMock(ContainerInterface::class),
                 appManager: $appManager,
                 userSession: $this->createMock(IUserSession::class),
+                l10n: $l10n,
+            );
+        }
+
+        if ($class === PollsProvider::class) {
+            return new $class(
+                pollLinkMapper: $this->getMockBuilder(\OCA\OpenRegister\Db\PollLinkMapper::class)
+                    ->disableOriginalConstructor()
+                    ->getMock(),
+                db: $this->createMock(IDBConnection::class),
+                appManager: $appManager,
+                userSession: $this->createMock(IUserSession::class),
+                l10n: $l10n,
+            );
+        }
+
+        if ($class === BookmarksProvider::class) {
+            return new $class(
+                bookmarkLinkMapper: $this->getMockBuilder(\OCA\OpenRegister\Db\BookmarkLinkMapper::class)
+                    ->disableOriginalConstructor()
+                    ->getMock(),
+                appManager: $appManager,
                 l10n: $l10n,
             );
         }


### PR DESCRIPTION
## Summary
Promotes the **bookmarks** integration leaf from the Tier-1 `or:{uuid}` tag-marker convention to a proper Tier-2 link table, matching the contacts (I-1) and polls (I-2) exemplars.

- **Migration `Version1Date20260525140000`** — `openregister_bookmark_links` (`object_uuid`, `register_id`, `schema_id`, `bookmark_id`, `title`, `url`, `description`, `tags` json, `added_at`, `linked_by`, `linked_at`); composite unique `(object_uuid, bookmark_id)`; idempotent create-or-extend.
- **`BookmarkLink` entity + `BookmarkLinkMapper`**.
- **`BookmarkLinkService`** — `linkBookmark` (idempotent), `unlinkBookmark`, `getLinkedBookmarks` (24h cache refresh), `getAvailableBookmarks(search?, tags?)`, `createAndLinkBookmark`. Composes NC Bookmarks' `BookmarkMapper` + `TagMapper` lazily via `\OCP\Server::get()` behind a `class_exists` guard, so OR boots cleanly when Bookmarks is absent and historical link rows survive uninstall.
- **`BookmarkLinksController` + routes** (specific `/new` before the wildcard `{bookmarkId}`; GET picker is app-global).
- **`BookmarksProvider`** now reads link rows via `BookmarkLinkMapper` instead of scanning Bookmarks tags.
- Registration updated in `Application.php`.

## Quality gates
- PHPUnit: 36 tests / 93 assertions green (entity, service, controller, provider).
- PHPStan (level 5) + Psalm: clean on all new files (added `OCA\Bookmarks\*` ignore patterns for the optional lazy-resolved peer app).
- PHPMD: clean.
- Also fixed the pre-existing `LeafProvidersMetadataTest` constructor mismatch for the polls provider plus added the bookmarks case.

## Test plan
- [ ] Enable NC Bookmarks; object → Bookmarks tab → Link existing / Create new / per-row unlink.
- [ ] Disable Bookmarks → tab degrades gracefully, link rows persist.
- [ ] Re-run migration to confirm idempotency.

Refs openregister#1315, ADR-019, ADR-022.