### PR TITLE
feat(time-tracker): Tier-2 — link table + picker + create

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -432,6 +432,19 @@ return [
         ['name' => 'mapLinks#link',         'url' => '/api/objects/{register}/{schema}/{id}/maps',             'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
         ['name' => 'mapLinks#destroy',      'url' => '/api/objects/{register}/{schema}/{id}/maps/{favoriteId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'favoriteId' => '[0-9]+']],
 
+        // Time-tracker (NC TimeManager) — Tier-2 link-table API. User-scoped
+        // (no admin gate). The leaf slug is `time-tracker` (hyphen); the NC
+        // app id is `timemanager`. The specific `/time-tracker/new` (create +
+        // link client) route MUST precede the wildcard
+        // `/time-tracker/{entryId}` unlink route, and the app-global
+        // `available` route precedes the object-scoped routes. entryId is a
+        // TimeManager uuid (not numeric), so it matches `[^/]+`.
+        ['name' => 'timeTrackerLinks#available',    'url' => '/api/integrations/time-tracker/available',                    'verb' => 'GET'],
+        ['name' => 'timeTrackerLinks#index',        'url' => '/api/objects/{register}/{schema}/{id}/time-tracker',          'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
+        ['name' => 'timeTrackerLinks#createAndLink','url' => '/api/objects/{register}/{schema}/{id}/time-tracker/new',      'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'timeTrackerLinks#link',         'url' => '/api/objects/{register}/{schema}/{id}/time-tracker',          'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'timeTrackerLinks#destroy',      'url' => '/api/objects/{register}/{schema}/{id}/time-tracker/{entryId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'entryId' => '[^/]+']],
+
         // Analytics (NC Analytics) — Tier-2 link-table API. User-scoped
         // (no admin gate). The specific `/analytics/new` (create + link)
         // route MUST precede the wildcard `/analytics/{reportId}` unlink

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1157,8 +1157,8 @@ class Application extends App implements IBootstrap
             // takes a MapLinkMapper. Registered separately below.
             // NB: PhotosProvider was Tier-1 greenfield until Tier-2; it now
             // takes a PhotoLinkMapper. Registered separately below.
-            // @spec openspec/changes/integration-time-tracker/tasks.md.
-            \OCA\OpenRegister\Service\Integration\Providers\TimeProvider::class,
+            // NB: TimeProvider was Tier-1 greenfield until Tier-2; it now
+            // takes a TimeTrackerLinkMapper. Registered separately below.
         ];
         // Each greenfield provider now uses MarkerLookupTrait to query
         // its upstream app's main table directly via IDBConnection. All
@@ -1487,6 +1487,44 @@ class Application extends App implements IBootstrap
             function (ContainerInterface $container) {
                 return new \OCA\OpenRegister\Service\AnalyticsLinkService(
                     analyticsLinkMapper: $container->get(\OCA\OpenRegister\Db\AnalyticsLinkMapper::class),
+                    appManager: $container->get('OCP\App\IAppManager'),
+                    userSession: $container->get('OCP\IUserSession'),
+                    logger: $container->get('Psr\Log\LoggerInterface'),
+                );
+            }
+        );
+
+        // TimeProvider — Tier-2: backed by the TimeTrackerLinkMapper. The
+        // provider still gracefully degrades to the legacy
+        // `[or:{uuid}]` note/name marker scan in `timemanager_client` /
+        // `timemanager_task` when the link table is empty (entries that
+        // pre-date the Tier-2 link table; wave-2.4 marker convention). The
+        // leaf slug is `time-tracker`; the NC app id is `timemanager`.
+        // @spec openspec/changes/integration-time-tracker/tasks.md.
+        $context->registerService(
+            \OCA\OpenRegister\Service\Integration\Providers\TimeProvider::class,
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\Service\Integration\Providers\TimeProvider(
+                    db: $container->get('OCP\IDBConnection'),
+                    appManager: $container->get('OCP\App\IAppManager'),
+                    l10n: $container->get('OCP\IL10N'),
+                    timeTrackerLinkMapper: $container->get(\OCA\OpenRegister\Db\TimeTrackerLinkMapper::class),
+                );
+            }
+        );
+
+        // TimeTrackerLinkService — Tier-2 link/create/unlink/picker service
+        // backing the TimeTrackerLinksController. NC TimeManager entries are
+        // user-scoped; ClientMapper + TaskMapper are resolved lazily via the
+        // container so the service loads even when TimeManager is absent.
+        // @spec openspec/changes/integration-time-tracker/tasks.md.
+        $context->registerService(
+            \OCA\OpenRegister\Service\TimeTrackerLinkService::class,
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\Service\TimeTrackerLinkService(
+                    timeTrackerLinkMapper: $container->get(\OCA\OpenRegister\Db\TimeTrackerLinkMapper::class),
+                    db: $container->get('OCP\IDBConnection'),
+                    container: $container,
                     appManager: $container->get('OCP\App\IAppManager'),
                     userSession: $container->get('OCP\IUserSession'),
                     logger: $container->get('Psr\Log\LoggerInterface'),

--- a/lib/Controller/TimeTrackerLinksController.php
+++ b/lib/Controller/TimeTrackerLinksController.php
@@ -1,0 +1,328 @@
+<?php
+
+/**
+ * TimeTrackerLinksController — Tier-2 REST controller for NC TimeManager
+ * entry links.
+ *
+ * Surface:
+ *
+ *   - GET    /api/objects/{r}/{s}/{id}/time-tracker            — list linked entries
+ *   - POST   /api/objects/{r}/{s}/{id}/time-tracker            — link existing entry `{entryType,id}`
+ *   - POST   /api/objects/{r}/{s}/{id}/time-tracker/new        — create + link client `{name}`
+ *   - DELETE /api/objects/{r}/{s}/{id}/time-tracker/{entryId}  — unlink entry
+ *   - GET    /api/integrations/time-tracker/available?search=  — client picker source
+ *
+ * NC TimeManager entries are user-scoped (rows carry a `user_id`), so
+ * there is no admin gate — the active session's user owns the entries it
+ * can link/create.
+ *
+ * Note: the leaf slug is `time-tracker` (with a hyphen); the underlying
+ * NC app id is `timemanager` (no hyphen).
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use Exception;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\TimeTrackerLinkService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Tier-2 TimeManager links controller.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ */
+class TimeTrackerLinksController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param string                 $appName                App id.
+     * @param IRequest               $request                HTTP request.
+     * @param TimeTrackerLinkService $timeTrackerLinkService Backing service.
+     * @param ObjectService          $objectService          OR object resolver.
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly TimeTrackerLinkService $timeTrackerLinkService,
+        private readonly ObjectService $objectService,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * List linked TimeManager entries for an object.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function index(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->timeTrackerLinkService->isTimeManagerAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC TimeManager app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $results = $this->timeTrackerLinkService->getLinkedEntries($object->getUuid());
+
+            return new JSONResponse(
+                    [
+                        'results' => $results,
+                        'total'   => count($results),
+                    ]
+                    );
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return new JSONResponse(['error' => $e->getMessage()], 500);
+        }//end try
+    }//end index()
+
+    /**
+     * Link an existing TimeManager entry.
+     *
+     * Body: `{ entryType: 'client'|'task'|'time', id: string }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function link(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->timeTrackerLinkService->isTimeManagerAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC TimeManager app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $entryType = (string) $this->request->getParam('entryType', '');
+            if (trim($entryType) === '') {
+                return new JSONResponse(['error' => 'entryType is required'], 400);
+            }
+
+            $entryId = (string) $this->request->getParam('id', '');
+            if (trim($entryId) === '') {
+                return new JSONResponse(['error' => 'id is required'], 400);
+            }
+
+            $link = $this->timeTrackerLinkService->linkEntry(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $entryType,
+                $entryId
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end link()
+
+    /**
+     * Create a new TimeManager client and link it.
+     *
+     * Body: `{ name: string }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function createAndLink(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->timeTrackerLinkService->isTimeManagerAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC TimeManager app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $name = (string) $this->request->getParam('name', '');
+            if (trim($name) === '') {
+                return new JSONResponse(['error' => 'name is required'], 400);
+            }
+
+            $link = $this->timeTrackerLinkService->createAndLinkClient(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $name
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end createAndLink()
+
+    /**
+     * Unlink a TimeManager entry.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     * @param string $entryId  Upstream entry uuid.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function destroy(string $register, string $schema, string $id, string $entryId): JSONResponse
+    {
+        if ($this->timeTrackerLinkService->isTimeManagerAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC TimeManager app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $this->timeTrackerLinkService->unlink($object->getUuid(), $entryId);
+
+            return new JSONResponse(['success' => true]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end destroy()
+
+    /**
+     * List the current user's TimeManager clients (picker source).
+     *
+     * Query param: `search` — optional name substring.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function available(): JSONResponse
+    {
+        if ($this->timeTrackerLinkService->isTimeManagerAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC TimeManager app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        $search = $this->request->getParam('search');
+        if ($search !== null) {
+            $search = (string) $search;
+        }
+
+        $clients = $this->timeTrackerLinkService->getAvailableClients($search);
+        return new JSONResponse(['results' => $clients, 'total' => count($clients)]);
+    }//end available()
+
+    /**
+     * Resolve an OR object from register/schema/id.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return ObjectEntity|null
+     */
+    private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
+    {
+        $this->objectService->setSchema($schema);
+        $this->objectService->setRegister($register);
+        $this->objectService->setObject($id);
+
+        return $this->objectService->getObject();
+    }//end validateObject()
+
+    /**
+     * Map a service-layer Exception to a JSONResponse.
+     *
+     * Exception codes carry HTTP intent:
+     *   - 400 → bad request
+     *   - 401 → unauthorized (no user)
+     *   - 404 → not found
+     *   - 409 → conflict (duplicate link)
+     *   - 503 → service unavailable
+     *   - everything else → 400 bad request
+     *
+     * @param Exception $exception Source exception.
+     *
+     * @return JSONResponse
+     */
+    private function mapException(Exception $exception): JSONResponse
+    {
+        $code = $exception->getCode();
+        if (in_array($code, [400, 401, 404, 409, 503], true) === true) {
+            return new JSONResponse(['error' => $exception->getMessage()], $code);
+        }
+
+        return new JSONResponse(['error' => $exception->getMessage()], 400);
+    }//end mapException()
+}//end class

--- a/lib/Db/TimeTrackerLink.php
+++ b/lib/Db/TimeTrackerLink.php
@@ -1,0 +1,209 @@
+<?php
+
+/**
+ * TimeTrackerLink entity for linking NC TimeManager entries (clients,
+ * tasks, time entries) to OpenRegister objects.
+ *
+ * Tier-2 schema: carries register_id, schema_id, an entry_type
+ * discriminator (`client` | `task` | `time`), the three upstream uuids
+ * (client_id / task_id / time_id), plus cached name, duration, billable
+ * and started_at so the link row alone can hydrate the sidebar tab + the
+ * picker UX without a per-entry roundtrip to NC TimeManager. Replaces the
+ * Tier-1 `TimeProvider`'s `[or:{uuid}]` note/name-marker convention with
+ * a proper persistence layer that survives entity renames.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Class TimeTrackerLink
+ *
+ * @method string getObjectUuid()
+ * @method void setObjectUuid(string $objectUuid)
+ * @method int getRegisterId()
+ * @method void setRegisterId(int $registerId)
+ * @method int|null getSchemaId()
+ * @method void setSchemaId(?int $schemaId)
+ * @method string getEntryType()
+ * @method void setEntryType(string $entryType)
+ * @method string|null getClientId()
+ * @method void setClientId(?string $clientId)
+ * @method string|null getTaskId()
+ * @method void setTaskId(?string $taskId)
+ * @method string|null getTimeId()
+ * @method void setTimeId(?string $timeId)
+ * @method string getName()
+ * @method void setName(string $name)
+ * @method int|null getDuration()
+ * @method void setDuration(?int $duration)
+ * @method bool|null getBillable()
+ * @method void setBillable(?bool $billable)
+ * @method DateTime|null getStartedAt()
+ * @method void setStartedAt(?DateTime $startedAt)
+ * @method string|null getLinkedBy()
+ * @method void setLinkedBy(string $linkedBy)
+ * @method DateTime|null getLinkedAt()
+ * @method void setLinkedAt(DateTime $linkedAt)
+ *
+ * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class
+ */
+class TimeTrackerLink extends Entity implements JsonSerializable
+{
+
+    /**
+     * The object uuid.
+     *
+     * @var string|null
+     */
+    protected ?string $objectUuid = null;
+
+    /**
+     * The register id.
+     *
+     * @var integer|null
+     */
+    protected ?int $registerId = null;
+
+    /**
+     * The schema id.
+     *
+     * @var integer|null
+     */
+    protected ?int $schemaId = null;
+
+    /**
+     * The entry kind discriminator: `client`, `task` or `time`.
+     *
+     * @var string|null
+     */
+    protected ?string $entryType = null;
+
+    /**
+     * The NC TimeManager client uuid (set for `client` entries; the
+     * owning client for `task`/`time` entries when known).
+     *
+     * @var string|null
+     */
+    protected ?string $clientId = null;
+
+    /**
+     * The NC TimeManager task uuid (set for `task` entries).
+     *
+     * @var string|null
+     */
+    protected ?string $taskId = null;
+
+    /**
+     * The NC TimeManager time-entry uuid (set for `time` entries).
+     *
+     * @var string|null
+     */
+    protected ?string $timeId = null;
+
+    /**
+     * The entry display name (cached at link time).
+     *
+     * @var string|null
+     */
+    protected ?string $name = null;
+
+    /**
+     * The cached duration in seconds.
+     *
+     * @var integer|null
+     */
+    protected ?int $duration = null;
+
+    /**
+     * The cached billable flag.
+     *
+     * @var boolean|null
+     */
+    protected ?bool $billable = null;
+
+    /**
+     * The cached entry start timestamp.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $startedAt = null;
+
+    /**
+     * The linked by uid.
+     *
+     * @var string|null
+     */
+    protected ?string $linkedBy = null;
+
+    /**
+     * The linked at timestamp.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $linkedAt = null;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->addType(fieldName: 'objectUuid', type: 'string');
+        $this->addType(fieldName: 'registerId', type: 'integer');
+        $this->addType(fieldName: 'schemaId', type: 'integer');
+        $this->addType(fieldName: 'entryType', type: 'string');
+        $this->addType(fieldName: 'clientId', type: 'string');
+        $this->addType(fieldName: 'taskId', type: 'string');
+        $this->addType(fieldName: 'timeId', type: 'string');
+        $this->addType(fieldName: 'name', type: 'string');
+        $this->addType(fieldName: 'duration', type: 'integer');
+        $this->addType(fieldName: 'billable', type: 'boolean');
+        $this->addType(fieldName: 'startedAt', type: 'datetime');
+        $this->addType(fieldName: 'linkedBy', type: 'string');
+        $this->addType(fieldName: 'linkedAt', type: 'datetime');
+    }//end __construct()
+
+    /**
+     * JSON serialization.
+     *
+     * @return array<string,mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'         => $this->id,
+            'objectUuid' => $this->objectUuid,
+            'registerId' => $this->registerId,
+            'schemaId'   => $this->schemaId,
+            'entryType'  => $this->entryType,
+            'clientId'   => $this->clientId,
+            'taskId'     => $this->taskId,
+            'timeId'     => $this->timeId,
+            'name'       => $this->name,
+            'duration'   => $this->duration,
+            'billable'   => $this->billable,
+            'startedAt'  => $this->startedAt?->format(DateTime::ATOM),
+            'linkedBy'   => $this->linkedBy,
+            'linkedAt'   => $this->linkedAt?->format(DateTime::ATOM),
+        ];
+    }//end jsonSerialize()
+}//end class

--- a/lib/Db/TimeTrackerLinkMapper.php
+++ b/lib/Db/TimeTrackerLinkMapper.php
@@ -1,0 +1,207 @@
+<?php
+
+/**
+ * Mapper for time-tracker link entities.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Class TimeTrackerLinkMapper
+ *
+ * @template-extends QBMapper<TimeTrackerLink>
+ */
+class TimeTrackerLinkMapper extends QBMapper
+{
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $db Database connection.
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(
+            db: $db,
+            tableName: 'openregister_timetracker_links',
+            entityClass: TimeTrackerLink::class
+        );
+    }//end __construct()
+
+    /**
+     * Find time-tracker links by object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return TimeTrackerLink[] Array of time-tracker links.
+     */
+    public function findByObjectUuid(string $objectUuid): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByObjectUuid()
+
+    /**
+     * Find a specific time-tracker link by object UUID + entry composite.
+     *
+     * The composite (entry_type + client_id + task_id + time_id) matches
+     * the unique index. Null id components are matched with `IS NULL`.
+     *
+     * @param string      $objectUuid The object UUID.
+     * @param string      $entryType  The entry kind (`client`|`task`|`time`).
+     * @param string|null $clientId   The client uuid (or null).
+     * @param string|null $taskId     The task uuid (or null).
+     * @param string|null $timeId     The time-entry uuid (or null).
+     *
+     * @return TimeTrackerLink|null The link or null if not found.
+     */
+    public function findByObjectAndEntry(
+        string $objectUuid,
+        string $entryType,
+        ?string $clientId,
+        ?string $taskId,
+        ?string $timeId
+    ): ?TimeTrackerLink {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('entry_type', $qb->createNamedParameter($entryType)));
+
+        $this->applyIdComponent(qb: $qb, column: 'client_id', value: $clientId);
+        $this->applyIdComponent(qb: $qb, column: 'task_id', value: $taskId);
+        $this->applyIdComponent(qb: $qb, column: 'time_id', value: $timeId);
+
+        try {
+            return $this->findEntity(query: $qb);
+        } catch (DoesNotExistException $e) {
+            return null;
+        }
+    }//end findByObjectAndEntry()
+
+    /**
+     * Find a time-tracker link for an object by its upstream entry id,
+     * regardless of which id column carries it.
+     *
+     * The Tier-2 unlink path passes a single opaque `entryId`; this
+     * matches it against any of the three id columns for the object.
+     *
+     * @param string $objectUuid The object UUID.
+     * @param string $entryId    The upstream entry id (client/task/time uuid).
+     *
+     * @return TimeTrackerLink|null The link or null if not found.
+     */
+    public function findByObjectAndEntryId(string $objectUuid, string $entryId): ?TimeTrackerLink
+    {
+        $qb    = $this->db->getQueryBuilder();
+        $param = $qb->createNamedParameter($entryId);
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere(
+                $qb->expr()->orX(
+                    $qb->expr()->eq('client_id', $param),
+                    $qb->expr()->eq('task_id', $param),
+                    $qb->expr()->eq('time_id', $param)
+                )
+            )
+            ->setMaxResults(1);
+
+        try {
+            return $this->findEntity(query: $qb);
+        } catch (DoesNotExistException $e) {
+            return null;
+        }
+    }//end findByObjectAndEntryId()
+
+    /**
+     * Delete all time-tracker links for an object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectUuid(string $objectUuid): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectUuid()
+
+    /**
+     * Delete a time-tracker link by object UUID + upstream entry id
+     * (Tier-2 unlink path).
+     *
+     * Matches the entry id against any of the three id columns. Returns
+     * the number of rows actually deleted so callers can distinguish
+     * "no such link" (0) from "ok" (>=1).
+     *
+     * @param string $objectUuid The object UUID.
+     * @param string $entryId    The upstream entry id (client/task/time uuid).
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectAndEntryId(string $objectUuid, string $entryId): int
+    {
+        $qb    = $this->db->getQueryBuilder();
+        $param = $qb->createNamedParameter($entryId);
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere(
+                $qb->expr()->orX(
+                    $qb->expr()->eq('client_id', $param),
+                    $qb->expr()->eq('task_id', $param),
+                    $qb->expr()->eq('time_id', $param)
+                )
+            );
+
+        return $qb->executeStatement();
+    }//end deleteByObjectAndEntryId()
+
+    /**
+     * Apply an id-component constraint to the query builder, using
+     * `IS NULL` when the component is absent so the composite-unique
+     * match is exact.
+     *
+     * @param IQueryBuilder $qb     The query builder.
+     * @param string        $column The id column name.
+     * @param string|null   $value  The id value, or null.
+     *
+     * @return void
+     */
+    private function applyIdComponent(IQueryBuilder $qb, string $column, ?string $value): void
+    {
+        if ($value === null) {
+            $qb->andWhere($qb->expr()->isNull($column));
+            return;
+        }
+
+        $qb->andWhere($qb->expr()->eq($column, $qb->createNamedParameter($value)));
+    }//end applyIdComponent()
+}//end class

--- a/lib/Migration/Version1Date20260525220000.php
+++ b/lib/Migration/Version1Date20260525220000.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * Tier-2 time-tracker (NC TimeManager) integration migration.
+ *
+ * Ensures the `openregister_timetracker_links` table exists with the full
+ * Tier-2 schema:
+ *
+ *  - id (bigint, PK, autoincrement)
+ *  - object_uuid (string 36, not null, indexed)
+ *  - register_id (bigint unsigned, not null, indexed)
+ *  - schema_id (bigint unsigned, nullable, indexed)
+ *  - entry_type (string 16, not null) — `client` | `task` | `time`
+ *  - client_id (string 64, nullable) — NC TimeManager client uuid
+ *  - task_id (string 64, nullable) — NC TimeManager task uuid
+ *  - time_id (string 64, nullable) — NC TimeManager time-entry uuid
+ *  - name (string 255, not null) — cached entry name
+ *  - duration (integer, nullable) — cached duration in seconds
+ *  - billable (boolean, nullable) — cached billable flag
+ *  - started_at (datetime, nullable) — cached entry start timestamp
+ *  - linked_by (string 64, not null)
+ *  - linked_at (datetime, not null)
+ *
+ * Composite unique `(object_uuid, entry_type, client_id, task_id, time_id)`
+ * so the same client/task/time entry can only be linked to an object once.
+ *
+ * Idempotent: creates the table if missing, otherwise adds any missing
+ * Tier-2 columns. Companion to the Tier-2 collectives/analytics/talk/
+ * polls/email/forms/deck/flow/photos link tables; the wrapping
+ * `TimeTrackerLinkService` replaces the `[or:{uuid}]` note/name marker
+ * convention used by the Tier-1 `TimeProvider` with a proper persistence
+ * layer so links survive entity renames.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Tier-2 time-tracker-links table — create-or-extend.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+class Version1Date20260525220000 extends SimpleMigrationStep
+{
+    /**
+     * Change the database schema.
+     *
+     * @param IOutput                 $output        Output for the migration process
+     * @param Closure                 $schemaClosure The schema closure
+     * @param array<array-key, mixed> $options       Migration options
+     *
+     * @return ISchemaWrapper|null
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema  = $schemaClosure();
+        $changed = false;
+
+        if ($schema->hasTable('openregister_timetracker_links') === false) {
+            $this->createTimeTrackerLinksTable(schema: $schema, output: $output);
+            $changed = true;
+        }
+
+        if ($schema->hasTable('openregister_timetracker_links') === true
+            && $this->extendTimeTrackerLinksTable(schema: $schema, output: $output) === true
+        ) {
+            $changed = true;
+        }
+
+        if ($changed === false) {
+            return null;
+        }
+
+        return $schema;
+    }//end changeSchema()
+
+    /**
+     * Create the openregister_timetracker_links table at the Tier-2 shape.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return void
+     */
+    private function createTimeTrackerLinksTable(ISchemaWrapper $schema, IOutput $output): void
+    {
+        $table = $schema->createTable('openregister_timetracker_links');
+
+        $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'unsigned' => true]);
+        $table->addColumn('object_uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
+        $table->addColumn('register_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('schema_id', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]);
+        $table->addColumn('entry_type', Types::STRING, ['notnull' => true, 'length' => 16]);
+        $table->addColumn('client_id', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+        $table->addColumn('task_id', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+        $table->addColumn('time_id', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+        $table->addColumn('name', Types::STRING, ['notnull' => true, 'length' => 255]);
+        $table->addColumn('duration', Types::INTEGER, ['notnull' => false, 'default' => null]);
+        $table->addColumn('billable', Types::BOOLEAN, ['notnull' => false, 'default' => null]);
+        $table->addColumn('started_at', Types::DATETIME, ['notnull' => false, 'default' => null]);
+        $table->addColumn('linked_by', Types::STRING, ['notnull' => true, 'length' => 64]);
+        $table->addColumn('linked_at', Types::DATETIME, ['notnull' => true]);
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(
+            ['object_uuid', 'entry_type', 'client_id', 'task_id', 'time_id'],
+            'idx_tt_object_entry'
+        );
+        $table->addIndex(['object_uuid'], 'idx_tt_object');
+        $table->addIndex(['register_id'], 'idx_tt_register');
+        $table->addIndex(['schema_id'], 'idx_tt_schema');
+
+        $output->info('Created openregister_timetracker_links table (Tier-2 schema)');
+    }//end createTimeTrackerLinksTable()
+
+    /**
+     * Add any missing Tier-2 columns to an existing time-tracker links table.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return bool True when a column was added.
+     */
+    private function extendTimeTrackerLinksTable(ISchemaWrapper $schema, IOutput $output): bool
+    {
+        $table   = $schema->getTable('openregister_timetracker_links');
+        $changed = false;
+
+        if ($table->hasColumn('schema_id') === false) {
+            $table->addColumn(
+                'schema_id',
+                Types::BIGINT,
+                ['notnull' => false, 'unsigned' => true, 'default' => null]
+            );
+            $table->addIndex(['schema_id'], 'idx_tt_schema');
+            $output->info('Added schema_id column to openregister_timetracker_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('duration') === false) {
+            $table->addColumn('duration', Types::INTEGER, ['notnull' => false, 'default' => null]);
+            $output->info('Added duration column to openregister_timetracker_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('billable') === false) {
+            $table->addColumn('billable', Types::BOOLEAN, ['notnull' => false, 'default' => null]);
+            $output->info('Added billable column to openregister_timetracker_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('started_at') === false) {
+            $table->addColumn('started_at', Types::DATETIME, ['notnull' => false, 'default' => null]);
+            $output->info('Added started_at column to openregister_timetracker_links');
+            $changed = true;
+        }
+
+        return $changed;
+    }//end extendTimeTrackerLinksTable()
+}//end class

--- a/lib/Service/Integration/Providers/TimeProvider.php
+++ b/lib/Service/Integration/Providers/TimeProvider.php
@@ -1,12 +1,26 @@
 <?php
 
 /**
- * TimeProvider — exposes NC Time entities linked to an OpenRegister
- * object via a `[or:{objectUuid}]` marker in the entity's `name`
- * field.
+ * TimeProvider — exposes NC TimeManager entries (clients, tasks, time
+ * entries) linked to an OpenRegister object via the Tier-2
+ * `openregister_timetracker_links` table.
  *
- * Storage strategy is `link-table` — the marker lives in the upstream
- * app's own table (`timemanager_project`), not in OR.
+ * Pre-Tier-2 the provider matched a `[or:{objectUuid}]` marker embedded
+ * in the client's / task's `note` field (wave-2.4 three-kind design).
+ * Tier-2 (this file) reads the dedicated link table instead — the marker
+ * convention is retained as a backwards-compat fallback for entries that
+ * pre-date the link table.
+ *
+ * The leaf slug is `time-tracker` (with a hyphen); the underlying NC app
+ * id is `timemanager` (no hyphen).
+ *
+ * Each row carries a three-kind discriminator (`client` | `task` |
+ * `time`) so the bespoke CnTimeTrackerTab can render kind chips,
+ * durations and billable indicators.
+ *
+ * Storage strategy is `link-table` — the link rows live in OR; the
+ * upstream `timemanager_*` tables are only read for the legacy marker
+ * fallback.
  *
  * @category Service
  * @package  OCA\OpenRegister\Service\Integration\Providers
@@ -19,6 +33,8 @@
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  *
  * @link https://conduction.nl
+ *
+ * @spec openspec/changes/integration-time-tracker/tasks.md
  */
 
 declare(strict_types=1);
@@ -27,10 +43,13 @@ namespace OCA\OpenRegister\Service\Integration\Providers;
 
 // phpcs:disable PEAR.Commenting.FunctionComment.Missing
 
+use OCA\OpenRegister\Db\TimeTrackerLink;
+use OCA\OpenRegister\Db\TimeTrackerLinkMapper;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCP\App\IAppManager;
 use OCP\IDBConnection;
 use OCP\IL10N;
+use Throwable;
 
 class TimeProvider extends AbstractIntegrationProvider
 {
@@ -40,10 +59,19 @@ class TimeProvider extends AbstractIntegrationProvider
 
     private const MARKER_PREFIX = '[or:';
 
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection         $db                    NC DB connection.
+     * @param IAppManager           $appManager            NC app manager.
+     * @param IL10N                 $l10n                  Localisation.
+     * @param TimeTrackerLinkMapper $timeTrackerLinkMapper Time-tracker-link mapper (Tier-2 link table).
+     */
     public function __construct(
         private IDBConnection $db,
         private IAppManager $appManager,
         private IL10N $l10n,
+        private TimeTrackerLinkMapper $timeTrackerLinkMapper,
     ) {
     }//end __construct()
 
@@ -83,18 +111,20 @@ class TimeProvider extends AbstractIntegrationProvider
     }//end isEnabled()
 
     /**
-     * List linked Time entities for an OR object.
+     * List linked TimeManager entries for an OR object.
      *
-     * Linking convention: the entity's `name` field contains
-     * the marker `[or:{objectUuid}]`. The trait runs the LIKE query;
-     * rows are normalised into the registry leaf row shape.
+     * Reads the Tier-2 link table first; if no link rows exist it falls
+     * back to the legacy `[or:{uuid}]` marker scan in
+     * `timemanager_client.note` + `timemanager_task.note` so entries that
+     * pre-date the link table still surface (preserving the wave-2.4
+     * three-kind row shape).
      *
      * @param string $register Register slug for the parent object.
      * @param string $schema   Schema slug for the parent object.
      * @param string $objectId UUID of the OR object whose rows we want.
      * @param array  $filters  Optional registry filters (unused).
      *
-     * @return array List of registry leaf rows.
+     * @return array<int,array<string,mixed>> List of registry leaf rows.
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -102,36 +132,169 @@ class TimeProvider extends AbstractIntegrationProvider
             return [];
         }
 
+        // Tier-2 path: read from the link table.
+        try {
+            $linkRows = $this->timeTrackerLinkMapper->findByObjectUuid($objectId);
+        } catch (Throwable $e) {
+            $linkRows = [];
+        }
+
+        if (count($linkRows) > 0) {
+            return array_map(
+                fn (TimeTrackerLink $link): array => $this->rowFromLink(link: $link),
+                $linkRows
+            );
+        }
+
+        // Backwards-compat fallback: scan the legacy `[or:{uuid}]` marker
+        // in `timemanager_client.note` + `timemanager_task.note`,
+        // preserving the three-kind row shape.
+        return $this->legacyMarkerRows(objectId: $objectId);
+    }//end list()
+
+    /**
+     * Convert a TimeTrackerLink row into the registry leaf-row shape (the
+     * three-kind shape the bespoke tab consumes).
+     *
+     * @param TimeTrackerLink $link Link row from the mapper.
+     *
+     * @return array<string,mixed>
+     */
+    private function rowFromLink(TimeTrackerLink $link): array
+    {
+        $entryType = (string) $link->getEntryType();
+        $id        = $this->entryIdOf(link: $link);
+
+        return [
+            'id'        => $id,
+            'kind'      => $entryType,
+            'type'      => $entryType,
+            'title'     => (string) $link->getName(),
+            'name'      => (string) $link->getName(),
+            'clientId'  => $link->getClientId(),
+            'taskId'    => $link->getTaskId(),
+            'timeId'    => $link->getTimeId(),
+            'duration'  => $link->getDuration(),
+            'billable'  => $link->getBillable(),
+            'startedAt' => $link->getStartedAt()?->format(\DateTime::ATOM),
+            'url'       => $this->entryDeepLink(entryType: $entryType, id: $id),
+            'data'      => $link->jsonSerialize(),
+        ];
+    }//end rowFromLink()
+
+    /**
+     * The upstream entry id carried by the link, per entry type.
+     *
+     * @param TimeTrackerLink $link Link row.
+     *
+     * @return string
+     */
+    private function entryIdOf(TimeTrackerLink $link): string
+    {
+        switch ((string) $link->getEntryType()) {
+            case 'task':
+                return (string) $link->getTaskId();
+            case 'time':
+                return (string) $link->getTimeId();
+            default:
+                return (string) $link->getClientId();
+        }
+    }//end entryIdOf()
+
+    /**
+     * Build the NC TimeManager deep link for an entry.
+     *
+     * @param string $entryType Entry kind.
+     * @param string $id        Upstream entry uuid.
+     *
+     * @return string
+     */
+    private function entryDeepLink(string $entryType, string $id): string
+    {
+        switch ($entryType) {
+            case 'task':
+                return '/index.php/apps/timemanager/tasks/'.$id;
+            case 'time':
+                return '/index.php/apps/timemanager/times/'.$id;
+            default:
+                return '/index.php/apps/timemanager/clients/'.$id;
+        }
+    }//end entryDeepLink()
+
+    /**
+     * Legacy marker scan: surface clients + tasks whose `note` carries
+     * the `[or:{uuid}]` marker, in the three-kind row shape.
+     *
+     * @param string $objectId The OR object uuid.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    private function legacyMarkerRows(string $objectId): array
+    {
         $marker = self::MARKER_PREFIX.$objectId.']';
-        $rows   = $this->findByMarker(
+
+        $clients = $this->findByMarker(
             db: $this->db,
-            table: 'timemanager_project',
-            markerColumn: 'name',
+            table: 'timemanager_client',
+            markerColumn: 'note',
             marker: $marker,
-            extraColumns: ['client_uuid', 'uuid'],
+            extraColumns: ['uuid', 'name'],
             idColumn: 'id',
         );
 
-        return array_map(
-                static function (array $row): array {
-                    return [
-                        'id'    => (string) ($row['id'] ?? ''),
-                        'title' => (string) ($row['name'] ?? ''),
-                        'url'   => '/index.php/apps/timemanager/projects/'.(string) ($row['id'] ?? ''),
-                        'data'  => $row,
-                    ];
-                },
-                $rows
-                );
-    }//end list()
+        $tasks = $this->findByMarker(
+            db: $this->db,
+            table: 'timemanager_task',
+            markerColumn: 'note',
+            marker: $marker,
+            extraColumns: ['uuid', 'name'],
+            idColumn: 'id',
+        );
+
+        $rows = [];
+        foreach ($clients as $row) {
+            $uuid   = (string) ($row['uuid'] ?? $row['id'] ?? '');
+            $rows[] = [
+                'id'    => $uuid,
+                'kind'  => 'client',
+                'type'  => 'client',
+                'title' => (string) ($row['name'] ?? ''),
+                'name'  => (string) ($row['name'] ?? ''),
+                'url'   => $this->entryDeepLink(entryType: 'client', id: $uuid),
+                'data'  => $row,
+            ];
+        }
+
+        foreach ($tasks as $row) {
+            $uuid   = (string) ($row['uuid'] ?? $row['id'] ?? '');
+            $rows[] = [
+                'id'    => $uuid,
+                'kind'  => 'task',
+                'type'  => 'task',
+                'title' => (string) ($row['name'] ?? ''),
+                'name'  => (string) ($row['name'] ?? ''),
+                'url'   => $this->entryDeepLink(entryType: 'task', id: $uuid),
+                'data'  => $row,
+            ];
+        }
+
+        return $rows;
+    }//end legacyMarkerRows()
 
     public function health(): array
     {
         $available = $this->isEnabled();
+        $status    = 'unavailable';
+        $message   = 'NC TimeManager app is not installed';
+        if ($available === true) {
+            $status  = 'ok';
+            $message = null;
+        }
+
         return [
-            'status'     => $available === true ? 'ok' : 'unavailable',
+            'status'     => $status,
             'authStatus' => 'configured',
-            'message'    => $available === true ? null : 'NC Time app is not installed',
+            'message'    => $message,
         ];
     }//end health()
 }//end class

--- a/lib/Service/TimeTrackerLinkService.php
+++ b/lib/Service/TimeTrackerLinkService.php
@@ -1,0 +1,860 @@
+<?php
+
+/**
+ * TimeTrackerLinkService — Tier-2 time-tracker (NC TimeManager)
+ * integration service.
+ *
+ * Composes the {@see TimeTrackerLinkMapper} with NC TimeManager's
+ * `OCA\TimeManager\Db\ClientMapper` + `TaskMapper` to expose the Tier-2
+ * surface:
+ *
+ *   - linkEntry(uuid, registerId, schemaId, entryType, id)
+ *       — link an existing client / task / time entry
+ *   - createAndLinkClient(uuid, registerId, schemaId, name)
+ *       — create a new TimeManager client and link it
+ *   - unlink(uuid, entryId)
+ *       — remove a link (the upstream entry stays in TimeManager)
+ *   - getLinkedEntries(uuid)
+ *       — list linked entries, refreshing cached
+ *       name/duration/billable/started_at when the row is older than 24h
+ *   - getAvailableClients(?search)
+ *       — picker source listing the current user's TimeManager clients
+ *
+ * NC TimeManager exposes its persistence via `ClientMapper` and
+ * `TaskMapper` (extending the shared `ObjectMapper`). Both are resolved
+ * lazily through the server container behind a `class_exists` +
+ * `Throwable` guard so this service loads even when TimeManager is not
+ * installed (ADR-019 AD-23 graceful degradation): when TimeManager is
+ * missing or a call throws, the stored link row is returned as-is so
+ * historical references survive.
+ *
+ * TimeManager entries are user-scoped (rows carry a `user_id`), so every
+ * mutating + picker call is scoped to the active session's UID.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://OpenRegister.app
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use DateTime;
+use Exception;
+use OCA\OpenRegister\Db\TimeTrackerLink;
+use OCA\OpenRegister\Db\TimeTrackerLinkMapper;
+use OCP\App\IAppManager;
+use OCP\IDBConnection;
+use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * TimeTrackerLinkService.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)   Composes mapper +
+ *     NC TimeManager ClientMapper + TaskMapper (late-bound) + db + user
+ *     session + app manager + container + logger. Each dependency is
+ *     required for one of the Tier-2 flows (link, create, unlink, list,
+ *     picker, cache refresh, graceful degradation).
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ */
+class TimeTrackerLinkService
+{
+    private const REQUIRED_APP = 'timemanager';
+
+    private const CLIENT_MAPPER = 'OCA\\TimeManager\\Db\\ClientMapper';
+
+    private const TASK_MAPPER = 'OCA\\TimeManager\\Db\\TaskMapper';
+
+    private const ENTRY_CLIENT = 'client';
+
+    private const ENTRY_TASK = 'task';
+
+    private const ENTRY_TIME = 'time';
+
+    private const STALE_AFTER = 86400;
+    // 24 hours in seconds.
+
+    /**
+     * Constructor.
+     *
+     * @param TimeTrackerLinkMapper $timeTrackerLinkMapper Persistence for link rows.
+     * @param IDBConnection         $db                    DB connection for upstream client/task lookups.
+     * @param ContainerInterface    $container             Container for late-bound TimeManager classes.
+     * @param IAppManager           $appManager            NC app manager.
+     * @param IUserSession          $userSession           Active session.
+     * @param LoggerInterface       $logger                Logger.
+     */
+    public function __construct(
+        private readonly TimeTrackerLinkMapper $timeTrackerLinkMapper,
+        private readonly IDBConnection $db,
+        private readonly ContainerInterface $container,
+        private readonly IAppManager $appManager,
+        private readonly IUserSession $userSession,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Whether NC TimeManager is installed + enabled for the current user.
+     *
+     * @return bool
+     */
+    public function isTimeManagerAvailable(): bool
+    {
+        return $this->appManager->isEnabledForUser(self::REQUIRED_APP);
+    }//end isTimeManagerAvailable()
+
+    /**
+     * Resolve a late-bound NC TimeManager mapper lazily.
+     *
+     * Returns null when TimeManager is absent or the class can't be
+     * resolved, so callers degrade gracefully (ADR-019 AD-23).
+     *
+     * @param string $class The fully-qualified TimeManager mapper class.
+     *
+     * @return object|null The mapper instance or null.
+     */
+    private function resolveMapper(string $class): ?object
+    {
+        if ($this->isTimeManagerAvailable() === false || class_exists($class) === false) {
+            return null;
+        }
+
+        try {
+            return $this->container->get($class);
+        } catch (Throwable $e) {
+            $this->logger->debug('TimeTrackerLinkService: '.$class.' unavailable: '.$e->getMessage());
+            return null;
+        }
+    }//end resolveMapper()
+
+    /**
+     * Active session UID, or throw if no user is logged in.
+     *
+     * @return string The user id.
+     *
+     * @throws Exception When there is no active user.
+     */
+    private function requireUid(): string
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in', 401);
+        }
+
+        return $user->getUID();
+    }//end requireUid()
+
+    /**
+     * Normalise + validate an entry-type discriminator.
+     *
+     * @param string $entryType The raw entry type.
+     *
+     * @return string The normalised entry type.
+     *
+     * @throws Exception On an unknown entry type (400).
+     */
+    private function normaliseEntryType(string $entryType): string
+    {
+        $entryType = strtolower(trim($entryType));
+        if (in_array($entryType, [self::ENTRY_CLIENT, self::ENTRY_TASK, self::ENTRY_TIME], true) === false) {
+            throw new Exception('Unknown entry type', 400);
+        }
+
+        return $entryType;
+    }//end normaliseEntryType()
+
+    /**
+     * Link an existing NC TimeManager entry to an OR object.
+     *
+     * Idempotent: a duplicate link raises a 409 Exception. Entry metadata
+     * (name/duration/billable/started_at) is cached at link time.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $registerId OR register id.
+     * @param int    $schemaId   OR schema id.
+     * @param string $entryType  Entry kind (`client`|`task`|`time`).
+     * @param string $id         Upstream entry uuid.
+     *
+     * @return TimeTrackerLink The persisted link row.
+     *
+     * @throws Exception On missing user (401), bad type (400), missing
+     *                   entry (404), duplicate (409), TimeManager
+     *                   unavailable (503).
+     */
+    public function linkEntry(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        string $entryType,
+        string $id
+    ): TimeTrackerLink {
+        $uid       = $this->requireUid();
+        $entryType = $this->normaliseEntryType(entryType: $entryType);
+
+        $id = trim($id);
+        if ($id === '') {
+            throw new Exception('Entry id is required', 400);
+        }
+
+        if ($this->isTimeManagerAvailable() === false) {
+            throw new Exception('NC TimeManager is not available', 503);
+        }
+
+        $components = $this->idComponents(entryType: $entryType, id: $id);
+
+        $existing = $this->timeTrackerLinkMapper->findByObjectAndEntry(
+            $objectUuid,
+            $entryType,
+            $components['client_id'],
+            $components['task_id'],
+            $components['time_id']
+        );
+        if ($existing !== null) {
+            throw new Exception('Entry already linked to this object', 409);
+        }
+
+        $info = $this->fetchEntryInfo(entryType: $entryType, id: $id, uid: $uid);
+        if ($info === null) {
+            throw new Exception('TimeManager entry not found', 404);
+        }
+
+        $link = $this->hydrateLink(
+            objectUuid: $objectUuid,
+            registerId: $registerId,
+            schemaId: $schemaId,
+            entryType: $entryType,
+            id: $id,
+            info: $info,
+            uid: $uid
+        );
+
+        return $this->timeTrackerLinkMapper->insert($link);
+    }//end linkEntry()
+
+    /**
+     * Create a new NC TimeManager client and link it to an OR object.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $registerId OR register id.
+     * @param int    $schemaId   OR schema id.
+     * @param string $name       New client name.
+     *
+     * @return TimeTrackerLink The persisted link row.
+     *
+     * @throws Exception On missing user (401), empty name (400),
+     *                   TimeManager unavailable (503), create failure (500).
+     */
+    public function createAndLinkClient(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        string $name
+    ): TimeTrackerLink {
+        $uid = $this->requireUid();
+
+        $name = trim($name);
+        if ($name === '') {
+            throw new Exception('Client name is required', 400);
+        }
+
+        $clientMapper = $this->resolveMapper(class: self::CLIENT_MAPPER);
+        if ($clientMapper === null) {
+            throw new Exception('NC TimeManager is not available', 503);
+        }
+
+        try {
+            $clientUuid = $this->insertClient(clientMapper: $clientMapper, name: $name, uid: $uid);
+        } catch (Throwable $e) {
+            $this->logger->warning('TimeTrackerLinkService::createAndLinkClient failed: '.$e->getMessage());
+            throw new Exception('Failed to create TimeManager client', 500);
+        }
+
+        $info = [
+            'name'      => $name,
+            'duration'  => null,
+            'billable'  => null,
+            'startedAt' => null,
+        ];
+
+        $link = $this->hydrateLink(
+            objectUuid: $objectUuid,
+            registerId: $registerId,
+            schemaId: $schemaId,
+            entryType: self::ENTRY_CLIENT,
+            id: $clientUuid,
+            info: $info,
+            uid: $uid
+        );
+
+        return $this->timeTrackerLinkMapper->insert($link);
+    }//end createAndLinkClient()
+
+    /**
+     * Insert a new TimeManager client row and return its uuid.
+     *
+     * TimeManager's ClientMapper extends the shared ObjectMapper whose
+     * `insert()` expects a populated entity; we build the entity via the
+     * mapper's entity class so this stays decoupled from the upstream
+     * concrete class at compile time.
+     *
+     * @param object $clientMapper The late-bound TimeManager ClientMapper.
+     * @param string $name         The client name.
+     * @param string $uid          The owning user id.
+     *
+     * @return string The new client uuid.
+     *
+     * @throws Throwable On any upstream failure.
+     */
+    private function insertClient(object $clientMapper, string $name, string $uid): string
+    {
+        $uuid = $this->generateUuid();
+
+        $tableName = $clientMapper->getTableName();
+        $now       = (new DateTime())->format('Y-m-d\TH:i:sP');
+
+        $qb = $this->db->getQueryBuilder();
+        $qb->insert($tableName)
+            ->values(
+                [
+                    'name'    => $qb->createNamedParameter($name),
+                    'user_id' => $qb->createNamedParameter($uid),
+                    'uuid'    => $qb->createNamedParameter($uuid),
+                    'created' => $qb->createNamedParameter($now),
+                    'changed' => $qb->createNamedParameter($now),
+                    'commit'  => $qb->createNamedParameter(''),
+                ]
+            );
+        $qb->executeStatement();
+
+        return $uuid;
+    }//end insertClient()
+
+    /**
+     * Build a TimeTrackerLink from normalised entry info.
+     *
+     * @param string              $objectUuid Parent OR object uuid.
+     * @param int                 $registerId OR register id.
+     * @param int                 $schemaId   OR schema id.
+     * @param string              $entryType  Entry kind.
+     * @param string              $id         Upstream entry uuid.
+     * @param array<string,mixed> $info       Normalised entry info.
+     * @param string              $uid        The linking user id.
+     *
+     * @return TimeTrackerLink
+     */
+    private function hydrateLink(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        string $entryType,
+        string $id,
+        array $info,
+        string $uid
+    ): TimeTrackerLink {
+        $components = $this->idComponents(entryType: $entryType, id: $id);
+
+        $link = new TimeTrackerLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        $link->setSchemaId($schemaId);
+        $link->setEntryType($entryType);
+        $link->setClientId($components['client_id']);
+        $link->setTaskId($components['task_id']);
+        $link->setTimeId($components['time_id']);
+        $link->setName((string) ($info['name'] ?? ''));
+        $link->setDuration($info['duration'] ?? null);
+        $link->setBillable($info['billable'] ?? null);
+        $link->setStartedAt($info['startedAt'] ?? null);
+        $link->setLinkedBy($uid);
+        $link->setLinkedAt(new DateTime());
+
+        return $link;
+    }//end hydrateLink()
+
+    /**
+     * Map an entry id into the three id columns per entry type.
+     *
+     * @param string $entryType Entry kind.
+     * @param string $id        Upstream entry uuid.
+     *
+     * @return array{client_id:?string,task_id:?string,time_id:?string}
+     */
+    private function idComponents(string $entryType, string $id): array
+    {
+        $components = [
+            'client_id' => null,
+            'task_id'   => null,
+            'time_id'   => null,
+        ];
+
+        if ($entryType === self::ENTRY_CLIENT) {
+            $components['client_id'] = $id;
+        } else if ($entryType === self::ENTRY_TASK) {
+            $components['task_id'] = $id;
+        } else {
+            $components['time_id'] = $id;
+        }
+
+        return $components;
+    }//end idComponents()
+
+    /**
+     * Unlink an entry from an object.
+     *
+     * Does NOT delete the upstream entry — it stays in NC TimeManager.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param string $entryId    Upstream entry uuid.
+     *
+     * @return void
+     *
+     * @throws Exception On missing user (401) or no matching link (404).
+     */
+    public function unlink(string $objectUuid, string $entryId): void
+    {
+        $this->requireUid();
+
+        $deleted = $this->timeTrackerLinkMapper->deleteByObjectAndEntryId($objectUuid, $entryId);
+        if ($deleted === 0) {
+            throw new Exception('Time-tracker link not found', 404);
+        }
+    }//end unlink()
+
+    /**
+     * Return the linked entries for an object, refreshing the cached
+     * name/duration/billable/started_at columns when a row is older
+     * than 24h.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getLinkedEntries(string $objectUuid): array
+    {
+        $links     = $this->timeTrackerLinkMapper->findByObjectUuid($objectUuid);
+        $available = $this->isTimeManagerAvailable();
+        $uid       = $this->userSession->getUser()?->getUID();
+
+        $results = [];
+        foreach ($links as $link) {
+            if ($available === true && $uid !== null && $this->isStale(link: $link) === true) {
+                $link = $this->refreshLink(link: $link, uid: $uid);
+            }
+
+            $results[] = $this->rowFromLink(link: $link);
+        }
+
+        return $results;
+    }//end getLinkedEntries()
+
+    /**
+     * Convert a TimeTrackerLink into the registry leaf-row shape (the
+     * three-kind shape the bespoke tab + TimeProvider share).
+     *
+     * @param TimeTrackerLink $link Link row.
+     *
+     * @return array<string,mixed>
+     */
+    private function rowFromLink(TimeTrackerLink $link): array
+    {
+        $entryType = (string) $link->getEntryType();
+        $id        = $this->entryId(link: $link);
+
+        return [
+            'id'        => $id,
+            'kind'      => $entryType,
+            'type'      => $entryType,
+            'title'     => (string) $link->getName(),
+            'name'      => (string) $link->getName(),
+            'clientId'  => $link->getClientId(),
+            'taskId'    => $link->getTaskId(),
+            'timeId'    => $link->getTimeId(),
+            'duration'  => $link->getDuration(),
+            'billable'  => $link->getBillable(),
+            'startedAt' => $link->getStartedAt()?->format(DateTime::ATOM),
+            'url'       => $this->entryDeepLink(entryType: $entryType, id: $id),
+            'data'      => $link->jsonSerialize(),
+        ];
+    }//end rowFromLink()
+
+    /**
+     * The upstream entry id carried by the link, per entry type.
+     *
+     * @param TimeTrackerLink $link Link row.
+     *
+     * @return string
+     */
+    private function entryId(TimeTrackerLink $link): string
+    {
+        switch ((string) $link->getEntryType()) {
+            case self::ENTRY_TASK:
+                return (string) $link->getTaskId();
+            case self::ENTRY_TIME:
+                return (string) $link->getTimeId();
+            default:
+                return (string) $link->getClientId();
+        }
+    }//end entryId()
+
+    /**
+     * Return the current user's NC TimeManager clients (picker source).
+     *
+     * Returns an empty array when TimeManager is unavailable.
+     *
+     * @param string|null $search Optional name-substring filter.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getAvailableClients(?string $search=null): array
+    {
+        $clientMapper = $this->resolveMapper(class: self::CLIENT_MAPPER);
+        $uid          = $this->userSession->getUser()?->getUID();
+        if ($clientMapper === null || $uid === null) {
+            return [];
+        }
+
+        $rows = $this->fetchClientRows(clientMapper: $clientMapper, uid: $uid, search: $search);
+
+        $out = [];
+        foreach ($rows as $row) {
+            $uuid = '';
+            if (isset($row->uuid) === true) {
+                $uuid = (string) $row->uuid;
+            }
+
+            $name = '';
+            if (isset($row->name) === true) {
+                $name = (string) $row->name;
+            }
+
+            if ($uuid === '') {
+                continue;
+            }
+
+            $out[] = [
+                'id'    => $uuid,
+                'kind'  => self::ENTRY_CLIENT,
+                'name'  => $name,
+                'title' => $name,
+            ];
+        }//end foreach
+
+        return $out;
+    }//end getAvailableClients()
+
+    /**
+     * Run the LIKE/scan query for the current user's TimeManager clients.
+     *
+     * @param object      $clientMapper The late-bound TimeManager ClientMapper.
+     * @param string      $uid          The owning user id.
+     * @param string|null $search       Optional name-substring filter.
+     *
+     * @return array<int,object> Matching rows (loose-typed).
+     */
+    private function fetchClientRows(object $clientMapper, string $uid, ?string $search): array
+    {
+        try {
+            $tableName = $clientMapper->getTableName();
+            $qb        = $this->db->getQueryBuilder();
+            $qb->select('*')
+                ->from($tableName)
+                ->where($qb->expr()->eq('user_id', $qb->createNamedParameter($uid)));
+
+            if ($search !== null && $search !== '') {
+                $qb->andWhere(
+                    $qb->expr()->iLike(
+                        'name',
+                        $qb->createNamedParameter('%'.$this->db->escapeLikeParameter($search).'%')
+                    )
+                );
+            }
+
+            $qb->orderBy('name', 'ASC');
+
+            $result = $qb->executeQuery();
+            $rows   = [];
+            $row    = $result->fetch();
+            while ($row !== false) {
+                $rows[] = (object) $row;
+                $row    = $result->fetch();
+            }
+
+            $result->closeCursor();
+            return $rows;
+        } catch (Throwable $e) {
+            $this->logger->debug('TimeTrackerLinkService::fetchClientRows failed: '.$e->getMessage());
+            return [];
+        }//end try
+    }//end fetchClientRows()
+
+    /**
+     * Whether a link row's cache is older than the stale window.
+     *
+     * @param TimeTrackerLink $link The link row.
+     *
+     * @return bool
+     */
+    private function isStale(TimeTrackerLink $link): bool
+    {
+        $linkedAt = $link->getLinkedAt();
+        if ($linkedAt === null) {
+            return true;
+        }
+
+        return (time() - $linkedAt->getTimestamp()) > self::STALE_AFTER;
+    }//end isStale()
+
+    /**
+     * Refresh a link row's cached entry metadata in place.
+     *
+     * Best-effort: when the entry can't be resolved the link is left
+     * untouched (it may have been deleted in NC TimeManager).
+     *
+     * @param TimeTrackerLink $link The link row.
+     * @param string          $uid  The owning user id.
+     *
+     * @return TimeTrackerLink The (possibly updated) link row.
+     */
+    private function refreshLink(TimeTrackerLink $link, string $uid): TimeTrackerLink
+    {
+        $info = $this->fetchEntryInfo(
+            entryType: (string) $link->getEntryType(),
+            id: $this->entryId(link: $link),
+            uid: $uid
+        );
+        if ($info === null) {
+            return $link;
+        }
+
+        if (($info['name'] ?? '') !== '') {
+            $link->setName((string) $info['name']);
+        }
+
+        $link->setDuration($info['duration'] ?? $link->getDuration());
+        $link->setBillable($info['billable'] ?? $link->getBillable());
+        $link->setStartedAt($info['startedAt'] ?? $link->getStartedAt());
+        $link->setLinkedAt(new DateTime());
+
+        try {
+            return $this->timeTrackerLinkMapper->update($link);
+        } catch (Throwable $e) {
+            $this->logger->debug('TimeTrackerLinkService::refreshLink update failed: '.$e->getMessage());
+            return $link;
+        }
+    }//end refreshLink()
+
+    /**
+     * Fetch normalised entry metadata from NC TimeManager.
+     *
+     * Resolves against the `timemanager_client` / `timemanager_task` /
+     * `timemanager_time` tables (via the mapper's table-name accessor)
+     * for the active user, normalising into the shape used by
+     * hydrateLink / refreshLink.
+     *
+     * @param string $entryType Entry kind.
+     * @param string $id        Upstream entry uuid.
+     * @param string $uid       The owning user id.
+     *
+     * @return array<string,mixed>|null
+     */
+    private function fetchEntryInfo(string $entryType, string $id, string $uid): ?array
+    {
+        if ($entryType === self::ENTRY_CLIENT) {
+            return $this->fetchByUuid(
+                mapper: $this->resolveMapper(class: self::CLIENT_MAPPER),
+                uuid: $id,
+                uid: $uid,
+                table: 'timemanager_client'
+            );
+        }
+
+        if ($entryType === self::ENTRY_TASK) {
+            return $this->fetchByUuid(
+                mapper: $this->resolveMapper(class: self::TASK_MAPPER),
+                uuid: $id,
+                uid: $uid,
+                table: 'timemanager_task'
+            );
+        }
+
+        // Time entries: no dedicated mapper exposed; scan the table by uuid.
+        return $this->fetchTimeRow(uuid: $id, uid: $uid);
+    }//end fetchEntryInfo()
+
+    /**
+     * Fetch a single upstream row by uuid + user via a mapper's table.
+     *
+     * @param object|null $mapper The late-bound mapper (or null when absent).
+     * @param string      $uuid   The entry uuid.
+     * @param string      $uid    The owning user id.
+     * @param string      $table  Fallback table name when no mapper.
+     *
+     * @return array<string,mixed>|null
+     */
+    private function fetchByUuid(?object $mapper, string $uuid, string $uid, string $table): ?array
+    {
+        $tableName = $table;
+        if ($mapper !== null) {
+            try {
+                $tableName = $mapper->getTableName();
+            } catch (Throwable $e) {
+                $tableName = $table;
+            }
+        }
+
+        $row = $this->queryRowByUuid(table: $tableName, uuid: $uuid, uid: $uid);
+        if ($row === null) {
+            return null;
+        }
+
+        return $this->normaliseRow(row: $row);
+    }//end fetchByUuid()
+
+    /**
+     * Fetch a time-entry row by uuid + user.
+     *
+     * @param string $uuid The time-entry uuid.
+     * @param string $uid  The owning user id.
+     *
+     * @return array<string,mixed>|null
+     */
+    private function fetchTimeRow(string $uuid, string $uid): ?array
+    {
+        $row = $this->queryRowByUuid(table: 'timemanager_time', uuid: $uuid, uid: $uid);
+        if ($row === null) {
+            return null;
+        }
+
+        return $this->normaliseRow(row: $row);
+    }//end fetchTimeRow()
+
+    /**
+     * Run a uuid + user_id lookup against an upstream table.
+     *
+     * @param string $table The table name.
+     * @param string $uuid  The entry uuid.
+     * @param string $uid   The owning user id.
+     *
+     * @return object|null The row, or null.
+     */
+    private function queryRowByUuid(string $table, string $uuid, string $uid): ?object
+    {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('*')
+                ->from($table)
+                ->where($qb->expr()->eq('uuid', $qb->createNamedParameter($uuid)))
+                ->andWhere($qb->expr()->eq('user_id', $qb->createNamedParameter($uid)))
+                ->setMaxResults(1);
+
+            $result = $qb->executeQuery();
+            $row    = $result->fetch();
+            $result->closeCursor();
+
+            if ($row === false) {
+                return null;
+            }
+
+            return (object) $row;
+        } catch (Throwable $e) {
+            $this->logger->debug('TimeTrackerLinkService::queryRowByUuid failed: '.$e->getMessage());
+            return null;
+        }//end try
+    }//end queryRowByUuid()
+
+    /**
+     * Normalise a raw upstream row into the entry-info shape.
+     *
+     * @param object $row Raw upstream row.
+     *
+     * @return array<string,mixed>
+     */
+    private function normaliseRow(object $row): array
+    {
+        $name = '';
+        if (isset($row->name) === true) {
+            $name = (string) $row->name;
+        }
+
+        $duration = null;
+        if (isset($row->duration) === true && $row->duration !== '' && $row->duration !== null) {
+            $duration = (int) $row->duration;
+        }
+
+        $billable = null;
+        if (isset($row->payed) === true) {
+            $billable = ((int) $row->payed) === 0;
+        } else if (isset($row->billable) === true) {
+            $billable = (bool) $row->billable;
+        }
+
+        $startedAt = null;
+        if (isset($row->start) === true && (string) $row->start !== '') {
+            try {
+                $startedAt = new DateTime((string) $row->start);
+            } catch (Throwable $e) {
+                $startedAt = null;
+            }
+        }
+
+        return [
+            'name'      => $name,
+            'duration'  => $duration,
+            'billable'  => $billable,
+            'startedAt' => $startedAt,
+        ];
+    }//end normaliseRow()
+
+    /**
+     * Build the NC TimeManager deep link for an entry.
+     *
+     * @param string $entryType Entry kind.
+     * @param string $id        Upstream entry uuid.
+     *
+     * @return string
+     */
+    private function entryDeepLink(string $entryType, string $id): string
+    {
+        switch ($entryType) {
+            case self::ENTRY_TASK:
+                return '/index.php/apps/timemanager/tasks/'.$id;
+            case self::ENTRY_TIME:
+                return '/index.php/apps/timemanager/times/'.$id;
+            default:
+                return '/index.php/apps/timemanager/clients/'.$id;
+        }
+    }//end entryDeepLink()
+
+    /**
+     * Generate a v4 uuid for new TimeManager rows.
+     *
+     * @return string
+     */
+    private function generateUuid(): string
+    {
+        $data    = random_bytes(16);
+        $data[6] = chr((ord($data[6]) & 0x0f) | 0x40);
+        $data[8] = chr((ord($data[8]) & 0x3f) | 0x80);
+
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
+    }//end generateUuid()
+}//end class

--- a/tests/Unit/Service/TimeTrackerLinkServiceTest.php
+++ b/tests/Unit/Service/TimeTrackerLinkServiceTest.php
@@ -1,0 +1,283 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Service\TimeTrackerLinkService}.
+ *
+ * Exercises the Tier-2 service contract (linkEntry / createAndLinkClient /
+ * unlink / getLinkedEntries + available picker) against a mocked
+ * TimeTrackerLinkMapper. Tests that touch NC TimeManager's ClientMapper /
+ * TaskMapper use the "TimeManager unavailable" path because those classes
+ * are resolved from the container and aren't injectable into this unit
+ * test scope without the `timemanager` app on the classpath. Real
+ * round-trips are gated by `@group requires-app-timemanager`.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/integration-time-tracker/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use Exception;
+use OCA\OpenRegister\Db\TimeTrackerLink;
+use OCA\OpenRegister\Db\TimeTrackerLinkMapper;
+use OCA\OpenRegister\Service\TimeTrackerLinkService;
+use OCP\App\IAppManager;
+use OCP\IDBConnection;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * TimeTrackerLinkServiceTest.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ *
+ * @group requires-app-timemanager
+ */
+class TimeTrackerLinkServiceTest extends TestCase
+{
+
+    private TimeTrackerLinkMapper&MockObject $mapper;
+
+    private IDBConnection&MockObject $db;
+
+    private ContainerInterface&MockObject $container;
+
+    private IAppManager&MockObject $appManager;
+
+    private IUserSession&MockObject $userSession;
+
+    private LoggerInterface&MockObject $logger;
+
+    private TimeTrackerLinkService $service;
+
+    protected function setUp(): void
+    {
+        $this->mapper = $this->getMockBuilder(TimeTrackerLinkMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(
+                    [
+                        'findByObjectUuid',
+                        'findByObjectAndEntry',
+                        'deleteByObjectAndEntryId',
+                        'insert',
+                        'update',
+                    ]
+                    )
+            ->getMock();
+
+        $this->db          = $this->createMock(IDBConnection::class);
+        $this->container   = $this->createMock(ContainerInterface::class);
+        $this->appManager  = $this->createMock(IAppManager::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->logger      = $this->createMock(LoggerInterface::class);
+
+        $this->service = new TimeTrackerLinkService(
+            $this->mapper,
+            $this->db,
+            $this->container,
+            $this->appManager,
+            $this->userSession,
+            $this->logger
+        );
+    }//end setUp()
+
+    private function setupUser(string $uid='alice'): IUser&MockObject
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $this->userSession->method('getUser')->willReturn($user);
+        return $user;
+    }//end setupUser()
+
+    public function testIsTimeManagerAvailableTrue(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('timemanager')->willReturn(true);
+        $this->assertTrue($this->service->isTimeManagerAvailable());
+    }//end testIsTimeManagerAvailableTrue()
+
+    public function testIsTimeManagerAvailableFalse(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('timemanager')->willReturn(false);
+        $this->assertFalse($this->service->isTimeManagerAvailable());
+    }//end testIsTimeManagerAvailableFalse()
+
+    public function testLinkEntryThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->linkEntry('abc-123', 1, 2, 'client', 'cli-1');
+    }//end testLinkEntryThrowsWhenNoUser()
+
+    public function testLinkEntryThrowsOnUnknownType(): void
+    {
+        $this->setupUser();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+
+        $this->service->linkEntry('abc-123', 1, 2, 'banana', 'cli-1');
+    }//end testLinkEntryThrowsOnUnknownType()
+
+    public function testLinkEntryThrowsOnEmptyId(): void
+    {
+        $this->setupUser();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+
+        $this->service->linkEntry('abc-123', 1, 2, 'client', '   ');
+    }//end testLinkEntryThrowsOnEmptyId()
+
+    public function testLinkEntryThrowsWhenTimeManagerUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('timemanager')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+
+        $this->service->linkEntry('abc-123', 1, 2, 'client', 'cli-1');
+    }//end testLinkEntryThrowsWhenTimeManagerUnavailable()
+
+    public function testLinkEntryThrowsOnDuplicate(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->willReturn(true);
+        $this->mapper->method('findByObjectAndEntry')->willReturn(new TimeTrackerLink());
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(409);
+        $this->expectExceptionMessage('Entry already linked to this object');
+
+        $this->service->linkEntry('abc-123', 1, 2, 'client', 'cli-1');
+    }//end testLinkEntryThrowsOnDuplicate()
+
+    public function testCreateAndLinkClientThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->createAndLinkClient('abc-123', 1, 2, 'Acme');
+    }//end testCreateAndLinkClientThrowsWhenNoUser()
+
+    public function testCreateAndLinkClientThrowsOnEmptyName(): void
+    {
+        $this->setupUser();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+
+        $this->service->createAndLinkClient('abc-123', 1, 2, '   ');
+    }//end testCreateAndLinkClientThrowsOnEmptyName()
+
+    public function testCreateAndLinkClientThrowsWhenTimeManagerUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('timemanager')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+
+        $this->service->createAndLinkClient('abc-123', 1, 2, 'Acme');
+    }//end testCreateAndLinkClientThrowsWhenTimeManagerUnavailable()
+
+    public function testUnlinkThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->unlink('abc-123', 'cli-1');
+    }//end testUnlinkThrowsWhenNoUser()
+
+    public function testUnlinkThrowsWhenLinkMissing(): void
+    {
+        $this->setupUser();
+        $this->mapper->method('deleteByObjectAndEntryId')->with('abc-123', 'cli-1')->willReturn(0);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(404);
+
+        $this->service->unlink('abc-123', 'cli-1');
+    }//end testUnlinkThrowsWhenLinkMissing()
+
+    public function testUnlinkSucceeds(): void
+    {
+        $this->setupUser();
+        $this->mapper->expects($this->once())
+            ->method('deleteByObjectAndEntryId')
+            ->with('abc-123', 'cli-1')
+            ->willReturn(1);
+
+        $this->service->unlink('abc-123', 'cli-1');
+    }//end testUnlinkSucceeds()
+
+    public function testGetLinkedEntriesReturnsRows(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->willReturn(false);
+
+        $link = new TimeTrackerLink();
+        $link->setObjectUuid('abc-123');
+        $link->setEntryType('client');
+        $link->setClientId('cli-1');
+        $link->setName('Acme');
+
+        $this->mapper->method('findByObjectUuid')->with('abc-123')->willReturn([$link]);
+
+        $rows = $this->service->getLinkedEntries('abc-123');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('client', $rows[0]['kind']);
+        $this->assertSame('cli-1', $rows[0]['id']);
+        $this->assertSame('Acme', $rows[0]['name']);
+    }//end testGetLinkedEntriesReturnsRows()
+
+    public function testGetLinkedEntriesEmpty(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->willReturn(false);
+        $this->mapper->method('findByObjectUuid')->with('abc-123')->willReturn([]);
+
+        $this->assertSame([], $this->service->getLinkedEntries('abc-123'));
+    }//end testGetLinkedEntriesEmpty()
+
+    public function testGetAvailableClientsEmptyWhenTimeManagerUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('timemanager')->willReturn(false);
+
+        $this->assertSame([], $this->service->getAvailableClients());
+    }//end testGetAvailableClientsEmptyWhenTimeManagerUnavailable()
+
+    public function testGetAvailableClientsEmptyWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+        $this->appManager->method('isEnabledForUser')->with('timemanager')->willReturn(true);
+
+        $this->assertSame([], $this->service->getAvailableClients());
+    }//end testGetAvailableClientsEmptyWhenNoUser()
+}//end class


