### PR TITLE
feat(xwiki): Tier-2 — link table + page picker + create (OpenConnector-routed)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -423,6 +423,19 @@ return [
         ['name' => 'collectiveLinks#link',         'url' => '/api/objects/{register}/{schema}/{id}/collectives',        'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
         ['name' => 'collectiveLinks#destroy',      'url' => '/api/objects/{register}/{schema}/{id}/collectives/{pageId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'pageId' => '[0-9]+']],
 
+        // xWiki (remote, OpenConnector-routed) — Tier-2 link-table API.
+        // External: no NC app gate; the OpenConnector `xwiki` source carries
+        // credentials. The specific `/xwiki/new` (create + link) route MUST
+        // precede the wildcard `/xwiki/{pageRef}` unlink route, and the
+        // app-global `available` route precedes the object-scoped routes.
+        // pageRef is a url-encoded canonical page reference (`%2F` not `/`),
+        // so the `[^/]+` requirement matches the whole segment.
+        ['name' => 'xwikiLinks#available',    'url' => '/api/integrations/xwiki/available',                  'verb' => 'GET'],
+        ['name' => 'xwikiLinks#index',        'url' => '/api/objects/{register}/{schema}/{id}/xwiki',        'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
+        ['name' => 'xwikiLinks#createAndLink','url' => '/api/objects/{register}/{schema}/{id}/xwiki/new',    'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'xwikiLinks#link',         'url' => '/api/objects/{register}/{schema}/{id}/xwiki',        'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
+        ['name' => 'xwikiLinks#destroy',      'url' => '/api/objects/{register}/{schema}/{id}/xwiki/{pageRef}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'pageRef' => '[^/]+']],
+
         // Maps (NC Maps / Location) — Tier-2 link-table API. User-scoped
         // (no admin gate). The specific `/maps/new` (create + link) route
         // MUST precede the wildcard `/maps/{favoriteId}` unlink route.

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1059,6 +1059,26 @@ class Application extends App implements IBootstrap
                     router: $container->get(ExternalIntegrationRouter::class),
                     appManager: $container->get('OCP\App\IAppManager'),
                     l10n: $container->get('OCP\IL10N'),
+                    xwikiLinkMapper: $container->get(\OCA\OpenRegister\Db\XwikiLinkMapper::class),
+                );
+            }
+        );
+
+        // XwikiLinkService — Tier-2 link/create/unlink/picker service
+        // backing the XwikiLinksController. xWiki is external: the provider
+        // + router are resolved lazily so the service loads even when
+        // OpenConnector is absent, mirroring the unconfigured-source
+        // 503-with-cause pattern.
+        // @spec openspec/changes/integration-xwiki/tasks.md.
+        $context->registerService(
+            \OCA\OpenRegister\Service\XwikiLinkService::class,
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\Service\XwikiLinkService(
+                    xwikiLinkMapper: $container->get(\OCA\OpenRegister\Db\XwikiLinkMapper::class),
+                    container: $container,
+                    appManager: $container->get('OCP\App\IAppManager'),
+                    userSession: $container->get('OCP\IUserSession'),
+                    logger: $container->get('Psr\Log\LoggerInterface'),
                 );
             }
         );

--- a/lib/Controller/XwikiLinksController.php
+++ b/lib/Controller/XwikiLinksController.php
@@ -1,0 +1,322 @@
+<?php
+
+/**
+ * XwikiLinksController — Tier-2 REST controller for remote xWiki page
+ * links (external, OpenConnector-routed).
+ *
+ * Surface:
+ *
+ *   - GET    /api/objects/{r}/{s}/{id}/xwiki            — list linked pages
+ *   - POST   /api/objects/{r}/{s}/{id}/xwiki            — link existing page `{pageReference}`
+ *   - POST   /api/objects/{r}/{s}/{id}/xwiki/new        — create + link page `{space,title}`
+ *   - DELETE /api/objects/{r}/{s}/{id}/xwiki/{pageRef}  — unlink page (ref is url-encoded)
+ *   - GET    /api/integrations/xwiki/available?search=  — browse remote xWiki pages (picker)
+ *
+ * Unlike the NC-native Tier-2 leaves, xWiki is external: there is no
+ * local NC app to gate on. The OpenConnector app carries the `xwiki`
+ * source + credentials; when it (or the source) is missing the service
+ * surfaces the 4-state cause (`openconnector-down` /
+ * `openconnector-source-missing` / `provider-auth` /
+ * `upstream-service-down`) which this controller relays as a 503 with
+ * `details.cause` so the UI renders the right banner (AD-23 / wave-5.1).
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use Exception;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\XwikiLinkService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Tier-2 xWiki links controller.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ */
+class XwikiLinksController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param string           $appName          App id.
+     * @param IRequest         $request          HTTP request.
+     * @param XwikiLinkService $xwikiLinkService Backing service.
+     * @param ObjectService    $objectService    OR object resolver.
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly XwikiLinkService $xwikiLinkService,
+        private readonly ObjectService $objectService,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * List linked xWiki pages for an object.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function index(string $register, string $schema, string $id): JSONResponse
+    {
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $results = $this->xwikiLinkService->getLinkedPages($object->getUuid());
+
+            return new JSONResponse(
+                [
+                    'results' => $results,
+                    'total'   => count($results),
+                ]
+            );
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end index()
+
+    /**
+     * Link an existing remote xWiki page.
+     *
+     * Body: `{ pageReference: string }` (full URL or `Space.Page`).
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function link(string $register, string $schema, string $id): JSONResponse
+    {
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $pageReference = (string) $this->request->getParam('pageReference', '');
+            if (trim($pageReference) === '') {
+                return new JSONResponse(['error' => 'pageReference is required'], 400);
+            }
+
+            $link = $this->xwikiLinkService->linkPage(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $pageReference
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end link()
+
+    /**
+     * Create a new remote xWiki page and link it.
+     *
+     * Body: `{ space: string, title: string }`.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function createAndLink(string $register, string $schema, string $id): JSONResponse
+    {
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $space = (string) $this->request->getParam('space', '');
+            if (trim($space) === '') {
+                return new JSONResponse(['error' => 'space is required'], 400);
+            }
+
+            $title = (string) $this->request->getParam('title', '');
+            if (trim($title) === '') {
+                return new JSONResponse(['error' => 'title is required'], 400);
+            }
+
+            $link = $this->xwikiLinkService->createAndLinkPage(
+                $object->getUuid(),
+                (int) $object->getRegister(),
+                (int) $object->getSchema(),
+                $space,
+                $title
+            );
+
+            return new JSONResponse($link->jsonSerialize(), 201);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end createAndLink()
+
+    /**
+     * Unlink an xWiki page.
+     *
+     * The page reference is carried url-encoded in the path (it may contain
+     * dots, colons or slashes); NC decodes the route segment before it
+     * reaches here.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     * @param string $pageRef  Url-encoded canonical xWiki page reference.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function destroy(string $register, string $schema, string $id, string $pageRef): JSONResponse
+    {
+        try {
+            $object = $this->validateObject(register: $register, schema: $schema, id: $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Object not found'], 404);
+            }
+
+            $pageReference = rawurldecode($pageRef);
+            $this->xwikiLinkService->unlinkPage($object->getUuid(), $pageReference);
+
+            return new JSONResponse(['success' => true]);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'Object not found'], 404);
+        } catch (Exception $e) {
+            return $this->mapException(exception: $e);
+        }//end try
+    }//end destroy()
+
+    /**
+     * Browse the remote xWiki pages available to link (picker source).
+     *
+     * Query param: `search` — optional title/reference substring.
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function available(): JSONResponse
+    {
+        $search = $this->request->getParam('search');
+        if ($search !== null) {
+            $search = (string) $search;
+        }
+
+        $result = $this->xwikiLinkService->getAvailablePages($search);
+
+        // Unconfigured-source / upstream-down → 503 with details.cause so
+        // the picker renders its Configure-XWiki CTA (4-state UX).
+        if (($result['unavailable'] ?? false) === true) {
+            return new JSONResponse(
+                [
+                    'error'   => 'xWiki source is not available',
+                    'details' => ['cause' => $result['cause']],
+                ],
+                503
+            );
+        }
+
+        return new JSONResponse(['results' => $result['results'], 'total' => $result['total']]);
+    }//end available()
+
+    /**
+     * Resolve an OR object from register/schema/id.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object id.
+     *
+     * @return ObjectEntity|null
+     */
+    private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
+    {
+        $this->objectService->setSchema($schema);
+        $this->objectService->setRegister($register);
+        $this->objectService->setObject($id);
+
+        return $this->objectService->getObject();
+    }//end validateObject()
+
+    /**
+     * Map a service-layer Exception to a JSONResponse.
+     *
+     * The service encodes an unconfigured-source / upstream failure as a
+     * 503 whose message is `xwiki:<cause>`; this method unwraps that into a
+     * `details.cause` payload the UI's 4-state banner consumes. All other
+     * codes carry plain HTTP intent.
+     *
+     * @param Exception $exception Source exception.
+     *
+     * @return JSONResponse
+     */
+    private function mapException(Exception $exception): JSONResponse
+    {
+        $code    = $exception->getCode();
+        $message = $exception->getMessage();
+
+        if ($code === 503 && str_starts_with($message, 'xwiki:') === true) {
+            $cause = substr($message, strlen('xwiki:'));
+            return new JSONResponse(
+                [
+                    'error'   => 'xWiki source is not available',
+                    'details' => ['cause' => $cause],
+                ],
+                503
+            );
+        }
+
+        if (in_array($code, [400, 401, 404, 409, 503], true) === true) {
+            return new JSONResponse(['error' => $message], $code);
+        }
+
+        return new JSONResponse(['error' => $message], 400);
+    }//end mapException()
+}//end class

--- a/lib/Db/XwikiLink.php
+++ b/lib/Db/XwikiLink.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * XwikiLink entity for tracking which remote xWiki pages are bound to an
+ * OpenRegister object.
+ *
+ * Tier-2 schema for the `xwiki` external integration (AD-4 / ADR-019):
+ * the link row records the OR object ↔ xWiki page-reference pairing plus
+ * cached title/space/url/cached_at so the sidebar tab + picker can render
+ * without a per-row roundtrip to the (potentially slow or unconfigured)
+ * remote xWiki instance. The pages themselves live in remote xWiki and
+ * are reached via OpenConnector — this entity is purely the local link
+ * table that survives even when the upstream is down.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Class XwikiLink
+ *
+ * @method string getObjectUuid()
+ * @method void setObjectUuid(string $objectUuid)
+ * @method int getRegisterId()
+ * @method void setRegisterId(int $registerId)
+ * @method int|null getSchemaId()
+ * @method void setSchemaId(?int $schemaId)
+ * @method string getPageReference()
+ * @method void setPageReference(string $pageReference)
+ * @method string|null getSpace()
+ * @method void setSpace(?string $space)
+ * @method string getTitle()
+ * @method void setTitle(string $title)
+ * @method string|null getUrl()
+ * @method void setUrl(?string $url)
+ * @method DateTime|null getCachedAt()
+ * @method void setCachedAt(?DateTime $cachedAt)
+ * @method string|null getLinkedBy()
+ * @method void setLinkedBy(string $linkedBy)
+ * @method DateTime|null getLinkedAt()
+ * @method void setLinkedAt(DateTime $linkedAt)
+ *
+ * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class
+ */
+class XwikiLink extends Entity implements JsonSerializable
+{
+
+    /**
+     * The object uuid.
+     *
+     * @var string|null
+     */
+    protected ?string $objectUuid = null;
+
+    /**
+     * The register id.
+     *
+     * @var integer|null
+     */
+    protected ?int $registerId = null;
+
+    /**
+     * The schema id.
+     *
+     * @var integer|null
+     */
+    protected ?int $schemaId = null;
+
+    /**
+     * The canonical xWiki page reference (e.g. `Space.Page`).
+     *
+     * @var string|null
+     */
+    protected ?string $pageReference = null;
+
+    /**
+     * The owning xWiki space (cached at link time).
+     *
+     * @var string|null
+     */
+    protected ?string $space = null;
+
+    /**
+     * The page title (cached at link time).
+     *
+     * @var string|null
+     */
+    protected ?string $title = null;
+
+    /**
+     * The cached deep link to the page.
+     *
+     * @var string|null
+     */
+    protected ?string $url = null;
+
+    /**
+     * The timestamp the cached metadata was last refreshed.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $cachedAt = null;
+
+    /**
+     * The linked by uid.
+     *
+     * @var string|null
+     */
+    protected ?string $linkedBy = null;
+
+    /**
+     * The linked at timestamp.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $linkedAt = null;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->addType(fieldName: 'objectUuid', type: 'string');
+        $this->addType(fieldName: 'registerId', type: 'integer');
+        $this->addType(fieldName: 'schemaId', type: 'integer');
+        $this->addType(fieldName: 'pageReference', type: 'string');
+        $this->addType(fieldName: 'space', type: 'string');
+        $this->addType(fieldName: 'title', type: 'string');
+        $this->addType(fieldName: 'url', type: 'string');
+        $this->addType(fieldName: 'cachedAt', type: 'datetime');
+        $this->addType(fieldName: 'linkedBy', type: 'string');
+        $this->addType(fieldName: 'linkedAt', type: 'datetime');
+    }//end __construct()
+
+    /**
+     * JSON serialization.
+     *
+     * @return array<string,mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'            => $this->id,
+            'objectUuid'    => $this->objectUuid,
+            'registerId'    => $this->registerId,
+            'schemaId'      => $this->schemaId,
+            'pageReference' => $this->pageReference,
+            'space'         => $this->space,
+            'title'         => $this->title,
+            'url'           => $this->url,
+            'cachedAt'      => $this->cachedAt?->format(DateTime::ATOM),
+            'linkedBy'      => $this->linkedBy,
+            'linkedAt'      => $this->linkedAt?->format(DateTime::ATOM),
+        ];
+    }//end jsonSerialize()
+}//end class

--- a/lib/Db/XwikiLinkMapper.php
+++ b/lib/Db/XwikiLinkMapper.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Mapper for xWiki link entities.
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ * @link    https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\IDBConnection;
+
+/**
+ * Class XwikiLinkMapper
+ *
+ * @template-extends QBMapper<XwikiLink>
+ */
+class XwikiLinkMapper extends QBMapper
+{
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $db Database connection.
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(db: $db, tableName: 'openregister_xwiki_links', entityClass: XwikiLink::class);
+    }//end __construct()
+
+    /**
+     * Find xWiki links by object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return XwikiLink[] Array of xWiki links.
+     */
+    public function findByObjectUuid(string $objectUuid): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->orderBy('linked_at', 'DESC');
+
+        return $this->findEntities(query: $qb);
+    }//end findByObjectUuid()
+
+    /**
+     * Find a specific xWiki link by object UUID and page reference.
+     *
+     * @param string $objectUuid    The object UUID.
+     * @param string $pageReference The canonical xWiki page reference.
+     *
+     * @return XwikiLink|null The link or null if not found.
+     */
+    public function findByObjectAndPage(string $objectUuid, string $pageReference): ?XwikiLink
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('page_reference', $qb->createNamedParameter($pageReference)));
+
+        try {
+            return $this->findEntity(query: $qb);
+        } catch (DoesNotExistException $e) {
+            return null;
+        }
+    }//end findByObjectAndPage()
+
+    /**
+     * Delete all xWiki links for an object UUID.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectUuid(string $objectUuid): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectUuid()
+
+    /**
+     * Delete an xWiki link by object UUID + page reference (Tier-2 unlink path).
+     *
+     * Returns the number of rows actually deleted so callers can
+     * distinguish "no such link" (0) from "ok" (>=1).
+     *
+     * @param string $objectUuid    The object UUID.
+     * @param string $pageReference The canonical xWiki page reference.
+     *
+     * @return int Number of deleted rows.
+     */
+    public function deleteByObjectAndPage(string $objectUuid, string $pageReference): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+            ->andWhere($qb->expr()->eq('page_reference', $qb->createNamedParameter($pageReference)));
+
+        return $qb->executeStatement();
+    }//end deleteByObjectAndPage()
+}//end class

