### PR TITLE
retrofit: frontend coverage — views (chunk 2)

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-fe-views-2/design.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-views-2/design.md
@@ -1,0 +1,27 @@
+# Design — Retrofit frontend coverage, views (chunk 2)
+
+**Documentation-only retrofit change. Tasks describe retroactive `@spec exclude` annotation, not new implementation work. No spec delta.**
+
+## Context
+
+The coverage scan placed 223 methods across 18 `src/views/**/*.vue` files into the "missing @spec" bucket. ADR-003 requires every code unit either to point at a spec task (`@spec openspec/changes/{change}/tasks.md#task-N`) or to carry an explicit `@spec exclude <reason>`. This change closes that gap for the chunk.
+
+## Why exclude rather than reverse-spec
+
+Frontend views in openregister are thin rendering + wiring over store/API behavior that is already specified at the capability layer. Concretely, the chunk's methods fall into recurring plumbing shapes:
+
+- **Computed list/selection state** — `paginatedX`, `allSelected`, `someSelected`, `totalPages`, `currentPage`, `filteredX`, `emptyContentName/Description`.
+- **Pagination/selection handlers** — `onPageChanged`, `onPageSizeChanged`, `toggleSelectAll`, `toggleXSelection`, `toggleSidebar`, `toggleSort`.
+- **Lifecycle fetch** — `mounted`, `beforeDestroy`, store-refresh watchers.
+- **Formatting helpers** — `formatDate`, `formatTime`, `formatBytes`, `formatFileSize`, `formatMimeType`, `formatStatus`, `formatRiskLevel`, `formatExecutionTime`, `formatGroups`, `formatPurgeDate`.
+- **Navigation / store wiring / dialog glue** — `viewX`, `editX`, `openXModal`, `selectX`, `saveX`, `loadX`, `refreshX`, clipboard/download/redoc-link openers.
+
+Each renders behavior owned by an existing capability (`object-lifecycle`, `linked-entity-types`, `archivering-vernietiging`, `zoeken-filteren`, `ai-chat-companion`, `auth-system`, `tenant-lifecycle`, `registers-management`, `oas-validation`, schema workflow). Minting a new REQ for a `formatDate` helper or a `toggleSelectAll` checkbox would dilute the spec without describing a contract a consumer depends on. Per the playbook's "bias toward exclude for UI plumbing," every method is excluded with a specific reason.
+
+## Why no new REQs
+
+No method in the chunk introduces a user-facing contract that is both novel and unowned. The closest candidates (chat feedback, permission-matrix bulk role apply, OAS download) are frontend surfaces over already-specified backend capabilities; their contracts live with those capabilities, not in the view. Reverse-speccing them here would create cross-capability REQ drift. They are therefore excluded, not spec'd.
+
+## Tag format
+
+Each method's JSDoc block carries `@spec exclude <reason>` where `<reason>` is method-specific (e.g. `list-view pagination plumbing`, `detail-view date formatting helper`, `settings-section store fetch`). Existing JSDoc blocks gain the tag line; methods without a block get a minimal block. No behavior is changed.

