### PR TITLE
feat(field-types): implement color validation + recurrence type (#1842)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,6 @@
 		"react/async": "^4.3",
 		"react/event-loop": "^1.5",
 		"react/promise": "^3.2",
-		"sabre/vobject": "^4.5",
 		"smalot/pdfparser": "^2.9",
 		"symfony/console": "^6.4",
 		"symfony/http-kernel": "^6.4",
@@ -125,6 +124,7 @@
 		"phpstan/phpstan": "^1.10",
 		"phpunit/phpunit": "^10.5.62",
 		"roave/security-advisories": "dev-latest",
+		"sabre/vobject": "^4.5",
 		"squizlabs/php_codesniffer": "^3.9",
 		"symfony/http-foundation": "^6.4",
 		"vimeo/psalm": "^5.26"

--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,7 @@
 		]
 	},
 	"require": {
+		"php": "^8.3",
 		"adbario/php-dot-notation": "^3.3.0",
 		"bamarni/composer-bin-plugin": "^1.8",
 		"cweagans/composer-patches": "^1.7",
@@ -95,12 +96,12 @@
 		"elasticsearch/elasticsearch": "^v8.14.0",
 		"guzzlehttp/guzzle": "^7.0",
 		"opis/json-schema": "^2.3",
-		"php": "^8.3",
 		"phpoffice/phpspreadsheet": "^5.0",
 		"phpoffice/phpword": "^1.2",
 		"react/async": "^4.3",
 		"react/event-loop": "^1.5",
 		"react/promise": "^3.2",
+		"sabre/vobject": "^4.5",
 		"smalot/pdfparser": "^2.9",
 		"symfony/console": "^6.4",
 		"symfony/http-kernel": "^6.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c9b9dd2c36993303abeac8602b7b6ac",
+    "content-hash": "3fa3b89cb72c898fc69adb35a63e848a",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -3234,244 +3234,6 @@
                 "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v9.3.0"
             },
             "time": "2026-03-03T17:31:43+00:00"
-        },
-        {
-            "name": "sabre/uri",
-            "version": "3.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sabre-io/uri.git",
-                "reference": "a926c749dddfb289b8a9b5218d16ac06affdc631"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/uri/zipball/a926c749dddfb289b8a9b5218d16ac06affdc631",
-                "reference": "a926c749dddfb289b8a9b5218d16ac06affdc631",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.2"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.95",
-                "phpstan/extension-installer": "^1.4",
-                "phpstan/phpstan": "^2.1",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^10.5",
-                "rector/rector": "^2.4"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "lib/functions.php"
-                ],
-                "psr-4": {
-                    "Sabre\\Uri\\": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Evert Pot",
-                    "email": "me@evertpot.com",
-                    "homepage": "http://evertpot.com/",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Functions for making sense out of URIs.",
-            "homepage": "http://sabre.io/uri/",
-            "keywords": [
-                "rfc3986",
-                "uri",
-                "url"
-            ],
-            "support": {
-                "forum": "https://groups.google.com/group/sabredav-discuss",
-                "issues": "https://github.com/sabre-io/uri/issues",
-                "source": "https://github.com/fruux/sabre-uri"
-            },
-            "time": "2026-04-26T04:19:03+00:00"
-        },
-        {
-            "name": "sabre/vobject",
-            "version": "4.5.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sabre-io/vobject.git",
-                "reference": "d554eb24d64232922e1eab5896cc2f84b3b9ffb1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/vobject/zipball/d554eb24d64232922e1eab5896cc2f84b3b9ffb1",
-                "reference": "d554eb24d64232922e1eab5896cc2f84b3b9ffb1",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": "^7.1 || ^8.0",
-                "sabre/xml": "^2.1 || ^3.0 || ^4.0"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2.17.1",
-                "phpstan/phpstan": "^0.12 || ^1.12 || ^2.0",
-                "phpunit/php-invoker": "^2.0 || ^3.1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
-            },
-            "suggest": {
-                "hoa/bench": "If you would like to run the benchmark scripts"
-            },
-            "bin": [
-                "bin/vobject",
-                "bin/generate_vcards"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Sabre\\VObject\\": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Evert Pot",
-                    "email": "me@evertpot.com",
-                    "homepage": "http://evertpot.com/",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Dominik Tobschall",
-                    "email": "dominik@fruux.com",
-                    "homepage": "http://tobschall.de/",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Ivan Enderlin",
-                    "email": "ivan.enderlin@hoa-project.net",
-                    "homepage": "http://mnt.io/",
-                    "role": "Developer"
-                }
-            ],
-            "description": "The VObject library for PHP allows you to easily parse and manipulate iCalendar and vCard objects",
-            "homepage": "http://sabre.io/vobject/",
-            "keywords": [
-                "availability",
-                "freebusy",
-                "iCalendar",
-                "ical",
-                "ics",
-                "jCal",
-                "jCard",
-                "recurrence",
-                "rfc2425",
-                "rfc2426",
-                "rfc2739",
-                "rfc4770",
-                "rfc5545",
-                "rfc5546",
-                "rfc6321",
-                "rfc6350",
-                "rfc6351",
-                "rfc6474",
-                "rfc6638",
-                "rfc6715",
-                "rfc6868",
-                "vCalendar",
-                "vCard",
-                "vcf",
-                "xCal",
-                "xCard"
-            ],
-            "support": {
-                "forum": "https://groups.google.com/group/sabredav-discuss",
-                "issues": "https://github.com/sabre-io/vobject/issues",
-                "source": "https://github.com/fruux/sabre-vobject"
-            },
-            "time": "2026-01-12T10:45:19+00:00"
-        },
-        {
-            "name": "sabre/xml",
-            "version": "4.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sabre-io/xml.git",
-                "reference": "bec83cbe2f4e1e1ca4254ed8d7caa7e32cc74b05"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/xml/zipball/bec83cbe2f4e1e1ca4254ed8d7caa7e32cc74b05",
-                "reference": "bec83cbe2f4e1e1ca4254ed8d7caa7e32cc74b05",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-xmlreader": "*",
-                "ext-xmlwriter": "*",
-                "lib-libxml": ">=2.6.20",
-                "php": "^8.2",
-                "sabre/uri": ">=2.0,<4.0.0"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.95",
-                "phpstan/extension-installer": "^1.4",
-                "phpstan/phpstan": "^2.1",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^10.5",
-                "rector/rector": "^2.4"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "lib/Deserializer/functions.php",
-                    "lib/Serializer/functions.php"
-                ],
-                "psr-4": {
-                    "Sabre\\Xml\\": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Evert Pot",
-                    "email": "me@evertpot.com",
-                    "homepage": "http://evertpot.com/",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Markus Staab",
-                    "email": "markus.staab@redaxo.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "sabre/xml is an XML library that you may not hate.",
-            "homepage": "https://sabre.io/xml/",
-            "keywords": [
-                "XMLReader",
-                "XMLWriter",
-                "dom",
-                "xml"
-            ],
-            "support": {
-                "forum": "https://groups.google.com/group/sabredav-discuss",
-                "issues": "https://github.com/sabre-io/xml/issues",
-                "source": "https://github.com/fruux/sabre-xml"
-            },
-            "time": "2026-04-27T10:56:01+00:00"
         },
         {
             "name": "smalot/pdfparser",
@@ -11206,6 +10968,244 @@
                 }
             ],
             "time": "2026-05-22T16:47:49+00:00"
