### PR TITLE
feat(integrations): OCS capabilities surface + MCP discovery for the integration registry

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -226,6 +226,7 @@ use OCA\OpenRegister\Mcp\IMcpToolProvider;
 use OCA\OpenRegister\Mcp\BuiltIn\RegistersToolProvider;
 use OCA\OpenRegister\Mcp\BuiltIn\SchemasToolProvider;
 use OCA\OpenRegister\Mcp\BuiltIn\ObjectsToolProvider;
+use OCA\OpenRegister\Mcp\BuiltIn\IntegrationsToolProvider;
 use OCA\OpenRegister\Repair\LogDanglingLinkedTypes;
 use OCA\OpenRegister\Service\Integration\BuiltinProviders\AuditTrailProvider;
 use OCA\OpenRegister\Service\Integration\BuiltinProviders\FilesProvider;
@@ -971,7 +972,8 @@ class Application extends App implements IBootstrap
                 return new IntegrationsCapability(
                     registry: $container->get(IntegrationRegistry::class),
                     userSession: $container->get('OCP\IUserSession'),
-                    groupManager: $container->get('OCP\IGroupManager')
+                    groupManager: $container->get('OCP\IGroupManager'),
+                    appManager: $container->get('OCP\App\IAppManager')
                 );
             }
         );
@@ -1744,7 +1746,7 @@ class Application extends App implements IBootstrap
     /**
      * Register MCP tool providers (built-ins first).
      *
-     * Wires the three built-in IMcpToolProvider implementations into
+     * Wires the four built-in IMcpToolProvider implementations into
      * McpToolsService. External apps may call addProvider() after boot
      * or override the McpToolsService binding to prepend their own providers.
      *
@@ -1764,6 +1766,7 @@ class Application extends App implements IBootstrap
                     $container->get(RegistersToolProvider::class),
                     $container->get(SchemasToolProvider::class),
                     $container->get(ObjectsToolProvider::class),
+                    $container->get(IntegrationsToolProvider::class),
                 ];
 
                 // Per-app tool providers: try two discovery paths for each

--- a/lib/Capabilities/IntegrationsCapability.php
+++ b/lib/Capabilities/IntegrationsCapability.php
@@ -32,6 +32,7 @@ namespace OCA\OpenRegister\Capabilities;
 
 use OCA\OpenRegister\Service\Integration\IntegrationProvider;
 use OCA\OpenRegister\Service\Integration\IntegrationRegistry;
+use OCP\App\IAppManager;
 use OCP\Capabilities\ICapability;
 use OCP\IGroupManager;
 use OCP\IUserSession;
@@ -42,11 +43,24 @@ use OCP\IUserSession;
 class IntegrationsCapability implements ICapability
 {
     /**
+     * Contract version of the `openregister.integrations` capability shape.
+     *
+     * Bumped when the descriptor shape changes incompatibly so consumers
+     * (clients, AI agents) can branch on it. Per ADR-019 the registry is
+     * advertised through OCS discoverability; this is the version of THAT
+     * surface, distinct from any individual provider's own versioning.
+     *
+     * @var int
+     */
+    public const CONTRACT_VERSION = 1;
+
+    /**
      * Constructor.
      *
      * @param IntegrationRegistry $registry     Integration registry.
      * @param IUserSession        $userSession  Current user session.
      * @param IGroupManager       $groupManager Group manager (admin check).
+     * @param IAppManager         $appManager   App manager (installed check).
      *
      * @return void
      */
@@ -54,6 +68,7 @@ class IntegrationsCapability implements ICapability
         private IntegrationRegistry $registry,
         private IUserSession $userSession,
         private IGroupManager $groupManager,
+        private IAppManager $appManager,
     ) {
     }//end __construct()
 
@@ -76,8 +91,17 @@ class IntegrationsCapability implements ICapability
         return [
             'openregister' => [
                 'integrations' => [
-                    'version'   => 1,
-                    'providers' => $rows,
+                    // `version` retained for back-compat with the original
+                    // Phase E shape; `contractVersion` is the canonical key
+                    // going forward (ADR-019 discoverability contract).
+                    'version'         => self::CONTRACT_VERSION,
+                    'contractVersion' => self::CONTRACT_VERSION,
+                    // Flat id list — the cheapest discovery primitive, mirrors
+                    // IntegrationRegistry::listIds(). AI agents / clients that
+                    // only need "what exists" read this without walking
+                    // `providers`.
+                    'registered'      => $this->registry->listIds(),
+                    'providers'       => $rows,
                 ],
             ],
         ];
