### PR TITLE
retrofit: reverse-spec controller bundle — settings/observability (5 sub-clusters)

### DIFF
--- a/lib/Controller/HeartbeatController.php
+++ b/lib/Controller/HeartbeatController.php
@@ -87,6 +87,8 @@ class HeartbeatController extends Controller
      *     array{status: 'alive', timestamp: int<1, max>,
      *     message: 'Heartbeat successful - connection kept alive'},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-5
      */
     public function heartbeat(): JSONResponse
     {

--- a/lib/Controller/NamesController.php
+++ b/lib/Controller/NamesController.php
@@ -108,6 +108,8 @@ class NamesController extends Controller
      * @throws \Exception If name lookup fails
      *
      * @return JSONResponse JSON response with object names or error
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-22
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -248,6 +250,8 @@ class NamesController extends Controller
      * @throws \Exception If name lookup fails
      *
      * @return JSONResponse JSON response with object names or error
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-22
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -351,6 +355,8 @@ class NamesController extends Controller
      * @throws \Exception If name lookup fails
      *
      * @return JSONResponse JSON response with object name or error
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-22
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -446,6 +452,8 @@ class NamesController extends Controller
      *     performance_metrics?: array{name_cache_enabled: true,
      *     distributed_cache_available: true, warmup_available: true}},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-22
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -492,6 +500,8 @@ class NamesController extends Controller
      * for improved performance after system maintenance.
      *
      * @return JSONResponse JSON response with warmup result or error
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-22
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]

