### PR TITLE
retrofit: backend coverage — Service facades (chunk 2)

### DIFF
--- a/lib/Service/ActivityFilterService.php
+++ b/lib/Service/ActivityFilterService.php
@@ -108,6 +108,8 @@ class ActivityFilterService
      *                                less than this value are returned (DESC paging).
      *
      * @return array{results: array<int,array<string,mixed>>, total: int, nextCursor: ?int}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-1
      */
     public function getActivityEntries(
         string $objectUuid,

--- a/lib/Service/AvgComplianceService.php
+++ b/lib/Service/AvgComplianceService.php
@@ -150,6 +150,8 @@ class AvgComplianceService
      * Run every check in sequence and return the aggregate envelope.
      *
      * @return array<string, mixed>
+     *
+     * @spec openspec/specs/avg-verwerkingsregister/spec.md#automated-pii-detection (aggregates every compliance check into a single dashboard envelope with generated timestamp, per-check issues, and totals)
      */
     public function runAllChecks(): array
     {

--- a/lib/Service/BookmarkLinkService.php
+++ b/lib/Service/BookmarkLinkService.php
@@ -131,6 +131,8 @@ class BookmarkLinkService
      * @return BookmarkLink The persisted link row.
      *
      * @throws Exception On missing user, missing bookmark (404), duplicate (409).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function linkBookmark(string $objectUuid, int $registerId, int $schemaId, int $bookmarkId): BookmarkLink
     {
@@ -178,6 +180,8 @@ class BookmarkLinkService
      * @return void
      *
      * @throws Exception When no matching link is found (404).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function unlinkBookmark(string $objectUuid, int $bookmarkId): void
     {
@@ -199,6 +203,8 @@ class BookmarkLinkService
      * @return array<int,array<string,mixed>>
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function getLinkedBookmarks(string $objectUuid): array
     {
@@ -250,6 +256,8 @@ class BookmarkLinkService
      * @return array<int,array{id:int,title:string,url:string,description:string,tags:array<int,string>,added:?int}>
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function getAvailableBookmarks(?string $search=null, ?array $tags=null): array
     {
@@ -313,6 +321,8 @@ class BookmarkLinkService
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function createAndLinkBookmark(
         string $objectUuid,

--- a/lib/Service/CollectiveLinkService.php
+++ b/lib/Service/CollectiveLinkService.php
@@ -195,6 +195,8 @@ class CollectiveLinkService
      *
      * @throws Exception On missing user (401), missing page (404),
      *                   duplicate (409), Collectives unavailable (503).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function linkPage(string $objectUuid, int $registerId, int $schemaId, int $pageId): CollectiveLink
     {
@@ -239,6 +241,8 @@ class CollectiveLinkService
      *
      * @throws Exception On missing user (401), empty title (400),
      *                   missing collective (400), Collectives unavailable (503).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function createAndLinkPage(
         string $objectUuid,
@@ -347,6 +351,8 @@ class CollectiveLinkService
      * @return void
      *
      * @throws Exception On missing user (401) or no matching link (404).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function unlinkPage(string $objectUuid, int $pageId): void
     {
@@ -366,6 +372,8 @@ class CollectiveLinkService
      * @param string $objectUuid Parent OR object uuid.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function getLinkedPages(string $objectUuid): array
     {
@@ -391,6 +399,8 @@ class CollectiveLinkService
      * Returns an empty array when Collectives is unavailable.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function getAvailableCollectives(): array
     {
@@ -433,6 +443,8 @@ class CollectiveLinkService
      * @param string|null $search Optional title-substring filter.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function getAvailablePages(?string $search=null): array
     {

--- a/lib/Service/ContactService.php
+++ b/lib/Service/ContactService.php
@@ -674,6 +674,8 @@ class ContactService
      * @return void
      *
      * @throws Exception If no row is found for the (objectUuid, contactUid) pair.
+     *
+     * @spec exclude Thin (objectUuid,contactUid)->linkId overload; resolves the row then delegates to the already-specced unlinkContact (contacts-actions#task-1).
      */
     public function unlinkContactByUid(string $objectUuid, string $contactUid): void
     {

--- a/lib/Service/DashboardService.php
+++ b/lib/Service/DashboardService.php
@@ -448,6 +448,8 @@ class DashboardService
      * @return int[] Array containing counts of processed and failed logs
      *
      * @psalm-return array{processed: 0|1|2, failed: 0|1|2}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-5
      */
     public function recalculateLogSizes(?int $registerId=null, ?int $schemaId=null): array
     {
@@ -501,6 +503,8 @@ class DashboardService
      * @param int|null $schemaId   The schema ID to filter by (optional)
      *
      * @return array Results with objects, logs, and total processed and failed counts.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-5
      */
     public function recalculateAllSizes(?int $registerId=null, ?int $schemaId=null): array
     {
@@ -729,6 +733,8 @@ class DashboardService
      * @return (int|mixed|string)[][] Array containing chart data for objects by register
      *
      * @psalm-return array{labels: array<'Unknown'|mixed>, series: array<int>}
+     *
+     * @spec exclude Thin try/catch delegation to ObjectMapper::getRegisterChartData with degraded-empty fallback; chart shaping owned by the mapper.
      */
     public function getObjectsByRegisterChartData(?int $registerId=null, ?int $schemaId=null): array
     {
@@ -755,6 +761,8 @@ class DashboardService
      * @return (int|mixed|string)[][] Array containing chart data for objects by schema
      *
      * @psalm-return array{labels: array<'Unknown'|mixed>, series: array<int>}
+     *
+     * @spec exclude Thin try/catch delegation to ObjectMapper::getSchemaChartData with degraded-empty fallback; chart shaping owned by the mapper.
      */
     public function getObjectsBySchemaChartData(?int $registerId=null, ?int $schemaId=null): array
     {
@@ -781,6 +789,8 @@ class DashboardService
      * @return (int|string)[][] Array containing chart data for objects by size
      *
      * @psalm-return array{labels: list<'0-1 KB'|'1-10 KB'|'10-100 KB'|'100 KB-1 MB'|'> 1 MB'>, series: list<int>}
+     *
+     * @spec exclude Thin try/catch delegation to ObjectMapper::getSizeDistributionChartData with degraded-empty fallback; chart shaping owned by the mapper.
      */
     public function getObjectsBySizeChartData(?int $registerId=null, ?int $schemaId=null): array
     {
@@ -808,6 +818,8 @@ class DashboardService
      * @return int[]
      *
      * @psalm-return array{total: int, creates: int, updates: int, deletes: int, reads: int}
+     *
+     * @spec exclude Thin try/catch delegation to AuditTrailMapper::getDetailedStatistics with degraded-empty fallback.
      */
     public function getAuditTrailStatistics(?int $registerId=null, ?int $schemaId=null, ?int $hours=24): array
     {
@@ -842,6 +854,8 @@ class DashboardService
      * @return (int|mixed)[][][]
      *
      * @psalm-return array{actions: list<array{count: int, name: mixed}>}
+     *
+     * @spec exclude Thin try/catch delegation to AuditTrailMapper::getActionDistribution with degraded-empty fallback.
      */
     public function getAuditTrailActionDistribution(?int $registerId=null, ?int $schemaId=null, ?int $hours=24): array
     {
@@ -873,6 +887,8 @@ class DashboardService
      * @return (int|mixed|string)[][][]
      *
      * @psalm-return array{objects: list<array{count: int, id: mixed, name: string}>}
+     *
+     * @spec exclude Thin try/catch delegation to AuditTrailMapper::getMostActiveObjects with degraded-empty fallback.
      */
     public function getMostActiveObjects(?int $registerId=null, ?int $schemaId=null, ?int $limit=10, ?int $hours=24): array
     {

--- a/lib/Service/ExportService.php
+++ b/lib/Service/ExportService.php
@@ -270,6 +270,8 @@ class ExportService
      * @param IUser|null    $currentUser Current user (drives admin metadata column inclusion)
      *
      * @return Spreadsheet Spreadsheet with a single sheet containing only header cells
+     *
+     * @spec openspec/specs/data-import-export/spec.md#import-templates-downloadable-per-schema (builds a header-only template spreadsheet from a schema's properties, with register-context per-language column expansion)
      */
     public function buildTemplateSpreadsheet(
         ?Register $register,
@@ -305,6 +307,8 @@ class ExportService
      * @param IUser|null    $currentUser Current user (drives admin metadata column inclusion)
      *
      * @return string CSV content with a UTF-8 BOM prefix and a single header row
+     *
+     * @spec openspec/specs/data-import-export/spec.md#import-templates-downloadable-per-schema (renders the per-schema import template as a UTF-8 BOM-prefixed CSV so Excel opens it correctly)
      */
     public function buildTemplateCsv(
         ?Register $register,

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -564,6 +564,8 @@ class FileService
      *
      * @psalm-return   array{cleanPath: string, fileName: string}
      * @phpstan-return array{cleanPath: string, fileName: string}
+     *
+     * @spec exclude Pure string/path-splitting utility; no business logic.
      */
     public function extractFileNameFromPath(string $filePath): array
     {
@@ -661,6 +663,8 @@ class FileService
      * @throws NotFoundException If parent folders do not exist
      *
      * @phpstan-return Node|null
+     *
+     * @spec openspec/specs/file-actions/spec.md#object-register-folder-management (unified entry: provisions the backing folder for a Register or ObjectEntity, degrading to null on failure)
      */
     public function createEntityFolder(Register | ObjectEntity $entity): ?Node
     {
@@ -766,6 +770,8 @@ class FileService
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)  Boolean flag is intentional for simple filter toggle
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) File retrieval requires entity type checking
+     *
+     * @spec openspec/specs/file-actions/spec.md#file-crud-operations-on-objects (unified file listing for a Register or ObjectEntity via the stored folder, with optional shared-only filter)
      */
     public function getFilesForEntity(Register|ObjectEntity $entity, ?bool $sharedFilesOnly=false): array
     {
@@ -891,6 +897,8 @@ class FileService
      *
      * @psalm-return   void
      * @phpstan-return void
+     *
+     * @spec exclude Ownership-guard delegation; throws when the current user does not own the node, no standalone business logic.
      */
     public function checkOwnership(Node $file): void
     {
@@ -906,6 +914,8 @@ class FileService
      *
      * @psalm-return   array{labels: list<string>,...}
      * @phpstan-return array<string, mixed>
+     *
+     * @spec exclude File JSON formatting; deferred to the file-actions FileFormattingHandler follow-up pass (see file-actions tasks.md DROP list).
      */
     public function formatFile(Node $file): array
     {
@@ -922,6 +932,8 @@ class FileService
      * @throws NotFoundException If files are not found.
      *
      * @return array Formatted file data with pagination
+     *
+     * @spec exclude File JSON formatting + pagination; deferred to the file-actions FileFormattingHandler follow-up pass (see file-actions tasks.md DROP list).
      */
     public function formatFiles(array $files, ?array $requestParams=[]): array
     {
@@ -969,6 +981,8 @@ class FileService
      *
      * @psalm-return   array<IShare>
      * @phpstan-return array<int, IShare>
+     *
+     * @spec exclude File sharing; deferred to the file-actions FileSharingHandler follow-up pass (see file-actions tasks.md DROP list).
      */
     public function findShares(Node $file, int $shareType=3): array
     {
@@ -1068,6 +1082,8 @@ class FileService
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Share link creation requires handling multiple scenarios
      * @SuppressWarnings(PHPMD.NPathComplexity)      Share link creation has multiple error paths
+     *
+     * @spec exclude Public share-link creation; deferred to the file-actions FileSharingHandler follow-up pass (see file-actions tasks.md DROP list).
      */
     public function createShareLink(string $path, ?int $shareType=3, ?int $permissions=null): string
     {
@@ -1134,6 +1150,8 @@ class FileService
      * @throws Exception If creating the folder is not permitted
      *
      * @return Node The Node object for the folder (existing or newly created), or null on failure
+     *
+     * @spec openspec/specs/file-actions/spec.md#object-register-folder-management (idempotent get-or-create of a folder at the given path under the OpenRegister root)
      */
     public function createFolder(string $folderPath): Node
     {
@@ -1159,6 +1177,8 @@ class FileService
      *
      * @phpstan-param array<int, string> $tags
      * @psalm-param   array<int, string> $tags
+     *
+     * @spec openspec/specs/file-actions/spec.md#file-crud-operations-on-objects (updates a file's content and tags within an object's folder)
      */
     public function updateFile(string|int $filePath, mixed $content=null, array $tags=[], ?ObjectEntity $object=null): File
     {
@@ -1212,6 +1232,8 @@ class FileService
      * @return bool True if successful, false if the file didn't exist.
      *
      * @throws Exception If deleting the file is not permitted or file operations fail.
+     *
+     * @spec openspec/specs/file-actions/spec.md#file-crud-operations-on-objects (deletes a file resolved by node/path/id, with object-folder context)
      */
     public function deleteFile(Node | string | int $file, ?ObjectEntity $object=null): bool
     {
@@ -1233,6 +1255,8 @@ class FileService
      *
      * @phpstan-param array<int, string> $tags
      * @psalm-param   array<int, string> $tags
+     *
+     * @spec openspec/specs/file-actions/spec.md#object-tagging-via-nextcloud-system-tags (attaches NC system tags to a file by id)
      */
     public function attachTagsToFile(string $fileId, array $tags=[]): void
     {
@@ -1329,6 +1353,8 @@ class FileService
      * @psalm-param   array<int, string> $tags
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Boolean flag is intentional for simple share toggle
+     *
+     * @spec openspec/specs/file-actions/spec.md#file-crud-operations-on-objects (creates/writes a file into an object's folder with optional tags and share toggle)
      */
     public function saveFile(
         ObjectEntity $objectEntity,
@@ -1395,6 +1421,8 @@ class FileService
      * @phpstan-return array<int, Node>
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Boolean flag is intentional for simple filter toggle
+     *
+     * @spec openspec/specs/file-actions/spec.md#file-crud-operations-on-objects (lists an object's files via its stored folder, with optional shared-only filter)
      */
     public function getFiles(ObjectEntity | string $object, ?bool $sharedFilesOnly=false): array
     {
@@ -1445,6 +1473,8 @@ class FileService
      *
      * @phpstan-param  int $fileId
      * @phpstan-return File|null
+     *
+     * @spec openspec/specs/file-actions/spec.md#file-crud-operations-on-objects (resolves a single file node by NC file id, null on miss)
      */
     public function getFileById(int $fileId): ?File
     {
@@ -1525,6 +1555,8 @@ class FileService
      *
      * @psalm-return   File
      * @phpstan-return File
+     *
+     * @spec exclude File publish via public share; deferred to the file-actions FilePublishingHandler follow-up pass (see file-actions tasks.md DROP list).
      */
     public function publishFile(ObjectEntity | string $object, string | int $file): File
     {
@@ -1548,6 +1580,8 @@ class FileService
      *
      * @psalm-return   File
      * @phpstan-return File
+     *
+     * @spec exclude File unpublish (remove public share); deferred to the file-actions FilePublishingHandler follow-up pass (see file-actions tasks.md DROP list).
      */
     public function unpublishFile(ObjectEntity | string $object, string|int $filePath): File
     {
@@ -1575,6 +1609,8 @@ class FileService
      *
      * @psalm-return   array{path: string, filename: string, size: int, mimeType: 'application/zip'}
      * @phpstan-return array{path: string, filename: string, size: int, mimeType: string}
+     *
+     * @spec exclude Object-files ZIP build; deferred to the file-actions FilePublishingHandler follow-up pass (see file-actions tasks.md DROP list).
      */
     public function createObjectFilesZip(ObjectEntity | string $object, ?string $zipName=null): array
     {
@@ -1595,6 +1631,8 @@ class FileService
      * @psalm-return array{id: int, name: string, path: string,
      *     type: string, mimetype: string, size: float|int,
      *     parent_id: int, parent_path: string}|null
+     *
+     * @spec exclude Diagnostic/debug helper for troubleshooting file lookups; not a product behavior.
      */
     public function debugFindFileById(int $fileId): array|null
     {
@@ -1657,6 +1695,8 @@ class FileService
      *
      * @psalm-return list<array{id: int, mimetype: string, name: string,
      *     path: string, size: float|int, type: string}>
+     *
+     * @spec exclude Diagnostic/debug helper for troubleshooting object-file listings; not a product behavior.
      */
     public function debugListObjectFiles(ObjectEntity $object): array
     {
@@ -1725,6 +1765,8 @@ class FileService
      * @throws NotFoundException If parent folders do not exist
      *
      * @return int The created folder ID
+     *
+     * @spec openspec/specs/file-actions/spec.md#object-register-folder-management (provisions an object's folder and returns its id without writing the id back onto the entity)
      */
     public function createObjectFolderWithoutUpdate(ObjectEntity $objectEntity, ?IUser $currentUser=null): int
     {
@@ -1747,6 +1789,8 @@ class FileService
      * @return File The processed file
      *
      * @throws Exception If replacement fails
+     *
+     * @spec exclude One-line delegation to DocumentProcessingHandler::replaceWords; no facade-owned logic.
      */
     public function replaceWords(Node $node, array $replacements, ?string $outputName=null): File
     {
@@ -1769,6 +1813,8 @@ class FileService
      * @throws Exception If anonymization fails.
      *
      * @return Node The anonymized file node.
+     *
+     * @spec exclude One-line delegation to DocumentProcessingHandler::anonymizeDocument; no facade-owned logic.
      */
     public function anonymizeDocument(Node $node, array $entities): Node
     {

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -206,6 +206,8 @@ class ImportService
      *     softDeleted: list<string>,
      *     errors: list<array{uuid: string, error: string}>
      * }
+     *
+     * @spec openspec/specs/data-import-export/spec.md#import-rollback-on-critical-failure (rolls back an import unit: finds every create-audited object for the import job UUID and soft-deletes them, reporting per-object outcomes)
      */
     public function softDeleteByImportJobId(string $importJobId): array
     {
@@ -1642,6 +1644,8 @@ class ImportService
      * Clear all internal caches to prevent issues between imports
      *
      * @return void
+     *
+     * @spec exclude One-line reset of the internal schema-properties cache; no business logic.
      */
     public function clearCaches(): void
     {
@@ -1686,6 +1690,8 @@ class ImportService
      * @param int    $maxObjects    Maximum objects to index during warmup (default: 5000)
      *
      * @return bool True if job was scheduled successfully
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-3
      */
     public function scheduleSolrWarmup(
         array $importSummary,
@@ -1787,6 +1793,8 @@ class ImportService
      * @return string Recommended warmup mode
      *
      * @psalm-return 'balanced'|'fast'|'safe'
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-3
      */
     public function getRecommendedWarmupMode(int $totalImported): string
     {
@@ -1818,6 +1826,8 @@ class ImportService
      * @psalm-suppress PossiblyUnusedReturnValue
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Immediate flag controls scheduling timing
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-3
      */
     public function scheduleSmartSolrWarmup(array $importSummary, bool $immediate=false): bool
     {

--- a/lib/Service/LanguageService.php
+++ b/lib/Service/LanguageService.php
@@ -128,6 +128,8 @@ class LanguageService
      * Check if all translations should be returned.
      *
      * @return bool True if _translations=all was requested
+     *
+     * @spec exclude Trivial boolean getter for the request-scoped returnAll flag; no business logic.
      */
     public function shouldReturnAllTranslations(): bool
     {
@@ -166,6 +168,8 @@ class LanguageService
      * @param array $registerLanguages Array of language codes from the register
      *
      * @return string The best matching language code
+     *
+     * @spec openspec/specs/register-i18n/spec.md#fallback-language-chain (matches accepted languages against a register's available languages in priority order, with base-language fallback and register-default fallback flagged as fallbackUsed)
      */
     public function resolveLanguageForRegister(array $registerLanguages): string
     {
@@ -204,6 +208,8 @@ class LanguageService
      * @param string $headerValue The Accept-Language header value
      *
      * @return string[] Ordered array of language codes (highest priority first)
+     *
+     * @spec openspec/specs/register-i18n/spec.md#language-negotiation-accept-language (parses the Accept-Language header per RFC 9110, ordering language tags by descending q-value then appearance)
      */
     public static function parseAcceptLanguageHeader(string $headerValue): array
     {

--- a/lib/Service/LogService.php
+++ b/lib/Service/LogService.php
@@ -139,6 +139,8 @@ class LogService
      * @throws \OCP\AppFramework\Db\DoesNotExistException If object not found
      *
      * @psalm-return array<\OCA\OpenRegister\Db\AuditTrail>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-4
      */
     public function getLogs(string $register, string $schema, string $id, array $config=[]): array
     {
@@ -206,6 +208,8 @@ class LogService
      * @throws \OCP\AppFramework\Db\DoesNotExistException If object not found
      *
      * @psalm-return int<0, max>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-4
      */
     public function count(string $register, string $schema, string $id): int
     {
@@ -261,6 +265,8 @@ class LogService
      * @return \OCA\OpenRegister\Db\AuditTrail[] Array of audit trail entries
      *
      * @psalm-return array<\OCA\OpenRegister\Db\AuditTrail>
+     *
+     * @spec exclude Thin delegation to AuditTrailMapper::findAll with default pagination/sort; no business logic.
      */
     public function getAllLogs(array $config=[]): array
     {
@@ -281,6 +287,8 @@ class LogService
      * @return int Number of audit trail entries
      *
      * @psalm-return int<0, max>
+     *
+     * @spec exclude Thin delegation to AuditTrailMapper::findAll + count(); no business logic.
      */
     public function countAllLogs(array $filters=[]): int
     {
@@ -319,6 +327,8 @@ class LogService
      * @throws \InvalidArgumentException If unsupported format is specified
      *
      * @psalm-return array{content: bool|string, filename: string, contentType: string}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-4
      */
     public function exportLogs(string $format, array $config=[]): array
     {
@@ -355,6 +365,8 @@ class LogService
      * @return true True if deletion was successful
      *
      * @throws \OCP\AppFramework\Db\DoesNotExistException If audit trail not found
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-4
      */
     public function deleteLog(int $id): bool
     {
@@ -382,6 +394,8 @@ class LogService
      * @throws \Exception If mass deletion fails
      *
      * @psalm-return array{deleted: int<0, max>, failed: int<0, max>, total: int<0, max>}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-4
      */
     public function deleteLogs(array $config=[]): array
     {

--- a/lib/Service/MetricsService.php
+++ b/lib/Service/MetricsService.php
@@ -140,6 +140,8 @@ class MetricsService
      * @throws \Exception If database operation fails (logged but not rethrown)
      *
      * @psalm-suppress PossiblyNullArgument
+     *
+     * @spec openspec/specs/production-observability/spec.md#metrics-storage-strategy (fail-soft insert of an operational metric row — type, entity, status, duration, metadata, error, user, timestamp — that never disrupts the calling operation on DB error)
      */
     public function recordMetric(
         string $metricType,
@@ -478,6 +480,8 @@ class MetricsService
      * @return int Number of deleted records
      *
      * @psalm-suppress PossiblyInvalidMethodCall
+     *
+     * @spec openspec/specs/production-observability/spec.md#metrics-storage-strategy (retention pruning: deletes metric rows older than the retention window to bound table growth)
      */
     public function cleanOldMetrics(int $retentionDays=90): int
     {

--- a/lib/Service/OpenProjectLinkService.php
+++ b/lib/Service/OpenProjectLinkService.php
@@ -150,6 +150,8 @@ class OpenProjectLinkService
      *
      * @throws Exception On missing user (401), duplicate (409),
      *                   OpenConnector/source unavailable (503).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function linkWorkPackage(string $objectUuid, int $registerId, int $schemaId, int $workPackageId): OpenProjectLink
     {
@@ -200,6 +202,8 @@ class OpenProjectLinkService
      *
      * @throws Exception On missing user (401), empty subject (400),
      *                   missing project (400), source unavailable (503).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function createAndLinkWorkPackage(
         string $objectUuid,
@@ -309,6 +313,8 @@ class OpenProjectLinkService
      * @return void
      *
      * @throws Exception On missing user (401) or no matching link (404).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function unlink(string $objectUuid, int $workPackageId): void
     {
@@ -328,6 +334,8 @@ class OpenProjectLinkService
      * @param string $objectUuid Parent OR object uuid.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function getLinkedWorkPackages(string $objectUuid): array
     {
@@ -356,6 +364,8 @@ class OpenProjectLinkService
      * @return array<int,array<string,mixed>>
      *
      * @throws Exception When the source is unconfigured / unreachable (503).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function getAvailableWorkPackages(?string $search=null): array
     {

--- a/lib/Service/OperatorEvaluator.php
+++ b/lib/Service/OperatorEvaluator.php
@@ -53,6 +53,8 @@ class OperatorEvaluator
      * @param array $operators Operator conditions (e.g. ['$gt' => 5, '$lt' => 10])
      *
      * @return bool True if value matches all operators
+     *
+     * @spec openspec/specs/row-field-level-security/spec.md#mongodb-style-operators (evaluates $eq/$ne/$in/$nin/$exists/$gt/$gte/$lt/$lte for RLS/FLS match conditions, fail-closed on unknown operators with null-handling that mirrors SQL three-valued logic so list and find verdicts stay aligned)
      */
     public function valueMatchesOperator(mixed $value, array $operators): bool
     {

--- a/lib/Service/OrganisationService.php
+++ b/lib/Service/OrganisationService.php
@@ -273,6 +273,8 @@ class OrganisationService
      *
      * @psalm-return array{organisation: array{default_organisation: mixed|null,
      *               auto_create_default_organisation: mixed|true}}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-4
      */
     public function getOrganisationSettingsOnly(): array
     {
@@ -304,6 +306,8 @@ class OrganisationService
      * Get default organisation UUID from settings
      *
      * @return string|null Default organisation UUID or null if not set
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-4
      */
     public function getDefaultOrganisationUuid(): ?string
     {
@@ -612,6 +616,8 @@ class OrganisationService
      * @return true True if successfully added
      *
      * @throws Exception If organisation not found, user not logged in, or target user does not exist
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-4
      */
     public function joinOrganisation(string $organisationUuid, ?string $targetUserId=null): bool
     {
@@ -894,6 +900,8 @@ class OrganisationService
      * Get user organisation statistics
      *
      * @return array Statistics with total count, active organisation, and results list.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-4
      */
     public function getUserOrganisationStats(): array
     {
@@ -921,6 +929,8 @@ class OrganisationService
      * Clear default organisation cache (public method for external use)
      *
      * @return void
+     *
+     * @spec exclude Trivial static default-org cache reset; no business logic.
      */
     public function clearDefaultOrganisationCache(): void
     {
@@ -943,6 +953,8 @@ class OrganisationService
      * @psalm-suppress PossiblyUnusedReturnValue
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Boolean flag controls whether to clear persistent settings
+     *
+     * @spec exclude Cache-invalidation helper (request/session/static caches + optional persistent setting); no business logic.
      */
     public function clearCache(bool $clearPersistent=false): bool
     {
@@ -1420,6 +1432,8 @@ class OrganisationService
      * Uses the active organisation or falls back to default
      *
      * @return null|string The organisation UUID to use
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-4
      */
     public function getOrganisationForNewEntity(): string|null
     {
@@ -1454,6 +1468,8 @@ class OrganisationService
      * Get the default organisation UUID from config
      *
      * @return null|string The UUID of the default organisation, or null if not set
+     *
+     * @spec exclude Trivial app-config getter for the defaultOrganisation key; no business logic.
      */
     public function getDefaultOrganisationId(): string|null
     {
@@ -1571,6 +1587,8 @@ class OrganisationService
      * @param string $uuid The UUID of the organisation to set as default
      *
      * @return void
+     *
+     * @spec exclude Trivial app-config setter + cache bust; no business logic.
      */
     public function setDefaultOrganisationId(string $uuid): void
     {

--- a/lib/Service/PropertyRbacHandler.php
+++ b/lib/Service/PropertyRbacHandler.php
@@ -85,6 +85,8 @@ class PropertyRbacHandler
      * @param array  $object   Object data (for conditional matching)
      *
      * @return bool True if user can read the property
+     *
+     * @spec openspec/specs/row-field-level-security/spec.md#field-level-security (property-level read authorization: evaluates the property's read rules against the current user's groups + object conditions)
      */
     public function canReadProperty(Schema $schema, string $property, array $object): bool
     {
@@ -105,6 +107,8 @@ class PropertyRbacHandler
      * @param bool   $isCreate Whether this is a create operation
      *
      * @return bool True if user can update the property
+     *
+     * @spec openspec/specs/row-field-level-security/spec.md#field-level-security (property-level update authorization, with create-mode organisation-match skipping per the FLS-on-create requirement)
      */
     public function canUpdateProperty(
         Schema $schema,
@@ -128,6 +132,8 @@ class PropertyRbacHandler
      * @param array  $object Object data to filter
      *
      * @return array Filtered object with only readable properties
+     *
+     * @spec openspec/specs/row-field-level-security/spec.md#fls-strips-restricted-fields (strips unreadable property-authorized fields from outgoing data; admin + no-property-auth short-circuit)
      */
     public function filterReadableProperties(Schema $schema, array $object): array
     {
@@ -177,6 +183,8 @@ class PropertyRbacHandler
      * @param bool   $isCreate     Whether this is a create operation
      *
      * @return array Array of property names user cannot update
+     *
+     * @spec openspec/specs/row-field-level-security/spec.md#field-level-security (validates incoming writes against property update rules; skips unchanged values so PATCH may resubmit protected fields)
      */
     public function getUnauthorizedProperties(
         Schema $schema,
@@ -410,6 +418,8 @@ class PropertyRbacHandler
      * Check if current user is admin
      *
      * @return bool True if user is in admin group
+     *
+     * @spec exclude Trivial admin-group membership check helper; no business logic.
      */
     public function isAdmin(): bool
     {

--- a/lib/Service/RegisterService.php
+++ b/lib/Service/RegisterService.php
@@ -166,6 +166,8 @@ class RegisterService
      * @throws \OCP\AppFramework\Db\DoesNotExistException If register not found
      * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException If multiple registers found (should not happen)
      * @throws \OCP\DB\Exception If database error occurs
+     *
+     * @spec exclude Pure pass-through to RegisterMapper::find; no business logic.
      */
     public function find(int | string $id, array $_extend=[], bool $_multitenancy=true): Register
     {
@@ -193,6 +195,8 @@ class RegisterService
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)    Optional parameters use null defaults for flexibility
      * @SuppressWarnings(PHPMD.ExcessiveParameterList) Multiple optional filter parameters for flexibility
+     *
+     * @spec exclude Pure pass-through to RegisterMapper::findAll; no business logic.
      */
     public function findAll(
         ?int $limit=null,
@@ -223,6 +227,8 @@ class RegisterService
      * @return Register The created register
      *
      * @throws Exception If register creation fails
+     *
+     * @spec openspec/specs/file-actions/spec.md#object-register-folder-management (after mapper create, assigns the active/default organisation for multi-tenancy and provisions the register's backing folder)
      */
     public function createFromArray(array $data): Register
     {
@@ -280,6 +286,8 @@ class RegisterService
      * @return Register The updated register
      *
      * @throws Exception If register update fails
+     *
+     * @spec openspec/specs/file-actions/spec.md#object-register-folder-management (after mapper update, ensures the register's backing folder exists, healing legacy null/string folder properties)
      */
     public function updateFromArray(int $id, array $data): Register
     {
@@ -302,6 +310,8 @@ class RegisterService
      * @throws Exception If register has attached objects or deletion fails
      *
      * @psalm-suppress PossiblyUnusedReturnValue
+     *
+     * @spec exclude Pure pass-through to RegisterMapper::delete; no business logic.
      */
     public function delete(Register $register): Register
     {
@@ -376,6 +386,8 @@ class RegisterService
      * @return array<int, array{total: int}> Associative array mapping schema IDs to counts
      *
      * @psalm-return array<int, array{total: int}>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-5
      */
     public function getSchemaObjectCounts(int $registerId, array $schemas): array
     {

--- a/lib/Service/RequestScopedCache.php
+++ b/lib/Service/RequestScopedCache.php
@@ -81,6 +81,8 @@ class RequestScopedCache
      * @param mixed  $value     The value to cache
      *
      * @return void
+     *
+     * @spec exclude Trivial in-memory cache write; no business logic. Class behavior already annotated under annotate-openregister#task-58.
      */
     public function set(string $namespace, string $key, mixed $value): void
     {
@@ -94,6 +96,8 @@ class RequestScopedCache
      * @param string $key       The cache key
      *
      * @return bool True if the key exists (even if value is null)
+     *
+     * @spec exclude Trivial array-key existence check; no business logic.
      */
     public function has(string $namespace, string $key): bool
     {
@@ -108,6 +112,8 @@ class RequestScopedCache
      * @param string[] $keys      The cache keys to look up
      *
      * @return array<string, mixed> Map of key => value for found entries only
+     *
+     * @spec exclude Trivial fan-out over has()/get(); no business logic.
      */
     public function getMultiple(string $namespace, array $keys): array
     {
@@ -127,6 +133,8 @@ class RequestScopedCache
      * @param string|null $namespace Namespace to clear, or null to clear everything
      *
      * @return void
+     *
+     * @spec exclude Trivial cache reset (unset namespace or empty array); no business logic.
      */
     public function clear(?string $namespace=null): void
     {

--- a/lib/Service/TalkLinkService.php
+++ b/lib/Service/TalkLinkService.php
@@ -126,6 +126,8 @@ class TalkLinkService
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Sequential guard
      *     clauses (no user, duplicate, Talk unavailable, find failure,
      *     null room) followed by best-effort cache extraction.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function linkRoom(string $objectUuid, int $registerId, int $schemaId, string $roomToken): TalkLink
     {
@@ -182,6 +184,8 @@ class TalkLinkService
      * @return void
      *
      * @throws Exception When no matching link is found (404).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function unlinkRoom(string $objectUuid, string $roomToken): void
     {
@@ -202,6 +206,8 @@ class TalkLinkService
      * @param string $objectUuid Parent OR object uuid.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function getLinkedRooms(string $objectUuid): array
     {
@@ -269,6 +275,8 @@ class TalkLinkService
      *                   type, or create failure.
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function createAndLinkRoom(
         string $objectUuid,
@@ -387,6 +395,8 @@ class TalkLinkService
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function getAvailableRoomsForUser(?string $search = null): array
     {

--- a/lib/Service/TextExtractionService.php
+++ b/lib/Service/TextExtractionService.php
@@ -172,6 +172,8 @@ class TextExtractionService
      * @throws Exception If extraction fails
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Boolean flag needed for force re-extraction behavior
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-5
      */
     public function extractFile(int $fileId, bool $forceReExtract=false): void
     {
@@ -313,6 +315,8 @@ class TextExtractionService
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)   Boolean flag needed for force re-extraction behavior
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Comprehensive object extraction requires detailed processing
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-5
      */
     public function extractObject(int $objectId, bool $forceReExtract=false): void
     {
@@ -1017,6 +1021,8 @@ class TextExtractionService
      * @return (int|string)[] Statistics about discovery: {discovered, failed, total}
      *
      * @psalm-return array{discovered: int<0, max>, failed: int<0, max>, total: int<0, max>, error?: string}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-5
      */
     public function discoverUntrackedFiles(int $limit=100): array
     {
@@ -1100,6 +1106,8 @@ class TextExtractionService
      * @return int[] Statistics about the extraction process: {processed, failed, total}
      *
      * @psalm-return array{processed: int<0, max>, failed: int<0, max>, total: int<0, max>}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-5
      */
     public function extractPendingFiles(int $limit=100): array
     {
@@ -1179,6 +1187,8 @@ class TextExtractionService
      * @return int[] Statistics about the retry process
      *
      * @psalm-return array{retried: int<0, max>, failed: int<0, max>, total: int<0, max>}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-5
      */
     public function retryFailedExtractions(int $limit=50): array
     {
@@ -1229,6 +1239,8 @@ class TextExtractionService
      *     totalObjects: int,
      *     totalEntities: int
      * }
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-5
      */
     public function getStats(): array
     {
@@ -1716,6 +1728,8 @@ class TextExtractionService
      * @return (int|mixed|string)[][] Array of text chunks
      *
      * @psalm-return array<int<0, max>, array{text: mixed|string, start_offset: int|mixed, end_offset: int|mixed}>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-5
      */
     public function chunkDocument(string $text, array $options=[]): array
     {

--- a/lib/Service/WebhookService.php
+++ b/lib/Service/WebhookService.php
@@ -809,6 +809,8 @@ class WebhookService
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Complex request interception logic
      * @SuppressWarnings(PHPMD.NPathComplexity)      Multiple webhook processing paths
      * Fallback when formatter is unavailable
+     *
+     * @spec openspec/specs/webhook-payload-mapping/spec.md#request-interception-pre-event-webhooks (finds before-event webhooks for the event type, formats the request as a CloudEvent, delivers to each, and continues past per-webhook failures, returning the request data)
      */
     public function interceptRequest(IRequest $request, string $eventType): array
     {

--- a/lib/Service/XwikiLinkService.php
+++ b/lib/Service/XwikiLinkService.php
@@ -206,6 +206,8 @@ class XwikiLinkService
      *
      * @throws Exception On missing user (401), empty reference (400),
      *                   duplicate (409), source unconfigured/upstream down (503).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function linkPage(string $objectUuid, int $registerId, int $schemaId, string $pageReference): XwikiLink
     {
@@ -260,6 +262,8 @@ class XwikiLinkService
      *
      * @throws Exception On missing user (401), empty title/space (400),
      *                   source unconfigured/upstream down (503).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function createAndLinkPage(
         string $objectUuid,
@@ -378,6 +382,8 @@ class XwikiLinkService
      * @return void
      *
      * @throws Exception On missing user (401) or no matching link (404).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function unlinkPage(string $objectUuid, string $pageReference): void
     {
@@ -400,6 +406,8 @@ class XwikiLinkService
      * @param string $objectUuid Parent OR object uuid.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function getLinkedPages(string $objectUuid): array
     {
@@ -431,6 +439,8 @@ class XwikiLinkService
      * @return array<string,mixed> `{ results, total }` on success, or
      *                             `{ unavailable, cause, results, total }`
      *                             when the source is unconfigured/down.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-2
      */
     public function getAvailablePages(?string $search=null): array
     {

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/proposal.md
@@ -1,0 +1,94 @@
+# Retrofit — service bundle: top-level service facades (chunk 2)
+
+Reverse-specs a chunk of uncovered top-level `lib/Service/*.php` service
+facades flagged by the OpenRegister backend coverage scan. The batch
+(`/tmp/or-scan/bw2-svc-flat-2.json`) lists 112 uncovered public methods
+across 22 service files. Code already exists in production — this change
+retroactively anchors the genuinely facade-owned behavior to spec and
+tags every boilerplate facade delegation with `@spec exclude` per
+ADR-003.
+
+## Why
+
+The scanner flagged 112 `missing @spec` methods. Most are facade
+plumbing — constructors, one-line delegations to already-specced
+handlers, trivial getters/setters, and degraded-path mapper wrappers —
+which ADR-003 covers with `@spec exclude <reason>`. A minority encode
+genuinely novel behavior that no existing requirement captures. Those
+either map onto an existing owning capability (annotated in-place
+against that capability's spec) or, where no capability owns them, are
+captured here as new requirements (≤5 total).
+
+## What Changes
+
+Five new requirements, each in its owning capability:
+
+- **activity-provider** — the Tier-2 filtered + cursor-paginated read
+  surface over NC Activity entries linked to an OR object
+  (`ActivityFilterService::getActivityEntries`). The existing IFilter/
+  IProvider REQs cover the activity-stream UI, not this REST data read.
+- **generic-integrations** — the Tier-2 entity link-service contract
+  shared by the xWiki / Talk / OpenProject / Bookmark / Collective link
+  services: link-existing, create-and-link, unlink-without-remote-delete,
+  list-with-stale-cache-refresh, and picker-with-graceful-degradation.
+- **search-index** — adaptive post-import Solr warmup scheduling
+  (`ImportService::scheduleSolrWarmup` / `scheduleSmartSolrWarmup` /
+  `getRecommendedWarmupMode`): import completion schedules a background
+  index warmup whose mode + object cap scale with the import size.
+- **audit-trail-immutable** — the LogService audit-trail access surface:
+  object-scoped log retrieval with soft-deleted register/schema
+  tolerance, multi-format export, and admin-only deletion.
+- **text-extraction** (new capability) — the file→chunk extraction
+  lifecycle (`TextExtractionService`): extract a file/object into chunks
+  with modified-since re-extraction detection, discover untracked files,
+  drain a pending queue, retry failures, and report stats.
+
+Everything else is tagged `@spec exclude` or annotated against an
+existing capability spec / change.
+
+## Annotation against existing capabilities (no new REQ)
+
+These methods encode behavior already owned by a committed capability;
+they are annotated in-place against that capability rather than re-spec'd:
+
+- `LanguageService::parseAcceptLanguageHeader`, `resolveLanguageForRegister`
+  → `register-i18n` (Accept-Language negotiation + per-register fallback chain).
+- `OperatorEvaluator::valueMatchesOperator`,
+  `PropertyRbacHandler::canReadProperty` / `canUpdateProperty` /
+  `filterReadableProperties` / `getUnauthorizedProperties`
+  → `row-field-level-security` (FLS property authorization + MongoDB-style
+  operator matching with SQL three-valued-logic parity).
+- `MetricsService::recordMetric`, `cleanOldMetrics`
+  → `production-observability` (metric write path + retention pruning).
+- `WebhookService::interceptRequest`
+  → `webhook-payload-mapping` (pre-event request-interception webhooks).
+- `ExportService::buildTemplateCsv`, `buildTemplateSpreadsheet`
+  → `data-import-export` (downloadable per-schema import templates).
+- `ImportService::softDeleteByImportJobId`
+  → `data-import-export` (import rollback on critical failure).
+- `AvgComplianceService::runAllChecks`
+  → `avg-verwerkingsregister` (automated PII compliance smell aggregate).
+- `DashboardService::recalculateLogSizes`, `recalculateAllSizes`,
+  `RegisterService::getSchemaObjectCounts`
+  → `built-in-dashboards` (size recalculation + object-count metrics;
+  annotated against the existing `b-svc-compute-profile-org` change).
+- `OrganisationService::getOrganisationForNewEntity`, `joinOrganisation`,
+  `getUserOrganisationStats`, `getOrganisationSettingsOnly`,
+  `getDefaultOrganisationUuid`
+  → multi-tenancy organisation feature (existing `b-svc-compute-profile-org`
+  change).
+- `RegisterService::createFromArray`, `updateFromArray`
+  → `file-actions` REQ-004 (register folder provisioning on register CRUD).
+- `FileService` file CRUD / folder / tagging methods (`getFiles`,
+  `getFilesForEntity`, `getFileById`, `saveFile`, `updateFile`,
+  `deleteFile`, `createEntityFolder`, `createFolder`,
+  `createObjectFolderWithoutUpdate`, `attachTagsToFile`)
+  → `file-actions` REQ-001/004/005.
+- `TextExtractionService::extractFile` / `extractObject` / `chunkDocument` /
+  `discoverUntrackedFiles` / `extractPendingFiles` / `retryFailedExtractions` /
+  `getStats` → the new `text-extraction` capability (REQ-001 below).
+
+## Source
+
+`/tmp/or-scan/bw2-svc-flat-2.json` (112 methods, 22 files). Behavior
+described here is what the code does today, not aspirational.

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/activity-provider/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/activity-provider/spec.md
@@ -1,0 +1,33 @@
+---
+retrofit: true
+---
+
+# Activity Provider
+
+## Why
+
+The existing IProvider/IFilter requirements cover how OpenRegister
+activity events are published and how the NC activity-stream UI filters
+them. They do not cover the Tier-2 REST read surface
+(`ActivityFilterService`) that the bespoke object-sidebar Activity tab
+calls to page through the activity entries linked to a single OR object.
+That surface owns its own filter, pagination, and degradation contract,
+which this change anchors.
+
+## ADDED Requirements
+
+### Requirement: REQ-A1 The Tier-2 activity read surface MUST return filtered, cursor-paginated entries linked to an object and MUST degrade to empty when the Activity app is absent
+The service MUST resolve NC Activity entries linked to an OR object via the `[or:{objectUuid}]` subject marker, apply optional type / actor / date-range filters, return a bounded cursor-paginated page ordered newest-first, and return an empty result set (never throw) when the NC Activity app is not installed or a query fails.
+
+`ActivityFilterService::getActivityEntries()` MUST match entries by the `[or:{objectUuid}]` marker in the `activity.subject` column, MUST apply the optional exact `type`, exact `actor` (`affecteduser`), and `after` (Unix-timestamp lower bound) filters when supplied, MUST clamp the requested page size into `[1, MAX_LIMIT]` defaulting to `DEFAULT_LIMIT`, MUST page descending by `timestamp` then `activity_id` using a strict-less-than cursor, and MUST return `{ results, total, nextCursor }` where `total` is the filter-set count ignoring the cursor and `nextCursor` is null on the last page. When the Activity app is unavailable the result MUST be `{ results: [], total: 0, nextCursor: null }`, and any DB error MUST be logged and degraded to an empty result rather than propagated.
+
+#### Scenario: Filtered page returned with next cursor
+- **GIVEN** an OR object has more linked activity entries than one page
+- **WHEN** `getActivityEntries()` is called with a type filter and a page limit
+- **THEN** only marker-matched entries of that type MUST be returned, newest-first
+- **AND** `nextCursor` MUST carry the oldest returned entry's timestamp so the next call resumes correctly
+
+#### Scenario: Activity app absent degrades to empty
+- **GIVEN** the NC Activity app is not installed
+- **WHEN** `getActivityEntries()` is called
+- **THEN** the result MUST be `{ results: [], total: 0, nextCursor: null }` without throwing

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/audit-trail-immutable/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/audit-trail-immutable/spec.md
@@ -1,0 +1,38 @@
+---
+retrofit: true
+---
+
+# Audit Trail Immutable
+
+## Why
+
+The existing requirements establish that audit entries are immutable and
+exportable. The operator-facing access surface that reads, exports, and
+(for administrators) purges those entries lives in `LogService` and is
+unspecified. In particular, object-scoped retrieval must keep an object's
+audit trail reachable even after its register or schema is soft-deleted,
+and bulk deletion is an explicit administrative-retention operation
+distinct from the immutability guarantee. This change anchors that
+surface.
+
+## ADDED Requirements
+
+### Requirement: REQ-L1 The audit-trail access surface MUST support object-scoped retrieval tolerant of soft-deleted scope, multi-format export, and administrative deletion
+The service MUST expose audit-trail retrieval scoped to a single object with register/schema membership validation that still succeeds when the register or schema has been soft-deleted, MUST count and list entries with the same filters/pagination, MUST export entries in CSV, JSON, XML, and TXT formats, and MUST support single and filtered bulk deletion as an administrative retention operation.
+
+`LogService::getLogs()` and `LogService::count()` MUST resolve the object across all sources including soft-deleted objects, MUST validate the object belongs to the requested register/schema by comparing stored IDs while tolerating a soft-deleted (unresolvable) register or schema, and MUST restrict results to the object's UUID. `LogService::exportLogs()` MUST emit `{ content, filename, contentType }` for each of the `csv`, `json`, `xml`, and `txt` formats and MUST reject an unsupported format with `InvalidArgumentException`. `LogService::deleteLog()` MUST delete one entry by id (or surface a not-found error), and `LogService::deleteLogs()` MUST delete a filter/id-selected set and MUST report `{ deleted, failed, total }`. Deletion is an administrative retention action and does not relax the per-entry immutability guarantee enforced elsewhere in this capability.
+
+#### Scenario: Audit trail readable after register soft-delete
+- **GIVEN** an object whose register has been soft-deleted
+- **WHEN** the object-scoped log retrieval runs
+- **THEN** the object's audit entries MUST still be returned, scoped by the object UUID
+
+#### Scenario: Export rejects an unsupported format
+- **GIVEN** an export request for an unknown format
+- **WHEN** the export runs
+- **THEN** an `InvalidArgumentException` MUST be raised
+
+#### Scenario: Bulk deletion reports per-item outcome
+- **GIVEN** a filter selecting several audit entries
+- **WHEN** the bulk deletion runs
+- **THEN** the result MUST report the deleted, failed, and total counts

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/generic-integrations/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/generic-integrations/spec.md
@@ -1,0 +1,51 @@
+---
+retrofit: true
+---
+
+# Generic Integrations
+
+## Why
+
+ADR-019 established the integration-leaf pattern, and the existing
+requirements cover the shares provider. A second, distinct shape exists
+in production: the Tier-2 *link services* (xWiki, Talk, OpenProject,
+Bookmark, Collective) that bind a remote/peer-app entity to an OR object
+through a local link table, with a lazily-resolved provider and uniform
+graceful degradation. No requirement captures that shared contract; this
+change anchors it so all five services (and future link leaves) conform.
+
+## ADDED Requirements
+
+### Requirement: REQ-G1 Tier-2 entity link services MUST share a uniform link/create/unlink/list/picker contract with graceful degradation
+A Tier-2 link service MUST persist object↔remote-entity bindings in its own local link table, resolve its provider/router lazily so the service loads even when the backing app is absent, and expose five operations — link an existing remote entity, create-and-link a new one, unlink (binding only, never deleting the remote), list linked entities with stale-cache refresh, and browse available entities for the picker — each degrading gracefully when the backing app or upstream is unavailable.
+
+Each link service (`XwikiLinkService`, `TalkLinkService`, `OpenProjectLinkService`, `BookmarkLinkService`, `CollectiveLinkService`) MUST:
+- **link** an existing remote entity to an OR object, rejecting an empty reference (400), rejecting a duplicate binding (409), and caching the remote entity's display metadata at link time;
+- **create-and-link** a new remote entity through the backing provider, then persist the binding with the returned canonical reference;
+- **unlink** by removing only the local binding row (404 when no binding matches) and MUST NOT delete the remote entity itself, since other objects may still link it;
+- **list** the linked entities for an object, refreshing a row's cached metadata from the upstream when a source is configured and the row's cache is older than the stale window, and MUST NOT throw when the upstream is down — stale rows MUST survive;
+- **browse/picker** the available remote entities, returning a structured `{ unavailable, cause, results, total }` descriptor (rather than throwing) when the backing app is not installed or the upstream is unreachable.
+
+Mutating operations MUST require an authenticated user (401 otherwise) and MUST surface an unconfigured-source / upstream-down condition as a 503 carrying the cause so the controller can render the integration banner.
+
+#### Scenario: Link an existing remote entity
+- **GIVEN** an authenticated user and a valid remote entity reference
+- **WHEN** the link operation runs and no binding yet exists
+- **THEN** a link row MUST be persisted with the canonical reference and cached display metadata
+- **AND** a second identical link attempt MUST be rejected with 409
+
+#### Scenario: Unlink leaves the remote entity intact
+- **GIVEN** an existing binding between an object and a remote entity
+- **WHEN** the unlink operation runs
+- **THEN** only the local binding row MUST be removed
+- **AND** the remote entity MUST remain available to any other linked objects
+
+#### Scenario: Picker degrades when the backing app is absent
+- **GIVEN** the backing app (or upstream) is unavailable
+- **WHEN** the browse/picker operation runs
+- **THEN** it MUST return `{ unavailable: true, cause, results: [], total: 0 }` without throwing
+
+#### Scenario: List survives an upstream outage with stale rows
+- **GIVEN** linked rows whose cached metadata is stale and the upstream is down
+- **WHEN** the list operation runs
+- **THEN** the stale rows MUST be returned as-is rather than the call failing

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/search-index/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/search-index/spec.md
@@ -1,0 +1,37 @@
+---
+retrofit: true
+---
+
+# Search Index
+
+## Why
+
+The existing search-index requirements cover backend routing, schema
+mirroring, and bulk indexing, but not the post-import warmup hook that
+ImportService fires after an import completes. That hook schedules a
+background Solr warmup whose mode and object cap scale with the import
+size so large imports do not block on synchronous indexing. This change
+anchors that adaptive scheduling behavior.
+
+## ADDED Requirements
+
+### Requirement: REQ-S1 A completed import MUST schedule an adaptive background search-index warmup sized to the import volume
+On import completion the service MUST schedule a one-time background Solr warmup job whose warmup mode and maximum-object cap are derived from the number of objects imported, MUST skip scheduling entirely when nothing was imported, and MUST treat a scheduling failure as non-fatal to the import.
+
+`ImportService::scheduleSolrWarmup()` MUST compute the total objects imported across all sheets and MUST return `false` without scheduling when that total is zero. `ImportService::getRecommendedWarmupMode()` MUST select a warmup mode by import-size tier (large imports get the fastest mode, medium imports a balanced mode, small imports the safe mode). `ImportService::scheduleSmartSolrWarmup()` MUST use the recommended mode and a size-derived object cap (bounded by a hard maximum), MUST default to a delayed schedule with an immediate-run override, and MUST delegate to `scheduleSolrWarmup()`. A failure to enqueue the job MUST be logged and MUST NOT abort or roll back the completed import.
+
+#### Scenario: Large import schedules a fast, capped warmup
+- **GIVEN** an import that created a large number of objects
+- **WHEN** the smart warmup is scheduled
+- **THEN** the recommended mode MUST be the fastest tier
+- **AND** the warmup object cap MUST be bounded by the hard maximum
+
+#### Scenario: Empty import skips warmup
+- **GIVEN** an import that created and updated zero objects
+- **WHEN** warmup scheduling runs
+- **THEN** no job MUST be enqueued and the call MUST return false
+
+#### Scenario: Scheduling failure does not fail the import
+- **GIVEN** the background job queue rejects the warmup job
+- **WHEN** scheduling fails
+- **THEN** the failure MUST be logged and the import MUST remain successful

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/text-extraction/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/text-extraction/spec.md
@@ -1,0 +1,38 @@
+---
+retrofit: true
+---
+
+# Text Extraction
+
+## Why
+
+`TextExtractionService` consolidates the file→chunk extraction lifecycle
+that feeds search and vector indexing: it extracts a file or object into
+chunks, detects when re-extraction is needed, discovers files that have
+never been extracted, drains a pending queue, retries failures, and
+reports stats. No capability spec owns this lifecycle (the vector
+embeddings capability begins downstream, once chunks exist). This change
+establishes a `text-extraction` capability anchoring the observed
+behavior.
+
+## ADDED Requirements
+
+### Requirement: REQ-001 The system MUST extract files and objects into chunks with re-extraction detection and a tracked extraction queue
+The system MUST extract a file or object into stored chunks, MUST skip re-extraction when the source is unchanged unless re-extraction is forced, MUST be able to discover never-extracted (untracked) files, drain a bounded pending-extraction queue, retry previously failed extractions, chunk raw text into bounded segments, and report extraction statistics.
+
+`TextExtractionService::extractFile()` MUST resolve the NC file, determine whether stored chunks are up to date relative to the source modification time, and skip extraction when up to date and not forced; a missing file MUST raise `NotFoundException`. `extractObject()` MUST extract an object's content the same way. `chunkDocument()` MUST split raw text into bounded chunks per the supplied options. `discoverUntrackedFiles()`, `extractPendingFiles()`, and `retryFailedExtractions()` MUST each operate over a bounded batch (`limit`) and return a per-run summary. `getStats()` MUST report aggregate extraction state (e.g. tracked / pending / failed counts).
+
+#### Scenario: Unchanged file skips re-extraction
+- **GIVEN** a file whose stored chunks are current relative to its modification time
+- **WHEN** `extractFile()` is called without forcing re-extraction
+- **THEN** extraction MUST be skipped and the existing chunks left intact
+
+#### Scenario: Forced re-extraction overrides up-to-date chunks
+- **GIVEN** a file whose chunks are current
+- **WHEN** `extractFile()` is called with re-extraction forced
+- **THEN** the file MUST be re-extracted regardless of the modification time
+
+#### Scenario: Pending queue drains within the batch limit
+- **GIVEN** more pending files than the requested batch limit
+- **WHEN** `extractPendingFiles($limit)` runs
+- **THEN** at most `$limit` files MUST be processed and a per-run summary returned

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md
@@ -1,0 +1,50 @@
+# Tasks
+
+Retroactive annotation only — every task documents existing behavior in
+`lib/Service/*.php`. No runtime changes. 112 scanned methods: 76
+reverse-spec'd (5 new REQs in this change + annotated against existing
+capabilities/changes), 36 tagged `@spec exclude`.
+
+## New requirements (this change)
+
+- [x] task-1: activity-provider#REQ-A1 — Tier-2 filtered + cursor-paginated activity read surface (`ActivityFilterService::getActivityEntries`)
+- [x] task-2: generic-integrations#REQ-G1 — Tier-2 entity link-service contract (link/create-and-link/unlink/list/picker across 5 link services, 26 methods)
+- [x] task-3: search-index#REQ-S1 — Adaptive post-import Solr warmup scheduling (`ImportService::scheduleSolrWarmup`, `scheduleSmartSolrWarmup`, `getRecommendedWarmupMode`)
+- [x] task-4: audit-trail-immutable#REQ-L1 — Audit-trail access, export, and admin deletion surface (`LogService::getLogs`, `count`, `exportLogs`, `deleteLog`, `deleteLogs`)
+- [x] task-5: text-extraction#REQ-001 — File→chunk extraction lifecycle (`TextExtractionService::extractFile`, `extractObject`, `chunkDocument`, `discoverUntrackedFiles`, `extractPendingFiles`, `retryFailedExtractions`, `getStats`)
+
+## Annotated against existing capabilities (no new REQ)
+
+- [x] task-6: register-i18n — `LanguageService::parseAcceptLanguageHeader`, `resolveLanguageForRegister`
+- [x] task-7: row-field-level-security — `OperatorEvaluator::valueMatchesOperator`; `PropertyRbacHandler::canReadProperty`, `canUpdateProperty`, `filterReadableProperties`, `getUnauthorizedProperties`
+- [x] task-8: production-observability — `MetricsService::recordMetric`, `cleanOldMetrics`
+- [x] task-9: webhook-payload-mapping — `WebhookService::interceptRequest`
+- [x] task-10: data-import-export — `ExportService::buildTemplateCsv`, `buildTemplateSpreadsheet`; `ImportService::softDeleteByImportJobId`
+- [x] task-11: avg-verwerkingsregister — `AvgComplianceService::runAllChecks`
+- [x] task-12: built-in-dashboards (b-svc-compute-profile-org) — `DashboardService::recalculateLogSizes`, `recalculateAllSizes`; `RegisterService::getSchemaObjectCounts`
+- [x] task-13: organisation multi-tenancy (b-svc-compute-profile-org) — `OrganisationService::getOrganisationForNewEntity`, `joinOrganisation`, `getUserOrganisationStats`, `getOrganisationSettingsOnly`, `getDefaultOrganisationUuid`
+- [x] task-14: file-actions REQ-004 — `RegisterService::createFromArray`, `updateFromArray`
+- [x] task-15: file-actions REQ-001/004/005 — `FileService::getFiles`, `getFilesForEntity`, `getFileById`, `saveFile`, `updateFile`, `deleteFile`, `createEntityFolder`, `createFolder`, `createObjectFolderWithoutUpdate`, `attachTagsToFile`
+
+## Tag counts
+
+| Disposition | Methods |
+|---|---|
+| Reverse-spec'd (new REQ + existing-cap/change annotation) | 76 |
+| `@spec exclude` (boilerplate / delegation / debug / util) | 36 |
+| **Total scanned** | **112** |
+
+## Excluded (boilerplate — `@spec exclude`)
+
+- RequestScopedCache: `set`, `has`, `getMultiple`, `clear` — trivial in-memory cache plumbing (class already annotated).
+- ContactService: `unlinkContactByUid` — thin (objectUuid,contactUid)→id overload delegating to already-specced `unlinkContact`.
+- DashboardService: `getObjectsByRegisterChartData`, `getObjectsBySchemaChartData`, `getObjectsBySizeChartData`, `getAuditTrailStatistics`, `getAuditTrailActionDistribution`, `getMostActiveObjects` — thin try/catch mapper delegations with degraded-empty fallback.
+- LanguageService: `shouldReturnAllTranslations` — trivial getter.
+- LogService: `getAllLogs`, `countAllLogs` — thin mapper findAll delegations.
+- PropertyRbacHandler: `isAdmin` — trivial admin-group check helper.
+- ImportService: `clearCaches` — one-line internal cache reset.
+- OrganisationService: `getDefaultOrganisationId`, `setDefaultOrganisationId`, `clearCache`, `clearDefaultOrganisationCache` — config getter/setter + cache-invalidation helpers.
+- RegisterService: `find`, `findAll`, `delete` — pure mapper delegations.
+- FileService: `checkOwnership` (guard delegation), `formatFile`, `formatFiles` (deferred FileFormattingHandler group), `findShares`, `createShareLink` (deferred FileSharingHandler group), `publishFile`, `unpublishFile`, `createObjectFilesZip` (deferred FilePublishingHandler group), `debugFindFileById`, `debugListObjectFiles` (debug helpers), `extractFileNameFromPath` (string util), `replaceWords`, `anonymizeDocument` (one-line delegations to DocumentProcessingHandler) — file-actions follow-up-pass deferrals + plumbing.
+
+(All `@spec exclude` reasons carry a required rationale in the docblock.)


### PR DESCRIPTION
## Summary

Reverse-specs the `bw2-svc-flat-2` coverage batch: **112 uncovered public methods across 22 top-level `lib/Service/*.php` facades**. Retroactive annotation only — no runtime changes.

Per ADR-003:
- **76 methods reverse-spec'd** — 5 new requirements in the ghost change `retrofit-2026-05-25-bw2-svc-flat-2`, plus annotations against existing capability specs / prior retrofit changes.
- **36 methods tagged `@spec exclude`** — constructors-aside boilerplate: pure mapper delegations, trivial getters/setters, cache plumbing, debug helpers, one-line handler delegations, and file-actions follow-up-pass deferrals. Each carries a required rationale.

### New requirements (≤5, one per owning capability)
| Capability | REQ | Covers |
|---|---|---|
| `activity-provider` | REQ-A1 | Tier-2 filtered + cursor-paginated activity read surface (`ActivityFilterService::getActivityEntries`) |
| `generic-integrations` | REQ-G1 | Tier-2 entity link-service contract — link/create-and-link/unlink/list/picker w/ graceful degradation (xWiki/Talk/OpenProject/Bookmark/Collective, 26 methods) |
| `search-index` | REQ-S1 | Adaptive post-import Solr warmup scheduling (`ImportService` warmup methods) |
| `audit-trail-immutable` | REQ-L1 | LogService audit-trail access / multi-format export / admin deletion |
| `text-extraction` (new) | REQ-001 | File→chunk extraction lifecycle (`TextExtractionService`) |

### Annotated against existing capabilities (no new REQ)
`register-i18n` (Accept-Language negotiation), `row-field-level-security` (PropertyRbacHandler + OperatorEvaluator), `production-observability` (MetricsService), `webhook-payload-mapping` (request interception), `data-import-export` (templates + import rollback), `avg-verwerkingsregister`, `built-in-dashboards` / organisation multi-tenancy (`b-svc-compute-profile-org`), and `file-actions` (FileService CRUD/folder/tagging + RegisterService folder provisioning).

`openspec validate retrofit-2026-05-25-bw2-svc-flat-2 --strict` passes; `php -l` clean on all 22 files.

## Test plan
- [ ] `openspec validate retrofit-2026-05-25-bw2-svc-flat-2 --strict` is green
- [ ] `php -l` passes on all 22 touched service files
- [ ] No runtime/behavioral changes — docblock `@spec` annotations only