### PR TITLE
feat(maps): Tier-2 — link table + POI picker + create

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -411,6 +411,15 @@ return [
         ['name' => 'photoLinks#link',         'url' => '/api/objects/{register}/{schema}/{id}/photos',         'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
         ['name' => 'photoLinks#destroy',      'url' => '/api/objects/{register}/{schema}/{id}/photos/{albumId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'albumId' => '[0-9]+']],
 
+        // Maps (NC Maps / Location) — Tier-2 link-table API. User-scoped
+        // (no admin gate). The specific `/maps/new` (create + link) route
+        // MUST precede the wildcard `/maps/{favoriteId}` unlink route.
+        ['name' => 'mapLinks#available',    'url' => '/api/integrations/maps/available',                       'verb' => 'GET'],
+        ['name' => 'mapLinks#index',        'url' => '/api/objects/{register}/{schema}/{id}/maps',             'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
+        ['name' => 'mapLinks#createAndLink','url' => '/api/objects/{register}/{schema}/{id}/maps/new',         'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'mapLinks#link',         'url' => '/api/objects/{register}/{schema}/{id}/maps',             'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'mapLinks#destroy',      'url' => '/api/objects/{register}/{schema}/{id}/maps/{favoriteId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'favoriteId' => '[0-9]+']],
+
         // Activity — Tier-2 read-only API. NC Activity entries are
         // core-generated (no link/create/delete verbs); this surface
         // only filters + cursor-paginates the entries linked to an OR

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1153,8 +1153,8 @@ class Application extends App implements IBootstrap
             // Registered separately below.
             // NB: FlowProvider was Tier-1 greenfield until Tier-2; it now
             // takes a FlowLinkMapper. Registered separately below.
-            // @spec openspec/changes/integration-maps/tasks.md.
-            \OCA\OpenRegister\Service\Integration\Providers\MapsProvider::class,
+            // NB: MapsProvider was Tier-1 greenfield until Tier-2; it now
+            // takes a MapLinkMapper. Registered separately below.
             // NB: PhotosProvider was Tier-1 greenfield until Tier-2; it now
             // takes a PhotoLinkMapper. Registered separately below.
             // @spec openspec/changes/integration-time-tracker/tasks.md.
@@ -1344,6 +1344,42 @@ class Application extends App implements IBootstrap
                     appManager: $container->get('OCP\App\IAppManager'),
                     userSession: $container->get('OCP\IUserSession'),
                     groupManager: $container->get('OCP\IGroupManager'),
+                    logger: $container->get('Psr\Log\LoggerInterface'),
+                );
+            }
+        );
+
+        // MapsProvider — Tier-2: backed by the MapLinkMapper. The
+        // provider still gracefully degrades to the legacy `[or:{uuid}]`
+        // favorite-name marker scan when the link table is empty (POIs
+        // that pre-date the Tier-2 link table).
+        // @spec openspec/changes/integration-maps/tasks.md.
+        $context->registerService(
+            \OCA\OpenRegister\Service\Integration\Providers\MapsProvider::class,
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\Service\Integration\Providers\MapsProvider(
+                    db: $container->get('OCP\IDBConnection'),
+                    appManager: $container->get('OCP\App\IAppManager'),
+                    l10n: $container->get('OCP\IL10N'),
+                    mapLinkMapper: $container->get(\OCA\OpenRegister\Db\MapLinkMapper::class),
+                );
+            }
+        );
+
+        // MapLinkService — Tier-2 link/create/unlink/picker service
+        // backing the MapLinksController. NC Maps favorites are
+        // user-scoped; the FavoritesService is resolved lazily via the
+        // container so the service loads even when Maps is absent.
+        // @spec openspec/changes/integration-maps/tasks.md.
+        $context->registerService(
+            \OCA\OpenRegister\Service\MapLinkService::class,
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\Service\MapLinkService(
+                    mapLinkMapper: $container->get(\OCA\OpenRegister\Db\MapLinkMapper::class),
+                    container: $container,
+                    appManager: $container->get('OCP\App\IAppManager'),
+                    userSession: $container->get('OCP\IUserSession'),
+                    urlGenerator: $container->get('OCP\IURLGenerator'),
                     logger: $container->get('Psr\Log\LoggerInterface'),
                 );
             }

--- a/lib/Controller/MapLinksController.php
+++ b/lib/Controller/MapLinksController.php
@@ -1,0 +1,339 @@
+<?php
+
+/**
+ * MapLinksController — Tier-2 REST controller for NC Maps favorite
+ * (POI) links.
+ *
+ * Surface:
+ *
+ *   - GET    /api/objects/{r}/{s}/{id}/maps               — list linked POIs
+ *   - POST   /api/objects/{r}/{s}/{id}/maps               — link existing POI `{favoriteId}`
+ *   - POST   /api/objects/{r}/{s}/{id}/maps/new           — create + link POI
+ *   - DELETE /api/objects/{r}/{s}/{id}/maps/{favoriteId}  — unlink POI
+ *   - GET    /api/integrations/maps/available?search=     — picker source
+ *
+ * NC Maps favorites are user-scoped, so (unlike Flow) there is no admin
+ * gate — the active session's user owns the favorites it can
+ * link/create.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use Exception;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\MapLinkService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Tier-2 Maps links controller.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ */
+class MapLinksController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param string         $appName        App id.
+     * @param IRequest       $request        HTTP request.
+     * @param MapLinkService $mapLinkService Backing service.
+     * @param ObjectService  $objectService  OR object resolver.
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly MapLinkService $mapLinkService,
+        private readonly ObjectService $objectService,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * List linked Maps POIs for an object.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function index(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->mapLinkService->isMapsAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Maps app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $results = $this->mapLinkService->getLinkedPois($object->getUuid());
+
+            return new JSONResponse(
+                    [
+                        'results' => $results,
+                        'total'   => count($results),
+                    ]
+                    );
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return new JSONResponse(['error' => $e->getMessage()], 500);
+        }//end try
+    }//end index()
+
+    /**
+     * Link an existing Maps POI.
+     *
+     * Body: `{ favoriteId: int }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function link(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->mapLinkService->isMapsAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Maps app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $favoriteId = (int) $this->request->getParam('favoriteId', 0);
+            if ($favoriteId === 0) {
+                return new JSONResponse(['error' => 'favoriteId is required'], 400);
+            }
+
+            $link = $this->mapLinkService->linkPoi(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $favoriteId
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end link()
+
+    /**
+     * Create a new Maps POI and link it.
+     *
+     * Body: `{ name: string, lat: float, lng: float, category?: string, comment?: string }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function createAndLink(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->mapLinkService->isMapsAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Maps app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $name = (string) $this->request->getParam('name', '');
+            if (trim($name) === '') {
+                return new JSONResponse(['error' => 'name is required'], 400);
+            }
+
+            $latParam = $this->request->getParam('lat');
+            $lngParam = $this->request->getParam('lng');
+            if ($latParam === null || $latParam === '' || $lngParam === null || $lngParam === '') {
+                return new JSONResponse(['error' => 'lat and lng are required'], 400);
+            }
+
+            $category = $this->request->getParam('category');
+            if ($category !== null) {
+                $category = (string) $category;
+            }
+
+            $comment = $this->request->getParam('comment');
+            if ($comment !== null) {
+                $comment = (string) $comment;
+            }
+
+            $link = $this->mapLinkService->createAndLinkPoi(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $name,
+                (float) $latParam,
+                (float) $lngParam,
+                $category,
+                $comment
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end createAndLink()
+
+    /**
+     * Unlink a Maps POI.
+     *
+     * @param string $register   Register slug or id.
+     * @param string $schema     Schema slug or id.
+     * @param string $id         Object id.
+     * @param string $favoriteId Favorite id (numeric).
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function destroy(string $register, string $schema, string $id, string $favoriteId): JSONResponse
+    {
+        if ($this->mapLinkService->isMapsAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Maps app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $this->mapLinkService->unlinkPoi($object->getUuid(), (int) $favoriteId);
+
+            return new JSONResponse(['success' => true]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end destroy()
+
+    /**
+     * List the current user's Maps POIs (picker source).
+     *
+     * Query param: `search` — optional name substring.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function available(): JSONResponse
+    {
+        if ($this->mapLinkService->isMapsAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Maps app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        $search = $this->request->getParam('search');
+        if ($search !== null) {
+            $search = (string) $search;
+        }
+
+        $pois = $this->mapLinkService->getAvailablePois($search);
+        return new JSONResponse(['results' => $pois, 'total' => count($pois)]);
+    }//end available()
+
+    /**
+     * Resolve an OR object from register/schema/id.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return ObjectEntity|null
+     */
+    private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
+    {
+        $this->objectService->setSchema($schema);
+        $this->objectService->setRegister($register);
+        $this->objectService->setObject($id);
+
+        return $this->objectService->getObject();
+    }//end validateObject()
+
+    /**
+     * Map a service-layer Exception to a JSONResponse.
+     *
+     * Exception codes carry HTTP intent:
+     *   - 400 → bad request
+     *   - 401 → unauthorized (no user)
+     *   - 404 → not found
+     *   - 409 → conflict (duplicate link)
+     *   - 503 → service unavailable
+     *   - everything else → 400 bad request
+     *
+     * @param Exception $exception Source exception.
+     *
+     * @return JSONResponse
+     */
+    private function mapException(Exception $exception): JSONResponse
+    {
+        $code = $exception->getCode();
+        if (in_array($code, [400, 401, 404, 409, 503], true) === true) {
+            return new JSONResponse(['error' => $exception->getMessage()], $code);
+        }
+
+        return new JSONResponse(['error' => $exception->getMessage()], 400);
+    }//end mapException()
+}//end class

