### PR TITLE
feat(cospend): Tier-2 — link table + picker + create

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -423,6 +423,18 @@ return [
         ['name' => 'collectiveLinks#link',         'url' => '/api/objects/{register}/{schema}/{id}/collectives',        'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
         ['name' => 'collectiveLinks#destroy',      'url' => '/api/objects/{register}/{schema}/{id}/collectives/{pageId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'pageId' => '[0-9]+']],
 
+        // Cospend (NC Costs) — Tier-2 link-table API. User-scoped (no
+        // admin gate). The specific `/cospend/new` (create + link) route
+        // MUST precede the wildcard `/cospend/{entryId}` unlink route, and
+        // the app-global `available` route precedes the object-scoped
+        // routes. The link POST handles BOTH project and bill rows
+        // (discriminated by a `billId`/`entryType` in the body).
+        ['name' => 'cospendLinks#available',    'url' => '/api/integrations/cospend/available',                  'verb' => 'GET'],
+        ['name' => 'cospendLinks#index',        'url' => '/api/objects/{register}/{schema}/{id}/cospend',        'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
+        ['name' => 'cospendLinks#createAndLink','url' => '/api/objects/{register}/{schema}/{id}/cospend/new',    'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'cospendLinks#link',         'url' => '/api/objects/{register}/{schema}/{id}/cospend',        'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'cospendLinks#destroy',      'url' => '/api/objects/{register}/{schema}/{id}/cospend/{entryId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'entryId' => '[0-9]+']],
+
         // Maps (NC Maps / Location) — Tier-2 link-table API. User-scoped
         // (no admin gate). The specific `/maps/new` (create + link) route
         // MUST precede the wildcard `/maps/{favoriteId}` unlink route.

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1141,12 +1141,10 @@ class Application extends App implements IBootstrap
         $greenfieldProviders = [
             // @spec openspec/changes/integration-activity/tasks.md.
             \OCA\OpenRegister\Service\Integration\Providers\ActivityProvider::class,
-            // NB: AnalyticsProvider + CollectivesProvider were Tier-1
-            // greenfield until Tier-2; each now takes its own link mapper
-            // (AnalyticsLinkMapper / CollectiveLinkMapper) and is registered
-            // separately below.
-            // @spec openspec/changes/integration-cospend/tasks.md.
-            \OCA\OpenRegister\Service\Integration\Providers\CospendProvider::class,
+            // NB: AnalyticsProvider + CollectivesProvider + CospendProvider
+            // were Tier-1 greenfield until Tier-2; each now takes its own
+            // link mapper (AnalyticsLinkMapper / CollectiveLinkMapper /
+            // CospendLinkMapper) and is registered separately below.
             // NB: FormsProvider is NO LONGER greenfield — it has a Tier-2
             // link-table dep (FormLinkMapper) that doesn't fit the (db,
             // appManager, l10n) signature shared by the rest of this list.
@@ -1452,6 +1450,45 @@ class Application extends App implements IBootstrap
                     appManager: $container->get('OCP\App\IAppManager'),
                     l10n: $container->get('OCP\IL10N'),
                     analyticsLinkMapper: $container->get(\OCA\OpenRegister\Db\AnalyticsLinkMapper::class),
+                );
+            }
+        );
+
+        // CospendProvider — Tier-2: backed by the CospendLinkMapper. The
+        // provider still gracefully degrades to the legacy `[or:{uuid}]`
+        // name-marker scan (projects + bills) when the link table is empty
+        // (entities that pre-date the Tier-2 link table; wave-2.3
+        // marker-on-name convention).
+        // @spec openspec/changes/integration-cospend/tasks.md.
+        $context->registerService(
+            \OCA\OpenRegister\Service\Integration\Providers\CospendProvider::class,
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\Service\Integration\Providers\CospendProvider(
+                    db: $container->get('OCP\IDBConnection'),
+                    appManager: $container->get('OCP\App\IAppManager'),
+                    l10n: $container->get('OCP\IL10N'),
+                    cospendLinkMapper: $container->get(\OCA\OpenRegister\Db\CospendLinkMapper::class),
+                );
+            }
+        );
+
+        // CospendLinkService — Tier-2 link/create/unlink/picker service
+        // backing the CospendLinksController. NC Cospend projects are
+        // user-scoped; the ProjectService is resolved lazily via the
+        // container (behind a class_exists guard) and bills/projects are
+        // read directly from the cospend_* tables, so the service loads
+        // even when Cospend is absent.
+        // @spec openspec/changes/integration-cospend/tasks.md.
+        $context->registerService(
+            \OCA\OpenRegister\Service\CospendLinkService::class,
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\Service\CospendLinkService(
+                    cospendLinkMapper: $container->get(\OCA\OpenRegister\Db\CospendLinkMapper::class),
+                    container: $container,
+                    appManager: $container->get('OCP\App\IAppManager'),
+                    userSession: $container->get('OCP\IUserSession'),
+                    db: $container->get('OCP\IDBConnection'),
+                    logger: $container->get('Psr\Log\LoggerInterface'),
                 );
             }
         );

--- a/lib/Controller/CospendLinksController.php
+++ b/lib/Controller/CospendLinksController.php
@@ -1,0 +1,342 @@
+<?php
+
+/**
+ * CospendLinksController — Tier-2 REST controller for NC Cospend (Costs)
+ * project + bill links.
+ *
+ * Surface:
+ *
+ *   - GET    /api/objects/{r}/{s}/{id}/cospend             — list linked entries
+ *   - POST   /api/objects/{r}/{s}/{id}/cospend             — link existing project/bill
+ *   - POST   /api/objects/{r}/{s}/{id}/cospend/new         — create + link project
+ *   - DELETE /api/objects/{r}/{s}/{id}/cospend/{entryId}   — unlink an entry
+ *   - GET    /api/integrations/cospend/available?search=   — project picker source
+ *
+ * The link POST handles BOTH project and bill rows: a `billId` in the
+ * body (or `entryType: bill`) links the specific bill, otherwise the
+ * whole project is linked. NC Cospend entities are user-scoped, so there
+ * is no admin gate — the active session's user owns the projects it can
+ * link/create.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use Exception;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\CospendLinkService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Tier-2 Cospend links controller.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ */
+class CospendLinksController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param string             $appName            App id.
+     * @param IRequest           $request            HTTP request.
+     * @param CospendLinkService $cospendLinkService Backing service.
+     * @param ObjectService      $objectService      OR object resolver.
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly CospendLinkService $cospendLinkService,
+        private readonly ObjectService $objectService,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * List linked Cospend entries for an object.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function index(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->cospendLinkService->isCospendAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Cospend app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $results = $this->cospendLinkService->getLinkedEntries($object->getUuid());
+
+            return new JSONResponse(
+                    [
+                        'results' => $results,
+                        'total'   => count($results),
+                    ]
+                    );
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return new JSONResponse(['error' => $e->getMessage()], 500);
+        }//end try
+    }//end index()
+
+    /**
+     * Link an existing Cospend project or bill.
+     *
+     * Body: `{ projectId: string, billId?: int, entryType?: string }`.
+     * A non-empty `billId` (or `entryType: 'bill'`) links the bill;
+     * otherwise the whole project is linked.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function link(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->cospendLinkService->isCospendAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Cospend app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $projectId = (string) $this->request->getParam('projectId', '');
+            if (trim($projectId) === '') {
+                return new JSONResponse(['error' => 'projectId is required'], 400);
+            }
+
+            $billIdParam = $this->request->getParam('billId');
+            $entryType   = (string) $this->request->getParam('entryType', '');
+
+            $registerId = (int) $object->getRegister();
+            $schemaId   = (int) $object->getSchema();
+
+            if (($billIdParam !== null && (int) $billIdParam !== 0) || $entryType === 'bill') {
+                $link = $this->cospendLinkService->linkBill(
+                    $object->getUuid(),
+                    $registerId,
+                    $schemaId,
+                    $projectId,
+                    (int) $billIdParam
+                );
+            } else {
+                $link = $this->cospendLinkService->linkProject(
+                    $object->getUuid(),
+                    $registerId,
+                    $schemaId,
+                    $projectId
+                );
+            }
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end link()
+
+    /**
+     * Create a new Cospend project and link it.
+     *
+     * Body: `{ name: string, currency?: string }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function createAndLink(string $register, string $schema, string $id): JSONResponse
+    {
+        if ($this->cospendLinkService->isCospendAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Cospend app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $name = (string) $this->request->getParam('name', '');
+            if (trim($name) === '') {
+                return new JSONResponse(['error' => 'name is required'], 400);
+            }
+
+            $currency = (string) $this->request->getParam('currency', '');
+
+            $link = $this->cospendLinkService->createAndLinkProject(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $name,
+                $currency
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end createAndLink()
+
+    /**
+     * Unlink a Cospend entry.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     * @param string $entryId  Link row id (numeric).
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function destroy(string $register, string $schema, string $id, string $entryId): JSONResponse
+    {
+        if ($this->cospendLinkService->isCospendAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Cospend app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $this->cospendLinkService->unlink($object->getUuid(), (int) $entryId);
+
+            return new JSONResponse(['success' => true]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end destroy()
+
+    /**
+     * List the current user's Cospend projects (picker source).
+     *
+     * Query param: `search` — optional name substring.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function available(): JSONResponse
+    {
+        if ($this->cospendLinkService->isCospendAvailable() === false) {
+            return new JSONResponse(
+                ['error' => 'NC Cospend app is not installed', 'code' => 'APP_NOT_AVAILABLE'],
+                501
+            );
+        }
+
+        $search = $this->request->getParam('search');
+        if ($search !== null) {
+            $search = (string) $search;
+        }
+
+        $projects = $this->cospendLinkService->getAvailableProjects($search);
+        return new JSONResponse(['results' => $projects, 'total' => count($projects)]);
+    }//end available()
+
+    /**
+     * Resolve an OR object from register/schema/id.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return ObjectEntity|null
+     */
+    private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
+    {
+        $this->objectService->setSchema($schema);
+        $this->objectService->setRegister($register);
+        $this->objectService->setObject($id);
+
+        return $this->objectService->getObject();
+    }//end validateObject()
+
+    /**
+     * Map a service-layer Exception to a JSONResponse.
+     *
+     * Exception codes carry HTTP intent:
+     *   - 400 → bad request
+     *   - 401 → unauthorized (no user)
+     *   - 404 → not found
+     *   - 409 → conflict (duplicate link)
+     *   - 503 → service unavailable
+     *   - everything else → 400 bad request
+     *
+     * @param Exception $exception Source exception.
+     *
+     * @return JSONResponse
+     */
+    private function mapException(Exception $exception): JSONResponse
+    {
+        $code = $exception->getCode();
+        if (in_array($code, [400, 401, 404, 409, 503], true) === true) {
+            return new JSONResponse(['error' => $exception->getMessage()], $code);
+        }
+
+        return new JSONResponse(['error' => $exception->getMessage()], 400);
+    }//end mapException()
+}//end class

