### PR TITLE
retrofit: backend coverage — Service settings/notification/object

### DIFF
--- a/lib/Service/Notification/AnnotationNotificationDispatcher.php
+++ b/lib/Service/Notification/AnnotationNotificationDispatcher.php
@@ -108,6 +108,8 @@ class AnnotationNotificationDispatcher
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-5
      */
     public function dispatch(ObjectEntity $object, string $trigger, array $context=[]): void
     {

--- a/lib/Service/Notification/NotificationAnnotationValidator.php
+++ b/lib/Service/Notification/NotificationAnnotationValidator.php
@@ -57,6 +57,8 @@ final class NotificationAnnotationValidator
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-5
      */
     public function validate(array $schema): array
     {

--- a/lib/Service/Notification/NotificationCoalescer.php
+++ b/lib/Service/Notification/NotificationCoalescer.php
@@ -133,6 +133,8 @@ class NotificationCoalescer
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-9
      */
     public function shouldDispatch(string $ruleId, string $recipient, ?array $perRuleOverride): bool
     {
@@ -221,6 +223,8 @@ class NotificationCoalescer
      * @param string $recipient Recipient identifier.
      *
      * @return array{count:int,opened:int}|null Null when no state exists.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-9
      */
     public function inspect(string $ruleId, string $recipient): ?array
     {

--- a/lib/Service/Notification/NotificationDigest.php
+++ b/lib/Service/Notification/NotificationDigest.php
@@ -53,6 +53,8 @@ class NotificationDigest
      * @param array  $event       The event payload (free-form).
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-6
      */
     public function enqueue(string $recipientId, array $event): void
     {
@@ -68,6 +70,8 @@ class NotificationDigest
      * Number of recipients currently buffered.
      *
      * @return int
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-6
      */
     public function recipientCount(): int
     {
@@ -81,6 +85,8 @@ class NotificationDigest
      * @param string $recipientId The recipient identifier.
      *
      * @return int
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-6
      */
     public function pendingCount(string $recipientId): int
     {
@@ -92,6 +98,8 @@ class NotificationDigest
      * Total pending events across all recipients.
      *
      * @return int
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-6
      */
     public function totalPending(): int
     {
@@ -109,6 +117,8 @@ class NotificationDigest
      * pending events, in original enqueue order. Clears state.
      *
      * @return array<string, array<int, array>> recipientId → list of events
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-6
      */
     public function flush(): array
     {

--- a/lib/Service/Notification/NotificationReadState.php
+++ b/lib/Service/Notification/NotificationReadState.php
@@ -58,6 +58,8 @@ class NotificationReadState
      * @param string $notificationId The notification id.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-7
      */
     public function markRead(string $userId, string $notificationId): void
     {
@@ -72,6 +74,8 @@ class NotificationReadState
      * @param string $notificationId The notification id.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-7
      */
     public function markUnread(string $userId, string $notificationId): void
     {
@@ -97,6 +101,8 @@ class NotificationReadState
      * Number of "read" rows currently tracked across all users.
      *
      * @return int
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-7
      */
     public function readCount(): int
     {

--- a/lib/Service/Notification/NotificationsAnnotationInstaller.php
+++ b/lib/Service/Notification/NotificationsAnnotationInstaller.php
@@ -63,6 +63,8 @@ class NotificationsAnnotationInstaller implements IEventListener
      * @param Event $event The event carrying the saved schema.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-5
      */
     public function handle(Event $event): void
     {
@@ -86,6 +88,8 @@ class NotificationsAnnotationInstaller implements IEventListener
      * @param Schema $schema The schema whose annotations should be installed.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-5
      */
     public function installSchema(Schema $schema): void
     {

--- a/lib/Service/Notification/RateLimiter.php
+++ b/lib/Service/Notification/RateLimiter.php
@@ -129,6 +129,8 @@ class RateLimiter
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-8
      */
     public function tryConsume(string $ruleId, string $recipient, ?array $perRuleOverride=null): bool
     {

--- a/lib/Service/Notification/RecipientResolverInterface.php
+++ b/lib/Service/Notification/RecipientResolverInterface.php
@@ -47,6 +47,8 @@ interface RecipientResolverInterface
      * @param array<string, mixed> $context Trigger-specific extras (action, from, to, aggregation, ...).
      *
      * @return array<int, string> List of Nextcloud uids.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-11
      */
     public function resolve(ObjectEntity $object, array $context): array;
 }//end interface

--- a/lib/Service/Notification/VngNotificatiesEnvelope.php
+++ b/lib/Service/Notification/VngNotificatiesEnvelope.php
@@ -87,6 +87,8 @@ class VngNotificatiesEnvelope
      *               aanmaakdatum: string, kenmerken: array}
      *
      * @throws InvalidArgumentException When the action is not a recognised VNG actie.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-10
      */
     public function buildEnvelope(
         string $action,
@@ -127,6 +129,8 @@ class VngNotificatiesEnvelope
      * @return string The VNG actie value.
      *
      * @throws InvalidArgumentException When the action is unrecognised.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-10
      */
     public function mapAction(string $action): string
     {

--- a/lib/Service/Object/BatchOperationStatus.php
+++ b/lib/Service/Object/BatchOperationStatus.php
@@ -111,6 +111,8 @@ class BatchOperationStatus
      * reset; use a fresh instance for a fresh run.
      *
      * @return void
+     *
+     * @spec exclude Boilerplate value-object timing setter; the batch outcome aggregator is anchored to reference-existence-validation at class level.
      */
     public function start(): void
     {
@@ -123,6 +125,8 @@ class BatchOperationStatus
      * Mark the end of the batch.
      *
      * @return void
+     *
+     * @spec exclude Boilerplate value-object timing setter; the batch outcome aggregator is anchored to reference-existence-validation at class level.
      */
     public function complete(): void
     {
@@ -137,6 +141,8 @@ class BatchOperationStatus
      * @param string $uuid UUID of the newly created row.
      *
      * @return void
+     *
+     * @spec exclude Boilerplate value-object outcome recorder; the batch outcome aggregator is anchored to reference-existence-validation at class level.
      */
     public function recordCreated(string $uuid): void
     {
@@ -149,6 +155,8 @@ class BatchOperationStatus
      * @param string $uuid UUID of the updated row.
      *
      * @return void
+     *
+     * @spec exclude Boilerplate value-object outcome recorder; the batch outcome aggregator is anchored to reference-existence-validation at class level.
      */
     public function recordUpdated(string $uuid): void
     {
@@ -161,6 +169,8 @@ class BatchOperationStatus
      * @param string $uuid UUID of the unchanged row.
      *
      * @return void
+     *
+     * @spec exclude Boilerplate value-object outcome recorder; the batch outcome aggregator is anchored to reference-existence-validation at class level.
      */
     public function recordUnchanged(string $uuid): void
     {
@@ -175,6 +185,8 @@ class BatchOperationStatus
      * @param string      $exceptionClass Fully-qualified class name of the exception.
      *
      * @return void
+     *
+     * @spec exclude Boilerplate value-object outcome recorder; the batch outcome aggregator is anchored to reference-existence-validation at class level.
      */
     public function recordFailed(?string $uuid, string $message, string $exceptionClass): void
     {
@@ -191,6 +203,8 @@ class BatchOperationStatus
      * via the request-scoped cache instead of a fresh DB lookup.
      *
      * @return void
+     *
+     * @spec exclude Boilerplate value-object counter; the batch outcome aggregator is anchored to reference-existence-validation at class level.
      */
     public function recordReferenceCacheHit(): void
     {
@@ -201,6 +215,8 @@ class BatchOperationStatus
      * Increment the reference-cache-miss counter (fresh DB lookup).
      *
      * @return void
+     *
+     * @spec exclude Boilerplate value-object counter; the batch outcome aggregator is anchored to reference-existence-validation at class level.
      */
     public function recordReferenceCacheMiss(): void
     {
@@ -291,6 +307,8 @@ class BatchOperationStatus
      * Total number of rows processed (created + updated + unchanged + failed).
      *
      * @return int
+     *
+     * @spec exclude Boilerplate value-object derived accessor; the batch outcome aggregator is anchored to reference-existence-validation at class level.
      */
     public function getProcessedCount(): int
     {
@@ -326,6 +344,8 @@ class BatchOperationStatus
      * been completed yet.
      *
      * @return float|null
+     *
+     * @spec exclude Boilerplate value-object derived accessor; the batch outcome aggregator is anchored to reference-existence-validation at class level.
      */
     public function getDurationSeconds(): ?float
     {
@@ -341,6 +361,8 @@ class BatchOperationStatus
      * responses, log lines, or persistence.
      *
      * @return array<string, mixed>
+     *
+     * @spec exclude Boilerplate value-object serialization; the batch outcome aggregator is anchored to reference-existence-validation at class level.
      */
     public function toArray(): array
     {

--- a/lib/Service/Object/LockHandler.php
+++ b/lib/Service/Object/LockHandler.php
@@ -243,6 +243,8 @@ class LockHandler
      * @param string $identifier Object ID or UUID
      *
      * @return bool True if locked, false otherwise
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-12
      */
     public function isLocked(string $identifier): bool
     {
@@ -289,6 +291,8 @@ class LockHandler
      * @param string $identifier Object ID or UUID
      *
      * @return array|null Lock info array or null if not locked.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-12
      */
     public function getLockInfo(string $identifier): array|null
     {

--- a/lib/Service/Object/MergeHandler.php
+++ b/lib/Service/Object/MergeHandler.php
@@ -88,6 +88,8 @@ class MergeHandler
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Complex merge operation handling files, relations, and references
      * @SuppressWarnings(PHPMD.NPathComplexity)       Multiple merge paths for different data types and actions
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Comprehensive merge requires handling all object aspects
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-13
      */
     public function mergeObjects(string $sourceObjectId, array $mergeData): array
     {

--- a/lib/Service/Object/RenderObject.php
+++ b/lib/Service/Object/RenderObject.php
@@ -482,6 +482,8 @@ class RenderObject
      *
      * Caller must not call this when rows already have full file metadata from
      * renderEntities() — this method overwrites with IDs.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-15
      */
     public function attachLightweightFilesToRows(array &$rows): void
     {

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -4225,6 +4225,8 @@ class SaveObject
      * verdicts leak across logical request boundaries.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-14
      */
     public function clearReferenceValidationCache(): void
     {
@@ -4271,6 +4273,8 @@ class SaveObject
      * @return BatchOperationStatus
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-14
      */
     public function saveObjectsStreaming(
         Register | int | string | null $register,

--- a/lib/Service/Settings/ConfigurationSettingsHandler.php
+++ b/lib/Service/Settings/ConfigurationSettingsHandler.php
@@ -133,6 +133,8 @@ class ConfigurationSettingsHandler
      * Check if multi-tenancy is enabled
      *
      * @return bool True if multi-tenancy is enabled, false otherwise
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-3
      */
     public function isMultiTenancyEnabled(): bool
     {
@@ -630,6 +632,8 @@ class ConfigurationSettingsHandler
      *     auto_publish_objects?: bool,
      *     auto_publish_attachments?: bool
      * }
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-1
      */
     public function updatePublishingOptions(array $options): array
     {
@@ -678,6 +682,8 @@ class ConfigurationSettingsHandler
      *     defaultObjectOwner: ''|mixed, adminOverride: mixed|true},
      *     availableGroups: array<string, string>,
      *     availableUsers: array<string, string>}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-1
      */
     public function getRbacSettingsOnly(): array
     {
@@ -730,6 +736,8 @@ class ConfigurationSettingsHandler
      *     defaultObjectOwner: ''|mixed, adminOverride: mixed|true},
      *     availableGroups: array<string, string>,
      *     availableUsers: array<string, string>}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-1
      */
     public function updateRbacSettingsOnly(array $rbacData): array
     {
@@ -765,6 +773,8 @@ class ConfigurationSettingsHandler
      *     default_organisation: mixed|null,
      *     auto_create_default_organisation: mixed|true
      * }}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-1
      */
     public function getOrganisationSettingsOnly(): array
     {
@@ -808,6 +818,8 @@ class ConfigurationSettingsHandler
      *     default_organisation: mixed|null,
      *     auto_create_default_organisation: mixed|true
      * }}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-1
      */
     public function updateOrganisationSettingsOnly(array $organisationData): array
     {
@@ -831,6 +843,8 @@ class ConfigurationSettingsHandler
      * Get default organisation UUID from settings
      *
      * @return string|null Default organisation UUID or null if not set
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-3
      */
     public function getDefaultOrganisationUuid(): ?string
     {
@@ -850,6 +864,8 @@ class ConfigurationSettingsHandler
      * Get tenant ID from multitenancy settings
      *
      * @return string|null Tenant ID (default user tenant) or null if not set
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-3
      */
     public function getTenantId(): ?string
     {
@@ -881,6 +897,8 @@ class ConfigurationSettingsHandler
      * @param string|null $uuid Default organisation UUID
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-3
      */
     public function setDefaultOrganisationUuid(?string $uuid): void
     {
@@ -911,6 +929,8 @@ class ConfigurationSettingsHandler
      * @psalm-return array{multitenancy: array{enabled: false|mixed,
      *     defaultUserTenant: ''|mixed, defaultObjectTenant: ''|mixed,
      *     adminOverride: mixed|true}, availableTenants: array}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-1
      */
     public function getMultitenancySettingsOnly(): array
     {
@@ -957,6 +977,8 @@ class ConfigurationSettingsHandler
      * @throws \RuntimeException If Multitenancy settings update fails
      *
      * @return array Updated multitenancy config with settings and available tenants.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-1
      */
     public function updateMultitenancySettingsOnly(array $multitenancyData): array
     {
@@ -993,6 +1015,8 @@ class ConfigurationSettingsHandler
      * @SuppressWarnings(PHPMD.NPathComplexity)
      *     Default configuration structure requires comprehensive initialization
      *     Nested else branches handle optional vector config backward compatibility
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-1
      */
     public function getLLMSettingsOnly(): array
     {
@@ -1074,6 +1098,8 @@ class ConfigurationSettingsHandler
      * @return array Updated LLM config with providers and their configurations.
      *
      * @SuppressWarnings(PHPMD.NPathComplexity) PATCH behavior requires merging multiple nested configuration structures
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-1
      */
     public function updateLLMSettingsOnly(array $llmData): array
     {
@@ -1135,6 +1161,8 @@ class ConfigurationSettingsHandler
      * @throws \RuntimeException If File Management settings retrieval fails
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Comprehensive file settings require many default configuration values
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-1
      */
     public function getFileSettingsOnly(): array
     {
@@ -1210,6 +1238,8 @@ class ConfigurationSettingsHandler
      *     dolphinApiEndpoint: ''|mixed, dolphinApiKey: ''|mixed}
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Comprehensive file settings require many configuration fields
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-1
      */
     public function updateFileSettingsOnly(array $fileData): array
     {
@@ -1268,6 +1298,8 @@ class ConfigurationSettingsHandler
      * @return array n8n configuration.
      *
      * @throws \RuntimeException If n8n settings retrieval fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-1
      */
     public function getN8nSettingsOnly(): array
     {
@@ -1302,6 +1334,8 @@ class ConfigurationSettingsHandler
      * @throws \RuntimeException If n8n settings update fails.
      *
      * @psalm-return array{enabled: false|mixed, url: ''|mixed, apiKey: ''|mixed, project: 'openregister'|mixed}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-1
      */
     public function updateN8nSettingsOnly(array $n8nData): array
     {
@@ -1326,6 +1360,8 @@ class ConfigurationSettingsHandler
      * Returns version and build information for the application.
      *
      * @return array Version info with name, version, description, author, licence, timestamp, and date.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-2
      */
     public function getVersionInfoOnly(): array
     {

--- a/lib/Service/Settings/FileSettingsHandler.php
+++ b/lib/Service/Settings/FileSettingsHandler.php
@@ -82,6 +82,8 @@ class FileSettingsHandler
      * @return array File management configuration.
      *
      * @throws \RuntimeException If File Management settings retrieval fails.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-1
      */
     public function getFileSettingsOnly(): array
     {
@@ -156,6 +158,8 @@ class FileSettingsHandler
      *     textExtractor: 'llphant'|mixed, extractionMode: 'background'|mixed,
      *     maxFileSize: 100|mixed, batchSize: 10|mixed,
      *     dolphinApiEndpoint: ''|mixed, dolphinApiKey: ''|mixed}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-1
      */
     public function updateFileSettingsOnly(array $fileData): array
     {

--- a/lib/Service/Settings/SolrSettingsHandler.php
+++ b/lib/Service/Settings/SolrSettingsHandler.php
@@ -179,6 +179,8 @@ class SolrSettingsHandler
      * @deprecated This method is deprecated. Use IndexService->warmupIndex() directly via controller.
      * This method is kept for backward compatibility but should not be used.
      * The controller now uses IndexService directly to avoid circular dependencies.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-4
      */
     public function warmupSolrIndex()
     {
@@ -201,6 +203,8 @@ class SolrSettingsHandler
      * @throws \RuntimeException If SOLR statistics retrieval fails.
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Comprehensive dashboard requires complete statistics structure
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-4
      */
     public function getSolrDashboardStats(): array
     {
@@ -452,6 +456,8 @@ class SolrSettingsHandler
      *     fileCollection: mixed|null}
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) SOLR configuration requires many settings fields
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-4
      */
     public function getSolrSettingsOnly(): array
     {
@@ -576,6 +582,8 @@ class SolrSettingsHandler
      * @return array Backend configuration with 'active' key
      *
      * @throws \RuntimeException If backend configuration retrieval fails
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-4
      */
     public function getSearchBackendConfig(): array
     {
@@ -608,6 +616,8 @@ class SolrSettingsHandler
      * @throws \RuntimeException If backend configuration update fails
      *
      * @psalm-return array{active: string, available: list{'solr', 'elasticsearch'}, updated: int<1, max>}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-4
      */
     public function updateSearchBackendConfig(string $backend): array
     {
@@ -655,6 +665,8 @@ class SolrSettingsHandler
      * @throws \RuntimeException If facet configuration retrieval fails
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Default configuration structure requires comprehensive initialization
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-4
      */
     public function getSolrFacetConfiguration(): array
     {
@@ -711,6 +723,8 @@ class SolrSettingsHandler
      * @throws \RuntimeException If facet configuration update fails.
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Facet configuration validation requires multiple checks
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md#task-4
      */
     public function updateSolrFacetConfiguration(array $facetConfig): array
     {

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid1/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid1/proposal.md
@@ -1,0 +1,76 @@
+# Proposal: Reverse-spec a mid-cluster of Service settings/notification/object methods
+
+## Why
+
+A coverage scan flagged 62 uncovered public methods across three
+`lib/Service/` sub-trees — `Settings/`, `Notification/`, and `Object/`.
+Almost all of them implement behaviors that already-shipped capabilities
+describe: the settings handlers are the typed per-domain persistence the
+`settings-management` capability specifies; the notification primitives
+(digest, read-state, rate limiter, coalescer, VNG envelope, recipient
+resolver, annotation dispatcher/validator/installer) are the delivery and
+governance layer the `notificatie-engine` capability already enumerates;
+the streaming bulk-upsert and reference-cache reset belong to
+`reference-existence-validation`; and the lightweight `@self.files` row
+attachment belongs to `files-render-extension`. Two object behaviors have
+no owning requirement yet — the object **locking** state contract
+(`isLocked` / `getLockInfo`, companions to the already-annotated
+`lockObject` / `unlock`) and object **merge/deduplication**
+(`MergeHandler::mergeObjects`).
+
+This is a reverse-spec retrofit: it documents observed behavior of
+already-shipped code without changing it. It annotates the 62 methods —
+extending `object-lifecycle` with two new requirements for locking and
+merge, and pointing the rest at the existing capabilities — and excludes
+the pure value-object accessors of `BatchOperationStatus` as boilerplate.
+
+## What Changes
+
+- **MODIFY** capability `object-lifecycle`: add REQ-011 (object locking
+  state contract) and REQ-012 (object merge / deduplication).
+- Annotate 51 methods with `@spec` pointers to this change's tasks,
+  grouped by capability: `settings-management` (sliced per-domain
+  get/update, environment introspection, multitenancy/organisation
+  defaults, search-backend + SOLR config), `notificatie-engine`
+  (dispatch, annotation validation/install, digest, read-state, rate
+  limiting, coalescing, VNG envelope, recipient resolution),
+  `object-lifecycle` (locking, merge), `reference-existence-validation`
+  (streaming bulk-upsert + request-scope cache reset), and
+  `files-render-extension` (lightweight `@self.files` list-row attach).
+- **EXCLUDE** the 11 `BatchOperationStatus` value-object methods as
+  boilerplate DTO accessors (`@spec exclude`) — the class itself is
+  already anchored to `reference-existence-validation`.
+- No production code behavior changes — annotations and documentation only.
+
+## Counts
+
+- Methods in batch: 62
+- Spec'd (annotated against a requirement): 51
+- Excluded as boilerplate: 11
+- New requirements: 2 (`object-lifecycle` REQ-011, REQ-012)
+
+## Impact
+
+- Affected specs: `object-lifecycle` (2 new requirements).
+- Capabilities referenced for annotation (no spec change):
+  `settings-management`, `notificatie-engine`,
+  `reference-existence-validation`, `files-render-extension`.
+- Affected code (annotations only):
+  - `lib/Service/Settings/ConfigurationSettingsHandler.php`
+  - `lib/Service/Settings/FileSettingsHandler.php`
+  - `lib/Service/Settings/SolrSettingsHandler.php`
+  - `lib/Service/Notification/AnnotationNotificationDispatcher.php`
+  - `lib/Service/Notification/NotificationAnnotationValidator.php`
+  - `lib/Service/Notification/NotificationsAnnotationInstaller.php`
+  - `lib/Service/Notification/NotificationCoalescer.php`
+  - `lib/Service/Notification/NotificationDigest.php`
+  - `lib/Service/Notification/NotificationReadState.php`
+  - `lib/Service/Notification/RateLimiter.php`
+  - `lib/Service/Notification/RecipientResolverInterface.php`
+  - `lib/Service/Notification/VngNotificatiesEnvelope.php`
+  - `lib/Service/Object/BatchOperationStatus.php` (excludes)
+  - `lib/Service/Object/LockHandler.php`
+  - `lib/Service/Object/MergeHandler.php`
+  - `lib/Service/Object/RenderObject.php`
+  - `lib/Service/Object/SaveObject.php`
+- No migrations, no API changes, no behavioral change.

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid1/specs/object-lifecycle/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid1/specs/object-lifecycle/spec.md
@@ -1,0 +1,54 @@
+---
+retrofit: true
+---
+
+# Object Lifecycle
+
+## Why
+
+Two object-management behaviors implemented in the `Service\Object` handler layer have no owning requirement. Object **locking** is referenced by other capabilities (content-versioning rollback refuses to revert a locked object) but the lock-state contract itself — how lock presence is determined, how expiry is honored, and what lock metadata is exposed — is unspecified; the write side (`LockHandler::lockObject` / `unlock`) carries only a change-tasks annotation. Object **merge / deduplication** (`MergeHandler::mergeObjects`) — folding a duplicate source object into a target, transferring its files, relations, and inbound references, then soft-deleting the source — is entirely unspecified. This change retroactively documents both observed behaviors so the handler contracts are anchored.
+
+## ADDED Requirements
+
+### Requirement: REQ-011 Objects MUST expose an expiry-aware lock-state contract
+MUST report whether an object is currently locked, treating an expired lock as unlocked, and MUST expose the lock's metadata (who locked it, when, optional process identifier, and expiry) when a live lock is present.
+
+`LockHandler::isLocked()` MUST resolve the object by id or UUID, read its `locked` metadata, and return `false` when no lock metadata is present. When lock metadata carries an `expiresAt` timestamp that is in the past, `isLocked()` MUST treat the lock as expired and return `false`. `getLockInfo()` MUST return `null` when the object is not locked and otherwise MUST return a normalized array exposing `locked_at`, `locked_by`, `process`, and `expires_at`. Both reads MUST be defensive: a lookup failure MUST be logged and degrade to "not locked" (`false` / `null`) rather than propagating an exception, so a read-side lock probe never breaks the calling flow.
+
+#### Scenario: Active lock is reported as locked
+- **GIVEN** an object whose `locked` metadata has no `expiresAt` or an `expiresAt` in the future
+- **WHEN** `isLocked()` is called with its identifier
+- **THEN** it MUST return `true`
+- **AND** `getLockInfo()` MUST return an array with `locked_by`, `locked_at`, `process`, and `expires_at` keys sourced from the metadata
+
+#### Scenario: Expired lock is reported as unlocked
+- **GIVEN** an object whose `locked.expiresAt` is in the past
+- **WHEN** `isLocked()` is called
+- **THEN** it MUST return `false`
+
+#### Scenario: Lookup failure degrades to not-locked
+- **GIVEN** the object cannot be resolved (lookup throws)
+- **WHEN** `isLocked()` or `getLockInfo()` is called
+- **THEN** the failure MUST be logged
+- **AND** `isLocked()` MUST return `false` and `getLockInfo()` MUST return `null` rather than throwing
+
+### Requirement: REQ-012 The system MUST support merging a duplicate object into a target within the same register and schema
+MUST merge a source object into a target object — applying property overrides, transferring or deleting the source's files, transferring or dropping its relations, updating inbound references from other objects, and soft-deleting the source — while rejecting merges across mismatched register or schema, and MUST return a structured report of the actions taken.
+
+`MergeHandler::mergeObjects()` MUST require a non-empty target identifier and MUST throw an `InvalidArgumentException` when it is missing. It MUST resolve both source and target across all magic-table sources, throwing a not-found exception when either cannot be located. It MUST reject the merge with an `InvalidArgumentException` when the source and target belong to a different register or a different schema. Merge behavior MUST be configurable per call: `fileAction` of `transfer` (default) or `delete`, `relationAction` of `transfer` (default) or `drop`, and a reference action governing how inbound references to the source are rewritten to the target. After applying property overrides and the configured file/relation/reference handling, the source object MUST be soft-deleted. The method MUST return a merge report containing the original source and target, the merged result, the per-category actions taken, aggregate statistics (properties changed, files transferred/deleted, relations transferred/dropped, references updated), and any warnings or errors — rather than throwing on partial, recoverable problems.
+
+#### Scenario: Merge requires a target
+- **GIVEN** a merge request with no `target`
+- **WHEN** `mergeObjects()` is called
+- **THEN** it MUST throw an `InvalidArgumentException` before resolving any object
+
+#### Scenario: Cross-register or cross-schema merge is rejected
+- **GIVEN** a source and target object that belong to different registers (or different schemas)
+- **WHEN** `mergeObjects()` is called
+- **THEN** it MUST throw an `InvalidArgumentException` and MUST NOT soft-delete the source
+
+#### Scenario: Successful merge transfers and soft-deletes the source
+- **GIVEN** a source and target in the same register and schema, with `fileAction: transfer` and `relationAction: transfer`
+- **WHEN** `mergeObjects()` is called with property overrides
+- **THEN** the target MUST receive the property overrides, the source's files and relations MUST be transferred, inbound references MUST be rewritten to the target, and the source MUST be soft-deleted
+- **AND** the returned report MUST include the merged object and statistics for the actions taken

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid1/tasks.md
@@ -1,0 +1,35 @@
+# Tasks
+
+## Settings (settings-management)
+
+- [x] task-1: settings-management — sliced typed per-domain get/update persisted as JSON in IAppConfig (ConfigurationSettingsHandler get/updateRbacSettingsOnly, get/updateOrganisationSettingsOnly, get/updateMultitenancySettingsOnly, get/updateLLMSettingsOnly, get/updateFileSettingsOnly, get/updateN8nSettingsOnly, updatePublishingOptions; FileSettingsHandler get/updateFileSettingsOnly) (retroactive annotation)
+- [x] task-2: settings-management — environment / version introspection (ConfigurationSettingsHandler::getVersionInfoOnly) (retroactive annotation)
+- [x] task-3: settings-management — multitenancy / organisation default reads and writes through the settings layer (ConfigurationSettingsHandler::isMultiTenancyEnabled, getTenantId, getDefaultOrganisationUuid, setDefaultOrganisationUuid) (retroactive annotation)
+- [x] task-4: settings-management — search-backend + SOLR sliced config, bootstrap-safe search-backend read, dashboard stats, facet config, and index warmup (SolrSettingsHandler::getSolrSettingsOnly, getSearchBackendConfig, updateSearchBackendConfig, getSolrFacetConfiguration, updateSolrFacetConfiguration, getSolrDashboardStats, warmupSolrIndex) (retroactive annotation)
+
+## Notification (notificatie-engine)
+
+- [x] task-5: notificatie-engine — schema-declared notification-rule dispatch, annotation shape validation, and persistent-webhook install (AnnotationNotificationDispatcher::dispatch, NotificationAnnotationValidator::validate, NotificationsAnnotationInstaller::handle, NotificationsAnnotationInstaller::installSchema) (retroactive annotation)
+- [x] task-6: notificatie-engine — per-recipient digest batching primitive (NotificationDigest::enqueue, flush, pendingCount, recipientCount, totalPending) (retroactive annotation)
+- [x] task-7: notificatie-engine — per-user-per-notification read/unread tracking (NotificationReadState::markRead, markUnread, readCount) (retroactive annotation)
+- [x] task-8: notificatie-engine — per-(rule,recipient) token-bucket rate limiting (RateLimiter::tryConsume) (retroactive annotation)
+- [x] task-9: notificatie-engine — per-(rule,recipient) coalescing / grouping to reduce noise (NotificationCoalescer::shouldDispatch, inspect) (retroactive annotation)
+- [x] task-10: notificatie-engine — VNG Notificaties API envelope mapping (VngNotificatiesEnvelope::buildEnvelope, mapAction) (retroactive annotation)
+- [x] task-11: notificatie-engine — pluggable dynamic recipient resolution contract (RecipientResolverInterface::resolve) (retroactive annotation)
+
+## Object lifecycle
+
+- [x] task-12: object-lifecycle#REQ-011 — object locking state contract: lock presence and expiry-aware lock-info reads (LockHandler::isLocked, getLockInfo) (NEW requirement)
+- [x] task-13: object-lifecycle#REQ-012 — object merge / deduplication: same-register/schema property, file, relation, and reference transfer with source soft-delete (MergeHandler::mergeObjects) (NEW requirement)
+
+## Reference-existence-validation
+
+- [x] task-14: reference-existence-validation — streaming bulk-upsert primitive engaging the request-scoped reference-existence cache, plus the cache reset for long-running CLI processes (SaveObject::saveObjectsStreaming, SaveObject::clearReferenceValidationCache) (retroactive annotation)
+
+## Files-render-extension
+
+- [x] task-15: files-render-extension — lightweight `@self.files` file-ID list attached to un-rendered list rows via a single batched lookup (RenderObject::attachLightweightFilesToRows) (retroactive annotation)
+
+## Dropped / excluded (boilerplate)
+
+- EXCLUDE: `BatchOperationStatus` — pure in-memory value object whose `start`, `complete`, `recordCreated`, `recordUpdated`, `recordUnchanged`, `recordFailed`, `recordReferenceCacheHit`, `recordReferenceCacheMiss`, `getProcessedCount`, `getDurationSeconds`, and `toArray` are trivial counter/accessor/serialization boilerplate. The class concept (batch outcome aggregation for the streaming upsert) is already anchored to `reference-existence-validation`; per-method annotations would be noise. Tagged `@spec exclude`.


### PR DESCRIPTION
## Summary
Reverse-spec retrofit of 62 uncovered public methods across `lib/Service/Settings/`, `lib/Service/Notification/`, and `lib/Service/Object/`. Documentation/annotations only — no production behavior change.

- **51 spec'd**: anchored to existing capabilities — `settings-management` (sliced per-domain get/update, version/env introspection, multitenancy/organisation defaults, search-backend + SOLR config), `notificatie-engine` (dispatch, annotation validation/install, digest, read-state, rate limiting, coalescing, VNG envelope, recipient resolution), `reference-existence-validation` (streaming bulk-upsert + request-scope cache reset), `files-render-extension` (lightweight `@self.files` list-row attach).
- **11 excluded**: `BatchOperationStatus` value-object accessors tagged `@spec exclude` as boilerplate (the class is already anchored to `reference-existence-validation`).
- **2 new requirements** on `object-lifecycle`: REQ-011 (expiry-aware object locking state contract) and REQ-012 (object merge / deduplication) — the two behaviors with no owning requirement.

Ghost change: `openspec/changes/retrofit-2026-05-25-bw-svc-mid1/` (proposal, tasks, object-lifecycle delta). Validates `--strict`.

## Test plan
- [x] `openspec validate --type change retrofit-2026-05-25-bw-svc-mid1 --strict` passes
- [x] `php -l` clean on all 17 touched source files
- [x] All 62 batch methods carry an `@spec` (51) or `@spec exclude` (11) annotation