### PR TITLE
retrofit: reverse-spec controller bundle — misc (5 sub-clusters)

### DIFF
--- a/lib/Controller/DeckController.php
+++ b/lib/Controller/DeckController.php
@@ -85,6 +85,8 @@ class DeckController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-3
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -122,6 +124,8 @@ class DeckController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-3
      */
     public function create(string $register, string $schema, string $id): JSONResponse
     {
@@ -172,6 +176,8 @@ class DeckController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-3
      */
     public function objects(string $boardId): JSONResponse
     {
@@ -199,6 +205,8 @@ class DeckController extends Controller
      * @param string $id       The object ID
      *
      * @return \OCA\OpenRegister\Db\ObjectEntity|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-3
      */
     private function validateObject(
         string $register,

--- a/lib/Controller/MigrationController.php
+++ b/lib/Controller/MigrationController.php
@@ -56,6 +56,8 @@ class MigrationController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse Storage status.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-7
      */
     public function status(string $register, string $schema): JSONResponse
     {
@@ -87,6 +89,8 @@ class MigrationController extends Controller
      * Expected body: {register, schema, direction, batchSize?, dryRun?}
      *
      * @return JSONResponse Migration report.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-7
      */
     public function migrate(): JSONResponse
     {

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -182,6 +182,8 @@ class NotesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-4
      */
     public function update(
         string $register,
@@ -265,6 +267,8 @@ class NotesController extends Controller
      * @param string $id       The object ID
      *
      * @return \OCA\OpenRegister\Db\ObjectEntity|null The object or null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-4
      */
     private function validateObject(
         string $register,

--- a/lib/Controller/ScopesController.php
+++ b/lib/Controller/ScopesController.php
@@ -115,6 +115,8 @@ class ScopesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-5
      */
     public function index(?string $register=null, ?string $schema=null): JSONResponse
     {
@@ -172,6 +174,8 @@ class ScopesController extends Controller
      * @param string|null $filter Optional register filter (id|uuid|slug).
      *
      * @return Register[] Registers that should be reported on.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-5
      */
     private function resolveRegisters(?string $filter): array
     {
@@ -213,6 +217,8 @@ class ScopesController extends Controller
      * @param string|null $filter Optional schema filter (id|uuid|slug).
      *
      * @return Schema[] Schemas that should be reported on.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-5
      */
     private function resolveSchemas(?string $filter): array
     {
@@ -256,6 +262,8 @@ class ScopesController extends Controller
      *                             group.
      *
      * @return array<int, string> Permitted action vocabulary.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-5
      */
     private function collectActionsForUser(Schema $schema, ?string $userId, bool $isAdmin): array
     {

--- a/lib/Controller/TablesController.php
+++ b/lib/Controller/TablesController.php
@@ -80,6 +80,8 @@ class TablesController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-8
      */
     public function sync(int|string $registerId, int|string $schemaId): JSONResponse
     {
@@ -210,6 +212,8 @@ class TablesController extends Controller
      * @return JSONResponse
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-8
      */
     public function syncAll(): JSONResponse
     {

--- a/lib/Controller/TagsController.php
+++ b/lib/Controller/TagsController.php
@@ -88,6 +88,8 @@ class TagsController extends Controller
      * @return JSONResponse JSON response with all tags
      *
      * @psalm-return JSONResponse<200, list<string>, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-4
      */
     public function getAllTags(): JSONResponse
     {
@@ -107,6 +109,8 @@ class TagsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-4
      */
     public function index(
         string $register,
@@ -144,6 +148,8 @@ class TagsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-4
      */
     public function add(
         string $register,
@@ -192,6 +198,8 @@ class TagsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-4
      */
     public function remove(
         string $register,

--- a/lib/Controller/TasksController.php
+++ b/lib/Controller/TasksController.php
@@ -101,6 +101,8 @@ class TasksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-2
      */
     public function allUserTasks(): JSONResponse
     {
@@ -348,6 +350,8 @@ class TasksController extends Controller
      * @param string $id       The object ID
      *
      * @return \OCA\OpenRegister\Db\ObjectEntity|null The object or null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-4
      */
     private function validateObject(
         string $register,

--- a/lib/Controller/TransitionController.php
+++ b/lib/Controller/TransitionController.php
@@ -64,6 +64,8 @@ class TransitionController extends Controller
      * @return JSONResponse JSON response with the transitioned object or an error.
      *
      * @NoAdminRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-6
      */
     public function transition(string $id): JSONResponse
     {
@@ -114,6 +116,8 @@ class TransitionController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-6
      */
     public function availableActions(string $id): JSONResponse
     {

--- a/lib/Controller/UiController.php
+++ b/lib/Controller/UiController.php
@@ -76,6 +76,8 @@ class UiController extends Controller
      * @phpstan-return TemplateResponse
      *
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1
      */
     private function makeSpaResponse(): TemplateResponse
     {
@@ -265,6 +267,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1
      */
     public function integrationsView(): TemplateResponse
     {
@@ -468,6 +472,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1
      */
     public function avg(): TemplateResponse
     {

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-misc/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-misc/proposal.md
@@ -1,0 +1,126 @@
+---
+status: draft
+retrofit: true
+---
+
+# Retrofit: Reverse-spec controller bundle — misc (5 sub-clusters)
+
+## Why
+
+A coverage scan of OpenRegister's controller layer grouped five leftover
+"miscellaneous" controller sub-clusters whose HTTP-surface contracts were not
+yet captured by any spec. The underlying services are implemented; what was
+missing is the *controller* contract (route shape, status codes, parameter
+handling, error envelopes). This ghost change reverse-specs the observed
+controller behavior and annotates the methods, biasing strongly toward
+**extending** existing capabilities and toward **annotation-only** where the
+behavior is already owned by a live spec or in-flight change.
+
+This is a documentation/annotation change only. No runtime behavior is modified.
+
+## What changes
+
+Five sub-clusters, all `--extend`:
+
+### 1. `ui-spa-mount` → extend **no-code-app-builder** (one consolidated REQ)
+
+`UiController` is 25 history-mode deep-link routes (`/registers`, `/schemas`,
+`/objects`, `/tables`, `/chat`, `/avg`, `/reports`, `/endpoints`, ...) that all
+delegate to a single private `makeSpaResponse()` helper returning the same Vue
+SPA `index` template with a permissive `connect-src '*'` CSP. Twenty-three of
+the route methods are trivial one-line delegations (the SPA-mount stubs the
+`openregister-app-manifest` work references); per architect review they are
+**captured as ONE consolidated REQ describing the SPA-mount contract, not 25
+trivial per-route REQs**. The 23 trivial stubs are documented by the single REQ
+and not individually annotated. Only the load-bearing methods are annotated:
+the `makeSpaResponse()` contract helper, and the two non-trivial routes
+(`integrationsView` — the per-leaf screenshot-harness route — and the AVG/
+reports surface noted in the contract).
+
+> NOTE: `no-code-app-builder` is a local redirect stub; the canonical cross-app
+> no-code builder lives in the root openspec. The REQ added here documents the
+> **OpenRegister-local SPA shell** (`UiController`), which is the PHP mount
+> surface the manifest-driven UI loads into — distinct from the cross-app
+> builder. When the `openregister-app-manifest` spec lands in `openspec/specs/`,
+> this REQ SHOULD migrate there.
+
+### 2. `object-integration-dispatch` → CROSS-CUTTING (annotate-only)
+
+`IntegrationsController` (read-only registry discovery API) and
+`ObjectIntegrationsController` (object-scoped sub-resource dispatch through the
+pluggable registry) are **already annotated** with
+`@spec openspec/changes/pluggable-integration-registry/tasks.md#task-18` /
+`#task-19`, and that capability has its own dedicated reverse-spec change
+(`retrofit/rspec-newcap-pluggable-integration-registry-and-providers`). Per the
+"bias extend / do not duplicate" guardrail these two files are **NOT re-specced
+here and NOT re-annotated** — they are already covered by a more specific,
+live capability. The bundle's nominal `product-service-catalog` target is a
+redirect stub and is the wrong home; the existing `pluggable-integration-registry`
+annotations are authoritative. **No new REQs, no edits** for this sub-cluster.
+
+### 3. `object-collaboration-attachments` → extend **object-interactions**
+
+`NotesController`, `TasksController`, and `TagsController` are the object-scoped
+collaboration attachments. `object-interactions` already fully covers Notes,
+Tasks (per-object), Tags, and the sub-resource pattern — those members are
+**annotated to the existing REQs, not re-specced**. Two genuinely uncovered
+surfaces get new REQs:
+
+- `TasksController::allUserTasks()` — the cross-calendar `/api/tasks` aggregate
+  endpoint (all of the session user's VTODOs across every calendar, with
+  status/assignee filters). The existing spec only covers *per-object* task
+  endpoints; the user-wide aggregate is uncovered. → one new REQ.
+- `DeckController` (`index`/`create`/`objects`) — Nextcloud Deck card linkage on
+  objects, plus the board-reverse-lookup. Deck is not mentioned anywhere in
+  `object-interactions`. → one new REQ.
+
+### 4. `scope-rbac-api` → extend **rbac-scopes**
+
+`ScopesController` implements `GET /api/scopes` — the effective-scope discovery
+endpoint that returns the current user's permitted `(register, schema, actions)`
+tuples by probing `PermissionHandler` per canonical action, with admin
+short-circuit and optional `register`/`schema` filters. `rbac-scopes` documents
+the OAS scope generation and the "Frontend Scope Checking" need but has **no REQ
+for the runtime effective-scope discovery API itself**. → one new REQ.
+`resolveRegisters`/`resolveSchemas`/`collectActionsForUser` are private helpers
+of `index()` — annotated under the same REQ, no separate REQ.
+
+### 5. `workflow-transition-tables-migration` → extend **workflow-engine-abstraction**
+
+`TransitionController` (`transition`/`availableActions`), `MigrationController`
+(`migrate`/`status`), and `TablesController` (`sync`/`syncAll`) are data-shape
+and lifecycle operations, not REST CRUD. The existing spec covers engine
+adapters and `WorkflowEngineController` but **none of these three controllers**.
+Three new REQs:
+
+- Lifecycle transition HTTP surface (`TransitionController` over
+  `TransitionEngine` / `x-openregister-lifecycle`).
+- Storage migration HTTP surface (`MigrationController`: blob ↔ magic-table
+  migration runner + status).
+- Magic-table sync HTTP surface (`TablesController`: explicit per-pair and
+  all-pairs schema-to-table sync).
+
+## New requirements summary (target ≤ ~10)
+
+| Capability | New REQs | Notes |
+|---|---|---|
+| no-code-app-builder | 1 | consolidated SPA-mount contract (covers 23 stubs) |
+| object-interactions | 2 | cross-calendar tasks aggregate; Deck card linkage |
+| rbac-scopes | 1 | effective-scope discovery API (`GET /api/scopes`) |
+| workflow-engine-abstraction | 3 | transition / storage-migration / table-sync HTTP surfaces |
+| product-service-catalog | 0 | annotation-only — already covered by pluggable-integration-registry |
+| **Total** | **7** | within budget |
+
+## Impact
+
+- Specs extended: `no-code-app-builder`, `object-interactions`, `rbac-scopes`,
+  `workflow-engine-abstraction`.
+- Specs referenced (annotation targets, no delta): `pluggable-integration-registry`
+  (already annotated upstream).
+- Controllers annotated: `UiController`, `NotesController`, `TasksController`,
+  `TagsController`, `DeckController`, `ScopesController`, `TransitionController`,
+  `MigrationController`, `TablesController`.
+- Dropped: the 23 trivial `UiController` SPA-mount stubs (covered by one REQ,
+  not individually annotated); `IntegrationsController` /
+  `ObjectIntegrationsController` (already covered elsewhere).
+- No code behavior change; docblock `@spec` annotations only.

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-misc/specs/no-code-app-builder/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-misc/specs/no-code-app-builder/spec.md
@@ -1,0 +1,58 @@
+---
+status: draft
+---
+
+# No-Code App Builder
+
+## Purpose
+
+Extend the no-code-app-builder capability with the OpenRegister-local SPA-mount
+contract: the single PHP controller surface (`UiController`) that serves the Vue
+Single Page Application into which the manifest-driven, no-code UI loads. The
+canonical cross-app no-code builder is owned by the root openspec; this delta
+documents only the OR-local mount shell — the PHP entry points that put the SPA
+on screen — reverse-specced from the existing implementation.
+
+## ADDED Requirements
+
+### Requirement: SPA deep-link routes MUST serve the Vue mount template with a client-routing CSP
+
+The system MUST serve every history-mode deep-link route through a single
+SPA-mount contract so that all in-app navigation is handled client-side by the
+Vue Single Page Application. `UiController` MUST expose one route method per
+top-level UI surface (registers, register details, schemas, schema details,
+sources, organisation, objects, integrations view, tables, chat, configurations,
+deleted, audit trail, search trail, webhooks, webhook logs, entities, entity
+details, AVG, reports, report view, endpoints, endpoint logs), and every such
+method MUST delegate to a single private `makeSpaResponse()` helper rather than
+rendering surface-specific markup. `makeSpaResponse()` MUST return a
+`TemplateResponse` for the `index` template with a `ContentSecurityPolicy` whose
+`connect-src` permits all domains (`*`) so the frontend can reach the API, and
+MUST fall back to the `error` template with HTTP 500 if rendering throws. All
+route methods MUST be annotated `@NoAdminRequired` and `@NoCSRFRequired` so deep
+links resolve for any authenticated user without a CSRF token.
+
+#### Scenario: Deep-link route returns the SPA index template
+- **GIVEN** an authenticated user requests a history-mode route such as `/registers`, `/schemas/{id}`, `/objects`, `/tables`, `/chat`, or `/avg`
+- **WHEN** the corresponding `UiController` method runs
+- **THEN** it MUST delegate to `makeSpaResponse()`
+- **AND** the response MUST be a `TemplateResponse` for the `index` template
+- **AND** the response MUST carry a CSP allowing `connect-src '*'`
+
+#### Scenario: All surfaces share one mount helper
+- **GIVEN** the 25 history-mode route methods on `UiController`
+- **WHEN** each method body is inspected
+- **THEN** every method MUST return `makeSpaResponse()` with no surface-specific rendering
+- **AND** client-side Vue Router MUST own which view renders based on the URL path
+
+#### Scenario: Render failure falls back to the error template
+- **GIVEN** template rendering inside `makeSpaResponse()` throws an exception
+- **WHEN** the failure is caught
+- **THEN** the response MUST be a `TemplateResponse` for the `error` template carrying the exception message
+- **AND** the HTTP status MUST be 500
+
+#### Scenario: Standalone integrations view route for the screenshot harness
+- **GIVEN** a request to `/integrations/{register}/{schema}/{objectId}`
+- **WHEN** `integrationsView()` runs
+- **THEN** it MUST serve the same SPA mount via `makeSpaResponse()` so the harness lands directly on the IntegrationsView Vue route
+- **AND** it MUST NOT depend on ObjectDetails sub-resource plugin loading

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-misc/specs/object-interactions/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-misc/specs/object-interactions/spec.md
@@ -1,0 +1,78 @@
+---
+status: draft
+---
+
+# Object Interactions
+
+## Purpose
+
+Extend the object-interactions capability with two collaboration-attachment
+surfaces the existing spec does not cover: (1) the user-wide task aggregate
+endpoint (all of a user's CalDAV VTODOs across every calendar, not scoped to a
+single object), and (2) Nextcloud Deck card linkage on objects. The existing
+REQs already cover per-object Notes, Tasks, Tags, and the sub-resource pattern;
+these added REQs cover the cross-calendar aggregate and the Deck integration.
+Reverse-specced from the existing implementation.
+
+## ADDED Requirements
+
+### Requirement: User-Wide Task Aggregate Endpoint
+
+The system MUST expose a user-wide task aggregate endpoint that returns every
+CalDAV VTODO belonging to the current session user across all of their
+VTODO-supporting calendars, independent of any single object. `TasksController::allUserTasks()`
+MUST resolve the calendar set from the session user (`IUserSession`), never from
+a request parameter, so the endpoint cannot be used to read another user's tasks.
+It MUST accept optional `status`, `assignee`, and pagination (`_limit`/`limit`
+capped at 200, `_offset`/`offset`) filters, where `assignee` is a free-text
+filter applied within the caller's own task list and is NOT an identity claim.
+On error it MUST return HTTP 500 with an `error` message.
+
+#### Scenario: List all of the current user's tasks
+- **GIVEN** an authenticated user with VTODOs spread across multiple calendars
+- **WHEN** a GET request is sent to `/api/tasks`
+- **THEN** `TasksController::allUserTasks()` MUST return the aggregate via `TaskService::getAllUserTasks()` resolved from `IUserSession::getUser()->getUID()`
+- **AND** the response MUST NOT depend on any object register/schema/id
+
+#### Scenario: Filter the aggregate by status and assignee
+- **GIVEN** a GET request to `/api/tasks?status=needs-action&assignee=jan`
+- **WHEN** the controller reads the parameters
+- **THEN** `status` and `assignee` MUST be forwarded to `TaskService::getAllUserTasks()`
+- **AND** `assignee` MUST be applied as a free-text filter within the caller's own task list, not as an identity claim
+
+#### Scenario: Aggregate pagination caps the limit
+- **GIVEN** a GET request to `/api/tasks?_limit=500`
+- **WHEN** the controller computes the limit
+- **THEN** the effective limit MUST be capped at 200
+
+### Requirement: Deck Card Linkage on Objects
+
+The system MUST provide object-scoped Nextcloud Deck card linkage as a
+sub-resource of objects. `DeckController` MUST support listing the Deck cards
+linked to an object, creating or linking a card to an object, and a reverse
+lookup of every object linked to cards on a given board. When the Nextcloud Deck
+app is not installed, every endpoint MUST return HTTP 501 with
+`{"error": "Nextcloud Deck app is not installed", "code": "APP_NOT_AVAILABLE"}`.
+Object-scoped operations MUST validate the object exists (HTTP 404 otherwise) via
+`ObjectService` before delegating to `DeckCardService`.
+
+#### Scenario: List Deck cards for an object
+- **GIVEN** the Deck app is installed and object `abc-123` exists
+- **WHEN** a GET request is sent to `/api/objects/{register}/{schema}/abc-123/deck`
+- **THEN** the controller MUST validate the object and return `DeckCardService::getCardsForObject()` results
+
+#### Scenario: Create or link a Deck card to an object
+- **GIVEN** the Deck app is installed and object `abc-123` exists
+- **WHEN** a POST request supplies card link/create data
+- **THEN** `DeckCardService::linkOrCreateCard()` MUST be invoked and the link returned with HTTP 201
+- **AND** a duplicate link MUST return HTTP 409, a missing target MUST return HTTP 404
+
+#### Scenario: Reverse lookup objects on a board
+- **GIVEN** the Deck app is installed
+- **WHEN** a GET request is sent for objects linked to a board id
+- **THEN** the response MUST return `{"results": [...], "total": N}` from `DeckCardService::getObjectsForBoard()`
+
+#### Scenario: Deck app not installed
+- **GIVEN** the Nextcloud Deck app is not installed
+- **WHEN** any `DeckController` endpoint is called
+- **THEN** the response MUST be HTTP 501 with `code: "APP_NOT_AVAILABLE"`

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-misc/specs/rbac-scopes/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-misc/specs/rbac-scopes/spec.md
@@ -1,0 +1,57 @@
+---
+status: draft
+---
+
+# RBAC Scopes
+
+## Purpose
+
+Extend the rbac-scopes capability with the runtime effective-scope discovery API.
+The existing spec covers OAS scope generation and the frontend's need to discover
+permissions, but has no requirement for the `GET /api/scopes` endpoint that
+computes and returns the current user's permitted `(register, schema, actions)`
+tuples at runtime. Reverse-specced from the existing `ScopesController`.
+
+## ADDED Requirements
+
+### Requirement: Effective-Scope Discovery API
+
+The system MUST expose an effective-scope discovery endpoint so clients
+(frontend feature gates, OAuth2 token exchange, downstream apps) can learn which
+`(register, schema, action)` tuples the current user may perform without probing
+every endpoint. `ScopesController::index()` (`GET /api/scopes`) MUST return an
+envelope `{user, isAdmin, groups, scopes}` where `scopes` is a list of
+`{register, schema, actions}` entries keyed by slug. For each in-scope
+(register, schema) pair the controller MUST probe `PermissionHandler::hasPermission()`
+for the five canonical actions (`read`, `create`, `update`, `delete`, `list`)
+and include only the granted ones, omitting pairs with no granted actions. Admin
+callers MUST short-circuit to the full action vocabulary for every pair,
+mirroring the admin-bypass in `PermissionHandler`. Unauthenticated callers MUST
+be supported with `user: null`. Optional `register` and `schema` query
+parameters (id|uuid|slug) MUST narrow the response, and resolution MUST keep the
+multitenancy filter on so the endpoint cannot enumerate across tenants.
+
+#### Scenario: Authenticated user discovers effective scopes
+- **GIVEN** an authenticated non-admin user in groups `users` and `hr`
+- **WHEN** a GET request is sent to `/api/scopes`
+- **THEN** the response MUST include `user`, `isAdmin: false`, `groups`, and a `scopes` list
+- **AND** each scope entry MUST list only the actions granted by `PermissionHandler::hasPermission()` for that (register, schema) pair
+- **AND** pairs with no granted action MUST be omitted
+
+#### Scenario: Admin receives the full action vocabulary
+- **GIVEN** a caller in the `admin` group
+- **WHEN** `index()` builds the response
+- **THEN** `isAdmin` MUST be `true`
+- **AND** `collectActionsForUser()` MUST short-circuit to `["read", "create", "update", "delete", "list"]` for every (register, schema) pair
+
+#### Scenario: Filter discovery by register and schema
+- **GIVEN** a GET request to `/api/scopes?register=decidesk&schema=meeting`
+- **WHEN** `resolveRegisters()` and `resolveSchemas()` apply the filters
+- **THEN** only the matching register/schema MUST be evaluated
+- **AND** the multitenancy filter MUST remain on so cross-tenant enumeration is not possible
+
+#### Scenario: Unauthenticated caller is supported
+- **GIVEN** no active user session
+- **WHEN** a GET request is sent to `/api/scopes`
+- **THEN** the response MUST set `user: null` and `isAdmin: false`
+- **AND** only scopes reachable by the `public` pseudo-group MUST be returned

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-misc/specs/workflow-engine-abstraction/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-misc/specs/workflow-engine-abstraction/spec.md
@@ -1,0 +1,117 @@
+---
+status: draft
+---
+
+# Workflow Engine Abstraction
+
+## Purpose
+
+Extend the workflow-engine-abstraction capability with three HTTP-surface
+controllers that drive lifecycle and data-shape operations but are not covered
+by the existing engine-adapter and `WorkflowEngineController` requirements:
+state-machine transitions (`TransitionController`), blob ↔ magic-table storage
+migration (`MigrationController`), and explicit magic-table synchronisation
+(`TablesController`). Reverse-specced from the existing implementation.
+
+## ADDED Requirements
+
+### Requirement: Lifecycle Transition HTTP Surface
+
+The system MUST provide a sugar HTTP entry point over the lifecycle transition
+engine so apps adopting the `x-openregister-lifecycle` annotation do not write a
+per-schema action endpoint. `TransitionController::transition()` MUST read the
+transition `action` from the request body (HTTP 400 when missing or empty),
+delegate to `TransitionEngine::transition()`, and map failures to distinct
+statuses: HTTP 403 when the caller lacks `update` permission
+(`NotAuthorizedException`), HTTP 422 when a hook rejects the save
+(`HookStoppedException`) or the transition is refused/invalid (`RuntimeException`),
+and the serialized object on success. `availableActions()` MUST return the list
+of actions allowed from the object's current state, mapping `NotAuthorizedException`
+to HTTP 403 and a missing object/schema to HTTP 404.
+
+#### Scenario: Apply a named transition from the request body
+- **GIVEN** an object that supports a `publish` transition and a caller with `update` permission
+- **WHEN** a request is sent to the transition endpoint with body `{"action": "publish"}`
+- **THEN** `TransitionEngine::transition()` MUST be invoked with that action and object id
+- **AND** the response MUST be the transitioned object's `jsonSerialize()` output
+
+#### Scenario: Missing action is rejected
+- **GIVEN** a transition request with no `action` field
+- **WHEN** `transition()` validates the body
+- **THEN** the response MUST be HTTP 400 with `error: 'Missing required field "action".'`
+
+#### Scenario: Transition error mapping
+- **GIVEN** a transition request
+- **WHEN** the engine throws
+- **THEN** `NotAuthorizedException` MUST map to HTTP 403, `HookStoppedException` and `RuntimeException` MUST map to HTTP 422
+
+#### Scenario: List available actions from current state
+- **GIVEN** an object in a known lifecycle state
+- **WHEN** `availableActions()` runs
+- **THEN** the response MUST be `{"actions": [...]}` for the actions allowed from that state
+- **AND** a missing object MUST map to HTTP 404, an unauthorized caller to HTTP 403
+
+### Requirement: Storage Migration HTTP Surface
+
+The system MUST expose a storage-migration HTTP surface for moving object data
+between blob storage and magic tables. `MigrationController::migrate()` MUST
+require `register` and `schema` parameters (HTTP 400 when missing), validate
+`direction` against `to-magic`/`to-blob` (HTTP 400 otherwise), accept optional
+`batchSize` (default 100) and `dryRun` (boolean) parameters, resolve the
+register/schema via `MigrationService::resolveRegisterAndSchema()`, and run the
+matching migration returning the migration report. `status()` MUST return the
+storage status for a register/schema pair. Errors MUST return HTTP 500 with an
+`error` message.
+
+#### Scenario: Trigger a migration to magic tables
+- **GIVEN** a request with `register`, `schema`, and `direction=to-magic`
+- **WHEN** `migrate()` runs
+- **THEN** `MigrationService::migrateToMagicTable()` MUST be invoked with the resolved register/schema, `batchSize`, and `dryRun`
+- **AND** the migration report MUST be returned
+
+#### Scenario: Invalid direction is rejected
+- **GIVEN** a migration request with `direction` other than `to-magic` or `to-blob`
+- **WHEN** `migrate()` validates the direction
+- **THEN** the response MUST be HTTP 400 with `error: 'direction must be "to-magic" or "to-blob"'`
+
+#### Scenario: Missing register or schema is rejected
+- **GIVEN** a migration request missing `register` or `schema`
+- **WHEN** `migrate()` validates the parameters
+- **THEN** the response MUST be HTTP 400 with `error: 'register and schema parameters are required'`
+
+#### Scenario: Report storage status for a pair
+- **GIVEN** a request for a register/schema pair
+- **WHEN** `status()` runs
+- **THEN** the response MUST be the `MigrationService::getStorageStatus()` result for the resolved pair
+
+### Requirement: Magic-Table Sync HTTP Surface
+
+The system MUST expose a magic-table synchronisation HTTP surface that updates a
+schema-backed table structure to match its schema without dropping or recreating
+the table. `TablesController::sync()` MUST accept a register and schema reference
+(numeric id or slug), resolve both (HTTP 404 when either is not found), invoke
+`MagicMapper::syncTableForRegisterSchema()`, and return a result reporting the
+columns added, removed, de-required, re-required, and unchanged plus metadata and
+property counts. `syncAll()` MUST iterate every register/schema pair, accumulate
+per-pair success results and per-pair errors without aborting on a single
+failure, and return a summary with `synced`, `errors`, `totalSynced`, and
+`totalErrors`. On unexpected failure both endpoints MUST return HTTP 500 with an
+`error` message.
+
+#### Scenario: Sync the magic table for one register/schema pair
+- **GIVEN** a request for an existing register and schema
+- **WHEN** `sync()` runs
+- **THEN** `MagicMapper::syncTableForRegisterSchema()` MUST be invoked
+- **AND** the response MUST include column add/remove/de-require/re-require/unchanged statistics and the resolved table name
+
+#### Scenario: Unknown register or schema returns 404
+- **GIVEN** a sync request whose register or schema cannot be resolved
+- **WHEN** the controller resolves the references
+- **THEN** the response MUST be HTTP 404 with the appropriate `error`
+
+#### Scenario: Sync all pairs tolerates per-pair failures
+- **GIVEN** several register/schema pairs where one sync throws
+- **WHEN** `syncAll()` runs
+- **THEN** the failing pair MUST be recorded in `errors` while the others succeed
+- **AND** the response MUST report `totalSynced` and `totalErrors`
+- **AND** `success` MUST be true only when `errors` is empty

--- a/openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md
@@ -1,0 +1,73 @@
+# Tasks — Retrofit b-ctrl-misc
+
+Reverse-spec + annotation tasks for the miscellaneous controller bundle. Each
+task maps a controller method (group) to the capability that owns its contract.
+Tasks prefixed CROSS are cross-cutting annotation-only references (no new REQ;
+the behavior is already owned by a live spec or in-flight change).
+
+## ui-spa-mount → no-code-app-builder
+
+- [x] **task-1**: Document the `UiController` SPA-mount contract — `makeSpaResponse()`
+  returns the Vue `index` template with a permissive `connect-src '*'` CSP and a
+  500 `error` template fallback; all 25 history-mode deep-link routes delegate to
+  it so client-side Vue Router owns navigation. ONE consolidated
+  no-code-app-builder ADDED REQ covering the contract and the 23 trivial route
+  stubs. Annotate only `makeSpaResponse()`, `integrationsView()` (screenshot-harness
+  route), and `avg()` (AVG surface) — the other 22 trivial stubs are documented
+  by this REQ, not individually annotated.
+
+## object-collaboration-attachments → object-interactions
+
+- [x] **task-2**: Document `TasksController::allUserTasks()` — the cross-calendar
+  `/api/tasks` aggregate that returns all of the session user's VTODOs across
+  every VTODO-supporting calendar, with `status`/`assignee`/`_limit`/`_offset`
+  filters, anchored to `IUserSession` (not request-controlled identity).
+  object-interactions ADDED REQ "User-Wide Task Aggregate Endpoint".
+- [x] **task-3**: Document `DeckController` (`index`/`create`/`objects`) — Nextcloud
+  Deck card linkage on objects: list cards for an object, create-or-link a card,
+  and reverse board-to-objects lookup; 501 `APP_NOT_AVAILABLE` when the Deck app
+  is absent. object-interactions ADDED REQ "Deck Card Linkage on Objects".
+- [x] **task-4 (CROSS → object-interactions existing REQs)**: Annotate
+  `NotesController` (`index`/`create`/`update`/`destroy`/`validateObject`),
+  `TasksController` (`index`/`create`/`update`/`destroy`/`validateObject`), and
+  `TagsController` (`getAllTags`/`index`/`add`/`remove`) to the existing
+  object-interactions REQs ("Notes on Objects via ICommentsManager", "Tasks on
+  Objects via CalDAV VTODO", "Tags for Object Categorization", "Sub-Resource API
+  Endpoint Pattern"). No new REQ — extends coverage of existing REQs. (Notes/Tasks
+  already carry prior-retrofit `@spec` tags; only the un-annotated members and
+  TagsController are tagged.)
+
+## scope-rbac-api → rbac-scopes
+
+- [x] **task-5**: Document `ScopesController::index()` — `GET /api/scopes` effective-
+  scope discovery returning `{user, isAdmin, groups, scopes:[{register, schema,
+  actions}]}` by probing `PermissionHandler::hasPermission()` for the five
+  canonical actions per (register, schema) pair, with admin short-circuit, anon
+  support, and optional `register`/`schema` filters. rbac-scopes ADDED REQ
+  "Effective-Scope Discovery API". `resolveRegisters()`/`resolveSchemas()`/
+  `collectActionsForUser()` are private helpers annotated under the same REQ.
+
+## workflow-transition-tables-migration → workflow-engine-abstraction
+
+- [x] **task-6**: Document `TransitionController` (`transition`/`availableActions`) —
+  the sugar HTTP entry over `TransitionEngine` for schemas adopting
+  `x-openregister-lifecycle`: action-from-body transition with
+  403/422/404 error mapping, and a list of actions allowed from the current
+  state. workflow-engine-abstraction ADDED REQ "Lifecycle Transition HTTP Surface".
+- [x] **task-7**: Document `MigrationController` (`migrate`/`status`) — the blob ↔
+  magic-table storage migration runner (`direction` validation, `batchSize`/
+  `dryRun`, register/schema resolution) and the per-pair storage-status report.
+  workflow-engine-abstraction ADDED REQ "Storage Migration HTTP Surface".
+- [x] **task-8**: Document `TablesController` (`sync`/`syncAll`) — explicit magic-
+  table synchronisation (add/de-require/drop/index columns) for one register/
+  schema pair or across all pairs, returning per-pair statistics and an
+  errors array. workflow-engine-abstraction ADDED REQ "Magic-Table Sync HTTP Surface".
+
+## object-integration-dispatch → pluggable-integration-registry (annotate-only, CROSS)
+
+- [x] **task-9 (CROSS → pluggable-integration-registry)**: `IntegrationsController`
+  and `ObjectIntegrationsController` are already annotated with
+  `@spec ...pluggable-integration-registry/tasks.md#task-18`/`#task-19` and owned
+  by the `rspec-newcap-pluggable-integration-registry-and-providers` change. No
+  new REQ and no re-annotation — recorded here for bundle completeness only. The
+  bundle's `product-service-catalog` target is a redirect stub and is NOT used.


### PR DESCRIPTION
## Summary

Bundled `opsx-reverse-spec` run over five leftover OpenRegister controller sub-clusters. Documentation/annotation only — **no runtime behavior change** (docblock `@spec` tags + one ghost OpenSpec change). OpenSpec `--strict` validates; `php -l` clean on all 9 touched controllers.

Ghost change: `openspec/changes/retrofit-2026-05-24-b-ctrl-misc/` — proposal + tasks + 4 spec deltas. **7 new REQs total** (≤ budget).

### Sub-clusters (all `--extend`)

- **ui-spa-mount → no-code-app-builder**: ONE consolidated REQ for the `UiController` SPA-mount contract (`makeSpaResponse` + permissive CSP + `index` template; 25 history-mode deep-link routes delegate to it). The 23 trivial route stubs are covered by the single REQ and **dropped** from individual annotation; only `makeSpaResponse`, `integrationsView`, and `avg` are annotated. Noted that this is the OR-local SPA shell, distinct from the canonical cross-app builder; SHOULD migrate to `openregister-app-manifest` when that spec lands.
- **object-collaboration-attachments → object-interactions**: 2 new REQs — `TasksController::allUserTasks()` (cross-calendar `/api/tasks` aggregate) and `DeckController` (Deck card linkage on objects). Notes/Tasks/Tags members annotated to existing REQs (per-object Notes/Tasks/Tags already fully speced).
- **scope-rbac-api → rbac-scopes**: 1 new REQ for the `GET /api/scopes` effective-scope discovery endpoint (`ScopesController`).
- **workflow-transition-tables-migration → workflow-engine-abstraction**: 3 new REQs for `TransitionController` (lifecycle transitions), `MigrationController` (blob↔magic-table migration), `TablesController` (magic-table sync) HTTP surfaces.
- **object-integration-dispatch**: **annotation-only, no edits** — `IntegrationsController` / `ObjectIntegrationsController` already carry `@spec ...pluggable-integration-registry` and are owned by the dedicated `rspec-newcap-pluggable-integration-registry-and-providers` change. The bundle's `product-service-catalog` target is a redirect stub and was not used.

### New REQs

| Capability | New REQs |
|---|---|
| no-code-app-builder | 1 |
| object-interactions | 2 |
| rbac-scopes | 1 |
| workflow-engine-abstraction | 3 |
| **Total** | **7** |

## Test plan

- [x] `openspec validate retrofit-2026-05-24-b-ctrl-misc --strict` passes
- [x] `php -l` clean on all 9 touched controllers
- [ ] Spec review of the 7 new REQs against observed controller behavior