### PR TITLE
retrofit: frontend coverage — views (chunk 1)

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-fe-views-1/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-views-1/proposal.md
@@ -1,0 +1,81 @@
+# Retrofit — frontend coverage, views (chunk 1)
+
+## Why
+
+The `/opsx-coverage-scan` retrofit pass over `openregister` left 223 named methods
+across ten `src/views/**/*.vue` files without an `@spec` annotation. Per ADR-003 every
+public method must end with a `@spec` tag (pointing at the change that caused it) or an
+explicit `@spec exclude <reason>` tag. This ghost change brings those 223 methods under
+the convention.
+
+This is a documentation-only retrofit. No code behavior changes; only JSDoc `@spec`
+tags are added.
+
+## What the batch contains
+
+Batch file: `/tmp/or-scan/fw-fe-views-1.json` — 223 methods across:
+
+| File | Surface |
+|------|---------|
+| `src/views/account/sections/AccountSection.vue` | account self-service (deactivation) |
+| `src/views/account/sections/PasswordSection.vue` | account self-service (password) |
+| `src/views/account/sections/TokensSection.vue` | account self-service (API tokens) |
+| `src/views/configuration/ConfigurationsIndex.vue` | admin list view (configurations) |
+| `src/views/integration/IntegrationsView.vue` | integration-registry screenshot harness |
+| `src/views/object/ObjectsIndex.vue` | object index / deep-link prime |
+| `src/views/organisation/OrganisationsIndex.vue` | organisation (tenant) list view |
+| `src/views/register/RegisterDetail.vue` | register detail dashboard |
+| `src/views/settings/sections/ApiTokenConfiguration.vue` | admin settings (Git tokens) |
+| `src/views/settings/sections/FileConfiguration.vue` | admin settings (text extraction) |
+| `src/views/settings/sections/MultitenancyConfiguration.vue` | admin settings (multitenancy) |
+| `src/views/settings/sections/N8nConfiguration.vue` | admin settings (n8n) |
+| `src/views/settings/sections/SolrConfiguration.vue` | admin settings (Solr) |
+| `src/views/source/SourcesIndex.vue` | admin list view (sources) |
+| `src/views/templates/TemplatesIndex.vue` | admin list view (templates) |
+| `src/views/webhooks/WebhooksIndex.vue` | admin list view (webhooks) |
+
+## Triage outcome
+
+After reading every file, all 223 methods are **list/detail/settings UI plumbing**:
+pagination handlers, row-selection state, computed display getters, store passthroughs,
+modal/dialog dispatch, formatters, lifecycle hooks, watcher handlers, route-param
+accessors, and admin-settings load/save/test/clear handlers.
+
+The genuinely spec-worthy user-facing view contracts in these files
+(`toggleSelectAll`, `toggleSidebar`, `requestDeactivation`, `changePassword`,
+`loadTokens`) were already minted into the `admin-list-views` and
+`account-self-service` capabilities by the earlier `retrofit-2026-05-24-2b-views`
+change. The methods in this batch are the surrounding plumbing those capabilities do
+not (and should not) describe. Behavior whose contract lives elsewhere — object
+lifecycle (`object-lifecycle`), tenant lifecycle (`tenant-lifecycle`), register
+dashboards (`built-in-dashboards`), search/faceting (`zoeken-filteren` /
+`faceting-configuration`), webhook payloads (`webhook-payload-mapping`), the
+integration registry (ADR-019 / `generic-integrations`) — is excluded here with a
+reason pointing at the owning concern; annotation against those capabilities is their
+own retrofit runs' job, not this UI-plumbing pass.
+
+**Result: 0 reverse-spec REQs minted. All 223 methods tagged `@spec exclude <reason>`.**
+
+## Counts
+
+- Methods in batch: **223**
+- Spec'd (reverse-spec REQs): **0**
+- Excluded (`@spec exclude <reason>`): **223**
+- New REQs: **0**
+
+## Approach
+
+No spec delta (no REQs minted). Each of the 223 methods gets a JSDoc `@spec exclude
+<reason>` tag describing why it is not a spec-bearing contract (UI plumbing, store
+passthrough, formatter, lifecycle/watcher glue, or behavior owned by another
+capability).
+
+## Out of scope
+
+- Reshaping or "fixing" observed behavior — pure annotation.
+- Annotating the cross-capability behavior (object/tenant/dashboard/search/webhook/
+  integration) surfaced through these views — owned by those capabilities' own retrofit
+  runs.
+
+Source: `openspec/coverage-report.md`. See
+[retrofit playbook](../../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-25-fe-views-1/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-views-1/tasks.md
@@ -1,0 +1,22 @@
+# Tasks
+
+All tasks are marked `[x]` because the code already exists. This is a retrofit — tasks
+describe retroactive annotation, not new implementation work. No REQs were minted; every
+method in the batch is UI plumbing tagged `@spec exclude <reason>`.
+
+## Annotation
+
+- [x] task-1: Annotate `src/views/account/sections/*.vue` plumbing methods (AccountSection, PasswordSection, TokensSection) with `@spec exclude <reason>` — account self-service contract owned by `account-self-service`; these are formatters, lifecycle hooks, clipboard/token CRUD glue.
+- [x] task-2: Annotate `src/views/configuration/ConfigurationsIndex.vue` plumbing methods with `@spec exclude <reason>` — admin list-view pagination/selection/modal-dispatch/status-formatting glue; list contract owned by `admin-list-views`.
+- [x] task-3: Annotate `src/views/integration/IntegrationsView.vue` plumbing methods with `@spec exclude <reason>` — route-param accessors and registry setup for the screenshot harness; integration contract owned by ADR-019 / `generic-integrations`.
+- [x] task-4: Annotate `src/views/object/ObjectsIndex.vue` plumbing methods with `@spec exclude <reason>` — deep-link prime + add-object dispatch + route watcher; object contract owned by `object-lifecycle`.
+- [x] task-5: Annotate `src/views/organisation/OrganisationsIndex.vue` plumbing methods with `@spec exclude <reason>` — tenant list view selection/pagination/permission-display/switch glue; tenant contract owned by `tenant-lifecycle`.
+- [x] task-6: Annotate `src/views/register/RegisterDetail.vue` plumbing methods with `@spec exclude <reason>` — register dashboard chart-option computeds, schema/stat loaders, save/edit dispatch; dashboard contract owned by `built-in-dashboards`.
+- [x] task-7: Annotate `src/views/settings/sections/ApiTokenConfiguration.vue` plumbing methods with `@spec exclude <reason>` — Git token admin-settings load/save/test/clear/update glue.
+- [x] task-8: Annotate `src/views/settings/sections/FileConfiguration.vue` plumbing methods with `@spec exclude <reason>` — text-extraction admin-settings load/save/test/discover/extract/format glue.
+- [x] task-9: Annotate `src/views/settings/sections/MultitenancyConfiguration.vue` plumbing methods with `@spec exclude <reason>` — multitenancy admin-settings store passthroughs and save/rebase-dialog glue.
+- [x] task-10: Annotate `src/views/settings/sections/N8nConfiguration.vue` plumbing methods with `@spec exclude <reason>` — n8n admin-settings load/save/test/init/workflow glue.
+- [x] task-11: Annotate `src/views/settings/sections/SolrConfiguration.vue` plumbing methods with `@spec exclude <reason>` — Solr admin-settings store passthroughs, dialog open/close, field inspect/create/fix, warmup/reindex, stats loaders, formatters, loading-tip animation; search contract owned by `zoeken-filteren` / `faceting-configuration`.
+- [x] task-12: Annotate `src/views/source/SourcesIndex.vue` plumbing methods with `@spec exclude <reason>` — admin list-view pagination/selection/empty-state glue; list contract owned by `admin-list-views`.
+- [x] task-13: Annotate `src/views/templates/TemplatesIndex.vue` plumbing methods with `@spec exclude <reason>` — admin list-view pagination/load/view/format glue.
+- [x] task-14: Annotate `src/views/webhooks/WebhooksIndex.vue` plumbing methods with `@spec exclude <reason>` — webhook list-view CRUD/test/logs/format glue; payload contract owned by `webhook-payload-mapping`.

--- a/src/views/account/sections/AccountSection.vue
+++ b/src/views/account/sections/AccountSection.vue
@@ -74,6 +74,12 @@ export default {
 			isError: false,
 		}
 	},