--- a/lib/Db/CospendLink.php
+++ b/lib/Db/CospendLink.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * CospendLink entity for linking NC Cospend (Costs) projects + bills to
+ * OpenRegister objects.
+ *
+ * Tier-2 schema: carries register_id, schema_id, entry_type
+ * (`project`|`bill`), project_id, bill_id, name, amount and currency so
+ * the link row alone can hydrate the sidebar tab + picker UX without a
+ * per-entry roundtrip to NC Cospend. Replaces the Tier-1
+ * `CospendProvider`'s `[or:{objectUuid}]` marker-in-name convention with a
+ * proper persistence layer that survives project renames + bill edits.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Class CospendLink
+ *
+ * @method string getObjectUuid()
+ * @method void setObjectUuid(string $objectUuid)
+ * @method int getRegisterId()
+ * @method void setRegisterId(int $registerId)
+ * @method int|null getSchemaId()
+ * @method void setSchemaId(?int $schemaId)
+ * @method string getEntryType()
+ * @method void setEntryType(string $entryType)
+ * @method string getProjectId()
+ * @method void setProjectId(string $projectId)
+ * @method int|null getBillId()
+ * @method void setBillId(?int $billId)
+ * @method string getName()
+ * @method void setName(string $name)
+ * @method float|null getAmount()
+ * @method void setAmount(?float $amount)
+ * @method string|null getCurrency()
+ * @method void setCurrency(?string $currency)
+ * @method string|null getLinkedBy()
+ * @method void setLinkedBy(string $linkedBy)
+ * @method DateTime|null getLinkedAt()
+ * @method void setLinkedAt(DateTime $linkedAt)
+ *
+ * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class
+ */
+class CospendLink extends Entity implements JsonSerializable
+{
+
+    /**
+     * The object uuid.
+     *
+     * @var string|null
+     */
+    protected ?string $objectUuid = null;
+
+    /**
+     * The register id.
+     *
+     * @var integer|null
+     */
+    protected ?int $registerId = null;
+
+    /**
+     * The schema id.
+     *
+     * @var integer|null
+     */
+    protected ?int $schemaId = null;
+
+    /**
+     * The entry type — `project` or `bill`.
+     *
+     * @var string|null
+     */
+    protected ?string $entryType = null;
+
+    /**
+     * The NC Cospend project id (primary key in `cospend_projects`).
+     *
+     * @var string|null
+     */
+    protected ?string $projectId = null;
+
+    /**
+     * The NC Cospend bill id (primary key in `cospend_bills`); null for
+     * project rows.
+     *
+     * @var integer|null
+     */
+    protected ?int $billId = null;
+
+    /**
+     * The cached display name (project name or bill `what`).
+     *
+     * @var string|null
+     */
+    protected ?string $name = null;
+
+    /**
+     * The cached bill amount (null for projects).
+     *
+     * @var float|null
+     */
+    protected ?float $amount = null;
+
+    /**
+     * The cached currency name (owned by the project).
+     *
+     * @var string|null
+     */
+    protected ?string $currency = null;
+
+    /**
+     * The linked by uid.
+     *
+     * @var string|null
+     */
+    protected ?string $linkedBy = null;
+
+    /**
+     * The linked at timestamp.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $linkedAt = null;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->addType(fieldName: 'objectUuid', type: 'string');
+        $this->addType(fieldName: 'registerId', type: 'integer');
+        $this->addType(fieldName: 'schemaId', type: 'integer');
+        $this->addType(fieldName: 'entryType', type: 'string');
+        $this->addType(fieldName: 'projectId', type: 'string');
+        $this->addType(fieldName: 'billId', type: 'integer');
+        $this->addType(fieldName: 'name', type: 'string');
+        $this->addType(fieldName: 'amount', type: 'float');
+        $this->addType(fieldName: 'currency', type: 'string');
+        $this->addType(fieldName: 'linkedBy', type: 'string');
+        $this->addType(fieldName: 'linkedAt', type: 'datetime');
+    }//end __construct()
+
+    /**
+     * JSON serialization.
+     *
+     * @return array<string,mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'         => $this->id,
+            'objectUuid' => $this->objectUuid,
+            'registerId' => $this->registerId,
+            'schemaId'   => $this->schemaId,
+            'entryType'  => $this->entryType,
+            'projectId'  => $this->projectId,
+            'billId'     => $this->billId,
+            'name'       => $this->name,
+            'amount'     => $this->amount,
+            'currency'   => $this->currency,
+            'linkedBy'   => $this->linkedBy,
+            'linkedAt'   => $this->linkedAt?->format(DateTime::ATOM),
+        ];
+    }//end jsonSerialize()
+}//end class

--- a/lib/Db/CospendLinkMapper.php
+++ b/lib/Db/CospendLinkMapper.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * Mapper for cospend link entities.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Class CospendLinkMapper
+ *
+ * @template-extends QBMapper<CospendLink>
+ */
+class CospendLinkMapper extends QBMapper
+{
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $db Database connection.
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(db: $db, tableName: 'openregister_cospend_links', entityClass: CospendLink::class);
+    }//end __construct()
+
+    /**
+     * Find cospend links by object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return CospendLink[] Array of cospend links.
+     */
+    public function findByObjectUuid(string $objectUuid): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByObjectUuid()
+
+    /**
+     * Find a cospend link by id, scoped to the owning object UUID.
+     *
+     * The object UUID scope guards against deleting another object's link
+     * by guessing an entry id.
+     *
+     * @param string $objectUuid The object UUID.
+     * @param int    $entryId    The link row id.
+     *
+     * @return CospendLink|null The link or null if not found.
+     */
+    public function findByObjectAndId(string $objectUuid, int $entryId): ?CospendLink
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('id', $qb->createNamedParameter($entryId, IQueryBuilder::PARAM_INT)));
+
+        try {
+            return $this->findEntity(query: $qb);
+        } catch (DoesNotExistException $e) {
+            return null;
+        }
+    }//end findByObjectAndId()
+
+    /**
+     * Find a duplicate link by the composite-unique tuple.
+     *
+     * Bill rows match on (object_uuid, entry_type, project_id, bill_id);
+     * project rows pass billId = null which the query matches with an
+     * IS NULL predicate.
+     *
+     * @param string   $objectUuid The object UUID.
+     * @param string   $entryType  The entry type (`project`|`bill`).
+     * @param string   $projectId  The Cospend project id.
+     * @param int|null $billId     The Cospend bill id, or null for projects.
+     *
+     * @return CospendLink|null The existing link or null.
+     */
+    public function findDuplicate(
+        string $objectUuid,
+        string $entryType,
+        string $projectId,
+        ?int $billId
+    ): ?CospendLink {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('entry_type', $qb->createNamedParameter($entryType)))
+            ->andWhere($qb->expr()->eq('project_id', $qb->createNamedParameter($projectId)));
+
+        if ($billId === null) {
+            $qb->andWhere($qb->expr()->isNull('bill_id'));
+        } else {
+            $qb->andWhere($qb->expr()->eq('bill_id', $qb->createNamedParameter($billId, IQueryBuilder::PARAM_INT)));
+        }
+
+        try {
+            return $this->findEntity(query: $qb);
+        } catch (DoesNotExistException $e) {
+            return null;
+        }
+    }//end findDuplicate()
+
+    /**
+     * Delete all cospend links for an object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectUuid(string $objectUuid): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectUuid()
+
+    /**
+     * Delete a cospend link by object UUID + link row id (Tier-2 unlink path).
+     *
+     * Returns the number of rows actually deleted so callers can
+     * distinguish "no such link" (0) from "ok" (>=1).
+     *
+     * @param string $objectUuid The object UUID.
+     * @param int    $entryId    The link row id.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectAndId(string $objectUuid, int $entryId): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('id', $qb->createNamedParameter($entryId, IQueryBuilder::PARAM_INT)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectAndId()
+}//end class

--- a/lib/Migration/Version1Date20260525210000.php
+++ b/lib/Migration/Version1Date20260525210000.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * Tier-2 cospend (NC Cospend / Costs) integration migration.
+ *
+ * Ensures the `oc_openregister_cospend_links` table exists with the full
+ * Tier-2 schema:
+ *
+ *  - id (bigint, PK, autoincrement)
+ *  - object_uuid (string 36, not null, indexed)
+ *  - register_id (bigint unsigned, not null, indexed)
+ *  - schema_id (bigint unsigned, nullable, indexed)
+ *  - entry_type (string 16, not null) — `project` or `bill`
+ *  - project_id (string 64, not null) — `cospend_projects` row id
+ *  - bill_id (integer, nullable) — `cospend_bills` row id (bills only)
+ *  - name (string 255, not null) — cached project / bill label
+ *  - amount (double, nullable) — cached bill amount
+ *  - currency (string 16, nullable) — cached project currency
+ *  - linked_by (string 64, not null)
+ *  - linked_at (datetime, not null)
+ *
+ * Composite unique on (object_uuid, entry_type, project_id, bill_id) so a
+ * project and its bills can co-exist for the same object without clashing.
+ *
+ * Idempotent: creates the table if missing, otherwise adds any missing
+ * Tier-2 columns. Companion to the Tier-2 talk/polls/email/forms/deck/
+ * flow/photos/collectives link tables; the wrapping `CospendLinkService`
+ * replaces the `[or:{uuid}]` marker-in-name convention used by the Tier-1
+ * `CospendProvider` with a proper persistence layer so links survive
+ * project renames + bill edits.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Tier-2 cospend-links table — create-or-extend.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+class Version1Date20260525210000 extends SimpleMigrationStep
+{
+    /**
+     * Change the database schema.
+     *
+     * @param IOutput                 $output        Output for the migration process
+     * @param Closure                 $schemaClosure The schema closure
+     * @param array<array-key, mixed> $options       Migration options
+     *
+     * @return ISchemaWrapper|null
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema  = $schemaClosure();
+        $changed = false;
+
+        if ($schema->hasTable('openregister_cospend_links') === false) {
+            $this->createCospendLinksTable(schema: $schema, output: $output);
+            $changed = true;
+        }
+
+        if ($schema->hasTable('openregister_cospend_links') === true
+            && $this->extendCospendLinksTable(schema: $schema, output: $output) === true
+        ) {
+            $changed = true;
+        }
+
+        if ($changed === false) {
+            return null;
+        }
+
+        return $schema;
+    }//end changeSchema()
+
+    /**
+     * Create the openregister_cospend_links table at the Tier-2 shape.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return void
+     */
+    private function createCospendLinksTable(ISchemaWrapper $schema, IOutput $output): void
+    {
+        $table = $schema->createTable('openregister_cospend_links');
+
+        $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'unsigned' => true]);
+        $table->addColumn('object_uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
+        $table->addColumn('register_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('schema_id', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]);
+        $table->addColumn('entry_type', Types::STRING, ['notnull' => true, 'length' => 16]);
+        $table->addColumn('project_id', Types::STRING, ['notnull' => true, 'length' => 64]);
+        $table->addColumn('bill_id', Types::INTEGER, ['notnull' => false, 'default' => null]);
+        $table->addColumn('name', Types::STRING, ['notnull' => true, 'length' => 255]);
+        $table->addColumn('amount', Types::FLOAT, ['notnull' => false, 'default' => null]);
+        $table->addColumn('currency', Types::STRING, ['notnull' => false, 'length' => 16, 'default' => null]);
+        $table->addColumn('linked_by', Types::STRING, ['notnull' => true, 'length' => 64]);
+        $table->addColumn('linked_at', Types::DATETIME, ['notnull' => true]);
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['object_uuid', 'entry_type', 'project_id', 'bill_id'], 'idx_cospend_unique');
+        $table->addIndex(['object_uuid'], 'idx_cospend_object');
+        $table->addIndex(['register_id'], 'idx_cospend_register');
+        $table->addIndex(['schema_id'], 'idx_cospend_schema');
+
+        $output->info('Created openregister_cospend_links table (Tier-2 schema)');
+    }//end createCospendLinksTable()
+
+    /**
+     * Add any missing Tier-2 columns to an existing cospend_links table.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return bool True when a column was added.
+     */
+    private function extendCospendLinksTable(ISchemaWrapper $schema, IOutput $output): bool
+    {
+        $table   = $schema->getTable('openregister_cospend_links');
+        $changed = false;
+
+        if ($table->hasColumn('schema_id') === false) {
+            $table->addColumn(
+                'schema_id',
+                Types::BIGINT,
+                ['notnull' => false, 'unsigned' => true, 'default' => null]
+            );
+            $table->addIndex(['schema_id'], 'idx_cospend_schema');
+            $output->info('Added schema_id column to openregister_cospend_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('bill_id') === false) {
+            $table->addColumn('bill_id', Types::INTEGER, ['notnull' => false, 'default' => null]);
+            $output->info('Added bill_id column to openregister_cospend_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('amount') === false) {
+            $table->addColumn('amount', Types::FLOAT, ['notnull' => false, 'default' => null]);
+            $output->info('Added amount column to openregister_cospend_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('currency') === false) {
+            $table->addColumn('currency', Types::STRING, ['notnull' => false, 'length' => 16, 'default' => null]);
+            $output->info('Added currency column to openregister_cospend_links');
+            $changed = true;
+        }
+
+        return $changed;
+    }//end extendCospendLinksTable()
+}//end class

--- a/lib/Service/CospendLinkService.php
+++ b/lib/Service/CospendLinkService.php
@@ -1,0 +1,683 @@
+<?php
+
+/**
+ * CospendLinkService — Tier-2 cospend (NC Cospend / Costs) integration
+ * service.
+ *
+ * Composes the {@see CospendLinkMapper} with NC Cospend's
+ * `OCA\Cospend\Service\ProjectService` plus direct `cospend_projects` /
+ * `cospend_bills` queries (the wave-2.3 pattern) to expose the Tier-2
+ * surface:
+ *
+ *   - linkProject(uuid, registerId, schemaId, projectId)
+ *       — link an existing project
+ *   - linkBill(uuid, registerId, schemaId, projectId, billId)
+ *       — link a specific bill under a project
+ *   - createAndLinkProject(uuid, registerId, schemaId, name, currency)
+ *       — create a new Cospend project and link it
+ *   - unlink(uuid, entryId)
+ *       — remove a link row (the project/bill itself stays in Cospend)
+ *   - getLinkedEntries(uuid)
+ *       — list linked entries, refreshing cached amount/currency when the
+ *       row is older than 24h
+ *   - getAvailableProjects(?search)
+ *       — picker source listing the current user's projects
+ *
+ * NC Cospend's `ProjectService` + the `cospend_projects` / `cospend_bills`
+ * tables are resolved lazily through the server container behind a
+ * `class_exists` + `Throwable` guard so this service loads even when the
+ * Cospend app is not installed (ADR-019 AD-23 graceful degradation): when
+ * Cospend is missing or a call throws, the stored link row is returned
+ * as-is so historical references survive.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://OpenRegister.app
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use DateTime;
+use Exception;
+use OCA\OpenRegister\Db\CospendLink;
+use OCA\OpenRegister\Db\CospendLinkMapper;
+use OCP\App\IAppManager;
+use OCP\IDBConnection;
+use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * CospendLinkService.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)   Composes mapper +
+ *     NC Cospend ProjectService (late-bound) + DB connection + user
+ *     session + app manager + container + logger. Each dependency is
+ *     required for one of the Tier-2 flows (link, create, unlink, list,
+ *     picker, cache refresh, graceful degradation).
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ */
+class CospendLinkService
+{
+    private const REQUIRED_APP = 'cospend';
+
+    private const PROJECT_SERVICE = 'OCA\\Cospend\\Service\\ProjectService';
+
+    private const PROJECTS_TABLE = 'cospend_projects';
+
+    private const BILLS_TABLE = 'cospend_bills';
+
+    private const ENTRY_PROJECT = 'project';
+
+    private const ENTRY_BILL = 'bill';
+
+    private const STALE_AFTER = 86400;
+    // 24 hours in seconds.
+
+    /**
+     * Constructor.
+     *
+     * @param CospendLinkMapper  $cospendLinkMapper Persistence for link rows.
+     * @param ContainerInterface $container         Container for late-bound Cospend classes.
+     * @param IAppManager        $appManager        NC app manager.
+     * @param IUserSession       $userSession       Active session.
+     * @param IDBConnection      $db                DB connection for direct Cospend table queries.
+     * @param LoggerInterface    $logger            Logger.
+     */
+    public function __construct(
+        private readonly CospendLinkMapper $cospendLinkMapper,
+        private readonly ContainerInterface $container,
+        private readonly IAppManager $appManager,
+        private readonly IUserSession $userSession,
+        private readonly IDBConnection $db,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Whether NC Cospend is installed + enabled for the current user.
+     *
+     * @return bool
+     */
+    public function isCospendAvailable(): bool
+    {
+        return $this->appManager->isEnabledForUser(self::REQUIRED_APP);
+    }//end isCospendAvailable()
+
+    /**
+     * Resolve NC Cospend's ProjectService lazily.
+     *
+     * Returns null when Cospend is absent or the class can't be resolved,
+     * so callers degrade gracefully (ADR-019 AD-23).
+     *
+     * @return object|null The service instance or null.
+     */
+    private function getProjectService(): ?object
+    {
+        if ($this->isCospendAvailable() === false || class_exists(self::PROJECT_SERVICE) === false) {
+            return null;
+        }
+
+        try {
+            return $this->container->get(self::PROJECT_SERVICE);
+        } catch (Throwable $e) {
+            $this->logger->debug('CospendLinkService: ProjectService unavailable: '.$e->getMessage());
+            return null;
+        }
+    }//end getProjectService()
+
+    /**
+     * Active session UID, or throw if no user is logged in.
+     *
+     * @return string The user id.
+     *
+     * @throws Exception When there is no active user.
+     */
+    private function requireUid(): string
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in', 401);
+        }
+
+        return $user->getUID();
+    }//end requireUid()
+
+    /**
+     * Link an existing NC Cospend project to an OR object.
+     *
+     * Idempotent: a duplicate link raises a 409 Exception. Project name +
+     * currency are cached at link time.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $registerId OR register id.
+     * @param int    $schemaId   OR schema id.
+     * @param string $projectId  NC Cospend project id.
+     *
+     * @return CospendLink The persisted link row.
+     *
+     * @throws Exception On missing user (401), missing project (404),
+     *                   duplicate (409), Cospend unavailable (503).
+     */
+    public function linkProject(string $objectUuid, int $registerId, int $schemaId, string $projectId): CospendLink
+    {
+        $uid = $this->requireUid();
+
+        if ($this->isCospendAvailable() === false) {
+            throw new Exception('NC Cospend is not available', 503);
+        }
+
+        if (trim($projectId) === '') {
+            throw new Exception('Project id is required', 400);
+        }
+
+        $existing = $this->cospendLinkMapper->findDuplicate($objectUuid, self::ENTRY_PROJECT, $projectId, null);
+        if ($existing !== null) {
+            throw new Exception('Project already linked to this object', 409);
+        }
+
+        $project = $this->fetchProject(projectId: $projectId);
+        if ($project === null) {
+            throw new Exception('Cospend project not found', 404);
+        }
+
+        $link = $this->hydrateLink(
+            objectUuid: $objectUuid,
+            registerId: $registerId,
+            schemaId: $schemaId,
+            entryType: self::ENTRY_PROJECT,
+            projectId: $projectId,
+            billId: null,
+            name: (string) ($project['name'] ?? $projectId),
+            amount: null,
+            currency: ($project['currency'] ?? null),
+            uid: $uid
+        );
+
+        return $this->cospendLinkMapper->insert($link);
+    }//end linkProject()
+
+    /**
+     * Link a specific NC Cospend bill (under a project) to an OR object.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $registerId OR register id.
+     * @param int    $schemaId   OR schema id.
+     * @param string $projectId  NC Cospend project id.
+     * @param int    $billId     NC Cospend bill id.
+     *
+     * @return CospendLink The persisted link row.
+     *
+     * @throws Exception On missing user (401), missing bill (404),
+     *                   duplicate (409), Cospend unavailable (503).
+     */
+    public function linkBill(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        string $projectId,
+        int $billId
+    ): CospendLink {
+        $uid = $this->requireUid();
+
+        if ($this->isCospendAvailable() === false) {
+            throw new Exception('NC Cospend is not available', 503);
+        }
+
+        if (trim($projectId) === '' || $billId === 0) {
+            throw new Exception('Project id and bill id are required', 400);
+        }
+
+        $existing = $this->cospendLinkMapper->findDuplicate($objectUuid, self::ENTRY_BILL, $projectId, $billId);
+        if ($existing !== null) {
+            throw new Exception('Bill already linked to this object', 409);
+        }
+
+        $bill = $this->fetchBill(projectId: $projectId, billId: $billId);
+        if ($bill === null) {
+            throw new Exception('Cospend bill not found', 404);
+        }
+
+        $project  = $this->fetchProject(projectId: $projectId);
+        $currency = $project['currency'] ?? null;
+
+        $link = $this->hydrateLink(
+            objectUuid: $objectUuid,
+            registerId: $registerId,
+            schemaId: $schemaId,
+            entryType: self::ENTRY_BILL,
+            projectId: $projectId,
+            billId: $billId,
+            name: (string) ($bill['what'] ?? ($project['name'] ?? $projectId)),
+            amount: ($bill['amount'] ?? null),
+            currency: $currency,
+            uid: $uid
+        );
+
+        return $this->cospendLinkMapper->insert($link);
+    }//end linkBill()
+
+    /**
+     * Create a new NC Cospend project and link it to an OR object.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $registerId OR register id.
+     * @param int    $schemaId   OR schema id.
+     * @param string $name       New project name.
+     * @param string $currency   Project currency name.
+     *
+     * @return CospendLink The persisted link row.
+     *
+     * @throws Exception On missing user (401), empty name (400),
+     *                   Cospend unavailable (503), create failure (500).
+     */
+    public function createAndLinkProject(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        string $name,
+        string $currency
+    ): CospendLink {
+        $uid = $this->requireUid();
+
+        $name = trim($name);
+        if ($name === '') {
+            throw new Exception('Project name is required', 400);
+        }
+
+        $projectService = $this->getProjectService();
+        if ($projectService === null) {
+            throw new Exception('NC Cospend is not available', 503);
+        }
+
+        $projectId = $this->createProject(projectService: $projectService, name: $name, uid: $uid);
+        if ($projectId === null) {
+            throw new Exception('Failed to create Cospend project', 500);
+        }
+
+        $cleanCurrency = trim($currency);
+        if ($cleanCurrency === '') {
+            $project       = $this->fetchProject(projectId: $projectId);
+            $cleanCurrency = (string) ($project['currency'] ?? '');
+        }
+
+        $currencyValue = null;
+        if ($cleanCurrency !== '') {
+            $currencyValue = $cleanCurrency;
+        }
+
+        $link = $this->hydrateLink(
+            objectUuid: $objectUuid,
+            registerId: $registerId,
+            schemaId: $schemaId,
+            entryType: self::ENTRY_PROJECT,
+            projectId: $projectId,
+            billId: null,
+            name: $name,
+            amount: null,
+            currency: $currencyValue,
+            uid: $uid
+        );
+
+        return $this->cospendLinkMapper->insert($link);
+    }//end createAndLinkProject()
+
+    /**
+     * Create a Cospend project via ProjectService.
+     *
+     * NC Cospend's ProjectService::createProject has shifted signature
+     * across versions; we call it positionally (name, id, contact_email,
+     * userId) and fall back to (name, id, userId). Returns the resulting
+     * project id, or null on failure.
+     *
+     * @param object $projectService NC Cospend ProjectService.
+     * @param string $name           Project name.
+     * @param string $uid            Owning user id.
+     *
+     * @return string|null The new project id, or null on failure.
+     */
+    private function createProject(object $projectService, string $name, string $uid): ?string
+    {
+        // Cospend project ids are slugs; derive a stable-ish candidate
+        // from the name + a short random suffix to avoid collisions.
+        $base = preg_replace('/[^a-z0-9]+/i', '-', strtolower($name));
+        $base = trim((string) $base, '-');
+        if ($base === '') {
+            $base = 'project';
+        }
+
+        $projectId = substr($base, 0, 40).'-'.substr(bin2hex(random_bytes(4)), 0, 6);
+
+        try {
+            $result = $projectService->createProject($name, $projectId, null, $uid);
+        } catch (Throwable $first) {
+            try {
+                $result = $projectService->createProject($name, $projectId, $uid);
+            } catch (Throwable $second) {
+                $this->logger->warning('CospendLinkService::createProject failed: '.$second->getMessage());
+                return null;
+            }
+        }
+
+        // ProjectService::createProject returns the id (string) or an
+        // array carrying it; normalise both shapes.
+        if (is_string($result) === true && $result !== '') {
+            return $result;
+        }
+
+        if (is_array($result) === true && isset($result['id']) === true) {
+            return (string) $result['id'];
+        }
+
+        return $projectId;
+    }//end createProject()
+
+    /**
+     * Build a CospendLink from normalised entry info.
+     *
+     * @param string      $objectUuid Parent OR object uuid.
+     * @param int         $registerId OR register id.
+     * @param int         $schemaId   OR schema id.
+     * @param string      $entryType  Entry type (`project`|`bill`).
+     * @param string      $projectId  Cospend project id.
+     * @param int|null    $billId     Cospend bill id, or null.
+     * @param string      $name       Cached display name.
+     * @param float|null  $amount     Cached amount, or null.
+     * @param string|null $currency   Cached currency, or null.
+     * @param string      $uid        The linking user id.
+     *
+     * @return CospendLink
+     */
+    private function hydrateLink(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        string $entryType,
+        string $projectId,
+        ?int $billId,
+        string $name,
+        ?float $amount,
+        ?string $currency,
+        string $uid
+    ): CospendLink {
+        $link = new CospendLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        $link->setSchemaId($schemaId);
+        $link->setEntryType($entryType);
+        $link->setProjectId($projectId);
+        $link->setBillId($billId);
+        $link->setName($name);
+        $link->setAmount($amount);
+        $link->setCurrency($currency);
+        $link->setLinkedBy($uid);
+        $link->setLinkedAt(new DateTime());
+
+        return $link;
+    }//end hydrateLink()
+
+    /**
+     * Unlink a project / bill from an object.
+     *
+     * Does NOT delete the project/bill itself — it stays in NC Cospend.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $entryId    Link row id.
+     *
+     * @return void
+     *
+     * @throws Exception On missing user (401) or no matching link (404).
+     */
+    public function unlink(string $objectUuid, int $entryId): void
+    {
+        $this->requireUid();
+
+        $deleted = $this->cospendLinkMapper->deleteByObjectAndId($objectUuid, $entryId);
+        if ($deleted === 0) {
+            throw new Exception('Cospend link not found', 404);
+        }
+    }//end unlink()
+
+    /**
+     * Return the linked entries for an object, refreshing the cached
+     * amount/currency columns when a row is older than 24h.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getLinkedEntries(string $objectUuid): array
+    {
+        $links     = $this->cospendLinkMapper->findByObjectUuid($objectUuid);
+        $available = $this->isCospendAvailable();
+
+        $results = [];
+        foreach ($links as $link) {
+            if ($available === true && $this->isStale(link: $link) === true) {
+                $link = $this->refreshLink(link: $link);
+            }
+
+            $results[] = $link->jsonSerialize();
+        }
+
+        return $results;
+    }//end getLinkedEntries()
+
+    /**
+     * Return the current user's NC Cospend projects (picker source).
+     *
+     * Optionally filtered by a name substring. Returns an empty array
+     * when Cospend is unavailable.
+     *
+     * @param string|null $search Optional name-substring filter.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getAvailableProjects(?string $search=null): array
+    {
+        if ($this->isCospendAvailable() === false) {
+            return [];
+        }
+
+        $uid = $this->userSession->getUser()?->getUID();
+        if ($uid === null) {
+            return [];
+        }
+
+        $needle = null;
+        if ($search !== null && $search !== '') {
+            $needle = mb_strtolower($search);
+        }
+
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('*')
+                ->from(self::PROJECTS_TABLE)
+                ->where($qb->expr()->eq('user_id', $qb->createNamedParameter($uid)))
+                ->orderBy('name', 'ASC');
+
+            $result = $qb->executeQuery();
+            $out    = [];
+            $row    = $result->fetch();
+            while ($row !== false) {
+                $project = $this->normaliseProjectRow(row: $row);
+                $row     = $result->fetch();
+                if ($needle !== null && str_contains(mb_strtolower((string) $project['name']), $needle) === false) {
+                    continue;
+                }
+
+                $out[] = $project;
+            }
+
+            $result->closeCursor();
+            return $out;
+        } catch (Throwable $e) {
+            $this->logger->warning('CospendLinkService::getAvailableProjects failed: '.$e->getMessage());
+            return [];
+        }//end try
+    }//end getAvailableProjects()
+
+    /**
+     * Whether a link row's cache is older than the stale window.
+     *
+     * @param CospendLink $link The link row.
+     *
+     * @return bool
+     */
+    private function isStale(CospendLink $link): bool
+    {
+        $linkedAt = $link->getLinkedAt();
+        if ($linkedAt === null) {
+            return true;
+        }
+
+        return (time() - $linkedAt->getTimestamp()) > self::STALE_AFTER;
+    }//end isStale()
+
+    /**
+     * Refresh a link row's cached name/amount/currency in place.
+     *
+     * Best-effort: when the project/bill can't be resolved the link is
+     * left untouched (it may have been deleted in NC Cospend).
+     *
+     * @param CospendLink $link The link row.
+     *
+     * @return CospendLink The (possibly updated) link row.
+     */
+    private function refreshLink(CospendLink $link): CospendLink
+    {
+        $projectId = (string) $link->getProjectId();
+        $project   = $this->fetchProject(projectId: $projectId);
+        if ($project === null) {
+            return $link;
+        }
+
+        if ($link->getEntryType() === self::ENTRY_BILL && $link->getBillId() !== null) {
+            $bill = $this->fetchBill(projectId: $projectId, billId: (int) $link->getBillId());
+            if ($bill !== null) {
+                $link->setName((string) ($bill['what'] ?? $link->getName()));
+                $link->setAmount($bill['amount'] ?? $link->getAmount());
+            }
+        } else {
+            $link->setName((string) ($project['name'] ?? $link->getName()));
+        }
+
+        $link->setCurrency($project['currency'] ?? $link->getCurrency());
+        $link->setLinkedAt(new DateTime());
+
+        try {
+            return $this->cospendLinkMapper->update($link);
+        } catch (Throwable $e) {
+            $this->logger->debug('CospendLinkService::refreshLink update failed: '.$e->getMessage());
+            return $link;
+        }
+    }//end refreshLink()
+
+    /**
+     * Fetch a normalised Cospend project row by id.
+     *
+     * @param string $projectId The Cospend project id.
+     *
+     * @return array<string,mixed>|null
+     */
+    private function fetchProject(string $projectId): ?array
+    {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('*')
+                ->from(self::PROJECTS_TABLE)
+                ->where($qb->expr()->eq('id', $qb->createNamedParameter($projectId)))
+                ->setMaxResults(1);
+
+            $result = $qb->executeQuery();
+            $row    = $result->fetch();
+            $result->closeCursor();
+
+            if ($row === false) {
+                return null;
+            }
+
+            return $this->normaliseProjectRow(row: $row);
+        } catch (Throwable $e) {
+            $this->logger->debug('CospendLinkService::fetchProject failed: '.$e->getMessage());
+            return null;
+        }//end try
+    }//end fetchProject()
+
+    /**
+     * Fetch a normalised Cospend bill row by project + bill id.
+     *
+     * @param string $projectId The Cospend project id.
+     * @param int    $billId    The Cospend bill id.
+     *
+     * @return array<string,mixed>|null
+     */
+    private function fetchBill(string $projectId, int $billId): ?array
+    {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('*')
+                ->from(self::BILLS_TABLE)
+                ->where($qb->expr()->eq('id', $qb->createNamedParameter($billId, \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_INT)))
+                ->andWhere($qb->expr()->eq('project_id', $qb->createNamedParameter($projectId)))
+                ->setMaxResults(1);
+
+            $result = $qb->executeQuery();
+            $row    = $result->fetch();
+            $result->closeCursor();
+
+            if ($row === false) {
+                return null;
+            }
+
+            $amount = null;
+            if (isset($row['amount']) === true) {
+                $amount = (float) $row['amount'];
+            }
+
+            return [
+                'id'        => (int) ($row['id'] ?? 0),
+                'projectId' => (string) ($row['project_id'] ?? $projectId),
+                'what'      => (string) ($row['what'] ?? ''),
+                'amount'    => $amount,
+            ];
+        } catch (Throwable $e) {
+            $this->logger->debug('CospendLinkService::fetchBill failed: '.$e->getMessage());
+            return null;
+        }//end try
+    }//end fetchBill()
+
+    /**
+     * Normalise a raw cospend_projects row into the picker / cache shape.
+     *
+     * @param array<string,mixed> $row Raw DB row.
+     *
+     * @return array<string,mixed>
+     */
+    private function normaliseProjectRow(array $row): array
+    {
+        return [
+            'id'       => (string) ($row['id'] ?? ''),
+            'name'     => (string) ($row['name'] ?? ($row['id'] ?? '')),
+            'currency' => (string) ($row['currency_name'] ?? ''),
+            'userId'   => (string) ($row['user_id'] ?? ''),
+        ];
+    }//end normaliseProjectRow()
+}//end class

