### PR TITLE
retrofit: annotate-only triage — miscellaneous service helpers (65 methods)

### DIFF
--- a/lib/Service/GraphQL/GraphQLErrorFormatter.php
+++ b/lib/Service/GraphQL/GraphQLErrorFormatter.php
@@ -38,6 +38,8 @@ class GraphQLErrorFormatter
      * @param Error $error The GraphQL error
      *
      * @return array<string, mixed> The formatted error
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-8
      */
     public function format(Error $error): array
     {

--- a/lib/Service/GraphQL/Scalar/JsonType.php
+++ b/lib/Service/GraphQL/Scalar/JsonType.php
@@ -57,6 +57,8 @@ class JsonType extends ScalarType
      * @param mixed $value The value to serialize
      *
      * @return mixed The serialized value
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-2
      */
     public function serialize(mixed $value): mixed
     {

--- a/lib/Service/GraphQL/SchemaGenerator.php
+++ b/lib/Service/GraphQL/SchemaGenerator.php
@@ -220,6 +220,8 @@ class SchemaGenerator
      * @param array<string, mixed> $mutationFields Mutation fields accumulator
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-1
      */
     private function buildSchemaFields(
         RegisterSchema $schema,
@@ -316,6 +318,8 @@ class SchemaGenerator
      * @param array<string, mixed> $mutationFields Mutation fields accumulator
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-1
      */
     private function buildMutationFields(
         RegisterSchema $schema,
@@ -365,6 +369,8 @@ class SchemaGenerator
      * Initialize custom scalar types.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-2
      */
     private function initScalars(): void
     {
@@ -382,6 +388,8 @@ class SchemaGenerator
      * Initialize handler classes with callback dependencies.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-3
      */
     private function initHandlers(): void
     {
@@ -416,6 +424,8 @@ class SchemaGenerator
      * @param RegisterSchema $schema The register schema
      *
      * @return ObjectType The GraphQL object type
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-1
      */
     public function getObjectType(RegisterSchema $schema): ObjectType
     {
@@ -457,6 +467,8 @@ class SchemaGenerator
      * @param RegisterSchema $schema The register schema
      *
      * @return array<string, array<string, mixed>> The field configuration
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-1
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) JSON Schema composition (allOf/oneOf/anyOf) requires deep branching
      * @SuppressWarnings(PHPMD.NPathComplexity)      Composition + property mapping creates high path count
@@ -536,6 +548,8 @@ class SchemaGenerator
      * @param string $ref The reference string (slug, ID, or URI)
      *
      * @return RegisterSchema|null The resolved schema or null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-1
      */
     private function resolveRef(string $ref): ?RegisterSchema
     {
@@ -562,6 +576,8 @@ class SchemaGenerator
      * @param int|null $schemaId Schema ID for deduplication (optional)
      *
      * @return string The PascalCase type name
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-1
      */
     private function toTypeName(string $slug, ?int $schemaId=null): string
     {
@@ -599,6 +615,8 @@ class SchemaGenerator
      * @param string $slug The slug to convert
      *
      * @return string A valid GraphQL field name
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-1
      */
     private function toFieldName(string $slug): string
     {
@@ -630,6 +648,8 @@ class SchemaGenerator
      * @param string $plural The plural form
      *
      * @return string The singular form
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-1
      */
     private function singularize(string $plural): string
     {
@@ -669,6 +689,8 @@ class SchemaGenerator
      * @param RegisterSchema $schema The register schema
      *
      * @return callable The resolver function
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-3
      */
     private function createSingleResolverPlaceholder(RegisterSchema $schema): callable
     {
@@ -689,6 +711,8 @@ class SchemaGenerator
      * @param RegisterSchema $schema The register schema
      *
      * @return callable The resolver function
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-3
      */
     private function createListResolverPlaceholder(RegisterSchema $schema): callable
     {
@@ -710,6 +734,8 @@ class SchemaGenerator
      * @param string         $action The mutation action (create, update, delete)
      *
      * @return callable The resolver function
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-3
      */
     private function createMutationResolverPlaceholder(RegisterSchema $schema, string $action): callable
     {

--- a/lib/Service/GraphQL/SchemaGenerator/CompositionHandler.php
+++ b/lib/Service/GraphQL/SchemaGenerator/CompositionHandler.php
@@ -93,6 +93,8 @@ class CompositionHandler
      * @param array<string, mixed> $fields The fields array to modify in-place
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-7
      */
     public function applyComposition(RegisterSchema $schema, array &$fields): void
     {
@@ -109,6 +111,8 @@ class CompositionHandler
      * @param array<string, mixed> $fields The fields array to modify in-place
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-7
      */
     private function applyAllOf(RegisterSchema $schema, array &$fields): void
     {
@@ -149,6 +153,8 @@ class CompositionHandler
      * @param array<string, mixed> $fields The fields array to modify in-place
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-7
      */
     private function applyOneOf(RegisterSchema $schema, array &$fields): void
     {
@@ -192,6 +198,8 @@ class CompositionHandler
      * @param array<string, mixed> $fields The fields array to modify in-place
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-7
      */
     private function applyAnyOf(RegisterSchema $schema, array &$fields): void
     {
@@ -240,6 +248,8 @@ class CompositionHandler
      * @param array<mixed> $refs The composition references
      *
      * @return ObjectType[] The resolved object types
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-7
      */
     private function resolveCompositionRefs(array $refs): array
     {
@@ -272,6 +282,8 @@ class CompositionHandler
      * @param ObjectType[] $types The object types to intersect
      *
      * @return array<string, array<string, mixed>> Shared field configs
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-7
      */
     private function extractSharedFields(array $types): array
     {

--- a/lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php
+++ b/lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php
@@ -217,6 +217,8 @@ class TypeMapperHandler
      *
      * @return Type The GraphQL type
      *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-3
+     *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     public function mapPropertyToGraphQLType(array $property): Type
@@ -268,6 +270,8 @@ class TypeMapperHandler
      *
      * @return Type The GraphQL input type
      *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-3
+     *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     public function mapPropertyToInputType(array $property): Type
@@ -314,6 +318,8 @@ class TypeMapperHandler
      * @param RegisterSchema $schema The register schema
      *
      * @return InputObjectType The filter input type
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-4
      */
     public function getFilterInputType(RegisterSchema $schema): InputObjectType
     {
@@ -374,6 +380,8 @@ class TypeMapperHandler
      *
      * @return InputObjectType The create input type
      *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-4
+     *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     public function getCreateInputType(RegisterSchema $schema): InputObjectType
@@ -429,6 +437,8 @@ class TypeMapperHandler
      * @param RegisterSchema $schema The register schema
      *
      * @return InputObjectType The update input type
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-4
      */
     public function getUpdateInputType(RegisterSchema $schema): InputObjectType
     {
@@ -468,6 +478,8 @@ class TypeMapperHandler
      * @param RegisterSchema $schema The register schema
      *
      * @return array<string, Type|array<string,mixed>> The input fields
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-4
      */
     private function buildInputFields(RegisterSchema $schema): array
     {
@@ -495,6 +507,8 @@ class TypeMapperHandler
      * @param ObjectType     $objectType The object type for the schema
      *
      * @return ObjectType The connection type
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-5
      */
     public function getConnectionType(RegisterSchema $schema, ObjectType $objectType): ObjectType
     {
@@ -689,6 +703,8 @@ class TypeMapperHandler
      * Get the shared PageInfo type.
      *
      * @return ObjectType The PageInfo type
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-5
      */
     private function getPageInfoType(): ObjectType
     {
@@ -782,6 +798,8 @@ class TypeMapperHandler
      * Get the shared sort input type.
      *
      * @return InputObjectType The sort input type
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-4
      */
     private function getSortInputType(): InputObjectType
     {
@@ -811,6 +829,8 @@ class TypeMapperHandler
      * Get the shared self-filter input type for metadata columns.
      *
      * @return InputObjectType The self-filter input type
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-4
      */
     private function getSelfFilterType(): InputObjectType
     {
@@ -841,6 +861,8 @@ class TypeMapperHandler
      * @param RegisterSchema $schema The register schema
      *
      * @return array<string, string> Map of property name to auth description
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md#task-6
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */

--- a/openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/proposal.md
@@ -1,0 +1,100 @@
+# Retrofit — annotate-only triage, miscellaneous service helpers (2026-05-24)
+
+Annotate-only (Bucket 1 style) triage pass over the `miscellaneous-service-helpers`
+sub-cluster: 49 `lib/Service/**` files the architect flagged as "the dregs" —
+methods that did not cleanly fit any of the 22 other service sub-clusters and that
+aggressive Phase 2/3 triage already drained down to constructors and helpers.
+
+This is NOT a reverse-spec / spec-authoring run. No new capabilities are minted and
+no spec deltas are written. Every annotation points at a requirement that already
+exists in `openspec/specs/`. No code logic changes.
+
+## Outcome
+
+- **32 methods annotated** to the existing `graphql-api` capability (the GraphQL
+  `SchemaGenerator` suite — the architect's one named exception, which turned out to
+  already have a home in the `implemented` `graphql-api` spec).
+- **All other bare methods DROPped** — constructors, trivial getters/predicates,
+  private helpers with no standalone contract, and substantive methods that belong to
+  OTHER sub-clusters (out of scope for this dregs pass).
+- **0 future-pass flags** — the GraphQL suite was the only candidate for a future
+  reverse-spec pass, and it was fully covered by the existing `graphql-api` spec, so
+  nothing remains to flag.
+
+## Annotated (32 methods → graphql-api)
+
+The `graphql-api` spec (status: `implemented`) names these methods explicitly in its
+scenarios, so the annotations are faithful retroactive mappings, not new contracts:
+
+- `lib/Service/GraphQL/SchemaGenerator.php` — `buildSchemaFields`, `buildMutationFields`,
+  `initScalars`, `initHandlers`, `getObjectType`, `buildObjectFields`, `resolveRef`,
+  `toTypeName`, `toFieldName`, `singularize`, `createSingleResolverPlaceholder`,
+  `createListResolverPlaceholder`, `createMutationResolverPlaceholder` (13)
+- `lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php` — `mapPropertyToGraphQLType`,
+  `mapPropertyToInputType`, `getFilterInputType`, `getCreateInputType`, `getUpdateInputType`,
+  `buildInputFields`, `getConnectionType`, `getPageInfoType`, `getSortInputType`,
+  `getSelfFilterType`, `getPropertyAuthDescriptions` (11)
+- `lib/Service/GraphQL/SchemaGenerator/CompositionHandler.php` — `applyComposition`,
+  `applyAllOf`, `applyOneOf`, `applyAnyOf`, `resolveCompositionRefs`, `extractSharedFields` (6)
+- `lib/Service/GraphQL/Scalar/JsonType.php` — `serialize` (1)
+- `lib/Service/GraphQL/GraphQLErrorFormatter.php` — `format` (1)
+
+Constructors in the GraphQL classes were left as DROPs (see below).
+
+## Dropped (plumbing + out-of-sub-cluster)
+
+Nothing below was annotated. Two reasons drive a DROP:
+
+**(a) Pure plumbing — no standalone behavioral contract.** Constructors, DI wiring,
+trivial getters/`is*` predicates, and private formatting helpers across:
+`ActionExecutor`, `ActionService` (`getNestedValue`), `ApprovalService`,
+`AuditHashService`, `AuthorizationAuditService`, `ChatService`, `DateTimeNormalizer`
+(constructor), `DeepLinkRegistryService`, `DownloadService` (empty `@todo` stub class,
+zero methods), `HookExecutor`, `LinkedEntityService`, `McpDiscoveryService`
+(`getBaseUrl`, `getCapabilityIds`), `OasService` (constructor, `getLastValidationReport`),
+`RetentionService`, `TenantLifecycleService` (`isValidStatus`), `ToolRegistry`,
+`WorkflowEngineRegistry`, and the constructors of every GraphQL class. These are
+implementation scaffolding, not contracts a spec should pin.
+
+**(b) Substantive but owned by another sub-cluster.** Several files carry real
+behavioral methods, but those belong to one of the other 22 service sub-clusters and
+are (or will be) annotated there — annotating them here would steal scope and create
+duplicate/competing `@spec` homes. Left untouched for their owning pass:
+
+- `AuthorizationService`, `AuthenticationService` residue → **auth-system** /
+  **migrate-auth-system**
+- `AvgComplianceService`, `AvgRetentionService` → **avg-verwerkingsregister** /
+  **retention-management**
+- `CalendarEventService`, `CalendarLinkService` → **calendar-provider** /
+  **integration-calendar**
+- `ContactMatchingService`, `ContactService` → **contacts-actions** /
+  **integration-contacts**
+- `DeckLinkService` → **integration-deck**
+- `EmailService` → **mail-sidebar** / **integration-email**
+- `ExportService`, `ImportService` → **data-import-export**
+- `FileService`, `FileSidebarService` → **file-actions** / **files-sidebar-tabs**
+- `FlowLinkService` → **integration-flow**
+- `LogService` → log/audit-trail caps
+- `ManifestService` → **openregister-adopt-app-manifest**
+- `PropertyRbacHandler` → **row-field-level-security** / **rbac-scopes**
+- `RegisterService` → register CRUD caps (`register-resolver-service` et al.)
+- `SchemaService` (schema-exploration suite, ~30 methods) →
+  **openregister-runtime-schema-api** / schema-exploration caps
+- `SearchTrailService` → search/analytics caps
+- `TenantKeyService` → **tenant-isolation-audit** / tenant key caps
+- `TextExtractionService` → **text-extraction-eml** /
+  **text-extraction-office-completeness**
+- `TmloService` → **tmlo-metadata**
+
+These are recorded as out-of-scope DROPs for THIS sub-cluster, not as gaps.
+
+## Future reverse-spec passes
+
+None required out of this bundle. The architect's single flagged candidate (the
+GraphQL `SchemaGenerator`) was already covered by the existing `graphql-api`
+capability and is now annotated. The "owned by another sub-cluster" items above are
+not gaps — they have existing capability homes and belong to their own passes.
+
+Source: `/tmp/or-scan/bundle-svc-misc-annotate.json` (sub-cluster
+`miscellaneous-service-helpers`, mode `human-triage`).
+See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/tasks.md
@@ -1,0 +1,34 @@
+# Tasks
+
+Annotate-only retrofit (Bucket 1 style) for the `miscellaneous-service-helpers`
+sub-cluster. Each task below points at an EXISTING capability requirement; the
+matching method docblock carries a `@spec ...#task-N` annotation. No new
+capabilities are minted and no spec deltas are written — every annotated method
+maps to a requirement that already lives in `openspec/specs/`.
+
+The sub-cluster was flagged by the architect as "the dregs": constructor-only
+shells and private helpers that aggressive Phase 2/3 triage already drained. The
+only genuinely-annotatable residual is the GraphQL `SchemaGenerator` suite, which
+the architect explicitly called out as the one exception that may want coverage.
+It turned out to map cleanly onto the already-`implemented` `graphql-api`
+capability, so it is annotated here rather than deferred.
+
+## Annotated to graphql-api capability
+
+- [x] task-1: graphql-api#Requirement:The GraphQL schema MUST be auto-generated from register schemas — schema-field assembly (`buildSchemaFields`, `buildMutationFields`, `getObjectType`, `buildObjectFields`) and name derivation (`toTypeName`, `toFieldName`, `singularize`, `resolveRef`) (retroactive annotation)
+- [x] task-2: graphql-api#Requirement:Custom scalar types MUST map to OpenRegister property formats — `JsonType.serialize` (JSON scalar serialization) and `SchemaGenerator.initScalars` (scalar registration) (retroactive annotation)
+- [x] task-3: graphql-api#Requirement:GraphQL MUST support nested object resolution via DataLoader batching — `TypeMapperHandler.mapPropertyToGraphQLType` / `mapPropertyToInputType` ($ref + array-of-ref mapping) and `SchemaGenerator` resolver placeholders (`createSingleResolverPlaceholder`, `createListResolverPlaceholder`, `createMutationResolverPlaceholder`, `initHandlers`) (retroactive annotation)
+- [x] task-4: graphql-api#Requirement:GraphQL MUST support filtering and sorting matching the REST API — `TypeMapperHandler` input/filter/sort builders (`getFilterInputType`, `getCreateInputType`, `getUpdateInputType`, `buildInputFields`, `getSortInputType`, `getSelfFilterType`) (retroactive annotation)
+- [x] task-5: graphql-api#Requirement:GraphQL MUST support dual pagination modes — `TypeMapperHandler.getConnectionType` and `getPageInfoType` (Relay connection + page info) (retroactive annotation)
+- [x] task-6: graphql-api#Requirement:GraphQL MUST enforce property-level RBAC via PropertyRbacHandler — `TypeMapperHandler.getPropertyAuthDescriptions` (per-property auth descriptions surfaced on the schema) (retroactive annotation)
+- [x] task-7: graphql-api#Requirement:JSON Schema composition MUST map to GraphQL type system — `CompositionHandler.applyComposition` / `applyAllOf` / `applyOneOf` / `applyAnyOf` / `resolveCompositionRefs` / `extractSharedFields` (allOf/oneOf/anyOf → merged/union/interface) (retroactive annotation)
+- [x] task-8: graphql-api#Requirement:GraphQL errors MUST follow a structured format with machine-readable codes — `GraphQLErrorFormatter.format` (structured error envelope) (retroactive annotation)
+
+## Dropped as plumbing (documented in proposal.md, NOT annotated)
+
+- [x] task-9: DROP bucket — constructors, trivial getters/predicates, and private
+      helpers with no standalone behavioral contract; plus the substantive
+      bare methods that belong to OTHER sub-clusters (auth-system, contacts-actions,
+      calendar-provider, file-actions, data-import-export, text-extraction-*,
+      retention/archival, tenant-*, etc.) and are out of scope for this dregs pass.
+      See proposal.md "Dropped" section for the full enumeration.


### PR DESCRIPTION
## Summary

Annotate-only (Bucket 1 style, **NOT** reverse-spec) triage pass over the `miscellaneous-service-helpers` sub-cluster — the 49 `lib/Service/**` files the architect flagged as "the dregs" (65 methods: constructor shells and helpers that aggressive Phase 2/3 triage already drained).

- **32 methods annotated** to the existing `graphql-api` capability — the GraphQL `SchemaGenerator` suite (`SchemaGenerator`, `TypeMapperHandler`, `CompositionHandler`, `JsonType`, `GraphQLErrorFormatter`). This was the architect's one named exception, and it maps cleanly onto the already-`implemented` `graphql-api` spec (which names these methods explicitly in its scenarios).
- **All other bare methods DROPped** — constructors, trivial getters/predicates, private helpers with no standalone contract, plus substantive methods that belong to OTHER sub-clusters (auth-system, contacts-actions, calendar-provider, file-actions, data-import-export, text-extraction-*, retention/archival, tenant-*, etc.) and are out of scope for this dregs pass.
- **0 future-pass flags** — the GraphQL suite was the only future-reverse-spec candidate, and it was already covered, so nothing remains to flag.

No new capabilities minted. No spec deltas. No code logic changes. The ghost change (`openspec/changes/retrofit-2026-05-24-b-svc-misc-annotate/`) documents the full triage in `proposal.md` + `tasks.md`, following the same proposal+tasks (no `specs/`) shape as the archived `retrofit-2026-04-23` / `retrofit-2026-04-30` annotate passes.

## Test plan

- [x] `php -l` clean on all 5 touched files
- [x] `@spec` annotations follow the existing in-file format (blank line before `@spec`, after `@return` / before `@SuppressWarnings`)
- [ ] CI PHPCS/PHPMD/Psalm/PHPStan green (no logic changes; docblock-only additions)