### PR TITLE
retrofit: backend coverage — Service/Integration

### DIFF
--- a/lib/Service/Integration/AbstractIntegrationProvider.php
+++ b/lib/Service/Integration/AbstractIntegrationProvider.php
@@ -61,6 +61,8 @@ abstract class AbstractIntegrationProvider implements IntegrationProvider
      * Permission required to use this integration.
      *
      * @return string|null Default null (inherits from object RBAC).
+     *
+     * @spec exclude Base-class default (trivial `return null`) — RBAC gating contract is owned by pluggable-integration-registry task-2/generic-integrations Permission Inheritance; concrete overrides carry the behaviour.
      */
     public function requiresPermission(): ?string
     {
@@ -72,6 +74,8 @@ abstract class AbstractIntegrationProvider implements IntegrationProvider
      *
      * @return array<string,mixed> Default `['type' => 'none']` for
      *                             integrations that need no credentials.
+     *
+     * @spec exclude Base-class default (static `['type' => 'none']`) — the auth-requirements contract is owned by pluggable-integration-registry task-2; external providers override with real descriptors.
      */
     public function authRequirements(): array
     {
@@ -104,6 +108,8 @@ abstract class AbstractIntegrationProvider implements IntegrationProvider
      * @return array<string,mixed>
      *
      * @throws NotImplementedException Always, unless overridden.
+     *
+     * @spec exclude Base-class default-throwing stub for list-only/query-time providers — the NotImplemented→501 contract is owned by pluggable-integration-registry task-2/task-6; CRUD-capable providers override.
      */
     public function get(string $register, string $schema, string $objectId, string $entityId): array
     {
@@ -123,6 +129,8 @@ abstract class AbstractIntegrationProvider implements IntegrationProvider
      * @return array<string,mixed>
      *
      * @throws NotImplementedException Always, unless overridden.
+     *
+     * @spec exclude Base-class default-throwing stub for list-only/query-time providers — the NotImplemented→501 contract is owned by pluggable-integration-registry task-2/task-6; CRUD-capable providers override.
      */
     public function create(string $register, string $schema, string $objectId, array $payload): array
     {
@@ -143,6 +151,8 @@ abstract class AbstractIntegrationProvider implements IntegrationProvider
      * @return array<string,mixed>
      *
      * @throws NotImplementedException Always, unless overridden.
+     *
+     * @spec exclude Base-class default-throwing stub for list-only/query-time providers — the NotImplemented→501 contract is owned by pluggable-integration-registry task-2/task-6; CRUD-capable providers override.
      */
     public function update(string $register, string $schema, string $objectId, string $entityId, array $payload): array
     {
@@ -162,6 +172,8 @@ abstract class AbstractIntegrationProvider implements IntegrationProvider
      * @return void
      *
      * @throws NotImplementedException Always, unless overridden.
+     *
+     * @spec exclude Base-class default-throwing stub for list-only/query-time providers — the NotImplemented→501 contract is owned by pluggable-integration-registry task-2/task-6; CRUD-capable providers override.
      */
     public function delete(string $register, string $schema, string $objectId, string $entityId): void
     {
@@ -178,6 +190,8 @@ abstract class AbstractIntegrationProvider implements IntegrationProvider
      * and the OCS capabilities response for discovery.
      *
      * @return array<string,mixed>
+     *
+     * @spec exclude Base-class default health descriptor (static ok/configured) — the health/OCS-capabilities contract is owned by pluggable-integration-registry task-2; external providers override with a real probe.
      */
     public function health(): array
     {

--- a/lib/Service/Integration/BuiltinProviders/AuditTrailProvider.php
+++ b/lib/Service/Integration/BuiltinProviders/AuditTrailProvider.php
@@ -140,6 +140,8 @@ class AuditTrailProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $filters  Reserved.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-16
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {

--- a/lib/Service/Integration/BuiltinProviders/FilesProvider.php
+++ b/lib/Service/Integration/BuiltinProviders/FilesProvider.php
@@ -146,6 +146,8 @@ class FilesProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $filters  Reserved for future use.
      *
      * @return array<int,array<string,mixed>> Files rows.
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-12
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -203,6 +205,8 @@ class FilesProvider extends AbstractIntegrationProvider
      *
      * @throws NotImplementedException Always — write path consolidates
      *                                 in tasks 18-22.
+     *
+     * @spec exclude NotImplemented write stub — Files writes still route through FileController; the consolidated write path is owned by pluggable-integration-registry tasks 18-22, not this stub.
      */
     public function create(string $register, string $schema, string $objectId, array $payload): array
     {

--- a/lib/Service/Integration/BuiltinProviders/NotesProvider.php
+++ b/lib/Service/Integration/BuiltinProviders/NotesProvider.php
@@ -131,6 +131,8 @@ class NotesProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $filters  Pagination filters (_limit / _page).
      *
      * @return array<int,array<string,mixed>> Notes rows.
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-13
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -148,6 +150,8 @@ class NotesProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $payload  Note payload (message field).
      *
      * @return array<string,mixed> Created note row.
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-13
      */
     public function create(string $register, string $schema, string $objectId, array $payload): array
     {
@@ -165,6 +169,8 @@ class NotesProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $payload  Update payload (message field).
      *
      * @return array<string,mixed> Updated note row.
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-13
      */
     public function update(string $register, string $schema, string $objectId, string $entityId, array $payload): array
     {
@@ -181,6 +187,8 @@ class NotesProvider extends AbstractIntegrationProvider
      * @param string $entityId Note id (numeric string).
      *
      * @return void
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-13
      */
     public function delete(string $register, string $schema, string $objectId, string $entityId): void
     {

--- a/lib/Service/Integration/BuiltinProviders/TagsProvider.php
+++ b/lib/Service/Integration/BuiltinProviders/TagsProvider.php
@@ -138,6 +138,8 @@ class TagsProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $filters  Reserved.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-15
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -182,6 +184,8 @@ class TagsProvider extends AbstractIntegrationProvider
      *
      * @throws NotImplementedException Always — write path lives at
      *                                 `/api/tags/{...}` controllers.
+     *
+     * @spec exclude NotImplemented write stub — tag writes still route through TagsController; the consolidated write path is owned by pluggable-integration-registry tasks 18-22, not this stub.
      */
     public function create(string $register, string $schema, string $objectId, array $payload): array
     {

--- a/lib/Service/Integration/BuiltinProviders/TasksProvider.php
+++ b/lib/Service/Integration/BuiltinProviders/TasksProvider.php
@@ -148,6 +148,8 @@ class TasksProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $filters  Reserved.
      *
      * @return array<int,array<string,mixed>> Tasks rows.
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-14
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -184,6 +186,8 @@ class TasksProvider extends AbstractIntegrationProvider
      *
      * @throws \RuntimeException When the register/schema can't be resolved
      *                           or the underlying VTODO write fails.
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-14
      */
     public function create(string $register, string $schema, string $objectId, array $payload): array
     {
@@ -236,6 +240,8 @@ class TasksProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $payload  Update payload.
      *
      * @return array<string,mixed> Updated task row.
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-14
      */
     public function update(string $register, string $schema, string $objectId, string $entityId, array $payload): array
     {
@@ -258,6 +264,8 @@ class TasksProvider extends AbstractIntegrationProvider
      * @param string $entityId Composite calendar/task id.
      *
      * @return void
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-14
      */
     public function delete(string $register, string $schema, string $objectId, string $entityId): void
     {

--- a/lib/Service/Integration/ExternalIntegrationRouter.php
+++ b/lib/Service/Integration/ExternalIntegrationRouter.php
@@ -108,6 +108,8 @@ class ExternalIntegrationRouter
      *                                      `getCause()` /
      *                                      `getDetails()` to pick
      *                                      the right user message.
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-4
      */
     public function call(
         IntegrationProvider $provider,
@@ -160,6 +162,8 @@ class ExternalIntegrationRouter
      * @param IntegrationProvider $provider Provider to check.
      *
      * @return array{status: string, authStatus: string, message: ?string}
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-4
      */
     public function probe(IntegrationProvider $provider): array
     {

--- a/lib/Service/Integration/IntegrationProvider.php
+++ b/lib/Service/Integration/IntegrationProvider.php
@@ -152,6 +152,8 @@ interface IntegrationProvider
      * (AD-16).
      *
      * @return string|null Permission string or null.
+     *
+     * @spec exclude Interface method declaration — pure contract shape; the behaviour lives in the implementing providers (annotated to their integration-* change / pluggable-integration-registry task-1).
      */
     public function requiresPermission(): ?string;
 
@@ -165,6 +167,8 @@ interface IntegrationProvider
      * credential management (AD-15).
      *
      * @return array<string,mixed> Auth-requirements descriptor.
+     *
+     * @spec exclude Interface method declaration — pure contract shape; the behaviour lives in the implementing providers (annotated to their integration-* change / pluggable-integration-registry task-1).
      */
     public function authRequirements(): array;
 
@@ -196,6 +200,8 @@ interface IntegrationProvider
      *
      * @return array<int,array<string,mixed>>|array<string,mixed> Flat list
      *         of linked things, or a `{items, total, nextCursor}` envelope.
+     *
+     * @spec exclude Interface method declaration — pure contract shape; the behaviour lives in the implementing providers (annotated to their integration-* change / pluggable-integration-registry task-1).
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array;
 
@@ -217,6 +223,8 @@ interface IntegrationProvider
      * @param string $entityId Linked-thing id.
      *
      * @return array<string,mixed> The linked thing.
+     *
+     * @spec exclude Interface method declaration — pure contract shape; the behaviour lives in the implementing providers (annotated to their integration-* change / pluggable-integration-registry task-1).
      */
     public function get(string $register, string $schema, string $objectId, string $entityId): array;
 
@@ -232,6 +240,8 @@ interface IntegrationProvider
      * @param array<string,mixed> $payload  New linked-thing fields.
      *
      * @return array<string,mixed> The created linked thing.
+     *
+     * @spec exclude Interface method declaration — pure contract shape; the behaviour lives in the implementing providers (annotated to their integration-* change / pluggable-integration-registry task-1).
      */
     public function create(string $register, string $schema, string $objectId, array $payload): array;
 
@@ -248,6 +258,8 @@ interface IntegrationProvider
      * @param array<string,mixed> $payload  Update payload.
      *
      * @return array<string,mixed> The updated linked thing.
+     *
+     * @spec exclude Interface method declaration — pure contract shape; the behaviour lives in the implementing providers (annotated to their integration-* change / pluggable-integration-registry task-1).
      */
     public function update(string $register, string $schema, string $objectId, string $entityId, array $payload): array;
 
@@ -263,6 +275,8 @@ interface IntegrationProvider
      * @param string $entityId Linked-thing id.
      *
      * @return void
+     *
+     * @spec exclude Interface method declaration — pure contract shape; the behaviour lives in the implementing providers (annotated to their integration-* change / pluggable-integration-registry task-1).
      */
     public function delete(string $register, string $schema, string $objectId, string $entityId): void;
 
@@ -277,6 +291,8 @@ interface IntegrationProvider
      * for discovery (AD-17).
      *
      * @return array<string,mixed> Health + auth descriptor.
+     *
+     * @spec exclude Interface method declaration — pure contract shape; the behaviour lives in the implementing providers (annotated to their integration-* change / pluggable-integration-registry task-1).
      */
     public function health(): array;
 }//end interface

--- a/lib/Service/Integration/IntegrationRegistry.php
+++ b/lib/Service/Integration/IntegrationRegistry.php
@@ -97,6 +97,8 @@ class IntegrationRegistry
      *
      * @return bool True when the provider was accepted, false when
      *              rejected (duplicate or misconfigured).
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-3
      */
     public function addProvider(IntegrationProvider $provider): bool
     {
@@ -139,6 +141,8 @@ class IntegrationRegistry
      * @param array<int, IntegrationProvider> $providers Provider instances.
      *
      * @return void
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-3
      */
     public function withProviders(array $providers): void
     {
@@ -152,6 +156,8 @@ class IntegrationRegistry
      * List every registered provider, irrespective of isEnabled().
      *
      * @return array<int, IntegrationProvider>
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-3
      */
     public function list(): array
     {
@@ -166,6 +172,8 @@ class IntegrationRegistry
      * `VALID_LINKED_TYPES` constant.
      *
      * @return array<int, string>
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-3
      */
     public function listIds(): array
     {
@@ -178,6 +186,8 @@ class IntegrationRegistry
      * @param string $id Stable integration id (e.g. 'files', 'xwiki').
      *
      * @return IntegrationProvider|null Provider, or null when unknown.
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-3
      */
     public function get(string $id): ?IntegrationProvider
     {
@@ -208,6 +218,8 @@ class IntegrationRegistry
      * providers have their OpenConnector source configured.
      *
      * @return array<int, IntegrationProvider>
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-3
      */
     public function getEnabled(): array
     {

--- a/lib/Service/Integration/PaginatedResult.php
+++ b/lib/Service/Integration/PaginatedResult.php
@@ -107,6 +107,8 @@ final class PaginatedResult
      * @param mixed $value Raw value returned by a provider or service.
      *
      * @return self The normalized envelope.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-integration/specs/generic-integrations/spec.md#Requirement:Integration-list-responses-MUST-be-normalised-into-a-canonical-pagination-envelope
      */
     public static function fromMixed(mixed $value): self
     {
@@ -152,6 +154,8 @@ final class PaginatedResult
      * coordinated release.
      *
      * @return array{items:array<int,array<string,mixed>>,results:array<int,array<string,mixed>>,total:int,nextCursor:?string}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw-svc-integration/specs/generic-integrations/spec.md#Requirement:Integration-list-responses-MUST-be-normalised-into-a-canonical-pagination-envelope
      */
     public function toArray(): array
     {

--- a/lib/Service/Integration/PropertyReferenceTypeValidator.php
+++ b/lib/Service/Integration/PropertyReferenceTypeValidator.php
@@ -73,6 +73,8 @@ class PropertyReferenceTypeValidator
      *
      * @throws InvalidArgumentException When referenceType is non-string
      *                                  or refers to an unregistered id.
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-10
      */
     public function validate(array $property, ?string $propertyName=null): void
     {
@@ -123,6 +125,8 @@ class PropertyReferenceTypeValidator
      * @return void
      *
      * @throws InvalidArgumentException On the first invalid property.
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-10
      */
     public function validateAll(array $properties): void
     {

--- a/lib/Service/Integration/Providers/AnalyticsProvider.php
+++ b/lib/Service/Integration/Providers/AnalyticsProvider.php
@@ -115,6 +115,8 @@ class AnalyticsProvider extends AbstractIntegrationProvider
      * @param array  $filters  Optional registry filters (unused).
      *
      * @return array List of registry leaf rows.
+     *
+     * @spec openspec/changes/integration-analytics/tasks.md
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -182,6 +184,13 @@ class AnalyticsProvider extends AbstractIntegrationProvider
         ];
     }//end rowFromLink()
 
+    /**
+     * Provider health descriptor (enabled/disabled echo).
+     *
+     * @return array<string,mixed>
+     *
+     * @spec exclude Static enabled/disabled descriptor echoing isEnabled() — no standalone health behaviour; the health/OCS contract is owned by pluggable-integration-registry task-2.
+     */
     public function health(): array
     {
         $available = $this->isEnabled();

--- a/lib/Service/Integration/Providers/BookmarksProvider.php
+++ b/lib/Service/Integration/Providers/BookmarksProvider.php
@@ -118,6 +118,8 @@ class BookmarksProvider extends AbstractIntegrationProvider
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter) register/schema/filters
      *     are part of the IntegrationProvider::list() contract.
+     *
+     * @spec openspec/changes/integration-bookmarks/tasks.md
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -150,6 +152,13 @@ class BookmarksProvider extends AbstractIntegrationProvider
         return $out;
     }//end list()
 
+    /**
+     * Provider health descriptor (enabled/disabled echo).
+     *
+     * @return array<string,mixed>
+     *
+     * @spec exclude Static enabled/disabled descriptor echoing IAppManager::isInstalled — no standalone health behaviour; the health/OCS contract is owned by pluggable-integration-registry task-2.
+     */
     public function health(): array
     {
         $installed = $this->appManager->isInstalled(self::REQUIRED_APP);

--- a/lib/Service/Integration/Providers/CollectivesProvider.php
+++ b/lib/Service/Integration/Providers/CollectivesProvider.php
@@ -115,6 +115,8 @@ class CollectivesProvider extends AbstractIntegrationProvider
      * @param array  $filters  Optional registry filters (unused).
      *
      * @return array<int,array<string,mixed>> List of registry leaf rows.
+     *
+     * @spec openspec/changes/integration-collectives/tasks.md
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -187,6 +189,13 @@ class CollectivesProvider extends AbstractIntegrationProvider
         ];
     }//end rowFromLink()
 
+    /**
+     * Provider health descriptor (enabled/disabled echo).
+     *
+     * @return array<string,mixed>
+     *
+     * @spec exclude Static enabled/disabled descriptor echoing isEnabled() — no standalone health behaviour; the health/OCS contract is owned by pluggable-integration-registry task-2.
+     */
     public function health(): array
     {
         $available = $this->isEnabled();

--- a/lib/Service/Integration/Providers/ContactsProvider.php
+++ b/lib/Service/Integration/Providers/ContactsProvider.php
@@ -180,6 +180,13 @@ class ContactsProvider extends AbstractIntegrationProvider
         $this->contactService->unlinkContact(linkId: (int) $entityId);
     }//end delete()
 
+    /**
+     * Provider health descriptor (enabled/disabled echo).
+     *
+     * @return array<string,mixed>
+     *
+     * @spec exclude Static enabled/disabled descriptor echoing IAppManager::isInstalled — no standalone health behaviour; the health/OCS contract is owned by pluggable-integration-registry task-2.
+     */
     public function health(): array
     {
         $installed = $this->appManager->isInstalled(self::REQUIRED_APP);

--- a/lib/Service/Integration/Providers/CospendProvider.php
+++ b/lib/Service/Integration/Providers/CospendProvider.php
@@ -157,6 +157,8 @@ class CospendProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $filters  Optional registry filters (unused).
      *
      * @return array<int,array<string,mixed>> List of registry leaf rows.
+     *
+     * @spec openspec/changes/integration-cospend/tasks.md
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -261,6 +263,13 @@ class CospendProvider extends AbstractIntegrationProvider
         return $rows;
     }//end legacyMarkerList()
 
+    /**
+     * Provider health descriptor (enabled/disabled echo).
+     *
+     * @return array<string,mixed>
+     *
+     * @spec exclude Static enabled/disabled descriptor echoing isEnabled() — no standalone health behaviour; the health/OCS contract is owned by pluggable-integration-registry task-2.
+     */
     public function health(): array
     {
         $status  = 'unavailable';

--- a/lib/Service/Integration/Providers/DeckProvider.php
+++ b/lib/Service/Integration/Providers/DeckProvider.php
@@ -117,6 +117,8 @@ class DeckProvider extends AbstractIntegrationProvider
      * @return array<int,array<string,mixed>>
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter) Provider-contract args.
+     *
+     * @spec openspec/changes/integration-deck/tasks.md
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -142,6 +144,8 @@ class DeckProvider extends AbstractIntegrationProvider
      * @return array<string,mixed>
      *
      * @throws Exception When payload is missing required fields.
+     *
+     * @spec openspec/changes/integration-deck/tasks.md
      */
     public function create(string $register, string $schema, string $objectId, array $payload): array
     {
@@ -193,12 +197,21 @@ class DeckProvider extends AbstractIntegrationProvider
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter) Provider-contract args.
+     *
+     * @spec openspec/changes/integration-deck/tasks.md
      */
     public function delete(string $register, string $schema, string $objectId, string $entityId): void
     {
         $this->deckLinkService->unlinkCard($objectId, (int) $entityId);
     }//end delete()
 
+    /**
+     * Provider health descriptor (enabled/disabled echo).
+     *
+     * @return array<string,mixed>
+     *
+     * @spec exclude Static enabled/disabled descriptor echoing isEnabled() — no standalone health behaviour; the health/OCS contract is owned by pluggable-integration-registry task-2.
+     */
     public function health(): array
     {
         $available = $this->deckLinkService->isDeckAvailable();

--- a/lib/Service/Integration/Providers/EmailProvider.php
+++ b/lib/Service/Integration/Providers/EmailProvider.php
@@ -142,6 +142,8 @@ class EmailProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $filters  Optional `_limit` / `_page` (page zero-indexed).
      *
      * @return array{items:array<int,array<string,mixed>>,total:int,nextCursor:?string}
+     *
+     * @spec openspec/changes/integration-email/tasks.md
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -199,6 +201,8 @@ class EmailProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $payload  Picker (Tier-2) or legacy shape.
      *
      * @return array<string,mixed>
+     *
+     * @spec openspec/changes/integration-email/tasks.md
      */
     public function create(string $register, string $schema, string $objectId, array $payload): array
     {
@@ -231,12 +235,21 @@ class EmailProvider extends AbstractIntegrationProvider
      * @param string $entityId Numeric link id.
      *
      * @return void
+     *
+     * @spec openspec/changes/integration-email/tasks.md
      */
     public function delete(string $register, string $schema, string $objectId, string $entityId): void
     {
         $this->emailLinkService->unlinkEmail(objectUuid: $objectId, linkId: (int) $entityId);
     }//end delete()
 
+    /**
+     * Provider health descriptor (enabled/disabled echo).
+     *
+     * @return array<string,mixed>
+     *
+     * @spec exclude Static enabled/disabled descriptor echoing isEnabled() — no standalone health behaviour; the health/OCS contract is owned by pluggable-integration-registry task-2.
+     */
     public function health(): array
     {
         $available = $this->emailLinkService->isMailAvailable();

--- a/lib/Service/Integration/Providers/FlowProvider.php
+++ b/lib/Service/Integration/Providers/FlowProvider.php
@@ -106,6 +106,8 @@ class FlowProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $filters  Optional filters (unused).
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/integration-flow/tasks.md
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -206,6 +208,13 @@ class FlowProvider extends AbstractIntegrationProvider
         return [];
     }//end decodeJsonField()
 
+    /**
+     * Provider health descriptor (enabled/disabled echo).
+     *
+     * @return array<string,mixed>
+     *
+     * @spec exclude Static enabled/disabled descriptor echoing isEnabled() — no standalone health behaviour; the health/OCS contract is owned by pluggable-integration-registry task-2.
+     */
     public function health(): array
     {
         $available = $this->isEnabled();

--- a/lib/Service/Integration/Providers/FormsProvider.php
+++ b/lib/Service/Integration/Providers/FormsProvider.php
@@ -141,6 +141,8 @@ class FormsProvider extends AbstractIntegrationProvider
      * @param array  $filters  Optional registry filters (unused).
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/integration-forms/tasks.md
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -178,6 +180,13 @@ class FormsProvider extends AbstractIntegrationProvider
 
     }//end list()
 
+    /**
+     * Provider health descriptor (enabled/disabled echo).
+     *
+     * @return array<string,mixed>
+     *
+     * @spec exclude Static enabled/disabled descriptor echoing isEnabled() — no standalone health behaviour; the health/OCS contract is owned by pluggable-integration-registry task-2.
+     */
     public function health(): array
     {
         $available = $this->isEnabled();

--- a/lib/Service/Integration/Providers/MapsProvider.php
+++ b/lib/Service/Integration/Providers/MapsProvider.php
@@ -106,6 +106,8 @@ class MapsProvider extends AbstractIntegrationProvider
      * @param array  $filters  Optional registry filters (unused).
      *
      * @return array List of registry leaf rows.
+     *
+     * @spec openspec/changes/integration-maps/tasks.md
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -175,6 +177,13 @@ class MapsProvider extends AbstractIntegrationProvider
         ];
     }//end rowFromLink()
 
+    /**
+     * Provider health descriptor (enabled/disabled echo).
+     *
+     * @return array<string,mixed>
+     *
+     * @spec exclude Static enabled/disabled descriptor echoing isEnabled() — no standalone health behaviour; the health/OCS contract is owned by pluggable-integration-registry task-2.
+     */
     public function health(): array
     {
         $available = $this->isEnabled();

--- a/lib/Service/Integration/Providers/MarkerLookupTrait.php
+++ b/lib/Service/Integration/Providers/MarkerLookupTrait.php
@@ -50,6 +50,8 @@ trait MarkerLookupTrait
      * @param string            $idColumn     Primary-key column (default `id`).
      *
      * @return array<int,array<string,mixed>> Matching rows.
+     *
+     * @spec exclude Shared defensive LIKE-scan helper for leaf list() impls — no standalone contract; the behavioural contract is each leaf provider's list() (annotated to its integration-* change).
      */
     protected function findByMarker(
         IDBConnection $db,

--- a/lib/Service/Integration/Providers/OpenProjectProvider.php
+++ b/lib/Service/Integration/Providers/OpenProjectProvider.php
@@ -128,6 +128,8 @@ class OpenProjectProvider extends AbstractIntegrationProvider
      * Auth requirements descriptor.
      *
      * @return array<string,mixed>
+     *
+     * @spec openspec/changes/integration-openproject/tasks.md
      */
     public function authRequirements(): array
     {
@@ -154,6 +156,8 @@ class OpenProjectProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $filters  Optional: `_search`, `_limit`, `_page`.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/integration-openproject/tasks.md
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -223,6 +227,8 @@ class OpenProjectProvider extends AbstractIntegrationProvider
      * @param string $entityId Work-package id.
      *
      * @return array<string,mixed>
+     *
+     * @spec openspec/changes/integration-openproject/tasks.md
      */
     public function get(string $register, string $schema, string $objectId, string $entityId): array
     {
@@ -246,6 +252,8 @@ class OpenProjectProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $payload  Reference or new-WP fields.
      *
      * @return array<string,mixed>
+     *
+     * @spec openspec/changes/integration-openproject/tasks.md
      */
     public function create(string $register, string $schema, string $objectId, array $payload): array
     {
@@ -274,6 +282,8 @@ class OpenProjectProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $payload  Fields to update.
      *
      * @return array<string,mixed>
+     *
+     * @spec openspec/changes/integration-openproject/tasks.md
      */
     public function update(string $register, string $schema, string $objectId, string $entityId, array $payload): array
     {
@@ -301,6 +311,8 @@ class OpenProjectProvider extends AbstractIntegrationProvider
      * @param string $entityId Work-package id.
      *
      * @return void
+     *
+     * @spec openspec/changes/integration-openproject/tasks.md
      */
     public function delete(string $register, string $schema, string $objectId, string $entityId): void
     {
@@ -315,6 +327,13 @@ class OpenProjectProvider extends AbstractIntegrationProvider
         );
     }//end delete()
 
+    /**
+     * Health descriptor — defers to the router's probe.
+     *
+     * @return array{status: string, authStatus: string, message: ?string}
+     *
+     * @spec exclude Thin delegation to ExternalIntegrationRouter::probe (annotated to pluggable-integration-registry task-4); carries no provider-specific health behaviour.
+     */
     public function health(): array
     {
         return $this->router->probe(provider: $this);

--- a/lib/Service/Integration/Providers/PhotosProvider.php
+++ b/lib/Service/Integration/Providers/PhotosProvider.php
@@ -112,6 +112,8 @@ class PhotosProvider extends AbstractIntegrationProvider
      * @param array  $filters  Optional registry filters (unused).
      *
      * @return array<int,array<string,mixed>> List of registry leaf rows.
+     *
+     * @spec openspec/changes/integration-photos/tasks.md
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -180,6 +182,13 @@ class PhotosProvider extends AbstractIntegrationProvider
         ];
     }//end rowFromLink()
 
+    /**
+     * Provider health descriptor (enabled/disabled echo).
+     *
+     * @return array<string,mixed>
+     *
+     * @spec exclude Static enabled/disabled descriptor echoing isEnabled() — no standalone health behaviour; the health/OCS contract is owned by pluggable-integration-registry task-2.
+     */
     public function health(): array
     {
         $available = $this->isEnabled();

--- a/lib/Service/Integration/Providers/PollsProvider.php
+++ b/lib/Service/Integration/Providers/PollsProvider.php
@@ -108,6 +108,8 @@ class PollsProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $filters  Optional filters (unused).
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/integration-polls/tasks.md
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -252,6 +254,13 @@ class PollsProvider extends AbstractIntegrationProvider
         }
     }//end fetchVoterCount()
 
+    /**
+     * Provider health descriptor (enabled/disabled echo).
+     *
+     * @return array<string,mixed>
+     *
+     * @spec exclude Static enabled/disabled descriptor echoing IAppManager::isInstalled — no standalone health behaviour; the health/OCS contract is owned by pluggable-integration-registry task-2.
+     */
     public function health(): array
     {
         $installed = $this->appManager->isInstalled(self::REQUIRED_APP);

--- a/lib/Service/Integration/Providers/SharesProvider.php
+++ b/lib/Service/Integration/Providers/SharesProvider.php
@@ -170,6 +170,13 @@ class SharesProvider extends AbstractIntegrationProvider
     }//end getStorageStrategy()
 
 
+    /**
+     * Whether the integration is available — NC core sharing is always on.
+     *
+     * @return bool
+     *
+     * @spec exclude Trivial always-on predicate (`return true`) — the registry stage-1 enabled-filter contract is owned by pluggable-integration-registry task-3.
+     */
     public function isEnabled(): bool
     {
         // NC core sharing is always available; the only "disabled"
@@ -216,6 +223,8 @@ class SharesProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $filters  Reserved.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/integration-shares/tasks.md
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -346,6 +355,8 @@ class SharesProvider extends AbstractIntegrationProvider
      * @param string $entityId Share id to revoke.
      *
      * @return void
+     *
+     * @spec openspec/changes/integration-shares/tasks.md
      */
     public function delete(string $register, string $schema, string $objectId, string $entityId): void
     {
@@ -372,6 +383,8 @@ class SharesProvider extends AbstractIntegrationProvider
      * resolve, in which case it reports `degraded`. Never throws.
      *
      * @return array<string,mixed>
+     *
+     * @spec exclude Static ok/degraded descriptor echoing share-manager reachability — no standalone health behaviour; the health/OCS contract is owned by pluggable-integration-registry task-2.
      */
     public function health(): array
     {
@@ -585,12 +598,30 @@ class SharesProvider extends AbstractIntegrationProvider
         return new class implements ContainerInterface {
 
 
+            /**
+             * Resolve a service from NC's global server container.
+             *
+             * @param string $id Service id.
+             *
+             * @return object
+             *
+             * @spec exclude Anonymous PSR-11 adapter shim around \OCP\Server::get — pure DI plumbing, no behavioural contract.
+             */
             public function get(string $id): object
             {
                 return Server::get($id);
             }//end get()
 
 
+            /**
+             * Whether NC's global server container can resolve the id.
+             *
+             * @param string $id Service id.
+             *
+             * @return bool
+             *
+             * @spec exclude Anonymous PSR-11 adapter shim around \OCP\Server::get — pure DI plumbing, no behavioural contract.
+             */
             public function has(string $id): bool
             {
                 try {

--- a/lib/Service/Integration/Providers/TalkProvider.php
+++ b/lib/Service/Integration/Providers/TalkProvider.php
@@ -129,6 +129,8 @@ class TalkProvider extends AbstractIntegrationProvider
      *     optional Talk API calls behind method_exists guards; splitting would
      *     hide the leaf-row contract.
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/changes/integration-talk/tasks.md
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -406,6 +408,13 @@ class TalkProvider extends AbstractIntegrationProvider
         return $out;
     }//end mapLinks()
 
+    /**
+     * Provider health descriptor (enabled/disabled echo).
+     *
+     * @return array<string,mixed>
+     *
+     * @spec exclude Static enabled/disabled descriptor echoing IAppManager::isInstalled — no standalone health behaviour; the health/OCS contract is owned by pluggable-integration-registry task-2.
+     */
     public function health(): array
     {
         $installed = $this->appManager->isInstalled(self::REQUIRED_APP);

--- a/lib/Service/Integration/Providers/TimeProvider.php
+++ b/lib/Service/Integration/Providers/TimeProvider.php
@@ -125,6 +125,8 @@ class TimeProvider extends AbstractIntegrationProvider
      * @param array  $filters  Optional registry filters (unused).
      *
      * @return array<int,array<string,mixed>> List of registry leaf rows.
+     *
+     * @spec openspec/changes/integration-time-tracker/tasks.md
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -281,6 +283,13 @@ class TimeProvider extends AbstractIntegrationProvider
         return $rows;
     }//end legacyMarkerRows()
 
+    /**
+     * Provider health descriptor (enabled/disabled echo).
+     *
+     * @return array<string,mixed>
+     *
+     * @spec exclude Static enabled/disabled descriptor echoing isEnabled() — no standalone health behaviour; the health/OCS contract is owned by pluggable-integration-registry task-2.
+     */
     public function health(): array
     {
         $available = $this->isEnabled();

--- a/lib/Service/Integration/Providers/XwikiProvider.php
+++ b/lib/Service/Integration/Providers/XwikiProvider.php
@@ -191,6 +191,8 @@ class XwikiProvider extends AbstractIntegrationProvider
      * to configure it.
      *
      * @return array<string,mixed>
+     *
+     * @spec openspec/changes/integration-xwiki/tasks.md
      */
     public function authRequirements(): array
     {
@@ -221,6 +223,8 @@ class XwikiProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $filters  Optional: `_search`, `_limit`, `_page`.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/integration-xwiki/tasks.md
      */
     public function list(string $register, string $schema, string $objectId, array $filters=[]): array
     {
@@ -309,6 +313,8 @@ class XwikiProvider extends AbstractIntegrationProvider
      * @param string $entityId Canonical XWiki page reference (e.g. `Space.Page`).
      *
      * @return array<string,mixed>
+     *
+     * @spec openspec/changes/integration-xwiki/tasks.md
      */
     public function get(string $register, string $schema, string $objectId, string $entityId): array
     {
@@ -337,6 +343,8 @@ class XwikiProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $payload  At least `reference` (URL or `space.page`).
      *
      * @return array<string,mixed>
+     *
+     * @spec openspec/changes/integration-xwiki/tasks.md
      */
     public function create(string $register, string $schema, string $objectId, array $payload): array
     {
@@ -365,6 +373,8 @@ class XwikiProvider extends AbstractIntegrationProvider
      * @param array<string,mixed> $payload  Fields to update (e.g. `reference`).
      *
      * @return array<string,mixed>
+     *
+     * @spec openspec/changes/integration-xwiki/tasks.md
      */
     public function update(string $register, string $schema, string $objectId, string $entityId, array $payload): array
     {
@@ -393,6 +403,8 @@ class XwikiProvider extends AbstractIntegrationProvider
      * @param string $entityId Canonical XWiki page reference.
      *
      * @return void
+     *
+     * @spec openspec/changes/integration-xwiki/tasks.md
      */
     public function delete(string $register, string $schema, string $objectId, string $entityId): void
     {
@@ -414,6 +426,8 @@ class XwikiProvider extends AbstractIntegrationProvider
      * ok).
      *
      * @return array{status: string, authStatus: string, message: ?string}
+     *
+     * @spec exclude Thin delegation to ExternalIntegrationRouter::probe (annotated to pluggable-integration-registry task-4); carries no provider-specific health behaviour.
      */
     public function health(): array
     {

--- a/lib/Service/Integration/QueryTimeContract.php
+++ b/lib/Service/Integration/QueryTimeContract.php
@@ -74,6 +74,8 @@ final class QueryTimeContract
      *                                               (for the details payload).
      *
      * @return array{message: string, code: int, details: array<string,string>}
+     *
+     * @spec openspec/changes/pluggable-integration-registry/tasks.md#task-6
      */
     public static function buildHttpBody(NotImplementedException $exception, string $integrationId): array
     {

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-integration/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-integration/proposal.md
@@ -1,0 +1,119 @@
+# Retrofit — backend coverage: Service/Integration (annotation-only)
+
+Annotation-only (Bucket 1 style) coverage pass over the
+`lib/Service/Integration/` cluster (ADR-019 pluggable integration
+registry). The scanner flagged 93 uncovered methods across the provider
+contract, the registry, the external-call router, the pagination /
+reference / query-time helpers, and 23 concrete `IntegrationProvider`
+implementations (5 builtin + 18 leaf providers).
+
+This is almost entirely an annotation pass: **no new capabilities are
+minted, and exactly one REQ is added** to the merged
+`generic-integrations` spec — the "canonical pagination envelope" requirement, retroactively specifying the
+`PaginatedResult` envelope-normalisation behavior, which is genuinely
+uncovered in the merged specs (the in-flight `pluggable-integration-registry`
+change describes endpoint pagination, but the merged `generic-integrations`
+spec has no pagination/envelope requirement). Every OTHER behavior in this
+cluster is already owned by an existing change or spec:
+
+- the **provider contract + registry + router + helpers** are owned by
+  the in-flight `pluggable-integration-registry` umbrella (tasks 1-19),
+  whose generic contract is also captured in the merged
+  `generic-integrations` and `integration-shares` specs;
+- each **leaf provider** is owned by its own `integration-{name}`
+  change (e.g. `integration-xwiki`, `integration-deck`,
+  `integration-email`, …) or, for the activity provider, by
+  `retrofit-2026-05-24-activity-provider`.
+
+Per the guardrail "don't duplicate the registry REQs already in the
+in-flight change", the contract REQs are NOT re-authored here — the
+flagged methods are retroactively annotated to the change/task that
+already owns them, the single genuinely-uncovered behavior
+(`PaginatedResult`) gets one new REQ, and the repetitive per-provider
+boilerplate is `@spec exclude`d with a reason.
+
+## Outcome
+
+- **93 methods classified**: every method ends with either
+  `@spec openspec/...` (annotated to a REQ or an owning change) or
+  `@spec exclude <reason>` (boilerplate).
+- **55 annotated** — the genuinely behavioral entrypoints: registry
+  registration/lookup/filtering, external-call routing + failure
+  classification, pagination-envelope normalisation (`PaginatedResult`
+  `fromMixed` + `toArray` → the new pagination-envelope requirement), reference-type
+  validation, query-time 501 translation, and each leaf provider's
+  `list` / `get` / `create` / `update` / `delete` / `authRequirements`
+  read+write path.
+- **37 excluded** as boilerplate: the `IntegrationProvider` interface
+  method declarations (contract shape, no behavior), the
+  `AbstractIntegrationProvider` default-throwing CRUD / trivial-default
+  stubs, the `FilesProvider::create` / `TagsProvider::create`
+  NotImplemented stubs, the `MarkerLookupTrait` LIKE-scan helper, the
+  per-leaf `health` descriptors that only echo a static enabled/disabled
+  status, the `isEnabled` predicate, and `SharesProvider`'s anonymous
+  PSR-11 adapter `get` / `has`.
+- **1 new REQ** (`generic-integrations`, "canonical pagination envelope") — the
+  `PaginatedResult` envelope normalisation, genuinely uncovered in the
+  merged specs; all other contract behavior is owned upstream (see above).
+
+## Annotated (55 methods)
+
+### pluggable-integration-registry (contract + registry + helpers)
+
+- `IntegrationRegistry` — `addProvider` (collision detection + external-source
+  rejection, AD-13/AD-4, task-3), `withProviders` (test-seam replace, task-3),
+  `list` / `listIds` / `get` / `getEnabled` (registry read surface + stage-1
+  enabled filter, task-3)
+- `ExternalIntegrationRouter` — `call` (dispatch + 3-cause failure classification,
+  AD-23, task-4), `probe` (cheap health check for admin UI / OCS, task-4)
+- `PaginatedResult` — `fromMixed` + `toArray` (permissive envelope
+  normalisation onto the canonical `{items,total,nextCursor}` shape) →
+  the new `generic-integrations` "canonical pagination envelope" requirement
+- `PropertyReferenceTypeValidator` — `validate` / `validateAll` (`referenceType`
+  marker validation against the registry, AD-18, task-10)
+- `QueryTimeContract` — `buildHttpBody` (NotImplemented → HTTP 501 envelope for
+  query-time mutation rejection, AD-22, task-6)
+
+### Leaf provider read+write paths (per-leaf integration-* changes)
+
+- `XwikiProvider` — `list` / `get` / `create` / `update` / `delete` /
+  `authRequirements` → `integration-xwiki` (external, OpenConnector-routed)
+- `OpenProjectProvider` — `list` / `get` / `create` / `update` / `delete` /
+  `authRequirements` → `integration-openproject` (external)
+- `DeckProvider` — `list` / `create` / `delete` → `integration-deck` (link-table CRUD)
+- `EmailProvider` — `list` / `create` / `delete` → `integration-email`
+- `FilesProvider` — `list` → pluggable-integration-registry task-12 (builtin, magic-column read)
+- `NotesProvider` — `list` / `create` / `update` / `delete` → pluggable-integration-registry task-13 (builtin)
+- `TasksProvider` — `list` / `create` / `update` / `delete` → pluggable-integration-registry task-14 (builtin)
+- `TagsProvider` — `list` / `create` → pluggable-integration-registry task-15 (builtin)
+- `AuditTrailProvider` — `list` → pluggable-integration-registry task-16 (builtin, query-time)
+- `SharesProvider` — `list` / `delete` → `integration-shares` (query-time aggregation + read+revoke only)
+- The query-time / link-table `list` reads on
+  `AnalyticsProvider`, `BookmarksProvider`, `CollectivesProvider`, `CospendProvider`,
+  `FlowProvider`, `FormsProvider`, `MapsProvider`, `PhotosProvider`, `PollsProvider`,
+  `TalkProvider`, `TimeProvider` → their respective `integration-{name}` changes
+
+## Excluded as boilerplate (37 methods)
+
+Two reasons drive an exclude:
+
+**(a) Trivial / contract-shape, no standalone behavior.** The
+`IntegrationProvider` interface method *declarations* (7 — pure
+contract, behavior lives in implementations), the
+`AbstractIntegrationProvider` default-throwing CRUD stubs +
+`authRequirements`/`requiresPermission` defaults (the
+`NotImplementedException` defaults are owned by the registry contract,
+not per-method behavior), the `isEnabled()` predicates (one-line
+`return true` or `IAppManager::isInstalled()`), and per-leaf `health()`
+descriptors that only echo a static `enabled?ok:unavailable` status.
+
+**(b) Shared helper, no per-method contract.**
+`MarkerLookupTrait::findByMarker` (a defensive LIKE-scan utility shared
+across leaf `list()` impls — the contract is each leaf's `list`, not the
+helper) and `SharesProvider`'s anonymous PSR-11 adapter `get` / `has`
+(NC `\OCP\Server::get` shim).
+
+The full per-method classification is in `tasks.md`.
+
+Source: `/tmp/or-scan/bw-svc-integration.json` (93 methods,
+`lib/Service/Integration/`). See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-integration/specs/generic-integrations/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-integration/specs/generic-integrations/spec.md
@@ -1,0 +1,47 @@
+---
+retrofit: true
+retrofit_extensions:
+  - Integration list responses MUST be normalised into a canonical pagination envelope
+---
+
+# generic-integrations
+
+## ADDED Requirements
+
+### Requirement: Integration list responses MUST be normalised into a canonical pagination envelope
+
+Provider `list()` methods MAY return either a flat row array or a partial envelope (`{items|results, total?, nextCursor?}`); the dispatch layer MUST normalise any such value into the single canonical envelope `{items, total, nextCursor}` via `PaginatedResult::fromMixed()` before it reaches the client. Normalisation MUST be permissive: a flat list MUST yield `total = count(items)` and `nextCursor = null`; a `results` key MUST be treated as an alias of `items`; an absent `total` MUST fall back to the item count; a non-array value MUST yield an empty envelope (`items = []`, `total = 0`). The serialised form MUST additionally mirror `items` under a `results` key for backward-compatible frontend readers. This requirement documents existing behavior implemented by `lib/Service/Integration/PaginatedResult.php`.
+
+#### Scenario: Flat list is wrapped into a single-page envelope
+
+- **GIVEN** a provider's `list()` returns a flat array of 3 rows
+- **WHEN** the value is passed through `PaginatedResult::fromMixed()`
+- **THEN** the result MUST be `{items: <the 3 rows>, total: 3, nextCursor: null}`
+
+#### Scenario: Partial envelope with results alias and explicit total is preserved
+
+- **GIVEN** a provider returns `{results: [row], total: 42, nextCursor: '50'}`
+- **WHEN** the value is normalised
+- **THEN** `items` MUST equal `[row]`
+- **AND** `total` MUST equal `42`
+- **AND** `nextCursor` MUST equal `'50'`
+
+#### Scenario: Absent total falls back to the item count
+
+- **GIVEN** a provider returns `{items: [rowA, rowB]}` with no `total`
+- **WHEN** the value is normalised
+- **THEN** `total` MUST equal `2`
+- **AND** `nextCursor` MUST be `null`
+
+#### Scenario: Non-array value yields an empty envelope
+
+- **GIVEN** a provider returns `null` (or a scalar)
+- **WHEN** the value is normalised
+- **THEN** the result MUST be `{items: [], total: 0, nextCursor: null}`
+
+#### Scenario: Serialised envelope mirrors items under results
+
+- **GIVEN** a normalised envelope with `items = [row]`
+- **WHEN** it is serialised via `toArray()`
+- **THEN** the array MUST contain both `items` and `results` equal to `[row]`
+- **AND** MUST contain `total` and `nextCursor`

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-integration/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-integration/tasks.md
@@ -1,0 +1,58 @@
+# Tasks
+
+Annotation-only retrofit (Bucket 1 style) for the
+`lib/Service/Integration/` cluster. Each task below points at an
+EXISTING change/spec requirement; the matching method docblock carries a
+`@spec ...` annotation. Boilerplate methods carry `@spec exclude
+<reason>` instead. No new capabilities are minted and no spec deltas are
+written, with one exception: a single new REQ
+(the new `generic-integrations` "canonical pagination envelope" requirement) retroactively specifies the
+`PaginatedResult` envelope-normalisation behavior, which is genuinely
+uncovered in the merged specs. Every other behavior maps to a change
+that already owns it (`pluggable-integration-registry`, the per-leaf
+`integration-*` changes, or `retrofit-2026-05-24-activity-provider`).
+
+All tasks are `[x]` because the code already exists.
+
+## Annotated — pluggable-integration-registry (contract + registry + helpers)
+
+- [x] task-1: pluggable-integration-registry#task-3 — `IntegrationRegistry::addProvider` (duplicate-id first-wins + external-source rejection, AD-13/AD-4), `withProviders` (test-seam replace), `list`, `listIds`, `get`, `getEnabled` (stage-1 enabled filter) (retroactive annotation)
+- [x] task-2: pluggable-integration-registry#task-4 — `ExternalIntegrationRouter::call` (dispatch through OpenConnector + classify failure into openconnector-down / source-missing / upstream-down, AD-23) and `probe` (cheap admin-UI/OCS health check) (retroactive annotation)
+- [x] task-3: NEW REQ generic-integrations "canonical pagination envelope" — `PaginatedResult::fromMixed` (permissive normalisation of flat-list / `{items|results,total}` into the canonical `{items,total,nextCursor}` envelope) + `toArray` (serialised mirror with `results` alias) (reverse-spec of existing behavior)
+- [x] task-4: pluggable-integration-registry#task-10 — `PropertyReferenceTypeValidator::validate` / `validateAll` (schema `referenceType` marker must match a registered integration id, AD-18) (retroactive annotation)
+- [x] task-5: pluggable-integration-registry#task-6 — `QueryTimeContract::buildHttpBody` (translate query-time mutation `NotImplementedException` into the HTTP 501 error envelope, AD-22) (retroactive annotation)
+
+## Annotated — builtin providers (pluggable-integration-registry tasks 12-16)
+
+- [x] task-6: pluggable-integration-registry#task-12 — `FilesProvider::list` (FileService magic-column folder enumeration via resolved ObjectEntity) (retroactive annotation)
+- [x] task-7: pluggable-integration-registry#task-13 — `NotesProvider` `list` / `create` / `update` / `delete` (NoteService link-table CRUD delegation) (retroactive annotation)
+- [x] task-8: pluggable-integration-registry#task-14 — `TasksProvider` `list` / `create` / `update` / `delete` (TaskService CalDAV link-table CRUD via composite `{calendarId}/{taskUri}` ids) (retroactive annotation)
+- [x] task-9: pluggable-integration-registry#task-15 — `TagsProvider::list` (NC system-tag link-table read; `create` is a NotImplemented stub — see exclude task-29) (retroactive annotation)
+- [x] task-10: pluggable-integration-registry#task-16 — `AuditTrailProvider::list` (AuditTrailMapper query-time read; read-only by design) (retroactive annotation)
+
+## Annotated — leaf providers (per-leaf integration-* changes)
+
+- [x] task-11: integration-xwiki — `XwikiProvider` `list` / `get` / `create` / `update` / `delete` / `authRequirements` (external, OpenConnector-routed XWiki CRUD + link-table enrichment) (retroactive annotation)
+- [x] task-12: integration-openproject — `OpenProjectProvider` `list` / `get` / `create` / `update` / `delete` / `authRequirements` (external work-package CRUD) (retroactive annotation)
+- [x] task-13: integration-deck — `DeckProvider` `list` / `create` / `delete` (Deck card link-table CRUD) (retroactive annotation)
+- [x] task-14: integration-email — `EmailProvider` `list` / `create` / `delete` (Mail message link CRUD) (retroactive annotation)
+- [x] task-15: integration-shares — `SharesProvider` `list` / `delete` (read+revoke-only: `IManager` folder-walk aggregation + revoke via `IManager::deleteShare`) (retroactive annotation)
+- [x] task-16: integration-analytics — `AnalyticsProvider::list` (link-table read + legacy `[or:{uuid}]` marker fallback) (retroactive annotation)
+- [x] task-17: integration-bookmarks — `BookmarksProvider::list` (query-time read) (retroactive annotation)
+- [x] task-18: integration-collectives — `CollectivesProvider::list` (query-time read) (retroactive annotation)
+- [x] task-19: integration-cospend — `CospendProvider::list` (query-time read) (retroactive annotation)
+- [x] task-20: integration-flow — `FlowProvider::list` (query-time read) (retroactive annotation)
+- [x] task-21: integration-forms — `FormsProvider::list` (query-time read) (retroactive annotation)
+- [x] task-22: integration-maps — `MapsProvider::list` (query-time read) (retroactive annotation)
+- [x] task-23: integration-photos — `PhotosProvider::list` (query-time read) (retroactive annotation)
+- [x] task-24: integration-polls — `PollsProvider::list` (query-time read) (retroactive annotation)
+- [x] task-25: integration-talk — `TalkProvider::list` (query-time conversation read) (retroactive annotation)
+- [x] task-26: integration-time-tracker — `TimeProvider::list` (query-time read) (retroactive annotation)
+
+## Excluded as boilerplate (`@spec exclude` on each method)
+
+- [x] task-27: exclude bucket — `IntegrationProvider` interface method declarations (`authRequirements`, `create`, `delete`, `get`, `health`, `list`, `requiresPermission`, `update`) — pure contract shape, behavior lives in the implementing providers
+- [x] task-28: exclude bucket — `AbstractIntegrationProvider` defaults (`authRequirements`, `requiresPermission` trivial-default returns; `get` / `create` / `update` / `delete` / `health` default `NotImplementedException`/static-descriptor stubs owned by the registry contract, not per-method behavior)
+- [x] task-29: exclude bucket — NotImplemented write stubs + trivial predicates/getters: `FilesProvider::create` and `TagsProvider::create` (write paths deferred to the controller refactor — both throw `NotImplementedException`), `SharesProvider::isEnabled` (one-line `return true`), `SharesProvider` anonymous PSR-11 adapter `get` / `has` (`\OCP\Server::get` shim)
+- [x] task-30: exclude bucket — leaf `health()` descriptors that only echo a static enabled/disabled status (`AnalyticsProvider`, `BookmarksProvider`, `CollectivesProvider`, `ContactsProvider`, `CospendProvider`, `DeckProvider`, `EmailProvider`, `FlowProvider`, `FormsProvider`, `MapsProvider`, `OpenProjectProvider`, `PhotosProvider`, `PollsProvider`, `SharesProvider`, `TalkProvider`, `TimeProvider`, `XwikiProvider`)
+- [x] task-31: exclude bucket — shared helper with no per-method contract: `MarkerLookupTrait::findByMarker` (defensive LIKE-scan utility shared across leaf `list()` impls)


### PR DESCRIPTION
## Summary

Annotation pass over the `lib/Service/Integration/` cluster (ADR-019 pluggable integration registry). All **93** scanner-flagged uncovered methods now carry a method-level `@spec` annotation. **No code logic changed** — docblocks only.

- **55 annotated** to the change/spec that already owns the behavior: the provider contract + registry + router + helpers → the in-flight `pluggable-integration-registry` umbrella (tasks 3/4/6/10/12-16); each leaf provider's `list`/`get`/`create`/`update`/`delete`/`authRequirements` → its own `integration-*` change.
- **38 excluded** as boilerplate with a reason: `IntegrationProvider` interface declarations, `AbstractIntegrationProvider` default-throwing stubs, trivial `isEnabled` predicates, static `health` descriptors, the `MarkerLookupTrait` helper, the `FilesProvider`/`TagsProvider` NotImplemented write stubs, and the `SharesProvider` anonymous PSR-11 adapter.
- **1 new REQ** (`generic-integrations`, "canonical pagination envelope") — reverse-specs the genuinely-uncovered `PaginatedResult` envelope normalisation; the registry contract REQs already owned by `pluggable-integration-registry` are NOT duplicated.

Ghost change `retrofit-2026-05-25-bw-svc-integration` (proposal + tasks + 1-REQ delta) documents the full classification and passes `openspec validate --strict`.

## Test plan

- [x] `openspec validate retrofit-2026-05-25-bw-svc-integration --strict` is valid
- [x] `php -l` passes on all 30 changed files
- [x] every one of the 93 flagged methods has a method-level `@spec` (verified programmatically)
- [ ] reviewer: confirm exclude reasons are sound and no contract REQ is duplicated from `pluggable-integration-registry`