### PR TITLE
feat(integrations): standardize {items, total, nextCursor} pagination envelope across leaf controllers

### DIFF
--- a/lib/Controller/ObjectIntegrationsController.php
+++ b/lib/Controller/ObjectIntegrationsController.php
@@ -47,6 +47,7 @@ namespace OCA\OpenRegister\Controller;
 use OCA\OpenRegister\Exception\NotImplementedException;
 use OCA\OpenRegister\Exception\ProviderUnavailableException;
 use OCA\OpenRegister\Service\Integration\IntegrationRegistry;
+use OCA\OpenRegister\Service\Integration\PaginatedResult;
 use OCA\OpenRegister\Service\Integration\QueryTimeContract;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -85,6 +86,14 @@ class ObjectIntegrationsController extends Controller
      * Lists every linked thing the named integration exposes for the
      * given object.
      *
+     * The provider's `list()` return value is normalized into the
+     * canonical `{items, total, nextCursor}` envelope via
+     * {@see PaginatedResult::fromMixed()}. This is the backward-compatible
+     * normalization layer: a provider that returns a flat array yields
+     * `total = count(items)` and `nextCursor = null`; a provider that
+     * already returns an envelope (e.g. EmailProvider) is passed
+     * through with its real total and cursor preserved.
+     *
      * @param string $register      Register slug or numeric id.
      * @param string $schema        Schema slug or numeric id.
      * @param string $id            Object uuid.
@@ -97,7 +106,9 @@ class ObjectIntegrationsController extends Controller
     {
         return $this->dispatch(
             integrationId: $integrationId,
-            callback: fn ($provider) => ['items' => $provider->list($register, $schema, $id, $this->collectFilters())]
+            callback: fn ($provider) => PaginatedResult::fromMixed(
+                $provider->list($register, $schema, $id, $this->collectFilters())
+            )->toArray()
         );
     }//end index()
 

--- a/lib/Service/Integration/IntegrationProvider.php
+++ b/lib/Service/Integration/IntegrationProvider.php
@@ -175,12 +175,27 @@ interface IntegrationProvider
      * are `_limit` (int), `_page` (int), `_search` (string). Unknown
      * filters MUST be ignored, not rejected.
      *
+     * Return shape: implementations MAY return either
+     *   - a flat list `array<int,array<string,mixed>>`, or
+     *   - the paginated envelope `{items|results: array, total: int,
+     *     nextCursor: ?string}` (a `PaginatedResult` or its array form)
+     *     when the provider knows the cross-page total and/or can
+     *     produce a cursor for the next page.
+     *
+     * Either shape is accepted: `ObjectIntegrationsController` runs the
+     * value through {@see PaginatedResult::fromMixed()} and always emits
+     * the canonical `{items, total, nextCursor}` envelope to the client.
+     * Returning the envelope is preferred for providers backed by a
+     * counted/paged store, because the flat-list fallback sets
+     * `total = count(items)`, which disables frontend load-more.
+     *
      * @param string              $register Register slug or numeric id.
      * @param string              $schema   Schema slug or numeric id.
      * @param string              $objectId Object uuid.
      * @param array<string,mixed> $filters  Optional list filters.
      *
-     * @return array<int,array<string,mixed>> List of linked things.
+     * @return array<int,array<string,mixed>>|array<string,mixed> Flat list
+     *         of linked things, or a `{items, total, nextCursor}` envelope.
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array;
 

