### PR TITLE
retrofit: reverse-spec service bundle — report/import/link (4 sub-clusters)

### DIFF
--- a/lib/Service/ConfigurationService.php
+++ b/lib/Service/ConfigurationService.php
@@ -345,6 +345,8 @@ class ConfigurationService
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)  Toggle to include/exclude objects in export
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Export requires handling multiple input types
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-6
      */
     public function exportConfig(array | Configuration | Register $input=[], bool $includeObjects=false): array
     {
@@ -374,6 +376,8 @@ class ConfigurationService
      *
      * @throws Exception
      * @throws GuzzleException
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-6
      */
     public function getUploadedJson(array $data, ?array $uploadedFiles): array|JSONResponse
     {
@@ -514,6 +518,8 @@ class ConfigurationService
      * }
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Force flag to override version checks
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-6
      */
     public function importFromFilePath(string $appId, string $filePath, string $version, bool $force=false): array
     {
@@ -555,6 +561,8 @@ class ConfigurationService
      * }
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Force flag to override version checks
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-6
      */
     public function importFromApp(string $appId, array $data, string $version, bool $force=false): array
     {
@@ -578,6 +586,8 @@ class ConfigurationService
      * @throws GuzzleException If HTTP request fails
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Version check has multiple error and validation conditions
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-7
      */
     public function checkRemoteVersion(Configuration $configuration): ?string
     {
@@ -692,6 +702,8 @@ class ConfigurationService
      * }
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Version comparison has multiple null and comparison checks
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-7
      */
     public function compareVersions(Configuration $configuration): array
     {
@@ -759,6 +771,8 @@ class ConfigurationService
      * @throws GuzzleException If HTTP request fails.
      *
      * @psalm-return JSONResponse<400|500, array{error: string, 'Content-Type'?: string}, array<never, never>>|array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-6
      */
     public function fetchRemoteConfiguration(Configuration $configuration): array|JSONResponse
     {
@@ -778,6 +792,8 @@ class ConfigurationService
      * @throws GuzzleException If fetching remote configuration fails
      *
      * @return array|JSONResponse Preview data with registers, schemas, objects, endpoints, and metadata.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-6
      */
     public function previewConfigurationChanges(Configuration $configuration): array|JSONResponse
     {
@@ -793,6 +809,8 @@ class ConfigurationService
      * @param string $appId The app ID to get the version for.
      *
      * @return null|string The configured version or null if not set.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-7
      */
     public function getConfiguredAppVersion(string $appId): string|null
     {
@@ -850,6 +868,8 @@ class ConfigurationService
      * @param string $version The version to store.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-7
      */
     public function setConfiguredAppVersion(string $appId, string $version): void
     {
@@ -973,6 +993,8 @@ class ConfigurationService
      * @return array Import results
      *
      * @psalm-return array<never, never>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-6
      */
     public function importConfigurationWithSelection(Configuration $configuration, array $selection): array
     {

--- a/lib/Service/DeckCardService.php
+++ b/lib/Service/DeckCardService.php
@@ -129,6 +129,8 @@ class DeckCardService
      * @param string $objectUuid The object UUID.
      *
      * @return array{results: array, total: int}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-8
      */
     public function getCardsForObject(string $objectUuid): array
     {
@@ -349,6 +351,8 @@ class DeckCardService
      * @throws Exception If parameters are missing or Deck operations fail.
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-8
      */
     public function linkOrCreateCard(string $objectUuid, int $registerId, array $data): DeckLink
     {
@@ -427,6 +431,8 @@ class DeckCardService
      * @return void
      *
      * @throws Exception If link not found.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-8
      */
     public function unlinkCard(int $linkId): void
     {
@@ -444,6 +450,8 @@ class DeckCardService
      * @param int $boardId The Deck board ID.
      *
      * @return array Array of deck links.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-8
      */
     public function getObjectsForBoard(int $boardId): array
     {
@@ -463,6 +471,8 @@ class DeckCardService
      * @param string $objectUuid The object UUID.
      *
      * @return int Number of deleted links.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-8
      */
     public function deleteLinksForObject(string $objectUuid): int
     {

--- a/lib/Service/DsarService.php
+++ b/lib/Service/DsarService.php
@@ -133,6 +133,8 @@ class DsarService
      * @param string      $mode    `exact` (default) or `ilike`.
      *
      * @return array<int, array{object: array, gdprEntities: array}>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-11
      */
     public function findObjectsForSubject(string $subject, ?string $type=null, string $mode='exact'): array
     {
@@ -217,6 +219,8 @@ class DsarService
      * @return array<string, mixed>
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-11
      */
     public function eraseObjectsForSubject(string $subject, ?string $type=null, bool $dryRun=false): array
     {
@@ -362,6 +366,8 @@ class DsarService
      * @param array<string, mixed> $changes  Property → new value map.
      *
      * @return array<string, mixed>|null Updated object envelope or null on miss.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-12
      */
     public function rectifyObjectForSubject(int $objectId, array $changes): ?array
     {
@@ -408,6 +414,8 @@ class DsarService
      * defaults in that case.
      *
      * @return string|null Resolved activity uuid, or null.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-11
      */
     public function getDsarProcessingActivityUuid(): ?string
     {

--- a/lib/Service/NoteService.php
+++ b/lib/Service/NoteService.php
@@ -107,6 +107,8 @@ class NoteService
      * @param int    $offset     Number of notes to skip (default 0)
      *
      * @return array Array of note arrays in JSON-friendly format
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-9
      */
     public function getNotesForObject(string $objectUuid, int $limit=50, int $offset=0): array
     {
@@ -134,6 +136,8 @@ class NoteService
      * @return array The created note in JSON-friendly format
      *
      * @throws Exception If no user is logged in
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-9
      */
     public function createNote(string $objectUuid, string $message): array
     {
@@ -165,6 +169,8 @@ class NoteService
      * @return array The updated note in JSON-friendly format
      *
      * @throws Exception If the note is not found or user is not the author
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-9
      */
     public function updateNote(int $noteId, string $message): array
     {
@@ -197,6 +203,8 @@ class NoteService
      * @return void
      *
      * @throws Exception If the note is not found
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-9
      */
     public function deleteNote(int $noteId): void
     {
@@ -216,6 +224,8 @@ class NoteService
      * @param string $objectUuid The UUID of the OpenRegister object
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-9
      */
     public function deleteNotesForObject(string $objectUuid): void
     {

--- a/lib/Service/Reporting/HtmlReportWriter.php
+++ b/lib/Service/Reporting/HtmlReportWriter.php
@@ -38,6 +38,8 @@ class HtmlReportWriter
      * @param array<int, array{widget: array, data: array|null}> $resolvedWidgets Widget+data tuples.
      *
      * @return string Rendered HTML bytes.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-3
      */
     public function write(array $dashboard, array $resolvedWidgets): string
     {

--- a/lib/Service/Reporting/PdfReportWriter.php
+++ b/lib/Service/Reporting/PdfReportWriter.php
@@ -53,6 +53,8 @@ class PdfReportWriter
      * @param array<int, array{widget: array, data: array|null}> $resolvedWidgets Widget+data tuples.
      *
      * @return string Rendered PDF bytes.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-4
      */
     public function write(array $dashboard, array $resolvedWidgets): string
     {

--- a/lib/Service/Reporting/ReportRenderService.php
+++ b/lib/Service/Reporting/ReportRenderService.php
@@ -89,6 +89,8 @@ class ReportRenderService
      *
      * @throws InvalidArgumentException When the format is unsupported
      *                                  or the dashboard is malformed.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-1
      */
     public function render($dashboard, string $format='xlsx'): array
     {
@@ -159,6 +161,8 @@ class ReportRenderService
      * @param array<string, mixed> $widget Widget descriptor with `dataSource`.
      *
      * @return array<string, mixed>|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-2
      */
     private function resolveWidgetData(array $widget): ?array
     {

--- a/lib/Service/Reporting/SpreadsheetReportWriter.php
+++ b/lib/Service/Reporting/SpreadsheetReportWriter.php
@@ -44,6 +44,8 @@ class SpreadsheetReportWriter
      * @param string                                             $format          csv|xlsx|ods.
      *
      * @return string Rendered bytes.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-5
      */
     public function write(array $dashboard, array $resolvedWidgets, string $format): string
     {

--- a/lib/Service/TaskService.php
+++ b/lib/Service/TaskService.php
@@ -104,6 +104,8 @@ class TaskService
      * @return array{results: array, total: int} Task results with total count
      *
      * @throws Exception If no user is logged in
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-10
      */
     public function getAllUserTasks(
         ?string $status=null,
@@ -402,6 +404,8 @@ class TaskService
      * @return array|null The updated task in JSON-friendly format, or null if calendar data was not a VTODO
      *
      * @throws Exception If the task is not found or update fails
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-10
      */
     public function updateTask(string $calendarId, string $taskUri, array $data): ?array
     {
@@ -465,6 +469,8 @@ class TaskService
      * @return void
      *
      * @throws Exception If the task is not found or deletion fails
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md#task-10
      */
     public function deleteTask(string $calendarId, string $taskUri): void
     {

--- a/openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/proposal.md
@@ -1,0 +1,86 @@
+# Retrofit reverse-spec: service bundle — report / import / link (4 sub-clusters)
+
+## Why
+
+This is a **reverse-spec (ghost) change**: it documents already-shipped,
+already-merged service behavior that has no spec coverage and annotates the
+implementing methods with `@spec` back-references. No production code logic
+changes — only docblock annotations are added.
+
+Four service sub-clusters are covered, each extending an existing capability:
+
+1. **Report-rendering pipeline** (`lib/Service/Reporting/`) — the server-side
+   dashboard renderer (`ReportRenderService`) and its three pluggable format
+   writers (`HtmlReportWriter`, `PdfReportWriter`, `SpreadsheetReportWriter`).
+   The `rapportage-bi-export` spec already names these writers in its
+   Implementation section and declares the format-support requirement, but the
+   **writer-abstraction contract** (resolve-then-dispatch, per-widget sheets,
+   graceful per-widget failure) and the **Dompdf hardening invariant** (sandbox
+   flags + stylesheet/font stripping) are not formal requirements. Annotate the
+   19 methods; add writer-abstraction and PDF-sandbox requirements.
+
+2. **Configuration import/export facade** (`lib/Service/ConfigurationService.php`)
+   — the public facade over the already-spec'd `Configuration/ImportHandler`,
+   `Configuration/ExportHandler`, `FetchHandler`, `PreviewHandler`,
+   `UploadHandler`, and `CacheHandler` (those handlers were annotated by the
+   archived `retrofit-2026-04-23` / `retrofit-2026-05-24-annotate-openregister`
+   changes against `data-import-export`). The thin delegating wrappers on
+   `ConfigurationService` (`importFromFilePath`, `importFromApp`,
+   `fetchRemoteConfiguration`, `previewConfigurationChanges`,
+   `importConfigurationWithSelection`, `checkRemoteVersion`, `compareVersions`,
+   `getConfiguredAppVersion` / `setConfiguredAppVersion`, `getUploadedJson`,
+   `exportConfig`) are the un-annotated facade layer. Annotate them; add one
+   facade/version-lifecycle requirement.
+
+3. **Legacy flat external-app link services** (`lib/Service/DeckCardService.php`,
+   `lib/Service/NoteService.php`, `lib/Service/TaskService.php`) — the
+   **pre-ADR-019** flat link services that still exist alongside the new
+   `IntegrationProvider` registry being introduced by the in-flight
+   `pluggable-integration-registry` change (PR #1811). This bundle does **not**
+   re-specify the registry contract (owned there) — it records the
+   non-provider behavior these flat services carry that the provider migration
+   MUST preserve: Deck board-search + label/assignee enrichment + stale-card
+   degradation, comment-backed object notes with author-edit guard, and CalDAV
+   VTODO task linking with assignee-from-description extraction.
+
+4. **DSAR personal-data handlers** (`lib/Service/DsarService.php`) — the partial
+   implementation of the AVG data-subject rights flows the
+   `avg-verwerkingsregister` spec lists as NOT-implemented
+   (`DataSubjectSearchService`, `ErasureRequestHandler`). `DsarService`
+   composes the `GdprEntity` index + `entity_relations` join + `MagicMapper`
+   lookup into find / erase / rectify with processing-activity audit
+   attribution and LIKE-wildcard escaping. Annotate; add a find/erase
+   requirement and a rectify requirement. Authorization gaps are surfaced as
+   Notes (not new requirements).
+
+## What Changes
+
+- Add `@spec` annotations to the implementing methods (docblock-only).
+- `rapportage-bi-export`: ADD writer-abstraction + Dompdf-sandbox requirements.
+- `data-import-export`: ADD a `ConfigurationService` facade / version-lifecycle
+  requirement.
+- `integration-registry`: ADD two legacy-flat-link-service requirements
+  (behavior the provider migration must preserve).
+- `avg-verwerkingsregister`: ADD DSAR find/erase + rectify requirements.
+
+## Dropped scanner candidates (false positives)
+
+- `MigrationService` (`resolveRegisterAndSchema`, `getStorageStatus`,
+  `migrateToMagicTable`, `migrateToBlobStorage`) — magic-table / blob storage
+  lifecycle, belongs to `object-lifecycle`, not import/export. Dropped.
+- `Configuration/AttributionFormatter`, `Configuration/GitHubGuards`, and the
+  `GitHubHandler::listIssues` / `createIssue` + `ConfigurationService::searchGitHub`
+  / `searchGitLab` methods — these belong to the GitHub issue-proxy
+  (`add-github-issue-proxy` / `add-features-roadmap-menu`), not configuration
+  import. Already annotated there. Dropped from this bundle.
+- `ApplicationService` (`findAll` / `find` / `create` / `update` / `delete`) —
+  generic CRUD over the `applications` table, not an import/export concern.
+  Dropped.
+
+## Impact
+
+- Affected specs: `rapportage-bi-export`, `data-import-export`,
+  `integration-registry`, `avg-verwerkingsregister`.
+- Affected code: docblock annotations only across the report writers,
+  `ConfigurationService` facade, the three legacy link services, and
+  `DsarService`. No behavioral change.

--- a/openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/specs/avg-verwerkingsregister/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/specs/avg-verwerkingsregister/spec.md
@@ -1,0 +1,96 @@
+# AVG Verwerkingsregister (retrofit delta)
+
+These requirements document `DsarService`, the partial implementation of the
+data-subject rights flows the base spec lists as NOT-implemented
+(`DataSubjectSearchService`, `ErasureRequestHandler`). It composes the
+`GdprEntity` index, the `openregister_entity_relations` join, and `MagicMapper`
+object lookup into the find / erase / rectify flows with processing-activity
+audit attribution.
+
+## ADDED Requirements
+
+### Requirement: The system MUST locate and erase a data subject's objects across PII-indexed entities
+
+`DsarService` MUST find every object that references a data subject by matching
+the subject value against the `GdprEntity` index (`openregister_entities`) joined
+to `openregister_entity_relations`, deduplicating by object uuid (preferred) or
+legacy int id, and returning an inzage envelope of `{object, gdprEntities}` per
+matched object (Art 15). It MUST support an erase flow (Art 17 vergetelheid) that
+soft-deletes each matched object — recording `deletedBy`, `deletedAt`, a
+`reason` of `avg-vergetelheid`, and the subject — with a `dryRun` mode that
+returns the match set without erasing. The subject value MUST be escaped for SQL
+`LIKE` wildcards before matching, so an admin cannot pass `%` or `_` to match (and
+in the erase path, delete) every PII row.
+
+#### Scenario: Find returns one envelope per matched object
+- **GIVEN** a subject email `jan@example.nl` referenced by GdprEntity rows on two objects
+- **WHEN** `findObjectsForSubject('jan@example.nl')` is called
+- **THEN** the result MUST contain two envelopes, each with the object's `jsonSerialize()` payload and the matching `gdprEntities`
+- **AND** entity hits for the same object MUST be grouped into a single envelope
+
+#### Scenario: LIKE wildcards in the subject are escaped
+- **GIVEN** an admin calls the erase flow with subject `%@%`
+- **WHEN** `eraseObjectsForSubject('%@%')` matches entities
+- **THEN** the `%` characters MUST be escaped before the `LIKE` comparison so they match literally, not as wildcards
+- **AND** the call MUST NOT erase every PII-referencing object
+
+#### Scenario: Dry-run erase returns matches without writing
+- **GIVEN** three objects reference a subject
+- **WHEN** `eraseObjectsForSubject($subject, dryRun: true)` is called
+- **THEN** the summary MUST report `matchedCount: 3` and an empty `erased` list
+- **AND** no object MUST be soft-deleted
+
+#### Scenario: Erase soft-deletes with vergetelheid metadata
+- **GIVEN** an object referencing the subject and a non-dry-run erase
+- **WHEN** `eraseObjectsForSubject($subject)` runs
+- **THEN** each erased object MUST have its `deleted` metadata set with `reason: avg-vergetelheid` and the subject recorded
+- **AND** the erased entry MUST report the object's uuid, register, and schema
+
+### Requirement: DSAR write operations MUST attribute the audit trail to the configured processing activity
+
+`DsarService` MUST tag every DSAR write (erasure and rectificatie) with the
+operator-configured DSAR processing-activity uuid by calling
+`ObjectEntity::setProcessingActivityId()` before persisting, so the existing
+audit-trail hook records the legal basis. The activity reference MUST be read
+from app-config key `dsar_processing_activity`, falling back to the
+`dsar` activity code, and resolved through
+`VerwerkingsactiviteitMapper::resolveReference()`; when neither resolves the
+write MUST still proceed, falling back to the schema/register annotation.
+`rectifyObjectForSubject()` MUST merge the requested field changes into the
+object payload and persist them under this attribution (Art 16 rectificatie).
+
+#### Scenario: Rectification merges changes and attributes the activity
+- **GIVEN** the app-config key resolves to a DSAR verwerkingsactiviteit uuid
+- **WHEN** `rectifyObjectForSubject($objectId, ['adres' => 'Nieuwstraat 1'])` is called
+- **THEN** the object payload MUST be merged with the new `adres` value (other fields preserved)
+- **AND** `setProcessingActivityId()` MUST be called with the resolved DSAR activity uuid before `update()`
+
+#### Scenario: Unresolved activity does not block the write
+- **GIVEN** no `dsar_processing_activity` is configured and no `dsar`-coded activity exists
+- **WHEN** a DSAR erase or rectification runs
+- **THEN** `getDsarProcessingActivityUuid()` MUST return `null`
+- **AND** the write MUST still proceed (audit falls back to the schema/register annotation)
+
+#### Scenario: A missing object yields a null result, not an error
+- **GIVEN** an object id that does not exist
+- **WHEN** `rectifyObjectForSubject($missingId, $changes)` is called
+- **THEN** the method MUST return `null` rather than throwing
+
+## Notes — authorization gaps observed (not yet requirements)
+
+- **No in-service authz gate on the erase path.** `eraseObjectsForSubject()` and
+  `matchEntities()` rely on the caller (controller) being admin-gated; the LIKE
+  escaping is the only in-service guard. There is no per-call permission check
+  that the actor is a privacy officer / FG. The base spec's purpose-binding
+  middleware is the intended enforcement point — surfacing here so the provider
+  of the DSAR controller endpoints wires the authz before this service.
+- **find/erase load objects with `_rbac: false, _multitenancy: false`.**
+  `loadObjectByEntry()` and `rectifyObjectForSubject()` deliberately bypass RBAC
+  and tenant isolation to see every matching object. This is correct for a
+  privacy-officer DSAR sweep but means a multi-tenant deployment MUST gate the
+  endpoint at the organisation level (see base-spec "Data subject request scoped
+  to organisation"); the service itself does not scope by organisation.
+- **Rectification has no factual-record protection.** The base spec requires the
+  ability to reject rectification of professional-judgment records; `DsarService`
+  performs an unconditional merge. A future change should add the rejection +
+  objection-attachment workflow.

--- a/openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/specs/data-import-export/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/specs/data-import-export/spec.md
@@ -1,0 +1,68 @@
+# Data Import and Export (retrofit delta)
+
+## ADDED Requirements
+
+### Requirement: ConfigurationService MUST provide the public facade over the configuration import/export handlers
+
+`ConfigurationService` MUST expose the public entry points for register
+configuration portability, delegating to the dedicated handlers (which own the
+detailed import/export contract): `exportConfig()` → `Configuration/ExportHandler`,
+`getUploadedJson()` → `Configuration/UploadHandler`, `importFromFilePath()` /
+`importFromApp()` / `importFromJson()` → `Configuration/ImportHandler`,
+`fetchRemoteConfiguration()` → `Configuration/FetchHandler`,
+`previewConfigurationChanges()` / `importConfigurationWithSelection()` →
+`Configuration/PreviewHandler`. The facade MUST pass through the handler results
+unchanged and MUST be the single service consuming apps inject for
+configuration import/export.
+
+#### Scenario: App imports its bundled configuration through the facade
+- **GIVEN** a consuming app calls `ConfigurationService::importFromApp('opencatalogi', $data, $version)`
+- **WHEN** the facade runs
+- **THEN** it MUST delegate to `Configuration/ImportHandler::importFromApp()` with the same arguments
+- **AND** the returned summary MUST carry the handler's `registers`, `schemas`, `objects`, `endpoints`, `sources`, `mappings`, `jobs`, `synchronizations`, and `rules` keys unchanged
+
+#### Scenario: Export configuration through the facade
+- **GIVEN** a `Configuration` entity
+- **WHEN** `ConfigurationService::exportConfig($config, includeObjects: true)` is called
+- **THEN** the facade MUST delegate to `Configuration/ExportHandler::exportConfig()`, supplying the OpenConnector configuration service only when OpenConnector is installed (`hasOpenConnector()` true)
+- **AND** return the OpenAPI 3.0.0 export array unchanged
+
+#### Scenario: Upload resolution accepts file, URL, or inline JSON
+- **GIVEN** a request whose body carries one of an uploaded file, a `url`, or an inline `json` dump
+- **WHEN** `ConfigurationService::getUploadedJson($data, $uploadedFiles)` is called
+- **THEN** it MUST delegate to `Configuration/UploadHandler::getUploadedJson()` which resolves the payload in that precedence order
+- **AND** return either the parsed array or a `JSONResponse` error
+
+### Requirement: ConfigurationService MUST track and compare imported-configuration versions
+
+The system MUST support remote-version awareness for imported configurations.
+`checkRemoteVersion()` MUST fetch a remote-sourced configuration, extract its
+`version` (or `info.version`), and persist `remoteVersion` + `lastChecked` on the
+`Configuration` entity; it MUST be a no-op returning `null` for non-remote
+configurations or configurations without a source URL. `compareVersions()` MUST
+use `version_compare()` to report `hasUpdate` with a human-readable message.
+`getConfiguredAppVersion()` / `setConfiguredAppVersion()` MUST read/write the
+last-imported version per app in appconfig.
+
+#### Scenario: Remote version check persists the discovered version
+- **GIVEN** a `Configuration` that `isRemoteSource()` with a valid source URL serving `{"version": "1.4.0"}`
+- **WHEN** `checkRemoteVersion()` runs
+- **THEN** the configuration's `remoteVersion` MUST be set to `1.4.0` and `lastChecked` MUST be updated
+- **AND** the method MUST return `1.4.0`
+
+#### Scenario: Version check is a no-op for non-remote configurations
+- **GIVEN** a `Configuration` whose `isRemoteSource()` is false
+- **WHEN** `checkRemoteVersion()` runs
+- **THEN** the method MUST return `null` without performing an HTTP fetch
+
+#### Scenario: Version comparison reports an available update
+- **GIVEN** a configuration with `localVersion = 1.2.0` and `remoteVersion = 1.3.0`
+- **WHEN** `compareVersions()` runs
+- **THEN** the result MUST report `hasUpdate: true`
+- **AND** the message MUST read `Update available: 1.2.0 → 1.3.0`
+
+#### Scenario: Missing version information is reported, not assumed
+- **GIVEN** a configuration with a `localVersion` but no `remoteVersion`
+- **WHEN** `compareVersions()` runs
+- **THEN** the result MUST report `hasUpdate: false`
+- **AND** the message MUST indicate the remote version is unknown and prompt checking it first

--- a/openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/specs/integration-registry/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/specs/integration-registry/spec.md
@@ -1,0 +1,86 @@
+# Integration Registry (retrofit delta)
+
+These requirements document the **legacy pre-ADR-019 flat link services**
+(`DeckCardService`, `NoteService`, `TaskService`) that still exist alongside the
+new `IntegrationProvider` registry introduced by the `pluggable-integration-registry`
+change. They are recorded here so the provider migration preserves the
+non-provider behavior these flat services carry (board search, comment-backed
+notes with an author-edit guard, CalDAV VTODO linking). The registry contract
+itself (`IntegrationProvider`, `IntegrationRegistry`, the 8 builtin providers,
+parity gate) is owned by `pluggable-integration-registry` and is NOT re-specified
+here.
+
+## ADDED Requirements
+
+### Requirement: Legacy Deck and Note link services MUST preserve their non-provider behavior
+
+The system MUST retain, for the migration to the `deck` and `notes`
+`IntegrationProvider`s, the behavior of the legacy flat services. `DeckCardService`
+MUST list an object's Deck links enriched best-effort with `dueDate`, `labels`,
+and `assignees` resolved from the live Deck card (degrading to `null`/`[]` when
+Deck is disabled or the card is deleted), MUST support linking an existing card
+or creating a new one, MUST support board-scoped reverse lookup
+(`getObjectsForBoard`), and MUST delete all links for an object on cleanup.
+`NoteService` MUST back object notes with Nextcloud `ICommentsManager` comments
+under objectType `openregister`, and MUST enforce an author-only edit guard on
+note updates while allowing cleanup-time bulk deletion.
+
+#### Scenario: Deck link enrichment degrades gracefully when a card is gone
+- **GIVEN** an object with a Deck link whose underlying card has been deleted from Deck
+- **WHEN** `DeckCardService::getCardsForObject()` runs
+- **THEN** the stale link MUST still be returned in `results`
+- **AND** its `dueDate` MUST be `null` and `labels`/`assignees` MUST be empty arrays (no exception)
+
+#### Scenario: Reverse lookup of objects linked to a board
+- **GIVEN** several objects with Deck links on board id `42`
+- **WHEN** `DeckCardService::getObjectsForBoard(42)` is called
+- **THEN** the method MUST return the serialized link rows for every object linked to a card on that board
+
+#### Scenario: Object delete cascades Deck link cleanup
+- **GIVEN** an object with three Deck links
+- **WHEN** the object is deleted and `deleteLinksForObject($uuid)` runs
+- **THEN** all three link rows MUST be removed and the deleted count MUST be returned
+
+#### Scenario: A note can only be edited by its author
+- **GIVEN** a note created by user `alice` on an object
+- **WHEN** user `bob` calls `NoteService::updateNote()` for that note
+- **THEN** the service MUST reject the update ("You can only edit your own notes")
+- **AND** when `alice` updates it the comment message MUST be saved via `ICommentsManager`
+
+#### Scenario: Object delete cascades note cleanup
+- **GIVEN** an object with several notes (comments) under objectType `openregister`
+- **WHEN** `NoteService::deleteNotesForObject($uuid)` runs
+- **THEN** every comment for that object MUST be deleted via `ICommentsManager::deleteCommentsAtObject`
+
+### Requirement: The legacy CalDAV task link service MUST preserve VTODO linking semantics
+
+`TaskService` MUST link Nextcloud CalDAV VTODO items to OpenRegister objects for
+the migration to the `tasks` `IntegrationProvider`. It MUST create VTODOs
+carrying `X-OPENREGISTER-REGISTER` / `X-OPENREGISTER-SCHEMA` /
+`X-OPENREGISTER-OBJECT` properties plus an RFC 9253 `LINK` property, MUST list an
+object's tasks by scanning the user's first VTODO-supporting calendar and
+matching on the object UUID, MUST list all of a user's tasks across every
+VTODO-supporting calendar with optional status/assignee filtering and due-date
+ordering, and MUST support updating and deleting a task by calendar id + URI.
+
+#### Scenario: Creating a task links it back to the object
+- **GIVEN** a user with a VTODO-supporting calendar and an object `obj-1` titled `Aanvraag X`
+- **WHEN** `TaskService::createTask($registerId, $schemaId, 'obj-1', 'Aanvraag X', $data)` is called
+- **THEN** a VTODO MUST be stored carrying `X-OPENREGISTER-OBJECT:obj-1` plus register/schema properties
+- **AND** an RFC 9253 `LINK;LINKREL="related"` property MUST reference the object's API path
+
+#### Scenario: Listing tasks for an object filters by the linking property
+- **GIVEN** several VTODOs in the calendar, only some carrying `X-OPENREGISTER-OBJECT:obj-1`
+- **WHEN** `TaskService::getTasksForObject('obj-1')` is called
+- **THEN** only VTODOs whose `objectUuid` equals `obj-1` MUST be returned
+
+#### Scenario: Cross-calendar task listing is filtered and ordered
+- **GIVEN** a user with tasks across two VTODO-supporting calendars
+- **WHEN** `TaskService::getAllUserTasks(status: 'needs-action', assignee: 'jan')` is called
+- **THEN** only `needs-action` tasks whose description carries `Assigned to: jan` MUST be returned
+- **AND** the results MUST be ordered by due date (soonest first, undated last) and paginated by limit/offset
+
+#### Scenario: No suitable calendar raises a typed error
+- **GIVEN** a user with no VTODO-supporting calendar
+- **WHEN** `TaskService::createTask(...)` resolves the target calendar
+- **THEN** the service MUST raise `NoVtodoCalendarException` rather than silently failing

--- a/openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/specs/rapportage-bi-export/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/specs/rapportage-bi-export/spec.md
@@ -1,0 +1,76 @@
+# Rapportage en BI Export (retrofit delta)
+
+## ADDED Requirements
+
+### Requirement: Server-side report rendering MUST resolve widget data then dispatch to a pluggable format writer
+
+The system MUST render a dashboard object into downloadable bytes via a
+resolve-then-dispatch pipeline: `ReportRenderService::render()` MUST validate the
+requested format against its supported set (`csv`, `xlsx`, `ods`, `html`, `pdf`),
+resolve each widget's data, build a slugified `{title-slug}_{Y-m-d_His}.{ext}`
+filename, and dispatch to the writer that matches the format —
+`HtmlReportWriter` for `html`, `PdfReportWriter` for `pdf`, and
+`SpreadsheetReportWriter` for `csv`/`xlsx`/`ods` — returning a
+`{mime, filename, bytes}` envelope. Widget data resolution MUST be per-widget
+fault-tolerant: a widget whose data source fails to resolve MUST yield `null`
+data (logged at warning level) and MUST NOT abort the whole render.
+
+#### Scenario: Unsupported format is rejected before any work
+- **GIVEN** a dashboard object with a `widgets` array
+- **WHEN** `ReportRenderService::render($dashboard, 'docx')` is called
+- **THEN** the service MUST throw `InvalidArgumentException` naming the supported formats
+- **AND** no writer MUST be invoked
+
+#### Scenario: Aggregation widget resolves with RBAC bypassed at render time
+- **GIVEN** a widget whose `dataSource.mode` is `aggregation` with `register`, `schema`, and `aggregation` set
+- **WHEN** the widget is resolved during `render()`
+- **THEN** `AggregationRunner::run()` MUST be called with `bypassRbac: true` (the dashboard's own RBAC gate already filtered the viewer at load time)
+- **AND** the resolved data MUST be paired with its widget descriptor for the writer
+
+#### Scenario: A widget that fails to resolve does not abort the report
+- **GIVEN** a dashboard with three widgets where the second widget's data source throws
+- **WHEN** `render()` resolves the widgets
+- **THEN** the second widget's resolved data MUST be `null` and a warning MUST be logged
+- **AND** the first and third widgets MUST still resolve
+- **AND** the rendered output MUST include all three widgets (the failed one showing a no-data placeholder)
+
+#### Scenario: Filename is slugified from the dashboard title
+- **GIVEN** a dashboard titled `Wekelijks Meldingen Rapport`
+- **WHEN** it is rendered to `xlsx`
+- **THEN** the returned `filename` MUST match `wekelijks-meldingen-rapport_<timestamp>.xlsx`
+- **AND** the returned `mime` MUST be the XLSX spreadsheet MIME type
+
+#### Scenario: Spreadsheet writer produces one sheet per widget plus a cover sheet
+- **GIVEN** a dashboard with two widgets rendered to `xlsx`
+- **WHEN** `SpreadsheetReportWriter::write()` runs
+- **THEN** the workbook MUST contain an `Overview` cover sheet summarising the dashboard and listing each widget with its source and headline
+- **AND** one additional sheet per widget, each sheet title sanitised to ≤ 31 chars with `: \ / ? * [ ]` replaced
+- **AND** CSV output MUST be written with a UTF-8 BOM and concatenate every sheet
+
+### Requirement: PDF report rendering MUST keep the Dompdf renderer hermetic
+
+`PdfReportWriter::write()` MUST render through the `HtmlReportWriter` output with
+Dompdf locked down: it MUST strip `<link rel="stylesheet">` tags and
+`@font-face` declarations from the HTML before handing it to Dompdf, MUST set
+`isRemoteEnabled=false` and `isPhpEnabled=false`, and MUST assert those two flags
+did not drift (throwing `RuntimeException` if either is enabled) before
+rendering. This is the primary mitigation for Dompdf's SSRF / file-disclosure
+CVE class and MUST NOT be relaxed.
+
+#### Scenario: Smuggled stylesheet reference is stripped before rendering
+- **GIVEN** a dashboard whose rendered HTML contains a `<link rel="stylesheet" href="file:///etc/passwd">`
+- **WHEN** `PdfReportWriter::write()` runs
+- **THEN** the `<link>` tag MUST be removed before the HTML reaches Dompdf
+- **AND** `@font-face { ... }` declarations MUST likewise be removed
+
+#### Scenario: Sandbox-flag drift aborts the render
+- **GIVEN** a future refactor that enables Dompdf remote fetching or PHP execution
+- **WHEN** `PdfReportWriter::write()` checks the configured options
+- **THEN** the writer MUST throw `RuntimeException` indicating the sandbox configuration drifted
+- **AND** no PDF bytes MUST be produced
+
+#### Scenario: PDF renders A4 portrait from the HTML pipeline
+- **GIVEN** a resolved dashboard
+- **WHEN** the PDF is rendered
+- **THEN** Dompdf MUST load the (sanitised) HTML as UTF-8 and render at A4 portrait
+- **AND** the returned bytes MUST be a non-empty PDF document

--- a/openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-report-import-link/tasks.md
@@ -1,0 +1,72 @@
+# Tasks: retrofit reverse-spec service bundle — report / import / link
+
+Reverse-spec: every task annotates already-shipped behavior. No logic changes.
+
+## Sub-cluster 1 — Report-rendering pipeline (extend `rapportage-bi-export`)
+
+- [x] task-1 — `ReportRenderService::render()` dispatch: validate format against
+  `FORMATS`, normalise the dashboard payload, resolve every widget, build the
+  slugified `{slug}_{timestamp}.{ext}` filename, and route to the html / pdf /
+  spreadsheet writer with the correct MIME. (`lib/Service/Reporting/ReportRenderService.php`)
+- [x] task-2 — `ReportRenderService` widget resolution + payload normalisation:
+  `resolveWidgetData()` (aggregation via `AggregationRunner::run(bypassRbac:true)`,
+  graphql via `GraphQLService::execute`, per-widget try/catch → null on failure),
+  `normalisePayload()`, `slugify()`, `mimeFor()`.
+  (`lib/Service/Reporting/ReportRenderService.php`)
+- [x] task-3 — `HtmlReportWriter` print-friendly HTML composition: `write()`,
+  `renderWidget()`, `renderBody()`, `renderGroupTable()`, `renderStatsBlock()`,
+  `extractHeadline()`, `css()`, `escape()`. (`lib/Service/Reporting/HtmlReportWriter.php`)
+- [x] task-4 — `PdfReportWriter::write()` Dompdf hardening: strip
+  `<link rel=stylesheet>` + `@font-face` from the HTML, pin
+  `isRemoteEnabled=false` / `isPhpEnabled=false`, assert the flags did not drift
+  (throw on drift), render A4 portrait. (`lib/Service/Reporting/PdfReportWriter.php`)
+- [x] task-5 — `SpreadsheetReportWriter` per-widget sheets: `write()`,
+  `writeOverviewSheet()` (cover sheet), `writeWidgetSheet()` (31-char Excel-safe
+  sheet title sanitisation, group vs scalar layout), `writeFormat()` (csv with
+  BOM + per-sheet concat, xlsx, ods), `headlineFor()`, `describeSource()`,
+  `numericOrString()`. (`lib/Service/Reporting/SpreadsheetReportWriter.php`)
+
+## Sub-cluster 2 — Configuration import/export facade (extend `data-import-export`)
+
+- [x] task-6 — `ConfigurationService` import/export facade: `exportConfig()`,
+  `getUploadedJson()`, `importFromFilePath()`, `importFromApp()`,
+  `fetchRemoteConfiguration()`, `previewConfigurationChanges()`,
+  `importConfigurationWithSelection()` — thin delegations to the already-spec'd
+  Configuration/* handlers. (`lib/Service/ConfigurationService.php`)
+- [x] task-7 — `ConfigurationService` remote-version lifecycle: `checkRemoteVersion()`
+  (fetch + persist `remoteVersion`/`lastChecked`), `compareVersions()`
+  (`version_compare` → hasUpdate/message), `getConfiguredAppVersion()` /
+  `setConfiguredAppVersion()` (appconfig version tracking).
+  (`lib/Service/ConfigurationService.php`)
+
+## Sub-cluster 3 — Legacy flat link services (extend `integration-registry`)
+
+- [x] task-8 — `DeckCardService` legacy Deck link service: `getCardsForObject()`
+  (link rows enriched with dueDate/labels/assignees, best-effort, stale-card
+  degradation), `linkOrCreateCard()`, `unlinkCard()`, `getObjectsForBoard()`
+  (board search), `deleteLinksForObject()` (cleanup), plus the Deck-entity
+  extraction helpers. (`lib/Service/DeckCardService.php`)
+- [x] task-9 — `NoteService` comment-backed object notes: `getNotesForObject()`,
+  `createNote()`, `updateNote()` (author-only edit guard), `deleteNote()`,
+  `deleteNotesForObject()` (cleanup) over `ICommentsManager` with objectType
+  `openregister`. (`lib/Service/NoteService.php`)
+- [x] task-10 — `TaskService` CalDAV VTODO task linking:
+  `getAllUserTasks()` (cross-calendar, status/assignee filter, due-sorted),
+  `getTasksForObject()`, `createTask()` (X-OPENREGISTER-* + RFC 9253 LINK),
+  `updateTask()`, `deleteTask()`, `extractAssigneeFromDescription()`. NOTE:
+  `getTasksForObject` / `createTask` already carry an archived
+  `retrofit-annotate-openregister-2026-04-30#task-61` annotation; this task adds
+  the integration-registry back-reference to the remaining un-annotated methods.
+  (`lib/Service/TaskService.php`)
+
+## Sub-cluster 4 — DSAR personal-data handlers (extend `avg-verwerkingsregister`)
+
+- [x] task-11 — `DsarService` find / erase: `findObjectsForSubject()` (Art 15
+  inzage envelope), `eraseObjectsForSubject()` (Art 17 vergetelheid soft-delete
+  with dry-run + DSAR processing-activity audit attribution), plus the
+  `matchEntities()` LIKE-wildcard-escaped GdprEntity join, `buildObjectKey()`,
+  `loadObjectByEntry()`, `getDsarProcessingActivityUuid()`.
+  (`lib/Service/DsarService.php`)
+- [x] task-12 — `DsarService::rectifyObjectForSubject()` (Art 16 rectificatie):
+  merge changes into the object payload, pin the DSAR processing-activity uuid,
+  persist via `MagicMapper::update`. (`lib/Service/DsarService.php`)


### PR DESCRIPTION
## Summary

Reverse-spec (ghost) change documenting already-shipped, already-merged service behavior that lacked spec coverage, and annotating the implementing methods with `@spec` back-references. **Docblock-only — no production logic changes.**

Four service sub-clusters, each extending an existing capability:

- **Report-rendering pipeline** (`lib/Service/Reporting/`) → extends `rapportage-bi-export`. Adds the writer-abstraction contract (resolve-then-dispatch, per-widget fault tolerance, per-widget sheets) and the Dompdf sandbox-hardening invariant (strip `<link>`/`@font-face`, assert `isRemoteEnabled`/`isPhpEnabled` stay false).
- **Configuration import/export facade** (`ConfigurationService`) → extends `data-import-export`. The thin public delegating wrappers over the already-spec'd `Configuration/*` handlers, plus the remote-version lifecycle (`checkRemoteVersion`/`compareVersions`/`get|setConfiguredAppVersion`).
- **Legacy flat link services** (`DeckCardService`, `NoteService`, `TaskService`) → extends `integration-registry`. These are the **pre-ADR-019** flat services that still exist alongside the new `IntegrationProvider` registry from the in-flight `pluggable-integration-registry` change (PR #1811). The registry contract is owned there and **not duplicated** — this records the non-provider behavior the provider migration must preserve (Deck board-search + enrichment + stale-card degradation, comment-backed notes with author-edit guard, CalDAV VTODO linking).
- **DSAR personal-data handlers** (`DsarService`) → extends `avg-verwerkingsregister`. The partial implementation of the Art 15/16/17 find/erase/rectify flows the base spec lists as NOT-implemented, with processing-activity audit attribution and LIKE-wildcard escaping. Authorization gaps surfaced as **Notes**, not new requirements.

**8 new REQs** (2 per capability) / **33 methods annotated** across 9 files.

### Dropped scanner false-positives
- `MigrationService` (magic-table/blob lifecycle → `object-lifecycle`)
- `Configuration/AttributionFormatter`, `Configuration/GitHubGuards`, GitHub issue methods (→ `add-features-roadmap-menu` / `add-github-issue-proxy`, already annotated there)
- `ApplicationService` (generic CRUD, not import/export)

## Test plan

- [x] `openspec validate retrofit-2026-05-24-b-svc-report-import-link --strict` passes
- [x] `php -l` clean on all 9 touched files
- [ ] PHPCS blank-line-before-tag rule on the added `@spec` lines (CI)