### PR TITLE
retrofit: frontend coverage — modals (chunk 1, mostly @spec exclude)

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-fe-modals-1/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-modals-1/proposal.md
@@ -1,0 +1,54 @@
+# Retrofit — Frontend coverage: modals (chunk 1, all `@spec exclude`)
+
+The coverage scanner flagged 224 uncovered methods across `src/modals/` Vue components (batch `fw-fe-modals-1`). This change annotates every one of them with a JSDoc `@spec` tag per ADR-003.
+
+## Outcome: 100% exclude (annotation-only)
+
+Modal components are CRUD/admin dialogs: open/close handlers, form-state resets, debounced search loaders, computed display/validation helpers, pagination toggles, and submit handlers that delegate straight to an entity store action or a settings/operations REST endpoint. None of the 224 methods carries a spec-worthy domain contract that isn't already owned elsewhere:
+
+- **Submit handlers** (`saveObject`, `importRegister`, `joinSelectedOrganisation`, `startVectorization`, `createCollection`, …) are thin wrappers that delegate to a store action (`objectStore.saveObject`, `registerStore.importRegister`, `organisationStore.joinOrganisation`) or a settings/SOLR API — the behavioral contract lives in the backend capability / store action, not in the modal shell.
+- **Loaders / form-state initializers** (`loadInitialUsers`, `loadConfigSets`, `loadObjectCount`, `loadNextcloudGroups`, …) hydrate select options and dirty-tracking state; they orchestrate UI, they don't define a contract.
+- **Computed display & validation helpers** (`getModalTitle`, `formatFileSize`, `metadataProperties`, `getPropertyValidationClass`, `estimatedCost`, …) are pure presentation/derivation.
+- **Open/close, watcher, pagination, and toast helpers** are pure UI plumbing.
+
+Every method therefore received `@spec exclude <reason>` with a specific reason. **Zero new REQs are minted.**
+
+Per the retrofit playbook, an all-exclude change carries no spec delta. `--strict` requires a delta, so this change is intentionally delta-less and should not be validated with `--strict` on a (nonexistent) spec delta.
+
+## Counts
+
+- **R (reverse-spec'd / new REQs):** 0
+- **E (excluded):** 224
+- **New REQs:** 0
+
+## Affected files (21)
+
+- src/modals/application/DeleteApplication.vue (2)
+- src/modals/object/CopyObject.vue (2)
+- src/modals/object/MassCopyObjects.vue (3)
+- src/modals/object/MassDeleteObject.vue (4)
+- src/modals/object/UploadObject.vue (7)
+- src/modals/object/ViewObject.vue (85)
+- src/modals/organisation/JoinOrganisation.vue (11)
+- src/modals/organisation/ManageOrganisationRoles.vue (10)
+- src/modals/register/ImportRegister.vue (17)
+- src/modals/schema/DeleteSchemaObjects.vue (5)
+- src/modals/schema/EditSchema.vue (16)
+- src/modals/settings/ClearCacheModal.vue (2)
+- src/modals/settings/CollectionManagementModal.vue (19)
+- src/modals/settings/ConfigSetManagementModal.vue (4)
+- src/modals/settings/ConnectionConfigModal.vue (3)
+- src/modals/settings/DeleteConfigSetDialog.vue (1)
+- src/modals/settings/FileVectorizationModal.vue (9)
+- src/modals/settings/FileWarmupModal.vue (6)
+- src/modals/settings/InspectIndexModal.vue (11)
+- src/modals/settings/ObjectManagementModal.vue (5)
+- src/modals/settings/SolrTestResultsModal.vue (2)
+
+## Notes / drifts
+
+- The Vue components use JSDoc `@spec` blocks (above the method, inside the `methods:`/`computed:`/`watch:` object), not PHPDoc. PHPCS blank-line rules do not apply.
+- Watcher `handler` functions and Vue lifecycle hooks (`mounted`, `updated`, `beforeDestroy`) were also tagged where present in the batch.
+- Several methods were already annotated under prior `retrofit-2026-05-24-2b-modals` tasks (e.g. `ViewObject.vue::_getFileParams`, `deleteApplication`); those were left untouched. Only the 224 still-uncovered methods were tagged here.
+
+Source: `/tmp/or-scan/fw-fe-modals-1.json`, generated 2026-05-25. Retrofit playbook — frontend modal coverage, chunk 1.

--- a/openspec/changes/retrofit-2026-05-25-fe-modals-1/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-modals-1/tasks.md
@@ -1,0 +1,35 @@
+# Tasks — Frontend coverage: modals (chunk 1)
+
+All-exclude annotation change. No REQs minted, so there is no spec delta and no `--strict` validation step.
+
+## Annotation tasks
+
+- [x] task-1: Tag all 224 batch methods under `src/modals/` with JSDoc `@spec exclude <reason>` (ADR-003).
+- [x] task-2: Verify 0 untagged methods remain in the batch.
+- [x] task-3: Confirm every added line is comment-only (no functional code change).
+
+## Per-file completion
+
+- [x] DeleteApplication.vue — 2 excluded
+- [x] CopyObject.vue — 2 excluded
+- [x] MassCopyObjects.vue — 3 excluded
+- [x] MassDeleteObject.vue — 4 excluded
+- [x] UploadObject.vue — 7 excluded
+- [x] ViewObject.vue — 85 excluded
+- [x] JoinOrganisation.vue — 11 excluded
+- [x] ManageOrganisationRoles.vue — 10 excluded
+- [x] ImportRegister.vue — 17 excluded
+- [x] DeleteSchemaObjects.vue — 5 excluded
+- [x] EditSchema.vue — 16 excluded
+- [x] ClearCacheModal.vue — 2 excluded
+- [x] CollectionManagementModal.vue — 19 excluded
+- [x] ConfigSetManagementModal.vue — 4 excluded
+- [x] ConnectionConfigModal.vue — 3 excluded
+- [x] DeleteConfigSetDialog.vue — 1 excluded
+- [x] FileVectorizationModal.vue — 9 excluded
+- [x] FileWarmupModal.vue — 6 excluded
+- [x] InspectIndexModal.vue — 11 excluded
+- [x] ObjectManagementModal.vue — 5 excluded
+- [x] SolrTestResultsModal.vue — 2 excluded
+
+Total: 224 excluded / 0 reverse-spec'd / 0 new REQs.

--- a/src/modals/application/DeleteApplication.vue
+++ b/src/modals/application/DeleteApplication.vue
@@ -41,6 +41,9 @@ export default {
 		TrashCanOutline,
 	},
 	computed: {
+		/**
+		 * @spec exclude computed display helper for confirmation message
+		 */
 		deleteMessage() {
 			return t('openregister', 'Are you sure you want to delete the application "{name}"? This action cannot be undone.', {
 				name: applicationStore.applicationItem?.name || t('openregister', 'this application'),
@@ -59,6 +62,9 @@ export default {
 				console.error('Error deleting application:', error)
 			}
 		},
+		/**
+		 * @spec exclude modal open/close UI handler
+		 */
 		handleDialogClose(open) {
 			if (!open) {
 				navigationStore.setDialog(false)

--- a/src/modals/object/CopyObject.vue
+++ b/src/modals/object/CopyObject.vue
@@ -87,6 +87,9 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude computed display helper for default copy name
+		 */
 		defaultCopyName() {
 			const originalName = objectStore.objectItem?.['@self']?.name
 				|| objectStore.objectItem?.name
@@ -118,6 +121,9 @@ export default {
 			this.error = false
 			this.copyName = ''
 		},
+		/**
+		 * @spec exclude modal submit handler delegating to objectStore.saveObject
+		 */
 		async copyObject() {
 			if (!this.copyName.trim()) {
 				this.error = 'Please provide a name for the copy'

--- a/src/modals/object/MassCopyObjects.vue
+++ b/src/modals/object/MassCopyObjects.vue
@@ -157,6 +157,9 @@ export default {
 			// Clear selection after closing
 			objectStore.selectedObjects = []
 		},
+		/**
+		 * @spec exclude computed display helper for copy-name preview
+		 */
 		getPreviewName(object) {
 			if (!object) return 'Preview Name'
 
@@ -173,10 +176,16 @@ export default {
 				.replace('{name}', originalName)
 				.replace('{id}', object['@self']?.id || object.id || 'ID')
 		},
+		/**
+		 * @spec exclude form-state UI helper to refresh preview
+		 */
 		updateCustomPreview() {
 			// Trigger reactivity for preview update
 			this.$forceUpdate()
 		},
+		/**
+		 * @spec exclude modal bulk-submit handler delegating to objectStore.saveObject
+		 */
 		async copyObjects() {
 			this.loading = true
 			this.error = false

--- a/src/modals/object/MassDeleteObject.vue
+++ b/src/modals/object/MassDeleteObject.vue
@@ -130,6 +130,9 @@ export default {
 				this.closeDialog()
 			}
 		},
+		/**
+		 * @spec exclude form-state helper to deselect an object from the list
+		 */
 		removeObject(objectId) {
 			this.selectedObjects = this.selectedObjects.filter(obj => obj.id !== objectId)
 			// Update the store as well
@@ -138,17 +141,26 @@ export default {
 				this.closeDialog()
 			}
 		},
+		/**
+		 * @spec exclude modal close UI handler
+		 */
 		closeDialog() {
 			clearTimeout(this.closeModalTimeout)
 			this.startClosing = true
 			navigationStore.setDialog(false)
 		},
+		/**
+		 * @spec exclude router navigation UI handler
+		 */
 		navigateToDeleted() {
 			// Close the dialog first
 			this.closeDialog()
 			// Navigate to the deleted objects section
 			this.$router.push('/deleted')
 		},
+		/**
+		 * @spec exclude modal bulk-delete submit handler delegating to objectStore.massDeleteObject
+		 */
 		async deleteObject() {
 			this.loading = true
 

--- a/src/modals/object/UploadObject.vue
+++ b/src/modals/object/UploadObject.vue
@@ -155,6 +155,9 @@ export default {
 			hasUpdated: false,
 		}
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook initializing modal data
+	 */
 	mounted() {
 		this.initializeMappings()
 		this.initializeSchemas()
@@ -183,6 +186,9 @@ export default {
 					this.mappingsLoading = false
 				})
 		},
+		/**
+		 * @spec exclude form-state loader populating schema select options
+		 */
 		initializeSchemas() {
 			this.schemasLoading = true
 
@@ -202,6 +208,9 @@ export default {
 					this.schemasLoading = false
 				})
 		},
+		/**
+		 * @spec exclude form-state loader populating register select options
+		 */
 		initializeRegisters() {
 			this.registersLoading = true
 
@@ -221,6 +230,9 @@ export default {
 					this.registersLoading = false
 				})
 		},
+		/**
+		 * @spec exclude modal close + form-state reset handler
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 			this.success = null
@@ -232,6 +244,9 @@ export default {
 				url: '',
 			}
 		},
+		/**
+		 * @spec exclude modal submit handler delegating to objectStore.saveObject
+		 */
 		async uploadObject() {
 			this.loading = true
 
@@ -257,9 +272,15 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec exclude JSON formatting UI helper
+		 */
 		prettifyJson() {
 			this.object = JSON.stringify(JSON.parse(this.object), null, 2)
 		},
+		/**
+		 * @spec exclude client-side JSON validation helper
+		 */
 		validateJson(json) {
 			try {
 				JSON.parse(json)

--- a/src/modals/object/ViewObject.vue
+++ b/src/modals/object/ViewObject.vue
@@ -739,6 +739,9 @@ export default {
 	},
 	computed: {
 		// Check if we need to show register/schema selection
+		/**
+		 * @spec exclude computed gate for register/schema selection step
+		 */
 		showRegisterSchemaSelection() {
 			return this.isNewObject
 				&& !this.registerSchemaSelectionConfirmed
@@ -746,22 +749,34 @@ export default {
 		},
 
 		// Available registers for selection
+		/**
+		 * @spec exclude computed display helper exposing store registers
+		 */
 		availableRegisters() {
 			return objectStore.availableRegistersForNewObject || []
 		},
 
 		// Available schemas for selection
+		/**
+		 * @spec exclude computed display helper exposing store schemas
+		 */
 		availableSchemas() {
 			return objectStore.availableSchemasForNewObject || []
 		},
 
 		// Can proceed to properties if selections are made
+		/**
+		 * @spec exclude computed form-validation gate
+		 */
 		canProceedToProperties() {
 			const hasRegister = this.availableRegisters.length === 1 || this.selectedRegisterForNewObject
 			const hasSchema = this.availableSchemas.length === 1 || this.selectedSchemaForNewObject
 			return hasRegister && hasSchema
 		},
 
+		/**
+		 * @spec exclude computed display helper building property rows from schema
+		 */
 		objectProperties() {
 			console.info('objectProperties computed called:', {
 				objectItem: objectStore?.objectItem,
@@ -852,12 +867,21 @@ export default {
 			// Combine existing properties and missing schema properties
 			return [...existingProperties, ...missingSchemaProperties]
 		},
+		/**
+		 * @spec exclude computed JSON display helper
+		 */
 		editorContent() {
 			return JSON.stringify(objectStore.objectItem, null, 2)
 		},
+		/**
+		 * @spec exclude computed accessor for active register from store
+		 */
 		currentRegister() {
 			return registerStore.registerItem
 		},
+		/**
+		 * @spec exclude computed accessor merging inherited schema properties for display
+		 */
 		currentSchema() {
 			const schema = schemaStore.schemaItem
 			if (!schema) return schema
@@ -877,6 +901,9 @@ export default {
 			}
 			return { ...schema, properties: { ...inherited, ...(schema.properties || {}) } }
 		},
+		/**
+		 * @spec exclude computed count of selected published files
+		 */
 		selectedPublishedCount() {
 			return this.selectedAttachments.filter((a) => {
 				const found = objectStore.files.results
@@ -886,6 +913,9 @@ export default {
 				return !!found.published
 			}).length
 		},
+		/**
+		 * @spec exclude computed count of selected unpublished files
+		 */
 		selectedUnpublishedCount() {
 			return this.selectedAttachments.filter((a) => {
 				const found = objectStore.files.results
@@ -894,6 +924,9 @@ export default {
 				return found.published === null
 			}).length
 		},
+		/**
+		 * @spec exclude computed select-all state for published files
+		 */
 		allPublishedSelected() {
 			const published = objectStore.files.results
 				?.filter(item => !!item.published)
@@ -904,6 +937,9 @@ export default {
 			}
 			return published.every(pubId => this.selectedAttachments.includes(pubId))
 		},
+		/**
+		 * @spec exclude computed select-all state for unpublished files
+		 */
 		allUnpublishedSelected() {
 			const unpublished = objectStore.files.results
 				?.filter(item => !item.published)
@@ -914,31 +950,55 @@ export default {
 			}
 			return unpublished.every(unpubId => this.selectedAttachments.includes(unpubId))
 		},
+		/**
+		 * @spec exclude computed aggregate loading flag for file actions
+		 */
 		loading() {
 			return this.publishLoading.length > 0 || this.depublishLoading.length > 0 || this.fileIdsLoading.length > 0
 		},
+		/**
+		 * @spec exclude computed flag whether any file is published
+		 */
 		filesHasPublished() {
 			return objectStore.files.results?.some(item => !!item.published)
 		},
+		/**
+		 * @spec exclude computed flag whether any file is unpublished
+		 */
 		filesHasUnpublished() {
 			return objectStore.files.results?.some(item => !item.published)
 		},
+		/**
+		 * @spec exclude computed pagination slice of files
+		 */
 		paginatedFiles() {
 			const files = objectStore.files?.results || []
 			const start = (this.filesCurrentPage - 1) * this.filesPerPage
 			const end = start + this.filesPerPage
 			return files.slice(start, end)
 		},
+		/**
+		 * @spec exclude computed total page count for files pagination
+		 */
 		filesTotalPages() {
 			const totalFiles = objectStore.files?.results?.length || 0
 			return Math.ceil(totalFiles / this.filesPerPage)
 		},
+		/**
+		 * @spec exclude computed select-all state for current files page
+		 */
 		allFilesSelected() {
 			return this.paginatedFiles.length > 0 && this.paginatedFiles.every(file => this.selectedAttachments.includes(file.id))
 		},
+		/**
+		 * @spec exclude computed indeterminate-selection state for files
+		 */
 		someFilesSelected() {
 			return this.selectedAttachments.length > 0 && !this.allFilesSelected
 		},
+		/**
+		 * @spec exclude computed display helper merging schema + object fields
+		 */
 		formFields() {
 			console.info('formFields computed called:', {
 				currentSchema: this.currentSchema,
@@ -984,6 +1044,9 @@ export default {
 			console.info('formFields returning:', fields)
 			return fields
 		},
+		/**
+		 * @spec exclude computed display helper building metadata rows
+		 */
 		metadataProperties() {
 			// Return array of [key, value, hasAction] for metadata display
 			// Use formData instead of objectStore.objectItem to reflect real-time changes
@@ -1078,6 +1141,7 @@ export default {
 		 * object is being viewed.
 		 *
 		 * @return {{register:(string|number), schema:(string|number), id:string}|null}
+		 * @spec exclude computed context object for relation tabs
 		 */
 		relationContext() {
 			const self = objectStore?.objectItem?.['@self']
@@ -1098,6 +1162,9 @@ export default {
 	},
 	watch: {
 		objectStore: {
+			/**
+			 * @spec exclude watcher re-initializing data on store change
+			 */
 			handler(newValue) {
 				if (newValue) {
 					this.initializeData()
@@ -1107,6 +1174,9 @@ export default {
 		},
 		// Watch for schema changes to re-initialize data
 		currentSchema: {
+			/**
+			 * @spec exclude watcher re-resolving schema and re-initializing data
+			 */
 			async handler(newSchema) {
 				console.info('Schema changed in ViewObject:', newSchema)
 
@@ -1141,6 +1211,9 @@ export default {
 		},
 		// Watch for register changes to re-initialize data
 		currentRegister: {
+			/**
+			 * @spec exclude watcher re-initializing data on register change
+			 */
 			handler(newRegister) {
 				console.info('Register changed in ViewObject:', newRegister)
 				if (newRegister && this.isNewObject) {
@@ -1151,6 +1224,9 @@ export default {
 			immediate: true,
 		},
 		jsonData: {
+			/**
+			 * @spec exclude watcher syncing form from JSON editor
+			 */
 			handler(newValue) {
 				if (!this.isInternalUpdate && this.isValidJson(newValue)) {
 					this.updateFormFromJson()
@@ -1158,6 +1234,9 @@ export default {
 			},
 		},
 		formData: {
+			/**
+			 * @spec exclude watcher syncing JSON editor from form
+			 */
 			handler(_newValue) {
 				if (!this.isInternalUpdate) {
 					this.updateJsonFromForm()
@@ -1166,6 +1245,9 @@ export default {
 			deep: true,
 		},
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook initializing modal data
+	 */
 	async mounted() {
 		// Debug: Log current state when modal opens
 		console.info('ViewObject mounted:', {
@@ -1191,6 +1273,9 @@ export default {
 		this.initializeData()
 		this.loadTitles()
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook re-loading data on update
+	 */
 	updated() {
 		if (!this.isUpdated && navigationStore.modal === 'viewObject') {
 			this.isUpdated = true
@@ -1217,6 +1302,9 @@ export default {
 			}
 			return { type, objectId }
 		},
+		/**
+		 * @spec exclude modal step transition handler for register/schema selection
+		 */
 		confirmRegisterSchemaSelection() {
 			// Set the selected register and schema in the store
 			const selectedRegister = this.selectedRegisterForNewObject || this.availableRegisters[0]
@@ -1237,6 +1325,9 @@ export default {
 			this.initializeData()
 		},
 
+		/**
+		 * @spec exclude computed display helper for modal title
+		 */
 		getModalTitle() {
 			if (!objectStore?.objectItem || !objectStore.objectItem['@self']?.id) {
 				return 'Add Object'
@@ -1252,6 +1343,9 @@ export default {
 
 			return `${name} (${schemaName})`
 		},
+		/**
+		 * @spec exclude form-state loader resolving register/schema titles for display
+		 */
 		async loadTitles() {
 			// Only load titles if we have an existing object with @self data
 			if (!objectStore.objectItem || !objectStore.objectItem['@self']) {
@@ -1266,6 +1360,9 @@ export default {
 			this.registerTitle = register?.title || 'Not set'
 			this.schemaTitle = schema?.title || 'Not set'
 		},
+		/**
+		 * @spec exclude modal close + form-state reset handler
+		 */
 		closeModal() {
 			// Clear state first
 			this.isUpdated = false
@@ -1299,6 +1396,9 @@ export default {
 			navigationStore.setModal(null)
 			navigationStore.setDialog(null)
 		},
+		/**
+		 * @spec exclude modal open/close UI handler
+		 */
 		handleDialogClose(isOpen) {
 			if (!isOpen) {
 				this.closeModal()
@@ -1307,6 +1407,7 @@ export default {
 		/**
 		 * Open a file in the Nextcloud Files app
 		 * @param {object} file - The file object to open
+		 * @spec exclude opens file in Nextcloud Files app (UI navigation)
 		 */
 		openFile(file) {
 			const dirPath = file.path.substring(0, file.path.lastIndexOf('/'))
@@ -1318,6 +1419,7 @@ export default {
 		 * Format file size for display
 		 * @param {number} bytes - The file size in bytes
 		 * @return {string} The formatted file size
+		 * @spec exclude display helper formatting file size
 		 */
 		formatFileSize(bytes) {
 			const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB']
@@ -1331,22 +1433,32 @@ export default {
 		 * Truncate file name to prevent dialog alignment issues
 		 * @param {string} fileName - The file name to truncate
 		 * @return {string} The truncated file name (22 chars + ... if longer than 25)
+		 * @spec exclude display helper truncating file name
 		 */
 		truncateFileName(fileName) {
 			if (!fileName) return ''
 			if (fileName.length <= 25) return fileName
 			return fileName.substring(0, 22) + '...'
 		},
+		/**
+		 * @spec exclude client-side date validation helper
+		 */
 		isValidDate(value) {
 			if (!value) return false
 			const date = new Date(value)
 			return date instanceof Date && !isNaN(date)
 		},
+		/**
+		 * @spec exclude display helper formatting value as JSON
+		 */
 		formatValue(val) {
 			return JSON.stringify(val, null, 2)
 		},
 
 		getTheme,
+		/**
+		 * @spec exclude clipboard UI helper
+		 */
 		async copyToClipboard(text) {
 			try {
 				await navigator.clipboard.writeText(text)
@@ -1356,6 +1468,9 @@ export default {
 				console.error('Failed to copy text:', err)
 			}
 		},
+		/**
+		 * @spec exclude form-state initializer seeding formData/jsonData
+		 */
 		initializeData() {
 			console.info('initializeData called:', {
 				objectItem: objectStore.objectItem,
@@ -1434,6 +1549,9 @@ export default {
 
 		},
 
+		/**
+		 * @spec exclude modal submit handler delegating to objectStore.saveObject
+		 */
 		async saveObject() {
 			if (!this.currentRegister || !this.currentSchema) {
 				this.error = 'Register and schema are required'
@@ -1480,6 +1598,9 @@ export default {
 				this.isSaving = false
 			}
 		},
+		/**
+		 * @spec exclude form/JSON sync helper (JSON editor to form)
+		 */
 		updateFormFromJson() {
 			if (this.isInternalUpdate) return
 
@@ -1496,6 +1617,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude form/JSON sync helper (form to JSON editor)
+		 */
 		updateJsonFromForm() {
 			if (this.isInternalUpdate) return
 
@@ -1511,6 +1635,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude client-side JSON validation helper
+		 */
 		isValidJson(str) {
 			if (!str || !str.trim()) {
 				return false
@@ -1523,6 +1650,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude JSON formatting UI helper
+		 */
 		formatJSON() {
 			try {
 				if (this.jsonData) {
@@ -1537,26 +1667,44 @@ export default {
 		setFieldValue(key, value) {
 			this.formData[key] = value
 		},
+		/**
+		 * @spec exclude form-state helper updating an array item
+		 */
 		updateArrayItem(key, index, value) {
 			if (!this.formData[key]) {
 				this.formData[key] = []
 			}
 			this.formData[key][index] = value
 		},
+		/**
+		 * @spec exclude display/payload coercion helper for null values
+		 */
 		toDisplay(v) { return v === null ? '' : v },
+		/**
+		 * @spec exclude display/payload coercion helper for empty values
+		 */
 		toPayload(v) { return v === '' ? null : v },
 
+		/**
+		 * @spec exclude form-state helper adding an array item
+		 */
 		addArrayItem(key) {
 			if (!this.formData[key] || !Array.isArray(this.formData[key])) {
 				this.formData[key] = []
 			}
 			this.formData[key].push('')
 		},
+		/**
+		 * @spec exclude form-state helper removing an array item
+		 */
 		removeArrayItem(key, i) {
 			if (this.formData[key] && Array.isArray(this.formData[key])) {
 				this.formData[key].splice(i, 1)
 			}
 		},
+		/**
+		 * @spec exclude form-state helper updating an object-typed field
+		 */
 		updateObjectField(key, val) {
 			this.objectEditors[key] = val
 			try {
@@ -1565,6 +1713,9 @@ export default {
 				console.error('Invalid JSON format:', e)
 			}
 		},
+		/**
+		 * @spec exclude file-selection UI toggle (select all)
+		 */
 		toggleSelectAllFiles(checked) {
 			if (checked) {
 				// Add all current page files to selection
@@ -1579,6 +1730,9 @@ export default {
 				this.selectedAttachments = this.selectedAttachments.filter(id => !currentPageIds.includes(id))
 			}
 		},
+		/**
+		 * @spec exclude file-selection UI toggle (single file)
+		 */
 		toggleFileSelection(fileId, checked) {
 			if (checked) {
 				if (!this.selectedAttachments.includes(fileId)) {
@@ -1588,13 +1742,22 @@ export default {
 				this.selectedAttachments = this.selectedAttachments.filter(id => id !== fileId)
 			}
 		},
+		/**
+		 * @spec exclude files pagination UI handler
+		 */
 		onFilesPageChanged(page) {
 			this.filesCurrentPage = page
 		},
+		/**
+		 * @spec exclude files page-size UI handler
+		 */
 		onFilesPageSizeChanged(pageSize) {
 			this.filesPerPage = pageSize
 			this.filesCurrentPage = 1
 		},
+		/**
+		 * @spec exclude router navigation UI handler to audit trails
+		 */
 		viewAuditTrails() {
 			// Close the current modal and navigate to audit trails
 			this.closeModal()
@@ -1606,6 +1769,9 @@ export default {
 		// doesn't expose batchFiles yet (older @conduction/nextcloud-vue).
 		// Per-action callbacks let callers swap in publishFile / unpublishFile
 		// / deleteFile for the legacy fallback path.
+		/**
+		 * @spec exclude file batch-action dispatch helper delegating to objectStore.batchFiles
+		 */
 		async _runBatchAction(action, perFileFallback) {
 			if (this.selectedAttachments.length === 0) return
 			const { type, objectId } = this._getFileParams()
@@ -1621,6 +1787,9 @@ export default {
 				await perFileFallback(type, objectId, fileId)
 			}
 		},
+		/**
+		 * @spec exclude bulk file-publish handler delegating to objectStore
+		 */
 		async publishSelectedFiles() {
 			if (this.selectedAttachments.length === 0) return
 
@@ -1638,6 +1807,9 @@ export default {
 				this.publishLoading = []
 			}
 		},
+		/**
+		 * @spec exclude bulk file-depublish handler delegating to objectStore
+		 */
 		async depublishSelectedFiles() {
 			if (this.selectedAttachments.length === 0) return
 
@@ -1655,6 +1827,9 @@ export default {
 				this.depublishLoading = []
 			}
 		},
+		/**
+		 * @spec exclude bulk file-delete handler delegating to objectStore
+		 */
 		async deleteSelectedFiles() {
 			if (this.selectedAttachments.length === 0) return
 
@@ -1672,6 +1847,9 @@ export default {
 				this.fileIdsLoading = []
 			}
 		},
+		/**
+		 * @spec exclude single file-publish handler delegating to objectStore.publishFile
+		 */
 		async publishFile(file) {
 			try {
 				this.publishLoading.push(file.id)
@@ -1684,6 +1862,9 @@ export default {
 				this.publishLoading = this.publishLoading.filter(id => id !== file.id)
 			}
 		},
+		/**
+		 * @spec exclude single file-depublish handler delegating to objectStore.unpublishFile
+		 */
 		async depublishFile(file) {
 			try {
 				this.depublishLoading.push(file.id)
@@ -1696,6 +1877,9 @@ export default {
 				this.depublishLoading = this.depublishLoading.filter(id => id !== file.id)
 			}
 		},
+		/**
+		 * @spec exclude single file-delete handler delegating to objectStore.deleteFile
+		 */
 		async deleteFile(file) {
 			try {
 				this.fileIdsLoading.push(file.id)
@@ -1708,12 +1892,18 @@ export default {
 				this.fileIdsLoading = this.fileIdsLoading.filter(id => id !== file.id)
 			}
 		},
+		/**
+		 * @spec exclude form-state handler entering file-label edit mode
+		 */
 		async editFileLabels(file) {
 			this.editingLabelsFileId = file.id
 			this.editingLabels = [...(file.labels || [])]
 			const tags = await objectStore.fetchTags()
 			this.availableLabels = Array.isArray(tags) ? tags : objectStore.getTags || []
 		},
+		/**
+		 * @spec exclude form-state handler cancelling file-label edit
+		 */
 		cancelFileLabels() {
 			this.editingLabelsFileId = null
 			this.editingLabels = []
@@ -1724,6 +1914,9 @@ export default {
 		// reverts on error so the UI never lies if the request fails.
 		// API call shape is implemented in services/fileMetadata.js so it
 		// can be unit-tested without mounting this modal.
+		/**
+		 * @spec exclude file-label save handler delegating to services/fileMetadata
+		 */
 		async saveFileLabels(file) {
 			const { type, objectId } = this._getFileParams()
 			const rawRegister = objectStore.objectItem['@self']?.register
@@ -1761,6 +1954,9 @@ export default {
 				this.labelsLoading = false
 			}
 		},
+		/**
+		 * @spec exclude computed CSS-class helper for property validation state
+		 */
 		getPropertyValidationClass(key, value) {
 			// Skip @self as it's metadata
 			if (key === '@self') {
@@ -1790,6 +1986,9 @@ export default {
 				return 'property-invalid'
 			}
 		},
+		/**
+		 * @spec exclude client-side property-value validation helper
+		 */
 		isValidPropertyValue(key, value, schemaProperty) {
 			// Handle null/undefined values
 			if (value === null || value === undefined || value === '') {
@@ -1828,6 +2027,9 @@ export default {
 				return true // Unknown type, assume valid
 			}
 		},
+		/**
+		 * @spec exclude display helper building property error message
+		 */
 		getPropertyErrorMessage(key, value) {
 			const schemaProperty = this.currentSchema?.properties?.[key]
 
@@ -1871,6 +2073,7 @@ export default {
 		 * Convert any value to a string suitable for NcTextField
 		 * @param {*} value - The value to convert
 		 * @return {string} The string representation
+		 * @spec exclude display helper coercing value to string
 		 */
 		getStringValue(value) {
 			if (value === null || value === undefined) {
@@ -1892,6 +2095,9 @@ export default {
 			}
 			return String(value)
 		},
+		/**
+		 * @spec exclude table-row click UI handler for inline edit
+		 */
 		handleRowClick(key, event) {
 			// Don't select if clicking on an input or button
 			if (event.target.tagName === 'INPUT' || event.target.tagName === 'BUTTON' || event.target.closest('.value-input-container')) {
@@ -1926,6 +2132,9 @@ export default {
 				this.showWarningNotification(`Property '${this.getPropertyDisplayName(key)}' has type '${schemaProperty.type}' which is not supported for inline editing. Use the Data tab for complex types.`)
 			}
 		},
+		/**
+		 * @spec exclude form-state handler selecting/focusing a property for edit
+		 */
 		selectProperty(key) {
 			this.selectedProperty = key
 
@@ -1940,6 +2149,9 @@ export default {
 				}
 			})
 		},
+		/**
+		 * @spec exclude form-state handler updating a property value with type coercion
+		 */
 		updatePropertyValue(key, newValue) {
 			// Get the old value for comparison
 			const oldValue = this.formData[key] !== undefined
@@ -2003,6 +2215,7 @@ export default {
 		},
 		/**
 		 * Remove all existing toast notifications
+		 * @spec exclude toast cleanup UI helper
 		 */
 		clearAllToasts() {
 			const toasts = document.querySelectorAll('.property-change-toast, .property-warning-toast')
@@ -2012,6 +2225,9 @@ export default {
 				}
 			})
 		},
+		/**
+		 * @spec exclude toast notification UI helper for property changes
+		 */
 		showPropertyChangeNotification(key, oldValue, newValue) {
 			// Clear any existing toasts before showing a new one
 			this.clearAllToasts()
@@ -2043,10 +2259,16 @@ export default {
 				}
 			}, 3000)
 		},
+		/**
+		 * @spec exclude display helper checking string-typed property
+		 */
 		isStringProperty(key) {
 			const schemaProperty = this.currentSchema?.properties?.[key]
 			return schemaProperty?.type === 'string'
 		},
+		/**
+		 * @spec exclude display helper checking property editability (const/immutable)
+		 */
 		isPropertyEditable(key, value) {
 			const schemaProperty = this.currentSchema?.properties?.[key]
 
@@ -2065,6 +2287,9 @@ export default {
 
 			return true
 		},
+		/**
+		 * @spec exclude display helper building editability warning text
+		 */
 		getEditabilityWarning(key, value) {
 			const schemaProperty = this.currentSchema?.properties?.[key]
 
@@ -2078,9 +2303,15 @@ export default {
 
 			return null
 		},
+		/**
+		 * @spec exclude display helper delegating to dateUtils.stringToDate
+		 */
 		stringToDate(value, format) {
 			return stringToDate(value, format)
 		},
+		/**
+		 * @spec exclude display helper mapping schema type to input type
+		 */
 		getPropertyInputType(key) {
 			const schemaProperty = this.currentSchema?.properties?.[key]
 			if (!schemaProperty) return 'text'
@@ -2107,6 +2338,9 @@ export default {
 				return 'text'
 			}
 		},
+		/**
+		 * @spec exclude display helper mapping schema type to input component
+		 */
 		getPropertyInputComponent(key) {
 			const schemaProperty = this.currentSchema?.properties?.[key]
 			if (!schemaProperty) return 'NcTextField'
@@ -2134,6 +2368,7 @@ export default {
 		 * Get the display name for a property (title if available, otherwise key)
 		 * @param {string} key - The property key
 		 * @return {string} The display name
+		 * @spec exclude display helper for property display name
 		 */
 		getPropertyDisplayName(key) {
 			const schemaProperty = this.currentSchema?.properties?.[key]
@@ -2143,6 +2378,7 @@ export default {
 		 * Get the tooltip text for a property
 		 * @param {string} key - The property key
 		 * @return {string} The tooltip text
+		 * @spec exclude display helper for property tooltip text
 		 */
 		getPropertyTooltip(key) {
 			const schemaProperty = this.currentSchema?.properties?.[key]
@@ -2163,6 +2399,7 @@ export default {
 		 * Get the minimum value for a property
 		 * @param {string} key - The property key
 		 * @return {number|undefined} The minimum value
+		 * @spec exclude display helper exposing schema minimum
 		 */
 		getPropertyMinimum(key) {
 			const schemaProperty = this.currentSchema?.properties?.[key]
@@ -2172,6 +2409,7 @@ export default {
 		 * Get the maximum value for a property
 		 * @param {string} key - The property key
 		 * @return {number|undefined} The maximum value
+		 * @spec exclude display helper exposing schema maximum
 		 */
 		getPropertyMaximum(key) {
 			const schemaProperty = this.currentSchema?.properties?.[key]
@@ -2181,6 +2419,7 @@ export default {
 		 * Get the step value for a property
 		 * @param {string} key - The property key
 		 * @return {string|undefined} The step value
+		 * @spec exclude display helper exposing input step
 		 */
 		getPropertyStep(key) {
 			const schemaProperty = this.currentSchema?.properties?.[key]
@@ -2192,6 +2431,9 @@ export default {
 			}
 			return undefined
 		},
+		/**
+		 * @spec exclude display helper resolving value to show for a property
+		 */
 		getDisplayValue(key, value) {
 			const schemaProperty = this.currentSchema?.properties?.[key]
 
@@ -2213,6 +2455,9 @@ export default {
 			// Otherwise use the original value
 			return value
 		},
+		/**
+		 * @spec exclude toast notification UI helper for warnings
+		 */
 		showWarningNotification(warning) {
 			// Clear any existing toasts before showing a new one
 			this.clearAllToasts()

--- a/src/modals/organisation/JoinOrganisation.vue
+++ b/src/modals/organisation/JoinOrganisation.vue
@@ -152,6 +152,9 @@ export default {
 			closeModalTimeout: null,
 		}
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook loading initial modal data
+	 */
 	async mounted() {
 		// Set default user to current user
 		this.setDefaultUser()
@@ -189,6 +192,7 @@ export default {
 		},
 		/**
 		 * Set default user to current user
+		 * @spec exclude form-state default-user initializer
 		 */
 		setDefaultUser() {
 			const currentUser = this.getCurrentUser()
@@ -204,6 +208,7 @@ export default {
 		},
 		/**
 		 * Load initial list of organisations (first 20)
+		 * @spec exclude form-state loader for organisation options
 		 */
 		async loadInitialOrganisations() {
 			try {
@@ -231,6 +236,7 @@ export default {
 		/**
 		 * Load a preselected organisation
 		 * @param {string} uuid - The UUID of the organisation to load
+		 * @spec exclude form-state loader for preselected organisation
 		 */
 		async loadPreselectedOrganisation(uuid) {
 			try {
@@ -269,6 +275,7 @@ export default {
 		/**
 		 * Handle organisation search with pagination
 		 * @param {string} query - The query to search for
+		 * @spec exclude debounced search UI handler delegating to organisationStore
 		 */
 		async handleOrganisationSearch(query) {
 			// Clear previous timeout
@@ -316,6 +323,7 @@ export default {
 		},
 		/**
 		 * Load initial list of users (first 20)
+		 * @spec exclude form-state loader for user options via OCS API
 		 */
 		async loadInitialUsers() {
 			this.loadingUsers = true
@@ -372,6 +380,7 @@ export default {
 		/**
 		 * Handle user search with pagination
 		 * @param {string} query - The query to search for
+		 * @spec exclude debounced user-search UI handler via OCS API
 		 */
 		async handleUserSearch(query) {
 			// Clear previous timeout
@@ -440,6 +449,7 @@ export default {
 		 * @param {object} option - The organisation option to filter
 		 * @param {string} label - The label of the organisation option
 		 * @param {string} search - The search query
+		 * @spec exclude client-side filter helper for organisation select
 		 */
 		filterOrganisation(option, label, search) {
 			return (
@@ -449,6 +459,7 @@ export default {
 		},
 		/**
 		 * Join the selected organisation
+		 * @spec exclude modal submit handler delegating to organisationStore.joinOrganisation
 		 */
 		async joinSelectedOrganisation() {
 			if (!this.selectedOrganisation) {
@@ -487,6 +498,7 @@ export default {
 		},
 		/**
 		 * Close the modal
+		 * @spec exclude modal close + form-state reset handler
 		 */
 		closeModal() {
 			this.success = false
@@ -503,6 +515,7 @@ export default {
 		},
 		/**
 		 * Handle dialog close event
+		 * @spec exclude modal open/close UI handler
 		 */
 		handleDialogClose() {
 			this.closeModal()

--- a/src/modals/organisation/ManageOrganisationRoles.vue
+++ b/src/modals/organisation/ManageOrganisationRoles.vue
@@ -153,6 +153,7 @@ export default {
 		 * Get available groups that haven't been selected yet
 		 *
 		 * @return {Array} Available groups
+		 * @spec exclude computed display helper filtering available groups
 		 */
 		availableGroupOptions() {
 			const selectedIds = this.selectedRoles.map(r => r.id)
@@ -168,6 +169,7 @@ export default {
 		 * Check if there are unsaved changes
 		 *
 		 * @return {boolean} True if there are changes
+		 * @spec exclude computed dirty-state flag for unsaved changes
 		 */
 		hasChanges() {
 			const originalIds = this.originalRoles.map(r => r.id).sort()
@@ -175,6 +177,9 @@ export default {
 			return JSON.stringify(originalIds) !== JSON.stringify(currentIds)
 		},
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook loading initial modal data
+	 */
 	mounted() {
 		this.initializeOrganisationItem()
 		this.loadNextcloudGroups()
@@ -184,6 +189,7 @@ export default {
 		 * Initialize organisation data
 		 *
 		 * @return {void}
+		 * @spec exclude form-state initializer from organisationStore
 		 */
 		initializeOrganisationItem() {
 			if (organisationStore.organisationItem?.uuid) {
@@ -204,6 +210,7 @@ export default {
 		 * Load available Nextcloud groups
 		 *
 		 * @return {Promise<void>}
+		 * @spec exclude form-state loader for Nextcloud groups via OCS API
 		 */
 		async loadNextcloudGroups() {
 			this.loadingGroups = true
@@ -240,6 +247,7 @@ export default {
 		 *
 		 * @param {object} group - The group to add
 		 * @return {void}
+		 * @spec exclude form-state helper adding a role to selection
 		 */
 		addRole(group) {
 			if (group && !this.selectedRoles.find(r => r.id === group.id)) {
@@ -257,6 +265,7 @@ export default {
 		 *
 		 * @param {object} role - The role to remove
 		 * @return {void}
+		 * @spec exclude form-state helper removing a role from selection
 		 */
 		removeRole(role) {
 			this.selectedRoles = this.selectedRoles.filter(r => r.id !== role.id)
@@ -266,6 +275,7 @@ export default {
 		 * Save the roles to the organisation
 		 *
 		 * @return {Promise<void>}
+		 * @spec exclude modal submit handler delegating to organisationStore.saveOrganisation
 		 */
 		async saveRoles() {
 			this.loading = true
@@ -295,6 +305,7 @@ export default {
 		 * Close the modal
 		 *
 		 * @return {void}
+		 * @spec exclude modal close + form-state reset handler
 		 */
 		closeModal() {
 			this.success = false
@@ -308,6 +319,7 @@ export default {
 		 * Handle dialog close
 		 *
 		 * @return {void}
+		 * @spec exclude modal open/close UI handler
 		 */
 		handleDialogClose() {
 			this.closeModal()

--- a/src/modals/register/ImportRegister.vue
+++ b/src/modals/register/ImportRegister.vue
@@ -392,12 +392,16 @@ export default {
 		/**
 		 * Check if the selected file type is valid
 		 * @return {boolean}
+		 * @spec exclude computed client-side file-type validation
 		 */
 		isValidFileType() {
 			if (!this.selectedFile) return false
 			const extension = this.getFileExtension(this.selectedFile.name)
 			return this.allowedFileTypes.includes(extension)
 		},
+		/**
+		 * @spec exclude computed display helper building register select options
+		 */
 		registerOptions() {
 			return {
 				options: registerStore.registerList.map(register => ({
@@ -447,6 +451,9 @@ export default {
 				},
 			}
 		},
+		/**
+		 * @spec exclude computed display helper for selected register value
+		 */
 		selectedRegisterValue() {
 			if (!registerStore.registerItem) return null
 			const register = registerStore.registerItem
@@ -473,6 +480,7 @@ export default {
 		/**
 		 * Check if there are any errors in the import results
 		 * @return {boolean} - Whether there are import errors
+		 * @spec exclude computed flag for import errors
 		 */
 		hasImportErrors() {
 			if (!this.importResults) return false
@@ -483,6 +491,9 @@ export default {
 			)
 		},
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook preloading registers/schemas
+	 */
 	mounted() {
 		dashboardStore.preload()
 		this.registerLoading = true
@@ -513,6 +524,7 @@ export default {
 		 * Get the file type label for display
 		 * @param {string} filename - The name of the file to get type label from
 		 * @return {string}
+		 * @spec exclude display helper mapping extension to label
 		 */
 		getFileType(filename) {
 			const extension = this.getFileExtension(filename)
@@ -531,6 +543,7 @@ export default {
 		/**
 		 * Handle file input change event
 		 * @param {Event} event - The file input change event
+		 * @spec exclude file-input UI handler with client-side validation
 		 */
 		handleFileUpload(event) {
 			const file = event.target.files[0]
@@ -552,6 +565,7 @@ export default {
 		},
 		/**
 		 * Close the import modal and reset state
+		 * @spec exclude modal close + form-state reset handler
 		 */
 		closeModal() {
 			navigationStore.setModal(false)
@@ -574,6 +588,7 @@ export default {
 		/**
 		 * Handle dialog close event from X button
 		 * @param {boolean} isOpen - Whether the dialog is open
+		 * @spec exclude modal open/close UI handler
 		 */
 		handleDialogClose(isOpen) {
 			if (!isOpen) {
@@ -583,6 +598,7 @@ export default {
 		/**
 		 * Import the selected register file and handle the summary
 		 * @return {Promise<void>}
+		 * @spec exclude modal submit handler delegating to registerStore.importRegister
 		 */
 		async importRegister() {
 			if (!this.selectedFile || !this.isValidFileType) {
@@ -640,6 +656,7 @@ export default {
 		 * Format file size for display
 		 * @param {number} bytes - The size in bytes
 		 * @return {string}
+		 * @spec exclude display helper formatting file size
 		 */
 		formatFileSize(bytes) {
 			if (bytes === 0) return '0 Bytes'
@@ -648,6 +665,9 @@ export default {
 			const i = Math.floor(Math.log(bytes) / Math.log(k))
 			return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
 		},
+		/**
+		 * @spec exclude select-change UI handler updating register/schema stores
+		 */
 		async handleRegisterChange(option) {
 			if (!option) {
 				registerStore.setRegisterItem(null)
@@ -686,6 +706,7 @@ export default {
 		/**
 		 * Check based on the selected file type if all the required data is selected
 		 * @return {boolean}
+		 * @spec exclude computed form-completion gate
 		 */
 		checkDataCompleted() {
 			if (!this.selectedFile) return false
@@ -704,6 +725,7 @@ export default {
 		/**
 		 * Toggle the expanded state for a sheet's details
 		 * @param {string} sheetName - The name of the sheet to toggle
+		 * @spec exclude UI toggle for sheet details
 		 */
 		toggleDetails(sheetName) {
 			// Use Vue.set to ensure reactivity for dynamic object properties
@@ -712,6 +734,7 @@ export default {
 		/**
 		 * Toggle the expanded state for a sheet's error details
 		 * @param {string} sheetName - The name of the sheet to toggle
+		 * @spec exclude UI toggle for sheet error details
 		 */
 		toggleErrorDetails(sheetName) {
 			this.$set(this.expandedErrors, sheetName, !this.expandedErrors[sheetName])
@@ -720,6 +743,7 @@ export default {
 		 * Get the count of invalid objects from validation errors
 		 * @param {object} sheetSummary - The sheet summary object
 		 * @return {number} - The number of invalid objects
+		 * @spec exclude display helper counting validation errors
 		 */
 		getInvalidCount(sheetSummary) {
 			if (!sheetSummary.errors || !Array.isArray(sheetSummary.errors)) {
@@ -733,6 +757,7 @@ export default {
 		 * Check if the error might be cache-related
 		 * @param {object} sheetSummary - The sheet summary object
 		 * @return {boolean} - Whether cache issues might be causing problems
+		 * @spec exclude display helper detecting cache-related errors
 		 */
 		isCacheRelatedError(sheetSummary) {
 			if (!sheetSummary.errors || !Array.isArray(sheetSummary.errors)) {

--- a/src/modals/schema/DeleteSchemaObjects.vue
+++ b/src/modals/schema/DeleteSchemaObjects.vue
@@ -156,6 +156,9 @@ export default {
 	watch: {
 		// Watch for changes in schemaItem and reload count if needed
 		'schemaStore.schemaItem': {
+			/**
+			 * @spec exclude watcher reloading object count on schema change
+			 */
 			handler(newSchemaItem) {
 				console.info('Schema item changed in DeleteSchemaObjects:', newSchemaItem)
 				if (newSchemaItem?.id && this.objectCount === 0) {
@@ -166,6 +169,9 @@ export default {
 		},
 		// Watch for dialog state changes to load count when dialog becomes visible
 		'navigationStore.dialog': {
+			/**
+			 * @spec exclude watcher loading object count when dialog opens
+			 */
 			handler(newDialog) {
 				console.info('Dialog changed to:', newDialog)
 				if (newDialog === 'deleteSchemaObjects' && schemaStore.schemaItem?.id) {
@@ -176,11 +182,17 @@ export default {
 			immediate: true,
 		},
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook loading object count
+	 */
 	async mounted() {
 		console.info('DeleteSchemaObjects dialog mounted, schemaItem:', schemaStore.schemaItem)
 		await this.loadObjectCount()
 	},
 	methods: {
+		/**
+		 * @spec exclude form-state loader for schema object count via schemaStore
+		 */
 		async loadObjectCount() {
 			console.info('DeleteSchemaObjects loadObjectCount called, schemaItem:', schemaStore.schemaItem)
 			try {
@@ -203,6 +215,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude modal submit handler for bulk schema-object deletion
+		 */
 		async confirmDeletion() {
 			this.loading = true
 			this.error = false
@@ -256,6 +271,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude modal close + form-state reset handler
+		 */
 		closeDialog() {
 			navigationStore.setDialog(false)
 			this.loading = false

--- a/src/modals/schema/EditSchema.vue
+++ b/src/modals/schema/EditSchema.vue
@@ -63,6 +63,9 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude computed display helper listing other schemas for extension
+		 */
 		computedAvailableSchemas() {
 			const currentId = schemaStore.schemaItem?.id
 			const currentUuid = schemaStore.schemaItem?.uuid
@@ -81,12 +84,18 @@ export default {
 					reference: `#/components/schemas/${schema.slug || schema.title || schema.id}`,
 				}))
 		},
+		/**
+		 * @spec exclude computed display helper listing registers for select
+		 */
 		computedAvailableRegisters() {
 			return registerStore.registerList.map(register => ({
 				id: register.id,
 				label: register.title || register.name || register.id,
 			}))
 		},
+		/**
+		 * @spec exclude computed display helper merging inherited schema properties
+		 */
 		computedInheritedProperties() {
 			const allOf = schemaStore.schemaItem?.allOf || []
 			if (!allOf.length) return {}
@@ -104,12 +113,18 @@ export default {
 			return merged
 		},
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook loading initial modal data
+	 */
 	mounted() {
 		this.loadRegistersAndSchemas()
 		this.loadUserGroups()
 		this.fetchAvailableTags()
 	},
 	methods: {
+		/**
+		 * @spec exclude form-state loader for registers and schemas
+		 */
 		async loadRegistersAndSchemas() {
 			try {
 				if (!registerStore.registerList.length) {
@@ -122,6 +137,9 @@ export default {
 				console.error('Error loading registers and schemas:', error)
 			}
 		},
+		/**
+		 * @spec exclude form-state loader for user groups via OCS API
+		 */
 		async loadUserGroups() {
 			this.loadingGroups = true
 			try {
@@ -149,6 +167,9 @@ export default {
 				this.loadingGroups = false
 			}
 		},
+		/**
+		 * @spec exclude form-state fallback group defaults
+		 */
 		setFallbackGroups() {
 			this.userGroups = [
 				{ id: 'users', displayname: 'All Users' },
@@ -157,6 +178,9 @@ export default {
 				{ id: 'viewers', displayname: 'Viewers' },
 			]
 		},
+		/**
+		 * @spec exclude form-state loader for available tags
+		 */
 		async fetchAvailableTags() {
 			try {
 				const response = await fetch('/index.php/apps/openregister/api/tags')
@@ -171,6 +195,9 @@ export default {
 				this.availableTags = []
 			}
 		},
+		/**
+		 * @spec exclude modal submit handler delegating to schemaStore.saveSchema
+		 */
 		async onConfirm(schemaData) {
 			try {
 				const { response } = await schemaStore.saveSchema(schemaData)
@@ -184,10 +211,16 @@ export default {
 				})
 			}
 		},
+		/**
+		 * @spec exclude modal close UI handler
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 			navigationStore.setDialog(false)
 		},
+		/**
+		 * @spec exclude form-state helper seeding an extending schema
+		 */
 		extendSchema() {
 			const currentItem = schemaStore.schemaItem
 			const newSchema = {
@@ -199,18 +232,33 @@ export default {
 			}
 			schemaStore.setSchemaItem(newSchema)
 		},
+		/**
+		 * @spec exclude dialog-open UI handler for schema analysis
+		 */
 		analyzeProperties() {
 			navigationStore.setDialog('exploreSchema')
 		},
+		/**
+		 * @spec exclude dialog-open UI handler for object validation
+		 */
 		validateObjects() {
 			navigationStore.setDialog('validateSchema')
 		},
+		/**
+		 * @spec exclude dialog-open UI handler for object deletion
+		 */
 		deleteObjects() {
 			navigationStore.setDialog('deleteSchemaObjects')
 		},
+		/**
+		 * @spec exclude dialog-open UI handler for object publication
+		 */
 		publishObjects() {
 			navigationStore.setDialog('publishSchemaObjects')
 		},
+		/**
+		 * @spec exclude dialog-open UI handler for schema deletion
+		 */
 		deleteSchema() {
 			navigationStore.setDialog('deleteSchema')
 		},

--- a/src/modals/settings/ClearCacheModal.vue
+++ b/src/modals/settings/ClearCacheModal.vue
@@ -120,9 +120,15 @@ export default {
 	},
 
 	watch: {
+		/**
+		 * @spec exclude watcher syncing local cache-type from prop
+		 */
 		cacheType(newValue) {
 			this.localCacheType = newValue
 		},
+		/**
+		 * @spec exclude watcher emitting cache-type change
+		 */
 		localCacheType(newValue) {
 			this.$emit('cache-type-changed', newValue)
 		},

--- a/src/modals/settings/CollectionManagementModal.vue
+++ b/src/modals/settings/CollectionManagementModal.vue
@@ -368,6 +368,9 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude computed display helper for collection select options
+		 */
 		collectionOptions() {
 			return this.collections.map(col => ({
 				id: col.name,
@@ -375,6 +378,9 @@ export default {
 			}))
 		},
 
+		/**
+		 * @spec exclude computed display helper for config-set select options
+		 */
 		configSetOptions() {
 			return this.configSets.map(cs => ({
 				id: cs.name,
@@ -383,6 +389,9 @@ export default {
 		},
 	},
 
+	/**
+	 * @spec exclude Vue lifecycle hook loading initial modal data
+	 */
 	async mounted() {
 		await this.loadCollections()
 		await this.loadConfigSets()
@@ -391,6 +400,9 @@ export default {
 		this.$root.$on('configset-updated', this.handleConfigSetUpdate)
 	},
 
+	/**
+	 * @spec exclude Vue lifecycle hook cleaning up event listener
+	 */
 	beforeDestroy() {
 		// Clean up event listener
 		this.$root.$off('configset-updated', this.handleConfigSetUpdate)
@@ -425,6 +437,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude form-state loader for config sets via API
+		 */
 		async loadConfigSets() {
 			try {
 				const url = generateUrl('/apps/openregister/api/solr/configsets')
@@ -438,6 +453,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude form-state loader for current collection assignments
+		 */
 		async loadCurrentAssignments() {
 			try {
 				// Load settings to get current collection assignments
@@ -474,6 +492,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude modal submit handler persisting collection assignments via API
+		 */
 		async updateAssignments() {
 			try {
 				// Extract the IDs from the objects (NcSelect returns {id, label})
@@ -508,6 +529,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude sub-dialog open handler resetting create-collection form
+		 */
 		async openCreateDialog() {
 			// Show loading state on button
 			this.loadingConfigSets = true
@@ -530,11 +554,17 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude event-listener handler reloading config sets
+		 */
 		handleConfigSetUpdate() {
 			console.info('📦 ConfigSet updated, reloading ConfigSets list')
 			this.loadConfigSets()
 		},
 
+		/**
+		 * @spec exclude sub-dialog close + form-state reset handler
+		 */
 		closeCreateDialog() {
 			this.showCreateDialog = false
 			this.newCollectionData = {
@@ -546,6 +576,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude sub-dialog submit handler creating a collection via API
+		 */
 		async createCollection() {
 			this.creating = true
 
@@ -579,18 +612,27 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude sub-dialog open handler seeding copy form
+		 */
 		openCopyDialog(collection) {
 			this.collectionToCopy = collection
 			this.newCollectionName = `${collection.name}_copy`
 			this.showCopyDialog = true
 		},
 
+		/**
+		 * @spec exclude sub-dialog close + form-state reset handler
+		 */
 		closeCopyDialog() {
 			this.showCopyDialog = false
 			this.collectionToCopy = null
 			this.newCollectionName = ''
 		},
 
+		/**
+		 * @spec exclude sub-dialog submit handler copying a collection via API
+		 */
 		async copyCollection() {
 			this.copying = true
 
@@ -617,16 +659,25 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude display helper truncating name
+		 */
 		truncateName(name, maxLength = 35) {
 			if (!name || name.length <= maxLength) return name
 			return name.substring(0, maxLength) + '...'
 		},
 
+		/**
+		 * @spec exclude display helper formatting number
+		 */
 		formatNumber(num) {
 			if (typeof num !== 'number') return num
 			return num.toLocaleString()
 		},
 
+		/**
+		 * @spec exclude action handler reindexing a collection via API
+		 */
 		async reindexCollection(collection) {
 			if (!confirm(this.t('openregister', 'Are you sure you want to reindex collection "{name}"?\n\nThis will:\n• Rebuild the index with all objects\n• Take several minutes to complete\n• May impact search performance during reindexing', { name: collection.name }))) {
 				return
@@ -652,6 +703,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude action handler clearing a collection via API
+		 */
 		async clearCollection(collection) {
 			if (!confirm(this.t('openregister', 'Are you sure you want to clear all data from collection "{name}"?\n\nThis will:\n• Delete all indexed documents\n• Keep the collection structure intact\n• This action cannot be undone', { name: collection.name }))) {
 				return
@@ -673,6 +727,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude action handler deleting a collection via API
+		 */
 		async deleteCollection(collection) {
 			if (!confirm(this.t('openregister', 'Are you sure you want to DELETE collection "{name}"?\n\nThis will:\n• Permanently delete the collection and all its data\n• Remove all indexed documents\n• This action cannot be undone', { name: collection.name }))) {
 				return

--- a/src/modals/settings/ConfigSetManagementModal.vue
+++ b/src/modals/settings/ConfigSetManagementModal.vue
@@ -169,12 +169,18 @@ export default {
 		}
 	},
 
+	/**
+	 * @spec exclude Vue lifecycle hook loading config sets
+	 */
 	mounted() {
 		this.loadConfigSets()
 		// Listen for updates from Create/Delete dialogs
 		this.$root.$on('configset-updated', this.loadConfigSets)
 	},
 
+	/**
+	 * @spec exclude Vue lifecycle hook cleaning up event listener
+	 */
 	beforeDestroy() {
 		// Clean up event listener
 		this.$root.$off('configset-updated', this.loadConfigSets)
@@ -208,12 +214,18 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude dialog-open UI handler for config-set creation
+		 */
 		openCreateDialog() {
 			console.info('🔵 Opening create dialog, setting navigationStore.dialog to "createConfigSet"')
 			navigationStore.setDialog('createConfigSet')
 			console.info('🔵 navigationStore.dialog is now:', navigationStore.dialog)
 		},
 
+		/**
+		 * @spec exclude dialog-open UI handler for config-set deletion
+		 */
 		openDeleteDialog(configSet) {
 			console.info('🔴 Opening delete dialog for configSet:', configSet)
 			navigationStore.setTransferData(configSet)

--- a/src/modals/settings/ConnectionConfigModal.vue
+++ b/src/modals/settings/ConnectionConfigModal.vue
@@ -393,6 +393,9 @@ export default {
 		config: {
 			immediate: true,
 			deep: true,
+			/**
+			 * @spec exclude watcher syncing local config copy from prop
+			 */
 			handler(newConfig) {
 				this.localConfig = { ...newConfig }
 			},
@@ -413,6 +416,7 @@ export default {
 
 		/**
 		 * Handle save button click
+		 * @spec exclude modal save handler emitting config to parent
 		 */
 		handleSave() {
 			this.$emit('save', this.localConfig)
@@ -420,6 +424,7 @@ export default {
 
 		/**
 		 * Test connection with current settings
+		 * @spec exclude connection-test handler delegating to API
 		 */
 		async handleTestConnection() {
 			this.testing = true

--- a/src/modals/settings/DeleteConfigSetDialog.vue
+++ b/src/modals/settings/DeleteConfigSetDialog.vue
@@ -66,6 +66,9 @@ export default {
 			this.deleting = false
 		},
 
+		/**
+		 * @spec exclude modal submit handler deleting a config set via API
+		 */
 		async deleteConfigSet() {
 			const configSet = navigationStore.transferData
 			if (!configSet) return

--- a/src/modals/settings/FileVectorizationModal.vue
+++ b/src/modals/settings/FileVectorizationModal.vue
@@ -214,6 +214,9 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude computed display helper aggregating vectorization stats
+		 */
 		stats() {
 			const extractedFiles = this.extractionStats?.completed || this.extractionStats?.processedFiles || 0
 			const totalChunks = this.extractionStats?.totalChunks || 0
@@ -227,16 +230,25 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude computed progress percentage helper
+		 */
 		progress() {
 			if (this.stats.chunksToProcess === 0) return 0
 			return Math.round((this.processed / this.stats.chunksToProcess) * 100)
 		},
 
+		/**
+		 * @spec exclude computed estimate of batch count
+		 */
 		estimatedBatches() {
 			if (this.stats.chunksToProcess === 0 || this.batchSize === 0) return 0
 			return Math.ceil(this.stats.chunksToProcess / this.batchSize)
 		},
 
+		/**
+		 * @spec exclude computed estimate of duration
+		 */
 		estimatedDuration() {
 			// Estimate ~100-200ms per chunk for embedding generation
 			const avgTimePerChunk = 0.15 // seconds
@@ -251,6 +263,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude computed estimate of cost
+		 */
 		estimatedCost() {
 			// Assuming OpenAI pricing: $0.0001 per 1K tokens
 			// Average chunk is ~1000 characters = ~750 tokens
@@ -263,6 +278,9 @@ export default {
 	},
 
 	watch: {
+		/**
+		 * @spec exclude watcher reloading file types when modal opens
+		 */
 		show(newValue) {
 			if (newValue) {
 				// Reload file types when modal is opened
@@ -271,6 +289,9 @@ export default {
 		},
 	},
 
+	/**
+	 * @spec exclude Vue lifecycle hook loading file types
+	 */
 	mounted() {
 		if (this.show) {
 			this.loadFileTypes()
@@ -278,6 +299,9 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * @spec exclude form-state loader for file types via API
+		 */
 		async loadFileTypes() {
 			try {
 				const response = await axios.get(generateUrl('/apps/openregister/api/files/types'))
@@ -290,6 +314,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude modal submit handler triggering batch vectorization via API
+		 */
 		async startVectorization() {
 			if (this.stats.chunksToProcess === 0) {
 				showError(this.t('openregister', 'No chunks to vectorize'))

--- a/src/modals/settings/FileWarmupModal.vue
+++ b/src/modals/settings/FileWarmupModal.vue
@@ -241,6 +241,9 @@ export default {
 	watch: {
 		open: {
 			immediate: true,
+			/**
+			 * @spec exclude watcher syncing dialog state and loading stats
+			 */
 			handler(newVal) {
 				console.info('🔍 FileWarmupModal: open prop changed to:', newVal)
 				this.showDialog = newVal
@@ -255,6 +258,7 @@ export default {
 	methods: {
 		/**
 		 * Load file processing statistics
+		 * @spec exclude form-state loader for warmup stats via API
 		 */
 		async loadStats() {
 			try {
@@ -282,6 +286,7 @@ export default {
 
 		/**
 		 * Refresh statistics
+		 * @spec exclude stats-refresh UI handler
 		 */
 		async refreshStats() {
 			await this.loadStats()
@@ -290,6 +295,7 @@ export default {
 
 		/**
 		 * Start file warmup process
+		 * @spec exclude modal submit handler triggering file warmup via API
 		 */
 		async startWarmup() {
 			this.isProcessing = true
@@ -344,6 +350,7 @@ export default {
 		/**
 		 * Handle dialog open/close state update
 		 * @param {boolean} isOpen - The new state of the dialog
+		 * @spec exclude modal open/close UI handler
 		 */
 		handleDialogUpdate(isOpen) {
 			console.info('🔄 FileWarmupModal: Dialog update event, isOpen:', isOpen)
@@ -354,6 +361,7 @@ export default {
 
 		/**
 		 * Handle dialog close
+		 * @spec exclude modal close handler emitting close events
 		 */
 		handleClose() {
 			console.info('❌ FileWarmupModal: Closing dialog...')

--- a/src/modals/settings/InspectIndexModal.vue
+++ b/src/modals/settings/InspectIndexModal.vue
@@ -269,6 +269,7 @@ export default {
 	computed: {
 		/**
 		 * Get preview fields to show in collapsed view
+		 * @spec exclude computed display helper for document preview fields
 		 */
 		getPreviewFields() {
 			return (document) => {
@@ -298,6 +299,9 @@ export default {
 		},
 	},
 	watch: {
+		/**
+		 * @spec exclude watcher loading fields / resetting modal on open change
+		 */
 		show(newVal) {
 			if (newVal) {
 				this.loadAvailableFields()
@@ -329,6 +333,7 @@ export default {
 
 		/**
 		 * Search documents in SOLR index
+		 * @spec exclude search handler delegating to SOLR inspect API
 		 */
 		async searchDocuments() {
 			this.loading = true
@@ -371,6 +376,7 @@ export default {
 
 		/**
 		 * Go to next page
+		 * @spec exclude pagination UI handler
 		 */
 		nextPage() {
 			if (this.startIndex + this.pageSize < this.totalResults) {
@@ -381,6 +387,7 @@ export default {
 
 		/**
 		 * Go to previous page
+		 * @spec exclude pagination UI handler
 		 */
 		previousPage() {
 			if (this.startIndex > 0) {
@@ -392,6 +399,7 @@ export default {
 		/**
 		 * Toggle document expansion.
 		 * @param {number} index - The index of the document to toggle.
+		 * @spec exclude UI toggle for document expansion
 		 */
 		toggleDocument(index) {
 			const docIndex = this.expandedDocs.indexOf(index)
@@ -405,6 +413,7 @@ export default {
 		/**
 		 * Truncate long values for preview
 		 * @param {string} value - The value to truncate.
+		 * @spec exclude display helper truncating value
 		 */
 		truncateValue(value) {
 			if (typeof value !== 'string') {
@@ -416,6 +425,7 @@ export default {
 		/**
 		 * Get field type for display
 		 * @param {any} value - The value to get the field type for
+		 * @spec exclude display helper inferring field type
 		 */
 		getFieldType(value) {
 			if (Array.isArray(value)) return 'array'
@@ -442,6 +452,7 @@ export default {
 		/**
 		 * Get CSS class for field based on name and type
 		 * @param {string} fieldName - The name of the field to get the CSS class for
+		 * @spec exclude display helper mapping field name to CSS class
 		 */
 		getFieldClass(fieldName) {
 			if (fieldName === 'id' || fieldName.endsWith('_id')) return 'field-id'
@@ -453,6 +464,7 @@ export default {
 
 		/**
 		 * Open query help documentation
+		 * @spec exclude opens external query docs (UI navigation)
 		 */
 		openQueryHelp() {
 			// Open the official SOLR query documentation in a new tab
@@ -462,6 +474,7 @@ export default {
 
 		/**
 		 * Reset modal state
+		 * @spec exclude modal form-state reset handler
 		 */
 		resetModal() {
 			this.documents = []

--- a/src/modals/settings/ObjectManagementModal.vue
+++ b/src/modals/settings/ObjectManagementModal.vue
@@ -278,11 +278,17 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude computed count of selected views
+		 */
 		selectedViewsCount() {
 			return this.config.enabledViews.length
 		},
 	},
 
+	/**
+	 * @spec exclude Vue lifecycle hook loading initial modal data
+	 */
 	mounted() {
 		this.loadConfiguration()
 		this.loadViews()
@@ -309,6 +315,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude form-state loader for views via API
+		 */
 		async loadViews() {
 			try {
 				const response = await axios.get(generateUrl('/apps/openregister/api/views'))
@@ -319,6 +328,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude form-state loader for embedding-provider info via API
+		 */
 		async loadEmbeddingProviderInfo() {
 			try {
 				// Load current LLM configuration to show embedding provider info
@@ -333,6 +345,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude modal submit handler persisting vectorization config via API
+		 */
 		async saveConfiguration() {
 			this.saving = true
 

--- a/src/modals/settings/SolrTestResultsModal.vue
+++ b/src/modals/settings/SolrTestResultsModal.vue
@@ -136,10 +136,16 @@ export default {
 			return name.charAt(0).toUpperCase() + name.slice(1).replace(/([A-Z])/g, ' $1')
 		},
 
+		/**
+		 * @spec exclude display helper formatting detail label
+		 */
 		formatDetailLabel(key) {
 			return key.replace(/_/g, ' ').replace(/([A-Z])/g, ' $1').replace(/^\w/, c => c.toUpperCase())
 		},
 
+		/**
+		 * @spec exclude display helper formatting detail value
+		 */
 		formatDetailValue(value) {
 			if (typeof value === 'object') {
 				return JSON.stringify(value)


### PR DESCRIPTION
## Summary

Annotates 224 uncovered methods across 21 `src/modals/` Vue components with JSDoc `@spec exclude <reason>` tags per ADR-003.

Modal components are CRUD/admin dialogs — open/close handlers, form-state loaders, computed display/validation helpers, pagination toggles, and submit handlers that delegate straight to an entity store action or a settings/SOLR REST endpoint. None carries a spec-worthy domain contract not already owned elsewhere.

**Outcome: 224 excluded / 0 reverse-spec'd / 0 new REQs.**

## Counts

- R (reverse-spec'd): 0
- E (excluded): 224
- New REQs: 0

## Notes

- Comment-only change: all 567 added source lines are JSDoc blocks; zero functional code changes.
- Ghost change `openspec/changes/retrofit-2026-05-25-fe-modals-1/` is annotation-only (no spec delta — `--strict` intentionally not run on a delta-less change).
- Methods already annotated under prior `retrofit-2026-05-24-2b-modals` tasks were left untouched.

## Test plan

- [ ] Verify 0 untagged methods remain in batch `fw-fe-modals-1` (done: 224/224 tagged).
- [ ] Confirm no bare `@spec exclude` (done: all carry a reason).
- [ ] CI lint passes on touched Vue files.

Source: `/tmp/or-scan/fw-fe-modals-1.json`, generated 2026-05-25.