### PR TITLE
retrofit: frontend coverage — views (chunk 3)

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-fe-views-3/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-views-3/proposal.md
@@ -1,0 +1,77 @@
+# Retrofit — Frontend coverage, views (chunk 3)
+
+## Why
+
+The `/opsx-coverage-scan` coverage audit reported 223 uncovered methods across 17
+`src/views/**/*.vue` files (batch `fe-views-3`). These are frontend view components:
+list/index pages, detail pages, settings sections, and account self-service sections.
+Bucket 2b means "we have code but no spec REQ to point at."
+
+Per ADR-003 and the retrofit playbook, frontend view code is largely UI plumbing —
+list/detail rendering, data fetching for display, formatting helpers, dialog
+open/close toggles, pagination handlers, and lifecycle hooks that wire stores to the
+view. None of these establish a novel user-facing contract beyond what the owning
+backend capabilities already specify. They are therefore annotated with
+`@spec exclude <reason>` (ADR-003 documentation-only exclusion) rather than minting
+new REQs.
+
+## What the cluster contains
+
+All 223 methods fall into UI-plumbing categories:
+
+- **Lifecycle hooks** (`mounted`, `created`, `updated`, `beforeDestroy`, `setup`) —
+  framework glue that loads view data on entry and tears down timers on exit.
+- **Data-load methods** (`loadStats`, `loadLogs`, `loadCacheStats`, `getFiles`,
+  `getRelations`, …) — fetch backend data for display; the contract lives in the
+  backend service/controller specs.
+- **Formatting / display helpers** (`formatBytes`, `formatDate`, `formatTime`,
+  `truncateText`, `getHitRateClass`, `widgetIcon`, …) — pure presentation.
+- **Computed properties** (`loading`, `tabs`, `stats`, `paginationData`,
+  `tableColumns`, `normalizedObjects`, …) — derived view state.
+- **Dialog / sidebar toggles** (`openCreateDialog`, `closeDialog`,
+  `showClearCacheDialog`, `hideClearAuditTrailsDialog`, …) — UI visibility state.
+- **Pagination / sort / selection handlers** (`onPageChanged`, `handleSort`,
+  `handleSelect`, `nextPage`, …) — table interaction plumbing.
+- **Action triggers** that delegate to a store/API already specified elsewhere
+  (`publishSchema`, `clearAllAuditTrails`, `triggerWarmup`, `exportData`, …).
+
+## Approach
+
+Every one of the 223 methods is tagged with JSDoc `@spec exclude <reason>` where the
+reason names the UI-plumbing role. No new REQs are minted; this is a
+documentation-only ghost change with no `specs/` delta.
+
+## No new REQs
+
+This change drafts **no new REQs**. All 223 methods are UI plumbing fully covered (at
+the contract level) by their owning backend capabilities, or are pure presentation
+with no specifiable contract. The behaviors are excluded per ADR-003, not specified.
+
+## Affected files
+
+- `src/views/account/sections/AvatarSection.vue`
+- `src/views/account/sections/ExportSection.vue`
+- `src/views/avg/AvgIndex.vue`
+- `src/views/dashboard/DashboardIndex.vue`
+- `src/views/logs/AuditTrailIndex.vue`
+- `src/views/object/ObjectDetails.vue`
+- `src/views/reports/ReportView.vue`
+- `src/views/reports/ReportsIndex.vue`
+- `src/views/schema/CalendarProviderTab.vue`
+- `src/views/schema/SchemaDetails.vue`
+- `src/views/schema/SchemasIndex.vue`
+- `src/views/search/SearchIndex.vue`
+- `src/views/settings/Settings.vue`
+- `src/views/settings/sections/CacheManagement.vue`
+- `src/views/settings/sections/LlmConfiguration.vue`
+- `src/views/settings/sections/RetentionConfiguration.vue`
+- `src/views/settings/sections/StatisticsOverview.vue`
+- `src/views/webhooks/WebhookLogsIndex.vue`
+
+## Out of scope
+
+- Any reshaping of observed behavior — exclusions document, they do not change code.
+- The backend capabilities these views render — covered by their own specs.
+
+Source: `/opsx-coverage-scan` batch `/tmp/or-scan/fw-fe-views-3.json`.
+See [retrofit playbook](../../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-25-fe-views-3/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-views-3/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+This is a documentation-only retrofit. All 223 methods in batch `fe-views-3` are
+tagged `@spec exclude <reason>` as UI plumbing. No new REQs are minted, so there are
+no implementation tasks — only the annotation pass.
+
+- [x] task-1: Annotate all 223 uncovered `src/views/**/*.vue` methods with
+  `@spec exclude <reason>` (UI plumbing: list/detail rendering, data fetching for
+  display, formatting helpers, dialog/sidebar toggles, pagination/sort/selection
+  handlers, and lifecycle hooks). No new REQs drafted — behaviors are fully covered
+  at the contract level by the owning backend capabilities or are pure presentation.

--- a/src/views/account/sections/AvatarSection.vue
+++ b/src/views/account/sections/AvatarSection.vue
@@ -44,6 +44,12 @@ export default {
 			isError: false,
 		}
 	},
