### PR TITLE
fix(eslint): register @spec as a known JSDoc tag (-263 warnings)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,6 +34,9 @@ module.exports = defineConfig([{
 		// Allow unused i18n functions (t, n) — imported for future translation wiring
 		'no-unused-vars': ['error', { varsIgnorePattern: '^(t|n)$', argsIgnorePattern: '^_' }],
 		'jsdoc/require-jsdoc': 'off',
+		// `@spec` is the ADR-003 spec-traceability tag (links code to OpenSpec change tasks).
+		// Register it so jsdoc/check-tag-names does not flag it as an unknown tag.
+		'jsdoc/check-tag-names': ['warn', { definedTags: ['spec'] }],
 		'vue/first-attribute-linebreak': 'off',
 		'@typescript-eslint/no-explicit-any': 'off',
 		'n/no-missing-import': 'off',


### PR DESCRIPTION
The retrofit's `@spec` JSDoc annotations on Vue components (ADR-003 spec-traceability) were flagged by `jsdoc/check-tag-names` as unknown tags — **263 eslint warnings**. This registers `spec` via `definedTags` so the linter recognizes the convention.

Reduces eslint output from 386 problems → 123 (11 errors, 112 warnings). The remaining 11 errors are unrelated (dual-script-block import ordering + unused imports in DashboardIndex.vue / ObjectDetails.vue from the integration-widget work) — flagged separately.