### PR TITLE
fix(security): close cross-tenant PII exposure in GDPR/DSAR endpoints (#1825)

### DIFF
--- a/lib/Controller/GdprEntitiesController.php
+++ b/lib/Controller/GdprEntitiesController.php
@@ -26,14 +26,18 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Controller;
 
+use DateTime;
 use OCA\OpenRegister\Db\GdprEntityMapper;
 use OCA\OpenRegister\Db\EntityRelationMapper;
+use OCA\OpenRegister\Service\OrganisationService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -52,6 +56,8 @@ use Psr\Log\LoggerInterface;
  * @psalm-suppress UnusedClass
  *
  * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class GdprEntitiesController extends Controller
 {
@@ -64,6 +70,9 @@ class GdprEntitiesController extends Controller
      * @param EntityRelationMapper $entityRelationMapper Entity relation mapper
      * @param IDBConnection        $db                   Database connection
      * @param LoggerInterface      $logger               Logger
+     * @param IUserSession         $userSession          Current user (admin gate)
+     * @param IGroupManager        $groupManager         Group manager (admin gate)
+     * @param OrganisationService  $organisationService  Org-scoping helper
      */
     public function __construct(
         string $appName,
@@ -71,7 +80,10 @@ class GdprEntitiesController extends Controller
         private readonly GdprEntityMapper $entityMapper,
         private readonly EntityRelationMapper $entityRelationMapper,
         private readonly IDBConnection $db,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager,
+        private readonly OrganisationService $organisationService
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
@@ -90,6 +102,33 @@ class GdprEntitiesController extends Controller
     public function index(): JSONResponse
     {
         try {
+            if ($this->userSession->getUser() === null) {
+                return $this->unauthorized();
+            }
+
+            // SECURITY (#1825): rows in `openregister_entities` store raw
+            // detected PII (names, emails, BSNs) and carry an
+            // `organisation` UUID. Non-admins must only ever see PII
+            // detected within their own organisation(s); admins see all.
+            // A non-admin with no accessible organisation is denied
+            // (empty result set, not an error) — fail-closed.
+            $isAdmin  = $this->isAdmin();
+            $orgUuids = [];
+            if ($isAdmin === false) {
+                $orgUuids = $this->accessibleOrganisationUuids();
+                if ($orgUuids === []) {
+                    return new JSONResponse(
+                        data: [
+                            'success' => true,
+                            'data'    => [],
+                            'count'   => 0,
+                            'limit'   => (int) $this->request->getParam('limit', 50),
+                            'offset'  => (int) $this->request->getParam('offset', 0),
+                        ]
+                    );
+                }
+            }
+
             $limit    = (int) $this->request->getParam('limit', 50);
             $offset   = (int) $this->request->getParam('offset', 0);
             $search   = $this->request->getParam('search', '');
@@ -117,47 +156,18 @@ class GdprEntitiesController extends Controller
                 ->selectAlias($qb->createFunction('('.$subQb->getSQL().')'), 'relation_count')
                 ->from('openregister_entities', 'e');
 
-            // Apply filters.
-            if ($search !== '') {
-                $qb->andWhere(
-                    $qb->expr()->iLike('e.value', $qb->createNamedParameter('%'.$search.'%'))
-                );
-            }
-
-            if ($type !== '') {
-                $qb->andWhere(
-                    $qb->expr()->eq('e.type', $qb->createNamedParameter($type))
-                );
-            }
-
-            if ($category !== '') {
-                $qb->andWhere(
-                    $qb->expr()->eq('e.category', $qb->createNamedParameter($category))
-                );
-            }
+            // Tenant scoping for non-admins (#1825).
+            $this->applyOrgFilter(qb: $qb, isAdmin: $isAdmin, orgUuids: $orgUuids, column: 'e.organisation');
+            $this->applySearchFilters(qb: $qb, search: $search, type: $type, category: $category);
 
             // Get total count.
             $countQb = $this->db->getQueryBuilder();
             $countQb->select($countQb->func()->count('*', 'total'))
                 ->from('openregister_entities', 'e');
 
-            if ($search !== '') {
-                $countQb->andWhere(
-                    $countQb->expr()->iLike('e.value', $countQb->createNamedParameter('%'.$search.'%'))
-                );
-            }
-
-            if ($type !== '') {
-                $countQb->andWhere(
-                    $countQb->expr()->eq('e.type', $countQb->createNamedParameter($type))
-                );
-            }
-
-            if ($category !== '') {
-                $countQb->andWhere(
-                    $countQb->expr()->eq('e.category', $countQb->createNamedParameter($category))
-                );
-            }
+            // Tenant scoping for non-admins (#1825).
+            $this->applyOrgFilter(qb: $countQb, isAdmin: $isAdmin, orgUuids: $orgUuids, column: 'e.organisation');
+            $this->applySearchFilters(qb: $countQb, search: $search, type: $type, category: $category);
 
             $countResult = $countQb->executeQuery();
             $total       = (int) $countResult->fetchOne();
@@ -232,7 +242,27 @@ class GdprEntitiesController extends Controller
     public function show(int $id): JSONResponse
     {
         try {
+            if ($this->userSession->getUser() === null) {
+                return $this->unauthorized();
+            }
+
             $entity = $this->entityMapper->find($id);
+
+            // SECURITY (#1825): non-admins may only view PII detected
+            // within an organisation they belong to. Return 404 (not
+            // 403) so we don't leak the existence of cross-tenant rows.
+            if ($this->isAdmin() === false) {
+                $entityOrg = (string) $entity->getOrganisation();
+                if ($entityOrg === '' || in_array($entityOrg, $this->accessibleOrganisationUuids(), true) === false) {
+                    return new JSONResponse(
+                        data: [
+                            'success' => false,
+                            'message' => 'Entity not found',
+                        ],
+                        statusCode: Http::STATUS_NOT_FOUND
+                    );
+                }
+            }
 
             // Get relations for this entity.
             $relations = $this->entityRelationMapper->findByEntityId($id);
@@ -287,10 +317,26 @@ class GdprEntitiesController extends Controller
     public function getTypes(): JSONResponse
     {
         try {
+            if ($this->userSession->getUser() === null) {
+                return $this->unauthorized();
+            }
+
+            $isAdmin  = $this->isAdmin();
+            $orgUuids = [];
+            if ($isAdmin === false) {
+                $orgUuids = $this->accessibleOrganisationUuids();
+                if ($orgUuids === []) {
+                    return new JSONResponse(data: ['success' => true, 'data' => []]);
+                }
+            }
+
             $qb = $this->db->getQueryBuilder();
             $qb->selectDistinct('type')
                 ->from('openregister_entities')
                 ->orderBy('type', 'ASC');
+
+            // Tenant scoping for non-admins (#1825).
+            $this->applyOrgFilter(qb: $qb, isAdmin: $isAdmin, orgUuids: $orgUuids, column: 'organisation');
 
             $result = $qb->executeQuery();
             $types  = [];
@@ -337,10 +383,26 @@ class GdprEntitiesController extends Controller
     public function getCategories(): JSONResponse
     {
         try {
+            if ($this->userSession->getUser() === null) {
+                return $this->unauthorized();
+            }
+
+            $isAdmin  = $this->isAdmin();
+            $orgUuids = [];
+            if ($isAdmin === false) {
+                $orgUuids = $this->accessibleOrganisationUuids();
+                if ($orgUuids === []) {
+                    return new JSONResponse(data: ['success' => true, 'data' => []]);
+                }
+            }
+
             $qb = $this->db->getQueryBuilder();
             $qb->selectDistinct('category')
                 ->from('openregister_entities')
                 ->orderBy('category', 'ASC');
+
+            // Tenant scoping for non-admins (#1825).
+            $this->applyOrgFilter(qb: $qb, isAdmin: $isAdmin, orgUuids: $orgUuids, column: 'organisation');
 
             $result     = $qb->executeQuery();
             $categories = [];
@@ -387,10 +449,37 @@ class GdprEntitiesController extends Controller
     public function getStats(): JSONResponse
     {
         try {
+            if ($this->userSession->getUser() === null) {
+                return $this->unauthorized();
+            }
+
+            // SECURITY (#1825): stats aggregate raw PII counts; non-admins
+            // only see totals scoped to their own organisation(s).
+            $isAdmin  = $this->isAdmin();
+            $orgUuids = [];
+            if ($isAdmin === false) {
+                $orgUuids = $this->accessibleOrganisationUuids();
+                if ($orgUuids === []) {
+                    return new JSONResponse(
+                        data: [
+                            'success' => true,
+                            'data'    => [
+                                'totalEntities'  => 0,
+                                'totalRelations' => 0,
+                                'byType'         => [],
+                                'byCategory'     => [],
+                            ],
+                        ]
+                    );
+                }
+            }
+
             // Total entities.
             $totalQb = $this->db->getQueryBuilder();
             $totalQb->select($totalQb->func()->count('*', 'total'))
                 ->from('openregister_entities');
+            $this->applyOrgFilter(qb: $totalQb, isAdmin: $isAdmin, orgUuids: $orgUuids, column: 'organisation');
+
             $totalResult = $totalQb->executeQuery();
             $total       = (int) $totalResult->fetchOne();
             $totalResult->closeCursor();
@@ -402,6 +491,7 @@ class GdprEntitiesController extends Controller
                 ->from('openregister_entities')
                 ->groupBy('type')
                 ->orderBy('count', 'DESC');
+            $this->applyOrgFilter(qb: $typeQb, isAdmin: $isAdmin, orgUuids: $orgUuids, column: 'organisation');
 
             $typeResult = $typeQb->executeQuery();
             $byType     = [];
@@ -419,6 +509,7 @@ class GdprEntitiesController extends Controller
                 ->from('openregister_entities')
                 ->groupBy('category')
                 ->orderBy('count', 'DESC');
+            $this->applyOrgFilter(qb: $catQb, isAdmin: $isAdmin, orgUuids: $orgUuids, column: 'organisation');
 
             $catResult  = $catQb->executeQuery();
             $byCategory = [];
@@ -429,10 +520,23 @@ class GdprEntitiesController extends Controller
 
             $catResult->closeCursor();
 
-            // Total relations.
+            // Total relations. For non-admins, only count relations whose
+            // owning entity belongs to an accessible organisation (#1825).
             $relQb = $this->db->getQueryBuilder();
             $relQb->select($relQb->func()->count('*', 'total'))
-                ->from('openregister_entity_relations');
+                ->from('openregister_entity_relations', 'r');
+            if ($isAdmin === false) {
+                $relQb->innerJoin(
+                    'r',
+                    'openregister_entities',
+                    'e',
+                    $relQb->expr()->eq('r.entity_id', 'e.id')
+                )
+                    ->andWhere(
+                        $relQb->expr()->in('e.organisation', $relQb->createNamedParameter($orgUuids, IQueryBuilder::PARAM_STR_ARRAY))
+                    );
+            }
+
             $relResult      = $relQb->executeQuery();
             $totalRelations = (int) $relResult->fetchOne();
             $relResult->closeCursor();
@@ -480,8 +584,49 @@ class GdprEntitiesController extends Controller
     public function destroy(int $id): JSONResponse
     {
         try {
+            $user = $this->userSession->getUser();
+            if ($user === null) {
+                return $this->unauthorized();
+            }
+
             $entity = $this->entityMapper->find($id);
+
+            // SECURITY (#1825): non-admins may only delete PII detected
+            // within an organisation they belong to. Return 404 (not
+            // 403) so we don't leak existence of cross-tenant rows.
+            if ($this->isAdmin() === false) {
+                $entityOrg = (string) $entity->getOrganisation();
+                if ($entityOrg === '' || in_array($entityOrg, $this->accessibleOrganisationUuids(), true) === false) {
+                    return new JSONResponse(
+                        data: [
+                            'success' => false,
+                            'message' => 'Entity not found',
+                        ],
+                        statusCode: Http::STATUS_NOT_FOUND
+                    );
+                }
+            }
+
             $this->entityMapper->delete($entity);
+
+            // AVG / GDPR Art 30 §4: emit a structured audit record for the
+            // PII-row deletion. GdprEntity rows are not ObjectEntity rows,
+            // so the ObjectEntity-bound AuditTrailMapper does not apply;
+            // we log to the application audit channel with the actor,
+            // target identity and organisation for supervisory review.
+            $this->logger->info(
+                message: '[GdprEntitiesController] GDPR entity deleted',
+                context: [
+                    'audit'        => 'gdpr-entity-delete',
+                    'entityId'     => $id,
+                    'entityUuid'   => $entity->getUuid(),
+                    'type'         => $entity->getType(),
+                    'category'     => $entity->getCategory(),
+                    'organisation' => $entity->getOrganisation(),
+                    'deletedBy'    => $user->getUID(),
+                    'deletedAt'    => (new DateTime())->format(DateTime::ATOM),
+                ]
+            );
 
             return new JSONResponse(
                 data: [
@@ -517,4 +662,118 @@ class GdprEntitiesController extends Controller
             );
         }//end try
     }//end destroy()
+
+    /**
+     * Apply the non-admin organisation filter to a query builder.
+     *
+     * Centralises the `WHERE <column> IN (:orgUuids)` clause used to
+     * tenant-scope the entity queries (#1825). For admins this is a
+     * no-op (they see everything). Keeping the branch here keeps the
+     * individual endpoint methods linear.
+     *
+     * @param IQueryBuilder      $qb       Query builder to constrain.
+     * @param bool               $isAdmin  Whether the caller is an admin.
+     * @param array<int, string> $orgUuids Accessible organisation UUIDs.
+     * @param string             $column   Column holding the org UUID.
+     *
+     * @return void
+     */
+    private function applyOrgFilter(IQueryBuilder $qb, bool $isAdmin, array $orgUuids, string $column): void
+    {
+        if ($isAdmin === true) {
+            return;
+        }
+
+        $qb->andWhere(
+            $qb->expr()->in($column, $qb->createNamedParameter($orgUuids, IQueryBuilder::PARAM_STR_ARRAY))
+        );
+    }//end applyOrgFilter()
+
+    /**
+     * Apply the optional search / type / category filters to a query.
+     *
+     * Shared between the list query and its count query so both stay in
+     * lock-step. Empty values are treated as "no filter".
+     *
+     * @param IQueryBuilder $qb       Query builder to constrain.
+     * @param string        $search   Substring to match against `value`.
+     * @param string        $type     Exact entity `type` filter.
+     * @param string        $category Exact entity `category` filter.
+     *
+     * @return void
+     */
+    private function applySearchFilters(IQueryBuilder $qb, string $search, string $type, string $category): void
+    {
+        if ($search !== '') {
+            $qb->andWhere(
+                $qb->expr()->iLike('e.value', $qb->createNamedParameter('%'.$search.'%'))
+            );
+        }
+
+        if ($type !== '') {
+            $qb->andWhere(
+                $qb->expr()->eq('e.type', $qb->createNamedParameter($type))
+            );
+        }
+
+        if ($category !== '') {
+            $qb->andWhere(
+                $qb->expr()->eq('e.category', $qb->createNamedParameter($category))
+            );
+        }
+    }//end applySearchFilters()
+
+    /**
+     * Whether the active user is in the `admin` group.
+     *
+     * @return bool True when the active user is an admin.
+     */
+    private function isAdmin(): bool
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        return $this->groupManager->isAdmin($user->getUID());
+    }//end isAdmin()
+
+    /**
+     * Organisation UUIDs the active user is allowed to see.
+     *
+     * Returns the list of organisation UUIDs the current (non-admin)
+     * user belongs to. Admins are not scoped (callers should branch on
+     * `isAdmin()` first). An empty list means "no accessible
+     * organisations" and callers MUST treat that as deny-all.
+     *
+     * @return array<int, string> Accessible organisation UUIDs.
+     */
+    private function accessibleOrganisationUuids(): array
+    {
+        $uuids = [];
+        foreach ($this->organisationService->getUserOrganisations() as $organisation) {
+            $uuid = (string) $organisation->getUuid();
+            if ($uuid !== '') {
+                $uuids[] = $uuid;
+            }
+        }
+
+        return array_values(array_unique($uuids));
+    }//end accessibleOrganisationUuids()
+
+    /**
+     * 401 envelope used when no user is authenticated.
+     *
+     * @return JSONResponse Pre-baked 401.
+     */
+    private function unauthorized(): JSONResponse
+    {
+        return new JSONResponse(
+            data: [
+                'success' => false,
+                'message' => 'Authentication required',
+            ],
+            statusCode: Http::STATUS_UNAUTHORIZED
+        );
+    }//end unauthorized()
 }//end class

--- a/lib/Controller/VerwerkingsactiviteitenController.php
+++ b/lib/Controller/VerwerkingsactiviteitenController.php
@@ -36,6 +36,7 @@ namespace OCA\OpenRegister\Controller;
 use InvalidArgumentException;
 use OCA\OpenRegister\Db\Verwerkingsactiviteit;
 use OCA\OpenRegister\Db\VerwerkingsactiviteitMapper;
+use OCA\OpenRegister\Service\OrganisationService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
@@ -48,18 +49,22 @@ use OCP\IUserSession;
 
 /**
  * REST endpoints for managing AVG / GDPR Art 30 processing activities.
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class VerwerkingsactiviteitenController extends Controller
 {
     /**
      * Constructor.
      *
-     * @param string                      $appName      App identifier.
-     * @param IRequest                    $request      Active request.
-     * @param VerwerkingsactiviteitMapper $vrwMapper    Mapper for the catalog.
-     * @param IUserSession                $userSession  Current user session.
-     * @param IGroupManager               $groupManager Group manager (admin gate).
-     * @param IDBConnection               $db           DB for the verantwoording aggregation.
+     * @param string                      $appName             App identifier.
+     * @param IRequest                    $request             Active request.
+     * @param VerwerkingsactiviteitMapper $vrwMapper           Mapper for the catalog.
+     * @param IUserSession                $userSession         Current user session.
+     * @param IGroupManager               $groupManager        Group manager (admin gate).
+     * @param IDBConnection               $db                  DB for the verantwoording aggregation.
+     * @param OrganisationService         $organisationService Org-scoping helper.
      */
     public function __construct(
         string $appName,
@@ -68,6 +73,7 @@ class VerwerkingsactiviteitenController extends Controller
         private readonly IUserSession $userSession,
         private readonly IGroupManager $groupManager,
         private readonly IDBConnection $db,
+        private readonly OrganisationService $organisationService,
     ) {
         parent::__construct(appName: $appName, request: $request);
 
@@ -87,18 +93,42 @@ class VerwerkingsactiviteitenController extends Controller
      */
     public function index(): JSONResponse
     {
-        $status         = $this->request->getParam(key: 'status');
-        $organisationId = $this->request->getParam(key: 'organisation');
+        // SECURITY (#1825): the processing register is tenant-scoped.
+        // Non-admins only see activities bound to their own
+        // organisation(s); admins see the full catalog.
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return $this->unauthorized();
+        }
+
+        $isAdmin        = $this->isAdmin();
+        $accessibleOrgs = [];
+        if ($isAdmin === false) {
+            $accessibleOrgs = $this->accessibleOrganisationUuids();
+            if ($accessibleOrgs === []) {
+                return new JSONResponse(data: ['count' => 0, 'results' => []]);
+            }
+        }
 
         $rows = $this->vrwMapper->findAll(
-            organisationId: ($organisationId !== null && $organisationId !== '') ? (string) $organisationId : null,
-            status: ($status !== null && $status !== '') ? (string) $status : null
+            organisationId: $this->optionalStringParam(key: 'organisation'),
+            status: $this->optionalStringParam(key: 'status')
         );
+
+        // Enforce tenant scoping in-controller: the mapper filter accepts
+        // a single org while a user may belong to several, and a
+        // caller-supplied `organisation` must never widen visibility.
+        $visible = $this->filterVisibleActivities(activities: $rows, accessibleOrgs: $accessibleOrgs, isAdmin: $isAdmin);
+
+        $results = [];
+        foreach ($visible as $activity) {
+            $results[] = $activity->jsonSerialize();
+        }
 
         return new JSONResponse(
             data: [
-                'count'   => count($rows),
-                'results' => array_map(static fn (Verwerkingsactiviteit $a) => $a->jsonSerialize(), $rows),
+                'count'   => count($results),
+                'results' => $results,
             ]
         );
 
@@ -121,8 +151,31 @@ class VerwerkingsactiviteitenController extends Controller
      */
     public function show(string $id): JSONResponse
     {
-        $entity = $this->resolveOne(identifier: $id);
-        if ($entity === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return $this->unauthorized();
+        }
+
+        $entity  = $this->resolveOne(identifier: $id);
+        $isAdmin = $this->isAdmin();
+
+        $accessibleOrgs = [];
+        if ($isAdmin === false) {
+            $accessibleOrgs = $this->accessibleOrganisationUuids();
+        }
+
+        // SECURITY (#1825): hide cross-tenant activities from non-admins.
+        // Return 404 rather than 403 so existence isn't leaked.
+        $visible = false;
+        if ($entity !== null) {
+            $visible = $this->maySeeActivity(
+                activity: $entity,
+                accessibleOrgs: $accessibleOrgs,
+                isAdmin: $isAdmin
+            );
+        }
+
+        if ($visible === false) {
             return new JSONResponse(
                 data: ['error' => 'Verwerkingsactiviteit not found', 'identifier' => $id],
                 statusCode: Http::STATUS_NOT_FOUND
@@ -281,7 +334,28 @@ class VerwerkingsactiviteitenController extends Controller
      */
     public function verantwoording(): JSONResponse
     {
-        $activities = $this->vrwMapper->findAll();
+        // SECURITY (#1825): the Art 30 §4 report exposes one tenant's full
+        // processing register + audit aggregates. Non-admins only get
+        // their own organisation(s); admins get the full report.
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return $this->unauthorized();
+        }
+
+        $isAdmin        = $this->isAdmin();
+        $accessibleOrgs = [];
+        if ($isAdmin === false) {
+            $accessibleOrgs = $this->accessibleOrganisationUuids();
+            if ($accessibleOrgs === []) {
+                return new JSONResponse(data: ['count' => 0, 'activities' => []]);
+            }
+        }
+
+        $activities = $this->filterVisibleActivities(
+            activities: $this->vrwMapper->findAll(),
+            accessibleOrgs: $accessibleOrgs,
+            isAdmin: $isAdmin
+        );
 
         $auditCounts = $this->aggregateAuditCounts(
             uuids: array_map(static fn (Verwerkingsactiviteit $a) => (string) $a->getUuid(), $activities)
@@ -330,7 +404,12 @@ class VerwerkingsactiviteitenController extends Controller
         ];
         foreach ($stringFields as $field => $setter) {
             if (array_key_exists($field, $payload) === true) {
-                $entity->{$setter}(($payload[$field] === null) ? null : (string) $payload[$field]);
+                $value = null;
+                if ($payload[$field] !== null) {
+                    $value = (string) $payload[$field];
+                }
+
+                $entity->{$setter}($value);
             }
         }
 
@@ -345,7 +424,11 @@ class VerwerkingsactiviteitenController extends Controller
         foreach ($arrayFields as $field => $setter) {
             if (array_key_exists($field, $payload) === true) {
                 $value    = $payload[$field];
-                $hydrated = (is_array($value) === true) ? $value : null;
+                $hydrated = null;
+                if (is_array($value) === true) {
+                    $hydrated = $value;
+                }
+
                 $entity->{$setter}($hydrated);
             }
         }
@@ -449,6 +532,103 @@ class VerwerkingsactiviteitenController extends Controller
     }//end isAdmin()
 
     /**
+     * Organisation UUIDs the active user is allowed to see.
+     *
+     * Returns the organisation UUIDs the current (non-admin) user
+     * belongs to. Admins are not scoped (callers should branch on
+     * `isAdmin()` first). An empty list means deny-all.
+     *
+     * @return array<int, string> Accessible organisation UUIDs.
+     */
+    private function accessibleOrganisationUuids(): array
+    {
+        $uuids = [];
+        foreach ($this->organisationService->getUserOrganisations() as $organisation) {
+            $uuid = (string) $organisation->getUuid();
+            if ($uuid !== '') {
+                $uuids[] = $uuid;
+            }
+        }
+
+        return array_values(array_unique($uuids));
+
+    }//end accessibleOrganisationUuids()
+
+    /**
+     * Whether the active user may see an activity given its org binding.
+     *
+     * Admins see everything. Non-admins see activities bound to one of
+     * their organisations. Activities with no `organisationId` are
+     * treated as belonging to no tenant and are hidden from non-admins
+     * (fail-closed) — they remain visible to admins for maintenance.
+     *
+     * @param Verwerkingsactiviteit $activity       Candidate activity.
+     * @param array<int, string>    $accessibleOrgs Accessible org UUIDs.
+     * @param bool                  $isAdmin        Whether caller is admin.
+     *
+     * @return bool True when the caller may see the activity.
+     */
+    private function maySeeActivity(Verwerkingsactiviteit $activity, array $accessibleOrgs, bool $isAdmin): bool
+    {
+        if ($isAdmin === true) {
+            return true;
+        }
+
+        $org = (string) $activity->getOrganisationId();
+        if ($org === '') {
+            return false;
+        }
+
+        return in_array($org, $accessibleOrgs, true);
+
+    }//end maySeeActivity()
+
+    /**
+     * Reduce a list of activities to the ones the caller may see.
+     *
+     * @param array<int, Verwerkingsactiviteit> $activities     Candidates.
+     * @param array<int, string>                $accessibleOrgs Accessible org UUIDs.
+     * @param bool                              $isAdmin        Whether caller is admin.
+     *
+     * @return array<int, Verwerkingsactiviteit> Visible activities.
+     */
+    private function filterVisibleActivities(array $activities, array $accessibleOrgs, bool $isAdmin): array
+    {
+        $visible = [];
+        foreach ($activities as $activity) {
+            $allowed = $this->maySeeActivity(
+                activity: $activity,
+                accessibleOrgs: $accessibleOrgs,
+                isAdmin: $isAdmin
+            );
+            if ($allowed === true) {
+                $visible[] = $activity;
+            }
+        }
+
+        return $visible;
+
+    }//end filterVisibleActivities()
+
+    /**
+     * Read a request parameter as a non-empty string, or null.
+     *
+     * @param string $key Request parameter name.
+     *
+     * @return string|null Trimmed string value, or null when absent/empty.
+     */
+    private function optionalStringParam(string $key): ?string
+    {
+        $value = $this->request->getParam(key: $key);
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return (string) $value;
+
+    }//end optionalStringParam()
+
+    /**
      * 403 envelope used by all admin-gated endpoints.
      *
      * @return JSONResponse Pre-baked 403 with explanatory message.
@@ -461,4 +641,18 @@ class VerwerkingsactiviteitenController extends Controller
         );
 
     }//end forbidden()
+
+    /**
+     * 401 envelope used when no user is authenticated.
+     *
+     * @return JSONResponse Pre-baked 401.
+     */
+    private function unauthorized(): JSONResponse
+    {
+        return new JSONResponse(
+            data: ['error' => 'Authentication required'],
+            statusCode: Http::STATUS_UNAUTHORIZED
+        );
+
+    }//end unauthorized()
 }//end class

--- a/lib/Service/DsarService.php
+++ b/lib/Service/DsarService.php
@@ -45,8 +45,10 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IAppConfig;
 use OCP\IDBConnection;
+use OCP\IGroupManager;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Data-Subject Access Request orchestrator.
@@ -95,8 +97,13 @@ class DsarService
      * @param IAppConfig                  $appConfig    App-config reader.
      * @param IUserSession                $userSession  Current user (for
      *                                                  soft-delete
-     *                                                  metadata).
+     *                                                  metadata + the
+     *                                                  in-service
+     *                                                  privilege guard).
      * @param LoggerInterface             $logger       Logger.
+     * @param IGroupManager               $groupManager Group manager used
+     *                                                  by the in-service
+     *                                                  admin guard.
      */
     public function __construct(
         private readonly IDBConnection $db,
@@ -104,10 +111,49 @@ class DsarService
         private readonly VerwerkingsactiviteitMapper $vrwMapper,
         private readonly IAppConfig $appConfig,
         private readonly IUserSession $userSession,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly IGroupManager $groupManager
     ) {
 
     }//end __construct()
+
+    /**
+     * Fail-closed privilege guard for all DSAR composition entry points.
+     *
+     * DSAR flows load + mutate objects across the entire register
+     * surface with `_rbac:false` and `_multitenancy:false`, deliberately
+     * bypassing per-object access control because a privacy officer must
+     * be able to reach every object referencing a data subject. That
+     * makes this service a cross-tenant amplifier: any caller able to
+     * invoke it can read or erase PII for arbitrary subjects regardless
+     * of tenant.
+     *
+     * `DsarController` already admin-gates every endpoint, but a service
+     * this powerful must not rely solely on its callers. This guard is
+     * defense-in-depth: it throws unless the active user is an admin, so
+     * a future caller that forgets to gate (or a mis-wired route) cannot
+     * silently expose the bypass. Authorized (admin) callers are
+     * unaffected — the response shape is unchanged for them.
+     *
+     * @return void
+     *
+     * @throws RuntimeException When the active user is not an admin.
+     */
+    private function assertPrivileged(): void
+    {
+        $user = $this->userSession->getUser();
+        if ($user !== null && $this->groupManager->isAdmin($user->getUID()) === true) {
+            return;
+        }
+
+        $this->logger->warning(
+            message: '[DSAR] Blocked unprivileged DSAR composition call',
+            context: ['user' => $user?->getUID() ?? 'anonymous']
+        );
+
+        throw new RuntimeException('DSAR operations require administrator privileges');
+
+    }//end assertPrivileged()
 
     /**
      * Find every object that contains personal data for the given subject.
@@ -138,6 +184,8 @@ class DsarService
      */
     public function findObjectsForSubject(string $subject, ?string $type=null, string $mode='exact'): array
     {
+        $this->assertPrivileged();
+
         $subject = trim($subject);
         if ($subject === '') {
             return [];
@@ -224,6 +272,8 @@ class DsarService
      */
     public function eraseObjectsForSubject(string $subject, ?string $type=null, bool $dryRun=false): array
     {
+        $this->assertPrivileged();
+
         $hits = $this->matchEntities(subject: $subject, type: $type, mode: 'exact');
 
         // Dedupe by canonical key — uuid (preferred) or int id (legacy).
@@ -331,7 +381,11 @@ class DsarService
      */
     private function loadObjectByEntry(array $entry): ?ObjectEntity
     {
-        $identifier = ($entry['object_uuid'] !== '') ? $entry['object_uuid'] : $entry['object_id'];
+        $identifier = $entry['object_id'];
+        if ($entry['object_uuid'] !== '') {
+            $identifier = $entry['object_uuid'];
+        }
+
         if ($identifier === 0 || $identifier === '') {
             return null;
         }
@@ -371,6 +425,8 @@ class DsarService
      */
     public function rectifyObjectForSubject(int $objectId, array $changes): ?array
     {
+        $this->assertPrivileged();
+
         try {
             $object = $this->objectMapper->find(
                 $objectId,

--- a/tests/Service/ControllersIntegrationTest2.php
+++ b/tests/Service/ControllersIntegrationTest2.php
@@ -2038,7 +2038,10 @@ class ControllersIntegrationTest2 extends TestCase
             \OC::$server->get(GdprEntityMapper::class),
             \OC::$server->get(EntityRelationMapper::class),
             $this->db,
-            $this->logger
+            $this->logger,
+            \OC::$server->get(\OCP\IUserSession::class),
+            \OC::$server->get(\OCP\IGroupManager::class),
+            \OC::$server->get(OrganisationService::class)
         );
     }//end buildGdprEntitiesController()
 

--- a/tests/Service/DsarServiceIntegrationTest.php
+++ b/tests/Service/DsarServiceIntegrationTest.php
@@ -48,6 +48,9 @@ use OCA\OpenRegister\Service\DsarService;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IAppConfig;
 use OCP\IDBConnection;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\Uuid;
 
@@ -114,6 +117,16 @@ class DsarServiceIntegrationTest extends TestCase
         $this->auditMapper    = \OC::$server->get(AuditTrailMapper::class);
         $this->gdprMapper     = \OC::$server->get(GdprEntityMapper::class);
         $this->appConfig      = \OC::$server->get(IAppConfig::class);
+
+        // DSAR composition is admin-only (#1825): authenticate as admin so
+        // the in-service privilege guard (DsarService::assertPrivileged)
+        // permits the flows exercised here.
+        $userManager = \OC::$server->get(IUserManager::class);
+        $userSession = \OC::$server->get(IUserSession::class);
+        $admin       = $userManager->get('admin');
+        if ($admin instanceof IUser) {
+            $userSession->setUser($admin);
+        }
 
         $this->previousDsarConfig = $this->appConfig->getValueString(
             app: 'openregister',

--- a/tests/Service/VerwerkingsactiviteitenControllerIntegrationTest.php
+++ b/tests/Service/VerwerkingsactiviteitenControllerIntegrationTest.php
@@ -434,7 +434,8 @@ class VerwerkingsactiviteitenControllerIntegrationTest extends TestCase
             $this->vrwMapper,
             $this->userSession,
             \OC::$server->get(\OCP\IGroupManager::class),
-            \OC::$server->get(\OCP\IDBConnection::class)
+            \OC::$server->get(\OCP\IDBConnection::class),
+            \OC::$server->get(\OCA\OpenRegister\Service\OrganisationService::class)
         );
 
     }//end makeControllerWithBody()

--- a/tests/Unit/Controller/GdprEntitiesControllerTest.php
+++ b/tests/Unit/Controller/GdprEntitiesControllerTest.php
@@ -8,6 +8,7 @@ use OCA\OpenRegister\Controller\GdprEntitiesController;
 use OCA\OpenRegister\Db\EntityRelationMapper;
 use OCA\OpenRegister\Db\GdprEntity;
 use OCA\OpenRegister\Db\GdprEntityMapper;
+use OCA\OpenRegister\Service\OrganisationService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\DB\IResult;
@@ -16,7 +17,10 @@ use OCP\DB\QueryBuilder\IFunctionBuilder;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\DB\QueryBuilder\IQueryFunction;
 use OCP\IDBConnection;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -29,6 +33,9 @@ class GdprEntitiesControllerTest extends TestCase
     private EntityRelationMapper&MockObject $entityRelationMapper;
     private IDBConnection&MockObject $db;
     private LoggerInterface&MockObject $logger;
+    private IUserSession&MockObject $userSession;
+    private IGroupManager&MockObject $groupManager;
+    private OrganisationService&MockObject $organisationService;
 
     protected function setUp(): void
     {
@@ -40,13 +47,27 @@ class GdprEntitiesControllerTest extends TestCase
         $this->db = $this->createMock(IDBConnection::class);
         $this->logger = $this->createMock(LoggerInterface::class);
 
+        // Authenticated admin user: with #1825 fixes the admin path is the
+        // unscoped path, so existing assertions about unscoped results hold.
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('admin');
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager = $this->createMock(IGroupManager::class);
+        $this->groupManager->method('isAdmin')->willReturn(true);
+        $this->organisationService = $this->createMock(OrganisationService::class);
+        $this->organisationService->method('getUserOrganisations')->willReturn([]);
+
         $this->controller = new GdprEntitiesController(
             'openregister',
             $this->request,
             $this->entityMapper,
             $this->entityRelationMapper,
             $this->db,
-            $this->logger
+            $this->logger,
+            $this->userSession,
+            $this->groupManager,
+            $this->organisationService
         );
     }
 
@@ -912,5 +933,139 @@ class GdprEntitiesControllerTest extends TestCase
         $result = $this->controller->destroy(7);
 
         $this->assertEquals(200, $result->getStatus());
+    }
+
+    // =========================================================================
+    // #1825 cross-tenant authorization regression tests
+    // =========================================================================
+
+    /**
+     * Build a controller wired with a non-admin user belonging to the
+     * given organisation UUIDs.
+     *
+     * @param array<int, string> $orgUuids Organisation UUIDs.
+     *
+     * @return GdprEntitiesController
+     */
+    private function nonAdminController(array $orgUuids): GdprEntitiesController
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('bob');
+
+        $userSession = $this->createMock(IUserSession::class);
+        $userSession->method('getUser')->willReturn($user);
+
+        $groupManager = $this->createMock(IGroupManager::class);
+        $groupManager->method('isAdmin')->willReturn(false);
+
+        $orgs = [];
+        foreach ($orgUuids as $uuid) {
+            // Organisation uses Entity __call magic; use a real instance
+            // so getUuid() resolves (it cannot be configured on a mock).
+            $org = new \OCA\OpenRegister\Db\Organisation();
+            $org->setUuid($uuid);
+            $orgs[] = $org;
+        }
+
+        $organisationService = $this->createMock(OrganisationService::class);
+        $organisationService->method('getUserOrganisations')->willReturn($orgs);
+
+        return new GdprEntitiesController(
+            'openregister',
+            $this->request,
+            $this->entityMapper,
+            $this->entityRelationMapper,
+            $this->db,
+            $this->logger,
+            $userSession,
+            $groupManager,
+            $organisationService
+        );
+    }
+
+    public function testIndexUnauthenticatedReturns401(): void
+    {
+        $userSession = $this->createMock(IUserSession::class);
+        $userSession->method('getUser')->willReturn(null);
+
+        $controller = new GdprEntitiesController(
+            'openregister',
+            $this->request,
+            $this->entityMapper,
+            $this->entityRelationMapper,
+            $this->db,
+            $this->logger,
+            $userSession,
+            $this->groupManager,
+            $this->organisationService
+        );
+
+        $result = $controller->index();
+
+        $this->assertEquals(Http::STATUS_UNAUTHORIZED, $result->getStatus());
+    }
+
+    public function testIndexNonAdminWithNoOrgsReturnsEmpty(): void
+    {
+        $this->request->method('getParam')
+            ->willReturnMap([
+                ['limit', 50, 50],
+                ['offset', 0, 0],
+            ]);
+
+        // No DB query should be issued — fail-closed before touching data.
+        $this->db->expects($this->never())->method('getQueryBuilder');
+
+        $controller = $this->nonAdminController([]);
+        $result     = $controller->index();
+
+        $this->assertEquals(200, $result->getStatus());
+        $data = $result->getData();
+        $this->assertTrue($data['success']);
+        $this->assertEmpty($data['data']);
+        $this->assertEquals(0, $data['count']);
+    }
+
+    public function testShowNonAdminCrossTenantReturns404(): void
+    {
+        // GdprEntity uses Entity __call magic, so use a real instance
+        // (getOrganisation cannot be configured on a mock).
+        $entity = new GdprEntity();
+        $entity->setOrganisation('other-org-uuid');
+        $this->entityMapper->method('find')->willReturn($entity);
+
+        $controller = $this->nonAdminController(['my-org-uuid']);
+        $result     = $controller->show(1);
+
+        $this->assertEquals(Http::STATUS_NOT_FOUND, $result->getStatus());
+        $this->assertFalse($result->getData()['success']);
+    }
+
+    public function testShowNonAdminSameTenantSucceeds(): void
+    {
+        $entity = new GdprEntity();
+        $entity->setOrganisation('my-org-uuid');
+        $this->entityMapper->method('find')->willReturn($entity);
+        $this->entityRelationMapper->method('findByEntityId')->willReturn([]);
+
+        $controller = $this->nonAdminController(['my-org-uuid']);
+        $result     = $controller->show(1);
+
+        $this->assertEquals(200, $result->getStatus());
+        $this->assertTrue($result->getData()['success']);
+    }
+
+    public function testDestroyNonAdminCrossTenantReturns404(): void
+    {
+        $entity = new GdprEntity();
+        $entity->setOrganisation('other-org-uuid');
+        $this->entityMapper->method('find')->willReturn($entity);
+        // Must not delete a cross-tenant row.
+        $this->entityMapper->expects($this->never())->method('delete');
+
+        $controller = $this->nonAdminController(['my-org-uuid']);
+        $result     = $controller->destroy(1);
+
+        $this->assertEquals(Http::STATUS_NOT_FOUND, $result->getStatus());
     }
 }


### PR DESCRIPTION
## Summary

Closes #1825. Three GDPR/DSAR surfaces leaked or allowed mutation of personal data across tenant boundaries. This PR adds authentication gating, per-organisation scoping and a defense-in-depth service guard. Authorized callers see no change in response shape — only unauthorized/cross-tenant access is now blocked.

`DsarController` (already correctly admin-gated) was used as the template.

## Vulnerabilities fixed

### 1. `GdprEntitiesController` — cross-tenant PII enumeration / deletion
`openregister_entities` rows store raw detected PII (`value`: names, emails, BSNs) plus an `organisation` UUID. All read endpoints were `@NoAdminRequired` with no scoping, and `destroy` had no audit trail.

- **Before:** any authenticated user could list/search/inspect/stat **and delete** every PII row across **all** tenants via `index`, `show`, `getTypes`, `getCategories`, `getStats`, `destroy`.
- **After:** every endpoint requires authentication. Admins are unscoped (unchanged behavior). Non-admins are scoped to `e.organisation IN (their org UUIDs)` on every query; a non-admin with no organisation gets an empty result (fail-closed). `show`/`destroy` return **404** (not 403) for cross-tenant rows so existence isn't leaked. `destroy` now emits a structured audit log (actor, target identity, org, timestamp).

### 2. `VerwerkingsactiviteitenController` — cross-tenant processing register / Art 30 §4 report
`index`, `show`, `verantwoording` were `@NoAdminRequired` with no tenant filter.

- **Before:** any authenticated user could read another tenant's full processing register and its Art 30 §4 verantwoordingsdocument; a caller-supplied `organisation` query param could target any tenant.
- **After:** non-admins only see activities bound to one of their organisations (admins unchanged). Activities with no `organisationId` are hidden from non-admins. The `organisation` query param can no longer widen visibility. `show` returns 404 for cross-tenant activities.

### 3. `DsarService` — no in-service privilege check
`findObjectsForSubject` / `eraseObjectsForSubject` / `rectifyObjectForSubject` load + mutate objects with `_rbac:false, _multitenancy:false` and had no internal guard, relying entirely on the controller.

- **Before:** any caller of the service (now or future) could read/erase PII for arbitrary subjects across tenants.
- **After:** a fail-closed `assertPrivileged()` guard throws unless the active user is an admin, on every entry point. This is defense-in-depth — `DsarController` still admin-gates, so authorized flows are unaffected. The load-bearing LIKE-wildcard escaping in `matchEntities()` is preserved unchanged.

## Behavior change

Endpoints that previously served any authenticated user and now require **admin or matching organisation**. Clients relying on the old open behavior will see scoped/empty results or 401/403/404:

- `GET /api/.../gdpr-entities` (index) — now auth-required; non-admins scoped to their org, empty if none.
- `GET /api/.../gdpr-entities/{id}` (show) — 404 for cross-tenant rows (non-admin).
- `GET .../gdpr-entities/types|categories|stats` — non-admins scoped to their org.
- `DELETE /api/.../gdpr-entities/{id}` (destroy) — 404 for cross-tenant rows (non-admin); now audit-logged.
- `GET /api/avg/verwerkingsactiviteiten` (index) — non-admins scoped to their org(s).
- `GET /api/avg/verwerkingsactiviteiten/{id}` (show) — 404 for cross-tenant (non-admin).
- `GET /api/avg/verantwoording` — non-admins scoped to their org(s).
- `DsarService::{find,erase,rectify}` — now throw `RuntimeException` for non-admin callers (in practice only reachable via the already-admin-gated `DsarController`).

Admin callers and the existing `DsarController` flows are unchanged.

## Limitation / note

The GdprEntity `destroy` audit record is emitted via the application logger (structured `audit` context), not `AuditTrailMapper`: that mapper is bound to `ObjectEntity` (requires `object_uuid`/register/schema) and a GdprEntity is not an object, so wiring it in would require fabricating an ObjectEntity — out of scope for this conservative fix.

## Test plan

- [x] `php -l` clean on all touched files.
- [x] PHPCS (`lib/`, error severity) and PHPMD clean on the three source files.
- [x] `GdprEntitiesControllerTest` 45/45 green in the dev container, including 4 new #1825 regression tests (401 unauthenticated, non-admin no-org empty, cross-tenant show 404, cross-tenant destroy 404).
- [x] Integration test constructors updated; `DsarServiceIntegrationTest` + `VerwerkingsactiviteitenControllerIntegrationTest` now authenticate as admin so the new guard/scoping pass.
- [ ] CI strict suite + full integration tests (container).