### PR TITLE
retrofit: backend coverage — Service facades (chunk 3)

### DIFF
--- a/lib/Service/ApplicationService.php
+++ b/lib/Service/ApplicationService.php
@@ -97,6 +97,8 @@ class ApplicationService
      * @return Application[] Array of application entities
      *
      * @psalm-return array<int, Application>
+     *
+     * @spec exclude Facade plumbing: thin delegation to ApplicationMapper::findAll, no standalone behavioral contract.
      */
     public function findAll(?int $limit=null, ?int $offset=null, array $filters=[]): array
     {
@@ -121,6 +123,8 @@ class ApplicationService
      * @throws DoesNotExistException If application not found with the given ID
      *
      * @psalm-return Application
+     *
+     * @spec exclude Facade plumbing: thin delegation to ApplicationMapper::find, no standalone behavioral contract.
      */
     public function find(int $id): Application
     {
@@ -139,6 +143,8 @@ class ApplicationService
      * @return Application The created application entity with assigned ID
      *
      * @psalm-return Application
+     *
+     * @spec exclude Facade plumbing: log + delegate to ApplicationMapper::createFromArray, no standalone behavioral contract.
      */
     public function create(array $data): Application
     {
@@ -183,6 +189,8 @@ class ApplicationService
      * @throws DoesNotExistException If application not found with the given ID
      *
      * @psalm-return Application
+     *
+     * @spec exclude Facade plumbing: log + delegate to ApplicationMapper::updateFromArray, no standalone behavioral contract.
      */
     public function update(int $id, array $data): Application
     {
@@ -226,6 +234,8 @@ class ApplicationService
      * @return void
      *
      * @throws DoesNotExistException If application not found with the given ID
+     *
+     * @spec exclude Facade plumbing: find-then-delete delegation to ApplicationMapper, no standalone behavioral contract.
      */
     public function delete(int $id): void
     {
@@ -265,6 +275,8 @@ class ApplicationService
      * @return int Total number of applications
      *
      * @psalm-return int
+     *
+     * @spec exclude Facade plumbing: thin delegation to ApplicationMapper::countAll, no standalone behavioral contract.
      */
     public function countAll(): int
     {

--- a/lib/Service/AuthorizationAuditService.php
+++ b/lib/Service/AuthorizationAuditService.php
@@ -70,6 +70,8 @@ class AuthorizationAuditService
      * @param array|null $newAuthorization The new authorization value.
      *
      * @return void
+     *
+     * @spec exclude Facade plumbing: emits one structured audit log line; sibling of logRegisterAuthorizationChange (rbac-scopes REQ-002), no distinct behavioral contract.
      */
     public function logSchemaAuthorizationChange(
         int $schemaId,

--- a/lib/Service/AuthorizationService.php
+++ b/lib/Service/AuthorizationService.php
@@ -164,6 +164,8 @@ class AuthorizationService
      * @return void
      *
      * @throws AuthenticationException If the token is expired or missing iat.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/tasks.md#task-5
      */
     public function validatePayload(array $payload): void
     {
@@ -205,6 +207,8 @@ class AuthorizationService
      * @return void
      *
      * @throws AuthenticationException If the token is invalid.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/tasks.md#task-5
      */
     public function authorizeJwt(string $authorization): void
     {
@@ -295,6 +299,8 @@ class AuthorizationService
      * @return void
      *
      * @throws AuthenticationException If credentials are invalid.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/tasks.md#task-5
      */
     public function authorizeBasic(string $header, array $users=[], array $groups=[]): void
     {
@@ -322,6 +328,8 @@ class AuthorizationService
      * @return void
      *
      * @throws AuthenticationException If the token is invalid.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/tasks.md#task-5
      */
     public function authorizeOAuth(string $header, array $users=[], array $groups=[]): void
     {
@@ -352,6 +360,8 @@ class AuthorizationService
      * @throws SecurityException If CSRF-unsafe headers are detected.
      *
      * @psalm-suppress UndefinedClass SecurityException is a private Nextcloud internal class
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/tasks.md#task-5
      */
     public function corsAfterController(IRequest $request, Response $response): Response
     {
@@ -382,6 +392,8 @@ class AuthorizationService
      * @return void
      *
      * @throws AuthenticationException If the API key is invalid.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/tasks.md#task-5
      */
     public function authorizeApiKey(string $header, array $keys): void
     {

--- a/lib/Service/CalendarEventService.php
+++ b/lib/Service/CalendarEventService.php
@@ -122,6 +122,8 @@ class CalendarEventService
      * @return array Array of event arrays in JSON-friendly format
      *
      * @throws Exception If no user is logged in or no calendar found
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-1
      */
     public function getEventsForObject(string $objectUuid): array
     {
@@ -179,6 +181,8 @@ class CalendarEventService
      * @return array|null The created event in JSON-friendly format
      *
      * @throws Exception If no user or calendar found
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-1
      */
     public function createEvent(
         int $registerId,
@@ -260,6 +264,8 @@ class CalendarEventService
      * @return array|null The updated event
      *
      * @throws Exception If the event is not found
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-1
      */
     public function linkEvent(
         int $calendarId,
@@ -299,6 +305,8 @@ class CalendarEventService
      * @return void
      *
      * @throws Exception If the event is not found
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-1
      */
     public function unlinkEvent(string $calendarId, string $eventUri): void
     {

--- a/lib/Service/ChatService.php
+++ b/lib/Service/ChatService.php
@@ -402,6 +402,8 @@ class ChatService
      * @param string $_testMessage Optional test message to send.
      *
      * @return array Test result with success status, message, and optional error.
+     *
+     * @spec exclude Facade plumbing: simplified stub returning a static result; real testing goes through ResponseGenerationHandler (chat-ai). No standalone contract.
      */
     public function testChat(
         string $provider,

--- a/lib/Service/ConfigurationService.php
+++ b/lib/Service/ConfigurationService.php
@@ -311,6 +311,8 @@ class ConfigurationService
      *
      * @return bool True if the OpenConnector service is available, false otherwise.
      * @throws ContainerExceptionInterface|NotFoundExceptionInterface
+     *
+     * @spec exclude Facade plumbing: peer-app presence probe (installed-apps check + container resolve), no standalone behavioral contract.
      */
     public function hasOpenConnector(): bool
     {
@@ -920,6 +922,8 @@ class ConfigurationService
      * @throws Exception If search fails
      *
      * @return array Search results with total count, results array, page, and per_page.
+     *
+     * @spec exclude Facade plumbing: thin delegation to GitHubHandler::searchConfigurations, no standalone behavioral contract.
      */
     public function searchGitHub(string $search='', int $page=1, int $perPage=30): array
     {
@@ -942,6 +946,8 @@ class ConfigurationService
      * @throws Exception If search fails
      *
      * @return array Search results with total count, results array, page, and per_page.
+     *
+     * @spec exclude Facade plumbing: thin delegation to GitLabHandler::searchConfigurations, no standalone behavioral contract.
      */
     public function searchGitLab(string $search='', int $page=1, int $perPage=30): array
     {

--- a/lib/Service/ContactMatchingService.php
+++ b/lib/Service/ContactMatchingService.php
@@ -187,6 +187,8 @@ class ContactMatchingService
      * @param string $email The email address to match
      *
      * @return array The match results with confidence 1.0
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-contacts-actions/tasks.md#task-3
      */
     public function matchByEmail(string $email): array
     {
@@ -249,6 +251,8 @@ class ContactMatchingService
      * @param string|null $name The display name to match
      *
      * @return array The match results
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-contacts-actions/tasks.md#task-3
      */
     public function matchByName(?string $name): array
     {
@@ -311,6 +315,8 @@ class ContactMatchingService
      * @param string|null $organization The organization name to match
      *
      * @return array The match results with confidence 0.5
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-contacts-actions/tasks.md#task-3
      */
     public function matchByOrganization(?string $organization): array
     {
@@ -373,6 +379,8 @@ class ContactMatchingService
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-contacts-actions/tasks.md#task-3
      */
     public function matchContact(
         string $email,

--- a/lib/Service/CospendLinkService.php
+++ b/lib/Service/CospendLinkService.php
@@ -175,6 +175,8 @@ class CospendLinkService
      *
      * @throws Exception On missing user (401), missing project (404),
      *                   duplicate (409), Cospend unavailable (503).
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the link contract is owned by the integration-cospend capability.
      */
     public function linkProject(string $objectUuid, int $registerId, int $schemaId, string $projectId): CospendLink
     {
@@ -227,6 +229,8 @@ class CospendLinkService
      *
      * @throws Exception On missing user (401), missing bill (404),
      *                   duplicate (409), Cospend unavailable (503).
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the link contract is owned by the integration-cospend capability.
      */
     public function linkBill(
         string $objectUuid,
@@ -287,6 +291,8 @@ class CospendLinkService
      *
      * @throws Exception On missing user (401), empty name (400),
      *                   Cospend unavailable (503), create failure (500).
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the create-and-link contract is owned by the integration-cospend capability.
      */
     public function createAndLinkProject(
         string $objectUuid,
@@ -444,6 +450,8 @@ class CospendLinkService
      * @return void
      *
      * @throws Exception On missing user (401) or no matching link (404).
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the unlink contract is owned by the integration-cospend capability.
      */
     public function unlink(string $objectUuid, int $entryId): void
     {
@@ -462,6 +470,8 @@ class CospendLinkService
      * @param string $objectUuid Parent OR object uuid.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the linked-entries listing contract is owned by the integration-cospend capability.
      */
     public function getLinkedEntries(string $objectUuid): array
     {
@@ -489,6 +499,8 @@ class CospendLinkService
      * @param string|null $search Optional name-substring filter.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the picker-source contract is owned by the integration-cospend capability.
      */
     public function getAvailableProjects(?string $search=null): array
     {

--- a/lib/Service/FormLinkService.php
+++ b/lib/Service/FormLinkService.php
@@ -150,6 +150,8 @@ class FormLinkService
      * @param string $objectUuid The OR object UUID.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the linked-forms listing contract is owned by the integration-forms capability.
      */
     public function getLinkedForms(string $objectUuid): array
     {
@@ -214,6 +216,8 @@ class FormLinkService
      * @return FormLink The created (or existing) link row.
      *
      * @throws Exception If no user is logged in.
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the form-link contract is owned by the integration-forms capability.
      */
     public function linkForm(
         string $objectUuid,
@@ -262,6 +266,8 @@ class FormLinkService
      * @return FormLink The created (or existing) link row.
      *
      * @throws Exception If no user is logged in.
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the submission-link contract is owned by the integration-forms capability.
      */
     public function linkFormSubmission(
         string $objectUuid,
@@ -310,6 +316,8 @@ class FormLinkService
      * @param integer $formId     The NC Forms form id.
      *
      * @return integer Number of rows removed.
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the unlink-form contract is owned by the integration-forms capability.
      */
     public function unlinkForm(string $objectUuid, int $formId): int
     {
@@ -327,6 +335,8 @@ class FormLinkService
      * @param integer $submissionId The submission id.
      *
      * @return boolean True when a row was removed, false when none existed.
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the unlink-submission contract is owned by the integration-forms capability.
      */
     public function unlinkSubmission(string $objectUuid, int $formId, int $submissionId): bool
     {
@@ -363,6 +373,8 @@ class FormLinkService
      * @return FormLink The link row pointing at the freshly-created form.
      *
      * @throws Exception When the Forms app is missing or the create fails.
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the create-and-link contract is owned by the integration-forms capability.
      */
     public function createAndLinkForm(
         string $objectUuid,
@@ -447,6 +459,8 @@ class FormLinkService
      *                                the `linked` flag against.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the picker-source contract is owned by the integration-forms capability.
      */
     public function getAvailableForms(?string $objectUuid=null): array
     {
@@ -523,6 +537,8 @@ class FormLinkService
      * @param integer $formId     The NC Forms form id.
      *
      * @return array<string,mixed>|null
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the single-form view contract is owned by the integration-forms capability.
      */
     public function getLinkedForm(string $objectUuid, int $formId): ?array
     {

--- a/lib/Service/IndexService.php
+++ b/lib/Service/IndexService.php
@@ -107,6 +107,8 @@ class IndexService
      * @param int|null $limit Maximum number of files to process
      *
      * @return array Result with success status and processing stats.
+     *
+     * @spec exclude Facade plumbing: thin delegation to FileHandler::processUnindexedChunks (search-index), no standalone contract.
      */
     public function processUnindexedChunks(?int $limit=null): array
     {
@@ -221,6 +223,8 @@ class IndexService
      * @return bool Success status
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Commit flag controls transaction behavior
+     *
+     * @spec exclude Facade plumbing: thin delegation to SearchBackendInterface::deleteObject (search-index), no standalone contract.
      */
     public function deleteObject(string|int $objectId, bool $commit=false): bool
     {
@@ -241,6 +245,8 @@ class IndexService
      * @param string $similarity Similarity function
      *
      * @return bool Success status
+     *
+     * @spec exclude Facade plumbing: thin delegation to SchemaHandler::ensureVectorFieldType (search-index), no standalone contract.
      */
     public function ensureVectorFieldType(
         string $collection,
@@ -264,6 +270,8 @@ class IndexService
      * @return array Result with success status, stats, and optional errors.
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Force flag controls schema recreation behavior
+     *
+     * @spec exclude Facade plumbing: thin delegation to SchemaHandler::mirrorSchemas (search-index), no standalone contract.
      */
     public function mirrorSchemas(bool $force=false): array
     {
@@ -304,6 +312,8 @@ class IndexService
      * @return (array|true)[] Fields configuration
      *
      * @psalm-return array{success: true, fields: array}
+     *
+     * @spec exclude Facade plumbing: wraps SearchBackendInterface::getFields in a success envelope (search-index), no standalone contract.
      */
     public function getFieldsConfiguration(): array
     {
@@ -327,6 +337,8 @@ class IndexService
      * @return array Result with success status and field creation info.
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Dry-run flag enables preview mode
+     *
+     * @spec exclude Facade plumbing: thin delegation to SchemaHandler::createMissingFields (search-index), no standalone contract.
      */
     public function createMissingFields(string $collection, array $missingFields, bool $dryRun=false): array
     {
@@ -377,6 +389,8 @@ class IndexService
      * @return array Test results
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Flag controls test verbosity
+     *
+     * @spec exclude Facade plumbing: delegate to SearchBackendInterface::testConnection with error envelope (search-index), no standalone contract.
      */
     public function testConnection(bool $inclCollTests=true): array
     {
@@ -403,6 +417,8 @@ class IndexService
      * Get search backend statistics.
      *
      * @return array Statistics
+     *
+     * @spec exclude Facade plumbing: delegate to SearchBackendInterface::getStats with error envelope (search-index), no standalone contract.
      */
     public function getStats(): array
     {
@@ -437,6 +453,8 @@ class IndexService
      *     document_count?: int, error?: string},
      *     chunks?: array{total_chunks: int, indexed_chunks: int,
      *     unindexed_chunks: int, vectorized_chunks: int}}
+     *
+     * @spec exclude Facade plumbing: aggregates backend/file/chunk stats from collaborators (search-index), no standalone contract.
      */
     public function getDashboardStats(): array
     {
@@ -498,6 +516,8 @@ class IndexService
      * @param string|null $collectionName Collection to clear
      *
      * @return array Result
+     *
+     * @spec exclude Facade plumbing: delegate to SearchBackendInterface::clearIndex with error envelope (search-index), no standalone contract.
      */
     public function clearIndex(?string $collectionName=null): array
     {
@@ -525,6 +545,8 @@ class IndexService
      * Get search backend configuration.
      *
      * @return array Configuration
+     *
+     * @spec exclude Facade plumbing: delegate to SearchBackendInterface::getConfig with fail-soft empty (search-index), no standalone contract.
      */
     public function getConfig(): array
     {
@@ -554,6 +576,8 @@ class IndexService
      * @param string|null $collectionName Optional collection name.
      *
      * @return array Reindexing results with statistics.
+     *
+     * @spec exclude Facade plumbing: thin delegation to ObjectHandler::reindexAll (search-index), no standalone contract.
      */
     public function reindexAll(int $maxObjects=0, int $batchSize=1000, ?string $collectionName=null): array
     {
@@ -575,6 +599,8 @@ class IndexService
      * @return array Results with fixed/failed fields.
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Dry-run flag enables preview mode
+     *
+     * @spec exclude Facade plumbing: thin delegation to SchemaHandler::fixMismatchedFields (search-index), no standalone contract.
      */
     public function fixMismatchedFields(array $mismatchedFields, bool $dryRun=false): array
     {
@@ -683,6 +709,8 @@ class IndexService
      * @return array Search results with pagination info
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Flag controls total count inclusion
+     *
+     * @spec exclude Facade plumbing: maps IndexService params onto the query array then delegate to SearchBackendInterface::searchObjectsPaginated (search-index), no standalone contract.
      */
     public function searchObjectsPaginated(
         array $query=[],
@@ -747,6 +775,8 @@ class IndexService
      * @param array  $config Configuration options
      *
      * @return array Creation result
+     *
+     * @spec exclude Facade plumbing: thin delegation to SearchBackendInterface::createCollection (search-index), no standalone contract.
      */
     public function createCollection(string $name, array $config=[]): array
     {
@@ -759,6 +789,8 @@ class IndexService
      * Quick connectivity check without full collection validation.
      *
      * @return array Connection test results
+     *
+     * @spec exclude Facade plumbing: convenience wrapper over testConnection(inclCollTests:false) (search-index), no standalone contract.
      */
     public function testConnectivityOnly(): array
     {
@@ -782,6 +814,8 @@ class IndexService
      * @throws Exception If backend is not Solr
      *
      * @psalm-return array{collection: string, exists: true, tenant: null|string}
+     *
+     * @spec exclude Facade plumbing: composes getTenantSpecificCollectionName + collectionExists + createCollection (search-index), no standalone contract.
      */
     public function ensureTenantCollection(?string $tenant=null): array
     {
@@ -806,6 +840,8 @@ class IndexService
      * @param string|null $tenant Tenant identifier (null for default)
      *
      * @return string Collection name
+     *
+     * @spec exclude Facade plumbing: derives a collection name string from config + tenant suffix (search-index), no standalone contract.
      */
     public function getTenantSpecificCollectionName(?string $tenant=null): string
     {
@@ -827,6 +863,8 @@ class IndexService
      * @return string Endpoint URL
      *
      * @throws Exception If backend is not Solr
+     *
+     * @spec exclude Facade plumbing: reads endpoint from getSolrConfig (search-index), no standalone contract.
      */
     public function getEndpointUrl(): string
     {
@@ -845,6 +883,8 @@ class IndexService
      * @return string Solr base URL
      *
      * @throws Exception If backend is not Solr
+     *
+     * @spec exclude Facade plumbing: string-builds a Solr base URL from getSolrConfig (search-index), no standalone contract.
      */
     public function buildSolrBaseUrl(?string $collection=null): string
     {
@@ -870,6 +910,8 @@ class IndexService
      *
      * @psalm-return array{endpoint: ''|mixed, collection: 'openregister'|mixed, username: ''|mixed,
      *     password: ''|mixed, timeout: 30|mixed}
+     *
+     * @spec exclude Facade plumbing: projects getConfig into Solr-specific keys with defaults (search-index), no standalone contract.
      */
     public function getSolrConfig(): array
     {
@@ -894,6 +936,8 @@ class IndexService
      * @return object HTTP client instance
      *
      * @throws Exception If backend is not Solr or client not available
+     *
+     * @spec exclude Facade plumbing: method_exists guard then delegate to the Solr backend's getHttpClient (search-index), no standalone contract.
      */
     public function getHttpClient(): object
     {
@@ -912,6 +956,8 @@ class IndexService
      * backend doesn't support ConfigSets (non-Solr backends).
      *
      * @return array List of available ConfigSets.
+     *
+     * @spec exclude Facade plumbing: method_exists guard then delegate to the Solr backend's listConfigSets, empty for non-Solr (search-index), no standalone contract.
      */
     public function listConfigSets(): array
     {

--- a/lib/Service/ManifestService.php
+++ b/lib/Service/ManifestService.php
@@ -118,6 +118,8 @@ class ManifestService
      * @return array<string, mixed> Enriched manifest (original if no `currentUserSchema`).
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/manifest-user-context/tasks.md#task-1
      */
     public function getEnrichedManifest(array $manifest): array
     {

--- a/lib/Service/MapLinkService.php
+++ b/lib/Service/MapLinkService.php
@@ -165,6 +165,8 @@ class MapLinkService
      *
      * @throws Exception On missing user (401), missing POI (404),
      *                   duplicate (409), Maps unavailable (503).
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the link-POI contract is owned by the integration-maps capability.
      */
     public function linkPoi(string $objectUuid, int $registerId, int $schemaId, int $favoriteId): MapLink
     {
@@ -216,6 +218,8 @@ class MapLinkService
      *
      * @throws Exception On missing user (401), empty name (400),
      *                   Maps unavailable (503), create failure (500).
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the create-and-link-POI contract is owned by the integration-maps capability.
      */
     public function createAndLinkPoi(
         string $objectUuid,
@@ -278,6 +282,8 @@ class MapLinkService
      * @return void
      *
      * @throws Exception On missing user (401) or no matching link (404).
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the unlink-POI contract is owned by the integration-maps capability.
      */
     public function unlinkPoi(string $objectUuid, int $favoriteId): void
     {
@@ -299,6 +305,8 @@ class MapLinkService
      * @param string $objectUuid Parent OR object uuid.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the linked-POIs listing contract is owned by the integration-maps capability.
      */
     public function getLinkedPois(string $objectUuid): array
     {
@@ -323,6 +331,8 @@ class MapLinkService
      * @param string|null $search Optional name-substring filter.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the picker-source contract is owned by the integration-maps capability.
      */
     public function getAvailablePois(?string $search=null): array
     {

--- a/lib/Service/ObjectServiceMapperAdapter.php
+++ b/lib/Service/ObjectServiceMapperAdapter.php
@@ -50,6 +50,8 @@ class ObjectServiceMapperAdapter
      * @param array|null $extend     Relations to expand inline.
      *
      * @return ObjectEntity|null
+     *
+     * @spec exclude Facade plumbing: mapper-shaped adapter delegating to ObjectService::find with bound register/schema; no standalone contract.
      */
     public function find(int|string $identifier, ?array $extend=null): ?ObjectEntity
     {
@@ -83,6 +85,8 @@ class ObjectServiceMapperAdapter
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec exclude Facade plumbing: argument-normalisation + register/schema injection then delegate to ObjectService::findAll; no standalone contract.
      */
     public function findAll(
         array $config=[],
@@ -143,6 +147,8 @@ class ObjectServiceMapperAdapter
      * @param array $object Raw object data.
      *
      * @return ObjectEntity
+     *
+     * @spec exclude Facade plumbing: delegate to ObjectService::saveObject with bound register/schema; no standalone contract.
      */
     public function createFromArray(array $object): ObjectEntity
     {
@@ -175,6 +181,8 @@ class ObjectServiceMapperAdapter
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      * @SuppressWarnings(PHPMD.UnusedFormalParameter) $validate kept for interface compatibility.
+     *
+     * @spec exclude Facade plumbing: PUT/PATCH merge then delegate to ObjectService::saveObject; no standalone contract beyond ObjectService's save path.
      */
     public function updateFromArray(
         int|string $id,
@@ -213,6 +221,8 @@ class ObjectServiceMapperAdapter
      * @param ObjectEntity $object The entity to save.
      *
      * @return ObjectEntity
+     *
+     * @spec exclude Facade plumbing: delegate to ObjectService::saveObject with bound register/schema; no standalone contract.
      */
     public function update(ObjectEntity $object): ObjectEntity
     {
@@ -241,6 +251,8 @@ class ObjectServiceMapperAdapter
      * @throws \OCP\AppFramework\Db\DoesNotExistException When the adapter is
      *         bound to a specific `(register, schema)` and the UUID is not
      *         present in that magic table.
+     *
+     * @spec exclude Facade plumbing: id-extraction then delegate to ObjectService::deleteObject (scoped delete owned by ObjectService); no standalone contract.
      */
     public function delete(array $criteria): bool
     {
@@ -287,6 +299,8 @@ class ObjectServiceMapperAdapter
      * @param array $requestParams Raw query parameters (e.g. _limit, page, _search).
      *
      * @return array{results: array, total: int, page: int, pages: int}
+     *
+     * @spec exclude Facade plumbing: register/schema injection then delegate to ObjectService::searchObjectsPaginated; no standalone contract.
      */
     public function findAllPaginated(array $requestParams=[]): array
     {

--- a/lib/Service/PhotoLinkService.php
+++ b/lib/Service/PhotoLinkService.php
@@ -165,6 +165,8 @@ class PhotoLinkService
      *
      * @throws Exception On missing user (401), missing album (404),
      *                   duplicate (409), Photos unavailable (503).
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the link-album contract is owned by the integration-photos capability.
      */
     public function linkAlbum(string $objectUuid, int $registerId, int $schemaId, int $albumId): PhotoLink
     {
@@ -211,6 +213,8 @@ class PhotoLinkService
      *
      * @throws Exception On missing user (401), empty name (400),
      *                   Photos unavailable (503).
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the create-and-link-album contract is owned by the integration-photos capability.
      */
     public function createAndLinkAlbum(string $objectUuid, int $registerId, int $schemaId, string $name): PhotoLink
     {
@@ -261,6 +265,8 @@ class PhotoLinkService
      * @return void
      *
      * @throws Exception On missing user (401) or no matching link (404).
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the unlink-album contract is owned by the integration-photos capability.
      */
     public function unlinkAlbum(string $objectUuid, int $albumId): void
     {
@@ -279,6 +285,8 @@ class PhotoLinkService
      * @param string $objectUuid Parent OR object uuid.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the linked-albums listing contract is owned by the integration-photos capability.
      */
     public function getLinkedAlbums(string $objectUuid): array
     {
@@ -309,6 +317,8 @@ class PhotoLinkService
      * @param string|null $search Optional name-substring filter.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the picker-source contract is owned by the integration-photos capability.
      */
     public function getAvailableAlbums(?string $search=null): array
     {

--- a/lib/Service/RetentionService.php
+++ b/lib/Service/RetentionService.php
@@ -445,6 +445,8 @@ class RetentionService
      * @param ObjectEntity $object The object to check
      *
      * @return string|null Error code if immutable, null if mutable
+     *
+     * @spec exclude Archival-status immutability guard (vernietigd/overgebracht → error code); sibling of the already-annotated archival methods, owned by archival-destruction-workflow. No distinct contract.
      */
     public function validateNotImmutable(ObjectEntity $object): ?string
     {

--- a/lib/Service/RiskLevelService.php
+++ b/lib/Service/RiskLevelService.php
@@ -132,6 +132,8 @@ class RiskLevelService
      * @param int $fileId Nextcloud file ID from oc_filecache
      *
      * @return string Risk level constant (RISK_NONE through RISK_VERY_HIGH)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/tasks.md#task-3
      */
     public function computeRiskLevel(int $fileId): string
     {
@@ -168,6 +170,8 @@ class RiskLevelService
      * @param int $fileId Nextcloud file ID from oc_filecache
      *
      * @return string The computed risk level
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/tasks.md#task-4
      */
     public function updateRiskLevel(int $fileId): string
     {
@@ -199,6 +203,8 @@ class RiskLevelService
      * @param int $fileId Nextcloud file ID from oc_filecache
      *
      * @return string Risk level constant
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/tasks.md#task-4
      */
     public function getRiskLevel(int $fileId): string
     {
@@ -226,6 +232,8 @@ class RiskLevelService
      * This must be called from a repair step (not during app boot).
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/tasks.md#task-4
      */
     public function initMetadataKey(): void
     {
@@ -243,6 +251,8 @@ class RiskLevelService
      * Useful for API documentation and frontend dropdowns.
      *
      * @return array<string, string> Map of risk level value to human-readable label
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/tasks.md#task-4
      */
     public static function getAllRiskLevels(): array
     {

--- a/lib/Service/SchemaService.php
+++ b/lib/Service/SchemaService.php
@@ -107,6 +107,8 @@ class SchemaService
      * @return array Exploration results with discovered properties
      *
      * @throws \Exception If schema not found or analysis fails
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/tasks.md#task-1
      */
     public function exploreSchemaProperties(int $schemaId): array
     {
@@ -1742,6 +1744,8 @@ class SchemaService
      * @throws \Exception If schema update fails
      *
      * @return Schema Updated schema entity
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/tasks.md#task-2
      */
     public function updateSchemaFromExploration(int $schemaId, array $propertyUpdates): Schema
     {

--- a/lib/Service/ShareLinkService.php
+++ b/lib/Service/ShareLinkService.php
@@ -140,6 +140,8 @@ class ShareLinkService
      * @return array<int,array<string,mixed>> Normalised share rows.
      *
      * @throws Exception When the share subsystem is unreachable (503).
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the shares-listing contract is owned by the integration-shares / generic-integrations capability.
      */
     public function getLinkedShares(string $objectUuid): array
     {
@@ -216,6 +218,8 @@ class ShareLinkService
      *                   invalid recipient (400) or share-manager failure.
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the create-share contract is owned by the integration-shares / generic-integrations capability.
      */
     public function createShare(
         string $objectUuid,
@@ -298,6 +302,8 @@ class ShareLinkService
      *
      * @throws Exception On missing user (401), share-not-found (404),
      *                   ownership mismatch (403).
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the revoke-share contract is owned by the integration-shares / generic-integrations capability.
      */
     public function revokeShare(string $objectUuid, string $shareId): void
     {
@@ -327,6 +333,8 @@ class ShareLinkService
      * @param string $objectUuid Owning object uuid.
      *
      * @return array<int,array<string,mixed>> File descriptors `{fileId, fileName, mimetype, size}`.
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the shareable-files listing contract is owned by the integration-shares / generic-integrations capability.
      */
     public function getShareableFiles(string $objectUuid): array
     {
@@ -607,6 +615,8 @@ class ShareLinkService
              * @param string $id Service id.
              *
              * @return object
+             *
+             * @spec exclude Plumbing: PSR-11 adapter method around Server::get() on an inline anonymous container; no standalone behavioral contract.
              */
             public function get(string $id): object
             {
@@ -619,6 +629,8 @@ class ShareLinkService
              * @param string $id Service id.
              *
              * @return bool
+             *
+             * @spec exclude Plumbing: PSR-11 adapter method around Server::get() on an inline anonymous container; no standalone behavioral contract.
              */
             public function has(string $id): bool
             {

--- a/lib/Service/TimeTrackerLinkService.php
+++ b/lib/Service/TimeTrackerLinkService.php
@@ -199,6 +199,8 @@ class TimeTrackerLinkService
      * @throws Exception On missing user (401), bad type (400), missing
      *                   entry (404), duplicate (409), TimeManager
      *                   unavailable (503).
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the link-entry contract is owned by the integration-time-tracker capability.
      */
     public function linkEntry(
         string $objectUuid,
@@ -262,6 +264,8 @@ class TimeTrackerLinkService
      *
      * @throws Exception On missing user (401), empty name (400),
      *                   TimeManager unavailable (503), create failure (500).
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the create-and-link-client contract is owned by the integration-time-tracker capability.
      */
     public function createAndLinkClient(
         string $objectUuid,
@@ -428,6 +432,8 @@ class TimeTrackerLinkService
      * @return void
      *
      * @throws Exception On missing user (401) or no matching link (404).
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the unlink contract is owned by the integration-time-tracker capability.
      */
     public function unlink(string $objectUuid, string $entryId): void
     {
@@ -447,6 +453,8 @@ class TimeTrackerLinkService
      * @param string $objectUuid Parent OR object uuid.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the linked-entries listing contract is owned by the integration-time-tracker capability.
      */
     public function getLinkedEntries(string $objectUuid): array
     {
@@ -523,6 +531,8 @@ class TimeTrackerLinkService
      * @param string|null $search Optional name-substring filter.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec exclude ADR-019 Tier-2 integration link-service facade; the picker-source contract is owned by the integration-time-tracker capability.
      */
     public function getAvailableClients(?string $search=null): array
     {

--- a/lib/Service/TmloService.php
+++ b/lib/Service/TmloService.php
@@ -160,6 +160,8 @@ class TmloService
      * @param Schema $schema The schema to get defaults from
      *
      * @return array The TMLO default values
+     *
+     * @spec exclude Owned by tmlo-auto-populate spec (schema-defaults precedence is part of the auto-populate contract); not foundation behaviour.
      */
     public function getSchemaDefaults(Schema $schema): array
     {
@@ -392,6 +394,8 @@ class TmloService
      * @return string The MDTO XML string
      *
      * @throws InvalidArgumentException If the object has no TMLO metadata
+     *
+     * @spec exclude Owned by tmlo-export spec REQ "MDTO-compliant XML export" (single object); not foundation behaviour.
      */
     public function generateMdtoXml(ObjectEntity $object): string
     {
@@ -417,6 +421,8 @@ class TmloService
      * @param ObjectEntity[] $objects Array of objects to export
      *
      * @return string The MDTO XML string with multiple objects
+     *
+     * @spec exclude Owned by tmlo-export spec REQ "MDTO-compliant XML export" (batch); not foundation behaviour.
      */
     public function generateBatchMdtoXml(array $objects): string
     {

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -304,6 +304,8 @@ class UserService
      * @param array $data The data array containing updates
      *
      * @return array Result of the update operation including organization changes
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3
      */
     public function updateUserProperties(IUser $user, array $data): array
     {
@@ -422,6 +424,8 @@ class UserService
      * @param IUser $user The user object
      *
      * @return array Array containing name fields
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3
      */
     public function getCustomNameFields(IUser $user): array
     {
@@ -456,6 +460,8 @@ class UserService
      * @param array $nameFields Array containing name field values
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3
      */
     public function setCustomNameFields(IUser $user, array $nameFields): void
     {
@@ -1011,6 +1017,8 @@ class UserService
      * @return array Result array with success status
      *
      * @throws RuntimeException If deletion fails
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3
      */
     public function deleteAvatar(IUser $user): array
     {
@@ -1135,6 +1143,8 @@ class UserService
      * @return array The complete updated preferences
      *
      * @throws InvalidArgumentException If invalid preference values
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3
      */
     public function setNotificationPreferences(IUser $user, array $prefs): array
     {
@@ -1293,6 +1303,8 @@ class UserService
      * @param IUser $user The user to list tokens for
      *
      * @return array Array of token objects with masked values
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3
      */
     public function listApiTokens(IUser $user): array
     {
@@ -1324,6 +1336,8 @@ class UserService
      * @return array Result array
      *
      * @throws RuntimeException If token not found
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3
      */
     public function revokeApiToken(IUser $user, string $tokenId): array
     {
@@ -1399,6 +1413,8 @@ class UserService
      * @param IUser $user The user to check status for
      *
      * @return array Status information
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3
      */
     public function getDeactivationStatus(IUser $user): array
     {
@@ -1427,6 +1443,8 @@ class UserService
      * @return array Result array
      *
      * @throws RuntimeException If no pending request
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3
      */
     public function cancelDeactivation(IUser $user): array
     {

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/proposal.md
@@ -1,0 +1,58 @@
+# Retrofit — backend coverage, Service facades chunk 3 (2026-05-25)
+
+Reverse-spec / annotation pass over batch `bw2-svc-flat-3`: **111 uncovered public methods
+across 21 top-level `lib/Service/*.php` files**. These are the top-level service facades —
+thin wrappers, integration link services, and search/index plumbing that mostly delegate to
+mappers, handlers, or late-bound peer-app services. Per ADR-003 every method ends tagged:
+genuinely-novel un-homed behaviour is reverse-spec'd into a new capability; everything else is
+either annotated to an existing capability requirement or carries an `@spec exclude <reason>`.
+
+## Why
+
+These 21 files were flagged by `/opsx-coverage-scan` as carrying public methods without a
+`@spec` tag. The bias for facade plumbing is `@spec exclude` — a thin route into an
+already-specced collaborator does not warrant its own requirement. Only two clusters carry
+real behaviour with no existing capability home, and those are the ones reverse-spec'd here.
+
+## Counts
+
+- **111 methods** triaged total.
+- **7 spec'd** (reverse-spec → 4 new REQs across 2 new capabilities):
+  - `schema-property-exploration` (2 REQs): `SchemaService::exploreSchemaProperties`,
+    `SchemaService::updateSchemaFromExploration`.
+  - `file-risk-classification` (2 REQs): `RiskLevelService::computeRiskLevel`,
+    `updateRiskLevel`, `getRiskLevel`, `initMetadataKey`, `getAllRiskLevels`.
+- **24 annotated** to existing capability tasks (no new REQs):
+  - `UserService` self-service surface (9) → `retrofit-2026-05-24-b-svc-compute-profile-org`
+    task-3 (`profile-actions`), which already names every one of these methods.
+  - `ContactMatchingService` matchers (4) → `retrofit-2026-05-24-contacts-actions` task-3
+    (`contacts-actions` REQ "ContactMatchingService MUST match contacts ...").
+  - `CalendarEventService` CalDAV link/CRUD (4) → `retrofit-2026-05-24-calendar-integration`
+    task-1 (`calendar-integration` REQ-003 "REST link/unlink flow for CalDAV VEVENTs").
+  - `AuthorizationService` (6) → `auth-system` (cross-cap reference tasks in this change's
+    `tasks.md`; the `auth-system` spec already pins every method).
+  - `ManifestService::getEnrichedManifest` (1) → `manifest-user-context` (matches the
+    file-level `@spec`).
+- **80 excluded** as facade plumbing (`@spec exclude <reason>`), reasons name the owning
+  collaborator/capability:
+  - `ApplicationService` (6) — CRUD delegation to `ApplicationMapper`.
+  - `ObjectServiceMapperAdapter` (7) — mapper-shaped facade over `ObjectService`.
+  - `IndexService` (23) — search-index facade routing to handlers/backend (`search-index`).
+  - the six ADR-019 Tier-2 integration link services — `CospendLinkService` (6),
+    `FormLinkService` (8), `MapLinkService` (5), `PhotoLinkService` (5),
+    `TimeTrackerLinkService` (5), `ShareLinkService` (6) — owned by their `integration-*` caps.
+  - `ConfigurationService` (3) — app-presence probe + delegation to Git handlers.
+  - `TmloService` (3) — MDTO XML / schema-defaults, owned by `tmlo-export`/`tmlo-auto-populate`
+    (explicitly DROPped from the tmlo retrofit as "not foundation behaviour").
+  - `RetentionService::validateNotImmutable` (1) — archival-status immutability guard,
+    sibling of the already-annotated archival methods (`archival-destruction-workflow`).
+  - `ChatService::testChat` (1) — simplified facade stub.
+  - `AuthorizationAuditService::logSchemaAuthorizationChange` (1) — structured audit logging,
+    sibling of `logRegisterAuthorizationChange` (`rbac-scopes` REQ-002), no distinct contract.
+
+## New REQs
+
+4 (cap ≤5): 2 in `schema-property-exploration`, 2 in `file-risk-classification`.
+
+Source batch: `/tmp/or-scan/bw2-svc-flat-3.json`.
+See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/specs/file-risk-classification/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/specs/file-risk-classification/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: RiskLevelService MUST classify a file's PII risk from its detected entities
+
+`RiskLevelService::computeRiskLevel(int $fileId)` MUST derive a single risk tier for a file from the entities that text-extraction detected on it. The method MUST load the file's entity relations via `EntityRelationMapper::findEntitiesForFile()` and MUST return `RISK_NONE` ('none') when no entities are present. For each detected entity it MUST map the entity type to a base tier via the fixed `ENTITY_RISK_MAP` — `SSN` → `very_high`; `EMAIL` and `IBAN` → `high`; `PERSON`, `PHONE`, `ADDRESS` → `medium`; `LOCATION`, `ORGANIZATION`, `DATE`, `IP_ADDRESS` → `low` — with any unrecognised entity type defaulting to `low`. The file's base risk MUST be the highest tier observed across all its entities, compared using the `RISK_ORDER` ranking (`none` < `low` < `medium` < `high` < `very_high`).
+
+When the total number of detected entities exceeds `ESCALATION_THRESHOLD` (50) and the base tier is not already `very_high`, the result MUST be escalated by exactly one tier. The risk tier MUST never exceed `very_high`.
+
+#### Scenario: The highest-risk entity type determines the base tier
+
+- **GIVEN** a file with entities of types `LOCATION`, `PERSON`, and `EMAIL`
+- **WHEN** `computeRiskLevel($fileId)` is called
+- **THEN** the result MUST be `high` (the `EMAIL` tier, which outranks `PERSON` and `LOCATION`)
+
+#### Scenario: A file with no entities is classified as none
+
+- **GIVEN** a file for which `EntityRelationMapper::findEntitiesForFile()` returns an empty array
+- **WHEN** `computeRiskLevel($fileId)` is called
+- **THEN** the result MUST be `none`
+
+#### Scenario: High entity volume escalates the tier by one
+
+- **GIVEN** a file with 60 detected entities whose highest tier is `medium`
+- **WHEN** `computeRiskLevel($fileId)` is called
+- **THEN** the result MUST be escalated to `high`
+
+#### Scenario: Escalation never exceeds very_high
+
+- **GIVEN** a file with 60 detected entities whose highest tier is already `very_high`
+- **WHEN** `computeRiskLevel($fileId)` is called
+- **THEN** the result MUST remain `very_high`
+
+### Requirement: RiskLevelService MUST persist and expose risk levels through Nextcloud files metadata
+
+The computed risk level MUST be stored on the file using Nextcloud's `IFilesMetadata` API under the `METADATA_KEY` (`openregister-risk-level`). `RiskLevelService::updateRiskLevel(int $fileId)` MUST compute the level via `computeRiskLevel()`, write it as an indexed string metadata value, and return the computed level; a metadata write failure MUST be caught and logged at `warning` level WITHOUT propagating (the computed level is still returned). `RiskLevelService::getRiskLevel(int $fileId)` MUST return the stored level when the metadata key is present and MUST fall back to `RISK_NONE` ('none') when the key is absent or the metadata read throws. `RiskLevelService::initMetadataKey()` MUST register the metadata key with the files-metadata system as an indexed, edit-forbidden string type, and MUST be invoked from a repair step rather than during app boot. `RiskLevelService::getAllRiskLevels()` MUST return the map of every risk-level constant to its human-readable label for use in API documentation and frontend dropdowns.
+
+#### Scenario: updateRiskLevel returns the level even when persistence fails
+
+- **GIVEN** `IFilesMetadataManager::saveMetadata()` throws for a file
+- **WHEN** `updateRiskLevel($fileId)` is called
+- **THEN** a `warning` log MUST be emitted
+- **AND** the computed risk level MUST still be returned
+- **AND** no exception MUST propagate
+
+#### Scenario: getRiskLevel falls back to none when no level is stored
+
+- **GIVEN** a file whose metadata does not contain the `openregister-risk-level` key
+- **WHEN** `getRiskLevel($fileId)` is called
+- **THEN** the result MUST be `none`
+
+#### Scenario: getAllRiskLevels enumerates every tier with a label
+
+- **WHEN** `RiskLevelService::getAllRiskLevels()` is called
+- **THEN** the result MUST contain keys `none`, `low`, `medium`, `high`, `very_high`
+- **AND** each MUST map to a non-empty human-readable label

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/specs/schema-property-exploration/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/specs/schema-property-exploration/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: SchemaService MUST discover undeclared properties by analysing a schema's stored objects
+
+`SchemaService::exploreSchemaProperties(int $schemaId)` MUST inspect every `ObjectEntity` stored under the given schema and return a property-discovery report describing the JSON payload shape actually present in the data, independent of the schema's declared `properties`. The method MUST resolve the schema via `SchemaMapper::find()` and MUST throw an `\Exception` carrying the schema id when the schema does not exist. It MUST load the objects via `ObjectEntityMapper::findBySchema($schemaId)` and, when no objects exist, MUST return a report whose `total_objects` is `0`, whose `discovered_properties` and `suggestions` are empty, whose `existing_properties` echoes the schema's declared properties, and whose `message` states that no objects were available for analysis.
+
+For each object the method MUST analyse the `getObject()` payload after removing the `@self` metadata key, MUST count per-property usage across all objects (including objects where the value is `null` or the empty string), and MUST derive, for each non-empty value, the detected scalar/array/object type, string length range, detected string format, and numeric range. Per-property usage MUST be expressed both as a raw count and as a percentage of total objects. The returned report MUST include `discovered_properties`, `existing_properties`, `property_usage_stats`, `data_types`, an `analysis_date` in ISO-8601 (`c`) format, and a `suggestions` array that merges suggestions for newly-discovered properties with improvement suggestions for already-declared properties, plus an `analysis_summary` carrying `new_properties_count`, `existing_properties_improvements`, and `total_recommendations`.
+
+#### Scenario: Exploring a schema with no objects returns an empty report
+
+- **GIVEN** a schema with id `7` that has zero stored objects
+- **WHEN** `SchemaService::exploreSchemaProperties(7)` is called
+- **THEN** the report's `total_objects` MUST be `0`
+- **AND** `discovered_properties` and `suggestions` MUST be empty arrays
+- **AND** `existing_properties` MUST equal the schema's declared properties
+- **AND** a `message` field MUST indicate that no objects were available for analysis
+
+#### Scenario: Discovered properties carry usage counts and percentages
+
+- **GIVEN** a schema with 4 stored objects, 3 of which carry a `phoneNumber` string in their payload
+- **WHEN** `SchemaService::exploreSchemaProperties()` runs
+- **THEN** `property_usage_stats['counts']['phoneNumber']` MUST be `3`
+- **AND** `property_usage_stats['percentages']['phoneNumber']` MUST be `75.0`
+- **AND** the discovered `phoneNumber` entry MUST record a `usage_percentage` of `75.0`
+
+#### Scenario: The `@self` metadata key is excluded from analysis
+
+- **GIVEN** stored objects whose payloads include a `@self` key alongside business properties
+- **WHEN** the payloads are analysed
+- **THEN** the `@self` key MUST NOT appear in `discovered_properties` or `property_usage_stats`
+
+#### Scenario: A missing schema raises an exception
+
+- **GIVEN** a schema id that does not resolve via `SchemaMapper::find()`
+- **WHEN** `SchemaService::exploreSchemaProperties()` is called
+- **THEN** an `\Exception` MUST be thrown whose message references the requested schema id
+
+### Requirement: SchemaService MUST apply confirmed exploration suggestions back onto a schema
+
+`SchemaService::updateSchemaFromExploration(int $schemaId, array $propertyUpdates)` MUST merge the supplied property definitions onto the schema's existing `properties` map — each key in `$propertyUpdates` overwriting or adding the corresponding entry while leaving untouched properties intact — and MUST persist the result. After merging, the method MUST call `Schema::regenerateFacetsFromProperties()` so that facet configuration stays consistent with the new property set, then persist via `SchemaMapper::update()` and return the updated `Schema`. Any failure during lookup, merge, or persistence MUST be logged at `error` level and re-thrown as an `\Exception` whose message wraps the underlying error.
+
+#### Scenario: New and changed properties are merged without dropping existing ones
+
+- **GIVEN** a schema whose `properties` already contains `name`
+- **WHEN** `updateSchemaFromExploration($id, ['email' => ['type' => 'string'], 'name' => ['type' => 'string', 'format' => 'fullname']])` is called
+- **THEN** the persisted schema MUST contain `name` (with the updated definition) AND `email`
+- **AND** `Schema::regenerateFacetsFromProperties()` MUST be invoked before persistence
+- **AND** the updated `Schema` entity MUST be returned
+
+#### Scenario: A persistence failure is logged and re-thrown
+
+- **GIVEN** `SchemaMapper::update()` throws during the save
+- **WHEN** `updateSchemaFromExploration()` runs
+- **THEN** an `error` log MUST be emitted referencing the schema id
+- **AND** an `\Exception` whose message wraps the underlying error MUST be re-thrown

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/tasks.md
@@ -1,0 +1,34 @@
+# Tasks
+
+Reverse-spec + annotation pass for batch `bw2-svc-flat-3` (111 methods / 21 service
+facades). Tasks 1–4 mint the 4 new REQs (2 capabilities) and annotate the methods that
+implement them. Task 5 is a cross-capability annotation reference for methods whose
+contract already lives in `auth-system`. No code behaviour changes — only `@spec`
+docblock tags (annotations + excludes) are added.
+
+## Reverse-spec (new REQs)
+
+- [x] task-1: schema-property-exploration#Requirement:SchemaService MUST discover undeclared properties by analysing a schema's stored objects — annotate `SchemaService::exploreSchemaProperties` (object-payload analysis, per-property usage counts/percentages, `@self` exclusion, missing-schema exception, discovery report shape).
+- [x] task-2: schema-property-exploration#Requirement:SchemaService MUST apply confirmed exploration suggestions back onto a schema — annotate `SchemaService::updateSchemaFromExploration` (merge property updates onto existing properties, regenerate facets, persist via `SchemaMapper::update`, log+re-throw on failure).
+- [x] task-3: file-risk-classification#Requirement:RiskLevelService MUST classify a file's PII risk from its detected entities — annotate `RiskLevelService::computeRiskLevel` (entity-type→tier map, highest-tier-wins, count-threshold escalation capped at `very_high`).
+- [x] task-4: file-risk-classification#Requirement:RiskLevelService MUST persist and expose risk levels through Nextcloud files metadata — annotate `RiskLevelService::updateRiskLevel`, `getRiskLevel`, `initMetadataKey`, `getAllRiskLevels` (IFilesMetadata persistence, fail-soft read/write, repair-step registration, label map).
+
+## Cross-capability annotation (no new REQs)
+
+- [x] task-5: auth-system — `AuthorizationService` request-authorization surface (`authorizeJwt`, `authorizeBasic`, `authorizeOAuth`, `authorizeApiKey`, `validatePayload`, `corsAfterController`) maps to the existing `auth-system` capability requirements "The system MUST support multiple authentication methods with unified identity resolution" and "CORS policy MUST be enforced per Consumer and prevent CSRF", which already name every one of these methods in their scenarios (retroactive annotation).
+
+## Annotated to existing capability tasks (no new REQs, documented in proposal.md)
+
+- [x] task-6: `UserService` self-service methods (`updateUserProperties`, `getCustomNameFields`, `setCustomNameFields`, `deleteAvatar`, `setNotificationPreferences`, `listApiTokens`, `revokeApiToken`, `getDeactivationStatus`, `cancelDeactivation`) tagged at `retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-3` (`profile-actions`), matching their already-annotated siblings.
+- [x] task-7: `ContactMatchingService` matchers (`matchByEmail`, `matchByName`, `matchByOrganization`, `matchContact`) tagged at `retrofit-2026-05-24-contacts-actions/tasks.md#task-3` (`contacts-actions`), matching the already-annotated `getRelatedObjectCounts` sibling.
+- [x] task-8: `CalendarEventService` CalDAV link/CRUD (`createEvent`, `getEventsForObject`, `linkEvent`, `unlinkEvent`) tagged at `retrofit-2026-05-24-calendar-integration/tasks.md#task-1` (`calendar-integration` REQ-003).
+- [x] task-9: `ManifestService::getEnrichedManifest` tagged at `manifest-user-context/tasks.md#task-1`, matching the file-level `@spec`.
+
+## Excluded as facade plumbing (documented in proposal.md, NOT counted as REQs)
+
+- [x] task-10: `@spec exclude` applied to the 80 facade-plumbing methods across `ApplicationService` (6), `ObjectServiceMapperAdapter` (7), `IndexService` (23), `ConfigurationService` (3), `ChatService::testChat` (1), `TmloService` (3), `RetentionService::validateNotImmutable` (1), `AuthorizationAuditService::logSchemaAuthorizationChange` (1), and the six ADR-019 Tier-2 integration link services (`Cospend`/`Form`/`Map`/`Photo`/`TimeTracker`/`Share`). Each exclude reason names the owning collaborator/capability. See proposal.md "Counts" for the full enumeration.
+
+## Validation
+
+- [x] `php -l` clean on all 21 touched files.
+- [x] `openspec validate retrofit-2026-05-25-bw2-svc-flat-3 --strict` passes.


### PR DESCRIPTION
## Summary

Reverse-spec + annotation pass over batch `bw2-svc-flat-3`: **111 uncovered public methods across 21 top-level `lib/Service/*.php` facades**. Per ADR-003 every method ends tagged — only docblock `@spec` tags are added, no code behaviour changes.

- **7 spec'd** via **4 new REQs in 2 new capabilities** (the only genuinely-novel, un-homed behaviour):
  - `schema-property-exploration` (2 REQs) — `SchemaService::exploreSchemaProperties` (analyse stored objects, discover undeclared properties, infer types/usage) + `updateSchemaFromExploration` (merge confirmed suggestions back onto the schema).
  - `file-risk-classification` (2 REQs) — `RiskLevelService` PII risk tiering (entity-type → tier, highest-wins, count-threshold escalation) + `IFilesMetadata` persistence/read/init.
- **24 annotated** to existing capability tasks (no new REQs): UserService → `profile-actions`, ContactMatchingService → `contacts-actions`, CalendarEventService → `calendar-integration`, AuthorizationService → `auth-system`, ManifestService → `manifest-user-context`.
- **80 `@spec exclude`'d** as facade plumbing, each reason naming the owning collaborator/capability: ApplicationService, ObjectServiceMapperAdapter, IndexService (search-index facade), the six ADR-019 Tier-2 integration link services (Cospend/Form/Map/Photo/TimeTracker/Share → their `integration-*` caps), ConfigurationService, TmloService (`tmlo-export`/`tmlo-auto-populate`), RetentionService archival guard, ChatService stub, AuthorizationAuditService log.

Ghost change: `openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/`.

## Test plan

- [x] `php -l` clean on all 21 touched files
- [x] `openspec validate retrofit-2026-05-25-bw2-svc-flat-3 --strict` passes
- [x] All 111 batch methods carry an `@spec` tag (annotation or exclude)
- [ ] `composer check:strict` (PHPCS/PHPMD/Psalm/PHPStan) green in CI