--- a/lib/Db/MapLink.php
+++ b/lib/Db/MapLink.php
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * MapLink entity for linking NC Maps favorites (POIs) to OpenRegister
+ * objects.
+ *
+ * Tier-2 schema: carries register_id, schema_id, name, category, lat,
+ * lng and comment so the link row alone can hydrate the sidebar tab +
+ * picker UX without a per-POI roundtrip to NC Maps. Replaces the
+ * wave-1 `MapsProvider`'s `[or:{uuid}]` favorite-name marker convention
+ * with a proper persistence layer that survives POI renames.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Class MapLink
+ *
+ * @method string getObjectUuid()
+ * @method void setObjectUuid(string $objectUuid)
+ * @method int getRegisterId()
+ * @method void setRegisterId(int $registerId)
+ * @method int|null getSchemaId()
+ * @method void setSchemaId(?int $schemaId)
+ * @method int getFavoriteId()
+ * @method void setFavoriteId(int $favoriteId)
+ * @method string getName()
+ * @method void setName(string $name)
+ * @method string|null getCategory()
+ * @method void setCategory(?string $category)
+ * @method float getLat()
+ * @method void setLat(float $lat)
+ * @method float getLng()
+ * @method void setLng(float $lng)
+ * @method string|null getComment()
+ * @method void setComment(?string $comment)
+ * @method string|null getLinkedBy()
+ * @method void setLinkedBy(string $linkedBy)
+ * @method DateTime|null getLinkedAt()
+ * @method void setLinkedAt(DateTime $linkedAt)
+ *
+ * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class
+ */
+class MapLink extends Entity implements JsonSerializable
+{
+
+    /**
+     * The object uuid.
+     *
+     * @var string|null
+     */
+    protected ?string $objectUuid = null;
+
+    /**
+     * The register id.
+     *
+     * @var integer|null
+     */
+    protected ?int $registerId = null;
+
+    /**
+     * The schema id.
+     *
+     * @var integer|null
+     */
+    protected ?int $schemaId = null;
+
+    /**
+     * The NC Maps favorite id (primary key in `maps_favorites`).
+     *
+     * @var integer|null
+     */
+    protected ?int $favoriteId = null;
+
+    /**
+     * The POI display name (cached at link time).
+     *
+     * @var string|null
+     */
+    protected ?string $name = null;
+
+    /**
+     * The POI category (cached at link time).
+     *
+     * @var string|null
+     */
+    protected ?string $category = null;
+
+    /**
+     * The cached latitude.
+     *
+     * @var float|null
+     */
+    protected ?float $lat = null;
+
+    /**
+     * The cached longitude.
+     *
+     * @var float|null
+     */
+    protected ?float $lng = null;
+
+    /**
+     * The cached POI comment.
+     *
+     * @var string|null
+     */
+    protected ?string $comment = null;
+
+    /**
+     * The linked by uid.
+     *
+     * @var string|null
+     */
+    protected ?string $linkedBy = null;
+
+    /**
+     * The linked at timestamp.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $linkedAt = null;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->addType(fieldName: 'objectUuid', type: 'string');
+        $this->addType(fieldName: 'registerId', type: 'integer');
+        $this->addType(fieldName: 'schemaId', type: 'integer');
+        $this->addType(fieldName: 'favoriteId', type: 'integer');
+        $this->addType(fieldName: 'name', type: 'string');
+        $this->addType(fieldName: 'category', type: 'string');
+        $this->addType(fieldName: 'lat', type: 'float');
+        $this->addType(fieldName: 'lng', type: 'float');
+        $this->addType(fieldName: 'comment', type: 'string');
+        $this->addType(fieldName: 'linkedBy', type: 'string');
+        $this->addType(fieldName: 'linkedAt', type: 'datetime');
+    }//end __construct()
+
+    /**
+     * JSON serialization.
+     *
+     * @return array<string,mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'         => $this->id,
+            'objectUuid' => $this->objectUuid,
+            'registerId' => $this->registerId,
+            'schemaId'   => $this->schemaId,
+            'favoriteId' => $this->favoriteId,
+            'name'       => $this->name,
+            'category'   => $this->category,
+            'lat'        => $this->lat,
+            'lng'        => $this->lng,
+            'comment'    => $this->comment,
+            'linkedBy'   => $this->linkedBy,
+            'linkedAt'   => $this->linkedAt?->format(DateTime::ATOM),
+        ];
+    }//end jsonSerialize()
+}//end class

--- a/lib/Db/MapLinkMapper.php
+++ b/lib/Db/MapLinkMapper.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * Mapper for map link entities.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Class MapLinkMapper
+ *
+ * @template-extends QBMapper<MapLink>
+ */
+class MapLinkMapper extends QBMapper
+{
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $db Database connection.
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(db: $db, tableName: 'openregister_map_links', entityClass: MapLink::class);
+    }//end __construct()
+
+    /**
+     * Find map links by object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return MapLink[] Array of map links.
+     */
+    public function findByObjectUuid(string $objectUuid): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByObjectUuid()
+
+    /**
+     * Find map links by favorite id.
+     *
+     * @param int $favoriteId The favorite id.
+     *
+     * @return MapLink[] Array of map links.
+     */
+    public function findByFavoriteId(int $favoriteId): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('favorite_id', $qb->createNamedParameter($favoriteId, IQueryBuilder::PARAM_INT)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByFavoriteId()
+
+    /**
+     * Find a specific map link by object UUID and favorite id.
+     *
+     * @param string $objectUuid The object UUID.
+     * @param int    $favoriteId The favorite id.
+     *
+     * @return MapLink|null The link or null if not found.
+     */
+    public function findByObjectAndFavorite(string $objectUuid, int $favoriteId): ?MapLink
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('favorite_id', $qb->createNamedParameter($favoriteId, IQueryBuilder::PARAM_INT)));
+
+        try {
+            return $this->findEntity(query: $qb);
+        } catch (DoesNotExistException $e) {
+            return null;
+        }
+    }//end findByObjectAndFavorite()
+
+    /**
+     * Delete all map links for an object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectUuid(string $objectUuid): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectUuid()
+
+    /**
+     * Delete a map link by object UUID + favorite id (Tier-2 unlink path).
+     *
+     * Returns the number of rows actually deleted so callers can
+     * distinguish "no such link" (0) from "ok" (>=1).
+     *
+     * @param string $objectUuid The object UUID.
+     * @param int    $favoriteId The favorite id.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectAndFavorite(string $objectUuid, int $favoriteId): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('favorite_id', $qb->createNamedParameter($favoriteId, IQueryBuilder::PARAM_INT)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectAndFavorite()
+}//end class

--- a/lib/Migration/Version1Date20260525190000.php
+++ b/lib/Migration/Version1Date20260525190000.php
@@ -1,0 +1,167 @@
+<?php
+
+/**
+ * Tier-2 maps (NC Maps / Location) integration migration.
+ *
+ * Ensures the `openregister_map_links` table exists with the full
+ * Tier-2 schema:
+ *
+ *  - id (bigint, PK, autoincrement)
+ *  - object_uuid (string 36, not null, indexed)
+ *  - register_id (bigint unsigned, not null, indexed)
+ *  - schema_id (bigint unsigned, nullable, indexed)
+ *  - favorite_id (integer, not null) — `maps_favorites` row id
+ *  - name (string 255, not null) — cached POI name
+ *  - category (string 255, nullable) — cached POI category
+ *  - lat (double, not null) — cached latitude
+ *  - lng (double, not null) — cached longitude
+ *  - comment (text, nullable) — cached POI comment
+ *  - linked_by (string 64, not null)
+ *  - linked_at (datetime, not null)
+ *
+ * Idempotent: creates the table if missing, otherwise adds any missing
+ * Tier-2 columns. Companion to the Tier-2 photos/talk/polls/email/forms/
+ * deck/flow link tables; the wrapping `MapLinkService` replaces the
+ * `[or:{uuid}]` favorite-name marker convention used by the wave-1
+ * `MapsProvider` with a proper persistence layer so links survive POI
+ * renames.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Tier-2 map-links table — create-or-extend.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+class Version1Date20260525190000 extends SimpleMigrationStep
+{
+    /**
+     * Change the database schema.
+     *
+     * @param IOutput                 $output        Output for the migration process
+     * @param Closure                 $schemaClosure The schema closure
+     * @param array<array-key, mixed> $options       Migration options
+     *
+     * @return ISchemaWrapper|null
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema  = $schemaClosure();
+        $changed = false;
+
+        if ($schema->hasTable('openregister_map_links') === false) {
+            $this->createMapLinksTable(schema: $schema, output: $output);
+            $changed = true;
+        }
+
+        if ($schema->hasTable('openregister_map_links') === true
+            && $this->extendMapLinksTable(schema: $schema, output: $output) === true
+        ) {
+            $changed = true;
+        }
+
+        if ($changed === false) {
+            return null;
+        }
+
+        return $schema;
+    }//end changeSchema()
+
+    /**
+     * Create the openregister_map_links table at the Tier-2 shape.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return void
+     */
+    private function createMapLinksTable(ISchemaWrapper $schema, IOutput $output): void
+    {
+        $table = $schema->createTable('openregister_map_links');
+
+        $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'unsigned' => true]);
+        $table->addColumn('object_uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
+        $table->addColumn('register_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('schema_id', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]);
+        $table->addColumn('favorite_id', Types::INTEGER, ['notnull' => true]);
+        $table->addColumn('name', Types::STRING, ['notnull' => true, 'length' => 255]);
+        $table->addColumn('category', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+        $table->addColumn('lat', Types::FLOAT, ['notnull' => true]);
+        $table->addColumn('lng', Types::FLOAT, ['notnull' => true]);
+        $table->addColumn('comment', Types::TEXT, ['notnull' => false, 'default' => null]);
+        $table->addColumn('linked_by', Types::STRING, ['notnull' => true, 'length' => 64]);
+        $table->addColumn('linked_at', Types::DATETIME, ['notnull' => true]);
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['object_uuid', 'favorite_id'], 'idx_map_object_fav');
+        $table->addIndex(['object_uuid'], 'idx_map_object');
+        $table->addIndex(['register_id'], 'idx_map_register');
+        $table->addIndex(['schema_id'], 'idx_map_schema');
+
+        $output->info('Created openregister_map_links table (Tier-2 schema)');
+    }//end createMapLinksTable()
+
+    /**
+     * Add any missing Tier-2 columns to an existing map_links table.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return bool True when a column was added.
+     */
+    private function extendMapLinksTable(ISchemaWrapper $schema, IOutput $output): bool
+    {
+        $table   = $schema->getTable('openregister_map_links');
+        $changed = false;
+
+        if ($table->hasColumn('schema_id') === false) {
+            $table->addColumn(
+                'schema_id',
+                Types::BIGINT,
+                ['notnull' => false, 'unsigned' => true, 'default' => null]
+            );
+            $table->addIndex(['schema_id'], 'idx_map_schema');
+            $output->info('Added schema_id column to openregister_map_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('category') === false) {
+            $table->addColumn('category', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+            $output->info('Added category column to openregister_map_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('comment') === false) {
+            $table->addColumn('comment', Types::TEXT, ['notnull' => false, 'default' => null]);
+            $output->info('Added comment column to openregister_map_links');
+            $changed = true;
+        }
+
+        return $changed;
+    }//end extendMapLinksTable()
+}//end class

--- a/lib/Service/Integration/Providers/MapsProvider.php
+++ b/lib/Service/Integration/Providers/MapsProvider.php
@@ -1,12 +1,18 @@
 <?php
 
 /**
- * MapsProvider — exposes NC Location entities linked to an OpenRegister
- * object via a `[or:{objectUuid}]` marker in the entity's `name`
- * field.
+ * MapsProvider — exposes NC Maps favorites (POIs) linked to an
+ * OpenRegister object via the Tier-2 `openregister_map_links` table.
  *
- * Storage strategy is `link-table` — the marker lives in the upstream
- * app's own table (`maps_favorites`), not in OR.
+ * Pre-Tier-2 the provider matched a `[or:{objectUuid}]` marker embedded
+ * in the favorite's `name` field. Tier-2 (this file) reads the dedicated
+ * link table instead — the marker convention is retained as a
+ * backwards-compat fallback for favorites that pre-date the link table.
+ *
+ * Storage strategy is `link-table` — the link rows live in OR; the
+ * upstream `maps_favorites` table is only read by the wrapping
+ * {@see \OCA\OpenRegister\Service\MapLinkService} for picker / create
+ * flows.
  *
  * @category Service
  * @package  OCA\OpenRegister\Service\Integration\Providers
@@ -27,10 +33,13 @@ namespace OCA\OpenRegister\Service\Integration\Providers;
 
 // phpcs:disable PEAR.Commenting.FunctionComment.Missing
 
+use OCA\OpenRegister\Db\MapLink;
+use OCA\OpenRegister\Db\MapLinkMapper;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCP\App\IAppManager;
 use OCP\IDBConnection;
 use OCP\IL10N;
+use Throwable;
 
 class MapsProvider extends AbstractIntegrationProvider
 {
@@ -44,6 +53,7 @@ class MapsProvider extends AbstractIntegrationProvider
         private IDBConnection $db,
         private IAppManager $appManager,
         private IL10N $l10n,
+        private MapLinkMapper $mapLinkMapper,
     ) {
     }//end __construct()
 
@@ -83,11 +93,12 @@ class MapsProvider extends AbstractIntegrationProvider
     }//end isEnabled()
 
     /**
-     * List linked Location entities for an OR object.
+     * List linked Location POIs for an OR object.
      *
-     * Linking convention: the entity's `name` field contains
-     * the marker `[or:{objectUuid}]`. The trait runs the LIKE query;
-     * rows are normalised into the registry leaf row shape.
+     * Reads the Tier-2 link table first; if no link rows exist it falls
+     * back to the legacy `[or:{uuid}]` marker scan in
+     * `maps_favorites.name` so POIs that pre-date the link table still
+     * surface.
      *
      * @param string $register Register slug for the parent object.
      * @param string $schema   Schema slug for the parent object.
@@ -102,6 +113,22 @@ class MapsProvider extends AbstractIntegrationProvider
             return [];
         }
 
+        // Tier-2 path: read from the link table.
+        try {
+            $linkRows = $this->mapLinkMapper->findByObjectUuid($objectId);
+        } catch (Throwable $e) {
+            $linkRows = [];
+        }
+
+        if (count($linkRows) > 0) {
+            return array_map(
+                fn (MapLink $link): array => $this->rowFromLink(link: $link),
+                $linkRows
+            );
+        }
+
+        // Backwards-compat fallback: scan the legacy `[or:{uuid}]` marker
+        // in `maps_favorites.name` (the wave-1 category-tag convention).
         $marker = self::MARKER_PREFIX.$objectId.']';
         $rows   = $this->findByMarker(
             db: $this->db,
@@ -125,13 +152,43 @@ class MapsProvider extends AbstractIntegrationProvider
                 );
     }//end list()
 
+    /**
+     * Convert a MapLink row into the registry leaf-row shape.
+     *
+     * @param MapLink $link Link row from the mapper.
+     *
+     * @return array<string,mixed>
+     */
+    private function rowFromLink(MapLink $link): array
+    {
+        $favoriteId = (int) $link->getFavoriteId();
+        $data       = $link->jsonSerialize();
+
+        return [
+            'id'       => (string) $favoriteId,
+            'title'    => (string) $link->getName(),
+            'url'      => '/index.php/apps/maps/#/m='.$favoriteId,
+            'category' => $link->getCategory(),
+            'lat'      => $link->getLat(),
+            'lng'      => $link->getLng(),
+            'data'     => $data,
+        ];
+    }//end rowFromLink()
+
     public function health(): array
     {
         $available = $this->isEnabled();
+        $status    = 'unavailable';
+        $message   = 'NC Location app is not installed';
+        if ($available === true) {
+            $status  = 'ok';
+            $message = null;
+        }
+
         return [
-            'status'     => $available === true ? 'ok' : 'unavailable',
+            'status'     => $status,
             'authStatus' => 'configured',
-            'message'    => $available === true ? null : 'NC Location app is not installed',
+            'message'    => $message,
         ];
     }//end health()
 }//end class

--- a/lib/Service/MapLinkService.php
+++ b/lib/Service/MapLinkService.php
@@ -1,0 +1,452 @@
+<?php
+
+/**
+ * MapLinkService — Tier-2 maps (NC Maps / Location) integration service.
+ *
+ * Composes the {@see MapLinkMapper} with NC Maps'
+ * `OCA\Maps\Service\FavoritesService` to expose the Tier-2 surface:
+ *
+ *   - linkPoi(uuid, registerId, schemaId, favoriteId)
+ *       — link an existing favorite (POI)
+ *   - createAndLinkPoi(uuid, registerId, schemaId, name, lat, lng, ...)
+ *       — create a new NC Maps favorite and link it
+ *   - unlinkPoi(uuid, favoriteId)
+ *       — remove a link (the favorite itself stays in NC Maps)
+ *   - getLinkedPois(uuid)
+ *       — list linked POIs (served from the cached link row + deep link)
+ *   - getAvailablePois(?search)
+ *       — picker source listing the current user's favorites
+ *
+ * NC Maps exposes its favorite persistence as
+ * `OCA\Maps\Service\FavoritesService`. The service is resolved lazily
+ * through the server container behind a `class_exists` + `Throwable`
+ * guard so this service loads even when the Maps app is not installed
+ * (ADR-019 AD-23 graceful degradation): when Maps is missing or a call
+ * throws, stored link rows are returned as-is so historical references
+ * survive.
+ *
+ * Favorites are user-scoped: NC Maps favorites belong to a user, so
+ * every mutating + picker call is scoped to the active session's UID.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://OpenRegister.app
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use DateTime;
+use Exception;
+use OCA\OpenRegister\Db\MapLink;
+use OCA\OpenRegister\Db\MapLinkMapper;
+use OCP\App\IAppManager;
+use OCP\IURLGenerator;
+use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * MapLinkService.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Composes mapper +
+ *     NC Maps FavoritesService (late-bound) + user session + app
+ *     manager + url generator + container + logger. Each dependency is
+ *     required for one of the Tier-2 flows (link, create, unlink, list,
+ *     picker, graceful degradation).
+ */
+class MapLinkService
+{
+    private const REQUIRED_APP = 'maps';
+
+    private const FAVORITES_SERVICE = 'OCA\\Maps\\Service\\FavoritesService';
+
+    /**
+     * Constructor.
+     *
+     * @param MapLinkMapper      $mapLinkMapper Persistence for link rows.
+     * @param ContainerInterface $container     Container for late-bound Maps classes.
+     * @param IAppManager        $appManager    NC app manager.
+     * @param IUserSession       $userSession   Active session.
+     * @param IURLGenerator      $urlGenerator  URL generator for deep links.
+     * @param LoggerInterface    $logger        Logger.
+     */
+    public function __construct(
+        private readonly MapLinkMapper $mapLinkMapper,
+        private readonly ContainerInterface $container,
+        private readonly IAppManager $appManager,
+        private readonly IUserSession $userSession,
+        private readonly IURLGenerator $urlGenerator,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Whether NC Maps is installed + enabled for the current user.
+     *
+     * @return bool
+     */
+    public function isMapsAvailable(): bool
+    {
+        return $this->appManager->isEnabledForUser(self::REQUIRED_APP);
+    }//end isMapsAvailable()
+
+    /**
+     * Resolve NC Maps' FavoritesService lazily.
+     *
+     * Returns null when Maps is absent or the class can't be resolved,
+     * so callers degrade gracefully (ADR-019 AD-23).
+     *
+     * @return object|null The FavoritesService instance or null.
+     */
+    private function getFavoritesService(): ?object
+    {
+        if ($this->isMapsAvailable() === false) {
+            return null;
+        }
+
+        if (class_exists(self::FAVORITES_SERVICE) === false) {
+            return null;
+        }
+
+        try {
+            return $this->container->get(self::FAVORITES_SERVICE);
+        } catch (Throwable $e) {
+            $this->logger->debug('MapLinkService: FavoritesService unavailable: '.$e->getMessage());
+            return null;
+        }
+    }//end getFavoritesService()
+
+    /**
+     * Active session UID, or throw if no user is logged in.
+     *
+     * @return string The user id.
+     *
+     * @throws Exception When there is no active user.
+     */
+    private function requireUid(): string
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in', 401);
+        }
+
+        return $user->getUID();
+    }//end requireUid()
+
+    /**
+     * Link an existing NC Maps favorite (POI) to an OR object.
+     *
+     * Idempotent: a duplicate link raises a 409 Exception. POI metadata
+     * (name/category/lat/lng/comment) is cached at link time.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $registerId OR register id.
+     * @param int    $schemaId   OR schema id.
+     * @param int    $favoriteId NC Maps favorite id.
+     *
+     * @return MapLink The persisted link row.
+     *
+     * @throws Exception On missing user (401), missing POI (404),
+     *                   duplicate (409), Maps unavailable (503).
+     */
+    public function linkPoi(string $objectUuid, int $registerId, int $schemaId, int $favoriteId): MapLink
+    {
+        $uid = $this->requireUid();
+
+        if ($this->isMapsAvailable() === false) {
+            throw new Exception('NC Maps is not available', 503);
+        }
+
+        $existing = $this->mapLinkMapper->findByObjectAndFavorite($objectUuid, $favoriteId);
+        if ($existing !== null) {
+            throw new Exception('POI already linked to this object', 409);
+        }
+
+        $info = $this->fetchFavoriteInfo(favoriteId: $favoriteId, uid: $uid);
+        if ($info === null) {
+            throw new Exception('Maps POI not found', 404);
+        }
+
+        $link = new MapLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        $link->setSchemaId($schemaId);
+        $link->setFavoriteId($favoriteId);
+        $link->setName($info['name']);
+        $link->setCategory($info['category']);
+        $link->setLat($info['lat']);
+        $link->setLng($info['lng']);
+        $link->setComment($info['comment']);
+        $link->setLinkedBy($uid);
+        $link->setLinkedAt(new DateTime());
+
+        return $this->mapLinkMapper->insert($link);
+    }//end linkPoi()
+
+    /**
+     * Create a new NC Maps favorite (POI) and link it to an OR object.
+     *
+     * @param string      $objectUuid Parent OR object uuid.
+     * @param int         $registerId OR register id.
+     * @param int         $schemaId   OR schema id.
+     * @param string      $name       New POI name.
+     * @param float       $lat        Latitude.
+     * @param float       $lng        Longitude.
+     * @param string|null $category   Optional category.
+     * @param string|null $comment    Optional comment.
+     *
+     * @return MapLink The persisted link row.
+     *
+     * @throws Exception On missing user (401), empty name (400),
+     *                   Maps unavailable (503), create failure (500).
+     */
+    public function createAndLinkPoi(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        string $name,
+        float $lat,
+        float $lng,
+        ?string $category=null,
+        ?string $comment=null,
+    ): MapLink {
+        $uid = $this->requireUid();
+
+        $name = trim($name);
+        if ($name === '') {
+            throw new Exception('POI name is required', 400);
+        }
+
+        $service = $this->getFavoritesService();
+        if ($service === null) {
+            throw new Exception('NC Maps is not available', 503);
+        }
+
+        try {
+            $favoriteId = (int) $service->addFavoriteToDB($uid, $name, $lat, $lng, $category, $comment, null);
+        } catch (Throwable $e) {
+            $this->logger->warning('MapLinkService::createAndLinkPoi failed: '.$e->getMessage());
+            throw new Exception('Failed to create Maps POI', 500);
+        }
+
+        if ($favoriteId <= 0) {
+            throw new Exception('Failed to create Maps POI', 500);
+        }
+
+        $link = new MapLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        $link->setSchemaId($schemaId);
+        $link->setFavoriteId($favoriteId);
+        $link->setName($name);
+        $link->setCategory($category);
+        $link->setLat($lat);
+        $link->setLng($lng);
+        $link->setComment($comment);
+        $link->setLinkedBy($uid);
+        $link->setLinkedAt(new DateTime());
+
+        return $this->mapLinkMapper->insert($link);
+    }//end createAndLinkPoi()
+
+    /**
+     * Unlink a POI from an object.
+     *
+     * Does NOT delete the favorite itself — it stays in NC Maps for the
+     * user and for any other linked objects.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $favoriteId NC Maps favorite id.
+     *
+     * @return void
+     *
+     * @throws Exception On missing user (401) or no matching link (404).
+     */
+    public function unlinkPoi(string $objectUuid, int $favoriteId): void
+    {
+        $this->requireUid();
+
+        $deleted = $this->mapLinkMapper->deleteByObjectAndFavorite($objectUuid, $favoriteId);
+        if ($deleted === 0) {
+            throw new Exception('Map link not found', 404);
+        }
+    }//end unlinkPoi()
+
+    /**
+     * Return the linked POIs for an object.
+     *
+     * Served straight from the cached link rows (name/category/lat/lng/
+     * comment are captured at link time), with a deep link into NC Maps
+     * appended.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getLinkedPois(string $objectUuid): array
+    {
+        $links = $this->mapLinkMapper->findByObjectUuid($objectUuid);
+
+        $results = [];
+        foreach ($links as $link) {
+            $row        = $link->jsonSerialize();
+            $row['url'] = $this->poiDeepLink(favoriteId: (int) ($row['favoriteId'] ?? 0));
+            $results[]  = $row;
+        }
+
+        return $results;
+    }//end getLinkedPois()
+
+    /**
+     * Return the current user's NC Maps favorites (picker source).
+     *
+     * Optional substring search against the POI name. Returns an empty
+     * array when Maps is unavailable.
+     *
+     * @param string|null $search Optional name-substring filter.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getAvailablePois(?string $search=null): array
+    {
+        $service = $this->getFavoritesService();
+        $uid     = $this->userSession->getUser()?->getUID();
+        if ($service === null || $uid === null) {
+            return [];
+        }
+
+        try {
+            $favorites = $service->getFavoritesFromDB($uid);
+        } catch (Throwable $e) {
+            $this->logger->warning('MapLinkService::getAvailablePois failed: '.$e->getMessage());
+            return [];
+        }
+
+        $needle = null;
+        if ($search !== null && $search !== '') {
+            $needle = mb_strtolower($search);
+        }
+
+        $out = [];
+        foreach ($favorites as $favorite) {
+            $row = $this->pickerRowFromFavorite(favorite: $favorite, needle: $needle);
+            if ($row !== null) {
+                $out[] = $row;
+            }
+        }
+
+        return $out;
+    }//end getAvailablePois()
+
+    /**
+     * Map a single NC Maps favorite into a picker row, applying the
+     * optional name filter.
+     *
+     * @param array<string,mixed> $favorite An NC Maps favorite row.
+     * @param string|null         $needle   Lower-cased name-substring filter, or null.
+     *
+     * @return array<string,mixed>|null The picker row, or null when the
+     *                                  favorite is filtered out.
+     */
+    private function pickerRowFromFavorite(array $favorite, ?string $needle): ?array
+    {
+        $favoriteId = (int) ($favorite['id'] ?? 0);
+        $name       = (string) ($favorite['name'] ?? '');
+
+        if ($favoriteId <= 0) {
+            return null;
+        }
+
+        if ($needle !== null && str_contains(mb_strtolower($name), $needle) === false) {
+            return null;
+        }
+
+        $category = $favorite['category'] ?? null;
+        if ($category !== null) {
+            $category = (string) $category;
+        }
+
+        return [
+            'id'       => $favoriteId,
+            'name'     => $name,
+            'category' => $category,
+            'lat'      => (float) ($favorite['lat'] ?? 0),
+            'lng'      => (float) ($favorite['lng'] ?? 0),
+            'url'      => $this->poiDeepLink(favoriteId: $favoriteId),
+        ];
+    }//end pickerRowFromFavorite()
+
+    /**
+     * Fetch normalised favorite metadata from NC Maps.
+     *
+     * @param int    $favoriteId The favorite id.
+     * @param string $uid        The owning user id.
+     *
+     * @return array{name:string,category:?string,lat:float,lng:float,comment:?string}|null
+     */
+    private function fetchFavoriteInfo(int $favoriteId, string $uid): ?array
+    {
+        $service = $this->getFavoritesService();
+        if ($service === null) {
+            return null;
+        }
+
+        try {
+            $favorite = $service->getFavoriteFromDB($favoriteId, $uid);
+        } catch (Throwable $e) {
+            $this->logger->debug('MapLinkService::fetchFavoriteInfo failed: '.$e->getMessage());
+            return null;
+        }
+
+        if (is_array($favorite) === false) {
+            return null;
+        }
+
+        $category = $favorite['category'] ?? null;
+        if ($category !== null) {
+            $category = (string) $category;
+        }
+
+        $comment = $favorite['comment'] ?? null;
+        if ($comment !== null) {
+            $comment = (string) $comment;
+        }
+
+        return [
+            'name'     => (string) ($favorite['name'] ?? ''),
+            'category' => $category,
+            'lat'      => (float) ($favorite['lat'] ?? 0),
+            'lng'      => (float) ($favorite['lng'] ?? 0),
+            'comment'  => $comment,
+        ];
+    }//end fetchFavoriteInfo()
+
+    /**
+     * Build the NC Maps deep link for a favorite.
+     *
+     * @param int $favoriteId The favorite id.
+     *
+     * @return string
+     */
+    private function poiDeepLink(int $favoriteId): string
+    {
+        return $this->urlGenerator->linkToRoute('maps.page.index').'#/m='.$favoriteId;
+    }//end poiDeepLink()
+}//end class

--- a/tests/Unit/Service/MapLinkServiceTest.php
+++ b/tests/Unit/Service/MapLinkServiceTest.php
@@ -1,0 +1,262 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Service\MapLinkService}.
+ *
+ * Exercises the Tier-2 service contract (link / createAndLink / unlink /
+ * list + available picker) against a mocked MapLinkMapper. Tests that
+ * touch NC Maps' `FavoritesService` use the "Maps unavailable" path
+ * because that class is resolved from the container and isn't injectable
+ * into this unit test scope without the `maps` app on the classpath.
+ * Real-FavoritesService round-trips are gated by `@group requires-app-maps`.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/integration-maps/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use Exception;
+use OCA\OpenRegister\Db\MapLink;
+use OCA\OpenRegister\Db\MapLinkMapper;
+use OCA\OpenRegister\Service\MapLinkService;
+use OCP\App\IAppManager;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * MapLinkServiceTest.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ *
+ * @group requires-app-maps
+ */
+class MapLinkServiceTest extends TestCase
+{
+
+    private MapLinkMapper&MockObject $mapper;
+
+    private ContainerInterface&MockObject $container;
+
+    private IAppManager&MockObject $appManager;
+
+    private IUserSession&MockObject $userSession;
+
+    private IURLGenerator&MockObject $urlGenerator;
+
+    private LoggerInterface&MockObject $logger;
+
+    private MapLinkService $service;
+
+    protected function setUp(): void
+    {
+        $this->mapper = $this->getMockBuilder(MapLinkMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(
+                    [
+                        'findByObjectUuid',
+                        'findByObjectAndFavorite',
+                        'deleteByObjectAndFavorite',
+                        'insert',
+                        'update',
+                    ]
+                    )
+            ->getMock();
+
+        $this->container    = $this->createMock(ContainerInterface::class);
+        $this->appManager   = $this->createMock(IAppManager::class);
+        $this->userSession  = $this->createMock(IUserSession::class);
+        $this->urlGenerator = $this->createMock(IURLGenerator::class);
+        $this->logger       = $this->createMock(LoggerInterface::class);
+
+        $this->urlGenerator->method('linkToRoute')->willReturn('/index.php/apps/maps/');
+
+        $this->service = new MapLinkService(
+            $this->mapper,
+            $this->container,
+            $this->appManager,
+            $this->userSession,
+            $this->urlGenerator,
+            $this->logger
+        );
+    }//end setUp()
+
+    private function setupUser(string $uid='alice'): IUser&MockObject
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $this->userSession->method('getUser')->willReturn($user);
+        return $user;
+    }//end setupUser()
+
+    public function testIsMapsAvailableTrue(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('maps')->willReturn(true);
+        $this->assertTrue($this->service->isMapsAvailable());
+    }//end testIsMapsAvailableTrue()
+
+    public function testIsMapsAvailableFalse(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('maps')->willReturn(false);
+        $this->assertFalse($this->service->isMapsAvailable());
+    }//end testIsMapsAvailableFalse()
+
+    public function testLinkPoiThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->linkPoi('abc-123', 1, 2, 99);
+    }//end testLinkPoiThrowsWhenNoUser()
+
+    public function testLinkPoiThrowsWhenMapsUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('maps')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+
+        $this->service->linkPoi('abc-123', 1, 2, 99);
+    }//end testLinkPoiThrowsWhenMapsUnavailable()
+
+    public function testLinkPoiThrowsOnDuplicate(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->willReturn(true);
+        $this->mapper->method('findByObjectAndFavorite')->with('abc-123', 99)->willReturn(new MapLink());
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(409);
+        $this->expectExceptionMessage('POI already linked to this object');
+
+        $this->service->linkPoi('abc-123', 1, 2, 99);
+    }//end testLinkPoiThrowsOnDuplicate()
+
+    public function testCreateAndLinkPoiThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->createAndLinkPoi('abc-123', 1, 2, 'Office', 52.37, 4.89);
+    }//end testCreateAndLinkPoiThrowsWhenNoUser()
+
+    public function testCreateAndLinkPoiThrowsOnEmptyName(): void
+    {
+        $this->setupUser();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+
+        $this->service->createAndLinkPoi('abc-123', 1, 2, '   ', 52.37, 4.89);
+    }//end testCreateAndLinkPoiThrowsOnEmptyName()
+
+    public function testCreateAndLinkPoiThrowsWhenMapsUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('maps')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+
+        $this->service->createAndLinkPoi('abc-123', 1, 2, 'Office', 52.37, 4.89);
+    }//end testCreateAndLinkPoiThrowsWhenMapsUnavailable()
+
+    public function testUnlinkPoiThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->unlinkPoi('abc-123', 99);
+    }//end testUnlinkPoiThrowsWhenNoUser()
+
+    public function testUnlinkPoiThrowsWhenLinkMissing(): void
+    {
+        $this->setupUser();
+        $this->mapper->method('deleteByObjectAndFavorite')->with('abc-123', 99)->willReturn(0);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(404);
+
+        $this->service->unlinkPoi('abc-123', 99);
+    }//end testUnlinkPoiThrowsWhenLinkMissing()
+
+    public function testUnlinkPoiSucceeds(): void
+    {
+        $this->setupUser();
+        $this->mapper->expects($this->once())
+            ->method('deleteByObjectAndFavorite')
+            ->with('abc-123', 99)
+            ->willReturn(1);
+
+        $this->service->unlinkPoi('abc-123', 99);
+    }//end testUnlinkPoiSucceeds()
+
+    public function testGetLinkedPoisReturnsRowsWithDeepLink(): void
+    {
+        $link = new MapLink();
+        $link->setObjectUuid('abc-123');
+        $link->setFavoriteId(42);
+        $link->setName('Office');
+        $link->setCategory('Work');
+        $link->setLat(52.37);
+        $link->setLng(4.89);
+
+        $this->mapper->method('findByObjectUuid')->with('abc-123')->willReturn([$link]);
+
+        $rows = $this->service->getLinkedPois('abc-123');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame(42, $rows[0]['favoriteId']);
+        $this->assertSame('Office', $rows[0]['name']);
+        $this->assertSame('Work', $rows[0]['category']);
+        $this->assertStringContainsString('m=42', $rows[0]['url']);
+    }//end testGetLinkedPoisReturnsRowsWithDeepLink()
+
+    public function testGetLinkedPoisEmpty(): void
+    {
+        $this->mapper->method('findByObjectUuid')->with('abc-123')->willReturn([]);
+
+        $this->assertSame([], $this->service->getLinkedPois('abc-123'));
+    }//end testGetLinkedPoisEmpty()
+
+    public function testGetAvailablePoisEmptyWhenMapsUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('maps')->willReturn(false);
+
+        $this->assertSame([], $this->service->getAvailablePois());
+    }//end testGetAvailablePoisEmptyWhenMapsUnavailable()
+
+    public function testGetAvailablePoisEmptyWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+        $this->appManager->method('isEnabledForUser')->with('maps')->willReturn(true);
+
+        $this->assertSame([], $this->service->getAvailablePois());
+    }//end testGetAvailablePoisEmptyWhenNoUser()
+}//end class


