### PR TITLE
retrofit: reverse-spec service bundle — i18n/endpoint/graphql/webhook (5 sub-clusters)

### DIFF
--- a/lib/Service/BulkTranslationService.php
+++ b/lib/Service/BulkTranslationService.php
@@ -86,6 +86,8 @@ class BulkTranslationService
      *
      * @return array{translated: array<string, string>, skipped: array<string, string>}
      *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-7
+     *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)

--- a/lib/Service/EndpointService.php
+++ b/lib/Service/EndpointService.php
@@ -105,6 +105,8 @@ class EndpointService
      *
      * @phpstan-return array{success: bool, statusCode: int, response: mixed, error?: string}
      * @psalm-return   array{success: bool, statusCode: int, response: mixed, error?: string}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-15
      */
     public function testEndpoint(Endpoint $endpoint, array $testData=[]): array
     {
@@ -173,6 +175,8 @@ class EndpointService
      *
      * @phpstan-return array{success: bool, statusCode: int, response: mixed, error?: string}
      * @psalm-return   array{success: bool, statusCode: int, response: mixed, error?: string}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-14
      */
     private function executeEndpoint(Endpoint $endpoint, array $request): array
     {
@@ -239,6 +243,8 @@ class EndpointService
      * @phpstan-return array{success: bool, statusCode: int, response: mixed, error?: string}
      * @psalm-return   array{success: bool, statusCode: int, response: mixed, error?: string}
      * @psalm-suppress UnusedParam - False positive: both parameters are used within the method.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-16
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Agent execution has multiple provider and tool conditions
      * @SuppressWarnings(PHPMD.NPathComplexity)       Agent setup involves many validation and config paths
@@ -499,6 +505,8 @@ class EndpointService
      *
      * @return bool True if user can execute, false otherwise
      *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-17
+     *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Permission check has multiple user and group conditions
      */
     private function canExecuteEndpoint(Endpoint $endpoint): bool
@@ -545,6 +553,8 @@ class EndpointService
      * @param array    $result   Result data
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-18
      */
     private function logEndpointCall(Endpoint $endpoint, array $request, array $result): void
     {

--- a/lib/Service/GraphQL/GraphQLResolver.php
+++ b/lib/Service/GraphQL/GraphQLResolver.php
@@ -311,6 +311,8 @@ class GraphQLResolver
      * @return array<int, array{key: string, value: int|float}>|null Bucket array, or null when register/runner missing.
      *
      * @throws Error When validation fails or RBAC denies the request.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-19
      */
     private function resolveGroupBy(Schema $schema, ?Register $register, array $rawArgs): ?array
     {
@@ -608,6 +610,8 @@ class GraphQLResolver
      * Flush the DataLoader buffer — batch-load all buffered relation UUIDs.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-20
      */
     private function flushRelationBuffer(): void
     {
@@ -847,6 +851,8 @@ class GraphQLResolver
      * @param int|string $offset The offset position
      *
      * @return string The encoded cursor
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-21
      */
     private function encodeCursor(string $uuid, int|string $offset): string
     {

--- a/lib/Service/MetricsService.php
+++ b/lib/Service/MetricsService.php
@@ -199,6 +199,8 @@ class MetricsService
      * @return int[] Array of [date => count]
      *
      * @psalm-return array<int>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-27
      */
     public function getFilesProcessedPerDay(int $days=30): array
     {
@@ -245,6 +247,8 @@ class MetricsService
      *
      * @psalm-return array{total: int, successful: int, failed: int,
      *               success_rate: float, estimated_cost_usd: float, period_days: int}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-28
      */
     public function getEmbeddingStats(int $days=30): array
     {
@@ -305,6 +309,8 @@ class MetricsService
      * @return (float|int)[][]
      *
      * @psalm-return array<string, array{count: int, avg_ms: float, min_ms: int, max_ms: int}>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-29
      */
     public function getSearchLatencyStats(int $days=7): array
     {
@@ -377,6 +383,8 @@ class MetricsService
      * @psalm-return array{daily_vectors_added: array<string, int>,
      *     current_storage_bytes: int, current_storage_mb: float,
      *     avg_vectors_per_day: float, period_days: int}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-30
      */
     public function getStorageGrowth(int $days=30): array
     {
@@ -446,6 +454,8 @@ class MetricsService
      *     storage_growth: array{daily_vectors_added: array<string, int>,
      *     current_storage_bytes: int, current_storage_mb: float,
      *     avg_vectors_per_day: float, period_days: int}}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-31
      */
     public function getDashboardMetrics(): array
     {
@@ -534,6 +544,8 @@ class MetricsService
      * @param int $successful Number of successful operations
      *
      * @return float Success rate as percentage (0-100), rounded to 2 decimal places
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-32
      */
     private function calculateSuccessRate(int $total, int $successful): float
     {
@@ -559,6 +571,8 @@ class MetricsService
      * @return float Rounded average milliseconds (0.0 if invalid or null)
      *
      * @psalm-suppress MixedArgument
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-33
      */
     private function roundAverageMs($avgMs): float
     {
@@ -581,6 +595,8 @@ class MetricsService
      * @param array<string, int> $growthData Growth data array with [date => count] format
      *
      * @return float Average vectors per day, rounded to 2 decimal places
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-34
      */
     private function calculateAverageVectorsPerDay(array $growthData): float
     {

--- a/lib/Service/RealtimeService.php
+++ b/lib/Service/RealtimeService.php
@@ -88,6 +88,8 @@ class RealtimeService
      * @param array<string, mixed> $extra     Trigger-specific extras (e.g. transition action/from/to).
      *
      * @return RealtimeEvent|null The persisted event entity, or null on failure.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-35
      */
     public function record(string $eventType, ObjectEntity $object, array $extra=[]): ?RealtimeEvent
     {

--- a/lib/Service/Translation/IdentityTranslationProvider.php
+++ b/lib/Service/Translation/IdentityTranslationProvider.php
@@ -38,6 +38,8 @@ class IdentityTranslationProvider implements TranslationProviderInterface
      * @param string $toLang   BCP 47 target language code.
      *
      * @return string|null Always the source text (passthrough).
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-8
      */
     public function translate(string $text, string $fromLang, string $toLang): ?string
     {
@@ -51,6 +53,8 @@ class IdentityTranslationProvider implements TranslationProviderInterface
      * Provider identifier used for status attribution.
      *
      * @return string The literal `identity`.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-9
      */
     public function getIdentifier(): string
     {

--- a/lib/Service/Translation/TranslationCsvCodec.php
+++ b/lib/Service/Translation/TranslationCsvCodec.php
@@ -58,6 +58,8 @@ class TranslationCsvCodec
      *
      * @return array<string, scalar|null>
      *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-12
+     *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     public function flattenForCsv(array $data, Schema $schema): array
@@ -121,6 +123,8 @@ class TranslationCsvCodec
      * @param Schema               $schema The schema describing translatable properties.
      *
      * @return array<string, mixed>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-13
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */

--- a/lib/Service/Translation/TranslationProviderInterface.php
+++ b/lib/Service/Translation/TranslationProviderInterface.php
@@ -44,6 +44,8 @@ interface TranslationProviderInterface
      * @param string $toLang   BCP 47 target language code.
      *
      * @return string|null The translated text, or null on miss/error.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-10
      */
     public function translate(string $text, string $fromLang, string $toLang): ?string;
 
@@ -55,6 +57,8 @@ interface TranslationProviderInterface
      * vs human translations.
      *
      * @return string The provider identifier slug.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-11
      */
     public function getIdentifier(): string;
 }//end interface

--- a/lib/Service/TranslationProjectionService.php
+++ b/lib/Service/TranslationProjectionService.php
@@ -79,6 +79,8 @@ class TranslationProjectionService
      *
      * @return void
      *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-1
+     *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
@@ -184,6 +186,8 @@ class TranslationProjectionService
      * @param ObjectEntity $object The object to purge translations for.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-2
      */
     public function purge(ObjectEntity $object): void
     {

--- a/lib/Service/TranslationStatusService.php
+++ b/lib/Service/TranslationStatusService.php
@@ -64,6 +64,8 @@ class TranslationStatusService
      * @return Translation The persisted translation row.
      *
      * @throws InvalidArgumentException When status is invalid or no slot exists.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-3
      */
     public function setStatus(string $objectUuid, string $property, string $language, string $status): Translation
     {
@@ -113,6 +115,8 @@ class TranslationStatusService
      * @param Schema $schema     The schema entity.
      *
      * @return array<string, array{translated: int, total: int, ratio: float}>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-4
      */
     public function completenessForObject(string $objectUuid, Schema $schema): array
     {
@@ -145,6 +149,8 @@ class TranslationStatusService
      * @param int         $limit      Maximum number of results.
      *
      * @return array<string, mixed>[]
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-5
      */
     public function search(
         ?string $query=null,
@@ -168,6 +174,8 @@ class TranslationStatusService
      * @param string[] $candidateUuids List of object UUIDs to consider.
      *
      * @return string[] Subset of `$candidateUuids` lacking the language.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-6
      */
     public function findObjectsMissingLanguage(string $language, Schema $schema, array $candidateUuids): array
     {

--- a/lib/Service/Webhook/CloudEventFormatter.php
+++ b/lib/Service/Webhook/CloudEventFormatter.php
@@ -280,6 +280,8 @@ class CloudEventFormatter
      * @param IRequest $request Request object with getHeader method
      *
      * @return string Content type header value
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-26
      */
     private function getContentTypeHeader(IRequest $request): string
     {

--- a/lib/Service/WebhookService.php
+++ b/lib/Service/WebhookService.php
@@ -143,6 +143,8 @@ class WebhookService
      * Allows self-signed certificates and configures timeouts appropriately.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-22
      */
     private function initializeHttpClient(): void
     {
@@ -450,6 +452,8 @@ class WebhookService
      * @param string $key   Dot-notated key
      *
      * @return mixed
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-23
      */
     private function getNestedValue(array $array, string $key)
     {
@@ -624,6 +628,8 @@ class WebhookService
      * @param string $eventName Fully qualified event class name
      *
      * @return string Short class name (e.g., "ObjectCreatedEvent")
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-24
      */
     private function getShortEventName(string $eventName): string
     {
@@ -963,6 +969,8 @@ class WebhookService
      * @param string $eventType Event type (e.g., 'object.creating')
      *
      * @return string Event class name (e.g., 'OCA\OpenRegister\Event\ObjectCreatingEvent')
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-25
      */
     private function eventTypeToEventClass(string $eventType): string
     {

--- a/openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/proposal.md
@@ -1,0 +1,63 @@
+# Retrofit — service bundle: i18n / endpoint / graphql / webhook / observability
+
+Bundled reverse-spec of five service sub-clusters under the `service` parent cluster. All five EXTEND an existing capability with observed behavior that the current spec does not yet cover. Code already exists — this change retroactively specifies it.
+
+## Why
+
+The coverage scan flagged 52 implemented methods across 11 service files that have no spec annotation. Each maps onto an existing capability (`register-i18n`, `object-interactions`, `graphql-api`, `webhook-payload-mapping`, `production-observability`) but documents behavior the current spec text omits — the translation sidecar pipeline, the dynamic endpoint dispatcher, GraphQL aggregation/cursor/DataLoader helpers, webhook transport internals, and the metrics aggregation/realtime-emission helpers. Bringing these under the annotation convention (ADR-008) keeps the spec-to-code map complete and makes the behavior reviewable.
+
+## Affected code units
+
+### i18n-and-translation-pipeline → `register-i18n`
+- lib/Service/TranslationProjectionService.php::project
+- lib/Service/TranslationProjectionService.php::purge
+- lib/Service/TranslationStatusService.php::setStatus
+- lib/Service/TranslationStatusService.php::completenessForObject
+- lib/Service/TranslationStatusService.php::search
+- lib/Service/TranslationStatusService.php::findObjectsMissingLanguage
+- lib/Service/BulkTranslationService.php::translateObject
+- lib/Service/Translation/IdentityTranslationProvider.php::translate
+- lib/Service/Translation/IdentityTranslationProvider.php::getIdentifier
+- lib/Service/Translation/TranslationProviderInterface.php::translate
+- lib/Service/Translation/TranslationProviderInterface.php::getIdentifier
+- lib/Service/Translation/TranslationCsvCodec.php::flattenForCsv
+- lib/Service/Translation/TranslationCsvCodec.php::unflattenFromCsv
+
+### endpoint-service-execution-pipeline → `object-interactions`
+- lib/Service/EndpointService.php::testEndpoint
+- lib/Service/EndpointService.php::executeEndpoint
+- lib/Service/EndpointService.php::canExecuteEndpoint
+- lib/Service/EndpointService.php::executeAgentEndpoint
+- lib/Service/EndpointService.php::logEndpointCall
+
+### graphql-resolver-extras → `graphql-api`
+- lib/Service/GraphQL/GraphQLResolver.php::resolveGroupBy
+- lib/Service/GraphQL/GraphQLResolver.php::flushRelationBuffer
+- lib/Service/GraphQL/GraphQLResolver.php::encodeCursor
+
+### webhook-cloudevent-formatter-extends → `webhook-payload-mapping`
+- lib/Service/WebhookService.php::initializeHttpClient
+- lib/Service/WebhookService.php::getNestedValue
+- lib/Service/WebhookService.php::getShortEventName
+- lib/Service/WebhookService.php::eventTypeToEventClass
+- lib/Service/Webhook/CloudEventFormatter.php::getContentTypeHeader
+
+### metrics-and-realtime-observability-extends → `production-observability`
+- lib/Service/MetricsService.php::getFilesProcessedPerDay
+- lib/Service/MetricsService.php::getEmbeddingStats
+- lib/Service/MetricsService.php::getSearchLatencyStats
+- lib/Service/MetricsService.php::getStorageGrowth
+- lib/Service/MetricsService.php::getDashboardMetrics
+- lib/Service/MetricsService.php::calculateSuccessRate
+- lib/Service/MetricsService.php::roundAverageMs
+- lib/Service/MetricsService.php::calculateAverageVectorsPerDay
+- lib/Service/RealtimeService.php::record
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, and failure modes from the source.
+- Draft new `### Requirement:` entries (ADDED) onto the five target specs where behavior is genuinely uncovered; bias toward extend rather than new capabilities.
+- Annotate each documented method with a `@spec` pointer to the matching task in `tasks.md`.
+- DROP scanner false-positives: trivial placeholder dispatchers (`executeViewEndpoint`, `executeRegisterEndpoint`, `executeSchemaEndpoint`, `executeWebhookEndpoint`) that return a hardcoded placeholder response, and methods already annotated by prior retrofit changes (e.g. `WebhookService::buildPayload`, `generateSignature`, `interceptRequest`, the GraphQL resolve* CRUD methods, the CloudEventFormatter `formatAsCloudEvent` family).
+
+Source: `/tmp/or-scan/bundle-svc-i18n-endpoint-gql-wh.json`. See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/specs/graphql-api/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/specs/graphql-api/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: The resolver MUST provide aggregation, DataLoader-flush, and cursor helpers
+
+`GraphQLResolver` MUST expose the supporting helpers that back list queries: an aggregation resolver that dispatches `groupBy` to the timeseries pipeline, a DataLoader buffer flush that batch-loads buffered relation UUIDs, and an opaque cursor encoder for Relay pagination.
+
+#### Scenario: Resolve a groupBy aggregation
+
+- **GIVEN** a list query with a `groupBy` argument and a schema bound to a register
+- **WHEN** `resolveGroupBy()` runs
+- **THEN** it MUST normalize the raw args (field, interval, from, to, metric lowercased, metricField) and validate them through the timeseries validator
+- **AND** it MUST run the aggregation via the aggregation runner and return buckets as `[{key: string, value: float}]`
+- **AND** a validation error or RBAC denial MUST be re-thrown as a GraphQL `Error` (field-level), and a schema with no register MUST return `null` rather than erroring
+
+#### Scenario: Flush the relation buffer in one batch
+
+- **GIVEN** buffered relation UUIDs collected during nested resolution
+- **WHEN** `flushRelationBuffer()` runs
+- **THEN** it MUST clear the buffer, batch-load all UUIDs via `RelationHandler::bulkLoadRelationshipsBatched()`, and store each loaded object in `relationCache` keyed by UUID
+- **AND** an empty buffer MUST be a no-op, and a load failure MUST be caught and logged as a warning rather than propagated
+
+#### Scenario: Encode an opaque pagination cursor
+
+- **GIVEN** an object UUID and an offset position
+- **WHEN** `encodeCursor()` runs
+- **THEN** it MUST return a base64-encoded JSON string containing `{uuid, offset}`

--- a/openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/specs/object-interactions/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/specs/object-interactions/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: The endpoint dispatcher MUST route execution by target type
+
+`EndpointService` MUST act as the runtime dispatcher behind the dynamic endpoint surface, routing an endpoint to a target-type-specific handler (`view`, `agent`, `webhook`, `register`, `schema`) and returning a uniform result shape `{success, statusCode, response, error?}`. A test entry point MUST allow executing an endpoint with supplied test data without a real inbound request.
+
+#### Scenario: Route by target type
+
+- **GIVEN** an `Endpoint` with a `targetType`
+- **WHEN** `executeEndpoint()` runs
+- **THEN** it MUST dispatch to the matching handler for `view`, `agent`, `webhook`, `register`, or `schema`
+- **AND** an unknown target type MUST return `{success: false, statusCode: 400, error: "Unknown target type: ..."}`
+
+#### Scenario: Test an endpoint with supplied data
+
+- **GIVEN** an endpoint and an optional `testData` array
+- **WHEN** `testEndpoint()` runs
+- **THEN** it MUST first check access via `canExecuteEndpoint()` and return `statusCode: 403` when denied
+- **AND** on success it MUST build a request from the endpoint method/path plus test data, dispatch via `executeEndpoint()`, log the call, and return the handler result
+- **AND** any thrown exception MUST be caught, logged, and surfaced as `{success: false, statusCode: 500, error: <message>}`
+
+#### Scenario: Agent endpoint executes an AI agent
+
+- **GIVEN** an endpoint with `targetType: agent` and a `targetId` resolving to an agent
+- **WHEN** `executeAgentEndpoint()` runs
+- **THEN** a missing agent MUST return `statusCode: 404` and an empty message MUST return `statusCode: 400`
+- **AND** on success it MUST resolve the agent's configured tools through `ToolRegistry` and execute the agent with the request message
+
+### Requirement: Endpoint execution MUST enforce group access and log every call
+
+Endpoint execution MUST be gated by group-based access control and MUST persist an execution log entry for audit and debugging.
+
+#### Scenario: Group-based access control
+
+- **GIVEN** an endpoint with a configured `groups` list
+- **WHEN** `canExecuteEndpoint()` evaluates the current user
+- **THEN** an unauthenticated request MUST be allowed only when the endpoint declares no groups (public)
+- **AND** a member of the `admin` group MUST always be allowed
+- **AND** an authenticated user MUST be allowed when the endpoint declares no groups, or when the user belongs to at least one of the endpoint's groups; otherwise access MUST be denied
+
+#### Scenario: Execution call is logged with a TTL
+
+- **GIVEN** any endpoint execution
+- **WHEN** `logEndpointCall()` runs
+- **THEN** it MUST persist an `EndpointLog` with a generated uuid, the endpoint id, the acting user (when present), the request and response payloads, the status code and message, a creation timestamp, and an expiry one week out
+- **AND** the entry size MUST be computed before insert

--- a/openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/specs/production-observability/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/specs/production-observability/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Metrics aggregation helpers MUST summarize operational metrics from the metrics table
+
+`MetricsService` MUST aggregate rows from the `openregister_metrics` table into the per-day, per-type, and summary shapes consumed by the dashboard and operational reporting, plus the supporting numeric helpers those aggregations rely on.
+
+#### Scenario: Files processed per day
+
+- **GIVEN** file-processed metrics recorded over the last N days
+- **WHEN** `getFilesProcessedPerDay(days)` runs
+- **THEN** it MUST return a `[date => count]` map, grouped by `%Y-%m-%d` and ordered ascending, restricted to rows within the window
+
+#### Scenario: Embedding statistics with success rate and cost
+
+- **GIVEN** embedding-generated metrics with a `status` of `success` or otherwise
+- **WHEN** `getEmbeddingStats(days)` runs
+- **THEN** it MUST return `{total, successful, failed, success_rate, estimated_cost_usd, period_days}`
+- **AND** `failed` MUST be `total - successful`, `success_rate` MUST come from `calculateSuccessRate()`, and `estimated_cost_usd` MUST be derived from the successful count
+
+#### Scenario: Search latency per search type
+
+- **GIVEN** keyword, semantic, and hybrid search metrics within the window
+- **WHEN** `getSearchLatencyStats(days)` runs
+- **THEN** it MUST return `[type => {count, avg_ms, min_ms, max_ms}]` computed per search type
+
+#### Scenario: Storage growth and dashboard composition
+
+- **GIVEN** recorded vector/storage metrics
+- **WHEN** `getStorageGrowth(days)` runs
+- **THEN** it MUST return per-day vector additions plus current storage and an average derived from `calculateAverageVectorsPerDay()`
+- **AND** `getDashboardMetrics()` MUST compose `files_processed` (30d), `embedding_stats` (30d), `search_latency` (7d), and `storage_growth` (30d) into a single bundle
+
+#### Scenario: Numeric helper behavior
+
+- **GIVEN** the supporting helpers
+- **WHEN** they are called
+- **THEN** `calculateSuccessRate(total, successful)` MUST return `0.0` when total is zero, otherwise `(successful / total) * 100` rounded to two decimals
+- **AND** `roundAverageMs(value)` MUST coerce a numeric (possibly string) value to a float rounded to two decimals, returning `0.0` for non-numeric input
+- **AND** `calculateAverageVectorsPerDay(growthData)` MUST return `0.0` for empty data, otherwise the total divided by the number of days rounded to two decimals
+
+### Requirement: Realtime change records MUST be emitted as CloudEvent-shaped envelopes
+
+`RealtimeService` MUST record a CloudEvents 1.0 shaped change record for a register object on create, update, delete, and transition, persisting it to the realtime event store. A write failure MUST NOT break the originating save pipeline.
+
+#### Scenario: Record a change event
+
+- **GIVEN** an object change of a known type (`or.object.created`, `or.object.updated`, `or.object.deleted`, `or.object.transitioned`)
+- **WHEN** `record(eventType, object, extra)` runs
+- **THEN** it MUST build a CloudEvents 1.0 envelope with `specversion: "1.0"`, the event type, a `source` of `<baseUrl>/apps/openregister`, a subject of the object URN (or its uuid), a unique id, an ISO 8601 `time`, and a `data` block carrying register, schema, uuid, urn, organisation, owner, actor (session UID), and trigger-specific `extra`
+- **AND** it MUST persist a `RealtimeEvent` with the matching fields and the JSON-encoded payload, returning the inserted entity
+
+#### Scenario: Failure is non-fatal
+
+- **GIVEN** the underlying realtime store write throws
+- **WHEN** `record()` executes
+- **THEN** it MUST catch the error, log a warning, and return `null` so a missed realtime event never breaks the actual save

--- a/openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/specs/register-i18n/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/specs/register-i18n/spec.md
@@ -1,0 +1,116 @@
+## ADDED Requirements
+
+### Requirement: A translation sidecar MUST be projected from the authoritative object JSONB
+
+The authoritative store for translatable property values MUST remain the language-keyed JSONB on the object. The system MUST maintain a derived `openregister_translations` sidecar — one row per `(object uuid, property, language)` — kept in sync by `TranslationProjectionService`, optimized for per-language search, completeness queries, and workflow status tracking. The projection MUST NOT become a second source of truth.
+
+#### Scenario: Project translatable properties into the sidecar
+
+- **GIVEN** an object with a translatable property `omschrijving` holding `{"nl": "Paspoort", "en": "Passport"}`
+- **WHEN** `TranslationProjectionService::project()` runs (on object create or update)
+- **THEN** it MUST upsert one sidecar row per non-empty language value via `TranslationMapper::upsert()`
+- **AND** the upsert MUST pass `status: null` so the mapper preserves an existing status or defaults a new slot to `draft`
+- **AND** the translator MUST be set from the active session UID when available
+
+#### Scenario: Legacy single-language value is credited to the default language
+
+- **GIVEN** a translatable property whose value is a plain string (legacy, not language-keyed)
+- **WHEN** the projection runs
+- **THEN** the value MUST be projected under the register default language `nl`
+
+#### Scenario: Stale rows are removed when a value disappears
+
+- **GIVEN** an object that previously had an `en` translation now removed from its JSONB
+- **WHEN** the projection runs
+- **THEN** any sidecar row whose `(property, language)` no longer has a desired value MUST be deleted (best-effort)
+- **AND** when the schema declares no translatable properties, any pre-existing rows for properties no longer translatable MUST be deleted
+
+#### Scenario: Object with no uuid or unresolvable schema is skipped
+
+- **GIVEN** an object with a null/empty uuid, or whose schema reference cannot be resolved
+- **WHEN** the projection runs
+- **THEN** it MUST return without writing, and any thrown error MUST be caught and logged as a warning rather than propagated
+
+#### Scenario: Purge drops every translation row for an object
+
+- **GIVEN** an object being deleted
+- **WHEN** `TranslationProjectionService::purge()` is called
+- **THEN** it MUST delete all sidecar rows for the object uuid via `TranslationMapper::deleteByObject()`
+- **AND** a failure MUST be caught and logged as a warning, never blocking the deletion
+
+### Requirement: Translation workflow status and completeness MUST be queryable through the sidecar
+
+`TranslationStatusService` MUST expose the public API over the translation sidecar: promoting a slot's workflow status, computing per-object completeness, searching translation rows, and discovering objects that lack a given language.
+
+#### Scenario: Promote a translation slot's status
+
+- **GIVEN** an existing translation slot for `(object, property, language)`
+- **WHEN** `setStatus()` is called with a status in `Translation::ALL_STATUSES`
+- **THEN** the slot's status MUST be updated via `TranslationMapper::upsert()`, preserving the existing value and attributing the active session UID as translator
+
+#### Scenario: Invalid status or missing slot is rejected
+
+- **GIVEN** a `setStatus()` call with a status not in `Translation::ALL_STATUSES`, or for a `(object, property, language)` slot that does not yet exist
+- **WHEN** the method executes
+- **THEN** it MUST throw `InvalidArgumentException` with a message naming the invalid status or the missing slot — a value MUST be set before its status can be promoted
+
+#### Scenario: Per-object completeness ratio per language
+
+- **GIVEN** an object and its schema with N translatable properties
+- **WHEN** `completenessForObject()` is called
+- **THEN** it MUST return `[language => {translated, total, ratio}]` where `total` is N, `translated` is the count of filled slots for that language, and `ratio` is `translated / total` rounded to two decimals
+- **AND** when the schema has no translatable properties it MUST return an empty array
+
+#### Scenario: Search and missing-language discovery
+
+- **GIVEN** translation rows in the sidecar
+- **WHEN** `search()` is called with optional query, language, status, and object filters and a limit
+- **THEN** it MUST return the matching rows as `jsonSerialize()` arrays
+- **AND** `findObjectsMissingLanguage()` MUST return the subset of candidate uuids missing at least one translatable-property value in the requested language
+
+### Requirement: Machine translation MUST fill empty slots through a pluggable provider
+
+`BulkTranslationService` MUST translate an object's translatable properties from a source to a target language using a configured `TranslationProviderInterface`, filling only target-language slots that are currently empty. A default `IdentityTranslationProvider` MUST ship so the flow is testable without external API keys.
+
+#### Scenario: Translate only empty target slots
+
+- **GIVEN** an object with a source value in `fromLang` and no value in `toLang` for a translatable property
+- **WHEN** `translateObject()` runs
+- **THEN** it MUST call `provider->translate()`, record the result in the returned `translated` map, and immediately upsert the sidecar slot with status `Translation::STATUS_MACHINE_TRANSLATED` and translator `provider:{identifier}`
+- **AND** a property whose target slot is already non-empty MUST be skipped with reason `target-slot-already-filled`
+
+#### Scenario: No-op and skip conditions
+
+- **GIVEN** a `translateObject()` call where `fromLang === toLang`, the schema is unresolvable, or the schema has no translatable properties
+- **WHEN** the method executes
+- **THEN** it MUST return an empty `translated` map with a `_global` skip reason
+- **AND** a property with no usable source value MUST be skipped with reason `no-source-value`
+- **AND** a provider that throws or returns an empty string MUST be skipped (`provider-error: ...` / `provider-returned-empty`) without aborting the remaining properties
+
+#### Scenario: Provider strategy contract
+
+- **GIVEN** any `TranslationProviderInterface` implementation
+- **WHEN** `translate(text, fromLang, toLang)` is called
+- **THEN** it MUST return the translated string or `null` on a miss/error (callers MUST treat `null` as a skip, never persisting it)
+- **AND** `getIdentifier()` MUST return a stable slug used for `provider:{identifier}` status attribution
+- **AND** `IdentityTranslationProvider::translate()` MUST return the source text verbatim and `getIdentifier()` MUST return `identity`
+
+### Requirement: CSV import/export MUST round-trip translations via field-language columns
+
+`TranslationCsvCodec` MUST convert between the nested `{lang: value}` JSON shape and the flat `field_lang` column shape used by CSV/Excel, preserving language variants in both directions.
+
+#### Scenario: Flatten language-keyed values to columns
+
+- **GIVEN** an object row with a translatable property `title` holding `{"nl": "...", "en": "..."}`
+- **WHEN** `flattenForCsv()` runs
+- **THEN** it MUST emit one `title_nl` / `title_en` column per language present
+- **AND** a translatable property holding a plain legacy string MUST be emitted under `field_und` (BCP 47 undetermined) to avoid guessing the language
+- **AND** untranslatable properties MUST pass through unchanged, with non-scalar values JSON-encoded to keep one cell per column
+
+#### Scenario: Unflatten field-language columns back to nested shape
+
+- **GIVEN** a flat CSV row with columns `title_nl`, `title_en`, and unrelated columns
+- **WHEN** `unflattenFromCsv()` runs
+- **THEN** columns matching `<translatable-property>_<lang>` (where `<lang>` matches the language-code pattern) MUST be reassembled into `{property: {lang: value}}`
+- **AND** an empty cell MUST NOT create a slot (the projection treats it as untranslated)
+- **AND** unrecognized or untranslatable columns MUST pass through as-is

--- a/openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/specs/webhook-payload-mapping/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/specs/webhook-payload-mapping/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Webhook transport internals MUST configure delivery and normalize event identifiers
+
+The webhook delivery layer MUST initialize an HTTP client tolerant of webhook endpoints, resolve dot-notation filter keys against the payload, and normalize event identifiers between the dotted event-type form and the fully qualified event class form. These helpers underpin filtering, the standard payload, and request interception.
+
+#### Scenario: HTTP client is configured for webhook delivery
+
+- **GIVEN** the webhook service is constructed
+- **WHEN** `initializeHttpClient()` runs
+- **THEN** it MUST build a Guzzle client with `timeout: 30`, `connect_timeout: 10`, `verify: false` (self-signed endpoints allowed), `allow_redirects: true`, and `http_errors: false` so 4xx/5xx responses are handled manually rather than thrown
+
+#### Scenario: Dot-notation filter key resolution
+
+- **GIVEN** a payload and a filter key such as `object.status`
+- **WHEN** `getNestedValue()` traverses the payload
+- **THEN** it MUST descend each dot-separated segment and return the nested value, or `null` when any segment is absent
+
+#### Scenario: Short event name derivation
+
+- **GIVEN** a fully qualified event class such as `OCA\OpenRegister\Event\ObjectCreatedEvent`
+- **WHEN** `getShortEventName()` runs
+- **THEN** it MUST return the trailing class segment `ObjectCreatedEvent`, which is the value enriched onto mapping input as `event`
+
+#### Scenario: Event-type to event-class mapping
+
+- **GIVEN** a dotted interception event type such as `object.creating`
+- **WHEN** `eventTypeToEventClass()` runs
+- **THEN** it MUST return `OCA\OpenRegister\Event\ObjectCreatingEvent`, capitalizing the entity and action segments and defaulting the action to `created` when absent
+
+#### Scenario: CloudEvent datacontenttype derives from the request
+
+- **GIVEN** an intercepted HTTP request being formatted as a CloudEvent
+- **WHEN** `CloudEventFormatter::getContentTypeHeader()` runs
+- **THEN** it MUST return the request's `Content-Type` header when present, otherwise default to `application/json`

--- a/openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md
@@ -1,0 +1,51 @@
+# Tasks
+
+## i18n-and-translation-pipeline (→ register-i18n)
+
+- [x] task-1: register-i18n#REQ-TR-SIDECAR — TranslationProjectionService::project projects translatable JSONB into the sidecar (retroactive annotation)
+- [x] task-2: register-i18n#REQ-TR-SIDECAR — TranslationProjectionService::purge drops all sidecar rows for a deleted object (retroactive annotation)
+- [x] task-3: register-i18n#REQ-TR-WORKFLOW — TranslationStatusService::setStatus promotes a slot's workflow status (retroactive annotation)
+- [x] task-4: register-i18n#REQ-TR-WORKFLOW — TranslationStatusService::completenessForObject computes per-language completeness (retroactive annotation)
+- [x] task-5: register-i18n#REQ-TR-WORKFLOW — TranslationStatusService::search queries the sidecar by query/language/status/object (retroactive annotation)
+- [x] task-6: register-i18n#REQ-TR-WORKFLOW — TranslationStatusService::findObjectsMissingLanguage returns objects lacking a language (retroactive annotation)
+- [x] task-7: register-i18n#REQ-TR-MACHINE — BulkTranslationService::translateObject fills empty target-language slots via a provider (retroactive annotation)
+- [x] task-8: register-i18n#REQ-TR-MACHINE — IdentityTranslationProvider::translate passthrough implementation (retroactive annotation)
+- [x] task-9: register-i18n#REQ-TR-MACHINE — IdentityTranslationProvider::getIdentifier returns the provider slug (retroactive annotation)
+- [x] task-10: register-i18n#REQ-TR-MACHINE — TranslationProviderInterface::translate strategy contract (retroactive annotation)
+- [x] task-11: register-i18n#REQ-TR-MACHINE — TranslationProviderInterface::getIdentifier strategy contract (retroactive annotation)
+- [x] task-12: register-i18n#REQ-TR-CSV — TranslationCsvCodec::flattenForCsv flattens language-keyed values to field_lang columns (retroactive annotation)
+- [x] task-13: register-i18n#REQ-TR-CSV — TranslationCsvCodec::unflattenFromCsv reconstructs the nested shape from flat columns (retroactive annotation)
+
+## endpoint-service-execution-pipeline (→ object-interactions)
+
+- [x] task-14: object-interactions#REQ-EP-DISPATCH — EndpointService::executeEndpoint dispatches by target type (retroactive annotation)
+- [x] task-15: object-interactions#REQ-EP-DISPATCH — EndpointService::testEndpoint executes an endpoint with test data and logs the result (retroactive annotation)
+- [x] task-16: object-interactions#REQ-EP-DISPATCH — EndpointService::executeAgentEndpoint runs an AI agent endpoint (retroactive annotation)
+- [x] task-17: object-interactions#REQ-EP-ACCESS — EndpointService::canExecuteEndpoint enforces group-based access (retroactive annotation)
+- [x] task-18: object-interactions#REQ-EP-ACCESS — EndpointService::logEndpointCall persists an EndpointLog with TTL (retroactive annotation)
+
+## graphql-resolver-extras (→ graphql-api)
+
+- [x] task-19: graphql-api#REQ-GQL-EXTRAS — GraphQLResolver::resolveGroupBy dispatches aggregations through the resolver (retroactive annotation)
+- [x] task-20: graphql-api#REQ-GQL-EXTRAS — GraphQLResolver::flushRelationBuffer batch-loads buffered relation UUIDs (retroactive annotation)
+- [x] task-21: graphql-api#REQ-GQL-EXTRAS — GraphQLResolver::encodeCursor encodes opaque pagination cursors (retroactive annotation)
+
+## webhook-cloudevent-formatter-extends (→ webhook-payload-mapping)
+
+- [x] task-22: webhook-payload-mapping#REQ-WH-TRANSPORT — WebhookService::initializeHttpClient configures the Guzzle delivery client (retroactive annotation)
+- [x] task-23: webhook-payload-mapping#REQ-WH-TRANSPORT — WebhookService::getNestedValue resolves dot-notation filter keys (retroactive annotation)
+- [x] task-24: webhook-payload-mapping#REQ-WH-TRANSPORT — WebhookService::getShortEventName derives the short event name (retroactive annotation)
+- [x] task-25: webhook-payload-mapping#REQ-WH-TRANSPORT — WebhookService::eventTypeToEventClass maps dot-notation event types to event classes (retroactive annotation)
+- [x] task-26: webhook-payload-mapping#REQ-WH-TRANSPORT — CloudEventFormatter::getContentTypeHeader derives datacontenttype from the request (retroactive annotation)
+
+## metrics-and-realtime-observability-extends (→ production-observability)
+
+- [x] task-27: production-observability#REQ-OBS-AGG — MetricsService::getFilesProcessedPerDay aggregates per-day file processing counts (retroactive annotation)
+- [x] task-28: production-observability#REQ-OBS-AGG — MetricsService::getEmbeddingStats reports embedding success rate and cost (retroactive annotation)
+- [x] task-29: production-observability#REQ-OBS-AGG — MetricsService::getSearchLatencyStats reports per-type search latency (retroactive annotation)
+- [x] task-30: production-observability#REQ-OBS-AGG — MetricsService::getStorageGrowth reports vector storage growth (retroactive annotation)
+- [x] task-31: production-observability#REQ-OBS-AGG — MetricsService::getDashboardMetrics composes the dashboard metric bundle (retroactive annotation)
+- [x] task-32: production-observability#REQ-OBS-AGG — MetricsService::calculateSuccessRate computes a success percentage (retroactive annotation)
+- [x] task-33: production-observability#REQ-OBS-AGG — MetricsService::roundAverageMs coerces and rounds DB latency values (retroactive annotation)
+- [x] task-34: production-observability#REQ-OBS-AGG — MetricsService::calculateAverageVectorsPerDay averages daily growth (retroactive annotation)
+- [x] task-35: production-observability#REQ-OBS-REALTIME — RealtimeService::record emits a CloudEvent-shaped change record (retroactive annotation)


### PR DESCRIPTION
## Summary

Bundled reverse-spec of five `service` sub-clusters into ONE ghost change (`retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh`), all in EXTEND mode against existing capabilities. Documents observed behavior of already-shipped code; no code logic changes — only `@spec` annotations + spec deltas.

- **register-i18n** (+4 REQs): translation sidecar projection (`TranslationProjectionService`), workflow status/completeness/search (`TranslationStatusService`), pluggable machine translation + bulk fill (`BulkTranslationService`, `IdentityTranslationProvider`, `TranslationProviderInterface`), CSV field-language round-trip (`TranslationCsvCodec`)
- **object-interactions** (+2 REQs): dynamic endpoint dispatcher + test, group-based access control + execution logging (`EndpointService`)
- **graphql-api** (+1 REQ): `resolveGroupBy` / `flushRelationBuffer` / `encodeCursor` resolver helpers
- **webhook-payload-mapping** (+1 REQ): HTTP client init, dot-notation filter resolution, event-name/class normalization, CloudEvent content-type derivation
- **production-observability** (+2 REQs): metrics aggregation helpers (`MetricsService`) + CloudEvent-shaped realtime emission (`RealtimeService::record`)

**10 new REQs, 35 methods annotated across 12 files.** Trivial endpoint placeholders (`executeView/Register/Schema/WebhookEndpoint`) and already-annotated methods (prior retrofit changes) were DROPPED as scanner noise.

## Test plan

- [x] `php -l` passes on all 12 touched files
- [x] `openspec validate retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh --strict` passes
- [ ] Reviewer: confirm spec deltas match observed behavior (no aspirational requirements)