### PR TITLE
retrofit: backend coverage — Service/Index (reverse-spec + @spec exclude)

### DIFF
--- a/lib/Service/Index/Backends/Elasticsearch/ElasticsearchDocumentIndexer.php
+++ b/lib/Service/Index/Backends/Elasticsearch/ElasticsearchDocumentIndexer.php
@@ -90,6 +90,8 @@ class ElasticsearchDocumentIndexer
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec exclude thin delegation to ElasticsearchHttpClient — builds doc and PUTs it to ES
      */
     public function indexObject(ObjectEntity $object, bool $refresh=false): bool
     {
@@ -154,6 +156,8 @@ class ElasticsearchDocumentIndexer
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Complex multi-step bulk indexing process
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Bulk indexing requires handling multiple object and error scenarios
      * @SuppressWarnings(PHPMD.NPathComplexity)       Multiple paths for document building and indexing results
+     *
+     * @spec exclude thin delegation to ElasticsearchHttpClient — builds ndjson bulk body and POSTs it
      */
     public function bulkIndexObjects(array $objects, bool $refresh=false): array
     {
@@ -276,6 +280,8 @@ class ElasticsearchDocumentIndexer
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec exclude thin delegation to ElasticsearchHttpClient — DELETEs the document by id
      */
     public function deleteObject(string|int $objectId, bool $refresh=false): bool
     {
@@ -322,6 +328,8 @@ class ElasticsearchDocumentIndexer
      * Clear all documents from index.
      *
      * @return bool True if successful
+     *
+     * @spec exclude thin delegation to ElasticsearchIndexManager — delete-and-recreate index
      */
     public function clearIndex(): bool
     {

--- a/lib/Service/Index/Backends/Elasticsearch/ElasticsearchHttpClient.php
+++ b/lib/Service/Index/Backends/Elasticsearch/ElasticsearchHttpClient.php
@@ -120,6 +120,8 @@ class ElasticsearchHttpClient
      * Build Elasticsearch base URL.
      *
      * @return string Base URL
+     *
+     * @spec exclude boilerplate URL builder — scheme/host/port concatenation
      */
     public function buildBaseUrl(): string
     {
@@ -149,6 +151,8 @@ class ElasticsearchHttpClient
      * @param string $url The URL to request.
      *
      * @return array Response data
+     *
+     * @spec exclude thin Guzzle GET wrapper — request/json-decode/log-and-rethrow
      */
     public function get(string $url): array
     {
@@ -182,6 +186,8 @@ class ElasticsearchHttpClient
      * @param array  $data The data to send as JSON.
      *
      * @return array Response data
+     *
+     * @spec exclude thin Guzzle POST wrapper — request/json-decode/log-and-rethrow
      */
     public function post(string $url, array $data): array
     {
@@ -220,6 +226,8 @@ class ElasticsearchHttpClient
      * @param string $data The raw data to send.
      *
      * @return array Response data
+     *
+     * @spec exclude thin Guzzle POST wrapper — ndjson bulk body/json-decode/log-and-rethrow
      */
     public function postRaw(string $url, string $data): array
     {
@@ -261,6 +269,8 @@ class ElasticsearchHttpClient
      * @param array  $data The data to send as JSON.
      *
      * @return array Response data
+     *
+     * @spec exclude thin Guzzle PUT wrapper — request/json-decode/log-and-rethrow
      */
     public function put(string $url, array $data): array
     {
@@ -298,6 +308,8 @@ class ElasticsearchHttpClient
      * @param string $url The URL to request.
      *
      * @return array Response data
+     *
+     * @spec exclude thin Guzzle DELETE wrapper — request/json-decode/log-and-rethrow
      */
     public function delete(string $url): array
     {

--- a/lib/Service/Index/Backends/Elasticsearch/ElasticsearchIndexManager.php
+++ b/lib/Service/Index/Backends/Elasticsearch/ElasticsearchIndexManager.php
@@ -71,6 +71,8 @@ class ElasticsearchIndexManager
      * @param string $indexName The index name to check.
      *
      * @return bool True if index exists
+     *
+     * @spec exclude thin delegation to ElasticsearchHttpClient — GET index, no error means exists
      */
     public function indexExists(string $indexName): bool
     {
@@ -91,6 +93,8 @@ class ElasticsearchIndexManager
      * @param array  $mapping   Index mapping configuration (default: empty array).
      *
      * @return bool True on success
+     *
+     * @spec exclude thin delegation to ElasticsearchHttpClient — PUTs index settings/mappings
      */
     public function createIndex(string $indexName, array $mapping=[]): bool
     {
@@ -144,6 +148,8 @@ class ElasticsearchIndexManager
      * @param string $indexName The index name to delete.
      *
      * @return bool True on success
+     *
+     * @spec exclude thin delegation to ElasticsearchHttpClient — DELETEs the index
      */
     public function deleteIndex(string $indexName): bool
     {
@@ -185,6 +191,8 @@ class ElasticsearchIndexManager
      * @param string $indexName The index name to ensure exists.
      *
      * @return bool True on success
+     *
+     * @spec exclude thin helper — checks indexExists then createIndex
      */
     public function ensureIndex(string $indexName): bool
     {
@@ -219,6 +227,8 @@ class ElasticsearchIndexManager
      * @param string $indexName Index name
      *
      * @return array Index statistics
+     *
+     * @spec exclude thin delegation to ElasticsearchHttpClient — GETs /_stats
      */
     public function getIndexStats(string $indexName): array
     {
@@ -245,6 +255,8 @@ class ElasticsearchIndexManager
      * @param string $indexName Index name
      *
      * @return bool True on success
+     *
+     * @spec exclude thin delegation to ElasticsearchHttpClient — POSTs /_refresh
      */
     public function refreshIndex(string $indexName): bool
     {

--- a/lib/Service/Index/Backends/Elasticsearch/ElasticsearchQueryExecutor.php
+++ b/lib/Service/Index/Backends/Elasticsearch/ElasticsearchQueryExecutor.php
@@ -75,6 +75,8 @@ class ElasticsearchQueryExecutor
      * @param array $query Query parameters
      *
      * @return array Search results
+     *
+     * @spec exclude thin delegation to ElasticsearchHttpClient — builds ES query DSL and POSTs /_search
      */
     public function search(array $query): array
     {
@@ -167,6 +169,8 @@ class ElasticsearchQueryExecutor
      * Get document count.
      *
      * @return int Number of documents
+     *
+     * @spec exclude thin delegation to ElasticsearchHttpClient — GETs /_count
      */
     public function getDocumentCount(): int
     {

--- a/lib/Service/Index/Backends/ElasticsearchBackend.php
+++ b/lib/Service/Index/Backends/ElasticsearchBackend.php
@@ -108,6 +108,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @return bool True on success, false on failure
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude facade delegation to ElasticsearchDocumentIndexer::indexObject
      */
     public function indexObject(ObjectEntity $object, bool $commit=false): bool
     {
@@ -125,6 +127,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @psalm-return array{success: bool, indexed: int<0, max>, failed: int, error?: string}
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude facade delegation to ElasticsearchDocumentIndexer::bulkIndexObjects
      */
     public function bulkIndexObjects(array $objects, bool $commit=false): array
     {
@@ -140,6 +144,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @return bool True on success, false on failure
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude facade delegation to ElasticsearchDocumentIndexer::deleteObject
      */
     public function deleteObject(string|int $objectId, bool $commit=false): bool
     {
@@ -158,6 +164,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @psalm-return array{deleted: 0}|true
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude simplified stub — returns success without deleting (not yet implemented)
      */
     public function deleteByQuery(string $query, bool $commit=false, bool $returnDetails=false): array|bool
     {
@@ -225,6 +233,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * Commit changes (refresh index).
      *
      * @return bool True on success, false on failure
+     *
+     * @spec exclude facade delegation to ElasticsearchIndexManager::refreshIndex
      */
     public function commit(): bool
     {
@@ -239,6 +249,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @param array $params The search parameters
      *
      * @return array Search results
+     *
+     * @spec exclude facade delegation to ElasticsearchQueryExecutor::search
      */
     public function search(array $params): array
     {
@@ -255,6 +267,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @return (int|string|true)[] Reindexing results
      *
      * @psalm-return array{success: true, indexed: 0, message: 'Reindexing should be called via IndexService'}
+     *
+     * @spec exclude stub — defers reindex to IndexService; returns a static message
      */
     public function reindexAll(int $maxObjects=0, int $batchSize=1000, ?string $collectionName=null): array
     {
@@ -285,6 +299,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @psalm-return array{success: true, index: string, message: 'Index warmed up'}
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude facade — ensures the active index exists via ElasticsearchIndexManager
      */
     public function warmupIndex(
         array $schemas=[],
@@ -328,6 +344,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @psalm-return array{success: bool, error?: string, document_count?: int}
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude facade — probes connectivity via a document-count request
      */
     public function testConnection(bool $inclCollTests=true): array
     {
@@ -349,6 +367,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * Optimize index.
      *
      * @return true True on success
+     *
+     * @spec exclude no-op — Elasticsearch needs no manual optimization (returns true)
      */
     public function optimize(): bool
     {
@@ -364,6 +384,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @return int[] Clear operation results
      *
      * @psalm-return array{deleted: 0}
+     *
+     * @spec exclude facade delegation to ElasticsearchDocumentIndexer::clearIndex
      */
     public function clearIndex(?string $collectionName=null): array
     {
@@ -389,6 +411,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @return (int|string)[] Backend statistics
      *
      * @psalm-return array{document_count: int, backend: 'elasticsearch'}
+     *
+     * @spec exclude boilerplate stats — returns document count and backend label
      */
     public function getStats(): array
     {
@@ -407,6 +431,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @return bool[] Creation results
      *
      * @psalm-return array{success: bool}
+     *
+     * @spec exclude facade delegation to ElasticsearchIndexManager::createIndex
      */
     public function createCollection(string $name, array $config=[]): array
     {
@@ -422,6 +448,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @return bool[] Deletion results
      *
      * @psalm-return array{success: bool}
+     *
+     * @spec exclude facade delegation to ElasticsearchIndexManager::deleteIndex
      */
     public function deleteCollection(?string $collectionName=null): array
     {
@@ -436,6 +464,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @param string $collectionName Collection name to check
      *
      * @return bool True if collection exists
+     *
+     * @spec exclude facade delegation to ElasticsearchIndexManager::indexExists
      */
     public function collectionExists(string $collectionName): bool
     {
@@ -448,6 +478,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @return string[] List of collection names
      *
      * @psalm-return list{string}
+     *
+     * @spec exclude simplified stub — returns only the active index name
      */
     public function listCollections(): array
     {
@@ -461,6 +493,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @param array $documents Documents to index
      *
      * @return true True on success
+     *
+     * @spec exclude simplified stub — logs document count and returns true (not yet implemented)
      */
     public function index(array $documents): bool
     {
@@ -486,6 +520,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @param \OCA\OpenRegister\Service\Aggregation\AggregationQuery $query Portable aggregation request.
      *
      * @return array|null The aggregation result, or null when the backend cannot execute it.
+     *
+     * @spec exclude stub — returns null so caller falls back to PHP path (HTTP adapter not yet wired)
      */
     public function aggregate(\OCA\OpenRegister\Service\Aggregation\AggregationQuery $query): ?array
     {
@@ -517,6 +553,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @param array  $fieldType  Field type configuration
      *
      * @return true True on success
+     *
+     * @spec exclude no-op stub — ES infers field types dynamically (returns true)
      */
     public function addFieldType(string $collection, array $fieldType): bool
     {
@@ -546,6 +584,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @return string Status message
      *
      * @psalm-return 'skipped'
+     *
+     * @spec exclude no-op stub — ES infers field mappings dynamically (returns 'skipped')
      */
     public function addOrUpdateField(array $fieldConfig, bool $force): string
     {
@@ -559,6 +599,8 @@ class ElasticsearchBackend implements SearchBackendInterface
      * @param string|null $collectionName Optional collection name.
      *
      * @return array Indexing results.
+     *
+     * @spec exclude stub — returns empty result shape; file indexing handled by FileHandler (REQ-8)
      */
     public function indexFiles(array $fileIds, ?string $collectionName=null): array
     {

--- a/lib/Service/Index/Backends/Solr/SolrCollectionManager.php
+++ b/lib/Service/Index/Backends/Solr/SolrCollectionManager.php
@@ -110,6 +110,8 @@ class SolrCollectionManager
      * Returns tenant-specific collection if it exists, otherwise null.
      *
      * @return string|null Collection name or null
+     *
+     * @spec exclude boilerplate accessor — resolves active collection via existence check
      */
     public function getActiveCollectionName(): ?string
     {
@@ -146,6 +148,8 @@ class SolrCollectionManager
      * @psalm-return array{success: true,
      *     message: 'Collection created successfully', collection: string,
      *     configSet: 'openregister_configset'|mixed}
+     *
+     * @spec exclude thin delegation to Solr Collections API — CREATE action HTTP call
      */
     public function createCollection(string $name, array $config=[]): array
     {
@@ -214,6 +218,8 @@ class SolrCollectionManager
      * @return (bool|string)[]
      *
      * @psalm-return array{success: bool, message: string, exception?: string, collection?: string}
+     *
+     * @spec exclude thin delegation to Solr Collections API — DELETE action HTTP call
      */
     public function deleteCollection(?string $collectionName=null): array
     {
@@ -295,6 +301,8 @@ class SolrCollectionManager
      * List all Solr collections.
      *
      * @return array List of collections
+     *
+     * @spec exclude thin delegation to Solr Collections API — LIST action HTTP call
      */
     public function listCollections(): array
     {
@@ -320,6 +328,8 @@ class SolrCollectionManager
      * List all ConfigSets.
      *
      * @return array List of ConfigSets
+     *
+     * @spec exclude thin delegation to Solr Configs API — LIST action HTTP call
      */
     public function listConfigSets(): array
     {
@@ -353,6 +363,8 @@ class SolrCollectionManager
      *     message: 'ConfigSet created successfully'|
      *     'Exception during ConfigSet creation'|
      *     'Failed to create ConfigSet'|mixed, exception?: string, name?: string}
+     *
+     * @spec exclude thin delegation to Solr Configs API — CREATE action HTTP call
      */
     public function createConfigSet(string $name, string $baseConfigSet='_default'): array
     {
@@ -412,6 +424,8 @@ class SolrCollectionManager
      *     message: 'ConfigSet deleted successfully'|
      *     'Exception during ConfigSet deletion'|
      *     'Failed to delete ConfigSet'|mixed, exception?: string, name?: string}
+     *
+     * @spec exclude thin delegation to Solr Configs API — DELETE action HTTP call
      */
     public function deleteConfigSet(string $name): array
     {

--- a/lib/Service/Index/Backends/Solr/SolrDocumentIndexer.php
+++ b/lib/Service/Index/Backends/Solr/SolrDocumentIndexer.php
@@ -99,6 +99,8 @@ class SolrDocumentIndexer
      * @return bool True if successful
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude thin delegation to SolrHttpClient — builds Solr update doc and POSTs it
      */
     public function indexObject(ObjectEntity $object, bool $commit=false): bool
     {

--- a/lib/Service/Index/Backends/Solr/SolrFacetProcessor.php
+++ b/lib/Service/Index/Backends/Solr/SolrFacetProcessor.php
@@ -157,6 +157,8 @@ class SolrFacetProcessor
      * @return (array|int|string)[]
      *
      * @psalm-return array{facet?: 'true', 'facet.field'?: array, 'facet.limit'?: 100}
+     *
+     * @spec exclude boilerplate query-param builder — assembles Solr facet.* params array
      */
     public function buildFacetQuery(array $facetFields): array
     {

--- a/lib/Service/Index/Backends/Solr/SolrHttpClient.php
+++ b/lib/Service/Index/Backends/Solr/SolrHttpClient.php
@@ -131,6 +131,8 @@ class SolrHttpClient
      * Check if Solr is configured.
      *
      * @return bool True if configured
+     *
+     * @spec exclude boilerplate config getter — checks enabled/host/core presence
      */
     public function isConfigured(): bool
     {
@@ -163,6 +165,8 @@ class SolrHttpClient
      * Build base Solr URL.
      *
      * @return string Base Solr URL
+     *
+     * @spec exclude boilerplate URL builder — host/port/path string concatenation
      */
     public function buildSolrBaseUrl(): string
     {
@@ -179,6 +183,8 @@ class SolrHttpClient
      * @param string|null $collection Collection name (null = use default core)
      *
      * @return string Endpoint URL
+     *
+     * @spec exclude boilerplate URL builder — appends collection/core to base URL
      */
     public function getEndpointUrl(?string $collection=null): string
     {
@@ -197,6 +203,8 @@ class SolrHttpClient
      * @return array Response data
      *
      * @throws Exception If request fails
+     *
+     * @spec exclude thin Guzzle GET wrapper — request/json-decode/log-and-rethrow
      */
     public function get(string $url, array $opts=[]): array
     {
@@ -224,6 +232,8 @@ class SolrHttpClient
      * @return array Response data
      *
      * @throws Exception If request fails
+     *
+     * @spec exclude thin Guzzle POST wrapper — request/json-decode/log-and-rethrow
      */
     public function post(string $url, array $data=[], array $opts=[]): array
     {
@@ -250,6 +260,8 @@ class SolrHttpClient
      * @param string $baseCollectionName Base collection name
      *
      * @return string Tenant-specific collection name
+     *
+     * @spec exclude boilerplate config helper — optional tenant prefix from settings
      */
     public function getTenantSpecificCollectionName(string $baseCollectionName): string
     {

--- a/lib/Service/Index/Backends/Solr/SolrQueryExecutor.php
+++ b/lib/Service/Index/Backends/Solr/SolrQueryExecutor.php
@@ -330,6 +330,8 @@ class SolrQueryExecutor
      * @return (bool|int|mixed|null|string)[] Statistics
      *
      * @psalm-return array{available: bool, collection: null|string, error?: string, documents?: 0|mixed, status?: 'OK'}
+     *
+     * @spec exclude thin stats wrapper — runs a rows=0 search and reports numFound
      */
     public function getStats(): array
     {

--- a/lib/Service/Index/Backends/Solr/SolrSchemaManager.php
+++ b/lib/Service/Index/Backends/Solr/SolrSchemaManager.php
@@ -82,6 +82,8 @@ class SolrSchemaManager
      * @param string $collection Collection name
      *
      * @return array Field types indexed by name
+     *
+     * @spec exclude thin delegation to SolrHttpClient — GETs /schema/fieldtypes and indexes by name
      */
     public function getFieldTypes(string $collection): array
     {
@@ -129,6 +131,8 @@ class SolrSchemaManager
      * @param array  $fieldType  Field type definition
      *
      * @return bool True if successful
+     *
+     * @spec exclude thin delegation to SolrHttpClient — POSTs add-field-type command to /schema
      */
     public function addFieldType(string $collection, array $fieldType): bool
     {
@@ -186,6 +190,8 @@ class SolrSchemaManager
      * @param string $collection Collection name
      *
      * @return array Fields indexed by name
+     *
+     * @spec exclude thin delegation to SolrHttpClient — GETs /schema/fields and indexes by name
      */
     public function getFields(string $collection): array
     {
@@ -233,6 +239,8 @@ class SolrSchemaManager
      * @param bool  $force       Force update if exists
      *
      * @return string Action taken ('created', 'updated', 'skipped', 'failed')
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-search-index/tasks.md#task-2
      */
     public function addOrUpdateField(array $fieldConfig, bool $force): string
     {
@@ -377,6 +385,8 @@ class SolrSchemaManager
      * @param string $collection Collection name
      *
      * @return array Schema configuration
+     *
+     * @spec exclude thin delegation to SolrHttpClient — GETs /schema and returns its body
      */
     public function getSchema(string $collection): array
     {

--- a/lib/Service/Index/Backends/SolrBackend.php
+++ b/lib/Service/Index/Backends/SolrBackend.php
@@ -152,6 +152,8 @@ class SolrBackend implements SearchBackendInterface
      *     collection?: null|string, collection_exists?: bool, error?: 'Solr is not configured'}
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude facade — checks isConfigured and active collection presence
      */
     public function testConnection(bool $inclCollTests=true): array
     {
@@ -185,6 +187,8 @@ class SolrBackend implements SearchBackendInterface
      * @return bool True if successful
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude facade delegation to SolrDocumentIndexer::indexObject
      */
     public function indexObject(ObjectEntity $object, bool $commit=false): bool
     {
@@ -205,6 +209,8 @@ class SolrBackend implements SearchBackendInterface
      * @psalm-return array{success: bool, indexed: int<0, max>, failed: int<0, max>, error?: string}
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude facade delegation to SolrDocumentIndexer::bulkIndexObjects
      */
     public function bulkIndexObjects(array $objects, bool $commit=true): array
     {
@@ -223,6 +229,8 @@ class SolrBackend implements SearchBackendInterface
      * @return bool True if successful
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude facade delegation to SolrDocumentIndexer::deleteObject
      */
     public function deleteObject(string|int $objectId, bool $commit=false): bool
     {
@@ -244,6 +252,8 @@ class SolrBackend implements SearchBackendInterface
      * @psalm-return array{success: bool, error?: string, query?: string, result?: array}|bool
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude facade delegation to SolrDocumentIndexer::deleteByQuery
      */
     public function deleteByQuery(string $query, bool $commit=false, bool $returnDetails=false): array|bool
     {
@@ -265,6 +275,8 @@ class SolrBackend implements SearchBackendInterface
      * @return array Search results with pagination info.
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude facade delegation to SolrQueryExecutor::searchPaginated
      */
     public function searchObjectsPaginated(
         array $query=[],
@@ -294,6 +306,8 @@ class SolrBackend implements SearchBackendInterface
      * Commit changes.
      *
      * @return bool True if successful
+     *
+     * @spec exclude facade delegation to SolrDocumentIndexer::commit
      */
     public function commit(): bool
     {
@@ -304,6 +318,8 @@ class SolrBackend implements SearchBackendInterface
      * Optimize the index.
      *
      * @return bool True if successful
+     *
+     * @spec exclude facade delegation to SolrDocumentIndexer::optimize
      */
     public function optimize(): bool
     {
@@ -318,6 +334,8 @@ class SolrBackend implements SearchBackendInterface
      * @return (bool|string)[] Results
      *
      * @psalm-return array{success: bool, message: string, collection?: string}
+     *
+     * @spec exclude facade delegation to SolrDocumentIndexer::clearIndex
      */
     public function clearIndex(?string $collectionName=null): array
     {
@@ -342,6 +360,8 @@ class SolrBackend implements SearchBackendInterface
      * @psalm-return array{success: true, message: 'Simplified warmup - collection exists', collection_exists: bool}
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude simplified stub — returns collection-exists flag; full warmup deferred
      */
     public function warmupIndex(
         array $schemas=[],
@@ -386,6 +406,8 @@ class SolrBackend implements SearchBackendInterface
      * @return (bool|int|mixed|null|string)[] Statistics
      *
      * @psalm-return array{available: bool, collection: null|string, error?: string, documents?: 0|mixed, status?: 'OK'}
+     *
+     * @spec exclude facade delegation to SolrQueryExecutor::getStats
      */
     public function getStats(): array
     {
@@ -399,6 +421,8 @@ class SolrBackend implements SearchBackendInterface
      * @param array  $config Configuration
      *
      * @return array Results with success status and collection info.
+     *
+     * @spec exclude facade delegation to SolrCollectionManager::createCollection
      */
     public function createCollection(string $name, array $config=[]): array
     {
@@ -416,6 +440,8 @@ class SolrBackend implements SearchBackendInterface
      * @return (bool|string)[] Results
      *
      * @psalm-return array{success: bool, message: string, exception?: string, collection?: string}
+     *
+     * @spec exclude facade delegation to SolrCollectionManager::deleteCollection
      */
     public function deleteCollection(?string $collectionName=null): array
     {
@@ -428,6 +454,8 @@ class SolrBackend implements SearchBackendInterface
      * @param string $collectionName Collection name
      *
      * @return bool True if exists
+     *
+     * @spec exclude facade delegation to SolrCollectionManager::collectionExists
      */
     public function collectionExists(string $collectionName): bool
     {
@@ -438,6 +466,8 @@ class SolrBackend implements SearchBackendInterface
      * List all collections.
      *
      * @return array Collection names
+     *
+     * @spec exclude facade delegation to SolrCollectionManager::listCollections
      */
     public function listCollections(): array
     {
@@ -450,6 +480,8 @@ class SolrBackend implements SearchBackendInterface
      * @param array $documents Documents to index
      *
      * @return bool True if successful
+     *
+     * @spec exclude facade delegation to SolrDocumentIndexer::indexDocuments
      */
     public function index(array $documents): bool
     {
@@ -468,6 +500,8 @@ class SolrBackend implements SearchBackendInterface
      * @param \OCA\OpenRegister\Service\Aggregation\AggregationQuery $query Portable aggregation request.
      *
      * @return array|null The aggregation result, or null when the backend cannot execute it.
+     *
+     * @spec exclude stub — returns null so caller falls back to PHP path (HTTP adapter not yet wired)
      */
     public function aggregate(\OCA\OpenRegister\Service\Aggregation\AggregationQuery $query): ?array
     {
@@ -480,6 +514,8 @@ class SolrBackend implements SearchBackendInterface
      * @param array $params Search parameters
      *
      * @return array Search results
+     *
+     * @spec exclude facade delegation to SolrQueryExecutor::search
      */
     public function search(array $params): array
     {
@@ -505,6 +541,8 @@ class SolrBackend implements SearchBackendInterface
      * @param array  $fieldType  Field type definition
      *
      * @return bool True if successful
+     *
+     * @spec exclude facade delegation to SolrSchemaManager::addFieldType
      */
     public function addFieldType(string $collection, array $fieldType): bool
     {
@@ -533,6 +571,8 @@ class SolrBackend implements SearchBackendInterface
      * @param bool  $force       Force update
      *
      * @return string Action taken
+     *
+     * @spec exclude facade delegation to SolrSchemaManager::addOrUpdateField
      */
     public function addOrUpdateField(array $fieldConfig, bool $force): string
     {
@@ -555,6 +595,8 @@ class SolrBackend implements SearchBackendInterface
      * @return (bool|int|string)[]
      *
      * @psalm-return array{success: bool, message: 'Index cleared (simplified reindex)', indexed: 0}
+     *
+     * @spec exclude simplified stub — clears index only; full reindex deferred to IndexService
      */
     public function reindexAll(int $maxObjects=0, int $batchSize=1000, ?string $collectionName=null): array
     {
@@ -613,6 +655,8 @@ class SolrBackend implements SearchBackendInterface
      * @param string|null $collectionName Optional collection name.
      *
      * @return array Indexing results.
+     *
+     * @spec exclude stub — returns empty result shape; file indexing handled by FileHandler (REQ-8)
      */
     public function indexFiles(array $fileIds, ?string $collectionName=null): array
     {
@@ -636,6 +680,8 @@ class SolrBackend implements SearchBackendInterface
      * @param bool  $dryRun           Whether to preview changes only.
      *
      * @return array Results of the fix operation.
+     *
+     * @spec exclude stub — returns empty array; mismatch fixing handled by SchemaHandler (REQ-7)
      */
     public function fixMismatchedFields(array $mismatchedFields, bool $dryRun=false): array
     {

--- a/lib/Service/Index/BulkIndexer.php
+++ b/lib/Service/Index/BulkIndexer.php
@@ -136,6 +136,8 @@ class BulkIndexer
      * @psalm-return array{success: false, message: 'Method not yet extracted to BulkIndexer'}
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude TODO stub returning 'not yet extracted' — implemented path is bulkIndexFromDatabase (REQ-3)
      */
     public function bulkIndexObjects(array $_objects, bool $_commit=true): array
     {

--- a/lib/Service/Index/ConfigurationHandler.php
+++ b/lib/Service/Index/ConfigurationHandler.php
@@ -160,6 +160,8 @@ class ConfigurationHandler
      * Validates that all required configuration parameters are present.
      *
      * @return bool True if Solr is configured, false otherwise.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-search-index/tasks.md#task-4
      */
     public function isSolrConfigured(): bool
     {
@@ -201,6 +203,8 @@ class ConfigurationHandler
      * host, port, and path settings.
      *
      * @return string SOLR base URL.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-search-index/tasks.md#task-4
      */
     public function buildSolrBaseUrl(): string
     {
@@ -267,6 +271,8 @@ class ConfigurationHandler
      * @param string|null $collection Optional collection name.
      *
      * @return string Full endpoint URL.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-search-index/tasks.md#task-4
      */
     public function getEndpointUrl(?string $collection=null): string
     {
@@ -300,6 +306,8 @@ class ConfigurationHandler
      * Get port configuration status.
      *
      * @return string Port status description.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-search-index/tasks.md#task-4
      */
     public function getPortStatus(): string
     {
@@ -316,6 +324,8 @@ class ConfigurationHandler
      * Get core configuration status.
      *
      * @return string Core status description.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-search-index/tasks.md#task-4
      */
     public function getCoreStatus(): string
     {

--- a/lib/Service/Index/DocumentBuilder.php
+++ b/lib/Service/Index/DocumentBuilder.php
@@ -236,6 +236,8 @@ class DocumentBuilder
      * @psalm-return list<mixed|string>
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Files flattening requires handling multiple data formats
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-1
      */
     public function flattenFilesForSolr($files): array
     {
@@ -273,6 +275,8 @@ class DocumentBuilder
      * @param array $object Object/array to extract ID from
      *
      * @return string|null Extracted ID or null if not found
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-1
      */
     public function extractIdFromObject(array $object): ?string
     {
@@ -305,6 +309,8 @@ class DocumentBuilder
      * @psalm-return array<string, array<int, mixed>>
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Dot-notation parsing requires handling multiple scenarios
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-1
      */
     public function extractArraysFromRelations(array $relations): array
     {
@@ -380,6 +386,8 @@ class DocumentBuilder
      * @psalm-return list<string>
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Value extraction requires handling multiple data types
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-1
      */
     public function extractIndexableArrayValues(array $arrayValue, string $fieldName): array
     {
@@ -636,6 +644,8 @@ class DocumentBuilder
      * @return bool True if field is safe to index
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Field validation requires handling multiple type scenarios
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-1
      */
     public function validateFieldForSolr(string $fieldName, $fieldValue, array $solrFieldTypes): bool
     {
@@ -706,6 +716,8 @@ class DocumentBuilder
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Type compatibility check requires handling multiple SOLR types
      * @SuppressWarnings(PHPMD.NPathComplexity)      Multiple type combinations create many execution paths
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-1
      */
     public function isValueCompatibleWithSolrType($value, string $solrFieldType): bool
     {
@@ -764,6 +776,8 @@ class DocumentBuilder
      * @return int The resolved register ID
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Register resolution requires handling multiple input formats
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-1
      */
     public function resolveRegisterToId($registerValue, ?\OCA\OpenRegister\Db\Register $register=null): int
     {
@@ -823,6 +837,8 @@ class DocumentBuilder
      * @return int The resolved schema ID
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Schema resolution requires handling multiple input formats
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-1
      */
     public function resolveSchemaToId($schemaValue, ?\OCA\OpenRegister\Db\Schema $schema=null): int
     {

--- a/lib/Service/Index/FileHandler.php
+++ b/lib/Service/Index/FileHandler.php
@@ -77,6 +77,8 @@ class FileHandler
      * @throws Exception If fileCollection is not configured
      *
      * @psalm-return array{success: bool, indexed: int<0, max>, collection: 'files'}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-3
      */
     public function indexFileChunks(int $fileId, array $chunks, array $metadata): array
     {
@@ -131,6 +133,8 @@ class FileHandler
      * @return array Statistics including document count, collection info
      *
      * @psalm-return array{available: bool, collection?: string, document_count?: int, error?: string}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-3
      */
     public function getFileStats(): array
     {
@@ -178,6 +182,8 @@ class FileHandler
      * @param int|null $limit Maximum number of files to process
      *
      * @return array Result with success status and stats including processed, indexed, failed counts.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-3
      */
     public function processUnindexedChunks(?int $limit=null): array
     {
@@ -283,6 +289,8 @@ class FileHandler
      *
      * @psalm-return array{total_chunks: int, indexed_chunks: int,
      *     unindexed_chunks: int, vectorized_chunks: int}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-3
      */
     public function getChunkingStats(): array
     {
@@ -308,6 +316,8 @@ class FileHandler
      * @param string|null $collectionName Optional collection name.
      *
      * @return array Indexing results.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-3
      */
     public function indexFiles(array $fileIds, ?string $collectionName=null): array
     {
@@ -351,6 +361,8 @@ class FileHandler
      * Returns statistics about indexed files.
      *
      * @return array File indexing statistics.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-3
      */
     public function getFileIndexStats(): array
     {

--- a/lib/Service/Index/SchemaHandler.php
+++ b/lib/Service/Index/SchemaHandler.php
@@ -71,6 +71,8 @@ class SchemaHandler
      * @param string $similarity Similarity function: 'cosine', 'dot_product', or 'euclidean'
      *
      * @return bool Success status
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-2
      */
     public function ensureVectorFieldType(
         string $collection,
@@ -146,6 +148,8 @@ class SchemaHandler
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Schema mirroring requires handling multiple schema scenarios
      * @SuppressWarnings(PHPMD.NPathComplexity)       Multiple paths for conflict resolution and field processing
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Comprehensive schema mirroring requires extensive code
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-2
      */
     public function mirrorSchemas(bool $force=false): array
     {
@@ -612,6 +616,8 @@ class SchemaHandler
      * @return array Field status with collection, existing fields, missing fields, and counts.
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Field status requires handling multiple field comparison scenarios
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-2
      */
     public function getCollectionFieldStatus(string $collection): array
     {
@@ -667,6 +673,8 @@ class SchemaHandler
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Field creation requires handling dry run and multiple scenarios
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-2
      */
     public function createMissingFields(string $collection, array $missingFields, bool $dryRun=false): array
     {
@@ -710,6 +718,8 @@ class SchemaHandler
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Mismatch fixing requires handling dry run and error scenarios
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md#task-2
      */
     public function fixMismatchedFields(array $mismatchedFields, bool $dryRun=false): array
     {

--- a/lib/Service/Index/SearchBackendInterface.php
+++ b/lib/Service/Index/SearchBackendInterface.php
@@ -63,6 +63,8 @@ interface SearchBackendInterface
      * @return bool True if backend is available, false otherwise.
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function isAvailable(bool $forceRefresh=false): bool;
 
@@ -74,6 +76,8 @@ interface SearchBackendInterface
      * @return array Test results with status, timing, and error information.
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function testConnection(bool $inclCollTests=true): array;
 
@@ -86,6 +90,8 @@ interface SearchBackendInterface
      * @return bool True if indexing succeeded, false otherwise.
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function indexObject(ObjectEntity $object, bool $commit=false): bool;
 
@@ -98,6 +104,8 @@ interface SearchBackendInterface
      * @return array Result with success count, failure count, and errors.
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function bulkIndexObjects(array $objects, bool $commit=true): array;
 
@@ -110,6 +118,8 @@ interface SearchBackendInterface
      * @return bool True if deletion succeeded, false otherwise.
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function deleteObject(string|int $objectId, bool $commit=false): bool;
 
@@ -123,6 +133,8 @@ interface SearchBackendInterface
      * @return array|bool Results array if returnDetails=true, bool otherwise.
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function deleteByQuery(string $query, bool $commit=false, bool $returnDetails=false): array|bool;
 
@@ -158,6 +170,8 @@ interface SearchBackendInterface
      * Commit pending changes to the index.
      *
      * @return bool True if commit succeeded, false otherwise.
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function commit(): bool;
 
@@ -165,6 +179,8 @@ interface SearchBackendInterface
      * Optimize the search index for better performance.
      *
      * @return bool True if optimization succeeded, false otherwise.
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function optimize(): bool;
 
@@ -174,6 +190,8 @@ interface SearchBackendInterface
      * @param string|null $collectionName Optional collection/index name to clear.
      *
      * @return array Results with count of deleted documents.
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function clearIndex(?string $collectionName=null): array;
 
@@ -190,6 +208,8 @@ interface SearchBackendInterface
      * @return array Warmup results with statistics and errors.
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function warmupIndex(
         array $schemas=[],
@@ -221,6 +241,8 @@ interface SearchBackendInterface
      * @param array  $config Configuration for the collection.
      *
      * @return array Creation results.
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function createCollection(string $name, array $config=[]): array;
 
@@ -230,6 +252,8 @@ interface SearchBackendInterface
      * @param string|null $collectionName Name of collection to delete, null for default.
      *
      * @return array Deletion results.
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function deleteCollection(?string $collectionName=null): array;
 
@@ -239,6 +263,8 @@ interface SearchBackendInterface
      * @param string $collectionName Name of the collection to check.
      *
      * @return bool True if collection exists, false otherwise.
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function collectionExists(string $collectionName): bool;
 
@@ -246,6 +272,8 @@ interface SearchBackendInterface
      * List all collections/indices in the backend.
      *
      * @return array Array of collection names.
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function listCollections(): array;
 
@@ -257,6 +285,8 @@ interface SearchBackendInterface
      * @param array $documents Array of documents to index
      *
      * @return bool True if successful
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function index(array $documents): bool;
 
@@ -290,6 +320,8 @@ interface SearchBackendInterface
      * @param array $params Search parameters
      *
      * @return array Search results
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function search(array $params): array;
 
@@ -313,6 +345,8 @@ interface SearchBackendInterface
      * @param array  $fieldType  Field type definition
      *
      * @return bool True if successful
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function addFieldType(string $collection, array $fieldType): bool;
 
@@ -336,6 +370,8 @@ interface SearchBackendInterface
      * @param bool  $force       Force update if exists
      *
      * @return string Action taken ('created', 'updated', 'skipped')
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function addOrUpdateField(array $fieldConfig, bool $force): string;
 
@@ -349,6 +385,8 @@ interface SearchBackendInterface
      * @param string|null $collectionName Optional collection name.
      *
      * @return array Reindexing results with statistics.
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function reindexAll(int $maxObjects=0, int $batchSize=1000, ?string $collectionName=null): array;
 
@@ -361,6 +399,8 @@ interface SearchBackendInterface
      * @param string|null $collectionName Optional collection name.
      *
      * @return array Indexing results with 'indexed', 'failed', and 'errors' keys.
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function indexFiles(array $fileIds, ?string $collectionName=null): array;
 
@@ -385,6 +425,8 @@ interface SearchBackendInterface
      * @return array Results with fixed/failed fields.
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     *
+     * @spec exclude interface contract declaration — no implementation in this file
      */
     public function fixMismatchedFields(array $mismatchedFields, bool $dryRun=false): array;
 }//end interface

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-index/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-index/proposal.md
@@ -1,0 +1,29 @@
+# Retrofit: backend coverage — Service/Index (reverse-spec + @spec exclude)
+
+## Why
+
+The Bucket-Wide coverage scan (`/tmp/or-scan/bw-svc-index.json`, 2026-05-25) flagged 127 uncovered methods across 18 files under `lib/Service/Index/` — the residual search-index backend plumbing (the Solr and Elasticsearch concrete backends, their HTTP/collection/schema/query primitives, the `SearchBackendInterface` contract, and the document/file/schema handlers). The `search-index` capability already exists (REQ-1..5, reverse-spec'd by `retrofit-2026-05-24-search-index`) and covers the high-level facade behaviors. This change closes the gate-16 coverage gap on the remaining backend methods.
+
+Per ADR-003 (the two-tool approach, just merged), each method ends with EITHER an `@spec` pointer to a real behavior OR an `@spec exclude <reason>` for boilerplate. The overwhelming majority of these 127 methods are backend plumbing: Guzzle HTTP verb wrappers, facade delegations to extracted primitives, interface method declarations, and simplified stubs (`reindexAll`/`warmupIndex`/`fixMismatchedFields` that defer to `IndexService` or return empty). Those are excluded with reasons. A small set of genuinely novel value-transformation and schema-mirroring behaviors — not already in REQ-1..5 — are reverse-spec'd into three new REQs.
+
+## What changes
+
+- Extend the existing `search-index` capability spec with **three new REQs** (REQ-6, REQ-7, REQ-8):
+  - **REQ-6** — `DocumentBuilder` SOLR value coercion, type-compatibility validation, byte-limit truncation, dot-notation array reconstruction, and register/schema ID resolution.
+  - **REQ-7** — `SchemaHandler` cross-schema field-type conflict resolution (most-permissive type) and `knn_vector` dense-vector field-type provisioning.
+  - **REQ-8** — `FileHandler` file-chunk indexing from the database `ChunkMapper` into the backend file collection.
+- Annotate a subset of methods against existing REQs where they already implement spec'd behavior (`ConfigurationHandler` URL/status helpers → REQ-4).
+- `@spec exclude <reason>` the boilerplate majority (HTTP plumbing, facade delegations, interface declarations, stubs).
+- No production code changes — docblock-only edits.
+
+## Counts
+
+- **Reverse-spec'd / annotated to real behavior: 25** — 8 DocumentBuilder (REQ-6), 5 SchemaHandler (REQ-7), 6 FileHandler (REQ-8), 5 ConfigurationHandler annotated against existing REQ-4, and 1 `SolrSchemaManager::addOrUpdateField` annotated against existing REQ-2.
+- **Excluded (boilerplate): 102** — HTTP-client verb wrappers, facade delegations, interface contract declarations, simplified stubs.
+- **New REQs: 3** (REQ-6, REQ-7, REQ-8).
+
+## Impact
+
+- **Specs**: `search-index` grows from 5 to 8 REQs.
+- **Code**: docblock-only `@spec`/`@spec exclude` edits across 18 files; no runtime behavior changes.
+- **Risk**: none — annotation retrofit.

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-index/specs/search-index/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-index/specs/search-index/spec.md
@@ -1,0 +1,105 @@
+# Search Index (delta)
+
+## Why
+
+The `search-index` capability spec (REQ-1..5) covers the high-level facade and the major orchestration flows but leaves the backend value-transformation, schema-mirroring conflict logic, and file-chunk indexing paths undocumented. The 2026-05-25 Bucket-Wide scan flagged these as uncovered. These three requirements capture observed behavior in `DocumentBuilder`, `SchemaHandler`, and `FileHandler` so future changes to the coercion/conflict/chunking logic are recognised as behavior changes. No production code changes.
+
+## ADDED Requirements
+
+### Requirement: DocumentBuilder coerces, validates, and reshapes object data into backend-safe documents
+
+`DocumentBuilder` MUST transform raw `ObjectEntity` data into a backend-safe document by coercing each value to its declared SOLR field type, validating type compatibility, truncating oversized strings, reconstructing dot-notation array relations, and resolving register/schema references to integer IDs. The transformation MUST be lossy-safe — incompatible or unresolvable values are skipped or coerced rather than aborting the document build.
+
+#### Rationale
+
+SOLR is strongly typed and has a hard 32 KB byte ceiling on indexed string fields, while OpenRegister object bodies are schema-loose JSON that can carry base64 blobs, mixed-type arrays, and relations stored only as dot-notation keys (`standaarden.0`). Coercing, validating, and truncating at document-build time keeps a single malformed property from failing an entire batch index, and resolving register/schema slugs to integer IDs keeps `register:5` style filtering working regardless of how the reference was stored.
+
+#### Scenario: convertValueForSolr coerces by declared type and skips non-numeric values
+
+- **GIVEN** a value `"abc"` for a field declared `integer`
+- **WHEN** `DocumentBuilder::convertValueForSolr("abc", "integer")` runs
+- **THEN** the method MUST return `null` (non-numeric skipped, not cast to `0`)
+- **AND** a numeric `"42"` for an `integer` field MUST return the int `42`
+- **AND** a `date`/`datetime` value MUST be formatted as `Y-m-d\TH:i:s\Z`
+
+#### Scenario: isValueCompatibleWithSolrType rejects type mismatches but allows arrays element-wise
+
+- **GIVEN** a non-numeric string and a SOLR field type of `pint`
+- **WHEN** `DocumentBuilder::isValueCompatibleWithSolrType($value, 'pint')` runs
+- **THEN** the method MUST return `false`
+- **AND** for an array value the method MUST recurse, returning `true` only if every element is compatible
+- **AND** unknown SOLR field types MUST default to `true` (permissive)
+
+#### Scenario: truncateFieldValue caps strings at the SOLR byte ceiling
+
+- **GIVEN** a string longer than 32766 bytes
+- **WHEN** `DocumentBuilder::truncateFieldValue($value)` runs
+- **THEN** the result MUST be UTF-8-safe truncated to under the limit and suffixed with `...[TRUNCATED]`
+- **AND** values within the limit MUST be returned unchanged
+- **AND** non-string values MUST be returned unchanged
+
+#### Scenario: extractArraysFromRelations rebuilds arrays from dot-notation keys
+
+- **GIVEN** relations `["standaarden.1" => "b", "standaarden.0" => "a", "nested.x" => "y"]`
+- **WHEN** `DocumentBuilder::extractArraysFromRelations($relations)` runs
+- **THEN** the result MUST contain `standaarden => ["a", "b"]` (sorted by numeric index, re-keyed sequentially)
+- **AND** non-numeric indices (`nested.x`) MUST be skipped, not added as array elements
+
+#### Scenario: resolveRegisterToId returns integer IDs and falls back to 0
+
+- **GIVEN** a numeric register value
+- **WHEN** `DocumentBuilder::resolveRegisterToId($value)` runs
+- **THEN** the method MUST return it cast to int
+- **AND** a slug/name value MUST be resolved via `RegisterMapper::find()` to its ID
+- **AND** an empty or unresolvable value MUST return `0` (the same contract holds for `resolveSchemaToId` via `SchemaMapper`)
+
+---
+
+### Requirement: SchemaHandler resolves cross-schema field-type conflicts and provisions vector fields
+
+`SchemaHandler::mirrorSchemas()` MUST analyse every OpenRegister schema's properties before applying any field and, when the same field name resolves to different SOLR types across schemas, MUST resolve the conflict to the most permissive type using the hierarchy `string > text > float > integer > boolean`. `SchemaHandler::ensureVectorFieldType()` MUST provision a `knn_vector` dense-vector field type (idempotently) for vector-similarity search.
+
+#### Rationale
+
+A single SOLR collection mirrors fields from every schema, so a field named `code` that is an integer in one schema and a string in another would otherwise fail to index against whichever type was created first. Choosing the most permissive type (string can hold everything; integer cannot hold text) lets one collection serve heterogeneous schemas without per-schema collections. The `knn_vector` provisioning is the prerequisite for semantic/vector search and must be a no-op when the type already exists so re-runs of the mirror are safe.
+
+#### Scenario: mirrorSchemas resolves a field-type conflict to the most permissive type
+
+- **GIVEN** field `code` resolves to `integer` in one schema and `string` in another
+- **WHEN** `SchemaHandler::mirrorSchemas()` analyses the schemas
+- **THEN** the conflict MUST be recorded and resolved to `string` (most permissive)
+- **AND** the resolved type MUST be used when generating the SOLR field definition
+- **AND** the run MUST report `resolved_conflicts` in its result
+
+#### Scenario: ensureVectorFieldType is idempotent
+
+- **GIVEN** a collection that already has a `knn_vector` field type
+- **WHEN** `SchemaHandler::ensureVectorFieldType($collection)` runs
+- **THEN** the method MUST detect the existing type via `getFieldTypes()` and return `true` without re-creating it
+- **AND** when absent, it MUST create a `solr.DenseVectorField` with the requested `vectorDimension` and `similarityFunction`
+
+---
+
+### Requirement: FileHandler indexes database-resident file chunks into the backend file collection
+
+`FileHandler` MUST index file-content chunks — produced separately by the text-extraction flow and persisted via `ChunkMapper` — into the search backend's file collection. It MUST NOT extract text itself; it only reads existing chunks, maps each chunk to a document, submits them via `SearchBackendInterface::index()`, and marks successfully indexed chunks as indexed in the database.
+
+#### Rationale
+
+Text extraction (OCR, PDF parsing) is expensive and runs on its own schedule, writing chunks to the database. Decoupling indexing from extraction lets the index be (re)built from already-extracted chunks without re-parsing files, and lets a backfill (`processUnindexedChunks`) catch up chunks that were extracted while the backend was unavailable. Marking chunks indexed only after a successful submit keeps the backfill idempotent.
+
+#### Scenario: processUnindexedChunks groups by file, indexes, and marks chunks
+
+- **GIVEN** `ChunkMapper::findUnindexed()` returns chunks for two file IDs
+- **WHEN** `FileHandler::processUnindexedChunks()` runs
+- **THEN** chunks MUST be grouped by their source file ID and each group submitted via `indexFileChunks()`
+- **AND** on a successful index the chunks MUST be marked `indexed` via `ChunkMapper::update()`
+- **AND** a per-file failure MUST increment `failed` and record an error without aborting the remaining files
+
+#### Scenario: indexFileChunks maps chunks to documents and reports the indexed count
+
+- **GIVEN** a file ID, an array of chunk entities, and file metadata
+- **WHEN** `FileHandler::indexFileChunks($fileId, $chunks, $metadata)` runs
+- **THEN** each chunk MUST become a document carrying `file_id`, `chunk_index`, `total_chunks`, `chunk_text`, owner/organisation/language, and created/updated timestamps
+- **AND** the documents MUST be submitted via `SearchBackendInterface::index()`
+- **AND** the result MUST report `success` and an `indexed` count equal to the document count on success

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-index/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: backend coverage — Service/Index
+
+## 1. Reverse-spec new behaviors
+
+- [x] task-1 — Reverse-spec `DocumentBuilder` SOLR value coercion, type-compatibility validation, byte-limit truncation, dot-notation array reconstruction, and register/schema ID resolution (REQ-6). Annotate `extractArraysFromRelations`, `extractIdFromObject`, `extractIndexableArrayValues`, `flattenFilesForSolr`, `isValueCompatibleWithSolrType`, `resolveRegisterToId`, `resolveSchemaToId`, `validateFieldForSolr`.
+- [x] task-2 — Reverse-spec `SchemaHandler` cross-schema field-type conflict resolution and `knn_vector` provisioning (REQ-7). Annotate `mirrorSchemas`, `ensureVectorFieldType`, `getCollectionFieldStatus`, `createMissingFields`, `fixMismatchedFields`.
+- [x] task-3 — Reverse-spec `FileHandler` chunk indexing from `ChunkMapper` into the backend file collection (REQ-8). Annotate `indexFileChunks`, `processUnindexedChunks`, `getChunkingStats`, `getFileStats`, `getFileIndexStats`, `indexFiles`.
+
+## 2. Annotate against existing REQs
+
+- [x] task-4 — Annotate `ConfigurationHandler` URL/status helpers (`buildSolrBaseUrl`, `getEndpointUrl`, `getCoreStatus`, `getPortStatus`, `isSolrConfigured`) against the existing configuration requirement (REQ-4).
+
+## 3. Exclude boilerplate
+
+- [x] task-5 — `@spec exclude` the boilerplate majority: Guzzle HTTP verb wrappers, facade delegations to extracted primitives, `SearchBackendInterface` contract declarations, and simplified stubs.


### PR DESCRIPTION
## Summary

Closes the gate-16 coverage gap on the 127 uncovered methods under `lib/Service/Index/` flagged by the Bucket-Wide scan (`/tmp/or-scan/bw-svc-index.json`) — the residual search-index backend plumbing (Solr + Elasticsearch concrete backends, their HTTP/collection/schema/query primitives, the `SearchBackendInterface` contract, and the document/file/schema handlers).

Per ADR-003 (the two-tool approach), every method now ends with EITHER an `@spec` pointer to a real behavior OR an `@spec exclude <reason>` for boilerplate.

- **3 new REQs** on the existing `search-index` capability:
  - **REQ-6** — `DocumentBuilder` SOLR value coercion, type-compatibility validation, byte-limit truncation, dot-notation array reconstruction, register/schema ID resolution.
  - **REQ-7** — `SchemaHandler` cross-schema field-type conflict resolution (most-permissive type) + `knn_vector` dense-vector field provisioning.
  - **REQ-8** — `FileHandler` file-chunk indexing from the database `ChunkMapper` into the backend file collection.
- **25 methods** reverse-spec'd / annotated to real behavior (incl. 5 `ConfigurationHandler` against existing REQ-4, 1 `SolrSchemaManager::addOrUpdateField` against existing REQ-2).
- **102 methods** excluded as boilerplate (Guzzle verb wrappers, facade delegations, interface contract declarations, simplified stubs).

Docblock-only edits — no runtime behavior changes.

## Test plan

- [x] `php -l` clean on all 18 touched files
- [x] All 127 batch methods carry `@spec` or `@spec exclude <reason>` (verified; 0 bare excludes)
- [x] `openspec validate retrofit-2026-05-25-bw-svc-index --strict` passes