--- a/lib/Controller/Settings/ApiTokenSettingsController.php
+++ b/lib/Controller/Settings/ApiTokenSettingsController.php
@@ -69,6 +69,8 @@ class ApiTokenSettingsController extends Controller
      * @psalm-return JSONResponse<200|500,
      *     array{error?: string, github_token?: string, gitlab_token?: string,
      *     gitlab_url?: string}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-10
      */
     public function getApiTokens(): JSONResponse
     {
@@ -111,6 +113,8 @@ class ApiTokenSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with save result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-10
      */
     public function saveApiTokens(): JSONResponse
     {
@@ -157,6 +161,8 @@ class ApiTokenSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse Test result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-10
      */
     public function testGitHubToken(): JSONResponse
     {
@@ -214,6 +220,8 @@ class ApiTokenSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse Test result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-10
      */
     public function testGitLabToken(): JSONResponse
     {

--- a/lib/Controller/Settings/CacheSettingsController.php
+++ b/lib/Controller/Settings/CacheSettingsController.php
@@ -77,6 +77,8 @@ class CacheSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with cache statistics or error
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-6
      */
     public function getCacheStats(): JSONResponse
     {
@@ -97,6 +99,8 @@ class CacheSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with clear cache result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-6
      */
     public function clearCache(): JSONResponse
     {
@@ -120,6 +124,8 @@ class CacheSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with warmup result or error
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-6
      */
     public function warmupNamesCache(): JSONResponse
     {
@@ -139,6 +145,8 @@ class CacheSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with warmup interval config
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-6
      */
     public function getWarmupInterval(): JSONResponse
     {
@@ -181,6 +189,8 @@ class CacheSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with updated interval config
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-6
      */
     public function setWarmupInterval(): JSONResponse
     {
@@ -245,6 +255,8 @@ class CacheSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with invalidation result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-6
      */
     public function clearAppStoreCache(): JSONResponse
     {

--- a/lib/Controller/Settings/ConfigurationSettingsController.php
+++ b/lib/Controller/Settings/ConfigurationSettingsController.php
@@ -67,6 +67,8 @@ class ConfigurationSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with RBAC settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-12
      */
     public function getRbacSettings(): JSONResponse
     {
@@ -84,6 +86,8 @@ class ConfigurationSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with updated RBAC settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-12
      */
     public function updateRbacSettings(): JSONResponse
     {
@@ -102,6 +106,8 @@ class ConfigurationSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with organisation settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-13
      */
     public function getOrganisationSettings(): JSONResponse
     {
@@ -119,6 +125,8 @@ class ConfigurationSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with updated organisation settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-13
      */
     public function updateOrganisationSettings(): JSONResponse
     {
@@ -137,6 +145,8 @@ class ConfigurationSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with multitenancy settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-13
      */
     public function getMultitenancySettings(): JSONResponse
     {
@@ -154,6 +164,8 @@ class ConfigurationSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with updated multitenancy settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-13
      */
     public function updateMultitenancySettings(): JSONResponse
     {
@@ -172,6 +184,8 @@ class ConfigurationSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with object settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-1
      */
     public function getObjectSettings(): JSONResponse
     {
@@ -200,6 +214,8 @@ class ConfigurationSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with updated object settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-1
      */
     public function updateObjectSettings(): JSONResponse
     {
@@ -236,6 +252,8 @@ class ConfigurationSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with patched object settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-1
      */
     public function patchObjectSettings(): JSONResponse
     {
@@ -248,6 +266,8 @@ class ConfigurationSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with retention settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-11
      */
     public function getRetentionSettings(): JSONResponse
     {
@@ -265,6 +285,8 @@ class ConfigurationSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with updated retention settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-11
      */
     public function updateRetentionSettings(): JSONResponse
     {
@@ -283,6 +305,8 @@ class ConfigurationSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with archival settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-14
      */
     public function getArchivalSettings(): JSONResponse
     {
@@ -300,6 +324,8 @@ class ConfigurationSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with updated archival settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-14
      */
     public function updateArchivalSettings(): JSONResponse
     {
@@ -318,6 +344,8 @@ class ConfigurationSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with object collection fields
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-17
      */
     public function getObjectCollectionFields(): JSONResponse
     {
@@ -349,6 +377,8 @@ class ConfigurationSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with creation result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-17
      */
     public function createMissingObjectFields(): JSONResponse
     {

--- a/lib/Controller/Settings/N8nSettingsController.php
+++ b/lib/Controller/Settings/N8nSettingsController.php
@@ -108,6 +108,8 @@ class N8nSettingsController extends Controller
      * @return JSONResponse The n8n settings.
      *
      * @psalm-return JSONResponse<200|500, array, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-9
      */
     public function getN8nSettings(): JSONResponse
     {
@@ -140,6 +142,8 @@ class N8nSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with updated n8n settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-9
      */
     public function updateN8nSettings(): JSONResponse
     {
@@ -187,6 +191,8 @@ class N8nSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with connection test result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-9
      */
     public function testN8nConnection(): JSONResponse
     {
@@ -269,6 +275,8 @@ class N8nSettingsController extends Controller
      * @return JSONResponse JSON response with initialization result
      *
      * @suppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-9
      */
     public function initializeN8n(): JSONResponse
     {
@@ -411,6 +419,8 @@ class N8nSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with workflows list
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-9
      */
     public function getWorkflows(): JSONResponse
     {

--- a/lib/Controller/Settings/SecuritySettingsController.php
+++ b/lib/Controller/Settings/SecuritySettingsController.php
@@ -65,6 +65,8 @@ class SecuritySettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-8
      */
     public function clearIpRateLimits(): JSONResponse
     {
@@ -115,6 +117,8 @@ class SecuritySettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-8
      */
     public function clearUserRateLimits(): JSONResponse
     {
@@ -165,6 +169,8 @@ class SecuritySettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-8
      */
     public function clearAllRateLimits(): JSONResponse
     {

--- a/lib/Controller/Settings/SolrManagementController.php
+++ b/lib/Controller/Settings/SolrManagementController.php
@@ -79,6 +79,8 @@ class SolrManagementController extends Controller
      * @return JSONResponse JSON response with SOLR field configuration
      *
      * @suppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-17
      */
     public function getSolrFields(): JSONResponse
     {
@@ -191,6 +193,8 @@ class SolrManagementController extends Controller
      *
      * @suppressWarnings(PHPMD.ExcessiveMethodLength)
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-17
      */
     public function createMissingSolrFields(): JSONResponse
     {
@@ -325,6 +329,8 @@ class SolrManagementController extends Controller
      *     },
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-17
      */
     public function fixMismatchedSolrFields(): JSONResponse
     {
@@ -415,6 +421,8 @@ class SolrManagementController extends Controller
      * @return JSONResponse
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-17
      */
     public function deleteSolrField(string $fieldName): JSONResponse
     {
@@ -523,6 +531,8 @@ class SolrManagementController extends Controller
      * @return JSONResponse The deletion result
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-16
      */
     public function deleteSpecificSolrCollection(string $name): JSONResponse
     {
@@ -637,6 +647,8 @@ class SolrManagementController extends Controller
      *     },
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-16
      */
     public function updateSolrCollectionAssignments(
         ?string $objectCollection=null,

--- a/lib/Controller/Settings/SolrOperationsController.php
+++ b/lib/Controller/Settings/SolrOperationsController.php
@@ -79,6 +79,8 @@ class SolrOperationsController extends Controller
      *
      * @suppressWarnings(PHPMD.ExcessiveMethodLength)
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-16
      */
     public function setupSolr(): JSONResponse
     {
@@ -356,6 +358,8 @@ class SolrOperationsController extends Controller
      *     array<never, never>>|JSONResponse<422,
      *     array{success: false, message: string,
      *     details: array{exception: string}}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-16
      */
     public function testSolrConnection(): JSONResponse
     {
@@ -384,6 +388,8 @@ class SolrOperationsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse Warmup operation results
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-16
      */
     public function warmupSolrIndex(): JSONResponse
     {
@@ -475,6 +481,8 @@ class SolrOperationsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-16
      */
     public function inspectSolrIndex(): JSONResponse
     {
@@ -548,6 +556,8 @@ class SolrOperationsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with memory prediction
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-16
      */
     public function getSolrMemoryPrediction(): JSONResponse
     {
@@ -625,6 +635,8 @@ class SolrOperationsController extends Controller
      *     operation?: 'clear'|'commit'|'optimize', message?: string,
      *     timestamp?: string, error_details?: mixed|null},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-16
      */
     public function manageSolr(string $operation): JSONResponse
     {

--- a/lib/Controller/Settings/SolrSettingsController.php
+++ b/lib/Controller/Settings/SolrSettingsController.php
@@ -69,6 +69,8 @@ class SolrSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with SOLR settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-18
      */
     public function getSolrSettings(): JSONResponse
     {
@@ -86,6 +88,8 @@ class SolrSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with updated SOLR settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-18
      */
     public function updateSolrSettings(): JSONResponse
     {
@@ -106,6 +110,8 @@ class SolrSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with SOLR info
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-18
      */
     public function getSolrInfo(): JSONResponse
     {
@@ -206,6 +212,8 @@ class SolrSettingsController extends Controller
      * @psalm-return JSONResponse<200, array<array-key, mixed>,
      *     array<never, never>>|JSONResponse<500, array{error: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-18
      */
     public function getSolrDashboardStats(): JSONResponse
     {
@@ -227,6 +235,8 @@ class SolrSettingsController extends Controller
      * @return JSONResponse SOLR facet configuration
      *
      * @psalm-return JSONResponse<200|500, array, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-19
      */
     public function getSolrFacetConfiguration(): JSONResponse
     {
@@ -244,6 +254,8 @@ class SolrSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with updated facet configuration
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-19
      */
     public function updateSolrFacetConfiguration(): JSONResponse
     {
@@ -262,6 +274,8 @@ class SolrSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with discovered facets
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-19
      */
     public function discoverSolrFacets(): JSONResponse
     {
@@ -311,6 +325,8 @@ class SolrSettingsController extends Controller
      * @return JSONResponse JSON response with facet config and discovery
      *
      * @suppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-19
      */
     public function getSolrFacetConfigWithDiscovery(): JSONResponse
     {
@@ -453,6 +469,8 @@ class SolrSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with updated facet config
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-19
      */
     public function updateSolrFacetConfigWithDiscovery(): JSONResponse
     {

--- a/lib/Controller/Settings/ValidationSettingsController.php
+++ b/lib/Controller/Settings/ValidationSettingsController.php
@@ -66,6 +66,8 @@ class ValidationSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with validation results
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-7
      */
     public function validateAllObjects(): JSONResponse
     {
@@ -99,6 +101,8 @@ class ValidationSettingsController extends Controller
      * @return JSONResponse JSON response with mass validation results
      *
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-7
      */
     public function massValidateObjects(): JSONResponse
     {
@@ -182,6 +186,8 @@ class ValidationSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with memory prediction
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-7
      */
     public function predictMassValidationMemory(): JSONResponse
     {

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -223,6 +223,8 @@ class SettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with settings data
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-1
      */
     public function index(): JSONResponse
     {
@@ -240,6 +242,8 @@ class SettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with updated settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-1
      */
     public function update(): JSONResponse
     {
@@ -258,6 +262,8 @@ class SettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with loaded settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-1
      */
     public function load(): JSONResponse
     {
@@ -275,6 +281,8 @@ class SettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with updated publishing options
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-1
      */
     public function updatePublishingOptions(): JSONResponse
     {
@@ -296,6 +304,8 @@ class SettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with rebase result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-11
      */
     public function rebase(): JSONResponse
     {
@@ -316,6 +326,8 @@ class SettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with statistics
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-2
      */
     public function stats(): JSONResponse
     {
@@ -336,6 +348,8 @@ class SettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with statistics
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-2
      */
     public function getStatistics(): JSONResponse
     {
@@ -348,6 +362,8 @@ class SettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse The SOLR setup test results
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-15
      */
     public function testSetupHandler(): JSONResponse
     {
@@ -417,6 +433,8 @@ class SettingsController extends Controller
      * @psalm-return JSONResponse<200|400|422,
      *     array{success: bool, message: mixed|string, collection: string,
      *     stats?: array<never, never>|mixed}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-15
      */
     public function reindexSpecificCollection(string $name): JSONResponse
     {
@@ -495,6 +513,8 @@ class SettingsController extends Controller
      * @return JSONResponse Backend configuration
      *
      * @psalm-return JSONResponse<200|500, array, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-15
      */
     public function getSearchBackend(): JSONResponse
     {
@@ -514,6 +534,8 @@ class SettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with updated backend config
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-15
      */
     public function updateSearchBackend(): JSONResponse
     {
@@ -558,6 +580,8 @@ class SettingsController extends Controller
      * @suppressWarnings(PHPMD.ExcessiveMethodLength)
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
      * @suppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-3
      */
     public function getDatabaseInfo(): JSONResponse
     {
@@ -733,6 +757,8 @@ class SettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with refreshed database info
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-3
      */
     public function refreshDatabaseInfo(): JSONResponse
     {
@@ -749,6 +775,8 @@ class SettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with version info
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-4
      */
     public function getVersionInfo(): JSONResponse
     {
@@ -989,6 +1017,8 @@ class SettingsController extends Controller
      *     results?: array<int, array<string, mixed>>, total?: int<0, max>,
      *     limit?: int, filters?: array, timestamp?: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-20
      */
     public function semanticSearch(string $query, int $limit=10, array $filters=[], ?string $provider=null): JSONResponse
     {
@@ -1044,6 +1074,8 @@ class SettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with hybrid search results
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-20
      */
     public function hybridSearch(
         string $query,

--- a/lib/Controller/SolrController.php
+++ b/lib/Controller/SolrController.php
@@ -97,6 +97,8 @@ class SolrController extends Controller
      *     },
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-20
      */
     public function semanticSearch(
         string $query,
@@ -199,6 +201,8 @@ class SolrController extends Controller
      * >
      *
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-20
      */
     public function hybridSearch(
         string $query,
@@ -310,6 +314,8 @@ class SolrController extends Controller
      * @psalm-return JSONResponse<200|500,
      *     array{success: bool, error?: string, stats?: mixed, timestamp?: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-21
      */
     public function getVectorStats(): JSONResponse
     {
@@ -381,6 +387,8 @@ class SolrController extends Controller
      *
      * @suppressWarnings(PHPMD.ExcessiveMethodLength)
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-21
      */
     public function testVectorEmbedding(): JSONResponse
     {
@@ -544,6 +552,8 @@ class SolrController extends Controller
      *     },
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-16
      */
     public function listCollections(): JSONResponse
     {
@@ -599,6 +609,8 @@ class SolrController extends Controller
      *     },
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-16
      */
     public function listConfigSets(): JSONResponse
     {
@@ -661,6 +673,8 @@ class SolrController extends Controller
      *     },
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-16
      */
     public function createCollection(
         string $collectionName,
@@ -734,6 +748,8 @@ class SolrController extends Controller
      *     },
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-16
      */
     public function createConfigSet(string $name, string $baseConfigSet='_default'): JSONResponse
     {
@@ -795,6 +811,8 @@ class SolrController extends Controller
      *     },
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-16
      */
     public function deleteConfigSet(string $name): JSONResponse
     {
@@ -858,6 +876,8 @@ class SolrController extends Controller
      *     },
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-16
      */
     public function copyCollection(string $sourceCollection, string $targetCollection): JSONResponse
     {
@@ -928,6 +948,8 @@ class SolrController extends Controller
      *     },
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-21
      */
     public function vectorizeObject(int $objectId, ?string $provider=null): JSONResponse
     {
@@ -1013,6 +1035,8 @@ class SolrController extends Controller
      *     },
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-21
      */
     public function bulkVectorizeObjects(
         ?int $schemaId=null,
@@ -1144,6 +1168,8 @@ class SolrController extends Controller
      *     },
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md#task-21
      */
     public function getVectorizationStats(): JSONResponse
     {

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/proposal.md
@@ -1,0 +1,72 @@
+# Reverse-spec controller bundle — settings / observability
+
+## Why
+
+The OpenRegister settings and observability controllers were built ahead of their
+specs. This reverse-spec change documents the *observed behavior* of five controller
+sub-clusters and attaches each public endpoint to the capability that already owns its
+domain. No code is changed; every requirement is `## ADDED Requirements` against an
+existing spec (bias-to-extend), and every method carries an `@spec` annotation pointing
+at the task that documents it.
+
+Two of the five controllers are genuinely cross-cutting kitchen sinks. Their methods are
+split per-method to the owning capability rather than lumped into one bucket — see the
+mapping tables below.
+
+## What changes
+
+- **9 capabilities extended** with a total of **17 new requirements** documenting
+  observed admin/observability/search controller behavior.
+- **92 public controller methods annotated** with `@spec` task references.
+- DI helpers (`getObjectService`, `getConfigurationService`), debug-only endpoints with
+  no stable contract (`testSchemaMapping`, `debugTypeFiltering`), and the empty
+  `VectorSettingsController` are treated as scanner noise and **dropped** (not annotated,
+  no requirements).
+
+## Cross-cutting controller — per-method assignment
+
+### `SettingsController` (kitchen sink)
+
+| Method | Capability | Rationale |
+|---|---|---|
+| `index`, `update`, `load`, `updatePublishingOptions` | production-observability | Aggregate settings read/write admin surface |
+| `stats`, `getStatistics` | production-observability | Settings-dashboard warning/total statistics |
+| `getDatabaseInfo`, `refreshDatabaseInfo` | production-observability | DB platform + vector-capability introspection |
+| `getVersionInfo` | production-observability | App version reporting |
+| `rebase` | retention-management | Recomputes object/log deletion times from retention settings |
+| `testSetupHandler`, `reindexSpecificCollection`, `getSearchBackend`, `updateSearchBackend` | zoeken-filteren | Search-backend selection & index admin |
+| `semanticSearch`, `hybridSearch` | chat-ai | Facade copies of the vector/hybrid search endpoints |
+| `getObjectService`, `getConfigurationService` | — (dropped) | DI accessors, not HTTP endpoints |
+| `testSchemaMapping`, `debugTypeFiltering` | — (dropped) | Debug endpoints, no stable contract |
+
+### `ConfigurationSettingsController` (kitchen sink)
+
+| Method | Capability | Rationale |
+|---|---|---|
+| `getRbacSettings`, `updateRbacSettings` | rbac-scopes | RBAC enablement/configuration dials |
+| `getOrganisationSettings`, `updateOrganisationSettings`, `getMultitenancySettings`, `updateMultitenancySettings` | tenant-lifecycle | Organisation & multitenancy configuration |
+| `getRetentionSettings`, `updateRetentionSettings` | retention-management | Retention policy configuration |
+| `getArchivalSettings`, `updateArchivalSettings` | archival-destruction-workflow | Destruction-scheduling/selectielijst configuration |
+| `getObjectSettings`, `updateObjectSettings`, `patchObjectSettings` | production-observability | Object-management admin dials |
+| `getObjectCollectionFields`, `createMissingObjectFields` | zoeken-filteren | Solr object-collection field synchronization |
+
+## Sub-cluster → capability summary
+
+1. `settings-admin-cross-cutting` (`SettingsController`) → split across
+   production-observability / retention-management / zoeken-filteren / chat-ai.
+2. `settings-subsystem-admin` (`Settings/*`) → split across production-observability
+   (cache/validation/security/object/n8n/apitoken admin) + rbac-scopes / tenant-lifecycle
+   / retention-management / archival-destruction-workflow / zoeken-filteren
+   (ConfigurationSettingsController sections).
+3. `solr-search-admin` (`SolrController` + `Settings/Solr*`) → zoeken-filteren +
+   faceting-configuration (facet config endpoints) + chat-ai (vectorize/embedding ops).
+4. `observability-health-metrics-heartbeat` (`Health`/`Heartbeat`/`Metrics`) →
+   production-observability. Metrics/Health endpoints already covered by existing REQs;
+   only the heartbeat keep-alive endpoint is newly documented.
+5. `name-cache-warmup` (`NamesController`) → schema-driven-read-coercion.
+
+## Impact
+
+- Specs: 9 capability specs gain `## ADDED Requirements` deltas.
+- Code: annotation-only (`@spec` docblock tags); no behavior change.
+- Risk: none — documentation of existing behavior.

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/specs/archival-destruction-workflow/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/specs/archival-destruction-workflow/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Archival and destruction-scheduling configuration API
+The system SHALL expose an admin-gated API for reading and writing archival settings —
+destruction scheduling, selectielijst configuration, and related dials.
+`ConfigurationSettingsController` provides `getArchivalSettings` (delegating to
+`SettingsService::getArchivalSettingsOnly()`) and `updateArchivalSettings` (delegating to
+`SettingsService::updateArchivalSettingsOnly()`). Both return HTTP 500 with an `error`
+field on service failure.
+
+#### Scenario: Read archival settings
+- **WHEN** `getArchivalSettings` is called
+- **THEN** it MUST return the archival/destruction configuration from `SettingsService::getArchivalSettingsOnly()`
+
+#### Scenario: Update archival settings
+- **GIVEN** an admin posts updated destruction-scheduling values
+- **WHEN** `updateArchivalSettings` runs
+- **THEN** it MUST persist them via `SettingsService::updateArchivalSettingsOnly()` and return the result

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/specs/chat-ai/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/specs/chat-ai/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Semantic and hybrid vector search endpoints
+The system MUST expose endpoints for semantic (vector-embedding) search and hybrid
+(keyword + vector) search over registered objects. `SolrController::semanticSearch`
+embeds the query and retrieves nearest-neighbour matches; `SolrController::hybridSearch`
+combines Solr keyword scoring with vector similarity under caller-supplied weights.
+`SettingsController::semanticSearch` and `SettingsController::hybridSearch` are facade
+copies of these endpoints that delegate to `VectorizationService`. An empty or
+whitespace-only query MUST return HTTP 400, and both endpoints MUST attach a `timestamp`
+to the response.
+
+#### Scenario: Semantic search rejects empty query
+- **GIVEN** a caller invokes `semanticSearch` with a blank query
+- **WHEN** the controller validates input
+- **THEN** it MUST return HTTP 400 with a "Query parameter is required" message
+
+#### Scenario: Hybrid search combines keyword and vector results
+- **GIVEN** a caller invokes `hybridSearch` with `weights: {solr: 0.5, vector: 0.5}`
+- **WHEN** `VectorizationService::hybridSearch` runs
+- **THEN** the response MUST merge keyword and vector results and include `query` and `timestamp`
+
+### Requirement: Vectorization and embedding operations endpoints
+The system MUST expose admin/operations endpoints for managing object vectorization and
+inspecting embedding state. `SolrController` provides `getVectorStats` and
+`getVectorizationStats` (coverage/health metrics), `testVectorEmbedding` (probes the
+configured embedding provider), `vectorizeObject` (embeds a single object, optional
+provider override), and `bulkVectorizeObjects` (batch embedding).
+
+#### Scenario: Test embedding provider connectivity
+- **WHEN** `testVectorEmbedding` runs
+- **THEN** it MUST probe the configured embedding provider and report whether embeddings can be generated
+
+#### Scenario: Vectorize a single object
+- **GIVEN** an object id and an optional provider override
+- **WHEN** `vectorizeObject` runs
+- **THEN** it MUST generate and store the object's embedding and report the outcome
+
+#### Scenario: Report vectorization coverage
+- **WHEN** `getVectorizationStats` runs
+- **THEN** it MUST return coverage statistics describing how many objects currently carry embeddings

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/specs/faceting-configuration/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/specs/faceting-configuration/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Solr facet configuration discovery and management API
+The system SHALL expose an admin-gated API for discovering facetable fields and managing
+the Solr facet configuration. `SolrSettingsController` provides `getSolrFacetConfiguration`
+and `updateSolrFacetConfiguration` for the stored facet config, `discoverSolrFacets` for
+auto-detecting facetable fields from the live index, and the combined
+`getSolrFacetConfigWithDiscovery` / `updateSolrFacetConfigWithDiscovery` endpoints that
+merge stored configuration with live discovery results.
+
+#### Scenario: Discover facetable fields
+- **WHEN** `discoverSolrFacets` is called
+- **THEN** it MUST return the set of facetable fields detected from the active Solr index
+
+#### Scenario: Read facet config merged with discovery
+- **WHEN** `getSolrFacetConfigWithDiscovery` is called
+- **THEN** it MUST return the stored facet configuration enriched with currently discoverable facets
+
+#### Scenario: Persist updated facet configuration
+- **GIVEN** an admin posts an updated facet configuration
+- **WHEN** `updateSolrFacetConfiguration` runs
+- **THEN** it MUST persist the configuration and return the result

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/specs/production-observability/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/specs/production-observability/spec.md
@@ -1,0 +1,129 @@
+## ADDED Requirements
+
+### Requirement: Aggregate Settings Administration API
+The system SHALL expose an admin-gated REST surface for reading and writing the
+aggregate OpenRegister settings document, its publishing options, and the
+object-management dials. `SettingsController` provides `GET /api/settings` (read all),
+`POST /api/settings` (update all), a `load` alias that re-reads settings, and
+`updatePublishingOptions`; `ConfigurationSettingsController` provides
+`getObjectSettings`/`updateObjectSettings`/`patchObjectSettings`. All endpoints delegate
+to `SettingsService` and return service errors as HTTP 500 with an `error` field.
+
+#### Scenario: Read aggregate settings
+- **GIVEN** an admin requests `GET /api/settings`
+- **WHEN** `SettingsController::index` runs
+- **THEN** it MUST return the full settings document from `SettingsService::getSettings()`
+
+#### Scenario: Update aggregate settings
+- **GIVEN** an admin posts a settings payload to `POST /api/settings`
+- **WHEN** `SettingsController::update` runs
+- **THEN** it MUST pass the request params to `SettingsService::updateSettings()` and return the result
+
+#### Scenario: Object-management settings round-trip
+- **GIVEN** an admin reads object settings then writes them back
+- **WHEN** `getObjectSettings` then `updateObjectSettings` run
+- **THEN** each MUST return `{success: true, data: ...}` on success and `{success: false, error: ...}` with HTTP 500 on failure
+- **AND** a `provider` object payload MUST be reduced to its `id` before being persisted
+
+### Requirement: Settings Dashboard Statistics Endpoint
+The system SHALL expose a statistics endpoint for the settings dashboard that reports
+warning counts for objects/logs needing attention plus totals for objects, audit trails,
+and search trails. `SettingsController::stats` delegates to `SettingsService::getStats()`
+and `getStatistics` is an alias of `stats`. Service failures MUST surface as HTTP 422.
+
+#### Scenario: Retrieve dashboard statistics
+- **GIVEN** an admin requests the settings statistics
+- **WHEN** `SettingsController::stats` runs
+- **THEN** it MUST return the aggregated statistics from `SettingsService::getStats()`
+- **AND** a service exception MUST produce HTTP 422 with an `error` field
+
+#### Scenario: getStatistics aliases stats
+- **WHEN** `SettingsController::getStatistics` is invoked
+- **THEN** it MUST return exactly what `stats` returns
+
+### Requirement: Database Capability Introspection Endpoint
+The system SHALL expose an endpoint that introspects the active database platform,
+version, and native vector-search capability, caching the result in app config and
+allowing a forced refresh. `SettingsController::getDatabaseInfo` detects MySQL/MariaDB,
+PostgreSQL (including installed extensions and `pgvector` presence), and SQLite, and
+records a `vectorSupport` flag and a performance note. `refreshDatabaseInfo` clears the
+cache and re-queries.
+
+#### Scenario: Cached database info returned without refresh
+- **GIVEN** database info was previously cached in app config
+- **WHEN** `getDatabaseInfo` is called without `?refresh=true`
+- **THEN** it MUST return the cached payload with `fromCache: true`
+
+#### Scenario: PostgreSQL with pgvector reports vector support
+- **GIVEN** the active database is PostgreSQL with the `vector` extension installed
+- **WHEN** `getDatabaseInfo` runs with refresh
+- **THEN** the response MUST report `type: "PostgreSQL"`, `vectorSupport: true`, and list installed extensions
+
+#### Scenario: Forced refresh re-queries the database
+- **WHEN** `refreshDatabaseInfo` is called
+- **THEN** it MUST delete the `databaseInfo` app-config key and return freshly queried info with `fromCache: false`
+
+### Requirement: Application Version Reporting Endpoint
+The system SHALL expose an endpoint returning OpenRegister version information.
+`SettingsController::getVersionInfo` delegates to `SettingsService::getVersionInfoOnly()`
+and returns HTTP 500 with an `error` field on failure.
+
+#### Scenario: Retrieve version info
+- **WHEN** `getVersionInfo` is called
+- **THEN** it MUST return the version payload from `SettingsService::getVersionInfoOnly()`
+
+### Requirement: Connection Keep-Alive Heartbeat Endpoint
+The system SHALL expose a lightweight heartbeat endpoint that keeps HTTP connections
+alive during long-running operations (imports, exports, bulk operations) to prevent
+gateway timeouts. `HeartbeatController::heartbeat` performs minimal processing and is
+annotated `@NoAdminRequired` + `@NoCSRFRequired`.
+
+#### Scenario: Heartbeat returns alive status
+- **GIVEN** a long-running operation periodically calls the heartbeat endpoint
+- **WHEN** `HeartbeatController::heartbeat` runs
+- **THEN** it MUST return HTTP 200 with `{status: "alive", timestamp: <unix>, message: ...}`
+- **AND** it MUST require no admin role and no CSRF token
+
+### Requirement: Subsystem Administration Dials
+The system SHALL expose admin-gated operational dials for cache, object validation, and
+security rate limiting. `CacheSettingsController` provides cache statistics, granular
+cache clearing (`all`/`object`/`schema`/`facet`/`distributed`/`names`), names-cache
+warmup, a configurable warmup interval (`0` to disable, otherwise `>= 300s`), and Nextcloud
+app-store cache invalidation. `ValidationSettingsController` provides whole-corpus object
+validation, mass re-save validation, and a memory-usage prediction. `SecuritySettingsController`
+provides clearing of IP, user, and combined rate limits.
+
+#### Scenario: Clear a specific cache type
+- **GIVEN** an admin posts `{type: "facet"}` to the cache-clear endpoint
+- **WHEN** `CacheSettingsController::clearCache` runs
+- **THEN** it MUST delegate to `SettingsService::clearCache('facet')` and return the result
+
+#### Scenario: Warmup interval validation
+- **GIVEN** an admin posts `{interval: 120}` to set the warmup interval
+- **WHEN** `setWarmupInterval` runs
+- **THEN** it MUST reject with HTTP 422 because a non-zero interval below 300 seconds is invalid
+
+#### Scenario: Mass validation re-saves objects
+- **WHEN** `ValidationSettingsController::massValidateObjects` runs with `mode`/`batchSize`/`maxObjects`
+- **THEN** it MUST delegate to `SettingsService::massValidateObjects()` and return per-batch save statistics
+- **AND** invalid parameters MUST produce HTTP 400
+
+#### Scenario: Clear IP rate limit requires an IP
+- **WHEN** `SecuritySettingsController::clearIpRateLimits` runs without an `ip` param
+- **THEN** it MUST return HTTP 400 with an `error` field
+- **AND** a valid request MUST delegate to `SecurityService::clearIpRateLimits()` and log the admin action
+
+### Requirement: Integration Administration Endpoints
+The system SHALL expose admin-gated endpoints for configuring external integration
+credentials and connections. `N8nSettingsController` provides n8n connection settings
+read/write, connection testing, project initialization, and workflow listing.
+`ApiTokenSettingsController` provides GitHub/GitLab API token read/write and validation
+testing.
+
+#### Scenario: Test n8n connection
+- **WHEN** `N8nSettingsController::testN8nConnection` runs
+- **THEN** it MUST attempt a connection against the configured n8n endpoint and return the outcome
+
+#### Scenario: Validate a stored GitHub token
+- **WHEN** `ApiTokenSettingsController::testGitHubToken` runs
+- **THEN** it MUST validate the configured GitHub token and report whether it is accepted

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/specs/rbac-scopes/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/specs/rbac-scopes/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: RBAC settings configuration API
+The system SHALL expose an admin-gated API for reading and writing the RBAC enablement and
+configuration dials that govern scope enforcement. `ConfigurationSettingsController`
+provides `getRbacSettings` (delegating to `SettingsService::getRbacSettingsOnly()`) and
+`updateRbacSettings` (delegating to `SettingsService::updateRbacSettingsOnly()`). Both
+return HTTP 500 with an `error` field on service failure.
+
+#### Scenario: Read RBAC settings
+- **WHEN** `getRbacSettings` is called
+- **THEN** it MUST return the RBAC settings document from `SettingsService::getRbacSettingsOnly()`
+
+#### Scenario: Update RBAC settings
+- **GIVEN** an admin toggles RBAC enforcement and posts the change
+- **WHEN** `updateRbacSettings` runs
+- **THEN** it MUST persist the change via `SettingsService::updateRbacSettingsOnly()` and return the updated settings

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/specs/retention-management/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/specs/retention-management/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Retention configuration and rebase administration API
+The system SHALL expose an admin-gated API for reading and writing retention settings and
+for recalculating deletion times across the corpus. `ConfigurationSettingsController`
+provides `getRetentionSettings` (delegating to `SettingsService::getRetentionSettingsOnly()`)
+and `updateRetentionSettings` (delegating to `updateRetentionSettingsOnly()`).
+`SettingsController::rebase` recalculates deletion times for all objects and logs from the
+current retention settings and assigns default owners/organisations to objects that lack
+them.
+
+#### Scenario: Read retention settings
+- **WHEN** `getRetentionSettings` is called
+- **THEN** it MUST return the retention settings from `SettingsService::getRetentionSettingsOnly()`
+
+#### Scenario: Update retention settings
+- **GIVEN** an admin posts updated retention values
+- **WHEN** `updateRetentionSettings` runs
+- **THEN** it MUST persist them via `SettingsService::updateRetentionSettingsOnly()` and return the result
+
+#### Scenario: Rebase recalculates deletion times
+- **GIVEN** retention settings have changed
+- **WHEN** `SettingsController::rebase` runs
+- **THEN** it MUST delegate to `SettingsService::rebase()` to recompute object/log deletion times
+- **AND** a service failure MUST surface as HTTP 500 with an `error` field

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/specs/schema-driven-read-coercion/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/specs/schema-driven-read-coercion/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Object display-name cache resolution endpoints
+The system SHALL expose ultra-fast, aggressively cached endpoints that resolve object
+UUIDs/ids to their display names so frontends can render names instead of raw UUIDs.
+`NamesController` provides `index` (all names, or a subset via an `ids` query param that
+accepts a comma-separated string, a JSON-array string, or a PHP array), `create` (POST
+with a JSON `ids` array for sets too large for the URL), `show` (single id, HTTP 404 when
+not found), `stats` (cache statistics and performance metrics), and `warmup` (clears and
+re-populates the name cache). All endpoints are `@PublicPage` + `@NoAdminRequired` +
+`@NoCSRFRequired` and return execution timing in the response.
+
+#### Scenario: Bulk name lookup by ids query param
+- **GIVEN** a caller requests `GET /names?ids=uuid-1,uuid-2`
+- **WHEN** `NamesController::index` runs
+- **THEN** it MUST return `{names: {uuid-1: ..., uuid-2: ...}, total, cached, execution_time}` from the cache handler
+
+#### Scenario: POST bulk lookup requires an ids array
+- **GIVEN** a caller POSTs a body without an `ids` array
+- **WHEN** `NamesController::create` runs
+- **THEN** it MUST return HTTP 400 with an example payload
+
+#### Scenario: Single name not found
+- **GIVEN** a caller requests a name for an unknown id
+- **WHEN** `NamesController::show` runs
+- **THEN** it MUST return HTTP 404 with `{found: false}`
+
+#### Scenario: Manual cache warmup
+- **WHEN** `NamesController::warmup` runs
+- **THEN** it MUST clear the name cache, re-populate it, and return old/new cache statistics with a loaded-names count

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/specs/tenant-lifecycle/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/specs/tenant-lifecycle/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Organisation and multitenancy configuration API
+The system SHALL expose an admin-gated API for reading and writing organisation settings
+and multitenancy configuration that govern tenant isolation. `ConfigurationSettingsController`
+provides `getOrganisationSettings`/`updateOrganisationSettings` (delegating to
+`SettingsService::getOrganisationSettingsOnly()` / `updateOrganisationSettingsOnly()`) and
+`getMultitenancySettings`/`updateMultitenancySettings` (delegating to
+`getMultitenancySettingsOnly()` / `updateMultitenancySettingsOnly()`). All four return HTTP
+500 with an `error` field on service failure.
+
+#### Scenario: Read multitenancy settings
+- **WHEN** `getMultitenancySettings` is called
+- **THEN** it MUST return the multitenancy settings from `SettingsService::getMultitenancySettingsOnly()`
+
+#### Scenario: Update organisation settings
+- **GIVEN** an admin posts updated organisation defaults
+- **WHEN** `updateOrganisationSettings` runs
+- **THEN** it MUST persist them via `SettingsService::updateOrganisationSettingsOnly()` and return the result

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/specs/zoeken-filteren/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/specs/zoeken-filteren/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Search-backend selection and reindex administration
+The system SHALL expose an admin-gated API for selecting the active search backend and for
+reindexing collections. `SettingsController` provides `getSearchBackend` (current backend
+config), `updateSearchBackend` (sets the active backend and signals `reload_required:
+true`), `testSetupHandler` (runs Solr setup via `SetupHandler` when Solr is enabled), and
+`reindexSpecificCollection` (reindexes a named collection with validated `batchSize`
+1–5000 and `maxObjects` >= 0). `SolrSettingsController` provides `getSolrSettings`,
+`updateSolrSettings`, `getSolrInfo`, and `getSolrDashboardStats` for the Solr settings and
+status surface.
+
+#### Scenario: Update search backend signals reload
+- **GIVEN** an admin posts `{backend: "solr"}`
+- **WHEN** `updateSearchBackend` runs
+- **THEN** it MUST persist the backend via `SettingsService::updateSearchBackendConfig()` and return `reload_required: true`
+- **AND** an empty backend param MUST produce HTTP 400
+
+#### Scenario: Reindex validates batch size
+- **GIVEN** an admin requests a reindex with `batchSize=10000`
+- **WHEN** `reindexSpecificCollection` runs
+- **THEN** it MUST reject with HTTP 400 because batch size must be between 1 and 5000
+
+#### Scenario: Setup test refuses when Solr disabled
+- **GIVEN** Solr is disabled in settings
+- **WHEN** `testSetupHandler` runs
+- **THEN** it MUST return HTTP 400 with a "SOLR is disabled" message
+
+### Requirement: Solr collection, configset, and field administration
+The system SHALL expose an admin-gated API for managing Solr collections, configsets, and
+schema fields. `SolrController` provides `listCollections`, `listConfigSets`,
+`createCollection`, `createConfigSet`, `deleteConfigSet`, and `copyCollection`.
+`SolrManagementController` provides `getSolrFields`, `createMissingSolrFields`,
+`fixMismatchedSolrFields`, `deleteSolrField`, `deleteSpecificSolrCollection`, and
+`updateSolrCollectionAssignments`. `SolrOperationsController` provides `setupSolr`,
+`testSolrConnection`, `warmupSolrIndex`, `inspectSolrIndex`, `getSolrMemoryPrediction`,
+and `manageSolr`. `ConfigurationSettingsController` provides `getObjectCollectionFields`
+and `createMissingObjectFields` to inspect and mirror the object collection's field set.
+
+#### Scenario: Create a Solr collection
+- **WHEN** `SolrController::createCollection` runs with a collection name
+- **THEN** it MUST create the collection and report the outcome
+
+#### Scenario: Synchronize missing object-collection fields
+- **GIVEN** the object collection is configured
+- **WHEN** `ConfigurationSettingsController::createMissingObjectFields` runs
+- **THEN** it MUST mirror schemas into the collection via `IndexService::mirrorSchemas(force: true)` and report success
+- **AND** an unconfigured object collection MUST produce HTTP 400
+
+#### Scenario: Inspect and warm the Solr index
+- **WHEN** `SolrOperationsController::warmupSolrIndex` then `inspectSolrIndex` run
+- **THEN** warmup MUST populate the index and inspection MUST report current index state

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-settings-observ/tasks.md
@@ -1,0 +1,98 @@
+# Tasks — reverse-spec controller bundle (settings / observability)
+
+Each task documents the observed behavior of one or more controller endpoints and maps to
+exactly one new requirement in the matching capability spec delta. Method `@spec`
+annotations reference these task anchors.
+
+## production-observability
+
+- [x] task-1 Aggregate settings administration endpoints
+  (`SettingsController::index`, `update`, `load`, `updatePublishingOptions`,
+  `getObjectSettings`, `updateObjectSettings`, `patchObjectSettings`).
+- [x] task-2 Settings dashboard statistics endpoint
+  (`SettingsController::stats`, `getStatistics`).
+- [x] task-3 Database capability introspection endpoint
+  (`SettingsController::getDatabaseInfo`, `refreshDatabaseInfo`).
+- [x] task-4 Application version reporting endpoint
+  (`SettingsController::getVersionInfo`).
+- [x] task-5 Connection keep-alive heartbeat endpoint
+  (`HeartbeatController::heartbeat`).
+- [x] task-6 Cache administration endpoints
+  (`CacheSettingsController::getCacheStats`, `clearCache`, `warmupNamesCache`,
+  `getWarmupInterval`, `setWarmupInterval`, `clearAppStoreCache`).
+- [x] task-7 Object validation administration endpoints
+  (`ValidationSettingsController::validateAllObjects`, `massValidateObjects`,
+  `predictMassValidationMemory`).
+- [x] task-8 Rate-limit administration endpoints
+  (`SecuritySettingsController::clearIpRateLimits`, `clearUserRateLimits`,
+  `clearAllRateLimits`).
+- [x] task-9 Workflow-integration administration endpoints
+  (`N8nSettingsController::getN8nSettings`, `updateN8nSettings`, `testN8nConnection`,
+  `initializeN8n`, `getWorkflows`).
+- [x] task-10 Integration API-token administration endpoints
+  (`ApiTokenSettingsController::getApiTokens`, `saveApiTokens`, `testGitHubToken`,
+  `testGitLabToken`).
+
+## retention-management
+
+- [x] task-11 Retention configuration and rebase recalculation endpoints
+  (`ConfigurationSettingsController::getRetentionSettings`, `updateRetentionSettings`;
+  `SettingsController::rebase`).
+
+## rbac-scopes
+
+- [x] task-12 RBAC enablement/configuration endpoints
+  (`ConfigurationSettingsController::getRbacSettings`, `updateRbacSettings`).
+
+## tenant-lifecycle
+
+- [x] task-13 Organisation and multitenancy configuration endpoints
+  (`ConfigurationSettingsController::getOrganisationSettings`, `updateOrganisationSettings`,
+  `getMultitenancySettings`, `updateMultitenancySettings`).
+
+## archival-destruction-workflow
+
+- [x] task-14 Archival/destruction-scheduling configuration endpoints
+  (`ConfigurationSettingsController::getArchivalSettings`, `updateArchivalSettings`).
+
+## zoeken-filteren
+
+- [x] task-15 Search-backend selection and reindex administration
+  (`SettingsController::getSearchBackend`, `updateSearchBackend`, `testSetupHandler`,
+  `reindexSpecificCollection`).
+- [x] task-16 Solr collection and configset lifecycle administration
+  (`SolrController::listCollections`, `listConfigSets`, `createCollection`,
+  `createConfigSet`, `deleteConfigSet`, `copyCollection`;
+  `SolrManagementController::deleteSpecificSolrCollection`,
+  `updateSolrCollectionAssignments`;
+  `SolrOperationsController::setupSolr`, `testSolrConnection`, `warmupSolrIndex`,
+  `inspectSolrIndex`, `getSolrMemoryPrediction`, `manageSolr`).
+- [x] task-17 Solr field synchronization administration
+  (`SolrManagementController::getSolrFields`, `createMissingSolrFields`,
+  `fixMismatchedSolrFields`, `deleteSolrField`;
+  `ConfigurationSettingsController::getObjectCollectionFields`,
+  `createMissingObjectFields`).
+- [x] task-18 Solr settings, info, and dashboard endpoints
+  (`SolrSettingsController::getSolrSettings`, `updateSolrSettings`, `getSolrInfo`,
+  `getSolrDashboardStats`).
+
+## faceting-configuration
+
+- [x] task-19 Solr facet configuration discovery and management endpoints
+  (`SolrSettingsController::getSolrFacetConfiguration`, `updateSolrFacetConfiguration`,
+  `discoverSolrFacets`, `getSolrFacetConfigWithDiscovery`,
+  `updateSolrFacetConfigWithDiscovery`).
+
+## chat-ai
+
+- [x] task-20 Semantic and hybrid search endpoints
+  (`SolrController::semanticSearch`, `hybridSearch`;
+  `SettingsController::semanticSearch`, `hybridSearch`).
+- [x] task-21 Vectorization and embedding operations endpoints
+  (`SolrController::getVectorStats`, `testVectorEmbedding`, `vectorizeObject`,
+  `bulkVectorizeObjects`, `getVectorizationStats`).
+
+## schema-driven-read-coercion
+
+- [x] task-22 Object display-name cache resolution endpoints
+  (`NamesController::index`, `create`, `show`, `stats`, `warmup`).


### PR DESCRIPTION
## Summary

Reverse-spec ghost change documenting the *observed behavior* of the OpenRegister
settings / observability controller bundle (5 sub-clusters). Annotation-only — no
behavior change.

- **9 capabilities extended** with **17 new requirements** (all `## ADDED Requirements`,
  bias-to-extend).
- **92 public controller methods annotated** with `@spec` task references.
- The two cross-cutting kitchen-sink controllers are split **per-method** to their owning
  capability rather than lumped:
  - `SettingsController` → production-observability / retention-management /
    zoeken-filteren / chat-ai.
  - `ConfigurationSettingsController` → rbac-scopes / tenant-lifecycle /
    retention-management / archival-destruction-workflow / production-observability /
    zoeken-filteren.

### Capability → new REQ count
production-observability 7, zoeken-filteren 2, chat-ai 2, faceting-configuration 1,
retention-management 1, rbac-scopes 1, tenant-lifecycle 1, archival-destruction-workflow 1,
schema-driven-read-coercion 1.

### Dropped as scanner noise
- DI accessors `SettingsController::getObjectService`/`getConfigurationService`.
- Debug endpoints `SettingsController::testSchemaMapping`/`debugTypeFiltering`.
- Empty `VectorSettingsController`.
- `MetricsController` / `HealthController` endpoints already covered by existing
  production-observability requirements; only the heartbeat keep-alive endpoint is newly
  documented.

## Test plan
- [x] `openspec validate ... --strict` passes.
- [x] `php -l` clean on all 13 touched controllers.
- [ ] Reviewer confirms per-method capability assignments for the two cross-cutting controllers.