### PR TITLE
fix(security): wire rate-limiting into inbound auth (#1834)

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -327,6 +327,13 @@ class Application extends App implements IBootstrap
         // POST/PUT/PATCH with `?_validate=true`; pass-through otherwise.
         $context->registerMiddleware(\OCA\OpenRegister\Middleware\OasValidationMiddleware::class);
 
+        // Register the RateLimitMiddleware to wire SecurityService brute-force
+        // protection into the inbound API auth path (issue #1834). Records
+        // failed Basic/Bearer/session auth on protected endpoints (keyed on
+        // identity+trusted-IP) and pre-emptively blocks locked-out callers.
+        // Fail-OPEN: any limiter error allows the request through.
+        $context->registerMiddleware(\OCA\OpenRegister\Middleware\RateLimitMiddleware::class);
+
         // Register all services in phases to resolve circular dependencies.
         $this->registerMappersWithCircularDependencies(context: $context);
         $this->registerCacheAndFileHandlers(context: $context);

--- a/lib/Middleware/AuthRateLimitExceededException.php
+++ b/lib/Middleware/AuthRateLimitExceededException.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Auth Rate Limit Exceeded Exception
+ *
+ * Thrown by RateLimitMiddleware when an (identity + IP) pair has exceeded the
+ * inbound-API brute-force threshold and is temporarily locked out (issue #1834).
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Exception
+ * @package  OCA\OpenRegister\Middleware
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-3
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Middleware;
+
+use Exception;
+use OCP\AppFramework\Http;
+
+/**
+ * Exception for an exceeded inbound-API authentication rate limit.
+ *
+ * @package OCA\OpenRegister\Middleware
+ */
+class AuthRateLimitExceededException extends Exception
+{
+    /**
+     * Constructor
+     *
+     * @param string $message      The error message
+     * @param int    $lockoutUntil Unix timestamp the lockout expires at (0 if unknown)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-3
+     */
+    public function __construct(
+        string $message,
+        private readonly int $lockoutUntil=0
+    ) {
+        parent::__construct(message: $message, code: Http::STATUS_TOO_MANY_REQUESTS);
+    }//end __construct()
+
+    /**
+     * Get the Unix timestamp the lockout expires at.
+     *
+     * @return int The lockout expiry timestamp, or 0 when unknown
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-3
+     */
+    public function getLockoutUntil(): int
+    {
+        return $this->lockoutUntil;
+    }//end getLockoutUntil()
+}//end class

--- a/lib/Middleware/RateLimitMiddleware.php
+++ b/lib/Middleware/RateLimitMiddleware.php
@@ -1,0 +1,315 @@
+<?php
+
+/**
+ * Rate Limit Middleware
+ *
+ * Wires SecurityService brute-force protection into the inbound API
+ * authentication path (issue #1834). Nextcloud's core SecurityMiddleware
+ * runs BEFORE app middleware and throws NotLoggedInException / NotAdminException
+ * when Basic/Bearer/session credentials fail on a protected endpoint. Because
+ * app middleware is wrapped OUTSIDE the core middleware in the dispatch chain,
+ * this middleware's afterException() observes those failures and records them
+ * for rate-limiting; its beforeController() pre-emptively blocks once a
+ * (identity + IP) pair is locked out.
+ *
+ * Design guarantees:
+ * - FAIL-OPEN: any error inside this middleware allows the request through.
+ *   A bug in the limiter must never deny service to every client.
+ * - Only failures on PROTECTED endpoints are counted. Public pages
+ *   (@PublicPage) are never rate-limited here.
+ * - Successful authenticated requests are NEVER blocked; they only clear
+ *   accumulated failure counters for that identity.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Middleware
+ * @package  OCA\OpenRegister\Middleware
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-3
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Middleware;
+
+use OCA\OpenRegister\Service\SecurityService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\Response;
+use OCP\AppFramework\Middleware;
+use OCP\AppFramework\Utility\IControllerMethodReflector;
+use OCP\IRequest;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Middleware that rate-limits failed inbound-API authentication attempts.
+ *
+ * @package OCA\OpenRegister\Middleware
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class RateLimitMiddleware extends Middleware
+{
+    /**
+     * Constructor.
+     *
+     * @param IRequest                   $request         The current request
+     * @param IUserSession               $userSession     The user session
+     * @param IControllerMethodReflector $reflector       Reflector for controller annotations
+     * @param SecurityService            $securityService The security service
+     * @param LoggerInterface            $logger          Logger for security events
+     */
+    public function __construct(
+        private readonly IRequest $request,
+        private readonly IUserSession $userSession,
+        private readonly IControllerMethodReflector $reflector,
+        private readonly SecurityService $securityService,
+        private readonly LoggerInterface $logger
+    ) {
+    }//end __construct()
+
+    /**
+     * Pre-emptively block a request whose (identity + IP) pair is locked out.
+     *
+     * Runs before the controller. Skips public pages entirely. Fails OPEN:
+     * any error here allows the request through.
+     *
+     * @param Controller $controller The controller being dispatched
+     * @param string     $methodName The method being dispatched
+     *
+     * @return void
+     *
+     * @throws AuthRateLimitExceededException When the identity+IP is locked out
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-3
+     */
+    public function beforeController(Controller $controller, string $methodName): void
+    {
+        try {
+            // Only guard protected endpoints. Public pages are out of scope.
+            if ($this->isPublicPage(controller: $controller, methodName: $methodName) === true) {
+                return;
+            }
+
+            $ip       = $this->securityService->getTrustedClientIpAddress(request: $this->request);
+            $identity = $this->resolveIdentity();
+
+            $check = $this->securityService->checkAuthRateLimit(identity: $identity, ipAddress: $ip);
+            if (($check['allowed'] ?? true) === false) {
+                throw new AuthRateLimitExceededException(
+                    message: (string) ($check['reason'] ?? 'Too many failed authentication attempts.'),
+                    lockoutUntil: (int) ($check['lockout_until'] ?? 0)
+                );
+            }
+        } catch (AuthRateLimitExceededException $e) {
+            // Intentional lockout — let it propagate to afterException().
+            throw $e;
+        } catch (Throwable $e) {
+            // FAIL-OPEN: never block a request because the limiter errored.
+            $this->logger->warning(
+                '[RateLimitMiddleware] Rate-limit precheck failed open: '.$e->getMessage(),
+                ['file' => __FILE__, 'line' => __LINE__]
+            );
+        }//end try
+    }//end beforeController()
+
+    /**
+     * Clear failure counters after a successful authenticated request.
+     *
+     * Fails OPEN: never alters the response on error.
+     *
+     * @param Controller $controller The controller that was dispatched
+     * @param string     $methodName The method that was dispatched
+     * @param Response   $response   The response produced
+     *
+     * @return Response The unmodified response
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-3
+     */
+    public function afterController(Controller $controller, string $methodName, Response $response): Response
+    {
+        try {
+            $user = $this->userSession->getUser();
+            if ($user === null) {
+                return $response;
+            }
+
+            $ip = $this->securityService->getTrustedClientIpAddress(request: $this->request);
+            $this->securityService->recordSuccessfulAuth(identity: $user->getUID(), ipAddress: $ip);
+        } catch (Throwable $e) {
+            $this->logger->debug(
+                '[RateLimitMiddleware] recordSuccessfulAuth failed open: '.$e->getMessage(),
+                ['file' => __FILE__, 'line' => __LINE__]
+            );
+        }
+
+        return $response;
+    }//end afterController()
+
+    /**
+     * Record auth failures and surface the lockout response.
+     *
+     * Recognises:
+     * - AuthRateLimitExceededException (thrown by beforeController): returns 429.
+     * - Nextcloud core auth failures (NotLoggedInException / NotAdminException
+     *   / SecurityException with a 401/403 status) on a protected endpoint:
+     *   records a failed attempt, then RE-THROWS the original exception so
+     *   the normal Nextcloud error handling is preserved.
+     *
+     * Fails OPEN: recording errors never change the outcome; the original
+     * exception is always preserved for unrecognised cases.
+     *
+     * @param Controller $controller The controller that was dispatched
+     * @param string     $methodName The method that was dispatched
+     * @param \Exception $exception  The thrown exception
+     *
+     * @return Response|null A 429 response for an enforced lockout, otherwise null
+     *
+     * @throws \Exception The original exception is re-thrown for all non-lockout cases
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-3
+     */
+    public function afterException(Controller $controller, string $methodName, \Exception $exception): ?Response
+    {
+        // Enforced lockout: return a clean 429.
+        if ($exception instanceof AuthRateLimitExceededException) {
+            $response = new JSONResponse(
+                ['error' => $exception->getMessage(), 'lockout_until' => $exception->getLockoutUntil()],
+                Http::STATUS_TOO_MANY_REQUESTS
+            );
+
+            $retryAfter = max(1, ($exception->getLockoutUntil() - time()));
+            $response->addHeader('Retry-After', (string) $retryAfter);
+
+            return $response;
+        }
+
+        // Otherwise: only count genuine auth failures on protected endpoints,
+        // then re-throw so Nextcloud handles the response unchanged.
+        try {
+            if ($this->isAuthFailure(exception: $exception) === true
+                && $this->isPublicPage(controller: $controller, methodName: $methodName) === false
+            ) {
+                $ip       = $this->securityService->getTrustedClientIpAddress(request: $this->request);
+                $identity = $this->resolveIdentity();
+                $this->securityService->recordFailedAuthAttempt(
+                    identity: $identity,
+                    ipAddress: $ip,
+                    reason: 'inbound_auth_failed'
+                );
+            }
+        } catch (Throwable $e) {
+            // FAIL-OPEN: recording must not interfere with the original error.
+            $this->logger->warning(
+                '[RateLimitMiddleware] recordFailedAuthAttempt failed open: '.$e->getMessage(),
+                ['file' => __FILE__, 'line' => __LINE__]
+            );
+        }
+
+        throw $exception;
+    }//end afterException()
+
+    /**
+     * Determine whether the dispatched method is a public page.
+     *
+     * @param Controller $controller The controller being dispatched
+     * @param string     $methodName The method being dispatched
+     *
+     * @return bool True when the endpoint is public (skip rate-limiting)
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    private function isPublicPage(Controller $controller, string $methodName): bool
+    {
+        try {
+            $this->reflector->reflect($controller, $methodName);
+            return $this->reflector->hasAnnotation('PublicPage');
+        } catch (Throwable $e) {
+            // If reflection fails, treat as protected (safer: we may rate-limit,
+            // but we never accidentally exempt a protected endpoint).
+            return false;
+        }
+    }//end isPublicPage()
+
+    /**
+     * Decide whether an exception represents a failed authentication on a
+     * protected endpoint that should count toward brute-force limits.
+     *
+     * Matches Nextcloud's auth exceptions by class short-name (they live in
+     * the private OC\ namespace) and any SecurityException carrying a 401/403
+     * status code.
+     *
+     * @param \Throwable $exception The exception to classify
+     *
+     * @return bool True when the exception is an auth failure
+     */
+    private function isAuthFailure(\Throwable $exception): bool
+    {
+        $shortName = (new \ReflectionClass($exception))->getShortName();
+        if (in_array($shortName, ['NotLoggedInException', 'NotAdminException'], true) === true) {
+            return true;
+        }
+
+        // SecurityException (e.g. forbidden password login, CORS basic-auth)
+        // carries an HTTP status; treat 401/403 as auth failures.
+        $code = $exception->getCode();
+        if (($code === Http::STATUS_UNAUTHORIZED || $code === Http::STATUS_FORBIDDEN)
+            && str_contains(strtolower($shortName), 'security') === true
+        ) {
+            return true;
+        }
+
+        return false;
+    }//end isAuthFailure()
+
+    /**
+     * Resolve the identity for keying the rate-limit counter.
+     *
+     * Prefers the currently logged-in user (success path / partial auth);
+     * otherwise extracts the attempted username from an HTTP Basic
+     * Authorization header (NEVER the password). Falls back to '' (anonymous)
+     * when no identity is discoverable, in which case the per-IP backstop
+     * still applies.
+     *
+     * @return string The identity, or '' when unknown
+     */
+    private function resolveIdentity(): string
+    {
+        try {
+            $user = $this->userSession->getUser();
+            if ($user !== null) {
+                return $user->getUID();
+            }
+
+            $authHeader = $this->request->getHeader('Authorization');
+            if ($authHeader !== '' && stripos($authHeader, 'Basic ') === 0) {
+                $decoded = base64_decode(substr($authHeader, 6), true);
+                if ($decoded !== false && str_contains($decoded, ':') === true) {
+                    [$username] = explode(':', $decoded, 2);
+                    return $username;
+                }
+            }
+        } catch (Throwable $e) {
+            // Fall through to anonymous.
+            unset($e);
+        }
+
+        return '';
+    }//end resolveIdentity()
+}//end class

--- a/lib/Service/SecurityService.php
+++ b/lib/Service/SecurityService.php
@@ -72,6 +72,22 @@ class SecurityService
     private const MAX_PROGRESSIVE_DELAY  = 60;
 
     /**
+     * Inbound-API brute-force configuration constants.
+     *
+     * These are intentionally MORE generous than the interactive-login
+     * constants above. Inbound API auth is wired into a middleware that
+     * sees every authenticated request, so a tight threshold risks locking
+     * out legitimate automated traffic (mis-configured token in a cron job,
+     * a single client behind a shared NAT, etc). The composite identity+IP
+     * key (see checkAuthRateLimit) keeps a single bad actor from poisoning a
+     * shared IP, so we can afford a higher per-IP fallback ceiling.
+     */
+    private const AUTH_RATE_LIMIT_ATTEMPTS    = 20;
+    private const AUTH_RATE_LIMIT_IP_ATTEMPTS = 100;
+    private const AUTH_RATE_LIMIT_WINDOW      = 900;
+    private const AUTH_LOCKOUT_DURATION       = 900;
+
+    /**
      * Cache key prefixes for different security features
      */
     private const CACHE_PREFIX_LOGIN_ATTEMPTS    = 'openregister_login_attempts_';
@@ -79,6 +95,17 @@ class SecurityService
     private const CACHE_PREFIX_USER_LOCKOUT      = 'openregister_user_lockout_';
     private const CACHE_PREFIX_IP_LOCKOUT        = 'openregister_ip_lockout_';
     private const CACHE_PREFIX_PROGRESSIVE_DELAY = 'openregister_progressive_delay_';
+
+    /**
+     * Cache key prefixes for the inbound-API brute-force path.
+     *
+     * Kept separate from the interactive-login prefixes so the two paths
+     * never share counters: locking out a brute-forced API token must not
+     * lock the same identity out of the login form, and vice-versa.
+     */
+    private const CACHE_PREFIX_AUTH_ATTEMPTS    = 'openregister_auth_attempts_';
+    private const CACHE_PREFIX_AUTH_IP_ATTEMPTS = 'openregister_auth_ip_attempts_';
+    private const CACHE_PREFIX_AUTH_LOCKOUT     = 'openregister_auth_lockout_';
 
     /**
      * Constructor for SecurityService
@@ -350,6 +377,170 @@ class SecurityService
     }//end clearUserRateLimits()
 
     /**
+     * Check whether an inbound-API authentication attempt is allowed.
+     *
+     * This powers the brute-force protection wired into the inbound auth
+     * middleware (issue #1834). It is deliberately distinct from
+     * checkLoginRateLimit():
+     *
+     * - Lockout is keyed on a COMPOSITE (identity + IP) so a single bad
+     *   actor on a shared NAT/proxy IP cannot lock out, or reset the
+     *   counter of, other legitimate clients sharing that IP (issue #1834
+     *   item 2). A much higher per-IP ceiling is kept purely as a
+     *   coarse-grained backstop against a high-volume sprayer.
+     * - Thresholds are generous (see AUTH_RATE_LIMIT_* constants) to avoid
+     *   locking out legitimate automated traffic.
+     *
+     * The caller (middleware) MUST fail OPEN: if this method throws, the
+     * request should be allowed through. A bug in the limiter must never
+     * deny service to every client.
+     *
+     * @param string $identity  The authentication identity (username/token id) or '' if unknown
+     * @param string $ipAddress The trusted client IP address of the request
+     *
+     * @return array{allowed: bool, lockout_until?: int, reason?: string} Result
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-3
+     */
+    public function checkAuthRateLimit(string $identity, string $ipAddress): array
+    {
+        $compositeKey = $this->buildAuthCompositeKey(identity: $identity, ipAddress: $ipAddress);
+        $ipAddress    = $this->sanitizeForCacheKey(input: $ipAddress);
+
+        // Composite (identity+IP) lockout — the primary, narrowly-scoped gate.
+        $lockoutKey   = self::CACHE_PREFIX_AUTH_LOCKOUT.$compositeKey;
+        $lockoutUntil = $this->cache->get($lockoutKey);
+        if ($lockoutUntil !== null && $lockoutUntil > time()) {
+            return [
+                'allowed'       => false,
+                'lockout_until' => $lockoutUntil,
+                'reason'        => 'Too many failed authentication attempts. Please wait before trying again.',
+            ];
+        }
+
+        return ['allowed' => true];
+    }//end checkAuthRateLimit()
+
+    /**
+     * Record a failed inbound-API authentication attempt.
+     *
+     * Increments the composite (identity+IP) counter and a coarse per-IP
+     * counter, applying a lockout when either threshold is crossed. Callers
+     * (the middleware) MUST swallow any exception this throws (fail-open).
+     *
+     * @param string $identity  The authentication identity (username/token id) or '' if unknown
+     * @param string $ipAddress The trusted client IP address of the failed attempt
+     * @param string $reason    The reason for authentication failure
+     *
+     * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-3
+     */
+    public function recordFailedAuthAttempt(string $identity, string $ipAddress, string $reason='inbound_auth_failed'): void
+    {
+        $compositeKey = $this->buildAuthCompositeKey(identity: $identity, ipAddress: $ipAddress);
+        $sanitizedIp  = $this->sanitizeForCacheKey(input: $ipAddress);
+
+        // Composite (identity+IP) counter — primary gate.
+        $attemptsKey = self::CACHE_PREFIX_AUTH_ATTEMPTS.$compositeKey;
+        $attempts    = ($this->cache->get($attemptsKey) ?? 0) + 1;
+        $this->cache->set($attemptsKey, $attempts, self::AUTH_RATE_LIMIT_WINDOW);
+
+        // Coarse per-IP counter — high-ceiling backstop only.
+        $ipAttemptsKey = self::CACHE_PREFIX_AUTH_IP_ATTEMPTS.$sanitizedIp;
+        $ipAttempts    = ($this->cache->get($ipAttemptsKey) ?? 0) + 1;
+        $this->cache->set($ipAttemptsKey, $ipAttempts, self::AUTH_RATE_LIMIT_WINDOW);
+
+        $lockoutTriggered = false;
+        if ($attempts >= self::AUTH_RATE_LIMIT_ATTEMPTS || $ipAttempts >= self::AUTH_RATE_LIMIT_IP_ATTEMPTS) {
+            $lockoutTriggered = true;
+            $lockoutUntil     = time() + self::AUTH_LOCKOUT_DURATION;
+            $lockoutKey       = self::CACHE_PREFIX_AUTH_LOCKOUT.$compositeKey;
+            $this->cache->set($lockoutKey, $lockoutUntil, self::AUTH_LOCKOUT_DURATION);
+
+            $this->logSecurityEvent(
+                event: 'auth_locked_out',
+                context: [
+                    'identity'      => $identity,
+                    'ip_address'    => $sanitizedIp,
+                    'attempts'      => $attempts,
+                    'ip_attempts'   => $ipAttempts,
+                    'lockout_until' => $lockoutUntil,
+                ]
+            );
+        }
+
+        $this->logSecurityEvent(
+            event: 'failed_auth_attempt',
+            context: [
+                'identity'          => $identity,
+                'ip_address'        => $sanitizedIp,
+                'reason'            => $reason,
+                'attempts'          => $attempts,
+                'ip_attempts'       => $ipAttempts,
+                'lockout_triggered' => $lockoutTriggered,
+            ]
+        );
+    }//end recordFailedAuthAttempt()
+
+    /**
+     * Clear the inbound-API auth rate-limit counters for an identity+IP.
+     *
+     * Called on a successful authenticated request so a single mistyped
+     * credential earlier in the window doesn't accumulate toward a lockout.
+     *
+     * @param string $identity  The authentication identity (username/token id)
+     * @param string $ipAddress The trusted client IP address
+     *
+     * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-3
+     */
+    public function recordSuccessfulAuth(string $identity, string $ipAddress): void
+    {
+        $compositeKey = $this->buildAuthCompositeKey(identity: $identity, ipAddress: $ipAddress);
+
+        $this->cache->remove(self::CACHE_PREFIX_AUTH_ATTEMPTS.$compositeKey);
+        $this->cache->remove(self::CACHE_PREFIX_AUTH_LOCKOUT.$compositeKey);
+    }//end recordSuccessfulAuth()
+
+    /**
+     * Resolve the trusted client IP address for rate-limiting purposes.
+     *
+     * Unlike getClientIpAddress() — which trusts forwarding headers from
+     * ANY source and is therefore spoofable (issue #1834 item 3) — this
+     * method defers entirely to the platform's getRemoteAddress(), which
+     * only honours forwarding headers from configured `trusted_proxies`.
+     * This is the correct primitive for security decisions.
+     *
+     * @param IRequest $request The request object
+     *
+     * @return string The trusted client IP address
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-5
+     */
+    public function getTrustedClientIpAddress(IRequest $request): string
+    {
+        return $request->getRemoteAddress();
+    }//end getTrustedClientIpAddress()
+
+    /**
+     * Build the composite (identity + IP) cache key for inbound-API auth.
+     *
+     * @param string $identity  The authentication identity, may be empty
+     * @param string $ipAddress The trusted client IP address
+     *
+     * @return string The sanitized composite cache key
+     */
+    private function buildAuthCompositeKey(string $identity, string $ipAddress): string
+    {
+        $identity = $this->sanitizeForCacheKey(input: ($identity !== '' ? $identity : 'anonymous'));
+        $ip       = $this->sanitizeForCacheKey(input: $ipAddress);
+
+        return $identity.'_'.$ip;
+    }//end buildAuthCompositeKey()
+
+    /**
      * Sanitize input data to prevent XSS and injection attacks
      *
      * @param mixed $input     The input to sanitize
@@ -544,6 +735,7 @@ class SecurityService
         switch ($event) {
             case 'user_locked_out':
             case 'login_attempt_during_lockout':
+            case 'auth_locked_out':
                 $this->logger->warning(
                     message: "[SecurityService] Security event: {$event}",
                     context: array_merge(['file' => __FILE__, 'line' => __LINE__], $context)

--- a/tests/Unit/Service/SecurityServiceTest.php
+++ b/tests/Unit/Service/SecurityServiceTest.php
@@ -326,4 +326,145 @@ class SecurityServiceTest extends TestCase
         // Private IP in forwarded header is rejected, falls back to remote address.
         $this->assertSame('10.0.0.1', $result);
     }
+
+    // ── getTrustedClientIpAddress (issue #1834 item 3) ──
+
+    public function testGetTrustedClientIpAddressUsesPlatformRemoteAddress(): void
+    {
+        $request = $this->createMock(IRequest::class);
+        // Even if a spoofed forwarding header is present, the trusted resolver
+        // must defer entirely to getRemoteAddress() (which is trusted-proxy aware).
+        $request->method('getRemoteAddress')->willReturn('203.0.113.7');
+        $request->expects($this->never())->method('getHeader');
+
+        $result = $this->service->getTrustedClientIpAddress($request);
+        $this->assertSame('203.0.113.7', $result);
+    }
+
+    // ── checkAuthRateLimit (issue #1834 item 1 + 2) ──
+
+    public function testCheckAuthRateLimitAllowsWhenNoLockout(): void
+    {
+        $this->cache->method('get')->willReturn(null);
+
+        $result = $this->service->checkAuthRateLimit('user1', '1.2.3.4');
+
+        $this->assertTrue($result['allowed']);
+    }
+
+    public function testCheckAuthRateLimitBlocksLockedOutCompositeKey(): void
+    {
+        $this->cache->method('get')->willReturnCallback(function (string $key) {
+            if (str_contains($key, 'auth_lockout')) {
+                return time() + 900;
+            }
+            return null;
+        });
+
+        $result = $this->service->checkAuthRateLimit('user1', '1.2.3.4');
+
+        $this->assertFalse($result['allowed']);
+        $this->assertArrayHasKey('lockout_until', $result);
+    }
+
+    public function testCheckAuthRateLimitAllowsExpiredLockout(): void
+    {
+        $this->cache->method('get')->willReturnCallback(function (string $key) {
+            if (str_contains($key, 'auth_lockout')) {
+                return time() - 1;
+            }
+            return null;
+        });
+
+        $result = $this->service->checkAuthRateLimit('user1', '1.2.3.4');
+
+        $this->assertTrue($result['allowed']);
+    }
+
+    public function testCheckAuthRateLimitIsolatesCompositeKeysPerIdentity(): void
+    {
+        // A lockout set for user1@ip must NOT be returned for user2@ip
+        // (shared-IP isolation — issue #1834 item 2). The composite key
+        // includes the sanitized identity, so a key built for a different
+        // identity simply won't match the lockout entry.
+        $this->cache->method('get')->willReturnCallback(function (string $key) {
+            // Only user1's composite lockout exists.
+            if (str_contains($key, 'auth_lockout') && str_contains($key, 'user1')) {
+                return time() + 900;
+            }
+            return null;
+        });
+
+        $this->assertFalse($this->service->checkAuthRateLimit('user1', '1.2.3.4')['allowed']);
+        $this->assertTrue($this->service->checkAuthRateLimit('user2', '1.2.3.4')['allowed']);
+    }
+
+    // ── recordFailedAuthAttempt ──
+
+    public function testRecordFailedAuthAttemptIncrementsCounters(): void
+    {
+        $this->cache->method('get')->willReturn(0);
+        $setCalls = [];
+        $this->cache->method('set')->willReturnCallback(function ($key) use (&$setCalls) {
+            $setCalls[] = $key;
+        });
+
+        $this->service->recordFailedAuthAttempt('user1', '1.2.3.4');
+
+        // Both the composite and per-IP counters are written.
+        $this->assertNotEmpty(array_filter($setCalls, fn($k) => str_contains($k, 'auth_attempts')));
+        $this->assertNotEmpty(array_filter($setCalls, fn($k) => str_contains($k, 'auth_ip_attempts')));
+    }
+
+    public function testRecordFailedAuthAttemptLocksOutAtCompositeThreshold(): void
+    {
+        // 19 -> becomes 20, crossing AUTH_RATE_LIMIT_ATTEMPTS.
+        $this->cache->method('get')->willReturnCallback(function (string $key) {
+            if (str_contains($key, 'auth_attempts') && str_contains($key, 'auth_ip_attempts') === false) {
+                return 19;
+            }
+            return 0;
+        });
+
+        $setCalls = [];
+        $this->cache->method('set')->willReturnCallback(function ($key) use (&$setCalls) {
+            $setCalls[] = $key;
+        });
+
+        $this->service->recordFailedAuthAttempt('user1', '1.2.3.4');
+
+        $this->assertNotEmpty(array_filter($setCalls, fn($k) => str_contains($k, 'auth_lockout')));
+    }
+
+    public function testRecordFailedAuthAttemptDoesNotLockBelowThreshold(): void
+    {
+        $this->cache->method('get')->willReturn(1);
+
+        $setCalls = [];
+        $this->cache->method('set')->willReturnCallback(function ($key) use (&$setCalls) {
+            $setCalls[] = $key;
+        });
+
+        $this->service->recordFailedAuthAttempt('user1', '1.2.3.4');
+
+        $this->assertEmpty(array_filter($setCalls, fn($k) => str_contains($k, 'auth_lockout')));
+    }
+
+    // ── recordSuccessfulAuth ──
+
+    public function testRecordSuccessfulAuthClearsCompositeCounters(): void
+    {
+        $removedKeys = [];
+        $this->cache->method('remove')->willReturnCallback(function ($key) use (&$removedKeys) {
+            $removedKeys[] = $key;
+            return true;
+        });
+
+        $this->service->recordSuccessfulAuth('user1', '1.2.3.4');
+
+        // Clears the composite attempts + composite lockout.
+        $this->assertCount(2, $removedKeys);
+        $this->assertNotEmpty(array_filter($removedKeys, fn($k) => str_contains($k, 'auth_attempts')));
+        $this->assertNotEmpty(array_filter($removedKeys, fn($k) => str_contains($k, 'auth_lockout')));
+    }
 }


### PR DESCRIPTION
## Summary

`SecurityService`'s brute-force protection was dormant: it only fired where a caller explicitly invoked it (`UserController::login`). Inbound API authentication (Basic / JWT / app-password / session) had **no** rate-limiting, so credentials/tokens could be sprayed at unlimited rate (#1834 item 1).

This wires `SecurityService` into the inbound auth path via a new `RateLimitMiddleware`, and addresses the shared-IP reset (#1834 item 2) and spoofable-IP (#1834 item 3) findings.

### What changed
- **`RateLimitMiddleware`** (new) — registered in `Application::register()`. Nextcloud's core `SecurityMiddleware` runs *before* app middleware and throws `NotLoggedInException` / `NotAdminException` (and `SecurityException` for forbidden password login / CORS basic-auth) when credentials fail on a protected endpoint. Because app middleware wraps *outside* core middleware in the dispatch chain, this middleware's `afterException()` observes those failures and records them, then **re-throws the original exception unchanged**. `beforeController()` pre-emptively returns 429 when the caller is locked out; `afterController()` clears counters on a successful authenticated request.
- **`SecurityService`** — new `checkAuthRateLimit()`, `recordFailedAuthAttempt()`, `recordSuccessfulAuth()` (separate cache prefixes from the interactive-login path so the two never share counters), plus `getTrustedClientIpAddress()`.
- **`AuthRateLimitExceededException`** (new) — carries the lockout expiry; surfaced as a 429 with a `Retry-After` header.
- Tests: 12 new unit tests in `SecurityServiceTest` (all 35 green in-container).

## Blast radius & safety

**This middleware runs on EVERY request to an OpenRegister controller**, so it was built to be maximally conservative.

**Paths now rate-limited**
- Failed authentication on **protected** OpenRegister endpoints (Basic auth, app-password/Bearer, session) — i.e. requests that NC rejects with `NotLoggedInException` / `NotAdminException` / a 401/403 `SecurityException`.
- `@PublicPage` endpoints are **never** rate-limited here (explicitly skipped via the controller-method reflector).
- Successful authenticated requests are **never** blocked; they only clear that identity's failure counters.

**Thresholds (generous, to avoid locking out legitimate automated traffic)**
- Composite **identity + IP**: 20 failures / 15-min window → 15-min lockout (primary, narrowly-scoped gate).
- Coarse **per-IP** backstop: 100 failures / 15-min window → lockout (only to blunt a high-volume sprayer).
- Lockout is keyed on `(identity + trusted-IP)`, so a single bad actor behind a shared NAT/proxy IP **cannot** reset or trigger another legitimate client's lockout (#1834 item 2).

**Fail-open guarantee: YES.**
- Every code path in the middleware that touches the limiter is wrapped in `try { ... } catch (Throwable)` and logs-and-continues. If `SecurityService` throws, the cache/APCu is unavailable, or reflection fails, **the request is allowed through**. The only intentional block is `AuthRateLimitExceededException`, raised solely when `checkAuthRateLimit()` reports an active lockout.
- The recording path in `afterException()` never alters the outcome: it records (best-effort) and then **re-throws the original exception**, so Nextcloud's normal error response is preserved for every non-lockout case.

**IP resolution (#1834 item 3)**
- The limiter uses `getTrustedClientIpAddress()` → `IRequest::getRemoteAddress()`, which only honours `X-Forwarded-For` from configured `trusted_proxies`. The pre-existing spoofable `getClientIpAddress()` (trusts any forwarding header) is left untouched on the legacy `UserController::login` path to avoid changing its behavior, but is **not** used for the new middleware.

## Not covered (out of scope for this PR)
- **#1834 item 4 (RBAC-bypassing URN existence lookups)** — separate concern in `UrnService`; not touched here.
- The legacy `UserController::login` interactive path keeps its existing `checkLoginRateLimit` / `getClientIpAddress` behavior unchanged (no regression risk), so it still uses the spoofable IP helper. Migrating it to the trusted resolver is a low-risk follow-up but deliberately left out to keep this change scoped.
- No new admin UI to clear auth lockouts (the existing `clearIpRateLimits` / `clearUserRateLimits` cover the login path; auth-path counters expire after 15 min).

## Test plan
- [x] `php -l` on all touched files
- [x] PHPCS clean on all lib files
- [x] `SecurityServiceTest` — 35/35 green in-container (12 new tests covering composite lockout, shared-IP isolation, thresholds, trusted-IP resolution)
- [x] Middleware + exception classes reflect-load cleanly under the full NC bootstrap
- [ ] Manual: confirm repeated bad Basic-auth against a protected endpoint eventually returns 429 with `Retry-After`, and that a valid credential is never blocked

Closes #1834 (items 1-3; item 4 tracked separately).