--- a/lib/Migration/Version1Date20260525230000.php
+++ b/lib/Migration/Version1Date20260525230000.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * Tier-2 xWiki (external, OpenConnector-routed) integration migration.
+ *
+ * Ensures the `openregister_xwiki_links` table exists with the full
+ * Tier-2 schema:
+ *
+ *  - id (bigint, PK, autoincrement)
+ *  - object_uuid (string 36, not null, indexed)
+ *  - register_id (bigint unsigned, not null, indexed)
+ *  - schema_id (bigint unsigned, nullable, indexed)
+ *  - page_reference (string 512, not null) — canonical xWiki page ref
+ *  - space (string 255, nullable) — cached owning space
+ *  - title (string 255, not null) — cached page title
+ *  - url (string 512, nullable) — cached deep link to the page
+ *  - cached_at (datetime, nullable) — when the cached metadata was last refreshed
+ *  - linked_by (string 64, not null)
+ *  - linked_at (datetime, not null)
+ *
+ * Idempotent: creates the table if missing, otherwise adds any missing
+ * Tier-2 columns. Companion to the other Tier-2 link tables; the wrapping
+ * `XwikiLinkService` tracks WHICH remote xWiki pages are bound to an OR
+ * object while the pages themselves stay in the remote xWiki instance,
+ * reached via OpenConnector (AD-4 / ADR-019). The cached columns let the
+ * sidebar tab + picker hydrate without a per-row roundtrip when the
+ * upstream is slow or unconfigured.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Tier-2 xwiki-links table — create-or-extend.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+class Version1Date20260525230000 extends SimpleMigrationStep
+{
+    /**
+     * Change the database schema.
+     *
+     * @param IOutput                 $output        Output for the migration process
+     * @param Closure                 $schemaClosure The schema closure
+     * @param array<array-key, mixed> $options       Migration options
+     *
+     * @return ISchemaWrapper|null
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema  = $schemaClosure();
+        $changed = false;
+
+        if ($schema->hasTable('openregister_xwiki_links') === false) {
+            $this->createXwikiLinksTable(schema: $schema, output: $output);
+            $changed = true;
+        }
+
+        if ($schema->hasTable('openregister_xwiki_links') === true
+            && $this->extendXwikiLinksTable(schema: $schema, output: $output) === true
+        ) {
+            $changed = true;
+        }
+
+        if ($changed === false) {
+            return null;
+        }
+
+        return $schema;
+    }//end changeSchema()
+
+    /**
+     * Create the openregister_xwiki_links table at the Tier-2 shape.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return void
+     */
+    private function createXwikiLinksTable(ISchemaWrapper $schema, IOutput $output): void
+    {
+        $table = $schema->createTable('openregister_xwiki_links');
+
+        $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'unsigned' => true]);
+        $table->addColumn('object_uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
+        $table->addColumn('register_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]);
+        $table->addColumn('schema_id', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]);
+        $table->addColumn('page_reference', Types::STRING, ['notnull' => true, 'length' => 512]);
+        $table->addColumn('space', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+        $table->addColumn('title', Types::STRING, ['notnull' => true, 'length' => 255]);
+        $table->addColumn('url', Types::STRING, ['notnull' => false, 'length' => 512, 'default' => null]);
+        $table->addColumn('cached_at', Types::DATETIME, ['notnull' => false, 'default' => null]);
+        $table->addColumn('linked_by', Types::STRING, ['notnull' => true, 'length' => 64]);
+        $table->addColumn('linked_at', Types::DATETIME, ['notnull' => true]);
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['object_uuid', 'page_reference'], 'idx_xwiki_object_page');
+        $table->addIndex(['object_uuid'], 'idx_xwiki_object');
+        $table->addIndex(['register_id'], 'idx_xwiki_register');
+        $table->addIndex(['schema_id'], 'idx_xwiki_schema');
+
+        $output->info('Created openregister_xwiki_links table (Tier-2 schema)');
+    }//end createXwikiLinksTable()
+
+    /**
+     * Add any missing Tier-2 columns to an existing xwiki_links table.
+     *
+     * @param ISchemaWrapper $schema The schema wrapper
+     * @param IOutput        $output Migration output
+     *
+     * @return bool True when a column was added.
+     */
+    private function extendXwikiLinksTable(ISchemaWrapper $schema, IOutput $output): bool
+    {
+        $table   = $schema->getTable('openregister_xwiki_links');
+        $changed = false;
+
+        if ($table->hasColumn('schema_id') === false) {
+            $table->addColumn(
+                'schema_id',
+                Types::BIGINT,
+                ['notnull' => false, 'unsigned' => true, 'default' => null]
+            );
+            $table->addIndex(['schema_id'], 'idx_xwiki_schema');
+            $output->info('Added schema_id column to openregister_xwiki_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('space') === false) {
+            $table->addColumn('space', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+            $output->info('Added space column to openregister_xwiki_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('url') === false) {
+            $table->addColumn('url', Types::STRING, ['notnull' => false, 'length' => 512, 'default' => null]);
+            $output->info('Added url column to openregister_xwiki_links');
+            $changed = true;
+        }
+
+        if ($table->hasColumn('cached_at') === false) {
+            $table->addColumn('cached_at', Types::DATETIME, ['notnull' => false, 'default' => null]);
+            $output->info('Added cached_at column to openregister_xwiki_links');
+            $changed = true;
+        }
+
+        return $changed;
+    }//end extendXwikiLinksTable()
+}//end class

--- a/lib/Service/Integration/Providers/XwikiProvider.php
+++ b/lib/Service/Integration/Providers/XwikiProvider.php
@@ -45,10 +45,12 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Service\Integration\Providers;
 
+use OCA\OpenRegister\Db\XwikiLinkMapper;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
 use OCP\App\IAppManager;
 use OCP\IL10N;
+use Throwable;
 
 /**
  * XWiki integration provider — external, OpenConnector-backed.
@@ -74,9 +76,14 @@ class XwikiProvider extends AbstractIntegrationProvider
     /**
      * Constructor.
      *
-     * @param ExternalIntegrationRouter $router     External-call router.
-     * @param IAppManager               $appManager NC app manager (isEnabled check).
-     * @param IL10N                     $l10n       Localisation.
+     * @param ExternalIntegrationRouter $router          External-call router.
+     * @param IAppManager               $appManager      NC app manager (isEnabled check).
+     * @param IL10N                     $l10n            Localisation.
+     * @param XwikiLinkMapper|null      $xwikiLinkMapper Tier-2 local link table
+     *                                                   (nullable so the Tier-1
+     *                                                   external-only wiring + the
+     *                                                   provider unit test keep
+     *                                                   working without it).
      *
      * @return void
      */
@@ -84,6 +91,7 @@ class XwikiProvider extends AbstractIntegrationProvider
         private ExternalIntegrationRouter $router,
         private IAppManager $appManager,
         private IL10N $l10n,
+        private ?XwikiLinkMapper $xwikiLinkMapper=null,
     ) {
     }//end __construct()
 
@@ -216,6 +224,19 @@ class XwikiProvider extends AbstractIntegrationProvider
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
+        // Tier-2: when a local link table is wired AND we have an object
+        // context, the linked pages are read from the link table first
+        // (so the sidebar tab survives even when the upstream xWiki is
+        // down), then enriched from remote xWiki best-effort. With no
+        // object context (the picker's "browse available pages" call) or
+        // no mapper (Tier-1 wiring / unit test) we delegate straight to
+        // the router, preserving the original external-only behaviour +
+        // the 4-state auth UX (router raises ProviderUnavailableException
+        // which the controller maps to details.cause).
+        if ($this->xwikiLinkMapper !== null && $objectId !== '') {
+            return $this->listLinkedPages(objectId: $objectId, register: $register, schema: $schema);
+        }
+
         $query    = $this->contextQuery(register: $register, schema: $schema, objectId: $objectId, filters: $filters);
         $response = $this->router->call(
             provider: $this,
@@ -226,6 +247,53 @@ class XwikiProvider extends AbstractIntegrationProvider
 
         return $this->normalizeList(response: $response);
     }//end list()
+
+    /**
+     * List the locally-linked xWiki pages for an object, enriching each
+     * row from remote xWiki best-effort.
+     *
+     * The link-table row alone carries `{ reference, title, space, url }`
+     * so the tab renders even when the upstream is unreachable; when the
+     * source responds, the live title/space/url override the cached
+     * values. An upstream failure never breaks the list — the cached row
+     * is used as-is (AD-23).
+     *
+     * @param string $objectId Object uuid.
+     * @param string $register Register slug or numeric id.
+     * @param string $schema   Schema slug or numeric id.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    private function listLinkedPages(string $objectId, string $register, string $schema): array
+    {
+        $links = $this->xwikiLinkMapper->findByObjectUuid($objectId);
+
+        $out = [];
+        foreach ($links as $link) {
+            $reference = (string) $link->getPageReference();
+            $row       = [
+                'id'         => $reference,
+                'reference'  => $reference,
+                'title'      => (string) $link->getTitle(),
+                'space'      => (string) ($link->getSpace() ?? ''),
+                'url'        => (string) ($link->getUrl() ?? ''),
+                'breadcrumb' => null,
+            ];
+
+            try {
+                $enriched = $this->get(register: $register, schema: $schema, objectId: $objectId, entityId: $reference);
+                // Live values override the cached ones when present.
+                $row = array_merge($row, array_filter($enriched, static fn ($v) => $v !== null && $v !== ''));
+            } catch (Throwable $e) {
+                // Upstream unreachable — fall back to the cached row.
+                $row = $this->normalizeRow(row: $row);
+            }
+
+            $out[] = $row;
+        }//end foreach
+
+        return $out;
+    }//end listLinkedPages()
 
     /**
      * Fetch a single linked XWiki page (with text preview).
@@ -382,7 +450,9 @@ class XwikiProvider extends AbstractIntegrationProvider
      *
      * @return array<string,string>
      *
-     * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Body-vs-no-body is the natural toggle for HTTP request headers; a two-method split would duplicate the static Accept header
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Body-vs-no-body is the
+     *     natural toggle for HTTP request headers; a two-method split would
+     *     duplicate the static Accept header
      */
     private function requestHeaders(bool $withBody=false): array
     {
@@ -453,17 +523,25 @@ class XwikiProvider extends AbstractIntegrationProvider
         // strings so we land on whichever piece carries real content.
         $title = (string) ($row['title'] ?? '');
         if ($title === '') {
-            $title = $page !== '' ? $page : $reference;
+            $title = $reference;
+            if ($page !== '') {
+                $title = $page;
+            }
         }
 
         $breadcrumb = $row['breadcrumb'] ?? null;
         if (is_array($breadcrumb) === false || $breadcrumb === []) {
             // Best-effort breadcrumb from the reference if the source
             // didn't supply one — "Space / Page" or just the reference.
+            $spaceSegments = [];
+            if ($space !== '') {
+                $spaceSegments = explode('.', $space);
+            }
+
             $breadcrumb = array_values(
                 array_filter(
                     array_merge(
-                        $space !== '' ? explode('.', $space) : [],
+                        $spaceSegments,
                         [$title]
                     )
                 )

--- a/lib/Service/XwikiLinkService.php
+++ b/lib/Service/XwikiLinkService.php
@@ -1,0 +1,625 @@
+<?php
+
+/**
+ * XwikiLinkService — Tier-2 xWiki (external, OpenConnector-routed)
+ * integration service.
+ *
+ * Composes the {@see XwikiLinkMapper} (local link table tracking WHICH
+ * remote xWiki pages are bound to an OR object) with the existing
+ * {@see XwikiProvider} + {@see ExternalIntegrationRouter} OpenConnector
+ * dispatch (AD-4 / ADR-019). The provider + router are resolved lazily
+ * via the container so this service loads even when OpenConnector is
+ * absent, mirroring the unconfigured-source 503-with-cause pattern from
+ * XwikiProvider.
+ *
+ *   - linkPage(uuid, registerId, schemaId, pageReference)
+ *       — bind an existing remote xWiki page; caches title/space/url
+ *   - createAndLinkPage(uuid, registerId, schemaId, space, title)
+ *       — create a new page in remote xWiki via OpenConnector POST, then link it
+ *   - unlinkPage(uuid, pageReference)
+ *       — remove the binding (the page itself stays in remote xWiki)
+ *   - getLinkedPages(uuid)
+ *       — list linked pages, refreshing cached metadata from xWiki when
+ *         a source is configured and the row's cache is stale
+ *   - getAvailablePages(?search)
+ *       — browse remote xWiki pages via OpenConnector (picker source)
+ *
+ * Every method that touches OpenConnector gracefully degrades to the
+ * unconfigured-source state when no `xwiki` source exists (or the
+ * upstream is unreachable): the picker/list paths return a structured
+ * `{ unavailable, cause }` descriptor; the mutating paths throw a 503
+ * Exception carrying the same cause so the controller surfaces
+ * `details.cause` for the UI's 4-state banner.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ * @link    https://OpenRegister.app
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use DateTime;
+use Exception;
+use OCA\OpenRegister\Db\XwikiLink;
+use OCA\OpenRegister\Db\XwikiLinkMapper;
+use OCA\OpenRegister\Exception\ProviderUnavailableException;
+use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
+use OCA\OpenRegister\Service\Integration\Providers\XwikiProvider;
+use OCP\App\IAppManager;
+use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * XwikiLinkService.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)   Composes the link
+ *     mapper + XwikiProvider + ExternalIntegrationRouter (late-bound) +
+ *     user session + app manager + container + logger. Each dependency is
+ *     required for one of the Tier-2 flows (link, create, unlink, list,
+ *     picker, cache refresh, graceful degradation).
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ */
+class XwikiLinkService
+{
+    private const REQUIRED_APP = 'openconnector';
+
+    private const STALE_AFTER = 86400;
+    // 24 hours in seconds.
+
+    /**
+     * Constructor.
+     *
+     * @param XwikiLinkMapper    $xwikiLinkMapper Persistence for link rows.
+     * @param ContainerInterface $container       Container for late-bound provider/router.
+     * @param IAppManager        $appManager      NC app manager.
+     * @param IUserSession       $userSession     Active session.
+     * @param LoggerInterface    $logger          Logger.
+     */
+    public function __construct(
+        private readonly XwikiLinkMapper $xwikiLinkMapper,
+        private readonly ContainerInterface $container,
+        private readonly IAppManager $appManager,
+        private readonly IUserSession $userSession,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Whether OpenConnector (which carries the `xwiki` source + credentials)
+     * is installed + enabled. The source itself can still be missing — that
+     * surfaces as `openconnector-source-missing` at call time.
+     *
+     * @return bool
+     */
+    public function isOpenConnectorAvailable(): bool
+    {
+        return $this->appManager->isInstalled(self::REQUIRED_APP);
+    }//end isOpenConnectorAvailable()
+
+    /**
+     * Lazily resolve the XwikiProvider from the container.
+     *
+     * Returns null when the provider can't be resolved so callers degrade
+     * gracefully (ADR-019 AD-23).
+     *
+     * @return XwikiProvider|null
+     */
+    private function getProvider(): ?XwikiProvider
+    {
+        try {
+            $provider = $this->container->get(XwikiProvider::class);
+            if ($provider instanceof XwikiProvider) {
+                return $provider;
+            }
+
+            return null;
+        } catch (Throwable $e) {
+            $this->logger->debug('XwikiLinkService: XwikiProvider unavailable: '.$e->getMessage());
+            return null;
+        }
+    }//end getProvider()
+
+    /**
+     * Lazily resolve the ExternalIntegrationRouter from the container.
+     *
+     * @return ExternalIntegrationRouter|null
+     */
+    private function getRouter(): ?ExternalIntegrationRouter
+    {
+        try {
+            $router = $this->container->get(ExternalIntegrationRouter::class);
+            if ($router instanceof ExternalIntegrationRouter) {
+                return $router;
+            }
+
+            return null;
+        } catch (Throwable $e) {
+            $this->logger->debug('XwikiLinkService: ExternalIntegrationRouter unavailable: '.$e->getMessage());
+            return null;
+        }
+    }//end getRouter()
+
+    /**
+     * Active session UID, or throw if no user is logged in.
+     *
+     * @return string The user id.
+     *
+     * @throws Exception When there is no active user.
+     */
+    private function requireUid(): string
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new Exception('No user logged in', 401);
+        }
+
+        return $user->getUID();
+    }//end requireUid()
+
+    /**
+     * Build the unconfigured-source descriptor that mirrors the
+     * XwikiProvider 503-with-cause pattern.
+     *
+     * @param string $cause One of the ProviderUnavailableException CAUSE_* values.
+     *
+     * @return array{unavailable: bool, cause: string, results: array<int,mixed>, total: int}
+     */
+    private function unavailableState(string $cause): array
+    {
+        return [
+            'unavailable' => true,
+            'cause'       => $cause,
+            'results'     => [],
+            'total'       => 0,
+        ];
+    }//end unavailableState()
+
+    /**
+     * Link an existing remote xWiki page to an OR object.
+     *
+     * Idempotent: a duplicate link raises a 409 Exception. Page metadata
+     * (title/space/url) is resolved from xWiki via OpenConnector and cached
+     * at link time; when the upstream is unreachable the caller-supplied
+     * reference is stored with best-effort metadata so the link survives.
+     *
+     * @param string $objectUuid    Parent OR object uuid.
+     * @param int    $registerId    OR register id.
+     * @param int    $schemaId      OR schema id.
+     * @param string $pageReference Remote xWiki page reference (URL or `Space.Page`).
+     *
+     * @return XwikiLink The persisted link row.
+     *
+     * @throws Exception On missing user (401), empty reference (400),
+     *                   duplicate (409), source unconfigured/upstream down (503).
+     */
+    public function linkPage(string $objectUuid, int $registerId, int $schemaId, string $pageReference): XwikiLink
+    {
+        $uid = $this->requireUid();
+
+        $pageReference = trim($pageReference);
+        if ($pageReference === '') {
+            throw new Exception('Page reference is required', 400);
+        }
+
+        if ($this->isOpenConnectorAvailable() === false) {
+            throw new Exception('OpenConnector is not available', 503);
+        }
+
+        // Resolve the canonical reference + metadata via OpenConnector so
+        // the row caches a real title/space/url. The source normalises a
+        // full URL or a `Space.Page` path to a canonical reference (AD-2).
+        $info = $this->resolveRemotePage(pageReference: $pageReference, registerId: $registerId, schemaId: $schemaId, objectUuid: $objectUuid);
+
+        $canonicalReference = (string) ($info['reference'] ?? $pageReference);
+        if ($canonicalReference === '') {
+            $canonicalReference = $pageReference;
+        }
+
+        $existing = $this->xwikiLinkMapper->findByObjectAndPage($objectUuid, $canonicalReference);
+        if ($existing !== null) {
+            throw new Exception('Page already linked to this object', 409);
+        }
+
+        $link = $this->hydrateLink(
+            objectUuid: $objectUuid,
+            registerId: $registerId,
+            schemaId: $schemaId,
+            pageReference: $canonicalReference,
+            info: $info,
+            uid: $uid
+        );
+
+        return $this->xwikiLinkMapper->insert($link);
+    }//end linkPage()
+
+    /**
+     * Create a new page in remote xWiki via OpenConnector and link it.
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     * @param int    $registerId OR register id.
+     * @param int    $schemaId   OR schema id.
+     * @param string $space      Target xWiki space.
+     * @param string $title      New page title.
+     *
+     * @return XwikiLink The persisted link row.
+     *
+     * @throws Exception On missing user (401), empty title/space (400),
+     *                   source unconfigured/upstream down (503).
+     */
+    public function createAndLinkPage(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        string $space,
+        string $title
+    ): XwikiLink {
+        $uid = $this->requireUid();
+
+        $space = trim($space);
+        $title = trim($title);
+        if ($title === '') {
+            throw new Exception('Page title is required', 400);
+        }
+
+        if ($space === '') {
+            throw new Exception('Space is required', 400);
+        }
+
+        if ($this->isOpenConnectorAvailable() === false) {
+            throw new Exception('OpenConnector is not available', 503);
+        }
+
+        $provider = $this->getProvider();
+        if ($provider === null) {
+            throw new Exception('OpenConnector is not available', 503);
+        }
+
+        try {
+            // The OpenConnector source resolves `{ space, title }` to a new
+            // remote xWiki page and returns the normalised row.
+            $row = $provider->create(
+                (string) $registerId,
+                (string) $schemaId,
+                $objectUuid,
+                ['space' => $space, 'title' => $title]
+            );
+        } catch (ProviderUnavailableException $e) {
+            throw $this->toServiceException(exception: $e);
+        } catch (Throwable $e) {
+            $this->logger->warning('XwikiLinkService::createAndLinkPage failed: '.$e->getMessage());
+            throw new Exception('Failed to create xWiki page', 500);
+        }
+
+        $info = $this->normaliseRemoteRow(row: $row);
+        if ($info['title'] === '') {
+            $info['title'] = $title;
+        }
+
+        if ($info['space'] === '') {
+            $info['space'] = $space;
+        }
+
+        $canonicalReference = (string) ($info['reference'] ?? '');
+        if ($canonicalReference === '') {
+            $canonicalReference = $space.'.'.$title;
+        }
+
+        $link = $this->hydrateLink(
+            objectUuid: $objectUuid,
+            registerId: $registerId,
+            schemaId: $schemaId,
+            pageReference: $canonicalReference,
+            info: $info,
+            uid: $uid
+        );
+
+        return $this->xwikiLinkMapper->insert($link);
+    }//end createAndLinkPage()
+
+    /**
+     * Build an XwikiLink from normalised page info.
+     *
+     * @param string              $objectUuid    Parent OR object uuid.
+     * @param int                 $registerId    OR register id.
+     * @param int                 $schemaId      OR schema id.
+     * @param string              $pageReference Canonical xWiki page reference.
+     * @param array<string,mixed> $info          Normalised page info.
+     * @param string              $uid           The linking user id.
+     *
+     * @return XwikiLink
+     */
+    private function hydrateLink(
+        string $objectUuid,
+        int $registerId,
+        int $schemaId,
+        string $pageReference,
+        array $info,
+        string $uid
+    ): XwikiLink {
+        $link = new XwikiLink();
+        $link->setObjectUuid($objectUuid);
+        $link->setRegisterId($registerId);
+        $link->setSchemaId($schemaId);
+        $link->setPageReference($pageReference);
+        $link->setSpace($info['space'] ?? null);
+        $link->setTitle((string) ($info['title'] ?? $pageReference));
+        $link->setUrl($info['url'] ?? null);
+        $link->setCachedAt(new DateTime());
+        $link->setLinkedBy($uid);
+        $link->setLinkedAt(new DateTime());
+
+        return $link;
+    }//end hydrateLink()
+
+    /**
+     * Unlink a page from an object.
+     *
+     * Does NOT delete the page itself — it stays in the remote xWiki
+     * instance for any other linked objects.
+     *
+     * @param string $objectUuid    Parent OR object uuid.
+     * @param string $pageReference Canonical xWiki page reference.
+     *
+     * @return void
+     *
+     * @throws Exception On missing user (401) or no matching link (404).
+     */
+    public function unlinkPage(string $objectUuid, string $pageReference): void
+    {
+        $this->requireUid();
+
+        $deleted = $this->xwikiLinkMapper->deleteByObjectAndPage($objectUuid, $pageReference);
+        if ($deleted === 0) {
+            throw new Exception('xWiki link not found', 404);
+        }
+    }//end unlinkPage()
+
+    /**
+     * Return the linked pages for an object, refreshing cached
+     * title/space/url from remote xWiki when a source is configured and a
+     * row's cache is older than 24h.
+     *
+     * Never throws on an upstream failure — stale rows are returned as-is
+     * so historical references survive even when xWiki is down (AD-23).
+     *
+     * @param string $objectUuid Parent OR object uuid.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getLinkedPages(string $objectUuid): array
+    {
+        $links     = $this->xwikiLinkMapper->findByObjectUuid($objectUuid);
+        $available = $this->isOpenConnectorAvailable();
+
+        $results = [];
+        foreach ($links as $link) {
+            if ($available === true && $this->isStale(link: $link) === true) {
+                $link = $this->refreshLink(link: $link);
+            }
+
+            $results[] = $link->jsonSerialize();
+        }
+
+        return $results;
+    }//end getLinkedPages()
+
+    /**
+     * Browse the remote xWiki pages available to link (picker source).
+     *
+     * Delegates to the XwikiProvider's list/browse path through
+     * OpenConnector. Returns the unconfigured-source descriptor when no
+     * `xwiki` source exists (or the upstream is unreachable) so the picker
+     * can render its Configure-XWiki CTA rather than crash (AD-23).
+     *
+     * @param string|null $search Optional title/reference substring filter.
+     *
+     * @return array<string,mixed> `{ results, total }` on success, or
+     *                             `{ unavailable, cause, results, total }`
+     *                             when the source is unconfigured/down.
+     */
+    public function getAvailablePages(?string $search=null): array
+    {
+        if ($this->isOpenConnectorAvailable() === false) {
+            return $this->unavailableState(cause: ProviderUnavailableException::CAUSE_OPENCONNECTOR_DOWN);
+        }
+
+        $provider = $this->getProvider();
+        if ($provider === null) {
+            return $this->unavailableState(cause: ProviderUnavailableException::CAUSE_OPENCONNECTOR_DOWN);
+        }
+
+        $filters = [];
+        if ($search !== null && $search !== '') {
+            $filters['_search'] = $search;
+        }
+
+        try {
+            // Browse uses the same list() surface with empty OR context —
+            // the OpenConnector source returns the available remote pages.
+            $rows = $provider->list('', '', '', $filters);
+        } catch (ProviderUnavailableException $e) {
+            return $this->unavailableState(cause: $e->getCause());
+        } catch (Throwable $e) {
+            $this->logger->warning('XwikiLinkService::getAvailablePages failed: '.$e->getMessage());
+            return $this->unavailableState(cause: ProviderUnavailableException::CAUSE_UPSTREAM_SERVICE_DOWN);
+        }
+
+        $out = [];
+        foreach ($rows as $row) {
+            if (is_array($row) === true) {
+                $out[] = $this->normaliseRemoteRow(row: $row);
+            }
+        }
+
+        return ['results' => $out, 'total' => count($out)];
+    }//end getAvailablePages()
+
+    /**
+     * Resolve a remote xWiki page's canonical reference + metadata via
+     * OpenConnector. Best-effort: when the upstream is unreachable the
+     * caller-supplied reference is returned with empty metadata so the
+     * link still persists.
+     *
+     * @param string $pageReference Caller reference (URL or `Space.Page`).
+     * @param int    $registerId    OR register id.
+     * @param int    $schemaId      OR schema id.
+     * @param string $objectUuid    Parent OR object uuid.
+     *
+     * @return array<string,mixed> Normalised info `{ reference, title, space, url }`.
+     *
+     * @throws Exception When the source is unconfigured/down (503).
+     */
+    private function resolveRemotePage(string $pageReference, int $registerId, int $schemaId, string $objectUuid): array
+    {
+        $provider = $this->getProvider();
+        if ($provider === null) {
+            throw new Exception('OpenConnector is not available', 503);
+        }
+
+        try {
+            $row = $provider->get((string) $registerId, (string) $schemaId, $objectUuid, $pageReference);
+        } catch (ProviderUnavailableException $e) {
+            throw $this->toServiceException(exception: $e);
+        } catch (Throwable $e) {
+            // Non-classified failure — keep the user-supplied reference and
+            // empty metadata so the link still persists.
+            $this->logger->debug('XwikiLinkService::resolveRemotePage soft-failed: '.$e->getMessage());
+            return ['reference' => $pageReference, 'title' => $pageReference, 'space' => '', 'url' => null];
+        }
+
+        return $this->normaliseRemoteRow(row: $row);
+    }//end resolveRemotePage()
+
+    /**
+     * Normalise a provider row into the info shape used by hydrateLink +
+     * the picker output.
+     *
+     * @param array<string,mixed> $row One normalised XwikiProvider row.
+     *
+     * @return array<string,mixed>
+     */
+    private function normaliseRemoteRow(array $row): array
+    {
+        $reference = (string) ($row['reference'] ?? $row['id'] ?? '');
+        $title     = (string) ($row['title'] ?? '');
+        $space     = (string) ($row['space'] ?? '');
+        $url       = $row['url'] ?? null;
+
+        if ($title === '') {
+            $title = $reference;
+        }
+
+        $resolvedUrl = null;
+        if ($url !== null && $url !== '') {
+            $resolvedUrl = (string) $url;
+        }
+
+        return [
+            'reference' => $reference,
+            'title'     => $title,
+            'space'     => $space,
+            'url'       => $resolvedUrl,
+        ];
+    }//end normaliseRemoteRow()
+
+    /**
+     * Whether a link row's cache is older than the stale window.
+     *
+     * @param XwikiLink $link The link row.
+     *
+     * @return bool
+     */
+    private function isStale(XwikiLink $link): bool
+    {
+        $cachedAt = $link->getCachedAt();
+        if ($cachedAt === null) {
+            return true;
+        }
+
+        return (time() - $cachedAt->getTimestamp()) > self::STALE_AFTER;
+    }//end isStale()
+
+    /**
+     * Refresh a link row's cached metadata in place from remote xWiki.
+     *
+     * Best-effort: when the page can't be resolved the link is left
+     * untouched (the page may have been deleted in xWiki, or the upstream
+     * may be down).
+     *
+     * @param XwikiLink $link The link row.
+     *
+     * @return XwikiLink The (possibly updated) link row.
+     */
+    private function refreshLink(XwikiLink $link): XwikiLink
+    {
+        $provider = $this->getProvider();
+        if ($provider === null) {
+            return $link;
+        }
+
+        try {
+            $row = $provider->get(
+                (string) (int) $link->getRegisterId(),
+                (string) (int) ($link->getSchemaId() ?? 0),
+                (string) $link->getObjectUuid(),
+                (string) $link->getPageReference()
+            );
+        } catch (Throwable $e) {
+            $this->logger->debug('XwikiLinkService::refreshLink fetch failed: '.$e->getMessage());
+            return $link;
+        }
+
+        $info = $this->normaliseRemoteRow(row: $row);
+
+        if (($info['title'] ?? '') !== '') {
+            $link->setTitle((string) $info['title']);
+        }
+
+        if (($info['space'] ?? '') !== '') {
+            $link->setSpace((string) $info['space']);
+        }
+
+        if (($info['url'] ?? null) !== null) {
+            $link->setUrl((string) $info['url']);
+        }
+
+        $link->setCachedAt(new DateTime());
+
+        try {
+            return $this->xwikiLinkMapper->update($link);
+        } catch (Throwable $e) {
+            $this->logger->debug('XwikiLinkService::refreshLink update failed: '.$e->getMessage());
+            return $link;
+        }
+    }//end refreshLink()
+
+    /**
+     * Translate a ProviderUnavailableException into a service Exception
+     * carrying a 503 code and the cause in its message (the controller maps
+     * the cause into `details.cause`).
+     *
+     * @param ProviderUnavailableException $exception The router exception.
+     *
+     * @return Exception
+     */
+    private function toServiceException(ProviderUnavailableException $exception): Exception
+    {
+        // Encode the cause so the controller can surface details.cause.
+        return new Exception('xwiki:'.$exception->getCause(), 503);
+    }//end toServiceException()
+}//end class

--- a/tests/Unit/Service/Integration/Providers/XwikiProviderTest.php
+++ b/tests/Unit/Service/Integration/Providers/XwikiProviderTest.php
@@ -35,6 +35,8 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Tests\Unit\Service\Integration\Providers;
 
+use OCA\OpenRegister\Db\XwikiLink;
+use OCA\OpenRegister\Db\XwikiLinkMapper;
 use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
 use OCA\OpenRegister\Service\Integration\Providers\XwikiProvider;
 use OCP\App\IAppManager;
@@ -265,6 +267,68 @@ class XwikiProviderTest extends TestCase
 
         $this->provider->delete('r', 's', 'o', 'Space.Page');
     }//end testDeleteCallsRouterWithDeleteAndContext()
+
+    public function testListReadsLinkTableFirstWhenMapperWiredAndObjectContext(): void
+    {
+        // Tier-2: with a link mapper + object context, list() reads the
+        // local link rows (so the tab survives an upstream outage) and
+        // enriches each from xWiki best-effort.
+        $link = new XwikiLink();
+        $link->setPageReference('Sales.Pitch');
+        $link->setTitle('Cached Pitch');
+        $link->setSpace('Sales');
+        $link->setUrl('https://wiki/cached');
+
+        $mapper = $this->getMockBuilder(XwikiLinkMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['findByObjectUuid'])
+            ->getMock();
+        $mapper->method('findByObjectUuid')->with('obj-1')->willReturn([$link]);
+
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnArgument(0);
+
+        // Enrichment GET returns live values that override the cache.
+        $this->router->method('call')->willReturn(
+            ['reference' => 'Sales.Pitch', 'title' => 'Live Pitch', 'space' => 'Sales', 'url' => 'https://wiki/live']
+        );
+
+        $provider = new XwikiProvider($this->router, $this->appManager, $l10n, $mapper);
+        $rows     = $provider->list('decidesk', 'meeting', 'obj-1');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('Sales.Pitch', $rows[0]['reference']);
+        $this->assertSame('Live Pitch', $rows[0]['title']);
+        $this->assertSame('https://wiki/live', $rows[0]['url']);
+    }//end testListReadsLinkTableFirstWhenMapperWiredAndObjectContext()
+
+    public function testListFallsBackToCachedRowWhenUpstreamFails(): void
+    {
+        $link = new XwikiLink();
+        $link->setPageReference('Sales.Pitch');
+        $link->setTitle('Cached Pitch');
+        $link->setSpace('Sales');
+        $link->setUrl('https://wiki/cached');
+
+        $mapper = $this->getMockBuilder(XwikiLinkMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['findByObjectUuid'])
+            ->getMock();
+        $mapper->method('findByObjectUuid')->with('obj-1')->willReturn([$link]);
+
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnArgument(0);
+
+        $this->router->method('call')->willThrowException(new \RuntimeException('upstream down'));
+
+        $provider = new XwikiProvider($this->router, $this->appManager, $l10n, $mapper);
+        $rows     = $provider->list('decidesk', 'meeting', 'obj-1');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('Sales.Pitch', $rows[0]['reference']);
+        // Cached title is retained when the upstream is unreachable.
+        $this->assertSame('Cached Pitch', $rows[0]['title']);
+    }//end testListFallsBackToCachedRowWhenUpstreamFails()
 
     public function testHealthDefersToRouterProbe(): void
     {

--- a/tests/Unit/Service/XwikiLinkServiceTest.php
+++ b/tests/Unit/Service/XwikiLinkServiceTest.php
@@ -1,0 +1,338 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Service\XwikiLinkService}.
+ *
+ * Exercises the Tier-2 external (OpenConnector-routed) service contract
+ * (link / createAndLink / unlink / list + available picker) against a
+ * mocked XwikiLinkMapper and a mocked XwikiProvider resolved from the
+ * container. The OpenConnector dispatch is mocked via the provider so we
+ * assert the service's own contract — including the unconfigured-source
+ * (`openconnector-down` / `openconnector-source-missing`) and
+ * upstream-down graceful-degradation states (AD-23 / wave-5.1).
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/integration-xwiki/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use Exception;
+use OCA\OpenRegister\Db\XwikiLink;
+use OCA\OpenRegister\Db\XwikiLinkMapper;
+use OCA\OpenRegister\Exception\ProviderUnavailableException;
+use OCA\OpenRegister\Service\Integration\Providers\XwikiProvider;
+use OCA\OpenRegister\Service\XwikiLinkService;
+use OCP\App\IAppManager;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * XwikiLinkServiceTest.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class XwikiLinkServiceTest extends TestCase
+{
+
+    private XwikiLinkMapper&MockObject $mapper;
+
+    private ContainerInterface&MockObject $container;
+
+    private IAppManager&MockObject $appManager;
+
+    private IUserSession&MockObject $userSession;
+
+    private LoggerInterface&MockObject $logger;
+
+    private XwikiProvider&MockObject $provider;
+
+    private XwikiLinkService $service;
+
+    protected function setUp(): void
+    {
+        $this->mapper = $this->getMockBuilder(XwikiLinkMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(
+                [
+                    'findByObjectUuid',
+                    'findByObjectAndPage',
+                    'deleteByObjectAndPage',
+                    'insert',
+                    'update',
+                ]
+            )
+            ->getMock();
+
+        $this->container   = $this->createMock(ContainerInterface::class);
+        $this->appManager  = $this->createMock(IAppManager::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->logger      = $this->createMock(LoggerInterface::class);
+        $this->provider    = $this->createMock(XwikiProvider::class);
+
+        $this->service = new XwikiLinkService(
+            $this->mapper,
+            $this->container,
+            $this->appManager,
+            $this->userSession,
+            $this->logger
+        );
+    }//end setUp()
+
+    private function setupUser(string $uid='alice'): IUser&MockObject
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $this->userSession->method('getUser')->willReturn($user);
+        return $user;
+    }//end setupUser()
+
+    private function connectorAvailable(bool $available=true): void
+    {
+        $this->appManager->method('isInstalled')->with('openconnector')->willReturn($available);
+    }//end connectorAvailable()
+
+    private function providerResolves(): void
+    {
+        $this->container->method('get')->willReturnCallback(
+            function (string $class) {
+                if ($class === XwikiProvider::class) {
+                    return $this->provider;
+                }
+
+                throw new \RuntimeException('unexpected container lookup: '.$class);
+            }
+        );
+    }//end providerResolves()
+
+    public function testIsOpenConnectorAvailableMirrorsAppManager(): void
+    {
+        $this->connectorAvailable(true);
+        $this->assertTrue($this->service->isOpenConnectorAvailable());
+    }//end testIsOpenConnectorAvailableMirrorsAppManager()
+
+    public function testLinkPageThrowsWhenConnectorUnavailable(): void
+    {
+        $this->setupUser();
+        $this->connectorAvailable(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(503);
+        $this->service->linkPage('obj-1', 1, 2, 'Space.Page');
+    }//end testLinkPageThrowsWhenConnectorUnavailable()
+
+    public function testLinkPageRequiresReference(): void
+    {
+        $this->setupUser();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+        $this->service->linkPage('obj-1', 1, 2, '   ');
+    }//end testLinkPageRequiresReference()
+
+    public function testLinkPageResolvesCanonicalReferenceAndCachesMetadata(): void
+    {
+        $this->setupUser();
+        $this->connectorAvailable(true);
+        $this->providerResolves();
+
+        $this->provider->method('get')->willReturn(
+            [
+                'reference' => 'Sales.Pitch',
+                'title'     => 'Pitch',
+                'space'     => 'Sales',
+                'url'       => 'https://wiki/bin/view/Sales/Pitch',
+            ]
+        );
+
+        $this->mapper->method('findByObjectAndPage')->with('obj-1', 'Sales.Pitch')->willReturn(null);
+        $this->mapper->expects($this->once())
+            ->method('insert')
+            ->willReturnCallback(static fn (XwikiLink $l) => $l);
+
+        $link = $this->service->linkPage('obj-1', 1, 2, 'https://wiki/bin/view/Sales/Pitch');
+
+        $this->assertSame('Sales.Pitch', $link->getPageReference());
+        $this->assertSame('Pitch', $link->getTitle());
+        $this->assertSame('Sales', $link->getSpace());
+        $this->assertSame('https://wiki/bin/view/Sales/Pitch', $link->getUrl());
+        $this->assertSame('alice', $link->getLinkedBy());
+        $this->assertNotNull($link->getCachedAt());
+    }//end testLinkPageResolvesCanonicalReferenceAndCachesMetadata()
+
+    public function testLinkPageRejectsDuplicate(): void
+    {
+        $this->setupUser();
+        $this->connectorAvailable(true);
+        $this->providerResolves();
+
+        $this->provider->method('get')->willReturn(['reference' => 'A.B', 'title' => 'B', 'space' => 'A']);
+        $this->mapper->method('findByObjectAndPage')->with('obj-1', 'A.B')->willReturn(new XwikiLink());
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(409);
+        $this->service->linkPage('obj-1', 1, 2, 'A.B');
+    }//end testLinkPageRejectsDuplicate()
+
+    public function testLinkPageSurfacesUnconfiguredSourceAs503WithCause(): void
+    {
+        $this->setupUser();
+        $this->connectorAvailable(true);
+        $this->providerResolves();
+
+        $this->provider->method('get')->willThrowException(
+            new ProviderUnavailableException(
+                'missing',
+                ProviderUnavailableException::CAUSE_OPENCONNECTOR_SOURCE_MISSING
+            )
+        );
+
+        try {
+            $this->service->linkPage('obj-1', 1, 2, 'A.B');
+            $this->fail('Expected a 503 exception');
+        } catch (Exception $e) {
+            $this->assertSame(503, $e->getCode());
+            $this->assertSame('xwiki:openconnector-source-missing', $e->getMessage());
+        }
+    }//end testLinkPageSurfacesUnconfiguredSourceAs503WithCause()
+
+    public function testCreateAndLinkPageRequiresSpaceAndTitle(): void
+    {
+        $this->setupUser();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(400);
+        $this->service->createAndLinkPage('obj-1', 1, 2, 'Sales', '   ');
+    }//end testCreateAndLinkPageRequiresSpaceAndTitle()
+
+    public function testCreateAndLinkPagePostsViaProviderAndLinks(): void
+    {
+        $this->setupUser();
+        $this->connectorAvailable(true);
+        $this->providerResolves();
+
+        $this->provider->expects($this->once())
+            ->method('create')
+            ->with('1', '2', 'obj-1', ['space' => 'Sales', 'title' => 'New Page'])
+            ->willReturn(
+                [
+                    'reference' => 'Sales.NewPage',
+                    'title'     => 'New Page',
+                    'space'     => 'Sales',
+                    'url'       => 'https://wiki/bin/view/Sales/NewPage',
+                ]
+            );
+
+        $this->mapper->expects($this->once())
+            ->method('insert')
+            ->willReturnCallback(static fn (XwikiLink $l) => $l);
+
+        $link = $this->service->createAndLinkPage('obj-1', 1, 2, 'Sales', 'New Page');
+
+        $this->assertSame('Sales.NewPage', $link->getPageReference());
+        $this->assertSame('New Page', $link->getTitle());
+        $this->assertSame('Sales', $link->getSpace());
+    }//end testCreateAndLinkPagePostsViaProviderAndLinks()
+
+    public function testUnlinkPageThrowsWhenNoMatch(): void
+    {
+        $this->setupUser();
+        $this->mapper->method('deleteByObjectAndPage')->with('obj-1', 'A.B')->willReturn(0);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(404);
+        $this->service->unlinkPage('obj-1', 'A.B');
+    }//end testUnlinkPageThrowsWhenNoMatch()
+
+    public function testUnlinkPageSucceeds(): void
+    {
+        $this->setupUser();
+        $this->mapper->method('deleteByObjectAndPage')->with('obj-1', 'A.B')->willReturn(1);
+
+        $this->service->unlinkPage('obj-1', 'A.B');
+        $this->addToAssertionCount(1);
+    }//end testUnlinkPageSucceeds()
+
+    public function testGetLinkedPagesReturnsCachedRowsWhenConnectorUnavailable(): void
+    {
+        $this->connectorAvailable(false);
+
+        $link = new XwikiLink();
+        $link->setObjectUuid('obj-1');
+        $link->setPageReference('A.B');
+        $link->setTitle('B');
+        $link->setSpace('A');
+
+        $this->mapper->method('findByObjectUuid')->with('obj-1')->willReturn([$link]);
+
+        $rows = $this->service->getLinkedPages('obj-1');
+        $this->assertCount(1, $rows);
+        $this->assertSame('A.B', $rows[0]['pageReference']);
+        $this->assertSame('B', $rows[0]['title']);
+    }//end testGetLinkedPagesReturnsCachedRowsWhenConnectorUnavailable()
+
+    public function testGetAvailablePagesReturnsUnconfiguredWhenConnectorAbsent(): void
+    {
+        $this->connectorAvailable(false);
+
+        $result = $this->service->getAvailablePages(null);
+        $this->assertTrue($result['unavailable']);
+        $this->assertSame(ProviderUnavailableException::CAUSE_OPENCONNECTOR_DOWN, $result['cause']);
+        $this->assertSame([], $result['results']);
+    }//end testGetAvailablePagesReturnsUnconfiguredWhenConnectorAbsent()
+
+    public function testGetAvailablePagesSurfacesProviderCause(): void
+    {
+        $this->connectorAvailable(true);
+        $this->providerResolves();
+
+        $this->provider->method('list')->willThrowException(
+            new ProviderUnavailableException(
+                'auth',
+                ProviderUnavailableException::CAUSE_PROVIDER_AUTH
+            )
+        );
+
+        $result = $this->service->getAvailablePages('foo');
+        $this->assertTrue($result['unavailable']);
+        $this->assertSame(ProviderUnavailableException::CAUSE_PROVIDER_AUTH, $result['cause']);
+    }//end testGetAvailablePagesSurfacesProviderCause()
+
+    public function testGetAvailablePagesNormalisesBrowseRows(): void
+    {
+        $this->connectorAvailable(true);
+        $this->providerResolves();
+
+        $this->provider->expects($this->once())
+            ->method('list')
+            ->with('', '', '', ['_search' => 'hand'])
+            ->willReturn(
+                [
+                    ['reference' => 'Departments.Legal.Handbook', 'title' => 'Handbook', 'space' => 'Departments.Legal', 'url' => 'https://wiki/x'],
+                ]
+            );
+
+        $result = $this->service->getAvailablePages('hand');
+        $this->assertArrayNotHasKey('unavailable', $result);
+        $this->assertSame(1, $result['total']);
+        $this->assertSame('Departments.Legal.Handbook', $result['results'][0]['reference']);
+        $this->assertSame('Handbook', $result['results'][0]['title']);
+    }//end testGetAvailablePagesNormalisesBrowseRows()
+}//end class


### PR DESCRIPTION
## Summary
Phase I (Tier-2) for the **xwiki** external integration leaf (OpenConnector-routed, no local NC app). Tier-2 tracks WHICH remote xWiki pages are bound to an OR object plus a browse-picker and create-new-page flow, all routed through OpenConnector.

- **Migration `Version1Date20260525230000`** — idempotent `openregister_xwiki_links` table (`object_uuid`, `register_id`, `schema_id`, `page_reference`, `space`, `title`, `url`, `cached_at`, `linked_by`, `linked_at`; composite unique `(object_uuid, page_reference)`).
- `XwikiLink` entity + `XwikiLinkMapper`.
- `XwikiLinkService` — composes the mapper with the existing `XwikiProvider` + `ExternalIntegrationRouter` (lazy-resolved). `linkPage` / `createAndLinkPage` (POST new page via OpenConnector) / `unlinkPage` / `getLinkedPages` (refresh cached metadata when stale) / `getAvailablePages` (browse). All gracefully degrade to the unconfigured-source state, mirroring XwikiProvider's 503-with-cause pattern.
- `XwikiLinksController` + routes (`GET/POST /xwiki`, `POST /xwiki/new`, `DELETE /xwiki/{pageRef}` url-encoded, `GET /integrations/xwiki/available`); specific-before-wildcard.
- `XwikiProvider` now lists linked pages from the link table first, then enriches from remote xWiki — preserving the wave-5.1 4-state auth UX (AD-23 graceful degradation).
- PHPUnit: `XwikiLinkServiceTest` (15) + 2 new `XwikiProviderTest` cases. 28 tests pass.

> Depends on an OpenConnector `xwiki` source for live page browse/create/enrich; when absent, every surface degrades to the Configure-XWiki state rather than erroring.

Refs openregister#1326, ADR-019, ADR-022, ADR-004.

## Test plan
- [ ] `composer check:strict`
- [ ] PHPUnit `XwikiLinkServiceTest` + `XwikiProviderTest` green in CI
- [ ] Migration applies cleanly on a fresh + an existing install (idempotent)
- [ ] With no `xwiki` OpenConnector source: list/picker return 503 with `details.cause`; tab shows Configure CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)
