### PR TITLE
retrofit: frontend coverage — modals (chunk 3)

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-fe-modals-3/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-modals-3/proposal.md
@@ -1,0 +1,57 @@
+# Retrofit — frontend coverage: modals (chunk 3)
+
+The coverage scanner flagged 224 uncovered methods across 24 Vue files under `src/modals/` (batch `fw-fe-modals-3`). This change brings every one of those methods under the ADR-003 spec-traceability convention by adding a per-method `@spec` JSDoc tag.
+
+## Outcome
+
+- **Reverse-spec'd (new REQs): 0**
+- **Excluded (`@spec exclude <reason>`): 224**
+- **New REQs minted: 0**
+
+Per the frontend-retrofit strategy, modal methods are overwhelmingly UI plumbing — form-field bindings, modal open/close lifecycle, data-load fetches for pickers, display/format helpers, and thin store-delegating save/delete actions. None of these 224 methods represent a novel user-facing domain contract that is not already owned by an existing capability (the underlying domain mutations live in store actions specified under `entity-management-modals`, `object-lifecycle`, `platform-administration-modals`, etc.). Accordingly every method is annotated `@spec exclude <reason>` and no spec delta is produced.
+
+## Exclude categories used
+
+The reason text on each `@spec exclude` falls into a small set of plumbing categories:
+
+- **Vue lifecycle hook** — `mounted` / `created` / `updated` that hydrate the modal.
+- **Form-field binding** — `update*` / `add*` / `remove*` / `toggle*` that mutate local form state.
+- **Modal open/close plumbing** — `closeModal` / `closeDialog` / `handleDialogClose` resetting `navigationStore`.
+- **Modal data-load plumbing** — `fetch*` / `load*` populating pickers and counts.
+- **Modal save/action plumbing** — `save*` / `delete*` / `publish*` / `validate*` delegating to store actions or settings/ops endpoints.
+- **UI display / state / validation helpers** — computed properties and `format*` / `get*` / `*Options` helpers, plus `is*` / `can*` / `has*` guards.
+- **UI watchers / event handlers** — `watch` handlers and click/change handlers.
+
+## Affected files (24)
+
+- src/modals/agent/EditAgent.vue (20)
+- src/modals/application/EditApplication.vue (18)
+- src/modals/configuration/ExportConfiguration.vue (5)
+- src/modals/configuration/PublishConfiguration.vue (10)
+- src/modals/configuration/ViewConfiguration.vue (3)
+- src/modals/logs/ClearAuditTrails.vue (4)
+- src/modals/object/DeleteObject.vue (1)
+- src/modals/object/MassValidateObjects.vue (3)
+- src/modals/objectAuditTrail/ViewObjectAuditTrail.vue (1)
+- src/modals/register/DeleteRegister.vue (2)
+- src/modals/register/PublishRegister.vue (11)
+- src/modals/schema/DeleteSchema.vue (5)
+- src/modals/schema/EditSchemaProperty.vue (28)
+- src/modals/schema/ExploreSchema.vue (24)
+- src/modals/schema/UploadSchema.vue (4)
+- src/modals/schema/ValidateSchema.vue (7)
+- src/modals/settings/FacetConfigModal.vue (5)
+- src/modals/settings/FileManagementModal.vue (2)
+- src/modals/settings/LLMConfigModal.vue (13)
+- src/modals/settings/SolrWarmupModal.vue (17)
+- src/modals/source/EditSource.vue (3)
+- src/modals/source/ViewSource.vue (10)
+- src/modals/view/DeleteView.vue (1)
+- src/modals/webhook/EditWebhook.vue (27)
+
+## Notes / drifts
+
+- **Two files carried a duplicate `handler` watcher** the batch JSON listed once: `ValidateSchema.vue` (schemaItem + dialog watchers) and `SolrWarmupModal.vue` (config + localConfig watchers). Both watchers were untagged, so both were annotated — the actual `@spec exclude` count is 226, 2 above the 224 batch methods, with 0 untagged remaining.
+- A handful of files already had partial `@spec` tags from `retrofit-2026-05-24-2b-modals` / `retrofit-2026-04-23-annotate-openregister`; this change only touches the still-untagged methods from this batch.
+
+Source: `/tmp/or-scan/fw-fe-modals-3.json`, generated 2026-05-25.

--- a/openspec/changes/retrofit-2026-05-25-fe-modals-3/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-modals-3/tasks.md
@@ -1,0 +1,13 @@
+# Tasks
+
+- [x] task-1: Annotate `src/modals/agent/EditAgent.vue` — 20 methods `@spec exclude` (modal UI plumbing)
+- [x] task-2: Annotate `src/modals/application/EditApplication.vue` — 18 methods `@spec exclude`
+- [x] task-3: Annotate `src/modals/configuration/{ExportConfiguration,PublishConfiguration,ViewConfiguration}.vue` — 18 methods `@spec exclude`
+- [x] task-4: Annotate `src/modals/logs/ClearAuditTrails.vue` — 4 methods `@spec exclude`
+- [x] task-5: Annotate `src/modals/object/{DeleteObject,MassValidateObjects}.vue` + `src/modals/objectAuditTrail/ViewObjectAuditTrail.vue` — 5 methods `@spec exclude`
+- [x] task-6: Annotate `src/modals/register/{DeleteRegister,PublishRegister}.vue` — 13 methods `@spec exclude`
+- [x] task-7: Annotate `src/modals/schema/{DeleteSchema,EditSchemaProperty,ExploreSchema,UploadSchema,ValidateSchema}.vue` — 68 methods `@spec exclude`
+- [x] task-8: Annotate `src/modals/settings/{FacetConfigModal,FileManagementModal,LLMConfigModal,SolrWarmupModal}.vue` — 37 methods `@spec exclude`
+- [x] task-9: Annotate `src/modals/source/{EditSource,ViewSource}.vue` + `src/modals/view/DeleteView.vue` — 14 methods `@spec exclude`
+- [x] task-10: Annotate `src/modals/webhook/EditWebhook.vue` — 27 methods `@spec exclude`
+- [x] task-11: Verify 0 untagged batch methods remain (224 batch methods → 226 `@spec exclude` tags incl. 2 duplicate watchers)