### PR DESCRIPTION
## Summary
- Promote the **time-tracker** integration leaf to Tier-2 with a proper link-table persistence layer (NC app `timemanager`; leaf slug stays `time-tracker`).
- New migration `Version1Date20260525220000` creates `openregister_timetracker_links` (object_uuid, register_id, schema_id, entry_type `client|task|time`, client_id/task_id/time_id, name, duration, billable, started_at, linked_by, linked_at; composite unique on `(object_uuid, entry_type, client_id, task_id, time_id)`; idempotent).
- `TimeTrackerLink` entity + `TimeTrackerLinkMapper`; `TimeTrackerLinkService` (link/createAndLinkClient/unlink/getLinkedEntries with 24h cache refresh + `getAvailableClients` picker; lazy NC TimeManager `ClientMapper`/`TaskMapper` behind `class_exists` + `Throwable` guards for graceful degradation).
- `TimeTrackerLinksController` REST surface: `GET/POST /time-tracker`, `POST /time-tracker/new`, `DELETE /time-tracker/{entryId}`, `GET /api/integrations/time-tracker/available?search=` (routes specific-before-wildcard).
- `TimeProvider` now reads the link table first and falls back to the legacy `[or:{uuid}]` note marker, preserving the client/task/time three-kind row shape.

## Test plan
- [ ] `composer check:strict` (PHPCS clean on new `lib/` files locally — exit 0)
- [ ] PHPUnit `TimeTrackerLinkServiceTest` (`@group requires-app-timemanager`) green in CI
- [ ] Migration applies idempotently on a fresh + existing DB
- [ ] Link / create-client / unlink round-trip against a live NC TimeManager install

Refs: openregister#1322, ADR-019, ADR-022, ADR-004.