### PR TITLE
retrofit: reverse-spec service bundle — urn/security/edepot/view (4 sub-clusters)

### DIFF
--- a/lib/Service/Edepot/EdepotTransferService.php
+++ b/lib/Service/Edepot/EdepotTransferService.php
@@ -108,6 +108,7 @@ class EdepotTransferService
      *
      * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-22
      * @spec openspec/changes/retrofit-2026-04-30-annotate-openregister/tasks.md#task-38
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-6
      */
     public function executeTransfer(array $transferList, TransportInterface $transport): array
     {
@@ -237,6 +238,8 @@ class EdepotTransferService
      *         isRendition: bool
      *     }>
      * }> Objects with file metadata.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-6
      */
     private function gatherObjectsWithFiles(array $objectRefs): array
     {
@@ -284,6 +287,7 @@ class EdepotTransferService
      * }> File metadata array.
      *
      * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-21
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-6
      */
     private function getObjectFiles(ObjectEntity $object): array
     {
@@ -329,6 +333,8 @@ class EdepotTransferService
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-6
      */
     private function processResults(
         array $transferList,
@@ -423,6 +429,8 @@ class EdepotTransferService
      * @param string       $timestamp The transfer timestamp.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-6
      */
     private function markObjectTransferred(ObjectEntity $object, string $reference, string $timestamp): void
     {
@@ -453,6 +461,8 @@ class EdepotTransferService
      * @param string       $timestamp The failure timestamp.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-6
      */
     private function markObjectTransferFailed(ObjectEntity $object, string $error, string $timestamp): void
     {
@@ -631,6 +641,8 @@ class EdepotTransferService
      * @param array<string,mixed> $transferList The completed transfer list.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-6
      */
     private function notifyTransferCompletion(array $transferList): void
     {

--- a/lib/Service/Edepot/SipPackageBuilder.php
+++ b/lib/Service/Edepot/SipPackageBuilder.php
@@ -137,6 +137,8 @@ class SipPackageBuilder
      * @param int   $maxSize          Maximum package size in bytes.
      *
      * @return array<int, array> Array of batches.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-7
      */
     private function splitIntoBatches(array $objectsWithFiles, int $maxSize): array
     {
@@ -176,6 +178,8 @@ class SipPackageBuilder
      * @param int    $totalPackages    Total number of packages.
      *
      * @return string Path to the generated ZIP file.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-7
      */
     private function buildSinglePackage(
         string $transferId,
@@ -271,6 +275,8 @@ class SipPackageBuilder
      * @param string $content The file content.
      *
      * @return array{path: string, size: int, checksum: string} The manifest entry.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-7
      */
     private function createManifestEntry(string $path, string $content): array
     {

--- a/lib/Service/SecurityService.php
+++ b/lib/Service/SecurityService.php
@@ -103,6 +103,8 @@ class SecurityService
      * @return array Result with 'allowed' boolean and optional 'delay' or 'lockout_until'
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-3
      */
     public function checkLoginRateLimit(string $username, string $ipAddress): array
     {
@@ -189,6 +191,8 @@ class SecurityService
      * @param string $reason    The reason for login failure
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-3
      */
     public function recordFailedLoginAttempt(string $username, string $ipAddress, string $reason='invalid_credentials'): void
     {
@@ -254,6 +258,8 @@ class SecurityService
      * @param string $ipAddress The IP address of the successful attempt
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-3
      */
     public function recordSuccessfulLogin(string $username, string $ipAddress): void
     {
@@ -296,6 +302,8 @@ class SecurityService
      * @param string $ipAddress The IP address to unblock
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-3
      */
     public function clearIpRateLimits(string $ipAddress): void
     {
@@ -322,6 +330,8 @@ class SecurityService
      * @param string $username The username to unblock
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-3
      */
     public function clearUserRateLimits(string $username): void
     {
@@ -348,6 +358,8 @@ class SecurityService
      * @return mixed Sanitized input
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-4
      */
     public function sanitizeInput(mixed $input, int $maxLength=255): mixed
     {
@@ -392,6 +404,8 @@ class SecurityService
      * @param array $credentials The login credentials to validate
      *
      * @return array Validated and sanitized credentials or error information
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-4
      */
     public function validateLoginCredentials(array $credentials): array
     {
@@ -441,6 +455,8 @@ class SecurityService
      * @param JSONResponse $response The response to add headers to
      *
      * @return JSONResponse The response with added security headers
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-5
      */
     public function addSecurityHeaders(JSONResponse $response): JSONResponse
     {
@@ -464,6 +480,8 @@ class SecurityService
      * @return string The client IP address
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-5
      */
     public function getClientIpAddress(IRequest $request): string
     {

--- a/lib/Service/UrnService.php
+++ b/lib/Service/UrnService.php
@@ -112,6 +112,8 @@ class UrnService
      * @param ObjectEntity $object The object to build the URN for.
      *
      * @return string|null The URN, or null when identity is incomplete.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-1
      */
     public function buildForObject(ObjectEntity $object): ?string
     {
@@ -145,6 +147,8 @@ class UrnService
      * @param string $uuid         The object UUID.
      *
      * @return string The constructed URN.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-1
      */
     public function build(string $registerSlug, string $schemaSlug, string $uuid): string
     {
@@ -169,6 +173,8 @@ class UrnService
      * @param string $urn The URN to parse.
      *
      * @return array{instance: string, register: string, schema: string, uuid: string}|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-2
      */
     public function parse(string $urn): ?array
     {
@@ -215,6 +221,8 @@ class UrnService
      * @param string $urn The URN to resolve.
      *
      * @return string|null The absolute API URL, or null when not resolvable.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-2
      */
     public function resolveUrl(string $urn): ?string
     {
@@ -259,6 +267,8 @@ class UrnService
      * @param string $url The OpenRegister object URL.
      *
      * @return string|null The URN, or null when the URL is not a valid OR object reference.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-2
      */
     public function urnFromUrl(string $url): ?string
     {
@@ -323,6 +333,8 @@ class UrnService
      * @param array<int, string> $urns The list of URNs to resolve.
      *
      * @return array<string, ?string> Map of urn → url-or-null.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-2
      */
     public function resolveBulk(array $urns): array
     {
@@ -347,6 +359,8 @@ class UrnService
      *   3. Fallback: `localhost`.
      *
      * @return string The instance slug.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-1
      */
     public function getInstanceSlug(): string
     {

--- a/lib/Service/ViewService.php
+++ b/lib/Service/ViewService.php
@@ -105,6 +105,8 @@ class ViewService
      * @throws \OCP\AppFramework\Db\DoesNotExistException If view not found or access denied
      * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException If multiple views found (should not happen)
      * @throws \OCP\DB\Exception If database error occurs
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-8
      */
     public function find(int | string $id, string $owner): View
     {
@@ -133,6 +135,8 @@ class ViewService
      * @return View[] Array of found views accessible to the user
      *
      * @psalm-return array<View>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-8
      */
     public function findAll(string $owner): array
     {
@@ -156,6 +160,8 @@ class ViewService
      * @return View The created view entity
      *
      * @throws Exception If view creation fails (database error, validation error, etc.)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-8
      */
     public function create(
         string $name,
@@ -209,6 +215,8 @@ class ViewService
      * @return View The updated view
      *
      * @throws Exception If update fails
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-8
      */
     public function update(
         int | string $id,
@@ -258,6 +266,8 @@ class ViewService
      * @return void
      *
      * @throws Exception If deletion fails
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-8
      */
     public function delete(int | string $id, string $owner): void
     {

--- a/openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/annotations.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/annotations.md
@@ -1,0 +1,33 @@
+# Annotation-only maps (no new requirements)
+
+Two sub-clusters add NO new requirements — their methods are already fully covered by the canonical specs. They have no `specs/<cap>/spec.md` delta (which would require a delta section under `--strict`); instead the existing-requirement mapping lives here.
+
+## security-and-rate-limiting → auth-system (existing requirements)
+
+`lib/Service/SecurityService.php` is already covered by `auth-system`:
+
+- **Requirement: Rate limiting MUST protect against brute force attacks and API abuse** ← `checkLoginRateLimit`, `recordFailedLoginAttempt`, `recordSuccessfulLogin`, `clearIpRateLimits`, `clearUserRateLimits` (task-3). 5-attempt / 900s window, 3600s lockout, progressive 2s→60s delay, per-user + per-IP counters, success clears all caches, admin manual clear emits `ip_rate_limits_cleared` / `user_rate_limits_cleared`.
+- **Requirement: Authentication and security events MUST be audited** ← `logSecurityEvent` (private; exercised by every rate-limit method, task-3). `user_locked_out` / `login_attempt_during_lockout` at WARNING, rest at INFO, each timestamped.
+- **Requirement: Input sanitization MUST prevent XSS and injection attacks** ← `sanitizeInput`, `validateLoginCredentials` (task-4). Trim → length-cap → null-byte strip → `htmlspecialchars(ENT_QUOTES|ENT_HTML5)` → dangerous-pattern removal; credential validation (presence, username ≥2 chars, invalid-char reject `<>"'/\`, password ≤1000 chars).
+- **Requirement: CORS policy MUST be enforced per Consumer and prevent CSRF** (security-headers scenario) ← `addSecurityHeaders`, `getClientIpAddress` (task-5).
+
+### Security notes (auth-system)
+
+- **Rate limiting is dormant for API auth** — already a known `auth-system` gap: nothing calls `checkLoginRateLimit()` before `AuthorizationService::authorizeBasic/Jwt/ApiKey`; protection only applies where a caller (e.g. `UserController::login`) explicitly wires it in.
+- **`recordSuccessfulLogin()` clears IP lockout on any success** — one valid credential from a shared/NAT'd IP resets that IP's counters for everyone behind it. Low severity (success implies valid credential).
+- **`getClientIpAddress()` trusts client-supplied forwarding headers** when the first hop is a public IP — spoofable to an attacker-chosen public address unless a trusted reverse proxy normalises forwarding headers.
+- `sanitizeForCacheKey` maps to `[a-zA-Z0-9._@-]`, truncated to 64 chars — collision-prone for very long usernames but safe for cache-key use.
+
+## edepot-transfer-extras → edepot-transfer (existing requirements)
+
+`lib/Service/Edepot/EdepotTransferService.php` + `lib/Service/Edepot/SipPackageBuilder.php` are already covered by `edepot-transfer`:
+
+- **Requirement: The system MUST support multiple transport protocols for SIP delivery** (transport-failure-with-retry) ← `EdepotTransferService::executeTransfer` (task-6).
+- **Requirement: The system MUST track transfer status per object** ← `gatherObjectsWithFiles`, `getObjectFiles`, `processResults`, `markObjectTransferred`, `markObjectTransferFailed` (task-6).
+- **Requirement: The system MUST assemble SIP packages for e-Depot transfer** ← `SipPackageBuilder::splitIntoBatches`, `buildSinglePackage`, `createManifestEntry` (task-7).
+- **Requirement: The system MUST log all transfer actions in the audit trail** ← `notifyTransferCompletion` (task-6); `logTransferInitiated/logObjectTransferred/logTransferFailed` already annotated to earlier passes.
+
+### Notes (edepot-transfer)
+
+- `executeTransfer` hard-codes the completion-notification recipient to the `admin` user, not the archivist role named in the spec's notification scenarios.
+- `getObjectFiles` stats files off the local filesystem; objects whose files are absent at transfer time are silently skipped, producing metadata-only SIP entries — the same path serves both intentionally-fileless objects and missing-content failures.

--- a/openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/proposal.md
@@ -1,0 +1,64 @@
+# Retrofit — Service Bundle: URN / Security / e-Depot / View (4 sub-clusters)
+
+Reverse-spec of a bundle of service classes whose methods the coverage scanner could not map to an existing REQ. Each sub-cluster `--extend`s its closest canonical capability. NEW requirements are drafted strictly from *observed, shipped* behaviour; aspirational spec language (notably the URN spec's unimplemented design) is deliberately NOT adopted. Scanner false-positives and out-of-scope files were dropped.
+
+## Why
+
+Four service sub-clusters carry runtime behaviour that is either uncovered (URN construction/resolution as actually shipped, saved-view CRUD lifecycle) or already covered but unannotated (SecurityService, e-Depot transfer/SIP helpers). One ghost change, one PR, links the shipped code back to its capability home so future coverage scans stop re-flagging it.
+
+## Approach
+
+Four sub-clusters, three NEW REQs, one ghost change, one PR:
+
+| Sub-cluster | File(s) | Extends | New REQs |
+|---|---|---|---|
+| urn-and-mapping-utilities | `Service/UrnService` | `urn-resource-addressing` | REQ: shipped construction; REQ: shipped resolution |
+| security-and-rate-limiting | `Service/SecurityService` | `auth-system` | 0 (annotation-only) |
+| edepot-transfer-extras | `Service/Edepot/EdepotTransferService`, `Service/Edepot/SipPackageBuilder` | `edepot-transfer` | 0 (annotation-only) |
+| view-service-extras | `Service/ViewService` | `zoeken-filteren` | 1 (saved-view CRUD lifecycle) |
+
+**urn-resource-addressing** carries a large *aspirational* spec marked "Not implemented" (organisation-as-NID, a persisted `urn` column on `ObjectEntity`, `/api/urn/resolve` endpoints, a `UrnMapping` table, federation, NL-gov identifier mapping, schema `urn` property type). None of that ships. What *does* ship is `UrnService`, with a different, narrower shape:
+
+- Fixed informal NID `nl-or` (RFC 8141 §5.1), not the organisation slug.
+- URN shape `urn:nl-or:{instance-slug}:{register-slug}:{schema-slug}:{uuid}` where `instance-slug` derives from the configured host (or `openregister.urn_instance` app-config override), not from register `organisation`.
+- URNs are *built on demand*, never persisted on the object and never auto-generated at create time.
+- Resolution is in-memory only (parse → register/schema lookup → `IURLGenerator` API URL); reverse resolution mirrors `ObjectReferenceProvider`'s three URL shapes; bulk resolution is a simple per-URN loop with no 100-item cap. Cross-instance/federated URNs parse but return `null` (explicitly out of scope for v1).
+
+So the two NEW REQs here describe the *shipped* surface only and explicitly do NOT claim the aspirational endpoint/table/federation behaviour.
+
+**auth-system** already specifies SecurityService's full surface: rate limiting (`Requirement: Rate limiting MUST protect against brute force attacks and API abuse`), event auditing (`Requirement: Authentication and security events MUST be audited`), input sanitization (`Requirement: Input sanitization MUST prevent XSS and injection attacks`), and security headers (`Requirement: CORS policy MUST be enforced per Consumer and prevent CSRF`). The SecurityService methods are therefore annotation-only against those existing REQs — no new requirements.
+
+**edepot-transfer** already specifies SIP assembly (`Requirement: The system MUST assemble SIP packages for e-Depot transfer`), transport+retry (`Requirement: The system MUST support multiple transport protocols for SIP delivery`), per-object status tracking (`Requirement: The system MUST track transfer status per object`), and the audit trail (`Requirement: The system MUST log all transfer actions in the audit trail`). The `EdepotTransferService` orchestrator and `SipPackageBuilder` helpers are annotation-only against those existing REQs. (Some methods already carry `@spec` refs to two earlier annotate-openregister passes; those are left intact and this change adds refs only where the bundle's entrypoint/helper methods were unlinked here.)
+
+**no-code-app-builder** (the bundle's nominal target for the view sub-cluster) is a local redirect *stub* and `faceting-configuration` is about facet computation, not saved-view CRUD — neither is a correct home. The shipped `ViewService` is the management lifecycle for the saved-view definitions that `zoeken-filteren`'s existing `View-based search composition` requirement *consumes* (`SearchQueryHandler.applyViewsToQuery()`). It is retargeted to `zoeken-filteren` with one NEW REQ covering the CRUD + access-control + single-default-per-user lifecycle.
+
+3 NEW REQs total.
+
+## Affected code units (by sub-cluster)
+
+- **urn-and-mapping-utilities** → `urn-resource-addressing`
+  - `lib/Service/UrnService.php` — buildForObject, build, parse, resolveUrl, urnFromUrl, resolveBulk, getInstanceSlug (+ private sanitiseSlug, resolveRegisterSlug, resolveSchemaSlug, findRegister, findSchema)
+- **security-and-rate-limiting** → `auth-system` (annotation-only)
+  - `lib/Service/SecurityService.php` — checkLoginRateLimit, recordFailedLoginAttempt, recordSuccessfulLogin, clearIpRateLimits, clearUserRateLimits, sanitizeInput, validateLoginCredentials, addSecurityHeaders, getClientIpAddress (+ private sanitizeForCacheKey, logSecurityEvent)
+- **edepot-transfer-extras** → `edepot-transfer` (annotation-only)
+  - `lib/Service/Edepot/EdepotTransferService.php` — executeTransfer, gatherObjectsWithFiles, getObjectFiles, processResults, markObjectTransferred, markObjectTransferFailed, notifyTransferCompletion
+  - `lib/Service/Edepot/SipPackageBuilder.php` — splitIntoBatches, buildSinglePackage, createManifestEntry
+- **view-service-extras** → `zoeken-filteren`
+  - `lib/Service/ViewService.php` — find, findAll, create, update, delete (+ private clearDefaultForUser)
+
+## Dropped as scanner false-positives / wrong home
+
+- `lib/Service/MappingService.php` — Twig/dot-notation data transformation (encodeArrayKeys, executeMapping, handleCast, applyCast, getMapping(s), cache invalidation). This is a generic data-mapping/transform engine that belongs to `data-import-export`, not to `urn-resource-addressing`. Dropped from this bundle rather than mis-filed under the URN capability.
+- `lib/Service/RiskLevelService.php` — computes and persists a file PII *risk level* (none → very_high) from detected-entity counts via Nextcloud `IFilesMetadata`. This is text-extraction / GDPR risk classification, NOT authentication or authorization, so it does not belong under `auth-system`. Dropped from this bundle.
+- Private helpers with no externally observable contract of their own (`sanitiseSlug`, `findRegister/findSchema`, `sanitizeForCacheKey`, `logSecurityEvent`, `clearDefaultForUser`, `splitIntoBatches`, `createManifestEntry`) are described inline within the public-method REQs they serve.
+
+## Security observations (surfaced, not specced)
+
+See `## Notes` in each spec delta. Key items:
+
+- **SecurityService rate limiting is not wired into the inbound auth flow.** `auth-system` already records this as a known gap ("Rate limiting exists via `SecurityService` … but is not integrated into the `AuthorizationService` flow for every authentication method"). The methods exist and behave correctly in isolation; nothing calls `checkLoginRateLimit()` before `AuthorizationService::authorizeBasic/Jwt/ApiKey`, so the brute-force protection is presently dormant for API auth.
+- **`recordSuccessfulLogin()` clears IP lockouts on any single success** — one valid credential pair from a shared/NAT'd IP resets that IP's failed-attempt counter and lockout for all users behind it. Low severity (success implies a valid credential) but worth noting for shared-egress environments.
+- **`getClientIpAddress()` trusts forwarding headers** (`CF-Connecting-IP`, `X-Forwarded-For`, `X-Real-IP`, …) when the first hop value is a *public* IP. Behind a proxy that does not strip client-supplied forwarding headers, a caller can spoof the recorded/rate-limited IP. The public-range filter limits this to public addresses only; deployments must ensure a trusted reverse proxy normalises these headers.
+- **URN register/schema lookups bypass RBAC + multi-tenancy** (`findRegister/findSchema` call mappers with `_rbac: false, _multitenancy: false`). This matches the resolver's intent (a URN is a system-independent identifier and resolution only confirms register/schema *existence* + builds a URL; object-level RBAC still applies when the resolved URL is fetched), but the existence signal itself is not tenant-scoped.
+
+Source: openspec coverage scan, service bundle `svc-urn-sec-edepot-view`, 2026-05-24.

--- a/openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/specs/urn-resource-addressing/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/specs/urn-resource-addressing/spec.md
@@ -1,0 +1,72 @@
+# URN Resource Addressing — Shipped UrnService surface
+
+> Reverse-spec delta. The canonical `urn-resource-addressing` spec is marked **Not implemented** and describes an aspirational design (organisation-as-NID, a persisted `urn` column, `/api/urn/*` endpoints, a `UrnMapping` table, federation, NL-gov identifier mapping). The requirements below document ONLY the behaviour that actually ships in `lib/Service/UrnService.php` and deliberately do not adopt the aspirational surface.
+
+## ADDED Requirements
+
+### Requirement: URNs MUST be constructed on demand in the shipped `urn:nl-or:{instance}:{register}:{schema}:{uuid}` shape
+
+`UrnService` MUST construct RFC 8141 URNs using a fixed informal NID `nl-or` (per RFC 8141 §5.1) followed by four colon-separated segments: an instance slug, the register slug, the schema slug, and the object UUID. URNs MUST be built on demand and MUST NOT be persisted on the object or auto-generated at object-creation time.
+
+- `build(registerSlug, schemaSlug, uuid)` MUST emit `urn:nl-or:{instance}:{register}:{schema}:{uuid}` with the register slug, schema slug, and uuid lower-cased (URN comparison is case-insensitive per RFC 8141 §3; emitting one canonical case avoids cache mismatches).
+- `buildForObject(ObjectEntity)` MUST return `null` when the object lacks a UUID, or when the register or schema reference cannot be resolved to a slug; otherwise it MUST resolve the register/schema slugs and delegate to `build()`.
+- `getInstanceSlug()` MUST resolve the instance slug in order: (1) the `openregister.urn_instance` app-config value when non-empty, (2) the sanitised host portion of the absolute base URL, (3) the literal `localhost` as a final fallback. Sanitisation MUST lower-case and replace runs of non-alphanumeric characters with single hyphens, trimming leading/trailing hyphens.
+
+#### Scenario: Build a URN from explicit parts
+- **GIVEN** register slug `decidesk`, schema slug `meeting`, and uuid `1C1C970F-D50C-4943-8128-78999E240EEC`
+- **WHEN** `build()` is called
+- **THEN** the result MUST be `urn:nl-or:{instance}:decidesk:meeting:1c1c970f-d50c-4943-8128-78999e240eec` with all three trailing segments lower-cased
+- **AND** the `{instance}` segment MUST equal the value returned by `getInstanceSlug()`
+
+#### Scenario: Build for an object with incomplete identity returns null
+- **GIVEN** an `ObjectEntity` with a null or empty UUID, OR whose register/schema reference does not resolve to a slug
+- **WHEN** `buildForObject()` is called
+- **THEN** the method MUST return `null` rather than emitting a partial URN
+
+#### Scenario: Instance slug honours config override then host then localhost
+- **GIVEN** `openregister.urn_instance` is set to `My Stable ID`
+- **WHEN** `getInstanceSlug()` is called
+- **THEN** it MUST return the sanitised slug `my-stable-id`
+- **AND** when the config value is empty it MUST fall back to the sanitised host of the base URL, and to `localhost` when no host can be derived
+
+### Requirement: The shipped resolver MUST map URN↔URL in-memory for the local instance only
+
+`UrnService` MUST provide in-memory, on-demand resolution between URNs and OpenRegister API URLs for the local instance. Cross-instance / federated resolution is explicitly out of scope of the shipped service and MUST return `null`. There is no `/api/urn/*` HTTP endpoint and no external `UrnMapping` table in the shipped surface.
+
+- `parse(urn)` MUST return `['instance','register','schema','uuid']` only when the string matches the anchored RFC 8141 URN regex AND its NID equals `nl-or` AND the NSS has at least four colon-separated parts; otherwise it MUST return `null`.
+- `resolveUrl(urn)` MUST return `null` when the URN does not parse, when its instance segment differs from the local `getInstanceSlug()`, or when the register/schema cannot be looked up; otherwise it MUST return the absolute API URL `/apps/openregister/api/objects/{register-slug}/{schema-slug}/{uuid}` (each path segment `rawurlencode`d) via `IURLGenerator`.
+- `urnFromUrl(url)` MUST recognise the three URL shapes the Smart Picker `ObjectReferenceProvider` accepts — hash-routed (`#/registers/{id}/schemas/{id}/objects/{uuid}`), API (`/api/objects/{ref}/{ref}/{uuid}`), and direct (`/objects/{ref}/{ref}/{uuid}`) — resolve numeric ids or slugs to canonical slugs, and return the constructed URN, or `null` when the URL does not match or the register/schema does not resolve.
+- `resolveBulk(urns)` MUST return a `{urn => url|null}` map preserving input order, skipping non-string / empty entries, by delegating each entry to `resolveUrl()`. The shipped method imposes no per-request URN cap.
+
+#### Scenario: Parse rejects a foreign NID
+- **GIVEN** a string `urn:isbn:0451450523`
+- **WHEN** `parse()` is called
+- **THEN** it MUST return `null` because the NID is not `nl-or`
+- **AND** a well-formed `urn:nl-or:{instance}:{register}:{schema}:{uuid}` MUST parse into its four named parts
+
+#### Scenario: Resolve a local URN to its API URL
+- **GIVEN** a URN whose instance segment equals the local instance slug and whose register/schema resolve
+- **WHEN** `resolveUrl()` is called
+- **THEN** the result MUST be the absolute `/apps/openregister/api/objects/{register}/{schema}/{uuid}` URL with `rawurlencode`d segments
+
+#### Scenario: Cross-instance or unresolvable URN returns null
+- **GIVEN** a URN whose instance segment differs from the local instance slug, OR whose register/schema cannot be found
+- **WHEN** `resolveUrl()` is called
+- **THEN** it MUST return `null` (federation is out of scope for the shipped service)
+
+#### Scenario: Reverse-resolve a Smart Picker URL
+- **GIVEN** an OpenRegister object URL in the hash-routed, API, or direct shape
+- **WHEN** `urnFromUrl()` is called and the register/schema resolve
+- **THEN** the method MUST return the canonical `urn:nl-or:{instance}:{register-slug}:{schema-slug}:{uuid}` URN
+- **AND** a non-OpenRegister URL MUST yield `null`
+
+#### Scenario: Bulk resolve preserves order and maps misses to null
+- **GIVEN** a list mixing resolvable and unresolvable URNs plus a non-string entry
+- **WHEN** `resolveBulk()` is called
+- **THEN** the result MUST be a `{urn => url|null}` map where resolvable URNs map to their URL and unresolvable ones map to `null`
+- **AND** the non-string / empty entry MUST be skipped (absent from the map)
+
+## Notes
+
+- The shipped shape diverges from the canonical aspirational spec: NID is the fixed informal `nl-or` (not the organisation slug); the instance segment derives from host/config (not register `organisation`); URNs are not persisted on `ObjectEntity` nor surfaced in `@self`; there is no resolution endpoint, no `UrnMapping` table, no schema `urn` property type, and no federation. Those remain genuinely unimplemented and are intentionally NOT specced here.
+- `findRegister`/`findSchema` call the mappers with `_rbac: false, _multitenancy: false`, so URN resolution confirms register/schema *existence* without tenant scoping. Object-level RBAC still applies when the resolved URL is subsequently fetched; only the existence/buildability signal is unscoped.

--- a/openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/specs/zoeken-filteren/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/specs/zoeken-filteren/spec.md
@@ -1,0 +1,52 @@
+# Zoeken en Filteren — saved-view CRUD lifecycle (ViewService)
+
+> Reverse-spec delta. `ViewService` is the management lifecycle for the saved-view definitions that the canonical `zoeken-filteren` `View-based search composition` requirement *consumes* (`SearchQueryHandler.applyViewsToQuery()`). The bundle nominally targeted `no-code-app-builder`, but that local spec is a redirect stub and `faceting-configuration` covers facet computation, not view CRUD — so this is retargeted to `zoeken-filteren`. One NEW requirement, drafted from observed `ViewService` behaviour only.
+
+## Why
+
+`zoeken-filteren` specifies how saved views are *applied* to a search but not how they are *managed*. `ViewService` ships the access-controlled CRUD lifecycle (find / findAll / create / update / delete) plus the single-default-view-per-user invariant, which no existing requirement covers.
+
+## ADDED Requirements
+
+### Requirement: Saved views MUST be managed through an access-controlled CRUD lifecycle with a single default per user
+
+`ViewService` MUST manage saved `View` definitions (the `{registers, schemas, filters, searchTerms}` query objects consumed by `SearchQueryHandler.applyViewsToQuery()`) with owner/public access control and a single-default-view-per-user invariant.
+
+- `find(id, owner)` MUST load the view by id and grant access only when the caller is the owner OR the view is public; otherwise it MUST throw `DoesNotExistException("View not found or access denied")` (denial is indistinguishable from not-found, so a private view's existence is not leaked).
+- `findAll(owner)` MUST return the views the user owns or that are public, delegating to `ViewMapper::findAll(owner:)`.
+- `create(name, description, owner, isPublic, isDefault, query)` MUST persist a new `View`; when `isDefault` is `true` it MUST first clear any existing default for that owner so at most one default view exists per user; `favoredBy` MUST be initialised to an empty list.
+- `update(id, name, description, owner, isPublic, isDefault, query, favoredBy?)` MUST resolve the view via the access-controlled `find()`, and when it is being newly promoted to default (`isDefault` true and previously false) MUST clear the owner's existing default first; `favoredBy` MUST be updated only when explicitly provided (non-null).
+- `delete(id, owner)` MUST resolve the view via the access-controlled `find()` before deleting, so a caller cannot delete a view they cannot access.
+- The single-default invariant MUST be enforced by `clearDefaultForUser(owner)`, which unsets `isDefault` on every default view owned by that user.
+- All write operations MUST log and re-throw on failure (the persisted state is the mapper's; the service does not swallow errors).
+
+#### Scenario: Access control on find hides other users' private views
+- **GIVEN** a private view owned by `alice`
+- **WHEN** `find(id, owner: "bob")` is called and the view is not public
+- **THEN** the method MUST throw `DoesNotExistException("View not found or access denied")`
+- **AND** when `bob` is the owner OR the view is public, the view MUST be returned
+
+#### Scenario: Creating a default view clears the previous default
+- **GIVEN** user `alice` already has a default view
+- **WHEN** `create(..., isDefault: true, ...)` is called for `alice`
+- **THEN** `clearDefaultForUser("alice")` MUST run first so the prior default is unset
+- **AND** exactly one of `alice`'s views MUST have `isDefault = true` afterwards
+- **AND** the new view's `favoredBy` MUST be an empty list
+
+#### Scenario: Update only clears the default when newly promoting
+- **GIVEN** a view that is currently not the default
+- **WHEN** `update(..., isDefault: true, ...)` promotes it to default
+- **THEN** the owner's existing default MUST be cleared first
+- **AND** when the view was already default (`isDefault` unchanged) no extra clear MUST occur
+- **AND** `favoredBy` MUST be changed only when a non-null `favoredBy` argument is supplied
+
+#### Scenario: Delete is access-controlled
+- **GIVEN** a view the caller does not own and that is not public
+- **WHEN** `delete(id, owner)` is called
+- **THEN** the access-controlled `find()` MUST throw before any deletion occurs
+- **AND** an owned-or-public view MUST be deleted via `ViewMapper::delete()`
+
+## Notes
+
+- Access control is owner-or-public only; there is no group/RBAC layer on views themselves (a public view is readable by every authenticated caller). The query a view encodes is still subject to object-level RBAC when executed via `SearchQueryHandler`.
+- `find()` deliberately collapses access-denied into not-found, which avoids leaking the existence of other users' private views.

--- a/openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+Retroactive reverse-spec annotation. Each task corresponds either to one NEW requirement drafted in the matching `specs/<capability>/spec.md` delta, or to an annotation against an EXISTING requirement in the canonical spec. The methods listed are annotated with `@spec ...#task-N`.
+
+## urn-and-mapping-utilities → urn-resource-addressing
+
+- [x] task-1: urn-resource-addressing (NEW REQ — shipped URN construction) — `UrnService::buildForObject`, `build`, `getInstanceSlug` (RFC 8141 `urn:nl-or:{instance}:{register}:{schema}:{uuid}` construction with on-demand build, lower-cased components, configurable instance slug; null when object identity is incomplete) (reverse-spec annotation)
+- [x] task-2: urn-resource-addressing (NEW REQ — shipped URN resolution) — `UrnService::parse`, `resolveUrl`, `urnFromUrl`, `resolveBulk` (parse to components, resolve to canonical API URL, reverse URL→URN over the three ObjectReferenceProvider URL shapes, bulk loop; cross-instance/unknown register/schema return null) (reverse-spec annotation)
+
+## security-and-rate-limiting → auth-system (annotation-only, existing REQs)
+
+- [x] task-3: auth-system#"Rate limiting MUST protect against brute force attacks and API abuse" — `SecurityService::checkLoginRateLimit`, `recordFailedLoginAttempt`, `recordSuccessfulLogin`, `clearIpRateLimits`, `clearUserRateLimits` (5-attempt / 900s window, 3600s lockout, progressive 2s→60s delay, per-user + per-IP counters, success-clears, admin manual clear) (reverse-spec annotation against existing REQ)
+- [x] task-4: auth-system#"Input sanitization MUST prevent XSS and injection attacks" — `SecurityService::sanitizeInput`, `validateLoginCredentials` (trim/length-cap/null-byte-strip/htmlspecialchars + dangerous-pattern removal; credential presence/length/charset validation) (reverse-spec annotation against existing REQ)
+- [x] task-5: auth-system#"CORS policy MUST be enforced per Consumer and prevent CSRF" — `SecurityService::addSecurityHeaders`, `getClientIpAddress` (security-header set; client IP extraction honouring public-range forwarding headers) (reverse-spec annotation against existing REQ)
+
+## edepot-transfer-extras → edepot-transfer (annotation-only, existing REQs)
+
+- [x] task-6: edepot-transfer#"The system MUST support multiple transport protocols for SIP delivery" + #"The system MUST track transfer status per object" — `EdepotTransferService::executeTransfer`, `gatherObjectsWithFiles`, `getObjectFiles`, `processResults`, `markObjectTransferred`, `markObjectTransferFailed`, `notifyTransferCompletion` (transfer orchestration entrypoint: gather objects+files, send-with-retry, per-object accepted/failed status into `retention`, completion notification) (reverse-spec annotation against existing REQs)
+- [x] task-7: edepot-transfer#"The system MUST assemble SIP packages for e-Depot transfer" — `SipPackageBuilder::splitIntoBatches`, `buildSinglePackage`, `createManifestEntry` (size-based package splitting, per-object dir + mets/premis/manifest assembly, manifest entry with SHA-256) (reverse-spec annotation against existing REQ)
+
+## view-service-extras → zoeken-filteren
+
+- [x] task-8: zoeken-filteren (NEW REQ — saved-view CRUD lifecycle) — `ViewService::find`, `findAll`, `create`, `update`, `delete` (owner/public access-controlled CRUD over saved View definitions; single-default-view-per-user invariant via clearDefaultForUser) (reverse-spec annotation)


### PR DESCRIPTION
## Summary

Reverse-specs four service sub-clusters across four capability homes in one ghost change (`retrofit-2026-05-24-b-svc-urn-sec-edepot-view`), drafting **3 NEW REQs** from observed shipped behaviour and annotating **24 methods** with `@spec` refs. Strict-validated (`openspec validate --strict` → valid), all touched files `php -l` clean.

| Sub-cluster | File(s) | Extends | New REQs |
|---|---|---|---|
| urn-and-mapping-utilities | `Service/UrnService` | `urn-resource-addressing` | 2 |
| security-and-rate-limiting | `Service/SecurityService` | `auth-system` | 0 (annotation-only) |
| edepot-transfer-extras | `Service/Edepot/EdepotTransferService`, `SipPackageBuilder` | `edepot-transfer` | 0 (annotation-only) |
| view-service-extras | `Service/ViewService` | `zoeken-filteren` | 1 |

- **urn-resource-addressing** — the canonical spec is marked *Not implemented* and describes an aspirational design (org-as-NID, persisted `urn` column, `/api/urn/*` endpoints, `UrnMapping` table, federation, NL-gov identifier mapping). The 2 NEW REQs document **only the shipped `UrnService`**: fixed informal NID `nl-or`, instance-slug-from-host (or `openregister.urn_instance`), on-demand build (never persisted / never auto-generated), in-memory local-only resolve / reverse / bulk. The aspirational surface is deliberately NOT claimed.
- **auth-system / edepot-transfer** — annotation-only: `SecurityService` and the e-Depot orchestrator/SIP-builder helpers are already fully covered by existing REQs. Mapping recorded in the change's `annotations.md` (no `specs/` delta, to stay strict-valid).
- **zoeken-filteren** — retargeted from the `no-code-app-builder` redirect stub (and away from `faceting-configuration`, which is facet computation not view CRUD). `ViewService` is the saved-view CRUD lifecycle that `zoeken-filteren`'s existing view-composition REQ consumes.

**Dropped as wrong-home scanner flags:** `MappingService` (Twig/dot data-transform → belongs to `data-import-export`), `RiskLevelService` (file PII risk classification → not auth).

## Security observations (surfaced, not specced)

- `SecurityService` rate limiting is **dormant on the inbound API auth path** — nothing calls `checkLoginRateLimit()` before `AuthorizationService::authorizeBasic/Jwt/ApiKey` (already a known `auth-system` gap).
- `recordSuccessfulLogin()` clears **IP lockout for every user behind a shared/NAT'd egress IP** on any single success.
- `getClientIpAddress()` **trusts client-supplied forwarding headers** (public-IP first hop) — spoofable without a normalising reverse proxy.
- URN `findRegister/findSchema` lookups **bypass RBAC + multi-tenancy** (existence/buildability signal only; object-level RBAC still applies when the resolved URL is fetched).

## Test plan

- [x] `openspec validate retrofit-2026-05-24-b-svc-urn-sec-edepot-view --strict` → valid
- [x] `php -l` clean on all 5 touched service files
- [ ] PHPCS strict (run in CI — vendor/ not present in worktree)
- [ ] Reviewer confirms the URN delta claims only shipped behaviour and the two dropped files are correctly out of scope