### PR TITLE
retrofit: backend coverage — Service vector/agg/chat/etc

### DIFF
--- a/lib/Service/Aggregation/AggregationCache.php
+++ b/lib/Service/Aggregation/AggregationCache.php
@@ -139,6 +139,8 @@ class AggregationCache
      * @param array<string, mixed> $result       Result envelope to store.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-aggregations-backend-native/tasks.md#task-1
      */
     public function set(string $registerSlug, string $schemaSlug, string $name, array $filter, array $result): void
     {
@@ -201,6 +203,8 @@ class AggregationCache
      * @param array<string, mixed> $result       Result envelope to store.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-aggregations-backend-native/tasks.md#task-1
      */
     public function setAdhoc(string $registerSlug, string $schemaSlug, AggregationQuery $query, array $result): void
     {
@@ -247,6 +251,8 @@ class AggregationCache
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-aggregations-backend-native/tasks.md#task-1
      */
     public function evictForSchema(string $registerSlug, string $schemaSlug): void
     {

--- a/lib/Service/Aggregation/AggregationQuery.php
+++ b/lib/Service/Aggregation/AggregationQuery.php
@@ -240,6 +240,8 @@ class AggregationQuery
      *   groupBy: array<string, mixed>|null,
      *   dateBucket: array<string, mixed>|null
      * } Canonical wire shape of the query.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-aggregations-backend-native/tasks.md#task-1
      */
     public function toArray(): array
     {

--- a/lib/Service/Aggregation/AggregationRunner.php
+++ b/lib/Service/Aggregation/AggregationRunner.php
@@ -571,6 +571,8 @@ class AggregationRunner
      *
      * @throws RuntimeException        When the register or schema cannot be resolved.
      * @throws NotAuthorizedException  When the caller lacks list-permission.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-aggregations-backend-native/tasks.md#task-2
      */
     public function runAdhocByRef(
         string $registerRef,
@@ -596,6 +598,8 @@ class AggregationRunner
      * @return Schema The loaded schema.
      *
      * @throws RuntimeException When the schema can't be found.
+     *
+     * @spec exclude Thin public convenience wrapper over the private loadSchema mapper lookup; exposed only so the REST controller can validate field allow-lists before building an AggregationQuery. No business logic of its own.
      */
     public function findSchema(string $schemaRef): Schema
     {

--- a/lib/Service/Aggregation/ElasticsearchAggregationQueryBuilder.php
+++ b/lib/Service/Aggregation/ElasticsearchAggregationQueryBuilder.php
@@ -50,6 +50,8 @@ class ElasticsearchAggregationQueryBuilder
      * @param AggregationQuery $query The cross-backend request.
      *
      * @return array<string, mixed> The ES request body.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-aggregations-backend-native/tasks.md#task-2
      */
     public function build(AggregationQuery $query): array
     {

--- a/lib/Service/Aggregation/SolrAggregationQueryBuilder.php
+++ b/lib/Service/Aggregation/SolrAggregationQueryBuilder.php
@@ -54,6 +54,8 @@ class SolrAggregationQueryBuilder
      * @param AggregationQuery $query The cross-backend request.
      *
      * @return array<string, mixed> The Solr request parameter map.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-aggregations-backend-native/tasks.md#task-2
      */
     public function build(AggregationQuery $query): array
     {

--- a/lib/Service/Aggregation/TimeseriesRequestValidator.php
+++ b/lib/Service/Aggregation/TimeseriesRequestValidator.php
@@ -114,6 +114,8 @@ class TimeseriesRequestValidator
      * @SuppressWarnings(PHPMD.StaticAccess)
      *   AggregationQuery::create() is the canonical, validated factory
      *   for the value object.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid3/tasks.md#task-2
      */
     public function validate(array $input, Schema $schema): AggregationQuery
     {

--- a/lib/Service/Aggregation/WidgetAnnotationValidator.php
+++ b/lib/Service/Aggregation/WidgetAnnotationValidator.php
@@ -80,6 +80,8 @@ final class WidgetAnnotationValidator
      * @param array<string, mixed> $schema Full schema definition.
      *
      * @return array<int, array{code: string, message: string}>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid3/tasks.md#task-2
      */
     public function validate(array $schema): array
     {

--- a/lib/Service/Chat/StreamYieldChannel.php
+++ b/lib/Service/Chat/StreamYieldChannel.php
@@ -94,6 +94,8 @@ class StreamYieldChannel
      *                           (the new token delta).
      *
      * @return void
+     *
+     * @spec exclude Pure pub-sub forwarder plumbing — registers a callback; carries no business logic (the class is self-documented as "pure forwarding").
      */
     public function onToken(callable $callback): void
     {
@@ -108,6 +110,8 @@ class StreamYieldChannel
      *                           payload as a single associative-array argument.
      *
      * @return void
+     *
+     * @spec exclude Pure pub-sub forwarder plumbing — registers a callback; carries no business logic.
      */
     public function onToolCall(callable $callback): void
     {
@@ -122,6 +126,8 @@ class StreamYieldChannel
      *                           as a single associative-array argument.
      *
      * @return void
+     *
+     * @spec exclude Pure pub-sub forwarder plumbing — registers a callback; carries no business logic.
      */
     public function onToolResult(callable $callback): void
     {
@@ -136,6 +142,8 @@ class StreamYieldChannel
      * @param callable $callback Function invoked with no arguments.
      *
      * @return void
+     *
+     * @spec exclude Pure pub-sub forwarder plumbing — registers a callback; carries no business logic.
      */
     public function onHeartbeat(callable $callback): void
     {
@@ -149,6 +157,8 @@ class StreamYieldChannel
      * @param string $delta New token delta from the LLM stream.
      *
      * @return void
+     *
+     * @spec exclude Pure pub-sub forwarder plumbing — loops registered callbacks; carries no business logic.
      */
     public function emitToken(string $delta): void
     {
@@ -198,6 +208,8 @@ class StreamYieldChannel
      * registration order.
      *
      * @return void
+     *
+     * @spec exclude Pure pub-sub forwarder plumbing — loops registered callbacks; carries no business logic.
      */
     public function emitHeartbeat(): void
     {

--- a/lib/Service/Configuration/GitHubGuards.php
+++ b/lib/Service/Configuration/GitHubGuards.php
@@ -80,6 +80,8 @@ class GitHubGuards
      * @param array<callable(): ?JSONResponse> $guards Ordered guard closures.
      *
      * @return JSONResponse|null First failing response, or null when all guards pass.
+     *
+     * @spec exclude Generic guard-runner combinator — loops guard closures and short-circuits on the first non-null response; carries no policy itself (the individual guards are separately annotated).
      */
     public function runGuards(array $guards): ?JSONResponse
     {

--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -2909,6 +2909,8 @@ class ImportHandler
      * @SuppressWarnings(PHPMD.NPathComplexity)       Configuration creation requires many conditional checks
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Entity ID collection and metadata mapping has many branches
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Configuration tracking involves detailed entity management
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid3/tasks.md#task-4
      */
     public function createOrUpdateConfiguration(
         array $data,

--- a/lib/Service/Geo/GeoFilterParser.php
+++ b/lib/Service/Geo/GeoFilterParser.php
@@ -58,6 +58,8 @@ class GeoFilterParser
      * @return GeoFilter[]
      *
      * @throws InvalidArgumentException When `geo.near`/`geo.radius` are mismatched.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-openregister/tasks.md#task-15
      */
     public function fromQueryParams(array $params): array
     {

--- a/lib/Service/Geo/GeoSpatialEvaluator.php
+++ b/lib/Service/Geo/GeoSpatialEvaluator.php
@@ -72,6 +72,8 @@ class GeoSpatialEvaluator
      * @param GeoFilter  $filter      The filter to apply.
      *
      * @return bool True when the row passes the filter; null geometries always fail.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-openregister/tasks.md#task-15
      */
     public function matches(?array $rowGeometry, GeoFilter $filter): bool
     {

--- a/lib/Service/GraphQL/GraphQLResolver.php
+++ b/lib/Service/GraphQL/GraphQLResolver.php
@@ -545,6 +545,8 @@ class GraphQLResolver
      * @param array  $path         The field path for error reporting
      *
      * @return Deferred A deferred value that resolves after batching
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-20
      */
     public function resolveRelation(string $uuid, Schema $parentSchema, array $path): Deferred
     {

--- a/lib/Service/Lifecycle/TransitionEngine.php
+++ b/lib/Service/Lifecycle/TransitionEngine.php
@@ -189,6 +189,8 @@ class TransitionEngine
      * @param string $objectId Object id/uuid/slug.
      *
      * @return array<int, array{action: string, to: string, requires: ?string, description: ?string}>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-object-lifecycle/tasks.md#task-2
      */
     public function availableActions(string $objectId): array
     {

--- a/lib/Service/Search/PlaceholderResolver.php
+++ b/lib/Service/Search/PlaceholderResolver.php
@@ -20,6 +20,8 @@
  * @version GIT: <git-id>
  *
  * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid3/tasks.md#task-3
  */
 
 declare(strict_types=1);
@@ -62,6 +64,8 @@ final class PlaceholderResolver
      *
      * @return mixed Resolved value: DateTimeImmutable for date placeholders,
      *               string for $currentUser, original value otherwise.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid3/tasks.md#task-3
      */
     public function resolve(mixed $value): mixed
     {
@@ -82,6 +86,8 @@ final class PlaceholderResolver
      * @param array<string, mixed> $values The array whose leaf values may contain placeholders.
      *
      * @return array<string, mixed>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid3/tasks.md#task-3
      */
     public function resolveArray(array $values): array
     {

--- a/lib/Service/Vectorization/Handlers/EmbeddingGeneratorHandler.php
+++ b/lib/Service/Vectorization/Handlers/EmbeddingGeneratorHandler.php
@@ -245,6 +245,8 @@ class EmbeddingGeneratorHandler
              * @return array<float> Embedding vector
              *
              * @throws \Exception If API call fails
+             *
+             * @spec openspec/changes/retrofit-2026-05-24-newcap-vector-embeddings/tasks.md#task-1
              */
             public function embedText(string $text): array
             {
@@ -314,6 +316,8 @@ class EmbeddingGeneratorHandler
              * @return int Embedding length
              *
              * @psalm-return 768|1024
+             *
+             * @spec openspec/changes/retrofit-2026-05-24-newcap-vector-embeddings/tasks.md#task-1
              */
             public function getEmbeddingLength(): int
             {
@@ -333,6 +337,8 @@ class EmbeddingGeneratorHandler
              * @param \LLPhant\Embeddings\Document $document Document to embed
              *
              * @return \LLPhant\Embeddings\Document Embedded document
+             *
+             * @spec openspec/changes/retrofit-2026-05-24-newcap-vector-embeddings/tasks.md#task-1
              */
             public function embedDocument(\LLPhant\Embeddings\Document $document): \LLPhant\Embeddings\Document
             {
@@ -346,6 +352,8 @@ class EmbeddingGeneratorHandler
              * @param array<int,\LLPhant\Embeddings\Document> $documents Documents to embed
              *
              * @return array<int,\LLPhant\Embeddings\Document> Embedded documents
+             *
+             * @spec openspec/changes/retrofit-2026-05-24-newcap-vector-embeddings/tasks.md#task-1
              */
             public function embedDocuments(array $documents): array
             {

--- a/lib/Service/Vectorization/Handlers/VectorSearchHandler.php
+++ b/lib/Service/Vectorization/Handlers/VectorSearchHandler.php
@@ -78,6 +78,8 @@ class VectorSearchHandler
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Multi-backend search requires multiple conditions
      * @SuppressWarnings(PHPMD.NPathComplexity)       Complex search path handling
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Comprehensive semantic search with multiple backends
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid3/tasks.md#task-1
      */
     public function semanticSearch(
         array $queryEmbedding,
@@ -373,6 +375,8 @@ class VectorSearchHandler
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Hybrid search combines multiple result sets
      * @SuppressWarnings(PHPMD.NPathComplexity)       Multiple search path combinations
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Comprehensive hybrid search with result fusion
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid3/tasks.md#task-1
      */
     public function hybridSearch(
         array $queryEmbedding,

--- a/lib/Service/Vectorization/Strategies/FileVectorizationStrategy.php
+++ b/lib/Service/Vectorization/Strategies/FileVectorizationStrategy.php
@@ -18,6 +18,8 @@
  * @version GIT: <git_id>
  *
  * @link https://www.OpenRegister.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-newcap-vector-embeddings/tasks.md#task-3
  */
 
 namespace OCA\OpenRegister\Service\Vectorization\Strategies;
@@ -88,6 +90,8 @@ class FileVectorizationStrategy implements VectorizationStrategyInterface
      * @return \OCA\OpenRegister\Db\Chunk[]
      *
      * @psalm-return list<\OCA\OpenRegister\Db\Chunk>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-newcap-vector-embeddings/tasks.md#task-3
      */
     public function fetchEntities(array $options): array
     {
@@ -150,6 +154,8 @@ class FileVectorizationStrategy implements VectorizationStrategyInterface
      * @return ((int|string)|mixed|null)[][] Array of items with 'text' and chunk data
      *
      * @psalm-return list<array{end_offset: mixed|null, index: array-key, start_offset: mixed|null, text: mixed}>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-newcap-vector-embeddings/tasks.md#task-3
      */
     public function extractVectorizationItems($entity): array
     {
@@ -184,6 +190,8 @@ class FileVectorizationStrategy implements VectorizationStrategyInterface
      *         end_offset: mixed
      *     }
      * }
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-newcap-vector-embeddings/tasks.md#task-3
      */
     public function prepareVectorMetadata($entity, array $item): array
     {

--- a/lib/Service/Vectorization/VectorEmbeddings.php
+++ b/lib/Service/Vectorization/VectorEmbeddings.php
@@ -452,6 +452,8 @@ class VectorEmbeddings
      * @return array<int,array<string,mixed>> Search results
      *
      * @throws \Exception If search fails
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid3/tasks.md#task-1
      */
     public function semanticSearch(
         string $query,
@@ -486,6 +488,8 @@ class VectorEmbeddings
      * @return array
      *
      * @throws \Exception If hybrid search fails
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid3/tasks.md#task-1
      */
     public function hybridSearch(
         string $query,

--- a/lib/Service/Webhook/CloudEventFormatter.php
+++ b/lib/Service/Webhook/CloudEventFormatter.php
@@ -72,6 +72,8 @@ class CloudEventFormatter
      *     id: string, time: string, datacontenttype: 'application/json',
      *     subject: null|string, dataschema: null, data: array,
      *     openregister: array{app: 'openregister', version: '1.0.0'}}
+     *
+     * @spec openspec/changes/retrofit-2026-04-30-annotate-openregister/tasks.md#task-84
      */
     public function formatAsCloudEvent(
         string $eventType,
@@ -128,6 +130,8 @@ class CloudEventFormatter
      *     data: array{method: mixed|string, path: false|mixed|string,
      *     queryParams: array|mixed, headers: array|mixed, body: array|mixed,...},
      *     openregister: array{app: 'openregister', version: '1.0.0'}}
+     *
+     * @spec openspec/changes/retrofit-2026-04-30-annotate-openregister/tasks.md#task-84
      */
     public function formatRequestAsCloudEvent(
         IRequest $request,

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid3/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid3/proposal.md
@@ -1,0 +1,38 @@
+# Retrofit — backend Service mid-tier batch 3 (vector / aggregation / chat / config / geo / graphql / lifecycle / search / webhook)
+
+## Why
+
+The 2026-05-25 coverage scan (`/tmp/or-scan/bw-svc-mid3.json`) flagged 37 uncovered methods spread across nine `lib/Service/` sub-trees. Most are siblings or read/write twins of methods already annotated by earlier retrofit passes (the 2026-04-23 / 2026-04-30 / 2026-05-24 annotate changes and the `aggregations-backend-native`, `vector-embeddings`, `object-lifecycle`, `geo-metadata-kaart` reverse-spec changes). A handful describe genuine, observable behavior that no existing REQ covers. This change drains the batch with the ADR-003 two-tool approach: extend the matching capability where there is a real gap, cross-reference an existing task where the method is a twin/wrapper of an already-spec'd one, and `@spec exclude` the pure plumbing.
+
+## What the batch contains
+
+| Sub-tree | Methods | Disposition |
+| --- | --- | --- |
+| `Vectorization/` | 13 | mix: 4 Fireworks-adapter methods + 3 FileVectorizationStrategy methods cross-ref the existing `vector-embeddings` REQs; 4 semantic/hybrid search facade+handler methods → 1 NEW REQ (vector query execution) |
+| `Aggregation/` | 10 | mix: cache write/evict + query-builder `build` + ad-hoc-by-ref cross-ref existing `aggregations-backend-native` tasks; 2 validators + placeholder resolver → 2 NEW REQs; `findSchema` excluded |
+| `Chat/` | 6 | all `@spec exclude` — `StreamYieldChannel` is a pure pub-sub event forwarder (self-documented "pure forwarding") |
+| `Configuration/` | 2 | `createOrUpdateConfiguration` → 1 NEW REQ (import-tracking entity); `runGuards` excluded (generic guard-runner combinator) |
+| `Geo/` | 2 | both cross-ref existing `geo-metadata-kaart` REQ-GEO-004 (twins of already-annotated parsers/evaluators) |
+| `GraphQL/` | 1 | `resolveRelation` cross-refs `graphql-api` REQ-GQL-EXTRAS (public half of the already-annotated DataLoader `flushRelationBuffer`) |
+| `Lifecycle/` | 1 | `availableActions` cross-refs `object-lifecycle` REQ-007 — honoring the explicit DROP triage recorded by `retrofit-2026-05-24-object-lifecycle` ("read-only enumeration adequately implied by REQ-007's transition lookup") |
+| `Search/` | 2 | `PlaceholderResolver::resolve` / `::resolveArray` → folded into 1 NEW aggregations REQ (the filter placeholder DSL the runner depends on) |
+| `Webhook/` | 2 | `CloudEventFormatter` — cross-ref existing `webhook-payload-mapping` |
+
+## Approach (ADR-003 two-tool)
+
+- **Reverse-spec (4 new REQs):**
+  - `vector-embeddings` +1 REQ — vector *query* execution (semantic KNN/cosine + hybrid RRF). The earlier `vector-embeddings` change deferred this to a `search` capability gated on PR #1791; that PR has not landed on this branch and no `search` spec exists, so the observed behavior is captured here against `vector-embeddings` rather than left uncovered.
+  - `aggregations-backend-native` +2 REQs — (a) REST timeseries-request + widget-annotation validation; (b) the time/session placeholder DSL (`PlaceholderResolver`) that the runner resolves filters through.
+  - `data-import-export` +1 REQ — the import-tracking `Configuration` entity (`createOrUpdateConfiguration`): OAS→`x-openregister`→legacy metadata fallback and entity-ID merge for idempotent re-import.
+- **Cross-reference (no new REQs):** cache write/evict, query-builder `build`, ad-hoc-by-ref, geo parser/evaluator, graphql relation resolver, lifecycle available-actions, webhook formatter, Fireworks adapter, file strategy — all map cleanly to an existing task in a prior change.
+- **Exclude (boilerplate):** the six `StreamYieldChannel` pub-sub methods, `GitHubGuards::runGuards` (generic short-circuit guard runner), `AggregationRunner::findSchema` (thin `loadSchema` convenience wrapper).
+
+**4 new REQs total** (under the ≤5 cap).
+
+## Out of scope
+
+- Any reshaping or "fixing" of observed behavior — drift (asymmetric Solr/DB vector storage, serialized-blob KNN, ad-hoc-by-ref re-validation) is flagged in prior change Notes, not corrected here.
+- The deferred `search`-capability home for vector query execution. If/when PR #1791 lands a `search` spec, the new `vector-embeddings` query REQ can be re-homed in a follow-up.
+- `StreamYieldChannel` SSE framing / heartbeat interleaving — owned by `ChatStreamController` (`ai-chat-companion-streaming`), not the forwarder.
+
+Source: `/tmp/or-scan/bw-svc-mid3.json` (37 methods, 9 sub-trees). Playbook: `.github/docs/claude/retrofit.md`.

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid3/specs/aggregations-backend-native/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid3/specs/aggregations-backend-native/spec.md
@@ -1,0 +1,74 @@
+---
+retrofit_extensions:
+  - REQ-ABN-006
+  - REQ-ABN-007
+---
+
+# Aggregations Backend-Native Specification (delta)
+
+**Status**: implemented (retrofit — code already exists)
+**Scope**: openregister
+
+## ADDED Requirements
+
+### Requirement: The system MUST validate aggregation-API request shapes and widget annotations before execution
+
+`TimeseriesRequestValidator::validate(array $input, Schema $schema): AggregationQuery` MUST guard the REST timeseries-aggregation request shape and return a validated `AggregationQuery` value object, throwing a client-safe `InvalidArgumentException` (mapped to HTTP 400) on any violation. It MUST require a non-empty `field`, and the `field` MUST be a declared property of `$schema` (allow-listed) — an undeclared field MUST be rejected. When `metric !== 'count'` it MUST require a `metricField` that is also a declared schema property; for `count` the value-object field MUST be null. When an `interval` is supplied it MUST be one of the closed interval vocabulary; a sub-day interval (e.g. hour/minute) MUST require the bucket field to have `format: date-time`; and `from` / `to` MUST be present and parseable ISO-8601 datetimes. An interval request MUST produce a `dateBucket` (and null `groupBy`); a no-interval request MUST produce a categorical `groupBy` on the field — never both (the value object rejects the combination).
+
+`WidgetAnnotationValidator::validate(array $schema): array` MUST validate the `x-openregister-widgets` schema annotation and return a list of `{code, message}` error descriptors (empty list = valid). When the annotation is absent it MUST return `[]`. When present but empty or non-array it MUST return a single `widgets-empty` error. For each widget it MUST require a `type` from the supported set (`kpi`, `chart`, `table`, `stats`, `sparkline`, `tile`), a non-empty `title`, and a `dataSource` object whose `mode` is one of `aggregation`, `graphql`, `statistics`. Each violated rule MUST emit its own coded error so the caller can surface field-level feedback.
+
+#### Scenario: Timeseries validator rejects an undeclared field
+- **GIVEN** a schema declaring properties `status` and `created`
+- **WHEN** `TimeseriesRequestValidator::validate(['field' => 'nope'], $schema)` runs
+- **THEN** an `InvalidArgumentException` MUST be thrown noting `field "nope" is not a declared property of the schema`
+
+#### Scenario: Sub-day interval requires a date-time field
+- **GIVEN** `field = 'createdDate'` whose schema `format` is `date` (not `date-time`)
+- **WHEN** `validate(['field' => 'createdDate', 'interval' => 'HOUR', 'from' => '2026-01-01', 'to' => '2026-02-01'], $schema)` runs
+- **THEN** an `InvalidArgumentException` MUST be thrown stating the sub-day interval requires a `date-time` field
+
+#### Scenario: Interval request produces a dateBucket, no-interval produces a groupBy
+- **GIVEN** `field = 'created'` (a declared `date-time` property)
+- **WHEN** `validate` is called with a valid `interval` + `from`/`to`
+- **THEN** the returned `AggregationQuery` MUST carry a `dateBucket` and a null `groupBy`
+- **AND** when `interval` is omitted the returned query MUST carry a categorical `groupBy` on `field` and a null `dateBucket`
+
+#### Scenario: Widget validator flags bad type, missing title, and bad dataSource mode
+- **GIVEN** a schema with `x-openregister-widgets: [{type: 'gauge', dataSource: {mode: 'rest'}}]`
+- **WHEN** `WidgetAnnotationValidator::validate($schema)` runs
+- **THEN** the returned list MUST include a `widget-bad-type` error (`gauge` not in the supported set)
+- **AND** a `widget-title-missing` error
+- **AND** a `widget-datasource-bad-mode` error (`rest` not in `aggregation`/`graphql`/`statistics`)
+
+#### Scenario: Absent widget annotation is valid
+- **GIVEN** a schema with no `x-openregister-widgets` key
+- **WHEN** `WidgetAnnotationValidator::validate($schema)` runs
+- **THEN** the result MUST be `[]`
+
+### Requirement: The system MUST resolve time and session placeholders inside aggregation filters before dispatch
+
+`PlaceholderResolver::resolve(mixed $value): mixed` MUST pass through any non-string or any string not starting with `$` unchanged. It MUST resolve `$currentUser` to the current session UID (or `''` when unauthenticated). It MUST resolve the date placeholders `$now`, `$startOfDay`, `$startOfWeek`, `$startOfMonth`, `$startOfYear` to a `DateTimeImmutable` anchored at the appropriate boundary (week starts Monday). It MUST support signed offset arithmetic via the `^(\$[a-zA-Z]+)([+-]\d+)([dwmy]?)$` grammar: the suffix selects days/weeks/months/years, and a bare integer offset MUST default to the placeholder's natural unit (`$startOfMonth-1` = one month earlier, `$startOfYear+1` = one year later, `$now-7d` = seven days earlier). An unrecognised `$`-prefixed string MUST be returned unchanged for the caller to surface.
+
+`PlaceholderResolver::resolveArray(array $values): array` MUST recurse into nested arrays and apply `resolve()` to every leaf value, preserving keys. `AggregationRunner` MUST call `resolveArray()` on the filter map before the cache-key derivation and the native/PHP dispatch, so placeholder-bearing filters resolve to concrete values exactly once per request.
+
+#### Scenario: Date placeholder with default-unit offset
+- **WHEN** `PlaceholderResolver::resolve('$startOfMonth-1')` runs
+- **THEN** the result MUST be a `DateTimeImmutable` at the first day of the month one month before the current month (the `m` unit is defaulted from the placeholder)
+
+#### Scenario: Explicit-suffix offset overrides the default unit
+- **WHEN** `PlaceholderResolver::resolve('$now-7d')` runs
+- **THEN** the result MUST be a `DateTimeImmutable` seven days before now
+
+#### Scenario: currentUser resolves to the session UID, unknown placeholder passes through
+- **GIVEN** a logged-in user `alice`
+- **WHEN** `resolve('$currentUser')` runs
+- **THEN** the result MUST be `'alice'`
+- **AND** `resolve('$notAThing')` MUST return the string `'$notAThing'` unchanged
+- **AND** `resolve(42)` MUST return `42` unchanged
+
+#### Scenario: resolveArray recurses and preserves keys
+- **GIVEN** `['status' => 'open', 'createdAfter' => '$startOfWeek', 'nested' => ['by' => '$currentUser']]`
+- **WHEN** `resolveArray(...)` runs
+- **THEN** `status` MUST remain `'open'`
+- **AND** `createdAfter` MUST be the Monday-anchored `DateTimeImmutable` for the current week
+- **AND** `nested.by` MUST be the resolved session UID

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid3/specs/data-import-export/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid3/specs/data-import-export/spec.md
@@ -1,0 +1,48 @@
+---
+retrofit_extensions:
+  - REQ-CFG-TRACK-001
+---
+
+# Data Import/Export Specification (delta)
+
+**Status**: implemented (retrofit — code already exists)
+**Scope**: openregister
+
+## ADDED Requirements
+
+### Requirement: Configuration imports MUST be tracked in a per-app Configuration entity for idempotent re-import
+
+`ImportHandler::createOrUpdateConfiguration(array $data, string $appId, string $version, array $result, ?string $owner = null): Configuration` MUST find-or-create a single `Configuration` entity per `$appId` (looked up via `ConfigurationMapper::findByApp($appId)`, taking the first match) so repeated imports of the same app reconcile into one tracking record rather than accumulating duplicates.
+
+Metadata MUST be extracted via a fallback chain: title and description MUST be read from `data.info.*` (OAS) first, then `data.x-openregister.*`, then top-level `data.*`, falling back to `"Configuration for {appId}"` / `"Imported configuration for application {appId}"`; `type` MUST be read from `x-openregister.type` → `data.type` → `'imported'`. Imported entity IDs MUST be collected from `$result['registers']`, `$result['schemas']`, and `$result['objects']`, taking only `Register` / `Schema` / `ObjectEntity` instances.
+
+On an **existing** configuration the handler MUST update title/description/type/version and MUST merge the freshly imported register/schema/object IDs with the previously tracked IDs using `array_unique(array_merge(existing, new))` — so re-importing never loses previously tracked entities — then persist via `ConfigurationMapper::update()`.
+
+On a **new** configuration the handler MUST set title/description/type/app/version and the fresh ID lists, MUST mark it `isLocal = true`, `syncEnabled = false`, `syncStatus = 'never'`, MUST fold optional `x-openregister` source/version metadata (`openregister`, `sourceType`, `sourceUrl`), MUST accept GitHub coordinates in either the new nested `x-openregister.github.{repo,branch,path}` shape or the legacy flat `x-openregister.github{Repo,Branch,Path}` shape, MUST set `owner` when the `$owner` argument is provided, then persist via `ConfigurationMapper::insert()`.
+
+Any failure MUST be logged and re-thrown wrapped as `Failed to create or update configuration: {message}`.
+
+#### Scenario: Re-import merges entity IDs into the existing configuration
+- **GIVEN** an existing `Configuration` for app `myapp` tracking registers `[1]`, schemas `[10]`, objects `[100]`
+- **WHEN** `createOrUpdateConfiguration` runs with a result importing registers `[1, 2]`, schemas `[11]`, objects `[100, 101]`
+- **THEN** the existing record MUST be updated (not a new one created)
+- **AND** its registers MUST become `[1, 2]`, schemas `[10, 11]`, objects `[100, 101]` (union, de-duplicated)
+- **AND** title/description/type/version MUST be refreshed from the new import data
+
+#### Scenario: First import creates a local, sync-disabled tracking record
+- **GIVEN** no existing `Configuration` for app `freshapp`
+- **WHEN** `createOrUpdateConfiguration` runs
+- **THEN** a new `Configuration` MUST be inserted with `app = 'freshapp'`, `isLocal = true`, `syncEnabled = false`, `syncStatus = 'never'`
+- **AND** the register/schema/object ID lists MUST equal the freshly imported IDs
+
+#### Scenario: Metadata falls back through OAS → x-openregister → default
+- **GIVEN** import data with no `info.title` and no `x-openregister.title` and no top-level `title`, for app `acme`
+- **WHEN** `createOrUpdateConfiguration` runs
+- **THEN** the configuration title MUST default to `"Configuration for acme"`
+- **AND** when `info.title` IS present it MUST take precedence over both `x-openregister.title` and the default
+
+#### Scenario: GitHub coordinates accepted in nested or legacy-flat shape
+- **GIVEN** a new configuration import whose `x-openregister` carries `github: {repo, branch, path}` (nested)
+- **WHEN** the new-configuration branch runs
+- **THEN** `githubRepo`/`githubBranch`/`githubPath` MUST be populated from the nested keys
+- **AND** an import using the legacy flat `githubRepo`/`githubBranch`/`githubPath` keys MUST populate the same fields

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid3/specs/vector-embeddings/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid3/specs/vector-embeddings/spec.md
@@ -1,0 +1,55 @@
+---
+retrofit_extensions:
+  - REQ-006
+---
+
+# Vector Embeddings Specification (delta)
+
+**Status**: implemented (retrofit — code already exists)
+**Scope**: openregister
+
+## ADDED Requirements
+
+### Requirement: The system MUST execute vector queries via semantic KNN/cosine similarity and hybrid Reciprocal-Rank-Fusion search
+
+`VectorEmbeddings::semanticSearch(string $query, int $limit = 10, array $filters = [], ?string $provider = null)` MUST first generate a query embedding for `$query` via `generateEmbedding()` (vector-embeddings REQ-001), resolve the configured backend via `getVectorSearchBackend()` (vector-embeddings REQ-002), and delegate to `VectorSearchHandler::semanticSearch(array $queryEmbedding, int $limit, array $filters, string $backend)`.
+
+`VectorSearchHandler::semanticSearch` MUST route by backend: when `$backend === 'solr'` it MUST execute a dense-vector KNN query through the Solr backend (`IndexService::getBackend()`, which MUST report `isAvailable() === true` or the call MUST throw `Solr service is not available`); otherwise it MUST fetch candidate vectors from `openregister_vectors` (honouring the `$filters` predicate), `unserialize()` each stored embedding BLOB, compute `cosineSimilarity()` against the query embedding, sort by similarity descending, and return the top `$limit`. A vector row whose deserialised embedding is not an array MUST be skipped (not fatal). When the database path finds no vectors the call MUST return `[]`. Any thrown error MUST be re-wrapped as `Semantic search failed: {message}`.
+
+Each result entry MUST carry `vector_id`, `entity_type`, `entity_id`, `similarity`, `chunk_index`, `total_chunks`, `chunk_text`, `metadata` (JSON-decoded from the row, `[]` when absent), `model`, and `dimensions`.
+
+`VectorEmbeddings::hybridSearch(string $query, array $solrFilters = [], int $limit = 20, array $weights = ['solr' => 0.5, 'vector' => 0.5], ?string $provider = null)` MUST generate the query embedding, read pre-computed Solr results from `$solrFilters['solr_results']` (default `[]`), and delegate to `VectorSearchHandler::hybridSearch(array $queryEmbedding, array $solrResults, int $limit, array $weights, string $backend)`.
+
+`VectorSearchHandler::hybridSearch` MUST normalise the supplied `solr` / `vector` weights to sum to 1 (when their sum is `> 0`), run the vector leg via `semanticSearch` with `limit * 2` candidates ONLY when `vectorWeight > 0`, fuse the vector and Solr result sets via Reciprocal Rank Fusion (`reciprocalRankFusion()`), and return the top `$limit` fused results. A failure in the vector leg MUST be logged and tolerated (the Solr leg still contributes) — it MUST NOT abort hybrid search. The response MUST include `results`, `total`, `search_time_ms`, a `source_breakdown` of `vector_only` / `solr_only` / `both` counts, and the normalised `weights`.
+
+#### Scenario: Database semantic search ranks by cosine similarity and caps at limit
+- **GIVEN** backend resolves to `'php'` and `openregister_vectors` holds 50 candidate rows for the filter
+- **WHEN** `VectorEmbeddings::semanticSearch('find me', 10)` runs
+- **THEN** the query MUST first be embedded via `generateEmbedding('find me')`
+- **AND** cosine similarity MUST be computed against each deserialised stored embedding
+- **AND** the result MUST be the 10 highest-similarity entries sorted descending, each carrying `vector_id`, `entity_type`, `entity_id`, `similarity`, `chunk_text`, `model`, and `dimensions`
+
+#### Scenario: Unparseable stored embedding is skipped, not fatal
+- **GIVEN** one of the fetched vector rows deserialises to a non-array value
+- **WHEN** the database semantic-search loop processes it
+- **THEN** that row MUST be skipped with a warning log
+- **AND** the remaining rows MUST still be scored and returned
+
+#### Scenario: Empty vector table returns empty result on the database path
+- **GIVEN** backend is not `'solr'` and `fetchVectors($filters)` returns `[]`
+- **WHEN** `VectorSearchHandler::semanticSearch(...)` runs
+- **THEN** the call MUST return `[]`
+- **AND** no cosine-similarity computation MUST be attempted
+
+#### Scenario: Hybrid search tolerates a failing vector leg
+- **GIVEN** `weights = ['solr' => 0.5, 'vector' => 0.5]` and the vector `semanticSearch` call throws
+- **WHEN** `VectorSearchHandler::hybridSearch(...)` runs
+- **THEN** the failure MUST be logged and swallowed (no exception propagates)
+- **AND** the Solr results MUST still be fused and returned via Reciprocal Rank Fusion
+- **AND** the response MUST include `results`, `total`, `search_time_ms`, `source_breakdown`, and the normalised `weights`
+
+#### Scenario: Hybrid weights are normalised to sum to one
+- **GIVEN** `weights = ['solr' => 3, 'vector' => 1]`
+- **WHEN** `hybridSearch(...)` normalises them
+- **THEN** the effective weights MUST be `['solr' => 0.75, 'vector' => 0.25]`
+- **AND** the returned `weights` field MUST reflect the normalised values

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid3/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid3/tasks.md
@@ -1,0 +1,39 @@
+# Tasks
+
+All tasks are `[x]` — the code already exists. This is a retrofit: tasks describe retroactive annotation, not new implementation.
+
+## Reverse-spec (new REQs, annotated against this ghost change)
+
+- [x] task-1: vector-embeddings#REQ-006 — Vector query execution: semantic KNN/cosine similarity search (PHP/database or Solr backend) and hybrid Reciprocal-Rank-Fusion search combining vector + Solr result sets, with per-result source breakdown and graceful degradation when the vector leg fails (retroactive annotation: `VectorEmbeddings::semanticSearch`, `VectorEmbeddings::hybridSearch`, `VectorSearchHandler::semanticSearch`, `VectorSearchHandler::hybridSearch`)
+
+- [x] task-2: aggregations-backend-native#REQ-ABN-006 — Aggregation API request and widget-annotation validation: the REST timeseries request validator (field allow-listing against schema properties, closed interval vocabulary, sub-day-gap date-time field requirement, from/to bounds) and the `x-openregister-widgets` schema-annotation validator (widget type / title / dataSource mode rules) (retroactive annotation: `TimeseriesRequestValidator::validate`, `WidgetAnnotationValidator::validate`)
+
+- [x] task-3: aggregations-backend-native#REQ-ABN-007 — Filter placeholder DSL: resolution of `$now` / `$startOfDay|Week|Month|Year` / `$currentUser` placeholders with signed offset arithmetic (`d`/`w`/`m`/`y` suffixes, unit defaulting per placeholder) and recursive array resolution, consumed by `AggregationRunner` before native/PHP dispatch (retroactive annotation: `PlaceholderResolver::resolve`, `PlaceholderResolver::resolveArray`)
+
+- [x] task-4: data-import-export#REQ-CFG-TRACK-001 — Import-tracking Configuration entity: `createOrUpdateConfiguration` finds-or-creates a `Configuration` per app, extracts title/description/type via an OAS-`info` → `x-openregister` → top-level fallback chain, and merges newly imported register/schema/object IDs with any previously tracked IDs (de-duplicated) so repeated imports accumulate rather than overwrite (idempotent re-import bookkeeping) (retroactive annotation: `ImportHandler::createOrUpdateConfiguration`)
+
+## Cross-reference (no new REQs — methods map to existing tasks in prior changes)
+
+The following methods are twins / read-write counterparts / public entry points of methods already annotated by earlier changes. They are annotated against those existing change tasks, not this ghost change.
+
+- [x] xref-1: `AggregationCache::set`, `::setAdhoc`, `::evictForSchema` → `retrofit-2026-05-24-aggregations-backend-native/tasks.md#task-1` (REQ-ABN-001 — cache key scoping + eviction; write/evict twins of the already-annotated `get`/`getAdhoc`)
+- [x] xref-2: `AggregationQuery::toArray` → `retrofit-2026-05-24-aggregations-backend-native/tasks.md#task-1` (canonical ksort-stable wire shape that is the ad-hoc cache key)
+- [x] xref-3: `AggregationRunner::runAdhocByRef` → `retrofit-2026-05-24-aggregations-backend-native/tasks.md#task-2` (ref-based convenience wrapper over `runAdhoc` — the same external → native → PHP dispatch)
+- [x] xref-4: `ElasticsearchAggregationQueryBuilder::build`, `SolrAggregationQueryBuilder::build` → `retrofit-2026-05-24-aggregations-backend-native/tasks.md#task-2` (translate the portable `AggregationQuery` into native ES/Solr params on the external-backend dispatch leg)
+- [x] xref-5: `GeoFilterParser::fromQueryParams` → `retrofit-2026-05-24-annotate-openregister/tasks.md#task-15` (geo-metadata-kaart REQ-GEO-004 — wire-format twin of the already-annotated `fromGeoSearchBody`)
+- [x] xref-6: `GeoSpatialEvaluator::matches` → `retrofit-2026-05-24-annotate-openregister/tasks.md#task-15` (geo-metadata-kaart REQ-GEO-004 — public dispatcher over the already-annotated `matchesBbox`/`matchesNear`/`matchesWithin`/`matchesIntersects` helpers)
+- [x] xref-7: `GraphQLResolver::resolveRelation` → `retrofit-2026-05-24-b-svc-i18n-endpoint-gql-wh/tasks.md#task-20` (graphql-api REQ-GQL-EXTRAS — public deferred half of the already-annotated DataLoader `flushRelationBuffer`)
+- [x] xref-8: `TransitionEngine::availableActions` → `retrofit-2026-05-24-object-lifecycle/tasks.md#task-2` (object-lifecycle REQ-007 — read-only enumeration over the same transition annotation surface; honors the explicit DROP triage recorded by that change that it is "adequately implied by REQ-007's transition lookup")
+- [x] xref-9: `CloudEventFormatter::formatAsCloudEvent`, `::formatRequestAsCloudEvent` → `retrofit-2026-04-30-annotate-openregister/tasks.md#task-84` (webhook-payload-mapping Req:CloudEventsFormat — the two public CloudEvents 1.0 formatters)
+- [x] xref-10: `EmbeddingGeneratorHandler` Fireworks adapter `embedText`, `embedDocument`, `embedDocuments`, `getEmbeddingLength` → `retrofit-2026-05-24-newcap-vector-embeddings/tasks.md#task-1` (vector-embeddings REQ-001 — the anonymous Fireworks `EmbeddingGeneratorInterface` adapter whose behavior REQ-001 already specifies)
+- [x] xref-11: `FileVectorizationStrategy::fetchEntities`, `::extractVectorizationItems`, `::prepareVectorMetadata` → `retrofit-2026-05-24-newcap-vector-embeddings/tasks.md#task-3` (vector-embeddings REQ-003 — concrete `VectorizationStrategyInterface` implementation for file chunks; the interface contract REQ-003 specifies. The earlier change's "file strategy" deferral lands here.)
+
+## Excluded (`@spec exclude` — boilerplate / plumbing)
+
+- [x] excl-1: `StreamYieldChannel::onToken`, `::onToolCall`, `::onToolResult`, `::onHeartbeat`, `::emitToken`, `::emitHeartbeat` — pure pub-sub event forwarder (register-callback / loop-and-invoke); the class is self-documented as "pure forwarding: it does not buffer, format, or filter events"
+- [x] excl-2: `GitHubGuards::runGuards` — generic guard-runner combinator (loop guards, short-circuit on first non-null response); carries no policy itself, the actual guards are separately annotated
+- [x] excl-3: `AggregationRunner::findSchema` — thin public convenience wrapper over the private `loadSchema` mapper lookup (exposed only so the REST controller can validate field allow-lists before constructing an `AggregationQuery`)
+
+## Deferred (`future-pass:next`)
+
+- Vector query execution (task-1 REQ-006) is captured under `vector-embeddings` because no `search` capability spec exists on this branch. If PR #1791 lands a `search` spec, re-home REQ-006 there in a follow-up.


### PR DESCRIPTION
## Retrofit — Reverse-Spec (bw-svc-mid3)

Drains the 2026-05-25 `svc-mid3` coverage batch — 37 uncovered methods across nine `lib/Service/` sub-trees (`Vectorization/`, `Aggregation/`, `Chat/`, `Configuration/`, `Geo/`, `GraphQL/`, `Lifecycle/`, `Search/`, `Webhook/`) — under the ADR-003 `@spec` convention.

Ghost change: `retrofit-2026-05-25-bw-svc-mid3` (validates with `--strict`; **not** archived in this run).

### Disposition
- **Reverse-spec — 4 new REQs:**
  - `vector-embeddings#REQ-006` — vector query execution (semantic KNN/cosine + hybrid Reciprocal-Rank-Fusion). Captured here rather than the deferred `search` cap because no `search` spec exists on this branch (PR #1791 not landed).
  - `aggregations-backend-native#REQ-ABN-006` — REST timeseries-request + `x-openregister-widgets` annotation validation.
  - `aggregations-backend-native#REQ-ABN-007` — the time/session placeholder DSL (`PlaceholderResolver`) the runner resolves filters through.
  - `data-import-export#REQ-CFG-TRACK-001` — the import-tracking `Configuration` entity (OAS→x-openregister→legacy metadata fallback + entity-ID merge for idempotent re-import).
- **Cross-reference — 11 methods**, no new REQs, mapped to existing tasks in prior changes (cache write/evict, ES/Solr query builders, ad-hoc-by-ref, geo parser/evaluator, graphql relation resolver, lifecycle available-actions [honoring the prior DROP triage], webhook CloudEvents formatters, Fireworks adapter, file vectorisation strategy).
- **Excluded — boilerplate:** `StreamYieldChannel` pub-sub forwarder (6 methods), `GitHubGuards::runGuards` (generic guard combinator), `AggregationRunner::findSchema` (thin `loadSchema` wrapper).

**Totals: 26 spec'd (4 new-REQ + 11 cross-ref methods, several files multi-method) / 8 excluded / 4 new REQs.**

### Verification
- All 37 batch methods carry an adjacent `@spec` (new / cross-ref / exclude).
- `openspec validate retrofit-2026-05-25-bw-svc-mid3 --strict` → valid.
- `php -l` clean on all 20 touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)