+        },
+        {
+            "name": "sabre/uri",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/uri.git",
+                "reference": "a926c749dddfb289b8a9b5218d16ac06affdc631"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/uri/zipball/a926c749dddfb289b8a9b5218d16ac06affdc631",
+                "reference": "a926c749dddfb289b8a9b5218d16ac06affdc631",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.95",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^10.5",
+                "rector/rector": "^2.4"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\Uri\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Functions for making sense out of URIs.",
+            "homepage": "http://sabre.io/uri/",
+            "keywords": [
+                "rfc3986",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/uri/issues",
+                "source": "https://github.com/fruux/sabre-uri"
+            },
+            "time": "2026-04-26T04:19:03+00:00"
+        },
+        {
+            "name": "sabre/vobject",
+            "version": "4.5.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/vobject.git",
+                "reference": "d554eb24d64232922e1eab5896cc2f84b3b9ffb1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/vobject/zipball/d554eb24d64232922e1eab5896cc2f84b3b9ffb1",
+                "reference": "d554eb24d64232922e1eab5896cc2f84b3b9ffb1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabre/xml": "^2.1 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.17.1",
+                "phpstan/phpstan": "^0.12 || ^1.12 || ^2.0",
+                "phpunit/php-invoker": "^2.0 || ^3.1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
+            },
+            "suggest": {
+                "hoa/bench": "If you would like to run the benchmark scripts"
+            },
+            "bin": [
+                "bin/vobject",
+                "bin/generate_vcards"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sabre\\VObject\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Dominik Tobschall",
+                    "email": "dominik@fruux.com",
+                    "homepage": "http://tobschall.de/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Ivan Enderlin",
+                    "email": "ivan.enderlin@hoa-project.net",
+                    "homepage": "http://mnt.io/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "The VObject library for PHP allows you to easily parse and manipulate iCalendar and vCard objects",
+            "homepage": "http://sabre.io/vobject/",
+            "keywords": [
+                "availability",
+                "freebusy",
+                "iCalendar",
+                "ical",
+                "ics",
+                "jCal",
+                "jCard",
+                "recurrence",
+                "rfc2425",
+                "rfc2426",
+                "rfc2739",
+                "rfc4770",
+                "rfc5545",
+                "rfc5546",
+                "rfc6321",
+                "rfc6350",
+                "rfc6351",
+                "rfc6474",
+                "rfc6638",
+                "rfc6715",
+                "rfc6868",
+                "vCalendar",
+                "vCard",
+                "vcf",
+                "xCal",
+                "xCard"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/vobject/issues",
+                "source": "https://github.com/fruux/sabre-vobject"
+            },
+            "time": "2026-01-12T10:45:19+00:00"
+        },
+        {
+            "name": "sabre/xml",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/xml.git",
+                "reference": "bec83cbe2f4e1e1ca4254ed8d7caa7e32cc74b05"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/xml/zipball/bec83cbe2f4e1e1ca4254ed8d7caa7e32cc74b05",
+                "reference": "bec83cbe2f4e1e1ca4254ed8d7caa7e32cc74b05",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlreader": "*",
+                "ext-xmlwriter": "*",
+                "lib-libxml": ">=2.6.20",
+                "php": "^8.2",
+                "sabre/uri": ">=2.0,<4.0.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.95",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^10.5",
+                "rector/rector": "^2.4"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/Deserializer/functions.php",
+                    "lib/Serializer/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\Xml\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Markus Staab",
+                    "email": "markus.staab@redaxo.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "sabre/xml is an XML library that you may not hate.",
+            "homepage": "https://sabre.io/xml/",
+            "keywords": [
+                "XMLReader",
+                "XMLWriter",
+                "dom",
+                "xml"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/xml/issues",
+                "source": "https://github.com/fruux/sabre-xml"
+            },
+            "time": "2026-04-27T10:56:01+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "114d0f3e1af57a0d8f30b0ddb0adb582",
+    "content-hash": "7c9b9dd2c36993303abeac8602b7b6ac",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -3234,6 +3234,244 @@
                 "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v9.3.0"
             },
             "time": "2026-03-03T17:31:43+00:00"
