### PR TITLE
retrofit: Bucket 3a investigation — geo/fieldtypes/oas (5 REQs)

### DIFF
--- a/lib/Service/Oas/ProblemDetailsBuilder.php
+++ b/lib/Service/Oas/ProblemDetailsBuilder.php
@@ -32,6 +32,7 @@
  * @link https://www.OpenRegister.app
  *
  * @spec openspec/changes/oas-validation/tasks.md "API-46 Problem Details (RFC 7807)"
+ * @spec openspec/changes/oas-validation/specs/oas-validation/spec.md "Error responses include problem details (API-46 / RFC 7807)"
  */
 
 declare(strict_types=1);
@@ -40,6 +41,8 @@ namespace OCA\OpenRegister\Service\Oas;
 
 /**
  * Builds RFC 7807 problem-details response payloads.
+ *
+ * @spec openspec/changes/oas-validation/specs/oas-validation/spec.md "Error responses include problem details (API-46 / RFC 7807)"
  */
 class ProblemDetailsBuilder
 {

--- a/openspec/changes/retrofit-2026-05-24-b3a-geo-fieldtypes-oas/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-b3a-geo-fieldtypes-oas/proposal.md
@@ -1,0 +1,59 @@
+# Retrofit — Bucket 3a investigation: geo / field-types / OAS (5 REQs)
+
+Bucket 3a collects requirements the coverage scanner flagged with **no
+annotated implementation found**. This change records the investigation
+outcome for 5 such REQs across three capabilities (geo-metadata-kaart,
+extended-field-types, oas-validation), classifying each as
+IMPLEMENTED / PARTIAL / MISSING and annotating the one that turned out to
+already ship.
+
+Source: `/tmp/or-scan/b3a-geo-fieldtypes-oas.json` (scanner batch, 5 REQs).
+This is an annotations-only / paper-trail change — no behaviour is added.
+Missing REQs are listed below for GitHub issue filing.
+
+## Per-REQ classification
+
+| REQ | Title | Classification | Evidence |
+|-----|-------|----------------|----------|
+| `oas-validation#API-46` | Error responses include problem details (RFC 7807) | **IMPLEMENTED** | `lib/Service/Oas/ProblemDetailsBuilder.php` builds the full RFC 7807 shape (`type`/`title`/`status`/`detail`/`instance` + extensions). `lib/Service/Resources/BaseOas.json` `Error` schema declares every RFC 7807 field plus legacy `error`/`code` aliases. Wired via `OasValidationMiddleware` (sends `application/problem+json`) and `OasRequestValidator`. Exceeds the spec, which only marked the RFC 7807 fields as a "future enhancement SHOULD". |
+| `extended-field-types#EFT-005` | `color` type accepts hex / rgba / oklch + validates per declared format | **PARTIAL** | `color` is NOT a schema `type` (not in `PropertyValidatorHandler::$validTypes`). It exists only as accepted string-**format** names in `$validStringFormats` (`color`, `color-hex`, `color-hex-alpha`, `color-rgb`, `color-rgba`, `color-hsl`, `color-hsla`). `SchemaService::detectStringFormat()` infers `color` from a 6-digit-hex heuristic only. There is **no** per-format validation regex, **no** `oklch`, and **no** per-format 422 error messages the REQ mandates. Recognised in name only. |
+| `extended-field-types#EFT-003` | `recurrence` type stores RFC 5545 RRULE + emits upcoming occurrences | **MISSING** | No `recurrence` schema type. No `sabre/vobject` RRULE parsing (`sabre/vobject` is not even a composer dependency — only a transitive `sabre/dav` advisory pin in `composer.lock`). No `_occurrences` enrichment, no `?recurrenceOccurrences=N` handling. `SchemaTypeConverter` only dispatches the 6 JSON-Schema primitives. |
+| `geo-metadata-kaart#GEO-003` | Map visualization component with PDOK tile layers | **MISSING** | No map UI. `leaflet` / `maplibre` / `openlayers` / `mapbox` / `markercluster` absent from `package.json`. No `pdok` / `achtergrondkaart` / `L.map` reference anywhere in `src/`. No map view toggle, no marker clustering, no polygon overlay component. (Backend geo-filtering under `lib/Service/Geo/` exists — that covers GEO-004, not GEO-003.) |
+| `geo-metadata-kaart#GEO-010` | Geo-fencing with event triggers | **MISSING** | No geo-fence schema configuration. No `ObjectEnteredGeoFence` / `ObjectCreatedInGeoFence` events (not in `lib/Event/`). No boundary-crossing detection. Entirely unimplemented. |
+
+## Summary
+
+- **IMPLEMENTED: 1** — API-46
+- **PARTIAL: 1** — EFT-005
+- **MISSING: 3** — EFT-003, GEO-003, GEO-010
+
+## Affected code units (annotated)
+
+- `lib/Service/Oas/ProblemDetailsBuilder.php` — added scenario-level `@spec`
+  pointer to the API-46 / RFC 7807 scenario in
+  `openspec/changes/oas-validation/specs/oas-validation/spec.md`. The class
+  already carried a `tasks.md`-level `@spec`; the scanner missed it because
+  no annotation named the scenario. No behaviour change.
+
+## Gaps for issue filing
+
+The following REQs are genuinely unimplemented (or only nominally present)
+and should be tracked as GitHub issues — they are aspirational parts of
+feature-rich specs that do not yet ship:
+
+1. **`extended-field-types#EFT-003`** — implement the `recurrence` field
+   type: add `sabre/vobject` as a dependency, parse/validate RRULE on write
+   (HTTP 422 on parse error with the exact spec message), preserve the
+   literal RRULE on read, and emit `_occurrences` (configurable
+   `?recurrenceOccurrences=N`, default 5, max 100).
+2. **`extended-field-types#EFT-005`** — promote `color` to a real field type
+   with per-declared-`format` validation (`hex` 6/8-digit, `rgba` 4-component,
+   `oklch`), returning the exact 422 messages in the spec scenarios. Today
+   only string-format *names* are whitelisted; no notation validation runs and
+   `oklch` is absent.
+3. **`geo-metadata-kaart#GEO-003`** — build the interactive map UI component
+   (PDOK BRT Achtergrondkaart base layer, marker clustering, polygon overlays,
+   map-view toggle alongside table/card, responsive mobile behaviour).
+4. **`geo-metadata-kaart#GEO-010`** — implement schema-level geo-fence
+   configuration plus `ObjectEnteredGeoFence` / `ObjectCreatedInGeoFence`
+   (and exit) events surfaced to n8n/webhooks.

--- a/openspec/changes/retrofit-2026-05-24-b3a-geo-fieldtypes-oas/specs/oas-validation/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-b3a-geo-fieldtypes-oas/specs/oas-validation/spec.md
@@ -1,0 +1,39 @@
+---
+retrofit: true
+---
+
+# OAS Validation — RFC 7807 Problem Details (retrofit)
+
+## Purpose
+
+Records the observed, already-shipping RFC 7807 problem-details behaviour that
+satisfies `oas-validation#API-46`. The coverage scanner flagged API-46 as
+having no annotated implementation; investigation found a complete
+implementation in `lib/Service/Oas/ProblemDetailsBuilder.php` and the `Error`
+schema in `lib/Service/Resources/BaseOas.json`. This retrofit annotates the
+builder and specifies the observed behaviour.
+
+## ADDED Requirements
+
+### Requirement: Error responses MUST follow RFC 7807 problem details (API-46)
+
+OpenRegister error responses MUST be emitted as RFC 7807 problem documents.
+`ProblemDetailsBuilder::build()` MUST produce a payload carrying `type`
+(defaulting to `about:blank`), `title`, and `status`, with optional `detail`
+and `instance`, plus free-form extensions (e.g. `errors`, legacy `code`). The
+response MUST carry `Content-Type: application/problem+json`. The `Error`
+schema in `BaseOas.json` MUST document these fields, retaining the legacy
+`error` and `code` aliases for backward compatibility.
+
+#### Scenario: Validation failure returns an RFC 7807 422 document
+- **GIVEN** a request fails OAS schema validation
+- **WHEN** `ProblemDetailsBuilder::validationFailed()` builds the response
+- **THEN** the payload MUST include `type: "about:blank"`, `title: "Validation failed"`, and `status: 422`
+- **AND** the per-field errors MUST be carried in the `errors` extension array
+- **AND** the response MUST be sent with `Content-Type: application/problem+json`
+
+#### Scenario: Not-found error carries problem-details shape
+- **GIVEN** an object lookup misses
+- **WHEN** `ProblemDetailsBuilder::notFound()` builds the response
+- **THEN** the payload MUST include `title: "Not found"` and `status: 404`
+- **AND** the `Error` schema in `BaseOas.json` MUST declare `type`, `title`, `status`, `detail`, and `instance` per RFC 7807

--- a/openspec/changes/retrofit-2026-05-24-b3a-geo-fieldtypes-oas/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-b3a-geo-fieldtypes-oas/tasks.md
@@ -1,0 +1,25 @@
+# Tasks — Bucket 3a investigation: geo / field-types / OAS
+
+Annotations-only retrofit. No production behaviour is added; missing REQs are
+deferred to GitHub issues (see proposal.md "Gaps for issue filing").
+
+## 1. Investigation (done)
+
+- [x] Read all 5 REQs in their specs.
+- [x] grep `lib/` + `src/` for each implementing unit.
+- [x] Classify each REQ (1 IMPLEMENTED, 1 PARTIAL, 3 MISSING).
+
+## 2. Annotation (done)
+
+- [x] `oas-validation#API-46` — add scenario-level `@spec` to
+      `lib/Service/Oas/ProblemDetailsBuilder.php` (class docblock + file
+      docblock) pointing at the API-46 / RFC 7807 scenario.
+- [x] `php -l` the annotated file (clean).
+
+## 3. Gaps deferred to issues (do NOT implement here)
+
+- [ ] `extended-field-types#EFT-003` — `recurrence` type (file issue).
+- [ ] `extended-field-types#EFT-005` — real `color` type with per-format
+      validation incl. `oklch` (file issue).
+- [ ] `geo-metadata-kaart#GEO-003` — PDOK map UI component (file issue).
+- [ ] `geo-metadata-kaart#GEO-010` — geo-fencing + event triggers (file issue).


### PR DESCRIPTION
## Summary

Coverage-scanner **Bucket 3a**: 5 REQs the scanner flagged with no annotated implementation. This PR records the investigation outcome (annotations-only paper trail — no behaviour added) and lists genuine gaps for issue filing.

| REQ | Classification |
|-----|----------------|
| `oas-validation#API-46` (RFC 7807 problem details) | **IMPLEMENTED** |
| `extended-field-types#EFT-005` (`color` type per-format validation) | **PARTIAL** |
| `extended-field-types#EFT-003` (`recurrence` RRULE type) | **MISSING** |
| `geo-metadata-kaart#GEO-003` (PDOK map UI) | **MISSING** |
| `geo-metadata-kaart#GEO-010` (geo-fencing + events) | **MISSING** |

**Tally: 1 implemented / 1 partial / 3 missing.**

### Annotation
- `lib/Service/Oas/ProblemDetailsBuilder.php` — added a scenario-level `@spec` pointer to the API-46 / RFC 7807 scenario. The builder + `BaseOas.json` `Error` schema already shipped the full RFC 7807 shape; the scanner missed it because no annotation named the scenario.

### Findings
- **API-46** ships completely (and exceeds the spec, which marked the RFC 7807 fields as a "future enhancement SHOULD").
- **EFT-005** is partial: `color`/`color-*` exist only as whitelisted string-*format* names in `PropertyValidatorHandler`; there is no per-format regex validation, no `oklch`, and no 422 error messages the REQ mandates.
- **EFT-003 / GEO-003 / GEO-010** are unimplemented — aspirational parts of feature-rich specs.

### Gaps for issue filing
See `proposal.md` "Gaps for issue filing": EFT-003 (`recurrence` type + sabre/vobject), EFT-005 (real `color` type w/ oklch), GEO-003 (PDOK map component), GEO-010 (geo-fence events).

## Test plan
- [x] `php -l lib/Service/Oas/ProblemDetailsBuilder.php` clean
- [x] `openspec validate retrofit-2026-05-24-b3a-geo-fieldtypes-oas --strict` passes