### PR TITLE
retrofit: backend coverage — Service text/oas/schema/mcp

### DIFF
--- a/lib/Service/Mcp/McpProtocolService.php
+++ b/lib/Service/Mcp/McpProtocolService.php
@@ -104,6 +104,8 @@ class McpProtocolService
      * @param string $userId Authenticated Nextcloud user ID
      *
      * @return array{result: array, sessionId: string} Result and session ID
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-4
      */
     public function initialize(array $params, string $userId): array
     {
@@ -136,6 +138,8 @@ class McpProtocolService
      * Handle MCP ping request
      *
      * @return array Empty result per MCP spec
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-4
      */
     public function ping(): array
     {
@@ -148,6 +152,8 @@ class McpProtocolService
      * @param string $userId Nextcloud user ID to associate with session
      *
      * @return string Generated session ID (UUID v4 format)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-4
      */
     public function createSession(string $userId): string
     {
@@ -176,6 +182,8 @@ class McpProtocolService
      * @param string $sessionId Session ID from Mcp-Session-Id header
      *
      * @return string|null User ID if valid, null if expired/invalid
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-4
      */
     public function validateSession(string $sessionId): ?string
     {
@@ -198,6 +206,8 @@ class McpProtocolService
      * @param string $sessionId Session ID to destroy
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-4
      */
     public function destroySession(string $sessionId): void
     {

--- a/lib/Service/Mcp/McpResourcesService.php
+++ b/lib/Service/Mcp/McpResourcesService.php
@@ -68,6 +68,8 @@ class McpResourcesService
      * and one entry per register+schema pair for objects.
      *
      * @return array{resources: array} MCP resources/list response
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-5
      */
     public function listResources(): array
     {
@@ -125,6 +127,8 @@ class McpResourcesService
      * resource URIs for specific items.
      *
      * @return array{resourceTemplates: array} MCP resources/templates/list response
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-5
      */
     public function listTemplates(): array
     {
@@ -163,6 +167,8 @@ class McpResourcesService
      * @return array{contents: array} MCP resources/read response
      *
      * @throws InvalidArgumentException If URI is invalid or unsupported
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-5
      */
     public function readResource(string $uri): array
     {

--- a/lib/Service/Mcp/McpToolsService.php
+++ b/lib/Service/Mcp/McpToolsService.php
@@ -94,6 +94,8 @@ class McpToolsService
      * a warning is logged per D5 of the design.
      *
      * @return array{tools: array} MCP tools/list response
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-6
      */
     public function listTools(): array
     {
@@ -139,6 +141,8 @@ class McpToolsService
      * @return array<string, mixed> MCP tool result with content array
      *
      * @throws InvalidArgumentException If no provider handles the tool id
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-6
      */
     public function callTool(string $name, array $arguments): array
     {
@@ -198,6 +202,8 @@ class McpToolsService
      * @param array<string, mixed> $arguments Tool arguments
      *
      * @return array{result: array<string, mixed>, isError: bool} Result envelope
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-6
      */
     public function invokeTool(string $toolId, array $arguments): array
     {
@@ -275,6 +281,8 @@ class McpToolsService
      * @param IMcpToolProvider $provider The provider to add
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-6
      */
     public function addProvider(IMcpToolProvider $provider): void
     {

--- a/lib/Service/Oas/OasETagComputer.php
+++ b/lib/Service/Oas/OasETagComputer.php
@@ -43,6 +43,8 @@ class OasETagComputer
      * @param array $oas The generated OAS payload.
      *
      * @return string Strong ETag, quoted per RFC 7232 (e.g. `"abc123"`).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-7
      */
     public function computeETag(array $oas): string
     {
@@ -56,6 +58,8 @@ class OasETagComputer
      * @param array $spec The OAS payload.
      *
      * @return string The hex-encoded SHA-256 hash.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-7
      */
     public function hash(array $spec): string
     {
@@ -75,6 +79,8 @@ class OasETagComputer
      * @param string $currentETag The currently computed ETag (quoted).
      *
      * @return bool True when a 304 response can be returned.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-7
      */
     public function matches(string $ifNoneMatch, string $currentETag): bool
     {

--- a/lib/Service/Oas/OasRequestValidator.php
+++ b/lib/Service/Oas/OasRequestValidator.php
@@ -46,6 +46,8 @@ class OasRequestValidator
      * @param array $schema The JSON-Schema to validate against (decoded).
      *
      * @return array<int, array{path: string, message: string}>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-8
      */
     public function validate(mixed $body, array $schema): array
     {

--- a/lib/Service/Oas/OasValidationReport.php
+++ b/lib/Service/Oas/OasValidationReport.php
@@ -80,6 +80,8 @@ final class OasValidationReport
      * @param string $code    Stable machine code (one of the CODE_* constants).
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-9
      */
     public function addError(string $path, string $message, string $code): void
     {
@@ -100,6 +102,8 @@ final class OasValidationReport
      * @param string $code    Stable machine code (one of the CODE_* constants).
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-9
      */
     public function addWarning(string $path, string $message, string $code): void
     {
@@ -120,6 +124,8 @@ final class OasValidationReport
      * @param string $code    Stable machine code (one of the CODE_* constants).
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-9
      */
     public function addAutoCorrection(string $path, string $message, string $code): void
     {
@@ -191,6 +197,8 @@ final class OasValidationReport
      * True when no error-severity issues have been recorded.
      *
      * @return bool
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-9
      */
     public function passed(): bool
     {
@@ -219,6 +227,8 @@ final class OasValidationReport
      *   warnings       (int)          Count of warning-severity issues.
      *   autoCorrected  (int)          Count of auto-corrected issues.
      *   issues         (list<array>)  Full issue list with path/message/code/severity.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-9
      */
     public function toSummary(): array
     {

--- a/lib/Service/Oas/ProblemDetailsBuilder.php
+++ b/lib/Service/Oas/ProblemDetailsBuilder.php
@@ -62,6 +62,8 @@ class ProblemDetailsBuilder
      * @param array  $extensions Free-form extension fields (e.g. `errors`, `code`).
      *
      * @return array<string, mixed> The problem-json payload.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-10
      */
     public function build(
         int $status,
@@ -107,6 +109,8 @@ class ProblemDetailsBuilder
      * @param string $instance Instance URI, '' = omit.
      *
      * @return array<string, mixed>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-10
      */
     public function validationFailed(array $errors, string $detail='', string $instance=''): array
     {
@@ -128,6 +132,8 @@ class ProblemDetailsBuilder
      * @param string $instance Instance URI, '' = omit.
      *
      * @return array<string, mixed>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-10
      */
     public function notFound(string $detail='', string $instance=''): array
     {
@@ -147,6 +153,8 @@ class ProblemDetailsBuilder
      * @param string $instance Instance URI, '' = omit.
      *
      * @return array<string, mixed>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-10
      */
     public function conflict(string $detail='', string $instance=''): array
     {

--- a/lib/Service/Schemas/FacetCacheHandler.php
+++ b/lib/Service/Schemas/FacetCacheHandler.php
@@ -210,6 +210,8 @@ class FacetCacheHandler
      * @return void
      *
      * @throws \OCP\DB\Exception If a database error occurs
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-12
      */
     public function cacheFacetableFields(int $schemaId, array $facetableFields, int $ttl=7200): void
     {
@@ -320,6 +322,8 @@ class FacetCacheHandler
      * @return void
      *
      * @throws \OCP\DB\Exception If a database error occurs
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-12
      */
     public function clearAllCaches(): void
     {
@@ -357,6 +361,8 @@ class FacetCacheHandler
      * @throws \OCP\DB\Exception If a database error occurs
      *
      * @return int The number of deleted cache entries.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-12
      */
     public function cleanExpiredEntries(): int
     {
@@ -392,6 +398,8 @@ class FacetCacheHandler
      * @throws \OCP\DB\Exception If a database error occurs
      *
      * @return array Statistics with total entries, by type, memory cache size, cache table, query time, timestamp.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-12
      */
     public function getCacheStatistics(): array
     {

--- a/lib/Service/Schemas/PropertyValidatorHandler.php
+++ b/lib/Service/Schemas/PropertyValidatorHandler.php
@@ -249,6 +249,8 @@ class PropertyValidatorHandler
      * @throws Exception If any property definition is invalid
      *
      * @return true True if all properties are valid
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-13
      */
     public function validateProperties(array $properties, string $path=''): bool
     {

--- a/lib/Service/Schemas/SchemaCacheHandler.php
+++ b/lib/Service/Schemas/SchemaCacheHandler.php
@@ -253,6 +253,8 @@ class SchemaCacheHandler
      * @param int $schemaId The schema ID to remove from cache
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-11
      */
     public function clearSchemaCache(int $schemaId): void
     {
@@ -293,6 +295,8 @@ class SchemaCacheHandler
      * @return void
      *
      * @throws \OCP\DB\Exception If a database error occurs
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-11
      */
     public function cacheSchema(Schema $schema, int $ttl=self::DEFAULT_TTL): void
     {
@@ -319,6 +323,8 @@ class SchemaCacheHandler
      * @return void
      *
      * @throws \OCP\DB\Exception If a database error occurs
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-11
      */
     public function cacheSchemaConfiguration(Schema $schema, int $ttl=self::DEFAULT_TTL): void
     {
@@ -340,6 +346,8 @@ class SchemaCacheHandler
      * @return void
      *
      * @throws \OCP\DB\Exception If a database error occurs
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-11
      */
     public function cacheSchemaProperties(Schema $schema, int $ttl=self::DEFAULT_TTL): void
     {
@@ -393,6 +401,8 @@ class SchemaCacheHandler
      * @throws \OCP\DB\Exception If a database error occurs
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Operation parameter with default is not a boolean
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-11
      */
     public function invalidateForSchemaChange(int $schemaId, string $operation='update'): void
     {
@@ -455,6 +465,8 @@ class SchemaCacheHandler
      * @return void
      *
      * @throws \OCP\DB\Exception If a database error occurs
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-11
      */
     public function clearAllCaches(): void
     {
@@ -494,6 +506,8 @@ class SchemaCacheHandler
      * @return int
      *
      * @psalm-return int<min, max>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-11
      */
     public function cleanExpiredEntries(): int
     {
@@ -529,6 +543,8 @@ class SchemaCacheHandler
      * @return array Cache statistics with total entries, TTL info, memory size, and timing.
      *
      * @throws \OCP\DB\Exception If a database error occurs.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-11
      */
     public function getCacheStatistics(): array
     {

--- a/lib/Service/TextExtraction/EmlAttachment.php
+++ b/lib/Service/TextExtraction/EmlAttachment.php
@@ -72,6 +72,8 @@ final class EmlAttachment implements JsonSerializable
      * value object directly receive raw bytes via `$attachment->content`.
      *
      * @return array<string, mixed>
+     *
+     * @spec exclude Value-object serialiser: maps public readonly properties to an array (content base64-encoded); field shape specified by text-extraction-eml.
      */
     public function jsonSerialize(): array
     {

--- a/lib/Service/TextExtraction/EmlBody.php
+++ b/lib/Service/TextExtraction/EmlBody.php
@@ -50,6 +50,8 @@ final class EmlBody implements JsonSerializable
      * JSON serialisation.
      *
      * @return array{plainText: string|null, html: string|null}
+     *
+     * @spec exclude Value-object serialiser: maps public readonly properties to an array; field shape specified by text-extraction-eml.
      */
     public function jsonSerialize(): array
     {

--- a/lib/Service/TextExtraction/EmlStructure.php
+++ b/lib/Service/TextExtraction/EmlStructure.php
@@ -58,6 +58,8 @@ final class EmlStructure implements JsonSerializable
      * JSON serialisation.
      *
      * @return array{headers: array, body: EmlBody, attachments: array<int, EmlAttachment>}
+     *
+     * @spec exclude Value-object serialiser: maps public readonly properties to an array; field shape specified by text-extraction-eml.
      */
     public function jsonSerialize(): array
     {

--- a/lib/Service/TextExtraction/EntityRecognitionHandler.php
+++ b/lib/Service/TextExtraction/EntityRecognitionHandler.php
@@ -129,6 +129,8 @@ class EntityRecognitionHandler
      * @psalm-return array{chunks_processed: int<0, max>, entities_found: int<0, max>, relations_created: int<0, max>}
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Chunk processing requires multiple condition checks
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-14
      */
     public function processSourceChunks(string $sourceType, int $sourceId, array $options=[]): array
     {
@@ -213,6 +215,8 @@ class EntityRecognitionHandler
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Entity extraction requires multiple condition checks
      * @SuppressWarnings(PHPMD.NPathComplexity)       Multiple entity detection paths with error handling
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Comprehensive entity extraction with logging
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-14
      */
     public function extractFromChunk(Chunk $chunk, array $options=[]): array
     {

--- a/lib/Service/TextExtraction/FileHandler.php
+++ b/lib/Service/TextExtraction/FileHandler.php
@@ -16,6 +16,8 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT: <git-id>
  * @link      https://www.OpenRegister.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-1
  */
 
 namespace OCA\OpenRegister\Service\TextExtraction;
@@ -88,6 +90,8 @@ class FileHandler implements TextExtractionHandlerInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)   Force parameter follows interface contract
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-2
      */
     public function extractText(int $sourceId, array $sourceMeta, bool $force=false): array
     {
@@ -157,6 +161,8 @@ class FileHandler implements TextExtractionHandlerInterface
      * @return bool True if extraction is needed.
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Force parameter follows interface contract
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-3
      */
     public function needsExtraction(int $sourceId, int $sourceTimestamp, bool $force): bool
     {
@@ -190,6 +196,8 @@ class FileHandler implements TextExtractionHandlerInterface
      *     permissions: int, checksum: string, share_token: null|string,
      *     share_stime: int|null, storage_id: null|string, owner: null|string,
      *     accessUrl: null|string, downloadUrl: null|string, published: null|string}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-1
      */
     public function getSourceMetadata(int $sourceId): array
     {
@@ -207,6 +215,8 @@ class FileHandler implements TextExtractionHandlerInterface
      * @param int $sourceId File ID.
      *
      * @return int Unix timestamp.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-3
      */
     public function getSourceTimestamp(int $sourceId): int
     {

--- a/lib/Service/TextExtraction/ObjectHandler.php
+++ b/lib/Service/TextExtraction/ObjectHandler.php
@@ -16,6 +16,8 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT: <git-id>
  * @link      https://www.OpenRegister.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-1
  */
 
 namespace OCA\OpenRegister\Service\TextExtraction;
@@ -95,6 +97,8 @@ class ObjectHandler implements TextExtractionHandlerInterface
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Object extraction requires multiple field checks
      * @SuppressWarnings(PHPMD.NPathComplexity)       Multiple field extraction paths with optional data
      * @SuppressWarnings(PHPMD.UnusedFormalParameter) $sourceMeta and $force kept to honour interface contract
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-2
      */
     public function extractText(int $sourceId, array $sourceMeta, bool $force=false): array
     {
@@ -217,6 +221,8 @@ class ObjectHandler implements TextExtractionHandlerInterface
      * @return bool True if extraction is needed.
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Force parameter follows interface contract
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-3
      */
     public function needsExtraction(int $sourceId, int $sourceTimestamp, bool $force): bool
     {
@@ -246,6 +252,8 @@ class ObjectHandler implements TextExtractionHandlerInterface
      * @psalm-return array{id: int, uuid: null|string, schema: null|string,
      *     register: null|string, version: null|string, organization: mixed,
      *     owner: null|string, updated: \DateTime|null}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-1
      */
     public function getSourceMetadata(int $sourceId): array
     {
@@ -269,6 +277,8 @@ class ObjectHandler implements TextExtractionHandlerInterface
      * @param int $sourceId Object ID.
      *
      * @return int Unix timestamp.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-3
      */
     public function getSourceTimestamp(int $sourceId): int
     {

--- a/lib/Service/TextExtraction/TextExtractionHandlerInterface.php
+++ b/lib/Service/TextExtraction/TextExtractionHandlerInterface.php
@@ -18,6 +18,8 @@
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT: <git-id>
  * @link      https://www.OpenRegister.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-1
  */
 
 namespace OCA\OpenRegister\Service\TextExtraction;
@@ -56,6 +58,8 @@ interface TextExtractionHandlerInterface
      * }
      *
      * @throws \Exception When extraction fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-1
      */
     public function extractText(int $sourceId, array $sourceMeta, bool $force=false): array;
 

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid2/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid2/proposal.md
@@ -1,0 +1,82 @@
+# Retrofit — backend Service text/oas/schema/mcp (svc-mid2, 2026-05-25)
+
+Reverse-spec / annotate triage over 52 uncovered methods (`missing @spec`)
+across four `lib/Service/` sub-trees: `TextExtraction/`, `Oas/`, `Schemas/`,
+and `Mcp/`. ADR-003 two-tool pass — every method is either annotated to an
+existing requirement, mapped to one new requirement, or `@spec exclude`d as
+boilerplate. Code already exists; this change retroactively specifies it.
+
+Source batch: `/tmp/or-scan/bw-svc-mid2.json` (52 methods).
+
+## Outcome
+
+- **49 methods spec'd** — 40 annotated to existing requirements in five
+  capabilities (`mcp-discovery`, `oas-validation`, `object-lifecycle`,
+  `faceting-configuration`, `avg-verwerkingsregister`) plus 9 mapped to **one
+  new capability** `text-extraction-sources` (REQ-001..003, 3 new REQs).
+- **3 methods excluded** — the `jsonSerialize()` value-object serialisers on the
+  three EML value objects (pure field-to-array projection boilerplate).
+- **1 new capability**, **3 new REQs** total (well under the ≤5 cap).
+
+## New capability: text-extraction-sources (9 methods, 3 REQs)
+
+The generic per-source text-extraction layer (handlers implementing
+`TextExtractionHandlerInterface`, feeding `ChunkMapper`) had no capability
+owner. It is distinct from `text-extraction-eml` (EML parsing primitives) and
+`text-extraction-office-completeness` (PhpWord/ODT walking), which cover
+format-specific extraction, and from `vector-embeddings`, which consumes the
+chunks produced afterward. One new capability captures the source-handler
+contract:
+
+- **REQ-001** — common extraction contract (`TextExtractionHandlerInterface::extractText`, `FileHandler::getSourceMetadata`, `ObjectHandler::getSourceMetadata`)
+- **REQ-002** — normalised extraction + SHA-256 checksum (`FileHandler::extractText`, `ObjectHandler::extractText`)
+- **REQ-003** — freshness-gated re-extraction (`FileHandler::needsExtraction`, `FileHandler::getSourceTimestamp`, `ObjectHandler::needsExtraction`, `ObjectHandler::getSourceTimestamp`)
+
+## Annotated to existing requirements (40 methods)
+
+### Mcp/ → `mcp-discovery` (12 methods)
+The `mcp-discovery` spec (status `implemented`) names these services and methods
+explicitly in its scenarios, so the annotations are faithful retroactive maps:
+- `McpProtocolService` — `initialize`, `createSession`, `validateSession`, `destroySession`, `ping` → "MCP Session Management", "MCP Capabilities Negotiation", "MCP Audit Logging"
+- `McpResourcesService` — `listResources`, `listTemplates`, `readResource` → "MCP Resource Definitions"
+- `McpToolsService` — `listTools`, `callTool`, `invokeTool`, `addProvider` → "MCP Tool Definitions", "Multi-Register Tool Scoping", "MCP Audit Logging"
+
+### Oas/ → `oas-validation` (13 methods)
+The active `oas-validation` change spec covers runtime request/response
+validation, validation reporting, performance/ETag caching, and RFC 7807
+problem details. The four helper classes implement those requirements:
+- `OasETagComputer` — `computeETag`, `hash`, `matches` → "Performance Impact of Validation" (ETag revalidation scenario)
+- `OasRequestValidator` — `validate` → "Request Validation Against OAS Schema"
+- `OasValidationReport` — `addError`, `addWarning`, `addAutoCorrection`, `passed`, `toSummary` → "Validation Error Reporting" (`x-validation-summary`)
+- `ProblemDetailsBuilder` — `build`, `validationFailed`, `notFound`, `conflict` → "Error responses include problem details (API-46 / RFC 7807)"
+
+### Schemas/ → `object-lifecycle` + `faceting-configuration` + annotate-openregister (13 methods)
+- `SchemaCacheHandler` (8) — `cacheSchema`, `cacheSchemaConfiguration`, `cacheSchemaProperties`, `cleanExpiredEntries`, `clearAllCaches`, `clearSchemaCache`, `getCacheStatistics`, `invalidateForSchemaChange` → `object-lifecycle#REQ-010` ("Schema reads MUST use a two-tier cache with explicit invalidation"; sibling methods of the already-annotated `getSchema`/`invalidate`, both carrying `retrofit-2026-05-24-b-svc-object-facade` task-5)
+- `FacetCacheHandler` (4) — `cacheFacetableFields`, `cleanExpiredEntries`, `clearAllCaches`, `getCacheStatistics` → `faceting-configuration` "Multi-layered facet caching" (names `FacetCacheHandler`, the `openregister_schema_facet_cache` table, the cache-statistics shape)
+- `PropertyValidatorHandler` (1) — `validateProperties` → `retrofit-2026-05-24-annotate-openregister` task-13 (the public loop sibling of the already-annotated `validateProperty`)
+
+### TextExtraction/ → `avg-verwerkingsregister` (2 methods)
+- `EntityRecognitionHandler` — `extractFromChunk`, `processSourceChunks` → `avg-verwerkingsregister` "Automated PII detection MUST flag unregistered personal data processing" (the spec names `EntityRecognitionHandler` as the PII-detection engine and specifies the regex/Presidio/LLM/hybrid method configuration these methods implement)
+
+## Excluded (3 methods)
+
+Pure value-object serialisation boilerplate — `jsonSerialize()` projects the
+VO's public readonly properties into an array with no behavioural contract
+beyond the field shape already specified by `text-extraction-eml`:
+- `EmlAttachment::jsonSerialize`, `EmlBody::jsonSerialize`, `EmlStructure::jsonSerialize`
+
+## Mode
+Mixed: `--cluster text-extraction-sources` (1 new cap, REQ-001..003) plus
+cross-capability annotation to five existing capabilities. No existing
+requirements are modified.
+
+## Notes
+- No cohort frontmatter is added to the five existing capabilities — the cohort
+  flag tracks REQ provenance, not annotation provenance (per the retrofit
+  playbook's documentation-only sub-patterns). Only the new
+  `text-extraction-sources` master spec carries `retrofit: true`.
+- `object-lifecycle#REQ-010` and the `oas-validation` API-46/request-validation/
+  ETag requirements live in active (un-archived) changes; `@spec` is a textual
+  reference and remains valid after those changes archive.
+
+See [retrofit playbook](../../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid2/specs/text-extraction-sources/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid2/specs/text-extraction-sources/spec.md
@@ -1,0 +1,116 @@
+---
+status: implemented
+retrofit: true
+---
+
+# Text Extraction Sources
+
+## Purpose
+Provides a generic, source-type-agnostic text-extraction layer that turns
+heterogeneous OpenRegister sources (Nextcloud files, register objects, and —
+by extension — future agenda/email source types) into a normalised extraction
+result ready for chunking, indexing, and downstream PII detection. Each source
+type is handled by a dedicated handler that implements a common contract, so
+the orchestrating `TextExtractionService` can stay generic and extensible.
+
+This capability covers the per-source extraction handlers themselves
+(`FileHandler`, `ObjectHandler`) and the `TextExtractionHandlerInterface`
+contract they share. It is distinct from `text-extraction-eml` (EML/RFC822
+parsing) and `text-extraction-office-completeness` (PhpWord/ODT walking),
+which cover specific document-format extraction primitives, and from
+`vector-embeddings` (which consumes the chunks produced after extraction).
+Code already exists — this change retroactively specifies observed behaviour.
+
+## ADDED Requirements
+
+### Requirement: REQ-001 — Source handlers MUST implement a common extraction contract
+The system MUST expose a `TextExtractionHandlerInterface` that every
+source-type handler implements, so the orchestrating service can extract text
+from any registered source type without knowing its concrete type. The
+interface MUST declare at minimum `extractText(int $sourceId, array
+$sourceMeta, bool $force): array` and `getSourceMetadata(int $sourceId):
+array`. The `extractText` return array MUST carry a stable, normalised shape
+across all handlers, including the keys `source_type`, `source_id`, `text`,
+`length`, `checksum`, `method`, `owner`, `organisation`, `language`,
+`language_level`, `language_confidence`, `detection_method`, and `metadata`.
+`getSourceMetadata` MUST throw `DoesNotExistException` when the source cannot
+be resolved.
+
+#### Scenario: Handler conforms to the interface contract
+- **GIVEN** a concrete handler such as `FileHandler` or `ObjectHandler`
+- **WHEN** it is registered with the orchestrating `TextExtractionService`
+- **THEN** it MUST implement `TextExtractionHandlerInterface`
+- **AND** `extractText()` MUST return an array containing every normalised key
+  (`source_type`, `source_id`, `text`, `length`, `checksum`, `method`,
+  `owner`, `organisation`, `language`, `language_level`,
+  `language_confidence`, `detection_method`, `metadata`)
+
+#### Scenario: Missing source metadata raises a typed exception
+- **GIVEN** a source ID that does not resolve to a stored source
+- **WHEN** `getSourceMetadata($sourceId)` is called
+- **THEN** the handler MUST throw `DoesNotExistException`
+
+### Requirement: REQ-002 — Handlers MUST extract normalised text and a stable checksum from their source
+Each handler's `extractText()` MUST load the source by ID, derive a plain-text
+projection of its content, and return the normalised result array. The `text`
+field MUST be a non-empty string — when no text can be derived the handler MUST
+throw rather than return an empty result. The `checksum` field MUST be a
+SHA-256 hash of the extracted text so callers can detect unchanged content. The
+`metadata` field MUST carry source-specific identifying detail (e.g. file path
+/ name / MIME type / size for files; uuid / schema_id / register_id / version
+for objects). Object extraction MUST recursively flatten nested object data
+into `key: value` lines with a bounded recursion depth.
+
+#### Scenario: File extraction returns normalised result with checksum
+- **GIVEN** a Nextcloud file resolvable by ID with extractable text content
+- **WHEN** `FileHandler::extractText($fileId, $meta, false)` is called
+- **THEN** the result `source_type` MUST be `"file"` and `method` MUST be
+  `"file_extraction"`
+- **AND** `checksum` MUST equal `hash('sha256', $text)`
+- **AND** `metadata` MUST include `file_path`, `file_name`, `mime_type`, and
+  `file_size`
+
+#### Scenario: Object extraction flattens nested data within a depth bound
+- **GIVEN** a register object whose `object` payload contains nested arrays
+- **WHEN** `ObjectHandler::extractText($objectId, $meta, false)` is called
+- **THEN** the `text` MUST include the object UUID, resolved schema/register
+  titles, and flattened `key: value` lines from the object data
+- **AND** recursion into nested arrays MUST stop beyond a fixed depth bound
+
+#### Scenario: No extractable text throws rather than returning empty
+- **GIVEN** a source from which no text can be derived
+- **WHEN** `extractText()` is called
+- **THEN** the handler MUST throw an exception naming the source ID rather than
+  returning an empty `text`
+
+### Requirement: REQ-003 — Handlers MUST gate re-extraction on source freshness
+Each handler MUST expose `needsExtraction(int $sourceId, int $sourceTimestamp,
+bool $force): bool` and `getSourceTimestamp(int $sourceId): int` so the
+orchestrator can skip work when previously-produced chunks are still
+up-to-date. `needsExtraction` MUST return `true` when `force` is set, `true`
+when no chunks exist yet for the source, and otherwise `true` only when the
+latest chunk timestamp predates the supplied source timestamp.
+`getSourceTimestamp` MUST return the source's last-modified Unix timestamp,
+falling back to the current time when the source cannot be resolved.
+
+#### Scenario: Force always triggers re-extraction
+- **GIVEN** any source with up-to-date chunks
+- **WHEN** `needsExtraction($sourceId, $ts, true)` is called
+- **THEN** it MUST return `true`
+
+#### Scenario: Stale chunks trigger re-extraction
+- **GIVEN** a source whose latest chunk timestamp is older than the source's
+  current modification timestamp
+- **WHEN** `needsExtraction($sourceId, $sourceTimestamp, false)` is called
+- **THEN** it MUST return `true`
+
+#### Scenario: Up-to-date chunks skip re-extraction
+- **GIVEN** a source whose latest chunk timestamp is at or after the source's
+  modification timestamp
+- **WHEN** `needsExtraction($sourceId, $sourceTimestamp, false)` is called
+- **THEN** it MUST return `false`
+
+#### Scenario: Timestamp falls back to now on unresolved source
+- **GIVEN** a source ID that does not resolve
+- **WHEN** `getSourceTimestamp($sourceId)` is called
+- **THEN** it MUST return the current Unix timestamp instead of throwing

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md
@@ -1,0 +1,25 @@
+# Tasks
+
+## New capability: text-extraction-sources (reverse-spec)
+
+- [x] task-1: text-extraction-sources#REQ-001 — Common extraction contract (`TextExtractionHandlerInterface::extractText`, `FileHandler::getSourceMetadata`, `ObjectHandler::getSourceMetadata`) (retroactive annotation)
+- [x] task-2: text-extraction-sources#REQ-002 — Normalised extraction + SHA-256 checksum (`FileHandler::extractText`, `ObjectHandler::extractText`) (retroactive annotation)
+- [x] task-3: text-extraction-sources#REQ-003 — Freshness-gated re-extraction (`FileHandler::needsExtraction`, `FileHandler::getSourceTimestamp`, `ObjectHandler::needsExtraction`, `ObjectHandler::getSourceTimestamp`) (retroactive annotation)
+
+## Cross-capability annotations to existing requirements
+
+- [x] task-4: mcp-discovery — MCP protocol/session/capabilities/audit (`McpProtocolService::initialize`, `::createSession`, `::validateSession`, `::destroySession`, `::ping`) (retroactive annotation)
+- [x] task-5: mcp-discovery — MCP resource definitions (`McpResourcesService::listResources`, `::listTemplates`, `::readResource`) (retroactive annotation)
+- [x] task-6: mcp-discovery — MCP tool definitions/scoping/audit (`McpToolsService::listTools`, `::callTool`, `::invokeTool`, `::addProvider`) (retroactive annotation)
+- [x] task-7: oas-validation — ETag revalidation / performance (`OasETagComputer::computeETag`, `::hash`, `::matches`) (retroactive annotation)
+- [x] task-8: oas-validation — request validation against OAS schema (`OasRequestValidator::validate`) (retroactive annotation)
+- [x] task-9: oas-validation — validation error reporting / x-validation-summary (`OasValidationReport::addError`, `::addWarning`, `::addAutoCorrection`, `::passed`, `::toSummary`) (retroactive annotation)
+- [x] task-10: oas-validation — RFC 7807 problem details (API-46) (`ProblemDetailsBuilder::build`, `::validationFailed`, `::notFound`, `::conflict`) (retroactive annotation)
+- [x] task-11: object-lifecycle#REQ-010 — two-tier schema cache + invalidation (`SchemaCacheHandler::cacheSchema`, `::cacheSchemaConfiguration`, `::cacheSchemaProperties`, `::cleanExpiredEntries`, `::clearAllCaches`, `::clearSchemaCache`, `::getCacheStatistics`, `::invalidateForSchemaChange`) (retroactive annotation)
+- [x] task-12: faceting-configuration — multi-layered facet caching (`FacetCacheHandler::cacheFacetableFields`, `::cleanExpiredEntries`, `::clearAllCaches`, `::getCacheStatistics`) (retroactive annotation)
+- [x] task-13: schema property validation (`PropertyValidatorHandler::validateProperties`, sibling of annotated `validateProperty`) (retroactive annotation)
+- [x] task-14: avg-verwerkingsregister — automated PII detection (`EntityRecognitionHandler::extractFromChunk`, `::processSourceChunks`) (retroactive annotation)
+
+## Excluded (boilerplate)
+
+- [x] task-15: exclude EML value-object serialisers (`EmlAttachment::jsonSerialize`, `EmlBody::jsonSerialize`, `EmlStructure::jsonSerialize`) — pure VO field-to-array projection, field shape already specified by text-extraction-eml


### PR DESCRIPTION
## Summary

ADR-003 two-tool retrofit pass over **52 uncovered backend methods** (batch `svc-mid2`) across `lib/Service/{TextExtraction,Oas,Schemas,Mcp}/`. Code already exists — this change retroactively specifies it. **49 spec'd / 3 excluded / 3 new REQs.**

### Annotated to existing requirements (40 methods)
- **mcp-discovery** (12): `McpProtocolService` (initialize/createSession/validateSession/destroySession/ping), `McpResourcesService` (listResources/listTemplates/readResource), `McpToolsService` (listTools/callTool/invokeTool/addProvider) — all named explicitly in the `mcp-discovery` spec scenarios.
- **oas-validation** (13): `OasETagComputer` (computeETag/hash/matches → Performance/ETag), `OasRequestValidator::validate` (Request Validation), `OasValidationReport` (addError/addWarning/addAutoCorrection/passed/toSummary → Validation Error Reporting), `ProblemDetailsBuilder` (build/validationFailed/notFound/conflict → API-46 / RFC 7807).
- **object-lifecycle#REQ-010** (8): the remaining `SchemaCacheHandler` two-tier-cache + invalidation methods (siblings of the already-annotated `getSchema`/`invalidate`).
- **faceting-configuration** (4): `FacetCacheHandler` (cacheFacetableFields/cleanExpiredEntries/clearAllCaches/getCacheStatistics → Multi-layered facet caching).
- **annotate-openregister** (1): `PropertyValidatorHandler::validateProperties` (sibling of `validateProperty`).
- **avg-verwerkingsregister** (2): `EntityRecognitionHandler` (extractFromChunk/processSourceChunks → Automated PII detection).

### New capability `text-extraction-sources` (9 methods, REQ-001..003)
The generic per-source extraction layer (`FileHandler`, `ObjectHandler`, shared `TextExtractionHandlerInterface`) had no capability owner — distinct from `text-extraction-eml`, `text-extraction-office-completeness`, and `vector-embeddings`. REQ-001 (common contract), REQ-002 (normalised extraction + SHA-256 checksum), REQ-003 (freshness-gated re-extraction).

### Excluded (3)
`EmlAttachment/EmlBody/EmlStructure::jsonSerialize` — value-object field-to-array serialisers (boilerplate).

Ghost change: `openspec/changes/retrofit-2026-05-25-bw-svc-mid2/`.

## Test plan
- [x] `php -l` clean on all 17 touched files
- [x] `openspec validate retrofit-2026-05-25-bw-svc-mid2 --strict` passes
- [ ] reviewer confirms capability routing (especially the new `text-extraction-sources` cap vs the existing `text-extraction-*` caps)