### PR TITLE
feat(analytics): Tier-2 — link table + report picker + create

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -411,6 +411,18 @@ return [
         ['name' => 'photoLinks#link',         'url' => '/api/objects/{register}/{schema}/{id}/photos',         'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
         ['name' => 'photoLinks#destroy',      'url' => '/api/objects/{register}/{schema}/{id}/photos/{albumId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'albumId' => '[0-9]+']],
 
+        // Analytics (NC Analytics) — Tier-2 link-table API. User-scoped
+        // (no admin gate). The specific `/analytics/new` (create + link)
+        // route MUST precede the wildcard `/analytics/{reportId}` unlink
+        // route, and the app-global `available` picker route MUST precede
+        // the per-object wildcard routes.
+        // @spec openspec/changes/integration-analytics/tasks.md.
+        ['name' => 'analyticsLinks#available',    'url' => '/api/integrations/analytics/available',                  'verb' => 'GET'],
+        ['name' => 'analyticsLinks#index',        'url' => '/api/objects/{register}/{schema}/{id}/analytics',        'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
+        ['name' => 'analyticsLinks#createAndLink','url' => '/api/objects/{register}/{schema}/{id}/analytics/new',    'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'analyticsLinks#link',         'url' => '/api/objects/{register}/{schema}/{id}/analytics',        'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'analyticsLinks#destroy',      'url' => '/api/objects/{register}/{schema}/{id}/analytics/{reportId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'reportId' => '[0-9]+']],
+
         // Activity — Tier-2 read-only API. NC Activity entries are
         // core-generated (no link/create/delete verbs); this surface
         // only filters + cursor-paginates the entries linked to an OR

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1141,8 +1141,8 @@ class Application extends App implements IBootstrap
         $greenfieldProviders = [
             // @spec openspec/changes/integration-activity/tasks.md.
             \OCA\OpenRegister\Service\Integration\Providers\ActivityProvider::class,
-            // @spec openspec/changes/integration-analytics/tasks.md.
-            \OCA\OpenRegister\Service\Integration\Providers\AnalyticsProvider::class,
+            // NB: AnalyticsProvider was Tier-1 greenfield until Tier-2; it
+            // now takes an AnalyticsLinkMapper. Registered separately below.
             // @spec openspec/changes/integration-collectives/tasks.md.
             \OCA\OpenRegister\Service\Integration\Providers\CollectivesProvider::class,
             // @spec openspec/changes/integration-cospend/tasks.md.
@@ -1380,6 +1380,42 @@ class Application extends App implements IBootstrap
                     appManager: $container->get('OCP\App\IAppManager'),
                     userSession: $container->get('OCP\IUserSession'),
                     urlGenerator: $container->get('OCP\IURLGenerator'),
+                    logger: $container->get('Psr\Log\LoggerInterface'),
+                );
+            }
+        );
+
+        // AnalyticsProvider — Tier-2: backed by the AnalyticsLinkMapper.
+        // The provider still gracefully degrades to the legacy
+        // `[or:{uuid}]` report-name marker scan when the link table is
+        // empty (reports that pre-date the Tier-2 link table; wave-2.2
+        // marker-on-name convention).
+        // @spec openspec/changes/integration-analytics/tasks.md.
+        $context->registerService(
+            \OCA\OpenRegister\Service\Integration\Providers\AnalyticsProvider::class,
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\Service\Integration\Providers\AnalyticsProvider(
+                    db: $container->get('OCP\IDBConnection'),
+                    appManager: $container->get('OCP\App\IAppManager'),
+                    l10n: $container->get('OCP\IL10N'),
+                    analyticsLinkMapper: $container->get(\OCA\OpenRegister\Db\AnalyticsLinkMapper::class),
+                );
+            }
+        );
+
+        // AnalyticsLinkService — Tier-2 link/create/unlink/picker service
+        // backing the AnalyticsLinksController. NC Analytics reports are
+        // user-scoped; the ReportService is resolved lazily via
+        // `\OCP\Server::get()` behind a class_exists guard so the service
+        // loads even when Analytics is absent.
+        // @spec openspec/changes/integration-analytics/tasks.md.
+        $context->registerService(
+            \OCA\OpenRegister\Service\AnalyticsLinkService::class,
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\Service\AnalyticsLinkService(
+                    analyticsLinkMapper: $container->get(\OCA\OpenRegister\Db\AnalyticsLinkMapper::class),
+                    appManager: $container->get('OCP\App\IAppManager'),
+                    userSession: $container->get('OCP\IUserSession'),
                     logger: $container->get('Psr\Log\LoggerInterface'),
                 );
             }

--- a/lib/Controller/AnalyticsLinksController.php
+++ b/lib/Controller/AnalyticsLinksController.php
@@ -1,0 +1,323 @@
+<?php
+
+/**
+ * AnalyticsLinksController — Tier-2 REST controller for NC Analytics
+ * report links.
+ *
+ * Surface:
+ *
+ *   - GET    /api/objects/{r}/{s}/{id}/analytics              — list linked reports
+ *   - POST   /api/objects/{r}/{s}/{id}/analytics              — link existing report `{reportId}`
+ *   - POST   /api/objects/{r}/{s}/{id}/analytics/new          — create + link report `{name,type?}`
+ *   - DELETE /api/objects/{r}/{s}/{id}/analytics/{reportId}   — unlink report
+ *   - GET    /api/integrations/analytics/available?search=    — picker source
+ *
+ * NC Analytics reports are user-scoped, so (unlike Flow) there is no
+ * admin gate — the active session's user owns the reports it can
+ * link/create.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use Exception;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\AnalyticsLinkService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Tier-2 Analytics links controller.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ */
+class AnalyticsLinksController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param string               $appName              App id.
+     * @param IRequest             $request              HTTP request.
+     * @param AnalyticsLinkService $analyticsLinkService Backing service.
+     * @param ObjectService        $objectService        OR object resolver.
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly AnalyticsLinkService $analyticsLinkService,
+        private readonly ObjectService $objectService,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * List linked Analytics reports for an object.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function index(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->analyticsLinkService->isAnalyticsAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Analytics app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $results = $this->analyticsLinkService->getLinkedReports($object->getUuid());
+
+            return new JSONResponse(
+                    [
+                        'results' => $results,
+                        'total'   => count($results),
+                    ]
+                    );
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return new JSONResponse(['error' => $e->getMessage()], 500);
+        }//end try
+    }//end index()
+
+    /**
+     * Link an existing Analytics report.
+     *
+     * Body: `{ reportId: int }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function link(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->analyticsLinkService->isAnalyticsAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Analytics app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $reportId = (int) $this->request->getParam('reportId', 0);
+            if ($reportId === 0) {
+                return new JSONResponse(['error' => 'reportId is required'], 400);
+            }
+
+            $link = $this->analyticsLinkService->linkReport(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $reportId
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end link()
+
+    /**
+     * Create a new Analytics report and link it.
+     *
+     * Body: `{ name: string, type?: int }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function createAndLink(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->analyticsLinkService->isAnalyticsAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Analytics app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $name = (string) $this->request->getParam('name', '');
+            if (trim($name) === '') {
+                return new JSONResponse(['error' => 'name is required'], 400);
+            }
+
+            $type    = $this->request->getParam('type');
+            $typeInt = ($type === null || $type === '') ? null : (int) $type;
+
+            $link = $this->analyticsLinkService->createAndLinkReport(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $name,
+                $typeInt
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end createAndLink()
+
+    /**
+     * Unlink an Analytics report.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     * @param string $reportId Report id (numeric).
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function destroy(string $register, string $schema, string $id, string $reportId): JSONResponse
+    {
+        if ($this->analyticsLinkService->isAnalyticsAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Analytics app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $this->analyticsLinkService->unlinkReport($object->getUuid(), (int) $reportId);
+
+            return new JSONResponse(['success' => true]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end destroy()
+
+    /**
+     * List the current user's Analytics reports (picker source).
+     *
+     * Query param: `search` — optional name substring.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function available(): JSONResponse
+    {
+        if ($this->analyticsLinkService->isAnalyticsAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Analytics app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        $search = $this->request->getParam('search');
+        if ($search !== null) {
+            $search = (string) $search;
+        }
+
+        $reports = $this->analyticsLinkService->getAvailableReports($search);
+        return new JSONResponse(['results' => $reports, 'total' => count($reports)]);
+    }//end available()
+
+    /**
+     * Resolve an OR object from register/schema/id.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return ObjectEntity|null
+     */
+    private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
+    {
+        $this->objectService->setSchema($schema);
+        $this->objectService->setRegister($register);
+        $this->objectService->setObject($id);
+
+        return $this->objectService->getObject();
+    }//end validateObject()
+
+    /**
+     * Map a service-layer Exception to a JSONResponse.
+     *
+     * Exception codes carry HTTP intent:
+     *   - 400 → bad request
+     *   - 401 → unauthorized (no user)
+     *   - 404 → not found
+     *   - 409 → conflict (duplicate link)
+     *   - 503 → service unavailable
+     *   - everything else → 400 bad request
+     *
+     * @param Exception $exception Source exception.
+     *
+     * @return JSONResponse
+     */
+    private function mapException(Exception $exception): JSONResponse
+    {
+        $code = $exception->getCode();
+        if (in_array($code, [400, 401, 404, 409, 503], true) === true) {
+            return new JSONResponse(['error' => $exception->getMessage()], $code);
+        }
+
+        return new JSONResponse(['error' => $exception->getMessage()], 400);
+    }//end mapException()
+}//end class

