### PR TITLE
retrofit: Bucket 3a investigation — workflow/seed (5 REQs)

### DIFF
--- a/lib/BackgroundJob/DestructionExecutionJob.php
+++ b/lib/BackgroundJob/DestructionExecutionJob.php
@@ -82,6 +82,7 @@ class DestructionExecutionJob extends QueuedJob
      *
      * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-2
      * @spec openspec/changes/retrofit-2026-04-30-annotate-openregister/tasks.md#task-5
+     * @spec openspec/changes/retrofit-2026-05-24-b3a-workflow-seed/tasks.md#task-2
      */
     protected function run($argument): void
     {

--- a/lib/Controller/ApprovalController.php
+++ b/lib/Controller/ApprovalController.php
@@ -225,6 +225,7 @@ class ApprovalController extends Controller
      * @return JSONResponse
      *
      * @spec openspec/changes/retrofit-2026-05-01-approval-workflow/tasks.md#task-3
+     * @spec openspec/changes/retrofit-2026-05-24-b3a-workflow-seed/tasks.md#task-1
      */
     public function steps(): JSONResponse
     {

--- a/lib/Db/ApprovalStepMapper.php
+++ b/lib/Db/ApprovalStepMapper.php
@@ -148,6 +148,8 @@ class ApprovalStepMapper extends QBMapper
      * @param int|null             $offset  Pagination offset
      *
      * @return array<int, ApprovalStep>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b3a-workflow-seed/tasks.md#task-1
      */
     public function findAllFiltered(array $filters=[], ?int $limit=null, ?int $offset=null): array
     {

--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -3089,6 +3089,8 @@ class ImportHandler
      * @return void
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-openregister/tasks.md#task-28
+     * @spec openspec/changes/retrofit-2026-05-24-b3a-workflow-seed/tasks.md#task-3
+     * @spec openspec/changes/retrofit-2026-05-24-b3a-workflow-seed/tasks.md#task-5
      */
     private function importSeedData(
         array $configData,
@@ -3558,6 +3560,9 @@ class ImportHandler
      * @return void
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-openregister/tasks.md#task-29
+     * @spec openspec/changes/retrofit-2026-05-24-b3a-workflow-seed/tasks.md#task-3
+     * @spec openspec/changes/retrofit-2026-05-24-b3a-workflow-seed/tasks.md#task-4
+     * @spec openspec/changes/retrofit-2026-05-24-b3a-workflow-seed/tasks.md#task-5
      */
     private function processRelatedItems(
         ObjectEntity $object,

--- a/lib/Service/RetentionService.php
+++ b/lib/Service/RetentionService.php
@@ -794,6 +794,7 @@ class RetentionService
      *
      * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-62
      * @spec openspec/changes/retrofit-2026-04-30-annotate-openregister/tasks.md#task-67
+     * @spec openspec/changes/retrofit-2026-05-24-b3a-workflow-seed/tasks.md#task-2
      */
     public function generateDestructionCertificate(
         array $destructionList,

--- a/openspec/changes/retrofit-2026-05-24-b3a-workflow-seed/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-b3a-workflow-seed/proposal.md
@@ -1,0 +1,40 @@
+# Retrofit: Bucket 3a investigation — workflow/seed (5 REQs)
+
+## Why
+
+The coverage scanner flagged 5 requirements as "specified but with no annotated
+implementation" — for each, the only evidence the scanner matched came from a
+removed-lines cache (deleted diff hunks), not from live, annotated code. This
+change records the investigation of those 5 REQs and adds the missing `@spec`
+annotations where the behaviour was found to be implemented.
+
+**Root cause (all 5 REQs):** the behaviour is fully implemented and the code
+already carried `@spec` tags — but those tags pointed at *other* requirements
+(or at archived change paths whose `tasks.md` the scanner could no longer
+resolve), so the specific REQ under investigation had no annotation matching it.
+None of the 5 REQs is missing. No new behaviour was implemented; only
+annotations were added.
+
+## Classification
+
+| REQ | Title | Classification | Implementation | Evidence |
+|-----|-------|----------------|----------------|----------|
+| `approval-workflow#REQ-003` | List and filter approval steps | **IMPLEMENTED** | `ApprovalController::steps()` + `ApprovalStepMapper::findAllFiltered()` | Reads `status`/`role`/`chainId`/`objectUuid` query params, applies each only when present, delegates to `findAllFiltered($filters)`. Was annotated against an *archived* change path (`retrofit-2026-05-01-approval-workflow/tasks.md#task-3`), which the scanner could not resolve. |
+| `archival-destruction-workflow#REQ-005` | Destruction Certificate Generation | **IMPLEMENTED** | `RetentionService::generateDestructionCertificate()` + `DestructionExecutionJob::run()` | Produces a `verklaring_van_vernietiging` with destruction date, approving archivist(s), counts grouped by schema/classificatie, selectielijst bron, `Archiefwet 1995` compliance statement, and `immutable: true`. The job persists it as a register object via `saveObject(...)` and tracks `skippedHolds`/`skippedErrors` for the partial-completion scenario. Existing tags pointed at REQ-009-era archived tasks, not REQ-005. |
+| `seed-related-items#REQ-03` | Process Related Items After Object Creation | **IMPLEMENTED** | `ImportHandler::importSeedData()` → `processRelatedItems()` | `processRelatedItems(...)` is invoked only inside the per-object `try` block *after* `$createdObject` is saved; if creation throws, the `catch` skips related items for that object. Method carried tags only for REQ-01/REQ-06. |
+| `seed-related-items#REQ-04` | Note Seeding | **IMPLEMENTED** | `ImportHandler::processRelatedItems()` | Iterates `_relatedItems.notes`, requires `message`, calls `NoteService::createNote($objectUuid, $message)` per note under the active user context. |
+| `seed-related-items#REQ-10` | Logging | **IMPLEMENTED** | `ImportHandler::processRelatedItems()` + `importSeedData()` | INFO at start of per-object processing (per-type counts); DEBUG after processing (per-type created counts); WARNING on each failed item (type + error); INFO summary at end of seed import (`related_files`/`related_notes`/`related_tasks`). |
+
+## What Changes
+
+Annotation-only. No spec deltas (the specs already exist). `@spec` tags added:
+
+- `lib/Controller/ApprovalController.php` — `steps()` → REQ-003
+- `lib/Db/ApprovalStepMapper.php` — `findAllFiltered()` → REQ-003
+- `lib/Service/RetentionService.php` — `generateDestructionCertificate()` → REQ-005
+- `lib/BackgroundJob/DestructionExecutionJob.php` — `run()` → REQ-005 (cert persistence)
+- `lib/Service/Configuration/ImportHandler.php` — `processRelatedItems()` → REQ-03, REQ-04, REQ-10; `importSeedData()` → REQ-03, REQ-10
+
+## Issues to File
+
+None. All 5 REQs are implemented; no missing/removed behaviour was found.

--- a/openspec/changes/retrofit-2026-05-24-b3a-workflow-seed/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-b3a-workflow-seed/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: Bucket 3a investigation — workflow/seed (5 REQs)
+
+Retroactive annotations. Each task records the canonical spec requirement and
+the code that implements it.
+
+- [x] task-1: approval-workflow#REQ-003 — List and filter approval steps (retroactive annotation)
+      `lib/Controller/ApprovalController.php::steps()`, `lib/Db/ApprovalStepMapper.php::findAllFiltered()`
+- [x] task-2: archival-destruction-workflow#REQ-005 — Destruction Certificate Generation (retroactive annotation)
+      `lib/Service/RetentionService.php::generateDestructionCertificate()`, `lib/BackgroundJob/DestructionExecutionJob.php::run()`
+- [x] task-3: seed-related-items#REQ-03 — Process Related Items After Object Creation (retroactive annotation)
+      `lib/Service/Configuration/ImportHandler.php::importSeedData()`, `::processRelatedItems()`
+- [x] task-4: seed-related-items#REQ-04 — Note Seeding (retroactive annotation)
+      `lib/Service/Configuration/ImportHandler.php::processRelatedItems()`
+- [x] task-5: seed-related-items#REQ-10 — Logging (retroactive annotation)
+      `lib/Service/Configuration/ImportHandler.php::importSeedData()`, `::processRelatedItems()`


### PR DESCRIPTION
## Summary

Bucket 3a coverage-scanner investigation: 5 REQs the scanner flagged as "specified but no annotated implementation" (evidence matched only a removed-lines cache). Investigated each in live code and classified.

**Result: all 5 IMPLEMENTED.** Each already carried `@spec` tags, but they pointed at *other* REQs or at *archived* change paths the scanner could not resolve — so the specific REQ had no matching annotation. Added the missing annotations. No behaviour implemented, no spec deltas, no issues to file.

| REQ | Classification | Implementation |
|-----|----------------|----------------|
| `approval-workflow#REQ-003` — List/filter approval steps | IMPLEMENTED | `ApprovalController::steps()` + `ApprovalStepMapper::findAllFiltered()` |
| `archival-destruction-workflow#REQ-005` — Destruction Certificate Generation | IMPLEMENTED | `RetentionService::generateDestructionCertificate()` + `DestructionExecutionJob::run()` (persists immutable cert) |
| `seed-related-items#REQ-03` — Process Related Items After Object Creation | IMPLEMENTED | `ImportHandler::importSeedData()` → `processRelatedItems()` (called after save, skipped on failure) |
| `seed-related-items#REQ-04` — Note Seeding | IMPLEMENTED | `ImportHandler::processRelatedItems()` (`NoteService::createNote`) |
| `seed-related-items#REQ-10` — Logging | IMPLEMENTED | `ImportHandler::processRelatedItems()` + `importSeedData()` (INFO/DEBUG/WARNING + end summary) |

Ghost change: `openspec/changes/retrofit-2026-05-24-b3a-workflow-seed/` (proposal.md classification table + tasks.md).

## Test plan

- [x] `php -l` passes on all 5 touched files
- [ ] CI quality gates (phpcs/psalm/phpstan) green
- Annotation-only change; no runtime behaviour modified