### PR TITLE
retrofit: reverse-spec service bundle — compute/profile/org (4 sub-clusters)

### DIFF
--- a/lib/Service/Calculation/CalculationAnnotationValidator.php
+++ b/lib/Service/Calculation/CalculationAnnotationValidator.php
@@ -36,6 +36,8 @@ namespace OCA\OpenRegister\Service\Calculation;
  *
  * Cross-calculation:
  * - Cycle detection across {prop:calcA, prop:calcB} dependency graph.
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-2
  */
 final class CalculationAnnotationValidator
 {
@@ -87,6 +89,8 @@ final class CalculationAnnotationValidator
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-2
      */
     public function validate(array $schema): array
     {
@@ -339,6 +343,8 @@ final class CalculationAnnotationValidator
      * @param array<string, array<int, string>> $deps Dependency map.
      *
      * @return array<int, string>|null A cycle path if found, else null.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-2
      */
     private function findCycle(array $deps): ?array
     {

--- a/lib/Service/Calculation/CalculationEvaluator.php
+++ b/lib/Service/Calculation/CalculationEvaluator.php
@@ -51,6 +51,8 @@ use Throwable;
  * resolved via the shared PlaceholderResolver.
  *
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-1
  */
 class CalculationEvaluator
 {
@@ -75,6 +77,8 @@ class CalculationEvaluator
      * @return mixed The computed value.
      *
      * @throws EvaluationException When the expression is malformed or references unknown properties/operators.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-1
      */
     public function evaluate(array $object, mixed $expression): mixed
     {
@@ -123,6 +127,8 @@ class CalculationEvaluator
      * @return mixed The resolved value, or null when the path is missing.
      *
      * @throws EvaluationException When the property name is empty.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-1
      */
     private function propValue(array $object, mixed $args): mixed
     {
@@ -518,6 +524,8 @@ class CalculationEvaluator
      * @return int|null The signed integer difference, or null when a date is unparseable.
      *
      * @throws EvaluationException When the args dict is missing required keys or the unit is unknown.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-1
      */
     private function dateDiff(array $object, mixed $args): ?int
     {

--- a/lib/Service/DashboardService.php
+++ b/lib/Service/DashboardService.php
@@ -54,6 +54,8 @@ use Psr\Log\LoggerInterface;
  * @link https://www.OpenRegister.app
  *
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-5
  */
 class DashboardService
 {
@@ -150,6 +152,8 @@ class DashboardService
      * @param int|null $schemaId   The schema ID (optional)
      *
      * @return array Statistics with objects, logs, webhookLogs, and files totals and sizes.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-5
      */
     private function getStats(?int $registerId=null, ?int $schemaId=null): array
     {
@@ -297,6 +301,8 @@ class DashboardService
      * @throws \Exception If there is an error getting the registers with schemas
      *
      * @return array Registers with their schemas and statistics for dashboard display.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-5
      */
     public function getRegistersWithSchemas(
         ?int $registerId=null,
@@ -385,6 +391,8 @@ class DashboardService
      * @return int[] Array containing counts of processed and failed objects
      *
      * @psalm-return array{processed: 0|1|2, failed: 0|1|2}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-5
      */
     public function recalculateSizes(?int $registerId=null, ?int $schemaId=null): array
     {
@@ -533,6 +541,8 @@ class DashboardService
      *     total: array{processed: mixed, failed: mixed}},
      *     summary: array{total_processed: mixed, total_failed: mixed,
      *     success_rate: float}}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-5
      */
     public function calculate(?int $registerId=null, ?int $schemaId=null): array
     {
@@ -682,6 +692,8 @@ class DashboardService
      * @return ((int[]|string)[]|(int|string))[][]
      *
      * @psalm-return array{labels: list<array-key>, series: list<array{data: list<int>, name: string}>}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-5
      */
     public function getAuditTrailActionChartData(
         ?\DateTime $from=null,

--- a/lib/Service/OrganisationService.php
+++ b/lib/Service/OrganisationService.php
@@ -52,6 +52,8 @@ use Symfony\Component\Uid\Uuid;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)   Requires multiple Nextcloud services for user and group management
  * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
  * @SuppressWarnings(PHPMD.NPathComplexity)
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-4
  */
 class OrganisationService
 {
@@ -232,6 +234,8 @@ class OrganisationService
      * Uses static application-level caching for performance optimization
      *
      * @return Organisation The default organisation
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-4
      */
     public function ensureDefaultOrganisation(): Organisation
     {
@@ -460,6 +464,8 @@ class OrganisationService
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)   Boolean flag controls caching behavior
      *
      * @psalm-return list<\OCA\OpenRegister\Db\Organisation>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-4
      */
     public function getUserOrganisations(bool $_useCache=true): array
     {
@@ -497,6 +503,8 @@ class OrganisationService
      * @param array|null $preloadedOrgs Pre-loaded organisations to avoid extra queries.
      *
      * @return Organisation|null The active organisation or null.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-4
      */
     public function getActiveOrganisation(?array $preloadedOrgs=null): ?Organisation
     {
@@ -542,6 +550,8 @@ class OrganisationService
      * @return true True if successfully set, false otherwise
      *
      * @throws Exception If user doesn't belong to the organisation
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-4
      */
     public function setActiveOrganisation(string $organisationUuid): bool
     {
@@ -647,6 +657,8 @@ class OrganisationService
      * @return true True if successfully removed
      *
      * @throws Exception If organisation not found, user not logged in, or trying to leave last organisation
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-4
      */
     public function leaveOrganisation(string $organisationUuid, ?string $targetUserId=null): bool
     {
@@ -732,6 +744,8 @@ class OrganisationService
      * @SuppressWarnings(PHPMD.StaticAccess)         Uuid::isValid is standard Symfony UID pattern
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)  Boolean flag controls whether to add current user to organisation
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Organisation creation requires multiple validation steps
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-4
      */
     public function createOrganisation(
         string $name,
@@ -852,6 +866,8 @@ class OrganisationService
      * @param string $organisationUuid The organisation UUID to check
      *
      * @return bool True if user has access
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-4
      */
     public function hasAccessToOrganisation(string $organisationUuid): bool
     {
@@ -1276,6 +1292,8 @@ class OrganisationService
      * @param string       $userId       The user ID to cache for
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-4
      */
     private function cacheActiveOrganisation(Organisation $organisation, string $userId): void
     {
@@ -1319,6 +1337,8 @@ class OrganisationService
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Cache reconstruction requires branches for each organisation property
      * @SuppressWarnings(PHPMD.NPathComplexity)      Multiple optional properties create many reconstruction paths
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-4
      */
     private function reconstructOrganisationFromCache(array $cachedData): Organisation
     {
@@ -1577,6 +1597,8 @@ class OrganisationService
      * @return (mixed|null|string)[]
      *
      * @psalm-return list{0?: null|string,...}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-4
      */
     public function getUserActiveOrganisations(): array
     {

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -60,6 +60,8 @@ use Psr\Log\LoggerInterface;
  * @SuppressWarnings(PHPMD.CyclomaticComplexity)
  * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3
  */
 class UserService
 {
@@ -174,6 +176,8 @@ class UserService
      * @return array The comprehensive user data array
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3
      */
     public function buildUserDataArray(IUser $user): array
     {
@@ -914,6 +918,8 @@ class UserService
      *
      * @throws InvalidArgumentException If inputs are invalid
      * @throws RuntimeException         If password change fails
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3
      */
     public function changePassword(IUser $user, string $currentPassword, string $newPassword): array
     {
@@ -959,6 +965,8 @@ class UserService
      * @return array Result array with success status and avatar URL
      *
      * @throws RuntimeException If upload fails
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3
      */
     public function uploadAvatar(IUser $user, string $data, string $mimeType, int $size): array
     {
@@ -1034,6 +1042,8 @@ class UserService
      * @return array The export data structure
      *
      * @throws RuntimeException If rate limited
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3
      */
     public function exportPersonalData(IUser $user): array
     {
@@ -1088,6 +1098,8 @@ class UserService
      * @param IUser $user The user to get preferences for
      *
      * @return array The notification preferences
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3
      */
     public function getNotificationPreferences(IUser $user): array
     {
@@ -1164,6 +1176,8 @@ class UserService
      * @param string|null $to     Optional end date (Y-m-d)
      *
      * @return array Activity results with total count
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3
      */
     public function getUserActivity(
         IUser $user,
@@ -1216,6 +1230,8 @@ class UserService
      * @return array The created token data (full value shown only once)
      *
      * @throws RuntimeException If maximum tokens reached
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3
      */
     public function createApiToken(IUser $user, string $name, ?string $expiresIn=null): array
     {
@@ -1338,6 +1354,8 @@ class UserService
      * @return array Result array with status
      *
      * @throws RuntimeException If duplicate request exists
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3
      */
     public function requestDeactivation(IUser $user, string $reason=''): array
     {

--- a/openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/proposal.md
@@ -1,0 +1,87 @@
+---
+kind: reverse-spec
+---
+
+## Why
+
+Four already-shipped OpenRegister service clusters carry substantial behaviour that
+no spec describes. This reverse-spec run documents the **observed** behaviour of
+those classes and annotates their methods with `@spec` pointers so the code is
+brought under the ADR-008 annotation convention. No behaviour changes — this is a
+documentation/annotation pass extending four existing capabilities.
+
+The four clusters:
+
+1. **JSON-AST calculation engine** (`lib/Service/Calculation/*`). The
+   `computed-fields` spec describes a *Twig-based* `ComputedFieldHandler`. The
+   `Calculation` namespace is a **second, distinct** derivation engine: a pure-function
+   evaluator over a single-key JSON expression AST (`{ "<op>": [args] }`) plus a
+   schema-save validator for the `x-openregister-calculations` annotation. Neither the
+   AST vocabulary, the save-time evaluation contract, nor the validator's cycle
+   detection is captured anywhere. Extends `computed-fields`.
+
+2. **Self-service profile actions backend** (`lib/Service/UserService.php`). The
+   `profile-actions` spec describes the controller surface as "Not implemented", yet
+   `UserService` already implements the service-layer logic for password change, avatar
+   CRUD, GDPR export, notification preferences, activity history, API-token lifecycle,
+   and account deactivation. The spec's scenarios target controllers; this run documents
+   the service-layer contract that backs them, including two security-relevant
+   observations (SHA-256 token-at-rest hashing; malformed-`expiresIn` rejection). Extends
+   `profile-actions`.
+
+3. **Organisation membership & multi-tenancy resolution** (`lib/Service/OrganisationService.php`).
+   The `tenant-lifecycle` spec covers *provisioning* state machines. This service is the
+   *runtime resolution* layer: per-user organisation membership, default-org bootstrap,
+   active-org session caching/reconstruction, join/leave guards, and parent-chain
+   resolution for hierarchical multi-tenancy. Distinct from provisioning and from
+   tenant-isolation enforcement. Extends `tenant-lifecycle`.
+
+4. **Built-in dashboard aggregations** (`lib/Service/DashboardService.php`). The OR-canned
+   register/schema statistics, orphaned-item detection, size recalculation, and chart-data
+   assembly (objects-by-register / -schema / -size, audit action distribution). Pure
+   read-side aggregation. Extends `built-in-dashboards`.
+
+## What Changes
+
+- Document observed behaviour of the four clusters as spec deltas (new `### Requirement`
+  blocks where uncovered; the existing specs gain ADDED requirements only — no scenarios
+  are rewritten).
+- Annotate the implementing methods with `@spec` pointers to this change's `tasks.md`.
+
+### Dropped scanner groupings
+
+- `lib/Service/ConditionMatcher.php` and `lib/Service/OperatorEvaluator.php` were bundled
+  under `computed-fields` by the scanner. They are **RBAC condition matching** (MongoDB-style
+  `$in/$gt/$lt/$exists` operators evaluated against authorization `match` rules), not
+  computed-field derivation. They belong to `rbac-scopes`. `ConditionMatcher` is already
+  annotated to `retrofit-2026-05-24-annotate-openregister`. Both are dropped from this bundle
+  to avoid mis-attributing RBAC behaviour to the computed-fields capability. See the Notes in
+  the computed-fields delta for the RBAC parity observation worth a future rbac-scopes run.
+
+## Capabilities
+
+### New Capabilities
+
+None — all four are extensions of existing capabilities.
+
+### Modified Capabilities
+
+- `computed-fields`: ADDED requirements for the JSON-AST calculation engine and its
+  schema-save validator.
+- `profile-actions`: ADDED requirement for the `UserService` self-service backend contract.
+- `tenant-lifecycle`: ADDED requirements for organisation membership resolution and active-org
+  session caching.
+- `built-in-dashboards`: ADDED requirement for the OR-canned dashboard aggregation contract.
+  (Note: the local `built-in-dashboards` spec is a redirect stub pointing to the root openspec;
+  this delta documents the OR-side service implementation only.)
+
+## Impact
+
+- **Code.** Docblock-only edits (`@spec` annotations) on:
+  `lib/Service/Calculation/CalculationEvaluator.php`,
+  `lib/Service/Calculation/CalculationAnnotationValidator.php`,
+  `lib/Service/UserService.php`,
+  `lib/Service/OrganisationService.php`,
+  `lib/Service/DashboardService.php`.
+- **No runtime behaviour change.** No new endpoints, no schema/DB migration.
+- **Security observations surfaced** (not changed) in the profile-actions delta Notes.

--- a/openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/specs/built-in-dashboards/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/specs/built-in-dashboards/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: DashboardService MUST assemble OR-canned statistics and chart payloads with fail-soft semantics
+
+`DashboardService` MUST provide the read-side aggregation that powers OpenRegister's
+built-in dashboards. It MUST produce per-register and per-schema statistics rollups, detect
+orphaned items (objects and audit entries referencing register/schema combinations that no
+longer exist), expose a size-recalculation pass, and assemble chart-ready
+`{labels, series}` payloads by delegating to the underlying mappers. Every aggregation
+method MUST be fail-soft: an underlying error MUST be logged and a well-formed
+zero/empty envelope returned, except the register-listing and size-recalculation entry
+points which MUST surface a wrapped exception to the caller.
+
+#### Scenario: Registers-with-schemas rollup includes synthetic totals and orphaned rows
+- **WHEN** `getRegistersWithSchemas()` is called
+- **THEN** the result MUST begin with a synthetic `totals` register carrying system-wide statistics
+- **AND** each real register MUST carry register-level stats and its schemas each carry schema-level stats
+- **AND** the result MUST end with a synthetic `orphaned` register carrying statistics for items referencing non-existent register/schema combinations
+
+#### Scenario: Statistics envelope is fail-soft
+- **GIVEN** an underlying mapper throws while computing statistics
+- **WHEN** `getStats()` (or `getOrphanedStats`, `getAuditTrailStatistics`, `getAuditTrailActionDistribution`, `getMostActiveObjects`) runs
+- **THEN** the error MUST be logged
+- **AND** a structurally-complete envelope with zero/empty values MUST be returned rather than propagating the exception
+
+#### Scenario: Size recalculation re-saves entities and tallies outcomes
+- **WHEN** `recalculateSizes()` / `recalculateLogSizes()` runs over the filtered entity set
+- **THEN** each entity MUST be re-saved to trigger recomputation of its stored size
+- **AND** the result MUST report `processed` and `failed` counts, a per-entity failure being logged and counted rather than aborting the run
+- **AND** `recalculateAllSizes()` MUST combine object and log tallies into a `total` block
+
+#### Scenario: Calculate endpoint validates scope and reports a success rate
+- **WHEN** `calculate($registerId, $schemaId)` runs
+- **THEN** an unknown register or schema, or a schema not belonging to the given register, MUST raise a wrapped exception
+- **AND** on success the response MUST include `status`, `timestamp`, `scope`, `results`, and a `summary` carrying `total_processed`, `total_failed`, and a computed `success_rate` percentage
+
+#### Scenario: Chart-data assemblers return a labels-and-series envelope
+- **WHEN** `getObjectsByRegisterChartData`, `getObjectsBySchemaChartData`, `getObjectsBySizeChartData`, or `getAuditTrailActionChartData` is called
+- **THEN** the mapper-produced `{labels, series}` envelope MUST be returned
+- **AND** on an underlying error an empty `{labels: [], series: []}` envelope MUST be returned after logging
+
+## Notes
+
+- The local `built-in-dashboards` spec is a redirect stub; the canonical capability lives
+  in the root openspec. This delta documents only the OpenRegister-side `DashboardService`
+  implementation contract, not the cross-app dashboard pattern.

--- a/openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/specs/computed-fields/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/specs/computed-fields/spec.md
@@ -1,0 +1,116 @@
+## ADDED Requirements
+
+### Requirement: JSON-AST calculation expressions MUST be evaluated by a pure-function evaluator
+
+OpenRegister MUST provide a second derivation engine, distinct from the Twig-based
+`ComputedFieldHandler`, that evaluates calculations expressed as a single-key JSON
+expression AST. `CalculationEvaluator::evaluate(array $object, mixed $expression)`
+MUST accept either a bare scalar literal (resolved through the shared
+`PlaceholderResolver`) or a single-key array of the form `{ "<op>": <args> }`, and MUST
+dispatch on the operator key. The recognised v1 vocabulary is: `prop`, `lit`, `concat`,
+`if`, `not`, `and`, `or`, the arithmetic operators `+ - * / %`, the comparison operators
+`eq ne lt lte gt gte`, and the date operators `now`, `diffDays`, `formatDate`, `dateDiff`.
+The evaluator MUST be side-effect-free: no I/O, no database access. Any malformed
+expression, unknown operator, non-numeric arithmetic operand, zero divisor, or unknown
+`dateDiff` unit MUST raise an `EvaluationException` rather than returning a silent default.
+
+#### Scenario: Single-key dispatch on a known operator
+- **GIVEN** the expression `{ "+": [{ "prop": "aantal" }, 1] }` and an object `{ "aantal": 4 }`
+- **WHEN** `evaluate()` is called
+- **THEN** the result MUST be `5`
+
+#### Scenario: Bare scalar resolves through the placeholder resolver
+- **GIVEN** the expression is the string `"$now"` (a placeholder, not an array)
+- **WHEN** `evaluate()` is called
+- **THEN** the value MUST be resolved by the shared `PlaceholderResolver` and returned as-is for non-placeholder scalars
+
+#### Scenario: Dotted-path and @self property resolution
+- **GIVEN** an object whose `@self` metadata was injected by the on-save listener
+- **WHEN** the expression `{ "prop": "@self.created" }` is evaluated
+- **THEN** the value at the dotted path MUST be returned
+- **AND** a path that does not exist MUST resolve to null rather than raising
+
+#### Scenario: Expression with more than one top-level key is rejected
+- **GIVEN** the expression `{ "+": [1, 2], "-": [3] }` (two keys)
+- **WHEN** `evaluate()` is called
+- **THEN** an `EvaluationException` MUST be raised stating the expression must be a single-key object
+
+#### Scenario: Arithmetic guards reject non-numeric and zero-divisor operands
+- **GIVEN** the expression `{ "/": [{ "prop": "a" }, { "prop": "b" }] }`
+- **WHEN** `b` resolves to `0`
+- **THEN** an `EvaluationException` MUST be raised requiring non-zero numeric operands
+- **AND** when any operand of `+ - * %` is non-numeric an `EvaluationException` MUST be raised
+
+#### Scenario: Comparison normalises ISO-date operands before ordering
+- **GIVEN** the expression `{ "lt": [{ "prop": "start" }, { "prop": "end" }] }` with ISO-8601 date strings
+- **WHEN** `evaluate()` is called
+- **THEN** both operands MUST be coerced to integer timestamps before the `<` comparison
+- **AND** an ordering comparison against a null operand MUST yield false
+
+#### Scenario: dateDiff computes a signed integer difference in the requested unit
+- **GIVEN** the expression `{ "dateDiff": { "from": "now", "to": { "prop": "@self.dueDate" }, "unit": "days" } }`
+- **WHEN** `to` is after `from`
+- **THEN** the result MUST be a positive integer day count
+- **AND** when `to` is before `from` the result MUST be negative
+- **AND** an unsupported `unit` MUST raise an `EvaluationException`
+- **AND** an unparseable `from` or `to` MUST yield null
+
+### Requirement: Calculation annotations MUST be validated at schema-save time
+
+`CalculationAnnotationValidator::validate(array $schema)` MUST validate the
+`x-openregister-calculations` annotation before a schema is persisted and MUST return a
+list of `{code, message}` errors (empty list when the annotation is absent or valid).
+Each calculation declaration MUST be an object with a `type` drawn from
+`[string, integer, number, boolean, date]` and a non-empty `expression`. Every `prop`
+reference inside an expression MUST resolve either to a property declared on the schema,
+to a sibling calculation declared in the same annotation, or to an allowlisted
+`@self.<field>` system field (`id`, `uuid`, `register`, `schema`, `owner`, `created`,
+`updated`). Every operator key MUST be in the v1 vocabulary. The validator MUST detect
+cycles in the calc-to-calc dependency graph and report them.
+
+#### Scenario: Absent annotation produces no errors
+- **GIVEN** a schema with no `x-openregister-calculations` key
+- **WHEN** `validate()` is called
+- **THEN** the result MUST be an empty error list
+
+#### Scenario: Empty annotation is rejected
+- **GIVEN** a schema with `x-openregister-calculations` present but empty
+- **WHEN** `validate()` is called
+- **THEN** the result MUST include an error with code `calculations-empty`
+
+#### Scenario: Bad type or missing expression is reported per calculation
+- **GIVEN** a calculation declaring `type: "object"` (not in the allowed set) or omitting `expression`
+- **WHEN** `validate()` is called
+- **THEN** an error with code `calculation-bad-type` or `calculation-no-expression` MUST be returned for that calculation
+
+#### Scenario: Unknown property reference is reported
+- **GIVEN** a calculation whose expression references `{ "prop": "doesNotExist" }`
+- **WHEN** `validate()` is called
+- **THEN** an error with code `calculation-prop-unknown` MUST be returned
+- **AND** a reference to a sibling calculation name MUST be accepted and recorded as a dependency edge
+
+#### Scenario: Unknown @self field is reported
+- **GIVEN** a calculation referencing `{ "prop": "@self.secret" }`
+- **WHEN** `validate()` is called
+- **THEN** an error with code `calculation-self-unknown` MUST be returned listing the allowed system fields
+
+#### Scenario: Calculation cycle is detected
+- **GIVEN** calculation `a` referencing `b` and calculation `b` referencing `a`
+- **WHEN** `validate()` runs DFS-colouring cycle detection over the dependency graph
+- **THEN** an error with code `calculation-cycle` MUST be returned naming the cycle path
+
+#### Scenario: dateDiff argument dict is validated
+- **GIVEN** a calculation using `dateDiff` without all of `from`, `to`, `unit`
+- **WHEN** `validate()` is called
+- **THEN** an error with code `calculation-dateDiff-missing-keys` MUST be returned
+- **AND** a `dateDiff` whose `unit` is a literal string outside the supported list MUST report `calculation-dateDiff-invalid-unit`
+
+## Notes
+
+- `ConditionMatcher` and `OperatorEvaluator` (scanner-bundled here) implement **RBAC
+  condition matching**, not computed-field derivation, and are dropped from this run.
+  Worth a future `rbac-scopes` reverse-spec: `OperatorEvaluator` deliberately **fails
+  closed** — an unknown operator and any null-operand comparison (`$gt/$gte/$lt/$lte`,
+  `$in/$nin`) return false to mirror SQL three-valued logic, preventing a list-vs-find
+  authorization drift (a real `publishedAt: null` bug fixed there). That SQL/PHP RBAC
+  parity is a security-relevant invariant currently undocumented in any spec.

--- a/openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/specs/profile-actions/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/specs/profile-actions/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: UserService MUST implement the self-service profile-action backend
+
+`UserService` MUST provide the service-layer logic that backs the profile-action
+controller endpoints. Every action MUST be scoped to a supplied `IUser` and MUST respect
+the user's Nextcloud backend capabilities. The service MUST surface failures as typed
+exceptions carrying the appropriate HTTP status code so the controller can map them to the
+documented error responses. The required service operations are: profile-data assembly,
+password change, avatar upload/delete, GDPR personal-data export, notification preferences,
+activity history, API-token lifecycle, and account-deactivation lifecycle.
+
+#### Scenario: Build comprehensive user data array
+- **GIVEN** an authenticated `IUser`
+- **WHEN** `buildUserDataArray($user)` is called
+- **THEN** the result MUST include profile fields, group memberships, quota information, language/locale, backend capability flags (`displayName`, `email`, `password`, `avatar`), and an `organisations` block (`active`, `all`, `total`)
+- **AND** organisation stats MUST be memoised per request so a second call within the same request does not re-query
+
+#### Scenario: Password change enforces backend capability and current-password verification
+- **WHEN** `changePassword($user, $current, $new)` is called
+- **THEN** a backend returning `canChangePassword() === false` MUST raise an exception with code 409
+- **AND** an incorrect current password MUST raise an exception with code 403
+- **AND** a new password failing policy MUST raise an exception with code 400
+
+#### Scenario: Avatar upload validates MIME type and size
+- **WHEN** `uploadAvatar($user, $data, $mimeType, $size)` is called
+- **THEN** a MIME type outside `[image/jpeg, image/png, image/gif, image/webp]` MUST raise an exception with code 400
+- **AND** a size exceeding 5 MB MUST raise an exception with code 400
+- **AND** a backend returning `canChangeAvatar() === false` MUST raise an exception with code 409
+- **AND** `deleteAvatar($user)` MUST call `IAvatar::remove()` after the same capability gate
+
+#### Scenario: Personal data export is rate limited to once per hour
+- **WHEN** `exportPersonalData($user)` is called
+- **THEN** the assembled structure MUST include `profile`, `organisations`, `objects`, and `auditTrail` (audit entries where the user is the actor)
+- **AND** a second call within `EXPORT_RATE_LIMIT` (3600 s) MUST raise an exception with code 429 carrying `retry_after`
+
+#### Scenario: Notification preferences default and validate
+- **WHEN** `getNotificationPreferences($user)` is called for a user who never set them
+- **THEN** the documented defaults MUST be returned with boolean values coerced from their stored string form
+- **AND** `setNotificationPreferences($user, $prefs)` MUST reject an `emailDigest` outside `[none, daily, weekly]` with an `InvalidArgumentException`
+- **AND** only keys present in the default preference set MUST be persisted
+
+#### Scenario: Activity history projects audit trail by actor
+- **WHEN** `getUserActivity($user, $limit, $offset, $type, $from, $to)` is called
+- **THEN** entries MUST be sourced from the audit trail filtered by the user's UID as actor
+- **AND** each entry MUST be projected to `{id, type, objectUuid, register, schema, timestamp, summary}` with the total count preserved across pagination
+
+#### Scenario: API tokens are hashed at rest and shown in plaintext only once
+- **WHEN** `createApiToken($user, $name, $expiresIn)` is called
+- **THEN** the stored record MUST contain only the SHA-256 hash of the token plus a last-4 preview, never the plaintext
+- **AND** the plaintext token MUST be returned exactly once in the create response
+- **AND** exceeding `MAX_TOKENS` (10) MUST raise an exception with code 400
+- **AND** `listApiTokens` MUST return masked previews; `revokeApiToken` MUST delete by id or raise 404
+
+#### Scenario: Account deactivation request lifecycle
+- **WHEN** `requestDeactivation($user, $reason)` is called
+- **THEN** a pending request MUST be stored and returned with status `pending` and a `requestedAt` timestamp
+- **AND** a second request while one is pending MUST raise an exception with code 409
+- **AND** `getDeactivationStatus` MUST report `active` with `pendingRequest: null` when none exists
+- **AND** `cancelDeactivation` MUST remove the request or raise 404 when none exists
+
+## Notes
+
+- **Security (observed, not changed):** API tokens are stored as `hash('sha256', $value)`
+  with only the last 4 characters retained as a preview — plaintext is never persisted and
+  is returned only once at creation. A prior bug let a malformed `expiresIn` (e.g. `"5x"`)
+  fall through to a non-expiring token; the current code rejects unparseable `expiresIn`
+  with an `InvalidArgumentException` so a typo can no longer mint a perpetual API key.
+- The `profile-actions` spec marks these as "Not implemented" at the controller layer; the
+  service-layer contract documented here is present and exercised. Controller-endpoint
+  scenarios remain owned by the existing spec.

--- a/openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/specs/tenant-lifecycle/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/specs/tenant-lifecycle/spec.md
@@ -1,0 +1,80 @@
+## ADDED Requirements
+
+### Requirement: OrganisationService MUST resolve per-user organisation membership and active context
+
+`OrganisationService` MUST provide the runtime membership-resolution layer that sits
+beneath the tenant provisioning state machine. The system MUST always guarantee a user
+has at least one organisation: a user with no memberships MUST be auto-added to the
+default organisation, which MUST itself be auto-created on first demand. Every user MUST
+have an active organisation; when none is explicitly set the system MUST auto-select the
+oldest organisation the user belongs to, falling back to the default organisation. Joining
+and leaving MUST be guarded — a user MUST NOT be able to leave their last organisation, and
+setting an active organisation the user does not belong to MUST be rejected.
+
+#### Scenario: User with no organisations is added to the default
+- **WHEN** `getUserOrganisations()` is called for a user with no memberships
+- **THEN** the default organisation MUST be ensured (created if absent) and the user added to it
+- **AND** the returned list MUST contain that default organisation
+
+#### Scenario: Active organisation auto-selects the oldest membership
+- **GIVEN** a user with two organisations and no explicitly-set active organisation
+- **WHEN** `getActiveOrganisation()` resolves from the database
+- **THEN** the oldest organisation (by created date) MUST be selected and persisted as active
+- **AND** when the user belongs to none, the default organisation MUST be used as the fallback
+
+#### Scenario: Setting an active organisation requires membership
+- **WHEN** `setActiveOrganisation($uuid)` is called
+- **THEN** an organisation the user does not belong to MUST raise an exception
+- **AND** a non-existent organisation UUID MUST raise an exception
+- **AND** on success the choice MUST be persisted to user config so it survives across sessions
+
+#### Scenario: Leaving the last organisation is forbidden
+- **WHEN** `leaveOrganisation($uuid)` would remove the user's only remaining organisation
+- **THEN** an exception MUST be raised preventing the user from being orphaned
+- **AND** when the left organisation was the active one, the active selection MUST be cleared and re-resolved
+
+#### Scenario: Admin users bypass membership for access checks
+- **WHEN** `hasAccessToOrganisation($uuid)` is called for a user in the `admin` group
+- **THEN** access MUST be granted regardless of explicit membership
+- **AND** for non-admin users access MUST require explicit membership
+
+#### Scenario: Active-organisation resolution includes the parent chain
+- **WHEN** `getUserActiveOrganisations()` is called with a hierarchical organisation active
+- **THEN** the result MUST contain the active organisation UUID followed by every ancestor UUID resolved via the parent chain
+- **AND** this list is what multi-tenancy query filtering uses to grant children visibility of parent resources
+
+#### Scenario: Creating an organisation recovers from a slug collision
+- **WHEN** `createOrganisation($name, ...)` produces a slug that already exists
+- **THEN** the unique-constraint violation MUST be caught and the existing organisation with that slug returned instead of crashing
+- **AND** when a specific UUID was requested it MUST be reconciled onto the existing entity
+- **AND** a newly-created organisation MUST seed the `admin` group into its RBAC authorization and add all admin-group users as members
+
+### Requirement: Active and default organisation lookups MUST be cached with bounded staleness
+
+`OrganisationService` MUST cache organisation lookups to keep RBAC-path resolution cheap.
+The active organisation MUST be cached in the session (per user) and the default
+organisation in static (cross-instance) memory, both with a 15-minute TTL. Cached
+organisations MUST be stored as plain arrays and reconstructed into `Organisation` entities
+on read to avoid serialization issues. The cache MUST self-invalidate when the underlying
+membership becomes stale: a cached active organisation the user no longer belongs to, or
+that no longer exists, MUST be cleared and re-resolved.
+
+#### Scenario: Active organisation is served from session cache within TTL
+- **GIVEN** an active organisation cached less than 15 minutes ago
+- **WHEN** `getActiveOrganisation()` is called
+- **THEN** the organisation MUST be reconstructed from the cached array without a database query
+
+#### Scenario: Stale active-organisation membership is invalidated
+- **GIVEN** a persisted active organisation UUID the user no longer belongs to
+- **WHEN** the active organisation is resolved from the database
+- **THEN** the stale user-config value and session cache MUST be cleared
+- **AND** resolution MUST continue to the oldest-membership / default fallback
+
+#### Scenario: Switching the active organisation clears and re-primes the cache
+- **WHEN** `setActiveOrganisation($uuid)` succeeds
+- **THEN** the prior session caches MUST be removed and the new active organisation cached immediately
+
+#### Scenario: Cache reconstruction round-trips DateTime fields
+- **GIVEN** a cached organisation whose `created`/`updated` were stored as ISO strings
+- **WHEN** `reconstructOrganisationFromCache()` runs
+- **THEN** the string timestamps MUST be parsed back into `DateTime` instances on the rebuilt entity

--- a/openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md
@@ -1,0 +1,38 @@
+## Tasks
+
+This is a reverse-spec annotation pass. Each task pins a cluster of already-shipped
+methods to the spec delta that documents their observed behaviour. No code behaviour
+changes — only `@spec` docblock annotations are added.
+
+### 1. computed-fields — JSON-AST calculation evaluator
+- [x] Annotate `CalculationEvaluator::evaluate()` — single-key AST dispatch over the v1 operator vocabulary (`prop`, `lit`, `concat`, `if`, `not`, `and`, `or`, `+ - * / %`, `eq/ne/lt/lte/gt/gte`, `now`, `diffDays`, `formatDate`, `dateDiff`).
+- [x] Annotate `CalculationEvaluator::propValue()` — dotted-path + `@self.<field>` property resolution, missing path → null.
+- [x] Annotate the arithmetic/boolean/comparison/date helpers (`concat`, `ifExpr`, `boolEval`, `reduceBool`, `arith`, `subOrNeg`, `divide`, `modulo`, `compare`, `normaliseForCompare`, `now`, `diffDays`, `formatDate`, `dateDiff`, `toDateOrNull`) — fail-fast `EvaluationException` on malformed args; non-numeric / zero-divisor / unknown-unit rejection; ISO-date coercion for ordering.
+
+### 2. computed-fields — calculation annotation validator
+- [x] Annotate `CalculationAnnotationValidator::validate()` — schema-save validation of `x-openregister-calculations`: per-calc `type`/`expression` shape, prop-reference resolution against schema properties + sibling calcs, `@self.<field>` allowlist, and cross-calc cycle detection.
+- [x] Annotate `walk()` / `walkDateDiff()` / `findCycle()` — recursive AST walk collecting errors + dependency edges; DFS-colouring cycle finder over calc-to-calc edges only.
+
+### 3. profile-actions — UserService self-service backend
+- [x] Annotate the profile-data builders (`buildUserDataArray`, `getCustomNameFields`, `setCustomNameFields`, `buildQuotaInformation`, `getUsedSpaceMemorySafe`, `getLanguageAndLocale`, `getAdditionalProfileInfo`, `getAccountManagerPropertiesSelectively`, `updateUserProperties`, `updateStandardUserProperties`, `updateProfileProperties`, `determineChangedFields`, `getDefaultPropertyScope`).
+- [x] Annotate `changePassword()` — backend-capability gate, current-password verify, policy-failure → typed exception.
+- [x] Annotate `uploadAvatar()` / `deleteAvatar()` — MIME allowlist, 5 MB cap, `canChangeAvatar()` gate.
+- [x] Annotate `exportPersonalData()` — GDPR Art. 20 assembly, once-per-hour rate limit.
+- [x] Annotate `getNotificationPreferences()` / `setNotificationPreferences()` — defaulted prefs, `emailDigest` enum validation, bool-string round-trip.
+- [x] Annotate `getUserActivity()` — audit-trail-by-actor projection with pagination + type/date filters.
+- [x] Annotate the API-token lifecycle (`createApiToken`, `listApiTokens`, `revokeApiToken`, `getStoredTokens`, `storeTokens`, `parseExpiration`) — SHA-256-at-rest, once-only plaintext return, MAX_TOKENS cap, malformed-`expiresIn` rejection.
+- [x] Annotate the deactivation lifecycle (`requestDeactivation`, `getDeactivationStatus`, `cancelDeactivation`) — pending-request store, duplicate guard, cancel.
+
+### 4. tenant-lifecycle — organisation membership & active-org resolution
+- [x] Annotate the membership-resolution methods (`getUserOrganisations`, `getActiveOrganisation`, `setActiveOrganisation`, `joinOrganisation`, `leaveOrganisation`, `hasAccessToOrganisation`, `getUserOrganisationStats`, `getOrganisationForNewEntity`, `getUserActiveOrganisations`) — per-user membership, last-org leave guard, admin-bypass access check, parent-chain resolution.
+- [x] Annotate the default-org bootstrap methods (`ensureDefaultOrganisation`, `fetchDefaultOrganisationFromDatabase`, `createOrganisation`, `getDefaultOrganisationUuid`, `getDefaultOrganisationId`, `setDefaultOrganisationId`, `getOrganisationSettingsOnly`, `generateSlug`, `addAdminUsersToOrganisation`, `addAdminGroupToAuthorization`, `hasAdminGroupInAuthorization`, `getAdminGroupUsers`) — auto-create default, slug-collision recovery, admin RBAC seeding.
+- [x] Annotate the active-org cache lifecycle (`cacheActiveOrganisation`, `reconstructOrganisationFromCache`, `clearActiveOrganisationCache`, `clearCache`, `clearDefaultOrganisationCache`, `cacheDefaultOrganisation`, `fetchActiveOrganisationFromDatabase`, `formatCreatedDate`, `formatUpdatedDate`) — session + static caching with 15-minute TTL, stale-access invalidation, oldest-org fallback.
+
+### 5. built-in-dashboards — dashboard aggregation service
+- [x] Annotate the stats aggregators (`getStats`, `getOrphanedStats`, `getRegistersWithSchemas`, `getAuditTrailStatistics`, `getAuditTrailActionDistribution`, `getMostActiveObjects`) — per-register/-schema rollups, system-totals + orphaned pseudo-registers, fail-soft zero envelopes.
+- [x] Annotate the size-recalculation methods (`recalculateSizes`, `recalculateLogSizes`, `recalculateAllSizes`, `calculate`, `fetchRegister`, `fetchSchema`, `buildResponseScope`, `calculateSuccessRate`) — re-save-to-recompute pass, processed/failed tallies, success-rate summary.
+- [x] Annotate the chart-data assemblers (`getAuditTrailActionChartData`, `getObjectsByRegisterChartData`, `getObjectsBySchemaChartData`, `getObjectsBySizeChartData`) — labels+series envelope delegated to mappers, fail-soft empty envelope.
+
+### 6. Validation
+- [x] `php -l` clean on all five touched files.
+- [x] `openspec validate retrofit-2026-05-24-b-svc-compute-profile-org --strict` passes.


### PR DESCRIPTION
## Summary

Reverse-spec (retrofit) run documenting the observed behaviour of four already-shipped OpenRegister service clusters and bringing their methods under the ADR-008 `@spec` annotation convention. One ghost change, no runtime behaviour change — docblock annotations + spec deltas only.

Ghost change: `openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/` (passes `openspec validate --strict`).

### Sub-clusters (all extend)

- **computed-fields** ← `CalculationEvaluator` + `CalculationAnnotationValidator`. The JSON-AST calculation engine (`{ "<op>": [args] }`) is a second, distinct derivation engine from the Twig `ComputedFieldHandler` the spec already covers. 2 ADDED reqs (evaluator vocabulary + save-time annotation validation with cycle detection).
- **profile-actions** ← `UserService`. Service-layer backend for password/avatar/GDPR-export/notifications/activity/API-token/deactivation. 1 ADDED req (the spec marks the controller layer "not implemented"; the service contract documented here is present and exercised).
- **tenant-lifecycle** ← `OrganisationService`. Runtime membership resolution + active-org session/static caching, distinct from the provisioning state machine. 2 ADDED reqs.
- **built-in-dashboards** ← `DashboardService`. OR-canned stats/orphaned-detection/size-recalc/chart payloads. 1 ADDED req. (Local spec is a redirect stub; delta scopes the OR-side service only.)

**6 new requirements total. 28 methods annotated** (anchor method per cluster, full method list in `tasks.md`).

### Dropped scanner groupings

`ConditionMatcher` + `OperatorEvaluator` were scanner-bundled under computed-fields but implement **RBAC condition matching** (MongoDB-style `$in/$gt/$lt/$exists` over authorization `match` rules), not computed-field derivation. They belong to `rbac-scopes`; `ConditionMatcher` is already annotated elsewhere. Dropped here; the SQL/PHP fail-closed RBAC parity invariant is surfaced as a Note for a future rbac-scopes run.

### Security observations (surfaced, not changed)

- API tokens are stored as `hash('sha256', ...)` with only a last-4 preview; plaintext is returned exactly once at creation.
- Malformed `expiresIn` is rejected (`InvalidArgumentException`) so a typo can no longer mint a non-expiring API key.

## Test plan

- [x] `php -l` clean on all 5 touched files
- [x] `openspec validate retrofit-2026-05-24-b-svc-compute-profile-org --strict` passes
- [ ] PHPCS/PHPMD/Psalm/PHPStan in CI (no vendor binaries in worktree)