--- a/lib/Db/AnalyticsLink.php
+++ b/lib/Db/AnalyticsLink.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * AnalyticsLink entity for linking NC Analytics reports to OpenRegister
+ * objects.
+ *
+ * Tier-2 schema: carries register_id, schema_id, report_title,
+ * report_type, subheader, created_at and modified_at so the link row
+ * alone can hydrate the sidebar tab + picker UX without a per-report
+ * roundtrip to NC Analytics. Replaces the Tier-1 `AnalyticsProvider`'s
+ * `[or:{uuid}]` report-name marker convention with a proper persistence
+ * layer that survives report renames.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Class AnalyticsLink
+ *
+ * @method string getObjectUuid()
+ * @method void setObjectUuid(string $objectUuid)
+ * @method int getRegisterId()
+ * @method void setRegisterId(int $registerId)
+ * @method int|null getSchemaId()
+ * @method void setSchemaId(?int $schemaId)
+ * @method int getReportId()
+ * @method void setReportId(int $reportId)
+ * @method string getReportTitle()
+ * @method void setReportTitle(string $reportTitle)
+ * @method string|null getReportType()
+ * @method void setReportType(?string $reportType)
+ * @method string|null getSubheader()
+ * @method void setSubheader(?string $subheader)
+ * @method DateTime|null getCreatedAt()
+ * @method void setCreatedAt(?DateTime $createdAt)
+ * @method DateTime|null getModifiedAt()
+ * @method void setModifiedAt(?DateTime $modifiedAt)
+ * @method string|null getLinkedBy()
+ * @method void setLinkedBy(string $linkedBy)
+ * @method DateTime|null getLinkedAt()
+ * @method void setLinkedAt(DateTime $linkedAt)
+ *
+ * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class
+ */
+class AnalyticsLink extends Entity implements JsonSerializable
+{
+
+    /**
+     * The object uuid.
+     *
+     * @var string|null
+     */
+    protected ?string $objectUuid = null;
+
+    /**
+     * The register id.
+     *
+     * @var integer|null
+     */
+    protected ?int $registerId = null;
+
+    /**
+     * The schema id.
+     *
+     * @var integer|null
+     */
+    protected ?int $schemaId = null;
+
+    /**
+     * The NC Analytics report id (primary key in `analytics_report`).
+     *
+     * @var integer|null
+     */
+    protected ?int $reportId = null;
+
+    /**
+     * The report display name (cached at link time).
+     *
+     * @var string|null
+     */
+    protected ?string $reportTitle = null;
+
+    /**
+     * The report type / datasource type (cached at link time).
+     *
+     * @var string|null
+     */
+    protected ?string $reportType = null;
+
+    /**
+     * The report subheader (cached at link time).
+     *
+     * @var string|null
+     */
+    protected ?string $subheader = null;
+
+    /**
+     * The cached report created timestamp.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $createdAt = null;
+
+    /**
+     * The cached report modified timestamp.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $modifiedAt = null;
+
+    /**
+     * The linked by uid.
+     *
+     * @var string|null
+     */
+    protected ?string $linkedBy = null;
+
+    /**
+     * The linked at timestamp.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $linkedAt = null;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->addType(fieldName: 'objectUuid', type: 'string');
+        $this->addType(fieldName: 'registerId', type: 'integer');
+        $this->addType(fieldName: 'schemaId', type: 'integer');
+        $this->addType(fieldName: 'reportId', type: 'integer');
+        $this->addType(fieldName: 'reportTitle', type: 'string');
+        $this->addType(fieldName: 'reportType', type: 'string');
+        $this->addType(fieldName: 'subheader', type: 'string');
+        $this->addType(fieldName: 'createdAt', type: 'datetime');
+        $this->addType(fieldName: 'modifiedAt', type: 'datetime');
+        $this->addType(fieldName: 'linkedBy', type: 'string');
+        $this->addType(fieldName: 'linkedAt', type: 'datetime');
+    }//end __construct()
+
+    /**
+     * JSON serialization.
+     *
+     * @return array<string,mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'          => $this->id,
+            'objectUuid'  => $this->objectUuid,
+            'registerId'  => $this->registerId,
+            'schemaId'    => $this->schemaId,
+            'reportId'    => $this->reportId,
+            'reportTitle' => $this->reportTitle,
+            'reportType'  => $this->reportType,
+            'subheader'   => $this->subheader,
+            'createdAt'   => $this->createdAt?->format(DateTime::ATOM),
+            'modifiedAt'  => $this->modifiedAt?->format(DateTime::ATOM),
+            'linkedBy'    => $this->linkedBy,
+            'linkedAt'    => $this->linkedAt?->format(DateTime::ATOM),
+        ];
+    }//end jsonSerialize()
+}//end class

--- a/lib/Db/AnalyticsLinkMapper.php
+++ b/lib/Db/AnalyticsLinkMapper.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * Mapper for analytics link entities.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Class AnalyticsLinkMapper
+ *
+ * @template-extends QBMapper<AnalyticsLink>
+ */
+class AnalyticsLinkMapper extends QBMapper
+{
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $db Database connection.
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(db: $db, tableName: 'openregister_analytics_links', entityClass: AnalyticsLink::class);
+    }//end __construct()
+
+    /**
+     * Find analytics links by object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return AnalyticsLink[] Array of analytics links.
+     */
+    public function findByObjectUuid(string $objectUuid): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByObjectUuid()
+
+    /**
+     * Find analytics links by report id.
+     *
+     * @param int $reportId The report id.
+     *
+     * @return AnalyticsLink[] Array of analytics links.
+     */
+    public function findByReportId(int $reportId): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('report_id', $qb->createNamedParameter($reportId, IQueryBuilder::PARAM_INT)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByReportId()
+
+    /**
+     * Find a specific analytics link by object UUID and report id.
+     *
+     * @param string $objectUuid The object UUID.
+     * @param int    $reportId   The report id.
+     *
+     * @return AnalyticsLink|null The link or null if not found.
+     */
+    public function findByObjectAndReport(string $objectUuid, int $reportId): ?AnalyticsLink
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('report_id', $qb->createNamedParameter($reportId, IQueryBuilder::PARAM_INT)));
+
+        try {
+            return $this->findEntity(query: $qb);
+        } catch (DoesNotExistException $e) {
+            return null;
+        }
+    }//end findByObjectAndReport()
+
+    /**
+     * Delete all analytics links for an object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectUuid(string $objectUuid): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectUuid()
+
+    /**
+     * Delete an analytics link by object UUID + report id (Tier-2 unlink
+     * path).
+     *
+     * Returns the number of rows actually deleted so callers can
+     * distinguish "no such link" (0) from "ok" (>=1).
+     *
+     * @param string $objectUuid The object UUID.
+     * @param int    $reportId   The report id.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectAndReport(string $objectUuid, int $reportId): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('report_id', $qb->createNamedParameter($reportId, IQueryBuilder::PARAM_INT)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectAndReport()
+}//end class

--- a/lib/Migration/Version1Date20260525180000.php
+++ b/lib/Migration/Version1Date20260525180000.php
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * Tier-2 analytics (NC Analytics) integration migration.
+ *
+ * Ensures the `openregister_analytics_links` table exists with the full
+ * Tier-2 schema:
+ *
+ *  - id (bigint, PK, autoincrement)
+ *  - object_uuid (string 36, not null, indexed)
+ *  - register_id (bigint unsigned, not null, indexed)
+ *  - schema_id (bigint unsigned, nullable, indexed)
+ *  - report_id (integer, not null) — `analytics_report` row id
+ *  - report_title (string 255, not null) — cached report name
+ *  - report_type (string 64, nullable) — cached report type/datasource
+ *  - subheader (string 255, nullable) — cached report subheader
+ *  - created_at (datetime, nullable) — cached report created timestamp
+ *  - modified_at (datetime, nullable) — cached report modified timestamp
+ *  - linked_by (string 64, not null)
+ *  - linked_at (datetime, not null)
+ *
+ * Idempotent: creates the table if missing, otherwise adds any missing
+ * Tier-2 columns. Companion to the Tier-2 talk/polls/email/forms/deck/flow/
+ * photos link tables; the wrapping `AnalyticsLinkService` replaces the
+ * `[or:{uuid}]` report-name marker convention used by the Tier-1
+ * `AnalyticsProvider` with a proper persistence layer so links survive
+ * report renames.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Tier-2 analytics-links table — create-or-extend.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+class Version1Date20260525180000 extends SimpleMigrationStep
+{
+    /**
+     * Change the database schema.
+     *
+     * @param IOutput                 $output        Output for the migration process
+     * @param Closure                 $schemaClosure The schema closure
+     * @param array<array-key, mixed> $options       Migration options
+     *
+     * @return ISchemaWrapper|null
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema  = $schemaClosure();
+        $changed = false;
+
+        if ($schema->hasTable('openregister_analytics_links') === false) {
+            $this->createAnalyticsLinksTable(schema: $schema, output: $output);
+            $changed = true;
+        }
+
+        if ($schema->hasTable('openregister_analytics_links') === true
+            && $this->extendAnalyticsLinksTable(schema: $schema, output: $output) === true
+        ) {
+            $changed = true;
+        }
+
+        if ($changed === false) {
+            return null;
+        }
+
+        return $schema;
+    }//end changeSchema()
+
+    /**
+     * Create the openregister_analytics_links table at the Tier-2 shape.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return void
+     */
+    private function createAnalyticsLinksTable(ISchemaWrapper $schema, IOutput $output): void
+    {
+        $table = $schema->createTable('openregister_analytics_links');
+
+        $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'unsigned' => true]);
+        $table->addColumn('object_uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
+        $table->addColumn('register_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('schema_id', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]);
+        $table->addColumn('report_id', Types::INTEGER, ['notnull' => true]);
+        $table->addColumn('report_title', Types::STRING, ['notnull' => true, 'length' => 255]);
+        $table->addColumn('report_type', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+        $table->addColumn('subheader', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+        $table->addColumn('created_at', Types::DATETIME, ['notnull' => false, 'default' => null]);
+        $table->addColumn('modified_at', Types::DATETIME, ['notnull' => false, 'default' => null]);
+        $table->addColumn('linked_by', Types::STRING, ['notnull' => true, 'length' => 64]);
+        $table->addColumn('linked_at', Types::DATETIME, ['notnull' => true]);
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['object_uuid', 'report_id'], 'idx_analytics_object_report');
+        $table->addIndex(['object_uuid'], 'idx_analytics_object');
+        $table->addIndex(['register_id'], 'idx_analytics_register');
+        $table->addIndex(['schema_id'], 'idx_analytics_schema');
+
+        $output->info('Created openregister_analytics_links table (Tier-2 schema)');
+    }//end createAnalyticsLinksTable()
+
+    /**
+     * Add any missing Tier-2 columns to an existing analytics_links table.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return bool True when a column was added.
+     */
+    private function extendAnalyticsLinksTable(ISchemaWrapper $schema, IOutput $output): bool
+    {
+        $table   = $schema->getTable('openregister_analytics_links');
+        $changed = false;
+
+        if ($table->hasColumn('schema_id') === false) {
+            $table->addColumn(
+                'schema_id',
+                Types::BIGINT,
+                ['notnull' => false, 'unsigned' => true, 'default' => null]
+            );
+            $table->addIndex(['schema_id'], 'idx_analytics_schema');
+            $output->info('Added schema_id column to openregister_analytics_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('report_type') === false) {
+            $table->addColumn('report_type', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+            $output->info('Added report_type column to openregister_analytics_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('subheader') === false) {
+            $table->addColumn('subheader', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+            $output->info('Added subheader column to openregister_analytics_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('created_at') === false) {
+            $table->addColumn('created_at', Types::DATETIME, ['notnull' => false, 'default' => null]);
+            $output->info('Added created_at column to openregister_analytics_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('modified_at') === false) {
+            $table->addColumn('modified_at', Types::DATETIME, ['notnull' => false, 'default' => null]);
+            $output->info('Added modified_at column to openregister_analytics_links');
+            $changed = true;
+        }
+
+        return $changed;
+    }//end extendAnalyticsLinksTable()
+}//end class

--- a/lib/Service/AnalyticsLinkService.php
+++ b/lib/Service/AnalyticsLinkService.php
@@ -1,0 +1,599 @@
+<?php
+
+/**
+ * AnalyticsLinkService — Tier-2 analytics (NC Analytics) integration
+ * service.
+ *
+ * Composes the {@see \OCA\OpenRegister\Db\AnalyticsLinkMapper} with NC
+ * Analytics' own `OCA\Analytics\Service\ReportService` (lazy-resolved via
+ * `\OCP\Server::get()` behind a `class_exists` guard so OR boots cleanly
+ * when Analytics is not installed) to expose the Tier-2 surface:
+ *
+ *   - linkReport(uuid, registerId, schemaId, reportId)
+ *       — link an existing report
+ *   - createAndLinkReport(uuid, registerId, schemaId, name, type)
+ *       — create a new NC Analytics report and link it
+ *   - unlinkReport(uuid, reportId)
+ *       — remove a link (the report itself stays in NC Analytics)
+ *   - getLinkedReports(uuid)
+ *       — list linked reports, refreshing cached title/type/subheader/
+ *       modified when the row is older than 24h
+ *   - getAvailableReports(?search)
+ *       — picker source listing the current user's reports
+ *
+ * Replaces the Tier-1 `AnalyticsProvider`'s `[or:{uuid}]` report-name
+ * marker convention with a proper persistence layer so links survive
+ * report renames + don't pollute the report title. When Analytics is
+ * unavailable, the cached link-row values are returned unchanged so
+ * historical references survive even after Analytics is uninstalled
+ * (ADR-019 AD-23 graceful degradation).
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://OpenRegister.app
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use DateTime;
+use Exception;
+use OCA\OpenRegister\Db\AnalyticsLink;
+use OCA\OpenRegister\Db\AnalyticsLinkMapper;
+use OCP\App\IAppManager;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * AnalyticsLinkService.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)   Composes mapper +
+ *     IAppManager + IUserSession + logger + the lazily-resolved NC
+ *     Analytics ReportService. Each dependency is required for one of the
+ *     Tier-2 flows (link, create, unlink, list, picker, cache refresh,
+ *     graceful degradation).
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) The create+link path
+ *     and cache-refresh hydration inflate the count; re-implementing NC
+ *     Analytics' write path would be worse.
+ * @SuppressWarnings(PHPMD.StaticAccess)             `\OCP\Server::get()`
+ *     is the documented way to late-resolve an optional peer app's
+ *     services behind a class_exists guard (ADR-019).
+ * @SuppressWarnings(PHPMD.MissingImport)            NC Analytics classes
+ *     are referenced FQN-only on purpose — importing them would break
+ *     autoloading when Analytics is not installed.
+ */
+class AnalyticsLinkService
+{
+    /**
+     * NC Analytics app id.
+     *
+     * @var string
+     */
+    private const REQUIRED_APP = 'analytics';
+
+    /**
+     * NC Analytics ReportService FQCN (late-bound).
+     *
+     * @var string
+     */
+    private const REPORT_SERVICE = '\OCA\Analytics\Service\ReportService';
+
+    /**
+     * Cache-refresh staleness threshold in seconds (24h).
+     *
+     * @var int
+     */
+    private const CACHE_TTL = 86400;
+
+    /**
+     * NC Analytics group/folder report type (DATASET_TYPE_GROUP = 0).
+     *
+     * @var int
+     */
+    private const REPORT_TYPE_GROUP = 0;
+
+    /**
+     * Constructor.
+     *
+     * @param AnalyticsLinkMapper $analyticsLinkMapper Persistence for link rows.
+     * @param IAppManager         $appManager          NC app manager.
+     * @param IUserSession        $userSession         Active session.
+     * @param LoggerInterface     $logger              Logger.
+     */
+    public function __construct(
+        private readonly AnalyticsLinkMapper $analyticsLinkMapper,
+        private readonly IAppManager $appManager,
+        private readonly IUserSession $userSession,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Whether NC Analytics is installed + enabled for the current user.
+     *
+     * @return bool
+     */
+    public function isAnalyticsAvailable(): bool
+    {
+        return $this->appManager->isEnabledForUser(self::REQUIRED_APP);
+    }//end isAnalyticsAvailable()
+
+    /**
+     * Active session UID, or throw if no user is logged in.
+     *
+     * @return string The user id.
+     *
+     * @throws Exception When there is no active user.
+     */
+    private function requireUid(): string
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in', 401);
+        }
+
+        return $user->getUID();
+    }//end requireUid()
+
+    /**
+     * Lazily resolve NC Analytics' ReportService behind a class_exists
+     * guard so OR boots cleanly without the Analytics app.
+     *
+     * Returns null when Analytics is absent or the class can't be
+     * resolved, so callers degrade gracefully (ADR-019 AD-23).
+     *
+     * @return object|null The ReportService instance or null.
+     */
+    private function resolveReportService(): ?object
+    {
+        if ($this->isAnalyticsAvailable() === false) {
+            return null;
+        }
+
+        if (class_exists(self::REPORT_SERVICE) === false) {
+            return null;
+        }
+
+        try {
+            return \OCP\Server::get(self::REPORT_SERVICE);
+        } catch (Throwable $e) {
+            $this->logger->debug('AnalyticsLinkService: ReportService unavailable: '.$e->getMessage());
+            return null;
+        }
+    }//end resolveReportService()
+
+    /**
+     * Link an existing NC Analytics report to an OR object.
+     *
+     * Idempotent: a duplicate link raises a 409 Exception. Report
+     * metadata (title/type/subheader/created/modified) is cached at link
+     * time.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $registerId OR register id.
+     * @param int    $schemaId   OR schema id.
+     * @param int    $reportId   NC Analytics report id.
+     *
+     * @return AnalyticsLink The persisted link row.
+     *
+     * @throws Exception On missing user (401), missing report (404),
+     *                   duplicate (409), Analytics unavailable (503).
+     */
+    public function linkReport(string $objectUuid, int $registerId, int $schemaId, int $reportId): AnalyticsLink
+    {
+        $uid = $this->requireUid();
+
+        if ($this->isAnalyticsAvailable() === false) {
+            throw new Exception('NC Analytics is not available', 503);
+        }
+
+        $existing = $this->analyticsLinkMapper->findByObjectAndReport($objectUuid, $reportId);
+        if ($existing !== null) {
+            throw new Exception('Report already linked to this object', 409);
+        }
+
+        $info = $this->fetchReportInfo(reportId: $reportId);
+        if ($info === null) {
+            throw new Exception('Analytics report not found', 404);
+        }
+
+        $link = $this->buildLink(
+            objectUuid: $objectUuid,
+            registerId: $registerId,
+            schemaId: $schemaId,
+            reportId: $reportId,
+            info: $info,
+            uid: $uid,
+        );
+
+        return $this->analyticsLinkMapper->insert($link);
+    }//end linkReport()
+
+    /**
+     * Create a new NC Analytics report and link it to an OR object.
+     *
+     * The new report is a blank group/folder report by default; callers
+     * may pass a different NC Analytics datasource type integer via
+     * `$type`.
+     *
+     * @param string   $objectUuid Parent OR object uuid.
+     * @param int      $registerId OR register id.
+     * @param int      $schemaId   OR schema id.
+     * @param string   $name       New report name.
+     * @param int|null $type       NC Analytics datasource type (default group).
+     *
+     * @return AnalyticsLink The persisted link row.
+     *
+     * @throws Exception On missing user (401), empty name (400),
+     *                   Analytics unavailable (503), create failure (500).
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
+    public function createAndLinkReport(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        string $name,
+        ?int $type=null
+    ): AnalyticsLink {
+        $uid = $this->requireUid();
+
+        $name = trim($name);
+        if ($name === '') {
+            throw new Exception('Report name is required', 400);
+        }
+
+        $service = $this->resolveReportService();
+        if ($service === null) {
+            throw new Exception('NC Analytics is not available', 503);
+        }
+
+        $reportType = ($type ?? self::REPORT_TYPE_GROUP);
+
+        try {
+            $reportId = (int) $service->create(
+                $name,
+                '',
+                0,
+                $reportType,
+                0,
+                '',
+                '',
+                '',
+                '',
+                '',
+                ''
+            );
+        } catch (Throwable $e) {
+            $this->logger->warning('AnalyticsLinkService::createAndLinkReport failed: '.$e->getMessage());
+            throw new Exception('Failed to create Analytics report', 500);
+        }
+
+        if ($reportId === 0) {
+            throw new Exception('Failed to create Analytics report', 500);
+        }
+
+        $info = $this->fetchReportInfo(reportId: $reportId);
+
+        $link = $this->buildLink(
+            objectUuid: $objectUuid,
+            registerId: $registerId,
+            schemaId: $schemaId,
+            reportId: $reportId,
+            info: ($info ?? [
+                'title'      => $name,
+                'type'       => (string) $reportType,
+                'subheader'  => null,
+                'createdAt'  => new DateTime(),
+                'modifiedAt' => new DateTime(),
+            ]),
+            uid: $uid,
+        );
+
+        return $this->analyticsLinkMapper->insert($link);
+    }//end createAndLinkReport()
+
+    /**
+     * Unlink a report from an object.
+     *
+     * Does NOT delete the report itself — it stays in NC Analytics for
+     * the user and for any other linked objects.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $reportId   NC Analytics report id.
+     *
+     * @return void
+     *
+     * @throws Exception On missing user (401) or no matching link (404).
+     */
+    public function unlinkReport(string $objectUuid, int $reportId): void
+    {
+        $this->requireUid();
+
+        $deleted = $this->analyticsLinkMapper->deleteByObjectAndReport($objectUuid, $reportId);
+        if ($deleted === 0) {
+            throw new Exception('Analytics link not found', 404);
+        }
+    }//end unlinkReport()
+
+    /**
+     * Return the linked reports for an object, refreshing the cached
+     * title/type/subheader/modified columns when a row is older than 24h.
+     *
+     * When Analytics is unavailable the cached link-row values are
+     * returned unchanged.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getLinkedReports(string $objectUuid): array
+    {
+        $links     = $this->analyticsLinkMapper->findByObjectUuid($objectUuid);
+        $available = $this->isAnalyticsAvailable();
+        $now       = time();
+
+        $results = [];
+        foreach ($links as $link) {
+            if ($available === true && $this->isStale(link: $link, now: $now) === true) {
+                $link = $this->refreshLink(link: $link);
+            }
+
+            $row        = $link->jsonSerialize();
+            $row['url'] = $this->reportDeepLink(reportId: (int) ($row['reportId'] ?? 0));
+            $results[]  = $row;
+        }
+
+        return $results;
+    }//end getLinkedReports()
+
+    /**
+     * Return the current user's NC Analytics reports (picker source).
+     *
+     * Optional substring search against the report name. Returns an empty
+     * array when Analytics is unavailable.
+     *
+     * @param string|null $search Optional name-substring filter.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getAvailableReports(?string $search=null): array
+    {
+        $service = $this->resolveReportService();
+        if ($service === null) {
+            return [];
+        }
+
+        try {
+            $reports = $service->index();
+        } catch (Throwable $e) {
+            $this->logger->warning('AnalyticsLinkService::getAvailableReports failed: '.$e->getMessage());
+            return [];
+        }
+
+        $needle = null;
+        if ($search !== null && $search !== '') {
+            $needle = mb_strtolower($search);
+        }
+
+        $out = [];
+        foreach ($reports as $report) {
+            $row = $this->pickerRowFromReport(report: (array) $report, needle: $needle);
+            if ($row !== null) {
+                $out[] = $row;
+            }
+        }
+
+        return $out;
+    }//end getAvailableReports()
+
+    /**
+     * Build an AnalyticsLink entity from cached report info.
+     *
+     * @param string              $objectUuid Parent OR object uuid.
+     * @param int                 $registerId OR register id.
+     * @param int                 $schemaId   OR schema id.
+     * @param int                 $reportId   NC Analytics report id.
+     * @param array<string,mixed> $info       Normalised report info.
+     * @param string              $uid        Owning user id.
+     *
+     * @return AnalyticsLink
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
+    private function buildLink(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        int $reportId,
+        array $info,
+        string $uid
+    ): AnalyticsLink {
+        $link = new AnalyticsLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        $link->setSchemaId($schemaId);
+        $link->setReportId($reportId);
+        $link->setReportTitle((string) ($info['title'] ?? ''));
+        $link->setReportType($info['type']);
+        $link->setSubheader($info['subheader']);
+        $link->setCreatedAt($info['createdAt']);
+        $link->setModifiedAt($info['modifiedAt']);
+        $link->setLinkedBy($uid);
+        $link->setLinkedAt(new DateTime());
+
+        return $link;
+    }//end buildLink()
+
+    /**
+     * Map a single NC Analytics report row into a picker row, applying
+     * the optional name filter.
+     *
+     * @param array<string,mixed> $report A normalised report row.
+     * @param string|null         $needle Lower-cased name-substring filter, or null.
+     *
+     * @return array<string,mixed>|null The picker row, or null when the
+     *                                  report is unreadable or filtered out.
+     */
+    private function pickerRowFromReport(array $report, ?string $needle): ?array
+    {
+        $reportId = (int) ($report['id'] ?? 0);
+        if ($reportId === 0) {
+            return null;
+        }
+
+        $name = (string) ($report['name'] ?? '');
+        if ($needle !== null && str_contains(mb_strtolower($name), $needle) === false) {
+            return null;
+        }
+
+        return [
+            'id'        => $reportId,
+            'name'      => $name,
+            'type'      => isset($report['type']) === true ? (string) $report['type'] : null,
+            'subheader' => isset($report['subheader']) === true ? (string) $report['subheader'] : null,
+            'url'       => $this->reportDeepLink(reportId: $reportId),
+        ];
+    }//end pickerRowFromReport()
+
+    /**
+     * Whether a link row's cache is older than the stale window.
+     *
+     * @param AnalyticsLink $link The link row.
+     * @param int           $now  Current epoch seconds.
+     *
+     * @return bool
+     */
+    private function isStale(AnalyticsLink $link, int $now): bool
+    {
+        $linkedAt = $link->getLinkedAt();
+        if ($linkedAt === null) {
+            return true;
+        }
+
+        return ($now - $linkedAt->getTimestamp()) > self::CACHE_TTL;
+    }//end isStale()
+
+    /**
+     * Refresh a link row's cached report metadata in place.
+     *
+     * Best-effort: when the report can't be resolved the link is left
+     * untouched (the report may have been deleted in NC Analytics).
+     *
+     * @param AnalyticsLink $link The link row.
+     *
+     * @return AnalyticsLink The (possibly updated) link row.
+     */
+    private function refreshLink(AnalyticsLink $link): AnalyticsLink
+    {
+        $info = $this->fetchReportInfo(reportId: (int) $link->getReportId());
+        if ($info === null) {
+            return $link;
+        }
+
+        $link->setReportTitle((string) ($info['title'] ?? ''));
+        $link->setReportType($info['type']);
+        $link->setSubheader($info['subheader']);
+        $link->setModifiedAt($info['modifiedAt']);
+        if ($info['createdAt'] !== null) {
+            $link->setCreatedAt($info['createdAt']);
+        }
+
+        $link->setLinkedAt(new DateTime());
+
+        try {
+            return $this->analyticsLinkMapper->update($link);
+        } catch (Throwable $e) {
+            $this->logger->debug('AnalyticsLinkService::refreshLink update failed: '.$e->getMessage());
+            return $link;
+        }
+    }//end refreshLink()
+
+    /**
+     * Fetch normalised report metadata from NC Analytics.
+     *
+     * @param int $reportId The report id.
+     *
+     * @return array{title:string,type:?string,subheader:?string,createdAt:?DateTime,modifiedAt:?DateTime}|null
+     */
+    private function fetchReportInfo(int $reportId): ?array
+    {
+        $service = $this->resolveReportService();
+        if ($service === null) {
+            return null;
+        }
+
+        try {
+            $report = $service->read($reportId);
+        } catch (Throwable $e) {
+            $this->logger->debug('AnalyticsLinkService::fetchReportInfo read failed: '.$e->getMessage());
+            return null;
+        }
+
+        if (is_array($report) === false || $report === []) {
+            return null;
+        }
+
+        return [
+            'title'      => (string) ($report['name'] ?? ''),
+            'type'       => isset($report['type']) === true ? (string) $report['type'] : null,
+            'subheader'  => isset($report['subheader']) === true ? (string) $report['subheader'] : null,
+            'createdAt'  => $this->parseTimestamp(value: ($report['created_at'] ?? null)),
+            'modifiedAt' => $this->parseTimestamp(value: ($report['modified_at'] ?? ($report['updated_at'] ?? null))),
+        ];
+    }//end fetchReportInfo()
+
+    /**
+     * Parse a NC Analytics timestamp (epoch int or datetime string) into
+     * a DateTime, best-effort.
+     *
+     * @param mixed $value Raw timestamp value.
+     *
+     * @return DateTime|null
+     */
+    private function parseTimestamp(mixed $value): ?DateTime
+    {
+        if ($value === null || $value === '' || $value === 0) {
+            return null;
+        }
+
+        try {
+            if (is_numeric($value) === true) {
+                return (new DateTime())->setTimestamp((int) $value);
+            }
+
+            return new DateTime((string) $value);
+        } catch (Throwable $e) {
+            return null;
+        }
+    }//end parseTimestamp()
+
+    /**
+     * Build the NC Analytics deep link for a report.
+     *
+     * @param int $reportId The report id.
+     *
+     * @return string
+     */
+    private function reportDeepLink(int $reportId): string
+    {
+        return '/index.php/apps/analytics/#/r/'.$reportId;
+    }//end reportDeepLink()
+}//end class

--- a/lib/Service/Integration/Providers/AnalyticsProvider.php
+++ b/lib/Service/Integration/Providers/AnalyticsProvider.php
@@ -1,12 +1,19 @@
 <?php
 
 /**
- * AnalyticsProvider — exposes NC Analytics entities linked to an OpenRegister
- * object via a `[or:{objectUuid}]` marker in the entity's `name`
- * field.
+ * AnalyticsProvider — exposes NC Analytics reports linked to an
+ * OpenRegister object via the Tier-2 `openregister_analytics_links`
+ * table.
  *
- * Storage strategy is `link-table` — the marker lives in the upstream
- * app's own table (`analytics_report`), not in OR.
+ * Pre-Tier-2 the provider matched a `[or:{objectUuid}]` marker embedded
+ * in the report's `name` field (wave-2.2). Tier-2 (this file) reads the
+ * dedicated link table instead — the marker convention is retained as a
+ * backwards-compat fallback for reports that pre-date the link table.
+ *
+ * Storage strategy is `link-table` — the link rows live in OR; the
+ * upstream `analytics_report` table is only read for live title / type
+ * data via the wrapping
+ * {@see \OCA\OpenRegister\Service\AnalyticsLinkService}.
  *
  * @category Service
  * @package  OCA\OpenRegister\Service\Integration\Providers
@@ -27,10 +34,13 @@ namespace OCA\OpenRegister\Service\Integration\Providers;
 
 // phpcs:disable PEAR.Commenting.FunctionComment.Missing
 
+use OCA\OpenRegister\Db\AnalyticsLink;
+use OCA\OpenRegister\Db\AnalyticsLinkMapper;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCP\App\IAppManager;
 use OCP\IDBConnection;
 use OCP\IL10N;
+use Throwable;
 
 class AnalyticsProvider extends AbstractIntegrationProvider
 {
@@ -40,10 +50,19 @@ class AnalyticsProvider extends AbstractIntegrationProvider
 
     private const MARKER_PREFIX = '[or:';
 
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection       $db                  NC DB connection.
+     * @param IAppManager         $appManager          NC app manager.
+     * @param IL10N               $l10n                Localisation.
+     * @param AnalyticsLinkMapper $analyticsLinkMapper Analytics-link mapper (Tier-2 link table).
+     */
     public function __construct(
         private IDBConnection $db,
         private IAppManager $appManager,
         private IL10N $l10n,
+        private AnalyticsLinkMapper $analyticsLinkMapper,
     ) {
     }//end __construct()
 
@@ -83,11 +102,12 @@ class AnalyticsProvider extends AbstractIntegrationProvider
     }//end isEnabled()
 
     /**
-     * List linked Analytics entities for an OR object.
+     * List linked Analytics reports for an OR object.
      *
-     * Linking convention: the entity's `name` field contains
-     * the marker `[or:{objectUuid}]`. The trait runs the LIKE query;
-     * rows are normalised into the registry leaf row shape.
+     * Reads the Tier-2 link table first; if no link rows exist it falls
+     * back to the legacy `[or:{uuid}]` marker scan in
+     * `analytics_report.name` (wave-2.2 convention) so reports that
+     * pre-date the link table still surface.
      *
      * @param string $register Register slug for the parent object.
      * @param string $schema   Schema slug for the parent object.
@@ -102,6 +122,22 @@ class AnalyticsProvider extends AbstractIntegrationProvider
             return [];
         }
 
+        // Tier-2 path: read from the link table.
+        try {
+            $linkRows = $this->analyticsLinkMapper->findByObjectUuid($objectId);
+        } catch (Throwable $e) {
+            $linkRows = [];
+        }
+
+        if (count($linkRows) > 0) {
+            return array_map(
+                fn (AnalyticsLink $link): array => $this->rowFromLink(link: $link),
+                $linkRows
+            );
+        }
+
+        // Backwards-compat fallback: scan the legacy `[or:{uuid}]` marker
+        // in `analytics_report.name` (wave-2.2 marker-on-name convention).
         $marker = self::MARKER_PREFIX.$objectId.']';
         $rows   = $this->findByMarker(
             db: $this->db,
@@ -124,6 +160,27 @@ class AnalyticsProvider extends AbstractIntegrationProvider
                 $rows
                 );
     }//end list()
+
+    /**
+     * Convert an AnalyticsLink row into the registry leaf-row shape.
+     *
+     * @param AnalyticsLink $link Link row from the mapper.
+     *
+     * @return array<string,mixed>
+     */
+    private function rowFromLink(AnalyticsLink $link): array
+    {
+        $reportId = (int) $link->getReportId();
+        $data     = $link->jsonSerialize();
+
+        return [
+            'id'        => (string) $reportId,
+            'title'     => (string) $link->getReportTitle(),
+            'url'       => '/index.php/apps/analytics/#/r/'.$reportId,
+            'subheader' => $link->getSubheader(),
+            'data'      => $data,
+        ];
+    }//end rowFromLink()
 
     public function health(): array
     {

--- a/tests/Unit/Service/AnalyticsLinkServiceTest.php
+++ b/tests/Unit/Service/AnalyticsLinkServiceTest.php
@@ -1,0 +1,241 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Service\AnalyticsLinkService}.
+ *
+ * Exercises the Tier-2 service contract (link / createAndLink / unlink /
+ * list + available picker) against a mocked AnalyticsLinkMapper. Tests
+ * that touch NC Analytics' `ReportService` use the "Analytics
+ * unavailable" path because that class is resolved via `\OCP\Server::get()`
+ * and isn't injectable into this unit-test scope without the `analytics`
+ * app on the classpath. Real-ReportService round-trips are gated by
+ * `@group requires-app-analytics`.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/integration-analytics/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use Exception;
+use OCA\OpenRegister\Db\AnalyticsLink;
+use OCA\OpenRegister\Db\AnalyticsLinkMapper;
+use OCA\OpenRegister\Service\AnalyticsLinkService;
+use OCP\App\IAppManager;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * AnalyticsLinkServiceTest.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ *
+ * @group requires-app-analytics
+ */
+class AnalyticsLinkServiceTest extends TestCase
+{
+
+    private AnalyticsLinkMapper&MockObject $mapper;
+
+    private IAppManager&MockObject $appManager;
+
+    private IUserSession&MockObject $userSession;
+
+    private LoggerInterface&MockObject $logger;
+
+    private AnalyticsLinkService $service;
+
+    protected function setUp(): void
+    {
+        $this->mapper = $this->getMockBuilder(AnalyticsLinkMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(
+                    [
+                        'findByObjectUuid',
+                        'findByObjectAndReport',
+                        'deleteByObjectAndReport',
+                        'insert',
+                        'update',
+                    ]
+                    )
+            ->getMock();
+
+        $this->appManager  = $this->createMock(IAppManager::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->logger      = $this->createMock(LoggerInterface::class);
+
+        $this->service = new AnalyticsLinkService(
+            $this->mapper,
+            $this->appManager,
+            $this->userSession,
+            $this->logger
+        );
+    }//end setUp()
+
+    private function setupUser(string $uid='alice'): IUser&MockObject
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $this->userSession->method('getUser')->willReturn($user);
+        return $user;
+    }//end setupUser()
+
+    public function testIsAnalyticsAvailableTrue(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('analytics')->willReturn(true);
+        $this->assertTrue($this->service->isAnalyticsAvailable());
+    }//end testIsAnalyticsAvailableTrue()
+
+    public function testIsAnalyticsAvailableFalse(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('analytics')->willReturn(false);
+        $this->assertFalse($this->service->isAnalyticsAvailable());
+    }//end testIsAnalyticsAvailableFalse()
+
+    public function testLinkReportThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->linkReport('abc-123', 1, 2, 99);
+    }//end testLinkReportThrowsWhenNoUser()
+
+    public function testLinkReportThrowsWhenAnalyticsUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('analytics')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+
+        $this->service->linkReport('abc-123', 1, 2, 99);
+    }//end testLinkReportThrowsWhenAnalyticsUnavailable()
+
+    public function testLinkReportThrowsOnDuplicate(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->willReturn(true);
+        $this->mapper->method('findByObjectAndReport')->with('abc-123', 99)->willReturn(new AnalyticsLink());
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(409);
+        $this->expectExceptionMessage('Report already linked to this object');
+
+        $this->service->linkReport('abc-123', 1, 2, 99);
+    }//end testLinkReportThrowsOnDuplicate()
+
+    public function testCreateAndLinkReportThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->createAndLinkReport('abc-123', 1, 2, 'Sales');
+    }//end testCreateAndLinkReportThrowsWhenNoUser()
+
+    public function testCreateAndLinkReportThrowsOnEmptyName(): void
+    {
+        $this->setupUser();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+
+        $this->service->createAndLinkReport('abc-123', 1, 2, '   ');
+    }//end testCreateAndLinkReportThrowsOnEmptyName()
+
+    public function testCreateAndLinkReportThrowsWhenAnalyticsUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('analytics')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+
+        $this->service->createAndLinkReport('abc-123', 1, 2, 'Sales');
+    }//end testCreateAndLinkReportThrowsWhenAnalyticsUnavailable()
+
+    public function testUnlinkReportThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->unlinkReport('abc-123', 99);
+    }//end testUnlinkReportThrowsWhenNoUser()
+
+    public function testUnlinkReportThrowsWhenLinkMissing(): void
+    {
+        $this->setupUser();
+        $this->mapper->method('deleteByObjectAndReport')->with('abc-123', 99)->willReturn(0);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(404);
+
+        $this->service->unlinkReport('abc-123', 99);
+    }//end testUnlinkReportThrowsWhenLinkMissing()
+
+    public function testUnlinkReportSucceeds(): void
+    {
+        $this->setupUser();
+        $this->mapper->expects($this->once())
+            ->method('deleteByObjectAndReport')
+            ->with('abc-123', 99)
+            ->willReturn(1);
+
+        $this->service->unlinkReport('abc-123', 99);
+    }//end testUnlinkReportSucceeds()
+
+    public function testGetLinkedReportsReturnsRowsWithDeepLink(): void
+    {
+        $this->appManager->method('isEnabledForUser')->willReturn(false);
+
+        $link = new AnalyticsLink();
+        $link->setObjectUuid('abc-123');
+        $link->setReportId(42);
+        $link->setReportTitle('Sales');
+
+        $this->mapper->method('findByObjectUuid')->with('abc-123')->willReturn([$link]);
+
+        $rows = $this->service->getLinkedReports('abc-123');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame(42, $rows[0]['reportId']);
+        $this->assertSame('Sales', $rows[0]['reportTitle']);
+        $this->assertStringContainsString('/r/42', $rows[0]['url']);
+    }//end testGetLinkedReportsReturnsRowsWithDeepLink()
+
+    public function testGetLinkedReportsEmpty(): void
+    {
+        $this->appManager->method('isEnabledForUser')->willReturn(false);
+        $this->mapper->method('findByObjectUuid')->with('abc-123')->willReturn([]);
+
+        $this->assertSame([], $this->service->getLinkedReports('abc-123'));
+    }//end testGetLinkedReportsEmpty()
+
+    public function testGetAvailableReportsEmptyWhenAnalyticsUnavailable(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('analytics')->willReturn(false);
+
+        $this->assertSame([], $this->service->getAvailableReports());
+    }//end testGetAvailableReportsEmptyWhenAnalyticsUnavailable()
+}//end class


### PR DESCRIPTION
## Summary
- Promote the `analytics` integration leaf to Tier-2 with a dedicated `openregister_analytics_links` table (migration `Version1Date20260525180000`), `AnalyticsLink` entity + `AnalyticsLinkMapper`.
- Add `AnalyticsLinkService` composing NC Analytics' `ReportService` (lazy-resolved via `\OCP\Server::get()` behind a `class_exists` guard for ADR-019 graceful degradation; cache refresh >24h).
- Add `AnalyticsLinksController` REST surface: GET/POST `/analytics`, POST `/analytics/new`, DELETE `/analytics/{reportId}`, GET `/api/integrations/analytics/available` (routes registered specific-before-wildcard).
- `AnalyticsProvider` now reads the link table first, falling back to the legacy `[or:{uuid}]` marker on the report `name` field (wave-2.2 convention) for pre-Tier-2 reports.

## Test plan
- [ ] `composer check:strict` (PHPCS clean on all new `lib/` files — verified locally in the php8.3 container)
- [ ] PHPUnit `AnalyticsLinkServiceTest` (`@group requires-app-analytics`) — 14 tests green
- [ ] Manual: link/create/unlink a report from a host app sidebar with NC Analytics installed
- [ ] Manual: confirm graceful 501 when NC Analytics is absent

Refs: openregister#1321, ADR-019, ADR-022, ADR-004.