+	/**
+	 * Lifecycle hook: load the current user's id and avatar capability for display.
+	 *
+	 * @spec exclude UI plumbing — view-mount data fetch for display only
+	 * @return {Promise<void>}
+	 */
 	async mounted() {
 		try {
 			const { data } = await axios.get(generateUrl('/apps/openregister/api/user/me'))
@@ -66,6 +72,13 @@ export default {
 		triggerUpload() {
 			this.$refs.fileInput.click()
 		},
+		/**
+		 * Upload the selected image as the user's avatar via the account API.
+		 *
+		 * @param {Event} event The file input change event.
+		 * @spec exclude UI plumbing — delegates to the account avatar API
+		 * @return {Promise<void>}
+		 */
 		async uploadAvatar(event) {
 			const file = event.target.files[0]
 			if (!file) return
@@ -84,6 +97,12 @@ export default {
 				this.isError = true
 			}
 		},
+		/**
+		 * Remove the user's avatar via the account API.
+		 *
+		 * @spec exclude UI plumbing — delegates to the account avatar API
+		 * @return {Promise<void>}
+		 */
 		async deleteAvatar() {
 			this.message = ''
 			try {

--- a/src/views/account/sections/ExportSection.vue
+++ b/src/views/account/sections/ExportSection.vue
@@ -36,6 +36,13 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * Download the signed-in user's data export as a JSON file.
+		 *
+		 * @spec exclude UI plumbing — delegates to the account export API and
+		 *   triggers a browser download
+		 * @return {Promise<void>}
+		 */
 		async exportData() {
 			this.loading = true
 			this.message = ''

--- a/src/views/avg/AvgIndex.vue
+++ b/src/views/avg/AvgIndex.vue
@@ -401,9 +401,21 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * Expose the l10n translate helper to the template.
+		 *
+		 * @spec exclude UI plumbing — template translation helper
+		 * @return {Function}
+		 */
 		t() {
 			return t
 		},
+		/**
+		 * Tab definitions for the AVG view header.
+		 *
+		 * @spec exclude UI plumbing — static tab list for display
+		 * @return {Array<object>}
+		 */
 		tabs() {
 			return [
 				{ id: 'activities', label: t('openregister', 'Activities'), icon: 'ShieldLockOutline' },
@@ -412,31 +424,80 @@ export default {
 				{ id: 'compliance', label: t('openregister', 'Compliance'), icon: 'ShieldAlertOutline' },
 			]
 		},
+		/**
+		 * Activities list from the AVG store, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {Array<object>}
+		 */
 		activities() {
 			return avgStore.getActivities ?? []
 		},
+		/**
+		 * Verantwoording report from the AVG store, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {object}
+		 */
 		verantwoording() {
 			return avgStore.getVerantwoording
 		},
+		/**
+		 * DSAR result rows from the AVG store, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {object}
+		 */
 		dsarResults() {
 			return avgStore.getDsarResults
 		},
+		/**
+		 * DSAR summary from the AVG store, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {object}
+		 */
 		dsarSummary() {
 			return avgStore.getDsarSummary
 		},
+		/**
+		 * Compliance report from the AVG store, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {object}
+		 */
 		complianceReport() {
 			return avgStore.getComplianceReport
 		},
+		/**
+		 * Whether the AVG store is currently loading, for spinner display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		loading() {
 			return avgStore.isLoading
 		},
 	},
 
+	/**
+	 * Lifecycle hook: load activities when the view mounts.
+	 *
+	 * @spec exclude UI plumbing — view-mount data fetch for display only
+	 * @return {void}
+	 */
 	mounted() {
 		this.refreshActivities()
 	},
 
 	methods: {
+		/**
+		 * Format an ISO timestamp as a locale string for display.
+		 *
+		 * @param {string} value The timestamp to format.
+		 * @spec exclude UI plumbing — pure presentation helper
+		 * @return {string}
+		 */
 		formatTime(value) {
 			if (!value) return ''
 			try {
@@ -446,6 +507,12 @@ export default {
 			}
 		},
 
+		/**
+		 * Reload the activities list from the store.
+		 *
+		 * @spec exclude UI plumbing — delegates to the AVG store fetch
+		 * @return {Promise<void>}
+		 */
 		async refreshActivities() {
 			try {
 				await avgStore.fetchActivities()
@@ -454,26 +521,58 @@ export default {
 			}
 		},
 
+		/**
+		 * Open the create-activity dialog.
+		 *
+		 * @spec exclude UI plumbing — dialog visibility toggle
+		 * @return {void}
+		 */
 		openCreateDialog() {
 			this.dialogActivity = null
 			this.dialogOpen = true
 		},
 
+		/**
+		 * Open the edit-activity dialog for a given activity.
+		 *
+		 * @param {object} activity The activity to edit.
+		 * @spec exclude UI plumbing — dialog visibility toggle
+		 * @return {void}
+		 */
 		openEditDialog(activity) {
 			this.dialogActivity = { ...activity }
 			this.dialogOpen = true
 		},
 
+		/**
+		 * Close the activity dialog and clear its state.
+		 *
+		 * @spec exclude UI plumbing — dialog visibility toggle
+		 * @return {void}
+		 */
 		closeDialog() {
 			this.dialogOpen = false
 			this.dialogActivity = null
 		},
 
+		/**
+		 * Handle the dialog's saved event by closing it and refreshing the list.
+		 *
+		 * @spec exclude UI plumbing — dialog callback wiring
+		 * @return {void}
+		 */
 		onActivitySaved() {
 			this.closeDialog()
 			this.refreshActivities()
 		},
 
+		/**
+		 * Archive an activity after user confirmation.
+		 *
+		 * @param {object} activity The activity to archive.
+		 * @spec exclude UI plumbing — confirm dialog plus store delegation
+		 * @return {Promise<void>}
+		 */
 		async archiveActivity(activity) {
 			// eslint-disable-next-line no-alert
 			if (!confirm(t('openregister', 'Archive this verwerkingsactiviteit? Audit-trail rows will keep referring to it.'))) {
@@ -487,6 +586,12 @@ export default {
 			}
 		},
 
+		/**
+		 * Load the verantwoording report from the store.
+		 *
+		 * @spec exclude UI plumbing — delegates to the AVG store fetch
+		 * @return {Promise<void>}
+		 */
 		async loadVerantwoording() {
 			try {
 				await avgStore.fetchVerantwoording()
@@ -495,6 +600,12 @@ export default {
 			}
 		},
 
+		/**
+		 * Run a DSAR inzage (subject-access) request via the store.
+		 *
+		 * @spec exclude UI plumbing — delegates to the AVG store action
+		 * @return {Promise<void>}
+		 */
 		async runInzage() {
 			try {
 				await avgStore.runInzage({
@@ -506,6 +617,12 @@ export default {
 			}
 		},
 
+		/**
+		 * Run a vergetelheid (erasure) dry-run via the store.
+		 *
+		 * @spec exclude UI plumbing — delegates to the AVG store action
+		 * @return {Promise<void>}
+		 */
 		async runVergetelheidDryRun() {
 			try {
 				await avgStore.runVergetelheid({
@@ -518,6 +635,12 @@ export default {
 			}
 		},
 
+		/**
+		 * Confirm and run a vergetelheid (erasure) after user confirmation.
+		 *
+		 * @spec exclude UI plumbing — confirm dialog plus store delegation
+		 * @return {Promise<void>}
+		 */
 		async confirmVergetelheid() {
 			// eslint-disable-next-line no-alert
 			if (!confirm(t('openregister', 'Erase {count} object(s) for this subject? This action is logged in the audit trail.', {
@@ -536,6 +659,12 @@ export default {
 			}
 		},
 
+		/**
+		 * Run a portabiliteit export and download the result as JSON.
+		 *
+		 * @spec exclude UI plumbing — store delegation plus browser download
+		 * @return {Promise<void>}
+		 */
 		async downloadPortabiliteit() {
 			try {
 				const data = await avgStore.runPortabiliteit({
@@ -555,6 +684,12 @@ export default {
 			}
 		},
 
+		/**
+		 * Load the compliance report from the store.
+		 *
+		 * @spec exclude UI plumbing — delegates to the AVG store fetch
+		 * @return {Promise<void>}
+		 */
 		async loadCompliance() {
 			try {
 				await avgStore.fetchCompliance()

--- a/src/views/dashboard/DashboardIndex.vue
+++ b/src/views/dashboard/DashboardIndex.vue
@@ -251,10 +251,22 @@ export default {
 		isLoading() {
 			return dashboardStore.loading || searchTrailStore.statisticsLoading
 		},
+		/**
+		 * Whether the dashboard has any data to display.
+		 *
+		 * @spec exclude UI plumbing — derived view state for empty-content gating
+		 * @return {boolean}
+		 */
 		hasData() {
 			return searchTrailStore.statistics.total > 0
 				|| this.registerData.length > 0
 		},
+		/**
+		 * Objects-by-register chart rows mapped from store chart data.
+		 *
+		 * @spec exclude UI plumbing — derived chart view state
+		 * @return {Array<object>}
+		 */
 		registerData() {
 			const chartData = dashboardStore.chartData.objectsByRegister
 			if (!chartData?.labels || !chartData?.series) return []
@@ -263,6 +275,12 @@ export default {
 				count: chartData.series[i] || 0,
 			}))
 		},
+		/**
+		 * Objects-by-schema chart rows mapped from store chart data.
+		 *
+		 * @spec exclude UI plumbing — derived chart view state
+		 * @return {Array<object>}
+		 */
 		schemaData() {
 			const chartData = dashboardStore.chartData.objectsBySchema
 			if (!chartData?.labels || !chartData?.series) return []
@@ -271,6 +289,12 @@ export default {
 				count: chartData.series[i] || 0,
 			}))
 		},
+		/**
+		 * Widget definitions for the dashboard grid.
+		 *
+		 * @spec exclude UI plumbing — static widget list for display
+		 * @return {Array<object>}
+		 */
 		widgetDefs() {
 			return [
 				{ id: 'count-searches', title: t('openregister', 'Total Searches'), type: 'custom' },
@@ -284,6 +308,12 @@ export default {
 			]
 		},
 	},
+	/**
+	 * Lifecycle hook: preload dashboard and search-trail data on mount.
+	 *
+	 * @spec exclude UI plumbing — view-mount data fetch for display only
+	 * @return {Promise<void>}
+	 */
 	async mounted() {
 		dashboardStore.preload()
 		dashboardStore.fetchAllChartData()
@@ -295,6 +325,12 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * Reset search-trail statistics to empty defaults for display.
+		 *
+		 * @spec exclude UI plumbing — empty-state seed for display
+		 * @return {void}
+		 */
 		setEmptySearchTrailData() {
 			searchTrailStore.setStatistics({
 				total_searches: 0,
@@ -310,6 +346,12 @@ export default {
 			searchTrailStore.setPopularTerms({ results: [] })
 			searchTrailStore.setActivity({ daily: { activity: [] } })
 		},
+		/**
+		 * Load search-trail statistics and popular terms from the store.
+		 *
+		 * @spec exclude UI plumbing — delegates to the search-trail store fetch
+		 * @return {Promise<void>}
+		 */
 		async loadSearchTrailData() {
 			try {
 				await searchTrailStore.fetchStatistics()
@@ -319,6 +361,12 @@ export default {
 				this.setEmptySearchTrailData()
 			}
 		},
+		/**
+		 * Reload all dashboard and search-trail data.
+		 *
+		 * @spec exclude UI plumbing — refresh button delegates to store fetches
+		 * @return {Promise<void>}
+		 */
 		async refreshDashboard() {
 			this.refreshing = true
 			try {
@@ -331,6 +379,13 @@ export default {
 				this.refreshing = false
 			}
 		},
+		/**
+		 * Update the stored dashboard grid layout when the user rearranges widgets.
+		 *
+		 * @param {Array<object>} newLayout The new widget layout.
+		 * @spec exclude UI plumbing — local layout state update
+		 * @return {void}
+		 */
 		onLayoutChange(newLayout) {
 			this.dashboardLayout = newLayout
 		},

--- a/src/views/logs/AuditTrailIndex.vue
+++ b/src/views/logs/AuditTrailIndex.vue
@@ -302,6 +302,12 @@ export default {
 			deep: false,
 		},
 	},
+	/**
+	 * Lifecycle hook: load audit trails and subscribe to sidebar events on mount.
+	 *
+	 * @spec exclude UI plumbing — view-mount data fetch and event wiring
+	 * @return {void}
+	 */
 	mounted() {
 		// Initialize with safe defaults
 		try {
@@ -320,6 +326,12 @@ export default {
 			this.updateCounts()
 		})
 	},
+	/**
+	 * Lifecycle hook: unsubscribe from sidebar events before teardown.
+	 *
+	 * @spec exclude UI plumbing — event-listener teardown
+	 * @return {void}
+	 */
 	beforeDestroy() {
 		this.$root.$off('audit-trail-filters-changed')
 		this.$root.$off('audit-trail-export')

--- a/src/views/object/ObjectDetails.vue
+++ b/src/views/object/ObjectDetails.vue
@@ -375,6 +375,13 @@ export default {
 		RelationsTab,
 		CnIntegrationTab,
 	},
+	/**
+	 * Composition-API setup: expose the integration-provider registry and
+	 * template helpers to the Options-API template.
+	 *
+	 * @spec exclude UI plumbing — registry snapshot and template helper exposure
+	 * @return {object}
+	 */
 	setup() {
 		// Reactive snapshot of every IntegrationProvider registered through
 		// nc-vue's in-page registry — drained from window.OCA.OpenRegister
@@ -447,6 +454,7 @@ export default {
 		 * any of the three is missing, so the tabs only render once a saved
 		 * object is being viewed.
 		 *
+		 * @spec exclude UI plumbing — derived view state gating relation tabs
 		 * @return {{register:(string|number), schema:(string|number), id:string}|null}
 		 */
 		relationContext() {
@@ -468,21 +476,45 @@ export default {
 	},
 	watch: {
 		'pagination.files.currentPage': {
+			/**
+			 * Reload files when the files page changes.
+			 *
+			 * @spec exclude UI plumbing — pagination watch handler
+			 * @return {void}
+			 */
 			handler() {
 				this.getFiles()
 			},
 		},
 		'pagination.auditTrails.currentPage': {
+			/**
+			 * Reload audit trails when the audit-trails page changes.
+			 *
+			 * @spec exclude UI plumbing — pagination watch handler
+			 * @return {void}
+			 */
 			handler() {
 				this.getAuditTrails()
 			},
 		},
 		'pagination.relations.currentPage': {
+			/**
+			 * Reload relations when the relations page changes.
+			 *
+			 * @spec exclude UI plumbing — pagination watch handler
+			 * @return {void}
+			 */
 			handler() {
 				this.getRelations()
 			},
 		},
 	},
+	/**
+	 * Lifecycle hook: load files, audit trails and relations on mount.
+	 *
+	 * @spec exclude UI plumbing — view-mount data fetch for display only
+	 * @return {void}
+	 */
 	mounted() {
 		if (objectStore.objectItem?.id) {
 			this.currentActiveObject = objectStore.objectItem?.id
@@ -491,6 +523,12 @@ export default {
 			this.getRelations()
 		}
 	},
+	/**
+	 * Lifecycle hook: reload sub-resources when the viewed object changes.
+	 *
+	 * @spec exclude UI plumbing — re-fetch on active-object change
+	 * @return {void}
+	 */
 	updated() {
 		if (this.currentActiveObject !== objectStore.objectItem?.id) {
 			this.currentActiveObject = objectStore.objectItem?.id
@@ -506,6 +544,12 @@ export default {
 		// relationsPlugin) have installed them. Calling a method that
 		// doesn't exist on the store throws TypeError mid-mount and
 		// aborts the whole render — guard each call.
+		/**
+		 * Fetch the object's attached files for display (race-safe).
+		 *
+		 * @spec exclude UI plumbing — delegates to the object store fetch
+		 * @return {void}
+		 */
 		getFiles() {
 			if (!objectStore.objectItem?.id || typeof objectStore.getFiles !== 'function') {
 				return
@@ -519,6 +563,12 @@ export default {
 				this.fileLoading = false
 			})
 		},
+		/**
+		 * Fetch the object's audit trails for display (race-safe).
+		 *
+		 * @spec exclude UI plumbing — delegates to the object store fetch
+		 * @return {void}
+		 */
 		getAuditTrails() {
 			if (!objectStore.objectItem?.id || typeof objectStore.getAuditTrails !== 'function') {
 				return
@@ -537,6 +587,12 @@ export default {
 					this.auditTrailLoading = false
 				})
 		},
+		/**
+		 * Fetch the object's relations for display (race-safe).
+		 *
+		 * @spec exclude UI plumbing — delegates to the object store fetch
+		 * @return {void}
+		 */
 		getRelations() {
 			if (!objectStore.objectItem?.id || typeof objectStore.getRelations !== 'function') {
 				return
@@ -558,6 +614,7 @@ export default {
 		/**
 		 * Opens the folder URL in a new tab after parsing the encoded URL and converting to Nextcloud format
 		 * @param {string} url - The encoded folder URL to open (e.g. "Open Registers\/Publicatie Register\/Publicatie\/123")
+		 * @spec exclude UI plumbing — opens the Nextcloud Files app in a new tab
 		 */
 		openFolder(url) {
 			// Parse the encoded URL by replacing escaped characters
@@ -576,6 +633,7 @@ export default {
 		/**
 		 * Opens a file in the Nextcloud Files app
 		 * @param {object} file - The file object containing id, path, and other metadata
+		 * @spec exclude UI plumbing — opens the Nextcloud Files app in a new tab
 		 */
 		openFile(file) {
 			// Extract the directory path without the filename
@@ -593,6 +651,7 @@ export default {
 		/**
 		 * Formats a file size in bytes to a human readable string
 		 * @param {number} bytes - The file size in bytes
+		 * @spec exclude UI plumbing — pure presentation helper
 		 * @return {string} Formatted file size (e.g. "1.5 MB")
 		 */
 		 formatFileSize(bytes) {

--- a/src/views/reports/ReportView.vue
+++ b/src/views/reports/ReportView.vue
@@ -225,18 +225,48 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * Expose the l10n translate helper to the template.
+		 *
+		 * @spec exclude UI plumbing — template translation helper
+		 * @return {Function}
+		 */
 		t() {
 			return t
 		},
+		/**
+		 * The active report dashboard from the store, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {object}
+		 */
 		dashboard() {
 			return reportsStore.getActiveDashboard
 		},
+		/**
+		 * Whether the reports store is loading, for spinner display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		loading() {
 			return reportsStore.isLoading
 		},
+		/**
+		 * Widget list for the active dashboard, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {Array<object>}
+		 */
 		widgets() {
 			return this.dashboard?.widgets || []
 		},
+		/**
+		 * CSS grid custom properties derived from the dashboard layout.
+		 *
+		 * @spec exclude UI plumbing — derived presentation styles
+		 * @return {object}
+		 */
 		gridStyles() {
 			const cols = this.dashboard?.layout?.cols ?? 4
 			return {
@@ -248,6 +278,13 @@ export default {
 	watch: {
 		'$route.params.id': {
 			immediate: true,
+			/**
+			 * Load the dashboard when the route id changes.
+			 *
+			 * @param {string} value The new route id.
+			 * @spec exclude UI plumbing — route watch handler
+			 * @return {void}
+			 */
 			handler(value) {
 				if (value) this.load(value)
 			},
@@ -255,6 +292,13 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * Fetch a dashboard and its widget data for display.
+		 *
+		 * @param {string} identifier The dashboard identifier.
+		 * @spec exclude UI plumbing — delegates to the reports store fetch
+		 * @return {Promise<void>}
+		 */
 		async load(identifier) {
 			try {
 				await reportsStore.fetchDashboard(identifier)
@@ -266,6 +310,13 @@ export default {
 			}
 		},
 
+		/**
+		 * Fetch data for every widget in the active dashboard.
+		 *
+		 * @param {boolean} forceRefresh Whether to bypass cached widget data.
+		 * @spec exclude UI plumbing — delegates to the reports store fetch
+		 * @return {Promise<void>}
+		 */
 		async loadWidgetData(forceRefresh = false) {
 			const widgets = this.widgets
 			for (let i = 0; i < widgets.length; i++) {
@@ -289,10 +340,23 @@ export default {
 			}))
 		},
 
+		/**
+		 * Reload the current dashboard and its widget data.
+		 *
+		 * @spec exclude UI plumbing — refresh button delegates to load()
+		 * @return {Promise<void>}
+		 */
 		async refresh() {
 			await this.load(this.$route.params.id)
 		},
 
+		/**
+		 * Render and download the dashboard in the given export format.
+		 *
+		 * @param {string} format The export format (e.g. pdf, xlsx).
+		 * @spec exclude UI plumbing — delegates to the render API and downloads
+		 * @return {Promise<void>}
+		 */
 		async downloadAs(format) {
 			const id = this.$route.params.id
 			if (!id) return
@@ -315,6 +379,12 @@ export default {
 			}
 		},
 
+		/**
+		 * Open the dashboard's HTML preview in a new tab.
+		 *
+		 * @spec exclude UI plumbing — opens a preview URL in a new tab
+		 * @return {void}
+		 */
 		openHtmlPreview() {
 			const id = this.$route.params.id
 			if (!id) return
@@ -322,16 +392,37 @@ export default {
 			window.open(url, '_blank')
 		},
 
+		/**
+		 * Extract a filename from a response's content-disposition header.
+		 *
+		 * @param {object} response The axios response.
+		 * @spec exclude UI plumbing — private download-filename helper
+		 * @return {(string|null)}
+		 */
 		_extractFilename(response) {
 			const cd = response.headers?.['content-disposition'] || ''
 			const m = cd.match(/filename="?([^";]+)"?/i)
 			return m ? m[1] : null
 		},
 
+		/**
+		 * Return the per-widget loading/error/data state for display.
+		 *
+		 * @param {number} index The widget index.
+		 * @spec exclude UI plumbing — derived per-widget view state
+		 * @return {object}
+		 */
 		widgetState(index) {
 			return this.widgetStates[index] ?? { loading: false, error: null, data: null }
 		},
 
+		/**
+		 * Build the cache key for a widget's data source.
+		 *
+		 * @param {object} widget The widget definition.
+		 * @spec exclude UI plumbing — private cache-key helper
+		 * @return {string}
+		 */
 		_cacheKey(widget) {
 			const ds = widget?.dataSource
 			if (!ds) return ''
@@ -341,6 +432,13 @@ export default {
 			return `unknown:${ds.mode}`
 		},
 
+		/**
+		 * Compute the CSS grid span styles for a widget cell.
+		 *
+		 * @param {object} widget The widget definition.
+		 * @spec exclude UI plumbing — derived presentation styles
+		 * @return {object}
+		 */
 		widgetCellStyle(widget) {
 			const layout = widget.layout
 			if (!layout) return {}
@@ -350,10 +448,25 @@ export default {
 			return styles
 		},
 
+		/**
+		 * Resolve the icon component for a widget.
+		 *
+		 * @param {object} widget The widget definition.
+		 * @spec exclude UI plumbing — pure presentation helper
+		 * @return {object}
+		 */
 		widgetIcon(widget) {
 			return ICON_MAP[widget.options?.icon] || ChartBoxOutline
 		},
 
+		/**
+		 * Format a widget value for display per its configured format.
+		 *
+		 * @param {*} data The raw widget data.
+		 * @param {object} widget The widget definition.
+		 * @spec exclude UI plumbing — pure presentation helper
+		 * @return {string}
+		 */
 		formatValue(data, widget) {
 			if (data === null || data === undefined) return '—'
 			const field = widget.options?.valueField || 'count'
@@ -383,6 +496,14 @@ export default {
 			return String(raw)
 		},
 
+		/**
+		 * Build the ApexCharts series array from widget data.
+		 *
+		 * @param {object} data The widget data.
+		 * @param {object} widget The widget definition.
+		 * @spec exclude UI plumbing — pure presentation data mapping
+		 * @return {Array}
+		 */
 		chartSeries(data, widget) {
 			if (!data) return []
 			// If the aggregation returned grouped data: { groups: [{ key, value }] }
@@ -402,11 +523,27 @@ export default {
 			return []
 		},
 
+		/**
+		 * Build the chart x-axis categories from widget data.
+		 *
+		 * @param {object} data The widget data.
+		 * @param {object} _widget The widget definition (unused).
+		 * @spec exclude UI plumbing — pure presentation data mapping
+		 * @return {Array<string>}
+		 */
 		chartCategories(data, _widget) {
 			if (!data || !Array.isArray(data.groups)) return []
 			return data.groups.map((g) => String(g.key ?? g.label ?? ''))
 		},
 
+		/**
+		 * Build the pie/donut chart labels from widget data.
+		 *
+		 * @param {object} data The widget data.
+		 * @param {object} widget The widget definition.
+		 * @spec exclude UI plumbing — pure presentation data mapping
+		 * @return {Array<string>}
+		 */
 		chartLabels(data, widget) {
 			const chartType = widget.options?.chartType || 'bar'
 			if ((chartType === 'pie' || chartType === 'donut') && Array.isArray(data?.groups)) {
@@ -415,6 +552,13 @@ export default {
 			return []
 		},
 
+		/**
+		 * Extract table row data from a widget's payload.
+		 *
+		 * @param {object} data The widget data.
+		 * @spec exclude UI plumbing — pure presentation data mapping
+		 * @return {Array}
+		 */
 		tableRows(data) {
 			if (!data) return []
 			if (Array.isArray(data)) return data
@@ -423,6 +567,13 @@ export default {
 			return []
 		},
 
+		/**
+		 * Build the table column definitions for a widget.
+		 *
+		 * @param {object} widget The widget definition.
+		 * @spec exclude UI plumbing — pure presentation data mapping
+		 * @return {Array<object>}
+		 */
 		tableColumns(widget) {
 			const cols = widget.options?.columns
 			if (Array.isArray(cols) && cols.length > 0) {
@@ -435,6 +586,14 @@ export default {
 			]
 		},
 
+		/**
+		 * Build the sparkline value series from widget data.
+		 *
+		 * @param {object} data The widget data.
+		 * @param {object} widget The widget definition.
+		 * @spec exclude UI plumbing — pure presentation data mapping
+		 * @return {Array<number>}
+		 */
 		sparklineData(data, widget) {
 			if (!data) return []
 			const field = widget.options?.trendField || 'groups'
@@ -443,11 +602,26 @@ export default {
 			return arr.map((entry) => Number(entry[valueField] ?? entry.value ?? entry.count ?? entry))
 		},
 
+		/**
+		 * Build the sparkline x-axis categories from widget data.
+		 *
+		 * @param {object} data The widget data.
+		 * @spec exclude UI plumbing — pure presentation data mapping
+		 * @return {Array<string>}
+		 */
 		sparklineCategories(data) {
 			if (!data || !Array.isArray(data.groups)) return []
 			return data.groups.map((g) => String(g.key ?? ''))
 		},
 
+		/**
+		 * Build the label/value entries for a stats widget.
+		 *
+		 * @param {object} data The widget data.
+		 * @param {object} widget The widget definition.
+		 * @spec exclude UI plumbing — pure presentation data mapping
+		 * @return {Array<object>}
+		 */
 		statsEntries(data, widget) {
 			if (!data) return []
 			const valueField = widget.options?.valueField || 'value'

--- a/src/views/reports/ReportsIndex.vue
+++ b/src/views/reports/ReportsIndex.vue
@@ -93,22 +93,52 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * Expose the l10n translate helper to the template.
+		 *
+		 * @spec exclude UI plumbing — template translation helper
+		 * @return {Function}
+		 */
 		t() {
 			return t
 		},
+		/**
+		 * Report dashboards from the store, for list display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {Array<object>}
+		 */
 		dashboards() {
 			return reportsStore.getDashboards ?? []
 		},
+		/**
+		 * Whether the reports store is loading, for spinner display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		loading() {
 			return reportsStore.isLoading
 		},
 	},
 
+	/**
+	 * Lifecycle hook: load the dashboards list on mount.
+	 *
+	 * @spec exclude UI plumbing — view-mount data fetch for display only
+	 * @return {void}
+	 */
 	mounted() {
 		this.refresh()
 	},
 
 	methods: {
+		/**
+		 * Reload the dashboards list from the store.
+		 *
+		 * @spec exclude UI plumbing — delegates to the reports store fetch
+		 * @return {Promise<void>}
+		 */
 		async refresh() {
 			try {
 				await reportsStore.fetchDashboards()
@@ -117,6 +147,13 @@ export default {
 			}
 		},
 
+		/**
+		 * Navigate to a dashboard's detail route.
+		 *
+		 * @param {object} dashboard The dashboard to open.
+		 * @spec exclude UI plumbing — router navigation
+		 * @return {void}
+		 */
 		openDashboard(dashboard) {
 			const id = dashboard['@self']?.uuid || dashboard.uuid || dashboard.id
 			if (!id) return

--- a/src/views/schema/CalendarProviderTab.vue
+++ b/src/views/schema/CalendarProviderTab.vue
@@ -180,6 +180,7 @@ export default {
 	computed: {
 		/**
 		 * Property names available for placeholders
+		 * @spec exclude UI plumbing — derived select-option list
 		 * @return {string[]}
 		 */
 		propertyNames() {
@@ -190,6 +191,7 @@ export default {
 		},
 		/**
 		 * Date/datetime properties for dtstart/dtend selectors
+		 * @spec exclude UI plumbing — derived select-option list
 		 * @return {string[]}
 		 */
 		datePropertyOptions() {
@@ -206,6 +208,7 @@ export default {
 		},
 		/**
 		 * String properties for location selector
+		 * @spec exclude UI plumbing — derived select-option list
 		 * @return {string[]}
 		 */
 		stringPropertyOptions() {
@@ -218,6 +221,7 @@ export default {
 		},
 		/**
 		 * Validation: dtstart and titleTemplate required when enabled
+		 * @spec exclude UI plumbing — derived form-validity flag for display
 		 * @return {boolean}
 		 */
 		isValid() {
@@ -229,6 +233,13 @@ export default {
 	},
 	watch: {
 		schema: {
+			/**
+			 * Reload the calendar config when the schema prop changes.
+			 *
+			 * @param {object} newSchema The new schema.
+			 * @spec exclude UI plumbing — prop watch handler
+			 * @return {void}
+			 */
 			handler(newSchema) {
 				if (newSchema) {
 					this.loadConfig(newSchema)
@@ -259,6 +270,8 @@ export default {
 		},
 		/**
 		 * Save the calendar provider configuration via schema update
+		 * @spec exclude UI plumbing — save action delegates to the schema store
+		 * @return {Promise<void>}
 		 */
 		async save() {
 			this.saving = true

--- a/src/views/schema/SchemaDetails.vue
+++ b/src/views/schema/SchemaDetails.vue
@@ -237,6 +237,7 @@ export default {
 	computed: {
 		/**
 		 * Chart options for the Audit Trail Actions chart
+		 * @spec exclude UI plumbing — static chart configuration for display
 		 * @return {object}
 		 */
 		auditTrailChartOptions() {
@@ -259,6 +260,7 @@ export default {
 		},
 		/**
 		 * Chart options for the Objects by Register chart
+		 * @spec exclude UI plumbing — static chart configuration for display
 		 * @return {object}
 		 */
 		registerChartOptions() {
@@ -277,6 +279,7 @@ export default {
 		},
 		/**
 		 * Chart options for the Objects by Size Distribution chart
+		 * @spec exclude UI plumbing — static chart configuration for display
 		 * @return {object}
 		 */
 		sizeChartOptions() {
@@ -298,6 +301,12 @@ export default {
 			}
 		},
 	},
+	/**
+	 * Lifecycle hook: load chart data and schema stats on mount.
+	 *
+	 * @spec exclude UI plumbing — view-mount data fetch for display only
+	 * @return {Promise<void>}
+	 */
 	async mounted() {
 		// Fetch dashboard data if not already loaded
 		if (!dashboardStore.chartData || Object.keys(dashboardStore.chartData).length === 0) {
@@ -312,6 +321,7 @@ export default {
 	methods: {
 		/**
 		 * Load schema statistics from the dedicated stats endpoint
+		 * @spec exclude UI plumbing — delegates to the schema store stats fetch
 		 * @return {Promise<void>}
 		 */
 		async loadSchemaStats() {
@@ -334,6 +344,7 @@ export default {
 		/**
 		 * Set the active property for editing
 		 * @param {string|null} key - The key to process
+		 * @spec exclude UI plumbing — toggles active-property selection state
 		 * @return {void}
 		 */
 		setActiveProperty(key) {

--- a/src/views/schema/SchemasIndex.vue
+++ b/src/views/schema/SchemasIndex.vue
@@ -164,6 +164,12 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Column definitions for the schemas table.
+		 *
+		 * @spec exclude UI plumbing — static table column list for display
+		 * @return {Array<object>}
+		 */
 		tableColumns() {
 			return [
 				{ key: 'title', label: t('openregister', 'Title'), sortable: true },
@@ -172,6 +178,12 @@ export default {
 				{ key: 'updated', label: t('openregister', 'Updated'), sortable: true },
 			]
 		},
+		/**
+		 * Pagination state derived from the schema store, for display.
+		 *
+		 * @spec exclude UI plumbing — derived pagination view state
+		 * @return {object}
+		 */
 		paginationData() {
 			const page = schemaStore.pagination.page || 1
 			const limit = schemaStore.pagination.limit || 20
@@ -179,6 +191,12 @@ export default {
 			const pages = Math.ceil(total / limit)
 			return { page, pages, total, limit }
 		},
+		/**
+		 * Empty-content label shown when the schema list is empty or loading.
+		 *
+		 * @spec exclude UI plumbing — derived empty-state label
+		 * @return {string}
+		 */
 		emptyContentName() {
 			if (!schemaStore.schemaList.length) {
 				return t('openregister', 'No schemas found')
@@ -186,6 +204,12 @@ export default {
 			return t('openregister', 'Loading schemas...')
 		},
 	},
+	/**
+	 * Lifecycle hook: load schemas and configurations on mount.
+	 *
+	 * @spec exclude UI plumbing — view-mount data fetch for display only
+	 * @return {Promise<void>}
+	 */
 	async mounted() {
 		try {
 			await Promise.all([
@@ -197,6 +221,12 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * Reload the schema list from the store.
+		 *
+		 * @spec exclude UI plumbing — refresh button delegates to the store
+		 * @return {Promise<void>}
+		 */
 		async handleRefresh() {
 			this.isRefreshing = true
 			try {
@@ -206,18 +236,46 @@ export default {
 			}
 		},
 
+		/**
+		 * Update store pagination when the page changes.
+		 *
+		 * @param {number} page The new page number.
+		 * @spec exclude UI plumbing — pagination handler delegates to the store
+		 * @return {void}
+		 */
 		onPageChanged(page) {
 			schemaStore.setPagination(page, schemaStore.pagination.limit)
 		},
 
+		/**
+		 * Update store pagination when the page size changes.
+		 *
+		 * @param {number} pageSize The new page size.
+		 * @spec exclude UI plumbing — pagination handler delegates to the store
+		 * @return {void}
+		 */
 		onPageSizeChanged(pageSize) {
 			schemaStore.setPagination(1, pageSize)
 		},
 
+		/**
+		 * Track the selected schema ids for bulk actions.
+		 *
+		 * @param {Array} ids The selected schema ids.
+		 * @spec exclude UI plumbing — local selection state update
+		 * @return {void}
+		 */
 		onSelect(ids) {
 			this.selectedSchemas = ids
 		},
 
+		/**
+		 * Compute the CSS row class reflecting a schema's managed/in-use state.
+		 *
+		 * @param {object} schema The schema row.
+		 * @spec exclude UI plumbing — derived row-styling helper
+		 * @return {string}
+		 */
 		getRowClass(schema) {
 			if (this.isManagedByExternalConfig(schema)) return 'viewTableRow--managed'
 			if (this.isManagedByLocalConfig(schema)) return 'viewTableRow--local'
@@ -225,10 +283,24 @@ export default {
 			return ''
 		},
 
+		/**
+		 * Whether a schema has any objects.
+		 *
+		 * @param {object} schema The schema row.
+		 * @spec exclude UI plumbing — display predicate helper
+		 * @return {boolean}
+		 */
 		hasObjects(schema) {
 			return schema.stats?.objects?.total > 0
 		},
 
+		/**
+		 * Find the configuration that manages a given schema, if any.
+		 *
+		 * @param {object} schema The schema row.
+		 * @spec exclude UI plumbing — display lookup helper
+		 * @return {(object|null)}
+		 */
 		getManagingConfiguration(schema) {
 			if (!schema || !schema.id) return null
 			return configurationStore.configurationList.find(
@@ -236,18 +308,39 @@ export default {
 			) || null
 		},
 
+		/**
+		 * Whether a schema is managed by an external (git/url) configuration.
+		 *
+		 * @param {object} schema The schema row.
+		 * @spec exclude UI plumbing — display predicate helper
+		 * @return {boolean}
+		 */
 		isManagedByExternalConfig(schema) {
 			const config = this.getManagingConfiguration(schema)
 			if (!config) return false
 			return (config.sourceType && ['github', 'gitlab', 'url'].includes(config.sourceType)) || config.isLocal === false
 		},
 
+		/**
+		 * Whether a schema is managed by a local/manual configuration.
+		 *
+		 * @param {object} schema The schema row.
+		 * @spec exclude UI plumbing — display predicate helper
+		 * @return {boolean}
+		 */
 		isManagedByLocalConfig(schema) {
 			const config = this.getManagingConfiguration(schema)
 			if (!config) return false
 			return config.sourceType === 'local' || config.sourceType === 'manual' || config.isLocal === true
 		},
 
+		/**
+		 * Publish a schema via the store and surface a toast.
+		 *
+		 * @param {object} schema The schema to publish.
+		 * @spec exclude UI plumbing — action delegates to the schema store
+		 * @return {Promise<void>}
+		 */
 		async publishSchema(schema) {
 			try {
 				await schemaStore.publishSchema(schema.id)
@@ -258,6 +351,13 @@ export default {
 			}
 		},
 
+		/**
+		 * Depublish a schema via the store and surface a toast.
+		 *
+		 * @param {object} schema The schema to depublish.
+		 * @spec exclude UI plumbing — action delegates to the schema store
+		 * @return {Promise<void>}
+		 */
 		async depublishSchema(schema) {
 			try {
 				await schemaStore.depublishSchema(schema.id)

--- a/src/views/search/SearchIndex.vue
+++ b/src/views/search/SearchIndex.vue
@@ -41,6 +41,12 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Normalized search result objects for table display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {Array<object>}
+		 */
 		normalizedObjects() {
 			return normalizeObjects(objectStore.searchCollection)
 		},
@@ -53,6 +59,12 @@ export default {
 		hasSelectedSchemas() {
 			return objectStore.searchParams.schema != null
 		},
+		/**
+		 * Page title derived from the selected register and schema.
+		 *
+		 * @spec exclude UI plumbing — derived header title for display
+		 * @return {string}
+		 */
 		pageTitle() {
 			if (!this.hasSelectedRegisters) return 'No register selected'
 			const reg = registerStore.registerList.find((r) => r.id === objectStore.searchParams.register)
@@ -62,13 +74,31 @@ export default {
 			const schemaTitle = schema ? (schema.label || schema.title) : 'Schema'
 			return `${regTitle} / ${schemaTitle}`
 		},
+		/**
+		 * Selected object ids for the current page, as strings.
+		 *
+		 * @spec exclude UI plumbing — derived selection view state
+		 * @return {Array<string>}
+		 */
 		selectedIdsForPage() {
 			const list = objectStore.selectedObjects
 			return Array.isArray(list) ? list.map(String) : []
 		},
+		/**
+		 * Object-type slug derived from the selected register and schema.
+		 *
+		 * @spec exclude UI plumbing — derived identifier for the index page
+		 * @return {string}
+		 */
 		computedObjectType() {
 			return objectStore.createObjectTypeSlug(objectStore.searchRegister, objectStore.searchSchema)
 		},
+		/**
+		 * Search schema with inherited (allOf) properties merged in, for columns.
+		 *
+		 * @spec exclude UI plumbing — derived schema view state for display
+		 * @return {object}
+		 */
 		normalizedSchema() {
 			const schema = objectStore.searchSchema
 			if (!schema || !schema.properties) return schema
@@ -104,6 +134,12 @@ export default {
 		},
 	},
 	methods: {
+		/**
+		 * Open the new-object dialog for the selected register and schema.
+		 *
+		 * @spec exclude UI plumbing — opens the create-object modal
+		 * @return {void}
+		 */
 		handleAddObject() {
 			if (!this.hasSelectedRegisters || !this.hasSelectedSchemas) return
 			this.isAddingNewObject = true
@@ -116,41 +152,112 @@ export default {
 			}
 			navigationStore.setModal('viewObject')
 		},
+		/**
+		 * Re-run the current search.
+		 *
+		 * @spec exclude UI plumbing — refresh delegates to the object store
+		 * @return {void}
+		 */
 		handleRefresh() {
 			objectStore.refetchSearchCollection()
 		},
+		/**
+		 * Apply a sort change and re-run the search.
+		 *
+		 * @param {object} root0 The sort event payload.
+		 * @param {string} root0.key The sort column key.
+		 * @param {string} root0.order The sort order.
+		 * @spec exclude UI plumbing — sort handler delegates to the store
+		 * @return {void}
+		 */
 		handleSort({ key, order }) {
 			objectStore.updateSearchParams({ sortKey: key, sortOrder: order })
 			objectStore.refetchSearchCollection()
 		},
+		/**
+		 * Apply a page change and re-run the search.
+		 *
+		 * @param {number} page The new page number.
+		 * @spec exclude UI plumbing — pagination handler delegates to the store
+		 * @return {void}
+		 */
 		handlePageChanged(page) {
 			objectStore.updateSearchParams({ page })
 			objectStore.refetchSearchCollection()
 		},
+		/**
+		 * Apply a page-size change and re-run the search.
+		 *
+		 * @param {number} limit The new page size.
+		 * @spec exclude UI plumbing — pagination handler delegates to the store
+		 * @return {void}
+		 */
 		handlePageSizeChanged(limit) {
 			objectStore.updateSearchParams({ page: 1, limit })
 			objectStore.refetchSearchCollection()
 		},
+		/**
+		 * Track the selected object ids.
+		 *
+		 * @param {Array} ids The selected ids.
+		 * @spec exclude UI plumbing — selection state delegates to the store
+		 * @return {void}
+		 */
 		handleSelect(ids) {
 			objectStore.setSelectedObjects(ids)
 		},
+		/**
+		 * Open the view-object modal for a clicked row.
+		 *
+		 * @param {object} row The clicked object row.
+		 * @spec exclude UI plumbing — opens the view-object modal
+		 * @return {void}
+		 */
 		handleRowClick(row) {
 			objectStore.setObjectItem(row)
 			navigationStore.setModal('viewObject')
 		},
+		/**
+		 * Open the copy-object dialog for a row.
+		 *
+		 * @param {object} row The object row to copy.
+		 * @spec exclude UI plumbing — opens the copy-object dialog
+		 * @return {void}
+		 */
 		handleCopyRow(row) {
 			objectStore.setObjectItem(row)
 			navigationStore.setDialog('copyObject')
 		},
+		/**
+		 * Open the delete-object dialog for a row.
+		 *
+		 * @param {object} row The object row to delete.
+		 * @spec exclude UI plumbing — opens the delete-object dialog
+		 * @return {void}
+		 */
 		handleDeleteRow(row) {
 			objectStore.setObjectItem(row)
 			navigationStore.setDialog('deleteObject')
 		},
+		/**
+		 * Open the mass-delete dialog for the selected ids.
+		 *
+		 * @param {Array} ids The selected row ids.
+		 * @spec exclude UI plumbing — opens the mass-delete dialog
+		 * @return {void}
+		 */
 		handleMassDelete(ids) {
 			const rows = this.normalizedObjects.filter((r) => ids.includes(String(r.id)))
 			objectStore.setSelectedObjects(rows.map((r) => r['@self']?.id ?? r.id))
 			navigationStore.setDialog('massDeleteObject')
 		},
+		/**
+		 * Open the mass-copy dialog for the selected ids.
+		 *
+		 * @param {object} payload The mass-copy event payload.
+		 * @spec exclude UI plumbing — opens the mass-copy dialog
+		 * @return {void}
+		 */
 		handleMassCopy(payload) {
 			const ids = payload?.ids || []
 			const rows = this.normalizedObjects.filter((r) => ids.includes(String(r.id)))

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -143,6 +143,8 @@ export default {
 	/**
 	 * Component created lifecycle hook
 	 * Initializes the settings store and loads all data
+	 * @spec exclude UI plumbing — view-creation data fetch for display only
+	 * @return {Promise<void>}
 	 */
 	async created() {
 		console.log('🔧 Settings component created - loading data from store')

--- a/src/views/settings/sections/CacheManagement.vue
+++ b/src/views/settings/sections/CacheManagement.vue
@@ -382,30 +382,73 @@ export default {
 	computed: {
 		...mapStores(useSettingsStore),
 
+		/**
+		 * Cache statistics from the settings store, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {object}
+		 */
 		cacheStats() {
 			return this.settingsStore.cacheStats
 		},
 
+		/**
+		 * Whether cache stats are loading, for spinner display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		loadingCache() {
 			return this.settingsStore.loadingCache
 		},
 
+		/**
+		 * Whether the cache is currently being cleared, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		clearingCache() {
 			return this.settingsStore.clearingCache
 		},
 
+		/**
+		 * Whether the settings store is loading, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		loading() {
 			return this.settingsStore.loading
 		},
 
+		/**
+		 * Whether the clear-cache confirmation is showing, for display.
+		 *
+		 * @spec exclude UI plumbing — derived dialog visibility state
+		 * @return {boolean}
+		 */
 		showClearCacheConfirmation() {
 			return this.settingsStore.showClearCacheConfirmation
 		},
 
 		clearCacheType: {
+			/**
+			 * Read the selected clear-cache type from the store.
+			 *
+			 * @spec exclude UI plumbing — computed getter proxies the store
+			 * @return {string}
+			 */
 			get() {
 				return this.settingsStore.clearCacheType
 			},
+			/**
+			 * Write the selected clear-cache type to the store.
+			 *
+			 * @param {string} value The new clear-cache type.
+			 * @spec exclude UI plumbing — computed setter proxies the store
+			 * @return {void}
+			 */
 			set(value) {
 				this.settingsStore.clearCacheType = value
 			},
@@ -414,24 +457,49 @@ export default {
 		/**
 		 * Get CSS class for overall hit rate
 		 *
+		 * @spec exclude UI plumbing — derived row-styling helper
 		 * @return {string} CSS class name
 		 */
 		hitRateClass() {
 			return this.getHitRateClass(this.cacheStats.overview?.overallHitRate || 0)
 		},
 
+		/**
+		 * Whether a cache warmup is in progress, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		warmingUpCache() {
 			return this.settingsStore.warmingUpCache
 		},
 
+		/**
+		 * Whether the warmup interval is being saved, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		savingWarmupInterval() {
 			return this.settingsStore.savingWarmupInterval
 		},
 
+		/**
+		 * Timestamp of the last warmup run, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {(string|null)}
+		 */
 		warmupLastRun() {
 			return this.settingsStore.warmupLastRun
 		},
 
+		/**
+		 * Selectable warmup-interval options for the dropdown.
+		 *
+		 * @spec exclude UI plumbing — static select-option list
+		 * @return {Array<object>}
+		 */
 		warmupIntervalOptions() {
 			return [
 				{ label: 'Disabled', value: 0 },
@@ -443,12 +511,24 @@ export default {
 			]
 		},
 
+		/**
+		 * Currently selected warmup-interval option, for display.
+		 *
+		 * @spec exclude UI plumbing — derived select-value state
+		 * @return {object}
+		 */
 		selectedWarmupOption() {
 			const interval = this.settingsStore.warmupInterval
 			return this.warmupIntervalOptions.find((o) => o.value === interval) || this.warmupIntervalOptions[3]
 		},
 	},
 
+	/**
+	 * Lifecycle hook: load the warmup interval setting on mount.
+	 *
+	 * @spec exclude UI plumbing — view-mount data fetch for display only
+	 * @return {void}
+	 */
 	mounted() {
 		this.settingsStore.loadWarmupInterval()
 	},
@@ -456,6 +536,8 @@ export default {
 	methods: {
 		/**
 		 * Load cache statistics
+		 * @spec exclude UI plumbing — delegates to the settings store
+		 * @return {void}
 		 */
 		loadCacheStats() {
 			this.settingsStore.loadCacheStats()
@@ -463,6 +545,8 @@ export default {
 
 		/**
 		 * Show clear cache dialog
+		 * @spec exclude UI plumbing — dialog visibility toggle via store
+		 * @return {void}
 		 */
 		showClearCacheDialog() {
 			this.settingsStore.showClearCacheDialog()
@@ -470,6 +554,8 @@ export default {
 
 		/**
 		 * Hide clear cache dialog
+		 * @spec exclude UI plumbing — dialog visibility toggle via store
+		 * @return {void}
 		 */
 		hideClearCacheDialog() {
 			this.settingsStore.hideClearCacheDialog()
@@ -477,6 +563,8 @@ export default {
 
 		/**
 		 * Perform cache clearing
+		 * @spec exclude UI plumbing — action delegates to the settings store
+		 * @return {void}
 		 */
 		performClearCache() {
 			this.settingsStore.performClearCache()
@@ -486,6 +574,7 @@ export default {
 		 * Format bytes to human readable format
 		 *
 		 * @param {number} bytes Number of bytes
+		 * @spec exclude UI plumbing — pure presentation helper
 		 * @return {string} Formatted string
 		 */
 		formatBytes(bytes) {
@@ -502,6 +591,7 @@ export default {
 		 * Get service hit rate
 		 *
 		 * @param {object} service Service stats object
+		 * @spec exclude UI plumbing — pure presentation helper
 		 * @return {number} Hit rate percentage
 		 */
 		getServiceHitRate(service) {
@@ -515,6 +605,7 @@ export default {
 		 * Get CSS class for hit rate
 		 *
 		 * @param {number} hitRate Hit rate percentage
+		 * @spec exclude UI plumbing — pure presentation helper
 		 * @return {string} CSS class name
 		 */
 		getHitRateClass(hitRate) {
@@ -527,6 +618,7 @@ export default {
 		 * Get hit rate text
 		 *
 		 * @param {number} hitRate Hit rate percentage
+		 * @spec exclude UI plumbing — pure presentation helper
 		 * @return {string} Status text
 		 */
 		getHitRateText(hitRate) {
@@ -538,6 +630,7 @@ export default {
 		/**
 		 * Get distributed cache backend name
 		 *
+		 * @spec exclude UI plumbing — pure presentation helper
 		 * @return {string} Backend name
 		 */
 		getDistributedCacheBackend() {
@@ -551,6 +644,8 @@ export default {
 		 * Handle warmup interval change
 		 *
 		 * @param {object} option Selected option
+		 * @spec exclude UI plumbing — delegates to the settings store
+		 * @return {void}
 		 */
 		onWarmupIntervalChange(option) {
 			if (option) {
@@ -560,6 +655,8 @@ export default {
 
 		/**
 		 * Trigger manual cache warmup
+		 * @spec exclude UI plumbing — action delegates to the settings store
+		 * @return {void}
 		 */
 		triggerWarmup() {
 			this.settingsStore.warmupNamesCache()
@@ -569,6 +666,7 @@ export default {
 		 * Format date for display
 		 *
 		 * @param {string|null} dateString ISO date string
+		 * @spec exclude UI plumbing — pure presentation helper
 		 * @return {string} Formatted date
 		 */
 		formatDate(dateString) {

--- a/src/views/settings/sections/LlmConfiguration.vue
+++ b/src/views/settings/sections/LlmConfiguration.vue
@@ -423,6 +423,8 @@ export default {
 
 		/**
 		 * Get connection status CSS class
+		 * @spec exclude UI plumbing — derived status-styling helper
+		 * @return {string}
 		 */
 		connectionStatusClass() {
 			if (this.llmConnectionStatus === 'Connected' || this.llmConnectionStatus.includes('✓')) {
@@ -435,6 +437,12 @@ export default {
 		},
 	},
 
+	/**
+	 * Lifecycle hook: load LLM settings and all statistics on mount.
+	 *
+	 * @spec exclude UI plumbing — view-mount data fetch for display only
+	 * @return {Promise<void>}
+	 */
 	async mounted() {
 		await this.loadSettings()
 		await this.loadAllStats()
@@ -443,6 +451,8 @@ export default {
 	methods: {
 		/**
 		 * Load LLM configuration settings
+		 * @spec exclude UI plumbing — delegates to the settings store
+		 * @return {Promise<void>}
 		 */
 		async loadSettings() {
 			try {
@@ -479,6 +489,7 @@ export default {
 		/**
 		 * Get display name for provider.
 		 * @param {string} providerId - The ID of the provider.
+		 * @spec exclude UI plumbing — pure presentation helper
 		 * @return {string} The display name for the provider.
 		 */
 		getProviderDisplayName(providerId) {
@@ -492,6 +503,8 @@ export default {
 
 		/**
 		 * Load all statistics (chat, vector, etc.)
+		 * @spec exclude UI plumbing — fans out to other store-backed loaders
+		 * @return {Promise<void>}
 		 */
 		async loadAllStats() {
 			await Promise.all([
@@ -504,6 +517,8 @@ export default {
 
 		/**
 		 * Load chat and agent statistics
+		 * @spec exclude UI plumbing — delegates to the settings store
+		 * @return {Promise<void>}
 		 */
 		async loadChatStats() {
 			try {
@@ -523,6 +538,8 @@ export default {
 
 		/**
 		 * Refresh database information (force re-query)
+		 * @spec exclude UI plumbing — delegates to the database refresh API
+		 * @return {Promise<void>}
 		 */
 		async refreshDatabaseInfo() {
 			this.refreshingDatabase = true
@@ -541,6 +558,7 @@ export default {
 		/**
 		 * Format date for display
 		 * @param {string} dateString - ISO date string
+		 * @spec exclude UI plumbing — pure presentation helper
 		 * @return {string} Formatted date
 		 */
 		formatDate(dateString) {
@@ -551,6 +569,8 @@ export default {
 
 		/**
 		 * Load database information
+		 * @spec exclude UI plumbing — fetches database info for display
+		 * @return {Promise<void>}
 		 */
 		async loadDatabaseInfo() {
 			try {
@@ -610,6 +630,8 @@ export default {
 
 		/**
 		 * Retry connection - tests LLM connectivity
+		 * @spec exclude UI plumbing — reloads stats and updates status display
+		 * @return {Promise<void>}
 		 */
 		async retryConnection() {
 			this.loadingStats = true
@@ -630,6 +652,8 @@ export default {
 
 		/**
 		 * Handle LLM Config Modal closing - reload stats to show updated backend
+		 * @spec exclude UI plumbing — modal-close callback reloads stats
+		 * @return {void}
 		 */
 		onLLMConfigClosed() {
 			this.showLLMConfigDialog = false
@@ -639,6 +663,8 @@ export default {
 
 		/**
 		 * Save LLM configuration settings
+		 * @spec exclude UI plumbing — save action delegates to the settings store
+		 * @return {Promise<void>}
 		 */
 		async saveSettings() {
 			this.saving = true
@@ -653,6 +679,8 @@ export default {
 
 		/**
 		 * Handle LLM enabled toggle change
+		 * @spec exclude UI plumbing — toggle delegates to the settings store
+		 * @return {Promise<void>}
 		 */
 		async onLlmEnabledChange() {
 			// Only send the enabled field via PATCH
@@ -664,6 +692,8 @@ export default {
 
 		/**
 		 * Load vector statistics
+		 * @spec exclude UI plumbing — fetches vector stats for display
+		 * @return {Promise<void>}
 		 */
 		async loadVectorStats() {
 			if (!this.llmSettings.enabled) return
@@ -717,6 +747,8 @@ export default {
 		/**
 		 * Format number with thousands separator
 		 * @param {number} num - The number to format
+		 * @spec exclude UI plumbing — pure presentation helper
+		 * @return {string}
 		 */
 		formatNumber(num) {
 			return new Intl.NumberFormat().format(num)
@@ -724,6 +756,8 @@ export default {
 
 		/**
 		 * Show object vectorization modal
+		 * @spec exclude UI plumbing — modal visibility toggle
+		 * @return {void}
 		 */
 		showVectorizeObjectsDialog() {
 			this.showObjectVectorizationModal = true
@@ -731,6 +765,8 @@ export default {
 
 		/**
 		 * Show dialog to vectorize all files
+		 * @spec exclude UI plumbing — modal visibility toggle
+		 * @return {void}
 		 */
 		showVectorizeFilesDialog() {
 			this.showFileVectorizationModal = true
@@ -738,6 +774,8 @@ export default {
 
 		/**
 		 * Vectorize all files
+		 * @spec exclude UI plumbing — starts a background vectorize job via API
+		 * @return {Promise<void>}
 		 */
 		async vectorizeAllFiles() {
 			this.vectorizing = true

--- a/src/views/settings/sections/RetentionConfiguration.vue
+++ b/src/views/settings/sections/RetentionConfiguration.vue
@@ -301,58 +301,139 @@ export default {
 		...mapStores(useSettingsStore),
 
 		retentionOptions: {
+			/**
+			 * Read retention options from the store.
+			 *
+			 * @spec exclude UI plumbing — computed getter proxies the store
+			 * @return {object}
+			 */
 			get() {
 				return this.settingsStore.retentionOptions
 			},
+			/**
+			 * Write retention options to the store.
+			 *
+			 * @param {object} value The new retention options.
+			 * @spec exclude UI plumbing — computed setter proxies the store
+			 * @return {void}
+			 */
 			set(value) {
 				this.settingsStore.retentionOptions = value
 			},
 		},
 
 		auditTrailsEnabled: {
+			/**
+			 * Read the audit-trails-enabled flag from the store.
+			 *
+			 * @spec exclude UI plumbing — computed getter proxies the store
+			 * @return {boolean}
+			 */
 			get() {
 				return this.settingsStore.retentionOptions.auditTrailsEnabled ?? true
 			},
+			/**
+			 * Write the audit-trails-enabled flag to the store.
+			 *
+			 * @param {boolean} value The new value.
+			 * @spec exclude UI plumbing — computed setter proxies the store
+			 * @return {void}
+			 */
 			set(value) {
 				this.settingsStore.retentionOptions.auditTrailsEnabled = value
 			},
 		},
 
 		searchTrailsEnabled: {
+			/**
+			 * Read the search-trails-enabled flag from the store.
+			 *
+			 * @spec exclude UI plumbing — computed getter proxies the store
+			 * @return {boolean}
+			 */
 			get() {
 				return this.settingsStore.retentionOptions.searchTrailsEnabled ?? true
 			},
+			/**
+			 * Write the search-trails-enabled flag to the store.
+			 *
+			 * @param {boolean} value The new value.
+			 * @spec exclude UI plumbing — computed setter proxies the store
+			 * @return {void}
+			 */
 			set(value) {
 				this.settingsStore.retentionOptions.searchTrailsEnabled = value
 			},
 		},
 
+		/**
+		 * Whether the settings store is loading, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		loading() {
 			return this.settingsStore.loading
 		},
 
+		/**
+		 * Whether retention settings are saving, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		saving() {
 			return this.settingsStore.saving
 		},
 
+		/**
+		 * Whether a rebase is in progress, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		rebasing() {
 			return this.settingsStore.rebasing
 		},
 
+		/**
+		 * Retention status CSS class from the store, for display.
+		 *
+		 * @spec exclude UI plumbing — derived status-styling helper
+		 * @return {string}
+		 */
 		retentionStatusClass() {
 			return this.settingsStore.retentionStatusClass
 		},
 
+		/**
+		 * Retention status text CSS class from the store, for display.
+		 *
+		 * @spec exclude UI plumbing — derived status-styling helper
+		 * @return {string}
+		 */
 		retentionStatusTextClass() {
 			return this.settingsStore.retentionStatusTextClass
 		},
 
+		/**
+		 * Retention status message from the store, for display.
+		 *
+		 * @spec exclude UI plumbing — derived status message
+		 * @return {string}
+		 */
 		retentionStatusMessage() {
 			return this.settingsStore.retentionStatusMessage
 		},
 	},
 
 	methods: {
+		/**
+		 * Show the rebase confirmation dialog.
+		 *
+		 * @spec exclude UI plumbing — dialog visibility toggle via store
+		 * @return {void}
+		 */
 		showRebaseDialog() {
 			this.settingsStore.showRebaseDialog()
 		},
@@ -367,6 +448,7 @@ export default {
 		 * Format retention period from milliseconds to human readable format
 		 *
 		 * @param {number} ms Milliseconds
+		 * @spec exclude UI plumbing — pure presentation helper
 		 * @return {string} Formatted period
 		 */
 		formatRetentionPeriod(ms) {

--- a/src/views/settings/sections/StatisticsOverview.vue
+++ b/src/views/settings/sections/StatisticsOverview.vue
@@ -557,62 +557,152 @@ export default {
 	computed: {
 		...mapStores(useSettingsStore),
 
+		/**
+		 * Statistics object from the settings store, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {object}
+		 */
 		stats() {
 			return this.settingsStore.stats
 		},
 
+		/**
+		 * Whether statistics are loading, for spinner display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		loadingStats() {
 			return this.settingsStore.loadingStats
 		},
 
+		/**
+		 * Whether the settings store is loading, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		loading() {
 			return this.settingsStore.loading
 		},
 
+		/**
+		 * Whether settings are saving, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		saving() {
 			return this.settingsStore.saving
 		},
 
+		/**
+		 * Whether a rebase is in progress, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		rebasing() {
 			return this.settingsStore.rebasing
 		},
 
+		/**
+		 * Whether the rebase confirmation is showing, for display.
+		 *
+		 * @spec exclude UI plumbing — derived dialog visibility state
+		 * @return {boolean}
+		 */
 		showRebaseConfirmation() {
 			return this.settingsStore.showRebaseConfirmation
 		},
 
+		/**
+		 * Whether mass validation is in progress, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		massValidating() {
 			return this.settingsStore.massValidating
 		},
 
+		/**
+		 * Whether the mass-validate confirmation is showing, for display.
+		 *
+		 * @spec exclude UI plumbing — derived dialog visibility state
+		 * @return {boolean}
+		 */
 		showMassValidateConfirmation() {
 			return this.settingsStore.showMassValidateConfirmation
 		},
 
+		/**
+		 * Mass-validate results from the store, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {object}
+		 */
 		massValidateResults() {
 			return this.settingsStore.massValidateResults
 		},
 
+		/**
+		 * Whether audit trails are being cleared, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		clearingAuditTrails() {
 			return this.settingsStore.clearingAuditTrails
 		},
 
+		/**
+		 * Whether search trails are being cleared, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		clearingSearchTrails() {
 			return this.settingsStore.clearingSearchTrails
 		},
 
+		/**
+		 * Whether blob objects are being cleared, for display.
+		 *
+		 * @spec exclude UI plumbing — derived view state from the store
+		 * @return {boolean}
+		 */
 		clearingBlobObjects() {
 			return this.settingsStore.clearingBlobObjects
 		},
 
+		/**
+		 * Whether the clear-audit-trails confirmation is showing, for display.
+		 *
+		 * @spec exclude UI plumbing — derived dialog visibility state
+		 * @return {boolean}
+		 */
 		showClearAuditTrailsConfirmation() {
 			return this.settingsStore.showClearAuditTrailsConfirmation
 		},
 
+		/**
+		 * Whether the clear-search-trails confirmation is showing, for display.
+		 *
+		 * @spec exclude UI plumbing — derived dialog visibility state
+		 * @return {boolean}
+		 */
 		showClearSearchTrailsConfirmation() {
 			return this.settingsStore.showClearSearchTrailsConfirmation
 		},
 
+		/**
+		 * Whether the clear-blob-objects confirmation is showing, for display.
+		 *
+		 * @spec exclude UI plumbing — derived dialog visibility state
+		 * @return {boolean}
+		 */
 		showClearBlobObjectsConfirmation() {
 			return this.settingsStore.showClearBlobObjectsConfirmation
 		},
@@ -628,6 +718,12 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * Load statistics from the settings store.
+		 *
+		 * @spec exclude UI plumbing — delegates to the settings store
+		 * @return {void}
+		 */
 		loadStats() {
 			this.settingsStore.loadStats()
 		},
@@ -636,6 +732,7 @@ export default {
 		 * Format bytes to human-readable size.
 		 *
 		 * @param {number} bytes - The size in bytes
+		 * @spec exclude UI plumbing — pure presentation helper
 		 * @return {string} Formatted size string (e.g., '1.5 MB')
 		 */
 		formatBytes(bytes) {
@@ -648,6 +745,12 @@ export default {
 			return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
 		},
 
+		/**
+		 * Open the mass-validate modal and load supporting data in the background.
+		 *
+		 * @spec exclude UI plumbing — modal open plus background data fetch
+		 * @return {Promise<void>}
+		 */
 		async openMassValidateModal() {
 			// Open modal immediately for better UX
 			this.showMassValidateModal = true
@@ -657,12 +760,25 @@ export default {
 			this.loadMemoryPrediction(0) // Default to all objects
 		},
 
+		/**
+		 * Close the mass-validate modal and reset its state.
+		 *
+		 * @spec exclude UI plumbing — modal visibility toggle
+		 * @return {void}
+		 */
 		closeMassValidateModal() {
 			this.showMassValidateModal = false
 			// Reset state when modal is closed
 			this.massValidateCompleted = false
 		},
 
+		/**
+		 * Start a mass-validate run with the given config.
+		 *
+		 * @param {object} config The mass-validate configuration.
+		 * @spec exclude UI plumbing — action delegates to the settings store
+		 * @return {Promise<void>}
+		 */
 		async handleStartMassValidate(config) {
 			this.massValidateCompleted = false
 			this.massValidateConfig = { ...config }
@@ -676,10 +792,22 @@ export default {
 			}
 		},
 
+		/**
+		 * Retry the last mass-validate run.
+		 *
+		 * @spec exclude UI plumbing — re-invokes the start handler
+		 * @return {Promise<void>}
+		 */
 		async handleRetryMassValidate() {
 			await this.handleStartMassValidate(this.massValidateConfig)
 		},
 
+		/**
+		 * Reset the mass-validate form to defaults.
+		 *
+		 * @spec exclude UI plumbing — resets local form state
+		 * @return {void}
+		 */
 		handleResetMassValidate() {
 			this.massValidateCompleted = false
 			// Reset to default configuration
@@ -691,6 +819,12 @@ export default {
 			}
 		},
 
+		/**
+		 * Load total object count from store stats for the modal.
+		 *
+		 * @spec exclude UI plumbing — reads store stats for display
+		 * @return {Promise<void>}
+		 */
 		async loadObjectStats() {
 			this.objectStats.loading = true
 
@@ -706,6 +840,13 @@ export default {
 			}
 		},
 
+		/**
+		 * Load the memory-usage prediction for a mass-validate run.
+		 *
+		 * @param {number} maxObjects The object cap for the prediction.
+		 * @spec exclude UI plumbing — delegates to the settings store
+		 * @return {Promise<void>}
+		 */
 		async loadMemoryPrediction(maxObjects = 0) {
 			this.memoryPredictionLoading = true
 			try {
@@ -719,14 +860,32 @@ export default {
 			}
 		},
 
+		/**
+		 * Show the clear-audit-trails confirmation dialog.
+		 *
+		 * @spec exclude UI plumbing — dialog visibility toggle via store
+		 * @return {void}
+		 */
 		showClearAuditTrailsDialog() {
 			this.settingsStore.showClearAuditTrailsDialog()
 		},
 
+		/**
+		 * Hide the clear-audit-trails confirmation dialog.
+		 *
+		 * @spec exclude UI plumbing — dialog visibility toggle via store
+		 * @return {void}
+		 */
 		hideClearAuditTrailsDialog() {
 			this.settingsStore.hideClearAuditTrailsDialog()
 		},
 
+		/**
+		 * Clear all audit trails and reload stats.
+		 *
+		 * @spec exclude UI plumbing — action delegates to the settings store
+		 * @return {Promise<void>}
+		 */
 		async clearAllAuditTrails() {
 			try {
 				await this.settingsStore.clearAllAuditTrails()
@@ -737,14 +896,32 @@ export default {
 			}
 		},
 
+		/**
+		 * Show the clear-search-trails confirmation dialog.
+		 *
+		 * @spec exclude UI plumbing — dialog visibility toggle via store
+		 * @return {void}
+		 */
 		showClearSearchTrailsDialog() {
 			this.settingsStore.showClearSearchTrailsDialog()
 		},
 
+		/**
+		 * Hide the clear-search-trails confirmation dialog.
+		 *
+		 * @spec exclude UI plumbing — dialog visibility toggle via store
+		 * @return {void}
+		 */
 		hideClearSearchTrailsDialog() {
 			this.settingsStore.hideClearSearchTrailsDialog()
 		},
 
+		/**
+		 * Clear all search trails and reload stats.
+		 *
+		 * @spec exclude UI plumbing — action delegates to the settings store
+		 * @return {Promise<void>}
+		 */
 		async clearAllSearchTrails() {
 			try {
 				await this.settingsStore.clearAllSearchTrails()
@@ -755,14 +932,32 @@ export default {
 			}
 		},
 
+		/**
+		 * Show the clear-blob-objects confirmation dialog.
+		 *
+		 * @spec exclude UI plumbing — dialog visibility toggle via store
+		 * @return {void}
+		 */
 		showClearBlobObjectsDialog() {
 			this.settingsStore.showClearBlobObjectsDialog()
 		},
 
+		/**
+		 * Hide the clear-blob-objects confirmation dialog.
+		 *
+		 * @spec exclude UI plumbing — dialog visibility toggle via store
+		 * @return {void}
+		 */
 		hideClearBlobObjectsDialog() {
 			this.settingsStore.hideClearBlobObjectsDialog()
 		},
 
+		/**
+		 * Clear all blob objects and reload stats.
+		 *
+		 * @spec exclude UI plumbing — action delegates to the settings store
+		 * @return {Promise<void>}
+		 */
 		async clearAllBlobObjects() {
 			try {
 				await this.settingsStore.clearAllBlobObjects()

--- a/src/views/webhooks/WebhookLogsIndex.vue
+++ b/src/views/webhooks/WebhookLogsIndex.vue
@@ -207,6 +207,7 @@ export default {
 		/**
 		 * Get current page number
 		 *
+		 * @spec exclude UI plumbing — derived pagination view state
 		 * @return {number} Current page
 		 */
 		currentPage() {
@@ -216,6 +217,7 @@ export default {
 		/**
 		 * Get total number of pages
 		 *
+		 * @spec exclude UI plumbing — derived pagination view state
 		 * @return {number} Total pages
 		 */
 		totalPages() {
@@ -225,6 +227,7 @@ export default {
 		/**
 		 * Webhook options for filter dropdown
 		 *
+		 * @spec exclude UI plumbing — derived select-option list
 		 * @return {Array} Webhook options
 		 */
 		webhookOptions() {
@@ -239,6 +242,12 @@ export default {
 			)
 		},
 	},
+	/**
+	 * Lifecycle hook: load webhooks and logs and subscribe to retry events.
+	 *
+	 * @spec exclude UI plumbing — view-mount data fetch and event wiring
+	 * @return {void}
+	 */
 	mounted() {
 		// Get webhook ID from transfer data if available.
 		const transferData = navigationStore.getTransferData()
@@ -251,6 +260,12 @@ export default {
 		// Listen for retry events to refresh logs.
 		window.addEventListener('webhook-log-retried', this.loadLogs)
 	},
+	/**
+	 * Lifecycle hook: remove the retry event listener before teardown.
+	 *
+	 * @spec exclude UI plumbing — event-listener teardown
+	 * @return {void}
+	 */
 	beforeDestroy() {
 		// Clean up event listener.
 		window.removeEventListener('webhook-log-retried', this.loadLogs)
@@ -259,6 +274,7 @@ export default {
 		/**
 		 * Load webhooks list
 		 *
+		 * @spec exclude UI plumbing — fetches the webhook list for display
 		 * @return {Promise<void>}
 		 */
 		async loadWebhooks() {
@@ -275,6 +291,7 @@ export default {
 		/**
 		 * Load logs list
 		 *
+		 * @spec exclude UI plumbing — fetches webhook logs for display
 		 * @return {Promise<void>}
 		 */
 		async loadLogs() {
@@ -305,6 +322,7 @@ export default {
 		 * Handle webhook filter change
 		 *
 		 * @param {number|null} webhookId - Selected webhook ID
+		 * @spec exclude UI plumbing — filter handler reloads logs
 		 * @return {void}
 		 */
 		handleWebhookFilterChange(webhookId) {
@@ -316,6 +334,7 @@ export default {
 		/**
 		 * Refresh logs
 		 *
+		 * @spec exclude UI plumbing — refresh button reloads logs
 		 * @return {void}
 		 */
 		refreshLogs() {
@@ -325,6 +344,7 @@ export default {
 		/**
 		 * Go to previous page
 		 *
+		 * @spec exclude UI plumbing — pagination handler reloads logs
 		 * @return {void}
 		 */
 		previousPage() {
@@ -337,6 +357,7 @@ export default {
 		/**
 		 * Go to next page
 		 *
+		 * @spec exclude UI plumbing — pagination handler reloads logs
 		 * @return {void}
 		 */
 		nextPage() {
@@ -350,6 +371,7 @@ export default {
 		 * Get webhook name by ID
 		 *
 		 * @param {number} webhookId - Webhook ID
+		 * @spec exclude UI plumbing — display lookup helper
 		 * @return {string} Webhook name
 		 */
 		getWebhookName(webhookId) {
@@ -361,6 +383,7 @@ export default {
 		 * Truncate event class name
 		 *
 		 * @param {string} eventClass - Event class name
+		 * @spec exclude UI plumbing — pure presentation helper
 		 * @return {string} Truncated event class
 		 */
 		truncateEventClass(eventClass) {
@@ -374,6 +397,7 @@ export default {
 		 *
 		 * @param {string} text - Text to truncate
 		 * @param {number} maxLength - Maximum length
+		 * @spec exclude UI plumbing — pure presentation helper
 		 * @return {string} Truncated text
 		 */
 		truncateText(text, maxLength) {
@@ -386,6 +410,7 @@ export default {
 		 * Format date for display
 		 *
 		 * @param {string} date - Date string
+		 * @spec exclude UI plumbing — pure presentation helper
 		 * @return {string} Formatted date
 		 */
 		formatDate(date) {
@@ -397,6 +422,7 @@ export default {
 		 * View log details
 		 *
 		 * @param {object} log - Log entry
+		 * @spec exclude UI plumbing — opens the log-details modal
 		 * @return {void}
 		 */
 		viewLogDetails(log) {
@@ -408,6 +434,7 @@ export default {
 		/**
 		 * Go back to webhooks list
 		 *
+		 * @spec exclude UI plumbing — router navigation
 		 * @return {void}
 		 */
 		goBack() {


### PR DESCRIPTION
## Summary

Retrofit annotation pass bringing 223 uncovered `src/views/**/*.vue` methods (batch `fe-views-3`) under the ADR-003 `@spec` convention.

- All 223 methods tagged with JSDoc `@spec exclude <reason>` — they are UI plumbing: list/detail rendering, data fetching for display, formatting helpers, dialog/sidebar toggles, pagination/sort/selection handlers, and lifecycle hooks.
- **No new REQs minted.** Documentation-only ghost change `openspec/changes/retrofit-2026-05-25-fe-views-3/` (proposal + tasks, no `specs/` delta) — contract-level behavior is owned by the backend capabilities these views render, or the method is pure presentation.
- 18 files touched across account, avg, dashboard, logs, object, reports, schema, search, settings, and webhooks views.

## Test plan

- [ ] Confirm every batch method now carries a preceding `@spec exclude <reason>` (verified locally: 0 untagged).
- [ ] `composer check:strict` / ESLint pass in CI (comment-only changes).