### PR TITLE
retrofit: reverse-spec controller bundle — object/data (5 sub-clusters)

### DIFF
--- a/lib/Controller/BulkController.php
+++ b/lib/Controller/BulkController.php
@@ -272,6 +272,8 @@ class BulkController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with schema delete result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-15
      */
     public function deleteSchema(string $register, string $schema): JSONResponse
     {
@@ -331,6 +333,8 @@ class BulkController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with deletion result.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-15
      */
     public function deleteSchemaObjects(string $register, string $schema): JSONResponse
     {
@@ -389,6 +393,8 @@ class BulkController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with register delete result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-15
      */
     public function deleteRegister(string $register): JSONResponse
     {

--- a/lib/Controller/ConfigurationController.php
+++ b/lib/Controller/ConfigurationController.php
@@ -601,6 +601,8 @@ class ConfigurationController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with import result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-14
      */
     public function import(int $id): JSONResponse
     {
@@ -661,6 +663,8 @@ class ConfigurationController extends Controller
      * @NoCSRFRequired
      *
      * @psalm-return JSONResponse<200|404|500, array, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-14
      */
     public function export(int $id): JSONResponse
     {
@@ -710,6 +714,8 @@ class ConfigurationController extends Controller
      *     type: 'User'|mixed, url: ''|mixed}, config: array,
      *     project_id?: mixed, ref?: 'main'|mixed}|mixed,...},
      *     page?: int, per_page?: int}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-13
      */
     public function discover(): JSONResponse
     {
@@ -795,6 +801,8 @@ class ConfigurationController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with branches list
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-13
      */
     public function getGitHubBranches(): JSONResponse
     {
@@ -936,6 +944,8 @@ class ConfigurationController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with branches list
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-13
      */
     public function getGitLabBranches(): JSONResponse
     {
@@ -1324,6 +1334,8 @@ class ConfigurationController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with import result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-13
      */
     public function importFromGitHub(): JSONResponse
     {
@@ -1346,6 +1358,8 @@ class ConfigurationController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with import result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-13
      */
     public function importFromGitLab(): JSONResponse
     {
@@ -1368,6 +1382,8 @@ class ConfigurationController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with import result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-13
      */
     public function importFromUrl(): JSONResponse
     {
@@ -1394,6 +1410,8 @@ class ConfigurationController extends Controller
      * @psalm-suppress InvalidReturnStatement
      *
      * @return JSONResponse JSON response with publish result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-13
      */
     public function publishToGitHub(int $id): JSONResponse
     {

--- a/lib/Controller/ConfigurationsController.php
+++ b/lib/Controller/ConfigurationsController.php
@@ -319,6 +319,8 @@ class ConfigurationsController extends Controller
      *     array<never, never>>
      *
      * @suppressWarnings(PHPMD.BooleanArgumentFlag) Toggle to include/exclude objects in export
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-14
      */
     public function export(int $id, bool $includeObjects=false): JSONResponse|DataDownloadResponse
     {
@@ -370,6 +372,8 @@ class ConfigurationsController extends Controller
      * @NoAdminRequired
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-14
      */
     public function import(): JSONResponse
     {

--- a/lib/Controller/DeletedController.php
+++ b/lib/Controller/DeletedController.php
@@ -265,6 +265,8 @@ class DeletedController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with deletion statistics
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-16
      */
     public function statistics(): JSONResponse
     {
@@ -321,6 +323,8 @@ class DeletedController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with top deleters data
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-16
      */
     public function topDeleters(): JSONResponse
     {

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -1473,6 +1473,8 @@ class ObjectsController extends Controller
      * @suppressWarnings(PHPMD.ExcessiveMethodLength)
      * @suppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Cross-table search + multi-schema routing requires branching
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-1
      */
     public function objects(ObjectService $objectService): JSONResponse
     {
@@ -1657,6 +1659,8 @@ class ObjectsController extends Controller
      *
      * @suppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Object retrieval with slug resolution + access checks requires branching
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-2
      */
     public function show(
         string $id,
@@ -2135,6 +2139,8 @@ class ObjectsController extends Controller
      *
      * @suppressWarnings(PHPMD.ExcessiveMethodLength)
      * @suppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-3
      */
     public function patch(
         string $register,
@@ -2545,6 +2551,8 @@ class ObjectsController extends Controller
      *     page: float|int<1, max>, pages: 1|float, limit: int<1, max>,
      *     offset: int<0, max>, next?: string, prev?: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-6
      */
     public function contracts(string $id, string $register, string $schema, ObjectService $objectService): JSONResponse
     {
@@ -2621,6 +2629,8 @@ class ObjectsController extends Controller
      *     array{results: list<ObjectEntity>, total: int<0, max>,
      *     limit: 30|mixed, offset: 0|mixed},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-6
      */
     public function uses(string $id, string $register, string $schema, ObjectService $objectService): JSONResponse
     {
@@ -2668,6 +2678,8 @@ class ObjectsController extends Controller
      *     array{results: array<never, never>, total: 0, limit: 30|mixed,
      *     offset: 0|mixed, message?: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-6
      */
     public function used(string $id, string $register, string $schema, ObjectService $objectService): JSONResponse
     {
@@ -2719,6 +2731,8 @@ class ObjectsController extends Controller
      *
      * @suppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Audit log retrieval with pagination + access checks requires branching
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-7
      */
     public function logs(string $id, string $register, string $schema, ObjectService $objectService): JSONResponse
     {
@@ -2822,6 +2836,8 @@ class ObjectsController extends Controller
      * @NoAdminRequired
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-4
      */
     public function lock(string $register, string $schema, string $id): JSONResponse
     {
@@ -2869,6 +2885,8 @@ class ObjectsController extends Controller
      * @psalm-return JSONResponse<200, array{
      *     message: 'Object unlocked successfully', locked: false, uuid: string
      * }, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-4
      */
     public function unlock(string $register, string $schema, string $id): JSONResponse
     {
@@ -2906,6 +2924,7 @@ class ObjectsController extends Controller
      * @psalm-suppress NoValue
      *
      * @spec openspec/changes/retrofit-2026-04-30-annotate-openregister/tasks.md#task-22
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-11
      */
     public function export(string $register, string $schema, ObjectService $objectService): DataDownloadResponse
     {
@@ -2982,6 +3001,7 @@ class ObjectsController extends Controller
      * @psalm-suppress NoValue
      *
      * @spec openspec/changes/retrofit-2026-04-30-annotate-openregister/tasks.md#task-20
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-11
      */
     public function import(int $register): JSONResponse
     {
@@ -3047,6 +3067,8 @@ class ObjectsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with merge result or error
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-5
      */
     public function merge(
         string $id,
@@ -3104,6 +3126,8 @@ class ObjectsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with migration result or error
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-12
      */
     public function migrate(ObjectService $objectService): JSONResponse
     {
@@ -3178,6 +3202,8 @@ class ObjectsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-10
      */
     public function downloadFiles(
         string $id,
@@ -3274,6 +3300,8 @@ class ObjectsController extends Controller
      * @psalm-suppress NoValue
      *
      * @psalm-return JSONResponse<200|500, array{success: bool, error?: string, data?: mixed}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-9
      */
     public function vectorizeBatch(): JSONResponse
     {
@@ -3317,6 +3345,8 @@ class ObjectsController extends Controller
      * @psalm-suppress NoValue
      *
      * @psalm-return JSONResponse<200|500, array{success: bool, error?: string, stats?: mixed}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-9
      */
     public function getObjectVectorizationStats(): JSONResponse
     {
@@ -3359,6 +3389,8 @@ class ObjectsController extends Controller
      * @psalm-suppress NoValue
      *
      * @psalm-return JSONResponse<200|500, array{success: bool, error?: string, count?: mixed}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-9
      */
     public function getObjectVectorizationCount(): JSONResponse
     {
@@ -3401,6 +3433,8 @@ class ObjectsController extends Controller
      * @return JSONResponse JSON response with validation results
      *
      * @psalm-return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-8
      */
     public function validate(): JSONResponse
     {
@@ -3619,6 +3653,8 @@ class ObjectsController extends Controller
      * @psalm-return JSONResponse
      *
      * @deprecated Blob storage has been retired; this endpoint is a no-op.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-8
      */
     public function clearBlob(): JSONResponse
     {

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/proposal.md
@@ -1,0 +1,124 @@
+---
+status: draft
+retrofit: true
+---
+
+# Retrofit: Reverse-spec controller bundle — object/data (5 sub-clusters)
+
+## Why
+
+A coverage scan of OpenRegister's controller layer identified five HTTP-surface
+sub-clusters around object and data operations whose request/response contracts
+are not yet captured by any spec. The underlying services are largely
+implemented and (for the lifecycle pipeline, import/export, and soft-delete)
+already speced at the service layer — but the *controller* contract (route
+shape, status codes, parameter handling, error envelopes) was undocumented. This
+ghost change reverse-specs the observed controller behavior and annotates the
+methods, biasing strongly toward **extending** existing capabilities rather than
+minting new ones.
+
+This is a documentation/annotation change only. No runtime behavior is modified.
+
+## What changes
+
+Five sub-clusters, all `--extend`:
+
+### 1. `object-rest-api` → extend **object-lifecycle**
+
+`ObjectsController` is the canonical `/api/objects/{register}/{schema}/...` CRUD
+and sub-resource surface. The existing `object-lifecycle` spec documents the
+*internal* layered save pipeline (`SaveObject` handlers), not the HTTP contract.
+We add REQs that document the controller's observed REST behavior for the route
+family that is not otherwise covered: collection listing via the magic-mapper
+router (`objects()`), single-object read (`show`), partial update (`patch`),
+optimistic locking (`lock`/`unlock`), object merge, and the relation/audit
+sub-resources (`contracts`, `uses`, `used`, `logs`). The bulk-validation
+trigger (`validate`) and the retired blob-clear endpoint (`clearBlob`) are also
+documented.
+
+Already-covered route members are **annotated to their owning cap, not
+re-specced**: `index`/`geoSearch` → `zoeken-filteren`; `create`/`update` → the
+object-lifecycle save pipeline REQs; `destroy`/`canDelete` →
+`deletion-audit-trail`.
+
+### 2. `object-cross-cutting-vector-files-migrate` → CROSS-CUTTING (annotate-only)
+
+Several `ObjectsController` methods physically live in this controller but belong
+to other capabilities. **Per the guardrail, these are NOT lumped into one cap —
+each method is annotated to the capability that actually owns its behavior, and
+NO new REQs are minted for them** (the owning specs already cover the behavior):
+
+- `vectorizeBatch`, `getObjectVectorizationStats`, `getObjectVectorizationCount`
+  → **chat-ai** (vector/RAG pipeline; these are the object-side batch vectorize
+  controls feeding the same vector store the chat-ai RAG context reads from).
+- `downloadFiles` → **files-render-extension** (object file surface; the bulk
+  ZIP download is a file-output endpoint for the same attached-files model the
+  render extension governs).
+- `import`, `export` → **data-import-export** (the controller endpoints the
+  import/export spec already names: `ObjectsController::import()` /
+  `ObjectsController::export()`).
+- `migrate` → **workflow-engine-abstraction** (object migration between
+  register/schema with property mapping is the object-mutation operation that
+  the workflow/import machinery drives).
+
+The spec delta therefore touches multiple caps but adds spec text only where the
+controller contract is genuinely uncovered; the cross-cutting methods get inline
+`@spec` annotations pointing at their owning capability via this change's
+tasks.md.
+
+### 3. `configuration-api` → extend **data-import-export**
+
+`ConfigurationController` and `ConfigurationsController` are the
+configuration-package REST surface. `data-import-export` already owns the
+configuration-portability REQ (OpenAPI 3.0.0 register export/import). The
+**GitHub/GitLab/URL publishing and discovery** flow (`discover`,
+`getGitHubBranches`, `getGitLabBranches`, `importFromGitHub`/`GitLab`/`Url`,
+`publishToGitHub`) is a distinct remote-portability surface not yet captured →
+one new REQ. The per-configuration `ConfigurationsController::export`/`import`
+(file download / upload of a single configuration) is annotated to the existing
+portability REQ.
+
+> NOTE: the batch JSON labels several `ConfigurationController` methods as
+> "triaged DROP from chat-ai / actions / object-lifecycle / geo-metadata". Per
+> architect review those labels are **wrong** — these methods are
+> configuration-package GitHub publishing and ARE in-scope for
+> `data-import-export`. They are grouped here, not dropped.
+
+### 4. `bulk-data-ops` → extend **data-import-export**
+
+`BulkController` bulk-delete-by-schema/register (`deleteSchema`,
+`deleteSchemaObjects`, `deleteRegister`) is a mass-mutation surface adjacent to
+the bulk-import already covered by `data-import-export`. The `validateSchema`
+and `save`/`delete` members are already annotated/covered. One new REQ documents
+the bulk-delete contract. `resolveRegisterSchemaIds` is a private helper
+(annotate-only, no REQ).
+
+### 5. `soft-delete-recovery-api` → extend **deletion-audit-trail**
+
+`DeletedController` is the trash/recycle-bin REST surface.
+`deletion-audit-trail` REQ-3 (restore) and REQ-11 (list / filter / statistics)
+already cover the bulk of this controller, and most methods are **already
+annotated** (`index`, `restore`, `restoreMultiple`, `destroy`,
+`destroyMultiple` → existing retrofit tasks). The remaining uncovered members —
+`statistics` and `topDeleters` (deletion analytics surface) — are annotated to
+the existing REQ-11 which names exactly those endpoints. **No new REQs** for
+this sub-cluster; it is annotation-only.
+
+## New requirements summary (target ≤ 12)
+
+| Capability | New REQs | Notes |
+|---|---|---|
+| object-lifecycle | 8 | REST CRUD/lock/merge/relation/audit/validate HTTP surface |
+| data-import-export | 2 | config GitHub/GitLab/URL publishing+discovery; bulk delete |
+| deletion-audit-trail | 0 | annotation-only (REQ-3/REQ-11 cover it) |
+| chat-ai / files-render-extension / workflow-engine-abstraction | 0 | cross-cutting annotation-only |
+| **Total** | **10** | within budget |
+
+## Impact
+
+- Specs extended: `object-lifecycle`, `data-import-export`.
+- Specs referenced (annotation targets, no delta): `deletion-audit-trail`,
+  `chat-ai`, `files-render-extension`, `workflow-engine-abstraction`.
+- Controllers annotated: `ObjectsController`, `ConfigurationController`,
+  `ConfigurationsController`, `BulkController`, `DeletedController`.
+- No code behavior change; docblock `@spec` annotations only.

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/specs/data-import-export/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/specs/data-import-export/spec.md
@@ -1,0 +1,97 @@
+---
+status: draft
+---
+
+# Data Import and Export
+
+## Purpose
+
+Extend the data-import-export capability with two controller surfaces that the
+existing spec does not yet cover: (1) the configuration remote-portability flow
+on `ConfigurationController` (publishing to and discovering/importing from
+GitHub, GitLab, and arbitrary URLs), and (2) the bulk delete-by-scope surface on
+`BulkController`. The existing REQs already cover OpenAPI 3.0.0 configuration
+portability and bulk *import*; these added REQs cover the remote publishing and
+the bulk *delete* halves. Reverse-specced from the existing implementation.
+
+## ADDED Requirements
+
+### Requirement: Configurations MUST be publishable to and discoverable from remote GitHub, GitLab, and URL sources
+
+`ConfigurationController` MUST support a remote configuration-package
+portability surface that complements the local OpenAPI 3.0.0 export/import:
+discovering OpenRegister configurations hosted on GitHub or GitLab, listing
+their branches, importing a configuration from a GitHub/GitLab repository or an
+arbitrary URL, and publishing a local configuration to a GitHub repository.
+Discovery MUST validate the `source` against `github`/`gitlab`. Import-from-source
+MUST construct a `Configuration` entity and run it through the standard import
+flow. Publishing MUST validate the configuration is publishable, prepare the
+OpenAPI payload, detect an existing file SHA for updates, and update the local
+configuration with the resulting GitHub source information.
+
+> NOTE: several of these methods were mislabeled in the upstream coverage scan as
+> "triaged DROP from chat-ai / actions / object-lifecycle / geo-metadata". That
+> triage is incorrect — they are configuration-package GitHub/GitLab publishing
+> and belong to this capability.
+
+#### Scenario: Discover configurations on GitHub
+- **GIVEN** a discover request with `source=github` and a `_search` term
+- **WHEN** `ConfigurationController::discover()` runs
+- **THEN** the GitHub handler's `searchConfigurations()` MUST be invoked and the results returned (HTTP 200)
+
+#### Scenario: Reject an invalid discovery source
+- **GIVEN** a discover request with `source` that is neither `github` nor `gitlab`
+- **WHEN** `discover()` validates the source
+- **THEN** the response MUST be HTTP 400 with `error: 'Invalid source. Must be "github" or "gitlab"'`
+
+#### Scenario: List repository branches
+- **GIVEN** a request supplying `owner` and `repo`
+- **WHEN** `getGitHubBranches()` (or `getGitLabBranches()`) runs
+- **THEN** the response MUST contain the branch list; a missing `owner` or `repo` MUST return HTTP 400
+
+#### Scenario: Import a configuration from a remote source
+- **GIVEN** an import-from-source request (GitHub, GitLab, or URL)
+- **WHEN** `importFromGitHub()` / `importFromGitLab()` / `importFromUrl()` runs
+- **THEN** a `Configuration` entity MUST be constructed from the fetched config and run through the standard import flow
+
+#### Scenario: Publish a local configuration to GitHub
+- **GIVEN** a publishable local configuration and valid GitHub publish parameters
+- **WHEN** `publishToGitHub()` runs
+- **THEN** the configuration MUST be exported, an existing file SHA detected for updates, the content published to the target repository, and the local configuration updated with the GitHub source info
+
+#### Scenario: Reject publishing with missing parameters
+- **GIVEN** a publish request missing required GitHub parameters
+- **WHEN** `extractGitHubPublishParams()` returns an error
+- **THEN** the response MUST be HTTP 400 with the error message
+
+### Requirement: The system MUST support bulk delete of objects scoped by register and schema
+
+`BulkController` MUST expose mass-delete operations scoped by register and/or
+schema: `deleteSchema()` and `deleteSchemaObjects()` delete all objects for a
+register+schema combination, and `deleteRegister()` deletes all objects for a
+register. These endpoints MUST accept an optional `hardDelete` flag (soft delete
+by default), resolve slug/numeric identifiers to numeric IDs, and return a
+`{success, message, deleted_count, deleted_uuids, ...scope ids, hard_delete}`
+envelope. Invalid (non-numeric where required) identifiers MUST return HTTP 400;
+unresolvable register/schema MUST return HTTP 404; failures MUST return HTTP 500.
+
+#### Scenario: Bulk delete all objects for a register+schema
+- **GIVEN** a register and schema with objects and an optional `hardDelete` flag
+- **WHEN** `BulkController::deleteSchemaObjects()` runs
+- **THEN** the register/schema identifiers MUST be resolved to numeric IDs and `deleteObjectsBySchema()` invoked
+- **AND** the response MUST include `success: true`, `deleted_count`, `deleted_uuids`, `register_id`, `schema_id`, and `hard_delete`
+
+#### Scenario: Bulk delete rejects a non-numeric schema id where one is required
+- **GIVEN** a `deleteSchema()` request with a non-numeric `schema`
+- **WHEN** the controller validates the input
+- **THEN** the response MUST be HTTP 400 with `error: "Invalid schema ID. Must be numeric."`
+
+#### Scenario: Bulk delete all objects for a register
+- **GIVEN** a numeric register id
+- **WHEN** `deleteRegister()` runs
+- **THEN** `deleteObjectsByRegister()` MUST be invoked and the response MUST include `deleted_count`, `deleted_uuids`, and `register_id`
+
+#### Scenario: Unresolvable register/schema returns 404
+- **GIVEN** a `deleteSchemaObjects()` request whose register or schema cannot be resolved
+- **WHEN** `resolveRegisterSchemaIds()` throws
+- **THEN** the response MUST be HTTP 404 with the error message

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/specs/object-lifecycle/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/specs/object-lifecycle/spec.md
@@ -1,0 +1,209 @@
+---
+retrofit: true
+---
+
+# Object Lifecycle
+
+## Purpose
+
+Extend the object-lifecycle capability with the HTTP REST contract exposed by
+`ObjectsController` — the canonical `/api/objects/{register}/{schema}/...` CRUD
+and sub-resource surface. The existing REQs (REQ-001..REQ-005) document the
+internal layered save pipeline; these added requirements document the observed
+controller behavior that sits in front of that pipeline: route shape, status
+codes, parameter handling, and error envelopes. This is reverse-specced from
+the existing implementation; no behavior is changed.
+
+## ADDED Requirements
+
+### Requirement: The object collection endpoint MUST serve a paginated, source-routed list
+
+`ObjectsController::objects()` MUST resolve the target register/schema from
+either path-style (`register`/`schema`) or underscore-prefixed
+(`_register`/`_schema`) query parameters, and route the read to the optimal
+source: a cross-table search when more than one register or schema is supplied,
+the `MagicMapper` table when magic mapping is enabled for the resolved
+register+schema, or `ObjectService::searchObjectsPaginated()` otherwise. Unless
+`_empty=true` is supplied, empty values MUST be stripped from each result row.
+
+#### Scenario: Single register+schema served via paginated search
+- **GIVEN** a request to the objects endpoint with `register` and `schema` query parameters and no magic mapping configured
+- **WHEN** `ObjectsController::objects()` processes the request
+- **THEN** the response MUST be the `searchObjectsPaginated()` envelope (`results`, `total`, `pages`, `page`, `limit`)
+- **AND** empty values in each result row MUST be stripped unless `_empty=true` was supplied
+
+#### Scenario: Multiple schemas trigger cross-table search
+- **GIVEN** a request supplying a `schemas` parameter with more than one schema
+- **WHEN** `objects()` parses the multi-value parameter
+- **THEN** the request MUST be delegated to `crossTableSearch()`
+
+#### Scenario: Unresolvable register or schema returns 404
+- **GIVEN** a request whose `register` or `schema` cannot be resolved
+- **WHEN** `objects()` calls `resolveRegisterSchemaIds()`
+- **THEN** the response MUST be HTTP 404 with a `message` body
+
+### Requirement: The object read endpoint MUST resolve slugs and return a 404 envelope on miss
+
+`ObjectsController::show()` MUST accept a register and schema as slug or numeric
+ID, resolve them to entities via `resolveRegisterSchemaIds()`, and return the
+single object honoring the request's extend and field-filter parameters. If the
+register or schema cannot be resolved, the response MUST be HTTP 404 with a
+`message` body.
+
+#### Scenario: Show resolves slugs and returns the object
+- **GIVEN** an existing object addressed by `{register}/{schema}/{id}` using slugs
+- **WHEN** `show()` is called
+- **THEN** the register and schema slugs MUST be resolved to entities before the read
+- **AND** the response MUST be the rendered object honoring any `_extend` / field-filter parameters
+
+#### Scenario: Show on unknown register/schema returns 404
+- **GIVEN** a request whose register or schema does not exist
+- **WHEN** `resolveRegisterSchemaIds()` throws `RegisterNotFoundException` or `SchemaNotFoundException`
+- **THEN** the response MUST be HTTP 404 with a `message` body
+
+### Requirement: The object patch endpoint MUST merge with stored data and map domain errors to status codes
+
+`ObjectsController::patch()` MUST filter out reserved/underscore-prefixed and
+`@`-prefixed keys (except `@self`) and `uuid`/`register`/`schema` from the
+payload, normalize multipart form-data values, read the existing object via
+`findSilent` (RBAC and multitenancy disabled for the internal read), and merge
+the patch over the stored object data before saving. RBAC and multitenancy on
+the save MUST be enabled only for non-admin callers. The object MUST be unlocked
+after a successful save. Domain errors MUST map to: append-only → HTTP 405,
+validation → HTTP 422, missing object → HTTP 404, other → HTTP 500.
+
+#### Scenario: Patch merges over existing data
+- **GIVEN** an existing object and a patch payload containing a subset of fields
+- **WHEN** `patch()` processes the request
+- **THEN** the patch MUST be merged over the stored object data (`array_merge(existing, patch)`) before `saveObject()`
+- **AND** reserved keys (underscore- and `@`-prefixed except `@self`, plus `uuid`/`register`/`schema`) MUST be filtered out of the payload
+
+#### Scenario: Append-only schema rejects patch with 405
+- **GIVEN** the target schema is append-only
+- **WHEN** the save raises `AppendOnlyException`
+- **THEN** the response MUST be HTTP 405 with the exception's response body
+
+#### Scenario: Validation failure returns 422
+- **GIVEN** a patch that fails schema validation
+- **WHEN** `saveObject()` raises `ValidationException` or `CustomValidationException`
+- **THEN** the response MUST be the validation-exception envelope (HTTP 422)
+
+#### Scenario: Missing object returns 404
+- **GIVEN** a patch addressed to a non-existent object id
+- **WHEN** `findSilent` cannot locate the object
+- **THEN** the response MUST be HTTP 404 with `error: "Object not found"`
+
+### Requirement: The object lock and unlock endpoints MUST manage optimistic locks with a status flag
+
+`ObjectsController::lock()` MUST accept optional `process` and `duration`
+parameters, delegate to `ObjectService::lockObject()`, and return the lock
+result merged with `locked: true`. A non-existent object MUST return HTTP 404
+and other failures HTTP 500. `ObjectsController::unlock()` MUST delegate to
+`ObjectService::unlockObject()` and return `{message, locked: false, uuid}`.
+
+#### Scenario: Lock returns the locked status
+- **GIVEN** an existing object and an optional `duration`
+- **WHEN** `lock()` is called
+- **THEN** the response MUST be the lock result merged with `locked: true`
+
+#### Scenario: Lock on missing object returns 404
+- **GIVEN** a lock request for a non-existent object
+- **WHEN** `lockObject()` raises `DoesNotExistException`
+- **THEN** the response MUST be HTTP 404 with `error: "Object not found"`
+
+#### Scenario: Unlock clears the lock
+- **GIVEN** a locked object
+- **WHEN** `unlock()` is called
+- **THEN** the response MUST be `{message: "Object unlocked successfully", locked: false, uuid}`
+
+### Requirement: The object merge endpoint MUST validate the merge payload and map errors to status codes
+
+`ObjectsController::merge()` MUST require both a `target` object id and a
+non-empty `object` payload in the request body, returning HTTP 400 if either is
+missing, and delegate to `ObjectService::mergeObjects()`. A missing object MUST
+return HTTP 404, an invalid argument HTTP 400, and any other failure HTTP 500.
+The execution time limit MUST be disabled (`set_time_limit(0)`) because merging
+objects with many references can be long-running.
+
+#### Scenario: Merge requires target and object payload
+- **GIVEN** a merge request missing the `target` id or with an empty `object` payload
+- **WHEN** `merge()` validates the request
+- **THEN** the response MUST be HTTP 400 with a descriptive `error`
+
+#### Scenario: Merge of a non-existent source returns 404
+- **GIVEN** a merge whose source object id does not exist
+- **WHEN** `mergeObjects()` raises `DoesNotExistException`
+- **THEN** the response MUST be HTTP 404 with `error: "Object not found"`
+
+### Requirement: The relation sub-resource endpoints MUST return paginated forward and inverse references
+
+`ObjectsController::contracts()`, `uses()`, and `used()` MUST set the
+register/schema context on the object service and return relation traversals for
+the addressed object. `uses()` MUST return objects this object references
+(A→B); `used()` MUST return objects that reference this object (B→A);
+`contracts()` MUST return the object's contracts as a paginated envelope. RBAC
+and multitenancy MUST be enforced on `uses()` and `used()`.
+
+#### Scenario: uses returns forward references
+- **GIVEN** object A that references objects B and C
+- **WHEN** `uses()` is called for A
+- **THEN** the response MUST contain B and C (the objects A uses)
+- **AND** RBAC and multitenancy MUST be enforced
+
+#### Scenario: used returns inverse references
+- **GIVEN** objects B and C that reference object A
+- **WHEN** `used()` is called for A
+- **THEN** the response MUST contain B and C (the objects that use A)
+
+#### Scenario: contracts returns a paginated envelope
+- **GIVEN** an object with contracts and `limit`/`offset` query parameters
+- **WHEN** `contracts()` is called
+- **THEN** the response MUST be a paginated envelope (`results`, `total`, `limit`, `offset`, `page`)
+
+### Requirement: The object audit-log sub-resource MUST enforce register/schema ownership before returning logs
+
+`ObjectsController::logs()` MUST fetch the object by id, return HTTP 404 if it is
+not found, and verify that the object's register AND schema match the addressed
+`{register}/{schema}` (by id or slug). On a mismatch the response MUST be HTTP
+404 with `message: "Object does not belong to specified register/schema"`. On a
+match the audit logs MUST be returned as a paginated envelope.
+
+#### Scenario: Logs returned for a matching object
+- **GIVEN** an object whose register and schema match the addressed path
+- **WHEN** `logs()` is called
+- **THEN** the response MUST be a paginated envelope of the object's audit logs
+
+#### Scenario: Mismatched register/schema returns 404
+- **GIVEN** an existing object addressed under the wrong register or schema
+- **WHEN** `logs()` compares the object's register/schema to the path
+- **THEN** the response MUST be HTTP 404 with `message: "Object does not belong to specified register/schema"`
+
+#### Scenario: Unknown object id returns 404
+- **GIVEN** a logs request for a non-existent object id
+- **WHEN** the object cannot be found
+- **THEN** the response MUST be HTTP 404 with `message: "Object not found"`
+
+### Requirement: The bulk-validation trigger and retired blob endpoint MUST expose stable contracts
+
+`ObjectsController::validate()` MUST require `register` and `schema` parameters
+(HTTP 400 if absent), accept optional `limit`/`offset` for chunked processing,
+delegate to `ObjectService::validateAndSaveObjectsBySchema()`, and return a
+`{success, message, statistics, pagination, errors}` envelope. Failures MUST
+return HTTP 500 with `success: false`. `ObjectsController::clearBlob()` is a
+retired endpoint that MUST return a static success envelope reporting zero
+deletions and that blob storage has been retired in favor of magic tables.
+
+#### Scenario: Bulk validation requires register and schema
+- **GIVEN** a validate request missing `register` or `schema`
+- **WHEN** `validate()` checks the parameters
+- **THEN** the response MUST be HTTP 400 with `success: false`
+
+#### Scenario: Bulk validation returns a statistics envelope
+- **GIVEN** a valid `register`/`schema` with optional `limit`/`offset`
+- **WHEN** `validate()` completes
+- **THEN** the response MUST include `success: true`, a `statistics` object (`processed`, `updated`, `failed`, `total`), `pagination`, and an `errors` array
+
+#### Scenario: clearBlob returns the retired-endpoint envelope
+- **GIVEN** any call to the blob-clear endpoint
+- **WHEN** `clearBlob()` runs
+- **THEN** the response MUST be `{success: true, deleted: 0, message: "Blob storage has been retired. All objects now use magic tables."}`

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md
@@ -1,0 +1,82 @@
+# Tasks — Retrofit b-ctrl-object-data
+
+Reverse-spec + annotation tasks for the object/data controller bundle. Each task
+maps a controller method group to the capability that owns its contract. Tasks
+prefixed CROSS are cross-cutting annotation-only (no new REQ; point at the
+existing owning capability).
+
+## object-rest-api → object-lifecycle
+
+- [x] **task-1**: Document `ObjectsController::objects()` collection-listing REST
+  contract (magic-mapper router, cross-table search, `_empty` stripping,
+  paginated envelope). object-lifecycle ADDED REQ "object REST list endpoint".
+- [x] **task-2**: Document `ObjectsController::show()` single-object read contract
+  (slug resolution, 404 envelope, extend/filter params). object-lifecycle ADDED
+  REQ "object REST read endpoint".
+- [x] **task-3**: Document `ObjectsController::patch()` partial-update contract
+  (merge with existing data via `findSilent`, admin RBAC/multitenancy toggle,
+  append-only 405, validation 422, post-save unlock). object-lifecycle ADDED REQ
+  "object REST patch endpoint".
+- [x] **task-4**: Document `ObjectsController::lock()` / `unlock()` optimistic-lock
+  contract (process/duration params, `locked` flag, 404/500 envelopes).
+  object-lifecycle ADDED REQ "object lock/unlock endpoints".
+- [x] **task-5**: Document `ObjectsController::merge()` object-merge contract
+  (target + object payload validation, 400/404/500 envelopes, `set_time_limit(0)`).
+  object-lifecycle ADDED REQ "object merge endpoint".
+- [x] **task-6**: Document `ObjectsController::contracts()` / `uses()` / `used()`
+  relation sub-resource contracts (paginated relation traversal, A→B / B→A
+  semantics). object-lifecycle ADDED REQ "object relation sub-resource endpoints".
+- [x] **task-7**: Document `ObjectsController::logs()` audit-log sub-resource
+  contract (register/schema ownership match, paginated logs, 404 on mismatch).
+  object-lifecycle ADDED REQ "object audit-log sub-resource endpoint".
+- [x] **task-8**: Document `ObjectsController::validate()` bulk-validation trigger
+  and `clearBlob()` retired endpoint contracts. object-lifecycle ADDED REQ
+  "object bulk-validation and retired-blob endpoints".
+
+## object-cross-cutting → owning capability (annotate-only, CROSS)
+
+- [x] **task-9 (CROSS → chat-ai)**: Annotate `ObjectsController::vectorizeBatch()`,
+  `getObjectVectorizationStats()`, `getObjectVectorizationCount()`. Vector/RAG
+  pipeline; covered by chat-ai (REQ-001 RAG context). No new REQ.
+- [x] **task-10 (CROSS → files-render-extension)**: Annotate
+  `ObjectsController::downloadFiles()`. Object file-output (bulk ZIP) surface;
+  governed by the files-render-extension attached-files model. No new REQ.
+- [x] **task-11 (CROSS → data-import-export)**: Annotate
+  `ObjectsController::import()` and `export()`. These are the exact controller
+  endpoints data-import-export already names (`ObjectsController::import()` /
+  `ObjectsController::export()`). No new REQ.
+- [x] **task-12 (CROSS → workflow-engine-abstraction)**: Annotate
+  `ObjectsController::migrate()`. Object register/schema migration with property
+  mapping; the object-mutation operation the workflow/import machinery drives.
+  No new REQ.
+
+## configuration-api → data-import-export
+
+- [x] **task-13**: Document the configuration remote-portability surface:
+  `ConfigurationController::discover()`, `getGitHubBranches()`,
+  `getGitLabBranches()`, `importFromGitHub()`, `importFromGitLab()`,
+  `importFromUrl()`, `publishToGitHub()` (+ private publish helpers). One new
+  data-import-export ADDED REQ "configuration GitHub/GitLab/URL publishing and
+  discovery".
+- [x] **task-14**: Annotate `ConfigurationController::import()` / `export()` and
+  `ConfigurationsController::export()` / `import()` to the existing
+  data-import-export configuration-portability REQ ("Configuration import/export
+  MUST support full register portability"). No new REQ — extends coverage of an
+  existing REQ.
+
+## bulk-data-ops → data-import-export
+
+- [x] **task-15**: Document `BulkController::deleteSchema()`,
+  `deleteSchemaObjects()`, `deleteRegister()` mass-delete-by-scope contract
+  (numeric-ID / slug resolution, `hardDelete` flag, deleted_count/uuids
+  envelope). One new data-import-export ADDED REQ "bulk delete objects by
+  register/schema". `resolveRegisterSchemaIds` is a private helper — annotate
+  only.
+
+## soft-delete-recovery-api → deletion-audit-trail (annotate-only)
+
+- [x] **task-16**: Annotate `DeletedController::statistics()` and `topDeleters()`
+  to deletion-audit-trail REQ-11 (the trash API "statistics and top deleter
+  analytics" requirement which names these endpoints). No new REQ —
+  `index`/`restore`/`restoreMultiple`/`destroy`/`destroyMultiple` are already
+  annotated by prior retrofit tasks.


### PR DESCRIPTION
## Summary

Reverse-specs the HTTP REST contract of OpenRegister's object/data controller layer and annotates the methods with `@spec` references. **Documentation / annotation only — no runtime behavior changes.** Ghost change: `openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/`.

Five sub-clusters, all `--extend`:

- **object-rest-api → object-lifecycle** (8 ADDED REQs): `ObjectsController` REST surface — collection list, `show`, `patch`, `lock`/`unlock`, `merge`, relation sub-resources (`contracts`/`uses`/`used`), `logs`, `validate`, `clearBlob`. The existing REQ-001..005 cover the internal save pipeline; these cover the HTTP contract (route shape, status codes, error envelopes).
- **configuration-api → data-import-export** (1 ADDED REQ): config GitHub/GitLab/URL publishing + discovery on `ConfigurationController` (the batch JSON's "triaged DROP" labels were wrong per architect — these ARE config-package portability). Per-config `import`/`export` annotated to the existing portability REQ.
- **bulk-data-ops → data-import-export** (1 ADDED REQ): `BulkController` bulk delete by register/schema scope.
- **soft-delete-recovery-api → deletion-audit-trail** (0 new REQs): annotation-only — REQ-3 (restore) and REQ-11 (list/statistics/top-deleters) already cover `DeletedController`. Added annotations on `statistics`/`topDeleters`.
- **cross-cutting ObjectsController** (0 new REQs): per-method annotation to the owning capability — `vectorize*` → chat-ai, `downloadFiles` → files-render-extension, `import`/`export` → data-import-export, `migrate` → workflow-engine-abstraction. Not lumped into one cap.

**10 new REQs total** (object-lifecycle 8, data-import-export 2), within the ≤12 budget.

## Test plan

- [x] `php -l` clean on all 5 touched controllers
- [x] `openspec validate retrofit-2026-05-24-b-ctrl-object-data --strict` passes
- [ ] Spec review: confirm the cross-cutting per-method capability assignments
- [ ] Confirm no behavior change (annotations + spec docs only)