### PR TITLE
retrofit: reverse-spec controller bundle — registry/views (5 sub-clusters)

### DIFF
--- a/lib/Controller/AgentsController.php
+++ b/lib/Controller/AgentsController.php
@@ -58,6 +58,8 @@ use Exception;
  * @link https://OpenRegister.app
  *
  * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
  */
 class AgentsController extends Controller
 {

--- a/lib/Controller/ApplicationsController.php
+++ b/lib/Controller/ApplicationsController.php
@@ -50,6 +50,8 @@ use Exception;
  * @link https://OpenRegister.app
  *
  * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
  */
 class ApplicationsController extends Controller
 {

--- a/lib/Controller/ConsumersController.php
+++ b/lib/Controller/ConsumersController.php
@@ -33,6 +33,8 @@ use OCP\IRequest;
  * Provides REST API endpoints for managing API consumers.
  *
  * @package OCA\OpenRegister\Controller
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
  */
 class ConsumersController extends Controller
 {

--- a/lib/Controller/EndpointsController.php
+++ b/lib/Controller/EndpointsController.php
@@ -56,6 +56,13 @@ use Psr\Log\LoggerInterface;
  * @psalm-suppress UnusedClass
  *
  * @SuppressWarnings(PHPMD.TooManyPublicMethods) One public method per endpoint route.
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
+ *
+ * The resource-CRUD verbs (index/show/create/update/patch/destroy) are governed by task-1.
+ * The test/logs/logStats/allLogs methods are a production-observability cross-cut (endpoint
+ * call logging) and are intentionally NOT annotated here — they belong to the
+ * production-observability capability.
  */
 class EndpointsController extends Controller
 {

--- a/lib/Controller/LinkedEntityController.php
+++ b/lib/Controller/LinkedEntityController.php
@@ -39,6 +39,8 @@ use Psr\Log\LoggerInterface;
  * @author   Conduction <info@conduction.nl>
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-6
  */
 class LinkedEntityController extends Controller
 {

--- a/lib/Controller/MappingsController.php
+++ b/lib/Controller/MappingsController.php
@@ -56,6 +56,8 @@ use Psr\Log\LoggerInterface;
  * @link https://OpenRegister.app
  *
  * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
  */
 class MappingsController extends Controller
 {

--- a/lib/Controller/RegistersController.php
+++ b/lib/Controller/RegistersController.php
@@ -84,6 +84,8 @@ use Symfony\Component\Uid\Uuid;
  * @suppressWarnings(PHPMD.TooManyPublicMethods)
  * @suppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
  */
 class RegistersController extends Controller
 {

--- a/lib/Controller/SchemasController.php
+++ b/lib/Controller/SchemasController.php
@@ -75,6 +75,8 @@ use Psr\Log\LoggerInterface;
  * @suppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @suppressWarnings(PHPMD.TooManyPublicMethods)
  * @suppressWarnings(PHPMD.CouplingBetweenObjects)
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
  */
 class SchemasController extends Controller
 {

--- a/lib/Controller/SourcesController.php
+++ b/lib/Controller/SourcesController.php
@@ -36,6 +36,8 @@ use OCP\IRequest;
  * Controller for managing source operations.
  *
  * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
  */
 class SourcesController extends Controller
 {

--- a/lib/Controller/UrnController.php
+++ b/lib/Controller/UrnController.php
@@ -37,6 +37,8 @@ use OCP\IRequest;
  * URN resolution controller.
  *
  * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-7
  */
 class UrnController extends Controller
 {

--- a/lib/Controller/ViewsController.php
+++ b/lib/Controller/ViewsController.php
@@ -42,6 +42,9 @@ use OCP\AppFramework\Db\DoesNotExistException;
  *
  * @suppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-2
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-3
  */
 class ViewsController extends Controller
 {

--- a/lib/Controller/WebhooksController.php
+++ b/lib/Controller/WebhooksController.php
@@ -58,6 +58,9 @@ use Psr\Log\LoggerInterface;
  * @suppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @suppressWarnings(PHPMD.TooManyPublicMethods)
  * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-4
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-5
  */
 class WebhooksController extends Controller
 {
@@ -972,6 +975,8 @@ class WebhooksController extends Controller
      *     },
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-5
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -1089,6 +1094,8 @@ class WebhooksController extends Controller
      * @NoCSRFRequired
      *
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-5
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/proposal.md
@@ -1,0 +1,88 @@
+# Retrofit — controller bundle: registry / views (5 sub-clusters)
+
+## Why
+The OpenRegister REST controller surface for the registry meta-entities, persisted views, webhook
+delivery API, linked-entity API, and the URN resolver already ships but is only partially covered
+by capability specs. This change reverse-specs the OBSERVED HTTP contracts so the spec corpus
+matches the shipped code, and annotates the controller methods with `@spec` task references.
+
+## What Changes
+Reverse-spec of the OpenRegister REST controller surface for the registry meta-entities,
+persisted views, webhook delivery API, linked-entity API, and the URN resolver. Code already
+exists — this change retroactively specifies the observed HTTP contracts and annotates the
+controller methods. All five sub-clusters EXTEND an existing capability spec; no new capability
+is minted.
+
+## Sub-clusters
+
+| Sub-cluster | Mode | Target capability | New REQs |
+|---|---|---|---|
+| registry-resource-crud | extend | openapi-generation | 1 (shared CRUD contract) |
+| views-faceting-rest | extend | faceting-configuration | 2 |
+| webhooks-delivery-api | extend | webhook-payload-mapping | 1 (delivery-log listing) |
+| linked-entity-api | extend | linked-entity-types | 0 (annotate-only) |
+| urn-resolver-api | extend | urn-resource-addressing | 1 (observed lean contract) |
+
+Total: 5 new REQs.
+
+## Affected code units
+
+### registry-resource-crud (8 controllers, uniform five-verb CRUD)
+- lib/Controller/RegistersController.php (index/show/create/update/patch/destroy)
+- lib/Controller/SchemasController.php (index/show/create/update/patch/destroy)
+- lib/Controller/SourcesController.php (index/show/create/update/patch/destroy)
+- lib/Controller/MappingsController.php (index/show/create/update/patch/destroy)
+- lib/Controller/ApplicationsController.php (index/show/create/update/patch/destroy)
+- lib/Controller/AgentsController.php (index/show/create/update/patch/destroy)
+- lib/Controller/EndpointsController.php (index/show/create/update/patch/destroy)
+- lib/Controller/ConsumersController.php (index/show/create/update/patch/destroy)
+
+The eight controllers share one resource-CRUD shape: `index` returns `{results, total?}`,
+`show` returns the entity or 404, `create` returns the persisted entity (201 where set),
+`update`/`patch` return the entity or 404 (`patch` delegates to `update`), `destroy` returns an
+empty body. ONE shared REQ describes the contract — eight near-identical REQs would add no
+information. The non-CRUD methods on these controllers (`export`, `import`, `publish`, `stats`,
+`schemas`, `objects`, `test`, etc.) belong to OTHER capabilities (data-import-export,
+deprecate-published-metadata, production-observability, mapping-execution) and are NOT annotated
+here — they are out of scope for the resource-CRUD contract.
+
+### views-faceting-rest
+- lib/Controller/ViewsController.php (index/show/create/update/patch/destroy)
+
+### webhooks-delivery-api
+- lib/Controller/WebhooksController.php (index/show/create/update/destroy/test/events/logs/logStats/allLogs/retry)
+
+### linked-entity-api
+- lib/Controller/LinkedEntityController.php (addObjectLink/removeObjectLink/addRegisterLink/addSchemaLink/reverseLookup)
+
+### urn-resolver-api
+- lib/Controller/UrnController.php (resolve/lookup/bulk)
+
+## Cross-capability flags (NOT annotated in this bundle)
+- `EndpointsController::test/logs/logStats/allLogs` → production-observability (endpoint call logs)
+- `WebhooksController::logStats` → already covered by webhook-payload-mapping#REQ "Webhook health monitoring"
+- `MappingsController::test` → mapping execution (separate concern)
+- `Registers/SchemasController` export/import/publish/stats/explore → data-import-export, deprecate-published-metadata
+
+## Approach & scanner false-positives dropped
+- The scanner bundled the registry CRUD controllers under `openapi-generation`. That spec
+  documents OAS *generation*, not the CRUD HTTP surface itself. Extending it with one shared
+  resource-CRUD-contract REQ keeps the API documentation capability contiguous without
+  minting a near-duplicate capability.
+- `faceting-configuration` documents facet *computation within* views, not the persisted-views
+  REST surface. The ViewsController CRUD contract (owner-scoped, distinct `{view}`/`{results,total}`
+  envelopes, 401 when unauthenticated) was genuinely uncovered → 2 new REQs.
+- `webhook-payload-mapping` already documents the WebhooksController CRUD/test/events/logStats/retry
+  surface in detail (and the controller already carries `@spec` annotations from the 2026-04-30
+  retrofit). Only the delivery-log listing endpoints (`logs`, `allLogs`) were uncovered → 1 new REQ.
+- `linked-entity-types` already documents the generic ad-hoc linking API and reverse lookup;
+  the LinkedEntityController is already annotated from the 2026-04-23 / 2026-04-30 retrofits.
+  Annotate-only against the existing REQs, no new REQs.
+- `urn-resource-addressing` spec status is "Not implemented" and describes a far richer design
+  (UrnMapping table, federation, OIN/RSIN, versioning, export) than the actual shipped controller.
+  The real `UrnController` exposes a lean three-operation contract
+  (`urn:nl-or:<instance>:<register>:<schema>:<uuid>`, resolve / lookup / bulk, 1000-URN cap).
+  Reverse-specced as ONE REQ documenting OBSERVED behavior; the unimplemented spec aspirations are
+  left untouched (this change does not claim them implemented).
+
+Source: /tmp/or-scan/bundle-ctrl-registry-views.json. See retrofit playbook.

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/specs/faceting-configuration/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/specs/faceting-configuration/spec.md
@@ -1,0 +1,90 @@
+# Faceting Configuration
+
+## Purpose
+Backend-agnostic faceting for OpenRegister, plus the persisted-views REST surface that stores the
+search/facet configurations users build up. This delta documents the `ViewsController` HTTP
+contract — the CRUD endpoints that persist saved views (which carry facet filters and enabled
+facets) — as observed in the shipped code.
+
+## ADDED Requirements
+
+### Requirement: Persisted views MUST be managed through an owner-scoped CRUD REST surface
+`ViewsController` MUST expose CRUD endpoints for saved search views at `/api/views`:
+`index` (GET), `show` (GET `/{id}`), `create` (POST), `update` (PUT `/{id}`), `patch`
+(PATCH `/{id}`), and `destroy` (DELETE `/{id}`). All endpoints are `@NoAdminRequired` /
+`@NoCSRFRequired` and MUST be scoped to the current user: every method MUST resolve the user via
+`IUserSession::getUser()` and return HTTP 401 with `{ "error": "User not authenticated" }` when no
+user is present. Persistence is delegated to `ViewService` (`findAll`, `find`, `create`,
+`update`, `delete`).
+
+#### Scenario: List the current user's views
+- **GIVEN** an authenticated user with saved views
+- **WHEN** `GET /api/views` is called
+- **THEN** the response MUST return HTTP 200 with `{ "results": [...serialized views...], "total": <count> }`
+- **AND** when `_limit` (optionally with `_page`) is supplied, results MUST be paginated client-side via `array_slice` while `total` reflects the full unsliced count
+
+#### Scenario: Unauthenticated request rejected
+- **GIVEN** no user is present in the session
+- **WHEN** any `ViewsController` endpoint is called
+- **THEN** the response MUST return HTTP 401 with `{ "error": "User not authenticated" }`
+
+#### Scenario: Fetch a single view
+- **GIVEN** an authenticated user owns view `abc-123`
+- **WHEN** `GET /api/views/abc-123` is called
+- **THEN** the response MUST return HTTP 200 with `{ "view": <serialized view> }`
+- **AND** a missing view MUST return HTTP 404 with `{ "error": "View not found" }` (from `DoesNotExistException`)
+
+#### Scenario: Create a view returns 201
+- **GIVEN** an authenticated user
+- **WHEN** `POST /api/views` is called with a valid body
+- **THEN** the response MUST return HTTP 201 with `{ "view": <serialized view> }`
+- **AND** a missing or empty `name` MUST return HTTP 400 with `{ "error": "View name is required" }`
+
+#### Scenario: Update a view
+- **GIVEN** an authenticated user owns view `abc-123`
+- **WHEN** `PUT /api/views/abc-123` is called with `name` and a query/configuration body
+- **THEN** the response MUST return HTTP 200 with `{ "view": <updated view> }`
+- **AND** a missing view MUST return HTTP 404 with `{ "error": "View not found" }`
+
+#### Scenario: Patch performs a partial update from the existing view
+- **GIVEN** an authenticated user owns view `abc-123`
+- **WHEN** `PATCH /api/views/abc-123` is called with only some fields
+- **THEN** unspecified fields (`name`, `description`, `isPublic`, `isDefault`, `favoredBy`, `query`) MUST fall back to the existing view's current values
+- **AND** the response MUST return HTTP 200 with `{ "view": <updated view> }`
+
+#### Scenario: Delete a view
+- **GIVEN** an authenticated user owns view `abc-123`
+- **WHEN** `DELETE /api/views/abc-123` is called
+- **THEN** the view MUST be deleted via `ViewService::delete()` and the response status code MUST be 204
+- **AND** a missing view MUST return HTTP 404 with `{ "error": "View not found" }`
+
+#### Scenario: Unexpected failures return 500
+- **GIVEN** any `ViewsController` endpoint
+- **WHEN** the underlying `ViewService` throws a non-`DoesNotExistException`
+- **THEN** the error MUST be logged and the response MUST return HTTP 500 with an `{ "error": ..., "message": ... }` body
+
+### Requirement: View create/update/patch MUST normalize the search query from either a query or configuration body
+When persisting a view, `ViewsController` MUST accept the search definition under EITHER a `query`
+key (used verbatim) OR a `configuration` key (the legacy frontend shape), and MUST normalize the
+`configuration` shape into the canonical query envelope. `create` and `update` MUST reject a body
+that provides neither.
+
+#### Scenario: configuration body normalized to canonical query keys
+- **GIVEN** a create/update body with a `configuration` object
+- **WHEN** the view is persisted
+- **THEN** the stored query MUST be built from `configuration` with keys `registers`, `schemas`, `source` (default `"auto"`), `searchTerms`, `facetFilters`, and `enabledFacets`, each defaulting to an empty array when absent
+
+#### Scenario: query body used verbatim
+- **GIVEN** a create/update body that supplies a `query` array (and no `configuration`)
+- **WHEN** the view is persisted
+- **THEN** the supplied `query` array MUST be stored as-is
+
+#### Scenario: Neither query nor configuration provided
+- **GIVEN** a create or update body with neither a valid `query` array nor a `configuration` array
+- **WHEN** the endpoint is called
+- **THEN** the response MUST return HTTP 400 with `{ "error": "View query or configuration is required" }`
+
+#### Scenario: Patch preserves the existing query when none supplied
+- **GIVEN** a `PATCH /api/views/{id}` body with neither `query` nor `configuration`
+- **WHEN** the patch is applied
+- **THEN** the view's existing stored `query` MUST be retained unchanged

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/specs/openapi-generation/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/specs/openapi-generation/spec.md
@@ -1,0 +1,64 @@
+# OpenAPI Generation
+
+## Purpose
+Auto-generate OpenAPI specs from register/schema definitions AND expose the underlying registry
+meta-entities (registers, schemas, sources, mappings, applications, agents, endpoints, consumers)
+through a uniform REST CRUD surface that the generated OAS documents.
+
+## ADDED Requirements
+
+### Requirement: Registry meta-entity controllers MUST expose a uniform resource-CRUD HTTP contract
+Each registry meta-entity controller MUST expose the same five-verb REST resource contract,
+registered via the `resources` block (plus an explicit `PATCH` route) in `appinfo/routes.php`:
+`index` (GET collection), `show` (GET item), `create` (POST), `update` (PUT), `patch` (PATCH),
+and `destroy` (DELETE). This applies to `RegistersController`, `SchemasController`,
+`SourcesController`, `MappingsController`, `ApplicationsController`, `AgentsController`,
+`EndpointsController`, and `ConsumersController`. The controllers MUST delegate persistence to
+their respective `*Mapper` (`findAll`, `find`, `createFromArray`, `updateFromArray`, `delete`).
+This requirement covers ONLY the resource-CRUD verbs; resource-specific operational methods
+(export, import, publish, stats, test, schemas, objects, logs) are governed by their own
+capability specs.
+
+#### Scenario: List a meta-entity collection
+- **GIVEN** any of the eight registry meta-entity resources (e.g. `sources`)
+- **WHEN** `GET /api/sources` is called
+- **THEN** the response MUST return HTTP 200 with a JSON body containing a `results` array of the matching entities
+- **AND** the controller MUST strip the internal query params (`_limit`, `_offset`, `_page`, `_search`, `_route`) from the filter set before querying
+- **AND** when `_page` and `_limit` are both provided, the offset MUST be computed as `(_page - 1) * _limit`
+
+#### Scenario: Collection responses MAY include a total count
+- **GIVEN** a resource whose controller exposes a count (e.g. `consumers`, `webhooks`-style controllers, `views`)
+- **WHEN** the collection endpoint is called
+- **THEN** the response MAY include a `total` field alongside `results`
+- **AND** controllers that do not compute a count (e.g. `sources`) MUST still return a `results` array
+
+#### Scenario: Fetch a single meta-entity by ID
+- **GIVEN** a source with ID `5` exists
+- **WHEN** `GET /api/sources/5` is called
+- **THEN** the response MUST return HTTP 200 with the entity's JSON serialization
+- **AND** if no entity matches the ID, the response MUST return HTTP 404 with an `{ "error": ... }` body (mapped from `DoesNotExistException`)
+
+#### Scenario: Create a new meta-entity
+- **GIVEN** a POST body of entity properties
+- **WHEN** `POST /api/{resource}` is called
+- **THEN** the controller MUST strip framework-injected and internal params (keys starting with `_`, and any supplied `id`) before persisting
+- **AND** the entity MUST be created via the mapper's `createFromArray()`
+- **AND** the response MUST return the persisted entity (HTTP 201 where the controller sets it explicitly, e.g. `ConsumersController`, otherwise HTTP 200)
+
+#### Scenario: Update a meta-entity (PUT)
+- **GIVEN** a source with ID `5` exists
+- **WHEN** `PUT /api/sources/5` is called with updated properties
+- **THEN** the controller MUST strip internal `_`-prefixed params and immutable fields (`id`, and where applicable `organisation`, `owner`, `created`) from the body
+- **AND** the entity MUST be updated via `updateFromArray()` and returned
+- **AND** updating a non-existent ID MUST return HTTP 404 for controllers that catch `DoesNotExistException`
+
+#### Scenario: Patch delegates to update
+- **GIVEN** any registry meta-entity controller
+- **WHEN** `PATCH /api/{resource}/{id}` is called
+- **THEN** the `patch()` method MUST delegate to `update($id)` (partial update via the same mapper write path)
+
+#### Scenario: Delete a meta-entity
+- **GIVEN** a source with ID `5` exists
+- **WHEN** `DELETE /api/sources/5` is called
+- **THEN** the entity MUST be deleted via the mapper and the response MUST return an empty JSON body
+- **AND** deleting a non-existent ID MUST return HTTP 404 for controllers that catch `DoesNotExistException`

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/specs/urn-resource-addressing/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/specs/urn-resource-addressing/spec.md
@@ -1,0 +1,56 @@
+# URN Resource Addressing
+
+## Purpose
+Bidirectional URN-URL mapping for system-independent resource identification. This delta documents
+the URN resolver HTTP contract AS SHIPPED (`UrnController` → `UrnService`), which is a lean
+three-operation surface. It does not claim the broader, still-unimplemented aspirational features
+(external mapping table, federation, OIN/RSIN mapping, versioning, export) described elsewhere in
+this capability.
+
+## ADDED Requirements
+
+### Requirement: The URN resolver MUST expose resolve, lookup, and bulk operations over a fixed URN grammar
+`UrnController` MUST expose three `@NoAdminRequired` / `@NoCSRFRequired` endpoints backed by
+`UrnService`: `GET /api/urn/resolve?urn=...` (URN → URL), `GET /api/urn/lookup?url=...`
+(URL → URN), and `POST /api/urn/bulk` with body `{ "urns": [...] }` (batch URN → URL). The URN
+grammar is `urn:<DEFAULT_NID>:<instance>:<register>:<schema>:<uuid>` where `<DEFAULT_NID>` is the
+`UrnService::DEFAULT_NID` constant (`nl-or`).
+
+#### Scenario: Resolve a URN to its canonical URL
+- **GIVEN** a syntactically valid URN whose register/schema exist on this instance
+- **WHEN** `GET /api/urn/resolve?urn=<urn>` is called
+- **THEN** the response MUST return HTTP 200 with `{ urn, url, instance, register, schema, uuid }` where `url` is produced by `UrnService::resolveUrl()` and the segment fields come from `UrnService::parse()`
+
+#### Scenario: Missing urn parameter
+- **GIVEN** no `urn` query parameter (null or empty)
+- **WHEN** the resolve endpoint is called
+- **THEN** the response MUST return HTTP 400 with `{ "error": "urn parameter is required" }`
+
+#### Scenario: Malformed URN
+- **GIVEN** a `urn` value that `UrnService::parse()` cannot parse
+- **WHEN** the resolve endpoint is called
+- **THEN** the response MUST return HTTP 400 with an error describing the expected `urn:<nid>:<instance>:<register>:<schema>:<uuid>` shape
+
+#### Scenario: Parsable URN that does not resolve on this instance
+- **GIVEN** a well-formed URN whose register/schema/object is not present on this instance
+- **WHEN** the resolve endpoint is called
+- **THEN** the response MUST return HTTP 404 with `{ "error": "URN does not resolve on this instance", "urn": ..., "parts": ... }`
+
+#### Scenario: Reverse lookup URL to URN
+- **GIVEN** an OpenRegister object URL
+- **WHEN** `GET /api/urn/lookup?url=<url>` is called
+- **THEN** the response MUST return HTTP 200 with `{ url, urn }` where `urn` is produced by `UrnService::urnFromUrl()`
+- **AND** a missing `url` parameter MUST return HTTP 400 with `{ "error": "url parameter is required" }`
+- **AND** a URL that is not an OpenRegister object reference MUST return HTTP 404 with `{ "error": "URL is not an OpenRegister object reference", "url": ... }`
+
+#### Scenario: Bulk resolution returns a urn→url map
+- **GIVEN** a POST body `{ "urns": ["urn:nl-or:...", ...] }`
+- **WHEN** `POST /api/urn/bulk` is called
+- **THEN** the response MUST return HTTP 200 with `{ "count": <n>, "resolved": { <urn>: <url-or-null>, ... } }` from `UrnService::resolveBulk()`
+- **AND** a missing/empty/non-array `urns` MUST return HTTP 400 with `{ "error": "urns array is required" }`
+
+#### Scenario: Bulk resolution enforces a hard input cap
+- **GIVEN** a POST body with more than 1000 URNs
+- **WHEN** `POST /api/urn/bulk` is called
+- **THEN** the response MUST return HTTP 422 with `{ "error": "Too many URNs (max 1000 per request)", "count": <n> }`
+- **AND** this cap MUST NOT be relaxed without an upstream per-user rate limit, because each URN triggers a parse → register-find → schema-find → object-find chain reachable by any authenticated user

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/specs/webhook-payload-mapping/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/specs/webhook-payload-mapping/spec.md
@@ -1,0 +1,48 @@
+# Webhook Payload Mapping
+
+## Purpose
+Configurable webhook payload mapping plus the webhook management/delivery REST surface. This delta
+documents the webhook delivery-log listing endpoints (`logs`, `allLogs`) on `WebhooksController`,
+which complement the already-specified `logStats` health-monitoring endpoint.
+
+## ADDED Requirements
+
+### Requirement: Webhook delivery logs MUST be listable per-webhook and globally
+`WebhooksController` MUST expose two delivery-log listing endpoints in addition to the
+already-specified `logStats` endpoint: `GET /api/webhooks/{id}/logs` (per-webhook) and
+`GET /api/webhooks/logs` (all webhooks). Both are `@NoAdminRequired` / `@NoCSRFRequired`, accept
+`limit` (default 50) and `offset` (default 0) query parameters, and return `{ results, total }`.
+The per-webhook endpoint MUST validate webhook existence first and the global endpoint MUST
+support optional `webhook_id` and `success` filtering.
+
+#### Scenario: List logs for a specific webhook
+- **GIVEN** webhook ID `7` exists with delivery history
+- **WHEN** `GET /api/webhooks/7/logs?limit=50&offset=0` is called
+- **THEN** the response MUST return HTTP 200 with `{ "results": [...WebhookLog...], "total": <count> }`
+- **AND** logs MUST be fetched via `WebhookLogMapper::findByWebhook(webhookId, limit, offset)`
+
+#### Scenario: Logs for a non-existent webhook
+- **GIVEN** no webhook exists with ID `999`
+- **WHEN** `GET /api/webhooks/999/logs` is called
+- **THEN** the response MUST return HTTP 404 with `{ "error": "Webhook not found" }`
+
+#### Scenario: Log retrieval failure
+- **GIVEN** the log mapper throws a non-`DoesNotExistException`
+- **WHEN** the logs endpoint is called
+- **THEN** the error MUST be logged and the response MUST return HTTP 500 with `{ "error": "Failed to retrieve webhook logs" }`
+
+#### Scenario: List all logs with default total
+- **WHEN** `GET /api/webhooks/logs` is called with no filters
+- **THEN** the response MUST return paginated logs from `WebhookLogMapper::findAll(limit, offset)`
+- **AND** `total` MUST be the count of all logs (unpaginated)
+
+#### Scenario: Filter all logs by webhook_id
+- **GIVEN** `GET /api/webhooks/logs?webhook_id=7`
+- **WHEN** `webhook_id` is non-empty and not `"0"`
+- **THEN** logs MUST be scoped to webhook `7` via `findByWebhook()` and `total` MUST reflect that webhook's full count
+
+#### Scenario: Filter all logs by success status
+- **GIVEN** `GET /api/webhooks/logs?success=false`
+- **WHEN** `success` is one of `true`/`1`/`false`/`0`
+- **THEN** the returned logs MUST be filtered to entries whose `getSuccess()` matches the boolean
+- **AND** `total` MUST be recomputed against the success-filtered full set

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md
@@ -1,0 +1,18 @@
+# Tasks
+
+## registry-resource-crud (extend openapi-generation)
+- [x] task-1: openapi-generation#REQ — Shared resource-CRUD HTTP contract for the registry meta-entity controllers (RegistersController, SchemasController, SourcesController, MappingsController, ApplicationsController, AgentsController, EndpointsController, ConsumersController) — index/show/create/update/patch/destroy (retroactive annotation)
+
+## views-faceting-rest (extend faceting-configuration)
+- [x] task-2: faceting-configuration#REQ — Persisted-views CRUD REST contract (ViewsController index/show/create/update/patch/destroy, owner-scoped, 401/404/201/204 semantics) (retroactive annotation)
+- [x] task-3: faceting-configuration#REQ — View query/configuration body normalization on create/update/patch (ViewsController) (retroactive annotation)
+
+## webhooks-delivery-api (extend webhook-payload-mapping)
+- [x] task-4: webhook-payload-mapping#REQ — Webhook CRUD + test + events + retry HTTP surface (WebhooksController index/show/create/update/destroy/test/events/retry) — already covered by existing webhook-payload-mapping requirements (retroactive annotation, no new REQ)
+- [x] task-5: webhook-payload-mapping#REQ — Webhook delivery-log listing API (WebhooksController logs, allLogs, logStats) (retroactive annotation)
+
+## linked-entity-api (extend linked-entity-types)
+- [x] task-6: linked-entity-types#REQ — Generic ad-hoc linking + reverse lookup API (LinkedEntityController addObjectLink/removeObjectLink/addRegisterLink/addSchemaLink/reverseLookup) — already covered by existing linked-entity-types requirements (retroactive annotation, no new REQ)
+
+## urn-resolver-api (extend urn-resource-addressing)
+- [x] task-7: urn-resource-addressing#REQ — Observed lean URN resolver HTTP contract (UrnController resolve/lookup/bulk) (retroactive annotation)


### PR DESCRIPTION
## Summary
Reverse-specs the OpenRegister REST controller surface for the registry meta-entities, persisted views, webhook delivery logs, linked-entity API, and the URN resolver. Documents the OBSERVED HTTP contracts and annotates controller methods with `@spec` task references. All five sub-clusters EXTEND an existing capability spec; no new capability is minted. **5 new REQs total** (under the ≤12 budget).

| Sub-cluster | Mode | Target capability | New REQs |
|---|---|---|---|
| registry-resource-crud | extend | openapi-generation | 1 (shared CRUD contract for 8 controllers) |
| views-faceting-rest | extend | faceting-configuration | 2 |
| webhooks-delivery-api | extend | webhook-payload-mapping | 1 (delivery-log listing) |
| linked-entity-api | extend | linked-entity-types | 0 (annotate-only) |
| urn-resolver-api | extend | urn-resource-addressing | 1 (observed lean contract) |

## Key decisions / observations
- registry-resource-crud: the 8 controllers share one uniform five-verb contract, so ONE shared REQ describes it rather than 8 near-identical ones. Resource-specific operational methods (export/import/publish/stats/test) are out of scope.
- EndpointsController test/logs/logStats/allLogs flagged inline as a production-observability cross-cut; not annotated here.
- webhooks: CRUD/test/events/retry already specified + annotated (2026-04-30 retrofit); only logs/allLogs were uncovered.
- linked-entity: already covered; annotate-only.
- urn-resolver: spec status is "Not implemented" and describes a much richer aspirational design. The SHIPPED UrnController is a lean 3-op surface (urn:nl-or:..., resolve/lookup/bulk, 1000-URN cap). Reverse-specced as ONE REQ for observed behavior; aspirations left untouched.

## Test plan
- [x] php -l clean on all 12 touched controllers
- [x] openspec validate --strict passes
- [ ] CI quality gate (PHPCS/PHPMD/Psalm/PHPStan) green