### PR TITLE
retrofit: backend coverage — Service facades (chunk 1)

### DIFF
--- a/lib/Service/AnalyticsLinkService.php
+++ b/lib/Service/AnalyticsLinkService.php
@@ -195,6 +195,8 @@ class AnalyticsLinkService
      *
      * @throws Exception On missing user (401), missing report (404),
      *                   duplicate (409), Analytics unavailable (503).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function linkReport(string $objectUuid, int $registerId, int $schemaId, int $reportId): AnalyticsLink
     {
@@ -245,6 +247,8 @@ class AnalyticsLinkService
      *                   Analytics unavailable (503), create failure (500).
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function createAndLinkReport(
         string $objectUuid,
@@ -322,6 +326,8 @@ class AnalyticsLinkService
      * @return void
      *
      * @throws Exception On missing user (401) or no matching link (404).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function unlinkReport(string $objectUuid, int $reportId): void
     {
@@ -343,6 +349,8 @@ class AnalyticsLinkService
      * @param string $objectUuid Parent OR object uuid.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function getLinkedReports(string $objectUuid): array
     {
@@ -373,6 +381,8 @@ class AnalyticsLinkService
      * @param string|null $search Optional name-substring filter.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function getAvailableReports(?string $search=null): array
     {

--- a/lib/Service/CalendarLinkService.php
+++ b/lib/Service/CalendarLinkService.php
@@ -86,6 +86,8 @@ class CalendarLinkService
      * @return CalendarLink The persisted link row.
      *
      * @throws Exception When no user is logged in or the event cannot be located.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function linkEvent(
         string $objectUuid,
@@ -144,6 +146,8 @@ class CalendarLinkService
      * @return CalendarLink The persisted link row.
      *
      * @throws Exception On creation failure.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function createAndLinkEvent(
         string $objectUuid,
@@ -224,6 +228,8 @@ class CalendarLinkService
      * @param string $eventUid   VEVENT UID.
      *
      * @return void
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function unlinkEvent(string $objectUuid, string $eventUid): void
     {
@@ -297,6 +303,8 @@ class CalendarLinkService
      * @param string $objectUuid Object UUID.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function getLinkedEvents(string $objectUuid): array
     {
@@ -377,6 +385,8 @@ class CalendarLinkService
      * @return array<int,array<string,mixed>> Each entry has id, uri, displayName, color.
      *
      * @throws Exception When no user is logged in.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function getAvailableCalendars(): array
     {
@@ -417,6 +427,8 @@ class CalendarLinkService
      * @return array<int,array<string,mixed>>
      *
      * @throws Exception When no user, no calendar, or calendar URI is unknown.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function getEventsForCalendar(string $calendarUri, ?int $limit = 100, ?DateTimeInterface $after = null): array
     {

--- a/lib/Service/ConditionMatcher.php
+++ b/lib/Service/ConditionMatcher.php
@@ -73,6 +73,8 @@ class ConditionMatcher
      * @param array $match  Match conditions
      *
      * @return bool True if object matches all conditions
+     *
+     * @spec openspec/specs/rbac-scopes/spec.md#requirement-conditional-scopes-with-dynamic-variables
      */
     public function objectMatchesConditions(array $object, array $match): bool
     {

--- a/lib/Service/DateTimeNormalizer.php
+++ b/lib/Service/DateTimeNormalizer.php
@@ -76,6 +76,8 @@ class DateTimeNormalizer
      * @return DateTimeImmutable|null A `DateTimeImmutable` when parseable, otherwise `null`.
      *
      * @SuppressWarnings(PHPMD.StaticAccess)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-2
      */
     public function normalize(mixed $value): ?DateTimeImmutable
     {
@@ -126,6 +128,8 @@ class DateTimeNormalizer
      * @param mixed $value Value to normalise and format.
      *
      * @return string|null `Y-m-d H:i:s`-formatted string, or `null` for empty/invalid input.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-2
      */
     public function formatForDatabase(mixed $value): ?string
     {
@@ -143,6 +147,8 @@ class DateTimeNormalizer
      * @param mixed $value Value to normalise and format.
      *
      * @return string|null ISO 8601 string with offset, or `null` for empty/invalid input.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-2
      */
     public function formatForIso8601(mixed $value): ?string
     {

--- a/lib/Service/DeckLinkService.php
+++ b/lib/Service/DeckLinkService.php
@@ -117,6 +117,8 @@ class DeckLinkService
      *     blocks around every getter on Deck's Card entity (which uses
      *     OCP\AppFramework\Db\Entity::__call magic) — required to
      *     tolerate missing fields without burying the call site.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function linkCard(string $objectUuid, int $registerId, int $schemaId, int $cardId): DeckLink
     {
@@ -188,6 +190,8 @@ class DeckLinkService
      * @return void
      *
      * @throws Exception When no matching link is found (404).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function unlinkCard(string $objectUuid, int $cardId): void
     {
@@ -208,6 +212,8 @@ class DeckLinkService
      * @param string $objectUuid Parent OR object uuid.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function getLinkedCards(string $objectUuid): array
     {
@@ -260,6 +266,8 @@ class DeckLinkService
      * @return DeckLink The persisted link row.
      *
      * @throws Exception On missing user, Deck unavailable, or create failure.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function createAndLinkCard(
         string $objectUuid,
@@ -352,6 +360,8 @@ class DeckLinkService
      * Each row is `{id, title}` — the minimum the picker needs.
      *
      * @return array<int,array{id:int,title:string}>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function getAvailableBoards(): array
     {
@@ -408,6 +418,8 @@ class DeckLinkService
      * @param int $boardId Deck board id.
      *
      * @return array<int,array{id:int,title:string,boardId:int}>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function getStacksForBoard(int $boardId): array
     {

--- a/lib/Service/EmailLinkService.php
+++ b/lib/Service/EmailLinkService.php
@@ -130,6 +130,8 @@ class EmailLinkService
      * Whether NC Mail is installed + enabled for the current user.
      *
      * @return bool
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function isMailAvailable(): bool
     {
@@ -166,6 +168,8 @@ class EmailLinkService
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Sequential guard
      *     clauses for the four required preconditions (user, Mail
      *     available, message exists, upsert idempotency).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function linkEmail(
         string $objectUuid,
@@ -249,6 +253,8 @@ class EmailLinkService
      * @return void
      *
      * @throws Exception When no matching link is found (404).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function unlinkEmail(string $objectUuid, int $linkId): void
     {
@@ -274,6 +280,8 @@ class EmailLinkService
      * @param int         $limit      Page size (clamped to [1, MAX_LIMIT]).
      *
      * @return array{items: array<int,array<string,mixed>>, total: int, nextCursor: ?int}
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function getLinkedEmails(string $objectUuid, ?string $cursor = null, int $limit = self::DEFAULT_LIMIT): array
     {
@@ -318,6 +326,8 @@ class EmailLinkService
      * needs. Backed by `oc_mail_accounts.user_id = <current uid>`.
      *
      * @return array<int,array{id:int,label:string,email:string}>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function getAvailableAccounts(): array
     {
@@ -377,6 +387,8 @@ class EmailLinkService
      * @param int $accountId Mail account id.
      *
      * @return array<int,array{id:int,name:string,displayName:string}>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function getMailboxesForAccount(int $accountId): array
     {
@@ -442,6 +454,8 @@ class EmailLinkService
      *     composes several guard clauses (Mail availability, mailbox
      *     resolution, cursor parse, ownership) then a defensive
      *     try/catch around the join query.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function getMessagesForMailbox(
         int $accountId,

--- a/lib/Service/EmailService.php
+++ b/lib/Service/EmailService.php
@@ -226,6 +226,8 @@ class EmailService
      * @return void
      *
      * @throws Exception If the link is not found.
+     *
+     * @spec exclude Legacy link-table delete by id; email link infrastructure being removed per linked-entity-types.
      */
     public function unlinkEmail(int $linkId): void
     {
@@ -351,6 +353,8 @@ class EmailService
      * @param string $objectUuid The object UUID.
      *
      * @return int Number of deleted links.
+     *
+     * @spec exclude Legacy link-table bulk cleanup delegating to EmailLinkMapper; email link infrastructure being removed per linked-entity-types.
      */
     public function deleteLinksForObject(string $objectUuid): int
     {

--- a/lib/Service/FileSidebarService.php
+++ b/lib/Service/FileSidebarService.php
@@ -87,6 +87,8 @@ class FileSidebarService
      *     register: array{id: int, title: string},
      *     schema: array{id: int, title: string}
      * }>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-4
      */
     public function getObjectsForFile(int $fileId): array
     {
@@ -272,6 +274,8 @@ class FileSidebarService
      *   anonymizedAt: string|null,
      *   anonymizedFileId: int|null
      * }
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-4
      */
     public function getExtractionStatus(int $fileId): array
     {

--- a/lib/Service/FlowLinkService.php
+++ b/lib/Service/FlowLinkService.php
@@ -113,6 +113,8 @@ class FlowLinkService
      * mutating service methods on this flag.
      *
      * @return bool
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function isCurrentUserAdmin(): bool
     {
@@ -138,6 +140,8 @@ class FlowLinkService
      *
      * @throws Exception On missing user, non-admin (403), missing operation (404),
      *                   duplicate (409), Flow unavailable (503).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function linkOperation(string $objectUuid, int $registerId, int $schemaId, int $operationId): FlowLink
     {
@@ -191,6 +195,8 @@ class FlowLinkService
      * @return void
      *
      * @throws Exception On non-admin (403) or no matching link (404).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function unlinkOperation(string $objectUuid, int $operationId): void
     {
@@ -216,6 +222,8 @@ class FlowLinkService
      * @param string $objectUuid Parent OR object uuid.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function getLinkedOperations(string $objectUuid): array
     {
@@ -263,6 +271,8 @@ class FlowLinkService
      * @param string|null $search Optional name-substring filter.
      *
      * @return array<int,array<string,mixed>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function getAvailableOperations(?string $search = null): array
     {

--- a/lib/Service/MappingService.php
+++ b/lib/Service/MappingService.php
@@ -136,6 +136,8 @@ class MappingService
      * @param string $replacement The encoded character.
      *
      * @return array The array with encoded array keys
+     *
+     * @spec exclude Pure array-key encoding helper used internally by executeMapping; no standalone behavior.
      */
     public function encodeArrayKeys(array $array, string $toReplace, string $replacement): array
     {
@@ -168,6 +170,8 @@ class MappingService
      * @return array The result (output) of the mapping process
      *
      * @throws Exception When mapping fails
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-3
      */
     public function executeMapping(Mapping $mapping, array $input, bool $list=false): array
     {
@@ -557,6 +561,8 @@ class MappingService
      * @param int|string $id The mapping ID, UUID, or slug to invalidate
      *
      * @return void
+     *
+     * @spec exclude One-line distributed-cache invalidation called by MappingMapper on write; cache plumbing.
      */
     public function invalidateMappingCache(int|string $id): void
     {
@@ -573,6 +579,8 @@ class MappingService
      * @param string $coordinates A string containing coordinates.
      *
      * @return array An array of coordinates.
+     *
+     * @spec exclude Pure coordinate-string parsing helper; no orchestration or persisted state.
      */
     public function coordinateStringToArray(string $coordinates): array
     {
@@ -610,6 +618,8 @@ class MappingService
      *
      * @throws \OCP\AppFramework\Db\DoesNotExistException          If mapping is not found
      * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException If multiple mappings found
+     *
+     * @spec exclude Cache-wrapped read delegating to MappingMapper::find; read-through caching plumbing.
      */
     public function getMapping(string $mappingId): Mapping
     {

--- a/lib/Service/McpDiscoveryService.php
+++ b/lib/Service/McpDiscoveryService.php
@@ -218,6 +218,8 @@ class McpDiscoveryService
      * Get the list of valid capability IDs
      *
      * @return array<string> List of capability IDs
+     *
+     * @spec openspec/specs/mcp-discovery/spec.md#requirement-capability-coverage
      */
     public function getCapabilityIds(): array
     {

--- a/lib/Service/MigrationService.php
+++ b/lib/Service/MigrationService.php
@@ -60,6 +60,8 @@ class MigrationService
      * @return array{register: Register, schema: Schema}
      *
      * @throws \Exception If register or schema not found.
+     *
+     * @spec exclude Two-line mapper lookup resolving register/schema by id or slug; no orchestration.
      */
     public function resolveRegisterAndSchema(string|int $registerId, string|int $schemaId): array
     {
@@ -78,6 +80,8 @@ class MigrationService
      * @param Schema   $schema   The schema.
      *
      * @return array Storage status with magic table counts.
+     *
+     * @spec exclude Reporting shim: assembles register/schema/magic-table-count read into a response array; no business rule.
      */
     public function getStorageStatus(Register $register, Schema $schema): array
     {
@@ -128,6 +132,8 @@ class MigrationService
      * @return array Migration report indicating blob storage is no longer available.
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec exclude Deprecated no-op stub; blob storage retired, returns a static report pointing to BlobMigrationJob.
      */
     public function migrateToMagicTable(
         Register $register,
@@ -161,6 +167,8 @@ class MigrationService
      * @return array Migration report indicating blob storage is no longer available.
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec exclude Deprecated no-op stub; reverse migration to retired blob storage is no longer supported.
      */
     public function migrateToBlobStorage(
         Register $register,

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -356,6 +356,8 @@ class ObjectService
      *
      * @psalm-return   void
      * @phpstan-return void
+     *
+     * @spec exclude Lazily creates the object's storage folder via FileService when missing; file-folder plumbing.
      */
     public function ensureObjectFolderExists(ObjectEntity $entity): void
     {
@@ -559,6 +561,8 @@ class ObjectService
      * Get the current object context.
      *
      * @return ObjectEntity|null The current object entity or null if not set.
+     *
+     * @spec exclude Context getter returning the current object field; no business rule.
      */
     public function getObject(): ?ObjectEntity
     {
@@ -584,6 +588,8 @@ class ObjectService
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Complex permission and context handling requires multiple branches
      * @SuppressWarnings(PHPMD.NPathComplexity)       Multiple optional parameters create many execution paths
+     *
+     * @spec exclude Facade coordinating GetObject + permission check + RenderObject handlers; read/RBAC/render behavior owned by object-interactions / rbac-scopes / files-render-extension.
      */
     public function find(
         int | string $id,
@@ -701,6 +707,8 @@ class ObjectService
      * @throws Exception If there is an error during retrieval.
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec exclude Facade variant of find() that skips audit logging; read behavior owned by object-interactions / audit-trail-immutable.
      */
     public function findSilent(
         string $id,
@@ -762,6 +770,8 @@ class ObjectService
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Complex configuration handling requires multiple branches
      * @SuppressWarnings(PHPMD.NPathComplexity)       Many configuration options create many execution paths
+     *
+     * @spec exclude Facade preparing config then delegating to the GetObject handler; list/search behavior owned by zoeken-filteren.
      */
     public function findAll(array $config=[], bool $_rbac=true, bool $_multitenancy=true): array
     {
@@ -974,6 +984,8 @@ class ObjectService
      * @return int The number of matching objects.
      *
      * @throws \Exception If register or schema is not set
+     *
+     * @spec exclude Facade injecting register/schema context then delegating to ObjectMapper::countAll(); count behavior owned by zoeken-filteren.
      */
     public function count(
         array $config=[]
@@ -1007,6 +1019,8 @@ class ObjectService
      * @return \OCA\OpenRegister\Db\ObjectEntity[]
      *
      * @psalm-return list<\OCA\OpenRegister\Db\ObjectEntity>
+     *
+     * @spec exclude One-line delegation to ObjectMapper::findByRelation(); relation lookup owned by nextcloud-entity-relations.
      */
     public function findByRelations(string $search, bool $partialMatch=true): array
     {
@@ -1027,6 +1041,8 @@ class ObjectService
      * @psalm-return array<\OCA\OpenRegister\Db\AuditTrail>
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec exclude Find-then-delegate to GetObject::findLogs(); audit-log read owned by audit-trail-immutable.
      */
     public function getLogs(string $uuid, array $filters=[], bool $_rbac=true, bool $_multitenancy=true): array
     {
@@ -1781,6 +1797,8 @@ class ObjectService
      *
      * @psalm-return   array<string, mixed>
      * @phpstan-return array<string, mixed>
+     *
+     * @spec exclude One-line delegation to SearchQueryHandler::buildSearchQuery(); query-building owned by zoeken-filteren.
      */
     public function buildSearchQuery(
         array $requestParams,
@@ -1855,6 +1873,8 @@ class ObjectService
      * @throws \OCP\DB\Exception If a database error occurs
      *
      * @psalm-return int<0, max>|list<\OCA\OpenRegister\Db\ObjectEntity>
+     *
+     * @spec exclude One-line delegation to QueryHandler::searchObjects(); search behavior owned by zoeken-filteren.
      */
     public function searchObjects(
         array $query=[],
@@ -1919,6 +1939,8 @@ class ObjectService
      * @psalm-return int<0, max>|list<\OCA\OpenRegister\Db\ObjectEntity>
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Flags mirror searchObjects() upstream.
+     *
+     * @spec exclude Slug-resolution bridge delegating to searchObjects(); search behavior owned by zoeken-filteren.
      */
     public function searchObjectsBySlug(
         string $registerSlug,
@@ -2001,6 +2023,8 @@ class ObjectService
      * @phpstan-return int
      *
      * @throws \OCP\DB\Exception If a database error occurs
+     *
+     * @spec exclude Resolves org context then delegates to ObjectMapper::countSearchObjects(); count behavior owned by zoeken-filteren.
      */
     public function countSearchObjects(
         array $query=[],
@@ -2049,6 +2073,8 @@ class ObjectService
      * @throws \OCP\DB\Exception If a database error occurs
      *
      * @psalm-return array<string, mixed>
+     *
+     * @spec exclude One-line delegation to FacetHandler::getFacetsForObjects(); faceting owned by faceting-configuration.
      */
     public function getFacetsForObjects(array $query=[]): array
     {
@@ -2084,6 +2110,8 @@ class ObjectService
      * @throws \Exception If facetable field discovery fails
      *
      * @psalm-return array{'@self': array, object_fields: array}
+     *
+     * @spec exclude One-line delegation to FacetHandler::getFacetableFields(); facetable-field discovery owned by faceting-configuration.
      */
     public function getFacetableFields(array $baseQuery=[], int $sampleSize=100): array
     {
@@ -2199,6 +2227,8 @@ class ObjectService
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Complex search routing requires multiple branches
      * @SuppressWarnings(PHPMD.NPathComplexity)      Many search options create many execution paths
+     *
+     * @spec exclude Facade routing the unified paginated/faceted search to the query + facet handlers; behavior owned by zoeken-filteren / faceting-configuration.
      */
     public function searchObjectsPaginated(
         array $query=[],
@@ -2419,6 +2449,8 @@ class ObjectService
      * @deprecated
      *
      * @return int The current schema
+     *
+     * @spec exclude Deprecated context getter returning the current schema id; no business rule.
      */
     public function getSchema(): int
     {
@@ -2435,6 +2467,8 @@ class ObjectService
      * @deprecated
      *
      * @return int
+     *
+     * @spec exclude Deprecated context getter returning the current register id; no business rule.
      */
     public function getRegister(): int
     {
@@ -2460,6 +2494,8 @@ class ObjectService
      * @return array Rendered entity data
      *
      * @SuppressWarnings (PHPMD.UnusedFormalParameter)
+     *
+     * @spec exclude Facade delegating object rendering to the render handler; render contract owned by files-render-extension / schema-driven-read-coercion.
      */
     public function renderEntity(
         ObjectEntity $entity,
@@ -2743,6 +2779,8 @@ class ObjectService
      * Should be called before processing a new parent object.
      *
      * @return void
+     *
+     * @spec exclude One-line delegation to SaveObject::clearCreatedSubObjects(); cache-reset plumbing.
      */
     public function clearCreatedSubObjects(): void
     {
@@ -2757,6 +2795,8 @@ class ObjectService
      * @return \OCP\AppFramework\Http\JSONResponse JSON error response
      *
      * @deprecated
+     *
+     * @spec exclude Deprecated one-line delegation to ValidateObject::handleValidationException(); error-shaping plumbing.
      */
     public function handleValidationException(
         ValidationException|CustomValidationException $exception
@@ -2776,6 +2816,8 @@ class ObjectService
      * @return array Lock information
      *
      * @throws \Exception If lock operation fails
+     *
+     * @spec exclude One-line delegation to lock handler; lock behavior owned by object-lifecycle.
      */
     public function lockObject(string $identifier, ?string $process=null, ?int $duration=null): array
     {
@@ -2792,6 +2834,8 @@ class ObjectService
      * @return true True if unlocked successfully
      *
      * @throws \Exception If unlock operation fails
+     *
+     * @spec exclude One-line delegation to lock handler; unlock behavior owned by object-lifecycle.
      */
     public function unlockObject(string|int $identifier): bool
     {
@@ -2954,6 +2998,8 @@ class ObjectService
      *
      * @throws \OCP\AppFramework\Db\DoesNotExistException If register or schema not found.
      * @throws \InvalidArgumentException If invalid parameters provided.
+     *
+     * @spec exclude One-line delegation to MigrationHandler::migrateObjects(); migration logic owned by the handler.
      */
     public function migrateObjects(
         string|int $sourceRegister,
@@ -2995,6 +3041,8 @@ class ObjectService
      * @psalm-param    array<int, string> $uuids
      * @phpstan-return array{deleted_uuids: array<int, string>, skipped_uuids: array<int, string>, cascade_count: int}
      * @psalm-return   array{deleted_uuids: array<int, string>, skipped_uuids: array<int, string>, cascade_count: int}
+     *
+     * @spec exclude Bulk-delete loop over deleteHandler->deleteObject(); per-object RESTRICT/CASCADE behavior owned by referential-integrity.
      */
     public function deleteObjects(array $uuids=[], bool $_rbac=true, bool $_multitenancy=true): array
     {
@@ -3100,6 +3148,8 @@ class ObjectService
      * @phpstan-return array{deleted_count: int, deleted_uuids: array<int, string>, schema_id: int}
      *
      * @psalm-return array{deleted_count: int<min, max>, deleted_uuids: array<int, string>, schema_id: int}
+     *
+     * @spec exclude Deprecated throwing stub; schema-wide delete awaits MagicMapper reimplementation (blob table retired).
      */
     public function deleteObjectsBySchema(int $registerId, int $schemaId, bool $hardDelete=false): array
     {
@@ -3124,6 +3174,8 @@ class ObjectService
      * @phpstan-return array{deleted_count: int, deleted_uuids: array<int, string>, register_id: int}
      *
      * @psalm-return array{deleted_count: int<min, max>, deleted_uuids: array<int, string>, register_id: int}
+     *
+     * @spec exclude Deprecated throwing stub; register-wide delete awaits MagicMapper reimplementation (blob table retired).
      */
     public function deleteObjectsByRegister(int $registerId): array
     {
@@ -3165,6 +3217,8 @@ class ObjectService
      * @return array Results with object entities and pagination info.
      *
      * @throws \Exception If retrieval fails.
+     *
+     * @spec exclude One-line delegation to RelationHandler::getUses(); outgoing-relation behavior owned by nextcloud-entity-relations.
      */
     public function getObjectUses(
         string $objectId,
@@ -3193,6 +3247,8 @@ class ObjectService
      * @return array Paginated results with referencing objects
      *
      * @throws \Exception If retrieval fails
+     *
+     * @spec exclude One-line delegation to RelationHandler::getUsedBy(); incoming-relation behavior owned by nextcloud-entity-relations.
      */
     public function getObjectUsedBy(
         string $objectId,
@@ -3219,6 +3275,8 @@ class ObjectService
      * @return never Vectorization results
      *
      * @throws \Exception If vectorization fails
+     *
+     * @spec exclude Deprecated throwing stub; disabled pending VectorizationService circular-dependency refactor.
      */
     public function vectorizeBatchObjects(?array $_views=null, int $_batchSize=25)
     {
@@ -3235,6 +3293,8 @@ class ObjectService
      * @return never Statistics data
      *
      * @throws \Exception If stats retrieval fails
+     *
+     * @spec exclude Deprecated throwing stub; disabled pending VectorizationService circular-dependency refactor.
      */
     public function getVectorizationStatistics(?array $_views=null)
     {
@@ -3250,6 +3310,8 @@ class ObjectService
      * @return never Object count
      *
      * @throws \Exception If count fails
+     *
+     * @spec exclude Deprecated throwing stub; disabled pending VectorizationService circular-dependency refactor.
      */
     public function getVectorizationCount(?array $_schemas=null)
     {
@@ -3277,6 +3339,8 @@ class ObjectService
      * @throws \Exception If listing fails
      *
      * @psalm-return int<0, max>|list<\OCA\OpenRegister\Db\ObjectEntity>
+     *
+     * @spec exclude Facade alias delegating to searchObjects(); listing behavior owned by zoeken-filteren.
      */
     public function listObjects(
         array $query=[],
@@ -3306,6 +3370,8 @@ class ObjectService
      * @return ObjectEntity Created object entity
      *
      * @throws \Exception If creation fails
+     *
+     * @spec exclude Facade delegating to saveObject(); create behavior owned by object-interactions / object-lifecycle.
      */
     public function createObject(array $data, bool $_rbac=true, bool $_multitenancy=true): ObjectEntity
     {
@@ -3324,6 +3390,8 @@ class ObjectService
      * @return ObjectEntity Updated object entity
      *
      * @throws \Exception If update fails
+     *
+     * @spec exclude Facade delegating to saveObject() with id; update behavior owned by object-interactions / object-lifecycle.
      */
     public function updateObject(
         string $objectId,
@@ -3349,6 +3417,8 @@ class ObjectService
      * @return ObjectEntity Patched object entity
      *
      * @throws \Exception If patch fails
+     *
+     * @spec exclude Facade delegating to saveObject() with merged partial data; patch behavior owned by object-interactions.
      */
     public function patchObject(
         string $objectId,
@@ -3372,6 +3442,8 @@ class ObjectService
      * @return array Normalized search query
      *
      * @psalm-return array<string, mixed>
+     *
+     * @spec exclude Facade alias delegating to buildSearchQuery(); query-building owned by zoeken-filteren.
      */
     public function buildObjectSearchQuery(array $params): array
     {
@@ -3395,6 +3467,8 @@ class ObjectService
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Complex merge logic delegated to handler
      * @SuppressWarnings(PHPMD.NPathComplexity)       Many merge scenarios handled by handler
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Merge operations require comprehensive handling
+     *
+     * @spec exclude One-line delegation to MergeHandler::mergeObjects(); merge logic owned by the handler.
      */
     public function mergeObjects(string $sourceObjectId, array $mergeData): array
     {
@@ -3428,6 +3502,8 @@ class ObjectService
      * @param int      $offset     Number of objects to skip before processing
      *
      * @return array{processed: int, updated: int, failed: int, total: int, errors: array} Validation statistics
+     *
+     * @spec exclude Delegation to ValidationHandler::validateAndSaveObjectsBySchema() with a saveObject callback; handler owns the loop.
      */
     public function validateAndSaveObjectsBySchema(int $registerId, int $schemaId, ?int $limit=null, int $offset=0): array
     {
@@ -3447,6 +3523,8 @@ class ObjectService
      * lookup to prevent stale context from a previous request bleeding through.
      *
      * @return void
+     *
+     * @spec exclude Context-reset setter nulling the current register/schema/object fields; no business rule.
      */
     public function clearCurrents(): void
     {
@@ -3482,6 +3560,8 @@ class ObjectService
      * @param int|string|null $schema   Schema ID.
      *
      * @return ObjectServiceMapperAdapter
+     *
+     * @spec exclude Factory accessor returning a register/schema-scoped mapper adapter for external callers; no business rule.
      */
     public function getMapper(int|string|null $register=null, int|string|null $schema=null): ObjectServiceMapperAdapter
     {

--- a/lib/Service/PollLinkService.php
+++ b/lib/Service/PollLinkService.php
@@ -112,6 +112,8 @@ class PollLinkService
      * @return PollLink The persisted link row.
      *
      * @throws Exception On missing user, missing poll (404), duplicate (409).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function linkPoll(string $objectUuid, int $registerId, int $schemaId, int $pollId): PollLink
     {
@@ -165,6 +167,8 @@ class PollLinkService
      * @return void
      *
      * @throws Exception When no matching link is found (404).
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function unlinkPoll(string $objectUuid, int $pollId): void
     {
@@ -189,6 +193,8 @@ class PollLinkService
      * @return array<int,array<string,mixed>>
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function getLinkedPolls(string $objectUuid): array
     {
@@ -230,6 +236,8 @@ class PollLinkService
      * @param string|null $search Optional title-substring filter.
      *
      * @return array<int,array{id:int,title:string,type:string,deadline:?string,closed:bool,voterCount:int,optionCount:int}>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function getAvailablePolls(?string $search = null): array
     {
@@ -302,6 +310,8 @@ class PollLinkService
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-1
      */
     public function createAndLinkPoll(
         string $objectUuid,

--- a/lib/Service/SearchTrailService.php
+++ b/lib/Service/SearchTrailService.php
@@ -116,6 +116,8 @@ class SearchTrailService
      * @throws Exception If search trail creation fails (database error, validation error, etc.)
      *
      * @psalm-suppress PossiblyUnusedReturnValue
+     *
+     * @spec openspec/specs/zoeken-filteren/spec.md#requirement-saved-searches-and-search-trails
      */
     public function createSearchTrail(
         array $query,
@@ -261,6 +263,8 @@ class SearchTrailService
      * @return SearchTrail The search trail entity
      *
      * @throws DoesNotExistException If the search trail is not found
+     *
+     * @spec exclude Thin find-by-id then name-enrich of a single trail; no analytics or orchestration.
      */
     public function getSearchTrail(int $id): SearchTrail
     {
@@ -282,6 +286,8 @@ class SearchTrailService
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Multiple statistics calculations and aggregations
      * @SuppressWarnings(PHPMD.NPathComplexity)      Multiple conditional statistics computations
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-5
      */
     public function getSearchStatistics(?DateTime $from=null, ?DateTime $to=null): array
     {
@@ -361,6 +367,8 @@ class SearchTrailService
      * @param DateTime|null $to    End date filter
      *
      * @return array Popular search terms data
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-5
      */
     public function getPopularSearchTerms(int $limit=10, ?DateTime $from=null, ?DateTime $to=null): array
     {
@@ -404,6 +412,8 @@ class SearchTrailService
      * @param DateTime|null $to       End date filter
      *
      * @return array Search activity data with insights
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-5
      */
     public function getSearchActivity(string $interval='day', ?DateTime $from=null, ?DateTime $to=null): array
     {
@@ -430,6 +440,8 @@ class SearchTrailService
      * @param DateTime|null $to   End date filter
      *
      * @return array Register/schema statistics data
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-5
      */
     public function getRegisterSchemaStatistics(?DateTime $from=null, ?DateTime $to=null): array
     {
@@ -477,6 +489,8 @@ class SearchTrailService
      * @param DateTime|null $to    End date filter
      *
      * @return array User agent statistics data
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md#task-5
      */
     public function getUserAgentStatistics(int $limit=10, ?DateTime $from=null, ?DateTime $to=null): array
     {

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -1615,6 +1615,8 @@ class SettingsService
      * @param int $precision Decimal precision.
      *
      * @return string Formatted string.
+     *
+     * @spec exclude Pure byte-to-human-readable formatting helper; no orchestration or persisted state.
      */
     public function formatBytes(int $bytes, int $precision=2): string
     {
@@ -1638,6 +1640,8 @@ class SettingsService
      * @param string $memoryLimit Memory limit string (e.g., '128M', '1G').
      *
      * @return int Memory limit in bytes.
+     *
+     * @spec exclude Pure memory-limit-string-to-bytes parsing helper; no orchestration or persisted state.
      */
     public function convertToBytes(string $memoryLimit): int
     {
@@ -1667,6 +1671,8 @@ class SettingsService
      * @param string $token The token to mask.
      *
      * @return string The masked token.
+     *
+     * @spec exclude Pure display helper masking the middle of a token; no orchestration or persisted state.
      */
     public function maskToken(string $token): string
     {
@@ -1691,6 +1697,8 @@ class SettingsService
      * @param \OCA\OpenRegister\Service\IndexService $solrSchemaService Index service for field analysis.
      *
      * @return array Expected field configuration.
+     *
+     * @spec exclude Assembles the expected Solr field set from core metadata + schema fields for diffing; admin-tooling helper.
      */
     public function getExpectedSchemaFields(
         \OCA\OpenRegister\Db\SchemaMapper $schemaMapper,
@@ -1747,6 +1755,8 @@ class SettingsService
      * @return array Field comparison results
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) Multiple field comparison paths
+     *
+     * @spec exclude Pure diff helper categorising missing/extra/mismatched Solr fields; admin-tooling computation.
      */
     public function compareFields(array $actualFields, array $expectedFields): array
     {

--- a/lib/Service/UploadService.php
+++ b/lib/Service/UploadService.php
@@ -93,6 +93,8 @@ class UploadService
      *
      * @throws \Exception If file processing fails
      * @throws \GuzzleHttp\Exception\GuzzleException If URL fetching fails
+     *
+     * @spec exclude Source-dispatch helper routing to per-source (file/url/json) processors; no business rule of its own.
      */
     public function getUploadedJson(array $data): array | JSONResponse
     {

--- a/lib/Service/VectorizationService.php
+++ b/lib/Service/VectorizationService.php
@@ -470,6 +470,8 @@ class VectorizationService
      * @return array<int,array<string,mixed>> Search results
      *
      * @throws \Exception If search fails
+     *
+     * @spec exclude One-line facade delegation to VectorEmbeddings::semanticSearch; no logic of its own.
      */
     public function semanticSearch(
         string $query,
@@ -494,6 +496,8 @@ class VectorizationService
      * @return array Hybrid search results with combined scores and source breakdown.
      *
      * @throws \Exception If hybrid search fails.
+     *
+     * @spec exclude One-line facade delegation to VectorEmbeddings::hybridSearch; no logic of its own.
      */
     public function hybridSearch(
         string $query,

--- a/lib/Service/WorkflowEngineRegistry.php
+++ b/lib/Service/WorkflowEngineRegistry.php
@@ -95,6 +95,8 @@ class WorkflowEngineRegistry
      * @param int $engineId Engine ID
      *
      * @return WorkflowEngineInterface
+     *
+     * @spec openspec/specs/workflow-engine-abstraction/spec.md#requirement-engine-registration-and-discovery
      */
     public function resolveAdapterById(int $engineId): WorkflowEngineInterface
     {
@@ -143,6 +145,8 @@ class WorkflowEngineRegistry
      * @param array<string, mixed> $data Engine configuration data
      *
      * @return WorkflowEngine
+     *
+     * @spec openspec/specs/workflow-engine-abstraction/spec.md#requirement-engine-specific-credential-management
      */
     public function createEngine(array $data): WorkflowEngine
     {
@@ -160,6 +164,8 @@ class WorkflowEngineRegistry
      * @param array<string, mixed> $data Updated data
      *
      * @return WorkflowEngine
+     *
+     * @spec openspec/specs/workflow-engine-abstraction/spec.md#requirement-engine-specific-credential-management
      */
     public function updateEngine(int $id, array $data): WorkflowEngine
     {
@@ -176,6 +182,8 @@ class WorkflowEngineRegistry
      * @param int $id Engine ID
      *
      * @return WorkflowEngine The deleted engine
+     *
+     * @spec openspec/specs/workflow-engine-abstraction/spec.md#requirement-engine-registration-and-discovery
      */
     public function deleteEngine(int $id): WorkflowEngine
     {
@@ -218,6 +226,8 @@ class WorkflowEngineRegistry
      * Discover available workflow engine ExApps.
      *
      * @return array<int, array{engineType: string, suggestedBaseUrl: string, installed: bool}>
+     *
+     * @spec openspec/specs/workflow-engine-abstraction/spec.md#requirement-engine-registration-and-discovery
      */
     public function discoverEngines(): array
     {

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/proposal.md
@@ -1,0 +1,69 @@
+# Reverse-spec service-facade bundle — chunk 1
+
+## Why
+
+A scanner flagged 112 public/private methods across 19 top-level `lib/Service/*.php`
+files as missing the `@spec` traceability tag mandated by ADR-003. These files are
+predominantly **facades** — they delegate to handlers, mappers, and lazily-resolved
+peer-app services, holding little business logic of their own. This reverse-spec change
+documents the *observed behavior* of the genuinely uncovered orchestration and attaches
+every method to a spec: either a new requirement against the capability that already owns
+its domain (bias-to-extend), an existing requirement that already documents it, or an
+`@spec exclude <reason>` annotation for boilerplate (per ADR-003's two-tool convention).
+
+No code behavior changes — this is annotation-only.
+
+## What changes
+
+- **53 methods spec'd**, **59 methods excluded** (facades are mostly plumbing).
+- **5 new requirements** across 5 capability specs documenting the genuinely uncovered
+  orchestration:
+  1. `generic-integrations` — the Tier-2 dedicated-mapper link-service pattern shared by
+     the six optional-peer-app link services (Analytics, Calendar, Deck, Email, Flow,
+     Poll): link / create-and-link / unlink / cache-refreshing list / picker, all behind
+     a `class_exists` + availability guard with graceful degradation (ADR-019 AD-23).
+  2. `datetime-input-handling` — the canonical `DateTimeNormalizer` entry points
+     (`normalize` / `formatForDatabase` / `formatForIso8601`) that all OR datetime
+     conversion delegates to (the capability spec body was a deferred placeholder).
+  3. `webhook-payload-mapping` — the `MappingService::executeMapping()` transformation
+     engine semantics (dot-notation source lookup, Twig rendering, pass-through, list
+     mode, key encoding) that the webhook spec referenced but never specced as its own
+     behavior.
+  4. `files-sidebar-tabs` — the backend `FileSidebarService` that powers the Files-app
+     sidebar tab: cross-magic-table reverse lookup of objects referencing a file plus
+     the document extraction / anonymization status read.
+  5. `zoeken-filteren` — the search-trail **analytics** statistics surface
+     (`getPopularSearchTerms` / `getRegisterSchemaStatistics` / `getSearchActivity` /
+     `getSearchStatistics` / `getUserAgentStatistics`) that enriches raw mapper
+     aggregations with percentages, effectiveness ratings, success rates, and
+     browser-distribution parsing.
+
+- **8 methods annotated against existing requirements** (no new REQ):
+  - `ConditionMatcher::objectMatchesConditions` → `rbac-scopes` Conditional Match
+    Evaluation (AND-logic entry point; matcher internals already specced).
+  - `WorkflowEngineRegistry` `createEngine` / `updateEngine` / `deleteEngine` /
+    `discoverEngines` / `resolveAdapterById` → `workflow-engine-abstraction` Engine
+    Registration and Discovery + Credential-management requirements.
+  - `McpDiscoveryService::getCapabilityIds` → `mcp-discovery` Capability Coverage
+    (the requirement names this method as the canonical capability-id source).
+  - `SearchTrailService::createSearchTrail` → `zoeken-filteren` Saved-searches-and-
+    search-trails requirement (self-clearing already documented there).
+
+## Excluded methods (boilerplate — `@spec exclude`)
+
+| File | Methods | Reason class |
+|---|---|---|
+| `ObjectService` | 40 | Facade: handler/mapper delegations, context getters/setters, deprecated throwing stubs. CRUD / lock / merge / search / facet / relation behaviors already owned by object-interactions / object-lifecycle / zoeken-filteren / faceting-configuration. |
+| `SettingsService` | 5 | Pure utility helpers (`convertToBytes`, `formatBytes`, `maskToken`, `compareFields`, `getExpectedSchemaFields`) backing the Solr/settings admin surface. |
+| `MigrationService` | 4 | Legacy facade — blob storage retired; `migrateToMagicTable` / `migrateToBlobStorage` return no-op reports, `resolveRegisterAndSchema` / `getStorageStatus` are mapper-read plumbing. |
+| `MappingService` | 4 | Cache-wrapped read (`getMapping`), cache invalidation (`invalidateMappingCache`), and two pure helpers (`encodeArrayKeys`, `coordinateStringToArray`). |
+| `EmailService` | 2 | Legacy link-table delete plumbing (`unlinkEmail`, `deleteLinksForObject`) being phased out per linked-entity-types "Remove Email-Specific Link Infrastructure". |
+| `VectorizationService` | 2 | One-line facade delegations to the underlying `vectorService` (`semanticSearch`, `hybridSearch`). |
+| `UploadService` | 1 | Source-dispatch helper (`getUploadedJson`) routing to per-source processors. |
+| `SearchTrailService` | 1 | Thin find + name-enrich (`getSearchTrail`). |
+
+## Impact
+
+- Specs: 5 capability specs gain a `## ADDED Requirements` delta (one new REQ each).
+- Code: annotation-only (`@spec` / `@spec exclude` docblock tags); zero behavior change.
+- Risk: none — documentation of existing behavior.

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/specs/datetime-input-handling/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/specs/datetime-input-handling/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Canonical DateTimeNormalizer Entry Points
+
+The system MUST provide a single canonical `DateTimeNormalizer` service that all
+OpenRegister code paths delegate to when converting user-supplied datetime input to a
+`DateTimeImmutable` or to a formatted string. Direct use of `new DateTime($value)` on user
+data is forbidden because PHP silently interprets `''` and `null` as "now".
+
+`normalize(mixed $value): ?DateTimeImmutable` MUST apply the following rules in order:
+`null` returns `null`; a `DateTimeImmutable` is returned unchanged; any other
+`DateTimeInterface` is converted to a `DateTimeImmutable` of the same instant; a string is
+trimmed and an empty/whitespace-only result returns `null`; a parseable string returns a
+`DateTimeImmutable`; an unparseable string or any non-string/non-DateTime type returns
+`null` (with a debug-level log). `formatForDatabase(mixed $value): ?string` MUST normalize
+then format as `Y-m-d H:i:s`, returning `null` for empty/invalid input.
+`formatForIso8601(mixed $value): ?string` MUST normalize then format as ISO 8601 with
+timezone offset (`DateTimeInterface::ATOM`), returning `null` for empty/invalid input.
+
+#### Scenario: Empty and whitespace input normalizes to null
+- **GIVEN** the value `''`, a whitespace-only string, or `null`
+- **WHEN** `normalize()` is called
+- **THEN** it MUST return `null` rather than the current date-time
+
+#### Scenario: Parseable string round-trips to formatted output
+- **GIVEN** a parseable datetime string
+- **WHEN** `formatForDatabase()` is called
+- **THEN** it MUST return the value formatted as `Y-m-d H:i:s`
+- **AND** `formatForIso8601()` MUST return the value formatted as ISO 8601 with offset
+
+#### Scenario: Unparseable or unsupported input degrades to null
+- **GIVEN** an unparseable string or a non-string, non-DateTime value
+- **WHEN** `normalize()` is called
+- **THEN** it MUST return `null`
+- **AND** a debug-level log entry MUST be written

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/specs/files-sidebar-tabs/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/specs/files-sidebar-tabs/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Backend File Reverse-Lookup and Extraction Status
+
+The system MUST provide a `FileSidebarService` that backs the OpenRegister tab in the
+Nextcloud Files app sidebar. `getObjectsForFile(int $fileId): array` MUST find every
+OpenRegister object that references a given Nextcloud file id by scanning the per-schema
+magic tables of every register the current user can access (RBAC-respecting), returning
+each match with its `uuid`, a derived `title`, and its register/schema identity. The scan
+MUST skip registers with no schemas and magic tables that do not exist, and MUST tolerate
+per-register/per-schema errors by continuing rather than failing the whole lookup.
+
+`getExtractionStatus(int $fileId): array` MUST report the document-processing state for a
+file: when no extraction chunks exist it MUST return a `none` status with zeroed counts;
+otherwise it MUST return the chunk count, the extracted-at timestamp, the linked GDPR
+entity count aggregated by entity type, an overall risk level, and the anonymization
+status (whether anonymized, when, and the anonymized file id).
+
+#### Scenario: Reverse-lookup finds referencing objects across accessible registers
+- **GIVEN** a Nextcloud file referenced by objects in two schemas the user can access
+- **WHEN** `getObjectsForFile()` is called
+- **THEN** it MUST return both objects with their uuid, title, register, and schema
+- **AND** registers the user cannot access MUST be excluded
+- **AND** missing magic tables and per-schema errors MUST be skipped without failing the lookup
+
+#### Scenario: Extraction status for an unprocessed file
+- **GIVEN** a file with no extraction chunks
+- **WHEN** `getExtractionStatus()` is called
+- **THEN** it MUST return `extractionStatus: 'none'` with zeroed chunk, entity, and risk values
+
+#### Scenario: Extraction status aggregates entities and anonymization
+- **GIVEN** a file with extraction chunks and linked GDPR entity relations
+- **WHEN** `getExtractionStatus()` is called
+- **THEN** it MUST return the chunk count, extracted-at timestamp, entity counts grouped by type, and the anonymization status

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/specs/generic-integrations/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/specs/generic-integrations/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Tier-2 Dedicated-Mapper Link Services for Optional Peer Apps
+
+The system SHALL provide a family of Tier-2 link services — `AnalyticsLinkService`,
+`CalendarLinkService`, `DeckLinkService`, `EmailLinkService`, `FlowLinkService`, and
+`PollLinkService` — that persist links between OpenRegister objects and entities owned by
+an optional Nextcloud peer app (NC Analytics, Calendar, Deck, Mail, Flow/n8n, Polls) via a
+dedicated link mapper rather than the report-name/marker conventions of the Tier-1
+providers. Each service MUST resolve the peer app's own services lazily through
+`\OCP\Server::get()` behind a `class_exists` guard and an `is*Available()` /
+`IAppManager` check, so OpenRegister boots and degrades gracefully when the peer app is
+not installed (ADR-019 AD-23).
+
+Each service MUST expose a consistent orchestration surface:
+
+- a **link** operation (`linkReport` / `linkEvent` / `linkCard` / `linkEmail` /
+  `linkOperation` / `linkPoll`) that is idempotent — a duplicate link MUST raise a 409 —
+  and caches the peer entity's display metadata on the link row at link time;
+- a **create-and-link** operation where the peer app supports creation
+  (`createAndLinkReport` / `createAndLinkEvent` / `createAndLinkCard` /
+  `createAndLinkPoll`) that creates the peer entity then links it, surfacing peer-app
+  failures as a 500 and empty required input as a 400;
+- an **unlink** operation (`unlinkReport` / `unlinkEvent` / `unlinkCard` / `unlinkEmail` /
+  `unlinkOperation` / `unlinkPoll`) that removes only the link row — the peer entity
+  itself is left intact — and raises a 404 when no matching link exists;
+- a **linked-list** read (`getLinkedReports` / `getLinkedEvents` / `getLinkedCards` /
+  `getLinkedEmails` / `getLinkedOperations` / `getLinkedPolls`) that returns the link rows
+  for an object, refreshing stale cached metadata from the peer app when available and
+  returning the cached values unchanged when it is not;
+- a **picker source** read (`getAvailableReports` / `getAvailableCalendars` /
+  `getAvailableBoards` / `getAvailableAccounts` / `getAvailableOperations` /
+  `getAvailablePolls`) that lists the current user's peer entities for selection,
+  returning an empty array when the peer app is unavailable;
+- optional **sub-resource pickers** for hierarchical peer apps
+  (`getEventsForCalendar`, `getStacksForBoard`, `getMailboxesForAccount`,
+  `getMessagesForMailbox`).
+
+#### Scenario: Link is idempotent and caches peer metadata
+- **GIVEN** the peer app is available and an object is not yet linked to a peer entity
+- **WHEN** the service's link operation runs
+- **THEN** a link row MUST be persisted with the peer entity's display metadata cached on it
+- **AND** a second link of the same object-to-entity pair MUST raise a 409
+
+#### Scenario: Unlink removes the link only
+- **GIVEN** an object linked to a peer entity
+- **WHEN** the service's unlink operation runs
+- **THEN** the link row MUST be deleted
+- **AND** the peer entity MUST remain in the peer app
+- **AND** unlinking a non-existent link MUST raise a 404
+
+#### Scenario: Graceful degradation when the peer app is uninstalled
+- **GIVEN** the peer app is not installed
+- **WHEN** the picker-source read runs
+- **THEN** it MUST return an empty array rather than throwing
+- **AND** the linked-list read MUST return the cached link-row values unchanged
+
+#### Scenario: Linked-list refreshes stale cached metadata
+- **GIVEN** a link row whose cached metadata is older than the service's staleness window and the peer app is available
+- **WHEN** the linked-list read runs
+- **THEN** the row's cached title/type/timestamps MUST be refreshed from the peer app
+- **AND** a refresh failure MUST leave the cached values untouched (the peer entity may have been deleted)

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/specs/webhook-payload-mapping/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/specs/webhook-payload-mapping/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Mapping Transformation Engine Semantics
+
+The system MUST transform an input array into an output array according to a `Mapping`
+entity's declarative rules via `MappingService::executeMapping(Mapping $mapping, array
+$input, bool $list = false): array`, independent of any caller (webhook delivery, sync,
+enrichment). The engine MUST support the following semantics:
+
+- **Dot-notation source lookup**: each mapping rule's value is first looked up against the
+  input using dot-notation (`adbario/php-dot-notation`); when the input contains that path,
+  the resolved value is copied to the rule's key.
+- **Twig rendering**: when the rule value is not a present input path, it MUST be rendered
+  as a Twig template against the original input, with HTML entities decoded; a render
+  failure MUST throw an `Exception` naming the mapping, key, and value.
+- **Pass-through**: when the mapping's `passThrough` flag is true, the full input MUST seed
+  the output before rules are applied; otherwise the output starts empty.
+- **Key encoding**: input keys MUST have `.` encoded to a safe token before dot-notation
+  processing so literal dots in keys are not misread as path separators.
+- **List mode**: when `$list` is true, the engine MUST apply the mapping to each element of
+  the input, supporting a `listInput` envelope that carries extra shared values merged into
+  every element.
+
+#### Scenario: Source path is copied via dot-notation
+- **GIVEN** a mapping rule whose value matches a dot-notation path present in the input
+- **WHEN** `executeMapping()` runs
+- **THEN** the input value at that path MUST be copied to the rule's output key
+
+#### Scenario: Missing source path is rendered as Twig
+- **GIVEN** a mapping rule whose value is not a present input path
+- **WHEN** `executeMapping()` runs
+- **THEN** the value MUST be rendered as a Twig template against the original input
+- **AND** a Twig render failure MUST throw an exception naming the mapping, key, and value
+
+#### Scenario: Pass-through seeds the output
+- **GIVEN** a mapping with `passThrough` true
+- **WHEN** `executeMapping()` runs
+- **THEN** the full input MUST be present in the output before the rules overwrite mapped keys
+
+#### Scenario: List mode maps each element
+- **GIVEN** `$list` is true and the input is a collection
+- **WHEN** `executeMapping()` runs
+- **THEN** the mapping MUST be applied to each element and the results returned keyed as the input

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/specs/zoeken-filteren/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/specs/zoeken-filteren/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Search-Trail Analytics Statistics Surface
+
+The system MUST expose a search-trail analytics surface through `SearchTrailService` that
+enriches raw aggregations from `SearchTrailMapper` into report-ready structures, each
+accepting an optional `from`/`to` datetime window. `getPopularSearchTerms()` MUST return
+the most-used search terms annotated with each term's share-of-total percentage and an
+effectiveness rating derived from its average result count. `getRegisterSchemaStatistics()`
+MUST return per-register/schema search counts annotated with percentage and a performance
+rating, sorted by percentage descending. `getSearchActivity()` MUST return search counts
+bucketed by a time interval (e.g. day) together with computed activity insights.
+`getSearchStatistics()` MUST return aggregate totals enriched with searches-with-results /
+without-results splits, a success rate, unique-term and unique-user counts, and
+per-session averages. `getUserAgentStatistics()` MUST return top user agents with parsed
+browser info plus an aggregated browser distribution.
+
+#### Scenario: Popular terms include percentage and effectiveness
+- **GIVEN** persisted search trails within the requested window
+- **WHEN** `getPopularSearchTerms()` is called
+- **THEN** each returned term MUST include its share-of-total percentage and an effectiveness rating
+
+#### Scenario: Aggregate statistics include success rate and uniqueness counts
+- **GIVEN** persisted search trails
+- **WHEN** `getSearchStatistics()` is called
+- **THEN** the result MUST include searches-with-results, searches-without-results, a success rate, unique-term and unique-user counts, and per-session averages
+
+#### Scenario: User-agent statistics aggregate by browser
+- **GIVEN** persisted search trails carrying user-agent strings
+- **WHEN** `getUserAgentStatistics()` is called
+- **THEN** each user agent MUST be annotated with parsed browser info
+- **AND** the result MUST include an aggregated browser distribution

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-1/tasks.md
@@ -1,0 +1,67 @@
+# Tasks — reverse-spec service-facade bundle (chunk 1)
+
+Each task documents the observed behavior of a cluster of service methods and maps to a
+new requirement in the matching capability spec delta, or records an exclusion bucket for
+boilerplate. Method `@spec` / `@spec exclude` annotations reference these task anchors or
+the relevant capability spec.
+
+## generic-integrations
+
+- [x] task-1 Tier-2 dedicated-mapper link-service pattern for optional peer apps.
+  Documents `AnalyticsLinkService` (`linkReport`, `createAndLinkReport`, `unlinkReport`,
+  `getLinkedReports`, `getAvailableReports`), `CalendarLinkService` (`linkEvent`,
+  `createAndLinkEvent`, `unlinkEvent`, `getLinkedEvents`, `getAvailableCalendars`,
+  `getEventsForCalendar`), `DeckLinkService` (`linkCard`, `createAndLinkCard`,
+  `unlinkCard`, `getLinkedCards`, `getAvailableBoards`, `getStacksForBoard`),
+  `EmailLinkService` (`linkEmail`, `unlinkEmail`, `getLinkedEmails`,
+  `getAvailableAccounts`, `getMailboxesForAccount`, `getMessagesForMailbox`,
+  `isMailAvailable`), `FlowLinkService` (`linkOperation`, `unlinkOperation`,
+  `getLinkedOperations`, `getAvailableOperations`, `isCurrentUserAdmin`), and
+  `PollLinkService` (`linkPoll`, `createAndLinkPoll`, `unlinkPoll`, `getLinkedPolls`,
+  `getAvailablePolls`).
+
+## datetime-input-handling
+
+- [x] task-2 Canonical datetime normalizer entry points
+  (`DateTimeNormalizer::normalize`, `formatForDatabase`, `formatForIso8601`).
+
+## webhook-payload-mapping
+
+- [x] task-3 Mapping transformation engine semantics
+  (`MappingService::executeMapping`).
+
+## files-sidebar-tabs
+
+- [x] task-4 Backend file reverse-lookup and document extraction status
+  (`FileSidebarService::getObjectsForFile`, `getExtractionStatus`).
+
+## zoeken-filteren
+
+- [x] task-5 Search-trail analytics statistics surface
+  (`SearchTrailService::getPopularSearchTerms`, `getRegisterSchemaStatistics`,
+  `getSearchActivity`, `getSearchStatistics`, `getUserAgentStatistics`).
+
+## Annotated against existing requirements (no new REQ)
+
+- [x] task-6 `ConditionMatcher::objectMatchesConditions` annotated against
+  `rbac-scopes` Conditional Match Evaluation.
+- [x] task-7 `WorkflowEngineRegistry` CRUD + discovery + adapter-resolution
+  (`createEngine`, `updateEngine`, `deleteEngine`, `discoverEngines`,
+  `resolveAdapterById`) annotated against `workflow-engine-abstraction` Engine
+  Registration and Discovery + credential-management requirements.
+- [x] task-8 `McpDiscoveryService::getCapabilityIds` annotated against `mcp-discovery`
+  Capability Coverage.
+- [x] task-9 `SearchTrailService::createSearchTrail` annotated against `zoeken-filteren`
+  Saved-searches-and-search-trails requirement.
+
+## Excluded boilerplate (`@spec exclude`)
+
+- [x] task-10 `ObjectService` (40 methods) — facade delegations, context
+  getters/setters, deprecated throwing stubs.
+- [x] task-11 `SettingsService` (5 methods) — pure utility helpers.
+- [x] task-12 `MigrationService` (4 methods) — legacy facade, blob storage retired.
+- [x] task-13 `MappingService` (4 methods) — cache wrappers and pure helpers.
+- [x] task-14 `EmailService` (2 methods) — legacy link-table delete plumbing.
+- [x] task-15 `VectorizationService` (2 methods) — one-line facade delegations.
+- [x] task-16 `UploadService` (1 method) — source-dispatch helper.
+- [x] task-17 `SearchTrailService::getSearchTrail` — thin find + name-enrich.


### PR DESCRIPTION
## Summary

Reverse-spec of 112 scanner-flagged methods across 19 top-level `lib/Service/*.php` facade files per ADR-003's two-tool `@spec` convention. Annotation-only — zero behavior change.

- **53 methods spec'd / 59 excluded.** Facades are mostly plumbing, so the bias is to `@spec exclude <reason>`; only genuinely uncovered orchestration is reverse-spec'd.
- **5 new requirements** (ghost change `retrofit-2026-05-25-bw2-svc-flat-1`):
  - `generic-integrations` — the Tier-2 dedicated-mapper link-service pattern shared by the six optional-peer-app link services (Analytics / Calendar / Deck / Email / Flow / Poll): link · create-and-link · unlink · cache-refreshing list · picker, all behind a `class_exists` + availability guard with graceful degradation (ADR-019 AD-23).
  - `datetime-input-handling` — the canonical `DateTimeNormalizer` entry points (`normalize` / `formatForDatabase` / `formatForIso8601`).
  - `webhook-payload-mapping` — the `MappingService::executeMapping()` transformation-engine semantics.
  - `files-sidebar-tabs` — the backend `FileSidebarService` (cross-magic-table file reverse-lookup + document extraction/anonymization status).
  - `zoeken-filteren` — the search-trail analytics statistics surface.
- **8 methods annotated against existing requirements** (no new REQ): `ConditionMatcher::objectMatchesConditions` → rbac-scopes; `WorkflowEngineRegistry` CRUD/discovery (5) → workflow-engine-abstraction; `McpDiscoveryService::getCapabilityIds` → mcp-discovery; `SearchTrailService::createSearchTrail` → zoeken-filteren.
- **59 excluded** as boilerplate: all 40 `ObjectService` facade/getter/stub methods, `SettingsService` utility helpers (5), `MigrationService` legacy stubs (4), `MappingService` cache/util helpers (4), `EmailService` legacy link-table deletes (2), `VectorizationService` delegations (2), `UploadService` source-dispatch (1), `SearchTrailService::getSearchTrail` (1).

## Test plan

- [x] `php -l` passes on all 19 touched files.
- [x] `openspec validate retrofit-2026-05-25-bw2-svc-flat-1 --strict` is valid.
- [x] All 112 batch methods end with `@spec openspec/...` or `@spec exclude <reason>` (no bare excludes, no double-tags).
- [ ] CI PHPCS/PHPMD/Psalm/PHPStan (host PHP is 8.2; repo requires 8.3 — Hydra CI verifies).