### PR TITLE
retrofit: backend coverage — jobs/listeners/cron

### DIFF
--- a/lib/BackgroundJob/BackfillCalendarLinksJob.php
+++ b/lib/BackgroundJob/BackfillCalendarLinksJob.php
@@ -94,6 +94,8 @@ class BackfillCalendarLinksJob extends QueuedJob
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec exclude Disabled-by-default one-time Tier-2 migration backfill, gated behind the `backfill_calendar_links` app-config flag; not a production capability surface.
      */
     protected function run($argument): void
     {

--- a/lib/BackgroundJob/BatchNotificationJob.php
+++ b/lib/BackgroundJob/BatchNotificationJob.php
@@ -97,6 +97,8 @@ class BatchNotificationJob extends TimedJob
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/tasks.md#task-1
      */
     protected function run(mixed $argument): void
     {

--- a/lib/BackgroundJob/CacheWarmupJob.php
+++ b/lib/BackgroundJob/CacheWarmupJob.php
@@ -105,6 +105,8 @@ class CacheWarmupJob extends TimedJob
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/tasks.md#task-4
      */
     protected function run($argument): void
     {

--- a/lib/BackgroundJob/ExecutionHistoryCleanupJob.php
+++ b/lib/BackgroundJob/ExecutionHistoryCleanupJob.php
@@ -75,6 +75,8 @@ class ExecutionHistoryCleanupJob extends TimedJob
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/tasks.md#task-6
      */
     protected function run($argument): void
     {

--- a/lib/BackgroundJob/FileTextExtractionJob.php
+++ b/lib/BackgroundJob/FileTextExtractionJob.php
@@ -107,6 +107,8 @@ class FileTextExtractionJob extends QueuedJob
      *                                       - file_id: The ID of the file to extract text from (required)
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/tasks.md#task-10
      */
     protected function run($argument): void
     {

--- a/lib/BackgroundJob/NameCacheWarmupJob.php
+++ b/lib/BackgroundJob/NameCacheWarmupJob.php
@@ -75,6 +75,8 @@ class NameCacheWarmupJob extends TimedJob
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/tasks.md#task-5
      */
     protected function run($argument): void
     {

--- a/lib/BackgroundJob/ReportRenderJob.php
+++ b/lib/BackgroundJob/ReportRenderJob.php
@@ -111,6 +111,8 @@ class ReportRenderJob extends TimedJob
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/tasks.md#task-8
      */
     protected function run($argument): void
     {

--- a/lib/BackgroundJob/ScheduledNotificationJob.php
+++ b/lib/BackgroundJob/ScheduledNotificationJob.php
@@ -96,6 +96,8 @@ final class ScheduledNotificationJob extends TimedJob
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/tasks.md#task-2
      */
     protected function run($argument): void
     {

--- a/lib/BackgroundJob/ScheduledWorkflowJob.php
+++ b/lib/BackgroundJob/ScheduledWorkflowJob.php
@@ -78,6 +78,8 @@ class ScheduledWorkflowJob extends TimedJob
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/tasks.md#task-7
      */
     protected function run($argument): void
     {

--- a/lib/BackgroundJob/SolrWarmupJob.php
+++ b/lib/BackgroundJob/SolrWarmupJob.php
@@ -101,6 +101,8 @@ class SolrWarmupJob extends QueuedJob
      * @throws \Exception If warmup fails critically (job will be marked as failed)
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/tasks.md#task-9
      */
     protected function run($argument): void
     {

--- a/lib/Cron/ArchivalRetentionTask.php
+++ b/lib/Cron/ArchivalRetentionTask.php
@@ -169,6 +169,8 @@ class ArchivalRetentionTask extends TimedJob
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/tasks.md#task-11
      */
     protected function run($argument): void
     {

--- a/lib/Listener/AggregationThresholdListener.php
+++ b/lib/Listener/AggregationThresholdListener.php
@@ -101,6 +101,8 @@ class AggregationThresholdListener implements IEventListener
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/tasks.md#task-3
      */
     public function handle(Event $event): void
     {

--- a/lib/Listener/AnnotationNotificationListener.php
+++ b/lib/Listener/AnnotationNotificationListener.php
@@ -58,6 +58,8 @@ class AnnotationNotificationListener implements IEventListener
      * @param Event $event Inbound dispatcher event.
      *
      * @return void
+     *
+     * @spec exclude Dispatch-only event router that delegates verbatim to AnnotationNotificationDispatcher; the dispatcher carries the notification behaviour.
      */
     public function handle(Event $event): void
     {

--- a/lib/Listener/LifecycleInitialStateListener.php
+++ b/lib/Listener/LifecycleInitialStateListener.php
@@ -64,6 +64,8 @@ class LifecycleInitialStateListener implements IEventListener
      * @param Event $event Inbound dispatcher event.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/tasks.md#task-12
      */
     public function handle(Event $event): void
     {

--- a/lib/Listener/LifecycleValidationListener.php
+++ b/lib/Listener/LifecycleValidationListener.php
@@ -92,6 +92,8 @@ class LifecycleValidationListener implements IEventListener
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/tasks.md#task-13
      */
     public function handle(Event $event): void
     {

--- a/openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/proposal.md
@@ -1,0 +1,76 @@
+# Retrofit — background jobs / listeners / cron bundle
+
+Reverse-specs a small backend cluster of uncovered background jobs, event listeners, and one cron task: 15 methods across `lib/BackgroundJob/`, `lib/Listener/`, and `lib/Cron/`. Most are the recurring / reactive half of a pipeline whose synchronous half is already specced, so the bias is `--extend` of an existing capability. The code already exists; this change retroactively specifies the observed behaviour and back-annotates each method.
+
+Source: `/tmp/or-scan/bw-jobs-listeners.json` (cluster `jobs-listeners`, generated 2026-05-25). See [retrofit playbook](../../../.github/docs/claude/retrofit.md).
+
+## Counts
+
+- **15 methods** tagged in total.
+- **10 spec'd to existing REQs** (annotated `@spec` pointing at the existing capability change/task).
+- **3 new REQs** drafted (1 on `search-index`, 2 on `object-lifecycle`).
+- **2 excluded** via `@spec exclude <reason>` (disabled-by-default migration backfill; dispatch-only event router).
+
+## Affected code units
+
+### Spec'd to existing capabilities (10 methods)
+
+| Method | Capability | Existing REQ |
+|---|---|---|
+| `BackgroundJob/BatchNotificationJob::run` | `notificatie-engine` | Notifications MUST support batching and digest delivery |
+| `BackgroundJob/ScheduledNotificationJob::run` | `notificatie-engine` | The notification engine MUST support event-driven trigger types beyond CRUD |
+| `Listener/AggregationThresholdListener::handle` | `notificatie-engine` | The notification engine MUST support event-driven trigger types beyond CRUD |
+| `BackgroundJob/CacheWarmupJob::run` | `faceting-configuration` | Facet label resolution for entity references |
+| `BackgroundJob/NameCacheWarmupJob::run` | `faceting-configuration` | Facet label resolution for entity references |
+| `BackgroundJob/ExecutionHistoryCleanupJob::run` | `workflow-operations` | Execution History Retention |
+| `BackgroundJob/ScheduledWorkflowJob::run` | `workflow-operations` | Scheduled Workflow Triggers |
+| `BackgroundJob/ReportRenderJob::run` | `rapportage-bi-export` | The system MUST support scheduled report generation |
+| `BackgroundJob/SolrWarmupJob::run` | `search-index` | Bulk indexing fetches searchable-schema objects from the database in batches |
+| `Cron/ArchivalRetentionTask::run` | `retention-management` | The system MUST generate destruction lists via a background job |
+
+### New REQs (3 methods)
+
+| Method | Capability | New REQ |
+|---|---|---|
+| `BackgroundJob/FileTextExtractionJob::run` | `search-index` | Asynchronous file text extraction MUST run as a queued background job |
+| `Listener/LifecycleInitialStateListener::handle` | `object-lifecycle` | REQ-010 — Declared initial lifecycle state MUST be applied on create |
+| `Listener/LifecycleValidationListener::handle` | `object-lifecycle` | REQ-011 — Direct lifecycle-field edits MUST be guarded on update |
+
+### Excluded (2 methods)
+
+| Method | Exclude reason |
+|---|---|
+| `BackgroundJob/BackfillCalendarLinksJob::run` | disabled-by-default one-time Tier-2 migration backfill, gated behind an app-config flag, not a production capability surface |
+| `Listener/AnnotationNotificationListener::handle` | dispatch-only event router that delegates verbatim to `AnnotationNotificationDispatcher` (the dispatcher carries the behaviour) |
+
+## Approach
+
+### notificatie-engine (3 methods, extend — no new REQ)
+`BatchNotificationJob::run` is the consumer side of the digest queue: it flushes `NotificationDigest` per-recipient on a configurable interval (`notification_batch_interval`, 0 disables via the standard 1-year-interval "off" pattern). This is exactly the "batching and digest delivery" REQ — the file already carries the file-level annotation; the `run()` method gets a method-level tag. `ScheduledNotificationJob::run` is the `trigger.type === 'scheduled'` driver: a 60s TimedJob that walks every schema's `x-openregister-notifications` block, fires due entries via the existing `AnnotationNotificationDispatcher`, and tracks last-fire state in the distributed cache. `AggregationThresholdListener::handle` is the `trigger.type === 'threshold'` driver: on object-write events it recomputes the referenced aggregation and dispatches on the rising-edge (below → above) crossing, with per-(schema, notification) state in the distributed cache. Both are concrete realisations of "event-driven trigger types beyond CRUD" (scheduled + threshold triggers), reusing the unchanged channel surface.
+
+### faceting-configuration (2 methods, extend — no new REQ)
+`CacheWarmupJob::run` (hourly, configurable) and `NameCacheWarmupJob::run` (nightly) both call `CacheHandler::warmupNameCache()` to pre-populate the distributed UUID-to-name cache so facet label resolution does not pay a cold-start penalty. This is the "Facet label resolution for entity references" REQ — the warmup jobs are its operational support.
+
+### workflow-operations (2 methods, extend — no new REQ)
+`ExecutionHistoryCleanupJob::run` is the daily pruner that deletes `WorkflowExecution` rows older than `workflow_execution_retention_days` (default 90) — the "Execution History Retention" REQ. `ScheduledWorkflowJob::run` is the 60s evaluator that runs each enabled `ScheduledWorkflow` whose interval has elapsed via the engine registry and records the result — the "Scheduled Workflow Triggers" REQ (the file already carries a `retrofit-2026-04-23-annotate-openregister` annotation; the method tag is brought onto the canonical `workflow-operations` capability).
+
+### rapportage-bi-export (1 method, extend — no new REQ)
+`ReportRenderJob::run` is the daily scheduled-report renderer: it walks dashboard objects in the `reports` register, decides per-`schedule.intervalSec` due-ness, renders to the configured format, and delivers to the operator-configured Files folder (with path-traversal hardening). This is the "scheduled report generation" REQ.
+
+### search-index (1 extend, 1 new REQ)
+`SolrWarmupJob::run` warms the Solr index after imports by bulk-indexing all schemas up to a cap — covered by the existing "Bulk indexing" REQ. `FileTextExtractionJob::run` is a different surface: a queued one-time job that extracts text from a single uploaded file via `TextExtractionService` so user requests are not blocked. The `search-index` spec covers Solr/document indexing but not the file-text-extraction feeder pipeline, so this is a **new REQ**.
+
+### object-lifecycle (2 new REQs)
+The object-lifecycle capability already specs the annotation validator (REQ-006), the named-action `TransitionEngine` (REQ-007), and the guard registry / `GuardResult` contract (REQ-008/009). The two listeners in this bundle are the **event-listener enforcement layer** that those REQs do not describe:
+
+- `LifecycleInitialStateListener::handle` force-sets the schema's declared `initial` value on `ObjectCreatingEvent` when the caller left the lifecycle field empty — so apps never have to remember the starting state. → **REQ-010**.
+- `LifecycleValidationListener::handle` guards **direct field edits** (not the named-action `TransitionEngine` path): on `ObjectUpdatingEvent` it rejects any lifecycle-field change that no declared transition allows from the current value, and runs the optional `requires` guard, stopping propagation with a structured error. This is the `saveObject()`-driven complement to REQ-007's explicit-action engine. → **REQ-011**.
+
+## Notes
+
+- **RBAC / multitenancy bypass (surfaced, not fixed)** — several system-level jobs/listeners deliberately call mapper `find()` / `findAll()` with `_rbac: false, _multitenancy: false` because they run as the system, not a user (`ArchivalRetentionTask`, `ReportRenderJob`, `AggregationThresholdListener`, `LifecycleInitialStateListener`, `LifecycleValidationListener`). Documented as observed behaviour, not changed in this retrofit.
+- **`ArchivalRetentionTask` is the only delete path on archival schemas** — user-driven deletes are rejected 403; the sweep uses `ObjectService::deleteObject(..., _retentionSweep: true)` to bypass the immutability gate while still firing the audit trail. It already carries an `add-archival-annotation-support` file-level annotation; the method tag is added to the canonical `retention-management` capability.
+- **`ReportRenderJob::writeToFiles` path-traversal hardening** — the job refuses to fall back to `admin` when the dashboard owner is null and rejects `..` segments in the user-controlled `delivery.filesFolder`. Captured in the existing scheduled-report REQ scenarios.
+- The two excluded methods are tagged `@spec exclude <reason>` (never bare).
+
+Source: `/tmp/or-scan/bw-jobs-listeners.json`. See retrofit playbook.

--- a/openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/specs/object-lifecycle/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/specs/object-lifecycle/spec.md
@@ -1,0 +1,77 @@
+# Object Lifecycle
+
+## ADDED Requirements
+
+### Requirement: REQ-010 — Declared initial lifecycle state MUST be applied on create
+
+`LifecycleInitialStateListener::handle()` MUST, on `ObjectCreatingEvent`, force-set the schema's declared initial lifecycle value when the caller did not supply one. The listener reads the `x-openregister-lifecycle` annotation from the object's schema, takes the annotation's `field` and `initial` keys, and writes `initial` into the object payload under `field` ONLY when that field is currently absent, null, or an empty string. A caller-supplied non-empty value MUST be left untouched (its validity is the validator's / update-guard's concern). The listener MUST be a no-op when the event is not an `ObjectCreatingEvent`, when the schema cannot be resolved, when the schema declares no lifecycle annotation, or when the annotation's `field`/`initial` are empty.
+
+Apps therefore never need to know the starting state — lifecycle is a declarative property of the schema.
+
+#### Scenario: Initial state applied when caller omits it
+- **GIVEN** a schema declaring `x-openregister-lifecycle` with `field: "status"` and `initial: "draft"`
+- **AND** an object being created whose `status` field is absent
+- **WHEN** `ObjectCreatingEvent` fires and `LifecycleInitialStateListener::handle()` runs
+- **THEN** the object payload MUST have `status` set to `"draft"` before persistence
+
+#### Scenario: Caller-supplied value is preserved
+- **GIVEN** the same schema and an object being created with `status: "open"`
+- **WHEN** the listener runs
+- **THEN** the `status` value MUST remain `"open"` (the listener MUST NOT overwrite it)
+
+#### Scenario: Empty string is treated as missing
+- **GIVEN** the same schema and an object being created with `status: ""`
+- **WHEN** the listener runs
+- **THEN** `status` MUST be set to the declared `initial` value `"draft"`
+
+#### Scenario: No-op without a lifecycle annotation
+- **GIVEN** a schema with no `x-openregister-lifecycle` annotation
+- **WHEN** the listener runs on an object of that schema
+- **THEN** the payload MUST be left unchanged
+
+#### Notes
+- `loadSchema()` resolves the object's schema via `SchemaMapper::find($ref, _multitenancy: false)` — a system-level lookup because the listener is not user-scoped. An unresolvable or empty schema reference yields a null schema and the listener returns early after logging a warning. See the change Notes for the multitenancy-boundary follow-up.
+- This is the create-time complement to REQ-006's annotation validator; it relies on the annotation already being shape-valid.
+
+### Requirement: REQ-011 — Direct lifecycle-field edits MUST be guarded on update
+
+`LifecycleValidationListener::handle()` MUST, on `ObjectUpdatingEvent`, reject lifecycle-field edits made through the ordinary save path (`ObjectService::saveObject()`) that no declared transition allows. This is the complement to REQ-007's named-action `TransitionEngine`: it guards the case where a caller edits the lifecycle field value directly rather than invoking a named action. When the old and new value of the annotation's `field` differ, the listener MUST:
+
+1. require the new value to be a non-empty string (else reject with code `lifecycle-invalid-value`);
+2. find a declared transition whose `to` equals the new value AND whose `from` array contains the old value (else reject with code `lifecycle-invalid-transition`);
+3. when the matched transition declares a non-empty `requires` tag, resolve the guard via `LifecycleGuardRegistry` and run `check()` with the new data, the action name, and the caller's uid — rejecting with code `lifecycle-guard-denied` when the verdict is not allowed.
+
+Each rejection MUST stamp a structured error onto the event and stop propagation, so the controller surfaces it (HTTP 422 for invalid value/transition, 403 for guard denial). The listener MUST be a no-op when the event is not an `ObjectUpdatingEvent`, when there is no prior object state (initial state is REQ-010's concern), when the schema or its lifecycle annotation is absent, or when the lifecycle field value is unchanged.
+
+#### Scenario: Allowed transition passes
+- **GIVEN** a schema declaring a transition `open` with `from: ["draft"], to: "open"`
+- **AND** an object whose `status` changes from `"draft"` to `"open"`
+- **WHEN** `ObjectUpdatingEvent` fires and the listener runs
+- **THEN** propagation MUST continue and no error MUST be stamped on the event
+
+#### Scenario: Disallowed transition is rejected
+- **GIVEN** the same schema and an object whose `status` changes from `"closed"` to `"open"` (no transition allows that pair)
+- **WHEN** the listener runs
+- **THEN** the event MUST carry a structured error with code `lifecycle-invalid-transition` naming the from/attempted values
+- **AND** propagation MUST be stopped
+
+#### Scenario: Non-string lifecycle value is rejected
+- **GIVEN** an object whose lifecycle field is changed to a null or empty value
+- **WHEN** the listener runs
+- **THEN** the event MUST carry an error with code `lifecycle-invalid-value`
+- **AND** propagation MUST be stopped
+
+#### Scenario: Guard denial maps to 403
+- **GIVEN** a matched transition declaring `requires: "decidesk.meeting.openGuard"` whose guard returns a deny verdict
+- **WHEN** the listener runs
+- **THEN** the event MUST carry an error with code `lifecycle-guard-denied` and the guard's message
+- **AND** propagation MUST be stopped
+
+#### Scenario: Unchanged lifecycle value is a no-op
+- **GIVEN** an object update where the lifecycle field value is identical between old and new
+- **WHEN** the listener runs
+- **THEN** no validation MUST be performed and propagation MUST continue
+
+#### Notes
+- Trust contract: this listener only fires on `ObjectUpdatingEvent`, dispatched by `ObjectService::saveObject()`. Code paths that mutate an object outside `saveObject()` (direct `MagicMapper::update`, raw SQL, import bypass) skip the listener and can persist an invalid lifecycle value. Callers MUST go through `saveObject()` for the guarantee to hold; a DB-level CHECK constraint is a future hardening step.
+- `loadSchema()` uses `_multitenancy: false` (system-level lookup). The guard receives the loaded object payload, the action name, and the caller's uid via `IUserSession`.

--- a/openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/specs/search-index/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/specs/search-index/spec.md
@@ -1,0 +1,46 @@
+---
+status: proposed
+retrofit_extensions:
+  - Asynchronous file text extraction MUST run as a queued background job
+---
+
+# Search Index — asynchronous file text extraction (delta)
+
+**Cross-references**: [search-index main spec](../../../../specs/search-index/spec.md).
+
+## Purpose of this delta
+
+The `search-index` capability covers Solr/document indexing, bulk re-indexing, and backend configuration. It does not yet describe the feeder pipeline that turns uploaded binary files into searchable text. This delta retroactively captures the observed behaviour of `FileTextExtractionJob` — the queued, one-time background job that extracts text from a single file via `TextExtractionService` so the extraction cost is paid off the user request path.
+
+## ADDED Requirements
+
+### Requirement: Asynchronous file text extraction MUST run as a queued background job
+
+When file text extraction is enabled, the system MUST extract text from uploaded files asynchronously via a one-time `QueuedJob` (`FileTextExtractionJob`) rather than blocking the user request that created or modified the file. The job MUST be a no-op when extraction is disabled in configuration, MUST validate that a `file_id` argument is present, and MUST delegate the actual extraction to `TextExtractionService::extractFile()`. Failures MUST be logged and MUST NOT propagate as uncaught exceptions out of the job.
+
+#### Scenario: Extraction is skipped when disabled
+- **GIVEN** the `fileManagement` app-config either has no value or declares `extractionScope === 'none'`
+- **WHEN** `FileTextExtractionJob::run()` executes
+- **THEN** the job MUST log an info message that extraction is disabled
+- **AND** it MUST return without calling `TextExtractionService`
+
+#### Scenario: Missing file_id is rejected
+- **GIVEN** the job is queued without a `file_id` argument
+- **WHEN** `run()` executes
+- **THEN** it MUST log an error naming the missing argument
+- **AND** it MUST return without attempting extraction
+
+#### Scenario: Text is extracted for a valid file id
+- **GIVEN** extraction is enabled and the job argument carries a valid `file_id`
+- **WHEN** `run()` executes
+- **THEN** it MUST call `TextExtractionService::extractFile(fileId: <id>, forceReExtract: false)`
+- **AND** it MUST log start and successful-completion entries including a processing-time metric
+
+#### Scenario: Extraction failure is contained
+- **GIVEN** `TextExtractionService::extractFile()` throws an exception
+- **WHEN** `run()` executes
+- **THEN** the exception MUST be caught and logged at error level with the file id and the error message
+- **AND** the job MUST NOT re-throw (the failure does not crash the cron worker)
+
+#### Notes
+- The job is queued from the file create/modify path so extraction never blocks the user request — this is the asynchronous complement to the synchronous Solr indexing covered by the bulk-indexing REQ.

--- a/openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/tasks.md
@@ -1,0 +1,37 @@
+# Tasks — background jobs / listeners / cron reverse-spec
+
+Each task back-annotates one method against its target REQ (existing capability or a new REQ drafted in this change). Excluded methods are tagged `@spec exclude <reason>` and are not listed as REQ tasks.
+
+## notificatie-engine (extend, existing REQs)
+
+- [x] task-1: notificatie-engine#Notifications MUST support batching and digest delivery — `BatchNotificationJob::run` flushes the `NotificationDigest` queue per recipient on the configurable `notification_batch_interval` (retroactive annotation)
+- [x] task-2: notificatie-engine#The notification engine MUST support event-driven trigger types beyond CRUD — `ScheduledNotificationJob::run` fires `trigger.type === 'scheduled'` notifications, tracking last-fire state in the distributed cache (retroactive annotation)
+- [x] task-3: notificatie-engine#The notification engine MUST support event-driven trigger types beyond CRUD — `AggregationThresholdListener::handle` fires `trigger.type === 'threshold'` notifications on rising-edge aggregation crossings (retroactive annotation)
+
+## faceting-configuration (extend, existing REQ)
+
+- [x] task-4: faceting-configuration#Facet label resolution for entity references — `CacheWarmupJob::run` warms the UUID-to-name cache on a configurable interval to keep facet label resolution warm (retroactive annotation)
+- [x] task-5: faceting-configuration#Facet label resolution for entity references — `NameCacheWarmupJob::run` runs the nightly UUID-to-name cache warmup for facet label resolution (retroactive annotation)
+
+## workflow-operations (extend, existing REQs)
+
+- [x] task-6: workflow-operations#Execution History Retention — `ExecutionHistoryCleanupJob::run` prunes workflow execution rows older than `workflow_execution_retention_days` (default 90) daily (retroactive annotation)
+- [x] task-7: workflow-operations#Scheduled Workflow Triggers — `ScheduledWorkflowJob::run` evaluates enabled scheduled workflows every 60s and executes those whose interval has elapsed via the engine registry (retroactive annotation)
+
+## rapportage-bi-export (extend, existing REQ)
+
+- [x] task-8: rapportage-bi-export#The system MUST support scheduled report generation — `ReportRenderJob::run` renders due dashboards in the `reports` register daily and delivers to the configured Files folder (retroactive annotation)
+
+## search-index (extend existing + new REQ)
+
+- [x] task-9: search-index#Bulk indexing fetches searchable-schema objects from the database in batches — `SolrWarmupJob::run` bulk-indexes all schemas up to a cap after imports to warm the Solr index (retroactive annotation)
+- [x] task-10: search-index#Asynchronous file text extraction MUST run as a queued background job — `FileTextExtractionJob::run` extracts text from a single uploaded file via `TextExtractionService` off the request path (new REQ)
+
+## retention-management (extend, existing REQ)
+
+- [x] task-11: retention-management#The system MUST generate destruction lists via a background job — `ArchivalRetentionTask::run` sweeps every `x-openregister-archival` schema hourly and deletes rows past retention via the retention-sweep delete path (retroactive annotation)
+
+## object-lifecycle (new REQs)
+
+- [x] task-12: object-lifecycle#REQ-010 — Declared initial lifecycle state MUST be applied on create — `LifecycleInitialStateListener::handle` force-sets the schema's declared `initial` lifecycle value on `ObjectCreatingEvent` when the caller left it empty (new REQ)
+- [x] task-13: object-lifecycle#REQ-011 — Direct lifecycle-field edits MUST be guarded on update — `LifecycleValidationListener::handle` rejects lifecycle-field changes with no allowing transition and runs the optional `requires` guard on `ObjectUpdatingEvent`, stopping propagation with a structured error (new REQ)


### PR DESCRIPTION
## Summary

Reverse-specs the `jobs-listeners` backend cluster — 15 uncovered methods across `lib/BackgroundJob/`, `lib/Listener/`, and `lib/Cron/` — under the ADR-003 `@spec` convention via the ghost change `retrofit-2026-05-25-bw-jobs-listeners`.

- **10 methods** annotated to **existing** capability REQs: `notificatie-engine` (batch/scheduled/threshold notifications), `faceting-configuration` (name-cache warmup), `workflow-operations` (execution-history cleanup + scheduled workflows), `rapportage-bi-export` (scheduled report render), `search-index` (Solr warmup), `retention-management` (archival retention sweep).
- **3 new REQs** drafted: `search-index` — *Asynchronous file text extraction MUST run as a queued background job*; `object-lifecycle` — *REQ-010 Declared initial lifecycle state MUST be applied on create* and *REQ-011 Direct lifecycle-field edits MUST be guarded on update* (the event-listener enforcement layer complementing the existing validator/engine/guard REQs).
- **2 methods** tagged `@spec exclude <reason>` (never bare): the disabled-by-default Tier-2 `BackfillCalendarLinksJob` migration backfill, and the dispatch-only `AnnotationNotificationListener` event router.

Every one of the 15 methods is now tagged. `openspec validate retrofit-2026-05-25-bw-jobs-listeners --strict` is green; `php -l` clean on all touched files.

## Notes

- Several system-level jobs/listeners deliberately call mappers with `_rbac: false, _multitenancy: false` (they run as the system, not a user). Surfaced in the proposal Notes as observed behaviour — not changed here; worth a follow-up multitenancy-boundary review.
- `ArchivalRetentionTask` is the only legitimate delete path on archival schemas (user deletes are 403); the sweep uses `_retentionSweep: true` to bypass the immutability gate while still firing the audit trail.

## Test plan

- [ ] CI: PHPCS / PHPStan / Psalm green (annotation-only code change)
- [ ] `openspec validate retrofit-2026-05-25-bw-jobs-listeners --strict` passes
- [ ] Confirm the 3 new REQs read correctly against observed listener/job behaviour