@@ -93,11 +117,20 @@ class IntegrationsCapability implements ICapability
      */
     private function describe(IntegrationProvider $provider, bool $isAdmin): array
     {
+        $requiredApp = $provider->getRequiredApp();
+
         $row = [
             'id'              => $provider->getId(),
             'label'           => $provider->getLabel(),
             'group'           => $provider->getGroup(),
             'enabled'         => $provider->isEnabled(),
+            // `requiredApp` + `available` are public discovery fields: a
+            // non-admin needs to know whether an integration's backing NC
+            // app is installed to decide whether to render its surface.
+            // Built-in providers (requiredApp === null) ride on OpenRegister
+            // itself and are therefore always available.
+            'requiredApp'     => $requiredApp,
+            'available'       => $this->appIsInstalled(appId: $requiredApp),
             'storageStrategy' => $provider->getStorageStrategy(),
             'surfaces'        => ['user-dashboard', 'app-dashboard', 'detail-page', 'single-entity'],
         ];
@@ -121,6 +154,25 @@ class IntegrationsCapability implements ICapability
 
         return $row;
     }//end describe()
+
+    /**
+     * Whether the NC app backing an integration is installed and enabled.
+     *
+     * Built-in integrations declare a null `requiredApp` — they ride on
+     * OpenRegister itself and are therefore always considered available.
+     *
+     * @param string|null $appId The required NC app id, or null for built-ins.
+     *
+     * @return bool True when the integration's backing app is usable.
+     */
+    private function appIsInstalled(?string $appId): bool
+    {
+        if ($appId === null || $appId === '') {
+            return true;
+        }
+
+        return $this->appManager->isEnabledForUser($appId);
+    }//end appIsInstalled()
 
     /**
      * Check whether the current user is in the admin group.

--- a/lib/Mcp/BuiltIn/IntegrationsToolProvider.php
+++ b/lib/Mcp/BuiltIn/IntegrationsToolProvider.php
@@ -1,0 +1,315 @@
+<?php
+
+/**
+ * Built-in integrations MCP tool provider.
+ *
+ * Makes the pluggable integration registry (ADR-019) discoverable to AI
+ * agents through OpenRegister's MCP surface (ADR-022 "MCP discovery"
+ * abstraction). Each registered IntegrationProvider becomes addressable
+ * through the single namespaced tool `openregister.integrations`, whose
+ * `action` argument selects between discovery (`list-integrations`) and
+ * per-object operations (`list`, `get`, `link`, `create`).
+ *
+ * The tool delegates straight to IntegrationRegistry + the matched
+ * IntegrationProvider, so it inherits the providers' own storage-strategy
+ * semantics: query-time/list-only providers throw NotImplementedException
+ * on `link`/`create`, which McpToolsService surfaces as an MCP error
+ * envelope rather than a fatal.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Mcp
+ * @package  OCA\OpenRegister\Mcp\BuiltIn
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction BV
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/pluggable-integration-registry/proposal.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Mcp\BuiltIn;
+
+use InvalidArgumentException;
+use OCA\OpenRegister\Mcp\IMcpToolProvider;
+use OCA\OpenRegister\Service\Integration\IntegrationProvider;
+use OCA\OpenRegister\Service\Integration\IntegrationRegistry;
+
+/**
+ * IntegrationsToolProvider
+ *
+ * Built-in IMcpToolProvider exposing the integration registry as an
+ * AI-agent discovery + invocation surface. Registered alongside the other
+ * built-ins in Application::registerMcpToolProviders().
+ *
+ * @category Mcp
+ * @package  OCA\OpenRegister\Mcp\BuiltIn
+ *
+ * @psalm-suppress UnusedClass - Injected via DI container
+ */
+class IntegrationsToolProvider implements IMcpToolProvider
+{
+
+    /**
+     * Tool id for the integrations tool.
+     */
+    public const TOOL_ID = 'openregister.integrations';
+
+    /**
+     * Constructor.
+     *
+     * @param IntegrationRegistry $registry Integration registry.
+     */
+    public function __construct(
+        private readonly IntegrationRegistry $registry
+    ) {
+    }//end __construct()
+
+    /**
+     * Returns the owning app id.
+     *
+     * @return string Always "openregister"
+     */
+    public function getAppId(): string
+    {
+        return 'openregister';
+    }//end getAppId()
+
+    /**
+     * Returns tool descriptors.
+     *
+     * @return list<array{id: string, name: string, description: string, inputSchema: array}>
+     */
+    public function getTools(): array
+    {
+        return [
+            [
+                'id'          => self::TOOL_ID,
+                'name'        => 'integrations',
+                'description' => 'Discover and query pluggable integrations linked to OpenRegister objects '
+                    .'(e.g. files, calendar, contacts, xwiki). Use action "list-integrations" to enumerate '
+                    .'which integrations exist on this instance, then "list"/"get" to read linked things for '
+                    .'a specific object, and "link"/"create" to attach a new linked thing where the '
+                    .'integration supports it.',
+                'inputSchema' => [
+                    'type'       => 'object',
+                    'properties' => [
+                        'action'        => [
+                            'type'        => 'string',
+                            'enum'        => ['list-integrations', 'list', 'get', 'link', 'create'],
+                            'description' => 'list-integrations enumerates available integrations; '
+                                .'list/get/link/create operate on linked things for one object.',
+                        ],
+                        'integrationId' => [
+                            'type'        => 'string',
+                            'description' => 'Stable integration id (e.g. "files", "calendar"). '
+                                .'Required for list/get/link/create.',
+                        ],
+                        'register'      => [
+                            'type'        => 'string',
+                            'description' => 'Register slug or numeric id (required for list/get/link/create).',
+                        ],
+                        'schema'        => [
+                            'type'        => 'string',
+                            'description' => 'Schema slug or numeric id (required for list/get/link/create).',
+                        ],
+                        'objectId'      => [
+                            'type'        => 'string',
+                            'description' => 'Object uuid that owns the linked things (required for '
+                                .'list/get/link/create).',
+                        ],
+                        'entityId'      => [
+                            'type'        => 'string',
+                            'description' => 'Linked-thing id (required for get).',
+                        ],
+                        'filters'       => [
+                            'type'        => 'object',
+                            'description' => 'Optional list filters (_limit, _page, _search).',
+                        ],
+                        'payload'       => [
+                            'type'        => 'object',
+                            'description' => 'New linked-thing fields (for link/create).',
+                        ],
+                    ],
+                    'required'   => ['action'],
+                ],
+            ],
+        ];
+    }//end getTools()
+
+    /**
+     * Invoke the integrations tool.
+     *
+     * @param string               $toolId    Must be "openregister.integrations"
+     * @param array<string, mixed> $arguments Tool arguments with action and operation params
+     *
+     * @return array<string, mixed> JSON-encodable result
+     *
+     * @throws InvalidArgumentException If action is unknown or required params missing
+     */
+    public function invokeTool(string $toolId, array $arguments): array
+    {
+        $action = $arguments['action'] ?? null;
+
+        return match ($action) {
+            'list-integrations' => $this->listIntegrations(),
+            'list'              => $this->listLinked(arguments: $arguments),
+            'get'               => $this->getLinked(arguments: $arguments),
+            'link', 'create'    => $this->createLinked(arguments: $arguments),
+            default             => throw new InvalidArgumentException('Unknown action: '.$action),
+        };
+    }//end invokeTool()
+
+    /**
+     * Discovery: enumerate every registered integration with its metadata.
+     *
+     * Mirrors the OCS capability's public surface so an AI agent gets the
+     * same view of "what exists" regardless of which discovery channel it
+     * uses.
+     *
+     * @return array<string, mixed> Registered ids + per-integration descriptors
+     */
+    private function listIntegrations(): array
+    {
+        $integrations = [];
+        foreach ($this->registry->list() as $provider) {
+            $integrations[] = [
+                'id'              => $provider->getId(),
+                'label'           => $provider->getLabel(),
+                'group'           => $provider->getGroup(),
+                'enabled'         => $provider->isEnabled(),
+                'requiredApp'     => $provider->getRequiredApp(),
+                'storageStrategy' => $provider->getStorageStrategy(),
+            ];
+        }
+
+        return [
+            'registered'   => $this->registry->listIds(),
+            'integrations' => $integrations,
+        ];
+    }//end listIntegrations()
+
+    /**
+     * List linked things the named integration exposes for an object.
+     *
+     * @param array<string, mixed> $arguments Must contain integrationId, register, schema, objectId
+     *
+     * @return array<string, mixed> Items wrapper
+     */
+    private function listLinked(array $arguments): array
+    {
+        $provider = $this->resolveProvider(arguments: $arguments);
+        $filters  = $arguments['filters'] ?? [];
+        if (is_array($filters) === false) {
+            $filters = [];
+        }
+
+        $items = $provider->list(
+            $this->requireParam(arguments: $arguments, param: 'register'),
+            $this->requireParam(arguments: $arguments, param: 'schema'),
+            $this->requireParam(arguments: $arguments, param: 'objectId'),
+            $filters
+        );
+
+        return ['items' => $items];
+    }//end listLinked()
+
+    /**
+     * Fetch a single linked thing by id.
+     *
+     * @param array<string, mixed> $arguments Must contain integrationId, register, schema, objectId, entityId
+     *
+     * @return array<string, mixed> The linked thing
+     */
+    private function getLinked(array $arguments): array
+    {
+        $provider = $this->resolveProvider(arguments: $arguments);
+
+        return $provider->get(
+            $this->requireParam(arguments: $arguments, param: 'register'),
+            $this->requireParam(arguments: $arguments, param: 'schema'),
+            $this->requireParam(arguments: $arguments, param: 'objectId'),
+            $this->requireParam(arguments: $arguments, param: 'entityId')
+        );
+    }//end getLinked()
+
+    /**
+     * Create / attach a new linked thing.
+     *
+     * Providers with query-time/list-only storage throw
+     * NotImplementedException, which McpToolsService renders as an error
+     * envelope.
+     *
+     * @param array<string, mixed> $arguments Must contain integrationId, register, schema, objectId, payload
+     *
+     * @return array<string, mixed> The created linked thing
+     */
+    private function createLinked(array $arguments): array
+    {
+        $provider = $this->resolveProvider(arguments: $arguments);
+        $payload  = $arguments['payload'] ?? [];
+        if (is_array($payload) === false) {
+            $payload = [];
+        }
+
+        return $provider->create(
+            $this->requireParam(arguments: $arguments, param: 'register'),
+            $this->requireParam(arguments: $arguments, param: 'schema'),
+            $this->requireParam(arguments: $arguments, param: 'objectId'),
+            $payload
+        );
+    }//end createLinked()
+
+    /**
+     * Resolve and validate the integration provider for an operation.
+     *
+     * @param array<string, mixed> $arguments Must contain integrationId
+     *
+     * @return IntegrationProvider The matched, enabled provider
+     *
+     * @throws InvalidArgumentException When integrationId is missing, unknown, or disabled
+     */
+    private function resolveProvider(array $arguments): IntegrationProvider
+    {
+        $integrationId = $this->requireParam(arguments: $arguments, param: 'integrationId');
+        $provider      = $this->registry->get(id: $integrationId);
+
+        if ($provider === null) {
+            throw new InvalidArgumentException('Unknown integration: '.$integrationId);
+        }
+
+        // Mirror the controller's gate: a disabled integration (backing app
+        // missing / external source unconfigured) must not be invoked.
+        if ($provider->isEnabled() === false) {
+            throw new InvalidArgumentException('Integration not available: '.$integrationId);
+        }
+
+        return $provider;
+    }//end resolveProvider()
+
+    /**
+     * Assert a parameter is present and return it as a string.
+     *
+     * @param array<string, mixed> $arguments Tool arguments
+     * @param string               $param     Required parameter name
+     *
+     * @return string The parameter value cast to string
+     *
+     * @throws InvalidArgumentException If parameter is missing
+     */
+    private function requireParam(array $arguments, string $param): string
+    {
+        if (isset($arguments[$param]) === false || $arguments[$param] === '') {
+            throw new InvalidArgumentException('Missing required parameter: '.$param);
+        }
+
+        return (string) $arguments[$param];
+    }//end requireParam()
+}//end class

