### PR TITLE
retrofit: reverse-spec settings-management capability (mint)

### DIFF
--- a/lib/Service/Settings/CacheSettingsHandler.php
+++ b/lib/Service/Settings/CacheSettingsHandler.php
@@ -143,6 +143,8 @@ class CacheSettingsHandler
      * @return array Cache stats with overview, services, names, distributed, performance, and lastUpdated.
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Complex statistics aggregation requires comprehensive data structure
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-3
      */
     public function getCacheStats(): array
     {
@@ -405,6 +407,8 @@ class CacheSettingsHandler
       *
       * @SuppressWarnings(PHPMD.UnusedFormalParameter)
       * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Multiple cache types require switch-based routing
+      *
+      * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-3
       */
     public function clearCache(string $type='all', ?string $userId=null, array $_options=[]): array
     {
@@ -592,6 +596,8 @@ class CacheSettingsHandler
       *
       * @SuppressWarnings(PHPMD.CyclomaticComplexity) Cache warmup with fallback logic requires multiple branches
       * @SuppressWarnings(PHPMD.NPathComplexity)      Multiple conditional branches for cache service resolution
+      *
+      * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-3
       */
     public function warmupNamesCache(): array
     {

--- a/lib/Service/Settings/ConfigurationSettingsHandler.php
+++ b/lib/Service/Settings/ConfigurationSettingsHandler.php
@@ -211,6 +211,8 @@ class ConfigurationSettingsHandler
      *     Multiple configuration sections require conditional handling
      * @SuppressWarnings(PHPMD.NPathComplexity)
      *     Configuration defaults and overrides create multiple execution paths
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-2
      */
     public function getSettings(): array
     {
@@ -528,6 +530,8 @@ class ConfigurationSettingsHandler
      *     Multiple configuration sections require conditional handling
      * @SuppressWarnings(PHPMD.NPathComplexity)
      *     Configuration sections are independently optional
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-2
      */
     public function updateSettings(array $data): array
     {

--- a/lib/Service/Settings/LlmSettingsHandler.php
+++ b/lib/Service/Settings/LlmSettingsHandler.php
@@ -88,6 +88,8 @@ class LlmSettingsHandler
      * @SuppressWarnings(PHPMD.NPathComplexity)
      *     Default configuration structure requires comprehensive initialization
      *     Nested else branches handle optional vector config backward compatibility
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function getLLMSettingsOnly(): array
     {
@@ -169,6 +171,8 @@ class LlmSettingsHandler
      * @throws \RuntimeException If LLM settings update fails.
      *
      * @SuppressWarnings(PHPMD.NPathComplexity) PATCH behavior requires merging multiple nested configuration structures
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function updateLLMSettingsOnly(array $llmData): array
     {

--- a/lib/Service/Settings/SolrSettingsHandler.php
+++ b/lib/Service/Settings/SolrSettingsHandler.php
@@ -118,6 +118,8 @@ class SolrSettingsHandler
      * @throws \RuntimeException if SOLR settings retrieval fails
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) SOLR configuration requires many default settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-2
      */
     public function getSolrSettings(): array
     {
@@ -529,6 +531,8 @@ class SolrSettingsHandler
      *     fileCollection: mixed|null}
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) SOLR configuration requires many settings fields
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-2
      */
     public function updateSolrSettingsOnly(array $solrData): array
     {

--- a/lib/Service/Settings/ValidationOperationsHandler.php
+++ b/lib/Service/Settings/ValidationOperationsHandler.php
@@ -120,6 +120,8 @@ class ValidationOperationsHandler
      * @SuppressWarnings(PHPMD.NPathComplexity)
      *     Try-catch and conditional result handling creates multiple paths
      *     Circular dependency workaround and validation result handling require else branch
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-4
      */
     public function validateAllObjects(): array
     {

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -411,6 +411,8 @@ class SettingsService
      * Get search backend configuration
      *
      * @return array Search backend configuration
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-2
      */
     public function getSearchBackendConfig(): array
     {
@@ -445,6 +447,8 @@ class SettingsService
      * @param array $data Search backend configuration data
      *
      * @return array Updated configuration
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function updateSearchBackendConfig(array $data): array
     {
@@ -459,6 +463,8 @@ class SettingsService
      * Get LLM settings only
      *
      * @return array LLM settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function getLLMSettingsOnly(): array
     {
@@ -471,6 +477,8 @@ class SettingsService
      * @param array $data LLM settings data
      *
      * @return array Updated LLM settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function updateLLMSettingsOnly(array $data): array
     {
@@ -483,6 +491,8 @@ class SettingsService
      * Get file settings only
      *
      * @return array File settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function getFileSettingsOnly(): array
     {
@@ -495,6 +505,8 @@ class SettingsService
      * @param array $data File settings data
      *
      * @return array Updated file settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function updateFileSettingsOnly(array $data): array
     {
@@ -507,6 +519,8 @@ class SettingsService
      * Get object settings only
      *
      * @return array Object settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function getObjectSettingsOnly(): array
     {
@@ -519,6 +533,8 @@ class SettingsService
      * @param array $data Object settings data
      *
      * @return array Updated object settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function updateObjectSettingsOnly(array $data): array
     {
@@ -529,6 +545,8 @@ class SettingsService
      * Get retention settings only
      *
      * @return array Retention settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function getRetentionSettingsOnly(): array
     {
@@ -541,6 +559,8 @@ class SettingsService
      * @param array $data Retention settings data
      *
      * @return array Updated retention settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function updateRetentionSettingsOnly(array $data): array
     {
@@ -551,6 +571,8 @@ class SettingsService
      * Get archival settings only
      *
      * @return array Archival settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function getArchivalSettingsOnly(): array
     {
@@ -563,6 +585,8 @@ class SettingsService
      * @param array $data Archival settings data
      *
      * @return array Updated archival settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function updateArchivalSettingsOnly(array $data): array
     {
@@ -575,6 +599,8 @@ class SettingsService
      * Get cache statistics
      *
      * @return array Cache statistics
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-3
      */
     public function getCacheStats(): array
     {
@@ -587,6 +613,8 @@ class SettingsService
      * @param string|null $cacheType Type of cache to clear
      *
      * @return array Clear cache result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-3
      */
     public function clearCache(?string $cacheType=null): array
     {
@@ -597,6 +625,8 @@ class SettingsService
      * Warmup names cache
      *
      * @return array Warmup result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-3
      */
     public function warmupNamesCache(): array
     {
@@ -609,6 +639,8 @@ class SettingsService
      * Get SOLR settings
      *
      * @return array SOLR settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function getSolrSettings(): array
     {
@@ -619,6 +651,8 @@ class SettingsService
      * Get SOLR settings only
      *
      * @return array SOLR settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function getSolrSettingsOnly(): array
     {
@@ -631,6 +665,8 @@ class SettingsService
      * @param array $data SOLR settings data
      *
      * @return array Updated SOLR settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function updateSolrSettingsOnly(array $data): array
     {
@@ -641,6 +677,8 @@ class SettingsService
      * Get SOLR dashboard statistics
      *
      * @return array SOLR dashboard stats
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-5
      */
     public function getSolrDashboardStats(): array
     {
@@ -651,6 +689,8 @@ class SettingsService
      * Get SOLR facet configuration
      *
      * @return array Facet configuration
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-5
      */
     public function getSolrFacetConfiguration(): array
     {
@@ -663,6 +703,8 @@ class SettingsService
      * @param array $data Facet configuration data
      *
      * @return array Updated facet configuration
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-5
      */
     public function updateSolrFacetConfiguration(array $data): array
     {
@@ -682,7 +724,10 @@ class SettingsService
      * @return never Warmup result
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)   Boolean flag needed for error collection behavior
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter) Public facade signature kept while the deprecated delegate is refactored — see lib/Service/SettingsService.php TODO comment
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) Public facade signature kept while the deprecated
+     *     delegate is refactored — see the warmupSolrIndex TODO comment
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-3
      */
     public function warmupSolrIndex(
         array $schemas=[],
@@ -703,6 +748,8 @@ class SettingsService
      * Get settings
      *
      * @return array Settings configuration
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function getSettings(): array
     {
@@ -715,6 +762,8 @@ class SettingsService
      * @param array $data Settings data
      *
      * @return array Updated settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function updateSettings(array $data): array
     {
@@ -730,6 +779,8 @@ class SettingsService
      *
      * @psalm-return array{use_old_style_publishing_view?: bool,
      *               auto_publish_objects?: bool, auto_publish_attachments?: bool}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function updatePublishingOptions(array $data): array
     {
@@ -740,6 +791,8 @@ class SettingsService
      * Check if multi-tenancy is enabled
      *
      * @return bool True if enabled
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-2
      */
     public function isMultiTenancyEnabled(): bool
     {
@@ -750,6 +803,8 @@ class SettingsService
      * Get RBAC settings only
      *
      * @return array RBAC settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function getRbacSettingsOnly(): array
     {
@@ -762,6 +817,8 @@ class SettingsService
      * @param array $data RBAC settings data
      *
      * @return array Updated RBAC settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function updateRbacSettingsOnly(array $data): array
     {
@@ -775,6 +832,8 @@ class SettingsService
      *
      * @psalm-return array{organisation: array{default_organisation: mixed|null,
      *               auto_create_default_organisation: mixed|true}}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function getOrganisationSettingsOnly(): array
     {
@@ -790,6 +849,8 @@ class SettingsService
      *
      * @psalm-return array{organisation: array{default_organisation: mixed|null,
      *               auto_create_default_organisation: mixed|true}}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function updateOrganisationSettingsOnly(array $data): array
     {
@@ -800,6 +861,8 @@ class SettingsService
      * Get default organisation UUID
      *
      * @return string|null Organisation UUID
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-2
      */
     public function getDefaultOrganisationUuid(): ?string
     {
@@ -812,6 +875,8 @@ class SettingsService
      * @param string|null $uuid Organisation UUID
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-2
      */
     public function setDefaultOrganisationUuid(?string $uuid): void
     {
@@ -822,6 +887,8 @@ class SettingsService
      * Get tenant ID
      *
      * @return string|null Tenant ID
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-2
      */
     public function getTenantId(): ?string
     {
@@ -832,6 +899,8 @@ class SettingsService
      * Get organisation ID
      *
      * @return string|null Organisation ID
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-2
      */
     public function getOrganisationId(): ?string
     {
@@ -846,6 +915,8 @@ class SettingsService
      * @psalm-return array{multitenancy: array{enabled: false|mixed,
      *     defaultUserTenant: ''|mixed, defaultObjectTenant: ''|mixed,
      *     adminOverride: mixed|true}, availableTenants: array}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function getMultitenancySettingsOnly(): array
     {
@@ -858,6 +929,8 @@ class SettingsService
      * @param array $data Multitenancy settings data
      *
      * @return array Updated multitenancy settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-1
      */
     public function updateMultitenancySettingsOnly(array $data): array
     {
@@ -868,6 +941,8 @@ class SettingsService
      * Get version info only
      *
      * @return array Version information
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-5
      */
     public function getVersionInfoOnly(): array
     {
@@ -881,6 +956,8 @@ class SettingsService
      * Returns null if no cached data is available.
      *
      * @return array|null Database information or null if not cached
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-5
      */
     public function getDatabaseInfo(): ?array
     {
@@ -903,6 +980,8 @@ class SettingsService
      * @param string $extensionName The name of the extension to check (e.g., 'vector', 'pg_trgm')
      *
      * @return bool True if the extension is installed, false otherwise
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-5
      */
     public function hasPostgresExtension(string $extensionName): bool
     {
@@ -925,6 +1004,8 @@ class SettingsService
      * Get list of installed PostgreSQL extensions
      *
      * @return array List of extension names, empty array if not PostgreSQL or no extensions
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-5
      */
     public function getPostgresExtensions(): array
     {
@@ -945,6 +1026,8 @@ class SettingsService
      * @return array Validation results
      *
      * @throws Exception If validation operation fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-4
      */
     public function validateAllObjects(): array
     {
@@ -970,6 +1053,8 @@ class SettingsService
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Multiple validation paths and error handling
      * @SuppressWarnings(PHPMD.NPathComplexity)       Multiple validation paths and error handling
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)   Boolean flag needed for error collection behavior
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-4
      */
     public function massValidateObjects(
         int $maxObjects=0,
@@ -1178,6 +1263,8 @@ class SettingsService
      * @return int[][] Array of batch job definitions.
      *
      * @psalm-return list<array{batchNumber: int<1, max>, limit: int, offset: int}>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-4
      */
     private function createBatchJobs(int $totalObjects, int $batchSize): array
     {
@@ -1210,6 +1297,8 @@ class SettingsService
      * @return void
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Batch processing requires comprehensive logic
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-4
      */
     private function processJobsSerial(
         array $batchJobs,
@@ -1351,6 +1440,8 @@ class SettingsService
      * @param int                              $parallelBatches Number of parallel batches.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-4
      */
     private function processJobsParallel(
         array $batchJobs,
@@ -1431,6 +1522,8 @@ class SettingsService
      *     failed: int<0, max>, errors: list<array{batch_mode: 'parallel_optimized',
      *     error: string, object_id: null|string, object_name: null|string,
      *     register: null|string, schema: null|string}>, duration: float}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-4
      */
     private function processBatchDirectly(
         \OCA\OpenRegister\Db\MagicMapper $objectMapper,
@@ -1794,6 +1887,8 @@ class SettingsService
      *         max_execution_time: string
      *     }
      * }
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-5
      */
     public function getStats(): array
     {
@@ -2043,6 +2138,8 @@ class SettingsService
      *     message: 'Solr configuration rebased'}, cache?: array{success: true,
      *     message: 'Cache cleared and ready for rebuild'}},
      *     timestamp?: int<1, max>}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md#task-5
      */
     public function rebase(array $options=[]): array
     {

--- a/openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/proposal.md
@@ -1,0 +1,50 @@
+# Proposal: Reverse-spec the settings-management capability (mint)
+
+## Why
+
+OpenRegister exposes a large, cross-cutting settings surface — LLM providers,
+file/object vectorization, retention, archival, SOLR/search backend, RBAC,
+multitenancy, organisation defaults, publishing, n8n, and cache — that the admin
+UI and several business-logic services read and write. This surface is
+implemented today as a single `SettingsService` facade (2097 lines, ~50 public
+methods) delegating to seven specialized `Service\Settings\*` handlers, plus
+mass-validation batch orchestration and version/database/PostgreSQL-extension
+introspection. Despite the large method count, the behavior is highly uniform:
+every per-domain endpoint is a typed `getXSettingsOnly()` / `updateXSettingsOnly()`
+pair that reads a single JSON-encoded blob from `IAppConfig`, fills defaults for
+unconfigured keys, PATCH-merges incoming data over the stored values, and writes
+back. No capability currently describes this contract — the controller-side
+settings admin (specced separately under the `ctrl-settings-observ` bundle)
+delegates into this layer but has no documented persistence/orchestration
+contract beneath it.
+
+This is a reverse-spec retrofit: it documents observed behavior of already-shipped
+code. It mints one `settings-management` capability that specifies the
+**sliced-settings PATTERN** (typed per-domain get/update, defaults, PATCH-merge,
+JSON-in-`IAppConfig` persistence) once, enumerates the domains as a scenario,
+and adds the cross-cutting orchestration concerns (mass-validation batch jobs,
+environment introspection, rebase) as their own requirements — rather than
+emitting ~80 near-identical per-method annotations.
+
+## What Changes
+
+- **MINT** capability `settings-management` with five requirements covering the
+  sliced-settings persistence pattern, the facade/handler delegation
+  architecture, mass-validation batch orchestration, environment introspection
+  (version/database/PostgreSQL extensions), and configuration rebase.
+- Annotate the `SettingsService` facade and its `Service\Settings\*` handler
+  methods with `@spec` pointers to the tasks in this change, grouping the
+  repetitive per-domain get/update pairs under shared tasks.
+- No production code behavior changes — annotations and documentation only.
+
+## Impact
+
+- Affected specs: `settings-management` (new).
+- Affected code (annotations only):
+  - `lib/Service/SettingsService.php`
+  - `lib/Service/Settings/CacheSettingsHandler.php`
+  - `lib/Service/Settings/ConfigurationSettingsHandler.php`
+  - `lib/Service/Settings/LlmSettingsHandler.php`
+  - `lib/Service/Settings/SolrSettingsHandler.php`
+  - `lib/Service/Settings/ValidationOperationsHandler.php`
+- No migrations, no API changes, no behavioral change.

--- a/openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/specs/settings-management/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/specs/settings-management/spec.md
@@ -1,0 +1,164 @@
+---
+status: proposed
+---
+
+# Settings Management
+
+## Purpose
+The settings-management capability is the persistence and orchestration layer
+for OpenRegister's cross-cutting administrative configuration. It owns the
+contract by which per-domain settings (LLM, File, Object, Retention, Archival,
+SOLR, search backend, RBAC, Multitenancy, Organisation, n8n, Publishing) are
+stored, defaulted, and updated, and the orchestration of cache management,
+mass-validation batch jobs, environment introspection, and configuration rebase.
+It sits beneath the controller-side settings admin (specced separately) and is
+read by business-logic services (ChatService, VectorEmbeddingService,
+IndexService) that need configured values without owning their persistence.
+
+**Source**: Reverse-spec retrofit of shipped code — `SettingsService` and its
+`Service\Settings\*` handlers. Behavior is documented as observed, not changed.
+
+**Cross-references**: chat-ai and production-observability (controller-side
+settings admin delegating into this layer), faceting-configuration (SOLR facet
+settings), avg-verwerkingsregister / archivering-vernietiging (retention and
+archival settings consumers).
+
+## ADDED Requirements
+
+### Requirement: Per-domain settings MUST follow a sliced typed get/update pattern persisted as JSON in IAppConfig
+Each configuration domain MUST expose a typed retrieval method
+(`getXSettingsOnly()` form) and a typed update method
+(`updateXSettingsOnly(array $data)` form). The retrieval method MUST read a
+single JSON-encoded blob from `IAppConfig` under the `openregister` app and the
+domain's key, MUST return a complete defaults structure when the stored value is
+empty or unset, and MUST backfill any individually missing keys with their
+defaults for backward compatibility. The update method MUST apply PATCH
+semantics — merging the incoming partial data over the currently stored values
+so that omitted keys retain their existing value — and MUST persist the merged
+result back as a JSON string. The domains covered by this pattern are: LLM,
+File, Object, Retention, Archival, SOLR, search backend, RBAC, Multitenancy,
+Organisation, n8n, and Publishing.
+
+#### Scenario: Retrieve an unconfigured domain returns defaults
+- **GIVEN** the `llm` app-config key is empty or unset
+- **WHEN** `getLLMSettingsOnly()` is called
+- **THEN** a complete default structure MUST be returned (e.g. `enabled` is
+  `false`, provider sub-configs present with their default URLs/models, and
+  `vectorConfig` defaulting to `backend: 'php'`, `solrField: '_embedding_'`)
+- **AND** no value MUST be written to `IAppConfig` as a side effect of reading
+
+#### Scenario: Update applies PATCH-merge over stored values
+- **GIVEN** a domain already has stored settings in `IAppConfig`
+- **WHEN** `updateXSettingsOnly($data)` is called with only a subset of keys
+- **THEN** the supplied keys MUST overwrite their stored counterparts
+- **AND** keys absent from `$data` MUST retain their previously stored values
+- **AND** the merged result MUST be JSON-encoded and written back under the
+  domain's app-config key
+- **AND** the merged settings MUST be returned to the caller
+
+#### Scenario: All enumerated domains expose the get/update pair
+- **GIVEN** the settings facade
+- **THEN** each of LLM, File, Object, Retention, Archival, SOLR, search backend,
+  RBAC, Multitenancy, Organisation, n8n, and Publishing MUST be reachable through
+  its typed getter and (where mutable) its typed updater
+
+### Requirement: SettingsService MUST act as a thin facade delegating each domain to a specialized handler
+`SettingsService` MUST be the single public entry point for settings persistence
+and MUST delegate each domain to a dedicated `Service\Settings\*` handler
+(LLM, File, Object/Retention, Cache, SOLR, Configuration, search backend,
+validation). Handlers MAY be lazy-loaded through the app container to break
+circular dependencies during dependency-injection bootstrap. The facade MUST NOT
+embed domain business logic of the testing/using kind (connection testing,
+embedding generation, chat execution, searching) — those belong to the
+respective business-logic services.
+
+#### Scenario: Facade delegates a domain call to its handler
+- **GIVEN** a configured `SettingsService` with its handlers injected
+- **WHEN** `updateSolrSettingsOnly($data)` is called
+- **THEN** the call MUST be forwarded to `SolrSettingsHandler::updateSolrSettingsOnly`
+- **AND** the handler's result MUST be returned unchanged
+
+#### Scenario: Bootstrap-critical reads avoid uninitialized handlers
+- **GIVEN** the search-backend configuration is needed during DI bootstrap
+- **WHEN** `getSearchBackendConfig()` is called before its handler is fully wired
+- **THEN** the facade MUST read the value directly from `IAppConfig` and return a
+  safe default (`active: 'solr'`, `available: ['solr','elasticsearch']`) on
+  empty or error rather than dereferencing an uninitialized handler
+
+### Requirement: The capability MUST orchestrate cache statistics, clearing, and warmup
+The facade MUST expose cache management delegated to `CacheSettingsHandler`:
+gathering cache statistics, clearing a named cache type or all caches, and
+warming the names cache. Clearing MUST accept an optional cache type and MUST
+default to clearing all caches when none is supplied.
+
+#### Scenario: Clear cache with no type clears everything
+- **WHEN** `clearCache()` is called with no argument
+- **THEN** the handler MUST be invoked with cache type `'all'`
+- **AND** a result array describing the clear operation MUST be returned
+
+#### Scenario: Cache statistics are aggregated into dashboard stats
+- **WHEN** `getStats()` is called
+- **THEN** the returned array MUST include a `cache` section sourced from
+  `getCacheStats()`
+- **AND** a failure to gather cache stats MUST be captured as an `error` entry
+  rather than aborting the whole stats response
+
+### Requirement: Mass validation MUST orchestrate batch jobs over all objects with serial or parallel processing
+Mass validation MUST validate the `mode` parameter (only `serial` or `parallel`)
+and the `batchSize` parameter (between 1 and 5000), MUST partition the total
+object count (optionally capped by `maxObjects`) into evenly-sized batch jobs,
+and MUST re-save each object through `ObjectService::saveObject` to re-trigger
+business logic. In serial mode batches are processed sequentially; in parallel
+mode they are processed in fixed-size chunks. The `collectErrors` flag MUST
+control whether processing collects all errors or short-circuits on the first
+failure. The operation MUST return aggregate statistics including processed,
+successful, and failed counts, duration, throughput, and memory usage.
+
+#### Scenario: Invalid mode is rejected
+- **WHEN** `massValidateObjects(mode: 'turbo')` is called
+- **THEN** an `InvalidArgumentException` MUST be thrown before any object is
+  processed
+
+#### Scenario: collectErrors short-circuit behavior
+- **GIVEN** an object fails to re-save during serial processing
+- **WHEN** `collectErrors` is `false`
+- **THEN** processing of the current batch MUST stop at the first failure
+
+#### Scenario: collectErrors accumulates all failures
+- **GIVEN** multiple objects fail to re-save during processing
+- **WHEN** `collectErrors` is `true`
+- **THEN** processing MUST continue past each failure
+- **AND** every failure MUST be accumulated into the `errors` array
+
+#### Scenario: Results carry aggregate statistics
+- **WHEN** a mass-validation run completes
+- **THEN** the result MUST include `stats` with `total_objects`,
+  `processed_objects`, `successful_saves`, `failed_saves`, `duration_seconds`,
+  `batches_processed`, and `objects_per_second`
+- **AND** a `memory_usage` section with start/end/peak figures
+
+### Requirement: The capability MUST expose environment introspection and configuration rebase
+The facade MUST expose read-only environment introspection — application
+version info, cached database information, and PostgreSQL extension presence —
+and a `rebase` operation that resets or rebuilds selected configuration
+components (SOLR configuration, cache). Introspection MUST degrade gracefully
+when data is unavailable (e.g. return `null`/empty rather than throwing), and
+`rebase` MUST report per-component outcomes and overall success.
+
+#### Scenario: PostgreSQL extension check on a non-Postgres database
+- **GIVEN** the cached database info reports a non-PostgreSQL engine or is absent
+- **WHEN** `hasPostgresExtension('vector')` is called
+- **THEN** it MUST return `false`
+- **AND** `getPostgresExtensions()` MUST return an empty array
+
+#### Scenario: Rebase a selected component
+- **WHEN** `rebase(['components' => ['cache']])` is called
+- **THEN** the cache MUST be cleared
+- **AND** the result MUST report `success: true` with a `rebased.cache` entry
+  and a `timestamp`
+
+#### Scenario: Rebase failure is reported, not thrown
+- **GIVEN** a rebase sub-operation raises an exception
+- **WHEN** `rebase()` is called
+- **THEN** the result MUST report `success: false` with an `error` of
+  `'Rebase failed'` and the exception message rather than propagating the throw

--- a/openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/tasks.md
@@ -1,0 +1,80 @@
+# Tasks: Reverse-spec settings-management capability
+
+Reverse-spec retrofit. Tasks document observed behavior of shipped code; the
+work item is the `@spec` annotation linking each method group to its
+requirement. Repetitive per-domain get/update pairs are grouped under one task.
+
+## Task 1 — Sliced per-domain settings get/update pattern
+
+- [ ] Document that every per-domain settings endpoint is a typed
+      `getXSettingsOnly()` / `updateXSettingsOnly(array $data)` pair that reads a
+      single JSON blob from `IAppConfig`, returns hard-coded defaults when the
+      key is empty/unset, PATCH-merges incoming data over stored values, and
+      writes the merged result back as JSON. Domains observed: LLM, File,
+      Object, Retention, Archival, SOLR, search-backend, RBAC, Multitenancy,
+      Organisation, n8n, Publishing.
+- [ ] Annotate the facade delegation pairs in `lib/Service/SettingsService.php`:
+      `getLLMSettingsOnly`/`updateLLMSettingsOnly`,
+      `getFileSettingsOnly`/`updateFileSettingsOnly`,
+      `getObjectSettingsOnly`/`updateObjectSettingsOnly`,
+      `getRetentionSettingsOnly`/`updateRetentionSettingsOnly`,
+      `getArchivalSettingsOnly`/`updateArchivalSettingsOnly`,
+      `getSolrSettings`/`getSolrSettingsOnly`/`updateSolrSettingsOnly`,
+      `getSearchBackendConfig`/`updateSearchBackendConfig`,
+      `getRbacSettingsOnly`/`updateRbacSettingsOnly`,
+      `getMultitenancySettingsOnly`/`updateMultitenancySettingsOnly`,
+      `getOrganisationSettingsOnly`/`updateOrganisationSettingsOnly`,
+      `getSettings`/`updateSettings`, `updatePublishingOptions`.
+- [ ] Annotate the canonical handler implementation of the pattern in
+      `lib/Service/Settings/LlmSettingsHandler.php`
+      (`getLLMSettingsOnly`/`updateLLMSettingsOnly`).
+
+## Task 2 — Facade-and-handler delegation architecture
+
+- [ ] Document that `SettingsService` is a thin facade that delegates each domain
+      to a specialized `Service\Settings\*` handler injected via constructor
+      (lazy-loaded to break circular dependencies), and is the single
+      persistence/orchestration layer beneath the controller-side settings admin.
+- [ ] Annotate the delegation accessors and convenience getters in
+      `lib/Service/SettingsService.php`: `isMultiTenancyEnabled`,
+      `getDefaultOrganisationUuid`/`setDefaultOrganisationUuid`, `getTenantId`,
+      `getOrganisationId`.
+- [ ] Annotate the multi-method handler implementations in
+      `lib/Service/Settings/ConfigurationSettingsHandler.php` and
+      `lib/Service/Settings/SolrSettingsHandler.php` that back the facade
+      delegation.
+
+## Task 3 — Cache statistics, clear, and warmup orchestration
+
+- [ ] Document the cache management surface: statistics, typed clear
+      (`all` or a named cache type), and names-cache warmup, all delegated to
+      `CacheSettingsHandler`.
+- [ ] Annotate `getCacheStats`, `clearCache`, `warmupNamesCache` in
+      `lib/Service/SettingsService.php` and their implementations in
+      `lib/Service/Settings/CacheSettingsHandler.php`.
+
+## Task 4 — Mass-validation batch-job orchestration
+
+- [ ] Document that mass-validation creates evenly-sized batch jobs over the
+      total object count, processes them serially or in parallel chunks
+      (re-saving each object via `ObjectService::saveObject` to re-trigger
+      business logic), validates `mode` and `batchSize` parameters, collects or
+      short-circuits on errors per the `collectErrors` flag, and returns
+      aggregate stats (processed/successful/failed, duration, throughput,
+      memory).
+- [ ] Annotate `validateAllObjects`, `massValidateObjects`, `createBatchJobs`,
+      `processJobsSerial`, `processJobsParallel`, `processBatchDirectly` in
+      `lib/Service/SettingsService.php` and `validateAllObjects` in
+      `lib/Service/Settings/ValidationOperationsHandler.php`.
+
+## Task 5 — Environment introspection, stats, and rebase
+
+- [ ] Document version/database/PostgreSQL-extension introspection
+      (`getVersionInfoOnly`, `getDatabaseInfo`, `hasPostgresExtension`,
+      `getPostgresExtensions`), dashboard statistics aggregation (`getStats`,
+      `getSolrDashboardStats`), and the `rebase` configuration operation that
+      resets/rebuilds selected components (SOLR config, cache).
+- [ ] Annotate `getVersionInfoOnly`, `getDatabaseInfo`, `hasPostgresExtension`,
+      `getPostgresExtensions`, `getStats`, `getSolrDashboardStats`,
+      `getSolrFacetConfiguration`, `updateSolrFacetConfiguration`, `rebase` in
+      `lib/Service/SettingsService.php`.


### PR DESCRIPTION
## Summary

Reverse-spec retrofit (ADR-003 backfill). **Mints** a new `settings-management` capability documenting OpenRegister's cross-cutting settings persistence/orchestration layer — the `SettingsService` facade and its `Service\Settings\*` handlers — which the controller-side settings admin delegates into but which had no documented contract.

The surface is large (~80 methods) but highly uniform, so the spec describes the **sliced-settings PATTERN** once rather than emitting 80 near-identical per-method annotations. Five requirements:

1. Per-domain typed `getX`/`updateX` pairs — defaults for unconfigured, PATCH-merge on update, JSON-in-`IAppConfig` persistence (LLM, File, Object, Retention, Archival, SOLR, search backend, RBAC, Multitenancy, Organisation, n8n, Publishing).
2. Facade/handler delegation architecture (lazy-loaded handlers, no embedded business logic).
3. Cache statistics / clear / warmup orchestration.
4. Mass-validation batch-job orchestration (serial/parallel, collectErrors, aggregate stats).
5. Environment introspection (version/database/Postgres extensions, stats) and configuration rebase.

## Changes

- New ghost change `openspec/changes/retrofit-2026-05-24-b-svc-settings-mgmt/` (proposal + tasks + `specs/settings-management/spec.md`), `openspec validate --strict` green.
- `@spec` annotations across the 6 facade/handler files (repetitive get/set pairs grouped under shared tasks).
- Wrapped one pre-existing over-length PHPCS suppress-comment on `warmupSolrIndex`.
- **No production behavior changes** — annotations and documentation only.

## Test plan

- [x] `php -l` clean on all 6 touched files
- [x] `phpcs --standard=phpcs.xml` clean (0 errors) on all 6 files
- [x] `openspec validate retrofit-2026-05-24-b-svc-settings-mgmt --strict` passes