+        },
+        {
+            "name": "sabre/uri",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/uri.git",
+                "reference": "a926c749dddfb289b8a9b5218d16ac06affdc631"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/uri/zipball/a926c749dddfb289b8a9b5218d16ac06affdc631",
+                "reference": "a926c749dddfb289b8a9b5218d16ac06affdc631",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.95",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^10.5",
+                "rector/rector": "^2.4"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\Uri\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Functions for making sense out of URIs.",
+            "homepage": "http://sabre.io/uri/",
+            "keywords": [
+                "rfc3986",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/uri/issues",
+                "source": "https://github.com/fruux/sabre-uri"
+            },
+            "time": "2026-04-26T04:19:03+00:00"
+        },
+        {
+            "name": "sabre/vobject",
+            "version": "4.5.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/vobject.git",
+                "reference": "d554eb24d64232922e1eab5896cc2f84b3b9ffb1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/vobject/zipball/d554eb24d64232922e1eab5896cc2f84b3b9ffb1",
+                "reference": "d554eb24d64232922e1eab5896cc2f84b3b9ffb1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabre/xml": "^2.1 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.17.1",
+                "phpstan/phpstan": "^0.12 || ^1.12 || ^2.0",
+                "phpunit/php-invoker": "^2.0 || ^3.1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
+            },
+            "suggest": {
+                "hoa/bench": "If you would like to run the benchmark scripts"
+            },
+            "bin": [
+                "bin/vobject",
+                "bin/generate_vcards"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sabre\\VObject\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Dominik Tobschall",
+                    "email": "dominik@fruux.com",
+                    "homepage": "http://tobschall.de/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Ivan Enderlin",
+                    "email": "ivan.enderlin@hoa-project.net",
+                    "homepage": "http://mnt.io/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "The VObject library for PHP allows you to easily parse and manipulate iCalendar and vCard objects",
+            "homepage": "http://sabre.io/vobject/",
+            "keywords": [
+                "availability",
+                "freebusy",
+                "iCalendar",
+                "ical",
+                "ics",
+                "jCal",
+                "jCard",
+                "recurrence",
+                "rfc2425",
+                "rfc2426",
+                "rfc2739",
+                "rfc4770",
+                "rfc5545",
+                "rfc5546",
+                "rfc6321",
+                "rfc6350",
+                "rfc6351",
+                "rfc6474",
+                "rfc6638",
+                "rfc6715",
+                "rfc6868",
+                "vCalendar",
+                "vCard",
+                "vcf",
+                "xCal",
+                "xCard"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/vobject/issues",
+                "source": "https://github.com/fruux/sabre-vobject"
+            },
+            "time": "2026-01-12T10:45:19+00:00"
+        },
+        {
+            "name": "sabre/xml",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/xml.git",
+                "reference": "bec83cbe2f4e1e1ca4254ed8d7caa7e32cc74b05"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/xml/zipball/bec83cbe2f4e1e1ca4254ed8d7caa7e32cc74b05",
+                "reference": "bec83cbe2f4e1e1ca4254ed8d7caa7e32cc74b05",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlreader": "*",
+                "ext-xmlwriter": "*",
+                "lib-libxml": ">=2.6.20",
+                "php": "^8.2",
+                "sabre/uri": ">=2.0,<4.0.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.95",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^10.5",
+                "rector/rector": "^2.4"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/Deserializer/functions.php",
+                    "lib/Serializer/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\Xml\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Markus Staab",
+                    "email": "markus.staab@redaxo.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "sabre/xml is an XML library that you may not hate.",
+            "homepage": "https://sabre.io/xml/",
+            "keywords": [
+                "XMLReader",
+                "XMLWriter",
+                "dom",
+                "xml"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/xml/issues",
+                "source": "https://github.com/fruux/sabre-xml"
+            },
+            "time": "2026-04-27T10:56:01+00:00"
         },
         {
             "name": "smalot/pdfparser",

--- a/lib/Formats/ExtendedFieldTypeValidator.php
+++ b/lib/Formats/ExtendedFieldTypeValidator.php
@@ -1,0 +1,249 @@
+<?php
+
+/**
+ * Extended Field-Type Validator
+ *
+ * Stateless validation + occurrence-materialisation helpers for the extended
+ * OpenRegister property types declared in the `extended-field-types` spec.
+ *
+ * This class concentrates the per-type contract (regex, RRULE parsing) in one
+ * place so both the REST pre-validation hook (ValidateObject) and the read-side
+ * converter (SchemaTypeConverter) share a single implementation. Methods return
+ * a `null` error string on success or the exact, spec-mandated 422 message on
+ * failure — keeping the "single point of truth" property the spec requires for
+ * REST + GraphQL parity.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Formats
+ * @package  OCA\OpenRegister\Formats
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git-id>
+ * @link      https://www.OpenRegister.app
+ *
+ * @spec openspec/specs/extended-field-types/spec.md#REQ-EFT-003
+ * @spec openspec/specs/extended-field-types/spec.md#REQ-EFT-005
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Formats;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Sabre\VObject\InvalidDataException;
+use Sabre\VObject\Recur\RRuleIterator;
+use Throwable;
+
+/**
+ * Validator for the extended field types `color` and `recurrence`.
+ *
+ * The `color` type accepts one of three notations controlled by the property's
+ * declared `format` annotation (`hex` default, `rgba`, `oklch`). The `recurrence`
+ * type stores an RFC 5545 RRULE string validated via sabre/vobject and may emit
+ * the next N upcoming occurrences on read.
+ *
+ * @SuppressWarnings(PHPMD.CyclomaticComplexity) Per-format colour dispatch is inherently branchy
+ *
+ * @spec openspec/specs/extended-field-types/spec.md#REQ-EFT-003
+ * @spec openspec/specs/extended-field-types/spec.md#REQ-EFT-005
+ */
+class ExtendedFieldTypeValidator
+{
+
+    /**
+     * Default number of occurrences materialised for a recurrence value on read.
+     *
+     * @var int
+     */
+    public const DEFAULT_OCCURRENCES = 5;
+
+    /**
+     * Maximum number of occurrences a single request may materialise.
+     *
+     * @var int
+     */
+    public const MAX_OCCURRENCES = 100;
+
+    /**
+     * Hex colour regex: #RGB, #RRGGBB or #RRGGBBAA (case-insensitive).
+     *
+     * @var string
+     */
+    private const REGEX_HEX = '/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/';
+
+    /**
+     * OKLCH colour regex: oklch(L% C H) with optional alpha.
+     *
+     * Accepts lightness as percentage or number, chroma and hue as numbers, and
+     * an optional `/ A` alpha component.
+     *
+     * @var string
+     */
+    private const REGEX_OKLCH = '/^oklch\(\s*[0-9]*\.?[0-9]+%?\s+[0-9]*\.?[0-9]+\s+[0-9]*\.?[0-9]+(?:deg)?\s*(?:\/\s*[0-9]*\.?[0-9]+%?\s*)?\)$/i';
+
+    /**
+     * Validate a `color` value against the property's declared format.
+     *
+     * The default format is `hex`. The `rgba` format requires exactly four
+     * components inside the `rgba(...)` envelope. The `oklch` format validates
+     * the `oklch(L C H)` syntax. Returns `null` on success or the exact 422
+     * message mandated by REQ-EFT-005 on failure.
+     *
+     * @param mixed       $value        The colour value submitted by the client.
+     * @param string|null $format       The declared `format` annotation (null => hex).
+     * @param string      $propertyName The property name (for the error message).
+     *
+     * @return string|null Null on success, or the exact 422 error message on failure.
+     *
+     * @spec openspec/specs/extended-field-types/spec.md#REQ-EFT-005
+     */
+    public function validateColor(mixed $value, ?string $format, string $propertyName): ?string
+    {
+        if (is_string($value) === false) {
+            return "Property '{$propertyName}': color value must be a string";
+        }
+
+        if ($format === null || $format === '') {
+            $format = 'hex';
+        } else {
+            $format = strtolower($format);
+        }
+
+        if ($format === 'rgba') {
+            return $this->validateRgba(value: $value, propertyName: $propertyName);
+        }
+
+        if ($format === 'oklch') {
+            if (preg_match(self::REGEX_OKLCH, $value) === 1) {
+                return null;
+            }
+
+            return "Property '{$propertyName}' declared format 'oklch'; '{$value}' does not match oklch regex";
+        }
+
+        // Default + explicit `hex`.
+        if (preg_match(self::REGEX_HEX, $value) === 1) {
+            return null;
+        }
+
+        return "Property '{$propertyName}' declared format 'hex'; '{$value}' does not match hex regex";
+    }//end validateColor()
+
+    /**
+     * Validate an `rgba(...)` colour value: it MUST carry exactly 4 components.
+     *
+     * @param string $value        The submitted colour string.
+     * @param string $propertyName The property name (for the error message).
+     *
+     * @return string|null Null on success, or the exact 422 error message on failure.
+     *
+     * @spec openspec/specs/extended-field-types/spec.md#REQ-EFT-005
+     */
+    private function validateRgba(string $value, string $propertyName): ?string
+    {
+        $matched = preg_match('/^rgba\(\s*([^)]*)\)$/i', $value, $matches);
+        if ($matched !== 1) {
+            return "Property '{$propertyName}' declared format 'rgba'; '{$value}' does not match rgba regex";
+        }
+
+        $components = array_filter(
+            array_map('trim', explode(',', $matches[1])),
+            static function ($component) {
+                return $component !== '';
+            }
+        );
+        $count      = count($components);
+
+        if ($count !== 4) {
+            return "Property '{$propertyName}' format 'rgba' requires 4 components; got {$count}";
+        }
+
+        return null;
+    }//end validateRgba()
+
+    /**
+     * Validate a `recurrence` value as a parseable RFC 5545 RRULE string.
+     *
+     * Validation is delegated to sabre/vobject's RRULE parser, which surfaces a
+     * parse failure as an `InvalidDataException`. Returns `null` when the RRULE
+     * parses cleanly, or the exact 422 message mandated by REQ-EFT-003 on failure.
+     *
+     * @param mixed  $value        The RRULE string submitted by the client.
+     * @param string $propertyName The property name (for the error message).
+     *
+     * @return string|null Null on success, or the exact 422 error message on failure.
+     *
+     * @spec openspec/specs/extended-field-types/spec.md#REQ-EFT-003
+     */
+    public function validateRecurrence(mixed $value, string $propertyName): ?string
+    {
+        if (is_string($value) === false) {
+            return "Property '{$propertyName}': recurrence value must be an RRULE string";
+        }
+
+        try {
+            // Constructing the iterator parses the RRULE and throws on bad input.
+            new RRuleIterator($value, new DateTimeImmutable('now'));
+            return null;
+        } catch (InvalidDataException $e) {
+            return "Property '{$propertyName}': invalid RRULE '{$value}' (sabre/vobject parse error)";
+        } catch (Throwable $e) {
+            return "Property '{$propertyName}': invalid RRULE '{$value}' (sabre/vobject parse error)";
+        }//end try
+    }//end validateRecurrence()
+
+    /**
+     * Materialise the next N upcoming occurrences for a recurrence RRULE.
+     *
+     * Iterates the RRULE from `now` and collects up to `$count` ISO-8601
+     * occurrence timestamps. `$count` is clamped to [1, MAX_OCCURRENCES]. The
+     * RRULE string itself is never modified — callers preserve it for round-trip
+     * integrity and attach the result under the `_occurrences` virtual field.
+     *
+     * @param string                 $rrule The RFC 5545 RRULE string.
+     * @param int                    $count The number of occurrences to emit.
+     * @param DateTimeInterface|null $start The iteration start (defaults to now).
+     *
+     * @return array<int, string> ISO-8601 occurrence timestamps, or empty on parse failure.
+     *
+     * @spec openspec/specs/extended-field-types/spec.md#REQ-EFT-003
+     */
+    public function materialiseOccurrences(string $rrule, int $count, ?DateTimeInterface $start=null): array
+    {
+        if ($count < 1) {
+            $count = self::DEFAULT_OCCURRENCES;
+        }
+
+        if ($count > self::MAX_OCCURRENCES) {
+            $count = self::MAX_OCCURRENCES;
+        }
+
+        if ($start === null) {
+            $start = new DateTimeImmutable('now');
+        }
+
+        try {
+            $iterator    = new RRuleIterator($rrule, $start);
+            $occurrences = [];
+            while ($iterator->valid() === true && count($occurrences) < $count) {
+                $current = $iterator->current();
+                if ($current instanceof DateTimeInterface) {
+                    $occurrences[] = $current->format(DateTimeInterface::ATOM);
+                }
+
+                $iterator->next();
+            }
+
+            return $occurrences;
+        } catch (Throwable $e) {
+            // A value that fails to parse here would already have been rejected at
+            // write time; on read we degrade gracefully to no occurrences.
+            return [];
+        }//end try
+    }//end materialiseOccurrences()
+}//end class

--- a/lib/Service/Object/RenderObject.php
+++ b/lib/Service/Object/RenderObject.php
@@ -32,7 +32,9 @@ use Adbar\Dot;
 use Exception;
 use JsonSerializable;
 use OCA\OpenRegister\Db\FileMapper;
+use OCA\OpenRegister\Formats\ExtendedFieldTypeValidator;
 use OCA\OpenRegister\Service\FileService;
+use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\MagicMapper;
@@ -152,6 +154,7 @@ class RenderObject
      * @param CalculationEvaluator     $calculationEvaluator     Evaluator for derived/computed properties.
      * @param UrnService               $urnService               URN resolver for register/schema/object identifiers.
      * @param TranslationStatusService $translationStatusService Service exposing per-object translation status metadata.
+     * @param IRequest|null            $request                  Current request, used to read `?recurrenceOccurrences=N`.
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList) All parameters are DI-injected dependencies
      *