--- a/tests/Unit/Capabilities/IntegrationsCapabilityTest.php
+++ b/tests/Unit/Capabilities/IntegrationsCapabilityTest.php
@@ -1,0 +1,283 @@
+<?php
+
+/**
+ * Unit tests for IntegrationsCapability — the OCS capabilities surface
+ * that advertises the pluggable integration registry (ADR-019).
+ *
+ * Covers:
+ *  - payload shape: openregister.integrations.{contractVersion, registered, providers}
+ *  - per-provider descriptor fields (id, label, requiredApp, available,
+ *    storageStrategy, surfaces)
+ *  - `available` reflects IAppManager::isEnabledForUser() for the backing app
+ *  - built-in providers (requiredApp null) are always available
+ *  - role redaction: admins get operational fields, non-admins do not
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Capabilities
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/pluggable-integration-registry/proposal.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Capabilities;
+
+use OCA\OpenRegister\Capabilities\IntegrationsCapability;
+use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
+use OCA\OpenRegister\Service\Integration\IntegrationRegistry;
+use OCP\App\IAppManager;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * In-memory provider stub for capability descriptor assertions.
+ */
+class _CapStubProvider extends AbstractIntegrationProvider
+{
+
+    public function __construct(
+        private string $id = 'stub',
+        private ?string $requiredApp = null,
+        private string $storage = 'magic-column',
+        private bool $enabled = true,
+    ) {
+    }//end __construct()
+
+    public function getId(): string
+    {
+        return $this->id;
+    }//end getId()
+
+    public function getLabel(): string
+    {
+        return ucfirst($this->id);
+    }//end getLabel()
+
+    public function getIcon(): string
+    {
+        return 'Cube';
+    }//end getIcon()
+
+    public function getRequiredApp(): ?string
+    {
+        return $this->requiredApp;
+    }//end getRequiredApp()
+
+    public function getStorageStrategy(): string
+    {
+        return $this->storage;
+    }//end getStorageStrategy()
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }//end isEnabled()
+
+    public function list(string $register, string $schema, string $objectId, array $filters = []): array
+    {
+        return [];
+    }//end list()
+}//end class
+
+/**
+ * Unit tests for IntegrationsCapability.
+ */
+class IntegrationsCapabilityTest extends TestCase
+{
+
+    /**
+     * Build a registry seeded with the given providers.
+     *
+     * @param array<int, AbstractIntegrationProvider> $providers Providers.
+     *
+     * @return IntegrationRegistry
+     */
+    private function registryWith(array $providers): IntegrationRegistry
+    {
+        $registry = new IntegrationRegistry(new NullLogger());
+        $registry->withProviders($providers);
+        return $registry;
+    }//end registryWith()
+
+    /**
+     * Build a user session resolving to a user with the given uid (or null).
+     *
+     * @param string|null $uid User id, or null for an unauthenticated session.
+     *
+     * @return IUserSession
+     */
+    private function userSession(?string $uid): IUserSession
+    {
+        $session = $this->createMock(IUserSession::class);
+        if ($uid === null) {
+            $session->method('getUser')->willReturn(null);
+            return $session;
+        }
+
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $session->method('getUser')->willReturn($user);
+        return $session;
+    }//end userSession()
+
+    /**
+     * Build a group manager with a fixed admin verdict.
+     *
+     * @param bool $isAdmin Whether the user is considered admin.
+     *
+     * @return IGroupManager
+     */
+    private function groupManager(bool $isAdmin): IGroupManager
+    {
+        $gm = $this->createMock(IGroupManager::class);
+        $gm->method('isAdmin')->willReturn($isAdmin);
+        return $gm;
+    }//end groupManager()
+
+    /**
+     * Build an app manager that reports the given app ids as enabled.
+     *
+     * @param array<int, string> $enabledApps Enabled app ids.
+     *
+     * @return IAppManager
+     */
+    private function appManager(array $enabledApps): IAppManager
+    {
+        $am = $this->createMock(IAppManager::class);
+        $am->method('isEnabledForUser')->willReturnCallback(
+            fn ($appId) => in_array($appId, $enabledApps, true)
+        );
+        return $am;
+    }//end appManager()
+
+    /**
+     * The capability publishes the ADR-019 discovery shape.
+     *
+     * @return void
+     */
+    public function testPayloadShape(): void
+    {
+        $cap = new IntegrationsCapability(
+            registry: $this->registryWith([new _CapStubProvider(id: 'files')]),
+            userSession: $this->userSession(uid: 'alice'),
+            groupManager: $this->groupManager(isAdmin: false),
+            appManager: $this->appManager(enabledApps: [])
+        );
+
+        $payload = $cap->getCapabilities();
+
+        $this->assertArrayHasKey('openregister', $payload);
+        $integrations = $payload['openregister']['integrations'];
+        $this->assertSame(IntegrationsCapability::CONTRACT_VERSION, $integrations['contractVersion']);
+        $this->assertSame(IntegrationsCapability::CONTRACT_VERSION, $integrations['version']);
+        $this->assertSame(['files'], $integrations['registered']);
+        $this->assertCount(1, $integrations['providers']);
+    }//end testPayloadShape()
+
+    /**
+     * Built-in providers (requiredApp null) are always available.
+     *
+     * @return void
+     */
+    public function testBuiltinProviderAlwaysAvailable(): void
+    {
+        $cap = new IntegrationsCapability(
+            registry: $this->registryWith([new _CapStubProvider(id: 'tags', requiredApp: null)]),
+            userSession: $this->userSession(uid: 'alice'),
+            groupManager: $this->groupManager(isAdmin: false),
+            appManager: $this->appManager(enabledApps: [])
+        );
+
+        $row = $cap->getCapabilities()['openregister']['integrations']['providers'][0];
+
+        $this->assertNull($row['requiredApp']);
+        $this->assertTrue($row['available']);
+    }//end testBuiltinProviderAlwaysAvailable()
+
+    /**
+     * `available` reflects whether the backing NC app is installed.
+     *
+     * @return void
+     */
+    public function testAvailableReflectsInstalledApp(): void
+    {
+        $registry = $this->registryWith(
+            [
+                new _CapStubProvider(id: 'calendar', requiredApp: 'calendar'),
+                new _CapStubProvider(id: 'deck', requiredApp: 'deck'),
+            ]
+        );
+
+        $cap = new IntegrationsCapability(
+            registry: $registry,
+            userSession: $this->userSession(uid: 'alice'),
+            groupManager: $this->groupManager(isAdmin: false),
+            // Only `calendar` is installed; `deck` is not.
+            appManager: $this->appManager(enabledApps: ['calendar'])
+        );
+
+        $rows = $cap->getCapabilities()['openregister']['integrations']['providers'];
+        $byId = [];
+        foreach ($rows as $row) {
+            $byId[$row['id']] = $row;
+        }
+
+        $this->assertTrue($byId['calendar']['available']);
+        $this->assertSame('calendar', $byId['calendar']['requiredApp']);
+        $this->assertFalse($byId['deck']['available']);
+        $this->assertSame('deck', $byId['deck']['requiredApp']);
+    }//end testAvailableReflectsInstalledApp()
+
+    /**
+     * Non-admins get the public surface only (no operational fields).
+     *
+     * @return void
+     */
+    public function testNonAdminRedaction(): void
+    {
+        $cap = new IntegrationsCapability(
+            registry: $this->registryWith([new _CapStubProvider(id: 'files')]),
+            userSession: $this->userSession(uid: 'bob'),
+            groupManager: $this->groupManager(isAdmin: false),
+            appManager: $this->appManager(enabledApps: [])
+        );
+
+        $row = $cap->getCapabilities()['openregister']['integrations']['providers'][0];
+
+        $this->assertArrayHasKey('id', $row);
+        $this->assertArrayHasKey('available', $row);
+        $this->assertArrayNotHasKey('requiresPermission', $row);
+        $this->assertArrayNotHasKey('authStatus', $row);
+        $this->assertArrayNotHasKey('openConnectorSource', $row);
+    }//end testNonAdminRedaction()
+
+    /**
+     * Admins additionally receive the operational fields.
+     *
+     * @return void
+     */
+    public function testAdminGetsOperationalFields(): void
+    {
+        $cap = new IntegrationsCapability(
+            registry: $this->registryWith([new _CapStubProvider(id: 'files')]),
+            userSession: $this->userSession(uid: 'admin'),
+            groupManager: $this->groupManager(isAdmin: true),
+            appManager: $this->appManager(enabledApps: [])
+        );
+
+        $row = $cap->getCapabilities()['openregister']['integrations']['providers'][0];
+
+        $this->assertArrayHasKey('requiresPermission', $row);
+        $this->assertArrayHasKey('authStatus', $row);
+        $this->assertArrayHasKey('openConnectorSource', $row);
+    }//end testAdminGetsOperationalFields()
+}//end class

