### PR TITLE
retrofit: Bucket 3a investigation — deprecate/manifest (7 REQs)

### DIFF
--- a/lib/Db/MultiTenancyTrait.php
+++ b/lib/Db/MultiTenancyTrait.php
@@ -256,6 +256,8 @@ trait MultiTenancyTrait
      * @param string        $tableAlias          Optional table alias
      * @param bool          $multiTenancyEnabled Whether multitenancy is enabled (default: true)
      *
+     * @spec openspec/specs/deprecate-published-metadata/spec.md#REQ-5 (MultiTenancyTrait Documentation — published-bypass docs scoped to Register/Schema entities only; object-level published bypass removed)
+     *
      * @return void
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Flags control multitenancy filtering behavior

--- a/lib/Service/Object/SaveObject/MetadataHydrationHandler.php
+++ b/lib/Service/Object/SaveObject/MetadataHydrationHandler.php
@@ -97,6 +97,7 @@ class MetadataHydrationHandler
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      *
      * @spec openspec/changes/retrofit-2026-04-28-object-lifecycle/tasks.md#task-5
+     * @spec openspec/specs/deprecate-published-metadata/spec.md#REQ-6 (Deprecation Warnings — logs a warning for objectPublishedField/objectDepublishedField/autoPublish schema config keys, recommending RBAC $now rules)
      */
     public function hydrateObjectMetadata(ObjectEntity $entity, Schema $schema): void
     {

--- a/openspec/changes/retrofit-2026-05-24-b3a-deprecate-manifest/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-b3a-deprecate-manifest/proposal.md
@@ -1,0 +1,38 @@
+# Retrofit — b3a-deprecate-manifest
+
+Investigates 7 "Bucket 3a" REQs flagged by the coverage scanner as having NO
+annotated implementation. Each was read against its spec, grepped against the
+codebase, classified, and (where implemented) annotated with an `@spec` tag.
+
+This is an annotations-only retrofit. No behavior changed. No new REQs drafted.
+
+## Per-REQ classification
+
+| REQ | Title | Classification | Evidence |
+| --- | --- | --- | --- |
+| `deprecate-published-metadata#REQ-2` | Frontend Copy Modal Cleanup | SATISFIED-BY-ABSENCE | `src/modals/object/CopyObject.vue:135-149` and `src/modals/object/MassCopyObjects.vue:197-208` strip `@self.{id,uuid,uri,created,updated,version,files,relations,folder,size,deleted}` — no `published`/`depublished` keys deleted (they no longer exist). The cleanup the REQ asked for is complete. No code to annotate. |
+| `deprecate-published-metadata#REQ-4` | Import UI Cleanup | SATISFIED-BY-ABSENCE | `src/modals/register/ImportRegister.vue:256-307` declares import toggles `includeObjects`, `validation`, `events`, `rbac`, `multi` — the "Auto-publish imported objects" toggle has been removed. No code to annotate. |
+| `deprecate-published-metadata#REQ-5` | MultiTenancyTrait Documentation | IMPLEMENTED | `lib/Db/MultiTenancyTrait.php:234,242` — published-bypass docs are scoped to "Register/Schema entities only"; object-level published bypass references are gone, Register/Schema bypass docs remain. Annotated. |
+| `deprecate-published-metadata#REQ-6` | Deprecation Warnings | IMPLEMENTED | `lib/Service/Object/SaveObject/MetadataHydrationHandler.php:106-124` logs a `LoggerInterface::warning` for each of `objectPublishedField`, `objectDepublishedField`, `autoPublish` schema config keys, recommending RBAC `$now`. Annotated. |
+| `openregister-app-manifest#MAN-002` | Manifest declares zero Conduction-app dependencies | MISSING | `src/manifest.json` does not exist. `tests/validate-manifest.js:120-125` explicitly treats OR as the foundation app and skips when no manifest. With no manifest there is no `dependencies` field to set to `[]`. Cannot be satisfied until the manifest is authored (REQ-OR-MAN-001). |
+| `openregister-app-manifest#MAN-007` | Build gate validates the manifest | IMPLEMENTED | `package.json` declares `check:manifest` → `tests/validate-manifest.js`, included in the `check:specs` composite, and wired into CI via `.github/workflows/spec-validation.yml` (`npm run check:specs`). The validator Ajv-validates against the canonical `@conduction/nextcloud-vue` schema, prints error paths, and exits non-zero on schema violation. Annotated. |
+| `openregister-app-manifest#MAN-008` | Manifest version reflects the adoption tier | MISSING | No `src/manifest.json` → no top-level `version` field. Cannot be `0.1.0`/`0.2.0` until the manifest exists (REQ-OR-MAN-001/005). |
+
+Summary: 2 IMPLEMENTED, 0 PARTIAL, 2 MISSING, 2 SATISFIED-BY-ABSENCE (REQ-3 not in this batch).
+
+## Notes
+
+- The `deprecate-published-metadata` capability is marked `status: implemented`
+  in its canonical spec. REQ-2 and REQ-4 are "cleanup" requirements: the code
+  they asked to *remove* is gone, so they are satisfied by absence rather than
+  by an annotatable implementation.
+- `autoPublish` still appears in `lib/Service/Object/SaveObject/FilePropertyHandler.php`
+  (file-share publish), which is explicitly **out of scope** per the spec
+  ("File publish/depublish — Nextcloud share management, `autoPublish` in
+  FilePropertyHandler"). Not flagged.
+- The two MISSING manifest REQs depend on `REQ-OR-MAN-001` (author
+  `src/manifest.json`), which the upstream change `openregister-adopt-app-manifest`
+  has not yet landed. The build gate (MAN-007) is in place ahead of the manifest
+  and skips cleanly until the manifest exists — this is intentional.
+
+Source: /tmp/or-scan/b3a-deprecate-manifest.json. See retrofit playbook.

--- a/openspec/changes/retrofit-2026-05-24-b3a-deprecate-manifest/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-b3a-deprecate-manifest/tasks.md
@@ -1,0 +1,30 @@
+# Tasks — b3a-deprecate-manifest retrofit
+
+Annotations-only. Each task records the `@spec` tag added (or why none was added).
+
+## Annotations added
+
+- [x] task-1 — `deprecate-published-metadata#REQ-6` → annotated
+  `lib/Service/Object/SaveObject/MetadataHydrationHandler.php::hydrateObjectMetadata`
+  docblock with `@spec openspec/specs/deprecate-published-metadata/spec.md#REQ-6`.
+- [x] task-2 — `deprecate-published-metadata#REQ-5` → annotated
+  `lib/Db/MultiTenancyTrait.php::applyOrganisationFilter` docblock with
+  `@spec openspec/specs/deprecate-published-metadata/spec.md#REQ-5`.
+- [x] task-3 — `openregister-app-manifest#MAN-007` → annotated
+  `tests/validate-manifest.js` header comment with
+  `@spec openspec/changes/openregister-adopt-app-manifest/specs/openregister-app-manifest/spec.md#REQ-OR-MAN-007`.
+
+## No annotation (satisfied-by-absence)
+
+- [x] task-4 — `deprecate-published-metadata#REQ-2` — cleanup complete; no
+  `published`/`depublished` keys remain in the copy modals. Nothing to annotate.
+- [x] task-5 — `deprecate-published-metadata#REQ-4` — cleanup complete; the
+  auto-publish import toggle is gone. Nothing to annotate.
+
+## Gaps (MISSING — reported, not implemented)
+
+- [ ] task-6 — `openregister-app-manifest#MAN-002` — blocked on
+  `REQ-OR-MAN-001` (author `src/manifest.json`). No `dependencies: []` to assert
+  until the manifest exists.
+- [ ] task-7 — `openregister-app-manifest#MAN-008` — blocked on
+  `REQ-OR-MAN-001`/`REQ-OR-MAN-005`. No `version` field until the manifest exists.

--- a/tests/validate-manifest.js
+++ b/tests/validate-manifest.js
@@ -5,6 +5,13 @@
 // validate-manifest.js — schema-validates src/manifest.json against the
 // @conduction/nextcloud-vue app-manifest schema using Ajv.
 //
+// @spec openspec/changes/openregister-adopt-app-manifest/specs/openregister-app-manifest/spec.md#REQ-OR-MAN-007
+//   (Build gate validates the manifest — `npm run check:manifest` runs this CLI,
+//    is wired into CI via .github/workflows/spec-validation.yml → check:specs,
+//    Ajv-validates against the canonical schema, prints error paths, exits non-zero
+//    on schema violation. Cleanly skips with exit 0 when no src/manifest.json
+//    exists, since OpenRegister is the foundation app and ships no manifest yet.)
+//
 // Usage:
 //   node tests/validate-manifest.js
 //


### PR DESCRIPTION
## Summary

Annotations-only retrofit investigating 7 "Bucket 3a" REQs (specified in openspec, no annotated implementation found). Each was read against its spec, grepped, classified, and annotated where an implementation exists.

| REQ | Classification |
| --- | --- |
| `deprecate-published-metadata#REQ-2` (Copy Modal Cleanup) | SATISFIED-BY-ABSENCE |
| `deprecate-published-metadata#REQ-4` (Import UI Cleanup) | SATISFIED-BY-ABSENCE |
| `deprecate-published-metadata#REQ-5` (MultiTenancyTrait Docs) | IMPLEMENTED — annotated |
| `deprecate-published-metadata#REQ-6` (Deprecation Warnings) | IMPLEMENTED — annotated |
| `openregister-app-manifest#MAN-002` (zero deps) | MISSING |
| `openregister-app-manifest#MAN-007` (build gate) | IMPLEMENTED — annotated |
| `openregister-app-manifest#MAN-008` (version reflects tier) | MISSING |

**Totals:** 3 IMPLEMENTED / 0 PARTIAL / 2 MISSING / 2 SATISFIED-BY-ABSENCE.

### Annotations added (`@spec`)
- `lib/Service/Object/SaveObject/MetadataHydrationHandler.php` — REQ-6 deprecation warnings
- `lib/Db/MultiTenancyTrait.php` — REQ-5 Register/Schema-scoped published-bypass docs
- `tests/validate-manifest.js` — REQ-OR-MAN-007 build gate (wired into CI via `spec-validation.yml`)

### Gaps
- **MAN-002** and **MAN-008** are MISSING: `src/manifest.json` does not exist (the validator intentionally skips OR as the foundation app). Both are blocked on `REQ-OR-MAN-001` (author the manifest), part of the not-yet-landed `openregister-adopt-app-manifest` change.

No behavior changed. Ghost change: `openspec/changes/retrofit-2026-05-24-b3a-deprecate-manifest/`.

## Test plan
- [x] `php -l` clean on both touched PHP files
- [x] `node --check tests/validate-manifest.js` clean
- [x] `node tests/validate-manifest.js` exits 0 (skips cleanly, no manifest)