+	/**
+	 * Prime username + deactivation status on mount.
+	 *
+	 * @spec exclude UI plumbing — lifecycle hook hydrating local display state; account self-service contract owned by account-self-service.
+	 * @return {Promise<void>}
+	 */
 	async mounted() {
 		try {
 			const [userRes, statusRes] = await Promise.all([
@@ -113,6 +119,12 @@ export default {
 				this.isError = true
 			}
 		},
+		/**
+		 * Cancel a pending deactivation request.
+		 *
+		 * @spec exclude UI plumbing — inverse of the requestDeactivation contract (account-self-service); thin DELETE + local state reset.
+		 * @return {Promise<void>}
+		 */
 		async cancelDeactivation() {
 			try {
 				await axios.delete(generateUrl('/apps/openregister/api/user/me/deactivate'))
@@ -125,6 +137,13 @@ export default {
 				this.isError = true
 			}
 		},
+		/**
+		 * Format a date string for display.
+		 *
+		 * @spec exclude UI plumbing — pure display formatter, no observable contract.
+		 * @param {string} dateStr - ISO date string
+		 * @return {string} localized date/time
+		 */
 		formatDate(dateStr) {
 			if (!dateStr) return ''
 			return new Date(dateStr).toLocaleString()

--- a/src/views/account/sections/PasswordSection.vue
+++ b/src/views/account/sections/PasswordSection.vue
@@ -53,6 +53,12 @@ export default {
 			canChangePassword: true,
 		}
 	},
+	/**
+	 * Detect whether the auth backend supports password changes.
+	 *
+	 * @spec exclude UI plumbing — lifecycle hook toggling form visibility; password change contract owned by account-self-service.
+	 * @return {Promise<void>}
+	 */
 	async mounted() {
 		try {
 			const { data } = await axios.get(generateUrl('/apps/openregister/api/user/me'))

--- a/src/views/account/sections/TokensSection.vue
+++ b/src/views/account/sections/TokensSection.vue
@@ -118,6 +118,12 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * Create a personal API token and surface the one-time secret.
+		 *
+		 * @spec exclude UI plumbing — POST + reveal-modal glue around the account-self-service token list contract.
+		 * @return {Promise<void>}
+		 */
 		async createToken() {
 			try {
 				const payload = { name: this.newTokenName }
@@ -136,6 +142,13 @@ export default {
 				this.isError = true
 			}
 		},
+		/**
+		 * Revoke a personal API token by id.
+		 *
+		 * @spec exclude UI plumbing — thin DELETE + list refresh; token contract owned by account-self-service.
+		 * @param {string|number} id - token identifier
+		 * @return {Promise<void>}
+		 */
 		async revokeToken(id) {
 			try {
 				await axios.delete(generateUrl(`/apps/openregister/api/user/me/tokens/${id}`))
@@ -147,6 +160,12 @@ export default {
 				this.isError = true
 			}
 		},
+		/**
+		 * Copy the one-time token to the clipboard.
+		 *
+		 * @spec exclude UI plumbing — clipboard write + toast, no observable contract.
+		 * @return {Promise<void>}
+		 */
 		async copyToken() {
 			try {
 				await navigator.clipboard.writeText(this.createdToken)
@@ -157,6 +176,13 @@ export default {
 				this.isError = true
 			}
 		},
+		/**
+		 * Format a token expiry date for display.
+		 *
+		 * @spec exclude UI plumbing — pure display formatter, no observable contract.
+		 * @param {string} dateStr - ISO date string
+		 * @return {string} localized date
+		 */
 		formatDate(dateStr) {
 			if (!dateStr) return ''
 			return new Date(dateStr).toLocaleDateString()

--- a/src/views/configuration/ConfigurationsIndex.vue
+++ b/src/views/configuration/ConfigurationsIndex.vue
@@ -307,17 +307,41 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Current page slice of the configuration list.
+		 *
+		 * @spec exclude UI plumbing — client-side pagination computed; admin list contract owned by admin-list-views.
+		 * @return {Array} configurations on the active page
+		 */
 		paginatedConfigurations() {
 			const start = ((this.pagination.page || 1) - 1) * (this.pagination.limit || 20)
 			const end = start + (this.pagination.limit || 20)
 			return configurationStore.configurationList.slice(start, end)
 		},
+		/**
+		 * Whether every configuration is selected.
+		 *
+		 * @spec exclude UI plumbing — header-checkbox state derived from selection; admin list contract owned by admin-list-views.
+		 * @return {boolean}
+		 */
 		allSelected() {
 			return configurationStore.configurationList.length > 0 && configurationStore.configurationList.every(configuration => this.selectedConfigurations.includes(configuration.id))
 		},
+		/**
+		 * Whether a partial selection exists (indeterminate state).
+		 *
+		 * @spec exclude UI plumbing — header-checkbox indeterminate state; admin list contract owned by admin-list-views.
+		 * @return {boolean}
+		 */
 		someSelected() {
 			return this.selectedConfigurations.length > 0 && !this.allSelected
 		},
+		/**
+		 * Empty-state title reflecting loading/error/empty.
+		 *
+		 * @spec exclude UI plumbing — derived empty-state copy, no observable contract.
+		 * @return {string}
+		 */
 		emptyContentName() {
 			if (configurationStore.loading) {
 				return t('openregister', 'Loading configurations...')
@@ -328,6 +352,12 @@ export default {
 			}
 			return ''
 		},
+		/**
+		 * Empty-state description reflecting loading/error/empty.
+		 *
+		 * @spec exclude UI plumbing — derived empty-state copy, no observable contract.
+		 * @return {string}
+		 */
 		emptyContentDescription() {
 			if (configurationStore.loading) {
 				return t('openregister', 'Please wait while we fetch your configurations.')
@@ -339,6 +369,12 @@ export default {
 			return ''
 		},
 	},
+	/**
+	 * Soft-refresh the configuration list on mount.
+	 *
+	 * @spec exclude UI plumbing — lifecycle hook delegating to the store; list contract owned by admin-list-views.
+	 * @return {void}
+	 */
 	mounted() {
 		// Use soft reload (no loading spinner) since data is hot-loaded at app startup
 		configurationStore.refreshConfigurationList(null, true)
@@ -358,6 +394,14 @@ export default {
 				this.selectedConfigurations = []
 			}
 		},
+		/**
+		 * Toggle selection for a single configuration row.
+		 *
+		 * @spec exclude UI plumbing — row-selection state mutation; admin list contract owned by admin-list-views.
+		 * @param {string|number} configurationId - row id
+		 * @param {boolean} checked - selected state
+		 * @return {void}
+		 */
 		toggleConfigurationSelection(configurationId, checked) {
 			if (checked) {
 				this.selectedConfigurations.push(configurationId)
@@ -365,13 +409,34 @@ export default {
 				this.selectedConfigurations = this.selectedConfigurations.filter(id => id !== configurationId)
 			}
 		},
+		/**
+		 * Handle a page change from the paginator.
+		 *
+		 * @spec exclude UI plumbing — pagination state mutation; admin list contract owned by admin-list-views.
+		 * @param {number} page - new page number
+		 * @return {void}
+		 */
 		onPageChanged(page) {
 			this.pagination.page = page
 		},
+		/**
+		 * Handle a page-size change from the paginator.
+		 *
+		 * @spec exclude UI plumbing — pagination state mutation; admin list contract owned by admin-list-views.
+		 * @param {number} pageSize - new page size
+		 * @return {void}
+		 */
 		onPageSizeChanged(pageSize) {
 			this.pagination.page = 1
 			this.pagination.limit = pageSize
 		},
+		/**
+		 * Whether a configuration has a remote update available.
+		 *
+		 * @spec exclude UI plumbing — display badge predicate comparing local vs remote version.
+		 * @param {object} configuration - configuration row
+		 * @return {boolean}
+		 */
 		hasUpdateAvailable(configuration) {
 			if (!configuration.localVersion || !configuration.remoteVersion) {
 				return false
@@ -385,6 +450,13 @@ export default {
 		isManualConfiguration(configuration) {
 			return !configuration.sourceType || configuration.sourceType === 'local'
 		},
+		/**
+		 * Map a source-type id to a human label.
+		 *
+		 * @spec exclude UI plumbing — static label lookup for display.
+		 * @param {string} sourceType - source type id
+		 * @return {string} display label
+		 */
 		getSourceTypeLabel(sourceType) {
 			const labels = {
 				local: 'Local',
@@ -394,6 +466,13 @@ export default {
 			}
 			return labels[sourceType] || 'Unknown'
 		},
+		/**
+		 * Check a configuration's remote version and refresh the list.
+		 *
+		 * @spec exclude UI plumbing — thin POST + toast + list refresh; configuration sync contract owned elsewhere.
+		 * @param {object} configuration - configuration row
+		 * @return {Promise<void>}
+		 */
 		async checkVersion(configuration) {
 			try {
 				const response = await axios.post(
@@ -415,27 +494,69 @@ export default {
 				showError(t('openregister', 'Failed to check version: {error}', { error: error.response?.data?.error || error.message }))
 			}
 		},
+		/**
+		 * Open the view-configuration modal for a row.
+		 *
+		 * @spec exclude UI plumbing — store-set + modal dispatch.
+		 * @param {object} configuration - configuration row
+		 * @return {void}
+		 */
 		handleView(configuration) {
 			configurationStore.setConfigurationItem(configuration)
 			navigationStore.setModal('viewConfiguration')
 		},
+		/**
+		 * Open the edit-configuration modal for a row.
+		 *
+		 * @spec exclude UI plumbing — store-set + modal dispatch.
+		 * @param {object} configuration - configuration row
+		 * @return {void}
+		 */
 		handleEdit(configuration) {
 			configurationStore.setConfigurationItem(configuration)
 			navigationStore.setModal('editConfiguration')
 		},
+		/**
+		 * Open the export-configuration modal for a row.
+		 *
+		 * @spec exclude UI plumbing — store-set + modal dispatch.
+		 * @param {object} configuration - configuration row
+		 * @return {void}
+		 */
 		handleExport(configuration) {
 			configurationStore.setConfigurationItem(configuration)
 			navigationStore.setModal('exportConfiguration')
 		},
+		/**
+		 * Open the delete-configuration dialog for a row.
+		 *
+		 * @spec exclude UI plumbing — store-set + dialog dispatch.
+		 * @param {object} configuration - configuration row
+		 * @return {void}
+		 */
 		handleDelete(configuration) {
 			configurationStore.setConfigurationItem(configuration)
 			navigationStore.setDialog('deleteConfiguration')
 		},
+		/**
+		 * Open the preview-update modal for a row.
+		 *
+		 * @spec exclude UI plumbing — store-set + modal dispatch.
+		 * @param {object} configuration - configuration row
+		 * @return {void}
+		 */
 		previewUpdate(configuration) {
 			// Set the configuration and open preview modal
 			configurationStore.setConfigurationItem(configuration)
 			navigationStore.setModal('previewConfiguration')
 		},
+		/**
+		 * Build a relative sync-status label for a configuration.
+		 *
+		 * @spec exclude UI plumbing — display formatter computing relative time.
+		 * @param {object} configuration - configuration row
+		 * @return {string} display label
+		 */
 		getSyncStatusText(configuration) {
 			if (configuration.syncStatus === 'success' && configuration.lastSyncDate) {
 				const now = new Date()

--- a/src/views/integration/IntegrationsView.vue
+++ b/src/views/integration/IntegrationsView.vue
@@ -24,6 +24,12 @@ export default {
 		BTab,
 	},
 
+	/**
+	 * Composition entry wiring the integration registry into the view.
+	 *
+	 * @spec exclude UI plumbing — registry wiring for the screenshot harness; integration contract owned by ADR-019 / generic-integrations.
+	 * @return {object} exposed refs (providers, ready, CnIntegrationTab)
+	 */
 	setup() {
 		const { integrations } = useIntegrationRegistry()
 		const providers = computed(() => (integrations.value || []))
@@ -36,15 +42,39 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * Register slug from the route.
+		 *
+		 * @spec exclude UI plumbing — route-param accessor, no observable contract.
+		 * @return {string}
+		 */
 		register() {
 			return String(this.$route.params.register || '')
 		},
+		/**
+		 * Schema slug from the route.
+		 *
+		 * @spec exclude UI plumbing — route-param accessor, no observable contract.
+		 * @return {string}
+		 */
 		schema() {
 			return String(this.$route.params.schema || '')
 		},
+		/**
+		 * Object id from the route.
+		 *
+		 * @spec exclude UI plumbing — route-param accessor, no observable contract.
+		 * @return {string}
+		 */
 		objectId() {
 			return String(this.$route.params.objectId || '')
 		},
+		/**
+		 * Whether all params + providers are present to render tabs.
+		 *
+		 * @spec exclude UI plumbing — render-guard predicate, no observable contract.
+		 * @return {boolean}
+		 */
 		ok() {
 			return this.register && this.schema && this.objectId && this.providers.length > 0
 		},

--- a/src/views/object/ObjectsIndex.vue
+++ b/src/views/object/ObjectsIndex.vue
@@ -58,12 +58,24 @@ export default {
 	},
 	watch: {
 		'$route.params.id': {
+			/**
+			 * Re-prime the object when the route id changes.
+			 *
+			 * @spec exclude UI plumbing — route watcher delegating to loadFromRoute; object contract owned by object-lifecycle.
+			 * @return {void}
+			 */
 			handler() {
 				this.loadFromRoute()
 			},
 		},
 	},
 	methods: {
+		/**
+		 * Fetch the deep-linked object and prime the store for ObjectDetails.
+		 *
+		 * @spec exclude UI plumbing — deep-link prime for the screenshot harness; object fetch contract owned by object-lifecycle.
+		 * @return {Promise<void>}
+		 */
 		// Fetch the object referenced by /objects/:register/:schema/:id and
 		// prime the store so ObjectDetails (with its registry-driven
 		// integration tabs) renders. Used by the per-leaf screenshot harness
@@ -101,6 +113,12 @@ export default {
 				console.error('[ObjectsIndex] deep-link fetch failed', e)
 			}
 		},
+		/**
+		 * Open the add-object modal with register/schema context.
+		 *
+		 * @spec exclude UI plumbing — store-set + modal dispatch; object creation contract owned by object-lifecycle.
+		 * @return {void}
+		 */
 		addObject() {
 			// Clear any existing object and open the add object modal
 			objectStore.setObjectItem(null)

--- a/src/views/organisation/OrganisationsIndex.vue
+++ b/src/views/organisation/OrganisationsIndex.vue
@@ -389,18 +389,42 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Whether every organisation is selected.
+		 *
+		 * @spec exclude UI plumbing — header-checkbox state; admin list contract owned by admin-list-views.
+		 * @return {boolean}
+		 */
 		allSelected() {
 			return organisationStore.userStats.list.length > 0 && organisationStore.userStats.list.every(org => this.selectedOrganisations.includes(org.uuid))
 		},
+		/**
+		 * Whether a partial selection exists (indeterminate state).
+		 *
+		 * @spec exclude UI plumbing — header-checkbox indeterminate state; admin list contract owned by admin-list-views.
+		 * @return {boolean}
+		 */
 		someSelected() {
 			return this.selectedOrganisations.length > 0 && !this.allSelected
 		},
+		/**
+		 * Current page slice of the organisation list.
+		 *
+		 * @spec exclude UI plumbing — client-side pagination computed; admin list contract owned by admin-list-views.
+		 * @return {Array}
+		 */
 		paginatedOrganisations() {
 			const start = ((organisationStore.pagination.page || 1) - 1) * (organisationStore.pagination.limit || 20)
 			const end = start + (organisationStore.pagination.limit || 20)
 			return organisationStore.userStats.list.slice(start, end)
 		},
 	},
+	/**
+	 * Load Nextcloud groups, organisations, and active org on mount.
+	 *
+	 * @spec exclude UI plumbing — lifecycle hook delegating to the store; tenant contract owned by tenant-lifecycle.
+	 * @return {Promise<void>}
+	 */
 	async mounted() {
 		try {
 			// Load Nextcloud groups into store first (needed for edit modal)
@@ -413,30 +437,71 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * Whether an organisation is the active one.
+		 *
+		 * @spec exclude UI plumbing — display predicate; tenant contract owned by tenant-lifecycle.
+		 * @param {object} organisation - organisation row
+		 * @return {boolean}
+		 */
 		isActiveOrganisation(organisation) {
 			return organisationStore.userStats.active
 				   && organisationStore.userStats.active.uuid === organisation.uuid
 		},
+		/**
+		 * Resolve the current Nextcloud user id.
+		 *
+		 * @spec exclude UI plumbing — global OC accessor for permission display.
+		 * @return {string} user id or 'unknown'
+		 */
 		getCurrentUser() {
 			// Get current user from global OC object (Nextcloud's way)
 			return window.OC?.getCurrentUser?.()?.uid || 'unknown'
 		},
+		/**
+		 * Whether the current user may edit an organisation.
+		 *
+		 * @spec exclude UI plumbing — display permission predicate; tenant contract owned by tenant-lifecycle.
+		 * @param {object} organisation - organisation row
+		 * @return {boolean}
+		 */
 		canEditOrganisation(organisation) {
 			// Only the owner can edit the organisation (or system for default org)
 			return organisation.owner === 'system'
 				   || organisation.owner === this.getCurrentUser()
 		},
+		/**
+		 * Whether the current user may leave an organisation.
+		 *
+		 * @spec exclude UI plumbing — display permission predicate; tenant contract owned by tenant-lifecycle.
+		 * @param {object} organisation - organisation row
+		 * @return {boolean}
+		 */
 		canLeaveOrganisation(organisation) {
 			// Can't leave if it's your only organisation or if you're the owner
 			return organisationStore.userStats.total > 1
 				   && !organisation.isDefault
 				   && organisation.owner !== this.getCurrentUser()
 		},
+		/**
+		 * Whether the current user may delete an organisation.
+		 *
+		 * @spec exclude UI plumbing — display permission predicate; tenant contract owned by tenant-lifecycle.
+		 * @param {object} organisation - organisation row
+		 * @return {boolean}
+		 */
 		canDeleteOrganisation(organisation) {
 			// Only owners can delete, and can't delete default organisation
 			return !organisation.isDefault
 				   && organisation.owner === this.getCurrentUser()
 		},
+		/**
+		 * Set the active organisation and reload app data.
+		 *
+		 * @spec exclude UI plumbing — store delegation + app reload; tenant switch contract owned by tenant-lifecycle.
+		 * @param {string} uuid - organisation uuid
+		 * @return {Promise<void>}
+		 */
 		async setActiveOrganisation(uuid) {
 			try {
 				await organisationStore.setActiveOrganisationById(uuid)
@@ -449,6 +514,13 @@ export default {
 				showError(t('openregister', 'Failed to change active organisation: {error}', { error: error.message }))
 			}
 		},
+		/**
+		 * Switch to an organisation from the switcher modal.
+		 *
+		 * @spec exclude UI plumbing — delegates to setActiveOrganisation + closes modal; tenant switch owned by tenant-lifecycle.
+		 * @param {object} organisation - organisation row
+		 * @return {Promise<void>}
+		 */
 		async switchToOrganisation(organisation) {
 			try {
 				await this.setActiveOrganisation(organisation.uuid)
@@ -457,6 +529,13 @@ export default {
 				showError(t('openregister', 'Failed to switch organisation: {error}', { error: error.message }))
 			}
 		},
+		/**
+		 * Leave an organisation after confirmation.
+		 *
+		 * @spec exclude UI plumbing — confirm + store delegation + toast; membership contract owned by tenant-lifecycle.
+		 * @param {object} organisation - organisation row
+		 * @return {Promise<void>}
+		 */
 		async leaveOrganisation(organisation) {
 			if (!confirm(t('openregister', 'Are you sure you want to leave \'{name}\'?', { name: organisation.name }))) {
 				return
@@ -469,6 +548,13 @@ export default {
 				showError(t('openregister', 'Failed to leave organisation: {error}', { error: error.message }))
 			}
 		},
+		/**
+		 * Toggle selection state for every organisation.
+		 *
+		 * @spec exclude UI plumbing — bulk row-selection state; admin list contract owned by admin-list-views.
+		 * @param {boolean} checked - true selects all, false clears
+		 * @return {void}
+		 */
 		toggleSelectAll(checked) {
 			if (checked) {
 				this.selectedOrganisations = organisationStore.userStats.list.map(org => org.uuid)
@@ -476,6 +562,14 @@ export default {
 				this.selectedOrganisations = []
 			}
 		},
+		/**
+		 * Toggle selection for a single organisation row.
+		 *
+		 * @spec exclude UI plumbing — row-selection state mutation; admin list contract owned by admin-list-views.
+		 * @param {string} orgUuid - organisation uuid
+		 * @param {boolean} checked - selected state
+		 * @return {void}
+		 */
 		toggleOrganisationSelection(orgUuid, checked) {
 			if (checked) {
 				this.selectedOrganisations.push(orgUuid)
@@ -483,12 +577,33 @@ export default {
 				this.selectedOrganisations = this.selectedOrganisations.filter(uuid => uuid !== orgUuid)
 			}
 		},
+		/**
+		 * Handle a page change from the paginator.
+		 *
+		 * @spec exclude UI plumbing — pagination state delegation; admin list contract owned by admin-list-views.
+		 * @param {number} page - new page number
+		 * @return {void}
+		 */
 		onPageChanged(page) {
 			organisationStore.setPagination(page, organisationStore.pagination.limit)
 		},
+		/**
+		 * Handle a page-size change from the paginator.
+		 *
+		 * @spec exclude UI plumbing — pagination state delegation; admin list contract owned by admin-list-views.
+		 * @param {number} pageSize - new page size
+		 * @return {void}
+		 */
 		onPageSizeChanged(pageSize) {
 			organisationStore.setPagination(1, pageSize)
 		},
+		/**
+		 * Format a date for display.
+		 *
+		 * @spec exclude UI plumbing — pure display formatter, no observable contract.
+		 * @param {string} dateString - ISO date string
+		 * @return {string} localized date/time
+		 */
 		formatDate(dateString) {
 			return new Date(dateString).toLocaleDateString({
 				day: '2-digit',
@@ -500,14 +615,34 @@ export default {
 			})
 		},
 		// Organisation Modal Methods
+		/**
+		 * Open the create-organisation modal.
+		 *
+		 * @spec exclude UI plumbing — store-set + modal dispatch; tenant CRUD owned by tenant-lifecycle.
+		 * @return {void}
+		 */
 		createOrganisation() {
 			organisationStore.setOrganisationItem(null)
 			navigationStore.setModal('editOrganisation')
 		},
+		/**
+		 * Open the edit-organisation modal for a row.
+		 *
+		 * @spec exclude UI plumbing — store-set + modal dispatch; tenant CRUD owned by tenant-lifecycle.
+		 * @param {object} organisation - organisation row
+		 * @return {void}
+		 */
 		editOrganisation(organisation) {
 			organisationStore.setOrganisationItem(organisation)
 			navigationStore.setModal('editOrganisation')
 		},
+		/**
+		 * Open the join-organisation modal with transfer data.
+		 *
+		 * @spec exclude UI plumbing — transfer-data set + modal dispatch; membership contract owned by tenant-lifecycle.
+		 * @param {object} organisation - organisation row
+		 * @return {void}
+		 */
 		openJoinModal(organisation) {
 			// Set the transfer data with the organisation UUID
 			navigationStore.setTransferData({
@@ -516,6 +651,13 @@ export default {
 			// Open the join organisation modal
 			navigationStore.setModal('joinOrganisation')
 		},
+		/**
+		 * Open the manage-roles modal for a row.
+		 *
+		 * @spec exclude UI plumbing — store-set + modal dispatch; role contract owned by tenant-lifecycle.
+		 * @param {object} organisation - organisation row
+		 * @return {void}
+		 */
 		openManageRolesModal(organisation) {
 			// Set the organisation item in store
 			organisationStore.setOrganisationItem(organisation)
@@ -523,10 +665,24 @@ export default {
 			navigationStore.setModal('manageOrganisationRoles')
 		},
 		// Organisation Action Methods
+		/**
+		 * Open the organisation's public catalogue page.
+		 *
+		 * @spec exclude UI plumbing — external window.open navigation, no observable contract.
+		 * @param {object} organisation - organisation row
+		 * @return {void}
+		 */
 		viewOrganisation(organisation) {
 			const publicationUrl = `https://www.softwarecatalogus.nl/publicatie/${organisation.id}`
 			window.open(publicationUrl, '_blank')
 		},
+		/**
+		 * Open the organisation's website in a new tab.
+		 *
+		 * @spec exclude UI plumbing — external window.open navigation, no observable contract.
+		 * @param {object} organisation - organisation row
+		 * @return {void}
+		 */
 		goToOrganisation(organisation) {
 			if (organisation.website) {
 				let websiteUrl = organisation.website

--- a/src/views/register/RegisterDetail.vue
+++ b/src/views/register/RegisterDetail.vue
@@ -250,6 +250,12 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Inline JSON-schema describing the register edit form.
+		 *
+		 * @spec exclude UI plumbing — static form-schema for the edit dialog, no observable contract.
+		 * @return {object}
+		 */
 		registerSchema() {
 			return {
 				title: t('openregister', 'Register'),
@@ -262,11 +268,23 @@ export default {
 				required: ['title', 'slug'],
 			}
 		},
+		/**
+		 * Resolve the active register from the dashboard store.
+		 *
+		 * @spec exclude UI plumbing — store lookup; register dashboard contract owned by built-in-dashboards.
+		 * @return {object|undefined}
+		 */
 		register() {
 			// Find the register in the dashboard store using the ID from register store
 			const registerId = registerStore.getRegisterItem?.id
 			return dashboardStore.registers.find(r => r.id === registerId)
 		},
+		/**
+		 * ApexCharts options for the audit-trail line chart.
+		 *
+		 * @spec exclude UI plumbing — chart config computed; dashboard contract owned by built-in-dashboards.
+		 * @return {object}
+		 */
 		auditTrailChartOptions() {
 			return {
 				chart: {
@@ -302,6 +320,12 @@ export default {
 				},
 			}
 		},
+		/**
+		 * ApexCharts options for the objects-by-schema pie chart.
+		 *
+		 * @spec exclude UI plumbing — chart config computed; dashboard contract owned by built-in-dashboards.
+		 * @return {object}
+		 */
 		schemaChartOptions() {
 			return {
 				chart: {
@@ -324,6 +348,12 @@ export default {
 				}],
 			}
 		},
+		/**
+		 * ApexCharts options for the objects-by-size bar chart.
+		 *
+		 * @spec exclude UI plumbing — chart config computed; dashboard contract owned by built-in-dashboards.
+		 * @return {object}
+		 */
 		sizeChartOptions() {
 			return {
 				chart: {
@@ -355,6 +385,12 @@ export default {
 	},
 	watch: {
 		register: {
+			/**
+			 * Reload schemas + managing configuration when the register changes.
+			 *
+			 * @spec exclude UI plumbing — watcher delegating to loaders; dashboard contract owned by built-in-dashboards.
+			 * @return {void}
+			 */
 			handler() {
 				// Reload schemas and check configuration when register changes
 				this.loadSchemas()
@@ -362,12 +398,25 @@ export default {
 			},
 			deep: true,
 		},
+		/**
+		 * Lazy-load schema options when the edit dialog opens.
+		 *
+		 * @spec exclude UI plumbing — watcher triggering option load on dialog open.
+		 * @param {boolean} val - dialog visibility
+		 * @return {void}
+		 */
 		showEditDialog(val) {
 			if (val) {
 				this.loadSchemaOptions()
 			}
 		},
 	},
+	/**
+	 * Fetch register/dashboard data and stats on mount.
+	 *
+	 * @spec exclude UI plumbing — lifecycle hook delegating to store loaders; dashboard contract owned by built-in-dashboards.
+	 * @return {Promise<void>}
+	 */
 	async mounted() {
 		// If we have a register ID but no data, fetch dashboard data
 		if (registerStore.getRegisterItem?.id && !this.register) {
@@ -395,6 +444,8 @@ export default {
 	methods: {
 		/**
 		 * Load register statistics from the dedicated stats endpoint
+		 *
+		 * @spec exclude UI plumbing — store delegation hydrating local stats; dashboard contract owned by built-in-dashboards.
 		 * @return {Promise<void>}
 		 */
 		async loadRegisterStats() {
@@ -414,6 +465,12 @@ export default {
 				this.statsLoading = false
 			}
 		},
+		/**
+		 * ApexCharts options for a per-schema validity pie chart.
+		 *
+		 * @spec exclude UI plumbing — chart config builder; dashboard contract owned by built-in-dashboards.
+		 * @return {object}
+		 */
 		getSchemaChartOptions() {
 			return {
 				chart: {
@@ -427,6 +484,13 @@ export default {
 				colors: ['#41B883', '#E46651', '#00D8FF', '#DD6B20'],
 				tooltip: {
 					y: {
+						/**
+						 * Format a chart tooltip value as an object count.
+						 *
+						 * @spec exclude UI plumbing — inline chart tooltip formatter, no observable contract.
+						 * @param {number} val - data point value
+						 * @return {string}
+						 */
 						formatter(val) {
 							return val + ' objects'
 						},
@@ -435,6 +499,12 @@ export default {
 			}
 		},
 
+		/**
+		 * Load schema select options for the edit dialog.
+		 *
+		 * @spec exclude UI plumbing — store delegation hydrating select options.
+		 * @return {Promise<void>}
+		 */
 		async loadSchemaOptions() {
 			this.schemasLoading = true
 			try {
@@ -446,6 +516,13 @@ export default {
 				this.schemasLoading = false
 			}
 		},
+		/**
+		 * Map schema ids/objects to NcSelect option values.
+		 *
+		 * @spec exclude UI plumbing — select-value normalizer for the edit form.
+		 * @param {Array} schemas - schema ids or objects
+		 * @return {Array} option objects
+		 */
 		getSchemaSelectValue(schemas) {
 			if (!Array.isArray(schemas)) return []
 			return schemas.map(s => {
@@ -454,6 +531,13 @@ export default {
 					|| { id, label: String(id) }
 			})
 		},
+		/**
+		 * Persist the register edit form and refresh dashboard data.
+		 *
+		 * @spec exclude UI plumbing — store delegation + dialog result; register CRUD contract owned elsewhere.
+		 * @param {object} formData - edited register fields
+		 * @return {Promise<void>}
+		 */
 		async onSaveRegister(formData) {
 			try {
 				await registerStore.saveRegister({
@@ -466,12 +550,21 @@ export default {
 				this.$refs.editRegisterDialog.setResult({ error: error.message })
 			}
 		},
+		/**
+		 * Open the edit-schema modal for a schema row.
+		 *
+		 * @spec exclude UI plumbing — store-set + modal dispatch.
+		 * @param {object} schema - schema row
+		 * @return {void}
+		 */
 		editSchema(schema) {
 			registerStore.setSchemaItem(schema)
 			navigationStore.setModal('editSchema')
 		},
 		/**
 		 * Load full schema details from schema IDs
+		 *
+		 * @spec exclude UI plumbing — parallel fetch hydrating local schema cards; schema contract owned elsewhere.
 		 * @return {Promise<void>}
 		 */
 		async loadSchemas() {
@@ -512,6 +605,8 @@ export default {
 		},
 		/**
 		 * Check if this register is managed by a configuration
+		 *
+		 * @spec exclude UI plumbing — scans local configuration list to set a managed badge.
 		 * @return {Promise<void>}
 		 */
 		async checkManagingConfiguration() {

--- a/src/views/settings/sections/ApiTokenConfiguration.vue
+++ b/src/views/settings/sections/ApiTokenConfiguration.vue
@@ -352,6 +352,7 @@ export default {
 		/**
 		 * Load existing API tokens from the backend
 		 *
+		 * @spec exclude UI plumbing — admin-settings load hydrating local fields.
 		 * @return {Promise<void>}
 		 */
 		async loadTokens() {
@@ -375,6 +376,7 @@ export default {
 		/**
 		 * Update GitHub token value
 		 *
+		 * @spec exclude UI plumbing — local field setter for two-way binding.
 		 * @param {string} value New token value
 		 * @return {void}
 		 */
@@ -385,6 +387,7 @@ export default {
 		/**
 		 * Update GitLab token value
 		 *
+		 * @spec exclude UI plumbing — local field setter for two-way binding.
 		 * @param {string} value New token value
 		 * @return {void}
 		 */
@@ -395,6 +398,7 @@ export default {
 		/**
 		 * Update GitLab URL value
 		 *
+		 * @spec exclude UI plumbing — local field setter for two-way binding.
 		 * @param {string} value New URL value
 		 * @return {void}
 		 */
@@ -405,6 +409,7 @@ export default {
 		/**
 		 * Save GitHub token to the backend
 		 *
+		 * @spec exclude UI plumbing — admin-settings save + toast.
 		 * @return {Promise<void>}
 		 */
 		async saveGitHubToken() {
@@ -426,6 +431,7 @@ export default {
 		/**
 		 * Save GitLab token to the backend
 		 *
+		 * @spec exclude UI plumbing — admin-settings save + toast.
 		 * @return {Promise<void>}
 		 */
 		async saveGitLabToken() {
@@ -447,6 +453,7 @@ export default {
 		/**
 		 * Save GitLab URL to the backend
 		 *
+		 * @spec exclude UI plumbing — admin-settings save + toast.
 		 * @return {Promise<void>}
 		 */
 		async saveGitLabUrl() {
@@ -468,6 +475,7 @@ export default {
 		/**
 		 * Clear GitHub token
 		 *
+		 * @spec exclude UI plumbing — resets field then delegates to saveGitHubToken.
 		 * @return {Promise<void>}
 		 */
 		async clearGitHubToken() {
@@ -478,6 +486,7 @@ export default {
 		/**
 		 * Clear GitLab token
 		 *
+		 * @spec exclude UI plumbing — resets field then delegates to saveGitLabToken.
 		 * @return {Promise<void>}
 		 */
 		async clearGitLabToken() {
@@ -488,6 +497,7 @@ export default {
 		/**
 		 * Show save message
 		 *
+		 * @spec exclude UI plumbing — transient inline message with auto-clear timeout.
 		 * @param {string} message - The message to show
 		 * @param {string} type - The type of message ('success' or 'error')
 		 * @return {void}
@@ -503,6 +513,7 @@ export default {
 		/**
 		 * Test GitHub token validity
 		 *
+		 * @spec exclude UI plumbing — thin POST + result display; token validation contract owned by backend.
 		 * @return {Promise<void>}
 		 */
 		async testGitHubToken() {
@@ -540,6 +551,7 @@ export default {
 		/**
 		 * Test GitLab token validity
 		 *
+		 * @spec exclude UI plumbing — thin POST + result display; token validation contract owned by backend.
 		 * @return {Promise<void>}
 		 */
 		async testGitLabToken() {

--- a/src/views/settings/sections/FileConfiguration.vue
+++ b/src/views/settings/sections/FileConfiguration.vue
@@ -758,6 +758,8 @@ export default {
 
 		/**
 		 * Check if any file operation is currently running
+		 *
+		 * @spec exclude UI plumbing — derived busy-state for disabling buttons.
 		 */
 		isProcessing() {
 			return this.discoveringFiles || this.extractingFiles || this.retryingFiles
@@ -765,6 +767,8 @@ export default {
 
 		/**
 		 * Show Presidio config when presidio or hybrid is selected
+		 *
+		 * @spec exclude UI plumbing — conditional-render predicate for a settings block.
 		 */
 		showPresidioConfig() {
 			const methodId = this.fileSettings.entityRecognitionMethod?.id || 'regex'
@@ -773,6 +777,8 @@ export default {
 
 		/**
 		 * Show OpenAnonymiser config when openanonymiser is selected
+		 *
+		 * @spec exclude UI plumbing — conditional-render predicate for a settings block.
 		 */
 		showOpenAnonymiserConfig() {
 			const methodId = this.fileSettings.entityRecognitionMethod?.id || 'regex'
@@ -780,6 +786,12 @@ export default {
 		},
 	},
 
+	/**
+	 * Load settings and extraction stats on mount.
+	 *
+	 * @spec exclude UI plumbing — lifecycle hook delegating to loaders.
+	 * @return {Promise<void>}
+	 */
 	async mounted() {
 		await this.loadSettings()
 		await this.loadExtractionStats()
@@ -788,6 +800,8 @@ export default {
 	methods: {
 		/**
 		 * Load file configuration settings
+		 *
+		 * @spec exclude UI plumbing — admin-settings load hydrating local form state.
 		 */
 		async loadSettings() {
 			try {
@@ -858,6 +872,8 @@ export default {
 
 		/**
 		 * Load object text extraction settings
+		 *
+		 * @spec exclude UI plumbing — admin-settings load hydrating local form state.
 		 */
 		async loadObjectSettings() {
 			try {
@@ -876,6 +892,8 @@ export default {
 
 		/**
 		 * Save file configuration settings
+		 *
+		 * @spec exclude UI plumbing — admin-settings save delegating to the store.
 		 */
 		async saveSettings() {
 			try {
@@ -909,6 +927,8 @@ export default {
 
 		/**
 		 * Save object text extraction settings
+		 *
+		 * @spec exclude UI plumbing — admin-settings save delegating to the store.
 		 */
 		async saveObjectSettings() {
 			try {
@@ -925,6 +945,8 @@ export default {
 
 		/**
 		 * Test Dolphin API connection
+		 *
+		 * @spec exclude UI plumbing — thin store-delegated connection test + message.
 		 */
 		async testDolphinConnection() {
 			try {
@@ -958,6 +980,8 @@ export default {
 
 		/**
 		 * Test Presidio API connection
+		 *
+		 * @spec exclude UI plumbing — thin store-delegated connection test + message.
 		 */
 		async testPresidioConnection() {
 			try {
@@ -992,6 +1016,8 @@ export default {
 
 		/**
 		 * Test OpenAnonymiser API connection
+		 *
+		 * @spec exclude UI plumbing — thin store-delegated connection test + message.
 		 */
 		async testOpenAnonymiserConnection() {
 			try {
@@ -1026,6 +1052,8 @@ export default {
 
 		/**
 		 * Load extraction statistics
+		 *
+		 * @spec exclude UI plumbing — admin-settings stats load hydrating local display state.
 		 */
 		async loadExtractionStats() {
 			try {
@@ -1049,6 +1077,8 @@ export default {
 
 		/**
 		 * Discover files in Nextcloud that aren't tracked yet
+		 *
+		 * @spec exclude UI plumbing — store-delegated action trigger + feedback message.
 		 */
 		async discoverFiles() {
 			this.discoveringFiles = true
@@ -1077,6 +1107,8 @@ export default {
 
 		/**
 		 * Extract pending files (files already staged with status='pending')
+		 *
+		 * @spec exclude UI plumbing — store-delegated action trigger + feedback message.
 		 */
 		async extractAllPendingFiles() {
 			this.extractingFiles = true
@@ -1105,6 +1137,8 @@ export default {
 
 		/**
 		 * Retry failed file extractions
+		 *
+		 * @spec exclude UI plumbing — store-delegated action trigger + feedback message.
 		 */
 		async reprocessFailedFiles() {
 			this.retryingFiles = true
@@ -1133,6 +1167,8 @@ export default {
 
 		/**
 		 * Show save message
+		 *
+		 * @spec exclude UI plumbing — transient inline message with auto-clear timeout.
 		 * @param {string} message - The message to show
 		 * @param {string} type - The type of message to show
 		 */
@@ -1146,6 +1182,8 @@ export default {
 
 		/**
 		 * Format number with thousands separator
+		 *
+		 * @spec exclude UI plumbing — pure display formatter, no observable contract.
 		 * @param {number} num - The number to format
 		 */
 		formatNumber(num) {

--- a/src/views/settings/sections/MultitenancyConfiguration.vue
+++ b/src/views/settings/sections/MultitenancyConfiguration.vue
@@ -152,36 +152,85 @@ export default {
 		...mapStores(useSettingsStore),
 
 		multitenancyOptions: {
+			/**
+			 * Read multitenancy options from the settings store.
+			 *
+			 * @spec exclude UI plumbing — store passthrough getter; tenant config owned by tenant-lifecycle.
+			 * @return {object}
+			 */
 			get() {
 				return this.settingsStore.multitenancyOptions
 			},
+			/**
+			 * Write multitenancy options to the settings store.
+			 *
+			 * @spec exclude UI plumbing — store passthrough setter; tenant config owned by tenant-lifecycle.
+			 * @param {object} value - new options
+			 * @return {void}
+			 */
 			set(value) {
 				this.settingsStore.multitenancyOptions = value
 			},
 		},
 
+		/**
+		 * Tenant options from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {Array}
+		 */
 		tenantOptions() {
 			return this.settingsStore.tenantOptions
 		},
 
+		/**
+		 * Loading flag from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {boolean}
+		 */
 		loading() {
 			return this.settingsStore.loading
 		},
 
+		/**
+		 * Saving flag from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {boolean}
+		 */
 		saving() {
 			return this.settingsStore.saving
 		},
 
+		/**
+		 * Rebasing flag from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {boolean}
+		 */
 		rebasing() {
 			return this.settingsStore.rebasing
 		},
 	},
 
 	methods: {
+		/**
+		 * Open the tenant-rebase confirmation dialog.
+		 *
+		 * @spec exclude UI plumbing — store passthrough; rebase contract owned by tenant-lifecycle.
+		 * @return {void}
+		 */
 		showRebaseDialog() {
 			this.settingsStore.showRebaseDialog()
 		},
 
+		/**
+		 * Persist multitenancy settings.
+		 *
+		 * @spec exclude UI plumbing — store delegation; tenant config contract owned by tenant-lifecycle.
+		 * @return {Promise<void>}
+		 */
 		async saveSettings() {
 			await this.settingsStore.updateMultitenancySettings(this.multitenancyOptions)
 		},

--- a/src/views/settings/sections/N8nConfiguration.vue
+++ b/src/views/settings/sections/N8nConfiguration.vue
@@ -342,6 +342,7 @@ export default {
 		/**
 		 * Check if configuration has unsaved changes.
 		 *
+		 * @spec exclude UI plumbing — dirty-state predicate comparing local fields to snapshot.
 		 * @return {boolean} True if there are unsaved changes.
 		 */
 		hasChanges() {
@@ -362,6 +363,7 @@ export default {
 		/**
 		 * Load n8n configuration from backend.
 		 *
+		 * @spec exclude UI plumbing — admin-settings load hydrating local fields.
 		 * @return {Promise<void>}
 		 */
 		async loadConfiguration() {
@@ -398,6 +400,7 @@ export default {
 		/**
 		 * Update n8n URL value.
 		 *
+		 * @spec exclude UI plumbing — local field setter for two-way binding.
 		 * @param {string} value New URL value.
 		 * @return {void}
 		 */
@@ -408,6 +411,7 @@ export default {
 		/**
 		 * Update n8n API key value.
 		 *
+		 * @spec exclude UI plumbing — local field setter for two-way binding.
 		 * @param {string} value New API key value.
 		 * @return {void}
 		 */
@@ -418,6 +422,7 @@ export default {
 		/**
 		 * Update n8n project value.
 		 *
+		 * @spec exclude UI plumbing — local field setter for two-way binding.
 		 * @param {string} value New project value.
 		 * @return {void}
 		 */
@@ -428,6 +433,7 @@ export default {
 		/**
 		 * Handle toggle of n8n integration.
 		 *
+		 * @spec exclude UI plumbing — toggle handler delegating to saveConfiguration.
 		 * @param {boolean} checked New enabled state.
 		 * @return {Promise<void>}
 		 */
@@ -442,6 +448,7 @@ export default {
 		/**
 		 * Save n8n configuration to backend.
 		 *
+		 * @spec exclude UI plumbing — admin-settings save + toast.
 		 * @return {Promise<void>}
 		 */
 		async saveConfiguration() {
@@ -476,6 +483,7 @@ export default {
 		/**
 		 * Test n8n connection.
 		 *
+		 * @spec exclude UI plumbing — thin POST + result display.
 		 * @return {Promise<void>}
 		 */
 		async testConnection() {
@@ -515,6 +523,7 @@ export default {
 		/**
 		 * Initialize n8n project and user.
 		 *
+		 * @spec exclude UI plumbing — thin POST + result display + workflow refresh.
 		 * @return {Promise<void>}
 		 */
 		async initializeN8n() {
@@ -553,6 +562,7 @@ export default {
 		/**
 		 * Load workflows from n8n.
 		 *
+		 * @spec exclude UI plumbing — admin-settings load hydrating local workflow list.
 		 * @return {Promise<void>}
 		 */
 		async loadWorkflows() {
@@ -571,6 +581,7 @@ export default {
 		/**
 		 * Open n8n editor in new tab.
 		 *
+		 * @spec exclude UI plumbing — external window.open navigation, no observable contract.
 		 * @return {void}
 		 */
 		openN8nEditor() {

--- a/src/views/settings/sections/SolrConfiguration.vue
+++ b/src/views/settings/sections/SolrConfiguration.vue
@@ -1228,14 +1228,33 @@ export default {
 		...mapStores(useSettingsStore),
 
 		// Access the settings store
+		/**
+		 * Resolve the settings store instance.
+		 *
+		 * @spec exclude UI plumbing — store accessor, no observable contract.
+		 * @return {object}
+		 */
 		settingsStore() {
 			return useSettingsStore()
 		},
 
 		solrOptions: {
+			/**
+			 * Read Solr options from the settings store.
+			 *
+			 * @spec exclude UI plumbing — store passthrough getter; search config owned by zoeken-filteren / faceting-configuration.
+			 * @return {object}
+			 */
 			get() {
 				return this.settingsStore.solrOptions
 			},
+			/**
+			 * Write Solr options to the settings store.
+			 *
+			 * @spec exclude UI plumbing — store passthrough setter; search config owned by zoeken-filteren / faceting-configuration.
+			 * @param {object} value - new options
+			 * @return {void}
+			 */
 			set(value) {
 				this.settingsStore.solrOptions = value
 			},
@@ -1260,78 +1279,192 @@ export default {
 			},
 		},
 
+		/**
+		 * Solr connection status from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {*}
+		 */
 		solrConnectionStatus() {
 			return this.settingsStore.solrConnectionStatus
 		},
 
+		/**
+		 * Loading flag from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {boolean}
+		 */
 		loading() {
 			return this.settingsStore.loading
 		},
 
+		/**
+		 * Saving flag from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {boolean}
+		 */
 		saving() {
 			return this.settingsStore.saving
 		},
 
+		/**
+		 * Testing-connection flag from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {boolean}
+		 */
 		testingConnection() {
 			return this.settingsStore.testingConnection
 		},
 
+		/**
+		 * Warming-up flag from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {boolean}
+		 */
 		warmingUpSolr() {
 			return this.settingsStore.warmingUpSolr
 		},
 
+		/**
+		 * Setting-up flag from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {boolean}
+		 */
 		settingUpSolr() {
 			return this.settingsStore.settingUpSolr
 		},
 
+		/**
+		 * Scheme options from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {Array}
+		 */
 		schemeOptions() {
 			return this.settingsStore.schemeOptions
 		},
 
+		/**
+		 * Test-dialog visibility from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {boolean}
+		 */
 		showTestDialog() {
 			return this.settingsStore.showTestDialog
 		},
 
+		/**
+		 * Setup-dialog visibility from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {boolean}
+		 */
 		showSetupDialog() {
 			return this.settingsStore.showSetupDialog
 		},
 
+		/**
+		 * Test results from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {*}
+		 */
 		testResults() {
 			return this.settingsStore.testResults
 		},
 
+		/**
+		 * Setup results from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {*}
+		 */
 		setupResults() {
 			return this.settingsStore.setupResults
 		},
 
+		/**
+		 * Fields-dialog visibility from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {boolean}
+		 */
 		showFieldsDialog() {
 			return this.settingsStore.showFieldsDialog
 		},
 
+		/**
+		 * Loading-fields flag from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {boolean}
+		 */
 		loadingFields() {
 			return this.settingsStore.loadingFields
 		},
 
+		/**
+		 * Field info from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {*}
+		 */
 		fieldsInfo() {
 			return this.settingsStore.fieldsInfo
 		},
 
+		/**
+		 * Field comparison from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {*}
+		 */
 		fieldComparison() {
 			return this.settingsStore.fieldComparison
 		},
 
+		/**
+		 * Creating-fields flag from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {boolean}
+		 */
 		creatingFields() {
 			return this.settingsStore.creatingFields
 		},
 
+		/**
+		 * Fixing-fields flag from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {boolean}
+		 */
 		fixingFields() {
 			return this.settingsStore.fixingFields
 		},
 
+		/**
+		 * Field creation result from the settings store.
+		 *
+		 * @spec exclude UI plumbing — store passthrough computed.
+		 * @return {*}
+		 */
 		fieldCreationResult() {
 			return this.settingsStore.fieldCreationResult
 		},
 
+		/**
+		 * Fields filtered by the active text/type filters.
+		 *
+		 * @spec exclude UI plumbing — client-side display filter, no observable contract.
+		 * @return {object}
+		 */
 		filteredFields() {
 			if (!this.fieldsInfo || !this.fieldsInfo.fields) {
 				return {}
@@ -1361,6 +1494,12 @@ export default {
 			return fields
 		},
 
+		/**
+		 * Distinct field-type options for the type filter.
+		 *
+		 * @spec exclude UI plumbing — derived select options for display filtering.
+		 * @return {Array}
+		 */
 		fieldTypeOptions() {
 			if (!this.fieldsInfo || !this.fieldsInfo.fields) {
 				return []
@@ -1374,6 +1513,12 @@ export default {
 		},
 
 		// Dashboard computed properties
+		/**
+		 * CSS class reflecting connection status.
+		 *
+		 * @spec exclude UI plumbing — derived display class, no observable contract.
+		 * @return {string}
+		 */
 		connectionStatusClass() {
 			if (!this.solrStats || !this.solrStats.available) {
 				return 'status-error'
@@ -1385,6 +1530,12 @@ export default {
 		},
 	},
 
+	/**
+	 * Load settings and (if enabled) Solr + object stats on mount.
+	 *
+	 * @spec exclude UI plumbing — lifecycle hook delegating to loaders; search config owned by zoeken-filteren / faceting-configuration.
+	 * @return {Promise<void>}
+	 */
 	async mounted() {
 		// Wait for settings store to load first
 		try {
@@ -1408,6 +1559,12 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * Smooth-scroll to the field-mismatches section.
+		 *
+		 * @spec exclude UI plumbing — DOM scroll helper, no observable contract.
+		 * @return {void}
+		 */
 		scrollToMismatches() {
 			const element = document.getElementById('field-mismatches')
 			if (element) {
@@ -1415,12 +1572,24 @@ export default {
 			}
 		},
 
+		/**
+		 * Open the Solr setup confirmation dialog.
+		 *
+		 * @spec exclude UI plumbing — store-flag dialog toggle.
+		 * @return {Promise<void>}
+		 */
 		async setupSolr() {
 			// Just show the setup dialog - it will start with confirmation screen
 			this.settingsStore.showSetupDialog = true
 			this.settingsStore.setupResults = null
 		},
 
+		/**
+		 * Run the Solr setup with the loading animation.
+		 *
+		 * @spec exclude UI plumbing — store-delegated setup wrapped in loading animation; search config owned by zoeken-filteren.
+		 * @return {Promise<void>}
+		 */
 		async startSolrSetup() {
 			// Start the game-style loading
 			this.startGameLoading()
@@ -1432,6 +1601,12 @@ export default {
 			this.stopGameLoading()
 		},
 
+		/**
+		 * Start the game-style loading tip animation.
+		 *
+		 * @spec exclude UI plumbing — loading-screen animation, no observable contract.
+		 * @return {void}
+		 */
 		startGameLoading() {
 			this.visibleTips = []
 			this.tipIndex = 0
@@ -1447,6 +1622,12 @@ export default {
 			}, 3000)
 		},
 
+		/**
+		 * Stop the game-style loading tip animation.
+		 *
+		 * @spec exclude UI plumbing — loading-screen animation teardown, no observable contract.
+		 * @return {void}
+		 */
 		stopGameLoading() {
 			if (this.loadingInterval) {
 				clearInterval(this.loadingInterval)
@@ -1454,6 +1635,12 @@ export default {
 			}
 		},
 
+		/**
+		 * Reveal the next loading tip.
+		 *
+		 * @spec exclude UI plumbing — loading-screen animation step, no observable contract.
+		 * @return {void}
+		 */
 		showNextTip() {
 			if (this.tipIndex < this.loadingTips.length) {
 				this.visibleTips.push({
@@ -1469,6 +1656,12 @@ export default {
 			}
 		},
 
+		/**
+		 * Pick a random loading message.
+		 *
+		 * @spec exclude UI plumbing — loading-screen animation copy, no observable contract.
+		 * @return {void}
+		 */
 		updateLoadingMessage() {
 			const messages = [
 				'Connecting to SOLR cluster...',
@@ -1485,6 +1678,13 @@ export default {
 			this.currentLoadingMessage = randomMessage
 		},
 
+		/**
+		 * Format a timestamp as a local time string.
+		 *
+		 * @spec exclude UI plumbing — pure display formatter, no observable contract.
+		 * @param {string|number} timestamp - value to format
+		 * @return {string}
+		 */
 		formatTime(timestamp) {
 			if (!timestamp) return 'Unknown'
 
@@ -1496,38 +1696,93 @@ export default {
 			}
 		},
 
+		/**
+		 * Test the Solr connection.
+		 *
+		 * @spec exclude UI plumbing — store passthrough; connection contract owned by zoeken-filteren.
+		 * @return {Promise<void>}
+		 */
 		async testSolrConnection() {
 			await this.settingsStore.testSolrConnection()
 		},
 
+		/**
+		 * Persist Solr settings.
+		 *
+		 * @spec exclude UI plumbing — store delegation; search config owned by zoeken-filteren / faceting-configuration.
+		 * @return {Promise<void>}
+		 */
 		async saveSettings() {
 			await this.settingsStore.updateSolrSettings(this.solrOptions)
 		},
 
+		/**
+		 * Hide the test dialog.
+		 *
+		 * @spec exclude UI plumbing — store passthrough dialog toggle.
+		 * @return {void}
+		 */
 		hideTestDialog() {
 			this.settingsStore.hideTestDialog()
 		},
 
+		/**
+		 * Retry the connection test.
+		 *
+		 * @spec exclude UI plumbing — store passthrough.
+		 * @return {void}
+		 */
 		retryTest() {
 			this.settingsStore.retryTest()
 		},
 
+		/**
+		 * Hide the setup dialog.
+		 *
+		 * @spec exclude UI plumbing — store passthrough dialog toggle.
+		 * @return {void}
+		 */
 		hideSetupDialog() {
 			this.settingsStore.hideSetupDialog()
 		},
 
+		/**
+		 * Retry the Solr setup.
+		 *
+		 * @spec exclude UI plumbing — store passthrough.
+		 * @return {void}
+		 */
 		retrySetup() {
 			this.settingsStore.retrySetup()
 		},
 
+		/**
+		 * Load Solr field info for inspection.
+		 *
+		 * @spec exclude UI plumbing — store passthrough; field schema contract owned by zoeken-filteren.
+		 * @return {Promise<void>}
+		 */
 		async inspectFields() {
 			await this.settingsStore.loadSolrFields()
 		},
 
+		/**
+		 * Hide the fields dialog.
+		 *
+		 * @spec exclude UI plumbing — store passthrough dialog toggle.
+		 * @return {void}
+		 */
 		hideFieldsDialog() {
 			this.settingsStore.hideFieldsDialog()
 		},
 
+		/**
+		 * Create missing Solr fields (optionally dry-run).
+		 *
+		 * @spec exclude UI plumbing — store delegation + toast; field schema contract owned by zoeken-filteren.
+		 * @param {boolean} dryRun - preview without applying
+		 * @return {Promise<void>}
+		 */
 		async createMissingFields(dryRun = false) {
 			try {
 				await this.settingsStore.createMissingSolrFields(dryRun)
@@ -1546,6 +1801,13 @@ export default {
 			}
 		},
 
+		/**
+		 * Fix mismatched Solr fields (optionally dry-run).
+		 *
+		 * @spec exclude UI plumbing — store delegation + toast; field schema contract owned by zoeken-filteren.
+		 * @param {boolean} dryRun - preview without applying
+		 * @return {Promise<void>}
+		 */
 		async fixMismatchedFields(dryRun = false) {
 			try {
 				// Use the dedicated fix-mismatches endpoint (automatically detects and fixes all mismatches)
@@ -1568,10 +1830,23 @@ export default {
 			}
 		},
 
+		/**
+		 * Retry loading Solr fields.
+		 *
+		 * @spec exclude UI plumbing — delegates to inspectFields.
+		 * @return {void}
+		 */
 		retryLoadFields() {
 			this.inspectFields()
 		},
 
+		/**
+		 * Map a Solr field type to a CSS class.
+		 *
+		 * @spec exclude UI plumbing — static class lookup for display.
+		 * @param {string} type - field type
+		 * @return {string}
+		 */
 		getTypeClass(type) {
 			const typeMap = {
 				string: 'type-string',
@@ -1586,14 +1861,35 @@ export default {
 			return typeMap[type] || 'type-unknown'
 		},
 
+		/**
+		 * Humanize a component name for display.
+		 *
+		 * @spec exclude UI plumbing — pure display formatter, no observable contract.
+		 * @param {string} name - raw name
+		 * @return {string}
+		 */
 		formatComponentName(name) {
 			return name.replace(/([A-Z])/g, ' $1').replace(/^./, str => str.toUpperCase())
 		},
 
+		/**
+		 * Humanize a detail label for display.
+		 *
+		 * @spec exclude UI plumbing — pure display formatter, no observable contract.
+		 * @param {string} key - raw key
+		 * @return {string}
+		 */
 		formatDetailLabel(key) {
 			return key.replace(/([A-Z])/g, ' $1').replace(/^./, str => str.toUpperCase())
 		},
 
+		/**
+		 * Stringify a detail value for display.
+		 *
+		 * @spec exclude UI plumbing — pure display formatter, no observable contract.
+		 * @param {*} value - raw value
+		 * @return {string}
+		 */
 		formatDetailValue(value) {
 			if (typeof value === 'object') {
 				return JSON.stringify(value, null, 2)
@@ -1602,6 +1898,12 @@ export default {
 		},
 
 		// Dashboard methods
+		/**
+		 * Load Solr dashboard stats.
+		 *
+		 * @spec exclude UI plumbing — stats load hydrating local display state; dashboard contract owned by built-in-dashboards.
+		 * @return {Promise<void>}
+		 */
 		async loadSolrStats() {
 			this.loadingStats = true
 			this.solrError = false
@@ -1636,11 +1938,24 @@ export default {
 			}
 		},
 
+		/**
+		 * Format a number with locale separators.
+		 *
+		 * @spec exclude UI plumbing — pure display formatter, no observable contract.
+		 * @param {number} num - value to format
+		 * @return {string|number}
+		 */
 		formatNumber(num) {
 			if (typeof num !== 'number') return num
 			return num.toLocaleString()
 		},
 
+		/**
+		 * Open the warmup modal after loading stats/schemas.
+		 *
+		 * @spec exclude UI plumbing — loaders + dialog toggle.
+		 * @return {Promise<void>}
+		 */
 		async openWarmupModal() {
 			// Load object stats before opening the modal
 			await this.loadObjectStats()
@@ -1648,10 +1963,22 @@ export default {
 			this.showWarmupDialog = true
 		},
 
+		/**
+		 * Open the file-warmup dialog.
+		 *
+		 * @spec exclude UI plumbing — dialog toggle.
+		 * @return {void}
+		 */
 		openFileWarmup() {
 			this.showFileWarmupDialog = true
 		},
 
+		/**
+		 * Load available schemas with object counts for warmup.
+		 *
+		 * @spec exclude UI plumbing — list load hydrating local schema options.
+		 * @return {Promise<void>}
+		 */
 		async loadAvailableSchemas() {
 			this.schemasLoading = true
 			try {
@@ -1696,6 +2023,12 @@ export default {
 			}
 		},
 
+		/**
+		 * Close the warmup modal and reset its state.
+		 *
+		 * @spec exclude UI plumbing — dialog close + local state reset.
+		 * @return {void}
+		 */
 		closeWarmupModal() {
 			this.showWarmupDialog = false
 			// Reset warmup state when modal is closed
@@ -1712,22 +2045,53 @@ export default {
 			}
 		},
 
+		/**
+		 * Open the clear-index dialog.
+		 *
+		 * @spec exclude UI plumbing — dialog toggle.
+		 * @return {void}
+		 */
 		openClearModal() {
 			this.showClearDialog = true
 		},
 
+		/**
+		 * Open the inspect dialog.
+		 *
+		 * @spec exclude UI plumbing — dialog toggle.
+		 * @return {void}
+		 */
 		openInspectModal() {
 			this.showInspectDialog = true
 		},
 
+		/**
+		 * Open the delete-collection dialog.
+		 *
+		 * @spec exclude UI plumbing — dialog toggle.
+		 * @return {void}
+		 */
 		openDeleteCollectionModal() {
 			this.showDeleteCollectionDialog = true
 		},
 
+		/**
+		 * Close the delete-collection dialog.
+		 *
+		 * @spec exclude UI plumbing — dialog toggle.
+		 * @return {void}
+		 */
 		closeDeleteCollectionModal() {
 			this.showDeleteCollectionDialog = false
 		},
 
+		/**
+		 * Refresh stats after a collection is deleted.
+		 *
+		 * @spec exclude UI plumbing — dialog close + stats refresh.
+		 * @param {*} _result - deletion result (unused)
+		 * @return {Promise<void>}
+		 */
 		async handleCollectionDeleted(_result) {
 			// Close the modal
 			this.closeDeleteCollectionModal()
@@ -1736,6 +2100,12 @@ export default {
 			await this.loadSolrStats()
 		},
 
+		/**
+		 * Clear the Solr index and refresh stats.
+		 *
+		 * @spec exclude UI plumbing — thin POST + stats refresh; index contract owned by zoeken-filteren.
+		 * @return {Promise<void>}
+		 */
 		async handleClearIndex() {
 			try {
 				const url = generateUrl('/apps/openregister/api/settings/solr/clear')
@@ -1750,6 +2120,12 @@ export default {
 			}
 		},
 
+		/**
+		 * Load object stats + memory prediction for warmup.
+		 *
+		 * @spec exclude UI plumbing — stats load hydrating local display state; dashboard contract owned by built-in-dashboards.
+		 * @return {Promise<void>}
+		 */
 		async loadObjectStats() {
 			this.objectStats.loading = true
 
@@ -1782,6 +2158,13 @@ export default {
 			}
 		},
 
+		/**
+		 * Load a memory prediction for a given object cap.
+		 *
+		 * @spec exclude UI plumbing — thin POST hydrating local prediction state.
+		 * @param {number} maxObjects - object cap
+		 * @return {Promise<void>}
+		 */
 		async loadMemoryPrediction(maxObjects = 0) {
 			try {
 				const url = generateUrl('/apps/openregister/api/settings/solr/memory-prediction')
@@ -1796,6 +2179,13 @@ export default {
 			}
 		},
 
+		/**
+		 * Start a Solr warmup run with the given config.
+		 *
+		 * @spec exclude UI plumbing — thin POST + progress state; warmup contract owned by zoeken-filteren.
+		 * @param {object} config - warmup configuration
+		 * @return {Promise<void>}
+		 */
 		async handleStartWarmup(config) {
 			// Store the config so it can be displayed in the modal
 			this.warmupConfig = { ...config }
@@ -1851,6 +2241,13 @@ export default {
 		 * Delete a SOLR field
 		 * @param {string} fieldName - The name of the field to delete
 		 */
+		/**
+		 * Delete a Solr field after confirmation.
+		 *
+		 * @spec exclude UI plumbing — confirm + thin DELETE + field reload; field schema contract owned by zoeken-filteren.
+		 * @param {string} fieldName - field to delete
+		 * @return {Promise<void>}
+		 */
 		async deleteField(fieldName) {
 			if (!fieldName) {
 				this.$toast.error('Invalid field name')
@@ -1887,6 +2284,9 @@ export default {
 
 		/**
 		 * Start SOLR reindex operation
+		 *
+		 * @spec exclude UI plumbing — confirm + thin POST + stats refresh; reindex contract owned by zoeken-filteren.
+		 * @return {Promise<void>}
 		 */
 		async startReindex() {
 			// Confirm reindex operation
@@ -1928,6 +2328,9 @@ export default {
 
 		/**
 		 * Open facet configuration modal
+		 *
+		 * @spec exclude UI plumbing — dialog toggle; facet config contract owned by faceting-configuration.
+		 * @return {void}
 		 */
 		openFacetConfigModal() {
 			this.showFacetConfigDialog = true
@@ -1936,7 +2339,9 @@ export default {
 		/**
 		 * Handle connection settings save
 		 *
+		 * @spec exclude UI plumbing — merges config + delegates to saveSettings + closes dialog.
 		 * @param {object} updatedConfig - Updated connection configuration
+		 * @return {Promise<void>}
 		 */
 		async handleConnectionSave(updatedConfig) {
 			// Update the local configuration

--- a/src/views/source/SourcesIndex.vue
+++ b/src/views/source/SourcesIndex.vue
@@ -273,17 +273,41 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Current page slice of the source list.
+		 *
+		 * @spec exclude UI plumbing — client-side pagination computed; admin list contract owned by admin-list-views.
+		 * @return {Array}
+		 */
 		paginatedSources() {
 			const start = ((this.pagination.page || 1) - 1) * (this.pagination.limit || 20)
 			const end = start + (this.pagination.limit || 20)
 			return sourceStore.sourceList.slice(start, end)
 		},
+		/**
+		 * Whether every source is selected.
+		 *
+		 * @spec exclude UI plumbing — header-checkbox state; admin list contract owned by admin-list-views.
+		 * @return {boolean}
+		 */
 		allSelected() {
 			return sourceStore.sourceList.length > 0 && sourceStore.sourceList.every(source => this.selectedSources.includes(source.id))
 		},
+		/**
+		 * Whether a partial selection exists (indeterminate state).
+		 *
+		 * @spec exclude UI plumbing — header-checkbox indeterminate state; admin list contract owned by admin-list-views.
+		 * @return {boolean}
+		 */
 		someSelected() {
 			return this.selectedSources.length > 0 && !this.allSelected
 		},
+		/**
+		 * Empty-state title reflecting loading/error/empty.
+		 *
+		 * @spec exclude UI plumbing — derived empty-state copy, no observable contract.
+		 * @return {string}
+		 */
 		emptyContentName() {
 			if (sourceStore.loading) {
 				return t('openregister', 'Loading sources...')
@@ -294,6 +318,12 @@ export default {
 			}
 			return ''
 		},
+		/**
+		 * Empty-state description reflecting loading/error/empty.
+		 *
+		 * @spec exclude UI plumbing — derived empty-state copy, no observable contract.
+		 * @return {string}
+		 */
 		emptyContentDescription() {
 			if (sourceStore.loading) {
 				return t('openregister', 'Please wait while we fetch your sources.')
@@ -305,6 +335,12 @@ export default {
 			return ''
 		},
 	},
+	/**
+	 * Soft-refresh the source list on mount.
+	 *
+	 * @spec exclude UI plumbing — lifecycle hook delegating to the store; list contract owned by admin-list-views.
+	 * @return {void}
+	 */
 	mounted() {
 		// Use soft reload (no loading spinner) since data is hot-loaded at app startup
 		sourceStore.refreshSourceList(null, true)
@@ -324,6 +360,14 @@ export default {
 				this.selectedSources = []
 			}
 		},
+		/**
+		 * Toggle selection for a single source row.
+		 *
+		 * @spec exclude UI plumbing — row-selection state mutation; admin list contract owned by admin-list-views.
+		 * @param {string|number} sourceId - row id
+		 * @param {boolean} checked - selected state
+		 * @return {void}
+		 */
 		toggleSourceSelection(sourceId, checked) {
 			if (checked) {
 				this.selectedSources.push(sourceId)
@@ -331,13 +375,34 @@ export default {
 				this.selectedSources = this.selectedSources.filter(id => id !== sourceId)
 			}
 		},
+		/**
+		 * Handle a page change from the paginator.
+		 *
+		 * @spec exclude UI plumbing — pagination state mutation; admin list contract owned by admin-list-views.
+		 * @param {number} page - new page number
+		 * @return {void}
+		 */
 		onPageChanged(page) {
 			this.pagination.page = page
 		},
+		/**
+		 * Handle a page-size change from the paginator.
+		 *
+		 * @spec exclude UI plumbing — pagination state mutation; admin list contract owned by admin-list-views.
+		 * @param {number} pageSize - new page size
+		 * @return {void}
+		 */
 		onPageSizeChanged(pageSize) {
 			this.pagination.page = 1
 			this.pagination.limit = pageSize
 		},
+		/**
+		 * Placeholder register-count display for a source.
+		 *
+		 * @spec exclude UI plumbing — unimplemented display placeholder, no observable contract.
+		 * @param {string|number} _sourceId - source id
+		 * @return {string}
+		 */
 		getSourceRegisterCount(_sourceId) {
 			// This would need to be implemented based on how registers are linked to sources
 			// For now, return a placeholder

--- a/src/views/templates/TemplatesIndex.vue
+++ b/src/views/templates/TemplatesIndex.vue
@@ -184,6 +184,7 @@ export default {
 		/**
 		 * Get current page number
 		 *
+		 * @spec exclude UI plumbing — pagination computed; admin list contract owned by admin-list-views.
 		 * @return {number} Current page
 		 */
 		currentPage() {
@@ -193,6 +194,7 @@ export default {
 		/**
 		 * Get total number of pages
 		 *
+		 * @spec exclude UI plumbing — pagination computed; admin list contract owned by admin-list-views.
 		 * @return {number} Total pages
 		 */
 		totalPages() {
@@ -218,6 +220,7 @@ export default {
 		/**
 		 * Load templates from the API
 		 *
+		 * @spec exclude UI plumbing — list load hydrating local state (stubbed pending API); list contract owned by admin-list-views.
 		 * @return {Promise<void>}
 		 */
 		async loadTemplates() {
@@ -255,6 +258,7 @@ export default {
 		/**
 		 * Refresh the templates list
 		 *
+		 * @spec exclude UI plumbing — delegates to loadTemplates.
 		 * @return {void}
 		 */
 		refreshTemplates() {
@@ -264,6 +268,7 @@ export default {
 		/**
 		 * Go to previous page
 		 *
+		 * @spec exclude UI plumbing — pagination offset mutation + reload; admin list contract owned by admin-list-views.
 		 * @return {void}
 		 */
 		previousPage() {
@@ -276,6 +281,7 @@ export default {
 		/**
 		 * Go to next page
 		 *
+		 * @spec exclude UI plumbing — pagination offset mutation + reload; admin list contract owned by admin-list-views.
 		 * @return {void}
 		 */
 		nextPage() {
@@ -288,6 +294,7 @@ export default {
 		/**
 		 * View template details
 		 *
+		 * @spec exclude UI plumbing — unimplemented navigation stub, no observable contract.
 		 * @param {object} _template - Template object
 		 * @return {void}
 		 */
@@ -299,6 +306,7 @@ export default {
 		/**
 		 * Format date for display
 		 *
+		 * @spec exclude UI plumbing — pure display formatter, no observable contract.
 		 * @param {string} date - Date string
 		 * @return {string} Formatted date
 		 */

--- a/src/views/webhooks/WebhooksIndex.vue
+++ b/src/views/webhooks/WebhooksIndex.vue
@@ -275,6 +275,7 @@ export default {
 		/**
 		 * Get current page number
 		 *
+		 * @spec exclude UI plumbing — pagination computed; admin list contract owned by admin-list-views.
 		 * @return {number} Current page
 		 */
 		currentPage() {
@@ -284,6 +285,7 @@ export default {
 		/**
 		 * Get total number of pages
 		 *
+		 * @spec exclude UI plumbing — pagination computed; admin list contract owned by admin-list-views.
 		 * @return {number} Total pages
 		 */
 		totalPages() {
@@ -336,6 +338,7 @@ export default {
 		/**
 		 * Handle search query update
 		 *
+		 * @spec exclude UI plumbing — local filter state + reload; webhook contract owned by webhook-payload-mapping.
 		 * @param {string} query - Search query
 		 * @return {void}
 		 */
@@ -348,6 +351,7 @@ export default {
 		/**
 		 * Handle enabled filter update
 		 *
+		 * @spec exclude UI plumbing — local filter state + reload; webhook contract owned by webhook-payload-mapping.
 		 * @param {boolean|null} enabled - Enabled filter
 		 * @return {void}
 		 */
@@ -360,6 +364,7 @@ export default {
 		/**
 		 * Load webhooks from the API
 		 *
+		 * @spec exclude UI plumbing — list load + client-side filter/paginate; webhook contract owned by webhook-payload-mapping.
 		 * @return {Promise<void>}
 		 */
 		async loadWebhooks() {
@@ -403,6 +408,7 @@ export default {
 		/**
 		 * Refresh the webhooks list
 		 *
+		 * @spec exclude UI plumbing — delegates to loadWebhooks.
 		 * @return {void}
 		 */
 		refreshWebhooks() {
@@ -412,6 +418,7 @@ export default {
 		/**
 		 * Go to previous page
 		 *
+		 * @spec exclude UI plumbing — pagination offset mutation + reload; admin list contract owned by admin-list-views.
 		 * @return {void}
 		 */
 		previousPage() {
@@ -424,6 +431,7 @@ export default {
 		/**
 		 * Go to next page
 		 *
+		 * @spec exclude UI plumbing — pagination offset mutation + reload; admin list contract owned by admin-list-views.
 		 * @return {void}
 		 */
 		nextPage() {
@@ -436,6 +444,7 @@ export default {
 		/**
 		 * Test a webhook
 		 *
+		 * @spec exclude UI plumbing — thin POST + toast + list refresh; delivery contract owned by webhook-payload-mapping.
 		 * @param {number} webhookId - Webhook ID
 		 * @return {Promise<void>}
 		 */
@@ -465,6 +474,7 @@ export default {
 		/**
 		 * View logs for a webhook
 		 *
+		 * @spec exclude UI plumbing — transfer-data set + router navigation.
 		 * @param {number} webhookId - Webhook ID
 		 * @return {void}
 		 */
@@ -476,6 +486,7 @@ export default {
 		/**
 		 * Toggle webhook enabled status
 		 *
+		 * @spec exclude UI plumbing — thin PUT + toast + list refresh; webhook contract owned by webhook-payload-mapping.
 		 * @param {object} webhook - Webhook object
 		 * @return {Promise<void>}
 		 */
@@ -496,6 +507,7 @@ export default {
 		/**
 		 * Delete a webhook
 		 *
+		 * @spec exclude UI plumbing — thin DELETE + toast + list refresh; webhook contract owned by webhook-payload-mapping.
 		 * @param {number} webhookId - Webhook ID
 		 * @return {Promise<void>}
 		 */
@@ -515,6 +527,7 @@ export default {
 		/**
 		 * Open create webhook dialog
 		 *
+		 * @spec exclude UI plumbing — transfer-data set + modal dispatch.
 		 * @return {void}
 		 */
 		openCreateDialog() {
@@ -525,6 +538,7 @@ export default {
 		/**
 		 * Open edit webhook dialog
 		 *
+		 * @spec exclude UI plumbing — transfer-data set + modal dispatch.
 		 * @param {object} webhook - Webhook object to edit
 		 * @return {void}
 		 */
@@ -536,6 +550,7 @@ export default {
 		/**
 		 * Format success rate
 		 *
+		 * @spec exclude UI plumbing — pure display formatter, no observable contract.
 		 * @param {object} webhook - Webhook object
 		 * @return {string} Formatted success rate
 		 */
@@ -550,6 +565,7 @@ export default {
 		/**
 		 * Truncate URL for display
 		 *
+		 * @spec exclude UI plumbing — pure display formatter, no observable contract.
 		 * @param {string} url - Full URL
 		 * @return {string} Truncated URL
 		 */
@@ -562,6 +578,7 @@ export default {
 		/**
 		 * Format date for display
 		 *
+		 * @spec exclude UI plumbing — pure display formatter, no observable contract.
 		 * @param {string} date - Date string
 		 * @return {string} Formatted date
 		 */


### PR DESCRIPTION
## Summary

Documentation-only retrofit bringing 223 uncovered Vue methods across ten `src/views/**/*.vue` files under the ADR-003 `@spec` convention. Every method ends with a `@spec exclude <reason>` tag.

- **223** batch methods tagged (`/tmp/or-scan/fw-fe-views-1.json`)
- **0** reverse-spec REQs minted / **223** excluded
- All methods are list/detail/settings UI plumbing: pagination handlers, row-selection state, computed display getters, store passthroughs, modal/dialog dispatch, formatters, lifecycle hooks, watcher handlers, route-param accessors, admin-settings load/save/test/clear glue
- The genuinely spec-worthy view contracts in these files (`toggleSelectAll`, `toggleSidebar`, `requestDeactivation`, `changePassword`, `loadTokens`) were already minted into `admin-list-views` / `account-self-service` by `retrofit-2026-05-24-2b-views`; behavior owned by other capabilities (object-lifecycle, tenant-lifecycle, built-in-dashboards, zoeken-filteren, faceting-configuration, webhook-payload-mapping, generic-integrations/ADR-019) is excluded with a reason pointing at the owning concern
- Ghost change `openspec/changes/retrofit-2026-05-25-fe-views-1/` (proposal + tasks, no spec delta)

## Files

`account/sections/{AccountSection,PasswordSection,TokensSection}`, `configuration/ConfigurationsIndex`, `integration/IntegrationsView`, `object/ObjectsIndex`, `organisation/OrganisationsIndex`, `register/RegisterDetail`, `settings/sections/{ApiToken,File,Multitenancy,N8n,Solr}Configuration`, `source/SourcesIndex`, `templates/TemplatesIndex`, `webhooks/WebhooksIndex`

## Test plan

- [ ] Pure JSDoc additions (1076 insertions, 0 deletions) — no behavior change
- [ ] Verified all 223 batch methods carry a preceding `@spec` tag; 0 untagged
- [ ] `<script>` blocks of edited files parse cleanly