### PR TITLE
fix(integrations): pass Tier-2 constructor args in calendar/email/tasks DI factories + log provider boot failures

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1030,6 +1030,9 @@ class Application extends App implements IBootstrap
             function (ContainerInterface $container) {
                 return new TasksProvider(
                     taskService: $container->get(\OCA\OpenRegister\Service\TaskService::class),
+                    registerMapper: $container->get(\OCA\OpenRegister\Db\RegisterMapper::class),
+                    schemaMapper: $container->get(\OCA\OpenRegister\Db\SchemaMapper::class),
+                    objectService: $container->get(\OCA\OpenRegister\Service\ObjectService::class),
                     l10n: $container->get('OCP\IL10N'),
                 );
             }
@@ -1143,6 +1146,7 @@ class Application extends App implements IBootstrap
             function (ContainerInterface $container) {
                 return new CalendarProvider(
                     calendarEventService: $container->get(\OCA\OpenRegister\Service\CalendarEventService::class),
+                    calendarLinkService: $container->get(\OCA\OpenRegister\Service\CalendarLinkService::class),
                     appManager: $container->get('OCP\App\IAppManager'),
                     l10n: $container->get('OCP\IL10N'),
                     logger: $container->get(\Psr\Log\LoggerInterface::class),
@@ -1180,6 +1184,7 @@ class Application extends App implements IBootstrap
             function (ContainerInterface $container) {
                 return new EmailProvider(
                     emailService: $container->get(\OCA\OpenRegister\Service\EmailService::class),
+                    emailLinkService: $container->get(\OCA\OpenRegister\Service\EmailLinkService::class),
                     appManager: $container->get('OCP\App\IAppManager'),
                     l10n: $container->get('OCP\IL10N'),
                 );
@@ -2021,15 +2026,37 @@ class Application extends App implements IBootstrap
             \OCA\OpenRegister\Service\Integration\Providers\TimeProvider::class,
         ];
 
+        // Resolve a logger up-front so a mis-wired factory closure or an
+        // absent wrapped service is visible in the logs instead of a
+        // silently-missing tab. Guarded so a logger-less build still boots.
+        try {
+            $logger = $server->get(\Psr\Log\LoggerInterface::class);
+        } catch (\Throwable $e) {
+            $logger = null;
+        }
+
         foreach ($providerClasses as $providerClass) {
             try {
                 $provider = $server->get($providerClass);
                 $integrationRegistry->addProvider($provider);
             } catch (\Throwable $e) {
                 // Provider construction can fail if a wrapped service
-                // is missing on this NC build — don't take the whole
-                // app down for one absent provider. The user-facing
-                // surface will simply not show the failing tab.
+                // is missing on this NC build, or — as the live-NC E2E
+                // surfaced — if the DI factory closure was not updated
+                // for a Tier-2 constructor arg. Don't take the whole app
+                // down for one absent provider; the failing tab simply
+                // won't render. But log loudly so a mis-wired factory is
+                // diagnosable rather than silently swallowed.
+                if ($logger !== null) {
+                    $logger->warning(
+                        'OpenRegister: integration provider failed to construct and was dropped from the registry: {provider} — {message}',
+                        [
+                            'provider'  => $providerClass,
+                            'message'   => $e->getMessage(),
+                            'exception' => $e,
+                        ]
+                    );
+                }
             }
         }
     }//end bootBuiltinIntegrationProviders()

--- a/lib/Service/Integration/Providers/MapsProvider.php
+++ b/lib/Service/Integration/Providers/MapsProvider.php
@@ -64,7 +64,7 @@ class MapsProvider extends AbstractIntegrationProvider
 
     public function getLabel(): string
     {
-        return $this->l10n->t('Location');
+        return $this->l10n->t('Locations');
     }//end getLabel()
 
     public function getIcon(): string

--- a/lib/Service/Integration/Providers/TimeProvider.php
+++ b/lib/Service/Integration/Providers/TimeProvider.php
@@ -82,7 +82,7 @@ class TimeProvider extends AbstractIntegrationProvider
 
     public function getLabel(): string
     {
-        return $this->l10n->t('Time');
+        return $this->l10n->t('Time tracker');
     }//end getLabel()
 
     public function getIcon(): string

--- a/tests/Unit/Service/Integration/BuiltinProviderDiFactoryTest.php
+++ b/tests/Unit/Service/Integration/BuiltinProviderDiFactoryTest.php
@@ -1,0 +1,236 @@
+<?php
+
+/**
+ * DI-container regression tests for the built-in IntegrationProvider
+ * factory wiring.
+ *
+ * The pre-existing provider tests (BuiltinProvidersMetadataTest, the
+ * per-provider *Test classes) construct each provider DIRECTLY with
+ * mocked constructor args. That shape proves a provider behaves
+ * correctly once built, but it is blind to a mis-wired DI factory
+ * closure in Application::registerBuiltinIntegrationProviders().
+ *
+ * That blind spot bit us in production: when CalendarProvider,
+ * EmailProvider and TasksProvider gained Tier-2 constructor args, their
+ * factory closures were not updated to pass them. The providers threw
+ * on construction, the boot loop's try/catch silently swallowed the
+ * Throwable, and the three tabs simply vanished from the OCS registry
+ * (provider count 22 instead of 25) — only caught by a live-NC E2E.
+ *
+ * These tests close that gap by exercising the actual factory closures:
+ *  - capture every closure registered by
+ *    registerBuiltinIntegrationProviders() through a fake
+ *    IRegistrationContext;
+ *  - invoke each provider closure with a container that resolves any
+ *    requested dependency to a mock, and assert it builds the right
+ *    provider WITHOUT throwing.
+ *
+ * Running this test against the unfixed factories fails (the three
+ * closures throw ArgumentCountError on the missing Tier-2 args).
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Integration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-17
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Integration;
+
+use OCA\OpenRegister\AppInfo\Application;
+use OCA\OpenRegister\Service\Integration\BuiltinProviders\AuditTrailProvider;
+use OCA\OpenRegister\Service\Integration\BuiltinProviders\FilesProvider;
+use OCA\OpenRegister\Service\Integration\BuiltinProviders\NotesProvider;
+use OCA\OpenRegister\Service\Integration\BuiltinProviders\TagsProvider;
+use OCA\OpenRegister\Service\Integration\BuiltinProviders\TasksProvider;
+use OCA\OpenRegister\Service\Integration\IntegrationProvider;
+use OCA\OpenRegister\Service\Integration\Providers\BookmarksProvider;
+use OCA\OpenRegister\Service\Integration\Providers\CalendarProvider;
+use OCA\OpenRegister\Service\Integration\Providers\ContactsProvider;
+use OCA\OpenRegister\Service\Integration\Providers\DeckProvider;
+use OCA\OpenRegister\Service\Integration\Providers\EmailProvider;
+use OCA\OpenRegister\Service\Integration\Providers\OpenProjectProvider;
+use OCA\OpenRegister\Service\Integration\Providers\PollsProvider;
+use OCA\OpenRegister\Service\Integration\Providers\SharesProvider;
+use OCA\OpenRegister\Service\Integration\Providers\TalkProvider;
+use OCA\OpenRegister\Service\Integration\Providers\XwikiProvider;
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use ReflectionMethod;
+
+/**
+ * Exercises the provider DI factory closures the way the NC container
+ * does at boot, rather than instantiating providers directly.
+ */
+class BuiltinProviderDiFactoryTest extends TestCase
+{
+
+    /**
+     * The 22 built-in provider classes whose factory closures must
+     * construct without throwing. (External + greenfield leaves are
+     * registered via $greenfieldProviders directly with ::class, which
+     * the container can autowire; this list is the closures that pass
+     * explicit constructor args — i.e. the ones a Tier-2 arg can break.)
+     *
+     * @var array<class-string<IntegrationProvider>>
+     */
+    private const PROVIDER_CLASSES = [
+        FilesProvider::class,
+        NotesProvider::class,
+        TasksProvider::class,
+        TagsProvider::class,
+        AuditTrailProvider::class,
+        XwikiProvider::class,
+        OpenProjectProvider::class,
+        CalendarProvider::class,
+        ContactsProvider::class,
+        DeckProvider::class,
+        EmailProvider::class,
+        BookmarksProvider::class,
+        PollsProvider::class,
+        SharesProvider::class,
+        TalkProvider::class,
+    ];
+
+
+    /**
+     * Capture every closure registered by
+     * registerBuiltinIntegrationProviders() keyed by its service id.
+     *
+     * @return array<string, callable> service-id => factory closure
+     */
+    private function captureFactories(): array
+    {
+        $factories = [];
+
+        $context = $this->createMock(IRegistrationContext::class);
+        $context->method('registerService')
+            ->willReturnCallback(
+                static function (string $id, callable $factory) use (&$factories): void {
+                    $factories[$id] = $factory;
+                }
+            );
+
+        $app    = new Application();
+        $method = new ReflectionMethod(Application::class, 'registerBuiltinIntegrationProviders');
+        $method->setAccessible(true);
+        $method->invoke($app, $context);
+
+        return $factories;
+    }//end captureFactories()
+
+
+    /**
+     * A container that resolves any requested service to a PHPUnit mock.
+     * The factory closures only need their dependencies to be the right
+     * *type*; the closure bodies don't call into them, so mocks suffice
+     * to prove the wiring (arg count + named args) is correct.
+     */
+    private function mockingContainer(): ContainerInterface
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')
+            ->willReturnCallback(
+                function (string $id) use (&$container) {
+                    if ($id === ContainerInterface::class) {
+                        return $container;
+                    }
+
+                    if (interface_exists($id) === true || class_exists($id) === true) {
+                        return $this->createMock($id);
+                    }
+
+                    // Unknown service id — surface it loudly.
+                    throw new \RuntimeException('Unresolvable dependency: '.$id);
+                }
+            );
+        $container->method('has')->willReturn(true);
+
+        return $container;
+    }//end mockingContainer()
+
+
+    /**
+     * Every built-in provider factory closure must construct its
+     * provider through the (mocked) container without throwing. This is
+     * the assertion that fails on the unfixed Tier-2 wiring for
+     * Calendar/Email/Tasks.
+     */
+    public function testEveryProviderFactoryConstructsWithoutThrowing(): void
+    {
+        $factories = $this->captureFactories();
+        $container = $this->mockingContainer();
+
+        foreach (self::PROVIDER_CLASSES as $providerClass) {
+            $this->assertArrayHasKey(
+                $providerClass,
+                $factories,
+                $providerClass.' has no registered DI factory closure'
+            );
+
+            try {
+                $provider = ($factories[$providerClass])($container);
+            } catch (\Throwable $e) {
+                $this->fail(
+                    'DI factory for '.$providerClass.' threw on construction: '
+                    .get_class($e).': '.$e->getMessage()
+                );
+            }
+
+            $this->assertInstanceOf(
+                $providerClass,
+                $provider,
+                $providerClass.' factory returned the wrong type'
+            );
+            $this->assertInstanceOf(
+                IntegrationProvider::class,
+                $provider,
+                $providerClass.' is not an IntegrationProvider'
+            );
+        }
+    }//end testEveryProviderFactoryConstructsWithoutThrowing()
+
+
+    /**
+     * Guard the specific Tier-2 regressions: the three providers whose
+     * factory closures were the production bug must each build with
+     * their full constructor satisfied.
+     *
+     * @dataProvider tier2ProviderProvider
+     */
+    public function testTier2ProviderFactoriesAreConstructed(string $providerClass): void
+    {
+        $factories = $this->captureFactories();
+        $this->assertArrayHasKey($providerClass, $factories);
+
+        $provider = ($factories[$providerClass])($this->mockingContainer());
+        $this->assertInstanceOf($providerClass, $provider);
+    }//end testTier2ProviderFactoriesAreConstructed()
+
+
+    /**
+     * The three providers whose factory closures gained Tier-2 args.
+     *
+     * @return array<string, array{0: class-string}>
+     */
+    public static function tier2ProviderProvider(): array
+    {
+        return [
+            'calendar' => [CalendarProvider::class],
+            'email'    => [EmailProvider::class],
+            'tasks'    => [TasksProvider::class],
+        ];
+    }//end tier2ProviderProvider()
+
+}//end class