--- a/lib/Service/Integration/Providers/CospendProvider.php
+++ b/lib/Service/Integration/Providers/CospendProvider.php
@@ -1,12 +1,22 @@
 <?php
 
 /**
- * CospendProvider — exposes NC Costs entities linked to an OpenRegister
- * object via a `[or:{objectUuid}]` marker in the entity's `name`
- * field.
+ * CospendProvider — exposes NC Cospend (Costs) projects + bills linked to
+ * an OpenRegister object.
  *
- * Storage strategy is `link-table` — the marker lives in the upstream
- * app's own table (`cospend_projects`), not in OR.
+ * Tier-2 (this file) reads the dedicated `openregister_cospend_links`
+ * table via {@see CospendLinkMapper}. Pre-Tier-2 the provider matched a
+ * `[or:{objectUuid}]` marker embedded in a project's `name` field; that
+ * convention is retained as a backwards-compat fallback (two-type shape:
+ * a project row followed by its bill rows) for projects that pre-date the
+ * link table. Mapper lookups for the legacy fallback resolve NC Cospend's
+ * `ProjectMapper` / `BillMapper` lazily through the server container so
+ * the file loads even when the Cospend app is not installed (AD-23:
+ * graceful degradation).
+ *
+ * Storage strategy is `link-table` — Tier-2 link rows live in OR; the
+ * upstream `cospend_projects` / `cospend_bills` tables are only read for
+ * the legacy marker fallback.
  *
  * @category Service
  * @package  OCA\OpenRegister\Service\Integration\Providers
@@ -25,26 +35,77 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Service\Integration\Providers;
 
-// phpcs:disable PEAR.Commenting.FunctionComment.Missing
+// phpcs:disable PEAR.Commenting.FunctionComment.Missing -- self-documenting IntegrationProvider metadata getters mirror the contract in the interface.
 
+use OCA\OpenRegister\Db\CospendLink;
+use OCA\OpenRegister\Db\CospendLinkMapper;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCP\App\IAppManager;
 use OCP\IDBConnection;
 use OCP\IL10N;
+use OCP\Server;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+use Throwable;
 
+/**
+ * Cospend (NC Cospend) integration provider.
+ *
+ * Always-on metadata: id='cospend', group='workflow',
+ * requiredApp='cospend', storage='link-table'.
+ */
 class CospendProvider extends AbstractIntegrationProvider
 {
-    use MarkerLookupTrait;
 
+    /**
+     * NC app id required for this integration.
+     *
+     * @var string
+     */
     private const REQUIRED_APP = 'cospend';
 
+    /**
+     * Marker prefix used by the legacy Tier-1 link convention.
+     *
+     * @var string
+     */
     private const MARKER_PREFIX = '[or:';
 
+    /**
+     * Maximum number of bills to surface per linked project (legacy
+     * fallback path).
+     *
+     * @var int
+     */
+    private const BILLS_PER_PROJECT = 25;
+
+    /**
+     * Optional server container override for the legacy fallback mapper
+     * lookups. Tests inject a mock; production uses `\OCP\Server`.
+     *
+     * @var ContainerInterface|null
+     */
+    private ?ContainerInterface $container;
+
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection           $db                NC DB connection.
+     * @param IAppManager             $appManager        NC app manager.
+     * @param IL10N                   $l10n              Localisation.
+     * @param CospendLinkMapper       $cospendLinkMapper Tier-2 link table mapper.
+     * @param ContainerInterface|null $container         Optional server-container override (tests).
+     *
+     * @return void
+     */
     public function __construct(
         private IDBConnection $db,
         private IAppManager $appManager,
         private IL10N $l10n,
+        private CospendLinkMapper $cospendLinkMapper,
+        ?ContainerInterface $container=null,
     ) {
+        $this->container = $container;
     }//end __construct()
 
     public function getId(): string
@@ -83,18 +144,19 @@ class CospendProvider extends AbstractIntegrationProvider
     }//end isEnabled()
 
     /**
-     * List linked Costs entities for an OR object.
+     * List NC Cospend entries linked to an OR object.
      *
-     * Linking convention: the entity's `name` field contains
-     * the marker `[or:{objectUuid}]`. The trait runs the LIKE query;
-     * rows are normalised into the registry leaf row shape.
+     * Reads the Tier-2 link table first; if no link rows exist it falls
+     * back to the legacy `[or:{uuid}]` marker scan in
+     * `cospend_projects.name`, surfacing each matched project plus its
+     * bills (the wave-2.3 two-type shape).
      *
-     * @param string $register Register slug for the parent object.
-     * @param string $schema   Schema slug for the parent object.
-     * @param string $objectId UUID of the OR object whose rows we want.
-     * @param array  $filters  Optional registry filters (unused).
+     * @param string              $register Register slug for the parent object.
+     * @param string              $schema   Schema slug for the parent object.
+     * @param string              $objectId UUID of the OR object whose rows we want.
+     * @param array<string,mixed> $filters  Optional registry filters (unused).
      *
-     * @return array List of registry leaf rows.
+     * @return array<int,array<string,mixed>> List of registry leaf rows.
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -102,36 +164,360 @@ class CospendProvider extends AbstractIntegrationProvider
             return [];
         }
 
-        $marker = self::MARKER_PREFIX.$objectId.']';
-        $rows   = $this->findByMarker(
-            db: $this->db,
-            table: 'cospend_projects',
-            markerColumn: 'name',
-            marker: $marker,
-            extraColumns: ['currency_name', 'user_id'],
-            idColumn: 'id',
-        );
+        // Tier-2 path: read from the link table.
+        try {
+            $linkRows = $this->cospendLinkMapper->findByObjectUuid($objectId);
+        } catch (Throwable $e) {
+            $linkRows = [];
+        }
 
-        return array_map(
-                static function (array $row): array {
-                    return [
-                        'id'    => (string) ($row['id'] ?? ''),
-                        'title' => (string) ($row['name'] ?? ''),
-                        'url'   => '/index.php/apps/cospend/p/'.(string) ($row['id'] ?? ''),
-                        'data'  => $row,
-                    ];
-                },
-                $rows
-                );
+        if (count($linkRows) > 0) {
+            return array_map(
+                fn (CospendLink $link): array => $this->rowFromLink(link: $link),
+                $linkRows
+            );
+        }
+
+        // Backwards-compat fallback: scan the legacy `[or:{uuid}]` marker
+        // in `cospend_projects.name`, surfacing projects + their bills.
+        return $this->legacyMarkerList(objectId: $objectId);
     }//end list()
+
+    /**
+     * Convert a CospendLink row into the registry leaf-row shape.
+     *
+     * Mirrors the wave-2.3 project/bill row contract so the bespoke
+     * CnCospendTab renders link-table rows identically to legacy rows.
+     *
+     * @param CospendLink $link Link row from the mapper.
+     *
+     * @return array<string,mixed>
+     */
+    private function rowFromLink(CospendLink $link): array
+    {
+        $projectId = (string) $link->getProjectId();
+        $entryType = (string) $link->getEntryType();
+        $billId    = $link->getBillId();
+
+        $id = $projectId;
+        if ($entryType === 'bill' && $billId !== null) {
+            $id = $projectId.'/'.$billId;
+        }
+
+        return [
+            'type'     => $entryType,
+            'id'       => $id,
+            'entryId'  => $link->getId(),
+            'title'    => (string) $link->getName(),
+            'url'      => '/index.php/apps/cospend/p/'.$projectId,
+            'amount'   => $link->getAmount(),
+            'currency' => $link->getCurrency(),
+            'data'     => $link->jsonSerialize(),
+        ];
+    }//end rowFromLink()
+
+    /**
+     * Legacy marker-scan list (projects + bills).
+     *
+     * @param string $objectId Owning object uuid.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    private function legacyMarkerList(string $objectId): array
+    {
+        try {
+            $projectMapper = $this->lookup(serviceName: 'OCA\\Cospend\\Db\\ProjectMapper');
+        } catch (Throwable $e) {
+            return [];
+        }
+
+        $projects = $this->findProjectsByMarker(projectMapper: $projectMapper, objectId: $objectId);
+        if (count($projects) === 0) {
+            return [];
+        }
+
+        $billMapper = null;
+        try {
+            $billMapper = $this->lookup(serviceName: 'OCA\\Cospend\\Db\\BillMapper');
+        } catch (Throwable $e) {
+            $billMapper = null;
+        }
+
+        $rows = [];
+        foreach ($projects as $project) {
+            $projectRow = $this->normaliseProject(project: $project, objectId: $objectId);
+            $rows[]     = $projectRow;
+            $rows       = array_merge(
+                $rows,
+                $this->collectBills(
+                    billMapper: $billMapper,
+                    projectId: (string) $projectRow['data']['id'],
+                    projectName: (string) $projectRow['title'],
+                    currencyName: (string) ($projectRow['data']['currencyName'] ?? '')
+                )
+            );
+        }
+
+        return $rows;
+    }//end legacyMarkerList()
 
     public function health(): array
     {
-        $available = $this->isEnabled();
+        $status  = 'unavailable';
+        $message = 'NC Cospend app is not installed';
+        if ($this->isEnabled() === true) {
+            $status  = 'ok';
+            $message = null;
+        }
+
         return [
-            'status'     => $available === true ? 'ok' : 'unavailable',
+            'status'     => $status,
             'authStatus' => 'configured',
-            'message'    => $available === true ? null : 'NC Costs app is not installed',
+            'message'    => $message,
         ];
     }//end health()
+
+    /**
+     * Resolve a service from the container (legacy fallback).
+     *
+     * @param string $serviceName Fully qualified class name to resolve.
+     *
+     * @return object Resolved service instance.
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess) `\OCP\Server::get()` is the
+     * NC-canonical service-locator entry point for late-bound classes.
+     */
+    private function lookup(string $serviceName): object
+    {
+        if ($this->container !== null) {
+            $resolved = $this->container->get($serviceName);
+            if (is_object($resolved) === false) {
+                throw new RuntimeException(sprintf('Container returned non-object for %s', $serviceName));
+            }
+
+            return $resolved;
+        }
+
+        return Server::get($serviceName);
+    }//end lookup()
+
+    /**
+     * Find NC Cospend projects whose `name` contains the OR object marker.
+     *
+     * @param object $projectMapper NC Cospend ProjectMapper instance.
+     * @param string $objectId      Owning object uuid.
+     *
+     * @return array<int,object> Matching project rows (loose-typed).
+     */
+    private function findProjectsByMarker(object $projectMapper, string $objectId): array
+    {
+        $marker = self::MARKER_PREFIX.$objectId.']';
+
+        try {
+            $tableName = $projectMapper->getTableName();
+            $qb        = $this->db->getQueryBuilder();
+            $qb->select('*')
+                ->from($tableName)
+                ->where(
+                    $qb->expr()->iLike(
+                        'name',
+                        $qb->createNamedParameter('%'.$this->db->escapeLikeParameter($marker).'%')
+                    )
+                )
+                ->orderBy('last_changed', 'DESC');
+
+            $result = $qb->executeQuery();
+            $rows   = [];
+            $row    = $result->fetch();
+            while ($row !== false) {
+                $rows[] = (object) $row;
+                $row    = $result->fetch();
+            }
+
+            $result->closeCursor();
+            return $rows;
+        } catch (Throwable $e) {
+            return [];
+        }//end try
+    }//end findProjectsByMarker()
+
+    /**
+     * Normalise a raw cospend_projects row into a registry leaf row.
+     *
+     * @param object $project  Raw project row.
+     * @param string $objectId Owning object uuid (used to strip the marker).
+     *
+     * @return array<string,mixed>
+     */
+    private function normaliseProject(object $project, string $objectId): array
+    {
+        $lastChangedColumn = 'last_changed';
+        $lastChanged       = null;
+        if (isset($project->{$lastChangedColumn}) === true) {
+            $lastChanged = (int) $project->{$lastChangedColumn};
+        }
+
+        $userIdColumn   = 'user_id';
+        $currencyColumn = 'currency_name';
+
+        $marker  = self::MARKER_PREFIX.$objectId.']';
+        $rawName = '';
+        if (isset($project->name) === true) {
+            $rawName = (string) $project->name;
+        }
+
+        $cleanName = trim(str_replace($marker, '', $rawName));
+
+        $id = '';
+        if (isset($project->id) === true) {
+            $id = (string) $project->id;
+        }
+
+        $userId = '';
+        if (isset($project->{$userIdColumn}) === true) {
+            $userId = (string) $project->{$userIdColumn};
+        }
+
+        $currency = '';
+        if (isset($project->{$currencyColumn}) === true) {
+            $currency = (string) $project->{$currencyColumn};
+        }
+
+        return [
+            'type'        => 'project',
+            'id'          => $id,
+            'title'       => $cleanName,
+            'description' => $userId,
+            'url'         => '/index.php/apps/cospend/p/'.$id,
+            'lastUpdated' => $lastChanged,
+            'data'        => [
+                'id'           => $id,
+                'name'         => $cleanName,
+                'userId'       => $userId,
+                'currencyName' => $currency,
+                'lastChanged'  => $lastChanged,
+            ],
+        ];
+    }//end normaliseProject()
+
+    /**
+     * Collect bill rows for a single linked project (legacy fallback).
+     *
+     * @param object|null $billMapper   BillMapper instance (or null).
+     * @param string      $projectId    Cospend project id.
+     * @param string      $projectName  Cleaned project name (label fallback).
+     * @param string      $currencyName Currency name carried from the project.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    private function collectBills(
+        ?object $billMapper,
+        string $projectId,
+        string $projectName,
+        string $currencyName
+    ): array {
+        if ($billMapper === null) {
+            return [];
+        }
+
+        try {
+            $tableName = $billMapper->getTableName();
+            $qb        = $this->db->getQueryBuilder();
+            $qb->select('*')
+                ->from($tableName)
+                ->where($qb->expr()->eq('project_id', $qb->createNamedParameter($projectId)))
+                ->andWhere($qb->expr()->eq('deleted', $qb->createNamedParameter(0)))
+                ->orderBy('timestamp', 'DESC')
+                ->setMaxResults(self::BILLS_PER_PROJECT);
+
+            $result = $qb->executeQuery();
+            $rows   = [];
+            $raw    = $result->fetch();
+            while ($raw !== false) {
+                $rows[] = $this->normaliseBill(
+                    bill: (object) $raw,
+                    projectId: $projectId,
+                    projectName: $projectName,
+                    currencyName: $currencyName
+                );
+                $raw    = $result->fetch();
+            }
+
+            $result->closeCursor();
+            return $rows;
+        } catch (Throwable $e) {
+            return [];
+        }//end try
+    }//end collectBills()
+
+    /**
+     * Normalise a raw cospend_bills row into a leaf row.
+     *
+     * @param object $bill         Raw bill row.
+     * @param string $projectId    Cospend project id.
+     * @param string $projectName  Cleaned project name (label fallback).
+     * @param string $currencyName Currency name carried from the project.
+     *
+     * @return array<string,mixed>
+     */
+    private function normaliseBill(
+        object $bill,
+        string $projectId,
+        string $projectName,
+        string $currencyName
+    ): array {
+        $billId = '';
+        if (isset($bill->id) === true) {
+            $billId = (string) $bill->id;
+        }
+
+        $what = '';
+        if (isset($bill->what) === true) {
+            $what = (string) $bill->what;
+        }
+
+        $amount = 0.0;
+        if (isset($bill->amount) === true) {
+            $amount = (float) $bill->amount;
+        }
+
+        $tsCandidate = null;
+        if (isset($bill->timestamp) === true) {
+            $tsCandidate = (int) $bill->timestamp;
+        }
+
+        $payerColumn = 'payer_id';
+        $payerId     = null;
+        if (isset($bill->{$payerColumn}) === true) {
+            $payerId = (int) $bill->{$payerColumn};
+        }
+
+        $isoTimestamp = '';
+        if ($tsCandidate !== null) {
+            $isoTimestamp = gmdate('c', $tsCandidate);
+        }
+
+        $title = $projectName;
+        if ($what !== '') {
+            $title = $what;
+        }
+
+        return [
+            'type'        => 'bill',
+            'id'          => $projectId.'/'.$billId,
+            'title'       => $title,
+            'description' => $isoTimestamp,
+            'url'         => '/index.php/apps/cospend/p/'.$projectId,
+            'lastUpdated' => $tsCandidate,
+            'data'        => [
+                'id'           => $billId,
+                'projectId'    => $projectId,
+                'what'         => $what,
+                'amount'       => $amount,
+                'payerId'      => $payerId,
+                'timestamp'    => $tsCandidate,
+                'currencyName' => $currencyName,
+            ],
+        ];
+    }//end normaliseBill()
 }//end class