### PR DESCRIPTION
## Summary
Promotes the **maps** integration leaf from the wave-1 marker-only provider to a full Tier-2 link-table surface (mirrors the photos Tier-2 exemplar).

- Migration `Version1Date20260525190000` creates `openregister_map_links` (`object_uuid`/`register_id`/`schema_id`/`favorite_id`/`name`/`category`/`lat`/`lng`/`comment`/`linked_by`/`linked_at`) with composite unique `(object_uuid, favorite_id)`; idempotent create-or-extend.
- `MapLink` entity + `MapLinkMapper`.
- `MapLinkService` composes the mapper with NC Maps' `FavoritesService` (lazy-resolved behind `class_exists` + `Throwable` guard for ADR-019 AD-23 graceful degradation): `linkPoi` / `unlinkPoi` / `getLinkedPois` / `getAvailablePois` / `createAndLinkPoi`.
- `MapLinksController`: `GET`/`POST` `/maps`, `POST` `/maps/new`, `DELETE` `/maps/{favoriteId}`, `GET` `/integrations/maps/available` — user-scoped, specific-before-wildcard routes.
- `MapsProvider` reads the link table first, falling back to the legacy `[or:{uuid}]` favorite-name marker scan for pre-Tier-2 POIs.
- `MapLinkServiceTest` (`@group requires-app-maps`).

Refs openregister#1316, ADR-019, ADR-022, ADR-004.

## Test plan
- [x] `php -l` clean on all new/changed files
- [x] PHPCS passes on all `lib/` files (strict gate)
- [ ] PHPUnit `MapLinkServiceTest` (requires NC container with the maps app)
- [ ] Migration applies cleanly in the dev container
- [ ] E2E: link/create/unlink a POI from the sidebar via the nc-vue PR