### PR DESCRIPTION
## Summary

A live-NC E2E surfaced that three integration providers — **calendar**, **email**, **tasks** — were missing in production. Their OCS registry tabs 404'd and the registered-provider count was **22 instead of 25**.

### Root cause
The DI factory closures in `Application::registerBuiltinIntegrationProviders()` were not updated when these providers gained Tier-2 constructor args:

| Provider | Tier-2 arg(s) the factory failed to pass |
|---|---|
| `CalendarProvider` | `$calendarLinkService` |
| `EmailProvider` | `$emailLinkService` |
| `TasksProvider` | `$registerMapper`, `$schemaMapper`, `$objectService` |

The closures still passed the old arg lists, so each provider threw `ArgumentCountError` on construction. `bootBuiltinIntegrationProviders()`'s `try/catch` **silently swallowed** the `Throwable`, dropping the three providers from the `IntegrationRegistry`. Existing tests instantiate providers directly with mocks, so they were blind to the factory-wiring bug — only the live E2E caught it.

## Changes

- **The 3 factory fixes** — resolve and pass the Tier-2 dependencies, matching the already-correct contacts/deck/forms factories.
- **Harden the swallow** — `bootBuiltinIntegrationProviders()` now logs a `warning` (provider class + exception message) when a provider fails to construct, so a mis-wired factory is diagnosable in the logs instead of a silently-missing tab. Graceful degradation is preserved (boot does not crash on one bad provider).
- **Label consistency** (cosmetic) — align the maps/time-tracker OCS labels (`Location`/`Time`) with the in-page registry pills from the nc-vue descriptors (`Locations`/`Time tracker`). OR `getLabel()` is the smaller change, so no nc-vue PR is needed.
- **Regression test** — `BuiltinProviderDiFactoryTest` invokes the actual factory closures (via a captured `IRegistrationContext` + a mocking container) and asserts every provider constructs without throwing. This closes the direct-instantiation blind spot. It **fails on the pre-fix code** (3 `ArgumentCountError`s for calendar/email/tasks).

## Verification

- `php -l` clean on all 4 touched files.
- Resolved all 15 explicit-closure providers through the **real NC DI container**: 0 failures with the fix; reverting to `origin/development` produces exactly 3 `ArgumentCountError`s (Calendar #2 `$calendarLinkService`, Email #2 `$emailLinkService`, Tasks #2 `$registerMapper`).
- Live OCS capabilities after deploy + `apache2ctl graceful`: `integrations.registered` length **25**, now including `tasks`, `calendar`, `email`.

> Note: PHPCS/PHPUnit could not be run in the local dev container due to a pre-existing incomplete bind-mount `vendor/` (missing `sabre/uri`, unrelated to this change). CI runs both in a clean-vendor container.

Refs ADR-019, ADR-022.

## Test plan
- [ ] CI: PHPUnit (incl. new `BuiltinProviderDiFactoryTest`) + PHPCS/PHPMD/Psalm/PHPStan green
- [ ] OCS `capabilities.openregister.integrations.registered` length is 25 incl. calendar/email/tasks
- [ ] Calendar/email/tasks tabs render in the registry sidebar
- [ ] maps/time-tracker pill labels match OCS labels