@@ -175,6 +178,7 @@ class RenderObject
         private readonly CalculationEvaluator $calculationEvaluator,
         private readonly UrnService $urnService,
         private readonly TranslationStatusService $translationStatusService,
+        private readonly ?IRequest $request=null,
     ) {
     }//end __construct()
 
@@ -274,6 +278,95 @@ class RenderObject
             return null;
         }
     }//end getSchema()
+
+    /**
+     * Enrich `recurrence`-typed properties with their upcoming occurrences.
+     *
+     * For every property declared as `type: recurrence` whose value is a non-empty
+     * RRULE string, this attaches a sibling virtual field `_occurrences` listing
+     * the next N occurrences (ISO 8601). N defaults to 5 and may be overridden per
+     * request via `?recurrenceOccurrences=N` (clamped to 1..100). The RRULE string
+     * itself is preserved unchanged for round-trip integrity. When the object
+     * declares exactly one recurrence property, `_occurrences` is attached at the
+     * object root; with multiple, each is keyed as `<prop>_occurrences` to avoid
+     * collisions.
+     *
+     * @param array  $objectData The object data being rendered.
+     * @param Schema $schema     The schema for the object.
+     *
+     * @return array The object data, possibly enriched with occurrence lists.
+     *
+     * @spec openspec/specs/extended-field-types/spec.md#REQ-EFT-003
+     */
+    private function enrichRecurrenceOccurrences(array $objectData, Schema $schema): array
+    {
+        $properties = $schema->getProperties() ?? [];
+
+        // Collect recurrence properties present in the object with a string value.
+        $recurrenceProps = [];
+        foreach ($properties as $propertyName => $propertyConfig) {
+            $type = null;
+            if (is_array($propertyConfig) === true) {
+                $type = ($propertyConfig['type'] ?? null);
+            } else if (is_object($propertyConfig) === true) {
+                $type = ($propertyConfig->type ?? null);
+            }
+
+            if ($type !== 'recurrence') {
+                continue;
+            }
+
+            $value = ($objectData[$propertyName] ?? null);
+            if (is_string($value) === true && $value !== '') {
+                $recurrenceProps[$propertyName] = $value;
+            }
+        }//end foreach
+
+        if (empty($recurrenceProps) === true) {
+            return $objectData;
+        }
+
+        $count     = $this->resolveOccurrenceCount();
+        $validator = new ExtendedFieldTypeValidator();
+        $single    = (count($recurrenceProps) === 1);
+
+        foreach ($recurrenceProps as $propertyName => $rrule) {
+            $occurrences = $validator->materialiseOccurrences(rrule: $rrule, count: $count);
+            $key         = $propertyName.'_occurrences';
+            if ($single === true) {
+                $key = '_occurrences';
+            }
+
+            $objectData[$key] = $occurrences;
+        }
+
+        return $objectData;
+    }//end enrichRecurrenceOccurrences()
+
+    /**
+     * Resolve the requested number of recurrence occurrences from the request.
+     *
+     * Reads the `recurrenceOccurrences` query parameter (default 5, clamped to
+     * 1..100 by the validator). Falls back to the default when no request is
+     * available (e.g. in unit-test construction without an injected IRequest).
+     *
+     * @return int The requested occurrence count.
+     *
+     * @spec openspec/specs/extended-field-types/spec.md#REQ-EFT-003
+     */
+    private function resolveOccurrenceCount(): int
+    {
+        if ($this->request === null) {
+            return ExtendedFieldTypeValidator::DEFAULT_OCCURRENCES;
+        }
+
+        $raw = $this->request->getParam('recurrenceOccurrences', null);
+        if ($raw === null || is_numeric($raw) === false) {
+            return ExtendedFieldTypeValidator::DEFAULT_OCCURRENCES;
+        }
+
+        return (int) $raw;
+    }//end resolveOccurrenceCount()
 
     /**
      * Check if a string looks like a UUID (using regex, not strict RFC 4122 validation).
@@ -1310,6 +1403,13 @@ class RenderObject
                 schema: $readSchema,
                 evaluateOn: 'read'
             );
+            $entity->setObject($objectData);
+        }
+
+        // Enrich `recurrence` properties with upcoming occurrences under `_occurrences`.
+        // The base RRULE string is preserved unchanged for round-trip integrity.
+        if ($readSchema !== null) {
+            $objectData = $this->enrichRecurrenceOccurrences(objectData: $objectData, schema: $readSchema);
             $entity->setObject($objectData);
         }
 

--- a/lib/Service/Object/SchemaTypeConverter.php
+++ b/lib/Service/Object/SchemaTypeConverter.php
@@ -85,7 +85,13 @@ class SchemaTypeConverter
             'number'          => $this->convertNumber(value: $value),
             'integer'         => $this->convertInteger(value: $value),
             'boolean'         => $this->convertBoolean(value: $value),
-            default           => $this->convertString(value: $value, schemaType: $schemaType),
+            // Extended field types `color` and `recurrence` are typed strings:
+            // persisted and returned verbatim via the string path. The `recurrence`
+            // `_occurrences` enrichment is materialised by the render layer
+            // (RenderObject), not here, since it is a sibling virtual field on the
+            // parent object rather than a transform of the value itself.
+            'color', 'recurrence' => $this->convertString(value: $value, schemaType: $schemaType),
+            default               => $this->convertString(value: $value, schemaType: $schemaType),
         };
     }//end convertValue()
 

--- a/lib/Service/Object/ValidateObject.php
+++ b/lib/Service/Object/ValidateObject.php
@@ -41,6 +41,7 @@ use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Exception\ValidationException;
 use OCA\OpenRegister\Exception\CustomValidationException;
 use OCA\OpenRegister\Formats\BsnFormat;
+use OCA\OpenRegister\Formats\ExtendedFieldTypeValidator;
 use OCA\OpenRegister\Formats\SemVerFormat;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
@@ -1075,22 +1076,26 @@ class ValidateObject
     {
         // Map of custom OpenRegister types to their JSON Schema equivalents.
         $customTypeMap = [
-            'file'     => ['integer', 'string', 'null'],
+            'file'       => ['integer', 'string', 'null'],
         // File references are stored as integer file IDs, string data URIs, or null.
-            'datetime' => 'string',
+            'datetime'   => 'string',
         // Datetime values are stored as ISO 8601 strings.
-            'date'     => 'string',
+            'date'       => 'string',
         // Date values are stored as strings.
-            'time'     => 'string',
+            'time'       => 'string',
         // Time values are stored as strings.
-            'uuid'     => 'string',
+            'uuid'       => 'string',
         // UUIDs are strings.
-            'url'      => 'string',
+            'url'        => 'string',
         // URLs are strings.
-            'email'    => 'string',
+            'email'      => 'string',
         // Emails are strings.
-            'phone'    => 'string',
+            'phone'      => 'string',
         // Phone numbers are strings.
+            'color'      => 'string',
+        // Colour values (hex/rgba/oklch) are stored as literal strings.
+            'recurrence' => 'string',
+        // RFC 5545 RRULE recurrence patterns are stored as literal strings.
         ];
 
         // Check if type is set and needs transformation.
@@ -1320,6 +1325,10 @@ class ValidateObject
         }//end if
 
         $this->validateUniqueFields(object: $object, schema: $schema);
+
+        // Validate extended field types (color, recurrence) against the original,
+        // un-transformed schema so the declared `type`/`format` annotations are intact.
+        $this->validateExtendedFieldTypes(object: $object, schemaObject: $schemaObject);
 
         // Get the current schema slug for circular reference detection.
         $currentSchemaSlug = '';
@@ -1925,4 +1934,75 @@ class ValidateObject
             );
         }//end if
     }//end validateUniqueFields()
+
+    /**
+     * Validate extended field-type values (`color`, `recurrence`).
+     *
+     * The base Opis validator only understands JSON-Schema primitives, so the
+     * extended types are mapped to `string` for structural validation. This hook
+     * performs the per-type value validation that the spec mandates and emits the
+     * exact 422 messages required by REQ-EFT-003 / REQ-EFT-005. It walks the
+     * schema's declared properties, and for each `color`/`recurrence` property
+     * present in the submitted object validates the value via the shared
+     * ExtendedFieldTypeValidator. `null` values are skipped (handled by the
+     * required/optional logic elsewhere).
+     *
+     * @param array  $object       The submitted object data.
+     * @param object $schemaObject The original, un-transformed schema object.
+     *
+     * @return void
+     *
+     * @throws CustomValidationException When a color/recurrence value is invalid.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Per-type dispatch over schema properties
+     *
+     * @spec openspec/specs/extended-field-types/spec.md#REQ-EFT-003
+     * @spec openspec/specs/extended-field-types/spec.md#REQ-EFT-005
+     */
+    private function validateExtendedFieldTypes(array $object, object $schemaObject): void
+    {
+        $properties = ($schemaObject->properties ?? null);
+        if (is_object($properties) === false && is_array($properties) === false) {
+            return;
+        }
+
+        $validator = new ExtendedFieldTypeValidator();
+
+        foreach ($properties as $propertyName => $propertySchema) {
+            // Property not present in the submitted object - nothing to validate.
+            if (array_key_exists($propertyName, $object) === false) {
+                continue;
+            }
+
+            $value = $object[$propertyName];
+            if ($value === null) {
+                continue;
+            }
+
+            // Read the declared type and format from the (possibly object/array) schema.
+            $type   = null;
+            $format = null;
+            if (is_object($propertySchema) === true) {
+                $type   = ($propertySchema->type ?? null);
+                $format = ($propertySchema->format ?? null);
+            } else if (is_array($propertySchema) === true) {
+                $type   = ($propertySchema['type'] ?? null);
+                $format = ($propertySchema['format'] ?? null);
+            }
+
+            $error = null;
+            if ($type === 'color') {
+                $error = $validator->validateColor(value: $value, format: $format, propertyName: (string) $propertyName);
+            } else if ($type === 'recurrence') {
+                $error = $validator->validateRecurrence(value: $value, propertyName: (string) $propertyName);
+            }
+
+            if ($error !== null) {
+                throw new CustomValidationException(
+                    message: $error,
+                    errors: [(string) $propertyName => $error]
+                );
+            }
+        }//end foreach
+    }//end validateExtendedFieldTypes()
 }//end class