--- a/src/modals/agent/EditAgent.vue
+++ b/src/modals/agent/EditAgent.vue
@@ -468,6 +468,9 @@ export default {
 			}
 		},
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook — hydrates agent edit modal on mount.
+	 */
 	mounted() {
 		this.initializeAgent()
 		this.fetchGroups()
@@ -536,22 +539,40 @@ export default {
 			this.success = false
 			this.error = null
 		},
+		/**
+		 * @spec exclude Form-field binding — sets agent type from select input.
+		 */
 		updateType(type) {
 			this.agentItem.type = type ? type.value : 'chat'
 		},
+		/**
+		 * @spec exclude Form-field binding — sets RAG search mode from select input.
+		 */
 		updateRagSearchMode(mode) {
 			this.agentItem.ragSearchMode = mode ? mode.value : 'hybrid'
 		},
+		/**
+		 * @spec exclude Form-field binding — maps selected groups to id array.
+		 */
 		updateGroups(groups) {
 			this.agentItem.groups = groups ? groups.map(g => g.id) : []
 		},
+		/**
+		 * @spec exclude Form-field binding — removes a group from the selection.
+		 */
 		removeGroup(group) {
 			this.selectedGroups = this.selectedGroups.filter(g => g.id !== group.id)
 			this.agentItem.groups = this.selectedGroups.map(g => g.id)
 		},
+		/**
+		 * @spec exclude Form-field binding — maps selected views to id array.
+		 */
 		updateViews(views) {
 			this.agentItem.views = views ? views.map(v => v.id) : []
 		},
+		/**
+		 * @spec exclude Form-field binding — adds a username to the invited-users list.
+		 */
 		addInvitedUser() {
 			if (!this.newUserInput || !this.newUserInput.trim()) {
 				return
@@ -563,10 +584,16 @@ export default {
 			}
 			this.newUserInput = ''
 		},
+		/**
+		 * @spec exclude Form-field binding — removes a username from the invited-users list.
+		 */
 		removeInvitedUser(username) {
 			this.selectedInvitedUsers = this.selectedInvitedUsers.filter(u => u !== username)
 			this.agentItem.invitedUsers = [...this.selectedInvitedUsers]
 		},
+		/**
+		 * @spec exclude Modal data-load plumbing — fetches available agent tools for the picker.
+		 */
 		async fetchTools() {
 			this.loadingTools = true
 			try {
@@ -591,6 +618,9 @@ export default {
 				this.loadingTools = false
 			}
 		},
+		/**
+		 * @spec exclude Modal data-load plumbing — fetches selectable users for the picker.
+		 */
 		async fetchUsers() {
 			this.loadingUsers = true
 			try {
@@ -656,18 +686,30 @@ export default {
 				this.loadingUsers = false
 			}
 		},
+		/**
+		 * @spec exclude Form-field binding — sets the agent owner from the user picker.
+		 */
 		updateUser(selectedUser) {
 			this.agentItem.user = selectedUser ? selectedUser.id : ''
 		},
+		/**
+		 * @spec exclude UI event handler — toggles a tool when its card is clicked.
+		 */
 		handleCardClick(toolId, _event) {
 			// Card click handler - toggle the tool
 			const currentState = this.isToolChecked(toolId)
 			this.toggleTool(toolId, !currentState)
 		},
+		/**
+		 * @spec exclude UI event handler — toggles a tool when its switch is changed.
+		 */
 		handleToggleChange(toolId, newValue) {
 			// Toggle change handler - called when toggle is clicked directly
 			this.toggleTool(toolId, newValue)
 		},
+		/**
+		 * @spec exclude Form-field binding — adds/removes a tool id in the agent's tools array.
+		 */
 		toggleTool(toolId, enabled) {
 			if (!this.agentItem.tools) {
 				this.$set(this.agentItem, 'tools', [])
@@ -689,6 +731,9 @@ export default {
 				this.$set(this.agentItem, 'tools', newTools)
 			}
 		},
+		/**
+		 * @spec exclude UI state helper — reports whether a tool id is currently selected.
+		 */
 		isToolChecked(toolId) {
 			if (!this.agentItem.tools) {
 				return false
@@ -697,6 +742,9 @@ export default {
 			const legacyId = toolId.split('.').pop() // Extract 'register' from 'openregister.register'
 			return this.agentItem.tools.includes(toolId) || this.agentItem.tools.includes(legacyId)
 		},
+		/**
+		 * @spec exclude Modal data-load plumbing — fetches Nextcloud groups for the picker.
+		 */
 		async fetchGroups() {
 			this.loadingGroups = true
 			try {
@@ -724,6 +772,9 @@ export default {
 				this.loadingGroups = false
 			}
 		},
+		/**
+		 * @spec exclude Modal data-load plumbing — fetches available views for the picker.
+		 */
 		async fetchViews() {
 			this.loadingViews = true
 			try {
@@ -755,6 +806,9 @@ export default {
 				this.loadingViews = false
 			}
 		},
+		/**
+		 * @spec exclude Modal save plumbing — delegates persistence to agentStore.saveAgent.
+		 */
 		async saveAgent() {
 			this.loading = true
 			this.error = null
@@ -771,9 +825,15 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude Modal close plumbing — clears the active modal in navigationStore.
+		 */
 		closeModal() {
 			navigationStore.setModal(null)
 		},
+		/**
+		 * @spec exclude UI event handler — closes the modal on dialog dismiss.
+		 */
 		handleDialogClose(open) {
 			if (!open) {
 				this.closeModal()

--- a/src/modals/application/EditApplication.vue
+++ b/src/modals/application/EditApplication.vue
@@ -245,14 +245,23 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude UI display helper — converts storage quota bytes to MB for the form.
+		 */
 		storageQuotaMB() {
 			if (!this.applicationItem.quota?.storage) return 0
 			return Math.round(this.applicationItem.quota.storage / (1024 * 1024))
 		},
+		/**
+		 * @spec exclude UI display helper — converts bandwidth quota bytes to MB for the form.
+		 */
 		bandwidthQuotaMB() {
 			if (!this.applicationItem.quota?.bandwidth) return 0
 			return Math.round(this.applicationItem.quota.bandwidth / (1024 * 1024))
 		},
+		/**
+		 * @spec exclude UI display helper — filters available groups to those assigned to the application.
+		 */
 		filteredAvailableGroups() {
 		// Filter available groups to only show groups assigned to the application
 			if (!this.applicationItem.groups || this.applicationItem.groups.length === 0) {
@@ -261,6 +270,9 @@ export default {
 			return this.availableGroups.filter(group => this.applicationItem.groups.includes(group.id))
 		},
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook — loads organisations/groups and hydrates the modal.
+	 */
 	async mounted() {
 		await this.fetchOrganisations()
 		// Use cached Nextcloud groups from store (preloaded on index page)
@@ -284,6 +296,7 @@ export default {
 		 * Groups are preloaded on the index page for better performance
 		 *
 		 * @return {void}
+		 * @spec exclude Modal data-load plumbing — reads cached Nextcloud groups from the store.
 		 */
 		loadNextcloudGroupsFromStore() {
 			// If groups are already cached in store, use them immediately
@@ -313,6 +326,7 @@ export default {
 		 *
 		 * @param {string} searchQuery - The search query entered by user
 		 * @return {void}
+		 * @spec exclude Modal data-load plumbing — debounced group search via OCS API.
 		 */
 		searchGroups(searchQuery) {
 			// Clear existing debounce timer
@@ -371,6 +385,7 @@ export default {
 		 * Initialize application item from store
 		 *
 		 * @return {void}
+		 * @spec exclude Modal hydration plumbing — copies the store's applicationItem into local form state.
 		 */
 		initializeApplicationItem() {
 			if (applicationStore.applicationItem?.uuid) {
@@ -409,6 +424,7 @@ export default {
 		 *
 		 * @param {Array} groups - Selected groups
 		 * @return {void}
+		 * @spec exclude Form-field binding — maps selected groups to id array.
 		 */
 		updateGroups(groups) {
 			this.selectedGroups = groups || []
@@ -421,6 +437,7 @@ export default {
 		 *
 		 * @param {object} groupToRemove - Group to remove
 		 * @return {void}
+		 * @spec exclude Form-field binding — removes a group from the selection.
 		 */
 		removeGroup(groupToRemove) {
 			this.selectedGroups = this.selectedGroups.filter(g => g.id !== groupToRemove.id)
@@ -433,6 +450,7 @@ export default {
 		 *
 		 * @param {object} payload - Permission update payload
 		 * @return {void}
+		 * @spec exclude Form-field binding — toggles a group's CRUD permission in local authorization state.
 		 */
 		updateApplicationPermission(payload) {
 			const { groupId, action, hasPermission } = payload
@@ -474,6 +492,7 @@ export default {
 		 *
 		 * @param {number} value - Quota in MB
 		 * @return {void}
+		 * @spec exclude Form-field binding — sets storage quota (MB→bytes) in local state.
 		 */
 		updateStorageQuota(value) {
 		// Convert MB to bytes (0 = unlimited)
@@ -489,6 +508,7 @@ export default {
 		 *
 		 * @param {number} value - Quota in MB
 		 * @return {void}
+		 * @spec exclude Form-field binding — sets bandwidth quota (MB→bytes) in local state.
 		 */
 		updateBandwidthQuota(value) {
 		// Convert MB to bytes (0 = unlimited)
@@ -504,6 +524,7 @@ export default {
 		 *
 		 * @param {number} value - Quota value
 		 * @return {void}
+		 * @spec exclude Form-field binding — sets request quota in local state.
 		 */
 		updateRequestQuota(value) {
 			// 0 = unlimited
@@ -518,6 +539,7 @@ export default {
 		 *
 		 * @param {number} value - Quota value
 		 * @return {void}
+		 * @spec exclude Form-field binding — sets user quota in local state.
 		 */
 		updateUserQuota(value) {
 		// 0 = unlimited (not applicable for applications, but kept for consistency)
@@ -532,6 +554,7 @@ export default {
 		 *
 		 * @param {number} value - Quota value
 		 * @return {void}
+		 * @spec exclude Form-field binding — sets group quota in local state.
 		 */
 		updateGroupQuota(value) {
 		// 0 = unlimited
@@ -545,6 +568,7 @@ export default {
 		 * Close the modal and reset state
 		 *
 		 * @return {void}
+		 * @spec exclude Modal close plumbing — resets local state and clears modal/dialog.
 		 */
 		closeModal() {
 			this.success = false
@@ -560,6 +584,7 @@ export default {
 		 * Save the application
 		 *
 		 * @return {Promise<void>}
+		 * @spec exclude Modal save plumbing — validates name then delegates to applicationStore.saveApplication.
 		 */
 		async saveApplication() {
 			this.loading = true
@@ -597,6 +622,7 @@ export default {
 		 *
 		 * @param {boolean} isOpen - Whether the dialog is open
 		 * @return {void}
+		 * @spec exclude UI event handler — closes the modal on dialog dismiss.
 		 */
 		handleDialogOpen(isOpen) {
 			// Only close the modal if the dialog is being closed (isOpen = false)

--- a/src/modals/configuration/ExportConfiguration.vue
+++ b/src/modals/configuration/ExportConfiguration.vue
@@ -80,14 +80,23 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude UI display helper — returns the configuration title for the modal heading.
+		 */
 		configTitle() {
 			const item = configurationStore.configurationItem
 			return item?.title || ''
 		},
+		/**
+		 * @spec exclude UI state helper — enables the export button when a configuration is selected.
+		 */
 		isValid() {
 			const item = configurationStore.configurationItem
 			return Boolean(item?.id)
 		},
+		/**
+		 * @spec exclude UI display helper — derives the reactive error message for the modal.
+		 */
 		errorMessage() {
 			// Computed error message that updates reactively
 			if (!configurationStore.configurationItem?.id) {
@@ -97,12 +106,18 @@ export default {
 		},
 	},
 	methods: {
+		/**
+		 * @spec exclude Modal close plumbing — clears modal state.
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 			this.loading = false
 			this.error = null
 			this.includeObjects = false
 		},
+		/**
+		 * @spec exclude Modal action plumbing — triggers configuration export download.
+		 */
 		async exportConfiguration() {
 			const item = configurationStore.configurationItem
 			if (!item?.id) {

--- a/src/modals/configuration/PublishConfiguration.vue
+++ b/src/modals/configuration/PublishConfiguration.vue
@@ -144,12 +144,21 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude UI accessor — exposes the store's configurationItem to the template.
+		 */
 		configuration() {
 			return configurationStore.configurationItem
 		},
+		/**
+		 * @spec exclude UI state helper — enables the publish button when repo/branch/path are set.
+		 */
 		canPublish() {
 			return this.selectedRepository && this.selectedBranch && this.filePath.trim() !== ''
 		},
+		/**
+		 * @spec exclude UI display helper — maps repositories to NcSelect option objects.
+		 */
 		repositoryOptions() {
 			return this.repositories.map(repo => ({
 				value: repo.full_name,
@@ -157,6 +166,9 @@ export default {
 				...repo,
 			}))
 		},
+		/**
+		 * @spec exclude UI display helper — maps branches to NcSelect option objects.
+		 */
 		branchOptions() {
 			return this.branches.map(branch => ({
 				value: branch.name,
@@ -166,6 +178,9 @@ export default {
 		},
 	},
 	watch: {
+		/**
+		 * @spec exclude UI watcher — reloads branches when the selected repository changes.
+		 */
 		selectedRepository(newValue) {
 			if (newValue) {
 				// Extract value if it's an object, otherwise use the value directly
@@ -178,6 +193,9 @@ export default {
 			}
 		},
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook — loads repositories and sets default commit message.
+	 */
 	async mounted() {
 		await this.loadRepositories()
 
@@ -197,6 +215,9 @@ export default {
 				// so we don't need to clear data here - it will be reset on next mount
 			}
 		},
+		/**
+		 * @spec exclude Modal data-load plumbing — fetches GitHub repositories for the picker.
+		 */
 		async loadRepositories() {
 			this.loadingRepositories = true
 			this.error = null
@@ -241,6 +262,9 @@ export default {
 				this.loadingRepositories = false
 			}
 		},
+		/**
+		 * @spec exclude Modal data-load plumbing — fetches branches for the selected repository.
+		 */
 		async loadBranches(owner, repo) {
 			if (!owner || !repo) return
 
@@ -277,6 +301,9 @@ export default {
 				this.loadingBranches = false
 			}
 		},
+		/**
+		 * @spec exclude UI event handler — reloads branches when repository selection changes.
+		 */
 		onRepositoryChange(value) {
 			// Clear branches and selected branch when repository changes
 			this.branches = []
@@ -292,6 +319,9 @@ export default {
 				}
 			}
 		},
+		/**
+		 * @spec exclude Modal action plumbing — pushes the configuration to the selected GitHub repo/branch.
+		 */
 		async publishConfiguration() {
 			if (!this.canPublish || !this.configuration) return
 

--- a/src/modals/configuration/ViewConfiguration.vue
+++ b/src/modals/configuration/ViewConfiguration.vue
@@ -161,12 +161,21 @@ export default {
 		closeModal() {
 			navigationStore.setModal(false)
 		},
+		/**
+		 * @spec exclude Modal navigation plumbing — opens the edit-configuration modal.
+		 */
 		editConfiguration() {
 			navigationStore.setModal('editConfiguration')
 		},
+		/**
+		 * @spec exclude Modal navigation plumbing — opens the export-configuration modal.
+		 */
 		exportConfiguration() {
 			navigationStore.setModal('exportConfiguration')
 		},
+		/**
+		 * @spec exclude Modal navigation plumbing — opens the delete-configuration dialog.
+		 */
 		deleteConfiguration() {
 			navigationStore.setModal(false)
 			navigationStore.setDialog('deleteConfiguration')

--- a/src/modals/logs/ClearAuditTrails.vue
+++ b/src/modals/logs/ClearAuditTrails.vue
@@ -92,6 +92,9 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude UI state helper — reports whether any audit-trail filter is active.
+		 */
 		hasActiveFilters() {
 			return auditTrailStore.filters && Object.keys(auditTrailStore.filters).some(key =>
 				auditTrailStore.filters[key] !== null
@@ -99,6 +102,9 @@ export default {
 				&& auditTrailStore.filters[key] !== '',
 			)
 		},
+		/**
+		 * @spec exclude UI display helper — returns only the non-empty filters for display.
+		 */
 		displayFilters() {
 			if (!auditTrailStore.filters) return {}
 			return Object.fromEntries(
@@ -190,6 +196,7 @@ export default {
 		 * Format filter key for display
 		 * @param {string} key - Filter key
 		 * @return {string} Formatted key
+		 * @spec exclude UI display helper — translates filter keys to human labels.
 		 */
 		formatFilterKey(key) {
 			const keyMap = {
@@ -209,6 +216,7 @@ export default {
 		 * Format filter value for display
 		 * @param {any} value - Filter value
 		 * @return {string} Formatted value
+		 * @spec exclude UI display helper — formats filter values for display.
 		 */
 		formatFilterValue(value) {
 			if (typeof value === 'boolean') {

--- a/src/modals/object/DeleteObject.vue
+++ b/src/modals/object/DeleteObject.vue
@@ -84,6 +84,9 @@ export default {
 			this.loading = false
 			this.error = false
 		},
+		/**
+		 * @spec exclude Modal action plumbing — delegates deletion to objectStore.deleteObject (lifecycle owned elsewhere).
+		 */
 		async deleteObject() {
 			this.loading = true
 

--- a/src/modals/object/MassValidateObjects.vue
+++ b/src/modals/object/MassValidateObjects.vue
@@ -142,6 +142,9 @@ export default {
 				this.closeDialog()
 			}
 		},
+		/**
+		 * @spec exclude UI selection plumbing — removes an object from the mass-validate selection.
+		 */
 		removeObject(objectId) {
 			this.selectedObjects = this.selectedObjects.filter(obj => obj.id !== objectId)
 			// Update the store as well
@@ -150,11 +153,17 @@ export default {
 				this.closeDialog()
 			}
 		},
+		/**
+		 * @spec exclude Modal close plumbing — closes the mass-validate dialog.
+		 */
 		closeDialog() {
 			clearTimeout(this.closeModalTimeout)
 			this.startClosing = true
 			navigationStore.setDialog(false)
 		},
+		/**
+		 * @spec exclude Modal action plumbing — re-saves each selected object to trigger validation.
+		 */
 		async validateObjects() {
 			this.loading = true
 

--- a/src/modals/objectAuditTrail/ViewObjectAuditTrail.vue
+++ b/src/modals/objectAuditTrail/ViewObjectAuditTrail.vue
@@ -109,6 +109,9 @@ export default {
 			auditTrail: {}, // Initialize with an empty object
 		}
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook — hydrates the audit-trail view modal on mount.
+	 */
 	mounted() {
 		// Assuming objectStore.auditTrailItem is a single audit trail object
 		this.auditTrail = objectStore.auditTrailItem || {}

--- a/src/modals/register/DeleteRegister.vue
+++ b/src/modals/register/DeleteRegister.vue
@@ -82,6 +82,9 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec exclude Modal close plumbing — closes the delete-register dialog and resets state.
+		 */
 		closeDialog() {
 			navigationStore.setDialog(false)
 			clearTimeout(this.closeModalTimeout)
@@ -89,6 +92,9 @@ export default {
 			this.loading = false
 			this.error = false
 		},
+		/**
+		 * @spec exclude Modal action plumbing — delegates deletion to registerStore.deleteRegister.
+		 */
 		async deleteRegister() {
 			if (registerStore.registerItem?.schemas.length > 0) {
 				return

--- a/src/modals/register/PublishRegister.vue
+++ b/src/modals/register/PublishRegister.vue
@@ -144,12 +144,21 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude UI accessor — exposes the store's registerItem to the template.
+		 */
 		register() {
 			return registerStore.registerItem
 		},
+		/**
+		 * @spec exclude UI state helper — enables the publish button when repo/branch/path are set.
+		 */
 		canPublish() {
 			return this.selectedRepository && this.selectedBranch && this.filePath.trim() !== ''
 		},
+		/**
+		 * @spec exclude UI display helper — maps repositories to NcSelect option objects.
+		 */
 		repositoryOptions() {
 			return this.repositories.map(repo => ({
 				value: repo.full_name,
@@ -157,6 +166,9 @@ export default {
 				...repo,
 			}))
 		},
+		/**
+		 * @spec exclude UI display helper — maps branches to NcSelect option objects.
+		 */
 		branchOptions() {
 			return this.branches.map(branch => ({
 				value: branch.name,
@@ -166,6 +178,9 @@ export default {
 		},
 	},
 	watch: {
+		/**
+		 * @spec exclude UI watcher — reloads branches when the selected repository changes.
+		 */
 		selectedRepository(newValue) {
 			if (newValue) {
 				// Extract value if it's an object, otherwise use the value directly
@@ -178,6 +193,9 @@ export default {
 			}
 		},
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook — loads repositories and sets default commit message/path.
+	 */
 	async mounted() {
 		await this.loadRepositories()
 
@@ -191,6 +209,9 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec exclude Modal close plumbing — clears the active modal in navigationStore.
+		 */
 		closeModal() {
 			if (!this.loading) {
 				navigationStore.setModal(null)
@@ -198,6 +219,9 @@ export default {
 				// so we don't need to clear data here - it will be reset on next mount
 			}
 		},
+		/**
+		 * @spec exclude Modal data-load plumbing — fetches GitHub repositories for the picker.
+		 */
 		async loadRepositories() {
 			this.loadingRepositories = true
 			this.error = null
@@ -224,6 +248,9 @@ export default {
 				this.loadingRepositories = false
 			}
 		},
+		/**
+		 * @spec exclude Modal data-load plumbing — fetches branches for the selected repository.
+		 */
 		async loadBranches(owner, repo) {
 			if (!owner || !repo) return
 
@@ -260,6 +287,9 @@ export default {
 				this.loadingBranches = false
 			}
 		},
+		/**
+		 * @spec exclude UI event handler — reloads branches when repository selection changes.
+		 */
 		onRepositoryChange(value) {
 			// Clear branches and selected branch when repository changes
 			this.branches = []
@@ -275,6 +305,9 @@ export default {
 				}
 			}
 		},
+		/**
+		 * @spec exclude Modal action plumbing — pushes the register OAS to the selected GitHub repo/branch.
+		 */
 		async publishRegister() {
 			if (!this.canPublish || !this.register) return
 

--- a/src/modals/schema/DeleteSchema.vue
+++ b/src/modals/schema/DeleteSchema.vue
@@ -74,10 +74,16 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude UI state helper — enables deletion only when no objects reference the schema.
+		 */
 		canDelete() {
 			return this.objects.length === 0
 		},
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook — initializes the dialog once when it opens.
+	 */
 	updated() {
 		if (!this.isUpdated && navigationStore.dialog === 'deleteSchema') {
 			this.isUpdated = true
@@ -85,6 +91,9 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec exclude Modal data-load plumbing — counts objects referencing the schema before delete.
+		 */
 		async initDialog() {
 			await registerStore.refreshRegisterList()
 			if (!registerStore.registerList.length) {
@@ -128,6 +137,9 @@ export default {
 				}
 			}
 		},
+		/**
+		 * @spec exclude Modal close plumbing — closes the dialog and resets state.
+		 */
 		closeDialog() {
 			navigationStore.setDialog(false)
 			clearTimeout(this.closeModalTimeout)
@@ -138,6 +150,9 @@ export default {
 			this.registerName = ''
 			this.isUpdated = false
 		},
+		/**
+		 * @spec exclude Modal action plumbing — delegates deletion to schemaStore.deleteSchema.
+		 */
 		async deleteSchema() {
 			this.loading = true
 

--- a/src/modals/schema/EditSchemaProperty.vue
+++ b/src/modals/schema/EditSchemaProperty.vue
@@ -725,10 +725,16 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude UI state helper — reports whether the property is a date/date-time type.
+		 */
 		isDateProperty() {
 			return this.properties.type === 'string'
 				&& (this.properties.format === 'date' || this.properties.format === 'date-time')
 		},
+		/**
+		 * @spec exclude UI display helper — static facet-type select options.
+		 */
 		facetTypeOptions() {
 			return [
 				{ value: 'date_histogram', label: 'Date Histogram (group by interval)' },
@@ -736,9 +742,15 @@ export default {
 				{ value: 'terms', label: 'Terms (exact values)' },
 			]
 		},
+		/**
+		 * @spec exclude UI display helper — resolves the selected facet-type option.
+		 */
 		facetTypeOption() {
 			return this.facetTypeOptions.find(opt => opt.value === this.facetType) || this.facetTypeOptions[0]
 		},
+		/**
+		 * @spec exclude UI display helper — static facet-interval select options.
+		 */
 		facetIntervalOptions() {
 			return [
 				{ value: 'day', label: 'Day' },
@@ -748,9 +760,15 @@ export default {
 				{ value: 'year', label: 'Year' },
 			]
 		},
+		/**
+		 * @spec exclude UI display helper — resolves the selected facet-interval option.
+		 */
 		facetIntervalOption() {
 			return this.facetIntervalOptions.find(opt => opt.value === this.facetInterval) || this.facetIntervalOptions[2]
 		},
+		/**
+		 * @spec exclude UI display helper — static object-handling select configuration.
+		 */
 		objectConfiguration() {
 			return {
 				handling: {
@@ -784,21 +802,33 @@ export default {
 				},
 			}
 		},
+		/**
+		 * @spec exclude UI display helper — maps available schemas to select options.
+		 */
 		availableSchemas() {
 			return schemaStore.schemaList.map(schema => ({
 				id: schema.id,
 				label: schema.title || schema.name || schema.id,
 			}))
 		},
+		/**
+		 * @spec exclude UI display helper — maps available registers to select options.
+		 */
 		availableRegisters() {
 			return registerStore.registerList.map(register => ({
 				id: register.id,
 				label: register.title || register.name || register.id,
 			}))
 		},
+		/**
+		 * @spec exclude UI display helper — static list of selectable MIME types.
+		 */
 		mimeTypes() {
 			return ['image/jpeg', 'image/png', 'application/pdf', 'text/plain'] // Add more MIME types as needed
 		},
+		/**
+		 * @spec exclude UI display helper — static file-handling select configuration.
+		 */
 		fileConfiguration() {
 			return {
 				handling: {
@@ -809,6 +839,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude UI display helper — builds inversedBy property options from the selected schema.
+		 */
 		// Dynamic inversedBy options based on selected schema
 		inversedByOptions() {
 			const schema = this.selectedSchema || this.getSchemaFromRef(this.properties.$ref) || this.getSchemaFromRef(this.properties.items.$ref)
@@ -836,6 +869,9 @@ export default {
 	watch: {
 		schemaProperty: {
 			deep: true,
+			/**
+			 * @spec exclude UI watcher — resets type-specific form fields when the property type changes.
+			 */
 			handler(newVal, oldVal) {
 				if (newVal.type !== oldVal.type) {
 					// switch types between boolean and non boolean, as boolean type expects a boolean, but others expect a string
@@ -856,28 +892,49 @@ export default {
 			},
 		},
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook — hydrates the property form and loads registers/schemas.
+	 */
 	mounted() {
 		this.initializeSchemaItem()
 		this.loadRegistersAndSchemas()
 	},
 	methods: {
+		/**
+		 * @spec exclude Form-field binding — appends a blank oneOf entry.
+		 */
 		addOneOfEntry() {
 			// Push a new default object into the oneOf array
 			this.properties.oneOf.push({ type: '', format: '' })
 		},
+		/**
+		 * @spec exclude Form-field binding — removes a oneOf entry by index.
+		 */
 		removeOneOfEntry(index) {
 			// Remove the entry at the specified index
 			this.properties.oneOf.splice(index, 1)
 		},
+		/**
+		 * @spec exclude Form-field binding — sets the active facet type.
+		 */
 		updateFacetType(option) {
 			this.facetType = option.value
 		},
+		/**
+		 * @spec exclude Form-field binding — appends a blank custom facet range.
+		 */
 		addCustomRange() {
 			this.facetCustomRanges.push({ label: '', from: '', to: '' })
 		},
+		/**
+		 * @spec exclude Form-field binding — removes a custom facet range by index.
+		 */
 		removeCustomRange(index) {
 			this.facetCustomRanges.splice(index, 1)
 		},
+		/**
+		 * @spec exclude Modal hydration plumbing — loads existing property values into the form.
+		 */
 		initializeSchemaItem() {
 			if (schemaStore.schemaPropertyKey) {
 				const schemaProperty = schemaStore.schemaItem.properties[schemaStore.schemaPropertyKey]
@@ -957,16 +1014,23 @@ export default {
 		 * returns true if it exists, false if it doesn't.
 		 *
 		 * When dealing with a key which is the same key as you are editing return false
+		 * @spec exclude UI validation helper — checks for a duplicate property key.
 		 */
 		keyExists() {
 			if (this.propertyTitle === schemaStore.schemaPropertyKey) return false
 			return Object.keys(schemaStore.schemaItem.properties).includes(this.propertyTitle)
 		},
+		/**
+		 * @spec exclude Modal close plumbing — clears modal and property-key state.
+		 */
 		closeModal() {
 			navigationStore.setModal(null)
 			schemaStore.setSchemaPropertyKey(null)
 			clearTimeout(this.closeModalTimeout)
 		},
+		/**
+		 * @spec exclude Modal save plumbing — assembles the property payload and delegates to schemaStore.saveSchema.
+		 */
 		addSchemaProperty() {
 			this.loading = true
 
@@ -1078,6 +1142,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec exclude UI validation helper — reports whether a string parses as JSON.
+		 */
 		verifyJsonValidity(jsonInput) {
 			if (jsonInput === '') return true
 			try {
@@ -1087,6 +1154,9 @@ export default {
 				return false
 			}
 		},
+		/**
+		 * @spec exclude Modal data-load plumbing — refreshes register/schema lists for the pickers.
+		 */
 		async loadRegistersAndSchemas() {
 			this.registerLoading = true
 			this.schemaLoading = true
@@ -1109,6 +1179,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude UI lookup helper — resolves a schema object from a $ref string.
+		 */
 		getSchemaFromRef(ref) {
 			if (!ref) return null
 
@@ -1121,6 +1194,9 @@ export default {
 			)
 		},
 
+		/**
+		 * @spec exclude Form-field binding — sets register ref and clears dependent fields.
+		 */
 		handleRegisterChange(register) {
 			// Store the register ID, not the whole object
 			const registerId = typeof register === 'object' ? register.id : register
@@ -1140,6 +1216,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude Form-field binding — sets schema ref and clears dependent fields.
+		 */
 		handleSchemaChange(schema) {
 			// Store the schema ID, not the whole object
 			const schemaId = typeof schema === 'object' ? schema.id : schema
@@ -1157,6 +1236,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude Form-field binding — sets inversedBy and clears query params.
+		 */
 		handleInversedByChange(property) {
 			const propertyName = typeof property === 'object' ? property.value || property.id : property
 			this.properties.inversedBy = propertyName

--- a/src/modals/schema/ExploreSchema.vue
+++ b/src/modals/schema/ExploreSchema.vue
@@ -557,6 +557,9 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude UI display helper — static property-type select options.
+		 */
 		typeOptions() {
 			return [
 				{ label: 'String', value: 'string', key: 'string' },
@@ -567,6 +570,9 @@ export default {
 				{ label: 'Object', value: 'object', key: 'object' },
 			]
 		},
+		/**
+		 * @spec exclude UI display helper — builds format select options including any detected format.
+		 */
 		formatOptions() {
 			return (suggestion) => {
 				const commonFormats = [
@@ -596,6 +602,9 @@ export default {
 				return commonFormats
 			}
 		},
+		/**
+		 * @spec exclude UI display helper — static confidence-filter select options.
+		 */
 		confidenceFilterOptions() {
 			return [
 				{ label: this.t('openregister', 'All Confidence Levels'), value: 'all', key: 'all' },
@@ -604,6 +613,9 @@ export default {
 				{ label: this.t('openregister', 'Low Confidence'), value: 'low', key: 'low' },
 			]
 		},
+		/**
+		 * @spec exclude UI display helper — static type-filter select options.
+		 */
 		typeFilterOptions() {
 			return [
 				{ label: this.t('openregister', 'All'), value: 'all', key: 'all' },
@@ -611,6 +623,9 @@ export default {
 				{ label: this.t('openregister', 'Existing Improvements'), value: 'existing', key: 'existing' },
 			]
 		},
+		/**
+		 * @spec exclude UI display helper — applies search/confidence/type/selection filters to suggestions.
+		 */
 		filteredSuggestions() {
 			if (!this.explorationData?.suggestions) {
 				return []
@@ -656,15 +671,24 @@ export default {
 
 			return filtered
 		},
+		/**
+		 * @spec exclude UI pagination helper — slices filtered suggestions for the current page.
+		 */
 		paginatedSuggestions() {
 			const start = (this.currentPage - 1) * this.itemsPerPage
 			const end = start + this.itemsPerPage
 			return this.filteredSuggestions.slice(start, end)
 		},
+		/**
+		 * @spec exclude UI pagination helper — computes the total page count.
+		 */
 		totalPages() {
 			return Math.ceil(this.filteredSuggestions.length / this.itemsPerPage)
 		},
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook — counts objects for the schema on mount.
+	 */
 	mounted() {
 		// Initialize if we don't have schema item
 		if (!schemaStore.schemaItem) {
@@ -676,10 +700,16 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * @spec exclude UI event handler — closes the dialog and resets its state.
+		 */
 		async handleDialogClose() {
 			navigationStore.setDialog(false)
 			this.resetDialog()
 		},
+		/**
+		 * @spec exclude Modal state plumbing — resets all local exploration state.
+		 */
 		resetDialog() {
 			this.loading = false
 			this.error = null
@@ -696,6 +726,9 @@ export default {
 			this.objectCount = 0
 			this.objectStats = null
 		},
+		/**
+		 * @spec exclude Modal data-load plumbing — fetches object-count stats for the schema.
+		 */
 		async countObjects() {
 			try {
 				if (schemaStore.schemaItem?.id) {
@@ -711,6 +744,9 @@ export default {
 				this.objectStats = null
 			}
 		},
+		/**
+		 * @spec exclude Modal action plumbing — runs the schema-explore endpoint and seeds suggestion config.
+		 */
 		async startAnalysis() {
 			this.analysisStarted = true
 			this.loading = true
@@ -778,6 +814,9 @@ export default {
 				this.analysisStarted = false
 			}
 		},
+		/**
+		 * @spec exclude UI selection plumbing — toggles a suggested property in the selection.
+		 */
 		togglePropertySelection(propertyName) {
 			if (this.selectedProperties.includes(propertyName)) {
 				this.selectedProperties = this.selectedProperties.filter(name => name !== propertyName)
@@ -820,10 +859,16 @@ export default {
 		isPropertySelected(propertyName) {
 			return this.selectedProperties.includes(propertyName)
 		},
+		/**
+		 * @spec exclude UI selection plumbing — clears the property selection.
+		 */
 		clearSelection() {
 			this.selectedProperties = []
 			this.selectedPropertiesConfig = {}
 		},
+		/**
+		 * @spec exclude UI selection plumbing — selects all suggested properties.
+		 */
 		selectAll() {
 			this.explorationData?.suggestions?.forEach(suggestion => {
 				if (!this.selectedProperties.includes(suggestion.property_name)) {
@@ -840,6 +885,9 @@ export default {
 				}
 			})
 		},
+		/**
+		 * @spec exclude Modal action plumbing — posts selected property updates to the schema-update endpoint.
+		 */
 		async updateSchema() {
 			this.loading = true
 			this.error = null
@@ -903,6 +951,9 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude UI display helper — truncates/normalizes an example value for display.
+		 */
 		formatExample(value) {
 			if (value === null || value === undefined) {
 				return 'null'
@@ -918,6 +969,9 @@ export default {
 
 			return String(value)
 		},
+		/**
+		 * @spec exclude UI pagination handler — sets the current page and scrolls to top.
+		 */
 		onPageChanged(page) {
 			this.currentPage = page
 
@@ -927,14 +981,23 @@ export default {
 				container.scrollTop = 0
 			}
 		},
+		/**
+		 * @spec exclude UI pagination handler — sets page size and resets to page one.
+		 */
 		onPageSizeChanged(pageSize) {
 			this.itemsPerPage = pageSize
 			this.currentPage = 1
 		},
+		/**
+		 * @spec exclude Modal close plumbing — closes the dialog and resets state.
+		 */
 		closeDialog() {
 			navigationStore.setDialog(false)
 			this.resetDialog()
 		},
+		/**
+		 * @spec exclude UI display helper — maps issue-type strings to display objects.
+		 */
 		getIssueDetails(issues) {
 			// Convert issue type strings to more detailed objects
 			return issues.map(issueType => {
@@ -944,6 +1007,9 @@ export default {
 				}
 			})
 		},
+		/**
+		 * @spec exclude UI display helper — maps an issue type to a UI category.
+		 */
 		getIssueType(issueType) {
 			// Map issue types to UI-friendly categories
 			const typeMap = {
@@ -961,6 +1027,9 @@ export default {
 			}
 			return typeMap[issueType] || 'general'
 		},
+		/**
+		 * @spec exclude UI display helper — maps an issue category to a translated label.
+		 */
 		getIssueLabel(issueType) {
 			// Get UI-friendly labels for issue types
 			const labelMap = {
@@ -974,6 +1043,9 @@ export default {
 			}
 			return labelMap[issueType] || this.t('openregister', 'Issue')
 		},
+		/**
+		 * @spec exclude UI display helper — maps an issue type to a translated description.
+		 */
 		getIssueDescription(issueType) {
 			// Get descriptions for different issue types
 			const descriptionMap = {

--- a/src/modals/schema/UploadSchema.vue
+++ b/src/modals/schema/UploadSchema.vue
@@ -101,6 +101,9 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec exclude Modal close plumbing — resets upload form state and closes the modal.
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 			clearTimeout(this.closeModalTimeout)
@@ -113,9 +116,15 @@ export default {
 				url: '',
 			}
 		},
+		/**
+		 * @spec exclude UI helper — pretty-prints the JSON in the editor field.
+		 */
 		prettifyJson() {
 			this.schema.json = JSON.stringify(JSON.parse(this.schema.json), null, 2)
 		},
+		/**
+		 * @spec exclude Modal action plumbing — delegates schema upload to schemaStore.uploadSchema.
+		 */
 		async uploadSchema() {
 			this.loading = true
 
@@ -134,6 +143,9 @@ export default {
 				this.loading = false
 			})
 		},
+		/**
+		 * @spec exclude UI validation helper — reports whether a string parses as JSON.
+		 */
 		validateJson(json) {
 			try {
 				JSON.parse(json)

--- a/src/modals/schema/ValidateSchema.vue
+++ b/src/modals/schema/ValidateSchema.vue
@@ -210,6 +210,9 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude UI display helper — flattens/filters validation results for the table.
+		 */
 		filteredResults() {
 			if (!this.validationResults) return []
 
@@ -228,6 +231,9 @@ export default {
 	watch: {
 		// Watch for changes in schemaItem and reload count if needed
 		'schemaStore.schemaItem': {
+			/**
+			 * @spec exclude UI watcher — reloads the object count when the schema item changes.
+			 */
 			handler(newSchemaItem) {
 				console.info('Schema item changed in ValidateSchema:', newSchemaItem)
 				if (newSchemaItem?.id && this.objectCount === 0) {
@@ -238,6 +244,9 @@ export default {
 		},
 		// Watch for dialog state changes to load count when dialog becomes visible
 		'navigationStore.dialog': {
+			/**
+			 * @spec exclude UI watcher — loads the object count when the dialog opens.
+			 */
 			handler(newDialog) {
 				console.info('Dialog changed to:', newDialog)
 				if (newDialog === 'validateSchema' && schemaStore.schemaItem?.id) {
@@ -248,11 +257,17 @@ export default {
 			immediate: true,
 		},
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook — loads the object count on mount.
+	 */
 	async mounted() {
 		console.info('ValidateSchema dialog mounted, schemaItem:', schemaStore.schemaItem)
 		await this.loadObjectCount()
 	},
 	methods: {
+		/**
+		 * @spec exclude Modal data-load plumbing — fetches schema object-count stats.
+		 */
 		async loadObjectCount() {
 			console.info('loadObjectCount called, schemaItem:', schemaStore.schemaItem)
 			try {
@@ -276,6 +291,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude Modal action plumbing — posts to the bulk schema-validate endpoint.
+		 */
 		async startValidation() {
 			this.loading = true
 			this.error = false
@@ -312,12 +330,18 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude UI navigation stub — placeholder for viewing an object's details.
+		 */
 		viewObjectDetails(object) {
 			// Navigate to object details view
 			// This would need to be implemented based on your navigation structure
 			console.info('View object details:', object)
 		},
 
+		/**
+		 * @spec exclude Modal close plumbing — closes the dialog and resets validation state.
+		 */
 		closeDialog() {
 			navigationStore.setDialog(false)
 			this.loading = false

--- a/src/modals/settings/FacetConfigModal.vue
+++ b/src/modals/settings/FacetConfigModal.vue
@@ -398,10 +398,16 @@ export default {
 			if (!this.facetsData || !this.facetsData.facets) return 0
 			return this.metadataCount + this.objectFieldCount
 		},
+		/**
+		 * @spec exclude UI display helper — counts metadata (@self) facets.
+		 */
 		metadataCount() {
 			if (!this.facetsData || !this.facetsData.facets || !this.facetsData.facets['@self']) return 0
 			return Object.keys(this.facetsData.facets['@self']).length
 		},
+		/**
+		 * @spec exclude UI display helper — counts object-field facets.
+		 */
 		objectFieldCount() {
 			if (!this.facetsData || !this.facetsData.facets || !this.facetsData.facets.object_fields) return 0
 			return Object.keys(this.facetsData.facets.object_fields).length
@@ -409,6 +415,9 @@ export default {
 	},
 	watch: {
 		show: {
+			/**
+			 * @spec exclude UI watcher — loads facets when shown, resets when hidden.
+			 */
 			handler(newVal) {
 				if (newVal) {
 					this.loadFacets()
@@ -568,6 +577,7 @@ export default {
 		/**
 		 * Toggle facet expanded state
 		 * @param {object} facet - The facet to toggle
+		 * @spec exclude UI state helper — toggles a facet row's expanded flag.
 		 */
 		toggleFacetExpanded(facet) {
 			facet.expanded = !facet.expanded
@@ -575,6 +585,7 @@ export default {
 
 		/**
 		 * Reset modal state
+		 * @spec exclude Modal state plumbing — resets local facet state.
 		 */
 		resetModal() {
 			this.facetsData = null

--- a/src/modals/settings/FileManagementModal.vue
+++ b/src/modals/settings/FileManagementModal.vue
@@ -121,6 +121,9 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * @spec exclude Modal data-load plumbing — loads file-vectorization config (stubbed).
+		 */
 		async loadConfiguration() {
 			try {
 				// TODO: Load vectorization config from backend
@@ -131,6 +134,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude Modal save plumbing — posts file-vectorization config to the settings endpoint.
+		 */
 		async saveConfiguration() {
 			this.saving = true
 

--- a/src/modals/settings/LLMConfigModal.vue
+++ b/src/modals/settings/LLMConfigModal.vue
@@ -554,6 +554,9 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude UI state helper — enables the embedding test when its provider is configured.
+		 */
 		canTestEmbedding() {
 			const provider = this.selectedEmbeddingProvider?.id
 			if (!provider) return false
@@ -568,6 +571,9 @@ export default {
 			return false
 		},
 
+		/**
+		 * @spec exclude UI state helper — enables the chat test when its provider is configured.
+		 */
 		canTestChat() {
 			const provider = this.selectedChatProvider?.id
 			if (!provider) return false
@@ -585,11 +591,17 @@ export default {
 
 	watch: {
 		// Fetch Ollama models when Ollama is selected
+		/**
+		 * @spec exclude UI watcher — fetches Ollama models when the embedding provider is Ollama.
+		 */
 		selectedEmbeddingProvider(newVal) {
 			if (newVal?.id === 'ollama' && this.ollamaConfig.url) {
 				this.fetchOllamaModels()
 			}
 		},
+		/**
+		 * @spec exclude UI watcher — fetches Ollama models when the chat provider is Ollama.
+		 */
 		selectedChatProvider(newVal) {
 			if (newVal?.id === 'ollama' && this.ollamaConfig.url) {
 				this.fetchOllamaModels()
@@ -603,6 +615,9 @@ export default {
 		},
 	},
 
+	/**
+	 * @spec exclude Vue lifecycle hook — loads LLM config and available backends on mount.
+	 */
 	mounted() {
 		this.loadConfiguration()
 		this.loadAvailableBackends()
@@ -704,10 +719,16 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude UI event handler — clears the embedding test result on provider change.
+		 */
 		handleEmbeddingProviderChange() {
 			this.embeddingTestResult = null
 		},
 
+		/**
+		 * @spec exclude Modal action plumbing — tests the embedding provider connection.
+		 */
 		async testEmbeddingConnection() {
 			this.testingEmbedding = true
 			this.embeddingTestResult = null
@@ -756,6 +777,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude Modal action plumbing — tests the chat provider connection.
+		 */
 		async testChatConnection() {
 			this.testingChat = true
 			this.chatTestResult = null
@@ -804,6 +828,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude Modal save plumbing — posts LLM configuration to the settings endpoint.
+		 */
 		async saveConfiguration() {
 			this.saving = true
 
@@ -850,6 +877,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude Modal data-load plumbing — fetches available Ollama models for the picker.
+		 */
 		async fetchOllamaModels() {
 			if (!this.ollamaConfig.url || this.loadingOllamaModels) {
 				return
@@ -877,6 +907,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude UI event handler — prompts before clearing all embeddings.
+		 */
 		confirmClearEmbeddings() {
 			// Use native browser confirm to avoid focus-trap conflicts with nested modals
 			const message = this.t('openregister', 'This will permanently delete ALL embeddings (vectors) from the database. You will need to re-vectorize all objects and files. This action cannot be undone.\n\nAre you sure you want to continue?')
@@ -886,6 +919,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude Modal action plumbing — clears all stored embeddings via the API.
+		 */
 		async clearAllEmbeddings() {
 			this.clearingEmbeddings = true
 
@@ -909,6 +945,9 @@ export default {
 
 		/**
 		 * Load available vector search backends
+		 */
+		/**
+		 * @spec exclude Modal data-load plumbing — fetches available LLM backends for the pickers.
 		 */
 		async loadAvailableBackends() {
 			this.loadingBackends = true

--- a/src/modals/settings/SolrWarmupModal.vue
+++ b/src/modals/settings/SolrWarmupModal.vue
@@ -444,6 +444,9 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude UI display helper — resolves selected schema ids to detail objects.
+		 */
 		selectedSchemasDetails() {
 			if (!this.localConfig.selectedSchemas || !this.availableSchemas) {
 				return []
@@ -461,6 +464,7 @@ export default {
 		/**
 		 * Calculate the total number of objects based on selected schemas
 		 * If no schemas are selected, use the total from objectStats
+		 * @spec exclude UI display helper — sums object counts across selected schemas.
 		 */
 		effectiveTotalObjects() {
 			if (!this.localConfig.selectedSchemas || this.localConfig.selectedSchemas.length === 0) {
@@ -477,12 +481,18 @@ export default {
 
 	watch: {
 		config: {
+			/**
+			 * @spec exclude UI watcher — syncs the incoming config prop into local state.
+			 */
 			handler(newConfig) {
 				this.localConfig = { ...newConfig }
 			},
 			deep: true,
 		},
 		localConfig: {
+			/**
+			 * @spec exclude UI watcher — emits config changes to the parent.
+			 */
 			handler(newConfig) {
 				this.$emit('config-changed', newConfig)
 			},
@@ -498,6 +508,9 @@ export default {
 			this.$emit('start-warmup', this.localConfig)
 		},
 
+		/**
+		 * @spec exclude Modal state plumbing — emits a reset event to the parent.
+		 */
 		resetModal() {
 			this.$emit('reset')
 		},
@@ -507,6 +520,7 @@ export default {
 		 *
 		 * @param {string} mode Mode value
 		 * @return {string} Display name
+		 * @spec exclude UI display helper — maps a warmup mode to a display name.
 		 */
 		getModeDisplayName(mode) {
 			const modeNames = {
@@ -521,6 +535,7 @@ export default {
 		 * Estimate warmup duration based on configuration
 		 *
 		 * @return {string} Estimated duration in human-readable format
+		 * @spec exclude UI display helper — estimates warmup duration from config.
 		 */
 		estimateWarmupDuration() {
 			if (this.effectiveTotalObjects === 0) {
@@ -560,6 +575,7 @@ export default {
 		 *
 		 * @param {number} seconds Duration in seconds
 		 * @return {string} Formatted duration
+		 * @spec exclude UI display helper — formats a seconds duration for display.
 		 */
 		formatDuration(seconds) {
 			if (seconds < 1) {
@@ -578,6 +594,7 @@ export default {
 		 *
 		 * @param {number} milliseconds Execution time in milliseconds
 		 * @return {string} Formatted execution time
+		 * @spec exclude UI display helper — formats a milliseconds execution time for display.
 		 */
 		formatExecutionTime(milliseconds) {
 			if (milliseconds < 1000) {
@@ -596,6 +613,7 @@ export default {
 		 *
 		 * @param {boolean|number} status Operation status
 		 * @return {string} CSS class
+		 * @spec exclude UI display helper — maps an operation status to a CSS class.
 		 */
 		getOperationStatus(status) {
 			if (status === true || status === 1) return 'success'
@@ -608,6 +626,7 @@ export default {
 		 *
 		 * @param {boolean|number} status Operation status
 		 * @return {string} Icon character
+		 * @spec exclude UI display helper — maps an operation status to an icon glyph.
 		 */
 		getOperationIcon(status) {
 			if (status === true || status === 1) return '✅'
@@ -620,6 +639,7 @@ export default {
 		 *
 		 * @param {boolean|number} status Operation status
 		 * @return {string} Status text
+		 * @spec exclude UI display helper — maps an operation status to a status label.
 		 */
 		getOperationStatusText(status) {
 			if (status === true || status === 1) return 'Success'
@@ -632,6 +652,7 @@ export default {
 		 *
 		 * @param {string} operation Operation key
 		 * @return {string} Formatted operation name
+		 * @spec exclude UI display helper — maps an operation key to a display name.
 		 */
 		formatOperationName(operation) {
 			const operationNames = {
@@ -659,6 +680,7 @@ export default {
 		 * @param {string} operation Operation key
 		 * @param {boolean|number} status Operation status/value
 		 * @return {string|null} Details text
+		 * @spec exclude UI display helper — builds details text for an operation row.
 		 */
 		getOperationDetails(operation, status) {
 			if (typeof status === 'number' && status > 1) {
@@ -678,6 +700,7 @@ export default {
 		 * Format memory prediction for display
 		 *
 		 * @return {string} Formatted memory prediction
+		 * @spec exclude UI display helper — formats the memory-prediction summary.
 		 */
 		formatMemoryPrediction() {
 			if (!this.memoryPrediction || this.memoryPrediction.error) {
@@ -697,6 +720,7 @@ export default {
 		 *
 		 * @param {number} percentage Memory usage percentage
 		 * @return {string} CSS class
+		 * @spec exclude UI display helper — maps a memory-usage percentage to a CSS class.
 		 */
 		getMemoryUsageClass(percentage) {
 			const numPercentage = parseFloat(percentage)
@@ -709,6 +733,7 @@ export default {
 		 * Check if there are detailed error information available
 		 *
 		 * @return {boolean} True if detailed error info is available
+		 * @spec exclude UI state helper — reports whether detailed error info is present.
 		 */
 		hasDetailedError() {
 			return !!(this.results?.error_details
@@ -719,6 +744,7 @@ export default {
 		 * Format error details for display
 		 *
 		 * @return {string} Formatted error details
+		 * @spec exclude UI display helper — formats error details for display.
 		 */
 		formatErrorDetails() {
 			if (this.results?.error_details) {

--- a/src/modals/source/EditSource.vue
+++ b/src/modals/source/EditSource.vue
@@ -108,6 +108,9 @@ export default {
 	mounted() {
 		this.initializeSourceItem()
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook — initializes the source form once when the modal opens.
+	 */
 	updated() {
 		if (navigationStore.modal === 'editSource' && !this.hasUpdated) {
 			this.initializeSourceItem()
@@ -128,6 +131,9 @@ export default {
 				this.typeOptions.value = this.typeOptions.options.find(option => option.id === this.sourceItem.type)
 			}
 		},
+		/**
+		 * @spec exclude Modal close plumbing — resets the source form and closes the modal.
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 			clearTimeout(this.closeModalTimeout)
@@ -144,6 +150,9 @@ export default {
 			// reset typeOptions to the internal option
 			this.typeOptions.value = this.typeOptions.options.find(option => option.id === 'internal')
 		},
+		/**
+		 * @spec exclude Modal save plumbing — delegates source persistence to sourceStore.saveSource.
+		 */
 		async editSource() {
 			this.loading = true
 

--- a/src/modals/source/ViewSource.vue
+++ b/src/modals/source/ViewSource.vue
@@ -226,6 +226,9 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude UI display helper — inline schema definition for the edit-register dialog.
+		 */
 		registerSchema() {
 			return {
 				title: t('openregister', 'Register'),
@@ -238,6 +241,9 @@ export default {
 				required: ['title', 'slug'],
 			}
 		},
+		/**
+		 * @spec exclude UI display helper — filters registers belonging to the current source.
+		 */
 		filterRegisters() {
 			if (!registerStore.registerList || !sourceStore.sourceItem?.id) {
 				return []
@@ -257,23 +263,38 @@ export default {
 		closeModal() {
 			navigationStore.setModal(false)
 		},
+		/**
+		 * @spec exclude Modal navigation plumbing — opens the edit-source modal.
+		 */
 		editSource() {
 			navigationStore.setModal('editSource')
 		},
+		/**
+		 * @spec exclude Modal navigation plumbing — opens the delete-source dialog.
+		 */
 		deleteSource() {
 			navigationStore.setModal(false)
 			navigationStore.setDialog('deleteSource')
 		},
+		/**
+		 * @spec exclude UI navigation handler — selects a register and routes to the registers view.
+		 */
 		viewRegister(register) {
 			registerStore.setRegisterItem(register)
 			navigationStore.setModal(false)
 			this.$router.push('/registers')
 		},
+		/**
+		 * @spec exclude UI event handler — opens the inline edit-register dialog.
+		 */
 		editRegister(register) {
 			this.editingRegister = register
 			this.showEditRegisterDialog = true
 			this.loadSchemaOptions()
 		},
+		/**
+		 * @spec exclude Modal data-load plumbing — loads schema options for the register dialog.
+		 */
 		async loadSchemaOptions() {
 			this.schemasLoading = true
 			try {
@@ -285,6 +306,9 @@ export default {
 				this.schemasLoading = false
 			}
 		},
+		/**
+		 * @spec exclude UI display helper — resolves schema ids to select-value objects.
+		 */
 		getSchemaSelectValue(schemas) {
 			if (!Array.isArray(schemas)) return []
 			return schemas.map(s => {
@@ -293,6 +317,9 @@ export default {
 					|| { id, label: String(id) }
 			})
 		},
+		/**
+		 * @spec exclude Modal save plumbing — delegates register save to registerStore.saveRegister.
+		 */
 		async onSaveRegister(formData) {
 			try {
 				await registerStore.saveRegister({
@@ -305,6 +332,9 @@ export default {
 				this.$refs.editRegisterDialog.setResult({ error: error.message })
 			}
 		},
+		/**
+		 * @spec exclude Modal data-load plumbing — refreshes the register list for the source.
+		 */
 		fetchRegisters() {
 			this.registersLoading = true
 			registerStore.refreshRegisterList()

--- a/src/modals/view/DeleteView.vue
+++ b/src/modals/view/DeleteView.vue
@@ -95,6 +95,9 @@ export default {
 			this.error = null
 			this.$emit('close')
 		},
+		/**
+		 * @spec exclude Modal action plumbing — delegates deletion to viewsStore.deleteView.
+		 */
 		async deleteView() {
 			if (!this.view) return
 

--- a/src/modals/webhook/EditWebhook.vue
+++ b/src/modals/webhook/EditWebhook.vue
@@ -366,12 +366,18 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude UI accessor — exposes the navigation store to the template.
+		 */
 		navigationStore() {
 			return navigationStore
 		},
 		isValid() {
 			return Boolean(this.webhookItem?.name?.trim() && this.webhookItem?.url?.trim())
 		},
+		/**
+		 * @spec exclude UI display helper — builds event-property select options for the selected event.
+		 */
 		eventPropertyOptions() {
 			if (!this.selectedEvent) {
 				return []
@@ -388,6 +394,9 @@ export default {
 				label: prop,
 			}))
 		},
+		/**
+		 * @spec exclude UI display helper — serializes headers object to editable text.
+		 */
 		headersText() {
 			if (!this.webhookItem?.headers || typeof this.webhookItem.headers !== 'object') {
 				return ''
@@ -401,12 +410,21 @@ export default {
 		// compiled into an actual newline character inside a single-quoted JS
 		// string in the render function output, producing an "Invalid or
 		// unexpected token" SyntaxError that breaks the entire bundle.
+		/**
+		 * @spec exclude UI display helper — placeholder text for the headers field.
+		 */
 		headersPlaceholder() {
 			return this.t('openregister', 'X-Custom-Header: value\nAuthorization: Bearer token')
 		},
+		/**
+		 * @spec exclude UI display helper — placeholder text for the filters field.
+		 */
 		filtersPlaceholder() {
 			return this.t('openregister', 'objectType: object\naction: created')
 		},
+		/**
+		 * @spec exclude UI display helper — serializes filters object to editable text.
+		 */
 		filtersText() {
 			if (!this.webhookItem?.filters || typeof this.webhookItem.filters !== 'object') {
 				return ''
@@ -429,6 +447,9 @@ export default {
 			}
 		},
 	},
+	/**
+	 * @spec exclude Vue lifecycle hook — loads events and initializes the webhook form.
+	 */
 	async created() {
 		await this.loadAvailableEvents()
 		this.initializeWebhook()
@@ -470,18 +491,27 @@ export default {
 				this.selectedEventProperty = null
 			}
 		},
+		/**
+		 * @spec exclude Form-field binding — sets the webhook name.
+		 */
 		updateName(value) {
 			if (!this.webhookItem) {
 				this.webhookItem = {}
 			}
 			this.webhookItem.name = value
 		},
+		/**
+		 * @spec exclude Form-field binding — sets the webhook URL.
+		 */
 		updateUrl(value) {
 			if (!this.webhookItem) {
 				this.webhookItem = {}
 			}
 			this.webhookItem.url = value
 		},
+		/**
+		 * @spec exclude Form-field binding — sets the HTTP method.
+		 */
 		updateMethod(value) {
 			if (!this.webhookItem) {
 				this.webhookItem = {}
@@ -489,12 +519,18 @@ export default {
 			this.webhookItem.method = value ? value.value : 'POST'
 			this.selectedMethod = value
 		},
+		/**
+		 * @spec exclude Form-field binding — sets the enabled flag.
+		 */
 		updateEnabled(value) {
 			if (!this.webhookItem) {
 				this.webhookItem = {}
 			}
 			this.webhookItem.enabled = value
 		},
+		/**
+		 * @spec exclude Form-field binding — sets the subscribed event and resets event property.
+		 */
 		updateEvent(value) {
 			if (!this.webhookItem) {
 				this.webhookItem = {}
@@ -514,6 +550,9 @@ export default {
 				this.selectedEvent = null
 			}
 		},
+		/**
+		 * @spec exclude Form-field binding — sets the selected event property.
+		 */
 		updateEventProperty(value) {
 			if (!this.webhookItem) {
 				this.webhookItem = {}
@@ -524,6 +563,9 @@ export default {
 			this.webhookItem.configuration.eventProperty = value ? value.value : null
 			this.selectedEventProperty = value
 		},
+		/**
+		 * @spec exclude Form-field binding — sets the sendCloudEvent configuration flag.
+		 */
 		updateSendCloudEvent(value) {
 			if (!this.webhookItem) {
 				this.webhookItem = {}
@@ -534,6 +576,9 @@ export default {
 			this.configuration.sendCloudEvent = value
 			this.webhookItem.configuration.sendCloudEvent = value
 		},
+		/**
+		 * @spec exclude Form-field binding — sets the waitForResponse configuration flag.
+		 */
 		updateWaitForResponse(value) {
 			if (!this.webhookItem) {
 				this.webhookItem = {}
@@ -544,6 +589,9 @@ export default {
 			this.configuration.waitForResponse = value
 			this.webhookItem.configuration.waitForResponse = value
 		},
+		/**
+		 * @spec exclude Form-field binding — sets the retry policy.
+		 */
 		updateRetryPolicy(value) {
 			if (!this.webhookItem) {
 				this.webhookItem = {}
@@ -551,24 +599,36 @@ export default {
 			this.webhookItem.retryPolicy = value ? value.value : 'exponential'
 			this.selectedRetryPolicy = value
 		},
+		/**
+		 * @spec exclude Form-field binding — sets the max-retries count.
+		 */
 		updateMaxRetries(value) {
 			if (!this.webhookItem) {
 				this.webhookItem = {}
 			}
 			this.webhookItem.maxRetries = parseInt(value) || 3
 		},
+		/**
+		 * @spec exclude Form-field binding — sets the request timeout.
+		 */
 		updateTimeout(value) {
 			if (!this.webhookItem) {
 				this.webhookItem = {}
 			}
 			this.webhookItem.timeout = parseInt(value) || 30
 		},
+		/**
+		 * @spec exclude Form-field binding — sets the webhook secret.
+		 */
 		updateSecret(value) {
 			if (!this.webhookItem) {
 				this.webhookItem = {}
 			}
 			this.webhookItem.secret = value || null
 		},
+		/**
+		 * @spec exclude Form-field binding — parses header text into a headers object.
+		 */
 		updateHeaders(value) {
 			if (!this.webhookItem) {
 				this.webhookItem = {}
@@ -584,6 +644,9 @@ export default {
 			}
 			this.webhookItem.headers = headers
 		},
+		/**
+		 * @spec exclude Form-field binding — parses filter text into a filters object.
+		 */
 		updateFilters(value) {
 			if (!this.webhookItem) {
 				this.webhookItem = {}
@@ -605,6 +668,9 @@ export default {
 			}
 			this.webhookItem.filters = filters
 		},
+		/**
+		 * @spec exclude Modal data-load plumbing — fetches subscribable webhook events.
+		 */
 		async loadAvailableEvents() {
 			this.loadingEvents = true
 			try {
@@ -629,11 +695,17 @@ export default {
 				this.loadingEvents = false
 			}
 		},
+		/**
+		 * @spec exclude UI event handler — no-op search hook (NcSelect filters internally).
+		 */
 		searchEvents(_query) {
 			// Filter events based on search query.
 			// The NcSelect component handles filtering internally.
 			// Empty query is handled by the component itself.
 		},
+		/**
+		 * @spec exclude Modal hydration plumbing — maps stored webhook values onto select inputs.
+		 */
 		loadExistingSelections() {
 			const item = this.webhookItem
 			if (item) {
@@ -669,9 +741,15 @@ export default {
 				}
 			}
 		},
+		/**
+		 * @spec exclude UI event handler — closes the modal on dialog dismiss.
+		 */
 		handleDialogClose() {
 			this.closeModal()
 		},
+		/**
+		 * @spec exclude Modal close plumbing — resets the webhook form and closes the modal.
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 			this.loading = false
@@ -688,6 +766,9 @@ export default {
 				responseMapping: {},
 			}
 		},
+		/**
+		 * @spec exclude Modal save plumbing — assembles the payload and persists the webhook.
+		 */
 		async saveWebhook() {
 			this.loading = true
 			this.error = null


### PR DESCRIPTION
## Summary

Brings 224 uncovered methods across 24 `src/modals/` Vue files under the ADR-003 spec-traceability convention by adding per-method `@spec` JSDoc tags.

- **Reverse-spec'd (new REQs): 0**
- **Excluded (`@spec exclude <reason>`): 224** (226 tags total, incl. 2 duplicate `handler` watchers)
- Frontend modal methods are overwhelmingly UI plumbing — form-field bindings, open/close lifecycle, data-load fetches for pickers, display/format helpers, and thin store-delegating save/delete actions. None represent a novel user-facing domain contract not already owned by an existing capability, so each is annotated `@spec exclude <reason>` with no spec delta.

Ghost change: `openspec/changes/retrofit-2026-05-25-fe-modals-3/` (proposal + tasks; no spec delta since 0 REQs minted).

## Verification

- All 224 batch methods confirmed tagged (0 untagged).
- All `@spec exclude` lines carry a reason (no bare excludes).
- Only this batch's 24 files touched (+ the ghost change dir).

Source batch: `fw-fe-modals-3.json`.

## Test plan

- [ ] Confirm no method in `src/modals/` from this batch lacks a `@spec` tag.
- [ ] Confirm JSDoc blocks are well-formed (no broken comment blocks).