### PR TITLE
docs(integrations): fix broken cross-links in leaf docs

### DIFF
--- a/docs/Integrations/OpenRegister.md
+++ b/docs/Integrations/OpenRegister.md
@@ -85,7 +85,7 @@ PermissionHandler::getReadableByUsers($object)
     ])
 ```
 
-This means an object change costs `N` pushes where `N` = the number of users who can read it. For typical small-to-medium organisations this is correct and efficient. For installations where a single object has more than ~1,000 readers, consider a broadcast-channel approach (out of scope for v1; see the [realtime-updates spec](../../openspec/specs/realtime-updates/spec.md)).
+This means an object change costs `N` pushes where `N` = the number of users who can read it. For typical small-to-medium organisations this is correct and efficient. For installations where a single object has more than ~1,000 readers, consider a broadcast-channel approach (out of scope for v1; see the [realtime-updates spec](https://github.com/ConductionNL/openregister/blob/development/openspec/specs/realtime-updates/spec.md)).
 
 ### Open / public schemas
 
@@ -229,9 +229,9 @@ ObjectCreatedEvent / ObjectUpdatedEvent / ObjectDeletedEvent (single internal so
     └── GraphQLSubscriptionListener  → SubscriptionService (APCu/Redis)   → SSE /api/graphql/subscribe  [GraphQL clients]
 ```
 