--- a/lib/Service/Schemas/PropertyValidatorHandler.php
+++ b/lib/Service/Schemas/PropertyValidatorHandler.php
@@ -54,6 +54,9 @@ class PropertyValidatorHandler
         'null',
         'file',
         'geo',
+        // Extended field types (see extended-field-types spec).
+        'color',
+        'recurrence',
         'NcFile',
         'NcMail',
         'NcContact',

--- a/tests/Unit/Service/Formats/ExtendedFieldTypeValidatorTest.php
+++ b/tests/Unit/Service/Formats/ExtendedFieldTypeValidatorTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * ExtendedFieldTypeValidator Unit Test
+ *
+ * Pins the per-type contract defined in
+ * openspec/specs/extended-field-types/spec.md (REQ-EFT-003, REQ-EFT-005).
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Formats
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Formats;
+
+use DateTimeImmutable;
+use OCA\OpenRegister\Formats\ExtendedFieldTypeValidator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ExtendedFieldTypeValidator.
+ *
+ * Each test maps to a scenario in the extended-field-types spec.
+ */
+class ExtendedFieldTypeValidatorTest extends TestCase
+{
+
+    private ExtendedFieldTypeValidator $validator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validator = new ExtendedFieldTypeValidator();
+    }//end setUp()
+
+    /*
+        ====================================================================
+     * color — REQ-EFT-005
+     * ==================================================================== */
+
+    /**
+     * @dataProvider colorProvider
+     */
+    public function testValidateColor(mixed $value, ?string $format, ?string $expected, string $message): void
+    {
+        $this->assertSame($expected, $this->validator->validateColor($value, $format, 'accent'), $message);
+    }//end testValidateColor()
+
+    public static function colorProvider(): array
+    {
+        return [
+            'hex default 6-digit'      => ['#a4b8ff', null, null, '6-digit hex passes under default format'],
+            'hex default 8-digit'      => ['#a4b8ffcc', null, null, '8-digit hex (alpha) passes under default format'],
+            'hex default 3-digit'      => ['#fff', null, null, '3-digit hex passes'],
+            'hex explicit'             => ['#000000', 'hex', null, 'explicit hex format accepts hex'],
+            'hex rejects rgba'         => [
+                'rgba(0,0,0,1)',
+                'hex',
+                "Property 'accent' declared format 'hex'; 'rgba(0,0,0,1)' does not match hex regex",
+                'declared hex rejects rgba with exact message',
+            ],
+            'rgba 4 components'        => ['rgba(164, 184, 255, 0.8)', 'rgba', null, 'rgba with 4 components passes'],
+            'rgba 3 components'        => [
+                'rgba(164, 184, 255)',
+                'rgba',
+                "Property 'accent' format 'rgba' requires 4 components; got 3",
+                'rgba with 3 components fails with exact message',
+            ],
+            'oklch valid'              => ['oklch(0.7 0.15 250)', 'oklch', null, 'oklch L C H passes'],
+            'oklch with pct and alpha' => ['oklch(70% 0.15 250deg / 0.5)', 'oklch', null, 'oklch with percentage and alpha passes'],
+            'oklch rejects hex'        => [
+                '#fff',
+                'oklch',
+                "Property 'accent' declared format 'oklch'; '#fff' does not match oklch regex",
+                'declared oklch rejects hex',
+            ],
+        ];
+    }//end colorProvider()
+
+    /*
+        ====================================================================
+     * recurrence — REQ-EFT-003
+     * ==================================================================== */
+
+    public function testValidRruleReturnsNull(): void
+    {
+        $this->assertNull(
+            $this->validator->validateRecurrence('FREQ=WEEKLY;BYDAY=MO,WE;UNTIL=20261231T235959Z', 'pattern'),
+            'a valid RRULE must validate cleanly'
+        );
+    }//end testValidRruleReturnsNull()
+
+    public function testInvalidRruleReturnsExactMessage(): void
+    {
+        $this->assertSame(
+            "Property 'pattern': invalid RRULE 'BANANA=DAILY' (sabre/vobject parse error)",
+            $this->validator->validateRecurrence('BANANA=DAILY', 'pattern'),
+            'an invalid RRULE must fail with the exact spec message'
+        );
+    }//end testInvalidRruleReturnsExactMessage()
+
+    public function testMaterialiseOccurrencesReturnsRequestedCount(): void
+    {
+        // Anchor on a fixed Monday so the result is deterministic.
+        $start       = new DateTimeImmutable('2026-01-05T00:00:00Z');
+        $occurrences = $this->validator->materialiseOccurrences('FREQ=WEEKLY;BYDAY=MO;COUNT=10', 3, $start);
+
+        $this->assertCount(3, $occurrences, 'exactly 3 occurrences requested');
+        $this->assertSame('2026-01-05T00:00:00+00:00', $occurrences[0], 'first Monday is the anchor date');
+        $this->assertSame('2026-01-12T00:00:00+00:00', $occurrences[1], 'second Monday is one week later');
+        $this->assertSame('2026-01-19T00:00:00+00:00', $occurrences[2], 'third Monday is two weeks later');
+    }//end testMaterialiseOccurrencesReturnsRequestedCount()
+
+    public function testMaterialiseOccurrencesClampsToMax(): void
+    {
+        $start       = new DateTimeImmutable('2026-01-05T00:00:00Z');
+        $occurrences = $this->validator->materialiseOccurrences('FREQ=DAILY', 1000, $start);
+
+        $this->assertCount(
+            ExtendedFieldTypeValidator::MAX_OCCURRENCES,
+            $occurrences,
+            'requested count above the max must be clamped to MAX_OCCURRENCES'
+        );
+    }//end testMaterialiseOccurrencesClampsToMax()
+
+    public function testMaterialiseOccurrencesFallsBackToDefaultForZero(): void
+    {
+        $start       = new DateTimeImmutable('2026-01-05T00:00:00Z');
+        $occurrences = $this->validator->materialiseOccurrences('FREQ=DAILY', 0, $start);
+
+        $this->assertCount(
+            ExtendedFieldTypeValidator::DEFAULT_OCCURRENCES,
+            $occurrences,
+            'a zero count falls back to the default occurrence count'
+        );
+    }//end testMaterialiseOccurrencesFallsBackToDefaultForZero()
+}//end class