--- a/tests/Unit/Mcp/BuiltIn/IntegrationsToolProviderTest.php
+++ b/tests/Unit/Mcp/BuiltIn/IntegrationsToolProviderTest.php
@@ -1,0 +1,326 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit tests for IntegrationsToolProvider — the MCP discovery surface for
+ * the pluggable integration registry (ADR-019 / ADR-022 "MCP discovery").
+ *
+ * Covers:
+ *  - getAppId / namespaced tool id
+ *  - action "list-integrations" enumerates registered ids + descriptors
+ *  - action "list" delegates to the matched provider->list()
+ *  - action "get" delegates to provider->get()
+ *  - action "link"/"create" delegate to provider->create()
+ *  - unknown integration id / disabled provider raise InvalidArgumentException
+ *  - missing required params raise InvalidArgumentException
+ *  - unknown action raises InvalidArgumentException
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Mcp\BuiltIn
+ * @author   Conduction Development Team <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://conduction.nl
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Mcp\BuiltIn;
+
+use InvalidArgumentException;
+use OCA\OpenRegister\Mcp\BuiltIn\IntegrationsToolProvider;
+use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
+use OCA\OpenRegister\Service\Integration\IntegrationRegistry;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * In-memory provider stub recording delegated calls.
+ */
+class _McpStubProvider extends AbstractIntegrationProvider
+{
+
+    public array $listCalled   = [];
+    public array $getCalled    = [];
+    public array $createCalled = [];
+
+    public function __construct(
+        private string $id = 'files',
+        private ?string $requiredApp = 'files',
+        private string $storage = 'magic-column',
+        private bool $enabled = true,
+    ) {
+    }//end __construct()
+
+    public function getId(): string
+    {
+        return $this->id;
+    }//end getId()
+
+    public function getLabel(): string
+    {
+        return ucfirst($this->id);
+    }//end getLabel()
+
+    public function getIcon(): string
+    {
+        return 'Paperclip';
+    }//end getIcon()
+
+    public function getRequiredApp(): ?string
+    {
+        return $this->requiredApp;
+    }//end getRequiredApp()
+
+    public function getStorageStrategy(): string
+    {
+        return $this->storage;
+    }//end getStorageStrategy()
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }//end isEnabled()
+
+    public function list(string $register, string $schema, string $objectId, array $filters = []): array
+    {
+        $this->listCalled = compact('register', 'schema', 'objectId', 'filters');
+        return [['id' => 'a'], ['id' => 'b']];
+    }//end list()
+
+    public function get(string $register, string $schema, string $objectId, string $entityId): array
+    {
+        $this->getCalled = compact('register', 'schema', 'objectId', 'entityId');
+        return ['id' => $entityId, 'name' => 'thing'];
+    }//end get()
+
+    public function create(string $register, string $schema, string $objectId, array $payload): array
+    {
+        $this->createCalled = compact('register', 'schema', 'objectId', 'payload');
+        return ['id' => 'new-id'];
+    }//end create()
+}//end class
+
+/**
+ * Unit tests for IntegrationsToolProvider.
+ */
+class IntegrationsToolProviderTest extends TestCase
+{
+
+    /**
+     * Build a provider over a registry seeded with the given providers.
+     *
+     * @param array<int, AbstractIntegrationProvider> $providers Providers.
+     *
+     * @return IntegrationsToolProvider
+     */
+    private function build(array $providers): IntegrationsToolProvider
+    {
+        $registry = new IntegrationRegistry(new NullLogger());
+        $registry->withProviders($providers);
+        return new IntegrationsToolProvider($registry);
+    }//end build()
+
+    /**
+     * App id + descriptor namespace.
+     *
+     * @return void
+     */
+    public function testToolDescriptor(): void
+    {
+        $provider = $this->build([]);
+
+        $this->assertSame('openregister', $provider->getAppId());
+
+        $tools = $provider->getTools();
+        $this->assertCount(1, $tools);
+        $this->assertSame(IntegrationsToolProvider::TOOL_ID, $tools[0]['id']);
+        $this->assertStringStartsWith('openregister.', $tools[0]['id']);
+    }//end testToolDescriptor()
+
+    /**
+     * "list-integrations" enumerates registered ids + descriptors.
+     *
+     * @return void
+     */
+    public function testListIntegrationsDiscovery(): void
+    {
+        $provider = $this->build(
+            [
+                new _McpStubProvider(id: 'files', requiredApp: 'files'),
+                new _McpStubProvider(id: 'calendar', requiredApp: 'calendar'),
+            ]
+        );
+
+        $result = $provider->invokeTool(
+            toolId: IntegrationsToolProvider::TOOL_ID,
+            arguments: ['action' => 'list-integrations']
+        );
+
+        $this->assertSame(['files', 'calendar'], $result['registered']);
+        $this->assertCount(2, $result['integrations']);
+        $this->assertSame('files', $result['integrations'][0]['id']);
+        $this->assertSame('files', $result['integrations'][0]['requiredApp']);
+        $this->assertSame('magic-column', $result['integrations'][0]['storageStrategy']);
+    }//end testListIntegrationsDiscovery()
+
+    /**
+     * "list" delegates to the matched provider's list().
+     *
+     * @return void
+     */
+    public function testListDelegates(): void
+    {
+        $stub     = new _McpStubProvider(id: 'files');
+        $provider = $this->build([$stub]);
+
+        $result = $provider->invokeTool(
+            toolId: IntegrationsToolProvider::TOOL_ID,
+            arguments: [
+                'action'        => 'list',
+                'integrationId' => 'files',
+                'register'      => 'reg',
+                'schema'        => 'sch',
+                'objectId'      => 'obj-1',
+                'filters'       => ['_limit' => 5],
+            ]
+        );
+
+        $this->assertSame([['id' => 'a'], ['id' => 'b']], $result['items']);
+        $this->assertSame('reg', $stub->listCalled['register']);
+        $this->assertSame('obj-1', $stub->listCalled['objectId']);
+        $this->assertSame(['_limit' => 5], $stub->listCalled['filters']);
+    }//end testListDelegates()
+
+    /**
+     * "get" delegates to provider->get().
+     *
+     * @return void
+     */
+    public function testGetDelegates(): void
+    {
+        $stub     = new _McpStubProvider(id: 'files');
+        $provider = $this->build([$stub]);
+
+        $result = $provider->invokeTool(
+            toolId: IntegrationsToolProvider::TOOL_ID,
+            arguments: [
+                'action'        => 'get',
+                'integrationId' => 'files',
+                'register'      => 'reg',
+                'schema'        => 'sch',
+                'objectId'      => 'obj-1',
+                'entityId'      => 'ent-9',
+            ]
+        );
+
+        $this->assertSame('ent-9', $result['id']);
+        $this->assertSame('ent-9', $stub->getCalled['entityId']);
+    }//end testGetDelegates()
+
+    /**
+     * "link" and "create" both delegate to provider->create().
+     *
+     * @return void
+     */
+    public function testLinkAndCreateDelegate(): void
+    {
+        $stub     = new _McpStubProvider(id: 'files');
+        $provider = $this->build([$stub]);
+
+        foreach (['link', 'create'] as $action) {
+            $result = $provider->invokeTool(
+                toolId: IntegrationsToolProvider::TOOL_ID,
+                arguments: [
+                    'action'        => $action,
+                    'integrationId' => 'files',
+                    'register'      => 'reg',
+                    'schema'        => 'sch',
+                    'objectId'      => 'obj-1',
+                    'payload'       => ['name' => 'doc'],
+                ]
+            );
+
+            $this->assertSame('new-id', $result['id']);
+            $this->assertSame(['name' => 'doc'], $stub->createCalled['payload']);
+        }
+    }//end testLinkAndCreateDelegate()
+
+    /**
+     * Unknown integration id raises InvalidArgumentException.
+     *
+     * @return void
+     */
+    public function testUnknownIntegrationThrows(): void
+    {
+        $provider = $this->build([new _McpStubProvider(id: 'files')]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $provider->invokeTool(
+            toolId: IntegrationsToolProvider::TOOL_ID,
+            arguments: [
+                'action'        => 'list',
+                'integrationId' => 'nope',
+                'register'      => 'reg',
+                'schema'        => 'sch',
+                'objectId'      => 'obj-1',
+            ]
+        );
+    }//end testUnknownIntegrationThrows()
+
+    /**
+     * A disabled provider is not invokable.
+     *
+     * @return void
+     */
+    public function testDisabledProviderThrows(): void
+    {
+        $provider = $this->build([new _McpStubProvider(id: 'files', enabled: false)]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $provider->invokeTool(
+            toolId: IntegrationsToolProvider::TOOL_ID,
+            arguments: [
+                'action'        => 'list',
+                'integrationId' => 'files',
+                'register'      => 'reg',
+                'schema'        => 'sch',
+                'objectId'      => 'obj-1',
+            ]
+        );
+    }//end testDisabledProviderThrows()
+
+    /**
+     * Missing required parameter raises InvalidArgumentException.
+     *
+     * @return void
+     */
+    public function testMissingParamThrows(): void
+    {
+        $provider = $this->build([new _McpStubProvider(id: 'files')]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $provider->invokeTool(
+            toolId: IntegrationsToolProvider::TOOL_ID,
+            arguments: [
+                'action'        => 'list',
+                'integrationId' => 'files',
+                // register/schema/objectId omitted.
+            ]
+        );
+    }//end testMissingParamThrows()
+
+    /**
+     * Unknown action raises InvalidArgumentException.
+     *
+     * @return void
+     */
+    public function testUnknownActionThrows(): void
+    {
+        $provider = $this->build([new _McpStubProvider(id: 'files')]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $provider->invokeTool(
+            toolId: IntegrationsToolProvider::TOOL_ID,
+            arguments: ['action' => 'bogus']
+        );
+    }//end testUnknownActionThrows()
+}//end class


### PR DESCRIPTION
## Summary

Phase J-B (Tier 3): delivers the two discovery surfaces ADR-019 promised for the pluggable integration registry — OCS capabilities and MCP discovery. Backend-only (openregister); no nc-vue changes.

### J2 — OCS capabilities surface

Extends the existing `IntegrationsCapability` (registered in Phase E) with the ADR-019 discoverability contract. Under `openregister.integrations`:

- `contractVersion` (+ `version` kept for back-compat) — the registry's discovery-contract version
- `registered` — flat id list (mirrors `IntegrationRegistry::listIds()`)
- per-provider descriptors now carry `requiredApp` and `available` (reflecting `IAppManager::isEnabledForUser()`; built-ins with null `requiredApp` are always available)

Existing AD-17 role redaction is preserved: non-admins get the public surface; admins additionally get `requiresPermission`, `openConnectorSource`, `authStatus`.

### J3 — MCP discovery

OpenRegister already ships full MCP infrastructure (`IMcpToolProvider`, `McpToolsService` aggregator, built-in providers). Adds `IntegrationsToolProvider` as a **fourth built-in** (registered in `Application::registerMcpToolProviders` — `addProvider()` is appId-deduped so a separate registration would be dropped). The `openregister.integrations` tool exposes:

- `list-integrations` — discovery: enumerate registered integrations + metadata
- `list` / `get` / `link` / `create` — delegate to the matched `IntegrationProvider`, inheriting its storage-strategy semantics (query-time/list-only providers throw `NotImplementedException`, surfaced as an MCP error envelope). Disabled/unknown integrations are rejected.

## Test plan

- [x] `IntegrationsCapabilityTest` (5 tests): payload shape, built-in always-available, `available` tracks installed app, admin/non-admin redaction
- [x] `IntegrationsToolProviderTest` (9 tests): descriptor namespace, discovery action, list/get/link/create delegation, error paths
- [x] No regression in existing MCP suite (61) + ObjectIntegrationsController/IntegrationRegistry (15)
- [x] PHPCS: 0 errors (only codebase-wide advisory `@spec` warnings, matching existing built-in providers)

Refs: ADR-019 (OCS discoverability), ADR-022 (MCP discovery abstraction).