--- a/tests/Unit/Service/CospendLinkServiceTest.php
+++ b/tests/Unit/Service/CospendLinkServiceTest.php
@@ -1,0 +1,324 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Service\CospendLinkService}.
+ *
+ * Exercises the Tier-2 service contract (linkProject / linkBill /
+ * createAndLinkProject / unlink / getLinkedEntries + available picker)
+ * against a mocked CospendLinkMapper. Tests that touch NC Cospend's
+ * `ProjectService` or the `cospend_*` tables use the "Cospend
+ * unavailable" path because those are resolved from the container /
+ * `IDBConnection` and aren't injectable into this unit-test scope without
+ * the `cospend` app on the classpath. Real round-trips are gated by
+ * `@group requires-app-cospend`.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/integration-cospend/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use Exception;
+use OCA\OpenRegister\Db\CospendLink;
+use OCA\OpenRegister\Db\CospendLinkMapper;
+use OCA\OpenRegister\Service\CospendLinkService;
+use OCP\App\IAppManager;
+use OCP\IDBConnection;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * CospendLinkServiceTest.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ *
+ * @group requires-app-cospend
+ */
+class CospendLinkServiceTest extends TestCase
+{
+
+    private CospendLinkMapper&MockObject $mapper;
+
+    private ContainerInterface&MockObject $container;
+
+    private IAppManager&MockObject $appManager;
+
+    private IUserSession&MockObject $userSession;
+
+    private IDBConnection&MockObject $db;
+
+    private LoggerInterface&MockObject $logger;
+
+    private CospendLinkService $service;
+
+    protected function setUp(): void
+    {
+        $this->mapper = $this->getMockBuilder(CospendLinkMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(
+                    [
+                        'findByObjectUuid',
+                        'findByObjectAndId',
+                        'findDuplicate',
+                        'deleteByObjectAndId',
+                        'insert',
+                        'update',
+                    ]
+                    )
+            ->getMock();
+
+        $this->container   = $this->createMock(ContainerInterface::class);
+        $this->appManager  = $this->createMock(IAppManager::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->db          = $this->createMock(IDBConnection::class);
+        $this->logger      = $this->createMock(LoggerInterface::class);
+
+        $this->service = new CospendLinkService(
+            $this->mapper,
+            $this->container,
+            $this->appManager,
+            $this->userSession,
+            $this->db,
+            $this->logger
+        );
+    }//end setUp()
+
+    private function setupUser(string $uid='alice'): IUser&MockObject
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $this->userSession->method('getUser')->willReturn($user);
+        return $user;
+    }//end setupUser()
+
+    public function testIsCospendAvailableTrue(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('cospend')->willReturn(true);
+        $this->assertTrue($this->service->isCospendAvailable());
+    }//end testIsCospendAvailableTrue()
+
+    public function testIsCospendAvailableFalse(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('cospend')->willReturn(false);
+        $this->assertFalse($this->service->isCospendAvailable());
+    }//end testIsCospendAvailableFalse()
+
+    public function testLinkProjectThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->linkProject('abc-123', 1, 2, 'proj-1');
+    }//end testLinkProjectThrowsWhenNoUser()
+
+    public function testLinkProjectThrowsWhenCospendUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('cospend')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+
+        $this->service->linkProject('abc-123', 1, 2, 'proj-1');
+    }//end testLinkProjectThrowsWhenCospendUnavailable()
+
+    public function testLinkProjectThrowsOnEmptyProjectId(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->willReturn(true);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+
+        $this->service->linkProject('abc-123', 1, 2, '   ');
+    }//end testLinkProjectThrowsOnEmptyProjectId()
+
+    public function testLinkProjectThrowsOnDuplicate(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->willReturn(true);
+        $this->mapper->method('findDuplicate')
+            ->with('abc-123', 'project', 'proj-1', null)
+            ->willReturn(new CospendLink());
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(409);
+        $this->expectExceptionMessage('Project already linked to this object');
+
+        $this->service->linkProject('abc-123', 1, 2, 'proj-1');
+    }//end testLinkProjectThrowsOnDuplicate()
+
+    public function testLinkBillThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->linkBill('abc-123', 1, 2, 'proj-1', 7);
+    }//end testLinkBillThrowsWhenNoUser()
+
+    public function testLinkBillThrowsWhenCospendUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('cospend')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+
+        $this->service->linkBill('abc-123', 1, 2, 'proj-1', 7);
+    }//end testLinkBillThrowsWhenCospendUnavailable()
+
+    public function testLinkBillThrowsOnDuplicate(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->willReturn(true);
+        $this->mapper->method('findDuplicate')
+            ->with('abc-123', 'bill', 'proj-1', 7)
+            ->willReturn(new CospendLink());
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(409);
+        $this->expectExceptionMessage('Bill already linked to this object');
+
+        $this->service->linkBill('abc-123', 1, 2, 'proj-1', 7);
+    }//end testLinkBillThrowsOnDuplicate()
+
+    public function testCreateAndLinkProjectThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->createAndLinkProject('abc-123', 1, 2, 'Holiday', 'EUR');
+    }//end testCreateAndLinkProjectThrowsWhenNoUser()
+
+    public function testCreateAndLinkProjectThrowsOnEmptyName(): void
+    {
+        $this->setupUser();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+
+        $this->service->createAndLinkProject('abc-123', 1, 2, '   ', 'EUR');
+    }//end testCreateAndLinkProjectThrowsOnEmptyName()
+
+    public function testCreateAndLinkProjectThrowsWhenCospendUnavailable(): void
+    {
+        $this->setupUser();
+        $this->appManager->method('isEnabledForUser')->with('cospend')->willReturn(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+
+        $this->service->createAndLinkProject('abc-123', 1, 2, 'Holiday', 'EUR');
+    }//end testCreateAndLinkProjectThrowsWhenCospendUnavailable()
+
+    public function testUnlinkThrowsWhenNoUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(401);
+
+        $this->service->unlink('abc-123', 5);
+    }//end testUnlinkThrowsWhenNoUser()
+
+    public function testUnlinkThrowsWhenLinkMissing(): void
+    {
+        $this->setupUser();
+        $this->mapper->method('deleteByObjectAndId')->with('abc-123', 5)->willReturn(0);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(404);
+
+        $this->service->unlink('abc-123', 5);
+    }//end testUnlinkThrowsWhenLinkMissing()
+
+    public function testUnlinkSucceeds(): void
+    {
+        $this->setupUser();
+        $this->mapper->expects($this->once())
+            ->method('deleteByObjectAndId')
+            ->with('abc-123', 5)
+            ->willReturn(1);
+
+        $this->service->unlink('abc-123', 5);
+    }//end testUnlinkSucceeds()
+
+    public function testGetLinkedEntriesReturnsSerializedRows(): void
+    {
+        // Cospend unavailable so no stale-refresh DB access is attempted.
+        $this->appManager->method('isEnabledForUser')->willReturn(false);
+
+        $project = new CospendLink();
+        $project->setObjectUuid('abc-123');
+        $project->setEntryType('project');
+        $project->setProjectId('proj-1');
+        $project->setName('Holiday');
+        $project->setCurrency('EUR');
+
+        $bill = new CospendLink();
+        $bill->setObjectUuid('abc-123');
+        $bill->setEntryType('bill');
+        $bill->setProjectId('proj-1');
+        $bill->setBillId(7);
+        $bill->setName('Hotel');
+        $bill->setAmount(120.5);
+        $bill->setCurrency('EUR');
+
+        $this->mapper->method('findByObjectUuid')->with('abc-123')->willReturn([$project, $bill]);
+
+        $rows = $this->service->getLinkedEntries('abc-123');
+
+        $this->assertCount(2, $rows);
+        $this->assertSame('project', $rows[0]['entryType']);
+        $this->assertSame('Holiday', $rows[0]['name']);
+        $this->assertSame('bill', $rows[1]['entryType']);
+        $this->assertSame(7, $rows[1]['billId']);
+        $this->assertSame(120.5, $rows[1]['amount']);
+    }//end testGetLinkedEntriesReturnsSerializedRows()
+
+    public function testGetLinkedEntriesEmpty(): void
+    {
+        $this->appManager->method('isEnabledForUser')->willReturn(false);
+        $this->mapper->method('findByObjectUuid')->with('abc-123')->willReturn([]);
+
+        $this->assertSame([], $this->service->getLinkedEntries('abc-123'));
+    }//end testGetLinkedEntriesEmpty()
+
+    public function testGetAvailableProjectsEmptyWhenCospendUnavailable(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('cospend')->willReturn(false);
+
+        $this->assertSame([], $this->service->getAvailableProjects());
+    }//end testGetAvailableProjectsEmptyWhenCospendUnavailable()
+
+    public function testGetAvailableProjectsEmptyWhenNoUser(): void
+    {
+        $this->appManager->method('isEnabledForUser')->with('cospend')->willReturn(true);
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->assertSame([], $this->service->getAvailableProjects());
+    }//end testGetAvailableProjectsEmptyWhenNoUser()
+}//end class