--- a/tests/Unit/Service/Object/SchemaTypeConverterTest.php
+++ b/tests/Unit/Service/Object/SchemaTypeConverterTest.php
@@ -253,4 +253,23 @@ class SchemaTypeConverterTest extends TestCase
         $this->assertSame('hello', $this->converter->convertValue('hello', ''));
         $this->assertSame('5', $this->converter->convertValue(5, ''));
     }//end testEmptySchemaTypeUsesStringFallback()
+
+    /*
+        ====================================================================
+     * Extended field types — color / recurrence (extended-field-types spec)
+     * ==================================================================== */
+
+    public function testColorTypeReturnsStringUnchanged(): void
+    {
+        // REQ-EFT-005: color is a typed string returned verbatim on read.
+        $this->assertSame('#a4b8ff', $this->converter->convertValue('#a4b8ff', 'color'));
+        $this->assertSame('rgba(0,0,0,1)', $this->converter->convertValue('rgba(0,0,0,1)', 'color'));
+    }//end testColorTypeReturnsStringUnchanged()
+
+    public function testRecurrenceTypeReturnsRruleUnchanged(): void
+    {
+        // REQ-EFT-003: the base RRULE string is preserved unchanged for round-trip.
+        $rrule = 'FREQ=WEEKLY;BYDAY=MO;COUNT=10';
+        $this->assertSame($rrule, $this->converter->convertValue($rrule, 'recurrence'));
+    }//end testRecurrenceTypeReturnsRruleUnchanged()
 }//end class


