### PR TITLE
feat(openproject): Tier-2 — link table + work-package picker + create (OpenConnector-routed)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -423,6 +423,18 @@ return [
         ['name' => 'collectiveLinks#link',         'url' => '/api/objects/{register}/{schema}/{id}/collectives',        'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
         ['name' => 'collectiveLinks#destroy',      'url' => '/api/objects/{register}/{schema}/{id}/collectives/{pageId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'pageId' => '[0-9]+']],
 
+        // OpenProject (external / OpenConnector-routed) — Tier-2 link-table
+        // API. The picker source `available` is reached through the
+        // OpenConnector `openproject` source. The specific
+        // `/openproject/new` (create + link) route MUST precede the
+        // wildcard `/openproject/{wpId}` unlink route, and the app-global
+        // `available` route precedes the object-scoped routes.
+        ['name' => 'openProjectLinks#available',    'url' => '/api/integrations/openproject/available',                  'verb' => 'GET'],
+        ['name' => 'openProjectLinks#index',        'url' => '/api/objects/{register}/{schema}/{id}/openproject',        'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
+        ['name' => 'openProjectLinks#createAndLink','url' => '/api/objects/{register}/{schema}/{id}/openproject/new',    'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'openProjectLinks#link',         'url' => '/api/objects/{register}/{schema}/{id}/openproject',        'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'openProjectLinks#destroy',      'url' => '/api/objects/{register}/{schema}/{id}/openproject/{wpId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'wpId' => '[0-9]+']],
+
         // Maps (NC Maps / Location) — Tier-2 link-table API. User-scoped
         // (no admin gate). The specific `/maps/new` (create + link) route
         // MUST precede the wildcard `/maps/{favoriteId}` unlink route.

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1065,7 +1065,9 @@ class Application extends App implements IBootstrap
 
         // Leaf provider: OpenProject (external, OpenConnector-backed) —
         // mirrors the XwikiProvider pattern (AD-4 / AD-22). Credentials
-        // on the OpenConnector `openproject` source.
+        // on the OpenConnector `openproject` source. Tier-2: the
+        // OpenProjectLinkMapper backs the linked list so it renders from
+        // the cached link rows even when the source is temporarily down.
         // @spec openspec/changes/integration-openproject/tasks.md.
         $context->registerService(
             OpenProjectProvider::class,
@@ -1074,6 +1076,29 @@ class Application extends App implements IBootstrap
                     router: $container->get(ExternalIntegrationRouter::class),
                     appManager: $container->get('OCP\App\IAppManager'),
                     l10n: $container->get('OCP\IL10N'),
+                    openProjectLinkMapper: $container->get(\OCA\OpenRegister\Db\OpenProjectLinkMapper::class),
+                );
+            }
+        );
+
+        // OpenProjectLinkService — Tier-2 link/create/unlink/picker
+        // service backing the OpenProjectLinksController. OpenProject is
+        // external; the service composes the link mapper with the
+        // OpenProjectProvider + ExternalIntegrationRouter so picker /
+        // create / refresh flows go through the OpenConnector
+        // `openproject` source, degrading to a 503-with-cause when the
+        // source is missing or the upstream is unreachable (wave-5.2).
+        // @spec openspec/changes/integration-openproject/tasks.md.
+        $context->registerService(
+            \OCA\OpenRegister\Service\OpenProjectLinkService::class,
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\Service\OpenProjectLinkService(
+                    openProjectLinkMapper: $container->get(\OCA\OpenRegister\Db\OpenProjectLinkMapper::class),
+                    provider: $container->get(OpenProjectProvider::class),
+                    router: $container->get(ExternalIntegrationRouter::class),
+                    appManager: $container->get('OCP\App\IAppManager'),
+                    userSession: $container->get('OCP\IUserSession'),
+                    logger: $container->get('Psr\Log\LoggerInterface'),
                 );
             }
         );

--- a/lib/Controller/OpenProjectLinksController.php
+++ b/lib/Controller/OpenProjectLinksController.php
@@ -1,0 +1,336 @@
+<?php
+
+/**
+ * OpenProjectLinksController — Tier-2 REST controller for OpenProject
+ * work-package links (external / OpenConnector-routed).
+ *
+ * Surface:
+ *
+ *   - GET    /api/objects/{r}/{s}/{id}/openproject            — list linked work packages
+ *   - POST   /api/objects/{r}/{s}/{id}/openproject            — link existing work package `{workPackageId}`
+ *   - POST   /api/objects/{r}/{s}/{id}/openproject/new        — create + link `{projectId, subject, type?}`
+ *   - DELETE /api/objects/{r}/{s}/{id}/openproject/{wpId}     — unlink work package
+ *   - GET    /api/integrations/openproject/available?search=  — work-package picker source
+ *
+ * OpenProject is external — the install dependency is OpenConnector
+ * (which carries the `openproject` source + credentials, AD-4 / AD-22).
+ * When the source is unconfigured / unreachable the service raises a
+ * 503-with-cause Exception so the UI degrades to a "Configure" CTA
+ * rather than a broken tab (wave-5.2 4-state auth UX).
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use Exception;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\OpenProjectLinkService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Tier-2 OpenProject links controller.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ */
+class OpenProjectLinksController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param string                 $appName                App id.
+     * @param IRequest               $request                HTTP request.
+     * @param OpenProjectLinkService $openProjectLinkService Backing service.
+     * @param ObjectService          $objectService          OR object resolver.
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly OpenProjectLinkService $openProjectLinkService,
+        private readonly ObjectService $objectService,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * List linked OpenProject work packages for an object.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function index(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->openProjectLinkService->isOpenConnectorAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'OpenConnector app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $results = $this->openProjectLinkService->getLinkedWorkPackages($object->getUuid());
+
+            return new JSONResponse(
+                [
+                    'results' => $results,
+                    'total'   => count($results),
+                ]
+            );
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end index()
+
+    /**
+     * Link an existing OpenProject work package.
+     *
+     * Body: `{ workPackageId: int }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function link(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->openProjectLinkService->isOpenConnectorAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'OpenConnector app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $workPackageId = (int) $this->request->getParam('workPackageId', 0);
+            if ($workPackageId === 0) {
+                return new JSONResponse(['error' => 'workPackageId is required'], 400);
+            }
+
+            $link = $this->openProjectLinkService->linkWorkPackage(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $workPackageId
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end link()
+
+    /**
+     * Create a new OpenProject work package and link it.
+     *
+     * Body: `{ projectId: string, subject: string, type?: string }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function createAndLink(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->openProjectLinkService->isOpenConnectorAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'OpenConnector app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $projectId = (string) $this->request->getParam('projectId', '');
+            if (trim($projectId) === '') {
+                return new JSONResponse(['error' => 'projectId is required'], 400);
+            }
+
+            $subject = (string) $this->request->getParam('subject', '');
+            if (trim($subject) === '') {
+                return new JSONResponse(['error' => 'subject is required'], 400);
+            }
+
+            $type = (string) $this->request->getParam('type', '');
+
+            $link = $this->openProjectLinkService->createAndLinkWorkPackage(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $projectId,
+                $subject,
+                $type
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end createAndLink()
+
+    /**
+     * Unlink an OpenProject work package.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     * @param string $wpId     Work-package id (numeric).
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function destroy(string $register, string $schema, string $id, string $wpId): JSONResponse
+    {
+        if ($this->openProjectLinkService->isOpenConnectorAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'OpenConnector app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $this->openProjectLinkService->unlink($object->getUuid(), (int) $wpId);
+
+            return new JSONResponse(['success' => true]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end destroy()
+
+    /**
+     * List work packages reachable through the OpenConnector
+     * `openproject` source (picker source).
+     *
+     * Query param: `search` — optional subject substring.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function available(): JSONResponse
+    {
+        if ($this->openProjectLinkService->isOpenConnectorAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'OpenConnector app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        $search = $this->request->getParam('search');
+        if ($search !== null) {
+            $search = (string) $search;
+        }
+
+        try {
+            $workPackages = $this->openProjectLinkService->getAvailableWorkPackages($search);
+            return new JSONResponse(['results' => $workPackages, 'total' => count($workPackages)]);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }
+    }//end available()
+
+    /**
+     * Resolve an OR object from register/schema/id.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return ObjectEntity|null
+     */
+    private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
+    {
+        $this->objectService->setSchema($schema);
+        $this->objectService->setRegister($register);
+        $this->objectService->setObject($id);
+
+        return $this->objectService->getObject();
+    }//end validateObject()
+
+    /**
+     * Map a service-layer Exception to a JSONResponse.
+     *
+     * Exception codes carry HTTP intent:
+     *   - 400 → bad request
+     *   - 401 → unauthorized (no user)
+     *   - 404 → not found
+     *   - 409 → conflict (duplicate link)
+     *   - 502 → bad gateway (malformed upstream response)
+     *   - 503 → service unavailable (source unconfigured / down)
+     *   - everything else → 400 bad request
+     *
+     * @param Exception $exception Source exception.
+     *
+     * @return JSONResponse
+     */
+    private function mapException(Exception $exception): JSONResponse
+    {
+        $code = $exception->getCode();
+        if (in_array($code, [400, 401, 404, 409, 502, 503], true) === true) {
+            return new JSONResponse(['error' => $exception->getMessage()], $code);
+        }
+
+        return new JSONResponse(['error' => $exception->getMessage()], 400);
+    }//end mapException()
+}//end class

--- a/lib/Db/OpenProjectLink.php
+++ b/lib/Db/OpenProjectLink.php
@@ -1,0 +1,219 @@
+<?php
+
+/**
+ * OpenProjectLink entity for linking OpenProject work packages to
+ * OpenRegister objects.
+ *
+ * Tier-2 schema: carries register_id, schema_id, work_package_id,
+ * subject, type, status, priority, assignee, project, url and cached_at
+ * so the link row alone can hydrate the sidebar tab + picker UX without
+ * a per-work-package roundtrip to OpenProject (reached through
+ * OpenConnector — AD-4 / AD-22). The cached metadata also keeps
+ * historical references readable when the OpenConnector source is
+ * temporarily unconfigured or down.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Class OpenProjectLink
+ *
+ * @method string getObjectUuid()
+ * @method void setObjectUuid(string $objectUuid)
+ * @method int getRegisterId()
+ * @method void setRegisterId(int $registerId)
+ * @method int|null getSchemaId()
+ * @method void setSchemaId(?int $schemaId)
+ * @method int getWorkPackageId()
+ * @method void setWorkPackageId(int $workPackageId)
+ * @method string getSubject()
+ * @method void setSubject(string $subject)
+ * @method string|null getType()
+ * @method void setType(?string $type)
+ * @method string|null getStatus()
+ * @method void setStatus(?string $status)
+ * @method string|null getPriority()
+ * @method void setPriority(?string $priority)
+ * @method string|null getAssignee()
+ * @method void setAssignee(?string $assignee)
+ * @method string|null getProject()
+ * @method void setProject(?string $project)
+ * @method string|null getUrl()
+ * @method void setUrl(?string $url)
+ * @method DateTime|null getCachedAt()
+ * @method void setCachedAt(?DateTime $cachedAt)
+ * @method string|null getLinkedBy()
+ * @method void setLinkedBy(string $linkedBy)
+ * @method DateTime|null getLinkedAt()
+ * @method void setLinkedAt(DateTime $linkedAt)
+ *
+ * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class
+ */
+class OpenProjectLink extends Entity implements JsonSerializable
+{
+
+    /**
+     * The object uuid.
+     *
+     * @var string|null
+     */
+    protected ?string $objectUuid = null;
+
+    /**
+     * The register id.
+     *
+     * @var integer|null
+     */
+    protected ?int $registerId = null;
+
+    /**
+     * The schema id.
+     *
+     * @var integer|null
+     */
+    protected ?int $schemaId = null;
+
+    /**
+     * The OpenProject work-package id.
+     *
+     * @var integer|null
+     */
+    protected ?int $workPackageId = null;
+
+    /**
+     * The work-package subject (cached).
+     *
+     * @var string|null
+     */
+    protected ?string $subject = null;
+
+    /**
+     * The work-package type label (cached).
+     *
+     * @var string|null
+     */
+    protected ?string $type = null;
+
+    /**
+     * The work-package status label (cached).
+     *
+     * @var string|null
+     */
+    protected ?string $status = null;
+
+    /**
+     * The work-package priority label (cached).
+     *
+     * @var string|null
+     */
+    protected ?string $priority = null;
+
+    /**
+     * The work-package assignee label (cached).
+     *
+     * @var string|null
+     */
+    protected ?string $assignee = null;
+
+    /**
+     * The work-package project label (cached).
+     *
+     * @var string|null
+     */
+    protected ?string $project = null;
+
+    /**
+     * The cached deep link to the work package.
+     *
+     * @var string|null
+     */
+    protected ?string $url = null;
+
+    /**
+     * When the cached metadata was last refreshed.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $cachedAt = null;
+
+    /**
+     * The linked by uid.
+     *
+     * @var string|null
+     */
+    protected ?string $linkedBy = null;
+
+    /**
+     * The linked at timestamp.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $linkedAt = null;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->addType(fieldName: 'objectUuid', type: 'string');
+        $this->addType(fieldName: 'registerId', type: 'integer');
+        $this->addType(fieldName: 'schemaId', type: 'integer');
+        $this->addType(fieldName: 'workPackageId', type: 'integer');
+        $this->addType(fieldName: 'subject', type: 'string');
+        $this->addType(fieldName: 'type', type: 'string');
+        $this->addType(fieldName: 'status', type: 'string');
+        $this->addType(fieldName: 'priority', type: 'string');
+        $this->addType(fieldName: 'assignee', type: 'string');
+        $this->addType(fieldName: 'project', type: 'string');
+        $this->addType(fieldName: 'url', type: 'string');
+        $this->addType(fieldName: 'cachedAt', type: 'datetime');
+        $this->addType(fieldName: 'linkedBy', type: 'string');
+        $this->addType(fieldName: 'linkedAt', type: 'datetime');
+    }//end __construct()
+
+    /**
+     * JSON serialization.
+     *
+     * @return array<string,mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'            => $this->id,
+            'objectUuid'    => $this->objectUuid,
+            'registerId'    => $this->registerId,
+            'schemaId'      => $this->schemaId,
+            'workPackageId' => $this->workPackageId,
+            'subject'       => $this->subject,
+            'type'          => $this->type,
+            'status'        => $this->status,
+            'priority'      => $this->priority,
+            'assignee'      => $this->assignee,
+            'project'       => $this->project,
+            'url'           => $this->url,
+            'cachedAt'      => $this->cachedAt?->format(DateTime::ATOM),
+            'linkedBy'      => $this->linkedBy,
+            'linkedAt'      => $this->linkedAt?->format(DateTime::ATOM),
+        ];
+    }//end jsonSerialize()
+}//end class

--- a/lib/Db/OpenProjectLinkMapper.php
+++ b/lib/Db/OpenProjectLinkMapper.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * Mapper for OpenProject link entities.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Class OpenProjectLinkMapper
+ *
+ * @template-extends QBMapper<OpenProjectLink>
+ */
+class OpenProjectLinkMapper extends QBMapper
+{
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $db Database connection.
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(db: $db, tableName: 'openregister_openproject_links', entityClass: OpenProjectLink::class);
+    }//end __construct()
+
+    /**
+     * Find OpenProject links by object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return OpenProjectLink[] Array of OpenProject links.
+     */
+    public function findByObjectUuid(string $objectUuid): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByObjectUuid()
+
+    /**
+     * Find OpenProject links by work-package id.
+     *
+     * @param int $workPackageId The work-package id.
+     *
+     * @return OpenProjectLink[] Array of OpenProject links.
+     */
+    public function findByWorkPackageId(int $workPackageId): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('work_package_id', $qb->createNamedParameter($workPackageId, IQueryBuilder::PARAM_INT)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByWorkPackageId()
+
+    /**
+     * Find a specific OpenProject link by object UUID and work-package id.
+     *
+     * @param string $objectUuid    The object UUID.
+     * @param int    $workPackageId The work-package id.
+     *
+     * @return OpenProjectLink|null The link or null if not found.
+     */
+    public function findByObjectAndWorkPackage(string $objectUuid, int $workPackageId): ?OpenProjectLink
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('work_package_id', $qb->createNamedParameter($workPackageId, IQueryBuilder::PARAM_INT)));
+
+        try {
+            return $this->findEntity(query: $qb);
+        } catch (DoesNotExistException $e) {
+            return null;
+        }
+    }//end findByObjectAndWorkPackage()
+
+    /**
+     * Delete all OpenProject links for an object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectUuid(string $objectUuid): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectUuid()
+
+    /**
+     * Delete an OpenProject link by object UUID + work-package id (Tier-2
+     * unlink path).
+     *
+     * Returns the number of rows actually deleted so callers can
+     * distinguish "no such link" (0) from "ok" (>=1).
+     *
+     * @param string $objectUuid    The object UUID.
+     * @param int    $workPackageId The work-package id.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectAndWorkPackage(string $objectUuid, int $workPackageId): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('work_package_id', $qb->createNamedParameter($workPackageId, IQueryBuilder::PARAM_INT)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectAndWorkPackage()
+}//end class

--- a/lib/Migration/Version1Date20260525240000.php
+++ b/lib/Migration/Version1Date20260525240000.php
@@ -1,0 +1,205 @@
+<?php
+
+/**
+ * Tier-2 OpenProject (external / OpenConnector-routed) integration migration.
+ *
+ * Ensures the `openregister_openproject_links` table exists with the full
+ * Tier-2 schema:
+ *
+ *  - id (bigint, PK, autoincrement)
+ *  - object_uuid (string 36, not null, indexed)
+ *  - register_id (bigint unsigned, not null, indexed)
+ *  - schema_id (bigint unsigned, nullable, indexed)
+ *  - work_package_id (integer, not null) — OpenProject work-package id
+ *  - subject (string 512, not null) — cached work-package subject
+ *  - type (string 64, nullable) — cached work-package type label
+ *  - status (string 64, nullable) — cached status label
+ *  - priority (string 64, nullable) — cached priority label
+ *  - assignee (string 255, nullable) — cached assignee label
+ *  - project (string 255, nullable) — cached project label
+ *  - url (string 512, nullable) — cached deep link
+ *  - cached_at (datetime, nullable) — when the cache columns were refreshed
+ *  - linked_by (string 64, not null)
+ *  - linked_at (datetime, not null)
+ *
+ * Idempotent: creates the table if missing, otherwise adds any missing
+ * Tier-2 columns. Companion to the Tier-2 talk/polls/email/forms/deck/
+ * flow/photos/collectives link tables. Unlike the NC-native link tables
+ * the picker source for OpenProject is the external OpenProject instance
+ * reached through OpenConnector (AD-4 / AD-22); the link row caches the
+ * work-package metadata so the sidebar tab renders without a per-row
+ * upstream roundtrip and historical references survive an OpenConnector
+ * outage.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Tier-2 openproject-links table — create-or-extend.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+class Version1Date20260525240000 extends SimpleMigrationStep
+{
+    /**
+     * Change the database schema.
+     *
+     * @param IOutput                 $output        Output for the migration process
+     * @param Closure                 $schemaClosure The schema closure
+     * @param array<array-key, mixed> $options       Migration options
+     *
+     * @return ISchemaWrapper|null
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema  = $schemaClosure();
+        $changed = false;
+
+        if ($schema->hasTable('openregister_openproject_links') === false) {
+            $this->createOpenProjectLinksTable(schema: $schema, output: $output);
+            $changed = true;
+        }
+
+        if ($schema->hasTable('openregister_openproject_links') === true
+            && $this->extendOpenProjectLinksTable(schema: $schema, output: $output) === true
+        ) {
+            $changed = true;
+        }
+
+        if ($changed === false) {
+            return null;
+        }
+
+        return $schema;
+    }//end changeSchema()
+
+    /**
+     * Create the openregister_openproject_links table at the Tier-2 shape.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return void
+     */
+    private function createOpenProjectLinksTable(ISchemaWrapper $schema, IOutput $output): void
+    {
+        $table = $schema->createTable('openregister_openproject_links');
+
+        $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'unsigned' => true]);
+        $table->addColumn('object_uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
+        $table->addColumn('register_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('schema_id', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]);
+        $table->addColumn('work_package_id', Types::INTEGER, ['notnull' => true]);
+        $table->addColumn('subject', Types::STRING, ['notnull' => true, 'length' => 512]);
+        $table->addColumn('type', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+        $table->addColumn('status', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+        $table->addColumn('priority', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+        $table->addColumn('assignee', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+        $table->addColumn('project', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+        $table->addColumn('url', Types::STRING, ['notnull' => false, 'length' => 512, 'default' => null]);
+        $table->addColumn('cached_at', Types::DATETIME, ['notnull' => false, 'default' => null]);
+        $table->addColumn('linked_by', Types::STRING, ['notnull' => true, 'length' => 64]);
+        $table->addColumn('linked_at', Types::DATETIME, ['notnull' => true]);
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['object_uuid', 'work_package_id'], 'idx_op_object_wp');
+        $table->addIndex(['object_uuid'], 'idx_op_object');
+        $table->addIndex(['register_id'], 'idx_op_register');
+        $table->addIndex(['schema_id'], 'idx_op_schema');
+
+        $output->info('Created openregister_openproject_links table (Tier-2 schema)');
+    }//end createOpenProjectLinksTable()
+
+    /**
+     * Add any missing Tier-2 columns to an existing openproject_links table.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return bool True when a column was added.
+     */
+    private function extendOpenProjectLinksTable(ISchemaWrapper $schema, IOutput $output): bool
+    {
+        $table   = $schema->getTable('openregister_openproject_links');
+        $changed = false;
+
+        if ($table->hasColumn('schema_id') === false) {
+            $table->addColumn(
+                'schema_id',
+                Types::BIGINT,
+                ['notnull' => false, 'unsigned' => true, 'default' => null]
+            );
+            $table->addIndex(['schema_id'], 'idx_op_schema');
+            $output->info('Added schema_id column to openregister_openproject_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('type') === false) {
+            $table->addColumn('type', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+            $output->info('Added type column to openregister_openproject_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('status') === false) {
+            $table->addColumn('status', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+            $output->info('Added status column to openregister_openproject_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('priority') === false) {
+            $table->addColumn('priority', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+            $output->info('Added priority column to openregister_openproject_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('assignee') === false) {
+            $table->addColumn('assignee', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+            $output->info('Added assignee column to openregister_openproject_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('project') === false) {
+            $table->addColumn('project', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+            $output->info('Added project column to openregister_openproject_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('url') === false) {
+            $table->addColumn('url', Types::STRING, ['notnull' => false, 'length' => 512, 'default' => null]);
+            $output->info('Added url column to openregister_openproject_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('cached_at') === false) {
+            $table->addColumn('cached_at', Types::DATETIME, ['notnull' => false, 'default' => null]);
+            $output->info('Added cached_at column to openregister_openproject_links');
+            $changed = true;
+        }
+
+        return $changed;
+    }//end extendOpenProjectLinksTable()
+}//end class

--- a/lib/Service/Integration/Providers/OpenProjectProvider.php
+++ b/lib/Service/Integration/Providers/OpenProjectProvider.php
@@ -37,10 +37,13 @@ namespace OCA\OpenRegister\Service\Integration\Providers;
 
 // phpcs:disable PEAR.Commenting.FunctionComment.Missing -- self-documenting IntegrationProvider metadata getters mirror the contract in the interface.
 
+use OCA\OpenRegister\Db\OpenProjectLink;
+use OCA\OpenRegister\Db\OpenProjectLinkMapper;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
 use OCP\App\IAppManager;
 use OCP\IL10N;
+use Throwable;
 
 /**
  * OpenProject integration provider — external, OpenConnector-backed.
@@ -66,9 +69,10 @@ class OpenProjectProvider extends AbstractIntegrationProvider
     /**
      * Constructor.
      *
-     * @param ExternalIntegrationRouter $router     External-call router.
-     * @param IAppManager               $appManager NC app manager.
-     * @param IL10N                     $l10n       Localisation.
+     * @param ExternalIntegrationRouter  $router                External-call router.
+     * @param IAppManager                $appManager            NC app manager.
+     * @param IL10N                      $l10n                  Localisation.
+     * @param OpenProjectLinkMapper|null $openProjectLinkMapper Tier-2 link table (optional).
      *
      * @return void
      */
@@ -76,6 +80,7 @@ class OpenProjectProvider extends AbstractIntegrationProvider
         private ExternalIntegrationRouter $router,
         private IAppManager $appManager,
         private IL10N $l10n,
+        private ?OpenProjectLinkMapper $openProjectLinkMapper=null,
     ) {
     }//end __construct()
 
@@ -137,6 +142,12 @@ class OpenProjectProvider extends AbstractIntegrationProvider
     /**
      * List OpenProject work packages linked to an OR object.
      *
+     * Tier-2 path: reads the dedicated `openregister_openproject_links`
+     * table first so the linked list renders from the cached row even
+     * when the OpenConnector source is temporarily unconfigured / down.
+     * When no link rows exist (or the mapper isn't wired) it falls back
+     * to the external router so a fresh source still surfaces rows.
+     *
      * @param string              $register Register slug or numeric id.
      * @param string              $schema   Schema slug or numeric id.
      * @param string              $objectId Object uuid.
@@ -146,6 +157,23 @@ class OpenProjectProvider extends AbstractIntegrationProvider
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
+        // Tier-2 path: read from the link table first.
+        if ($this->openProjectLinkMapper !== null) {
+            try {
+                $linkRows = $this->openProjectLinkMapper->findByObjectUuid($objectId);
+            } catch (Throwable $e) {
+                $linkRows = [];
+            }
+
+            if (count($linkRows) > 0) {
+                return array_map(
+                    fn (OpenProjectLink $link): array => $this->rowFromLink(link: $link),
+                    $linkRows
+                );
+            }
+        }
+
+        // Fallback: query the external source through OpenConnector.
         $query    = $this->contextQuery(register: $register, schema: $schema, objectId: $objectId, filters: $filters);
         $response = $this->router->call(
             provider: $this,
@@ -156,6 +184,35 @@ class OpenProjectProvider extends AbstractIntegrationProvider
 
         return $this->normalizeList(response: $response);
     }//end list()
+
+    /**
+     * Convert an OpenProjectLink row into the registry leaf-row shape,
+     * preserving the flat type / status / priority / assignee / project
+     * fields the bespoke CnOpenprojectTab renders.
+     *
+     * @param OpenProjectLink $link Link row from the mapper.
+     *
+     * @return array<string,mixed>
+     */
+    private function rowFromLink(OpenProjectLink $link): array
+    {
+        $id   = (string) $link->getWorkPackageId();
+        $data = $link->jsonSerialize();
+
+        return [
+            'id'        => $id,
+            'reference' => $id,
+            'subject'   => (string) $link->getSubject(),
+            'title'     => (string) $link->getSubject(),
+            'status'    => (string) ($link->getStatus() ?? ''),
+            'type'      => (string) ($link->getType() ?? ''),
+            'priority'  => (string) ($link->getPriority() ?? ''),
+            'assignee'  => (string) ($link->getAssignee() ?? ''),
+            'project'   => (string) ($link->getProject() ?? ''),
+            'url'       => (string) ($link->getUrl() ?? ''),
+            'data'      => $data,
+        ];
+    }//end rowFromLink()
 
     /**
      * Fetch a single linked OpenProject work package.
@@ -288,7 +345,10 @@ class OpenProjectProvider extends AbstractIntegrationProvider
      *
      * @return array<string,string>
      *
-     * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Body-vs-no-body is the natural toggle for HTTP request headers; a two-method split (requestHeaders / requestHeadersWithBody) would duplicate the static Accept header
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Body-vs-no-body is the
+     *     natural toggle for HTTP request headers; a two-method split
+     *     (requestHeaders / requestHeadersWithBody) would duplicate the
+     *     static Accept header.
      */
     private function requestHeaders(bool $withBody=false): array
     {
@@ -380,7 +440,6 @@ class OpenProjectProvider extends AbstractIntegrationProvider
             ]
         );
     }//end normalizeRow()
-
 
     /**
      * Pick a hAL label from a work-package row, preferring a top-level

--- a/lib/Service/OpenProjectLinkService.php
+++ b/lib/Service/OpenProjectLinkService.php
@@ -1,0 +1,620 @@
+<?php
+
+/**
+ * OpenProjectLinkService — Tier-2 OpenProject (external / OpenConnector-
+ * routed) integration service.
+ *
+ * Composes the {@see OpenProjectLinkMapper} (Tier-2 link table) with the
+ * {@see OpenProjectProvider} + {@see ExternalIntegrationRouter} external
+ * dispatch so the service exposes the Tier-2 surface:
+ *
+ *   - linkWorkPackage(uuid, registerId, schemaId, workPackageId)
+ *       — link an existing OpenProject work package
+ *   - createAndLinkWorkPackage(uuid, registerId, schemaId, projectId,
+ *       subject, type) — create a new work package in OpenProject and
+ *       link it
+ *   - unlink(uuid, workPackageId)
+ *       — remove a link (the work package itself stays in OpenProject)
+ *   - getLinkedWorkPackages(uuid)
+ *       — list linked work packages, refreshing the cached
+ *       subject/type/status/priority/assignee/project/url columns when a
+ *       row is older than 24h and the source is configured
+ *   - getAvailableWorkPackages(?search)
+ *       — picker source listing work packages reachable through the
+ *       OpenConnector `openproject` source
+ *
+ * Unlike the NC-native Tier-2 services (Collectives / Photos / Deck …)
+ * OpenProject lives outside Nextcloud: the only install dependency is
+ * OpenConnector (which carries the `openproject` source + credentials,
+ * AD-4 / AD-22). When the source is missing or the upstream OpenProject
+ * is unreachable the {@see ExternalIntegrationRouter} raises a
+ * {@see ProviderUnavailableException}; this service translates that into
+ * a 503-with-cause Exception so the controller + UI degrade to a
+ * "Configure" CTA rather than a broken tab (wave-5.2 4-state auth UX).
+ * Stored link rows are always returned as-is for the linked list so
+ * historical references survive an outage.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://OpenRegister.app
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use DateTime;
+use Exception;
+use OCA\OpenRegister\Db\OpenProjectLink;
+use OCA\OpenRegister\Db\OpenProjectLinkMapper;
+use OCA\OpenRegister\Exception\ProviderUnavailableException;
+use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
+use OCA\OpenRegister\Service\Integration\Providers\OpenProjectProvider;
+use OCP\App\IAppManager;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * OpenProjectLinkService.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)   Composes mapper +
+ *     OpenProjectProvider + ExternalIntegrationRouter + app manager +
+ *     user session + logger. Each dependency is required for one of the
+ *     Tier-2 flows (link, create, unlink, list, picker, cache refresh,
+ *     graceful degradation).
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ */
+class OpenProjectLinkService
+{
+    private const REQUIRED_APP = 'openconnector';
+
+    private const STALE_AFTER = 86400;
+    // 24 hours in seconds.
+
+    /**
+     * Constructor.
+     *
+     * @param OpenProjectLinkMapper     $openProjectLinkMapper Persistence for link rows.
+     * @param OpenProjectProvider       $provider              Provider exposing the external dispatch.
+     * @param ExternalIntegrationRouter $router                External-call router (OpenConnector).
+     * @param IAppManager               $appManager            NC app manager.
+     * @param IUserSession              $userSession           Active session.
+     * @param LoggerInterface           $logger                Logger.
+     */
+    public function __construct(
+        private readonly OpenProjectLinkMapper $openProjectLinkMapper,
+        private readonly OpenProjectProvider $provider,
+        private readonly ExternalIntegrationRouter $router,
+        private readonly IAppManager $appManager,
+        private readonly IUserSession $userSession,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Whether OpenConnector (which carries the OpenProject source) is
+     * installed + enabled for the current user.
+     *
+     * @return bool
+     */
+    public function isOpenConnectorAvailable(): bool
+    {
+        return $this->appManager->isEnabledForUser(self::REQUIRED_APP);
+    }//end isOpenConnectorAvailable()
+
+    /**
+     * Active session UID, or throw if no user is logged in.
+     *
+     * @return string The user id.
+     *
+     * @throws Exception When there is no active user.
+     */
+    private function requireUid(): string
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in', 401);
+        }
+
+        return $user->getUID();
+    }//end requireUid()
+
+    /**
+     * Link an existing OpenProject work package to an OR object.
+     *
+     * Idempotent: a duplicate link raises a 409 Exception. Work-package
+     * metadata is cached at link time, pulled fresh from OpenProject when
+     * the source is configured.
+     *
+     * @param string $objectUuid    Parent OR object uuid.
+     * @param int    $registerId    OR register id.
+     * @param int    $schemaId      OR schema id.
+     * @param int    $workPackageId OpenProject work-package id.
+     *
+     * @return OpenProjectLink The persisted link row.
+     *
+     * @throws Exception On missing user (401), duplicate (409),
+     *                   OpenConnector/source unavailable (503).
+     */
+    public function linkWorkPackage(string $objectUuid, int $registerId, int $schemaId, int $workPackageId): OpenProjectLink
+    {
+        $uid = $this->requireUid();
+
+        if ($workPackageId === 0) {
+            throw new Exception('workPackageId is required', 400);
+        }
+
+        $existing = $this->openProjectLinkMapper->findByObjectAndWorkPackage($objectUuid, $workPackageId);
+        if ($existing !== null) {
+            throw new Exception('Work package already linked to this object', 409);
+        }
+
+        // Best-effort metadata fetch — when the source is unconfigured /
+        // down we still persist the link with the id so the row survives,
+        // then refresh later (wave-5.2 graceful degradation).
+        $info = $this->fetchWorkPackage(
+            register: (string) $registerId,
+            schema: (string) $schemaId,
+            objectUuid: $objectUuid,
+            workPackageId: $workPackageId
+        );
+
+        $link = $this->hydrateLink(
+            objectUuid: $objectUuid,
+            registerId: $registerId,
+            schemaId: $schemaId,
+            workPackageId: $workPackageId,
+            info: ($info ?? ['subject' => '#'.$workPackageId]),
+            uid: $uid
+        );
+
+        return $this->openProjectLinkMapper->insert($link);
+    }//end linkWorkPackage()
+
+    /**
+     * Create a new OpenProject work package and link it to an OR object.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $registerId OR register id.
+     * @param int    $schemaId   OR schema id.
+     * @param string $projectId  Target OpenProject project id.
+     * @param string $subject    New work-package subject.
+     * @param string $type       Optional work-package type (id or label).
+     *
+     * @return OpenProjectLink The persisted link row.
+     *
+     * @throws Exception On missing user (401), empty subject (400),
+     *                   missing project (400), source unavailable (503).
+     */
+    public function createAndLinkWorkPackage(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        string $projectId,
+        string $subject,
+        string $type=''
+    ): OpenProjectLink {
+        $uid = $this->requireUid();
+
+        $subject   = trim($subject);
+        $projectId = trim($projectId);
+        if ($subject === '') {
+            throw new Exception('Subject is required', 400);
+        }
+
+        if ($projectId === '') {
+            throw new Exception('Project id is required', 400);
+        }
+
+        $payload = ['subject' => $subject, 'project' => $projectId];
+        if ($type !== '') {
+            $payload['type'] = $type;
+        }
+
+        try {
+            $created = $this->provider->create(
+                register: (string) $registerId,
+                schema: (string) $schemaId,
+                objectId: $objectUuid,
+                payload: $payload
+            );
+        } catch (ProviderUnavailableException $e) {
+            throw $this->unavailable(exception: $e);
+        } catch (Throwable $e) {
+            $this->logger->warning('OpenProjectLinkService::createAndLinkWorkPackage failed: '.$e->getMessage());
+            throw new Exception('Failed to create OpenProject work package', 500);
+        }
+
+        $workPackageId = (int) ($created['id'] ?? $created['reference'] ?? 0);
+        if ($workPackageId === 0) {
+            throw new Exception('OpenProject did not return a work-package id', 502);
+        }
+
+        $info = $this->normaliseRow(row: $created);
+
+        $link = $this->hydrateLink(
+            objectUuid: $objectUuid,
+            registerId: $registerId,
+            schemaId: $schemaId,
+            workPackageId: $workPackageId,
+            info: $info,
+            uid: $uid
+        );
+
+        return $this->openProjectLinkMapper->insert($link);
+    }//end createAndLinkWorkPackage()
+
+    /**
+     * Build an OpenProjectLink from normalised work-package info.
+     *
+     * @param string              $objectUuid    Parent OR object uuid.
+     * @param int                 $registerId    OR register id.
+     * @param int                 $schemaId      OR schema id.
+     * @param int                 $workPackageId OpenProject work-package id.
+     * @param array<string,mixed> $info          Normalised work-package info.
+     * @param string              $uid           The linking user id.
+     *
+     * @return OpenProjectLink
+     */
+    private function hydrateLink(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        int $workPackageId,
+        array $info,
+        string $uid
+    ): OpenProjectLink {
+        $link = new OpenProjectLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        $link->setSchemaId($schemaId);
+        $link->setWorkPackageId($workPackageId);
+        $link->setSubject((string) ($info['subject'] ?? ('#'.$workPackageId)));
+        $link->setType($this->stringOrNull(value: ($info['type'] ?? null)));
+        $link->setStatus($this->stringOrNull(value: ($info['status'] ?? null)));
+        $link->setPriority($this->stringOrNull(value: ($info['priority'] ?? null)));
+        $link->setAssignee($this->stringOrNull(value: ($info['assignee'] ?? null)));
+        $link->setProject($this->stringOrNull(value: ($info['project'] ?? null)));
+        $link->setUrl($this->stringOrNull(value: ($info['url'] ?? null)));
+        $link->setCachedAt(new DateTime());
+        $link->setLinkedBy($uid);
+        $link->setLinkedAt(new DateTime());
+
+        return $link;
+    }//end hydrateLink()
+
+    /**
+     * Unlink a work package from an object.
+     *
+     * Does NOT delete the work package itself — it stays in OpenProject.
+     *
+     * @param string $objectUuid    Parent OR object uuid.
+     * @param int    $workPackageId OpenProject work-package id.
+     *
+     * @return void
+     *
+     * @throws Exception On missing user (401) or no matching link (404).
+     */
+    public function unlink(string $objectUuid, int $workPackageId): void
+    {
+        $this->requireUid();
+
+        $deleted = $this->openProjectLinkMapper->deleteByObjectAndWorkPackage($objectUuid, $workPackageId);
+        if ($deleted === 0) {
+            throw new Exception('OpenProject link not found', 404);
+        }
+    }//end unlink()
+
+    /**
+     * Return the linked work packages for an object, refreshing the
+     * cached metadata columns when a row is older than 24h and the
+     * OpenConnector source is reachable.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getLinkedWorkPackages(string $objectUuid): array
+    {
+        $links     = $this->openProjectLinkMapper->findByObjectUuid($objectUuid);
+        $available = $this->isOpenConnectorAvailable();
+
+        $results = [];
+        foreach ($links as $link) {
+            if ($available === true && $this->isStale(link: $link) === true) {
+                $link = $this->refreshLink(link: $link);
+            }
+
+            $results[] = $link->jsonSerialize();
+        }
+
+        return $results;
+    }//end getLinkedWorkPackages()
+
+    /**
+     * Return the work packages reachable through the OpenConnector
+     * `openproject` source (picker source), optionally filtered by a
+     * search substring.
+     *
+     * @param string|null $search Optional subject-substring filter.
+     *
+     * @return array<int,array<string,mixed>>
+     *
+     * @throws Exception When the source is unconfigured / unreachable (503).
+     */
+    public function getAvailableWorkPackages(?string $search=null): array
+    {
+        if ($this->isOpenConnectorAvailable() === false) {
+            throw new Exception('OpenConnector app is not available', 503);
+        }
+
+        $options = ['headers' => ['Accept' => 'application/json']];
+        if ($search !== null && $search !== '') {
+            $options['query'] = ['_search' => $search];
+        }
+
+        try {
+            $response = $this->router->call(
+                provider: $this->provider,
+                method: 'GET',
+                path: '',
+                options: $options
+            );
+        } catch (ProviderUnavailableException $e) {
+            throw $this->unavailable(exception: $e);
+        } catch (Throwable $e) {
+            $this->logger->warning('OpenProjectLinkService::getAvailableWorkPackages failed: '.$e->getMessage());
+            throw new Exception('OpenProject is currently unavailable', 503);
+        }
+
+        return $this->normaliseList(response: $response);
+    }//end getAvailableWorkPackages()
+
+    /**
+     * Whether a link row's cache is older than the stale window.
+     *
+     * @param OpenProjectLink $link The link row.
+     *
+     * @return bool
+     */
+    private function isStale(OpenProjectLink $link): bool
+    {
+        $cachedAt = ($link->getCachedAt() ?? $link->getLinkedAt());
+        if ($cachedAt === null) {
+            return true;
+        }
+
+        return (time() - $cachedAt->getTimestamp()) > self::STALE_AFTER;
+    }//end isStale()
+
+    /**
+     * Refresh a link row's cached work-package metadata in place.
+     *
+     * Best-effort: when the work package can't be resolved (source down,
+     * package deleted) the link is left untouched.
+     *
+     * @param OpenProjectLink $link The link row.
+     *
+     * @return OpenProjectLink The (possibly updated) link row.
+     */
+    private function refreshLink(OpenProjectLink $link): OpenProjectLink
+    {
+        $info = $this->fetchWorkPackage(
+            register: (string) $link->getRegisterId(),
+            schema: (string) ($link->getSchemaId() ?? 0),
+            objectUuid: (string) $link->getObjectUuid(),
+            workPackageId: (int) $link->getWorkPackageId()
+        );
+        if ($info === null) {
+            return $link;
+        }
+
+        $link->setSubject((string) ($info['subject'] ?? $link->getSubject()));
+        $link->setType($this->stringOrNull(value: ($info['type'] ?? null)));
+        $link->setStatus($this->stringOrNull(value: ($info['status'] ?? null)));
+        $link->setPriority($this->stringOrNull(value: ($info['priority'] ?? null)));
+        $link->setAssignee($this->stringOrNull(value: ($info['assignee'] ?? null)));
+        $link->setProject($this->stringOrNull(value: ($info['project'] ?? null)));
+        $link->setUrl($this->stringOrNull(value: ($info['url'] ?? $link->getUrl())));
+        $link->setCachedAt(new DateTime());
+
+        try {
+            return $this->openProjectLinkMapper->update($link);
+        } catch (Throwable $e) {
+            $this->logger->debug('OpenProjectLinkService::refreshLink update failed: '.$e->getMessage());
+            return $link;
+        }
+    }//end refreshLink()
+
+    /**
+     * Fetch one work package from OpenProject (through the provider).
+     *
+     * Returns null when the source is unconfigured / unreachable or the
+     * package cannot be resolved, so callers degrade gracefully.
+     *
+     * @param string $register      OR register id (context).
+     * @param string $schema        OR schema id (context).
+     * @param string $objectUuid    Parent OR object uuid (context).
+     * @param int    $workPackageId OpenProject work-package id.
+     *
+     * @return array<string,mixed>|null
+     */
+    private function fetchWorkPackage(string $register, string $schema, string $objectUuid, int $workPackageId): ?array
+    {
+        if ($this->isOpenConnectorAvailable() === false) {
+            return null;
+        }
+
+        try {
+            $row = $this->provider->get(
+                register: $register,
+                schema: $schema,
+                objectId: $objectUuid,
+                entityId: (string) $workPackageId
+            );
+        } catch (Throwable $e) {
+            $this->logger->debug('OpenProjectLinkService::fetchWorkPackage failed: '.$e->getMessage());
+            return null;
+        }
+
+        return $this->normaliseRow(row: $row);
+    }//end fetchWorkPackage()
+
+    /**
+     * Translate a ProviderUnavailableException into a 503 Exception that
+     * the controller maps to the right "Configure" / "reconnect" UX.
+     *
+     * @param ProviderUnavailableException $exception The router failure.
+     *
+     * @return Exception
+     */
+    private function unavailable(ProviderUnavailableException $exception): Exception
+    {
+        $this->logger->info('OpenProjectLinkService: provider unavailable ('.$exception->getCause().'): '.$exception->getMessage());
+        return new Exception($exception->getMessage(), 503);
+    }//end unavailable()
+
+    /**
+     * Normalise a list response from the provider/router into picker rows.
+     *
+     * The OpenProjectProvider already flattens hAL envelopes for its own
+     * `list()`; here we re-apply the same shaping to the raw router
+     * envelope so the picker rows carry the flat fields.
+     *
+     * @param array<string,mixed> $response Decoded source response.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    private function normaliseList(array $response): array
+    {
+        $rows = [];
+        foreach (['results', 'items', '_embedded', 'elements'] as $key) {
+            if (isset($response[$key]) === true && is_array($response[$key]) === true) {
+                $candidate = $response[$key];
+                if ($key === '_embedded'
+                    && isset($candidate['elements']) === true
+                    && is_array($candidate['elements']) === true
+                ) {
+                    $candidate = $candidate['elements'];
+                }
+
+                $rows = $candidate;
+                break;
+            }
+        }
+
+        if ($rows === [] && array_is_list($response) === true) {
+            $rows = $response;
+        }
+
+        $out = [];
+        foreach ($rows as $row) {
+            if (is_array($row) === true) {
+                $out[] = $this->normaliseRow(row: $row);
+            }
+        }
+
+        return $out;
+    }//end normaliseList()
+
+    /**
+     * Shape one work-package row to the Tier-2 contract, flattening the
+     * OpenProject hAL `_links` / `_embedded` envelopes onto top-level
+     * keys (mirrors OpenProjectProvider::normalizeRow()).
+     *
+     * @param array<string,mixed> $row One source row.
+     *
+     * @return array<string,mixed>
+     */
+    private function normaliseRow(array $row): array
+    {
+        $id       = (int) ($row['id'] ?? $row['reference'] ?? 0);
+        $subject  = (string) ($row['subject'] ?? $row['title'] ?? $row['name'] ?? ('#'.$id));
+        $status   = $this->pickHalLabel(row: $row, field: 'status', linkKey: 'title', embedKey: 'name');
+        $type     = $this->pickHalLabel(row: $row, field: 'type', linkKey: 'title', embedKey: 'name');
+        $priority = $this->pickHalLabel(row: $row, field: 'priority', linkKey: 'title', embedKey: 'name');
+        $assignee = $this->pickHalLabel(row: $row, field: 'assignee', linkKey: 'title', embedKey: 'name');
+        $project  = $this->pickHalLabel(row: $row, field: 'project', linkKey: 'title', embedKey: 'name');
+        $url      = (string) ($row['url'] ?? ($row['_links']['self']['href'] ?? ''));
+
+        return [
+            'id'            => $id,
+            'workPackageId' => $id,
+            'subject'       => $subject,
+            'type'          => $type,
+            'status'        => $status,
+            'priority'      => $priority,
+            'assignee'      => $assignee,
+            'project'       => $project,
+            'url'           => $url,
+        ];
+    }//end normaliseRow()
+
+    /**
+     * Pick a hAL label from a work-package row, preferring a top-level
+     * field, then `_links.<field>.<linkKey>`, then
+     * `_embedded.<field>.<embedKey>`.
+     *
+     * @param array<string,mixed> $row      Raw work-package row.
+     * @param string              $field    Field name.
+     * @param string              $linkKey  Label key under `_links.<field>`.
+     * @param string              $embedKey Label key under `_embedded.<field>`.
+     *
+     * @return string Resolved label or empty string.
+     */
+    private function pickHalLabel(array $row, string $field, string $linkKey, string $embedKey): string
+    {
+        $top = ($row[$field] ?? null);
+        if (is_string($top) === true && $top !== '') {
+            return $top;
+        }
+
+        $link = ($row['_links'][$field][$linkKey] ?? null);
+        if (is_string($link) === true && $link !== '') {
+            return $link;
+        }
+
+        $embed = ($row['_embedded'][$field][$embedKey] ?? null);
+        if (is_string($embed) === true && $embed !== '') {
+            return $embed;
+        }
+
+        return '';
+    }//end pickHalLabel()
+
+    /**
+     * Coerce a value to a non-empty string, or null when empty/absent.
+     *
+     * @param mixed $value The candidate value.
+     *
+     * @return string|null
+     */
+    private function stringOrNull(mixed $value): ?string
+    {
+        if (is_string($value) === false) {
+            return null;
+        }
+
+        $value = trim($value);
+        if ($value === '') {
+            return null;
+        }
+
+        return $value;
+    }//end stringOrNull()
+}//end class

--- a/tests/Unit/Service/OpenProjectLinkServiceTest.php
+++ b/tests/Unit/Service/OpenProjectLinkServiceTest.php
@@ -1,0 +1,359 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Service\OpenProjectLinkService}.
+ *
+ * Exercises the Tier-2 service contract (link / createAndLink / unlink /
+ * list + available picker) against a mocked OpenProjectLinkMapper and a
+ * mocked OpenProjectProvider / ExternalIntegrationRouter. Tests that
+ * touch the external OpenProject source use the "OpenConnector
+ * unavailable" path or a stubbed provider response because the real
+ * round-trip requires the OpenConnector app + a live source.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/integration-openproject/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+// phpcs:disable PEAR.Commenting.FunctionComment.Missing -- arrange/act/assert PHPUnit conventions.
+// phpcs:disable CustomSniffs.Functions.NamedParameters.RequireNamedParameters -- PHPUnit positional assertions.
+
+use Exception;
+use OCA\OpenRegister\Db\OpenProjectLink;
+use OCA\OpenRegister\Db\OpenProjectLinkMapper;
+use OCA\OpenRegister\Exception\ProviderUnavailableException;
+use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
+use OCA\OpenRegister\Service\Integration\Providers\OpenProjectProvider;
+use OCA\OpenRegister\Service\OpenProjectLinkService;
+use OCP\App\IAppManager;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * OpenProjectLinkServiceTest.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class OpenProjectLinkServiceTest extends TestCase
+{
+
+    private OpenProjectLinkMapper&MockObject $mapper;
+
+    private OpenProjectProvider&MockObject $provider;
+
+    private ExternalIntegrationRouter&MockObject $router;
+
+    private IAppManager&MockObject $appManager;
+
+    private IUserSession&MockObject $userSession;
+
+    private LoggerInterface&MockObject $logger;
+
+    private OpenProjectLinkService $service;
+
+    protected function setUp(): void
+    {
+        $this->mapper = $this->getMockBuilder(OpenProjectLinkMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(
+                [
+                    'findByObjectUuid',
+                    'findByObjectAndWorkPackage',
+                    'deleteByObjectAndWorkPackage',
+                    'insert',
+                    'update',
+                ]
+            )
+            ->getMock();
+
+        $this->provider    = $this->createMock(OpenProjectProvider::class);
+        $this->router      = $this->createMock(ExternalIntegrationRouter::class);
+        $this->appManager  = $this->createMock(IAppManager::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->logger      = $this->createMock(LoggerInterface::class);
+
+        $this->service = new OpenProjectLinkService(
+            $this->mapper,
+            $this->provider,
+            $this->router,
+            $this->appManager,
+            $this->userSession,
+            $this->logger
+        );
+    }//end setUp()
+
+    private function setupUser(string $uid='alice'): IUser&MockObject
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $this->userSession->method('getUser')->willReturn($user);
+        return $user;
+    }//end setupUser()
+
+    public function testIsOpenConnectorAvailableTrue(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('openconnector')->willReturn(true);
+        $this->assertTrue($this->service->isOpenConnectorAvailable());
+    }//end testIsOpenConnectorAvailableTrue()
+
+    public function testIsOpenConnectorAvailableFalse(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('openconnector')->willReturn(false);
+        $this->assertFalse($this->service->isOpenConnectorAvailable());
+    }//end testIsOpenConnectorAvailableFalse()
+
+    public function testLinkWorkPackageThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->linkWorkPackage('abc-123', 1, 2, 99);
+    }//end testLinkWorkPackageThrowsWhenNoUser()
+
+    public function testLinkWorkPackageThrowsOnZeroId(): void
+    {
+        $this->setupUser();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+
+        $this->service->linkWorkPackage('abc-123', 1, 2, 0);
+    }//end testLinkWorkPackageThrowsOnZeroId()
+
+    public function testLinkWorkPackageThrowsOnDuplicate(): void
+    {
+        $this->setupUser();
+        $this->mapper->method('findByObjectAndWorkPackage')->with('abc-123', 99)->willReturn(new OpenProjectLink());
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(409);
+        $this->expectExceptionMessage('Work package already linked to this object');
+
+        $this->service->linkWorkPackage('abc-123', 1, 2, 99);
+    }//end testLinkWorkPackageThrowsOnDuplicate()
+
+    public function testLinkWorkPackagePersistsEvenWhenSourceUnconfigured(): void
+    {
+        $this->setupUser();
+        // OpenConnector unavailable → metadata fetch skipped, link still persisted.
+        $this->appManager->method('isEnabledForUser')->with('openconnector')->willReturn(false);
+        $this->mapper->method('findByObjectAndWorkPackage')->with('abc-123', 99)->willReturn(null);
+        $this->mapper->expects($this->once())
+            ->method('insert')
+            ->willReturnCallback(static fn (OpenProjectLink $link): OpenProjectLink => $link);
+
+        $link = $this->service->linkWorkPackage('abc-123', 1, 2, 99);
+
+        $this->assertSame(99, $link->getWorkPackageId());
+        $this->assertSame('#99', $link->getSubject());
+        $this->assertSame('alice', $link->getLinkedBy());
+    }//end testLinkWorkPackagePersistsEvenWhenSourceUnconfigured()
+
+    public function testCreateAndLinkWorkPackageThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->createAndLinkWorkPackage('abc-123', 1, 2, '5', 'Ship it');
+    }//end testCreateAndLinkWorkPackageThrowsWhenNoUser()
+
+    public function testCreateAndLinkWorkPackageThrowsOnEmptySubject(): void
+    {
+        $this->setupUser();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+
+        $this->service->createAndLinkWorkPackage('abc-123', 1, 2, '5', '   ');
+    }//end testCreateAndLinkWorkPackageThrowsOnEmptySubject()
+
+    public function testCreateAndLinkWorkPackageThrowsOnMissingProject(): void
+    {
+        $this->setupUser();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+
+        $this->service->createAndLinkWorkPackage('abc-123', 1, 2, '', 'Ship it');
+    }//end testCreateAndLinkWorkPackageThrowsOnMissingProject()
+
+    public function testCreateAndLinkWorkPackageSurfaces503WhenSourceUnavailable(): void
+    {
+        $this->setupUser();
+        $this->provider->method('create')->willThrowException(
+            new ProviderUnavailableException(
+                'no source',
+                ProviderUnavailableException::CAUSE_OPENCONNECTOR_SOURCE_MISSING
+            )
+        );
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+
+        $this->service->createAndLinkWorkPackage('abc-123', 1, 2, '5', 'Ship it');
+    }//end testCreateAndLinkWorkPackageSurfaces503WhenSourceUnavailable()
+
+    public function testCreateAndLinkWorkPackagePersistsLink(): void
+    {
+        $this->setupUser();
+        $this->provider->method('create')->willReturn(
+            [
+                'id'       => 42,
+                'subject'  => 'Ship it',
+                'status'   => 'New',
+                'type'     => 'Task',
+                'priority' => 'High',
+                'project'  => 'Portal',
+                'url'      => 'https://op.example.org/wp/42',
+            ]
+        );
+        $this->mapper->expects($this->once())
+            ->method('insert')
+            ->willReturnCallback(static fn (OpenProjectLink $link): OpenProjectLink => $link);
+
+        $link = $this->service->createAndLinkWorkPackage('abc-123', 1, 2, '5', 'Ship it', 'Task');
+
+        $this->assertSame(42, $link->getWorkPackageId());
+        $this->assertSame('Ship it', $link->getSubject());
+        $this->assertSame('Task', $link->getType());
+        $this->assertSame('High', $link->getPriority());
+        $this->assertSame('Portal', $link->getProject());
+    }//end testCreateAndLinkWorkPackagePersistsLink()
+
+    public function testUnlinkThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->unlink('abc-123', 99);
+    }//end testUnlinkThrowsWhenNoUser()
+
+    public function testUnlinkThrowsWhenLinkMissing(): void
+    {
+        $this->setupUser();
+        $this->mapper->method('deleteByObjectAndWorkPackage')->with('abc-123', 99)->willReturn(0);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(404);
+
+        $this->service->unlink('abc-123', 99);
+    }//end testUnlinkThrowsWhenLinkMissing()
+
+    public function testUnlinkSucceeds(): void
+    {
+        $this->setupUser();
+        $this->mapper->expects($this->once())
+            ->method('deleteByObjectAndWorkPackage')
+            ->with('abc-123', 99)
+            ->willReturn(1);
+
+        $this->service->unlink('abc-123', 99);
+    }//end testUnlinkSucceeds()
+
+    public function testGetLinkedWorkPackagesReturnsRows(): void
+    {
+        // OpenConnector unavailable → no refresh, rows returned as-is.
+        $this->appManager->method('isEnabledForUser')->with('openconnector')->willReturn(false);
+
+        $link = new OpenProjectLink();
+        $link->setObjectUuid('abc-123');
+        $link->setWorkPackageId(42);
+        $link->setSubject('Ship it');
+        $link->setStatus('New');
+
+        $this->mapper->method('findByObjectUuid')->with('abc-123')->willReturn([$link]);
+
+        $rows = $this->service->getLinkedWorkPackages('abc-123');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame(42, $rows[0]['workPackageId']);
+        $this->assertSame('Ship it', $rows[0]['subject']);
+        $this->assertSame('New', $rows[0]['status']);
+    }//end testGetLinkedWorkPackagesReturnsRows()
+
+    public function testGetLinkedWorkPackagesEmpty(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('openconnector')->willReturn(false);
+        $this->mapper->method('findByObjectUuid')->with('abc-123')->willReturn([]);
+
+        $this->assertSame([], $this->service->getLinkedWorkPackages('abc-123'));
+    }//end testGetLinkedWorkPackagesEmpty()
+
+    public function testGetAvailableWorkPackagesThrowsWhenOpenConnectorUnavailable(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('openconnector')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+
+        $this->service->getAvailableWorkPackages();
+    }//end testGetAvailableWorkPackagesThrowsWhenOpenConnectorUnavailable()
+
+    public function testGetAvailableWorkPackagesSurfaces503OnRouterFailure(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('openconnector')->willReturn(true);
+        $this->router->method('call')->willThrowException(
+            new ProviderUnavailableException(
+                'down',
+                ProviderUnavailableException::CAUSE_UPSTREAM_SERVICE_DOWN
+            )
+        );
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+
+        $this->service->getAvailableWorkPackages('export');
+    }//end testGetAvailableWorkPackagesSurfaces503OnRouterFailure()
+
+    public function testGetAvailableWorkPackagesNormalisesRows(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('openconnector')->willReturn(true);
+        $this->router->method('call')->willReturn(
+            [
+                'results' => [
+                    [
+                        'id'      => 7,
+                        'subject' => 'Refactor auth',
+                        '_links'  => [
+                            'self'   => ['href' => '/api/v3/work_packages/7'],
+                            'status' => ['title' => 'Open'],
+                            'type'   => ['title' => 'Bug'],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $rows = $this->service->getAvailableWorkPackages();
+
+        $this->assertCount(1, $rows);
+        $this->assertSame(7, $rows[0]['workPackageId']);
+        $this->assertSame('Refactor auth', $rows[0]['subject']);
+        $this->assertSame('Bug', $rows[0]['type']);
+        $this->assertSame('Open', $rows[0]['status']);
+        $this->assertSame('/api/v3/work_packages/7', $rows[0]['url']);
+    }//end testGetAvailableWorkPackagesNormalisesRows()
+}//end class


### PR DESCRIPTION
## Summary
Phase I (Tier-2) for the **openproject** external integration leaf — OpenConnector-routed, no local NC app. Adds a dedicated link table tracking OpenProject work packages bound to an OR object, plus picker + create flows. Mirrors the collectives Tier-2 shape (AD-4 / AD-22) while preserving wave-5.2's hAL handling and 4-state auth UX.

- **Migration** `Version1Date20260525240000` → `oc_openregister_openproject_links` (idempotent create-or-extend; composite unique `(object_uuid, work_package_id)`; caches subject/type/status/priority/assignee/project/url + `cached_at`).
- **Db** `OpenProjectLink` entity + `OpenProjectLinkMapper`.
- **Service** `OpenProjectLinkService` composes the mapper with `OpenProjectProvider` + `ExternalIntegrationRouter`: link / unlink / getLinkedWorkPackages (24h cache refresh) / getAvailableWorkPackages / createAndLinkWorkPackage. Graceful 503-with-cause when the OpenConnector source is unconfigured/down.
- **Controller** `OpenProjectLinksController` — GET/POST `/api/objects/{r}/{s}/{id}/openproject`, POST `.../openproject/new`, DELETE `.../openproject/{wpId}`, GET `/api/integrations/openproject/available?search=` (routes specific-before-wildcard).
- **Provider** `OpenProjectProvider::list()` reads the link table first (renders from cached rows even when the source is down), falling back to the external router; preserves hAL flattening.
- DI wiring in `Application.php`.

## Test plan
- [x] `OpenProjectLinkServiceTest` — 19 cases (link/create/unlink/list/available + 503/409/401/400 paths) — green.
- [x] `OpenProjectProviderTest` — existing hAL flattening cases still green (provider ctor change is backward-compatible).
- [x] PHP lint + PHPCS (0 errors) on all new/modified files.
- [ ] Manual: configure an `openproject` OpenConnector source, link/create/unlink a work package from an object sidebar.

**Note:** picker/create/refresh require a configured OpenConnector `openproject` source; without it the surface degrades to a "Configure" CTA.

Refs: openregister#1325, ADR-019, ADR-022, ADR-004.