### PR TITLE
feat(collectives): Tier-2 — link table + page picker + create

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -411,6 +411,18 @@ return [
         ['name' => 'photoLinks#link',         'url' => '/api/objects/{register}/{schema}/{id}/photos',         'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
         ['name' => 'photoLinks#destroy',      'url' => '/api/objects/{register}/{schema}/{id}/photos/{albumId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'albumId' => '[0-9]+']],
 
+        // Collectives (NC Knowledge) — Tier-2 link-table API. User-scoped
+        // (no admin gate). The specific `/collectives/new` (create + link)
+        // route MUST precede the wildcard `/collectives/{pageId}` unlink
+        // route, and the app-global `available`/`list` routes precede the
+        // object-scoped routes.
+        ['name' => 'collectiveLinks#available',    'url' => '/api/integrations/collectives/available',                  'verb' => 'GET'],
+        ['name' => 'collectiveLinks#collectives',  'url' => '/api/integrations/collectives/list',                       'verb' => 'GET'],
+        ['name' => 'collectiveLinks#index',        'url' => '/api/objects/{register}/{schema}/{id}/collectives',        'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
+        ['name' => 'collectiveLinks#createAndLink','url' => '/api/objects/{register}/{schema}/{id}/collectives/new',    'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'collectiveLinks#link',         'url' => '/api/objects/{register}/{schema}/{id}/collectives',        'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'collectiveLinks#destroy',      'url' => '/api/objects/{register}/{schema}/{id}/collectives/{pageId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'pageId' => '[0-9]+']],
+
         // Activity — Tier-2 read-only API. NC Activity entries are
         // core-generated (no link/create/delete verbs); this surface
         // only filters + cursor-paginates the entries linked to an OR

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1143,8 +1143,9 @@ class Application extends App implements IBootstrap
             \OCA\OpenRegister\Service\Integration\Providers\ActivityProvider::class,
             // @spec openspec/changes/integration-analytics/tasks.md.
             \OCA\OpenRegister\Service\Integration\Providers\AnalyticsProvider::class,
-            // @spec openspec/changes/integration-collectives/tasks.md.
-            \OCA\OpenRegister\Service\Integration\Providers\CollectivesProvider::class,
+            // NB: CollectivesProvider was Tier-1 greenfield until Tier-2;
+            // it now takes a CollectiveLinkMapper. Registered separately
+            // below.
             // @spec openspec/changes/integration-cospend/tasks.md.
             \OCA\OpenRegister\Service\Integration\Providers\CospendProvider::class,
             // NB: FormsProvider is NO LONGER greenfield — it has a Tier-2
@@ -1376,6 +1377,43 @@ class Application extends App implements IBootstrap
             function (ContainerInterface $container) {
                 return new \OCA\OpenRegister\Service\PhotoLinkService(
                     photoLinkMapper: $container->get(\OCA\OpenRegister\Db\PhotoLinkMapper::class),
+                    container: $container,
+                    appManager: $container->get('OCP\App\IAppManager'),
+                    userSession: $container->get('OCP\IUserSession'),
+                    urlGenerator: $container->get('OCP\IURLGenerator'),
+                    logger: $container->get('Psr\Log\LoggerInterface'),
+                );
+            }
+        );
+
+        // CollectivesProvider — Tier-2: backed by the CollectiveLinkMapper.
+        // The provider still gracefully degrades to the legacy
+        // `[or:{uuid}]` slug-marker scan when the link table is empty
+        // (pages that pre-date the Tier-2 link table).
+        // @spec openspec/changes/integration-collectives/tasks.md.
+        $context->registerService(
+            \OCA\OpenRegister\Service\Integration\Providers\CollectivesProvider::class,
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\Service\Integration\Providers\CollectivesProvider(
+                    db: $container->get('OCP\IDBConnection'),
+                    appManager: $container->get('OCP\App\IAppManager'),
+                    l10n: $container->get('OCP\IL10N'),
+                    collectiveLinkMapper: $container->get(\OCA\OpenRegister\Db\CollectiveLinkMapper::class),
+                );
+            }
+        );
+
+        // CollectiveLinkService — Tier-2 link/create/unlink/picker service
+        // backing the CollectiveLinksController. NC Collectives pages are
+        // user-scoped; CollectiveService + PageService are resolved lazily
+        // via the container so the service loads even when Collectives is
+        // absent.
+        // @spec openspec/changes/integration-collectives/tasks.md.
+        $context->registerService(
+            \OCA\OpenRegister\Service\CollectiveLinkService::class,
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\Service\CollectiveLinkService(
+                    collectiveLinkMapper: $container->get(\OCA\OpenRegister\Db\CollectiveLinkMapper::class),
                     container: $container,
                     appManager: $container->get('OCP\App\IAppManager'),
                     userSession: $container->get('OCP\IUserSession'),

--- a/lib/Controller/CollectiveLinksController.php
+++ b/lib/Controller/CollectiveLinksController.php
@@ -1,0 +1,347 @@
+<?php
+
+/**
+ * CollectiveLinksController — Tier-2 REST controller for NC Collectives
+ * (Knowledge) page links.
+ *
+ * Surface:
+ *
+ *   - GET    /api/objects/{r}/{s}/{id}/collectives             — list linked pages
+ *   - POST   /api/objects/{r}/{s}/{id}/collectives             — link existing page `{pageId}`
+ *   - POST   /api/objects/{r}/{s}/{id}/collectives/new         — create + link page `{collectiveId,title}`
+ *   - DELETE /api/objects/{r}/{s}/{id}/collectives/{pageId}    — unlink page
+ *   - GET    /api/integrations/collectives/available?search=   — page picker source
+ *   - GET    /api/integrations/collectives/list                — collectives for the create cascade
+ *
+ * NC Collectives pages are user-scoped (via the collective's circle
+ * membership), so (unlike Flow) there is no admin gate — the active
+ * session's user owns the pages it can link/create.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use Exception;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\CollectiveLinkService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Tier-2 Collectives links controller.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ */
+class CollectiveLinksController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param string                $appName               App id.
+     * @param IRequest              $request               HTTP request.
+     * @param CollectiveLinkService $collectiveLinkService Backing service.
+     * @param ObjectService         $objectService         OR object resolver.
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly CollectiveLinkService $collectiveLinkService,
+        private readonly ObjectService $objectService,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * List linked Collectives pages for an object.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function index(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->collectiveLinkService->isCollectivesAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Collectives app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $results = $this->collectiveLinkService->getLinkedPages($object->getUuid());
+
+            return new JSONResponse(
+                    [
+                        'results' => $results,
+                        'total'   => count($results),
+                    ]
+                    );
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return new JSONResponse(['error' => $e->getMessage()], 500);
+        }//end try
+    }//end index()
+
+    /**
+     * Link an existing Collectives page.
+     *
+     * Body: `{ pageId: int }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function link(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->collectiveLinkService->isCollectivesAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Collectives app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $pageId = (int) $this->request->getParam('pageId', 0);
+            if ($pageId === 0) {
+                return new JSONResponse(['error' => 'pageId is required'], 400);
+            }
+
+            $link = $this->collectiveLinkService->linkPage(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $pageId
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end link()
+
+    /**
+     * Create a new Collectives page and link it.
+     *
+     * Body: `{ collectiveId: int, title: string }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function createAndLink(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->collectiveLinkService->isCollectivesAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Collectives app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $collectiveId = (int) $this->request->getParam('collectiveId', 0);
+            if ($collectiveId === 0) {
+                return new JSONResponse(['error' => 'collectiveId is required'], 400);
+            }
+
+            $title = (string) $this->request->getParam('title', '');
+            if (trim($title) === '') {
+                return new JSONResponse(['error' => 'title is required'], 400);
+            }
+
+            $link = $this->collectiveLinkService->createAndLinkPage(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $collectiveId,
+                $title
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end createAndLink()
+
+    /**
+     * Unlink a Collectives page.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     * @param string $pageId   Page id (numeric).
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function destroy(string $register, string $schema, string $id, string $pageId): JSONResponse
+    {
+        if ($this->collectiveLinkService->isCollectivesAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Collectives app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $this->collectiveLinkService->unlinkPage($object->getUuid(), (int) $pageId);
+
+            return new JSONResponse(['success' => true]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end destroy()
+
+    /**
+     * List the current user's Collectives pages (picker source).
+     *
+     * Query param: `search` — optional title substring.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function available(): JSONResponse
+    {
+        if ($this->collectiveLinkService->isCollectivesAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Collectives app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        $search = $this->request->getParam('search');
+        if ($search !== null) {
+            $search = (string) $search;
+        }
+
+        $pages = $this->collectiveLinkService->getAvailablePages($search);
+        return new JSONResponse(['results' => $pages, 'total' => count($pages)]);
+    }//end available()
+
+    /**
+     * List the current user's collectives (create-cascade source).
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function collectives(): JSONResponse
+    {
+        if ($this->collectiveLinkService->isCollectivesAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Collectives app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        $collectives = $this->collectiveLinkService->getAvailableCollectives();
+        return new JSONResponse(['results' => $collectives, 'total' => count($collectives)]);
+    }//end collectives()
+
+    /**
+     * Resolve an OR object from register/schema/id.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return ObjectEntity|null
+     */
+    private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
+    {
+        $this->objectService->setSchema($schema);
+        $this->objectService->setRegister($register);
+        $this->objectService->setObject($id);
+
+        return $this->objectService->getObject();
+    }//end validateObject()
+
+    /**
+     * Map a service-layer Exception to a JSONResponse.
+     *
+     * Exception codes carry HTTP intent:
+     *   - 400 → bad request
+     *   - 401 → unauthorized (no user)
+     *   - 404 → not found
+     *   - 409 → conflict (duplicate link)
+     *   - 503 → service unavailable
+     *   - everything else → 400 bad request
+     *
+     * @param Exception $exception Source exception.
+     *
+     * @return JSONResponse
+     */
+    private function mapException(Exception $exception): JSONResponse
+    {
+        $code = $exception->getCode();
+        if (in_array($code, [400, 401, 404, 409, 503], true) === true) {
+            return new JSONResponse(['error' => $exception->getMessage()], $code);
+        }
+
+        return new JSONResponse(['error' => $exception->getMessage()], 400);
+    }//end mapException()
+}//end class

--- a/lib/Db/CollectiveLink.php
+++ b/lib/Db/CollectiveLink.php
@@ -1,0 +1,207 @@
+<?php
+
+/**
+ * CollectiveLink entity for linking NC Collectives (Knowledge) pages to
+ * OpenRegister objects.
+ *
+ * Tier-2 schema: carries register_id, schema_id, collective_id,
+ * collective_name, page_title, slug, emoji, last_modified and url so the
+ * link row alone can hydrate the sidebar tab + picker UX without a
+ * per-page roundtrip to NC Collectives. Replaces the Tier-1
+ * `CollectivesProvider`'s `[or:{uuid}]` slug-marker convention with a
+ * proper persistence layer that survives page renames + moves.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Class CollectiveLink
+ *
+ * @method string getObjectUuid()
+ * @method void setObjectUuid(string $objectUuid)
+ * @method int getRegisterId()
+ * @method void setRegisterId(int $registerId)
+ * @method int|null getSchemaId()
+ * @method void setSchemaId(?int $schemaId)
+ * @method int getPageId()
+ * @method void setPageId(int $pageId)
+ * @method int getCollectiveId()
+ * @method void setCollectiveId(int $collectiveId)
+ * @method string getCollectiveName()
+ * @method void setCollectiveName(string $collectiveName)
+ * @method string getPageTitle()
+ * @method void setPageTitle(string $pageTitle)
+ * @method string|null getSlug()
+ * @method void setSlug(?string $slug)
+ * @method string|null getEmoji()
+ * @method void setEmoji(?string $emoji)
+ * @method DateTime|null getLastModified()
+ * @method void setLastModified(?DateTime $lastModified)
+ * @method string|null getUrl()
+ * @method void setUrl(?string $url)
+ * @method string|null getLinkedBy()
+ * @method void setLinkedBy(string $linkedBy)
+ * @method DateTime|null getLinkedAt()
+ * @method void setLinkedAt(DateTime $linkedAt)
+ *
+ * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class
+ */
+class CollectiveLink extends Entity implements JsonSerializable
+{
+
+    /**
+     * The object uuid.
+     *
+     * @var string|null
+     */
+    protected ?string $objectUuid = null;
+
+    /**
+     * The register id.
+     *
+     * @var integer|null
+     */
+    protected ?int $registerId = null;
+
+    /**
+     * The schema id.
+     *
+     * @var integer|null
+     */
+    protected ?int $schemaId = null;
+
+    /**
+     * The NC Collectives page id (primary key in `oc_collectives_pages`).
+     *
+     * @var integer|null
+     */
+    protected ?int $pageId = null;
+
+    /**
+     * The owning collective id.
+     *
+     * @var integer|null
+     */
+    protected ?int $collectiveId = null;
+
+    /**
+     * The collective display name (cached at link time).
+     *
+     * @var string|null
+     */
+    protected ?string $collectiveName = null;
+
+    /**
+     * The page title (cached at link time).
+     *
+     * @var string|null
+     */
+    protected ?string $pageTitle = null;
+
+    /**
+     * The cached page slug.
+     *
+     * @var string|null
+     */
+    protected ?string $slug = null;
+
+    /**
+     * The cached page emoji.
+     *
+     * @var string|null
+     */
+    protected ?string $emoji = null;
+
+    /**
+     * The cached page last-modified timestamp.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $lastModified = null;
+
+    /**
+     * The cached deep link to the page.
+     *
+     * @var string|null
+     */
+    protected ?string $url = null;
+
+    /**
+     * The linked by uid.
+     *
+     * @var string|null
+     */
+    protected ?string $linkedBy = null;
+
+    /**
+     * The linked at timestamp.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $linkedAt = null;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->addType(fieldName: 'objectUuid', type: 'string');
+        $this->addType(fieldName: 'registerId', type: 'integer');
+        $this->addType(fieldName: 'schemaId', type: 'integer');
+        $this->addType(fieldName: 'pageId', type: 'integer');
+        $this->addType(fieldName: 'collectiveId', type: 'integer');
+        $this->addType(fieldName: 'collectiveName', type: 'string');
+        $this->addType(fieldName: 'pageTitle', type: 'string');
+        $this->addType(fieldName: 'slug', type: 'string');
+        $this->addType(fieldName: 'emoji', type: 'string');
+        $this->addType(fieldName: 'lastModified', type: 'datetime');
+        $this->addType(fieldName: 'url', type: 'string');
+        $this->addType(fieldName: 'linkedBy', type: 'string');
+        $this->addType(fieldName: 'linkedAt', type: 'datetime');
+    }//end __construct()
+
+    /**
+     * JSON serialization.
+     *
+     * @return array<string,mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'             => $this->id,
+            'objectUuid'     => $this->objectUuid,
+            'registerId'     => $this->registerId,
+            'schemaId'       => $this->schemaId,
+            'pageId'         => $this->pageId,
+            'collectiveId'   => $this->collectiveId,
+            'collectiveName' => $this->collectiveName,
+            'pageTitle'      => $this->pageTitle,
+            'slug'           => $this->slug,
+            'emoji'          => $this->emoji,
+            'lastModified'   => $this->lastModified?->format(DateTime::ATOM),
+            'url'            => $this->url,
+            'linkedBy'       => $this->linkedBy,
+            'linkedAt'       => $this->linkedAt?->format(DateTime::ATOM),
+        ];
+    }//end jsonSerialize()
+}//end class

--- a/lib/Db/CollectiveLinkMapper.php
+++ b/lib/Db/CollectiveLinkMapper.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * Mapper for collective link entities.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Class CollectiveLinkMapper
+ *
+ * @template-extends QBMapper<CollectiveLink>
+ */
+class CollectiveLinkMapper extends QBMapper
+{
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $db Database connection.
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(db: $db, tableName: 'openregister_collective_links', entityClass: CollectiveLink::class);
+    }//end __construct()
+
+    /**
+     * Find collective links by object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return CollectiveLink[] Array of collective links.
+     */
+    public function findByObjectUuid(string $objectUuid): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByObjectUuid()
+
+    /**
+     * Find collective links by page id.
+     *
+     * @param int $pageId The page id.
+     *
+     * @return CollectiveLink[] Array of collective links.
+     */
+    public function findByPageId(int $pageId): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('page_id', $qb->createNamedParameter($pageId, IQueryBuilder::PARAM_INT)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByPageId()
+
+    /**
+     * Find a specific collective link by object UUID and page id.
+     *
+     * @param string $objectUuid The object UUID.
+     * @param int    $pageId     The page id.
+     *
+     * @return CollectiveLink|null The link or null if not found.
+     */
+    public function findByObjectAndPage(string $objectUuid, int $pageId): ?CollectiveLink
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('page_id', $qb->createNamedParameter($pageId, IQueryBuilder::PARAM_INT)));
+
+        try {
+            return $this->findEntity(query: $qb);
+        } catch (DoesNotExistException $e) {
+            return null;
+        }
+    }//end findByObjectAndPage()
+
+    /**
+     * Delete all collective links for an object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectUuid(string $objectUuid): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectUuid()
+
+    /**
+     * Delete a collective link by object UUID + page id (Tier-2 unlink path).
+     *
+     * Returns the number of rows actually deleted so callers can
+     * distinguish "no such link" (0) from "ok" (>=1).
+     *
+     * @param string $objectUuid The object UUID.
+     * @param int    $pageId     The page id.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectAndPage(string $objectUuid, int $pageId): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('page_id', $qb->createNamedParameter($pageId, IQueryBuilder::PARAM_INT)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectAndPage()
+}//end class

--- a/lib/Migration/Version1Date20260525200000.php
+++ b/lib/Migration/Version1Date20260525200000.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * Tier-2 collectives (NC Collectives / Knowledge) integration migration.
+ *
+ * Ensures the `openregister_collective_links` table exists with the full
+ * Tier-2 schema:
+ *
+ *  - id (bigint, PK, autoincrement)
+ *  - object_uuid (string 36, not null, indexed)
+ *  - register_id (bigint unsigned, not null, indexed)
+ *  - schema_id (bigint unsigned, nullable, indexed)
+ *  - page_id (integer, not null) — `collectives_pages` row id
+ *  - collective_id (integer, not null) — owning collective id
+ *  - collective_name (string 255, not null) — cached collective title
+ *  - page_title (string 255, not null) — cached page title
+ *  - slug (string 255, nullable) — cached page slug
+ *  - emoji (string 16, nullable) — cached page emoji
+ *  - last_modified (datetime, nullable) — cached page timestamp
+ *  - url (string 512, nullable) — cached deep link to the page
+ *  - linked_by (string 64, not null)
+ *  - linked_at (datetime, not null)
+ *
+ * Idempotent: creates the table if missing, otherwise adds any missing
+ * Tier-2 columns. Companion to the Tier-2 talk/polls/email/forms/deck/
+ * flow/photos link tables; the wrapping `CollectiveLinkService` replaces
+ * the `[or:{uuid}]` slug marker convention used by the Tier-1
+ * `CollectivesProvider` with a proper persistence layer so links survive
+ * page renames + moves.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Tier-2 collective-links table — create-or-extend.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+class Version1Date20260525200000 extends SimpleMigrationStep
+{
+    /**
+     * Change the database schema.
+     *
+     * @param IOutput                 $output        Output for the migration process
+     * @param Closure                 $schemaClosure The schema closure
+     * @param array<array-key, mixed> $options       Migration options
+     *
+     * @return ISchemaWrapper|null
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema  = $schemaClosure();
+        $changed = false;
+
+        if ($schema->hasTable('openregister_collective_links') === false) {
+            $this->createCollectiveLinksTable(schema: $schema, output: $output);
+            $changed = true;
+        }
+
+        if ($schema->hasTable('openregister_collective_links') === true
+            && $this->extendCollectiveLinksTable(schema: $schema, output: $output) === true
+        ) {
+            $changed = true;
+        }
+
+        if ($changed === false) {
+            return null;
+        }
+
+        return $schema;
+    }//end changeSchema()
+
+    /**
+     * Create the openregister_collective_links table at the Tier-2 shape.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return void
+     */
+    private function createCollectiveLinksTable(ISchemaWrapper $schema, IOutput $output): void
+    {
+        $table = $schema->createTable('openregister_collective_links');
+
+        $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'unsigned' => true]);
+        $table->addColumn('object_uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
+        $table->addColumn('register_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('schema_id', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]);
+        $table->addColumn('page_id', Types::INTEGER, ['notnull' => true]);
+        $table->addColumn('collective_id', Types::INTEGER, ['notnull' => true]);
+        $table->addColumn('collective_name', Types::STRING, ['notnull' => true, 'length' => 255]);
+        $table->addColumn('page_title', Types::STRING, ['notnull' => true, 'length' => 255]);
+        $table->addColumn('slug', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+        $table->addColumn('emoji', Types::STRING, ['notnull' => false, 'length' => 16, 'default' => null]);
+        $table->addColumn('last_modified', Types::DATETIME, ['notnull' => false, 'default' => null]);
+        $table->addColumn('url', Types::STRING, ['notnull' => false, 'length' => 512, 'default' => null]);
+        $table->addColumn('linked_by', Types::STRING, ['notnull' => true, 'length' => 64]);
+        $table->addColumn('linked_at', Types::DATETIME, ['notnull' => true]);
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['object_uuid', 'page_id'], 'idx_coll_object_page');
+        $table->addIndex(['object_uuid'], 'idx_coll_object');
+        $table->addIndex(['register_id'], 'idx_coll_register');
+        $table->addIndex(['schema_id'], 'idx_coll_schema');
+
+        $output->info('Created openregister_collective_links table (Tier-2 schema)');
+    }//end createCollectiveLinksTable()
+
+    /**
+     * Add any missing Tier-2 columns to an existing collective_links table.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return bool True when a column was added.
+     */
+    private function extendCollectiveLinksTable(ISchemaWrapper $schema, IOutput $output): bool
+    {
+        $table   = $schema->getTable('openregister_collective_links');
+        $changed = false;
+
+        if ($table->hasColumn('schema_id') === false) {
+            $table->addColumn(
+                'schema_id',
+                Types::BIGINT,
+                ['notnull' => false, 'unsigned' => true, 'default' => null]
+            );
+            $table->addIndex(['schema_id'], 'idx_coll_schema');
+            $output->info('Added schema_id column to openregister_collective_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('slug') === false) {
+            $table->addColumn('slug', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+            $output->info('Added slug column to openregister_collective_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('emoji') === false) {
+            $table->addColumn('emoji', Types::STRING, ['notnull' => false, 'length' => 16, 'default' => null]);
+            $output->info('Added emoji column to openregister_collective_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('last_modified') === false) {
+            $table->addColumn('last_modified', Types::DATETIME, ['notnull' => false, 'default' => null]);
+            $output->info('Added last_modified column to openregister_collective_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('url') === false) {
+            $table->addColumn('url', Types::STRING, ['notnull' => false, 'length' => 512, 'default' => null]);
+            $output->info('Added url column to openregister_collective_links');
+            $changed = true;
+        }
+
+        return $changed;
+    }//end extendCollectiveLinksTable()
+}//end class

--- a/lib/Service/CollectiveLinkService.php
+++ b/lib/Service/CollectiveLinkService.php
@@ -1,0 +1,723 @@
+<?php
+
+/**
+ * CollectiveLinkService — Tier-2 collectives (NC Collectives / Knowledge)
+ * integration service.
+ *
+ * Composes the {@see CollectiveLinkMapper} with NC Collectives'
+ * `OCA\Collectives\Service\CollectiveService` + `PageService` to expose
+ * the Tier-2 surface:
+ *
+ *   - linkPage(uuid, registerId, schemaId, pageId)
+ *       — link an existing page
+ *   - createAndLinkPage(uuid, registerId, schemaId, collectiveId, title)
+ *       — create a new page in a collective and link it
+ *   - unlinkPage(uuid, pageId)
+ *       — remove a link (the page itself stays in NC Collectives)
+ *   - getLinkedPages(uuid)
+ *       — list linked pages, refreshing cached
+ *       title/slug/emoji/last_modified/url when the row is older than 24h
+ *   - getAvailablePages(?search)
+ *       — picker source listing the current user's pages (collective→page)
+ *   - getAvailableCollectives()
+ *       — collectives for the create cascade
+ *
+ * NC Collectives exposes its persistence as the `CollectiveService`
+ * (collective listing) and `PageService` (page listing + create + deep
+ * link). Both are resolved lazily through the server container behind a
+ * `class_exists` + `Throwable` guard so this service loads even when the
+ * Collectives app is not installed (ADR-019 AD-23 graceful degradation):
+ * when Collectives is missing or a call throws, the stored link row is
+ * returned as-is so historical references survive.
+ *
+ * Pages are user-scoped: NC Collectives pages belong to a user (via the
+ * collective's circle membership), so every mutating + picker call is
+ * scoped to the active session's UID.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://OpenRegister.app
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use DateTime;
+use Exception;
+use OCA\OpenRegister\Db\CollectiveLink;
+use OCA\OpenRegister\Db\CollectiveLinkMapper;
+use OCP\App\IAppManager;
+use OCP\IURLGenerator;
+use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * CollectiveLinkService.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)   Composes mapper +
+ *     NC Collectives CollectiveService + PageService (late-bound) + user
+ *     session + app manager + url generator + container + logger. Each
+ *     dependency is required for one of the Tier-2 flows (link, create,
+ *     unlink, list, picker, cache refresh, graceful degradation).
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ */
+class CollectiveLinkService
+{
+    private const REQUIRED_APP = 'collectives';
+
+    private const COLLECTIVE_SERVICE = 'OCA\\Collectives\\Service\\CollectiveService';
+
+    private const PAGE_SERVICE = 'OCA\\Collectives\\Service\\PageService';
+
+    private const STALE_AFTER = 86400;
+    // 24 hours in seconds.
+
+    /**
+     * Constructor.
+     *
+     * @param CollectiveLinkMapper $collectiveLinkMapper Persistence for link rows.
+     * @param ContainerInterface   $container            Container for late-bound Collectives classes.
+     * @param IAppManager          $appManager           NC app manager.
+     * @param IUserSession         $userSession          Active session.
+     * @param IURLGenerator        $urlGenerator         URL generator for deep links.
+     * @param LoggerInterface      $logger               Logger.
+     */
+    public function __construct(
+        private readonly CollectiveLinkMapper $collectiveLinkMapper,
+        private readonly ContainerInterface $container,
+        private readonly IAppManager $appManager,
+        private readonly IUserSession $userSession,
+        private readonly IURLGenerator $urlGenerator,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Whether NC Collectives is installed + enabled for the current user.
+     *
+     * @return bool
+     */
+    public function isCollectivesAvailable(): bool
+    {
+        return $this->appManager->isEnabledForUser(self::REQUIRED_APP);
+    }//end isCollectivesAvailable()
+
+    /**
+     * Resolve a late-bound NC Collectives service lazily.
+     *
+     * Returns null when Collectives is absent or the class can't be
+     * resolved, so callers degrade gracefully (ADR-019 AD-23).
+     *
+     * @param string $class The fully-qualified Collectives service class.
+     *
+     * @return object|null The service instance or null.
+     */
+    private function resolveService(string $class): ?object
+    {
+        if ($this->isCollectivesAvailable() === false || class_exists($class) === false) {
+            return null;
+        }
+
+        try {
+            return $this->container->get($class);
+        } catch (Throwable $e) {
+            $this->logger->debug('CollectiveLinkService: '.$class.' unavailable: '.$e->getMessage());
+            return null;
+        }
+    }//end resolveService()
+
+    /**
+     * Resolve NC Collectives' CollectiveService.
+     *
+     * @return object|null
+     */
+    private function getCollectiveService(): ?object
+    {
+        return $this->resolveService(class: self::COLLECTIVE_SERVICE);
+    }//end getCollectiveService()
+
+    /**
+     * Resolve NC Collectives' PageService.
+     *
+     * @return object|null
+     */
+    private function getPageService(): ?object
+    {
+        return $this->resolveService(class: self::PAGE_SERVICE);
+    }//end getPageService()
+
+    /**
+     * Active session UID, or throw if no user is logged in.
+     *
+     * @return string The user id.
+     *
+     * @throws Exception When there is no active user.
+     */
+    private function requireUid(): string
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in', 401);
+        }
+
+        return $user->getUID();
+    }//end requireUid()
+
+    /**
+     * Link an existing NC Collectives page to an OR object.
+     *
+     * Idempotent: a duplicate link raises a 409 Exception. Page metadata
+     * (title/slug/emoji/last_modified/url) is cached at link time.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $registerId OR register id.
+     * @param int    $schemaId   OR schema id.
+     * @param int    $pageId     NC Collectives page id.
+     *
+     * @return CollectiveLink The persisted link row.
+     *
+     * @throws Exception On missing user (401), missing page (404),
+     *                   duplicate (409), Collectives unavailable (503).
+     */
+    public function linkPage(string $objectUuid, int $registerId, int $schemaId, int $pageId): CollectiveLink
+    {
+        $uid = $this->requireUid();
+
+        if ($this->isCollectivesAvailable() === false) {
+            throw new Exception('NC Collectives is not available', 503);
+        }
+
+        $existing = $this->collectiveLinkMapper->findByObjectAndPage($objectUuid, $pageId);
+        if ($existing !== null) {
+            throw new Exception('Page already linked to this object', 409);
+        }
+
+        $info = $this->fetchPageInfo(pageId: $pageId, uid: $uid);
+        if ($info === null) {
+            throw new Exception('Collectives page not found', 404);
+        }
+
+        $link = $this->hydrateLink(
+            objectUuid: $objectUuid,
+            registerId: $registerId,
+            schemaId: $schemaId,
+            pageId: $pageId,
+            info: $info,
+            uid: $uid
+        );
+
+        return $this->collectiveLinkMapper->insert($link);
+    }//end linkPage()
+
+    /**
+     * Create a new NC Collectives page and link it to an OR object.
+     *
+     * @param string $objectUuid   Parent OR object uuid.
+     * @param int    $registerId   OR register id.
+     * @param int    $schemaId     OR schema id.
+     * @param int    $collectiveId Target collective id.
+     * @param string $title        New page title.
+     *
+     * @return CollectiveLink The persisted link row.
+     *
+     * @throws Exception On missing user (401), empty title (400),
+     *                   missing collective (400), Collectives unavailable (503).
+     */
+    public function createAndLinkPage(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        int $collectiveId,
+        string $title
+    ): CollectiveLink {
+        $uid = $this->requireUid();
+
+        $title = trim($title);
+        if ($title === '') {
+            throw new Exception('Page title is required', 400);
+        }
+
+        if ($collectiveId === 0) {
+            throw new Exception('Collective id is required', 400);
+        }
+
+        $pageService = $this->getPageService();
+        if ($pageService === null) {
+            throw new Exception('NC Collectives is not available', 503);
+        }
+
+        try {
+            // PageService::create(collectiveId, parentId, title, templateId, userId).
+            // parentId 0 places the page at the collective root.
+            $pageInfo = $pageService->create($collectiveId, 0, $title, null, $uid);
+            $pageId   = (int) $pageInfo->getId();
+        } catch (Throwable $e) {
+            $this->logger->warning('CollectiveLinkService::createAndLinkPage failed: '.$e->getMessage());
+            throw new Exception('Failed to create Collectives page', 500);
+        }
+
+        $info = $this->fetchPageInfo(pageId: $pageId, uid: $uid);
+        if ($info === null) {
+            $info = [
+                'title'        => $title,
+                'collectiveId' => $collectiveId,
+                'slug'         => null,
+                'emoji'        => null,
+                'lastModified' => new DateTime(),
+                'url'          => $this->pageDeepLink(pageId: $pageId),
+            ];
+        }
+
+        $link = $this->hydrateLink(
+            objectUuid: $objectUuid,
+            registerId: $registerId,
+            schemaId: $schemaId,
+            pageId: $pageId,
+            info: $info,
+            uid: $uid
+        );
+
+        return $this->collectiveLinkMapper->insert($link);
+    }//end createAndLinkPage()
+
+    /**
+     * Build a CollectiveLink from normalised page info.
+     *
+     * @param string              $objectUuid Parent OR object uuid.
+     * @param int                 $registerId OR register id.
+     * @param int                 $schemaId   OR schema id.
+     * @param int                 $pageId     NC Collectives page id.
+     * @param array<string,mixed> $info       Normalised page info.
+     * @param string              $uid        The linking user id.
+     *
+     * @return CollectiveLink
+     */
+    private function hydrateLink(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        int $pageId,
+        array $info,
+        string $uid
+    ): CollectiveLink {
+        $link = new CollectiveLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        $link->setSchemaId($schemaId);
+        $link->setPageId($pageId);
+        $link->setCollectiveId((int) ($info['collectiveId'] ?? 0));
+        $link->setCollectiveName((string) ($info['collectiveName'] ?? ''));
+        $link->setPageTitle((string) ($info['title'] ?? ''));
+        $link->setSlug($info['slug'] ?? null);
+        $link->setEmoji($info['emoji'] ?? null);
+        $link->setLastModified($info['lastModified'] ?? null);
+        $link->setUrl($info['url'] ?? $this->pageDeepLink(pageId: $pageId));
+        $link->setLinkedBy($uid);
+        $link->setLinkedAt(new DateTime());
+
+        return $link;
+    }//end hydrateLink()
+
+    /**
+     * Unlink a page from an object.
+     *
+     * Does NOT delete the page itself — it stays in NC Collectives for the
+     * user and for any other linked objects.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $pageId     NC Collectives page id.
+     *
+     * @return void
+     *
+     * @throws Exception On missing user (401) or no matching link (404).
+     */
+    public function unlinkPage(string $objectUuid, int $pageId): void
+    {
+        $this->requireUid();
+
+        $deleted = $this->collectiveLinkMapper->deleteByObjectAndPage($objectUuid, $pageId);
+        if ($deleted === 0) {
+            throw new Exception('Collective link not found', 404);
+        }
+    }//end unlinkPage()
+
+    /**
+     * Return the linked pages for an object, refreshing the cached
+     * title/slug/emoji/last_modified/url columns when a row is older
+     * than 24h.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getLinkedPages(string $objectUuid): array
+    {
+        $links     = $this->collectiveLinkMapper->findByObjectUuid($objectUuid);
+        $available = $this->isCollectivesAvailable();
+        $uid       = $this->userSession->getUser()?->getUID();
+
+        $results = [];
+        foreach ($links as $link) {
+            if ($available === true && $uid !== null && $this->isStale(link: $link) === true) {
+                $link = $this->refreshLink(link: $link, uid: $uid);
+            }
+
+            $results[] = $link->jsonSerialize();
+        }
+
+        return $results;
+    }//end getLinkedPages()
+
+    /**
+     * Return the current user's collectives (create cascade source).
+     *
+     * Returns an empty array when Collectives is unavailable.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getAvailableCollectives(): array
+    {
+        $service = $this->getCollectiveService();
+        $uid     = $this->userSession->getUser()?->getUID();
+        if ($service === null || $uid === null) {
+            return [];
+        }
+
+        try {
+            $collectives = $service->getCollectives($uid);
+        } catch (Throwable $e) {
+            $this->logger->warning('CollectiveLinkService::getAvailableCollectives failed: '.$e->getMessage());
+            return [];
+        }
+
+        $out = [];
+        foreach ($collectives as $collective) {
+            try {
+                $out[] = [
+                    'id'    => (int) $collective->getId(),
+                    'name'  => (string) $collective->getName(),
+                    'emoji' => $collective->getEmoji(),
+                ];
+            } catch (Throwable $e) {
+                continue;
+            }
+        }
+
+        return $out;
+    }//end getAvailableCollectives()
+
+    /**
+     * Return the current user's NC Collectives pages (picker source).
+     *
+     * Walks every collective the user can see and lists its pages,
+     * optionally filtered by a name substring. Returns an empty array
+     * when Collectives is unavailable.
+     *
+     * @param string|null $search Optional title-substring filter.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getAvailablePages(?string $search=null): array
+    {
+        $collectiveService = $this->getCollectiveService();
+        $pageService       = $this->getPageService();
+        $uid = $this->userSession->getUser()?->getUID();
+        if ($collectiveService === null || $pageService === null || $uid === null) {
+            return [];
+        }
+
+        try {
+            $collectives = $collectiveService->getCollectives($uid);
+        } catch (Throwable $e) {
+            $this->logger->warning('CollectiveLinkService::getAvailablePages failed: '.$e->getMessage());
+            return [];
+        }
+
+        $needle = null;
+        if ($search !== null && $search !== '') {
+            $needle = mb_strtolower($search);
+        }
+
+        $out = [];
+        foreach ($collectives as $collective) {
+            $this->collectPages(
+                pageService: $pageService,
+                collective: $collective,
+                uid: $uid,
+                needle: $needle,
+                out: $out
+            );
+        }
+
+        return $out;
+    }//end getAvailablePages()
+
+    /**
+     * Append a collective's pages to the picker output.
+     *
+     * @param object           $pageService The Collectives PageService.
+     * @param object           $collective  A Collective entity.
+     * @param string           $uid         The owning user id.
+     * @param string|null      $needle      Lower-cased title filter, or null.
+     * @param array<int,mixed> $out         Output array (by reference).
+     *
+     * @return void
+     */
+    private function collectPages(
+        object $pageService,
+        object $collective,
+        string $uid,
+        ?string $needle,
+        array &$out
+    ): void {
+        try {
+            $collectiveId   = (int) $collective->getId();
+            $collectiveName = (string) $collective->getName();
+            $pages          = $pageService->findAll($collectiveId, $uid);
+        } catch (Throwable $e) {
+            return;
+        }
+
+        foreach ($pages as $page) {
+            $row = $this->pickerRowFromPage(
+                page: $page,
+                collectiveId: $collectiveId,
+                collectiveName: $collectiveName,
+                needle: $needle
+            );
+            if ($row !== null) {
+                $out[] = $row;
+            }
+        }
+    }//end collectPages()
+
+    /**
+     * Map a single NC Collectives page into a picker row, applying the
+     * optional title filter.
+     *
+     * @param object      $page           A Collectives PageInfo instance.
+     * @param int         $collectiveId   The owning collective id.
+     * @param string      $collectiveName The owning collective name.
+     * @param string|null $needle         Lower-cased title filter, or null.
+     *
+     * @return array<string,mixed>|null The picker row, or null when the
+     *                                  page is unreadable or filtered out.
+     */
+    private function pickerRowFromPage(
+        object $page,
+        int $collectiveId,
+        string $collectiveName,
+        ?string $needle
+    ): ?array {
+        try {
+            $title  = (string) $page->getTitle();
+            $pageId = (int) $page->getId();
+        } catch (Throwable $e) {
+            return null;
+        }
+
+        if ($needle !== null && str_contains(mb_strtolower($title), $needle) === false) {
+            return null;
+        }
+
+        $lastModified = null;
+        try {
+            $timestamp = (int) $page->getTimestamp();
+            if ($timestamp > 0) {
+                $lastModified = (new DateTime())->setTimestamp($timestamp)->format(DateTime::ATOM);
+            }
+        } catch (Throwable $e) {
+            $lastModified = null;
+        }
+
+        $emoji = null;
+        try {
+            $emoji = $page->getEmoji();
+        } catch (Throwable $e) {
+            $emoji = null;
+        }
+
+        return [
+            'pageId'         => $pageId,
+            'collectiveId'   => $collectiveId,
+            'collectiveName' => $collectiveName,
+            'title'          => $title,
+            'emoji'          => $emoji,
+            'lastModified'   => $lastModified,
+            'url'            => $this->pageDeepLink(pageId: $pageId),
+        ];
+    }//end pickerRowFromPage()
+
+    /**
+     * Whether a link row's cache is older than the stale window.
+     *
+     * @param CollectiveLink $link The link row.
+     *
+     * @return bool
+     */
+    private function isStale(CollectiveLink $link): bool
+    {
+        $linkedAt = $link->getLinkedAt();
+        if ($linkedAt === null) {
+            return true;
+        }
+
+        return (time() - $linkedAt->getTimestamp()) > self::STALE_AFTER;
+    }//end isStale()
+
+    /**
+     * Refresh a link row's cached page metadata in place.
+     *
+     * Best-effort: when the page can't be resolved the link is left
+     * untouched (the page may have been deleted in NC Collectives).
+     *
+     * @param CollectiveLink $link The link row.
+     * @param string         $uid  The owning user id.
+     *
+     * @return CollectiveLink The (possibly updated) link row.
+     */
+    private function refreshLink(CollectiveLink $link, string $uid): CollectiveLink
+    {
+        $info = $this->fetchPageInfo(pageId: (int) $link->getPageId(), uid: $uid);
+        if ($info === null) {
+            return $link;
+        }
+
+        if (($info['collectiveName'] ?? '') !== '') {
+            $link->setCollectiveName((string) $info['collectiveName']);
+        }
+
+        $link->setPageTitle((string) ($info['title'] ?? $link->getPageTitle()));
+        $link->setSlug($info['slug'] ?? null);
+        $link->setEmoji($info['emoji'] ?? null);
+        $link->setLastModified($info['lastModified'] ?? null);
+        $link->setUrl($info['url'] ?? $link->getUrl());
+        $link->setLinkedAt(new DateTime());
+
+        try {
+            return $this->collectiveLinkMapper->update($link);
+        } catch (Throwable $e) {
+            $this->logger->debug('CollectiveLinkService::refreshLink update failed: '.$e->getMessage());
+            return $link;
+        }
+    }//end refreshLink()
+
+    /**
+     * Fetch normalised page metadata from NC Collectives.
+     *
+     * Walks the user's collectives to find the one owning the page, then
+     * normalises the PageInfo into the shape used by hydrateLink /
+     * refreshLink.
+     *
+     * @param int    $pageId The page id.
+     * @param string $uid    The owning user id.
+     *
+     * @return array<string,mixed>|null
+     */
+    private function fetchPageInfo(int $pageId, string $uid): ?array
+    {
+        $collectiveService = $this->getCollectiveService();
+        $pageService       = $this->getPageService();
+        if ($collectiveService === null || $pageService === null) {
+            return null;
+        }
+
+        try {
+            $collectives = $collectiveService->getCollectives($uid);
+        } catch (Throwable $e) {
+            $this->logger->debug('CollectiveLinkService::fetchPageInfo getCollectives failed: '.$e->getMessage());
+            return null;
+        }
+
+        foreach ($collectives as $collective) {
+            try {
+                $collectiveId = (int) $collective->getId();
+                $page         = $pageService->find($collectiveId, $pageId, $uid);
+            } catch (Throwable $e) {
+                continue;
+            }
+
+            return $this->normalisePage(page: $page, collective: $collective);
+        }
+
+        return null;
+    }//end fetchPageInfo()
+
+    /**
+     * Normalise a Collectives PageInfo + Collective into the info shape.
+     *
+     * @param object $page       A Collectives PageInfo instance.
+     * @param object $collective The owning Collective entity.
+     *
+     * @return array<string,mixed>
+     */
+    private function normalisePage(object $page, object $collective): array
+    {
+        $lastModified = null;
+        try {
+            $timestamp = (int) $page->getTimestamp();
+            if ($timestamp > 0) {
+                $lastModified = (new DateTime())->setTimestamp($timestamp);
+            }
+        } catch (Throwable $e) {
+            $lastModified = null;
+        }
+
+        $emoji = null;
+        try {
+            $emoji = $page->getEmoji();
+        } catch (Throwable $e) {
+            $emoji = null;
+        }
+
+        $slug = null;
+        try {
+            $slug = $page->getSlug();
+        } catch (Throwable $e) {
+            $slug = null;
+        }
+
+        return [
+            'title'          => (string) $page->getTitle(),
+            'collectiveId'   => (int) $collective->getId(),
+            'collectiveName' => (string) $collective->getName(),
+            'slug'           => $slug,
+            'emoji'          => $emoji,
+            'lastModified'   => $lastModified,
+            'url'            => $this->pageDeepLink(pageId: (int) $page->getId()),
+        ];
+    }//end normalisePage()
+
+    /**
+     * Build the NC Collectives deep link for a page.
+     *
+     * Uses the stable `?fileId=` query form which Collectives resolves to
+     * the correct page regardless of slug/path, so the link survives
+     * renames + moves.
+     *
+     * @param int $pageId The page id.
+     *
+     * @return string
+     */
+    private function pageDeepLink(int $pageId): string
+    {
+        return $this->urlGenerator->linkToRoute('collectives.start.index').'?fileId='.$pageId;
+    }//end pageDeepLink()
+}//end class

--- a/lib/Service/Integration/Providers/CollectivesProvider.php
+++ b/lib/Service/Integration/Providers/CollectivesProvider.php
@@ -1,12 +1,19 @@
 <?php
 
 /**
- * CollectivesProvider — exposes NC Knowledge entities linked to an OpenRegister
- * object via a `[or:{objectUuid}]` marker in the entity's `slug`
- * field.
+ * CollectivesProvider — exposes NC Knowledge pages linked to an
+ * OpenRegister object via the Tier-2 `openregister_collective_links`
+ * table.
  *
- * Storage strategy is `link-table` — the marker lives in the upstream
- * app's own table (`collectives_pages`), not in OR.
+ * Pre-Tier-2 the provider matched a `[or:{objectUuid}]` marker embedded
+ * in the page's `slug` field. Tier-2 (this file) reads the dedicated
+ * link table instead — the marker convention is retained as a
+ * backwards-compat fallback for pages that pre-date the link table.
+ *
+ * Storage strategy is `link-table` — the link rows live in OR; the
+ * upstream `collectives_pages` table is only read for the legacy marker
+ * fallback via the wrapping
+ * {@see \OCA\OpenRegister\Service\CollectiveLinkService}.
  *
  * @category Service
  * @package  OCA\OpenRegister\Service\Integration\Providers
@@ -27,10 +34,13 @@ namespace OCA\OpenRegister\Service\Integration\Providers;
 
 // phpcs:disable PEAR.Commenting.FunctionComment.Missing
 
+use OCA\OpenRegister\Db\CollectiveLink;
+use OCA\OpenRegister\Db\CollectiveLinkMapper;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCP\App\IAppManager;
 use OCP\IDBConnection;
 use OCP\IL10N;
+use Throwable;
 
 class CollectivesProvider extends AbstractIntegrationProvider
 {
@@ -40,10 +50,19 @@ class CollectivesProvider extends AbstractIntegrationProvider
 
     private const MARKER_PREFIX = '[or:';
 
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection        $db                   NC DB connection.
+     * @param IAppManager          $appManager           NC app manager.
+     * @param IL10N                $l10n                 Localisation.
+     * @param CollectiveLinkMapper $collectiveLinkMapper Collective-link mapper (Tier-2 link table).
+     */
     public function __construct(
         private IDBConnection $db,
         private IAppManager $appManager,
         private IL10N $l10n,
+        private CollectiveLinkMapper $collectiveLinkMapper,
     ) {
     }//end __construct()
 
@@ -83,18 +102,19 @@ class CollectivesProvider extends AbstractIntegrationProvider
     }//end isEnabled()
 
     /**
-     * List linked Knowledge entities for an OR object.
+     * List linked Knowledge pages for an OR object.
      *
-     * Linking convention: the entity's `slug` field contains
-     * the marker `[or:{objectUuid}]`. The trait runs the LIKE query;
-     * rows are normalised into the registry leaf row shape.
+     * Reads the Tier-2 link table first; if no link rows exist it falls
+     * back to the legacy `[or:{uuid}]` marker scan in
+     * `collectives_pages.slug` so pages that pre-date the link table
+     * still surface.
      *
      * @param string $register Register slug for the parent object.
      * @param string $schema   Schema slug for the parent object.
      * @param string $objectId UUID of the OR object whose rows we want.
      * @param array  $filters  Optional registry filters (unused).
      *
-     * @return array List of registry leaf rows.
+     * @return array<int,array<string,mixed>> List of registry leaf rows.
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -102,6 +122,22 @@ class CollectivesProvider extends AbstractIntegrationProvider
             return [];
         }
 
+        // Tier-2 path: read from the link table.
+        try {
+            $linkRows = $this->collectiveLinkMapper->findByObjectUuid($objectId);
+        } catch (Throwable $e) {
+            $linkRows = [];
+        }
+
+        if (count($linkRows) > 0) {
+            return array_map(
+                fn (CollectiveLink $link): array => $this->rowFromLink(link: $link),
+                $linkRows
+            );
+        }
+
+        // Backwards-compat fallback: scan the legacy `[or:{uuid}]`
+        // marker in `collectives_pages.slug`.
         $marker = self::MARKER_PREFIX.$objectId.']';
         $rows   = $this->findByMarker(
             db: $this->db,
@@ -125,13 +161,46 @@ class CollectivesProvider extends AbstractIntegrationProvider
                 );
     }//end list()
 
+    /**
+     * Convert a CollectiveLink row into the registry leaf-row shape.
+     *
+     * @param CollectiveLink $link Link row from the mapper.
+     *
+     * @return array<string,mixed>
+     */
+    private function rowFromLink(CollectiveLink $link): array
+    {
+        $pageId = (int) $link->getPageId();
+        $data   = $link->jsonSerialize();
+        $url    = $link->getUrl();
+        if ($url === null || $url === '') {
+            $url = '/index.php/apps/collectives/?fileId='.$pageId;
+        }
+
+        return [
+            'id'             => (string) $pageId,
+            'title'          => (string) $link->getPageTitle(),
+            'url'            => $url,
+            'emoji'          => $link->getEmoji(),
+            'collectiveName' => $link->getCollectiveName(),
+            'data'           => $data,
+        ];
+    }//end rowFromLink()
+
     public function health(): array
     {
         $available = $this->isEnabled();
+        $status    = 'unavailable';
+        $message   = 'NC Knowledge app is not installed';
+        if ($available === true) {
+            $status  = 'ok';
+            $message = null;
+        }
+
         return [
-            'status'     => $available === true ? 'ok' : 'unavailable',
+            'status'     => $status,
             'authStatus' => 'configured',
-            'message'    => $available === true ? null : 'NC Knowledge app is not installed',
+            'message'    => $message,
         ];
     }//end health()
 }//end class

--- a/tests/Unit/Service/CollectiveLinkServiceTest.php
+++ b/tests/Unit/Service/CollectiveLinkServiceTest.php
@@ -1,0 +1,293 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Service\CollectiveLinkService}.
+ *
+ * Exercises the Tier-2 service contract (link / createAndLink / unlink /
+ * list + available picker + collectives cascade) against a mocked
+ * CollectiveLinkMapper. Tests that touch NC Collectives'
+ * `CollectiveService` / `PageService` use the "Collectives unavailable"
+ * path because those classes are resolved from the container and aren't
+ * injectable into this unit test scope without the `collectives` app on
+ * the classpath. Real round-trips are gated by
+ * `@group requires-app-collectives`.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/integration-collectives/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use Exception;
+use OCA\OpenRegister\Db\CollectiveLink;
+use OCA\OpenRegister\Db\CollectiveLinkMapper;
+use OCA\OpenRegister\Service\CollectiveLinkService;
+use OCP\App\IAppManager;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * CollectiveLinkServiceTest.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ *
+ * @group requires-app-collectives
+ */
+class CollectiveLinkServiceTest extends TestCase
+{
+
+    private CollectiveLinkMapper&MockObject $mapper;
+
+    private ContainerInterface&MockObject $container;
+
+    private IAppManager&MockObject $appManager;
+
+    private IUserSession&MockObject $userSession;
+
+    private IURLGenerator&MockObject $urlGenerator;
+
+    private LoggerInterface&MockObject $logger;
+
+    private CollectiveLinkService $service;
+
+    protected function setUp(): void
+    {
+        $this->mapper = $this->getMockBuilder(CollectiveLinkMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(
+                    [
+                        'findByObjectUuid',
+                        'findByObjectAndPage',
+                        'deleteByObjectAndPage',
+                        'insert',
+                        'update',
+                    ]
+                    )
+            ->getMock();
+
+        $this->container    = $this->createMock(ContainerInterface::class);
+        $this->appManager   = $this->createMock(IAppManager::class);
+        $this->userSession  = $this->createMock(IUserSession::class);
+        $this->urlGenerator = $this->createMock(IURLGenerator::class);
+        $this->logger       = $this->createMock(LoggerInterface::class);
+
+        $this->urlGenerator->method('linkToRoute')->willReturn('/index.php/apps/collectives/');
+
+        $this->service = new CollectiveLinkService(
+            $this->mapper,
+            $this->container,
+            $this->appManager,
+            $this->userSession,
+            $this->urlGenerator,
+            $this->logger
+        );
+    }//end setUp()
+
+    private function setupUser(string $uid='alice'): IUser&MockObject
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $this->userSession->method('getUser')->willReturn($user);
+        return $user;
+    }//end setupUser()
+
+    public function testIsCollectivesAvailableTrue(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('collectives')->willReturn(true);
+        $this->assertTrue($this->service->isCollectivesAvailable());
+    }//end testIsCollectivesAvailableTrue()
+
+    public function testIsCollectivesAvailableFalse(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('collectives')->willReturn(false);
+        $this->assertFalse($this->service->isCollectivesAvailable());
+    }//end testIsCollectivesAvailableFalse()
+
+    public function testLinkPageThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->linkPage('abc-123', 1, 2, 99);
+    }//end testLinkPageThrowsWhenNoUser()
+
+    public function testLinkPageThrowsWhenCollectivesUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('collectives')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+
+        $this->service->linkPage('abc-123', 1, 2, 99);
+    }//end testLinkPageThrowsWhenCollectivesUnavailable()
+
+    public function testLinkPageThrowsOnDuplicate(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->willReturn(true);
+        $this->mapper->method('findByObjectAndPage')->with('abc-123', 99)->willReturn(new CollectiveLink());
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(409);
+        $this->expectExceptionMessage('Page already linked to this object');
+
+        $this->service->linkPage('abc-123', 1, 2, 99);
+    }//end testLinkPageThrowsOnDuplicate()
+
+    public function testCreateAndLinkPageThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->createAndLinkPage('abc-123', 1, 2, 5, 'Runbook');
+    }//end testCreateAndLinkPageThrowsWhenNoUser()
+
+    public function testCreateAndLinkPageThrowsOnEmptyTitle(): void
+    {
+        $this->setupUser();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+
+        $this->service->createAndLinkPage('abc-123', 1, 2, 5, '   ');
+    }//end testCreateAndLinkPageThrowsOnEmptyTitle()
+
+    public function testCreateAndLinkPageThrowsOnMissingCollective(): void
+    {
+        $this->setupUser();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+
+        $this->service->createAndLinkPage('abc-123', 1, 2, 0, 'Runbook');
+    }//end testCreateAndLinkPageThrowsOnMissingCollective()
+
+    public function testCreateAndLinkPageThrowsWhenCollectivesUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('collectives')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+
+        $this->service->createAndLinkPage('abc-123', 1, 2, 5, 'Runbook');
+    }//end testCreateAndLinkPageThrowsWhenCollectivesUnavailable()
+
+    public function testUnlinkPageThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->unlinkPage('abc-123', 99);
+    }//end testUnlinkPageThrowsWhenNoUser()
+
+    public function testUnlinkPageThrowsWhenLinkMissing(): void
+    {
+        $this->setupUser();
+        $this->mapper->method('deleteByObjectAndPage')->with('abc-123', 99)->willReturn(0);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(404);
+
+        $this->service->unlinkPage('abc-123', 99);
+    }//end testUnlinkPageThrowsWhenLinkMissing()
+
+    public function testUnlinkPageSucceeds(): void
+    {
+        $this->setupUser();
+        $this->mapper->expects($this->once())
+            ->method('deleteByObjectAndPage')
+            ->with('abc-123', 99)
+            ->willReturn(1);
+
+        $this->service->unlinkPage('abc-123', 99);
+    }//end testUnlinkPageSucceeds()
+
+    public function testGetLinkedPagesReturnsRows(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->willReturn(false);
+
+        $link = new CollectiveLink();
+        $link->setObjectUuid('abc-123');
+        $link->setPageId(42);
+        $link->setPageTitle('Runbook');
+        $link->setCollectiveName('Ops');
+        $link->setUrl('/index.php/apps/collectives/?fileId=42');
+
+        $this->mapper->method('findByObjectUuid')->with('abc-123')->willReturn([$link]);
+
+        $rows = $this->service->getLinkedPages('abc-123');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame(42, $rows[0]['pageId']);
+        $this->assertSame('Runbook', $rows[0]['pageTitle']);
+        $this->assertSame('Ops', $rows[0]['collectiveName']);
+    }//end testGetLinkedPagesReturnsRows()
+
+    public function testGetLinkedPagesEmpty(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->willReturn(false);
+        $this->mapper->method('findByObjectUuid')->with('abc-123')->willReturn([]);
+
+        $this->assertSame([], $this->service->getLinkedPages('abc-123'));
+    }//end testGetLinkedPagesEmpty()
+
+    public function testGetAvailablePagesEmptyWhenCollectivesUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('collectives')->willReturn(false);
+
+        $this->assertSame([], $this->service->getAvailablePages());
+    }//end testGetAvailablePagesEmptyWhenCollectivesUnavailable()
+
+    public function testGetAvailablePagesEmptyWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+        $this->appManager->method('isEnabledForUser')->with('collectives')->willReturn(true);
+
+        $this->assertSame([], $this->service->getAvailablePages());
+    }//end testGetAvailablePagesEmptyWhenNoUser()
+
+    public function testGetAvailableCollectivesEmptyWhenCollectivesUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('collectives')->willReturn(false);
+
+        $this->assertSame([], $this->service->getAvailableCollectives());
+    }//end testGetAvailableCollectivesEmptyWhenCollectivesUnavailable()
+
+    public function testGetAvailableCollectivesEmptyWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+        $this->appManager->method('isEnabledForUser')->with('collectives')->willReturn(true);
+
+        $this->assertSame([], $this->service->getAvailableCollectives());
+    }//end testGetAvailableCollectivesEmptyWhenNoUser()
+}//end class