### PR DESCRIPTION
## Summary

Implements the two missing extended-field-type features tracked in #1842, per `openspec/.../extended-field-types/spec.md` (REQ-EFT-003, REQ-EFT-005).

### `color` (REQ-EFT-005) — PARTIAL → complete
Previously `color*` existed only as whitelisted string-format names with a hex heuristic. Now `color` is a first-class property type with per-format value validation:
- **hex** (default): `#RGB`, `#RRGGBB`, `#RRGGBBAA`
- **rgba**: `rgba(R, G, B, A)` with a strict 4-component check
- **oklch**: `oklch(L C H)` incl. percentage lightness, `deg` hue and optional `/ A` alpha

Invalid input returns the exact 422 messages the spec mandates, e.g.
`Property 'accent' format 'rgba' requires 4 components; got 3` and
`Property 'accent' declared format 'hex'; 'rgba(0,0,0,1)' does not match hex regex`.

### `recurrence` (REQ-EFT-003) — MISSING → built
- Stores an RFC 5545 RRULE string, validated via **sabre/vobject**'s RRULE parser. Invalid rules fail with `Property 'pattern': invalid RRULE 'BANANA=DAILY' (sabre/vobject parse error)`.
- On read, `RenderObject` enriches the object with `_occurrences` (next N upcoming occurrences, ISO 8601). N defaults to 5, max 100, overridable per request via `?recurrenceOccurrences=N`. The RRULE string is preserved unchanged for round-trip integrity.