### PR DESCRIPTION
## Summary
- Adds the `openregister_cospend_links` table (migration `Version1Date20260525210000`) with `CospendLink` entity + `CospendLinkMapper` (composite unique on `object_uuid, entry_type, project_id, bill_id`).
- Adds `CospendLinkService` wrapping NC Cospend's `ProjectService` + direct `cospend_projects`/`cospend_bills` queries (lazy-resolved, graceful degradation per ADR-019 AD-23): `linkProject` / `linkBill` / `createAndLinkProject` / `unlink` / `getLinkedEntries` (refreshes amount/currency when a row is >24h old) / `getAvailableProjects(?search)`.
- Adds `CospendLinksController` (GET/POST `/cospend`, POST `/cospend/new`, DELETE `/cospend/{entryId}`, GET `/integrations/cospend/available`); routes ordered specific-before-wildcard.
- Promotes `CospendProvider` to read the link table, with a legacy `[or:{uuid}]` name-marker fallback that preserves the wave-2.3 two-type projects+bills row shape.
- PHPUnit `CospendLinkServiceTest` (`@group requires-app-cospend`).

## Gates
- PHP lint: clean
- PHPCS (`lib/`, CI scope): clean
- PHPStan level config: no errors
- PHPUnit: mirrors merged collectives exemplar; runs in the NC-container CI (host lacks PHP 8.3 + installed NC)

Refs openregister#1324, ADR-019, ADR-022, ADR-004.