-REST clients (the default for `@conduction/nextcloud-vue`'s object store) consume `notify_push`. GraphQL clients use the existing SSE transport from the [graphql-api capability](../../openspec/specs/graphql-api/spec.md). Both transports receive the same logical change at the same instant; consumers should pick one transport per page, not both.
+REST clients (the default for `@conduction/nextcloud-vue`'s object store) consume `notify_push`. GraphQL clients use the existing SSE transport from the [graphql-api capability](https://github.com/ConductionNL/openregister/blob/development/openspec/specs/graphql-api/spec.md). Both transports receive the same logical change at the same instant; consumers should pick one transport per page, not both.
 
-A third transport MUST NOT be added without extending the [realtime-updates spec](../../openspec/specs/realtime-updates/spec.md).
+A third transport MUST NOT be added without extending the [realtime-updates spec](https://github.com/ConductionNL/openregister/blob/development/openspec/specs/realtime-updates/spec.md).
 
 ## Operational
 
@@ -257,7 +257,7 @@ OpenRegister push events require:
 
 ## Related documentation
 
-- [Realtime Updates capability spec](../../openspec/specs/realtime-updates/spec.md)
+- [Realtime Updates capability spec](https://github.com/ConductionNL/openregister/blob/development/openspec/specs/realtime-updates/spec.md)
 - [Deck Integration](./Deck.md) — Deck's own push events that complement OR events
 - [Custom Webhooks](./custom-webhooks.md) — push to external HTTP endpoints (different mechanism)
 - [notify_push on GitHub](https://github.com/nextcloud/notify_push)

--- a/docs/Integrations/activity.md
+++ b/docs/Integrations/activity.md
@@ -118,6 +118,6 @@ The provider is registered: the admin row appears, the JS sidebar tab renders, t
 
 ## Related
 
-- **[Audit trail leaf](./audit-trail)** — Open Register's own change log; ships today.
+- **[Audit trail](../features/versioning-and-audit.md)** — Open Register's own change log; ships today.
 - **[Leaf integration system](./leaf-system.md)** — how every leaf wires the same way.
 - **[Pluggable integration registry](./pluggable-integration-registry.md)** — the full ADR-019 contract.

--- a/docs/Integrations/cospend.md
+++ b/docs/Integrations/cospend.md
@@ -119,5 +119,5 @@ Provider registered. Wrapping service + link table tracked under [openspec/chang
 ## Related
 
 - **[Leaf integration system](./leaf-system.md)** — how every leaf wires the same way.
-- **[Time-tracker leaf](./time-tracker)** — link time entries to the same objects.
+- **[Time-tracker leaf](./time-tracker.md)** — link time entries to the same objects.
 - **[Pluggable integration registry](./pluggable-integration-registry.md)** — the full ADR-019 contract.

--- a/docs/Integrations/forms.md
+++ b/docs/Integrations/forms.md
@@ -120,5 +120,5 @@ Provider registered. Wrapping service + link table tracked under [openspec/chang
 ## Related
 
 - **[Leaf integration system](./leaf-system.md)** — how every leaf wires the same way.
-- **[Polls leaf](./polls)** — for collective decision-making instead of free-form submissions.
+- **[Polls leaf](./polls.md)** — for collective decision-making instead of free-form submissions.
 - **[Pluggable integration registry](./pluggable-integration-registry.md)** — the full ADR-019 contract.

--- a/docs/Integrations/photos.md
+++ b/docs/Integrations/photos.md
@@ -24,7 +24,7 @@ import {LeafCard, Pair} from '@conduction/docusaurus-preset/components';
   status="stub"
   description="Filter the object's linked files to image MIME types and enrich with EXIF / taken-at / camera / dimensions via NC Photos. Provider stub today." />
 
-Build on the [Files leaf](../features/files): pick only the image attachments and enrich them with NC Photos metadata (EXIF, taken-at, camera, dimensions). The Photos tab will render a gallery view; the detail-page widget shows a hero image. Provider registers today; the wrapping `PhotoService` lands in a follow-up.
+Build on the [Files leaf](../features/object-storage.md): pick only the image attachments and enrich them with NC Photos metadata (EXIF, taken-at, camera, dimensions). The Photos tab will render a gallery view; the detail-page widget shows a hero image. Provider registers today; the wrapping `PhotoService` lands in a follow-up.
 
 <Pair
   leftLabel="Open Register"
@@ -45,7 +45,7 @@ Captured by [`tests/e2e/leaf-screenshots.spec.ts`](https://github.com/Conduction
 
 ## What it will do
 
-- Reads the object's [linked files](../features/files), filters to image MIME types.
+- Reads the object's [linked files](../features/object-storage.md), filters to image MIME types.
 - Enriches each image with NC Photos metadata: EXIF, taken-at, camera, dimensions, location (when present).
 - Lists images on the **Photos** sidebar tab in a gallery layout.
 - Renders a hero image (the first or a chosen one) on the detail-page widget.
@@ -131,6 +131,6 @@ Provider registered. Wrapping service + link table tracked under [openspec/chang
 
 ## Related
 
-- **[Files leaf](../features/files)** — the base file attachments.
+- **[Files leaf](../features/object-storage.md)** — the base file attachments.
 - **[Leaf integration system](./leaf-system.md)** — how every leaf wires the same way.
 - **[Pluggable integration registry](./pluggable-integration-registry.md)** — the full ADR-019 contract.

--- a/docs/Integrations/pluggable-integration-registry.md
+++ b/docs/Integrations/pluggable-integration-registry.md
@@ -2,7 +2,7 @@
 
 OpenRegister's object surfaces — the per-object **sidebar tabs**, the **dashboard widgets**, the **detail-page widgets**, and **reference properties** in forms — are not hard-coded. They are driven by a registry of *integration providers*. Each provider exposes a small contract on the PHP side (data access, auth requirements, health) and a matching pair of Vue components on the JS side (a sidebar `tab` and a `widget`). Apps register their own providers without touching OpenRegister core; OpenConnector-backed integrations (xWiki, Confluence, …) plug in the same way.
 
-This page is the worked walkthrough. The normative contract lives in [`openspec/changes/pluggable-integration-registry/design.md`](../../openspec/changes/pluggable-integration-registry/design.md).
+This page is the worked walkthrough. The normative contract lives in [`openspec/changes/pluggable-integration-registry/design.md`](https://github.com/ConductionNL/openregister/blob/development/openspec/changes/pluggable-integration-registry/design.md).
 
 ## The five built-ins
 
@@ -112,6 +112,6 @@ OpenRegister's **Administration → OpenRegister → Integrations** page lists e
 
 ## Reference
 
-- Contract & ADs: [`openspec/changes/pluggable-integration-registry/design.md`](../../openspec/changes/pluggable-integration-registry/design.md)
+- Contract & ADs: [`openspec/changes/pluggable-integration-registry/design.md`](https://github.com/ConductionNL/openregister/blob/development/openspec/changes/pluggable-integration-registry/design.md)
 - JS API in `@conduction/nextcloud-vue`: `integrations`, `installIntegrationRegistry`, `registerBuiltinIntegrations`, `useIntegrationRegistry`, `VALID_SURFACES` (documented in that repo's `CLAUDE.md` and `docs/utilities/`)
 - xWiki leaf (worked external example): `openspec/changes/integration-xwiki/`

--- a/docs/Integrations/shares.md
+++ b/docs/Integrations/shares.md
@@ -121,6 +121,6 @@ Creating shares is a multi-step UX with permission pickers, group search, expiry
 
 ## Related
 
-- **[Files leaf](../features/files)** — files attached to the object. Shares ride on top of these.
+- **[Files leaf](../features/object-storage.md)** — files attached to the object. Shares ride on top of these.
 - **[Leaf integration system](./leaf-system.md)** — how every leaf wires the same way.
 - **[Pluggable integration registry](./pluggable-integration-registry.md)** — the full ADR-019 contract.


### PR DESCRIPTION
## Summary

Fixes pre-existing broken cross-links in the OpenRegister Integrations leaf docs, flagged by the Phase L docs agent (#1863). Markdown-only — no content rewrites.

Fixes:
- `activity.md` — `[Audit trail leaf](./audit-trail)` (no such doc page) → `[Audit trail](../features/versioning-and-audit.md)`
- `cospend.md` — `./time-tracker` → `./time-tracker.md`
- `forms.md` — `./polls` → `./polls.md`
- `photos.md` (3×) + `shares.md` (1×) — `../features/files` (no such doc) → `../features/object-storage.md`
- `OpenRegister.md` (4×) + `pluggable-integration-registry.md` (2×) — relative `../../openspec/...` links (target lives outside the docs tree, unresolvable in-site) → absolute `https://github.com/.../blob/development/openspec/...` URLs, matching the existing pattern in the leaf docs.

## Verification

- `docusaurus build` broken-markdown-link report: **all `docs/Integrations/` links resolved (0 remaining)**; total site-wide broken-link count also 0 after the change.
- Unrelated pre-existing build issue remains (an `@site/build/.../oas/Examples/ZaakRegister/project.md` webpack module-resolution error) — out of scope, not a markdown link, not in Integrations.

## Test plan

- [ ] CI docusaurus build passes with no Integrations broken-link warnings

Refs ADR-019 / ADR-022 (pluggable integration registry). Surfaced by #1863.