### PR TITLE
retrofit: backend coverage — Service/File

### DIFF
--- a/lib/Service/File/CreateFileHandler.php
+++ b/lib/Service/File/CreateFileHandler.php
@@ -120,6 +120,8 @@ class CreateFileHandler
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * File creation requires handling multiple content formats and error cases.
      * @SuppressWarnings(PHPMD.NPathComplexity)      Multiple execution paths for content processing and validation.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-006
      */
     public function addFile(
         ObjectEntity|string $objectEntity,
@@ -245,6 +247,8 @@ class CreateFileHandler
      * @psalm-param   array<int, string> $tags
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Boolean flag is intentional for simple share toggle.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-006
      */
     public function saveFile(
         ObjectEntity $objectEntity,

--- a/lib/Service/File/DocumentProcessingHandler.php
+++ b/lib/Service/File/DocumentProcessingHandler.php
@@ -107,6 +107,8 @@ class DocumentProcessingHandler
      * @phpstan-return File
      *
      * @psalm-return File
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-008
      */
     public function replaceWords(Node $node, array $replacements, ?string $outputName=null): File
     {
@@ -151,6 +153,8 @@ class DocumentProcessingHandler
      * @psalm-param array<int, array{text?: string, entityType?: string, key?: string}> $entities
      *
      * @return File The anonymized document file.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-008
      */
     public function anonymizeDocument(Node $node, array $entities): File
     {

--- a/lib/Service/File/FileAuditHandler.php
+++ b/lib/Service/File/FileAuditHandler.php
@@ -72,6 +72,8 @@ class FileAuditHandler
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec exclude No-op audit shim: only emits a log line; the AuditTrail insert is commented out, so there is no persisted behavior to specify.
      */
     public function logDownload(
         int $fileId,

--- a/lib/Service/File/FileBatchHandler.php
+++ b/lib/Service/File/FileBatchHandler.php
@@ -100,6 +100,8 @@ class FileBatchHandler
      * @return array{results: array, summary: array{total: int, succeeded: int, failed: int}} Batch results.
      *
      * @throws Exception If validation fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-009
      */
     public function executeBatch(
         ObjectEntity $object,

--- a/lib/Service/File/FileCrudHandler.php
+++ b/lib/Service/File/FileCrudHandler.php
@@ -90,6 +90,8 @@ class FileCrudHandler
      * @phpstan-return Node
      *
      * @todo Extract full implementation from FileService::createFolder()
+     *
+     * @spec exclude Phase-1B placeholder: throws "pending Phase 2 extraction" unconditionally, no observable behavior.
      */
     public function createFolder(string $_folderPath)
     {
@@ -129,6 +131,8 @@ class FileCrudHandler
      * @todo Extract full implementation from FileService::addFile()
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Boolean flag is intentional for simple share toggle.
+     *
+     * @spec exclude Phase-1B placeholder: throws "pending Phase 2 extraction" unconditionally, no observable behavior.
      */
     public function addFile(
         ObjectEntity|string $_objectEntity,
@@ -171,6 +175,8 @@ class FileCrudHandler
      * @phpstan-return File
      *
      * @todo Extract full implementation from FileService::updateFile()
+     *
+     * @spec exclude Phase-1B placeholder: throws "pending Phase 2 extraction" unconditionally, no observable behavior.
      */
     public function updateFile(string|int $_filePath, mixed $_content=null, array $_tags=[], ?ObjectEntity $_object=null)
     {
@@ -202,6 +208,8 @@ class FileCrudHandler
      * @phpstan-return bool
      *
      * @todo Extract full implementation from FileService::deleteFile()
+     *
+     * @spec exclude Phase-1B placeholder: throws "pending Phase 2 extraction" unconditionally, no observable behavior.
      */
     public function deleteFile(Node|string|int $_file, ?ObjectEntity $_object=null)
     {
@@ -228,6 +236,8 @@ class FileCrudHandler
      * @phpstan-return File|null
      *
      * @todo Extract full implementation from FileService::getFile()
+     *
+     * @spec exclude Phase-1B placeholder: throws "pending Phase 2 extraction" unconditionally, no observable behavior.
      */
     public function getFile(ObjectEntity|string|null $_object=null, string|int $_file='')
     {
@@ -253,6 +263,8 @@ class FileCrudHandler
      * @phpstan-return File|null
      *
      * @todo Extract full implementation from FileService::getFileById()
+     *
+     * @spec exclude Phase-1B placeholder: throws "pending Phase 2 extraction" unconditionally, no observable behavior.
      */
     public function getFileById(int $_fileId)
     {
@@ -280,6 +292,8 @@ class FileCrudHandler
      * @todo Extract full implementation from FileService::getFiles()
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Boolean flag is intentional for simple share toggle.
+     *
+     * @spec exclude Phase-1B placeholder: throws "pending Phase 2 extraction" unconditionally, no observable behavior.
      */
     public function getFiles(ObjectEntity|string $_object, ?bool $_sharedFilesOnly=false)
     {
@@ -317,6 +331,8 @@ class FileCrudHandler
      * @todo Extract full implementation from FileService::saveFile()
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Boolean flag is intentional for simple share toggle.
+     *
+     * @spec exclude Phase-1B placeholder: throws "pending Phase 2 extraction" unconditionally, no observable behavior.
      */
     public function saveFile(
         ObjectEntity $_objectEntity,

--- a/lib/Service/File/FileFormattingHandler.php
+++ b/lib/Service/File/FileFormattingHandler.php
@@ -119,6 +119,8 @@ class FileFormattingHandler
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-007
      */
     public function formatFile(Node $file): array
     {
@@ -288,6 +290,8 @@ class FileFormattingHandler
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) File formatting with pagination requires multiple branches
      * @SuppressWarnings(PHPMD.NPathComplexity)      Multiple filter and pagination paths
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-007
      */
     public function formatFiles(array $files, ?array $requestParams=[]): array
     {

--- a/lib/Service/File/FileLockHandler.php
+++ b/lib/Service/File/FileLockHandler.php
@@ -212,6 +212,8 @@ class FileLockHandler
      * @param int $fileId The file ID.
      *
      * @return array|null Lock metadata or null.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-007
      */
     public function getLockInfo(int $fileId): ?array
     {
@@ -257,6 +259,8 @@ class FileLockHandler
      * @return void
      *
      * @throws Exception If the file is locked by another user.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-008
      */
     public function assertCanModify(int $fileId): void
     {

--- a/lib/Service/File/FileOwnershipHandler.php
+++ b/lib/Service/File/FileOwnershipHandler.php
@@ -85,6 +85,8 @@ class FileOwnershipHandler
      *
      * @psalm-return   IUser
      * @phpstan-return IUser
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-009
      */
     public function getUser(): IUser
     {
@@ -159,6 +161,8 @@ class FileOwnershipHandler
      *
      * @psalm-return   void
      * @phpstan-return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-006
      */
     public function transferFileOwnershipIfNeeded(File $file, ?FileSharingHandler $fileSharingHandler=null): void
     {
@@ -244,6 +248,8 @@ class FileOwnershipHandler
      *
      * @psalm-return   void
      * @phpstan-return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-009
      */
     public function transferFolderOwnershipIfNeeded(Node $folder, ?FileSharingHandler $fileSharingHandler=null): void
     {

--- a/lib/Service/File/FilePublishingHandler.php
+++ b/lib/Service/File/FilePublishingHandler.php
@@ -101,6 +101,8 @@ class FilePublishingHandler
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  File lookup requires handling ID vs path scenarios
      * @SuppressWarnings(PHPMD.NPathComplexity)       Multiple file resolution paths with fallback logic
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Comprehensive file lookup and sharing requires extensive code
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-009
      */
     public function publishFile(ObjectEntity | string $object, string | int $file): File
     {
@@ -303,6 +305,8 @@ class FilePublishingHandler
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  File lookup requires handling ID vs path scenarios
      * @SuppressWarnings(PHPMD.NPathComplexity)       Multiple file resolution paths with fallback logic
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Comprehensive file lookup and unsharing requires extensive code
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-009
      */
     public function unpublishFile(ObjectEntity | string $object, string|int $filePath): File
     {
@@ -503,6 +507,8 @@ class FilePublishingHandler
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  ZIP creation requires handling multiple file and error scenarios
      * @SuppressWarnings(PHPMD.NPathComplexity)       Multiple paths for file processing and error handling
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) ZIP archive creation with file processing requires extensive code
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-009
      */
     public function createObjectFilesZip(ObjectEntity | string $object, ?string $zipName=null): array
     {

--- a/lib/Service/File/FileSharingHandler.php
+++ b/lib/Service/File/FileSharingHandler.php
@@ -98,6 +98,8 @@ class FileSharingHandler
      *
      * @psalm-return   array<IShare>
      * @phpstan-return array<int, IShare>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-009
      */
     public function findShares(Node $file, int $shareType=3): array
     {
@@ -129,6 +131,8 @@ class FileSharingHandler
      *
      * @psalm-return   IShare
      * @phpstan-return IShare
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-009
      */
     public function createShare(array $shareData): IShare
     {
@@ -197,6 +201,8 @@ class FileSharingHandler
      *
      * @psalm-return   void
      * @phpstan-return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-009
      */
     public function shareFileWithUser(File $file, string $userId, int $permissions=31): void
     {
@@ -250,6 +256,8 @@ class FileSharingHandler
      *
      * @psalm-return   IShare|null
      * @phpstan-return IShare|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-009
      */
     public function shareFolderWithUser(Node $folder, string $userId, int $permissions=31): ?IShare
     {

--- a/lib/Service/File/FileValidationHandler.php
+++ b/lib/Service/File/FileValidationHandler.php
@@ -77,6 +77,8 @@ class FileValidationHandler
      * @phpstan-return void
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Comprehensive list of dangerous extensions requires extensive code
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-010
      */
     public function blockExecutableFile(string $fileName, string $fileContent): void
     {
@@ -188,6 +190,8 @@ class FileValidationHandler
      *
      * @psalm-return   void
      * @phpstan-return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-010
      */
     public function detectExecutableMagicBytes(string $content, string $fileName): void
     {
@@ -267,6 +271,8 @@ class FileValidationHandler
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) The method fans out across
      * readability, owner-drift detection, and best-effort repair with a nested
      * try/catch; splitting further would obscure the ownership-repair intent.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-010
      */
     public function checkOwnership(Node $file): void
     {
@@ -319,6 +325,8 @@ class FileValidationHandler
      *
      * @psalm-return   bool
      * @phpstan-return bool
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-010
      */
     public function ownFile(Node $file): bool
     {

--- a/lib/Service/File/FolderManagementHandler.php
+++ b/lib/Service/File/FolderManagementHandler.php
@@ -129,6 +129,8 @@ class FolderManagementHandler
      *
      * @psalm-return   Node|null
      * @phpstan-return Node|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/specs/file-actions/spec.md#REQ-004
      */
     public function createEntityFolder(Register | ObjectEntity $entity): ?Node
     {
@@ -232,6 +234,8 @@ class FolderManagementHandler
      * @throws NotPermittedException If folder creation is not permitted.
      *
      * @return Folder The created or existing folder for the object.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/specs/file-actions/spec.md#REQ-004
      */
     public function createObjectFolderById(
         ObjectEntity|string $objectEntity,
@@ -357,6 +361,8 @@ class FolderManagementHandler
      *
      * @psalm-return   Folder|null
      * @phpstan-return Folder|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/specs/file-actions/spec.md#REQ-004
      */
     public function getObjectFolder(ObjectEntity|string $objectEntity, int|string|null $registerId=null): ?Folder
     {
@@ -417,6 +423,8 @@ class FolderManagementHandler
      * @psalm-return   int
      * @phpstan-return int
      * @return         int The folder ID.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/specs/file-actions/spec.md#REQ-004
      */
     public function createObjectFolderWithoutUpdate(ObjectEntity $objectEntity, ?IUser $currentUser=null): int
     {
@@ -553,6 +561,8 @@ class FolderManagementHandler
      *
      * @psalm-return   Node
      * @phpstan-return Node
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/specs/file-actions/spec.md#REQ-004
      */
     public function createFolder(string $folderPath): Node
     {
@@ -697,6 +707,8 @@ class FolderManagementHandler
      *
      * @psalm-return   'file'|'folder'|'unknown'
      * @phpstan-return 'file'|'folder'|'unknown'
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/specs/file-actions/spec.md#REQ-004
      */
     public function getNodeTypeFromFolder(Node $node): string
     {

--- a/lib/Service/File/ReadFileHandler.php
+++ b/lib/Service/File/ReadFileHandler.php
@@ -126,6 +126,8 @@ class ReadFileHandler
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) File lookup requires handling ID vs path scenarios
      * @SuppressWarnings(PHPMD.NPathComplexity)      Multiple file resolution paths with fallback logic
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-007
      */
     public function getFile(ObjectEntity|string|null $object=null, string|int $file=''): ?File
     {
@@ -209,6 +211,8 @@ class ReadFileHandler
      *
      * @phpstan-param  int $fileId
      * @phpstan-return File|null
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-007
      */
     public function getFileById(int $fileId): ?File
     {
@@ -256,6 +260,8 @@ class ReadFileHandler
      * @phpstan-return array<int, \OCP\Files\Node>
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Boolean flag is intentional for simple filter toggle
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-007
      */
     public function getFiles(
         ObjectEntity|string $object,

--- a/lib/Service/File/TaggingHandler.php
+++ b/lib/Service/File/TaggingHandler.php
@@ -87,6 +87,8 @@ class TaggingHandler
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Tag management requires handling create/find/attach scenarios
      * @SuppressWarnings(PHPMD.NPathComplexity)      Multiple paths for tag creation and attachment
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/specs/file-actions/spec.md#REQ-005
      */
     public function attachTagsToFile(string $fileId, array $tags=[]): void
     {
@@ -205,6 +207,8 @@ class TaggingHandler
      * @phpstan-return array<int, string>
      *
      * @psalm-return list<string>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-file-actions/specs/file-actions/spec.md#REQ-005
      */
     public function getFileTags(string $fileId): array
     {

--- a/lib/Service/File/UpdateFileHandler.php
+++ b/lib/Service/File/UpdateFileHandler.php
@@ -108,6 +108,8 @@ class UpdateFileHandler
      * @return \OCA\OpenRegister\Db\File The persisted entity reflecting the updated state.
      *
      * @throws Exception When the FileMapper is not wired (legacy fixtures).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-008
      */
     public function updateFileMetadata(
         int $fileId,
@@ -181,6 +183,8 @@ class UpdateFileHandler
      * @SuppressWarnings(PHPMD.NPathComplexity)       File update requires handling many file system scenarios
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Multiple file resolution and update paths
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Comprehensive file update with logging requires extensive code
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md#REQ-008
      */
     public function updateFile(
         string|int $filePath,

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-file/design.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-file/design.md
@@ -1,0 +1,50 @@
+# Design — retrofit-2026-05-25-bw-svc-file
+
+Reverse-spec retrofit. No code changes; this records the triage decisions behind
+the REQ-006 … REQ-010 deltas and the exclusions.
+
+## Decision 1 — Extend `file-actions`, do not mint a new capability
+
+The batch is the deferred `Service/File/` slice from
+`retrofit-2026-05-24-file-actions`'s `## DROP — future-pass:next`. It is the same
+capability surface (per-object files), so this change adds REQ-006 … REQ-010 to
+`file-actions` rather than creating `files-render-extension` (UI rendering) or a
+new capability. The capability hint mentioned `file-actions` / files-render — the
+shipped behavior here is server-side file actions, so `file-actions` is correct.
+
+## Decision 2 — Five REQs grouped by handler responsibility
+
+The handlers already follow single-responsibility, so the REQs map cleanly:
+
+- REQ-006 = CreateFileHandler (create/upsert)
+- REQ-007 = ReadFileHandler + FileFormattingHandler (read + projection)
+- REQ-008 = UpdateFileHandler + DocumentProcessingHandler (mutate)
+- REQ-009 = FilePublishingHandler + FileSharingHandler + FileBatchHandler + FileOwnershipHandler (publish/share/batch)
+- REQ-010 = FileValidationHandler (security)
+
+Folder management (FolderManagementHandler) and tagging (TaggingHandler) already
+have homes in REQ-004 / REQ-005 from the prior pass, so those batch methods are
+annotated to the existing REQs instead of inflating the new-REQ count.
+
+## Decision 3 — `FileCrudHandler` is excluded wholesale
+
+All eight `FileCrudHandler` methods are Phase-1B placeholders that throw
+`"... pending Phase 2 extraction"`. They have zero observable behavior beyond the
+throw, so each is `@spec exclude`d with that reason. They are NOT dropped silently —
+the exclusion reason names the Phase-2 follow-up so a future pass re-triages them
+once the real logic is extracted from `FileService`.
+
+## Decision 4 — `FileAuditHandler::logDownload` excluded as a no-op
+
+`logDownload()` builds a `$data` array and emits a single info log line — the
+actual `AuditTrail` insert is commented out in the shipped code. With no persisted
+effect there is no contract to spec. (Its sibling `logFileAction` / `logBulkDownload`
+DO persist and are already annotated to `audit-trail-immutable` from a prior pass.)
+
+## Decision 5 — Observed quirks captured, not fixed
+
+Heuristic base64 detection, all-digit-filename-as-id, `object:`-tag preservation,
+FileMapper-direct share writes, the broad executable blocklist, and the asymmetric
+file-vs-folder share failure contracts are all captured in the REQ text as observed
+behavior. Tightening any of them is a future functional change, out of scope for a
+reverse-spec pass.

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-file/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-file/proposal.md
@@ -1,0 +1,121 @@
+# Retrofit — backend coverage, Service/File (bw-svc-file, 2026-05-25)
+
+Reverse-specs the next behavioral slice of OpenRegister's shipped file-action
+surface (`lib/Service/File/*Handler`) by **extending the existing `file-actions`
+capability** with 5 new REQs (REQ-006 … REQ-010). Code already exists and is in
+production — this change retroactively specifies it. Every one of the 45 methods
+in the batch ends tagged either with an `@spec` pointer (annotated to a new or
+existing REQ) or with `@spec exclude <reason>` for boilerplate.
+
+This is a follow-up to `retrofit-2026-05-24-file-actions` (REQ-001 … REQ-005),
+which covered CRUD/lock/preview/folder/object-tagging. That change's
+`## DROP — future-pass:next` section listed the publishing/upload/update/read/
+ownership/validation surface as deferred — this change picks up exactly that
+deferred slice for `Service/File/`.
+
+## Coexistence with the original `file-actions` change
+
+The `file-actions` capability lives in the still-unarchived
+`openspec/changes/file-actions/` (status: draft) plus the
+`retrofit-2026-05-24-file-actions` delta. This change adds REQ-006 … REQ-010 as
+a further delta. When `file-actions` is finalised into
+`openspec/specs/file-actions/spec.md`, the maintainer should fold REQ-001 …
+REQ-010 together. Bias toward the retrofit-derived REQs — they describe observed,
+shipped behavior.
+
+## Counts
+
+- **Batch size:** 45 methods (`/tmp/or-scan/bw-svc-file.json`).
+- **Reverse-spec'd / annotated:** 36 methods.
+  - 28 methods annotated to the 5 new REQs (REQ-006 ×3, REQ-007 ×6, REQ-008 ×5,
+    REQ-009 ×10, REQ-010 ×4).
+  - 8 methods annotated to **existing** REQs from the 2026-05-24 pass
+    (REQ-004 folder management ×6, REQ-005 object tagging ×2).
+- **Excluded as boilerplate (`@spec exclude`):** 9 methods (8 FileCrudHandler
+  Phase-1B stubs + 1 FileAuditHandler no-op).
+- **New REQs minted:** 5 (REQ-006 … REQ-010), at the 5-REQ-per-run cap.
+- **Total tagged:** 36 spec'd + 9 excluded = 45.
+
+## New REQs (extend `file-actions`)
+
+### REQ-006 — File creation & upsert pipeline
+- `lib/Service/File/CreateFileHandler.php::addFile`
+- `lib/Service/File/CreateFileHandler.php::saveFile`
+
+### REQ-007 — File retrieval (by id, by name/path, per-object listing)
+- `lib/Service/File/ReadFileHandler.php::getFile`
+- `lib/Service/File/ReadFileHandler.php::getFileById`
+- `lib/Service/File/ReadFileHandler.php::getFiles`
+
+### REQ-008 — File content & OR-side metadata updates
+- `lib/Service/File/UpdateFileHandler.php::updateFile`
+- `lib/Service/File/UpdateFileHandler.php::updateFileMetadata`
+
+### REQ-009 — File publishing, ZIP export & user/folder sharing
+- `lib/Service/File/FilePublishingHandler.php::publishFile`
+- `lib/Service/File/FilePublishingHandler.php::unpublishFile`
+- `lib/Service/File/FilePublishingHandler.php::createObjectFilesZip`
+- `lib/Service/File/FileSharingHandler.php::createShare`
+- `lib/Service/File/FileSharingHandler.php::findShares`
+- `lib/Service/File/FileSharingHandler.php::shareFileWithUser`
+- `lib/Service/File/FileSharingHandler.php::shareFolderWithUser`
+
+### REQ-010 — Upload security validation (executable blocking, ownership repair)
+- `lib/Service/File/FileValidationHandler.php::blockExecutableFile`
+- `lib/Service/File/FileValidationHandler.php::detectExecutableMagicBytes`
+- `lib/Service/File/FileValidationHandler.php::checkOwnership`
+- `lib/Service/File/FileValidationHandler.php::ownFile`
+
+Additionally REQ-009 absorbs the multi-file batch dispatcher and ownership-
+transfer + document-processing helpers as supporting behavior:
+- `lib/Service/File/FileBatchHandler.php::executeBatch` (REQ-009 — batch publish/depublish/delete/label)
+- `lib/Service/File/FileOwnershipHandler.php::getUser` (REQ-009 — system-user provisioning underpinning shares)
+- `lib/Service/File/FileOwnershipHandler.php::transferFileOwnershipIfNeeded` (REQ-006)
+- `lib/Service/File/FileOwnershipHandler.php::transferFolderOwnershipIfNeeded` (REQ-009)
+- `lib/Service/File/FileFormattingHandler.php::formatFile` (REQ-007 — node→metadata projection)
+- `lib/Service/File/FileFormattingHandler.php::formatFiles` (REQ-007 — filtered/paginated listing)
+- `lib/Service/File/DocumentProcessingHandler.php::anonymizeDocument` (REQ-008 — content rewrite)
+- `lib/Service/File/DocumentProcessingHandler.php::replaceWords` (REQ-008 — content rewrite)
+- `lib/Service/File/FileLockHandler.php::assertCanModify` (REQ-006/REQ-008 — write-path lock guard)
+- `lib/Service/File/FileLockHandler.php::getLockInfo` (REQ-007 — lock-state read for formatting)
+
+## Annotated to EXISTING REQs (2026-05-24 pass)
+
+### file-actions#REQ-004 (Object & register folder management)
+- `lib/Service/File/FolderManagementHandler.php::createEntityFolder`
+- `lib/Service/File/FolderManagementHandler.php::createFolder`
+- `lib/Service/File/FolderManagementHandler.php::createObjectFolderById`
+- `lib/Service/File/FolderManagementHandler.php::createObjectFolderWithoutUpdate`
+- `lib/Service/File/FolderManagementHandler.php::getNodeTypeFromFolder`
+- `lib/Service/File/FolderManagementHandler.php::getObjectFolder`
+
+### file-actions#REQ-005 (Object tagging via Nextcloud system tags)
+- `lib/Service/File/TaggingHandler.php::attachTagsToFile`
+- `lib/Service/File/TaggingHandler.php::getFileTags`
+
+(Note: `FileOwnershipHandler::getUser` is annotated once, to REQ-009.)
+
+## Excluded as boilerplate (`@spec exclude <reason>`)
+
+- `lib/Service/File/FileCrudHandler.php::addFile` — Phase-1B stub; throws "pending Phase 2 extraction", no observable behavior.
+- `lib/Service/File/FileCrudHandler.php::createFolder` — Phase-1B stub; throws unconditionally.
+- `lib/Service/File/FileCrudHandler.php::deleteFile` — Phase-1B stub; throws unconditionally.
+- `lib/Service/File/FileCrudHandler.php::getFile` — Phase-1B stub; throws unconditionally.
+- `lib/Service/File/FileCrudHandler.php::getFileById` — Phase-1B stub; throws unconditionally.
+- `lib/Service/File/FileCrudHandler.php::getFiles` — Phase-1B stub; throws unconditionally.
+- `lib/Service/File/FileCrudHandler.php::saveFile` — Phase-1B stub; throws unconditionally.
+- `lib/Service/File/FileCrudHandler.php::updateFile` — Phase-1B stub; throws unconditionally.
+- `lib/Service/File/FileAuditHandler.php::logDownload` — no-op audit shim; only emits a log line (the AuditTrail insert is commented out), no persisted behavior to spec.
+
+## Notes (observed-but-flagged)
+
+Captured as-is rather than silently "fixed":
+
+- **`CreateFileHandler::addFile` data-URI/base64 auto-detection is heuristic.** It strips a `data:...;base64,` prefix, then runs a strict `base64_decode` round-trip check; legitimately base64-looking text content could be silently decoded. Documented as observed behavior.
+- **`ReadFileHandler::getFile` treats numeric strings as IDs, ignoring `$object`.** A filename that is all digits (e.g. `"12345"`) is resolved as a file ID, not a name within the object folder. Edge case captured in REQ-007.
+- **`UpdateFileHandler::updateFile` preserves only `object:`-prefixed tags.** On a tag update it keeps existing tags whose name starts with `object:` and replaces all others. Captured in REQ-008.
+- **`FilePublishingHandler::publishFile` writes shares directly via `FileMapper`, not `IManager`.** It bypasses the NC share manager and inserts the share row through `FileMapper::publishFile`. Captured in REQ-009.
+- **`FileValidationHandler::blockExecutableFile` rejects `.js`/`.php`/etc. on extension AND magic-byte/shebang content scan of the first 1 KiB.** The list is broad; legitimate text files beginning with `#!` or `<?php` are rejected. Captured in REQ-010.
+- **`FileSharingHandler::shareFolderWithUser` swallows failures and returns `null`.** A failed folder share logs an error and returns null rather than throwing, unlike `shareFileWithUser` which rethrows. Two different failure contracts on sibling methods. Captured in REQ-009.
+
+Source: `/tmp/or-scan/bw-svc-file.json` (45 methods). Capability home: `file-actions`.

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md
@@ -1,0 +1,303 @@
+# file-actions
+
+## Why
+
+OpenRegister's per-object file surface (`lib/Service/File/*Handler`) ships
+creation/upsert, retrieval, content+metadata update, publishing/ZIP export,
+sharing, and upload-security behavior that the `retrofit-2026-05-24-file-actions`
+pass explicitly deferred to a follow-up. This delta reverse-specs that deferred
+slice as REQ-006 … REQ-010 so the spec reflects the live, shipped system. No
+code changes — these requirements describe observed behavior.
+
+## ADDED Requirements
+
+### Requirement: REQ-006 — File creation and upsert MUST run a fixed validate-write-own-tag pipeline
+
+`CreateFileHandler::addFile()` MUST create a Nextcloud file under the object's
+folder following a fixed ordered pipeline, and `CreateFileHandler::saveFile()`
+MUST provide an upsert wrapper over it. The pipeline MUST:
+
+- resolve the object folder via `FolderManagementHandler::getObjectFolder()`,
+  tolerating an as-yet-uncreated object (a `DoesNotExistException` on a string
+  UUID is swallowed so files can be staged ahead of object creation, e.g. during
+  synchronisation);
+- decode `data:` URI / base64 content heuristically — a `data:<mime>;base64,`
+  prefix is stripped, then a strict `base64_decode` round-trip is applied and the
+  decoded bytes used only when re-encoding reproduces the input exactly;
+- reject an empty `$fileName` by throwing;
+- call `FileValidationHandler::blockExecutableFile()` BEFORE the node is created
+  (see REQ-010);
+- create the node, call `FileValidationHandler::checkOwnership()`, write content,
+  then `FileOwnershipHandler::transferFileOwnershipIfNeeded()`;
+- optionally create a public share link when `$share === true`;
+- ALWAYS attach an automatic `object:<uuid-or-id>` tag merged with caller tags
+  via `FileService::generateObjectTag()` + `attachTagsToFile()`.
+
+`saveFile()` MUST first look up an existing file of the same name for the object
+via `FileService::getFile()`; when found it MUST delegate to
+`FileService::updateFile()` (preserving the existing node), otherwise it MUST
+delegate to `addFile()`. Both methods MUST wrap failures and rethrow as
+`NotPermittedException` (permission errors) or `Exception` with a
+`"Failed to create file <name>"` / `"Cannot save file <name>"` prefix.
+
+#### Scenario: Add a new file to an object
+- **GIVEN** an `ObjectEntity` with a resolvable object folder and a non-empty filename
+- **WHEN** `CreateFileHandler::addFile(object, "report.pdf", content)` is called
+- **THEN** the handler MUST block executable content, create the node, write content, transfer ownership, and attach an `object:<uuid>` tag
+- **AND** the created `File` MUST be returned
+
+#### Scenario: Base64 data-URI content is decoded
+- **GIVEN** content of the form `data:application/pdf;base64,<b64>`
+- **WHEN** `addFile()` processes the content
+- **THEN** the handler MUST strip the data-URI prefix and write the decoded bytes when the base64 round-trip is exact
+
+#### Scenario: Empty filename is rejected
+- **GIVEN** an empty string filename
+- **WHEN** `addFile()` is called
+- **THEN** the handler MUST throw an `Exception` naming the object id and MUST NOT create a node
+
+#### Scenario: Upsert updates an existing file
+- **GIVEN** an object that already has a file named `data.json`
+- **WHEN** `saveFile(object, "data.json", newContent)` is called
+- **THEN** the handler MUST delegate to `FileService::updateFile()` for the existing node rather than creating a duplicate
+
+#### Scenario: Upsert creates a missing file
+- **GIVEN** an object with no file named `data.json`
+- **WHEN** `saveFile(object, "data.json", content)` is called
+- **THEN** the handler MUST delegate to `addFile()`
+
+### Requirement: REQ-007 — File retrieval MUST resolve by id or name and project nodes to metadata
+
+`ReadFileHandler` MUST expose three retrieval paths and `FileFormattingHandler`
+MUST project Nextcloud nodes into the public metadata shape.
+
+- `ReadFileHandler::getFile(object, file)` MUST treat `$file` as a Nextcloud file
+  ID when it is an integer OR an all-digit string (the `$object` parameter is then
+  effectively ignored for resolution); otherwise it MUST resolve `$file` as a
+  name/path within the object folder, trying the bare filename first and the full
+  cleaned path second. It MUST call `FileValidationHandler::checkOwnership()` on
+  the resolved node and MUST return `null` (not throw) when the file is absent.
+- `ReadFileHandler::getFileById(fileId)` MUST resolve via `IRootFolder::getById()`,
+  return `null` for a missing node or a non-`File` node, call `checkOwnership()`,
+  and swallow lookup errors as `null`.
+- `ReadFileHandler::getFiles(object, sharedFilesOnly, category)` MUST list the
+  object's files via `FileService::getFilesForEntity()` and, when a `$category`
+  is given AND a `FileMapper` is wired, MUST filter to nodes whose OR-side row
+  carries exactly that category (nodes without an OR-side row MUST be excluded —
+  left-join `WHERE category = :cat` semantics).
+- `FileFormattingHandler::formatFile(node)` MUST return a metadata array carrying
+  at least `id`, `path`, `title`, `accessUrl`, `downloadUrl`, `type`, `extension`,
+  `size`, `hash`, `published`, `modified`, and `labels`; labels containing `:`
+  MUST be split into `key`/`value` metadata entries; NC lock state and OR-side
+  enrichment (`description`/`category`/`downloadCount`/`orLock`) MUST be appended
+  ONLY for authenticated callers.
+- `FileFormattingHandler::formatFiles(files, requestParams)` MUST format each node
+  (emitting a minimal `{id, title, error: "locked"}` stub on per-file
+  `LockedException` rather than failing the whole listing), apply label/extension/
+  size/title/search filters, and paginate with a floor-of-1 page and limit and no
+  upper limit ceiling.
+
+#### Scenario: Resolve a file by numeric id
+- **GIVEN** `getFile(object, 42)` or `getFile(object, "42")`
+- **WHEN** the handler resolves the file
+- **THEN** it MUST treat the value as a Nextcloud file ID, check ownership, and return the `File` or `null`
+
+#### Scenario: Resolve a file by name within the object folder
+- **GIVEN** `getFile(object, "report.pdf")`
+- **WHEN** the bare filename is not found
+- **THEN** the handler MUST retry with the full cleaned path before returning `null`
+
+#### Scenario: Listing filters by OR-side category
+- **GIVEN** `getFiles(object, false, "invoice")` with a wired `FileMapper`
+- **WHEN** the object has files with and without an `invoice` OR-side category
+- **THEN** only nodes whose OR-side row category equals `"invoice"` MUST be returned
+
+#### Scenario: Locked file in a listing does not break the page
+- **GIVEN** a listing where one node raises `LockedException` during formatting
+- **WHEN** `formatFiles()` runs
+- **THEN** that entry MUST be replaced by a minimal stub `{id, title, error: "locked"}` and the remaining files MUST still be returned
+
+#### Scenario: Lock and OR-side fields are gated on authentication
+- **GIVEN** an anonymous caller formatting a file
+- **WHEN** `formatFile()` builds the metadata
+- **THEN** the `locked`/`lock`/`downloadCount`/`orLock` fields MUST be omitted
+
+### Requirement: REQ-008 — File update MUST guard locks, preserve object tags, and persist OR-side metadata separately
+
+`UpdateFileHandler::updateFile()` MUST update content and/or tags of an existing
+file resolved by ID or name/path, and `UpdateFileHandler::updateFileMetadata()`
+MUST persist OR-side metadata independently of the Nextcloud node.
+
+`updateFile()` MUST:
+- resolve the file by ID (object folder first, then OR user folder) or by
+  name/path, throwing `"File <path> does not exist"` when unresolved;
+- write content ONLY when content is provided AND its md5 differs from the
+  current node hash, decoding base64 content, calling
+  `FileValidationHandler::blockExecutableFile()` and `checkOwnership()` before the
+  write, then `FileOwnershipHandler::transferFileOwnershipIfNeeded()`;
+- on a tag update, PRESERVE existing tags whose name starts with `object:` and
+  replace all other tags, de-duplicating the merged set.
+
+`updateFileMetadata(fileId, description, category, labels)` MUST throw when no
+`FileMapper` is wired, MUST lazy-create the OR-side row, and MUST treat each of
+`description`/`category`/`labels` as independently optional — a `null` argument
+leaves the field unchanged while an explicit value (including `""` or `[]`)
+overwrites it. Document content rewrites (`DocumentProcessingHandler::replaceWords`
+for `.doc`/`.docx` via PHPWord and text files, and `::anonymizeDocument` which
+builds `[ENTITY_TYPE: key]` replacements) MUST write the result as a new
+`<name>_replaced` / `<name>_anonymized` sibling node rather than mutating the
+source. Write-path lock guarding MUST go through
+`FileLockHandler::assertCanModify()`, which throws when the file is locked by
+another user, and lock-state reads MUST go through `FileLockHandler::getLockInfo()`,
+which defensively clears malformed or expired entries and returns `null`.
+
+#### Scenario: Content is written only when it changed
+- **GIVEN** an `updateFile()` call whose new content md5 equals the node's current hash
+- **WHEN** the handler evaluates the content branch
+- **THEN** it MUST skip the write
+
+#### Scenario: Object tags survive a tag update
+- **GIVEN** a file carrying `object:abc` plus user tags `["draft"]`
+- **WHEN** `updateFile(..., tags: ["final"])` is called
+- **THEN** the resulting tag set MUST retain `object:abc` and replace `draft` with `final`
+
+#### Scenario: Metadata update requires a wired FileMapper
+- **GIVEN** `updateFileMetadata()` on a handler with no `FileMapper`
+- **WHEN** it is called
+- **THEN** it MUST throw `"FileMapper is not wired; cannot update OR-side metadata"`
+
+#### Scenario: Partial metadata update leaves unset fields untouched
+- **GIVEN** `updateFileMetadata(fileId, description: "x", category: null, labels: null)`
+- **WHEN** the handler runs
+- **THEN** only the description MUST be written; category and labels MUST be unchanged
+
+#### Scenario: Document anonymisation produces a new node
+- **GIVEN** a `.docx` node and a list of detected entities
+- **WHEN** `anonymizeDocument()` runs
+- **THEN** a new `<base>_anonymized.docx` sibling MUST be created with `[TYPE: key]` replacements, leaving the source intact
+
+#### Scenario: Write to a file locked by another user is blocked
+- **GIVEN** a file locked by user `bob`
+- **WHEN** the current user `alice` triggers a write and `assertCanModify(fileId)` is reached
+- **THEN** the guard MUST throw an `Exception` naming `bob`
+
+### Requirement: REQ-009 — Publishing, ZIP export, sharing and batch operations MUST follow the system-user share model
+
+The system MUST expose file publishing, object-files ZIP export, user/folder
+sharing, and a bounded multi-file batch dispatcher, all anchored on the
+OpenRegister system user.
+
+- `FilePublishingHandler::publishFile(object, file)` MUST resolve the file by ID
+  (via `FileService::getFile()`) or by name/path within the object folder, verify
+  it is a `File`, call `checkOwnership()`, and create the public share by writing
+  directly through `FileMapper::publishFile()` (NOT `IManager`), returning the
+  `File`.
+- `FilePublishingHandler::unpublishFile(object, filePath)` MUST resolve the file
+  the same way and remove all public shares via `FileMapper::depublishFile()`,
+  treating zero deleted shares as a non-error.
+- `FilePublishingHandler::createObjectFilesZip(object, zipName)` MUST collect the
+  object's files via `FileService::getFiles()`, require the `ZipArchive`
+  extension, skip non-`File` nodes and per-file errors (incrementing a skipped
+  count), and return `{path, filename, size, mimeType: "application/zip"}`.
+- `FileSharingHandler::findShares(node, shareType)` MUST query shares as the
+  system user (`FileOwnershipHandler::getUser()`), defaulting `shareType` to
+  public-link (3).
+- `FileSharingHandler::createShare(shareData)` MUST build an `IShare` from the
+  supplied node/nodeId, share type, permissions and `sharedWith`, attribute it to
+  the file owner when available (else the system user), and rethrow a wrapped
+  `Exception` on failure.
+- `FileSharingHandler::shareFileWithUser(file, userId, permissions)` MUST be
+  idempotent (skip when a user share already exists) and MUST rethrow on failure.
+- `FileSharingHandler::shareFolderWithUser(folder, userId, permissions)` MUST
+  return `null` when the target user does not exist AND MUST return `null` (after
+  logging) rather than throwing on a share failure — a deliberately softer
+  contract than `shareFileWithUser`.
+- `FileBatchHandler::executeBatch(object, action, fileIds, params)` MUST accept
+  only `publish`/`depublish`/`delete`/`label`, reject more than 100 file IDs and
+  an empty list, and return per-file `{fileId, success[, error]}` results plus a
+  `{total, succeeded, failed}` summary, continuing past individual failures.
+- `FileOwnershipHandler::getUser()` MUST get-or-create the `openregister` system
+  user and group; `transferFileOwnershipIfNeeded()` / `transferFolderOwnershipIfNeeded()`
+  MUST transfer ownership to that system user (when the current user owns the node
+  and is not the system user) and re-share with the current user, swallowing
+  failures so the underlying file operation still succeeds.
+
+#### Scenario: Publish writes the share via FileMapper
+- **GIVEN** a resolvable file under an object
+- **WHEN** `publishFile(object, fileId)` runs
+- **THEN** the share MUST be created through `FileMapper::publishFile()` and the `File` returned
+
+#### Scenario: Unpublish with no existing shares is not an error
+- **GIVEN** a file with no public shares
+- **WHEN** `unpublishFile(object, fileId)` runs
+- **THEN** `FileMapper::depublishFile()` MUST be called and a zero deleted-shares result MUST NOT raise
+
+#### Scenario: ZIP export skips non-file nodes
+- **GIVEN** an object folder containing a sub-folder and two files
+- **WHEN** `createObjectFilesZip(object)` runs
+- **THEN** the two files MUST be added and the folder skipped, returning a `application/zip` descriptor
+
+#### Scenario: Folder share to a missing user returns null
+- **GIVEN** `shareFolderWithUser(folder, "ghost")` where `ghost` does not exist
+- **WHEN** the method runs
+- **THEN** it MUST return `null` without throwing
+
+#### Scenario: Batch rejects oversized requests
+- **GIVEN** `executeBatch(object, "delete", fileIds)` with 101 IDs
+- **WHEN** the method runs
+- **THEN** it MUST throw before performing any deletion
+
+#### Scenario: Batch continues past per-file failures
+- **GIVEN** a 3-file `delete` batch where the middle file fails
+- **WHEN** `executeBatch()` runs
+- **THEN** the result MUST report `succeeded: 2, failed: 1` with a per-file error entry for the failure
+
+### Requirement: REQ-010 — Uploaded files MUST be screened for executable content and ownership repaired safely
+
+`FileValidationHandler` MUST screen uploaded content for executables and repair
+drifted OpenRegister ownership without forcing content reads.
+
+- `blockExecutableFile(fileName, fileContent)` MUST reject the file when its
+  extension is in the dangerous-extension list (Windows/Unix executables,
+  scripts including `php`/`js`/`py`/`sh`, packages, mobile/macOS installers) and,
+  when content is non-empty, MUST delegate to `detectExecutableMagicBytes()`.
+- `detectExecutableMagicBytes(content, fileName)` MUST reject content beginning
+  with known executable signatures (`MZ`, `\x7FELF`, shell/bash/env shebangs,
+  `<?php`, Java `\xCA\xFE\xBA\xBE`), MUST scan the first 1 KiB for a
+  script shebang (`#!.../sh|bash|...|node`), and MUST reject embedded
+  `<?php`/`<?=`/`<script language="php">` markers — throwing a descriptive
+  `Exception` on any match.
+- `checkOwnership(node)` MUST probe access via `Node::isReadable()` (a pure
+  permission-bitmask check that does NOT read content and does NOT acquire an NC
+  lock, so it is safe in a hot listing loop). It MUST throw
+  `NotPermittedException` when the node is not readable, and when readable but the
+  owner has drifted from the system user it MUST attempt `ownFile()` as a
+  best-effort repair whose failure is logged and swallowed.
+- `ownFile(node)` MUST set the OR-side ownership record to the system user via
+  `FileMapper::setFileOwnership()`, returning the mapper's boolean result and
+  rethrowing a wrapped `Exception` on error.
+
+#### Scenario: Executable extension is rejected
+- **GIVEN** a file named `payload.exe`
+- **WHEN** `blockExecutableFile("payload.exe", content)` runs
+- **THEN** it MUST throw an `Exception` identifying the executable extension before any node is created
+
+#### Scenario: Renamed executable is caught by magic bytes
+- **GIVEN** a file named `notes.txt` whose content begins with `MZ`
+- **WHEN** `blockExecutableFile()` runs
+- **THEN** `detectExecutableMagicBytes()` MUST throw because the content signature is a Windows executable
+
+#### Scenario: PHP content is rejected regardless of name
+- **GIVEN** content beginning with `<?php`
+- **WHEN** `detectExecutableMagicBytes()` runs
+- **THEN** it MUST throw, blocking the upload
+
+#### Scenario: Unreadable node is refused without repair
+- **GIVEN** a node where `isReadable()` returns false
+- **WHEN** `checkOwnership()` runs
+- **THEN** it MUST throw `NotPermittedException` and MUST NOT attempt ownership repair
+
+#### Scenario: Readable node with drifted owner is repaired best-effort
+- **GIVEN** a readable node whose owner is not the system user
+- **WHEN** `checkOwnership()` runs
+- **THEN** it MUST call `ownFile()`, and a failure inside `ownFile()` MUST be logged and swallowed so the caller is not failed

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-file/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-file/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: retrofit-2026-05-25-bw-svc-file
+
+This change retroactively annotates code that already exists in production. All
+covered tasks are `[x]` — no new implementation work is required. The batch is 45
+methods from `/tmp/or-scan/bw-svc-file.json`; every method ends tagged with an
+`@spec` pointer or `@spec exclude <reason>`.
+
+## Covered — new REQs (annotated this run)
+
+- [x] task-1: file-actions#REQ-006 — File creation & upsert pipeline (CreateFileHandler::addFile, ::saveFile; FileOwnershipHandler::transferFileOwnershipIfNeeded)
+- [x] task-2: file-actions#REQ-007 — File retrieval + node→metadata projection (ReadFileHandler::getFile, ::getFileById, ::getFiles; FileFormattingHandler::formatFile, ::formatFiles; FileLockHandler::getLockInfo)
+- [x] task-3: file-actions#REQ-008 — Content + OR-side metadata update, doc rewrite, write-lock guard (UpdateFileHandler::updateFile, ::updateFileMetadata; DocumentProcessingHandler::replaceWords, ::anonymizeDocument; FileLockHandler::assertCanModify)
+- [x] task-4: file-actions#REQ-009 — Publishing, ZIP export, sharing, batch (FilePublishingHandler::publishFile, ::unpublishFile, ::createObjectFilesZip; FileSharingHandler::createShare, ::findShares, ::shareFileWithUser, ::shareFolderWithUser; FileBatchHandler::executeBatch; FileOwnershipHandler::getUser, ::transferFolderOwnershipIfNeeded)
+- [x] task-5: file-actions#REQ-010 — Upload security validation + ownership repair (FileValidationHandler::blockExecutableFile, ::detectExecutableMagicBytes, ::checkOwnership, ::ownFile)
+
+## Covered — existing REQs (annotated to the 2026-05-24 pass)
+
+- [x] task-6: file-actions#REQ-004 — Folder management methods in batch (FolderManagementHandler::createEntityFolder, ::createFolder, ::createObjectFolderById, ::createObjectFolderWithoutUpdate, ::getNodeTypeFromFolder, ::getObjectFolder)
+- [x] task-7: file-actions#REQ-005 — Object/file tagging methods in batch (TaggingHandler::attachTagsToFile, ::getFileTags)
+
+## Excluded (`@spec exclude <reason>` — boilerplate)
+
+- [x] FileCrudHandler::addFile — Phase-1B stub, throws "pending Phase 2 extraction".
+- [x] FileCrudHandler::createFolder — Phase-1B stub, throws unconditionally.
+- [x] FileCrudHandler::deleteFile — Phase-1B stub, throws unconditionally.
+- [x] FileCrudHandler::getFile — Phase-1B stub, throws unconditionally.
+- [x] FileCrudHandler::getFileById — Phase-1B stub, throws unconditionally.
+- [x] FileCrudHandler::getFiles — Phase-1B stub, throws unconditionally.
+- [x] FileCrudHandler::saveFile — Phase-1B stub, throws unconditionally.
+- [x] FileCrudHandler::updateFile — Phase-1B stub, throws unconditionally.
+- [x] FileAuditHandler::logDownload — no-op audit shim; only logs, AuditTrail insert is commented out.
+
+## Notes
+
+`FileCrudHandler` is an entire Phase-1B placeholder class — all eight of its
+methods throw `"... pending Phase 2 extraction"` and have no observable behavior.
+When Phase 2 extraction lands (moving the real logic out of `FileService` into the
+handler), these methods should be re-triaged against REQ-006 … REQ-010.


### PR DESCRIPTION
## Summary

Reverse-spec retrofit of the `lib/Service/File/` handler family — the deferred
slice from `retrofit-2026-05-24-file-actions`'s `## DROP — future-pass:next`.
Extends the existing `file-actions` capability with 5 new REQs and annotates all
45 batch methods (`/tmp/or-scan/bw-svc-file.json`). No code logic changes —
docblock `@spec` tags + ghost change only.

- **New REQs (REQ-006 … REQ-010):** create/upsert pipeline, retrieval +
  node→metadata projection, content/OR-side-metadata update + doc rewrite,
  publishing/ZIP/sharing/batch, and upload-security validation.
- **36 methods spec'd:** 28 to the new REQs, 8 to existing REQ-004 (folder
  management) / REQ-005 (object tagging) from the prior pass.
- **9 methods excluded** as boilerplate via `@spec exclude <reason>`: 8
  `FileCrudHandler` Phase-1B stubs (throw "pending Phase 2 extraction"
  unconditionally) + 1 `FileAuditHandler::logDownload` no-op (AuditTrail insert
  commented out).
- Ghost change: `openspec/changes/retrofit-2026-05-25-bw-svc-file/` (proposal +
  design + tasks + `file-actions` spec delta).

Observed quirks captured as-is (not "fixed"): heuristic base64 detection,
all-digit-filename-as-id resolution, `object:`-tag preservation on update,
FileMapper-direct share writes bypassing `IManager`, broad executable blocklist,
and the asymmetric file-vs-folder share failure contracts.

## Validation

- `openspec validate retrofit-2026-05-25-bw-svc-file --strict` → valid.
- `php -l` clean on all 15 touched handler files.
- All 45 batch methods verified tagged exactly once (script-checked).

## Test plan

- [ ] Confirm `@spec` pointers resolve to the new spec delta / existing 2026-05-24 REQs.
- [ ] Spot-check a few REQ scenarios against the shipped handler behavior.