### PR TITLE
retrofit: reverse-spec controller bundle — graphql/realtime/dashboard (5 sub-clusters)

### DIFF
--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -47,6 +47,11 @@ use Psr\Log\LoggerInterface;
  *
  * @link https://OpenRegister.app
  *
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-5
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-6
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-7
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-8
+ *
  * @psalm-suppress UnusedClass
  */
 class DashboardController extends Controller
@@ -110,6 +115,8 @@ class DashboardController extends Controller
      * @NoCSRFRequired
      *
      * @psalm-return TemplateResponse<200, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-5
      */
     public function page(): TemplateResponse
     {
@@ -255,6 +262,8 @@ class DashboardController extends Controller
      *     },
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-6
      */
     public function index(): JSONResponse
     {
@@ -305,6 +314,8 @@ class DashboardController extends Controller
      *     total: array{processed: mixed, failed: mixed}},
      *     summary?: array{total_processed: mixed, total_failed: mixed,
      *     success_rate: float}}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-7
      */
     public function calculate(?int $registerId=null, ?int $schemaId=null): JSONResponse
     {
@@ -346,6 +357,8 @@ class DashboardController extends Controller
      *     array{error?: string, labels?: list<array-key>,
      *     series?: list<array{data: list<int>, name: string}>},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-8
      */
     public function getAuditTrailActionChart(
         ?string $from=null,
@@ -391,6 +404,8 @@ class DashboardController extends Controller
      * @psalm-return JSONResponse<200|500,
      *     array{error?: string, labels?: array<'Unknown'|mixed>, series?: array<int>},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-8
      */
     public function getObjectsByRegisterChart(?int $registerId=null, ?int $schemaId=null): JSONResponse
     {
@@ -417,6 +432,8 @@ class DashboardController extends Controller
      * @psalm-return JSONResponse<200|500,
      *     array{error?: string, labels?: array<'Unknown'|mixed>, series?: array<int>},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-8
      */
     public function getObjectsBySchemaChart(?int $registerId=null, ?int $schemaId=null): JSONResponse
     {
@@ -445,6 +462,8 @@ class DashboardController extends Controller
      *     labels?: list<'0-1 KB'|'1-10 KB'|'10-100 KB'|'100 KB-1 MB'|'> 1 MB'>,
      *     series?: list<int>},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-8
      */
     public function getObjectsBySizeChart(?int $registerId=null, ?int $schemaId=null): JSONResponse
     {
@@ -473,6 +492,8 @@ class DashboardController extends Controller
      *     array{error?: string, total?: int, creates?: int,
      *     updates?: int, deletes?: int, reads?: int},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-8
      */
     public function getAuditTrailStatistics(?int $registerId=null, ?int $schemaId=null, ?int $hours=24): JSONResponse
     {
@@ -504,6 +525,8 @@ class DashboardController extends Controller
      * @psalm-return JSONResponse<200|500,
      *     array{error?: string, actions?: list<array{count: int, name: mixed}>},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-8
      */
     public function getAuditTrailActionDistribution(?int $registerId=null, ?int $schemaId=null, ?int $hours=24): JSONResponse
     {
@@ -536,6 +559,8 @@ class DashboardController extends Controller
      * @psalm-return JSONResponse<200|500,
      *     array{error?: string, objects?: list<array{count: int, id: mixed, name: string}>},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-8
      */
     public function getMostActiveObjects(
         ?int $registerId=null,

--- a/lib/Controller/GraphQLController.php
+++ b/lib/Controller/GraphQLController.php
@@ -22,6 +22,9 @@
  *
  * @spec openspec/changes/retrofit-2026-04-30-annotate-openregister/tasks.md#task-46
  * @spec openspec/changes/retrofit-2026-04-30-annotate-openregister/tasks.md#task-47
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-2
  */
 
 namespace OCA\OpenRegister\Controller;
@@ -84,6 +87,8 @@ class GraphQLController extends Controller
      * @CORS
      *
      * @spec openspec/changes/retrofit-2026-04-30-annotate-openregister/tasks.md#task-46
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-1
      */
     public function execute(): JSONResponse
     {
@@ -142,6 +147,8 @@ class GraphQLController extends Controller
      * @NoCSRFRequired
      *
      * @spec openspec/changes/retrofit-2026-04-30-annotate-openregister/tasks.md#task-47
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-2
      */
     public function explorer(): Response
     {

--- a/lib/Controller/RealtimeController.php
+++ b/lib/Controller/RealtimeController.php
@@ -20,6 +20,9 @@
  * @version GIT: <git-id>
  *
  * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-3
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-4
  */
 
 declare(strict_types=1);
@@ -80,6 +83,8 @@ class RealtimeController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-3
      */
     public function events(
         ?int $since=null,
@@ -153,6 +158,8 @@ class RealtimeController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-4
      */
     public function cursor(): JSONResponse
     {

--- a/lib/Controller/ReportsController.php
+++ b/lib/Controller/ReportsController.php
@@ -24,6 +24,9 @@
  * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-9
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-10
  */
 
 declare(strict_types=1);
@@ -76,6 +79,8 @@ class ReportsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-9
      */
     public function render(string $id)
     {
@@ -144,6 +149,8 @@ class ReportsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-10
      */
     public function preview(string $id)
     {
@@ -184,6 +191,8 @@ class ReportsController extends Controller
      * @return ObjectEntity
      *
      * @throws DoesNotExistException
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-10
      */
     private function loadDashboard(string $identifier): ObjectEntity
     {

--- a/lib/Controller/RevertController.php
+++ b/lib/Controller/RevertController.php
@@ -19,6 +19,8 @@
  * @version GIT: <git-id>
  *
  * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-11
  */
 
 namespace OCA\OpenRegister\Controller;
@@ -73,6 +75,8 @@ class RevertController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with reverted object or error
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-11
      */
     public function revert(string $register, string $schema, string $id): JSONResponse
     {

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/proposal.md
@@ -1,0 +1,86 @@
+# Retrofit: reverse-spec controller bundle — graphql / realtime / dashboard / reports / revert
+
+**Type**: retrofit (reverse-spec, documentation-only — no behaviour change)
+
+**Date**: 2026-05-24
+
+**Bundle**: `ctrl-graphql-rt-dash` (5 controller sub-clusters)
+
+## Why
+
+Five HTTP controllers in `lib/Controller/` expose API surface that was either
+undocumented in its capability spec or documented only as an implementation
+note. This change is a reverse-spec pass: it captures the **observed**
+controller contracts as `@spec` annotations and extends the five target
+capabilities with the few endpoint-contract requirements that were genuinely
+uncovered. No production code behaviour changes — only docblock `@spec`
+annotations are added.
+
+Bias is toward **extend** (the capabilities already exist) and toward
+**annotation** where the contract is already specified. New requirements are
+added only where the controller's HTTP contract (status codes, response shape,
+auth gate, multi-tenancy scoping) was not described anywhere.
+
+## What changes
+
+Per sub-cluster (all `--extend`):
+
+- **graphql-api-surface** → `graphql-api`: `GraphQLController::execute` / `explorer`
+  / `getGraphiQLHtml`. **Annotation only** — the GraphiQL explorer, the
+  `POST /api/graphql` execute contract, the 429 + `Retry-After` rate-limit path,
+  and the error-response shape are already fully specified (see existing
+  requirements "The GraphQL endpoint MUST include an interactive GraphiQL
+  explorer" and the HTTP status-code scenarios). Re-point the existing
+  `task-46` / `task-47` annotations at this bundle. **0 new REQs.**
+
+- **realtime-sse-api** → `realtime-updates`: `RealtimeController::events` / `cursor`.
+  The spec covers SSE plus client-side polling fallback against the generic
+  REST list API, but the **dedicated cursor-polling HTTP endpoints**
+  (`GET /api/realtime/events?since=…` and `GET /api/realtime/cursor`) and their
+  contract — 401 anonymous short-circuit, active-organisation scoping (fail-closed
+  to empty / `cursor: 0`), `{events, cursor, hasMore}` envelope, and `limit`
+  clamping to `1..1000` — were undocumented. **2 new REQs.**
+
+- **dashboard-charts-api** → `built-in-dashboards`: `DashboardController` page /
+  index / calculate + the six audit/object chart & statistics feeds. The
+  `built-in-dashboards` local spec is a redirect stub with only one redirect
+  requirement, and the dashboard's own data-feed HTTP endpoints are documented
+  nowhere. Capture the observed data-feed surface (template page + CSP, the
+  registers-with-schemas feed, the size-calculation trigger, and the chart /
+  statistics read endpoints). **4 new REQs.**
+
+- **report-render-api** → `rapportage-bi-export`: `ReportsController::render` /
+  `preview` / `loadDashboard`. `POST /api/reports/{id}/render` appears in the
+  spec's design notes but has no requirement/scenario for the controller's HTTP
+  contract: default `xlsx` format, `DataDownloadResponse` download vs inline
+  preview, the 404 / 422 / 500 mapping, and the RBAC/multi-tenancy gate on
+  dashboard load. **2 new REQs.**
+
+- **revert-content-versioning** → `content-versioning`: `RevertController::revert`.
+  **Annotation only** — the `POST /api/revert/{register}/{schema}/{id}` endpoint
+  with `datetime` / `auditTrailId` / `version` modes, the `LockedException`
+  (423) path, and the new-version-on-revert semantics are already fully
+  specified (see "The system MUST support version rollback" and the
+  implementation note listing `RevertController`). **0 new REQs.**
+
+## Total new requirements
+
+8 new requirements (≤ 12 budget): 2 realtime + 4 dashboards + 2 reports.
+
+## Impact
+
+- **Code**: docblock `@spec` annotations only (Edit tool, no logic change).
+- **Specs**: extends `realtime-updates`, `built-in-dashboards`,
+  `rapportage-bi-export`; re-annotates `graphql-api` and `content-versioning`.
+- **Risk**: none — documentation/annotation pass over already-shipped endpoints.
+
+## Dropped scanner false-positives
+
+- `GraphQLController::render` and `getGraphiQLHtml` are private/anonymous-class
+  helpers behind `explorer()`; annotated at the method that owns the HTTP
+  contract (`explorer`), not as separate requirements.
+- `DashboardController::page` returns the SPA template, not a data feed; folded
+  into a single "dashboard page + data feed" requirement rather than its own REQ.
+- `ReportsController::loadDashboard` is a private RBAC-gated loader; its
+  multi-tenancy contract is captured inside the render/preview requirement, not
+  as a standalone REQ.

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/specs/built-in-dashboards/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/specs/built-in-dashboards/spec.md
@@ -1,0 +1,87 @@
+---
+status: proposed
+---
+
+# Built-in Dashboards — dashboard data-feed HTTP surface (delta)
+
+**OpenSpec change**: `retrofit-2026-05-24-b-ctrl-graphql-rt-dash`
+
+**Cross-references**: [built-in-dashboards stub](../../../../specs/built-in-dashboards/spec.md), [rapportage-bi-export spec](../../../../specs/rapportage-bi-export/spec.md), `lib/Controller/DashboardController.php`.
+
+## Purpose of this delta
+
+The local `built-in-dashboards` spec is a redirect stub. The HTTP endpoints that
+actually power the mounted OpenRegister dashboard — served by
+`DashboardController` against `DashboardService` — are documented nowhere. This
+delta captures the **observed** data-feed contract: the dashboard SPA page, the
+registers-with-schemas feed, the on-demand size-calculation trigger, and the
+audit/object chart & statistics read endpoints. These complement (and are
+distinct from) the user-configurable chart endpoints in `rapportage-bi-export`
+(`GET /api/objects/{register}/{schema}/chart`), which are operator-defined
+report queries rather than the fixed dashboard widget feeds. No behaviour change.
+
+---
+
+## ADDED Requirements
+
+### Requirement: The dashboard MUST serve its SPA page with API-permissive CSP
+
+`DashboardController::page` (`@NoAdminRequired`, `@NoCSRFRequired`) MUST render
+the dashboard single-page app and configure a Content Security Policy that
+permits the frontend to make API calls.
+
+#### Scenario: Render the dashboard page
+- **GIVEN** a request for the dashboard page
+- **WHEN** `DashboardController::page` runs
+- **THEN** it MUST return the `index` `TemplateResponse` with a CSP whose connect domain allows API calls (`addAllowedConnectDomain('*')`)
+- **AND** if template rendering throws, it MUST return the `error` template with HTTP status 500 and the error message in params
+
+### Requirement: The dashboard MUST expose a registers-with-schemas data feed
+
+`DashboardController::index` (`@NoAdminRequired`, `@NoCSRFRequired`) MUST return
+every register together with its schemas and per-schema statistics, optionally
+filtered by register or schema.
+
+#### Scenario: List registers with schemas and stats
+- **GIVEN** a request to the dashboard index feed
+- **WHEN** `DashboardController::index` calls `DashboardService::getRegistersWithSchemas` (passing optional `registerId` / `schemaId`)
+- **THEN** the response MUST be `{registers: [...]}` where each register carries its `schemas[]` and a `stats` block (objects / logs / files / webhookLogs totals and sizes)
+- **AND** pagination and routing params (`id`, `_route`, `limit`, `offset`, `page`) MUST be stripped before the service call
+- **AND** on failure the response MUST be `{error: <message>}` with HTTP status 500
+
+### Requirement: The dashboard MUST expose an on-demand size-calculation trigger
+
+`DashboardController::calculate` (`@NoAdminRequired`, `@NoCSRFRequired`) MUST
+recompute object and log storage sizes, optionally scoped to a register or
+schema.
+
+#### Scenario: Trigger size calculation
+- **GIVEN** a request with optional `registerId` / `schemaId`
+- **WHEN** `DashboardController::calculate` calls `DashboardService::calculate`
+- **THEN** the response MUST contain the calculation result (status, scope, results, summary) with HTTP status 200
+- **AND** on failure the response MUST be `{status: 'error', message: <message>, timestamp: <ISO-8601>}` with HTTP status 500
+
+### Requirement: The dashboard MUST expose audit and object chart & statistics feeds
+
+`DashboardController` MUST expose the fixed widget data feeds that drive the
+dashboard charts and sidebar statistics. Each feed (`@NoAdminRequired`,
+`@NoCSRFRequired`) accepts optional `registerId` / `schemaId` filters and maps
+any exception to `{error: <message>}` with HTTP status 500.
+
+#### Scenario: Audit-trail action chart over a date range
+- **GIVEN** a request with optional `from` / `till` (`Y-m-d`) and scope filters
+- **WHEN** `getAuditTrailActionChart` calls `DashboardService::getAuditTrailActionChartData`
+- **THEN** the response MUST be a chart shape `{labels: [...], series: [{name, data: [...]}]}`
+
+#### Scenario: Object distribution charts
+- **GIVEN** a request with optional scope filters
+- **WHEN** `getObjectsByRegisterChart`, `getObjectsBySchemaChart`, or `getObjectsBySizeChart` is called
+- **THEN** each MUST return `{labels: [...], series: [...]}`
+- **AND** `getObjectsBySizeChart` labels MUST be the fixed size buckets (`0-1 KB`, `1-10 KB`, `10-100 KB`, `100 KB-1 MB`, `> 1 MB`)
+
+#### Scenario: Audit statistics and most-active objects over a look-back window
+- **GIVEN** a request with optional scope filters and a `hours` look-back (default 24)
+- **WHEN** `getAuditTrailStatistics`, `getAuditTrailActionDistribution`, or `getMostActiveObjects` is called
+- **THEN** `getAuditTrailStatistics` MUST return action totals `{total, creates, updates, deletes, reads}`
+- **AND** `getAuditTrailActionDistribution` MUST return `{actions: [{name, count}]}`
+- **AND** `getMostActiveObjects` MUST return `{objects: [{id, name, count}]}` limited by the optional `limit` (default 10), logging the error context on failure before returning HTTP 500

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/specs/rapportage-bi-export/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/specs/rapportage-bi-export/spec.md
@@ -1,0 +1,63 @@
+---
+status: proposed
+---
+
+# Rapportage / BI Export — report render HTTP surface (delta)
+
+**OpenSpec change**: `retrofit-2026-05-24-b-ctrl-graphql-rt-dash`
+
+**Cross-references**: [rapportage-bi-export main spec](../../../../specs/rapportage-bi-export/spec.md), `lib/Controller/ReportsController.php`, `lib/Service/Reporting/ReportRenderService.php`.
+
+## Purpose of this delta
+
+The `rapportage-bi-export` spec mentions `POST /api/reports/{id}/render?format=…`
+in its design notes but has no requirement or scenario for the HTTP contract of
+`ReportsController` — the render/preview status-code mapping, the
+download-vs-inline behaviour, and the RBAC/multi-tenancy gate on dashboard load.
+This delta documents the **observed** controller contract. No behaviour change.
+
+---
+
+## ADDED Requirements
+
+### Requirement: The report render endpoint MUST stream a download with a defined error contract
+
+The report render endpoint MUST render a stored dashboard definition to the
+requested format and return it as a browser download, with a defined mapping
+from failure modes to HTTP status codes that never leaks internal exception
+detail. The endpoint is `ReportsController::render` (`POST /api/reports/{id}/render`,
+`@NoAdminRequired`, `@NoCSRFRequired`).
+
+#### Scenario: Successful render returns a download
+- **GIVEN** a `POST /api/reports/{id}/render?format=xlsx` for an accessible dashboard
+- **WHEN** `ReportsController::render` resolves the dashboard and calls `ReportRenderService::render`
+- **THEN** the `format` MUST default to `xlsx` (lower-cased) when omitted, supporting `csv` / `xlsx` / `ods` / `html`
+- **AND** the response MUST be a `DataDownloadResponse` carrying the rendered `bytes`, `filename`, and `mime`
+
+#### Scenario: Error contract for render failures
+- **GIVEN** a render request
+- **WHEN** the dashboard cannot be found (`DoesNotExistException`)
+- **THEN** the response MUST be HTTP 404 `{error: 'Dashboard not found', identifier: <id>}`
+- **AND** when load fails for any other reason, the response MUST be HTTP 500 `{error: 'Failed to load dashboard'}` with the internal detail logged (never returned in the body)
+- **AND** when `ReportRenderService::render` throws `InvalidArgumentException` (caller-controlled validation), the response MUST be HTTP 422 with the validation message
+- **AND** when render fails otherwise, the response MUST be HTTP 500 `{error: 'Render failed; see server logs for details'}` with the internal detail logged only
+
+### Requirement: The report preview endpoint MUST render inline and enforce tenant-scoped loads
+
+The report preview endpoint MUST render the dashboard to HTML for inline
+preview, and the private `loadDashboard` resolver MUST apply standard RBAC and
+multi-tenancy filtering on every dashboard load. The endpoint is
+`ReportsController::preview` (`GET /api/reports/{id}/preview`, `@NoAdminRequired`,
+`@NoCSRFRequired`).
+
+#### Scenario: Inline HTML preview
+- **GIVEN** a `GET /api/reports/{id}/preview` for an accessible dashboard
+- **WHEN** `ReportsController::preview` renders the dashboard with `format: 'html'`
+- **THEN** the response MUST be a `DataDownloadResponse` with header `Content-Disposition: inline; filename="…"` (preview, not forced download)
+- **AND** a dashboard that cannot be found MUST return HTTP 404 `{error: 'Dashboard not found', identifier: <id>}`
+
+#### Scenario: Dashboard load is RBAC- and tenant-filtered
+- **GIVEN** any render or preview request
+- **WHEN** `loadDashboard` resolves the identifier (numeric id, uuid, or slug) via `MagicMapper::find`
+- **THEN** the mapper's standard RBAC and multi-tenancy filters MUST apply on every load
+- **AND** the loader MUST NOT bypass those filters (preventing cross-tenant render exfiltration by guessing identifiers)

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/specs/realtime-updates/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/specs/realtime-updates/spec.md
@@ -1,0 +1,75 @@
+---
+status: proposed
+---
+
+# Realtime Updates — cursor-polling HTTP endpoints (delta)
+
+**OpenSpec change**: `retrofit-2026-05-24-b-ctrl-graphql-rt-dash`
+
+**Cross-references**: [realtime-updates main spec](../../../../specs/realtime-updates/spec.md), `lib/Controller/RealtimeController.php`.
+
+## Purpose of this delta
+
+The `realtime-updates` capability specifies SSE as the primary transport and a
+client-side polling fallback against the generic REST list API. It does **not**
+specify the dedicated cursor-polling HTTP endpoints implemented by
+`RealtimeController` — `GET /api/realtime/events` and `GET /api/realtime/cursor`.
+These provide a lightweight, RBAC- and tenant-scoped poll surface that clients
+use directly (rather than diffing full REST list pages). This delta documents
+their **observed** contracts. No behaviour change.
+
+---
+
+## ADDED Requirements
+
+### Requirement: The cursor-polling events endpoint MUST return a scoped, bounded event envelope
+
+The cursor-polling events endpoint MUST return change events newer than the
+supplied cursor in a fixed envelope, and MUST scope every response to the
+authenticated caller's active organisation, never leaking cross-tenant events.
+The endpoint is `GET /api/realtime/events` (`RealtimeController::events`,
+`@NoAdminRequired`, `@NoCSRFRequired`).
+
+#### Scenario: Anonymous caller is rejected
+- **GIVEN** an unauthenticated request to `GET /api/realtime/events`
+- **WHEN** `RealtimeController::events` resolves `IUserSession::getUser()` as `null`
+- **THEN** the endpoint MUST return HTTP 401 with body `{"error": "Unauthorized"}`
+- **AND** no events MUST be queried or returned
+
+#### Scenario: Authenticated poll returns a bounded envelope
+- **GIVEN** an authenticated caller with an active organisation and `?since=42&limit=100`
+- **WHEN** the endpoint queries `RealtimeEventMapper::findSince` with the org-scoped filters (`register`, `schema`, `objectUuid`, `eventType`, `organisation`)
+- **THEN** the response MUST be `{events: CloudEvent[], cursor: int, hasMore: bool}`
+- **AND** `cursor` MUST be the id of the last returned event, or `since` (or `0`) when no events were returned
+- **AND** `hasMore` MUST be `true` only when the number of returned events equals the effective limit
+
+#### Scenario: Limit is clamped and active-org scoping is enforced
+- **GIVEN** an authenticated caller requests `?limit=99999`
+- **WHEN** the endpoint computes the effective limit
+- **THEN** the limit MUST be clamped to the range `1..1000`
+- **AND** results MUST be filtered to the caller's active organisation UUID
+- **AND** when the caller has no resolvable active organisation, the endpoint MUST return an empty envelope `{events: [], cursor: since ?? 0, hasMore: false}` rather than HTTP 500
+
+### Requirement: The head-cursor endpoint MUST be tenant-scoped and fail closed
+
+The head-cursor endpoint MUST return the highest event id visible to the
+caller's active organisation so clients can fast-forward past historical events
+on initial subscription, and MUST NOT expose a global head pointer. The endpoint
+is `GET /api/realtime/cursor` (`RealtimeController::cursor`, `@NoAdminRequired`,
+`@NoCSRFRequired`).
+
+#### Scenario: Anonymous caller is rejected
+- **GIVEN** an unauthenticated request to `GET /api/realtime/cursor`
+- **WHEN** `RealtimeController::cursor` finds no session user
+- **THEN** the endpoint MUST return HTTP 401 with body `{"error": "Unauthorized"}`
+
+#### Scenario: Head cursor is scoped to the active organisation
+- **GIVEN** an authenticated caller with an active organisation
+- **WHEN** the endpoint resolves the head cursor
+- **THEN** it MUST return `{cursor: <RealtimeEventMapper::getMaxIdForOrganisation(org)>}`
+- **AND** the global head pointer MUST NOT be returned (no cross-tenant write-rate side channel)
+
+#### Scenario: No active organisation fails closed
+- **GIVEN** an authenticated caller with no resolvable active organisation
+- **WHEN** the endpoint resolves the head cursor
+- **THEN** it MUST return `{cursor: 0}` (fail closed — no head pointer to mine)

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md
@@ -1,0 +1,94 @@
+# Tasks: reverse-spec controller bundle — graphql / realtime / dashboard / reports / revert
+
+Reverse-spec annotation pass. Each task corresponds to a controller method (or
+group) whose `@spec` annotation points back to the task anchor below. No
+production behaviour changes.
+
+## Capability: graphql-api (annotation only)
+
+### Task 1 — GraphQLController::execute HTTP contract
+`POST /api/graphql` — public + CORS execute endpoint. Accepts JSON body
+`{query, variables, operationName}`; returns 400 when body is not JSON or
+`query` is missing; 200 for data (even with partial errors); 429 +
+`Retry-After` header when the first error code is `RATE_LIMITED`. Already
+specified by the existing graphql-api requirements (GraphiQL explorer, HTTP
+status codes, error response). Annotation re-point only.
+
+### Task 2 — GraphQLController::explorer GraphiQL surface
+`GET /api/graphql/explorer` — serves the CDN-hosted GraphiQL v3 HTML page with a
+relaxed CSP (unpkg.com script/style/font, inline style, eval) and the CSRF
+`requesttoken` baked into the fetcher. `getGraphiQLHtml()` is the private body
+builder. Already specified. Annotation re-point only.
+
+## Capability: realtime-updates (extend — cursor-polling HTTP surface)
+
+### Task 3 — RealtimeController::events cursor-polling endpoint
+`GET /api/realtime/events?since={cursor}&limit=100&register=&schema=&objectUuid=&eventType=`.
+Returns `{events: CloudEvent[], cursor: int, hasMore: bool}`. Anonymous callers
+get HTTP 401. `limit` is clamped to `1..1000`. Events are scoped to the caller's
+active organisation; with no active org the endpoint returns an empty envelope
+(fail-open to empty, not 500). `cursor` is the id of the last returned event, or
+`since` (or 0) when empty. `hasMore` is true when the clamped limit was reached.
+
+### Task 4 — RealtimeController::cursor head-pointer endpoint
+`GET /api/realtime/cursor` → `{cursor: int}`. Anonymous callers get HTTP 401.
+The head cursor is scoped to the caller's active organisation
+(`getMaxIdForOrganisation`) to avoid a cross-tenant write-rate side channel;
+with no active organisation it fails closed to `{cursor: 0}`. Clients call this
+once on subscribe to fast-forward past historical events.
+
+## Capability: built-in-dashboards (extend — dashboard data-feed HTTP surface)
+
+### Task 5 — DashboardController::page dashboard SPA page
+`GET` dashboard page — returns the `index` TemplateResponse with a CSP that
+allows API connect domains (`connect-src *`); on render failure returns the
+`error` template with status 500. Serves the dashboard SPA, not data.
+
+### Task 6 — DashboardController::index registers-with-schemas feed
+Returns `{registers: [...]}` — every register with its schemas and per-schema
+stats (objects / logs / files / webhookLogs totals + sizes). Optional
+`registerId` / `schemaId` filters; pagination/routing params are stripped before
+the service call. Errors return `{error}` with status 500.
+
+### Task 7 — DashboardController::calculate size-calculation trigger
+Triggers recomputation of object + log storage sizes (optionally scoped by
+`registerId` / `schemaId`). Returns the calculation result on 200; on failure
+returns `{status: 'error', message, timestamp}` with status 500.
+
+### Task 8 — DashboardController chart & statistics feeds
+The six audit/object data feeds powering the dashboard widgets:
+`getAuditTrailActionChart` (date-ranged action chart),
+`getObjectsByRegisterChart`, `getObjectsBySchemaChart`, `getObjectsBySizeChart`
+(distribution buckets), `getAuditTrailStatistics` (totals by action over a
+look-back window), `getAuditTrailActionDistribution`, and `getMostActiveObjects`
+(top-N by audit activity). All accept optional `registerId` / `schemaId` (and
+`from`/`till`/`hours`/`limit` where relevant), return `{labels, series}` /
+statistics shapes, and map exceptions to `{error}` with status 500.
+
+## Capability: rapportage-bi-export (extend — report render HTTP surface)
+
+### Task 9 — ReportsController::render on-demand report render
+`POST /api/reports/{id}/render?format=xlsx` — renders a stored dashboard
+definition to the requested format (default `xlsx`; `csv` / `ods` / `html`
+supported). Success returns a `DataDownloadResponse` (browser download).
+Dashboard-not-found maps to 404, `InvalidArgumentException` (validation) to 422,
+any other render/load failure to a generic 500 with internal detail logged
+(never leaked to the response body).
+
+### Task 10 — ReportsController::preview inline HTML preview + RBAC load
+`GET /api/reports/{id}/preview` — renders the dashboard to HTML and returns it
+with `Content-Disposition: inline` so an iframe can preview before download;
+not-found maps to 404. `loadDashboard()` resolves the dashboard by
+numeric-id / uuid / slug through `MagicMapper::find`, which applies standard
+RBAC + multi-tenancy filtering on every load (no bypass — prevents
+cross-tenant render exfiltration).
+
+## Capability: content-versioning (annotation only)
+
+### Task 11 — RevertController::revert object reversion endpoint
+`POST /api/revert/{register}/{schema}/{id}` — reverts an object to a prior state
+via one of `datetime` / `auditTrailId` / `version` (400 if none supplied),
+optional `overwriteVersion`. Maps `DoesNotExistException` → 404,
+`NotAuthorizedException` → 403, `LockedException` → 423, other failures → 500.
+Already specified by the content-versioning rollback requirements. Annotation
+re-point only.


### PR DESCRIPTION
## Summary

Reverse-spec (documentation-only) pass over five HTTP controllers in `lib/Controller/`. Adds `@spec` annotations linking each observed controller contract to a new ghost change, and extends three capabilities with the endpoint-contract requirements that were genuinely uncovered. **No production behaviour changes** — docblock `@spec` annotations only.

Bundle: `ctrl-graphql-rt-dash` (5 controller sub-clusters, all `--extend`).

## Sub-clusters

| Sub-cluster | Capability | Outcome | New REQs |
|---|---|---|---|
| graphql-api-surface | `graphql-api` | annotation only — execute/explorer already fully spec'd | 0 |
| realtime-sse-api | `realtime-updates` | extend — `/api/realtime/events` + `/cursor` cursor-polling HTTP surface | 2 |
| dashboard-charts-api | `built-in-dashboards` | extend — `DashboardController` page/index/calculate + 6 chart/stats feeds | 4 |
| report-render-api | `rapportage-bi-export` | extend — `ReportsController` render/preview HTTP contract | 2 |
| revert-content-versioning | `content-versioning` | annotation only — revert endpoint already fully spec'd | 0 |

**8 new requirements** (≤ 12 budget). Ghost change: `openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/`. `openspec validate --strict` passes.

## Annotations

5 controllers, 23 `@spec` annotations (5 file-level + 18 method-level), pointing at `tasks.md#task-1..11`. GraphQL and Revert re-point alongside the existing `retrofit-2026-04-30-annotate-openregister` anchors.

## Dropped scanner false-positives

- `GraphQLController::render`/`getGraphiQLHtml` — private/anonymous-class helpers behind `explorer()`.
- `DashboardController::page` — SPA template, folded into the page+feed requirement set.
- `ReportsController::loadDashboard` — private RBAC loader; captured inside the preview requirement.

## Test plan

- [x] `php -l` clean on all 5 controllers
- [x] `openspec validate ... --strict` passes
- [ ] PHPCS blank-line rule on `@spec` tags (CI)