### PR DESCRIPTION
## Summary
- Adds the `openregister_collective_links` Tier-2 link table (migration `Version1Date20260525200000`) with `CollectiveLink` entity + `CollectiveLinkMapper` (composite unique `object_uuid` + `page_id`, idempotent create-or-extend).
- Adds `CollectiveLinkService` wrapping NC Collectives' `CollectiveService` + `PageService` (lazy `class_exists` + container resolve; graceful degradation per ADR-019 AD-23) with link / createAndLink / unlink / getLinkedPages (24h cache refresh) / getAvailablePages (collective→page cascade) / getAvailableCollectives.
- Adds `CollectiveLinksController`: `GET/POST .../collectives`, `POST .../collectives/new`, `DELETE .../collectives/{pageId}`, `GET /api/integrations/collectives/available`, `GET /api/integrations/collectives/list` (specific-before-wildcard routes).
- Promotes `CollectivesProvider` to read the link table first, with a legacy `[or:{uuid}]` slug-marker fallback (mirrors PhotosProvider).

## Test plan
- [x] `php -l` clean on all new/changed files
- [x] PHPCS (`phpcs.xml`, warning-severity 0) clean on all `lib/` files
- [x] PHPUnit `CollectiveLinkServiceTest` — 18 tests / 31 assertions green (PHP 8.3 container)
- [ ] Browser-verify link/create/unlink in dev container

Refs openregister#1317, ADR-019, ADR-022, ADR-004.