### PR TITLE
retrofit: backend coverage — Controllers (chunk 2)

### DIFF
--- a/lib/Controller/ActivityLinksController.php
+++ b/lib/Controller/ActivityLinksController.php
@@ -79,6 +79,8 @@ class ActivityLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -124,6 +126,8 @@ class ActivityLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function types(): JSONResponse
     {
@@ -139,6 +143,8 @@ class ActivityLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function actors(): JSONResponse
     {

--- a/lib/Controller/AgentsController.php
+++ b/lib/Controller/AgentsController.php
@@ -158,6 +158,8 @@ class AgentsController extends Controller
      * @return TemplateResponse Template response for agents SPA
      *
      * @psalm-return TemplateResponse<200, array<never, never>>
+     *
+     * @spec exclude SPA-mount stub — returns the Vue `index` template; client-side router owns navigation. No HTTP contract beyond the shell.
      */
     public function page(): TemplateResponse
     {

--- a/lib/Controller/AggregationController.php
+++ b/lib/Controller/AggregationController.php
@@ -131,6 +131,8 @@ class AggregationController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-15
      */
     public function timeseries(string $register, string $schema): JSONResponse
     {

--- a/lib/Controller/BookmarkLinksController.php
+++ b/lib/Controller/BookmarkLinksController.php
@@ -72,6 +72,8 @@ class BookmarkLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -111,6 +113,8 @@ class BookmarkLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function link(string $register, string $schema, string $id): JSONResponse
     {
@@ -162,6 +166,8 @@ class BookmarkLinksController extends Controller
      * @NoCSRFRequired
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function createNew(string $register, string $schema, string $id): JSONResponse
     {
@@ -230,6 +236,8 @@ class BookmarkLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function destroy(string $register, string $schema, string $id, string $bookmarkId): JSONResponse
     {
@@ -266,6 +274,8 @@ class BookmarkLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function available(): JSONResponse
     {

--- a/lib/Controller/ConfigurationController.php
+++ b/lib/Controller/ConfigurationController.php
@@ -152,6 +152,8 @@ class ConfigurationController extends Controller
      * @NoCSRFRequired
      *
      * @psalm-return JSONResponse<200|500, array<'Failed to fetch configurations'|Configuration>, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-2
      */
     public function index(): JSONResponse
     {
@@ -187,6 +189,8 @@ class ConfigurationController extends Controller
      *     array<never, never>>|JSONResponse<404|500,
      *     array{error: 'Configuration not found'|'Failed to fetch configuration'},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-2
      */
     public function show(int $id): JSONResponse
     {
@@ -217,6 +221,8 @@ class ConfigurationController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with enriched configuration details
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-2
      */
     public function enrichDetails(): JSONResponse
     {
@@ -298,6 +304,8 @@ class ConfigurationController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with created configuration
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-2
      */
     public function create(): JSONResponse
     {
@@ -365,6 +373,8 @@ class ConfigurationController extends Controller
      * @return JSONResponse JSON response with updated configuration
      *
      * @SuppressWarnings(PHPMD.NPathComplexity) Already refactored — NPath from try/catch + field mapping
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-2
      */
     public function update(int $id): JSONResponse
     {
@@ -468,6 +478,8 @@ class ConfigurationController extends Controller
      * @psalm-return JSONResponse<200|404|500,
      *     array{error?: 'Configuration not found'|'Failed to delete configuration',
      *     success?: true}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-2
      */
     public function destroy(int $id): JSONResponse
     {
@@ -509,6 +521,8 @@ class ConfigurationController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with version comparison
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-2
      */
     public function checkVersion(int $id): JSONResponse
     {
@@ -564,6 +578,8 @@ class ConfigurationController extends Controller
      * @psalm-suppress InvalidReturnType
      *
      * @return JSONResponse JSON response with configuration preview
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-2
      */
     public function preview(int $id): JSONResponse
     {
@@ -846,6 +862,8 @@ class ConfigurationController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with repositories list
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-2
      */
     public function getGitHubRepositories(): JSONResponse
     {
@@ -897,6 +915,8 @@ class ConfigurationController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with configuration files
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-2
      */
     public function getGitHubConfigurations(): JSONResponse
     {
@@ -996,6 +1016,8 @@ class ConfigurationController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with configuration files
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-2
      */
     public function getGitLabConfigurations(): JSONResponse
     {

--- a/lib/Controller/ConfigurationsController.php
+++ b/lib/Controller/ConfigurationsController.php
@@ -89,6 +89,8 @@ class ConfigurationsController extends Controller
      * @NoCSRFRequired
      *
      * @psalm-return JSONResponse<200, array{results: array<\OCA\OpenRegister\Db\Configuration>}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-2
      */
     public function index(): JSONResponse
     {
@@ -131,6 +133,8 @@ class ConfigurationsController extends Controller
      * @psalm-return JSONResponse<200, \OCA\OpenRegister\Db\Configuration,
      *     array<never, never>>|JSONResponse<404,
      *     array{error: 'Configuration not found'}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-2
      */
     public function show(int $id): JSONResponse
     {
@@ -159,6 +163,8 @@ class ConfigurationsController extends Controller
      * @psalm-return JSONResponse<201, \OCA\OpenRegister\Db\Configuration,
      *     array<never, never>>|JSONResponse<400, array{error: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-2
      */
     public function create(): JSONResponse
     {
@@ -218,6 +224,8 @@ class ConfigurationsController extends Controller
      * @psalm-return JSONResponse<200, \OCA\OpenRegister\Db\Configuration,
      *     array<never, never>>|JSONResponse<400, array{error: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-2
      */
     public function update(int $id): JSONResponse
     {
@@ -268,6 +276,8 @@ class ConfigurationsController extends Controller
      * @psalm-return JSONResponse<200, \OCA\OpenRegister\Db\Configuration,
      *     array<never, never>>|JSONResponse<400, array{error: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-2
      */
     public function patch(int $id): JSONResponse
     {
@@ -288,6 +298,8 @@ class ConfigurationsController extends Controller
      * @psalm-return JSONResponse<204, null,
      *     array<never, never>>|JSONResponse<400, array{error: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-2
      */
     public function destroy(int $id): JSONResponse
     {

--- a/lib/Controller/ContactsController.php
+++ b/lib/Controller/ContactsController.php
@@ -250,6 +250,8 @@ class ContactsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-16
      */
     public function createNew(string $register, string $schema, string $id): JSONResponse
     {

--- a/lib/Controller/CospendLinksController.php
+++ b/lib/Controller/CospendLinksController.php
@@ -81,6 +81,8 @@ class CospendLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -127,6 +129,8 @@ class CospendLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function link(string $register, string $schema, string $id): JSONResponse
     {
@@ -192,6 +196,8 @@ class CospendLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function createAndLink(string $register, string $schema, string $id): JSONResponse
     {
@@ -243,6 +249,8 @@ class CospendLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function destroy(string $register, string $schema, string $id, string $entryId): JSONResponse
     {
@@ -278,6 +286,8 @@ class CospendLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function available(): JSONResponse
     {

--- a/lib/Controller/DeckLinksController.php
+++ b/lib/Controller/DeckLinksController.php
@@ -73,6 +73,8 @@ class DeckLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -112,6 +114,8 @@ class DeckLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function link(string $register, string $schema, string $id): JSONResponse
     {
@@ -167,6 +171,8 @@ class DeckLinksController extends Controller
      *     field checks, two optional-field reads, two HTTP error mappings).
      *     Each branch carries a distinct surface contract — splitting would
      *     scatter the request-handling intent across helper methods.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function createNew(string $register, string $schema, string $id): JSONResponse
     {
@@ -228,6 +234,8 @@ class DeckLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function destroy(string $register, string $schema, string $id, string $cardId): JSONResponse
     {
@@ -261,6 +269,8 @@ class DeckLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function boards(): JSONResponse
     {
@@ -284,6 +294,8 @@ class DeckLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function stacks(string $boardId): JSONResponse
     {

--- a/lib/Controller/EmailsController.php
+++ b/lib/Controller/EmailsController.php
@@ -108,6 +108,8 @@ class EmailsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function index(
         string $register,
@@ -152,6 +154,8 @@ class EmailsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function create(
         string $register,
@@ -216,6 +220,8 @@ class EmailsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function destroy(
         string $register,

--- a/lib/Controller/EndpointsController.php
+++ b/lib/Controller/EndpointsController.php
@@ -152,6 +152,8 @@ class EndpointsController extends Controller
      *     array{error?: 'Failed to list endpoints',
      *     results?: array<\OCA\OpenRegister\Db\Endpoint>, total?: int<0, max>},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -208,6 +210,8 @@ class EndpointsController extends Controller
      *     array<never, never>>|JSONResponse<404|500,
      *     array{error: 'Endpoint not found'|'Failed to retrieve endpoint'},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -265,6 +269,8 @@ class EndpointsController extends Controller
      * @psalm-return JSONResponse<201, \OCA\OpenRegister\Db\Endpoint,
      *     array<never, never>>|JSONResponse<400|500, array{error: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -341,6 +347,8 @@ class EndpointsController extends Controller
      * @psalm-return JSONResponse<200, \OCA\OpenRegister\Db\Endpoint,
      *     array<never, never>>|JSONResponse<404|500, array{error: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -435,6 +443,8 @@ class EndpointsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -450,6 +460,8 @@ class EndpointsController extends Controller
      * @param int $id The endpoint ID to delete.
      *
      * @return JSONResponse Empty response on success or error response on failure.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -527,6 +539,8 @@ class EndpointsController extends Controller
      *     array{error?: string, success?: bool, message?: string,
      *     statusCode?: int, response?: mixed},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-4
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -612,6 +626,8 @@ class EndpointsController extends Controller
      *     array{error?: 'Endpoint not found'|'Failed to retrieve endpoint logs',
      *     results?: list<\OCA\OpenRegister\Db\EndpointLog>, total?: int<0, max>},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-6
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -685,6 +701,8 @@ class EndpointsController extends Controller
      *     array{error?: 'Endpoint not found'|
      *     'Failed to retrieve endpoint log statistics', total?: int,
      *     success?: int, failed?: int}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-6
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -748,6 +766,8 @@ class EndpointsController extends Controller
      *     array{error?: string, results?: array<\OCA\OpenRegister\Db\EndpointLog>,
      *     total?: int<0, max>},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-6
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -242,6 +242,8 @@ class FilesController extends Controller
      * @NoCSRFRequired
      *
      * @PublicPage
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-12
      */
     public function show(
         string $register,
@@ -424,6 +426,8 @@ class FilesController extends Controller
      *     array<never, never>>
      *
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-12
      */
     public function save(
         string $register,
@@ -520,6 +524,8 @@ class FilesController extends Controller
      * @NoCSRFRequired
      *
      * @psalm-return JSONResponse<200|400|404, array{error?: string, 0?: array<string, mixed>,...}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-12
      */
     public function createMultipart(
         string $register,
@@ -835,6 +841,8 @@ class FilesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-12
      */
     public function update(
         string $register,
@@ -992,6 +1000,8 @@ class FilesController extends Controller
      * @psalm-return JSONResponse<200|400|404,
      *     array{error?: mixed|string, labels?: list<string>,...},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-12
      */
     public function depublish(
         string $register,
@@ -1051,6 +1061,8 @@ class FilesController extends Controller
      * @psalm-return JSONResponse<404|500, array{error: string},
      *     array<never, never>>|\OCP\AppFramework\Http\StreamResponse<200,
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-12
      */
     public function downloadById(int $fileId): JSONResponse|\OCP\AppFramework\Http\StreamResponse
     {
@@ -1634,6 +1646,8 @@ class FilesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-12
      */
     public function batch(string $register, string $schema, string $id): JSONResponse
     {
@@ -1746,6 +1760,8 @@ class FilesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-12
      */
     public function updateLabels(string $register, string $schema, string $id, int $fileId): JSONResponse
     {
@@ -1790,6 +1806,8 @@ class FilesController extends Controller
      * @return TemplateResponse
      *
      * @psalm-return TemplateResponse<200, array<never, never>>
+     *
+     * @spec exclude SPA-mount stub — returns the Vue `index` template; client-side router owns navigation. No HTTP contract beyond the shell.
      */
     public function page(): TemplateResponse
     {

--- a/lib/Controller/FlowLinksController.php
+++ b/lib/Controller/FlowLinksController.php
@@ -80,6 +80,8 @@ class FlowLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -123,6 +125,8 @@ class FlowLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function link(string $register, string $schema, string $id): JSONResponse
     {
@@ -171,6 +175,8 @@ class FlowLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function destroy(string $register, string $schema, string $id, string $operationId): JSONResponse
     {
@@ -210,6 +216,8 @@ class FlowLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function available(): JSONResponse
     {

--- a/lib/Controller/FormLinksController.php
+++ b/lib/Controller/FormLinksController.php
@@ -120,6 +120,8 @@ class FormLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -158,6 +160,8 @@ class FormLinksController extends Controller
      * @NoCSRFRequired
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function link(string $register, string $schema, string $id): JSONResponse
     {
@@ -238,6 +242,8 @@ class FormLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function create(string $register, string $schema, string $id): JSONResponse
     {
@@ -299,6 +305,8 @@ class FormLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function destroyForm(string $register, string $schema, string $id, string $formId): JSONResponse
     {
@@ -335,6 +343,8 @@ class FormLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function destroySubmission(
         string $register,
@@ -375,6 +385,8 @@ class FormLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function available(): JSONResponse
     {

--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -66,6 +66,8 @@ class HealthController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse Health status
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-18
      */
     public function index(): JSONResponse
     {

--- a/lib/Controller/IntegrationsController.php
+++ b/lib/Controller/IntegrationsController.php
@@ -85,6 +85,8 @@ class IntegrationsController extends Controller
      *   - enabled=true     filter to isEnabled() === true
      *
      * @return JSONResponse JSON list of integration descriptors.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-11
      */
     #[NoAdminRequired]
     public function index(): JSONResponse
@@ -125,6 +127,8 @@ class IntegrationsController extends Controller
      * @param string $id Integration id (e.g. 'files', 'xwiki').
      *
      * @return JSONResponse Single descriptor or 404.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-11
      */
     #[NoAdminRequired]
     public function show(string $id): JSONResponse

--- a/lib/Controller/MappingsController.php
+++ b/lib/Controller/MappingsController.php
@@ -99,6 +99,8 @@ class MappingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with array of mappings
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     public function index(): JSONResponse
     {
@@ -153,6 +155,8 @@ class MappingsController extends Controller
      * @NoAdminRequired
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     public function show(int|string $id): JSONResponse
     {
@@ -176,6 +180,8 @@ class MappingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with created mapping
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     public function create(): JSONResponse
     {
@@ -226,6 +232,8 @@ class MappingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with updated mapping
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     public function update(int $id): JSONResponse
     {
@@ -285,6 +293,8 @@ class MappingsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     public function patch(int $id): JSONResponse
     {
@@ -302,6 +312,8 @@ class MappingsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse Empty JSON response on success
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     public function destroy(int $id): JSONResponse
     {
@@ -330,6 +342,8 @@ class MappingsController extends Controller
      * @return JSONResponse JSON response with test results
      *
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-4
      */
     public function test(): JSONResponse
     {

--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -63,6 +63,8 @@ class MetricsController extends Controller
      * @NoCSRFRequired
      *
      * @return TextPlainResponse Prometheus-formatted metrics
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-18
      */
     public function index(): TextPlainResponse
     {

--- a/lib/Controller/ObjectIntegrationsController.php
+++ b/lib/Controller/ObjectIntegrationsController.php
@@ -100,6 +100,8 @@ class ObjectIntegrationsController extends Controller
      * @param string $integrationId Integration id.
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-11
      */
     #[NoAdminRequired]
     public function index(string $register, string $schema, string $id, string $integrationId): JSONResponse
@@ -124,6 +126,8 @@ class ObjectIntegrationsController extends Controller
      * @param string $entityId      Linked-thing id.
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-11
      */
     #[NoAdminRequired]
     public function show(string $register, string $schema, string $id, string $integrationId, string $entityId): JSONResponse
@@ -145,6 +149,8 @@ class ObjectIntegrationsController extends Controller
      * @param string $integrationId Integration id.
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-11
      */
     #[NoAdminRequired]
     public function create(string $register, string $schema, string $id, string $integrationId): JSONResponse
@@ -169,6 +175,8 @@ class ObjectIntegrationsController extends Controller
      * @param string $entityId      Linked-thing id.
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-11
      */
     #[NoAdminRequired]
     public function update(string $register, string $schema, string $id, string $integrationId, string $entityId): JSONResponse
@@ -192,6 +200,8 @@ class ObjectIntegrationsController extends Controller
      * @param string $entityId      Linked-thing id.
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-11
      */
     #[NoAdminRequired]
     public function destroy(string $register, string $schema, string $id, string $integrationId, string $entityId): JSONResponse

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -2325,6 +2325,8 @@ class ObjectsController extends Controller
      * @NoAdminRequired
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-13
      */
     public function postPatch(
         string $register,
@@ -2495,6 +2497,8 @@ class ObjectsController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-14
      */
     public function canDelete(
         string $id,

--- a/lib/Controller/PhotoLinksController.php
+++ b/lib/Controller/PhotoLinksController.php
@@ -78,6 +78,8 @@ class PhotoLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -122,6 +124,8 @@ class PhotoLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function link(string $register, string $schema, string $id): JSONResponse
     {
@@ -171,6 +175,8 @@ class PhotoLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function createAndLink(string $register, string $schema, string $id): JSONResponse
     {
@@ -219,6 +225,8 @@ class PhotoLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function destroy(string $register, string $schema, string $id, string $albumId): JSONResponse
     {
@@ -254,6 +262,8 @@ class PhotoLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function available(): JSONResponse
     {

--- a/lib/Controller/RegistersController.php
+++ b/lib/Controller/RegistersController.php
@@ -245,6 +245,8 @@ class RegistersController extends Controller
      *
      * @suppressWarnings(PHPMD.NPathComplexity)      Complex request parameter handling for flexible API
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     public function index(): JSONResponse
     {
@@ -395,6 +397,8 @@ class RegistersController extends Controller
      * @NoAdminRequired
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     public function show($id): JSONResponse
     {
@@ -433,6 +437,8 @@ class RegistersController extends Controller
      * @psalm-return JSONResponse<201, Register,
      *     array<never, never>>|JSONResponse<int, array{error: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     public function create(): JSONResponse
     {
@@ -504,6 +510,8 @@ class RegistersController extends Controller
      * @psalm-return JSONResponse<200, Register,
      *     array<never, never>>|JSONResponse<int, array{error: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     public function update(int $id): JSONResponse
     {
@@ -617,6 +625,8 @@ class RegistersController extends Controller
      * @psalm-return JSONResponse<200, Register,
      *     array<never, never>>|JSONResponse<int, array{error: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     public function patch(int $id): JSONResponse
     {
@@ -642,6 +652,8 @@ class RegistersController extends Controller
      *
      * @psalm-return JSONResponse<int, array{error?: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     public function destroy(int $id): JSONResponse
     {
@@ -720,6 +732,8 @@ class RegistersController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with schemas or error
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-4
      */
     public function schemas(int|string $id): JSONResponse
     {
@@ -762,6 +776,8 @@ class RegistersController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with objects
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-4
      */
     public function objects(int $register, int $schema): JSONResponse
     {
@@ -790,6 +806,8 @@ class RegistersController extends Controller
      * @NoAdminRequired
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-10
      */
     public function export(int $id): JSONResponse|DataDownloadResponse
     {
@@ -879,6 +897,8 @@ class RegistersController extends Controller
      * @NoAdminRequired
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-10
      */
     public function importTemplate(int|string $id, int|string $schema): JSONResponse|DataDownloadResponse
     {
@@ -949,6 +969,8 @@ class RegistersController extends Controller
      * @suppressWarnings(PHPMD.NPathComplexity)       GitHub publishing requires many conditional checks
      * @suppressWarnings(PHPMD.ExcessiveMethodLength)
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-5
      */
     public function publishToGitHub(int $id): JSONResponse
     {
@@ -1115,6 +1137,8 @@ class RegistersController extends Controller
      * @suppressWarnings(PHPMD.ExcessiveMethodLength)
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
      * @suppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-10
      */
     public function import(int $id, bool $force=false): JSONResponse
     {
@@ -1318,6 +1342,8 @@ class RegistersController extends Controller
      * @return JSONResponse Report with counts and per-object outcomes.
      *
      * @NoAdminRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-10
      */
     public function rollbackImport(): JSONResponse
     {
@@ -1433,6 +1459,8 @@ class RegistersController extends Controller
      *     },
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-6
      */
     public function stats(int $id): JSONResponse
     {
@@ -1550,6 +1578,8 @@ class RegistersController extends Controller
      *     },
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-5
      */
     public function publish(int $id): JSONResponse
     {
@@ -1652,6 +1682,8 @@ class RegistersController extends Controller
      *     },
      *     array<never, never>
      * >
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-5
      */
     public function depublish(int $id): JSONResponse
     {

--- a/lib/Controller/ScheduledWorkflowController.php
+++ b/lib/Controller/ScheduledWorkflowController.php
@@ -58,6 +58,8 @@ class ScheduledWorkflowController extends Controller
      * @NoAdminRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-17
      */
     public function index(): JSONResponse
     {
@@ -76,6 +78,8 @@ class ScheduledWorkflowController extends Controller
      * @NoAdminRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-17
      */
     public function show(int $id): JSONResponse
     {
@@ -92,6 +96,8 @@ class ScheduledWorkflowController extends Controller
      * Create a new scheduled workflow.
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-17
      */
     public function create(): JSONResponse
     {
@@ -122,6 +128,8 @@ class ScheduledWorkflowController extends Controller
      * @param int $id Scheduled workflow ID
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-17
      */
     public function update(int $id): JSONResponse
     {
@@ -152,6 +160,8 @@ class ScheduledWorkflowController extends Controller
      * @param int $id Scheduled workflow ID
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-17
      */
     public function destroy(int $id): JSONResponse
     {

--- a/lib/Controller/SchemasController.php
+++ b/lib/Controller/SchemasController.php
@@ -154,6 +154,8 @@ class SchemasController extends Controller
      *
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
      * @suppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     public function index(): JSONResponse
     {
@@ -264,6 +266,8 @@ class SchemasController extends Controller
      * @NoCSRFRequired
      *
      * @PublicPage
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     public function show($id): JSONResponse
     {
@@ -337,6 +341,8 @@ class SchemasController extends Controller
      * @psalm-return JSONResponse<201, Schema,
      *     array<never, never>>|JSONResponse<int, array{error: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     public function create(): JSONResponse
     {
@@ -462,6 +468,8 @@ class SchemasController extends Controller
      * @psalm-return JSONResponse<200, Schema,
      *     array<never, never>>|JSONResponse<int, array{error: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     public function update(int $id): JSONResponse
     {
@@ -603,6 +611,8 @@ class SchemasController extends Controller
      * @psalm-return JSONResponse<200, Schema,
      *     array<never, never>>|JSONResponse<int, array{error: string},
      *     array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     public function patch(int $id): JSONResponse
     {
@@ -625,6 +635,8 @@ class SchemasController extends Controller
      * @NoCSRFRequired
      *
      * @psalm-return JSONResponse<200|409|500, array{error?: string}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
      */
     public function destroy(int $id): JSONResponse
     {
@@ -712,6 +724,8 @@ class SchemasController extends Controller
      * @NoAdminRequired
      *
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-4
      */
     public function uploadUpdate(?int $id=null): JSONResponse
     {
@@ -739,6 +753,8 @@ class SchemasController extends Controller
      * @suppressWarnings(PHPMD.ExcessiveMethodLength)
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
      * @suppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-4
      */
     public function upload(?int $id=null): JSONResponse
     {
@@ -866,6 +882,8 @@ class SchemasController extends Controller
      * @psalm-return JSONResponse<200, Schema,
      *     array<never, never>>|JSONResponse<404,
      *     array{error: 'Schema not found'}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-4
      */
     public function download(int $id): JSONResponse
     {
@@ -895,6 +913,8 @@ class SchemasController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with related schemas
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-4
      */
     public function related(int|string $id): JSONResponse
     {
@@ -956,6 +976,8 @@ class SchemasController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with schema statistics
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-6
      */
     public function stats(int $id): JSONResponse
     {
@@ -1012,6 +1034,8 @@ class SchemasController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with exploration results
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-4
      */
     public function explore(int $id): JSONResponse
     {
@@ -1051,6 +1075,8 @@ class SchemasController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with updated schema
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-4
      */
     public function updateFromExploration(int $id): JSONResponse
     {
@@ -1124,6 +1150,8 @@ class SchemasController extends Controller
      *     published?: null|string, depublished?: null|string,
      *     configuration?: array|null|string, allOf?: array|null,
      *     oneOf?: array|null, anyOf?: array|null}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-5
      */
     public function publish(int $id): JSONResponse
     {
@@ -1208,6 +1236,8 @@ class SchemasController extends Controller
      *     published?: null|string, depublished?: null|string,
      *     configuration?: array|null|string, allOf?: array|null,
      *     oneOf?: array|null, anyOf?: array|null}, array<never, never>>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-5
      */
     public function depublish(int $id): JSONResponse
     {

--- a/lib/Controller/ShareLinksController.php
+++ b/lib/Controller/ShareLinksController.php
@@ -79,6 +79,8 @@ class ShareLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -113,6 +115,8 @@ class ShareLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function create(string $register, string $schema, string $id): JSONResponse
     {
@@ -172,6 +176,8 @@ class ShareLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function destroy(string $register, string $schema, string $id, string $shareId): JSONResponse
     {
@@ -202,6 +208,8 @@ class ShareLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function files(string $register, string $schema, string $id): JSONResponse
     {

--- a/lib/Controller/TimeTrackerLinksController.php
+++ b/lib/Controller/TimeTrackerLinksController.php
@@ -82,6 +82,8 @@ class TimeTrackerLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function index(string $register, string $schema, string $id): JSONResponse
     {
@@ -126,6 +128,8 @@ class TimeTrackerLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function link(string $register, string $schema, string $id): JSONResponse
     {
@@ -181,6 +185,8 @@ class TimeTrackerLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function createAndLink(string $register, string $schema, string $id): JSONResponse
     {
@@ -229,6 +235,8 @@ class TimeTrackerLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function destroy(string $register, string $schema, string $id, string $entryId): JSONResponse
     {
@@ -264,6 +272,8 @@ class TimeTrackerLinksController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-1
      */
     public function available(): JSONResponse
     {

--- a/lib/Controller/UrnController.php
+++ b/lib/Controller/UrnController.php
@@ -70,6 +70,8 @@ class UrnController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-9
      */
     public function resolve(?string $urn=null): JSONResponse
     {
@@ -114,6 +116,8 @@ class UrnController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-9
      */
     public function lookup(?string $url=null): JSONResponse
     {
@@ -150,6 +154,8 @@ class UrnController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-9
      */
     public function bulk(?array $urns=null): JSONResponse
     {

--- a/lib/Controller/ViewsController.php
+++ b/lib/Controller/ViewsController.php
@@ -105,6 +105,8 @@ class ViewsController extends Controller
      * @return JSONResponse JSON response with views or error
      *
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-8
      */
     public function index(): JSONResponse
     {
@@ -195,6 +197,8 @@ class ViewsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with view or error
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-8
      */
     public function show(string $id): JSONResponse
     {
@@ -258,6 +262,8 @@ class ViewsController extends Controller
      * @return JSONResponse JSON response with created view or error
      *
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-8
      */
     public function create(): JSONResponse
     {
@@ -372,6 +378,8 @@ class ViewsController extends Controller
      * @return JSONResponse JSON response with updated view or error
      *
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-8
      */
     public function update(string $id): JSONResponse
     {
@@ -497,6 +505,8 @@ class ViewsController extends Controller
      * @return JSONResponse JSON response with patched view or error
      *
      * @suppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-8
      */
     public function patch(string $id): JSONResponse
     {
@@ -606,6 +616,8 @@ class ViewsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse JSON response with delete confirmation or error
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-8
      */
     public function destroy(string $id): JSONResponse
     {

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/proposal.md
@@ -1,0 +1,186 @@
+---
+status: draft
+retrofit: true
+---
+
+# Retrofit: Reverse-spec controller bundle — Controllers (chunk 2)
+
+## Why
+
+A coverage scan of OpenRegister's controller layer surfaced 148 uncovered
+public methods across 28 controller files (`/tmp/or-scan/bw2-ctrl-2.json`)
+that carried no `@spec` tag, violating ADR-003's "every class and public
+method MUST have an `@spec` PHPDoc tag" rule. The underlying services are
+implemented; what was missing is the *controller* HTTP-surface contract
+(route shape, status codes, parameter handling, error envelopes,
+degradation behaviour).
+
+This ghost change reverse-specs the observed controller behaviour and tags
+every one of the 148 methods. Per ADR-003's two-tool convention each method
+ends either:
+
+- **reverse-spec'd** — load-bearing endpoints get an `@spec` tag pointing at
+  the capability that owns their contract (extended by route family, or an
+  existing REQ annotated), or
+- **`@spec exclude <reason>`** — boilerplate (constructors, SPA-mount stubs,
+  thin passthroughs, error-mapping helpers, private resolvers) is excluded
+  with a required reason.
+
+The change biases strongly toward **annotation-only**: most of the 148
+methods are already owned by a live capability spec or an in-flight retrofit
+change (the `2026-05-24-b-ctrl-*` series, `pluggable-integration-registry`,
+`urn-resource-addressing`, `object-interactions`, `workflow-operations`,
+`data-import-export`, `referential-integrity`, `production-observability`,
+`contacts-actions`, `add-time-bucket-aggregation`). Only the genuinely
+uncovered HTTP surfaces get new REQs (5 new REQs total, within the ≤6
+budget). This is a documentation/annotation change only — no runtime
+behaviour is modified.
+
+## What changes
+
+### Counts
+
+| Outcome | Methods |
+|---|---|
+| Reverse-spec'd (annotated to an `@spec` tag) | 146 |
+| `@spec exclude` (boilerplate) | 2 |
+| **Total** | **148** |
+| New REQs added | 5 |
+
+The 2 excludes are the two SPA-mount template stubs
+(`AgentsController::page`, `FilesController::page`) — each returns the Vue
+`index` template with client-side routing and carries no HTTP contract beyond
+the shell. The batch's 148 are exactly the uncovered **public** methods;
+constructors and the per-controller `validateObject` / `mapException` /
+`unavailable` / `nullableString` / `nullableInt` / `dropdown` /
+`currentUserIsAdmin` / `describe` private helpers are not in the batch
+(they are governed by the consolidated REQs / class-level `@spec`) and are
+left untouched.
+
+### Per-capability deltas
+
+#### 1. `generic-integrations` — NEW REQ (one shared REQ, uniform CRUD)
+
+The Tier-2 integration "leaf" link controllers
+(`ActivityLinksController`, `BookmarkLinksController`,
+`CospendLinksController`, `DeckLinksController`, `FlowLinksController`,
+`FormLinksController`, `PhotoLinksController`, `TimeTrackerLinksController`,
+`ShareLinksController`) and `EmailsController` share one uniform
+object-scoped link-CRUD contract:
+`index` (list), `link`/`create`/`createNew`/`createAndLink` (link-existing
+and create-and-link), `destroy` (unlink), plus a picker-source discovery
+surface (`available` / `boards` / `stacks` / `operations` / `types` /
+`actors`), with a uniform `501 APP_NOT_AVAILABLE` graceful-degradation
+envelope when the backing Nextcloud app is absent. Per the "one shared REQ
+for uniform CRUD" guardrail this is captured as **one** consolidated REQ, not
+one per controller. → 1 new REQ.
+
+#### 2. `data-import-export` — NEW REQ (config management + Git-remote sync)
+
+`ConfigurationController` and `ConfigurationsController` are the
+configuration-management + Git-remote-sync surface: CRUD over configuration
+entities, plus version-check / preview / detail-enrichment against a remote,
+and GitHub/GitLab repository + file discovery for config import. The existing
+`data-import-export` "Configuration import/export MUST support full register
+portability" REQ covers the *portability file format* but **not** the
+configuration-entity CRUD or the Git-remote-sync HTTP surface. The
+`export`/`import` methods on both controllers are annotated to the existing
+portability REQ; the CRUD + Git-sync surface gets one new REQ. → 1 new REQ.
+
+#### 3. `openapi-generation` — NEW REQ (schema authoring sub-resources + meta-entity operational endpoints)
+
+`SchemasController` schema-authoring sub-resources (`download`, `upload`,
+`uploadUpdate`, `related`, `explore`, `updateFromExploration`) and the
+registry-meta-entity *operational* endpoints that the shared resource-CRUD
+REQ (registry-views task-1) explicitly defers — `EndpointsController::test`
+and `MappingsController::test` (dry-run validation), plus the
+`RegistersController` register→schema and register→objects sub-resource
+lookups (`schemas`, `objects`) — get one new REQ here. → 1 new REQ.
+
+#### 4. `oas-generation` — NEW REQ (publish / depublish HTTP surface)
+
+`RegistersController` (`publish`, `depublish`, `publishToGitHub`) and
+`SchemasController` (`publish`, `depublish`) expose the register/schema
+publication lifecycle and OAS-to-GitHub publishing surface. `oas-generation`
+owns OAS document generation but has no REQ for the publish/depublish
+controller verbs. → 1 new REQ.
+
+#### 5. `production-observability` — NEW REQ (per-entity statistics + endpoint delivery logs)
+
+`RegistersController::stats`, `SchemasController::stats`, and the
+`EndpointsController` delivery-log surface (`logs`, `logStats`, `allLogs`)
+are operational/observability read endpoints. `production-observability`
+covers the Prometheus + health endpoints but has no REQ for per-entity
+statistics or the custom-endpoint delivery-log API. → 1 new REQ.
+
+### Annotate-only (no new REQ) — referenced existing specs
+
+- **openapi-generation** (registry-views task-1) — meta-entity resource CRUD
+  (`index`/`show`/`create`/`update`/`patch`/`destroy`) for
+  `RegistersController`, `SchemasController`, `EndpointsController`,
+  `MappingsController`. `ConfigurationsController` CRUD is annotated to the
+  new `data-import-export` config-management REQ instead (it is a config
+  entity, not in the task-1 meta-entity set).
+- **faceting-configuration** (registry-views task-2/3) —
+  `ViewsController` (`index`/`show`/`create`/`update`/`patch`/`destroy`).
+- **urn-resource-addressing** (registry-views task-7) —
+  `UrnController` (`resolve`/`lookup`/`bulk`).
+- **data-import-export** (existing REQs) — `RegistersController`
+  (`import`/`export`/`importTemplate`/`rollbackImport`).
+- **pluggable-integration-registry** (task-18/19) —
+  `IntegrationsController` (`index`/`show`) and
+  `ObjectIntegrationsController` (`index`/`show`/`create`/`update`/`destroy`)
+  — class already annotated; method-level tags added.
+- **object-interactions** ("File Attachments on Objects" / "Tags for Object
+  Categorization") — `FilesController`
+  (`show`/`save`/`createMultipart`/`update`/`depublish`/`downloadById`/`batch`/`updateLabels`).
+- **object CRUD** (annotate-openregister) — `ObjectsController::postPatch`
+  (multipart PATCH workaround).
+- **referential-integrity** — `ObjectsController::canDelete` (pre-flight
+  deletion analysis; the REQ scenarios already reference `canDelete()` and
+  `DeletionAnalysis`).
+- **add-time-bucket-aggregation** (task 2.1) —
+  `AggregationController::timeseries`.
+- **contacts-actions** (task-1) — `ContactsController::createNew`.
+- **workflow-operations** ("Scheduled Workflow Triggers") —
+  `ScheduledWorkflowController` (`index`/`show`/`create`/`update`/`destroy`).
+- **production-observability** ("Prometheus Metrics Endpoint" / "Health Check
+  Endpoint") — `MetricsController::index`, `HealthController::index`.
+- **chat-ai** (existing) — `AgentsController` is covered at class level; its
+  uncovered `page` is an SPA-mount stub (excluded).
+
+## Impact
+
+- Specs extended (new REQs): `generic-integrations`, `data-import-export`,
+  `openapi-generation`, `oas-generation`, `production-observability`.
+- Specs referenced (annotation targets, no delta): `faceting-configuration`,
+  `urn-resource-addressing`, `pluggable-integration-registry`,
+  `object-interactions`, `referential-integrity`, `add-time-bucket-aggregation`,
+  `contacts-actions`, `workflow-operations`.
+- Controllers annotated: all 28 in the batch.
+- No code behaviour change; docblock `@spec` / `@spec exclude` annotations only.
+
+## Security / authz notes (surfaced, not fixed here)
+
+These were observed during the reverse-spec and are recorded as Notes for a
+follow-up; this change does not modify behaviour:
+
+- **`ScheduledWorkflowController`** — all five CRUD verbs are
+  `@NoAdminRequired`, but the `workflow-operations` "Scheduled Workflow
+  Triggers" REQ scenarios assume an authenticated **admin**. A non-admin can
+  currently create/update/delete scheduled workflows that run server-side
+  TimedJobs. The controller also calls `ScheduledWorkflowMapper` directly,
+  violating ADR-003's Controller→Service→Mapper rule (no service-layer RBAC
+  gate between the HTTP surface and the mapper).
+- **`ObjectsController::postPatch`** — annotated `@PublicPage` +
+  `@NoAdminRequired`, exposing an object create/update (with file upload) path
+  to unauthenticated callers. RBAC is enforced downstream in `ObjectService`,
+  but the public-page annotation widens the attack surface relative to the
+  PUT/PATCH siblings.
+- **`UrnController::bulk`** — the 1000-URN cap is the only DoS guard on an
+  endpoint reachable by every authenticated user (~4 DB round-trips per URN);
+  the in-code comment documents this. No per-user rate limit upstream.
+- **`RegistersController::rollbackImport`** — wipes every object created by an
+  import job; the in-code guard requires the caller to be the original
+  importer or an admin, but the audit lookup does not filter by organisation
+  (cross-tenant exposure if the importer-UID check is bypassed).

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/data-import-export/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/data-import-export/spec.md
@@ -1,0 +1,65 @@
+---
+status: draft
+---
+
+# data-import-export
+
+## Purpose
+
+Extend data-import-export with the configuration-management and Git-remote
+synchronisation HTTP surface. The existing "Configuration import/export MUST
+support full register portability" requirement defines the portability *file
+format* and the export/import handlers, but there is no requirement for the
+configuration-entity CRUD or for the remote version-check / preview /
+GitHub-GitLab discovery surface that drives configuration sync from the UI.
+Reverse-specced from the live `ConfigurationController` and
+`ConfigurationsController`.
+
+## ADDED Requirements
+
+### Requirement: Configuration Management and Git-Remote Sync HTTP Surface
+
+The system MUST expose a configuration-management REST surface and a
+Git-remote synchronisation surface so administrators can manage configuration
+entities and import/sync configurations from GitHub or GitLab.
+`ConfigurationsController` MUST provide resource CRUD
+(`index`/`show`/`create`/`update`/`patch`/`destroy`) over configuration
+entities, returning `404` for unknown ids and `201` on create where set
+explicitly. `ConfigurationController` MUST additionally expose:
+
+- `checkVersion` (`POST /api/configurations/{id}/check-version`) — compare the
+  stored configuration against its remote source version;
+- `preview` (`GET /api/configurations/{id}/preview`) — return the diff/preview
+  of pending changes without applying them;
+- `enrichDetails` (`GET /api/configurations/enrich`) — fetch and attach the
+  actual remote file contents to configuration descriptors;
+- `getGitHubRepositories` (`GET /api/configurations/github/repositories`) —
+  list repositories the authenticated user can access;
+- `getGitHubConfigurations` (`GET /api/configurations/github/files`) — list
+  configuration files in a GitHub repository; and
+- `getGitLabConfigurations` (`GET /api/configurations/gitlab/files`) — the
+  GitLab equivalent.
+
+The Git-discovery endpoints MUST resolve the caller's credentials/token from
+configuration and MUST NOT leak repository contents the caller cannot access.
+The configuration `export` and `import` methods on both controllers remain
+governed by the existing "Configuration import/export MUST support full
+register portability" requirement and are not redefined here.
+
+#### Scenario: CRUD over configuration entities
+- **GIVEN** a configuration entity with a known id
+- **WHEN** `GET /api/configurations/{id}` is called
+- **THEN** the response MUST return HTTP 200 with the entity's JSON serialization
+- **AND** an unknown id MUST return HTTP 404 with an `{error}` body
+- **AND** `PATCH /api/configurations/{id}` MUST apply a partial update via the same write path as `update`
+
+#### Scenario: Check a configuration against its remote version
+- **GIVEN** a configuration with a remote source
+- **WHEN** `POST /api/configurations/{id}/check-version` is called
+- **THEN** the response MUST report whether the remote version is newer, equal, or older than the stored configuration
+
+#### Scenario: Discover GitHub configuration files
+- **GIVEN** an authenticated user with a configured GitHub token
+- **WHEN** `GET /api/configurations/github/files` is called for a repository
+- **THEN** the response MUST list the configuration files in that repository
+- **AND** repositories or files the caller cannot access MUST NOT be returned

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/generic-integrations/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/generic-integrations/spec.md
@@ -1,0 +1,85 @@
+---
+status: draft
+---
+
+# generic-integrations
+
+## Purpose
+
+Extend the generic-integrations capability with the uniform HTTP contract
+shared by the Tier-2 integration "leaf" link controllers. The existing spec
+covers the query-time `SharesProvider` and the registry surfacing; it has no
+requirement for the object-scoped link-CRUD contract that every leaf
+controller (Bookmarks, Cospend, Deck, Flow, Forms, Photos, TimeTracker,
+Activity, Shares, Mail) implements identically. Reverse-specced from the live
+`*LinksController` / `EmailsController` family. The `shares` leaf
+(`ShareLinksController`) is the same object-scoped link surface over NC core
+shares (the query-time `SharesProvider` documented elsewhere in this spec is
+its backing provider).
+
+## ADDED Requirements
+
+### Requirement: Tier-2 Integration Leaf Link Controller Contract
+
+The system MUST expose object-scoped integration "leaf" link controllers that
+share one uniform REST contract so a Nextcloud entity (bookmark, Cospend
+project/bill, Deck card, Flow operation, Form/submission, Photos album,
+TimeManager entry, Activity entry, mail message) can be linked to an
+OpenRegister object. Each leaf controller MUST resolve the target object from
+the `{register}/{schema}/{id}` path triple and MUST return `404` with an
+`{error}` body when the object does not resolve. The contract comprises:
+
+- a **list** verb (`index`, `GET /api/objects/{register}/{schema}/{id}/{leaf}`)
+  returning `{results, total}`;
+- a **link-existing** verb (`link`/`create`,
+  `POST /api/objects/{register}/{schema}/{id}/{leaf}`) returning `201` with the
+  link's JSON serialization, validating the required reference id in the body
+  and returning `400` when it is missing;
+- where the backing app supports creation, a **create-and-link** verb
+  (`createNew`/`createAndLink`/`create`,
+  `POST /api/objects/{register}/{schema}/{id}/{leaf}/new`) returning `201`;
+- an **unlink** verb (`destroy`,
+  `DELETE /api/objects/{register}/{schema}/{id}/{leaf}/{entityId}`) returning a
+  success body; and
+- one or more **picker-source discovery** verbs
+  (`available` / `boards` / `stacks` / `operations` / `types` / `actors`,
+  under `/api/integrations/{leaf}/...`) that surface candidate entities for the
+  link modal without leaking the backing app's internals.
+
+Every verb MUST degrade gracefully when the backing Nextcloud app is not
+installed by returning HTTP `501` with the envelope
+`{error, code: "APP_NOT_AVAILABLE"}`. Service-layer exceptions MUST be mapped
+to HTTP status by exception code (`409` conflict, `404` not found, `503`
+unavailable, `400` bad request). Read-only leaves (Activity) MUST expose only
+the list + discovery verbs and omit link/create/unlink. Admin-gated leaves
+(Flow) MUST restrict mutating verbs to admins while leaving list read-only for
+all authenticated users.
+
+#### Scenario: List linked entities for an object
+- **GIVEN** an OpenRegister object resolvable from `{register}/{schema}/{id}` and the backing app installed
+- **WHEN** `GET /api/objects/{register}/{schema}/{id}/{leaf}` is called
+- **THEN** the response MUST be HTTP 200 with a `{results, total}` body
+- **AND** an unresolvable object MUST return HTTP 404 with an `{error}` body
+
+#### Scenario: Link an existing entity requires the reference id
+- **GIVEN** a resolvable object
+- **WHEN** the link verb is called without the required reference id in the body
+- **THEN** the response MUST be HTTP 400 with an `{error}` body
+- **AND** a valid link request MUST return HTTP 201 with the link's JSON serialization
+
+#### Scenario: Graceful degradation when the backing app is absent
+- **GIVEN** the backing Nextcloud app (e.g. Bookmarks, Cospend, Deck) is not installed
+- **WHEN** any verb on the corresponding leaf controller is called
+- **THEN** the response MUST be HTTP 501 with the body `{error, code: "APP_NOT_AVAILABLE"}`
+
+#### Scenario: Picker-source discovery surfaces candidates without internals
+- **GIVEN** the backing app is installed
+- **WHEN** the discovery verb (`available`/`boards`/`stacks`/`operations`/`types`/`actors`) is called
+- **THEN** the response MUST return the candidate entities visible to the current user as `{results, total}` (or the verb-specific shape)
+- **AND** entities the current user cannot see MUST be omitted
+
+#### Scenario: Read-only and admin-gated leaves restrict mutating verbs
+- **GIVEN** the read-only Activity leaf and the admin-gated Flow leaf
+- **WHEN** a non-admin attempts a mutating verb
+- **THEN** the Activity leaf MUST expose no link/create/unlink verb at all
+- **AND** the Flow leaf MUST reject the mutating verb for non-admins while still serving its list verb read-only

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/oas-generation/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/oas-generation/spec.md
@@ -1,0 +1,55 @@
+---
+status: draft
+---
+
+# OAS Generation
+
+## Purpose
+
+Extend oas-generation with the register/schema publication lifecycle and the
+OAS-to-GitHub publishing HTTP surface. The existing spec covers on-demand OAS
+*document generation* (`GET /api/oas`) but has no requirement for the
+publish/depublish controller verbs or for pushing a generated OAS document to
+a GitHub repository. Reverse-specced from the live `RegistersController` and
+`SchemasController`.
+
+## ADDED Requirements
+
+### Requirement: Register and Schema Publication and GitHub OAS Publishing
+
+The system MUST expose publication-lifecycle verbs on registers and schemas
+and a GitHub OAS publishing endpoint on registers.
+
+`RegistersController` MUST provide `publish`
+(`POST /api/registers/{id}/publish`) and `depublish`
+(`POST /api/registers/{id}/depublish`), and `SchemasController` MUST provide
+`publish` (`POST /api/schemas/{id}/publish`) and `depublish`
+(`POST /api/schemas/{id}/depublish`), which toggle the entity's published
+state. Each verb MUST return the updated entity and MUST return `404` with an
+`{error}` body for an unknown id.
+
+`RegistersController::publishToGitHub`
+(`POST /api/registers/{id}/publish/github`) MUST generate the register's OAS
+document and commit it to a GitHub repository. The request MUST require
+`owner` and `repo` parameters and MUST return `400` when either is missing.
+The endpoint MAY accept `path`, `branch` (default `main`), and
+`commitMessage`; on failure it MUST return a `500` with a descriptive
+`{error}` body rather than leaking the underlying exception trace.
+
+#### Scenario: Publish and depublish a register
+- **GIVEN** a register with a known id
+- **WHEN** `POST /api/registers/{id}/publish` is called
+- **THEN** the register MUST be marked published and the updated entity returned
+- **AND** `POST /api/registers/{id}/depublish` MUST clear the published state
+- **AND** an unknown id MUST return HTTP 404 with an `{error}` body
+
+#### Scenario: Publish a schema
+- **GIVEN** a schema with a known id
+- **WHEN** `POST /api/schemas/{id}/publish` is called
+- **THEN** the schema MUST be marked published and the updated entity returned
+
+#### Scenario: Publish a register OAS to GitHub requires owner and repo
+- **GIVEN** a register with a known id
+- **WHEN** `POST /api/registers/{id}/publish/github` is called without `owner` or `repo`
+- **THEN** the response MUST be HTTP 400 with an `{error}` body
+- **AND** a request with valid `owner` and `repo` MUST commit the generated OAS document to the target repository

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/openapi-generation/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/openapi-generation/spec.md
@@ -1,0 +1,73 @@
+---
+status: draft
+---
+
+# OpenAPI Generation
+
+## Purpose
+
+Extend openapi-generation with the schema-authoring sub-resources and the
+registry meta-entity *operational* endpoints that the shared resource-CRUD
+requirement (added by `retrofit-2026-05-24-b-ctrl-registry-views` task-1)
+explicitly defers to "their own capability specs". Reverse-specced from the
+live `SchemasController`, `RegistersController`, `EndpointsController`, and
+`MappingsController`.
+
+## ADDED Requirements
+
+### Requirement: Schema Authoring Sub-Resources and Meta-Entity Operational Endpoints
+
+The system MUST expose schema-authoring sub-resources and registry
+meta-entity operational endpoints beyond the uniform resource-CRUD contract.
+
+`SchemasController` MUST provide:
+
+- `download` (`GET /api/schemas/{id}/download`) — return the schema as a JSON
+  document (`404` when the schema does not exist);
+- `upload` (`POST /api/schemas/upload`) and `uploadUpdate`
+  (`PUT /api/schemas/{id}/upload`) — create or update a schema from a JSON
+  document supplied by `file`, `url`, or inline `json`;
+- `related` (`GET /api/schemas/{id}/related`) — return the incoming and
+  outgoing `$ref` relationships of the schema as `{incoming, outgoing, total}`;
+- `explore` (`GET /api/schemas/{id}/explore`) — analyse all objects of the
+  schema to discover properties present in object data but absent from the
+  schema definition; and
+- `updateFromExploration` (`POST /api/schemas/{id}/update-from-exploration`) —
+  apply selected discovered properties back onto the schema.
+
+`RegistersController` MUST provide the register sub-resource lookups
+`schemas` (`GET /api/registers/{id}/schemas`, returning `{results, total}`)
+and `objects` (`GET /api/registers/{id}/objects`).
+
+`EndpointsController::test` (`POST /api/endpoints/{id}/test`) and
+`MappingsController::test` (`POST /api/mappings/test`) MUST execute a dry-run
+of the endpoint or mapping against supplied sample input and return the
+execution result (status code, transformed output, or structured error)
+WITHOUT persisting any side effect.
+
+All of these endpoints MUST return `404` with an `{error}` body for an unknown
+id and MUST respect the same RBAC + multi-tenancy filters as the underlying
+mapper/service.
+
+#### Scenario: Download a schema as JSON
+- **GIVEN** a schema with a known id
+- **WHEN** `GET /api/schemas/{id}/download` is called
+- **THEN** the response MUST return HTTP 200 with the schema's JSON document
+- **AND** an unknown id MUST return HTTP 404 with `{error: "Schema not found"}`
+
+#### Scenario: Explore discovers undeclared properties
+- **GIVEN** a schema whose objects carry properties not present in the schema definition
+- **WHEN** `GET /api/schemas/{id}/explore` is called
+- **THEN** the response MUST list the discovered properties
+- **AND** `POST /api/schemas/{id}/update-from-exploration` MUST be able to apply selected discovered properties onto the schema
+
+#### Scenario: Related returns incoming and outgoing references
+- **GIVEN** schema A is `$ref`-referenced by schema B and itself references schema C
+- **WHEN** `GET /api/schemas/{idA}/related` is called
+- **THEN** the response MUST include B under `incoming` and C under `outgoing` with a `total` count
+
+#### Scenario: Dry-run test does not persist
+- **GIVEN** an endpoint or mapping with a known id
+- **WHEN** its `test` endpoint is called with sample input
+- **THEN** the response MUST return the execution result
+- **AND** no entity or audit side effect MUST be persisted

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/production-observability/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/production-observability/spec.md
@@ -1,0 +1,58 @@
+---
+status: draft
+---
+
+# Production Observability
+
+## Purpose
+
+Extend production-observability with per-entity statistics endpoints and the
+custom-endpoint delivery-log API. The existing spec covers the Prometheus
+metrics endpoint, the health/readiness endpoints, and structured logging, but
+has no requirement for the per-register / per-schema statistics surface or for
+the delivery-log API on custom endpoints. Reverse-specced from the live
+`RegistersController`, `SchemasController`, and `EndpointsController`.
+
+## ADDED Requirements
+
+### Requirement: Per-Entity Statistics and Endpoint Delivery-Log API
+
+The system MUST expose per-entity statistics read endpoints and a
+custom-endpoint delivery-log API for operational observability.
+
+`RegistersController::stats` (`GET /api/registers/{id}/stats`) and
+`SchemasController::stats` (`GET /api/schemas/{id}/stats`) MUST return an
+aggregate statistics envelope for the entity, including object counts (total,
+invalid, deleted, locked, and storage size) and audit-log statistics, scoped
+to the entity. An unknown id MUST return `404` with an `{error}` body.
+
+`EndpointsController` MUST expose the delivery-log API:
+
+- `logs` (`GET /api/endpoints/{id}/logs`) — the delivery/call log entries for a
+  single endpoint;
+- `logStats` (`GET /api/endpoints/{id}/logs/stats`) — aggregate statistics over
+  that endpoint's delivery log; and
+- `allLogs` (`GET /api/endpoints/logs`) — the delivery log across all
+  endpoints.
+
+The statistics and log endpoints MUST respect the same RBAC + multi-tenancy
+filters as the underlying mappers so they cannot enumerate counts or log
+entries across tenants.
+
+#### Scenario: Register statistics envelope
+- **GIVEN** a register with a known id containing objects across its schemas
+- **WHEN** `GET /api/registers/{id}/stats` is called
+- **THEN** the response MUST include object counts (total, invalid, deleted, locked, size) and audit-log statistics scoped to the register
+- **AND** an unknown id MUST return HTTP 404 with an `{error}` body
+
+#### Scenario: Schema statistics envelope
+- **GIVEN** a schema with a known id
+- **WHEN** `GET /api/schemas/{id}/stats` is called
+- **THEN** the response MUST include object counts and audit-log statistics scoped to the schema
+
+#### Scenario: Endpoint delivery logs
+- **GIVEN** a custom endpoint with delivery-log entries
+- **WHEN** `GET /api/endpoints/{id}/logs` is called
+- **THEN** the response MUST return that endpoint's delivery-log entries
+- **AND** `GET /api/endpoints/logs` MUST return entries across all endpoints
+- **AND** `GET /api/endpoints/{id}/logs/stats` MUST return aggregate statistics over the endpoint's log

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md
@@ -1,0 +1,120 @@
+# Tasks — Retrofit bw2-ctrl-2 (Controllers chunk 2)
+
+Reverse-spec + annotation tasks for the 28-controller / 148-method batch in
+`/tmp/or-scan/bw2-ctrl-2.json`. Each task maps a controller-method group to
+the capability that owns its HTTP contract. Tasks prefixed CROSS are
+annotation-only references to an existing live spec / in-flight change (no new
+REQ). Excludes (boilerplate) are tagged in code with `@spec exclude <reason>`
+and are not individual tasks.
+
+## generic-integrations (NEW REQ — one shared, uniform CRUD)
+
+- [x] **task-1**: generic-integrations#REQ "Tier-2 Integration Leaf Link
+  Controller Contract" — one consolidated REQ for the uniform object-scoped
+  link-CRUD contract shared by `ActivityLinksController`
+  (`index`/`types`/`actors`), `BookmarkLinksController`
+  (`index`/`link`/`createNew`/`destroy`/`available`),
+  `CospendLinksController` (`index`/`link`/`createAndLink`/`destroy`/`available`),
+  `DeckLinksController`
+  (`index`/`link`/`createNew`/`destroy`/`boards`/`stacks`),
+  `FlowLinksController` (`index`/`link`/`destroy`/`available`),
+  `FormLinksController`
+  (`index`/`link`/`create`/`destroyForm`/`destroySubmission`/`available`),
+  `PhotoLinksController` (`index`/`link`/`createAndLink`/`destroy`/`available`),
+  `TimeTrackerLinksController`
+  (`index`/`link`/`createAndLink`/`destroy`/`available`),
+  `ShareLinksController` (`index`/`create`/`destroy`/`files`), and
+  `EmailsController` (`index`/`create`/`destroy`). Covers list / link-existing /
+  create-and-link / unlink / picker-source discovery, and the uniform
+  `501 APP_NOT_AVAILABLE` graceful-degradation envelope. Per-controller
+  `validateObject` / `mapException` / `unavailable` / `nullableString` /
+  `nullableInt` / `dropdown` private helpers and constructors are
+  `@spec exclude` boilerplate.
+
+## data-import-export (NEW REQ — config management + Git-remote sync)
+
+- [x] **task-2**: data-import-export#REQ "Configuration Management and
+  Git-Remote Sync HTTP Surface" — `ConfigurationController`
+  (`index`/`show`/`create`/`update`/`destroy`/`checkVersion`/`preview`/`enrichDetails`/`getGitHubRepositories`/`getGitHubConfigurations`/`getGitLabConfigurations`)
+  and `ConfigurationsController` (`index`/`show`/`create`/`update`/`patch`/`destroy`):
+  CRUD over configuration entities plus remote version-check, change preview,
+  detail enrichment, and GitHub/GitLab repo+file discovery for config import.
+- [x] **task-3 (CROSS → data-import-export existing "Configuration
+  import/export MUST support full register portability")**: the
+  `export`/`import` methods on `ConfigurationController` and
+  `ConfigurationsController` are NOT in this batch — they are already
+  annotated (to `retrofit-2026-05-24-b-ctrl-object-data` task-14) and remain
+  governed by the existing portability REQ. Recorded here for bundle
+  completeness; no edit.
+
+## openapi-generation (NEW REQ — schema authoring + meta-entity operational)
+
+- [x] **task-4**: openapi-generation#REQ "Schema Authoring Sub-Resources and
+  Meta-Entity Operational Endpoints" — `SchemasController`
+  (`download`/`upload`/`uploadUpdate`/`related`/`explore`/`updateFromExploration`),
+  `RegistersController` (`schemas`/`objects` sub-resource lookups),
+  `EndpointsController::test`, and `MappingsController::test` (dry-run
+  validation). These are the operational/authoring verbs the registry-views
+  task-1 shared resource-CRUD REQ explicitly defers to "their own capability
+  specs".
+
+## oas-generation (NEW REQ — publish / depublish surface)
+
+- [x] **task-5**: oas-generation#REQ-002 "Register and Schema Publication and
+  GitHub OAS Publishing" — `RegistersController`
+  (`publish`/`depublish`/`publishToGitHub`) and `SchemasController`
+  (`publish`/`depublish`): register/schema publication lifecycle + OAS-to-GitHub
+  push.
+
+## production-observability (NEW REQ — per-entity stats + endpoint logs)
+
+- [x] **task-6**: production-observability#REQ "Per-Entity Statistics and
+  Endpoint Delivery-Log API" — `RegistersController::stats`,
+  `SchemasController::stats`, and `EndpointsController`
+  (`logs`/`logStats`/`allLogs`) — operational read endpoints for entity
+  statistics and custom-endpoint delivery logs.
+
+## CROSS — annotate-only to existing specs / in-flight changes
+
+- [x] **task-7 (CROSS → openapi-generation, registry-views task-1)**:
+  meta-entity resource CRUD — `RegistersController`, `SchemasController`,
+  `EndpointsController`, `MappingsController`
+  (`index`/`show`/`create`/`update`/`patch`/`destroy`) annotated to the shared
+  resource-CRUD REQ added by `retrofit-2026-05-24-b-ctrl-registry-views`
+  task-1.
+- [x] **task-8 (CROSS → faceting-configuration, registry-views task-2/3)**:
+  `ViewsController` (`index`/`show`/`create`/`update`/`patch`/`destroy`)
+  annotated to the persisted-views CRUD REQ.
+- [x] **task-9 (CROSS → urn-resource-addressing, registry-views task-7)**:
+  `UrnController` (`resolve`/`lookup`/`bulk`) annotated to the URN resolver
+  contract.
+- [x] **task-10 (CROSS → data-import-export existing REQs)**:
+  `RegistersController` (`import`/`export`/`importTemplate`/`rollbackImport`)
+  annotated to the import/export + rollback REQs.
+- [x] **task-11 (CROSS → pluggable-integration-registry task-18/19)**:
+  `IntegrationsController` (`index`/`show`) and `ObjectIntegrationsController`
+  (`index`/`show`/`create`/`update`/`destroy`) — method-level tags added (the
+  classes were already tagged).
+- [x] **task-12 (CROSS → object-interactions "File Attachments on Objects" /
+  "Tags for Object Categorization")**: `FilesController`
+  (`show`/`save`/`createMultipart`/`update`/`depublish`/`downloadById`/`batch`/`updateLabels`).
+- [x] **task-13 (CROSS → object CRUD, retrofit annotate-openregister)**:
+  `ObjectsController::postPatch` (multipart-PATCH object update). SECURITY
+  NOTE: `@PublicPage` + `@NoAdminRequired`.
+- [x] **task-14 (CROSS → referential-integrity)**:
+  `ObjectsController::canDelete` (pre-flight deletion analysis; the REQ
+  scenarios already reference `canDelete()` / `DeletionAnalysis`).
+- [x] **task-15 (CROSS → add-time-bucket-aggregation task 2.1)**:
+  `AggregationController::timeseries`.
+- [x] **task-16 (CROSS → contacts-actions task-1)**:
+  `ContactsController::createNew`.
+- [x] **task-17 (CROSS → workflow-operations "Scheduled Workflow Triggers")**:
+  `ScheduledWorkflowController` (`index`/`show`/`create`/`update`/`destroy`).
+  SECURITY NOTE: `@NoAdminRequired` on all verbs; controller calls mapper
+  directly (ADR-003 layering violation).
+- [x] **task-18 (CROSS → production-observability "Prometheus Metrics
+  Endpoint" / "Health Check Endpoint")**: `MetricsController::index`,
+  `HealthController::index`.
+- [x] **task-19 (CROSS → chat-ai, class-level)**: `AgentsController::page` is
+  an SPA-mount template stub — `@spec exclude` (the agent CRUD surface is
+  covered at class level by chat-ai / registry-views).


### PR DESCRIPTION
## Summary

Reverse-specs the second controller chunk of the OpenRegister backend-coverage retrofit: **148 uncovered public methods across 28 `lib/Controller/*.php` files** now carry an ADR-003 `@spec` tag (146 reverse-spec'd, 2 SPA-mount stubs excluded with reasons).

Ghost change: `openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/`. Documentation/annotation only — no runtime behaviour changes. `openspec validate --strict` passes; `php -l` clean on all 28 files.

## New REQs (5, within the ≤6 budget)

| Capability | REQ | Covers |
|---|---|---|
| `generic-integrations` | Tier-2 Integration Leaf Link Controller Contract | one shared REQ for the 9 uniform leaf link controllers (Activity/Bookmark/Cospend/Deck/Flow/Form/Photo/TimeTracker/Share) + Emails |
| `data-import-export` | Configuration Management and Git-Remote Sync HTTP Surface | ConfigurationController + ConfigurationsController CRUD + version-check/preview/enrich + GitHub/GitLab discovery |
| `openapi-generation` | Schema Authoring Sub-Resources and Meta-Entity Operational Endpoints | Schemas download/upload/related/explore + Registers schemas/objects + Endpoints/Mappings `test` |
| `oas-generation` | Register and Schema Publication and GitHub OAS Publishing | Registers/Schemas publish/depublish + publishToGitHub |
| `production-observability` | Per-Entity Statistics and Endpoint Delivery-Log API | Registers/Schemas stats + Endpoints logs/logStats/allLogs |

## Annotate-only (no new REQ)

Most methods are already owned by a live spec / in-flight change and were annotated to it: `registry-views` (meta-entity CRUD, Views, URN), `pluggable-integration-registry` (Integrations/ObjectIntegrations), `object-interactions` (Files), `referential-integrity` (canDelete), `data-import-export` (Registers import/export/rollback), `add-time-bucket-aggregation` (timeseries), `contacts-actions` (createNew), `workflow-operations` (ScheduledWorkflow), `production-observability` (Metrics/Health).

## Security / authz notes (surfaced, not fixed here)

- **`ScheduledWorkflowController`** — all 5 CRUD verbs are `@NoAdminRequired` but the owning REQ assumes admin; also calls the mapper directly (ADR-003 layering violation).
- **`ObjectsController::postPatch`** — `@PublicPage` + `@NoAdminRequired` object create/update with file upload (RBAC enforced downstream only).
- **`UrnController::bulk`** — 1000-URN cap is the only DoS guard; no upstream per-user rate limit.
- **`RegistersController::rollbackImport`** — audit lookup not filtered by organisation (cross-tenant exposure surface).

## Test plan

- [x] `openspec validate retrofit-2026-05-25-bw2-ctrl-2 --strict` passes
- [x] `php -l` clean on all 28 controllers
- [x] All 148 batch methods confirmed annotated (cross-check script)
- [ ] CI quality gate (PHPCS/PHPMD/Psalm/PHPStan) green