### PR TITLE
retrofit: backend coverage — Controllers (chunk 1)

### DIFF
--- a/lib/Controller/AnalyticsLinksController.php
+++ b/lib/Controller/AnalyticsLinksController.php
@@ -79,6 +79,8 @@ class AnalyticsLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -123,6 +125,8 @@ class AnalyticsLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function link(string $register, string $schema, string $id): JSONResponse
     {
@@ -172,6 +176,8 @@ class AnalyticsLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function createAndLink(string $register, string $schema, string $id): JSONResponse
     {
@@ -224,6 +230,8 @@ class AnalyticsLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function destroy(string $register, string $schema, string $id, string $reportId): JSONResponse
     {
@@ -259,6 +267,8 @@ class AnalyticsLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function available(): JSONResponse
     {
@@ -286,6 +296,8 @@ class AnalyticsLinksController extends Controller
      * @param string $id       Object id.
      *
      * @return ObjectEntity|null
+     *
+     * @spec exclude Private helper: resolves an object from register/schema/id; the link REST contract is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1.
      */
     private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
     {
@@ -310,6 +322,8 @@ class AnalyticsLinksController extends Controller
      * @param Exception $exception Source exception.
      *
      * @return JSONResponse
+     *
+     * @spec exclude Private helper: maps a service exception code to an HTTP status; the link REST contract is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1.
      */
     private function mapException(Exception $exception): JSONResponse
     {

--- a/lib/Controller/ApplicationsController.php
+++ b/lib/Controller/ApplicationsController.php
@@ -126,6 +126,8 @@ class ApplicationsController extends Controller
      * @return TemplateResponse Template response for applications SPA
      *
      * @psalm-return TemplateResponse<200, array<never, never>>
+     *
+     * @spec exclude Trivial SPA-mount route stub: returns the Vue index template for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function page(): TemplateResponse
     {
@@ -153,6 +155,8 @@ class ApplicationsController extends Controller
      *     array{error?: 'Failed to retrieve applications',
      *     results?: array<\OCA\OpenRegister\Db\Application>},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
      */
     public function index(): JSONResponse
     {
@@ -229,6 +233,8 @@ class ApplicationsController extends Controller
      * @psalm-return JSONResponse<200, \OCA\OpenRegister\Db\Application,
      *     array<never, never>>|JSONResponse<404,
      *     array{error: 'Application not found'}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
      */
     public function show(int $id): JSONResponse
     {
@@ -272,6 +278,8 @@ class ApplicationsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with created application
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
      */
     public function create(): JSONResponse
     {
@@ -321,6 +329,8 @@ class ApplicationsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with updated application
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
      */
     public function update(int $id): JSONResponse
     {
@@ -379,6 +389,8 @@ class ApplicationsController extends Controller
      * @psalm-return JSONResponse<200, \OCA\OpenRegister\Db\Application,
      *     array<never, never>>|JSONResponse<400, array{error: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
      */
     public function patch(int $id): JSONResponse
     {
@@ -403,6 +415,8 @@ class ApplicationsController extends Controller
      * @psalm-return JSONResponse<200|400,
      *     array{error?: 'Failed to delete application',
      *     message?: 'Application deleted successfully'}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
      */
     public function destroy(int $id): JSONResponse
     {
@@ -446,6 +460,8 @@ class ApplicationsController extends Controller
      * @return int|null Limit value or null if not provided
      *
      * @psalm-return int|null
+     *
+     * @spec exclude Private pagination-param helper; the registry resource-CRUD contract is owned by retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1.
      */
     private function extractLimit(array $params): ?int
     {
@@ -469,6 +485,8 @@ class ApplicationsController extends Controller
      * @return int|null Offset value or null if not provided
      *
      * @psalm-return int|null
+     *
+     * @spec exclude Private pagination-param helper; the registry resource-CRUD contract is owned by retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1.
      */
     private function extractOffset(array $params): ?int
     {
@@ -492,6 +510,8 @@ class ApplicationsController extends Controller
      * @return int|null Page value or null if not provided
      *
      * @psalm-return int|null
+     *
+     * @spec exclude Private pagination-param helper; the registry resource-CRUD contract is owned by retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1.
      */
     private function extractPage(array $params): ?int
     {

--- a/lib/Controller/CalendarEventsController.php
+++ b/lib/Controller/CalendarEventsController.php
@@ -104,6 +104,8 @@ class CalendarEventsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-1
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -186,6 +188,8 @@ class CalendarEventsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-1
      */
     public function link(string $register, string $schema, string $id): JSONResponse
     {
@@ -238,6 +242,8 @@ class CalendarEventsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-1
      */
     public function unlink(string $register, string $schema, string $id, string $eventUid): JSONResponse
     {
@@ -331,6 +337,8 @@ class CalendarEventsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-1
      */
     public function listCalendars(): JSONResponse
     {
@@ -351,6 +359,8 @@ class CalendarEventsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-calendar-integration/tasks.md#task-1
      */
     public function listCalendarEvents(string $calendarUri): JSONResponse
     {
@@ -390,6 +400,8 @@ class CalendarEventsController extends Controller
      * @param string $id       The object ID
      *
      * @return \OCA\OpenRegister\Db\ObjectEntity|null The object or null
+     *
+     * @spec exclude Private helper: resolves an object from register/schema/id; the calendar link REST contract is owned by retrofit-2026-05-24-calendar-integration/tasks.md#task-1.
      */
     private function validateObject(
         string $register,

--- a/lib/Controller/ChatHealthController.php
+++ b/lib/Controller/ChatHealthController.php
@@ -102,6 +102,8 @@ class ChatHealthController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse 200 or 503 JSON response
+     *
+     * @spec openspec/changes/ai-chat-companion-orchestrator/specs/chat-ai/spec.md#health-probe-endpoint-get-apichathealth
      */
     #[PublicPage]
     #[NoCSRFRequired]

--- a/lib/Controller/ChatStreamController.php
+++ b/lib/Controller/ChatStreamController.php
@@ -197,6 +197,8 @@ class ChatStreamController extends Controller
      * @NoAdminRequired
      *
      * @return Response Never returned — emitAndExit() always terminates.
+     *
+     * @spec openspec/changes/ai-chat-companion-orchestrator/specs/chat-ai/spec.md#sse-streaming-endpoint-post-apichatstream
      */
     #[NoAdminRequired]
     public function stream(): Response
@@ -386,6 +388,8 @@ class ChatStreamController extends Controller
      * @param array<string, mixed> $payload   JSON-encodable payload.
      *
      * @return never
+     *
+     * @spec exclude SSE-framing helper: emits one frame, finalises the DB transaction, and exits; the streaming endpoint contract is owned by ai-chat-companion-orchestrator/specs/chat-ai/spec.md#sse-streaming-endpoint-post-apichatstream.
      */
     protected function emitAndExit(string $eventType, array $payload): never
     {
@@ -442,6 +446,8 @@ class ChatStreamController extends Controller
      * @param array<string, mixed> $payload   JSON-encodable payload.
      *
      * @return void
+     *
+     * @spec exclude SSE-framing helper: writes one `event:`/`data:` frame and flushes; the streaming endpoint contract is owned by ai-chat-companion-orchestrator/specs/chat-ai/spec.md#sse-streaming-endpoint-post-apichatstream.
      */
     protected function emitSseEvent(string $eventType, array $payload): void
     {
@@ -455,6 +461,8 @@ class ChatStreamController extends Controller
      * `microtime(true)`; tests override to drive a fake clock.
      *
      * @return float Seconds since the Unix epoch.
+     *
+     * @spec exclude SSE-framing helper: test-overridable wall-clock used by the heartbeat interleave; the streaming endpoint contract is owned by ai-chat-companion-orchestrator/specs/chat-ai/spec.md#sse-streaming-endpoint-post-apichatstream.
      */
     protected function now(): float
     {
@@ -479,6 +487,8 @@ class ChatStreamController extends Controller
      * @param array<string, mixed> $payload   Frame payload.
      *
      * @return void
+     *
+     * @spec exclude SSE-framing helper: interleaves a heartbeat frame before forwarding when >15s elapsed; the streaming endpoint contract is owned by ai-chat-companion-orchestrator/specs/chat-ai/spec.md#sse-streaming-endpoint-post-apichatstream.
      */
     protected function forwardWithHeartbeat(string $eventType, array $payload): void
     {
@@ -499,6 +509,8 @@ class ChatStreamController extends Controller
      * buffer trips its "risky" detector.
      *
      * @return void
+     *
+     * @spec exclude SSE-framing helper: clears output buffers so the first frame flushes immediately; the streaming endpoint contract is owned by ai-chat-companion-orchestrator/specs/chat-ai/spec.md#sse-streaming-endpoint-post-apichatstream.
      */
     protected function clearOutputBuffers(): void
     {
@@ -513,6 +525,8 @@ class ChatStreamController extends Controller
      * because the test runner has already written output).
      *
      * @return void
+     *
+     * @spec exclude SSE-framing helper: emits the three text/event-stream response headers; the streaming endpoint contract is owned by ai-chat-companion-orchestrator/specs/chat-ai/spec.md#sse-streaming-endpoint-post-apichatstream.
      */
     protected function emitSseHeaders(): void
     {

--- a/lib/Controller/CollectiveLinksController.php
+++ b/lib/Controller/CollectiveLinksController.php
@@ -80,6 +80,8 @@ class CollectiveLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -124,6 +126,8 @@ class CollectiveLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function link(string $register, string $schema, string $id): JSONResponse
     {
@@ -173,6 +177,8 @@ class CollectiveLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function createAndLink(string $register, string $schema, string $id): JSONResponse
     {
@@ -227,6 +233,8 @@ class CollectiveLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function destroy(string $register, string $schema, string $id, string $pageId): JSONResponse
     {
@@ -262,6 +270,8 @@ class CollectiveLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function available(): JSONResponse
     {
@@ -288,6 +298,8 @@ class CollectiveLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function collectives(): JSONResponse
     {
@@ -310,6 +322,8 @@ class CollectiveLinksController extends Controller
      * @param string $id       Object id.
      *
      * @return ObjectEntity|null
+     *
+     * @spec exclude Private helper: resolves an object from register/schema/id; the link REST contract is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1.
      */
     private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
     {
@@ -334,6 +348,8 @@ class CollectiveLinksController extends Controller
      * @param Exception $exception Source exception.
      *
      * @return JSONResponse
+     *
+     * @spec exclude Private helper: maps a service exception code to an HTTP status; the link REST contract is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1.
      */
     private function mapException(Exception $exception): JSONResponse
     {

--- a/lib/Controller/ConsumersController.php
+++ b/lib/Controller/ConsumersController.php
@@ -62,6 +62,8 @@ class ConsumersController extends Controller
      * @return JSONResponse The list of consumers
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
      */
     public function index(): JSONResponse
     {
@@ -84,6 +86,8 @@ class ConsumersController extends Controller
      * @return JSONResponse The consumer data or error
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
      */
     public function show(int $id): JSONResponse
     {
@@ -102,6 +106,8 @@ class ConsumersController extends Controller
      * @return JSONResponse The created consumer
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
      */
     public function create(): JSONResponse
     {
@@ -127,6 +133,8 @@ class ConsumersController extends Controller
      * @return JSONResponse The updated consumer or error
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
      */
     public function update(int $id): JSONResponse
     {
@@ -154,6 +162,8 @@ class ConsumersController extends Controller
      * @return JSONResponse Empty response or error
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
      */
     public function destroy(int $id): JSONResponse
     {
@@ -176,6 +186,8 @@ class ConsumersController extends Controller
      * @return JSONResponse The updated consumer or error
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
      */
     public function patch(int $id): JSONResponse
     {

--- a/lib/Controller/EmailLinksController.php
+++ b/lib/Controller/EmailLinksController.php
@@ -83,6 +83,8 @@ class EmailLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -122,6 +124,8 @@ class EmailLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function link(string $register, string $schema, string $id): JSONResponse
     {
@@ -178,6 +182,8 @@ class EmailLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function destroy(string $register, string $schema, string $id, string $linkId): JSONResponse
     {
@@ -204,6 +210,8 @@ class EmailLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function accounts(): JSONResponse
     {
@@ -227,6 +235,8 @@ class EmailLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function mailboxes(string $accountId): JSONResponse
     {
@@ -256,6 +266,8 @@ class EmailLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function messages(string $accountId): JSONResponse
     {
@@ -296,6 +308,8 @@ class EmailLinksController extends Controller
      * @param string $id       Object id.
      *
      * @return ObjectEntity|null
+     *
+     * @spec exclude Private helper: resolves an object from register/schema/id; the link REST contract is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1.
      */
     private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
     {
@@ -320,6 +334,8 @@ class EmailLinksController extends Controller
      * @param Exception $exception Source exception.
      *
      * @return JSONResponse
+     *
+     * @spec exclude Private helper: maps a service exception code to an HTTP status; the link REST contract is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1.
      */
     private function mapException(Exception $exception): JSONResponse
     {

--- a/lib/Controller/FileSearchController.php
+++ b/lib/Controller/FileSearchController.php
@@ -214,6 +214,8 @@ class FileSearchController extends Controller
      *     total?: int<0, max>, results?: array<int, array<string, mixed>>,
      *     search_type?: 'semantic'},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function semanticSearch(): JSONResponse
     {
@@ -275,6 +277,8 @@ class FileSearchController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with hybrid search results or error
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function hybridSearch(): JSONResponse
     {

--- a/lib/Controller/FileSidebarController.php
+++ b/lib/Controller/FileSidebarController.php
@@ -71,6 +71,8 @@ class FileSidebarController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function getObjectsForFile(int $fileId): JSONResponse
     {
@@ -107,6 +109,8 @@ class FileSidebarController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function getExtractionStatus(int $fileId): JSONResponse
     {

--- a/lib/Controller/FileTextController.php
+++ b/lib/Controller/FileTextController.php
@@ -87,6 +87,8 @@ class FileTextController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with file text or error
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function getFileText(int $fileId): JSONResponse
     {
@@ -133,6 +135,8 @@ class FileTextController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with extraction result
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function extractFileText(int $fileId): JSONResponse
     {
@@ -190,6 +194,8 @@ class FileTextController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with bulk extraction result
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function bulkExtract(): JSONResponse
     {
@@ -235,6 +241,8 @@ class FileTextController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with extraction stats
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function getStats(): JSONResponse
     {
@@ -277,6 +285,8 @@ class FileTextController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with deletion result
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function deleteFileText(int $fileId): JSONResponse
     {
@@ -324,6 +334,8 @@ class FileTextController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with indexing stats
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function processAndIndexExtracted(?int $limit=null, ?int $chunkSize=null, ?int $chunkOverlap=null): JSONResponse
     {
@@ -374,6 +386,8 @@ class FileTextController extends Controller
      * @SuppressWarnings (PHPMD.UnusedFormalParameter) $_chunkOverlap reserved for future implementation
      *
      * @return JSONResponse JSON response with indexing result
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function processAndIndexFile(int $fileId, ?int $chunkSize=null, ?int $_chunkOverlap=null): JSONResponse
     {
@@ -417,6 +431,8 @@ class FileTextController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with chunking stats
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function getChunkingStats(): JSONResponse
     {
@@ -463,6 +479,8 @@ class FileTextController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with anonymization result
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function anonymizeFile(int $fileId): JSONResponse
     {

--- a/lib/Controller/GraphQLController.php
+++ b/lib/Controller/GraphQLController.php
@@ -182,6 +182,8 @@ class GraphQLController extends Controller
              * Render the HTML body.
              *
              * @return string The HTML
+             *
+             * @spec exclude Framework Response::render() override on an inline anonymous class for the GraphiQL explorer; the explorer route is owned by retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-2.
              */
             public function render(): string
             {

--- a/lib/Controller/LinkedEntityController.php
+++ b/lib/Controller/LinkedEntityController.php
@@ -148,6 +148,8 @@ class LinkedEntityController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-6
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -181,6 +183,8 @@ class LinkedEntityController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-6
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]

--- a/lib/Controller/ManifestController.php
+++ b/lib/Controller/ManifestController.php
@@ -86,6 +86,8 @@ class ManifestController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      * @PublicPage
+     *
+     * @spec openspec/changes/manifest-user-context/tasks.md
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -126,6 +128,8 @@ class ManifestController extends Controller
      * @return array<string, mixed>|null Decoded manifest, or null if not readable.
      *
      * @SuppressWarnings(PHPMD.StaticAccess)
+     *
+     * @spec exclude Private helper: loads + JSON-decodes a host app's bundled manifest.json; the manifest endpoint contract is owned by manifest-user-context/tasks.md.
      */
     private function loadBundledManifest(string $appId): ?array
     {

--- a/lib/Controller/MapLinksController.php
+++ b/lib/Controller/MapLinksController.php
@@ -79,6 +79,8 @@ class MapLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -123,6 +125,8 @@ class MapLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function link(string $register, string $schema, string $id): JSONResponse
     {
@@ -172,6 +176,8 @@ class MapLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function createAndLink(string $register, string $schema, string $id): JSONResponse
     {
@@ -240,6 +246,8 @@ class MapLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function destroy(string $register, string $schema, string $id, string $favoriteId): JSONResponse
     {
@@ -275,6 +283,8 @@ class MapLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function available(): JSONResponse
     {
@@ -302,6 +312,8 @@ class MapLinksController extends Controller
      * @param string $id       Object id.
      *
      * @return ObjectEntity|null
+     *
+     * @spec exclude Private helper: resolves an object from register/schema/id; the link REST contract is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1.
      */
     private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
     {
@@ -326,6 +338,8 @@ class MapLinksController extends Controller
      * @param Exception $exception Source exception.
      *
      * @return JSONResponse
+     *
+     * @spec exclude Private helper: maps a service exception code to an HTTP status; the link REST contract is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1.
      */
     private function mapException(Exception $exception): JSONResponse
     {

--- a/lib/Controller/NotificationSubscriptionsController.php
+++ b/lib/Controller/NotificationSubscriptionsController.php
@@ -75,6 +75,8 @@ class NotificationSubscriptionsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/notificatie-engine/tasks.md "Users MUST be able to manage their notification preferences"
      */
     public function index(): JSONResponse
     {
@@ -102,6 +104,8 @@ class NotificationSubscriptionsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/notificatie-engine/tasks.md "Users MUST be able to manage their notification preferences"
      */
     public function create(): JSONResponse
     {
@@ -165,6 +169,8 @@ class NotificationSubscriptionsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/notificatie-engine/tasks.md "Users MUST be able to manage their notification preferences"
      */
     public function destroy(): JSONResponse
     {
@@ -190,6 +196,8 @@ class NotificationSubscriptionsController extends Controller
      * Resolve the current user's UID, or null when anonymous.
      *
      * @return ?string
+     *
+     * @spec exclude Private helper: resolves the session UID (null when anonymous); the subscription endpoints are owned by notificatie-engine/tasks.md.
      */
     private function resolveUserId(): ?string
     {
@@ -209,6 +217,8 @@ class NotificationSubscriptionsController extends Controller
      * @param mixed $value Input.
      *
      * @return ?int
+     *
+     * @spec exclude Private helper: coerces a request value to a nullable int; the subscription endpoints are owned by notificatie-engine/tasks.md.
      */
     private function coerceNullableInt(mixed $value): ?int
     {

--- a/lib/Controller/OpenProjectLinksController.php
+++ b/lib/Controller/OpenProjectLinksController.php
@@ -81,6 +81,8 @@ class OpenProjectLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -125,6 +127,8 @@ class OpenProjectLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function link(string $register, string $schema, string $id): JSONResponse
     {
@@ -174,6 +178,8 @@ class OpenProjectLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function createAndLink(string $register, string $schema, string $id): JSONResponse
     {
@@ -231,6 +237,8 @@ class OpenProjectLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function destroy(string $register, string $schema, string $id, string $wpId): JSONResponse
     {
@@ -267,6 +275,8 @@ class OpenProjectLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function available(): JSONResponse
     {
@@ -298,6 +308,8 @@ class OpenProjectLinksController extends Controller
      * @param string $id       Object id.
      *
      * @return ObjectEntity|null
+     *
+     * @spec exclude Private helper: resolves an object from register/schema/id; the link REST contract is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1.
      */
     private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
     {
@@ -323,6 +335,8 @@ class OpenProjectLinksController extends Controller
      * @param Exception $exception Source exception.
      *
      * @return JSONResponse
+     *
+     * @spec exclude Private helper: maps a service exception code to an HTTP status; the link REST contract is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1.
      */
     private function mapException(Exception $exception): JSONResponse
     {

--- a/lib/Controller/PollLinksController.php
+++ b/lib/Controller/PollLinksController.php
@@ -74,6 +74,8 @@ class PollLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -113,6 +115,8 @@ class PollLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function link(string $register, string $schema, string $id): JSONResponse
     {
@@ -165,6 +169,8 @@ class PollLinksController extends Controller
      * @NoCSRFRequired
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function createNew(string $register, string $schema, string $id): JSONResponse
     {
@@ -242,6 +248,8 @@ class PollLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function destroy(string $register, string $schema, string $id, string $pollId): JSONResponse
     {
@@ -277,6 +285,8 @@ class PollLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function available(): JSONResponse
     {
@@ -304,6 +314,8 @@ class PollLinksController extends Controller
      * @param string $id       Object id.
      *
      * @return ObjectEntity|null
+     *
+     * @spec exclude Private helper: resolves an object from register/schema/id; the link REST contract is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1.
      */
     private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
     {
@@ -327,6 +339,8 @@ class PollLinksController extends Controller
      * @param Exception $exception Source exception.
      *
      * @return JSONResponse
+     *
+     * @spec exclude Private helper: maps a service exception code to an HTTP status; the link REST contract is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1.
      */
     private function mapException(Exception $exception): JSONResponse
     {

--- a/lib/Controller/SearchTrailController.php
+++ b/lib/Controller/SearchTrailController.php
@@ -66,6 +66,8 @@ class SearchTrailController extends Controller
      * @suppressWarnings(PHPMD.NPathComplexity)       Request parameter extraction requires many conditional checks
      * @suppressWarnings(PHPMD.ExcessiveMethodLength)
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec exclude Private helper: parses pagination/filter/date params; the search-trail analytics API is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-3.
      */
     private function extractRequestParameters(): array
     {
@@ -211,6 +213,8 @@ class SearchTrailController extends Controller
      *
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
      * @suppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec exclude Private helper: shared pagination-envelope builder; the search-trail analytics API is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-3.
      */
     private function paginate(array $results, ?int $total=0, ?int $limit=20, ?int $offset=0, ?int $page=1): array
     {
@@ -304,6 +308,8 @@ class SearchTrailController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with search trail logs
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-3
      */
     public function index(): JSONResponse
     {
@@ -352,6 +358,8 @@ class SearchTrailController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with search trail data
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-3
      */
     public function show(int $id): JSONResponse
     {
@@ -377,6 +385,8 @@ class SearchTrailController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with search statistics
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-3
      */
     public function statistics(): JSONResponse
     {
@@ -404,6 +414,8 @@ class SearchTrailController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with popular search terms
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-3
      */
     public function popularTerms(): JSONResponse
     {
@@ -455,6 +467,8 @@ class SearchTrailController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with search activity data
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-3
      */
     public function activity(): JSONResponse
     {
@@ -483,6 +497,8 @@ class SearchTrailController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with register schema statistics
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-3
      */
     public function registerSchemaStats(): JSONResponse
     {
@@ -534,6 +550,8 @@ class SearchTrailController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with user agent statistics
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-3
      */
     public function userAgentStats(): JSONResponse
     {
@@ -634,6 +652,8 @@ class SearchTrailController extends Controller
      *     },
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-3
      */
     public function cleanup(): JSONResponse
     {
@@ -666,6 +686,8 @@ class SearchTrailController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with export data
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-3
      */
     public function export(): JSONResponse
     {
@@ -768,6 +790,8 @@ class SearchTrailController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with deletion result
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-3
      */
     public function destroy(int $id): JSONResponse
     {
@@ -878,6 +902,8 @@ class SearchTrailController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-3
      */
     public function clearAll(): JSONResponse
     {

--- a/lib/Controller/Settings/FileSettingsController.php
+++ b/lib/Controller/Settings/FileSettingsController.php
@@ -73,6 +73,8 @@ class FileSettingsController extends Controller
      * @return JSONResponse File settings
      *
      * @psalm-return JSONResponse<200|500, array, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function getFileSettings(): JSONResponse
     {
@@ -90,6 +92,8 @@ class FileSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with updated file settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function updateFileSettings(): JSONResponse
     {
@@ -136,6 +140,8 @@ class FileSettingsController extends Controller
      *
      * @psalm-return JSONResponse<200|400|500, array{success: bool, error?: string,
      *     message?: 'Dolphin connection successful'}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function testDolphinConnection(string $apiEndpoint, string $apiKey): JSONResponse
     {
@@ -185,6 +191,8 @@ class FileSettingsController extends Controller
      *
      * @psalm-return JSONResponse<200|400|500, array{success: bool, error?: string,
      *     message?: string, capabilities?: array}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function testPresidioConnection(string $apiEndpoint): JSONResponse
     {
@@ -234,6 +242,8 @@ class FileSettingsController extends Controller
      *
      * @psalm-return JSONResponse<200|400|500, array{success: bool, error?: string,
      *     message?: string}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function testOpenAnonymiserConnection(string $apiEndpoint): JSONResponse
     {
@@ -272,6 +282,8 @@ class FileSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with file collection fields
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function getFileCollectionFields(): JSONResponse
     {
@@ -303,6 +315,8 @@ class FileSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with creation result
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function createMissingFileFields(): JSONResponse
     {
@@ -364,6 +378,8 @@ class FileSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with warmup result
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function warmupFiles(): JSONResponse
     {
@@ -480,6 +496,8 @@ class FileSettingsController extends Controller
      *
      * @psalm-return JSONResponse<200|422|500, array{success: bool, message: mixed|string, file_id?: int},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function indexFile(int $fileId): JSONResponse
     {
@@ -533,6 +551,8 @@ class FileSettingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with reindex result
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function reindexFiles(): JSONResponse
     {
@@ -610,6 +630,8 @@ class FileSettingsController extends Controller
      * @psalm-return JSONResponse<200, array<array-key, mixed>,
      *     array<never, never>>|JSONResponse<500,
      *     array{success: false, message: string}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function getFileIndexStats(): JSONResponse
     {
@@ -669,6 +691,8 @@ class FileSettingsController extends Controller
      *     completed: 0|mixed, failed: 0|mixed, indexed: 0|mixed,
      *     processing: 0|mixed, vectorized: 0|mixed, error?: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2
      */
     public function getFileExtractionStats(): JSONResponse
     {
@@ -747,6 +771,8 @@ class FileSettingsController extends Controller
      * @param string[] $headers     Optional HTTP headers (default: Content-Type: application/json).
      *
      * @return array{success: bool, message?: string, error?: string} Health check result.
+     *
+     * @spec exclude Private helper: shared cURL health-check used by the connection-test endpoints; the file-index HTTP surface is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2.
      */
     private function performHealthCheck(string $url, string $serviceName, array $headers=[]): array
     {
@@ -799,6 +825,8 @@ class FileSettingsController extends Controller
      * @param string $apiEndpoint The Presidio API base endpoint URL.
      *
      * @return array Capabilities array, potentially containing 'supported_entities'.
+     *
+     * @spec exclude Private helper: fetches Presidio supported-entities for the connection test; the file-index HTTP surface is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-2.
      */
     private function fetchPresidioCapabilities(string $apiEndpoint): array
     {

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -186,6 +186,8 @@ class SettingsController extends Controller
      * @return null The OpenRegister service if available, null otherwise.
      *
      * @throws \RuntimeException If the service is not available.
+     *
+     * @spec exclude DI service accessor (not a routed endpoint): returns the OpenRegister ObjectService from the container.
      */
     public function getObjectService()
     {
@@ -203,6 +205,8 @@ class SettingsController extends Controller
      *
      * @return \OCA\OpenRegister\Service\ConfigurationService|null The Configuration service if available, null otherwise.
      * @throws \RuntimeException If the service is not available.
+     *
+     * @spec exclude DI service accessor (not a routed endpoint): returns the ConfigurationService from the container.
      */
     public function getConfigurationService(): ?\OCA\OpenRegister\Service\ConfigurationService
     {
@@ -798,6 +802,8 @@ class SettingsController extends Controller
      * @psalm-return JSONResponse<200, array<array-key, mixed>,
      *     array<never, never>>|JSONResponse<422,
      *     array{success: false, error: string}, array<never, never>>
+     *
+     * @spec exclude Debug/test scaffolding endpoint: indexes sample objects to exercise schema-aware SOLR mapping; not a product contract (see proposal Notes — routed debug surface).
      */
     public function testSchemaMapping(): JSONResponse
     {
@@ -851,6 +857,8 @@ class SettingsController extends Controller
      *     array<never, never>>
      *
      * @suppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
+     * @spec exclude Debug/test scaffolding endpoint ("Debug endpoint for type filtering issue"): dumps organisation/object data; not a product contract (see proposal Notes — routed debug surface, information-disclosure risk).
      */
     public function debugTypeFiltering(): JSONResponse
     {

--- a/lib/Controller/SourcesController.php
+++ b/lib/Controller/SourcesController.php
@@ -74,6 +74,8 @@ class SourcesController extends Controller
      * @NoCSRFRequired
      *
      * @psalm-return JSONResponse<200, array{results: array<Source>}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
      */
     public function index(): JSONResponse
     {
@@ -117,6 +119,8 @@ class SourcesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
      */
     public function show(string $id): JSONResponse
     {
@@ -141,6 +145,8 @@ class SourcesController extends Controller
      * @NoCSRFRequired
      *
      * @psalm-return JSONResponse<200, Source, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
      */
     public function create(): JSONResponse
     {
@@ -177,6 +183,8 @@ class SourcesController extends Controller
      * @NoCSRFRequired
      *
      * @psalm-return JSONResponse<200, Source, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
      */
     public function update(int $id): JSONResponse
     {
@@ -213,6 +221,8 @@ class SourcesController extends Controller
      * @NoCSRFRequired
      *
      * @psalm-return JSONResponse<200, Source, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
      */
     public function patch(int $id): JSONResponse
     {
@@ -235,6 +245,8 @@ class SourcesController extends Controller
      * @NoCSRFRequired
      *
      * @psalm-return JSONResponse<200, array<never, never>, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1
      */
     public function destroy(int $id): JSONResponse
     {
@@ -252,6 +264,8 @@ class SourcesController extends Controller
      * @param string               $key    Parameter key
      *
      * @return int|null Integer value or null
+     *
+     * @spec exclude Private pagination-param helper; the registry resource-CRUD contract is owned by retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1.
      */
     private function getIntParam(array $params, string $key): ?int
     {

--- a/lib/Controller/TalkLinksController.php
+++ b/lib/Controller/TalkLinksController.php
@@ -68,6 +68,8 @@ class TalkLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -107,6 +109,8 @@ class TalkLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function link(string $register, string $schema, string $id): JSONResponse
     {
@@ -158,6 +162,8 @@ class TalkLinksController extends Controller
      * @NoCSRFRequired
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function createNew(string $register, string $schema, string $id): JSONResponse
     {
@@ -212,6 +218,8 @@ class TalkLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function destroy(string $register, string $schema, string $id, string $roomToken): JSONResponse
     {
@@ -245,6 +253,8 @@ class TalkLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function rooms(): JSONResponse
     {
@@ -271,6 +281,8 @@ class TalkLinksController extends Controller
      * @param string $id       Object id.
      *
      * @return ObjectEntity|null
+     *
+     * @spec exclude Private helper: resolves an object from register/schema/id; the link REST contract is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1.
      */
     private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
     {
@@ -294,6 +306,8 @@ class TalkLinksController extends Controller
      * @param Exception $exception Source exception.
      *
      * @return JSONResponse
+     *
+     * @spec exclude Private helper: maps a service exception code to an HTTP status; the link REST contract is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1.
      */
     private function mapException(Exception $exception): JSONResponse
     {

--- a/lib/Controller/UiController.php
+++ b/lib/Controller/UiController.php
@@ -124,6 +124,8 @@ class UiController extends Controller
      * @phpstan-return TemplateResponse
      *
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function registers(): TemplateResponse
     {
@@ -146,6 +148,8 @@ class UiController extends Controller
      * @phpstan-return TemplateResponse
      *
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function registersDetails(): TemplateResponse
     {
@@ -168,6 +172,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function schemas(): TemplateResponse
     {
@@ -190,6 +196,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function schemasDetails(): TemplateResponse
     {
@@ -208,6 +216,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function sources(): TemplateResponse
     {
@@ -226,6 +236,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function organisation(): TemplateResponse
     {
@@ -244,6 +256,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function objects(): TemplateResponse
     {
@@ -287,6 +301,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function tables(): TemplateResponse
     {
@@ -305,6 +321,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function chat(): TemplateResponse
     {
@@ -323,6 +341,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function configurations(): TemplateResponse
     {
@@ -341,6 +361,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function deleted(): TemplateResponse
     {
@@ -359,6 +381,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function auditTrail(): TemplateResponse
     {
@@ -377,6 +401,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function searchTrail(): TemplateResponse
     {
@@ -395,6 +421,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function webhooks(): TemplateResponse
     {
@@ -413,6 +441,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function webhooksLogs(): TemplateResponse
     {
@@ -431,6 +461,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function entities(): TemplateResponse
     {
@@ -449,6 +481,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function entitiesDetails(): TemplateResponse
     {
@@ -491,6 +525,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function reports(): TemplateResponse
     {
@@ -509,6 +545,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function reportView(): TemplateResponse
     {
@@ -531,6 +569,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function endpoints(): TemplateResponse
     {
@@ -552,6 +592,8 @@ class UiController extends Controller
      * @psalm-return TemplateResponse<200|500, array<string, mixed>>
      *
      * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing. SPA-mount contract owned by no-code-app-builder via retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1.
      */
     public function endpointLogs(): TemplateResponse
     {

--- a/lib/Controller/WebhooksController.php
+++ b/lib/Controller/WebhooksController.php
@@ -252,6 +252,8 @@ class WebhooksController extends Controller
      *     array{error: 'Failed to retrieve webhook'|'Webhook not found'},
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-4
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -1040,6 +1042,8 @@ class WebhooksController extends Controller
      *     array{error?: 'Failed to retrieve webhook log statistics'|
      *     'Webhook not found', total?: int, successful?: int, failed?: int,
      *     pendingRetries?: int<0, max>}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-5
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]

--- a/lib/Controller/WorkflowEngineController.php
+++ b/lib/Controller/WorkflowEngineController.php
@@ -87,6 +87,8 @@ class WorkflowEngineController extends Controller
      * @NoAdminRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-04-30-annotate-openregister/tasks.md#task-91
      */
     public function show(int $id): JSONResponse
     {
@@ -167,6 +169,8 @@ class WorkflowEngineController extends Controller
      * @param int $id Engine ID
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-04-30-annotate-openregister/tasks.md#task-91
      */
     public function update(int $id): JSONResponse
     {
@@ -188,6 +192,8 @@ class WorkflowEngineController extends Controller
      * @param int $id Engine ID
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-04-30-annotate-openregister/tasks.md#task-91
      */
     public function destroy(int $id): JSONResponse
     {
@@ -245,6 +251,8 @@ class WorkflowEngineController extends Controller
      * @param int $id Engine ID
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-04-30-annotate-openregister/tasks.md#task-91
      */
     public function testHook(int $id): JSONResponse
     {

--- a/lib/Controller/XwikiLinksController.php
+++ b/lib/Controller/XwikiLinksController.php
@@ -83,6 +83,8 @@ class XwikiLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -120,6 +122,8 @@ class XwikiLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function link(string $register, string $schema, string $id): JSONResponse
     {
@@ -162,6 +166,8 @@ class XwikiLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function createAndLink(string $register, string $schema, string $id): JSONResponse
     {
@@ -213,6 +219,8 @@ class XwikiLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function destroy(string $register, string $schema, string $id, string $pageRef): JSONResponse
     {
@@ -242,6 +250,8 @@ class XwikiLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1
      */
     public function available(): JSONResponse
     {
@@ -275,6 +285,8 @@ class XwikiLinksController extends Controller
      * @param string $id       Object id.
      *
      * @return ObjectEntity|null
+     *
+     * @spec exclude Private helper: resolves an object from register/schema/id; the link REST contract is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1.
      */
     private function validateObject(string $register, string $schema, string $id): ?ObjectEntity
     {
@@ -296,6 +308,8 @@ class XwikiLinksController extends Controller
      * @param Exception $exception Source exception.
      *
      * @return JSONResponse
+     *
+     * @spec exclude Private helper: maps a service exception code to an HTTP status; the link REST contract is owned by retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-1.
      */
     private function mapException(Exception $exception): JSONResponse
     {

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/proposal.md
@@ -1,0 +1,171 @@
+---
+status: draft
+retrofit: true
+---
+
+# Retrofit: Reverse-spec controller bundle — Controllers (chunk 1)
+
+## Why
+
+A coverage scan of OpenRegister's controller layer (`lib/Controller/*.php`)
+found 148 public/protected methods across 27 controller files missing the
+ADR-003 `@spec` traceability tag. The backing services are implemented; what
+was missing is the *controller* contract (route shape, status codes, parameter
+handling, error envelopes). This ghost change reverse-specs the observed
+controller behavior and annotates every method, biasing strongly toward
+**extending** existing capabilities and toward **annotation-only** where the
+behavior is already owned by a live spec or an archived retrofit change.
+
+This is a documentation/annotation change only. No runtime behavior is modified.
+
+## Counts
+
+| Disposition | Methods |
+|---|---|
+| Reverse-spec'd (tagged to a REQ) | 115 |
+| `@spec exclude` (boilerplate / SPA-mount stub / private helper / debug) | 33 |
+| **Total** | **148** |
+
+Of the 115 reverse-spec'd, 96 annotate to existing REQs (registry-CRUD,
+calendar, chat-ai, linked-entity, manifest, notification, webhook, workflow) and
+19 are net-new coverage under the 3 ADDED REQs in this change. The 33 excludes
+are the 21 UiController SPA-mount stubs, 8 private link-controller helpers
+(`validateObject`/`mapException` ×… counted once-per-touched-file), the 6
+ChatStream SSE-framing helpers, the file-settings cURL helpers, and the
+SettingsController DI accessors + debug endpoints.
+
+New REQs added: **3** (well within the ≤6 budget). The dominant cost-saver is
+the **one shared REQ** for the eight near-identical object-scoped integration
+link controllers — per the "uniform CRUD across many controllers → ONE shared
+REQ" guardrail, that single REQ replaces what would otherwise be eight
+near-duplicate contracts.
+
+## What changes
+
+### 1. Object-scoped integration link controllers → extend **generic-integrations** (ONE shared REQ)
+
+`AnalyticsLinksController`, `CollectiveLinksController`, `MapLinksController`,
+`OpenProjectLinksController`, `PollLinksController`, `TalkLinksController`,
+`XwikiLinksController`, and `EmailLinksController` are eight near-identical
+Tier-2 REST controllers. Each exposes the same object-scoped link surface
+(`GET` list / `POST` link-existing / `POST` create-and-link / `DELETE` unlink)
+mounted under `/api/objects/{register}/{schema}/{id}/{provider}`, plus
+provider picker-source endpoints under `/api/integrations/{provider}/...`. They
+all share the same `501 APP_NOT_AVAILABLE` availability gate, the same
+`{results,total}` envelope, the same `validateObject()` 404 path, and the same
+`mapException()` HTTP-code mapping. Their provider/frontend behavior is already
+owned by the `integration-*` changes (`integration-collectives`,
+`integration-openproject`, `integration-xwiki`, `integration-polls`,
+`integration-maps`, `integration-talk`, `integration-analytics`,
+`integration-email`); what none of those captured is the **shared HTTP REST
+contract**. ONE ADDED REQ in `generic-integrations` documents that contract;
+all eight controllers' public methods annotate to it. Per-controller
+`validateObject()` / `mapException()` are private helpers → `@spec exclude`.
+
+`CalendarEventsController`'s uncovered methods (`index`/`link`/`unlink`/
+`listCalendars`/`listCalendarEvents`) are **annotation-only** to the existing
+`retrofit-2026-05-24-calendar-integration/tasks.md#task-1` (REST link/unlink
+flow) — that change already owns the calendar link REST surface; no new REQ.
+
+### 2. File text extraction + indexing HTTP surface → extend **search-index** (ONE new REQ)
+
+`FileTextController` (extract / bulk-extract / chunk-index / stats / anonymize),
+`FileSearchController::semanticSearch` + `hybridSearch` (vector/hybrid file
+search), `FileSidebarController` (`getObjectsForFile` / `getExtractionStatus`),
+and `FileSettingsController` (file-index admin: settings, collection-fields,
+warmup, index/reindex, index/extraction stats, and the Dolphin / Presidio /
+OpenAnonymiser connection tests) form the file text-extraction-and-indexing
+pipeline's HTTP surface. The `search-index` spec covers backend routing and
+collection mirroring but has no REQ for this controller surface. ONE ADDED REQ
+documents it; all the routed methods annotate to it. Private helpers
+(`performHealthCheck`, `fetchPresidioCapabilities`) → `@spec exclude`.
+`FileSearchController::keywordSearch` is already annotated upstream and is not
+in this batch.
+
+### 3. Search-trail analytics + audit API → extend **zoeken-filteren** (ONE new REQ)
+
+`SearchTrailController` exposes an 11-endpoint analytics/audit surface over the
+search-trail log: list/show, aggregate statistics, popular terms, activity
+time-series, per-register/schema stats, user-agent stats, CSV/JSON export, and
+cleanup/single-delete/clear-all retention operations. The class currently
+points at `zoeken-filteren#REQ-014` (view-based search composition), which is
+the wrong contract — that REQ is about composing searches, not auditing them.
+ONE ADDED REQ in `zoeken-filteren` documents the search-trail analytics/audit
+API; the uncovered public methods annotate to it. `extractRequestParameters`,
+`paginate`, and `arrayToCsv` are private helpers → `@spec exclude`.
+
+### 4. Annotation-only against existing / archived REQs (no new REQ)
+
+- **UiController** — 21 history-mode SPA-mount route stubs
+  (`registers`/`schemas`/`objects`/`tables`/`chat`/`reports`/`auditTrail`/...)
+  are trivial `return $this->makeSpaResponse();` passthroughs whose contract is
+  already owned by `no-code-app-builder` (the consolidated SPA-mount REQ in
+  `retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1`). Per the precedent and the
+  ADR-003 thin-passthrough rule they are `@spec exclude` (reason cites the
+  owning REQ); the load-bearing `makeSpaResponse()`/`integrationsView()`/`avg()`
+  are already annotated upstream and are not in this batch.
+- **ApplicationsController** / **ConsumersController** / **SourcesController** —
+  `index`/`show`/`create`/`update`/`patch`/`destroy` annotate to the existing
+  shared registry-resource-CRUD REQ
+  (`retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1`); the classes
+  already point there. `ApplicationsController::page` is an SPA-mount stub →
+  exclude. Pagination/param private helpers (`extractLimit`/`extractOffset`/
+  `extractPage`/`getIntParam`) → exclude.
+- **ChatHealthController::health** → existing
+  `ai-chat-companion-orchestrator/.../chat-ai/spec.md#health-probe-endpoint-get-apichathealth`.
+- **ChatStreamController::stream** → existing
+  `ai-chat-companion-orchestrator/.../chat-ai/spec.md#sse-streaming-endpoint-post-apichatstream`;
+  the SSE-framing helpers (`emitSseEvent`/`emitSseHeaders`/`emitAndExit`/
+  `forwardWithHeartbeat`/`clearOutputBuffers`/`now`) → exclude.
+- **LinkedEntityController** `addRegisterLink`/`addSchemaLink` → existing
+  generic ad-hoc linking REQ (`retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-6`).
+- **ManifestController::index** → existing `manifest-user-context/tasks.md`;
+  `loadBundledManifest` private → exclude.
+- **NotificationSubscriptionsController** `index`/`create`/`destroy` → existing
+  `notificatie-engine/tasks.md`; `resolveUserId`/`coerceNullableInt` private →
+  exclude.
+- **WebhooksController** `show`/`logStats` → existing registry-views REQs
+  (`#task-4` CRUD / `#task-5` delivery-log listing).
+- **WorkflowEngineController** `show`/`update`/`destroy`/`testHook` → existing
+  `workflow-engine-abstraction` engine-registration/CRUD REQ
+  (`retrofit-2026-04-30-annotate-openregister/tasks.md#task-91`).
+- **GraphQLController** `render` is the inline `Response` subclass's framework
+  `render()` override, not a route handler → exclude.
+- **SettingsController** `getObjectService`/`getConfigurationService` are DI
+  service accessors (not routed) → exclude; `testSchemaMapping`/
+  `debugTypeFiltering` are debug/test scaffolding endpoints → exclude (see
+  Notes).
+
+## New requirements summary (target ≤ 6)
+
+| Capability | New REQs | Notes |
+|---|---|---|
+| generic-integrations | 1 | shared object-scoped integration link REST contract (8 controllers) |
+| search-index | 1 | file text extraction + indexing HTTP surface |
+| zoeken-filteren | 1 | search-trail analytics + audit API |
+| **Total** | **3** | within budget |
+
+## Impact
+
+- Specs extended: `generic-integrations`, `search-index`, `zoeken-filteren`.
+- Specs/changes referenced (annotation targets, no delta): `no-code-app-builder`,
+  registry-views (`#task-1`/`#task-4`/`#task-5`/`#task-6`), `calendar-integration`
+  (retrofit), `chat-ai` (orchestrator), `manifest-user-context`,
+  `notificatie-engine`, `workflow-engine-abstraction`.
+- 27 controllers touched; docblock `@spec` annotations only.
+- No code behavior change.
+
+## Notes (security / authz observations — not fixed here)
+
+- **Debug/test endpoints are routed in production.** `SettingsController::
+  debugTypeFiltering()` ("Debug endpoint for type filtering issue") and
+  `::testSchemaMapping()` dump organisation/object data and run sample SOLR
+  indexing. They are reachable HTTP routes. Excluded as scaffolding here, but
+  routed debug endpoints that echo object data are an information-disclosure
+  surface worth gating behind admin-only / removing.
+- **Link-controller authz is session-user-scoped, no admin gate by design.**
+  The integration link controllers rely on `@NoAdminRequired` + the backing
+  service's user-scoping (e.g. NC Analytics/Collectives are user-owned). This
+  is intentional per their docblocks, but the shared REQ documents it so any
+  future provider that is NOT user-scoped must add its own gate rather than
+  inherit this assumption.

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/specs/generic-integrations/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/specs/generic-integrations/spec.md
@@ -1,0 +1,80 @@
+---
+status: draft
+---
+
+# generic-integrations
+
+## Purpose
+
+Extend the generic-integrations capability with the shared HTTP REST contract
+for the object-scoped integration link controllers. The provider/frontend
+behavior of each integration (tab rendering, widget surfaces, provider
+registration) is owned by the per-provider `integration-*` changes; what was
+missing is a single requirement describing the uniform REST surface that all
+eight link controllers implement identically. Reverse-specced from
+`AnalyticsLinksController`, `CollectiveLinksController`, `MapLinksController`,
+`OpenProjectLinksController`, `PollLinksController`, `TalkLinksController`,
+`XwikiLinksController`, and `EmailLinksController`.
+
+## ADDED Requirements
+
+### Requirement: Object-Scoped Integration Link REST Contract
+
+The system MUST expose a uniform object-scoped link REST surface so each
+integration provider links its external resources (reports, pages, work
+packages, polls, rooms, map favourites, wiki pages, mail messages) to an
+OpenRegister object through one consistent contract. Every object-scoped link
+controller MUST mount its routes under
+`/api/objects/{register}/{schema}/{id}/{provider}` and MUST implement: a `GET`
+list of linked resources, a `POST` to link an existing resource by id, an
+optional `POST` create-and-link, and a `DELETE` unlink keyed by the provider's
+resource id. Provider picker-source endpoints (the resources the current user
+may link, plus any create-cascade parents) MUST be exposed under
+`/api/integrations/{provider}/...`.
+
+The list and picker responses MUST use the `{results, total}` envelope.
+Successful link and create-and-link responses MUST return HTTP `201` with the
+serialised link row; successful unlink MUST return `{success: true}`. When the
+required Nextcloud app backing the provider is not installed, every endpoint
+MUST short-circuit with HTTP `501` and a body `{error, code:
+"APP_NOT_AVAILABLE"}`. When the target object cannot be resolved from
+`(register, schema, id)`, the endpoint MUST return HTTP `404` with
+`{error: "Object not found"}`. Service-layer exceptions MUST be mapped to HTTP
+status by exception code (`400`/`401`/`404`/`409`/`503`), defaulting to `400`.
+
+These controllers MUST authorize against the active user session (no admin
+gate) and MUST rely on the backing service to scope resources to that user;
+the contract therefore assumes a user-owned provider, and any provider whose
+resources are NOT user-scoped MUST add its own authorization rather than
+inherit this contract's session-only default.
+
+#### Scenario: List linked resources for an object
+- **GIVEN** an authenticated user and an object resolvable from `(register, schema, id)`
+- **WHEN** a GET request is sent to `/api/objects/{register}/{schema}/{id}/{provider}`
+- **THEN** the response MUST be a `{results, total}` envelope listing the resources linked to that object
+
+#### Scenario: Link an existing resource returns 201
+- **GIVEN** an authenticated user and a valid resource id in the request body
+- **WHEN** a POST request is sent to `/api/objects/{register}/{schema}/{id}/{provider}`
+- **THEN** the link row MUST be created and the response MUST be HTTP `201` carrying the serialised link
+
+#### Scenario: Unlink returns success envelope
+- **GIVEN** an existing link between an object and a provider resource
+- **WHEN** a DELETE request is sent to `/api/objects/{register}/{schema}/{id}/{provider}/{resourceId}`
+- **THEN** the link MUST be removed and the response MUST be `{success: true}`
+
+#### Scenario: Backing app not installed yields 501
+- **GIVEN** the Nextcloud app backing the provider is not installed
+- **WHEN** any of the provider's link endpoints is invoked
+- **THEN** the response MUST be HTTP `501` with body `{error, code: "APP_NOT_AVAILABLE"}`
+
+#### Scenario: Unresolvable object yields 404
+- **GIVEN** a `(register, schema, id)` triple that does not resolve to an object
+- **WHEN** any object-scoped link endpoint is invoked
+- **THEN** the response MUST be HTTP `404` with `{error: "Object not found"}`
+
+#### Scenario: Service exception codes map to HTTP status
+- **GIVEN** the backing service throws an exception carrying code `409` (duplicate link)
+- **WHEN** the controller catches it via its `mapException()` helper
+- **THEN** the response status MUST be `409`
+- **AND** an exception code outside `{400,401,404,409,503}` MUST default to HTTP `400`

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/specs/search-index/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/specs/search-index/spec.md
@@ -1,0 +1,73 @@
+---
+status: draft
+---
+
+# search-index
+
+## Purpose
+
+Extend the search-index capability with the file text extraction and indexing
+HTTP surface. The existing spec covers backend routing through
+`SearchBackendInterface`, schema-to-collection mirroring, and bulk object
+indexing, but has no requirement for the controller endpoints that drive file
+text extraction, chunk indexing, search over file chunks, extraction statistics,
+file-index administration, and PII anonymisation. Reverse-specced from
+`FileTextController`, `FileSearchController`, `FileSidebarController`, and
+`FileSettingsController`.
+
+## ADDED Requirements
+
+### Requirement: File Text Extraction and Indexing HTTP Surface
+
+The system MUST expose an HTTP surface for the file text-extraction-and-indexing
+pipeline so administrators and the Files UI can extract text from files, index
+the resulting chunks into the configured search backend, inspect extraction and
+chunking statistics, search over file contents, and anonymise detected PII.
+
+Text extraction MUST support per-file (re-)extraction and a bounded bulk
+extraction over pending files, and MUST return HTTP `501` when file management
+or extraction is disabled in configuration. Chunk indexing MUST process
+unindexed chunks into the search backend and report indexing counts. The
+surface MUST expose extraction statistics and chunking statistics. File search
+MUST support semantic (vector-similarity) and hybrid (keyword + vector) modes
+over the `file` entity type, each returning a `{success, query, total, results,
+search_type}` envelope and rejecting an empty `query` with HTTP `400`. The
+Files-sidebar endpoints MUST return the OpenRegister objects referencing a given
+Nextcloud file id and that file's extraction status. File-index administration
+MUST expose: read/update of file settings, file-collection field discovery and
+creation, index warmup, per-file and bulk (re)indexing, file-index and
+file-extraction statistics, and connection tests for the configured extraction
+and anonymisation backends (Dolphin / Presidio / OpenAnonymiser). Anonymisation
+MUST create a new anonymised copy of a file from previously detected entities,
+leaving the original unchanged, and MUST reject files that are already
+anonymised or have no detected entities.
+
+#### Scenario: Force per-file text extraction
+- **GIVEN** file management is enabled with an extraction scope other than `none`
+- **WHEN** a POST request is sent to extract text for a file id
+- **THEN** the controller MUST force re-extraction via the extraction service and return success
+
+#### Scenario: Extraction disabled yields 501
+- **GIVEN** file management is absent or its `extractionScope` is `none`
+- **WHEN** per-file extraction is requested
+- **THEN** the response MUST be HTTP `501` with `{success:false, message:"Text extraction disabled"}`
+
+#### Scenario: Bulk extraction is bounded
+- **GIVEN** a bulk-extract request with a `limit` above the cap
+- **WHEN** the controller invokes the extraction service
+- **THEN** the processed batch MUST be capped (at most 500 files) and the response MUST report `processed`/`failed`/`total`
+
+#### Scenario: Chunk indexing reports counts
+- **GIVEN** extracted file chunks awaiting indexing
+- **WHEN** the process-and-index endpoint is invoked
+- **THEN** unindexed chunks MUST be processed into the search backend and the response MUST carry the indexing result
+
+#### Scenario: Semantic file search rejects empty query
+- **GIVEN** a semantic-search request with an empty `query`
+- **WHEN** the endpoint is invoked
+- **THEN** the response MUST be HTTP `400` with `{success:false, message:"Query parameter is required"}`
+
+#### Scenario: Anonymisation guards already-anonymised files
+- **GIVEN** a file whose name already contains `_anonymized`
+- **WHEN** the anonymise endpoint is invoked
+- **THEN** the response MUST be HTTP `400` and no new anonymised copy MUST be created

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/specs/zoeken-filteren/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/specs/zoeken-filteren/spec.md
@@ -1,0 +1,57 @@
+---
+status: draft
+---
+
+# zoeken-filteren
+
+## Purpose
+
+Extend the zoeken-filteren capability with the search-trail analytics and audit
+API. The existing spec covers search composition and filtering; it has no
+requirement for the endpoint surface that lets operators inspect, aggregate,
+export, and prune the search-trail log (the record of who searched for what).
+Reverse-specced from `SearchTrailController`.
+
+## ADDED Requirements
+
+### Requirement: Search Trail Analytics and Audit API
+
+The system MUST expose an analytics and audit API over the search-trail log so
+operators can review search activity, surface aggregate insight, export the
+trail, and apply retention. The API MUST provide: a paginated list of trail
+entries returning the same `{results, total, page, pages, limit, offset}`
+pagination envelope used by the objects list endpoint; retrieval of a single
+trail entry by id returning HTTP `404` when it does not exist; aggregate search
+statistics over an optional `from`/`to` window; popular search terms; a search
+activity time-series; per-(register, schema) search statistics; and user-agent
+statistics. The API MUST support exporting the trail (CSV or JSON), and MUST
+provide retention operations: age-based cleanup, single-entry delete, and a
+clear-all purge. Date-window and pagination parameters MUST be parsed through a
+shared parameter-extraction helper, and system/query parameters (`_route`,
+`id`) MUST be stripped before they reach the service.
+
+#### Scenario: List search trail entries with pagination envelope
+- **GIVEN** search-trail entries exist
+- **WHEN** a GET request is sent to the search-trail list endpoint
+- **THEN** the response MUST be the shared pagination envelope (`results`, `total`, `page`, `pages`, `limit`, `offset`)
+- **AND** `_route` and `id` MUST be stripped from the parameters passed to the service
+
+#### Scenario: Fetch a missing trail entry yields 404
+- **GIVEN** no search-trail entry exists for the requested id
+- **WHEN** the show endpoint is invoked with that id
+- **THEN** the response MUST be HTTP `404` with `{error: "Search trail not found"}`
+
+#### Scenario: Aggregate statistics honour the date window
+- **GIVEN** a statistics request carrying optional `from` and `to` parameters
+- **WHEN** the statistics endpoint is invoked
+- **THEN** the service MUST receive the parsed `from`/`to` window and return aggregate search statistics
+
+#### Scenario: Export the search trail
+- **GIVEN** search-trail entries exist
+- **WHEN** the export endpoint is invoked
+- **THEN** the trail MUST be returned in the requested export format (CSV or JSON)
+
+#### Scenario: Retention operations prune the trail
+- **GIVEN** stale search-trail entries
+- **WHEN** the cleanup, single-delete, or clear-all endpoint is invoked
+- **THEN** the matching entries MUST be removed and the operation result MUST be reported

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/tasks.md
@@ -1,0 +1,108 @@
+# Tasks — Retrofit bw2-ctrl-1 (Controllers, chunk 1)
+
+Reverse-spec + annotation tasks for controller bundle chunk 1 (27 files, 148
+methods). Each task maps a controller method group to the capability that owns
+its contract. Tasks prefixed CROSS are annotation-only references (no new REQ;
+behavior already owned by a live spec or an archived retrofit change).
+
+## generic-integrations (1 new REQ)
+
+- [x] **task-1**: Document the shared object-scoped integration-link REST
+  contract — `GET` list / `POST` link-existing / `POST` create-and-link /
+  `DELETE` unlink under `/api/objects/{register}/{schema}/{id}/{provider}`, plus
+  provider picker-source endpoints under `/api/integrations/{provider}/...`,
+  with the `501 APP_NOT_AVAILABLE` availability gate, `{results,total}`
+  envelope, `validateObject()` 404 path, and `mapException()` HTTP-code mapping.
+  ONE ADDED generic-integrations REQ "Object-Scoped Integration Link REST
+  Contract". Annotate the public methods of `AnalyticsLinksController`
+  (`index`/`link`/`createAndLink`/`destroy`/`available`),
+  `CollectiveLinksController`
+  (`index`/`link`/`createAndLink`/`destroy`/`available`/`collectives`),
+  `MapLinksController` (`index`/`link`/`createAndLink`/`destroy`/`available`),
+  `OpenProjectLinksController`
+  (`index`/`link`/`createAndLink`/`destroy`/`available`),
+  `PollLinksController` (`index`/`link`/`createNew`/`destroy`/`available`),
+  `TalkLinksController` (`index`/`link`/`createNew`/`destroy`/`rooms`),
+  `XwikiLinksController` (`index`/`link`/`createAndLink`/`destroy`/`available`),
+  and `EmailLinksController`
+  (`index`/`link`/`destroy`/`accounts`/`mailboxes`/`messages`). Per-controller
+  `validateObject()` / `mapException()` are private helpers → `@spec exclude`.
+
+## search-index (1 new REQ)
+
+- [x] **task-2**: Document the file text extraction + indexing HTTP surface —
+  per-file and bulk text extraction, chunk indexing to the search backend,
+  extraction/chunking statistics, and PII anonymisation. ONE ADDED search-index
+  REQ "File Text Extraction and Indexing HTTP Surface". Annotate
+  `FileTextController`
+  (`getFileText`/`extractFileText`/`bulkExtract`/`getStats`/`deleteFileText`/
+  `processAndIndexExtracted`/`processAndIndexFile`/`getChunkingStats`/
+  `anonymizeFile`), `FileSearchController` (`semanticSearch`/`hybridSearch`),
+  `FileSidebarController` (`getObjectsForFile`/`getExtractionStatus`), and
+  `FileSettingsController` (`getFileSettings`/`updateFileSettings`/
+  `getFileCollectionFields`/`createMissingFileFields`/`warmupFiles`/`indexFile`/
+  `reindexFiles`/`getFileIndexStats`/`getFileExtractionStats`/
+  `testDolphinConnection`/`testPresidioConnection`/`testOpenAnonymiserConnection`).
+  Private helpers (`performHealthCheck`, `fetchPresidioCapabilities`) →
+  `@spec exclude`.
+
+## zoeken-filteren (1 new REQ)
+
+- [x] **task-3**: Document the search-trail analytics + audit API —
+  `SearchTrailController` list/show, aggregate statistics, popular terms,
+  activity time-series, per-register/schema stats, user-agent stats, CSV/JSON
+  export, and cleanup / single-delete / clear-all retention operations. ONE
+  ADDED zoeken-filteren REQ "Search Trail Analytics and Audit API". Annotate
+  the uncovered public methods (`index`/`show`/`statistics`/`popularTerms`/
+  `activity`/`registerSchemaStats`/`userAgentStats`/`cleanup`/`export`/
+  `destroy`/`clearAll`). `extractRequestParameters`/`paginate`/`arrayToCsv`
+  private helpers → `@spec exclude`.
+
+## CROSS — annotation-only against existing / archived REQs (no new REQ)
+
+- [x] **task-4 (CROSS → no-code-app-builder)**: `UiController`'s 21 history-mode
+  SPA-mount route stubs (`registers`/`registersDetails`/`schemas`/
+  `schemasDetails`/`sources`/`organisation`/`objects`/`tables`/`chat`/
+  `configurations`/`deleted`/`auditTrail`/`searchTrail`/`webhooks`/
+  `webhooksLogs`/`entities`/`entitiesDetails`/`reports`/`reportView`/
+  `endpoints`/`endpointLogs`) are trivial `return $this->makeSpaResponse();`
+  passthroughs. Contract owned by `no-code-app-builder` (consolidated SPA-mount
+  REQ, `retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-1`). Per ADR-003
+  thin-passthrough rule → `@spec exclude` (reason cites the owning REQ).
+- [x] **task-5 (CROSS → registry-resource-crud)**: `ApplicationsController`,
+  `ConsumersController`, `SourcesController`
+  `index`/`show`/`create`/`update`/`patch`/`destroy` → existing shared
+  registry-resource-CRUD REQ (`retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-1`;
+  the classes already point there). `ApplicationsController::page` is an
+  SPA-mount stub → exclude. Pagination/param private helpers
+  (`extractLimit`/`extractOffset`/`extractPage`/`getIntParam`) → exclude.
+- [x] **task-6 (CROSS → chat-ai orchestrator)**: `ChatHealthController::health`
+  → `ai-chat-companion-orchestrator/specs/chat-ai/spec.md#health-probe-endpoint-get-apichathealth`.
+  `ChatStreamController::stream` →
+  `ai-chat-companion-orchestrator/specs/chat-ai/spec.md#sse-streaming-endpoint-post-apichatstream`.
+  ChatStream SSE-framing helpers (`emitSseEvent`/`emitSseHeaders`/`emitAndExit`/
+  `forwardWithHeartbeat`/`clearOutputBuffers`/`now`) → `@spec exclude`.
+- [x] **task-7 (CROSS → linked-entity-types)**: `LinkedEntityController`
+  `addRegisterLink`/`addSchemaLink` → existing generic ad-hoc linking REQ
+  (`retrofit-2026-05-24-b-ctrl-registry-views/tasks.md#task-6`).
+- [x] **task-8 (CROSS → manifest-user-context)**: `ManifestController::index` →
+  existing `manifest-user-context/tasks.md`; `loadBundledManifest` private →
+  `@spec exclude`.
+- [x] **task-9 (CROSS → notificatie-engine)**:
+  `NotificationSubscriptionsController` `index`/`create`/`destroy` → existing
+  `notificatie-engine/tasks.md`; `resolveUserId`/`coerceNullableInt` private →
+  `@spec exclude`.
+- [x] **task-10 (CROSS → webhook-payload-mapping)**: `WebhooksController::show`
+  → registry-views `#task-4` (CRUD); `WebhooksController::logStats` →
+  registry-views `#task-5` (delivery-log listing).
+- [x] **task-11 (CROSS → workflow-engine-abstraction)**:
+  `WorkflowEngineController` `show`/`update`/`destroy`/`testHook` → existing
+  engine-registration/CRUD REQ
+  (`retrofit-2026-04-30-annotate-openregister/tasks.md#task-91`).
+- [x] **task-12 (CROSS → exclude, framework override)**:
+  `GraphQLController::render` is the inline `Response` subclass's framework
+  `render()` override, not a route handler → `@spec exclude`.
+- [x] **task-13 (CROSS → exclude, accessors + debug)**: `SettingsController`
+  `getObjectService`/`getConfigurationService` are DI service accessors (not
+  routed) → `@spec exclude`; `testSchemaMapping`/`debugTypeFiltering` are
+  debug/test scaffolding endpoints → `@spec exclude` (see proposal Notes).


### PR DESCRIPTION
## Summary

Reverse-spec + ADR-003 `@spec` annotation of **148 uncovered controller methods across 27 files** (bundle `bw2-ctrl-1`). Documentation/annotation only — no runtime behavior change.

- **115 reverse-spec'd / 33 `@spec exclude`** (boilerplate / SPA-mount stubs / private helpers / debug).
- **3 ADDED REQs** (≤6 budget):
  - `generic-integrations` — ONE shared object-scoped integration-link REST contract covering 8 near-identical link controllers (Analytics/Collective/Map/OpenProject/Poll/Talk/Xwiki/Email). The "uniform CRUD across many controllers → one shared REQ" guardrail in action.
  - `search-index` — file text extraction + indexing HTTP surface (FileText/FileSearch semantic+hybrid/FileSidebar/FileSettings).
  - `zoeken-filteren` — search-trail analytics + audit API (SearchTrailController).
- **96** methods annotate to existing/archived REQs (registry resource-CRUD, calendar, chat-ai orchestrator, linked-entity, manifest, notificatie-engine, webhook, workflow-engine); **19** are net-new coverage under the 3 ADDED REQs.
- **33 excludes**: 21 `UiController` SPA-mount route stubs (contract owned by `no-code-app-builder`), link-controller `validateObject`/`mapException` helpers, the 6 `ChatStream` SSE-framing helpers, file-settings cURL helpers, and `SettingsController` DI accessors + debug endpoints.

## Notes (security/authz observations — not fixed here, per guardrail)

- `SettingsController::debugTypeFiltering()` / `::testSchemaMapping()` are routed debug/test endpoints that dump organisation/object data — information-disclosure surface worth gating admin-only or removing.
- The integration link controllers are intentionally session-user-scoped with no admin gate; the shared REQ documents this so any future non-user-scoped provider must add its own authz.

## Test plan

- [x] `php -l` clean on all 27 controllers.
- [x] `openspec validate retrofit-2026-05-25-bw2-ctrl-1 --strict` passes.
- [x] All 148 batch methods verified to carry a `@spec` (or `@spec exclude`) tag.