--- a/openspec/changes/retrofit-2026-05-25-fe-views-2/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-views-2/proposal.md
@@ -1,0 +1,52 @@
+# Retrofit — frontend coverage, views (chunk 2)
+
+## Why
+
+The coverage scan flagged 223 methods across 18 `src/views/**/*.vue` files as carrying no `@spec` annotation. Under ADR-003 every code unit must point at a spec task or be explicitly excluded with a reason. This change is a documentation-only retrofit: it brings the chunk's 223 methods to fully-tagged status, overwhelmingly via JSDoc `@spec exclude <reason>` tags.
+
+These views are list/detail/settings UI plumbing — pagination, row selection, formatting helpers, lifecycle fetches, store wiring, navigation, and clipboard/download glue. The observable user-facing behavior they render is already owned by existing capabilities (`object-lifecycle`, `linked-entity-types`, `archivering-vernietiging`, `zoeken-filteren`, `ai-chat-companion`, `auth-system`, `tenant-lifecycle`, `registers-management`, `oas-validation`, schema workflow). None of the 223 methods expresses a novel contract that warrants a new REQ, so no spec delta is minted.
+
+## What
+
+- Tag all 223 methods with `@spec exclude <reason>` (reason REQUIRED per ADR-003; bare `exclude` is invalid).
+- No new REQs. No spec delta directory. This is a documentation-only retrofit ghost change (supported by the retrofit playbook).
+
+## Counts
+
+| Bucket | Count |
+|---|---|
+| Methods in chunk | 223 |
+| Reverse-spec'd (new REQs) | 0 |
+| Excluded (`@spec exclude`) | 223 |
+| New REQs minted | 0 |
+
+## Files (method counts)
+
+| File | Methods |
+|---|---|
+| `src/views/Endpoint/EndpointDetails.vue` | 1 |
+| `src/views/account/sections/ActivitySection.vue` | 3 |
+| `src/views/account/sections/NotificationsSection.vue` | 2 |
+| `src/views/agents/AgentsIndex.vue` | 9 |
+| `src/views/application/ApplicationDetails.vue` | 1 |
+| `src/views/application/ApplicationsIndex.vue` | 9 |
+| `src/views/chat/ChatIndex.vue` | 26 |
+| `src/views/deleted/DeletedIndex.vue` | 33 |
+| `src/views/entities/EntitiesIndex.vue` | 15 |
+| `src/views/entities/EntityDetail.vue` | 7 |
+| `src/views/files/FilesIndex.vue` | 18 |
+| `src/views/logs/SearchTrailIndex.vue` | 16 |
+| `src/views/object/ObjectsList.vue` | 4 |
+| `src/views/organisation/OrganisationDetails.vue` | 19 |
+| `src/views/register/RegistersIndex.vue` | 24 |
+| `src/views/schemas/SchemaWorkflowTab.vue` | 6 |
+| `src/views/settings/sections/OrganisationConfiguration.vue` | 11 |
+| `src/views/settings/sections/PermissionMatrix.vue` | 17 |
+| **Total** | **223** |
+
+## Out of scope
+
+- Reshaping or fixing observed behavior. Drift and TODOs (e.g. `viewSource`/`exportFilteredItems`/`removeMember` stubs) are left as-is.
+- Methods outside this chunk's 18 files.
+
+Source: coverage scan batch `fw-fe-views-2.json` (2026-05-25). See [retrofit playbook](../../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-25-fe-views-2/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-views-2/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+All tasks are marked `[x]` because the code already exists. This is a documentation-only retrofit — tasks describe retroactive `@spec exclude` annotation, not new implementation work. No new REQs are minted, so there is no spec delta.
+
+## Exclusions (UI plumbing)
+
+- [x] task-1: Annotate the 223 chunk methods across 18 `src/views/**/*.vue` files with `@spec exclude <reason>`. Each method is list/detail/settings UI plumbing — pagination, selection, formatting, lifecycle fetch, store wiring, navigation, or clipboard/download glue — whose user-facing behavior is already owned by an existing capability. Reasons are method-specific per ADR-003 (bare `exclude` is invalid).

--- a/src/views/Endpoint/EndpointDetails.vue
+++ b/src/views/Endpoint/EndpointDetails.vue
@@ -92,6 +92,9 @@ export default {
 		TrashCanOutline,
 	},
 	methods: {
+		/**
+		 * @spec exclude detail-view action button wiring; delegates to endpointStore.testEndpoint and surfaces a toast (endpoint test contract owned by oas-validation)
+		 */
 		testEndpoint() {
 			endpointStore.testEndpoint(endpointStore.endpointItem)
 				.then((result) => {

--- a/src/views/account/sections/ActivitySection.vue
+++ b/src/views/account/sections/ActivitySection.vue
@@ -70,10 +70,16 @@ export default {
 			this.activities = []
 			await this.fetchActivity()
 		},
+		/**
+		 * @spec exclude list-view pagination plumbing; advances offset and re-fetches the activity feed
+		 */
 		async loadMore() {
 			this.offset += this.limit
 			await this.fetchActivity()
 		},
+		/**
+		 * @spec exclude list-view store fetch plumbing for the user activity feed (activity contract owned by activity-provider)
+		 */
 		async fetchActivity() {
 			this.loading = true
 			try {
@@ -91,6 +97,9 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude detail-view timestamp formatting helper for display only
+		 */
 		formatTime(timestamp) {
 			if (!timestamp) return ''
 			const date = new Date(timestamp)

--- a/src/views/account/sections/NotificationsSection.vue
+++ b/src/views/account/sections/NotificationsSection.vue
@@ -55,6 +55,9 @@ export default {
 			},
 		}
 	},
+	/**
+	 * @spec exclude settings-section lifecycle fetch of notification preferences on mount
+	 */
 	async mounted() {
 		try {
 			const { data } = await axios.get(generateUrl('/apps/openregister/api/user/me/notifications'))
@@ -67,6 +70,9 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * @spec exclude settings-section save plumbing; PUTs notification preferences and shows a status message
+		 */
 		async save() {
 			this.message = ''
 			try {

--- a/src/views/agents/AgentsIndex.vue
+++ b/src/views/agents/AgentsIndex.vue
@@ -283,17 +283,29 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude list-view client-side pagination slice (computed)
+		 */
 		paginatedAgents() {
 			const start = ((this.pagination.page || 1) - 1) * (this.pagination.limit || 20)
 			const end = start + (this.pagination.limit || 20)
 			return agentStore.agentList.slice(start, end)
 		},
+		/**
+		 * @spec exclude list-view select-all checkbox state (computed)
+		 */
 		allSelected() {
 			return agentStore.agentList.length > 0 && agentStore.agentList.every(agent => this.selectedAgents.includes(agent.id))
 		},
+		/**
+		 * @spec exclude list-view indeterminate-selection checkbox state (computed)
+		 */
 		someSelected() {
 			return this.selectedAgents.length > 0 && !this.allSelected
 		},
+		/**
+		 * @spec exclude list-view empty-state title text helper (computed)
+		 */
 		emptyContentName() {
 			if (agentStore.loading) {
 				return t('openregister', 'Loading agents...')
@@ -304,6 +316,9 @@ export default {
 			}
 			return ''
 		},
+		/**
+		 * @spec exclude list-view empty-state description text helper (computed)
+		 */
 		emptyContentDescription() {
 			if (agentStore.loading) {
 				return t('openregister', 'Please wait while we fetch your agents.')
@@ -315,6 +330,9 @@ export default {
 			return ''
 		},
 	},
+	/**
+	 * @spec exclude list-view lifecycle soft-refresh of the agent list on mount
+	 */
 	mounted() {
 		// Use soft reload (no loading spinner) since data is hot-loaded at app startup
 		agentStore.refreshAgentList(null, true)
@@ -334,6 +352,9 @@ export default {
 				this.selectedAgents = []
 			}
 		},
+		/**
+		 * @spec exclude list-view single-row selection toggle plumbing
+		 */
 		toggleAgentSelection(agentId, checked) {
 			if (checked) {
 				this.selectedAgents.push(agentId)
@@ -341,9 +362,15 @@ export default {
 				this.selectedAgents = this.selectedAgents.filter(id => id !== agentId)
 			}
 		},
+		/**
+		 * @spec exclude list-view pagination page-change handler
+		 */
 		onPageChanged(page) {
 			this.pagination.page = page
 		},
+		/**
+		 * @spec exclude list-view pagination page-size-change handler
+		 */
 		onPageSizeChanged(pageSize) {
 			this.pagination.page = 1
 			this.pagination.limit = pageSize

--- a/src/views/application/ApplicationDetails.vue
+++ b/src/views/application/ApplicationDetails.vue
@@ -227,6 +227,9 @@ export default {
 		Database,
 		FileOutline,
 	},
+	/**
+	 * @spec exclude detail-view lifecycle fetch of the application by route id on mount
+	 */
 	async mounted() {
 		// Load application details if we have an ID in the route
 		const applicationId = this.$route.params.id

--- a/src/views/application/ApplicationsIndex.vue
+++ b/src/views/application/ApplicationsIndex.vue
@@ -272,17 +272,29 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude list-view client-side pagination slice (computed)
+		 */
 		paginatedApplications() {
 			const start = ((this.pagination.page || 1) - 1) * (this.pagination.limit || 20)
 			const end = start + (this.pagination.limit || 20)
 			return applicationStore.applicationList.slice(start, end)
 		},
+		/**
+		 * @spec exclude list-view select-all checkbox state (computed)
+		 */
 		allSelected() {
 			return applicationStore.applicationList.length > 0 && applicationStore.applicationList.every(application => this.selectedApplications.includes(application.id))
 		},
+		/**
+		 * @spec exclude list-view indeterminate-selection checkbox state (computed)
+		 */
 		someSelected() {
 			return this.selectedApplications.length > 0 && !this.allSelected
 		},
+		/**
+		 * @spec exclude list-view empty-state title text helper (computed)
+		 */
 		emptyContentName() {
 			if (applicationStore.loading) {
 				return t('openregister', 'Loading applications...')
@@ -293,6 +305,9 @@ export default {
 			}
 			return ''
 		},
+		/**
+		 * @spec exclude list-view empty-state description text helper (computed)
+		 */
 		emptyContentDescription() {
 			if (applicationStore.loading) {
 				return t('openregister', 'Please wait while we fetch your applications.')
@@ -304,6 +319,9 @@ export default {
 			return ''
 		},
 	},
+	/**
+	 * @spec exclude list-view lifecycle group preload + soft-refresh of the application list on mount
+	 */
 	async mounted() {
 		// Load Nextcloud groups into store first (needed for edit modal)
 		await applicationStore.loadNextcloudGroups()
@@ -325,6 +343,9 @@ export default {
 				this.selectedApplications = []
 			}
 		},
+		/**
+		 * @spec exclude list-view single-row selection toggle plumbing
+		 */
 		toggleApplicationSelection(applicationId, checked) {
 			if (checked) {
 				this.selectedApplications.push(applicationId)
@@ -332,9 +353,15 @@ export default {
 				this.selectedApplications = this.selectedApplications.filter(id => id !== applicationId)
 			}
 		},
+		/**
+		 * @spec exclude list-view pagination page-change handler
+		 */
 		onPageChanged(page) {
 			this.pagination.page = page
 		},
+		/**
+		 * @spec exclude list-view pagination page-size-change handler
+		 */
 		onPageSizeChanged(pageSize) {
 			this.pagination.page = 1
 			this.pagination.limit = pageSize

--- a/src/views/chat/ChatIndex.vue
+++ b/src/views/chat/ChatIndex.vue
@@ -428,31 +428,52 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude chat UI store passthrough for the conversation list (computed; ai-chat-companion contract)
+		 */
 		conversationList() {
 			return conversationStore.conversationList || []
 		},
 
+		/**
+		 * @spec exclude chat UI store passthrough for archived conversations (computed; ai-chat-companion contract)
+		 */
 		archivedConversations() {
 			return conversationStore.archivedConversations || []
 		},
 
+		/**
+		 * @spec exclude chat UI store passthrough for the active conversation (computed; ai-chat-companion contract)
+		 */
 		activeConversation() {
 			return conversationStore.activeConversation || null
 		},
 
+		/**
+		 * @spec exclude chat UI store passthrough for active-conversation messages (computed; ai-chat-companion contract)
+		 */
 		activeMessages() {
 			return conversationStore.activeConversationMessages || []
 		},
 
+		/**
+		 * @spec exclude chat UI store passthrough for conversation loading state (computed)
+		 */
 		conversationLoading() {
 			return conversationStore.loading || false
 		},
 
+		/**
+		 * @spec exclude chat UI store passthrough for messages loading state (computed)
+		 */
 		messagesLoading() {
 			return conversationStore.messagesLoading || false
 		},
 	},
 
+	/**
+	 * @spec exclude chat UI lifecycle; loads preloaded agents/conversations from the store on mount
+	 */
 	mounted() {
 		// Conversations are already loaded during app warmup
 		// Agents are already loaded during app warmup
@@ -467,6 +488,9 @@ export default {
 
 	methods: {
 
+		/**
+		 * @spec exclude chat UI dialog-open plumbing for the agent selector
+		 */
 		async showAgentSelector() {
 			this.showAgentSelectorDialog = true
 			this.selectedAgent = null
@@ -478,6 +502,7 @@ export default {
 		 * Load agents from the already-initialized agent store
 		 * Agents are preloaded during app warmup, so we just use them from the store
 		 *
+		 * @spec exclude chat UI store passthrough; reads preloaded agents from agentStore (ai-chat-companion contract)
 		 * @return {void}
 		 */
 		loadAgentsFromStore() {
@@ -507,10 +532,16 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude chat UI selection state setter for the chosen agent
+		 */
 		selectAgent(agent) {
 			this.selectedAgent = agent
 		},
 
+		/**
+		 * @spec exclude chat UI wiring; delegates to conversationStore.createConversation and shows toasts (ai-chat-companion contract)
+		 */
 		async startConversationWithAgent() {
 			if (!this.selectedAgent) {
 				showError(this.t('openregister', 'Please select an agent to continue'))
@@ -545,6 +576,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude chat UI wiring; loads a conversation + its agent via the store (ai-chat-companion contract)
+		 */
 		async selectConversation(conversation) {
 			try {
 				await conversationStore.loadConversation(conversation.uuid)
@@ -564,6 +598,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude chat UI wiring; confirms then delegates to store delete/permanent-delete (ai-chat-companion contract)
+		 */
 		async deleteConversation(conversation) {
 			const message = this.showArchive
 				? this.t('openregister', 'Permanently delete this conversation?')
@@ -585,6 +622,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude chat UI wiring; delegates to conversationStore.restoreConversation (ai-chat-companion contract)
+		 */
 		async restoreConversation(conversation) {
 			try {
 				await conversationStore.restoreConversation(conversation.uuid)
@@ -594,11 +634,17 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude chat UI dialog-open plumbing for renaming a conversation
+		 */
 		renameConversation() {
 			this.newConversationTitle = this.activeConversation.title || ''
 			this.showRenameDialog = true
 		},
 
+		/**
+		 * @spec exclude chat UI wiring; delegates to conversationStore.updateConversation to persist the title (ai-chat-companion contract)
+		 */
 		async saveConversationTitle() {
 			if (!this.newConversationTitle.trim()) {
 				return
@@ -615,6 +661,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude chat UI wiring; delegates to conversationStore.sendMessage with selected views/tools/RAG opts (ai-chat-companion contract)
+		 */
 		async handleSendMessage() {
 			if (!this.currentMessage.trim() || this.loading || !this.activeConversation) {
 				return
@@ -652,6 +701,8 @@ export default {
 		/**
 		 * Load available views and tools from the current agent
 		 * and initialize selections with all items enabled by default
+		 *
+		 * @spec exclude chat UI state init; maps agent views/tools/RAG settings into local selection state (ai-chat-companion contract)
 		 */
 		async loadAgentCapabilities() {
 			if (!this.currentAgent) {
@@ -714,6 +765,7 @@ export default {
 		/**
 		 * Toggle view selection
 		 *
+		 * @spec exclude chat UI checkbox selection toggle plumbing
 		 * @param {string} viewUuid - The UUID of the view to toggle
 		 */
 		toggleView(viewUuid) {
@@ -730,6 +782,7 @@ export default {
 		/**
 		 * Toggle tool selection
 		 *
+		 * @spec exclude chat UI checkbox selection toggle plumbing
 		 * @param {string} toolUuid - The UUID of the tool to toggle
 		 */
 		toggleTool(toolUuid) {
@@ -743,6 +796,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude chat UI wiring; posts thumbs up/down feedback for a message (ai-chat-companion contract)
+		 */
 		async sendFeedback(message, feedback) {
 			const isSameFeedback = message.feedback === feedback
 			message.feedback = isSameFeedback ? null : feedback
@@ -780,6 +836,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude chat UI wiring; posts an optional feedback comment for a message (ai-chat-companion contract)
+		 */
 		async saveFeedbackComment(message) {
 			if (!message.feedbackComment || !message.feedbackComment.trim()) {
 				return
@@ -801,16 +860,25 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude chat UI source-navigation stub (logs only; not yet implemented)
+		 */
 		viewSource(source) {
 			// TODO: Navigate to source object/file
 			console.info('View source:', source)
 		},
 
+		/**
+		 * @spec exclude chat UI markdown-to-HTML rendering helper for display only
+		 */
 		formatMessage(content) {
 			// Convert markdown to HTML using marked library
 			return marked.parse(content || '')
 		},
 
+		/**
+		 * @spec exclude chat UI relative-timestamp formatting helper for display only
+		 */
 		formatTime(timestamp) {
 			if (!timestamp) return ''
 
@@ -829,6 +897,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude chat UI textarea auto-resize DOM helper
+		 */
 		autoResize() {
 			const textarea = this.$refs.messageInput
 			if (textarea) {
@@ -837,6 +908,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude chat UI scroll-to-bottom DOM helper
+		 */
 		scrollToBottom() {
 			this.$nextTick(() => {
 				const container = this.$refs.messagesContainer
@@ -846,6 +920,9 @@ export default {
 			})
 		},
 
+		/**
+		 * @spec exclude chat UI translation/interpolation placeholder helper
+		 */
 		t(app, text, vars) {
 			// Translation function placeholder
 			return text.replace(/\{(\w+)\}/g, (match, key) => vars?.[key] || match)

--- a/src/views/deleted/DeletedIndex.vue
+++ b/src/views/deleted/DeletedIndex.vue
@@ -212,26 +212,47 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude list-view store passthrough for filtered deleted items (computed; archivering-vernietiging contract)
+		 */
 		filteredItems() {
 			// Items are already filtered by the store based on sidebar filters
 			return deletedStore.deletedList || []
 		},
+		/**
+		 * @spec exclude list-view store passthrough for paginated deleted items (computed)
+		 */
 		paginatedItems() {
 			// Items are already paginated by the store
 			return this.filteredItems
 		},
+		/**
+		 * @spec exclude list-view pagination total-pages helper (computed)
+		 */
 		totalPages() {
 			return deletedStore.deletedPagination.pages || 1
 		},
+		/**
+		 * @spec exclude list-view pagination current-page helper (computed)
+		 */
 		currentPage() {
 			return deletedStore.deletedPagination.page || 1
 		},
+		/**
+		 * @spec exclude list-view select-all checkbox state (computed)
+		 */
 		allSelected() {
 			return this.paginatedItems.length > 0 && this.paginatedItems.every(item => this.selectedItems.includes(item.id))
 		},
+		/**
+		 * @spec exclude list-view indeterminate-selection checkbox state (computed)
+		 */
 		someSelected() {
 			return this.selectedItems.length > 0 && !this.allSelected
 		},
+		/**
+		 * @spec exclude list-view empty-state title text helper (computed)
+		 */
 		emptyContentName() {
 			if (deletedStore.deletedLoading) {
 				return t('openregister', 'Loading deleted items...')
@@ -240,6 +261,9 @@ export default {
 			}
 			return ''
 		},
+		/**
+		 * @spec exclude list-view empty-state description text helper (computed)
+		 */
 		emptyContentDescription() {
 			if (deletedStore.deletedLoading) {
 				return t('openregister', 'Please wait while we fetch your deleted items.')
@@ -250,6 +274,9 @@ export default {
 		},
 	},
 	watch: {
+		/**
+		 * @spec exclude list-view watcher; re-emits counts when the selection changes
+		 */
 		selectedItems() {
 			this.updateCounts()
 		},
@@ -257,6 +284,9 @@ export default {
 			this.updateCounts()
 		},
 	},
+	/**
+	 * @spec exclude list-view lifecycle; loads data and registers sidebar/modal event listeners on mount
+	 */
 	async mounted() {
 		// Load initial data
 		await this.loadItems()
@@ -274,6 +304,9 @@ export default {
 		this.$root.$on('deleted-objects-permanently-deleted', this.handleObjectsDeleted)
 		this.$root.$on('deleted-objects-restored', this.handleObjectsRestored)
 	},
+	/**
+	 * @spec exclude list-view lifecycle; tears down sidebar/modal event listeners on destroy
+	 */
 	beforeDestroy() {
 		this.$root.$off('deleted-filters-changed')
 		this.$root.$off('deleted-bulk-restore')
@@ -285,6 +318,7 @@ export default {
 	methods: {
 		/**
 		 * Load deleted items from store
+		 * @spec exclude list-view store fetch plumbing (archivering-vernietiging contract)
 		 * @return {Promise<void>}
 		 */
 		async loadItems() {
@@ -304,6 +338,7 @@ export default {
 		},
 		/**
 		 * Handle filter changes from sidebar
+		 * @spec exclude list-view filter-change handler; converts and re-fetches via store
 		 * @param {object} filters - Filter object from sidebar
 		 * @return {void}
 		 */
@@ -328,6 +363,7 @@ export default {
 		},
 		/**
 		 * Convert sidebar filters to API format using @self.deleted notation
+		 * @spec exclude list-view filter-shape mapping helper for display/query only
 		 * @param {object} filters - Sidebar filters
 		 * @return {object} API filters
 		 */
@@ -358,6 +394,7 @@ export default {
 		},
 		/**
 		 * Get item title from object data
+		 * @spec exclude list-view title-resolution display helper
 		 * @param {object} item - The deleted item
 		 * @return {string} The item title
 		 */
@@ -375,6 +412,7 @@ export default {
 		},
 		/**
 		 * Get register name by ID
+		 * @spec exclude list-view id-to-name lookup display helper
 		 * @param {string|number} registerId - The register ID
 		 * @return {string} The register name
 		 */
@@ -386,6 +424,7 @@ export default {
 		},
 		/**
 		 * Get schema name by ID
+		 * @spec exclude list-view id-to-name lookup display helper
 		 * @param {string|number} schemaId - The schema ID
 		 * @return {string} The schema name
 		 */
@@ -397,6 +436,7 @@ export default {
 		},
 		/**
 		 * Toggle selection for all items on current page
+		 * @spec exclude list-view select-all checkbox plumbing
 		 * @param {boolean} checked - Whether to select or deselect all
 		 * @return {void}
 		 */
@@ -418,6 +458,7 @@ export default {
 		},
 		/**
 		 * Toggle selection for individual item
+		 * @spec exclude list-view single-row selection toggle plumbing
 		 * @param {string} itemId - ID of the item to toggle
 		 * @param {boolean} checked - Whether to select or deselect
 		 * @return {void}
@@ -436,6 +477,7 @@ export default {
 		},
 		/**
 		 * Restore selected items using dialog
+		 * @spec exclude list-view bulk-action dialog-open plumbing (archivering-vernietiging contract)
 		 * @return {void}
 		 */
 		bulkRestore() {
@@ -450,6 +492,7 @@ export default {
 		},
 		/**
 		 * Permanently delete selected items using dialog
+		 * @spec exclude list-view bulk-action dialog-open plumbing (archivering-vernietiging contract)
 		 * @return {void}
 		 */
 		bulkDelete() {
@@ -464,6 +507,7 @@ export default {
 		},
 		/**
 		 * Restore individual item using dialog
+		 * @spec exclude list-view row-action dialog-open plumbing (archivering-vernietiging contract)
 		 * @param {object} item - Item to restore
 		 * @return {void}
 		 */
@@ -474,6 +518,7 @@ export default {
 		},
 		/**
 		 * Permanently delete individual item using dialog
+		 * @spec exclude list-view row-action dialog-open plumbing (archivering-vernietiging contract)
 		 * @param {object} item - Item to delete
 		 * @return {void}
 		 */
@@ -485,6 +530,7 @@ export default {
 
 		/**
 		 * Handle multiple objects deletion event
+		 * @spec exclude list-view event handler; clears selection and reloads after modal delete
 		 * @param {Array<string>} objectIds - IDs of deleted objects
 		 * @return {Promise<void>}
 		 */
@@ -502,6 +548,7 @@ export default {
 		},
 		/**
 		 * Handle multiple objects restoration event
+		 * @spec exclude list-view event handler; clears selection and reloads after modal restore
 		 * @param {Array<string>} objectIds - IDs of restored objects
 		 * @return {Promise<void>}
 		 */
@@ -519,6 +566,7 @@ export default {
 		},
 		/**
 		 * Export filtered items with specified options
+		 * @spec exclude list-view export stub (not yet implemented)
 		 * @param {object} options - Export options
 		 * @param _options
 		 * @return {void}
@@ -528,6 +576,7 @@ export default {
 		},
 		/**
 		 * Handle page change from pagination component
+		 * @spec exclude list-view pagination page-change handler
 		 * @param {number} page - The page number to change to
 		 * @return {Promise<void>}
 		 */
@@ -545,6 +594,7 @@ export default {
 		},
 		/**
 		 * Handle page size change from pagination component
+		 * @spec exclude list-view pagination page-size-change handler
 		 * @param {number} pageSize - The new page size
 		 * @return {Promise<void>}
 		 */
@@ -562,6 +612,7 @@ export default {
 		},
 		/**
 		 * Refresh items list
+		 * @spec exclude list-view manual refresh plumbing
 		 * @return {Promise<void>}
 		 */
 		async refreshItems() {
@@ -570,6 +621,7 @@ export default {
 		},
 		/**
 		 * Update counts for sidebar
+		 * @spec exclude list-view count-emit plumbing for the sidebar
 		 * @return {void}
 		 */
 		updateCounts() {
@@ -578,6 +630,7 @@ export default {
 		},
 		/**
 		 * Handle row click for selection
+		 * @spec exclude list-view row-click selection plumbing
 		 * @param {string} id - Item ID
 		 * @param {Event} event - Click event
 		 * @return {void}
@@ -595,6 +648,7 @@ export default {
 		},
 		/**
 		 * Handle item selection toggle
+		 * @spec exclude list-view selection toggle plumbing
 		 * @param {string} id - Item ID
 		 * @return {void}
 		 */
@@ -607,6 +661,7 @@ export default {
 		},
 		/**
 		 * Format purge date in ISO format yyyy:mm:dd hh:mm
+		 * @spec exclude list-view date-formatting display helper
 		 * @param {string} timestamp - The purge date timestamp
 		 * @return {string} Formatted purge date
 		 */

--- a/src/views/entities/EntitiesIndex.vue
+++ b/src/views/entities/EntitiesIndex.vue
@@ -305,6 +305,7 @@ export default {
 		/**
 		 * Get total number of pages
 		 *
+		 * @spec exclude list-view pagination total-pages helper (computed)
 		 * @return {number} Total pages
 		 */
 		totalPages() {
@@ -314,6 +315,7 @@ export default {
 		/**
 		 * Get paginated entities for current page
 		 *
+		 * @spec exclude list-view client-side pagination slice (computed)
 		 * @return {Array} Paginated entities
 		 */
 		paginatedEntities() {
@@ -325,6 +327,7 @@ export default {
 		/**
 		 * Check if all entities are selected
 		 *
+		 * @spec exclude list-view select-all checkbox state (computed)
 		 * @return {boolean} True if all selected
 		 */
 		allSelected() {
@@ -334,6 +337,7 @@ export default {
 		/**
 		 * Check if some entities are selected
 		 *
+		 * @spec exclude list-view indeterminate-selection checkbox state (computed)
 		 * @return {boolean} True if some selected
 		 */
 		someSelected() {
@@ -359,6 +363,7 @@ export default {
 		/**
 		 * Handle search query update
 		 *
+		 * @spec exclude list-view search-input handler; resets page and reloads (linked-entity-types contract)
 		 * @param {string} query - Search query
 		 * @return {void}
 		 */
@@ -371,6 +376,7 @@ export default {
 		/**
 		 * Handle type filter update
 		 *
+		 * @spec exclude list-view filter-input handler; resets page and reloads
 		 * @param {string|null} type - Type filter
 		 * @return {void}
 		 */
@@ -383,6 +389,7 @@ export default {
 		/**
 		 * Handle category filter update
 		 *
+		 * @spec exclude list-view filter-input handler; resets page and reloads
 		 * @param {string|null} category - Category filter
 		 * @return {void}
 		 */
@@ -395,6 +402,7 @@ export default {
 		/**
 		 * Load entities from the API
 		 *
+		 * @spec exclude list-view API fetch plumbing (linked-entity-types contract)
 		 * @return {Promise<void>}
 		 */
 		async loadEntities() {
@@ -437,6 +445,7 @@ export default {
 		/**
 		 * Refresh the entities list
 		 *
+		 * @spec exclude list-view manual refresh plumbing
 		 * @return {void}
 		 */
 		refreshEntities() {
@@ -446,6 +455,7 @@ export default {
 		/**
 		 * Handle page change event
 		 *
+		 * @spec exclude list-view pagination page-change handler
 		 * @param {number} page - New page number
 		 * @return {void}
 		 */
@@ -457,6 +467,7 @@ export default {
 		/**
 		 * Handle page size change event
 		 *
+		 * @spec exclude list-view pagination page-size-change handler
 		 * @param {number} pageSize - New page size
 		 * @return {void}
 		 */
@@ -469,6 +480,7 @@ export default {
 		/**
 		 * Toggle select all entities
 		 *
+		 * @spec exclude list-view select-all checkbox plumbing
 		 * @param {boolean} checked - Whether to select all
 		 * @return {void}
 		 */
@@ -483,6 +495,7 @@ export default {
 		/**
 		 * Toggle entity selection
 		 *
+		 * @spec exclude list-view single-row selection toggle plumbing
 		 * @param {number} entityId - Entity ID
 		 * @param {boolean} checked - Whether entity is selected
 		 * @return {void}
@@ -498,6 +511,7 @@ export default {
 		/**
 		 * View entity details
 		 *
+		 * @spec exclude list-view router-navigation plumbing to the entity detail page
 		 * @param {object} entity - Entity object
 		 * @return {void}
 		 */
@@ -508,6 +522,7 @@ export default {
 		/**
 		 * Format date for display
 		 *
+		 * @spec exclude list-view date-formatting display helper
 		 * @param {string} date - Date string
 		 * @return {string} Formatted date
 		 */

--- a/src/views/entities/EntityDetail.vue
+++ b/src/views/entities/EntityDetail.vue
@@ -253,6 +253,7 @@ export default {
 		/**
 		 * Load entity from the API
 		 *
+		 * @spec exclude detail-view API fetch plumbing (linked-entity-types contract)
 		 * @return {Promise<void>}
 		 */
 		async loadEntity() {
@@ -286,6 +287,7 @@ export default {
 		/**
 		 * Refresh entity data
 		 *
+		 * @spec exclude detail-view manual refresh plumbing
 		 * @return {void}
 		 */
 		refreshEntity() {
@@ -295,6 +297,7 @@ export default {
 		/**
 		 * Get relation type string
 		 *
+		 * @spec exclude detail-view relation-type display helper
 		 * @param {object} relation - Relation object
 		 * @return {string} Type description
 		 */
@@ -311,6 +314,7 @@ export default {
 		/**
 		 * Get relation title
 		 *
+		 * @spec exclude detail-view relation-title display helper
 		 * @param {object} relation - Relation object
 		 * @return {string} Title string
 		 */
@@ -327,6 +331,7 @@ export default {
 		/**
 		 * View object details
 		 *
+		 * @spec exclude detail-view router-navigation plumbing to a related object
 		 * @param {object} relation - Relation object
 		 * @return {void}
 		 */
@@ -339,6 +344,7 @@ export default {
 		/**
 		 * View file in Nextcloud Files app with details sidebar
 		 *
+		 * @spec exclude detail-view navigation plumbing to the Nextcloud Files app
 		 * @param {object} relation - Relation object
 		 * @return {void}
 		 */
@@ -353,6 +359,7 @@ export default {
 		/**
 		 * Format date for display
 		 *
+		 * @spec exclude detail-view date-formatting display helper
 		 * @param {string} date - Date string
 		 * @return {string} Formatted date
 		 */

--- a/src/views/files/FilesIndex.vue
+++ b/src/views/files/FilesIndex.vue
@@ -245,6 +245,7 @@ export default {
 		/**
 		 * Get current page number
 		 *
+		 * @spec exclude list-view pagination current-page helper (computed)
 		 * @return {number} Current page
 		 */
 		currentPage() {
@@ -254,6 +255,7 @@ export default {
 		/**
 		 * Get total number of pages
 		 *
+		 * @spec exclude list-view pagination total-pages helper (computed)
 		 * @return {number} Total pages
 		 */
 		totalPages() {
@@ -269,6 +271,7 @@ export default {
 		/**
 		 * Toggle sidebar visibility
 		 *
+		 * @spec exclude list-view detail-sidebar toggle plumbing
 		 * @return {void}
 		 */
 		toggleSidebar() {
@@ -278,6 +281,7 @@ export default {
 		/**
 		 * Toggle sort field and direction
 		 *
+		 * @spec exclude list-view sort-toggle plumbing; resets offset and reloads
 		 * @param {string} field - The field to sort by
 		 * @return {void}
 		 */
@@ -295,6 +299,7 @@ export default {
 		/**
 		 * Handle search query update
 		 *
+		 * @spec exclude list-view search-input handler; resets offset and reloads
 		 * @param {string} query - Search query
 		 * @return {void}
 		 */
@@ -307,6 +312,7 @@ export default {
 		/**
 		 * Handle status filter update
 		 *
+		 * @spec exclude list-view filter-input handler; resets offset and reloads
 		 * @param {string|null} status - Status filter
 		 * @return {void}
 		 */
@@ -319,6 +325,7 @@ export default {
 		/**
 		 * Handle risk level filter update
 		 *
+		 * @spec exclude list-view filter-input handler; resets offset and reloads
 		 * @param {string|null} level - Risk level filter
 		 * @return {void}
 		 */
@@ -331,6 +338,7 @@ export default {
 		/**
 		 * Load files from the API
 		 *
+		 * @spec exclude list-view API fetch plumbing
 		 * @return {Promise<void>}
 		 */
 		async loadFiles() {
@@ -375,6 +383,7 @@ export default {
 		/**
 		 * Refresh the files list
 		 *
+		 * @spec exclude list-view manual refresh plumbing
 		 * @return {void}
 		 */
 		refreshFiles() {
@@ -384,6 +393,7 @@ export default {
 		/**
 		 * Go to previous page
 		 *
+		 * @spec exclude list-view pagination previous-page handler
 		 * @return {void}
 		 */
 		previousPage() {
@@ -396,6 +406,7 @@ export default {
 		/**
 		 * Go to next page
 		 *
+		 * @spec exclude list-view pagination next-page handler
 		 * @return {void}
 		 */
 		nextPage() {
@@ -408,6 +419,7 @@ export default {
 		/**
 		 * Retry extraction for a failed file
 		 *
+		 * @spec exclude list-view row-action wiring; POSTs a re-extract request and reloads
 		 * @param {number} fileId - File ID
 		 * @return {Promise<void>}
 		 */
@@ -428,6 +440,7 @@ export default {
 		/**
 		 * Show error details for a failed file
 		 *
+		 * @spec exclude list-view toast-display helper for extraction errors
 		 * @param {object} file - File object
 		 * @return {void}
 		 */
@@ -444,6 +457,7 @@ export default {
 		/**
 		 * Format file size in human-readable format
 		 *
+		 * @spec exclude list-view file-size formatting display helper
 		 * @param {number} bytes - File size in bytes
 		 * @return {string} Formatted file size
 		 */
@@ -458,6 +472,7 @@ export default {
 		/**
 		 * Format extraction status
 		 *
+		 * @spec exclude list-view status-label formatting display helper
 		 * @param {string} status - Extraction status
 		 * @return {string} Formatted status
 		 */
@@ -474,6 +489,7 @@ export default {
 		/**
 		 * Format mime type for display
 		 *
+		 * @spec exclude list-view mime-type formatting display helper
 		 * @param {string} mimeType - MIME type
 		 * @return {string} Formatted MIME type
 		 */
@@ -486,6 +502,7 @@ export default {
 		/**
 		 * Format risk level for display
 		 *
+		 * @spec exclude list-view risk-level formatting display helper
 		 * @param {string} level - Risk level
 		 * @return {string} Formatted risk level
 		 */
@@ -503,6 +520,7 @@ export default {
 		/**
 		 * Format date for display
 		 *
+		 * @spec exclude list-view date-formatting display helper
 		 * @param {string} date - Date string
 		 * @return {string} Formatted date
 		 */

--- a/src/views/logs/SearchTrailIndex.vue
+++ b/src/views/logs/SearchTrailIndex.vue
@@ -244,6 +244,9 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude list-view active-filter detection helper (computed)
+		 */
 		hasActiveFilters() {
 			return Object.keys(searchTrailStore.searchTrailFilters || {}).some(key =>
 				searchTrailStore.searchTrailFilters[key] !== null
@@ -263,15 +266,24 @@ export default {
 				return []
 			}
 		},
+		/**
+		 * @spec exclude list-view select-all checkbox state (computed)
+		 */
 		allSelected() {
 			return this.paginatedSearchTrails.length > 0 && this.paginatedSearchTrails.every(searchTrail => this.selectedSearchTrails.includes(searchTrail.id))
 		},
+		/**
+		 * @spec exclude list-view indeterminate-selection checkbox state (computed)
+		 */
 		someSelected() {
 			return this.selectedSearchTrails.length > 0 && !this.allSelected
 		},
 	},
 	watch: {
 		paginatedSearchTrails: {
+			/**
+			 * @spec exclude list-view watcher; re-emits counts when the trail list changes
+			 */
 			handler() {
 				this.$nextTick(() => {
 					this.updateCounts()
@@ -280,6 +292,9 @@ export default {
 			deep: false,
 		},
 	},
+	/**
+	 * @spec exclude list-view lifecycle; loads trails and registers sidebar listeners on mount
+	 */
 	mounted() {
 		// Initialize with safe defaults
 		try {
@@ -297,6 +312,9 @@ export default {
 			this.updateCounts()
 		})
 	},
+	/**
+	 * @spec exclude list-view lifecycle; tears down sidebar listeners on destroy
+	 */
 	beforeDestroy() {
 		this.$root.$off('search-trail-filters-changed')
 		this.$root.$off('search-trail-refresh')
@@ -318,6 +336,7 @@ export default {
 		},
 		/**
 		 * Handle filter changes from sidebar
+		 * @spec exclude list-view filter-change handler; sets store filters and reloads (zoeken-filteren contract)
 		 * @param {object} filters - Filter object from sidebar
 		 * @return {void}
 		 */
@@ -370,6 +389,7 @@ export default {
 		},
 		/**
 		 * Rerun a search based on the search trail parameters
+		 * @spec exclude list-view row-action; router-navigates to the search page with the trail's params (zoeken-filteren contract)
 		 * @param {object} searchTrail - Search trail entry to rerun
 		 * @return {void}
 		 */
@@ -408,6 +428,7 @@ export default {
 		},
 		/**
 		 * Delete a single search trail using the new modal
+		 * @spec exclude list-view row-action dialog-open plumbing
 		 * @param {object} searchTrail - Search trail to delete
 		 * @return {void}
 		 */
@@ -454,6 +475,7 @@ export default {
 		},
 		/**
 		 * Update counts for sidebar
+		 * @spec exclude list-view count-emit plumbing for the sidebar
 		 * @return {void}
 		 */
 		updateCounts() {
@@ -467,6 +489,7 @@ export default {
 		},
 		/**
 		 * Handle page change from pagination component
+		 * @spec exclude list-view pagination page-change handler
 		 * @param {number} page - The page number to change to
 		 * @return {Promise<void>}
 		 */
@@ -484,6 +507,7 @@ export default {
 		},
 		/**
 		 * Handle page size change from pagination component
+		 * @spec exclude list-view pagination page-size-change handler
 		 * @param {number} pageSize - The new page size
 		 * @return {Promise<void>}
 		 */
@@ -501,6 +525,7 @@ export default {
 		},
 		/**
 		 * Check if search trail has parameters
+		 * @spec exclude list-view parameter-presence display helper
 		 * @param {object} searchTrail - The search trail item
 		 * @return {boolean} Whether the search trail has parameters
 		 */
@@ -525,6 +550,7 @@ export default {
 		},
 		/**
 		 * Format execution time for display
+		 * @spec exclude list-view execution-time formatting display helper
 		 * @param {number} executionTime - Execution time in milliseconds
 		 * @return {string} Formatted execution time
 		 */
@@ -538,6 +564,9 @@ export default {
 			return `${(executionTime / 1000).toFixed(2)}s`
 		},
 		formatBytes,
+		/**
+		 * @spec exclude list-view select-all checkbox plumbing
+		 */
 		toggleSelectAll(checked) {
 			if (checked) {
 				this.selectedSearchTrails = this.paginatedSearchTrails.map(searchTrail => searchTrail.id)
@@ -545,6 +574,9 @@ export default {
 				this.selectedSearchTrails = []
 			}
 		},
+		/**
+		 * @spec exclude list-view single-row selection toggle plumbing
+		 */
 		toggleSearchTrailSelection(id, checked) {
 			if (checked) {
 				this.selectedSearchTrails.push(id)

--- a/src/views/object/ObjectsList.vue
+++ b/src/views/object/ObjectsList.vue
@@ -149,12 +149,18 @@ export default {
 		}
 	},
 	watch: {
+		/**
+		 * @spec exclude list-view watcher; reloads the object list on page change (object-lifecycle contract)
+		 */
 		currentPage(newVal) {
 			this.loading = true
 			objectStore.refreshObjectList({ limit: this.limit, page: newVal, search: this.search }).finally(() => {
 				this.loading = false
 			})
 		},
+		/**
+		 * @spec exclude list-view watcher; debounced reload of the object list on search change (object-lifecycle contract)
+		 */
 		search(newVal) {
 			clearTimeout(this.searchTimeout)
 			this.searchTimeout = setTimeout(() => {
@@ -165,6 +171,9 @@ export default {
 			}, 700)
 		},
 	},
+	/**
+	 * @spec exclude list-view lifecycle; conditionally loads the object list on mount when register+schema are scoped (object-lifecycle contract)
+	 */
 	mounted() {
 		// Skip the refresh when neither a register nor a schema is in
 		// scope — the deep-link route /objects/:register/:schema/:id
@@ -184,6 +193,9 @@ export default {
 		})
 	},
 	methods: {
+		/**
+		 * @spec exclude list-view action; opens the add-object modal with register/schema context (object-lifecycle contract)
+		 */
 		addObject() {
 			// Clear any existing object and open the add object modal
 			objectStore.setObjectItem(null)

--- a/src/views/organisation/OrganisationDetails.vue
+++ b/src/views/organisation/OrganisationDetails.vue
@@ -236,40 +236,64 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude detail-view active-organisation flag (computed; tenant-lifecycle contract)
+		 */
 		isActiveOrganisation() {
 			return organisationStore.userStats.active
 				   && organisationStore.userStats.active.uuid === organisationStore.organisationItem?.uuid
 		},
+		/**
+		 * @spec exclude detail-view edit-permission gate (computed)
+		 */
 		canEdit() {
 			// Only owner can edit (or system for default org)
 			return organisationStore.organisationItem?.owner === 'system'
 				   || organisationStore.organisationItem?.owner === this.getCurrentUser()
 		},
+		/**
+		 * @spec exclude detail-view leave-permission gate (computed)
+		 */
 		canLeave() {
 			// Can't leave if it's your only organisation, you're the owner, or it's default
 			return organisationStore.userStats.total > 1
 				   && !organisationStore.organisationItem?.isDefault
 				   && organisationStore.organisationItem?.owner !== this.getCurrentUser()
 		},
+		/**
+		 * @spec exclude detail-view delete-permission gate (computed)
+		 */
 		canDelete() {
 			// Only owners can delete, and can't delete default organisation
 			return !organisationStore.organisationItem?.isDefault
 				   && organisationStore.organisationItem?.owner === this.getCurrentUser()
 		},
+		/**
+		 * @spec exclude detail-view manage-members permission gate (computed)
+		 */
 		canManageMembers() {
 			// Only owners can manage members
 			return organisationStore.organisationItem?.owner === this.getCurrentUser()
 		},
 	},
+	/**
+	 * @spec exclude detail-view lifecycle; loads organisation statistics on mount
+	 */
 	async mounted() {
 		// Load organisation statistics (would need API endpoint)
 		await this.loadOrganisationStats()
 	},
 	methods: {
+		/**
+		 * @spec exclude detail-view current-user resolution helper from route meta
+		 */
 		getCurrentUser() {
 			// Implementation would depend on how you get current user
 			return this.$route.meta?.user?.uid || 'unknown'
 		},
+		/**
+		 * @spec exclude detail-view action; delegates to store to set the active organisation (tenant-lifecycle contract)
+		 */
 		async setActiveOrganisation() {
 			try {
 				await organisationStore.setActiveOrganisationById(organisationStore.organisationItem.uuid)
@@ -278,6 +302,9 @@ export default {
 				showError(t('openregister', 'Failed to set active organisation: {error}', { error: error.message }))
 			}
 		},
+		/**
+		 * @spec exclude detail-view action; confirms then delegates to store leave + navigates back (tenant-lifecycle contract)
+		 */
 		async leaveOrganisation() {
 			if (!confirm(t('openregister', 'Are you sure you want to leave \'{name}\'?', { name: organisationStore.organisationItem.name }))) {
 				return
@@ -292,6 +319,9 @@ export default {
 				showError(t('openregister', 'Failed to leave organisation: {error}', { error: error.message }))
 			}
 		},
+		/**
+		 * @spec exclude detail-view member-removal stub (confirm + toast; API endpoint not yet implemented)
+		 */
 		async removeMember(userId) {
 			if (!confirm(t('openregister', 'Remove {userId} from this organisation?', { userId }))) {
 				return
@@ -305,6 +335,9 @@ export default {
 				showError(t('openregister', 'Failed to remove member: {error}', { error: error.message }))
 			}
 		},
+		/**
+		 * @spec exclude detail-view stats placeholder; populates mock organisation statistics for display
+		 */
 		async loadOrganisationStats() {
 			// This would load organisation-specific statistics
 			// For now, using mock data
@@ -315,6 +348,9 @@ export default {
 				storage: Math.floor(Math.random() * 1000000000), // bytes
 			}
 		},
+		/**
+		 * @spec exclude detail-view clipboard helper with success/error toast
+		 */
 		async copyToClipboard(text) {
 			try {
 				await navigator.clipboard.writeText(text)
@@ -324,6 +360,9 @@ export default {
 				showError(t('openregister', 'Failed to copy to clipboard'))
 			}
 		},
+		/**
+		 * @spec exclude detail-view date-formatting display helper
+		 */
 		formatDate(dateString) {
 			return new Date(dateString).toLocaleDateString({
 				day: '2-digit',
@@ -334,6 +373,9 @@ export default {
 				minute: '2-digit',
 			})
 		},
+		/**
+		 * @spec exclude detail-view byte-size formatting display helper
+		 */
 		formatBytes(bytes) {
 			if (bytes === 0) return '0 Bytes'
 
@@ -344,14 +386,23 @@ export default {
 			return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
 		},
 		// Organisation Action Methods
+		/**
+		 * @spec exclude detail-view action; opens the public publication page in a new tab
+		 */
 		viewOrganisation() {
 			const publicationUrl = `https://www.softwarecatalogus.nl/publicatie/${organisationStore.organisationItem.uuid}`
 			window.open(publicationUrl, '_blank')
 		},
+		/**
+		 * @spec exclude detail-view action; opens the edit-organisation modal
+		 */
 		editOrganisation() {
 			// organisationStore.organisationItem is already set by the page
 			navigationStore.setModal('editOrganisation')
 		},
+		/**
+		 * @spec exclude detail-view action; opens the join-organisation modal with transfer data
+		 */
 		openJoinModal() {
 			// Set the transfer data with the current organisation UUID
 			navigationStore.setTransferData({
@@ -360,10 +411,16 @@ export default {
 			// Open the join organisation modal
 			navigationStore.setModal('joinOrganisation')
 		},
+		/**
+		 * @spec exclude detail-view action; opens the manage-roles modal
+		 */
 		openManageRolesModal() {
 			// Open the manage organisation roles modal
 			navigationStore.setModal('manageOrganisationRoles')
 		},
+		/**
+		 * @spec exclude detail-view action; opens the organisation website in a new tab
+		 */
 		goToOrganisation() {
 			if (organisationStore.organisationItem?.website) {
 				let websiteUrl = organisationStore.organisationItem.website

--- a/src/views/register/RegistersIndex.vue
+++ b/src/views/register/RegistersIndex.vue
@@ -260,9 +260,15 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude list-view store-reference passthrough (computed)
+		 */
 		registerStore() {
 			return registerStore
 		},
+		/**
+		 * @spec exclude list-view inline form-schema definition for the register editor (computed)
+		 */
 		registerSchema() {
 			return {
 				title: t('openregister', 'Register'),
@@ -275,12 +281,18 @@ export default {
 				required: ['title', 'slug'],
 			}
 		},
+		/**
+		 * @spec exclude list-view list filtering of synthetic rows (computed)
+		 */
 		filteredRegisters() {
 			return registerStore.registerList.filter(register =>
 				register.title !== 'System Totals'
 				&& register.title !== 'Orphaned Items',
 			)
 		},
+		/**
+		 * @spec exclude list-view table column definitions (computed)
+		 */
 		tableColumns() {
 			return [
 				{ key: 'title', label: t('openregister', 'Title'), sortable: true },
@@ -289,6 +301,9 @@ export default {
 				{ key: 'updated', label: t('openregister', 'Updated'), sortable: true },
 			]
 		},
+		/**
+		 * @spec exclude list-view pagination summary helper (computed)
+		 */
 		paginationData() {
 			const page = registerStore.pagination.page || 1
 			const limit = registerStore.pagination.limit || 20
@@ -296,6 +311,9 @@ export default {
 			const pages = Math.ceil(total / limit)
 			return { page, pages, total, limit }
 		},
+		/**
+		 * @spec exclude list-view empty-state title text helper (computed)
+		 */
 		emptyContentName() {
 			if (registerStore.error) {
 				return registerStore.error
@@ -305,6 +323,9 @@ export default {
 			return t('openregister', 'Loading registers...')
 		},
 	},
+	/**
+	 * @spec exclude list-view lifecycle; parallel-loads registers/configurations/schemas on mount
+	 */
 	async mounted() {
 		try {
 			this.schemasLoading = true
@@ -321,6 +342,9 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec exclude list-view manual refresh plumbing
+		 */
 		async handleRefresh() {
 			this.isRefreshing = true
 			try {
@@ -330,24 +354,39 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude list-view pagination page-change handler
+		 */
 		onPageChanged(page) {
 			registerStore.setPagination(page, registerStore.pagination.limit)
 		},
 
+		/**
+		 * @spec exclude list-view pagination page-size-change handler
+		 */
 		onPageSizeChanged(pageSize) {
 			registerStore.setPagination(1, pageSize)
 		},
 
+		/**
+		 * @spec exclude list-view row-selection state setter
+		 */
 		onSelect(ids) {
 			this.selectedRegisters = ids
 		},
 
+		/**
+		 * @spec exclude list-view row CSS-class helper based on managing-configuration state
+		 */
 		getRowClass(register) {
 			if (this.isManagedByExternalConfig(register)) return 'viewTableRow--managed'
 			if (this.isManagedByLocalConfig(register)) return 'viewTableRow--local'
 			return ''
 		},
 
+		/**
+		 * @spec exclude list-view lookup helper; finds the configuration managing a register
+		 */
 		getManagingConfiguration(register) {
 			if (!register || !register.id) return null
 			return configurationStore.configurationList.find(
@@ -355,18 +394,27 @@ export default {
 			) || null
 		},
 
+		/**
+		 * @spec exclude list-view display predicate; whether a register is externally managed
+		 */
 		isManagedByExternalConfig(register) {
 			const config = this.getManagingConfiguration(register)
 			if (!config) return false
 			return (config.sourceType && ['github', 'gitlab', 'url'].includes(config.sourceType)) || config.isLocal === false
 		},
 
+		/**
+		 * @spec exclude list-view display predicate; whether a register is locally managed
+		 */
 		isManagedByLocalConfig(register) {
 			const config = this.getManagingConfiguration(register)
 			if (!config) return false
 			return config.sourceType === 'local' || config.sourceType === 'manual' || config.isLocal === true
 		},
 
+		/**
+		 * @spec exclude list-view form-control mapping helper; resolves schema ids to select options
+		 */
 		getSchemaSelectValue(schemas) {
 			if (!Array.isArray(schemas)) return []
 			return schemas.map(s => {
@@ -376,6 +424,9 @@ export default {
 			})
 		},
 
+		/**
+		 * @spec exclude list-view form-submit wiring; delegates to registerStore.saveRegister (registers-management contract)
+		 */
 		async onSaveRegister(formData) {
 			try {
 				await registerStore.saveRegister({
@@ -388,6 +439,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude list-view row-action wiring; delegates to store publish + toast (registers-management contract)
+		 */
 		async publishRegister(register) {
 			try {
 				await registerStore.publishRegister(register.id)
@@ -398,6 +452,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude list-view row-action wiring; delegates to store depublish + toast (registers-management contract)
+		 */
 		async depublishRegister(register) {
 			try {
 				await registerStore.depublishRegister(register.id)
@@ -408,11 +465,17 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude list-view row-action; router-navigates to the register detail page
+		 */
 		viewRegisterDetails(register) {
 			registerStore.setRegisterItem({ id: register.id })
 			this.$router.push(`/registers/${register.id}`)
 		},
 
+		/**
+		 * @spec exclude list-view row-action; fetches and downloads the register OAS as JSON (oas-validation contract)
+		 */
 		async downloadOas(register) {
 			const baseUrl = window.location.origin
 			const apiUrl = `${baseUrl}/index.php/apps/openregister/api/registers/${register.id}/oas`
@@ -432,18 +495,27 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude list-view row-action; opens the register OAS in the Redoc viewer (oas-validation contract)
+		 */
 		viewOasDoc(register) {
 			const baseUrl = window.location.origin
 			const apiUrl = `${baseUrl}/index.php/apps/openregister/api/registers/${register.id}/oas`
 			window.open(`https://redocly.github.io/redoc/?url=${encodeURIComponent(apiUrl)}`, '_blank')
 		},
 
+		/**
+		 * @spec exclude list-view action; opens the combined all-registers OAS in the Redoc viewer (oas-validation contract)
+		 */
 		openAllApisDoc() {
 			const baseUrl = window.location.origin
 			const apiUrl = `${baseUrl}/apps/openregister/api/registers/oas`
 			window.open(`https://redocly.github.io/redoc/?url=${encodeURIComponent(apiUrl)}`, '_blank')
 		},
 
+		/**
+		 * @spec exclude list-view action; POSTs to the names-cache warmup endpoint and reports results via toast
+		 */
 		async warmupNamesCache() {
 			const baseUrl = window.location.origin
 			const apiUrl = `${baseUrl}/index.php/apps/openregister/api/names/warmup`

--- a/src/views/schemas/SchemaWorkflowTab.vue
+++ b/src/views/schemas/SchemaWorkflowTab.vue
@@ -73,23 +73,38 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude tab-view prop passthrough for the schema id (computed)
+		 */
 		schemaId() {
 			return this.schema?.id || null
 		},
+		/**
+		 * @spec exclude tab-view prop passthrough for the schema hooks list (computed)
+		 */
 		hooks() {
 			return this.schema?.hooks || []
 		},
 	},
 	methods: {
+		/**
+		 * @spec exclude tab-view hook-form open plumbing for editing
+		 */
 		editHook(index) {
 			this.editingHookIndex = index
 			this.showHookForm = true
 		},
+		/**
+		 * @spec exclude tab-view hook-list mutation; emits an update:hooks event with the entry removed
+		 */
 		deleteHook(index) {
 			const hooks = [...this.hooks]
 			hooks.splice(index, 1)
 			this.$emit('update:hooks', hooks)
 		},
+		/**
+		 * @spec exclude tab-view hook-list mutation; emits an update:hooks event with the saved entry
+		 */
 		saveHook(hookData) {
 			const hooks = [...this.hooks]
 			if (this.editingHookIndex !== null) {
@@ -102,6 +117,9 @@ export default {
 			this.showHookForm = false
 			this.editingHookIndex = null
 		},
+		/**
+		 * @spec exclude tab-view test-dialog open plumbing for a hook
+		 */
 		openTestDialog(hook) {
 			this.testHook = hook
 			this.testEngineId = 1

--- a/src/views/settings/sections/OrganisationConfiguration.vue
+++ b/src/views/settings/sections/OrganisationConfiguration.vue
@@ -216,6 +216,7 @@ export default {
 		/**
 		 * Format organisations for NcSelect
 		 *
+		 * @spec exclude settings-section select-option formatting helper (computed)
 		 * @return {Array} Formatted organisation options
 		 */
 		organisationOptions() {
@@ -229,6 +230,7 @@ export default {
 		/**
 		 * Check if there are unsaved changes
 		 *
+		 * @spec exclude settings-section dirty-state detection helper (computed)
 		 * @return {boolean} True if there are changes
 		 */
 		hasChanges() {
@@ -246,6 +248,7 @@ export default {
 		/**
 		 * Load all data
 		 *
+		 * @spec exclude settings-section aggregate-load plumbing (tenant-lifecycle contract)
 		 * @return {Promise<void>}
 		 */
 		async loadData() {
@@ -259,6 +262,7 @@ export default {
 		/**
 		 * Load organisations list
 		 *
+		 * @spec exclude settings-section API fetch plumbing for organisations
 		 * @return {Promise<void>}
 		 */
 		async loadOrganisations() {
@@ -282,6 +286,7 @@ export default {
 		/**
 		 * Load current settings
 		 *
+		 * @spec exclude settings-section API fetch plumbing for current settings
 		 * @return {Promise<void>}
 		 */
 		async loadSettings() {
@@ -318,6 +323,7 @@ export default {
 		/**
 		 * Load organisation statistics
 		 *
+		 * @spec exclude settings-section API fetch plumbing for non-critical statistics
 		 * @return {Promise<void>}
 		 */
 		async loadStatistics() {
@@ -343,6 +349,7 @@ export default {
 		/**
 		 * Handle default organisation change
 		 *
+		 * @spec exclude settings-section select-change state plumbing
 		 * @param {object} organisation - Selected organisation
 		 * @return {void}
 		 */
@@ -355,6 +362,7 @@ export default {
 		/**
 		 * Handle auto-create default change
 		 *
+		 * @spec exclude settings-section toggle-change state plumbing
 		 * @param {boolean} value - New value
 		 * @return {void}
 		 */
@@ -367,6 +375,7 @@ export default {
 		/**
 		 * Save settings
 		 *
+		 * @spec exclude settings-section save plumbing; PUTs organisation settings (tenant-lifecycle contract)
 		 * @return {Promise<void>}
 		 */
 		async saveSettings() {
@@ -405,6 +414,7 @@ export default {
 		/**
 		 * Reset changes to original values
 		 *
+		 * @spec exclude settings-section reset-to-original state plumbing
 		 * @return {void}
 		 */
 		resetSettings() {
@@ -417,6 +427,7 @@ export default {
 		/**
 		 * Refresh all data
 		 *
+		 * @spec exclude settings-section manual refresh plumbing
 		 * @return {Promise<void>}
 		 */
 		async refreshData() {

--- a/src/views/settings/sections/PermissionMatrix.vue
+++ b/src/views/settings/sections/PermissionMatrix.vue
@@ -179,6 +179,7 @@ export default {
 		 * Returns only the registers that are expanded and have role configuration.
 		 * Used in the bulk actions section to avoid mixing v-for with v-if.
 		 *
+		 * @spec exclude settings-matrix render-filter helper (computed; auth-system contract)
 		 * @return {Array} Filtered list of registers with bulk action support
 		 */
 		registersWithBulkActions() {
@@ -195,6 +196,9 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * @spec exclude settings-matrix data fetch plumbing; loads registers and schemas (auth-system contract)
+		 */
 		async loadData() {
 			this.loading = true
 			try {
@@ -210,15 +214,24 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude settings-matrix row expand/collapse toggle plumbing
+		 */
 		toggleRegister(registerId) {
 			this.$set(this.expandedRegisters, registerId, !this.expandedRegisters[registerId])
 		},
 
+		/**
+		 * @spec exclude settings-matrix lookup helper; resolves a register's schemas for display
+		 */
 		getRegisterSchemas(register) {
 			const schemaIds = register.schemas || []
 			return this.schemas.filter(s => schemaIds.includes(s.id) || schemaIds.includes(String(s.id)))
 		},
 
+		/**
+		 * @spec exclude settings-matrix authorization-read helper; extracts group names for an action (auth-system contract)
+		 */
 		getRegisterGroups(register, action) {
 			const auth = register.authorization
 			if (!auth || !auth[action]) return []
@@ -229,6 +242,9 @@ export default {
 			}).filter(Boolean)
 		},
 
+		/**
+		 * @spec exclude settings-matrix display helper; resolves effective (direct or inherited) groups
+		 */
 		getEffectiveGroups(schema, register, action) {
 			const schemaAuth = schema.authorization
 			if (schemaAuth && Object.keys(schemaAuth).length > 0) {
@@ -243,6 +259,9 @@ export default {
 			return this.getRegisterGroups(register, action)
 		},
 
+		/**
+		 * @spec exclude settings-matrix display helper; resolves the effective authorization object
+		 */
 		getEffectiveAuth(schema, register) {
 			const schemaAuth = schema.authorization
 			if (schemaAuth && Object.keys(schemaAuth).length > 0) {
@@ -251,6 +270,9 @@ export default {
 			return register.authorization || {}
 		},
 
+		/**
+		 * @spec exclude settings-matrix CSS-class helper for direct/inherited permission cells
+		 */
 		getPermissionClass(schema, register, action) {
 			const schemaAuth = schema.authorization
 			if (schemaAuth && Object.keys(schemaAuth).length > 0 && schemaAuth[action]) {
@@ -262,6 +284,9 @@ export default {
 			return 'group-list'
 		},
 
+		/**
+		 * @spec exclude settings-matrix tooltip-text display helper
+		 */
 		getEffectiveTooltip(schema, register, action) {
 			const schemaAuth = schema.authorization
 			if (schemaAuth && Object.keys(schemaAuth).length > 0 && schemaAuth[action]) {
@@ -274,17 +299,26 @@ export default {
 			return 'No restrictions (open access)'
 		},
 
+		/**
+		 * @spec exclude settings-matrix groups-tooltip display helper
+		 */
 		getGroupsTooltip(groups) {
 			if (groups.length === 0) return 'No restrictions'
 			return groups.join(', ')
 		},
 
+		/**
+		 * @spec exclude settings-matrix groups-label truncation display helper
+		 */
 		formatGroups(groups) {
 			if (groups.length === 0) return '-'
 			if (groups.length <= 2) return groups.join(', ')
 			return groups.slice(0, 2).join(', ') + ' +' + (groups.length - 2)
 		},
 
+		/**
+		 * @spec exclude settings-matrix public-access detection display helper
+		 */
 		isPublicAccess(authorization) {
 			if (!authorization || !authorization.read) return false
 			return authorization.read.some(entry => {
@@ -294,6 +328,9 @@ export default {
 			})
 		},
 
+		/**
+		 * @spec exclude settings-matrix toggle wiring; mutates register read-auth and persists via store (auth-system contract)
+		 */
 		async togglePublicAccess(register, enabled) {
 			const auth = { ...(register.authorization || {}) }
 			if (enabled) {
@@ -315,6 +352,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude settings-matrix toggle wiring; mutates schema read-auth and persists via store (auth-system contract)
+		 */
 		async toggleSchemaPublicAccess(schema, register, enabled) {
 			const schemaAuth = schema.authorization && Object.keys(schema.authorization).length > 0
 				? { ...schema.authorization }
@@ -339,11 +379,17 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude settings-matrix select-option helper; maps a register's configured roles
+		 */
 		getRoleOptions(register) {
 			const roles = register.configuration?.roles || []
 			return roles.map(r => ({ label: r.name + ' (' + (r.actions || []).join(', ') + ')', value: r.name }))
 		},
 
+		/**
+		 * @spec exclude settings-matrix select-option helper; collects unique groups across registers/schemas
+		 */
 		getGroupOptions() {
 			// Collect all unique groups from all registers and schemas
 			const groups = new Set()
@@ -374,6 +420,9 @@ export default {
 			return Array.from(groups).sort().map(g => ({ label: g, value: g }))
 		},
 
+		/**
+		 * @spec exclude settings-matrix bulk-action wiring; applies a role to a register's schemas via store (auth-system contract)
+		 */
 		async applyBulkRole(register) {
 			const roleName = this.bulkRole[register.id]?.value
 			const groupName = this.bulkGroup[register.id]?.value


### PR DESCRIPTION
## Summary

Brings 223 uncovered methods across 18 `src/views/**/*.vue` files to fully-tagged status under ADR-003. All 223 are tagged with JSDoc `@spec exclude <reason>` — these are list/detail/settings UI plumbing (pagination, row selection, formatting helpers, lifecycle fetch, store wiring, navigation, clipboard/download glue) whose user-facing behavior is already owned by existing capabilities (`object-lifecycle`, `linked-entity-types`, `archivering-vernietiging`, `zoeken-filteren`, `ai-chat-companion`, `auth-system`, `tenant-lifecycle`, `registers-management`, `oas-validation`, schema workflow).

- **0** reverse-spec'd / **223** excluded / **0** new REQs
- Documentation-only retrofit ghost change at `openspec/changes/retrofit-2026-05-25-fe-views-2/` (proposal + tasks + design; no spec delta)
- Annotation-only: every diff line is a JSDoc comment; no behavior changed

## Files

EndpointDetails, account ActivitySection/NotificationsSection, agents/ApplicationsIndex, ApplicationDetails, chat/ChatIndex, deleted/DeletedIndex, entities EntitiesIndex/EntityDetail, files/FilesIndex, logs/SearchTrailIndex, object/ObjectsList, organisation/OrganisationDetails, register/RegistersIndex, schemas/SchemaWorkflowTab, settings OrganisationConfiguration/PermissionMatrix.

## Test plan

- [ ] Coverage scan reports 0 untagged methods in the chunk's 18 files
- [ ] No bare `@spec exclude` (every tag carries a reason per ADR-003)