### Wiring
- `PropertyValidatorHandler::$validTypes` now accepts `color` + `recurrence`.
- `ValidateObject::transformCustomTypeToJsonSchemaType` maps both to `string` for Opis structural validation; a new pre-validation hook (`validateExtendedFieldTypes`) performs the per-type value validation with the exact spec messages.
- `SchemaTypeConverter` dispatches both as typed strings (returned verbatim on read).
- All validation/occurrence logic lives in one shared `OCA\OpenRegister\Formats\ExtendedFieldTypeValidator`, keeping REST the single source of truth (ready for GraphQL parity per REQ-EFT-007).

### Dependency
- Adds `sabre/vobject ^4.5` (composer.json + composer.lock). It is the standard RFC 5545 library; it was not previously installed in OpenRegister's vendor tree.

## Test plan

- [x] Unit tests: `tests/Unit/Service/Formats/ExtendedFieldTypeValidatorTest.php` (color hex/rgba/oklch accept+reject, RRULE valid/invalid, occurrence count/clamp/default) and `color`/`recurrence` dispatch cases in `SchemaTypeConverterTest.php` — 72 tests pass.
- [x] `php -l` clean on all touched files; PHPCS reports **0 errors** on the new/edited code (pre-existing inline-IF warnings elsewhere in RenderObject left untouched).
- [ ] Reviewer: confirm `composer install` regenerates vendor with sabre/vobject (vendor is gitignored).

Closes #1842