--- a/lib/Service/Integration/PaginatedResult.php
+++ b/lib/Service/Integration/PaginatedResult.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * PaginatedResult — the canonical list-response envelope for the
+ * pluggable integration registry.
+ *
+ * Standardizes every integration leaf's list endpoint on a single
+ * shape: `{items: array, total: int, nextCursor: ?string}`. Before
+ * this value object the read contract was inconsistent — some
+ * controllers returned a flat array, some `{items: [...]}` without a
+ * total, some `{results, total}`, and only a couple carried a
+ * `nextCursor`. That broke load-more in the frontend (e.g.
+ * `CnEmailTab.hasMore` could never become true because `total` was
+ * missing from the generic registry endpoint).
+ *
+ * The normalizer `fromMixed()` is intentionally permissive so the
+ * change is additive and backward-compatible: a provider that still
+ * returns a flat array, or a controller-shaped `{results, total}`
+ * envelope, is coerced into the canonical shape without anyone having
+ * to change their `IntegrationProvider::list()` signature.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Integration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-19
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Integration;
+
+/**
+ * Immutable value object describing a paginated list response.
+ *
+ * The canonical serialized shape is:
+ * ```json
+ * { "items": [...], "total": 42, "nextCursor": "50" }
+ * ```
+ *
+ * `nextCursor` is `null` when there are no further pages. For the
+ * frontend's backward-compatible `data.results || data.items` reader,
+ * `toArray()` additionally mirrors `items` under `results`.
+ */
+final class PaginatedResult
+{
+
+    /**
+     * The list rows for the current page.
+     *
+     * @var array<int,array<string,mixed>>
+     */
+    public readonly array $items;
+
+    /**
+     * Total number of rows across all pages.
+     *
+     * @var integer
+     */
+    public readonly int $total;
+
+    /**
+     * Opaque cursor for the next page, or null on the last page.
+     *
+     * @var string|null
+     */
+    public readonly ?string $nextCursor;
+
+    /**
+     * Constructor.
+     *
+     * @param array<int,array<string,mixed>> $items      The list rows.
+     * @param int                            $total      Total number of rows.
+     * @param string|null                    $nextCursor Next-page cursor or null.
+     *
+     * @return void
+     */
+    public function __construct(array $items, int $total, ?string $nextCursor=null)
+    {
+        $this->items      = $items;
+        $this->total      = $total;
+        $this->nextCursor = $nextCursor;
+    }//end __construct()
+
+    /**
+     * Normalize a mixed provider / service return value into the
+     * canonical envelope.
+     *
+     * Accepts, in order of preference:
+     *   - a `PaginatedResult` (returned unchanged)
+     *   - an envelope array with `items` or `results` (+ optional
+     *     `total` / `nextCursor`)
+     *   - a flat list array (total defaults to `count()`, no nextCursor)
+     *
+     * When `total` is absent it falls back to the item count, and
+     * `nextCursor` defaults to null — so a provider that returns a
+     * plain array still produces a valid (single-page) envelope.
+     *
+     * @param mixed $value Raw value returned by a provider or service.
+     *
+     * @return self The normalized envelope.
+     */
+    public static function fromMixed(mixed $value): self
+    {
+        if ($value instanceof self) {
+            return $value;
+        }
+
+        if (is_array($value) === false) {
+            return new self(items: [], total: 0, nextCursor: null);
+        }
+
+        // Envelope shape: has an explicit items/results key.
+        if (array_key_exists('items', $value) === true || array_key_exists('results', $value) === true) {
+            $items = $value['items'] ?? $value['results'] ?? [];
+            if (is_array($items) === false) {
+                $items = [];
+            }
+
+            $total = $items;
+            if (array_key_exists('total', $value) === true && is_numeric($value['total']) === true) {
+                $total = (int) $value['total'];
+            } else {
+                $total = count($items);
+            }
+
+            $nextCursor = null;
+            if (array_key_exists('nextCursor', $value) === true && $value['nextCursor'] !== null) {
+                $nextCursor = (string) $value['nextCursor'];
+            }
+
+            return new self(items: array_values($items), total: $total, nextCursor: $nextCursor);
+        }
+
+        // Flat list: numeric-keyed array of rows.
+        return new self(items: array_values($value), total: count($value), nextCursor: null);
+    }//end fromMixed()
+
+    /**
+     * Serialize to the canonical wire shape.
+     *
+     * Includes a `results` mirror of `items` so existing frontend
+     * readers (`data.results || data.items`) keep working without a
+     * coordinated release.
+     *
+     * @return array{items:array<int,array<string,mixed>>,results:array<int,array<string,mixed>>,total:int,nextCursor:?string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'items'      => $this->items,
+            'results'    => $this->items,
+            'total'      => $this->total,
+            'nextCursor' => $this->nextCursor,
+        ];
+    }//end toArray()
+}//end class

--- a/lib/Service/Integration/Providers/EmailProvider.php
+++ b/lib/Service/Integration/Providers/EmailProvider.php
@@ -125,46 +125,57 @@ class EmailProvider extends AbstractIntegrationProvider
      *
      * This shape matches every field `CnEmailTab` and `CnEmailCard`
      * consume (subject, sender, mailDate, mailAccountId,
-     * mailMessageId — used for the deep-link into NC Mail). No
-     * widening required for Phase B-2.
+     * mailMessageId — used for the deep-link into NC Mail).
      *
-     * Paging total: the inner `EmailService::getEmailsForObject()` does
-     * return `['results' => [...], 'total' => int]`, but the
-     * IntegrationProvider contract is `array<int,array>` (flat list),
-     * so the total is dropped at this layer. The
-     * `ObjectIntegrationsController` wraps the result in
-     * `{items: [...]}` with no `total`. UI load-more (which expects
-     * `data.total`) therefore relies on `messages.length === total`
-     * fallback. Tracked as a fleet-wide contract widening — out of
-     * scope for Phase B-2 (would change the IntegrationProvider return
-     * type and ripple to all 19 providers).
+     * Paging: the inner `EmailService::getEmailsForObject()` returns
+     * `['results' => [...], 'total' => int]`. Per the Tier-3 contract
+     * widening this provider now returns the full paginated envelope
+     * `{items, total, nextCursor}` so the generic
+     * `ObjectIntegrationsController` can pass the real `total` (and a
+     * next-page cursor) through to the frontend, which restores
+     * `CnEmailTab` load-more. The `nextCursor` is the zero-indexed next
+     * page number, present only while more rows remain.
      *
      * @param string              $register Register slug or numeric id (unused).
      * @param string              $schema   Schema slug or numeric id (unused).
      * @param string              $objectId Object uuid.
      * @param array<string,mixed> $filters  Optional `_limit` / `_page` (page zero-indexed).
      *
-     * @return array<int,array<string,mixed>>
+     * @return array{items:array<int,array<string,mixed>>,total:int,nextCursor:?string}
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
         $limit  = isset($filters['_limit']) === true ? (int) $filters['_limit'] : null;
-        $offset = null;
-        if ($limit !== null && isset($filters['_page']) === true) {
-            $offset = max(0, ((int) $filters['_page'])) * $limit;
-        }
+        $page   = isset($filters['_page']) === true ? max(0, (int) $filters['_page']) : 0;
+        $offset = ($limit !== null) ? ($page * $limit) : 0;
 
         try {
             $result = $this->emailService->getEmailsForObject(
                 objectUuid: $objectId,
                 limit: $limit,
-                offset: $offset
+                offset: ($limit !== null ? $offset : null)
             );
         } catch (Throwable $e) {
-            return [];
+            return ['items' => [], 'total' => 0, 'nextCursor' => null];
         }
 
-        return $result['results'] ?? [];
+        $items = $result['results'];
+        $total = (int) $result['total'];
+
+        // A further page exists when the rows seen so far (offset + this
+        // batch) is still short of the total. The cursor is the next
+        // zero-indexed page number consumed by `_page`. Paging only
+        // applies when a limit (and therefore a concrete offset) is set.
+        $nextCursor = null;
+        if ($limit !== null && (($offset + count($items)) < $total)) {
+            $nextCursor = (string) ($page + 1);
+        }
+
+        return [
+            'items'      => $items,
+            'total'      => $total,
+            'nextCursor' => $nextCursor,
+        ];
     }//end list()
 
     /**

--- a/tests/Unit/Controller/ObjectIntegrationsControllerTest.php
+++ b/tests/Unit/Controller/ObjectIntegrationsControllerTest.php
@@ -53,6 +53,7 @@ class _ControllerStubProvider extends AbstractIntegrationProvider
         private string $storage = 'magic-column',
         private bool $listThrowsNotImplemented = false,
         private bool $createThrowsUnavailable = false,
+        private ?array $listEnvelope = null,
     ) {
     }//end __construct()
 
@@ -91,6 +92,9 @@ class _ControllerStubProvider extends AbstractIntegrationProvider
         $this->listCalled = compact('register', 'schema', 'objectId', 'filters');
         if ($this->listThrowsNotImplemented === true) {
             throw new NotImplementedException('list not supported');
+        }
+        if ($this->listEnvelope !== null) {
+            return $this->listEnvelope;
         }
         return [['id' => 'a'], ['id' => 'b']];
     }//end list()
@@ -158,9 +162,65 @@ class ObjectIntegrationsControllerTest extends TestCase
 
         $response = $controller->index('r', 's', 'o', 'stub');
         $this->assertSame(Http::STATUS_OK, $response->getStatus());
-        $this->assertSame([['id' => 'a'], ['id' => 'b']], $response->getData()['items']);
+        $body = $response->getData();
+        // Flat-array provider output is normalized into the canonical
+        // {items, total, nextCursor} envelope; total defaults to count.
+        $this->assertSame([['id' => 'a'], ['id' => 'b']], $body['items']);
+        $this->assertSame([['id' => 'a'], ['id' => 'b']], $body['results']);
+        $this->assertSame(2, $body['total']);
+        $this->assertNull($body['nextCursor']);
         $this->assertSame(['_limit' => '5'], $stub->listCalled['filters']);
     }//end testIndexDispatchesAndReturnsItems()
+
+    public function testIndexPassesThroughProviderEnvelope(): void
+    {
+        $registry = new IntegrationRegistry(new NullLogger());
+        $registry->addProvider(
+            new _ControllerStubProvider(
+                id: 'stub',
+                listEnvelope: [
+                    'items'      => [['id' => 'a']],
+                    'total'      => 42,
+                    'nextCursor' => '1',
+                ]
+            )
+        );
+
+        $controller = $this->buildController($registry);
+        $response   = $controller->index('r', 's', 'o', 'stub');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $body = $response->getData();
+        // A provider that already returns an envelope keeps its real
+        // total + cursor — they are not flattened to count().
+        $this->assertSame([['id' => 'a']], $body['items']);
+        $this->assertSame(42, $body['total']);
+        $this->assertSame('1', $body['nextCursor']);
+    }//end testIndexPassesThroughProviderEnvelope()
+
+    public function testIndexNormalizesResultsKeyedEnvelope(): void
+    {
+        $registry = new IntegrationRegistry(new NullLogger());
+        $registry->addProvider(
+            new _ControllerStubProvider(
+                id: 'stub',
+                listEnvelope: [
+                    'results' => [['id' => 'x'], ['id' => 'y']],
+                    'total'   => 2,
+                ]
+            )
+        );
+
+        $controller = $this->buildController($registry);
+        $response   = $controller->index('r', 's', 'o', 'stub');
+
+        $body = $response->getData();
+        // The legacy `results`-keyed shape is coerced to canonical
+        // `items` while preserving the provided total.
+        $this->assertSame([['id' => 'x'], ['id' => 'y']], $body['items']);
+        $this->assertSame(2, $body['total']);
+        $this->assertNull($body['nextCursor']);
+    }//end testIndexNormalizesResultsKeyedEnvelope()
 
     public function testShowDispatchesAndReturnsEntity(): void
     {

--- a/tests/Unit/Service/Integration/PaginatedResultTest.php
+++ b/tests/Unit/Service/Integration/PaginatedResultTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Unit tests for the PaginatedResult list-response envelope normalizer.
+ *
+ * Covers the additive, backward-compatible normalization that lets a
+ * provider return either a flat array or an envelope while the
+ * controller always emits canonical `{items, total, nextCursor}`:
+ *  - flat list → total = count, nextCursor null (contacts/deck shape)
+ *  - `{items, total, nextCursor}` envelope → passed through (email shape)
+ *  - legacy `{results, total}` envelope → coerced to items
+ *  - non-array / scalar → empty envelope
+ *  - toArray() mirrors items under results for frontend back-compat
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Integration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-19
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Integration;
+
+use OCA\OpenRegister\Service\Integration\PaginatedResult;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for PaginatedResult.
+ */
+class PaginatedResultTest extends TestCase
+{
+
+    public function testFlatArrayDefaultsTotalToCount(): void
+    {
+        $result = PaginatedResult::fromMixed([['id' => 'a'], ['id' => 'b'], ['id' => 'c']]);
+
+        $this->assertCount(3, $result->items);
+        $this->assertSame(3, $result->total);
+        $this->assertNull($result->nextCursor);
+    }//end testFlatArrayDefaultsTotalToCount()
+
+    public function testFullEnvelopeIsPreserved(): void
+    {
+        $result = PaginatedResult::fromMixed(
+            [
+                'items'      => [['id' => 'a']],
+                'total'      => 99,
+                'nextCursor' => '25',
+            ]
+        );
+
+        $this->assertCount(1, $result->items);
+        $this->assertSame(99, $result->total);
+        $this->assertSame('25', $result->nextCursor);
+    }//end testFullEnvelopeIsPreserved()
+
+    public function testResultsKeyedEnvelopeIsCoercedToItems(): void
+    {
+        $result = PaginatedResult::fromMixed(
+            [
+                'results' => [['id' => 'x'], ['id' => 'y']],
+                'total'   => 2,
+            ]
+        );
+
+        $this->assertSame([['id' => 'x'], ['id' => 'y']], $result->items);
+        $this->assertSame(2, $result->total);
+        $this->assertNull($result->nextCursor);
+    }//end testResultsKeyedEnvelopeIsCoercedToItems()
+
+    public function testEnvelopeWithoutTotalFallsBackToItemCount(): void
+    {
+        $result = PaginatedResult::fromMixed(['items' => [['id' => 'a'], ['id' => 'b']]]);
+
+        $this->assertSame(2, $result->total);
+    }//end testEnvelopeWithoutTotalFallsBackToItemCount()
+
+    public function testNumericNextCursorIsCastToString(): void
+    {
+        $result = PaginatedResult::fromMixed(['items' => [], 'total' => 0, 'nextCursor' => 7]);
+
+        $this->assertSame('7', $result->nextCursor);
+    }//end testNumericNextCursorIsCastToString()
+
+    public function testNonArrayYieldsEmptyEnvelope(): void
+    {
+        $result = PaginatedResult::fromMixed('not-an-array');
+
+        $this->assertSame([], $result->items);
+        $this->assertSame(0, $result->total);
+        $this->assertNull($result->nextCursor);
+    }//end testNonArrayYieldsEmptyEnvelope()
+
+    public function testPaginatedResultInstanceIsReturnedUnchanged(): void
+    {
+        $original = new PaginatedResult(items: [['id' => 'a']], total: 5, nextCursor: '1');
+
+        $this->assertSame($original, PaginatedResult::fromMixed($original));
+    }//end testPaginatedResultInstanceIsReturnedUnchanged()
+
+    public function testToArrayMirrorsItemsUnderResults(): void
+    {
+        $result = new PaginatedResult(items: [['id' => 'a']], total: 1, nextCursor: null);
+        $array  = $result->toArray();
+
+        $this->assertSame($array['items'], $array['results']);
+        $this->assertSame(1, $array['total']);
+        $this->assertArrayHasKey('nextCursor', $array);
+        $this->assertNull($array['nextCursor']);
+    }//end testToArrayMirrorsItemsUnderResults()
+}//end class


### PR DESCRIPTION
## Summary
Phase J-A (Tier 3): widen the integration leaf list contract so every leaf endpoint returns a consistent `{items, total, nextCursor}` envelope, fixing pagination (e.g. `CnEmailTab.hasMore` was broken because the generic registry endpoint dropped `total`).

- Adds `lib/Service/Integration/PaginatedResult.php` — an immutable value object with a permissive `fromMixed()` normalizer that coerces a flat array, a legacy `{results, total}` shape, or a full envelope into the canonical `{items, total, nextCursor}`. `toArray()` mirrors `items` under `results` for backward-compatible frontend readers.
- `ObjectIntegrationsController::index()` now runs the provider's `list()` return through `PaginatedResult::fromMixed()` and always emits the envelope. Flat-array providers get `total = count(items)`, `nextCursor = null`; envelope-returning providers pass through with their real total/cursor.
- `EmailProvider::list()` now returns the full envelope with the real cross-page `total` plus a next-page cursor — previously dropped (the F5-deferred gap).
- `IntegrationProvider::list()` docblock widened additively (no signature change) to document the dual return shape.

### Tier-2 link controller audit
All 14 Tier-2 link controllers + ContactsController already return `{results, total}` from their list methods — no change needed. The only contract gaps were the generic registry endpoint and the EmailProvider total, both fixed here.

## Test plan
- [x] `PaginatedResultTest` — 8 tests / 19 assertions pass.
- [x] `ObjectIntegrationsControllerTest` extended: normalized flat output, provider-envelope passthrough, `results`-keyed normalization.
- [x] PHPCS clean on new/modified production files (controller/interface have only pre-existing long-line warnings on lines not touched here).
- [x] PHPStan: genuine EmailProvider issues resolved; remaining container output is pre-existing cross-app autoload noise.

Closes the Phase B-2 (commit 77507c010) / F5 deferred pagination-contract follow-up. Refs ADR-019, ADR-022.