### PR TITLE
retrofit: frontend coverage — modals (chunk 2)

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-fe-modals-2/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-modals-2/proposal.md
@@ -1,0 +1,54 @@
+# Retrofit — frontend coverage: modals (chunk 2)
+
+The coverage scanner flagged **224 uncovered methods** across Vue components under
+`src/modals/` as still missing `@spec` traceability. These are the leftover
+methods in modal files that were partially annotated by
+`retrofit-2026-05-24-2b-modals` — the prior pass tagged the obvious entity-CRUD
+entry points (Edit/Delete/View) but left the surrounding UI plumbing untagged.
+
+Per ADR-003 §Spec traceability, every public method needs a `@spec` tag. Per the
+retrofit playbook and ADR-003 exclude convention, frontend modal plumbing
+(open/close handlers, form-field update setters, computed display helpers,
+watchers, validation guards, value formatters, search/autocomplete callbacks,
+multi-step wizard navigation) is **boilerplate UI orchestration** and is tagged
+`@spec exclude <reason>` rather than minting new behavioral requirements.
+
+## Counts
+
+- **Methods in batch:** 224
+- **Spec'd (linked to a REQ):** 0
+- **Excluded (`@spec exclude`):** 224
+- **New REQs minted:** 0
+
+All 224 methods are UI plumbing: dialog lifecycle, reactive form setters,
+computed/display helpers, value/byte/date formatters, wizard step navigation,
+multi-select toggles, file-picker handlers, search-store passthroughs, and
+operational-job progress readouts. None introduces a novel user-facing domain
+contract beyond what `entity-management-modals` and `platform-administration-modals`
+(created in the 2b-modals change) already capture. This change is therefore a
+**delta-less, all-exclude annotation pass** — no `specs/` delta, so it is not
+subject to `--strict` spec validation.
+
+## Affected files
+
+- src/modals/agent/DeleteAgent.vue
+- src/modals/configuration/{DeleteConfiguration,EditConfiguration,ImportConfiguration,PreviewConfiguration}.vue
+- src/modals/deleted/{PurgeMultiple,RestoreMultiple}.vue
+- src/modals/file/UploadFiles.vue
+- src/modals/object/{DownloadObject,LockObject,MergeObject,MigrationObject}.vue
+- src/modals/organisation/{DeleteOrganisation,EditOrganisation}.vue
+- src/modals/register/ExportRegister.vue
+- src/modals/schema/DeleteSchemaProperty.vue
+- src/modals/settings/{CreateConfigSetDialog,DeleteCollectionModal,MassValidateModal,ObjectVectorizationModal,SolrSetupResultsModal}.vue
+- src/modals/source/DeleteSource.vue
+- src/modals/view/EditView.vue
+- src/modals/webhook/ViewWebhookLog.vue
+
+## Approach
+
+- No new capabilities, no `specs/` delta.
+- Every one of the 224 methods receives a `@spec exclude <reason>` JSDoc tag with
+  a required, specific reason.
+- Edit tool only; no logic changes, no refactors, no formatting cleanups.
+
+Source: `/tmp/or-scan/fw-fe-modals-2.json`, generated 2026-05-25.

--- a/openspec/changes/retrofit-2026-05-25-fe-modals-2/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-modals-2/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+All 224 batch methods are frontend modal UI plumbing and are tagged
+`@spec exclude <reason>` (ADR-003 exclude convention). No new REQs are minted, so
+there are no spec-linked tasks. This is a delta-less, all-exclude annotation pass.
+
+- [x] task-1: Tag all 224 uncovered `src/modals/` methods `@spec exclude <reason>` — dialog lifecycle, reactive form setters, computed/display helpers, formatters, wizard navigation, multi-select toggles, file-picker handlers, search passthroughs, and operational-job progress readouts (no novel domain contract beyond entity-management-modals / platform-administration-modals).

--- a/src/modals/agent/DeleteAgent.vue
+++ b/src/modals/agent/DeleteAgent.vue
@@ -71,6 +71,9 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude Modal dialog close handler — resets navigationStore.dialog; UI plumbing.
+		 */
 		closeDialog() {
 			navigationStore.setDialog(null)
 		},

--- a/src/modals/configuration/DeleteConfiguration.vue
+++ b/src/modals/configuration/DeleteConfiguration.vue
@@ -57,6 +57,9 @@ export default {
 		Cancel,
 		Delete,
 	},
+	/**
+	 * @spec exclude Vue setup() exposing stores to the template; framework plumbing.
+	 */
 	setup() {
 		return { configurationStore, navigationStore }
 	},
@@ -75,6 +78,9 @@ export default {
 			this.loading = false
 			this.error = null
 		},
+		/**
+		 * @spec exclude Delete-confirm handler delegating to configurationStore.deleteConfiguration; entity mutation lives in the store, this is modal orchestration plumbing.
+		 */
 		async deleteConfiguration() {
 			this.loading = true
 			this.error = null

--- a/src/modals/configuration/EditConfiguration.vue
+++ b/src/modals/configuration/EditConfiguration.vue
@@ -588,10 +588,16 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude Computed form-validity guard (title non-empty); UI validation helper.
+		 */
 		isValid() {
 			const item = configurationStore.configurationItem
 			return Boolean(item?.title?.trim())
 		},
+		/**
+		 * @spec exclude Computed static select-option list; UI presentation data.
+		 */
 		sourceTypeOptions() {
 			return [
 				{ value: 'local', label: 'Local', description: 'Manually managed configuration' },
@@ -600,6 +606,9 @@ export default {
 				{ value: 'url', label: 'URL', description: 'Configuration from any URL' },
 			]
 		},
+		/**
+		 * @spec exclude Computed static select-option list; UI presentation data.
+		 */
 		typeOptions() {
 			return [
 				{ value: 'default', label: 'Default', description: 'Standard configuration type' },
@@ -607,6 +616,9 @@ export default {
 				{ value: 'manual', label: 'Manual', description: 'Manually created configuration' },
 			]
 		},
+		/**
+		 * @spec exclude Computed static select-option list (placeholder groups); UI presentation data.
+		 */
 		notificationGroupOptions() {
 			// In a real implementation, this would fetch from Nextcloud groups API
 			// For now, return common groups
@@ -616,6 +628,9 @@ export default {
 			]
 		},
 	},
+	/**
+	 * @spec exclude Vue created() lifecycle hook — hydrates store lists and seeds a blank configurationItem; modal init plumbing.
+	 */
 	async created() {
 		// Organisations and applications are now hot-loaded at app startup
 		// Only refresh if somehow they're empty (shouldn't happen in normal flow)
@@ -689,18 +704,27 @@ export default {
 			}
 			configurationStore.configurationItem.title = value
 		},
+		/**
+		 * @spec exclude Reactive form-field setter binding input to configurationStore.configurationItem; UI plumbing.
+		 */
 		updateDescription(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
 			}
 			configurationStore.configurationItem.description = value
 		},
+		/**
+		 * @spec exclude Reactive form-field setter binding input to configurationStore.configurationItem; UI plumbing.
+		 */
 		updateVersion(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
 			}
 			configurationStore.configurationItem.version = value
 		},
+		/**
+		 * @spec exclude Reactive form-field setter binding select value to configurationStore.configurationItem; UI plumbing.
+		 */
 		updateType(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
@@ -708,12 +732,18 @@ export default {
 			configurationStore.configurationItem.type = value ? value.value : 'default'
 			this.selectedType = value
 		},
+		/**
+		 * @spec exclude Reactive form-field setter binding input to configurationStore.configurationItem; UI plumbing.
+		 */
 		updateApp(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
 			}
 			configurationStore.configurationItem.app = value || ''
 		},
+		/**
+		 * @spec exclude Reactive form-field setter binding selected application to configurationStore.configurationItem; UI plumbing.
+		 */
 		updateApplication(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
@@ -722,6 +752,9 @@ export default {
 			configurationStore.configurationItem.application = value ? value.uuid : ''
 			this.selectedApplication = value
 		},
+		/**
+		 * @spec exclude Reactive multi-select setter mapping selected registers to IDs on configurationItem; UI plumbing.
+		 */
 		updateRegisters(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
@@ -730,6 +763,9 @@ export default {
 			configurationStore.configurationItem.registers = value.map(r => parseInt(r.id))
 			this.selectedRegisters = value
 		},
+		/**
+		 * @spec exclude Reactive multi-select setter mapping selected schemas to IDs on configurationItem; UI plumbing.
+		 */
 		updateSchemas(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
@@ -738,6 +774,9 @@ export default {
 			configurationStore.configurationItem.schemas = value.map(s => parseInt(s.id))
 			this.selectedSchemas = value
 		},
+		/**
+		 * @spec exclude Reactive multi-select setter mapping selected objects to IDs on configurationItem; UI plumbing.
+		 */
 		updateObjects(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
@@ -746,6 +785,9 @@ export default {
 			configurationStore.configurationItem.objects = value.map(o => parseInt(o.id))
 			this.selectedObjects = value
 		},
+		/**
+		 * @spec exclude Reactive multi-select setter mapping selected sources to IDs on configurationItem; UI plumbing.
+		 */
 		updateSources(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
@@ -754,6 +796,9 @@ export default {
 			configurationStore.configurationItem.sources = value.map(s => parseInt(s.id))
 			this.selectedSources = value
 		},
+		/**
+		 * @spec exclude Reactive multi-select setter mapping selected agents to IDs on configurationItem; UI plumbing.
+		 */
 		updateAgents(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
@@ -762,6 +807,9 @@ export default {
 			configurationStore.configurationItem.agents = value.map(a => parseInt(a.id))
 			this.selectedAgents = value
 		},
+		/**
+		 * @spec exclude Reactive multi-select setter mapping selected views to IDs on configurationItem; UI plumbing.
+		 */
 		updateViews(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
@@ -770,6 +818,9 @@ export default {
 			configurationStore.configurationItem.views = value.map(v => parseInt(v.id))
 			this.selectedViews = value
 		},
+		/**
+		 * @spec exclude Reactive multi-select setter mapping managed applications to IDs on configurationItem; UI plumbing.
+		 */
 		updateManagedApplications(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
@@ -779,6 +830,9 @@ export default {
 			this.selectedManagedApplications = value
 		},
 		// Management tab update methods
+		/**
+		 * @spec exclude Reactive form-field setter binding source-type select to configurationItem; UI plumbing.
+		 */
 		updateSourceType(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
@@ -786,24 +840,36 @@ export default {
 			configurationStore.configurationItem.sourceType = value ? value.value : 'local'
 			this.selectedSourceType = value
 		},
+		/**
+		 * @spec exclude Reactive form-field setter binding input to configurationItem; UI plumbing.
+		 */
 		updateSourceUrl(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
 			}
 			configurationStore.configurationItem.sourceUrl = value
 		},
+		/**
+		 * @spec exclude Reactive form-field setter binding input to configurationItem; UI plumbing.
+		 */
 		updateLocalVersion(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
 			}
 			configurationStore.configurationItem.localVersion = value
 		},
+		/**
+		 * @spec exclude Reactive form-field setter binding toggle to configurationItem; UI plumbing.
+		 */
 		updateAutoUpdate(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
 			}
 			configurationStore.configurationItem.autoUpdate = value
 		},
+		/**
+		 * @spec exclude Reactive multi-select setter mapping notification groups to values on configurationItem; UI plumbing.
+		 */
 		updateNotificationGroups(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
@@ -811,24 +877,36 @@ export default {
 			configurationStore.configurationItem.notificationGroups = value.map(g => g.value)
 			this.selectedNotificationGroups = value
 		},
+		/**
+		 * @spec exclude Reactive form-field setter binding input to configurationItem; UI plumbing.
+		 */
 		updateGithubRepo(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
 			}
 			configurationStore.configurationItem.githubRepo = value
 		},
+		/**
+		 * @spec exclude Reactive form-field setter binding input to configurationItem; UI plumbing.
+		 */
 		updateGithubBranch(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
 			}
 			configurationStore.configurationItem.githubBranch = value
 		},
+		/**
+		 * @spec exclude Reactive form-field setter binding input to configurationItem; UI plumbing.
+		 */
 		updateGithubPath(value) {
 			if (!configurationStore.configurationItem) {
 				configurationStore.configurationItem = {}
 			}
 			configurationStore.configurationItem.githubPath = value
 		},
+		/**
+		 * @spec exclude Hydrates local select-model refs from an existing configurationItem on edit-open; modal init plumbing.
+		 */
 		async loadExistingSelections() {
 			const item = configurationStore.configurationItem
 			if (item) {
@@ -968,6 +1046,9 @@ export default {
 			}
 		},
 		// Search methods with debouncing
+		/**
+		 * @spec exclude Debounced autocomplete fetch populating select options; UI search plumbing.
+		 */
 		searchRegisters(query) {
 			clearTimeout(this.registerSearchDebounce)
 			this.registerSearchDebounce = setTimeout(async () => {
@@ -990,6 +1071,9 @@ export default {
 				}
 			}, 300)
 		},
+		/**
+		 * @spec exclude Debounced autocomplete fetch populating select options; UI search plumbing.
+		 */
 		searchSchemas(query) {
 			clearTimeout(this.schemaSearchDebounce)
 			this.schemaSearchDebounce = setTimeout(async () => {
@@ -1012,6 +1096,9 @@ export default {
 				}
 			}, 300)
 		},
+		/**
+		 * @spec exclude Debounced autocomplete fetch (register/schema-filtered) populating select options; UI search plumbing.
+		 */
 		searchObjects(query) {
 			clearTimeout(this.objectSearchDebounce)
 			this.objectSearchDebounce = setTimeout(async () => {
@@ -1053,6 +1140,9 @@ export default {
 				}
 			}, 300)
 		},
+		/**
+		 * @spec exclude Debounced autocomplete fetch populating select options; UI search plumbing.
+		 */
 		searchSources(query) {
 			clearTimeout(this.sourceSearchDebounce)
 			this.sourceSearchDebounce = setTimeout(async () => {
@@ -1075,6 +1165,9 @@ export default {
 				}
 			}, 300)
 		},
+		/**
+		 * @spec exclude Debounced autocomplete fetch populating select options; UI search plumbing.
+		 */
 		searchAgents(query) {
 			clearTimeout(this.agentSearchDebounce)
 			this.agentSearchDebounce = setTimeout(async () => {
@@ -1097,6 +1190,9 @@ export default {
 				}
 			}, 300)
 		},
+		/**
+		 * @spec exclude Debounced autocomplete fetch populating select options; UI search plumbing.
+		 */
 		searchViews(query) {
 			clearTimeout(this.viewSearchDebounce)
 			this.viewSearchDebounce = setTimeout(async () => {
@@ -1119,6 +1215,9 @@ export default {
 				}
 			}, 300)
 		},
+		/**
+		 * @spec exclude Debounced autocomplete fetch populating select options; UI search plumbing.
+		 */
 		searchApplications(query) {
 			clearTimeout(this.applicationSearchDebounce)
 			this.applicationSearchDebounce = setTimeout(async () => {
@@ -1141,9 +1240,15 @@ export default {
 				}
 			}, 300)
 		},
+		/**
+		 * @spec exclude Dialog close-event passthrough to closeModal; UI plumbing.
+		 */
 		handleDialogClose() {
 			this.closeModal()
 		},
+		/**
+		 * @spec exclude Modal close handler resetting navigationStore.modal and local select-model refs; UI plumbing.
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 			this.loading = false
@@ -1156,6 +1261,9 @@ export default {
 			this.selectedViews = []
 			this.selectedApplication = null
 		},
+		/**
+		 * @spec exclude Save-button handler delegating to configurationStore.saveConfiguration; entity persistence lives in the store, this is modal orchestration plumbing.
+		 */
 		async saveConfiguration() {
 			this.loading = true
 			this.error = null

--- a/src/modals/configuration/ImportConfiguration.vue
+++ b/src/modals/configuration/ImportConfiguration.vue
@@ -404,15 +404,24 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude Computed deep-link to the admin api-tokens settings page; UI presentation helper.
+		 */
 		settingsUrl() {
 			return window.location.origin + '/index.php/settings/admin/openregister#api-tokens'
 		},
+		/**
+		 * @spec exclude Computed form-enablement guard for the fetch-branches button; UI validation helper.
+		 */
 		canFetchBranches() {
 			if (this.repoSource === 'GitHub') {
 				return this.repoOwner && this.repoName
 			}
 			return this.repoNamespace && this.repoName
 		},
+		/**
+		 * @spec exclude Computed per-tab form-enablement guard for the import button; UI validation helper.
+		 */
 		canImport() {
 		// Tab 0: Discover (imports are handled per-card, not via main button)
 		// Tab 1: GitHub/GitLab
@@ -437,6 +446,8 @@ export default {
 	methods: {
 		/**
 		 * Check if API tokens are configured
+		 *
+		 * @spec exclude On-mount fetch of masked api-token presence to toggle UI warnings; modal init plumbing.
 		 */
 		async checkTokenAvailability() {
 			try {
@@ -459,6 +470,7 @@ export default {
 		 * Get token warning title based on which tokens are missing
 		 *
 		 * @return {string}
+		 * @spec exclude Computes a warning-banner title string from token-presence flags; UI presentation helper.
 		 */
 		getTokenWarningTitle() {
 			if (!this.hasGithubToken && !this.hasGitlabToken) {
@@ -474,6 +486,7 @@ export default {
 		 * Get token warning message based on which tokens are missing
 		 *
 		 * @return {string}
+		 * @spec exclude Computes a warning-banner message string from token-presence flags; UI presentation helper.
 		 */
 		getTokenWarningMessage() {
 			if (!this.hasGithubToken && !this.hasGitlabToken) {
@@ -485,10 +498,16 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude Modal close handler resetting navigationStore.modal and form state; UI plumbing.
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 			this.resetForm()
 		},
+		/**
+		 * @spec exclude Resets all local form/search/upload state to defaults; UI plumbing.
+		 */
 		resetForm() {
 			this.loading = false
 			this.success = false
@@ -513,6 +532,9 @@ export default {
 			this.syncEnabled = true
 			this.syncInterval = 24
 		},
+		/**
+		 * @spec exclude Discover-tab search handler delegating to configurationStore.discoverConfigurations; UI search plumbing.
+		 */
 		async searchConfigurations() {
 			this.searchLoading = true
 			this.hasSearched = true
@@ -535,6 +557,9 @@ export default {
 				this.searchLoading = false
 			}
 		},
+		/**
+		 * @spec exclude Per-card import handler dispatching to configurationStore.importFromGitHub/GitLab and refreshing lists; UI orchestration plumbing.
+		 */
 		async importDiscoveredConfiguration(result) {
 			this.loading = true
 			this.error = null
@@ -589,6 +614,9 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude Fetches repo branches via configurationStore.getBranches to populate the branch select; UI form-loading plumbing.
+		 */
 		async fetchBranches() {
 			this.loading = true
 			this.error = null
@@ -620,6 +648,9 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude Fetches config files for the selected branch via configurationStore.getConfigurationFiles; UI form-loading plumbing.
+		 */
 		async fetchConfigurationFiles() {
 			if (!this.selectedBranch) return
 
@@ -643,6 +674,9 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude Main import-button handler dispatching per-tab to configurationStore import actions and refreshing lists; UI orchestration plumbing.
+		 */
 		async performImport() {
 			this.loading = true
 			this.error = null
@@ -716,12 +750,18 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude File-input change handler passing the picked file to validateAndSetFile; UI file-picker plumbing.
+		 */
 		handleFileSelect(event) {
 			const file = event.target.files[0]
 			if (file) {
 				this.validateAndSetFile(file)
 			}
 		},
+		/**
+		 * @spec exclude Drag-drop handler passing the dropped file to validateAndSetFile; UI file-picker plumbing.
+		 */
 		handleFileDrop(event) {
 			this.isDragging = false
 			const file = event.dataTransfer.files[0]
@@ -729,6 +769,9 @@ export default {
 				this.validateAndSetFile(file)
 			}
 		},
+		/**
+		 * @spec exclude Client-side JSON-type/size validation before accepting an upload file; UI validation helper.
+		 */
 		validateAndSetFile(file) {
 			this.fileError = null
 
@@ -746,6 +789,9 @@ export default {
 
 			this.selectedUploadFile = file
 		},
+		/**
+		 * @spec exclude Clears the selected upload file and resets the file input; UI file-picker plumbing.
+		 */
 		clearFileSelection() {
 			this.selectedUploadFile = null
 			this.fileError = null
@@ -753,11 +799,17 @@ export default {
 				this.$refs.fileInput.value = ''
 			}
 		},
+		/**
+		 * @spec exclude Human-readable byte-size formatter for the file display; UI presentation helper.
+		 */
 		formatFileSize(bytes) {
 			if (bytes < 1024) return bytes + ' B'
 			if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB'
 			return (bytes / (1024 * 1024)).toFixed(1) + ' MB'
 		},
+		/**
+		 * @spec exclude Uploads the selected JSON file to the configurations/import endpoint; modal-local import call, list refresh handled by performImport.
+		 */
 		async importFromFile() {
 			const formData = new FormData()
 			formData.append('file', this.selectedUploadFile)
@@ -780,6 +832,9 @@ export default {
 
 			return response.data
 		},
+		/**
+		 * @spec exclude Triggers the configurations check-version endpoint and surfaces update toasts; UI orchestration plumbing.
+		 */
 		async handleCheckVersion(configuration) {
 			// Handle check version for already imported configurations
 			try {

--- a/src/modals/configuration/PreviewConfiguration.vue
+++ b/src/modals/configuration/PreviewConfiguration.vue
@@ -283,11 +283,17 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude Computed boolean true when any preview item is selected; UI state helper.
+		 */
 		hasSelection() {
 			return this.selectedRegisters.length > 0
 				   || this.selectedSchemas.length > 0
 				   || this.selectedObjects.length > 0
 		},
+		/**
+		 * @spec exclude Computed total count of selected preview items; UI state helper.
+		 */
 		selectionCount() {
 			return this.selectedRegisters.length
 				   + this.selectedSchemas.length
@@ -333,10 +339,16 @@ export default {
 		isSchemaSelected(slug) {
 			return this.selectedSchemas.includes(slug)
 		},
+		/**
+		 * @spec exclude Checkbox-state predicate for an object row in the preview list; UI state helper.
+		 */
 		isObjectSelected(change) {
 			const objectId = `${change.register}:${change.schema}:${change.slug}`
 			return this.selectedObjects.includes(objectId)
 		},
+		/**
+		 * @spec exclude Toggles a register slug in/out of the selection set; UI selection plumbing.
+		 */
 		toggleRegisterSelection(slug, checked) {
 			if (checked) {
 				if (!this.selectedRegisters.includes(slug)) {
@@ -346,6 +358,9 @@ export default {
 				this.selectedRegisters = this.selectedRegisters.filter(s => s !== slug)
 			}
 		},
+		/**
+		 * @spec exclude Toggles a schema slug in/out of the selection set; UI selection plumbing.
+		 */
 		toggleSchemaSelection(slug, checked) {
 			if (checked) {
 				if (!this.selectedSchemas.includes(slug)) {
@@ -355,6 +370,9 @@ export default {
 				this.selectedSchemas = this.selectedSchemas.filter(s => s !== slug)
 			}
 		},
+		/**
+		 * @spec exclude Toggles an object id in/out of the selection set; UI selection plumbing.
+		 */
 		toggleObjectSelection(change, checked) {
 			const objectId = `${change.register}:${change.schema}:${change.slug}`
 			if (checked) {
@@ -365,6 +383,9 @@ export default {
 				this.selectedObjects = this.selectedObjects.filter(id => id !== objectId)
 			}
 		},
+		/**
+		 * @spec exclude Selects all non-skip preview items; UI bulk-selection plumbing.
+		 */
 		selectAll() {
 			// Select all registers
 			if (this.preview.registers) {
@@ -385,16 +406,25 @@ export default {
 					.map(o => `${o.register}:${o.schema}:${o.slug}`)
 			}
 		},
+		/**
+		 * @spec exclude Clears all preview selections; UI bulk-selection plumbing.
+		 */
 		deselectAll() {
 			this.selectedRegisters = []
 			this.selectedSchemas = []
 			this.selectedObjects = []
 		},
+		/**
+		 * @spec exclude Truncating/stringifying value formatter for the preview table; UI presentation helper.
+		 */
 		formatValue(value) {
 			if (value === null || value === undefined) return '-'
 			if (typeof value === 'object') return JSON.stringify(value).substring(0, 50) + '...'
 			return String(value).substring(0, 50)
 		},
+		/**
+		 * @spec exclude Posts the selected preview subset to the configurations/import endpoint and refreshes the list; UI orchestration plumbing.
+		 */
 		async importSelected() {
 			const configuration = configurationStore.configurationItem
 			if (!configuration || !configuration.id) {
@@ -442,9 +472,15 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude Dialog close-event passthrough to closeModal; UI plumbing.
+		 */
 		handleDialogClose() {
 			this.closeModal()
 		},
+		/**
+		 * @spec exclude Modal close handler resetting navigationStore.modal and preview/selection state; UI plumbing.
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 			this.loading = false

--- a/src/modals/deleted/PurgeMultiple.vue
+++ b/src/modals/deleted/PurgeMultiple.vue
@@ -115,6 +115,9 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude Computed passthrough exposing the selected-objects list to the template; UI state helper.
+		 */
 		objectsToDelete() {
 			return this.selectedObjects
 		},
@@ -146,6 +149,7 @@ export default {
 		 * Remove object from selection
 		 * @param {string} objectId - ID of object to remove
 		 * @return {void}
+		 * @spec exclude Removes one object from the local bulk-selection list; UI selection plumbing.
 		 */
 		removeObject(objectId) {
 			this.selectedObjects = this.selectedObjects.filter(obj => obj.id !== objectId)
@@ -156,6 +160,7 @@ export default {
 		/**
 		 * Close the dialog and reset state
 		 * @return {void}
+		 * @spec exclude Modal close handler resetting navigationStore.dialog and local state; UI plumbing.
 		 */
 		closeDialog() {
 			navigationStore.setDialog(false)
@@ -170,6 +175,7 @@ export default {
 		/**
 		 * Permanently delete multiple objects
 		 * @return {Promise<void>}
+		 * @spec exclude Bulk-purge confirm handler delegating to deletedStore.permanentlyDeleteMultiple; entity mutation lives in the store, this is modal orchestration plumbing.
 		 */
 		async permanentlyDeleteMultiple() {
 			if (!this.objectsToDelete || this.objectsToDelete.length === 0) {

--- a/src/modals/deleted/RestoreMultiple.vue
+++ b/src/modals/deleted/RestoreMultiple.vue
@@ -115,6 +115,9 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude Computed passthrough exposing the selected-objects list to the template; UI state helper.
+		 */
 		objectsToRestore() {
 			return this.selectedObjects
 		},
@@ -146,6 +149,7 @@ export default {
 		 * Remove object from selection
 		 * @param {string} objectId - ID of object to remove
 		 * @return {void}
+		 * @spec exclude Removes one object from the local bulk-selection list; UI selection plumbing.
 		 */
 		removeObject(objectId) {
 			this.selectedObjects = this.selectedObjects.filter(obj => obj.id !== objectId)
@@ -156,6 +160,7 @@ export default {
 		/**
 		 * Close the dialog and reset state
 		 * @return {void}
+		 * @spec exclude Modal close handler resetting navigationStore.dialog and local state; UI plumbing.
 		 */
 		closeDialog() {
 			navigationStore.setDialog(false)
@@ -170,6 +175,7 @@ export default {
 		/**
 		 * Restore multiple objects
 		 * @return {Promise<void>}
+		 * @spec exclude Bulk-restore confirm handler delegating to deletedStore.restoreMultiple; entity mutation lives in the store, this is modal orchestration plumbing.
 		 */
 		async restoreMultiple() {
 			if (!this.objectsToRestore || this.objectsToRestore.length === 0) {

--- a/src/modals/file/UploadFiles.vue
+++ b/src/modals/file/UploadFiles.vue
@@ -318,26 +318,44 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude Computed passthrough exposing objectStore.objectItem to the template; UI state helper.
+		 */
 		objectItem() {
 			return objectStore.objectItem
 		},
+		/**
+		 * @spec exclude Computed register-id extraction from the object's @self metadata; UI state helper.
+		 */
 		registerId() {
 			const register = this.objectItem?.['@self']?.register
 			return typeof register === 'object' && register !== null ? register.id : register
 		},
+		/**
+		 * @spec exclude Computed schema-id extraction from the object's @self metadata; UI state helper.
+		 */
 		schemaId() {
 			const schema = this.objectItem?.['@self']?.schema
 			return typeof schema === 'object' && schema !== null ? schema.id : schema
 		},
+		/**
+		 * @spec exclude Computed object-id extraction from the object's @self metadata; UI state helper.
+		 */
 		objectId() {
 			return this.objectItem?.['@self']?.id || this.objectItem?.id
 		},
+		/**
+		 * @spec exclude Computed passthrough exposing the upload-queue ref to the template; UI state helper.
+		 */
 		filesComputed() {
 			return files.value
 		},
 	},
 	watch: {
 		filesComputed: {
+			/**
+			 * @spec exclude Watcher auto-triggering upload when files are queued; UI reactivity plumbing.
+			 */
 			handler(newFiles, _oldFiles) {
 				if (newFiles?.length) {
 					this.addAttachments()
@@ -356,12 +374,18 @@ export default {
 		this.getAllTags()
 	},
 	methods: {
+		/**
+		 * @spec exclude Modal close handler resetting upload state and navigationStore.modal; UI plumbing.
+		 */
 		closeModal() {
 			this.success = null
 			this.error = null
 			reset()
 			navigationStore.setModal(false)
 		},
+		/**
+		 * @spec exclude Human-readable byte-size formatter for file display; UI presentation helper.
+		 */
 		bytesToSize(bytes) {
 			const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB']
 			if (bytes === 0) return 'n/a'
@@ -371,6 +395,9 @@ export default {
 			return (bytes / Math.pow(1024, i)).toFixed(1) + ' ' + sizes[i]
 		},
 
+		/**
+		 * @spec exclude Splits a filename into name + extension for display; UI presentation helper.
+		 */
 		getFileNameAndExtension(fullname) {
 			const lastDot = fullname.lastIndexOf('.')
 			const name = fullname.slice(0, lastDot)
@@ -378,6 +405,9 @@ export default {
 			return { name, extension }
 		},
 
+		/**
+		 * @spec exclude Flags over-size files in the queue with a status; UI validation helper.
+		 */
 		checkForTooBigFiles(files) {
 			if (!files) return false
 			const wrongFiles = files.filter(file => {
@@ -395,6 +425,9 @@ export default {
 			return size > 536870480 // 512MB
 		},
 
+		/**
+		 * @spec exclude Mutual-exclusion guard for the tag multiselect ("No label" vs real tags); UI selection helper.
+		 */
 		isSelectable(option) {
 			if (this.labelOptions.value?.includes(t('openregister', 'No label')) && option !== t('openregister', 'No label')) {
 				return false
@@ -405,6 +438,9 @@ export default {
 			return true
 		},
 
+		/**
+		 * @spec exclude Maps the "No label" sentinel to null for the tag value; UI selection helper.
+		 */
 		getLabels() {
 			if (this.labelOptions.value?.includes(t('openregister', 'No label'))) {
 				return null
@@ -413,6 +449,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude Loads available tags via objectStore.fetchTags to populate the label multiselect; UI form-loading plumbing.
+		 */
 		getAllTags() {
 			this.tagsLoading = true
 			// @TODO - this functionality always calls and therefore always has to wait.
@@ -439,6 +478,7 @@ export default {
 		/**
 		 * Opens the folder URL in a new tab after parsing the encoded URL and converting to Nextcloud format
 		 * @param {string} url - The encoded folder URL to open (e.g. "Open Registers\/Publicatie Register\/Publicatie\/123")
+		 * @spec exclude Opens the Files app at the object's folder in a new tab; UI navigation helper.
 		 */
 		 openFolder(url) {
 			// Parse the encoded URL by replacing escaped characters
@@ -455,6 +495,9 @@ export default {
 			window.open(nextcloudUrl, '_blank')
 		},
 
+		/**
+		 * @spec exclude Applies edited tags to a queued file and re-triggers upload; UI selection plumbing.
+		 */
 		saveTags(file, editedTags) {
 			file.tags = editedTags
 			file.status = 'pending'
@@ -464,17 +507,26 @@ export default {
 			this.editedTags = []
 		},
 
+		/**
+		 * @spec exclude Removes a file from the upload queue; UI file-picker plumbing.
+		 */
 		removeFile(fileName) {
 			reset(fileName)
 			if (this.editingTags === fileName) {
 				this.editingTags = null
 			}
 		},
+		/**
+		 * @spec exclude Computed-style enablement guard for the upload action; UI state helper.
+		 */
 		checkIfDisabled() {
 			if (this.objectStore.objectItem.downloadUrl || this.objectStore.objectItem.title) return true
 			return false
 		},
 
+		/**
+		 * @spec exclude Uploads queued attachments to the object via objectStore; entity-file persistence lives in the store, this is modal orchestration plumbing.
+		 */
 		async addAttachments(specificFile = null) {
 			if (!this.registerId || !this.schemaId || !this.objectId) {
 				this.error = 'Missing object context'

--- a/src/modals/object/DownloadObject.vue
+++ b/src/modals/object/DownloadObject.vue
@@ -76,6 +76,9 @@ export default {
 			closeModalTimeout: null,
 		}
 	},
+	/**
+	 * @spec exclude Vue mounted() hook auto-starting the download when an object is set; modal init plumbing.
+	 */
 	mounted() {
 		if (objectStore.objectItem?.id) {
 			this.downloadObject()
@@ -95,6 +98,9 @@ export default {
 			this.loading = false
 			this.error = false
 		},
+		/**
+		 * @spec exclude Download handler delegating to objectStore.downloadObject; entity export lives in the store, this is modal orchestration plumbing.
+		 */
 		async downloadObject() {
 			this.loading = true
 

--- a/src/modals/object/LockObject.vue
+++ b/src/modals/object/LockObject.vue
@@ -97,6 +97,9 @@ export default {
 			this.process = ''
 			this.duration = 3600
 		},
+		/**
+		 * @spec exclude Lock-confirm handler delegating to objectStore.lockObject; entity lock lives in the store, this is modal orchestration plumbing.
+		 */
 		async lockObject() {
 			this.loading = true
 

--- a/src/modals/object/MergeObject.vue
+++ b/src/modals/object/MergeObject.vue
@@ -512,9 +512,15 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude Computed passthrough exposing objectStore.objectItem as the merge source; UI state helper.
+		 */
 		sourceObject() {
 			return objectStore.objectItem
 		},
+		/**
+		 * @spec exclude Computed union of source+target property keys for the merge UI; UI presentation helper.
+		 */
 		mergeableProperties() {
 			if (!this.sourceObject || !this.selectedTargetObject) {
 				return []
@@ -525,6 +531,9 @@ export default {
 
 			return [...new Set([...sourceProps, ...targetProps])]
 		},
+		/**
+		 * @spec exclude Computed enablement guard for the merge button; UI validation helper.
+		 */
 		canMerge() {
 			return Object.keys(this.mergedData).length > 0
 		},
@@ -533,6 +542,9 @@ export default {
 		this.initializeMerge()
 	},
 	methods: {
+		/**
+		 * @spec exclude Wizard bootstrap loading source data and candidate targets on open; modal init plumbing.
+		 */
 		initializeMerge() {
 			if (!this.sourceObject) {
 				this.closeModal()
@@ -541,6 +553,9 @@ export default {
 			this.loadSourceData()
 			this.searchObjects()
 		},
+		/**
+		 * @spec exclude Fetches candidate merge-target objects (excluding the source); UI search plumbing.
+		 */
 		async searchObjects() {
 			if (!registerStore.registerItem || !schemaStore.schemaItem) {
 				return
@@ -560,20 +575,32 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude Records the chosen merge target in local state; UI selection plumbing.
+		 */
 		selectTargetObject(obj) {
 			this.selectedTargetObject = obj
 		},
+		/**
+		 * @spec exclude Wizard forward-navigation guard advancing to the merge step; UI step plumbing.
+		 */
 		nextStep() {
 			if (this.step === 1 && this.selectedTargetObject) {
 				this.step = 2
 				this.initializeMergeData()
 			}
 		},
+		/**
+		 * @spec exclude Wizard back-navigation to the target-selection step; UI step plumbing.
+		 */
 		previousStep() {
 			if (this.step === 2) {
 				this.step = 1
 			}
 		},
+		/**
+		 * @spec exclude Seeds per-property merge defaults and dropdown selections; UI form-init plumbing.
+		 */
 		initializeMergeData() {
 			// Initialize merge data with default values
 			this.mergedData = {}
@@ -616,6 +643,9 @@ export default {
 			// eslint-disable-next-line no-console
 			console.log('Initial propertySelections after setup:', this.propertySelections)
 		},
+		/**
+		 * @spec exclude Builds the source/target/custom option list for a property dropdown; UI presentation helper.
+		 */
 		getMergeOptions(property) {
 			const options = []
 
@@ -642,6 +672,9 @@ export default {
 			return options
 		},
 
+		/**
+		 * @spec exclude Updates merged-data state when a per-property dropdown changes; UI reactivity plumbing.
+		 */
 		onPropertySelectionChange(property, selectedOption) {
 			// eslint-disable-next-line no-console
 			console.log('Property selection change:', property, selectedOption)
@@ -658,6 +691,9 @@ export default {
 				}
 			}
 		},
+		/**
+		 * @spec exclude Stringifying/truncating value formatter for property display; UI presentation helper.
+		 */
 		displayValue(value, maxLength = 100) {
 			if (value === null || value === undefined) {
 				return 'N/A'
@@ -677,11 +713,17 @@ export default {
 
 			return displayText
 		},
+		/**
+		 * @spec exclude Simple string-truncation helper for display; UI presentation helper.
+		 */
 		truncateText(text, maxLength) {
 			if (!text) return ''
 			if (text.length <= maxLength) return text
 			return text.substring(0, maxLength) + '...'
 		},
+		/**
+		 * @spec exclude Merge-confirm handler delegating to objectStore.mergeObjects; entity merge lives in the store, this is modal orchestration plumbing.
+		 */
 		async performMerge() {
 			if (!this.canMerge) {
 				return
@@ -744,6 +786,9 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude Navigates to the merged object's view modal; UI navigation plumbing.
+		 */
 		viewMergedObject() {
 			// Navigate to the merged object in view mode
 			if (this.selectedTargetObject) {
@@ -751,21 +796,36 @@ export default {
 				navigationStore.setModal('viewObject')
 			}
 		},
+		/**
+		 * @spec exclude Toggles the files-list disclosure; UI presentation plumbing.
+		 */
 		toggleFileList() {
 			this.showFileList = !this.showFileList
 		},
+		/**
+		 * @spec exclude Toggles the relations-list disclosure; UI presentation plumbing.
+		 */
 		toggleRelationList() {
 			this.showRelationList = !this.showRelationList
 		},
+		/**
+		 * @spec exclude Toggles the references-list disclosure; UI presentation plumbing.
+		 */
 		toggleReferenceList() {
 			this.showReferenceList = !this.showReferenceList
 		},
+		/**
+		 * @spec exclude Human-readable byte-size formatter for file display; UI presentation helper.
+		 */
 		formatFileSize(bytes) {
 			if (!bytes) return 'N/A'
 			const sizes = ['Bytes', 'KB', 'MB', 'GB']
 			const i = Math.floor(Math.log(bytes) / Math.log(1024))
 			return Math.round(bytes / Math.pow(1024, i) * 100) / 100 + ' ' + sizes[i]
 		},
+		/**
+		 * @spec exclude Maps a filename extension to a friendly type label; UI presentation helper.
+		 */
 		getFileType(filename) {
 			if (!filename) return 'Unknown'
 			const ext = filename.split('.').pop()?.toLowerCase()
@@ -787,6 +847,9 @@ export default {
 			}
 			return types[ext] || ext?.toUpperCase() || 'Unknown'
 		},
+		/**
+		 * @spec exclude Loads the source object's files/relations/references for the merge preview; UI form-loading plumbing.
+		 */
 		async loadSourceData() {
 			// Load files, outgoing relations, and incoming references for the source object
 			if (!this.sourceObject) return
@@ -837,6 +900,9 @@ export default {
 				this.sourceIncomingReferences = []
 			}
 		},
+		/**
+		 * @spec exclude Modal close handler resetting navigationStore.modal; UI plumbing.
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 		},

--- a/src/modals/object/MigrationObject.vue
+++ b/src/modals/object/MigrationObject.vue
@@ -378,6 +378,9 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude Computed dropdown options from target-schema properties; UI presentation helper.
+		 */
 		targetPropertyOptions() {
 			const options = this.targetProperties.map(prop => ({
 				label: `${prop.name} (${prop.type})`,
@@ -391,6 +394,9 @@ export default {
 
 			return options
 		},
+		/**
+		 * @spec exclude Computed enablement guard for the migrate button; UI validation helper.
+		 */
 		canMigrate() {
 			// Check if we have target register/schema and at least one property mapping
 			const hasValidMappings = Object.values(this.uiMappings).some(option => option && option.value)
@@ -413,6 +419,9 @@ export default {
 			}
 			this.loadAvailableRegisters()
 		},
+		/**
+		 * @spec exclude Fetches registers to populate the target-register select; UI form-loading plumbing.
+		 */
 		async loadAvailableRegisters() {
 			this.loading = true
 			try {
@@ -426,6 +435,9 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude Reloads target schemas when the register select changes; UI reactivity plumbing.
+		 */
 		async onRegisterChange() {
 			if (!this.targetRegister) {
 				this.availableSchemas = []
@@ -445,18 +457,27 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude Loads schema properties when the target-schema select changes; UI reactivity plumbing.
+		 */
 		async onSchemaChange() {
 			if (!this.targetSchema) {
 				return
 			}
 			await this.loadSchemaProperties()
 		},
+		/**
+		 * @spec exclude Removes one object from the local migration selection; UI selection plumbing.
+		 */
 		removeObject(objectId) {
 			this.selectedObjects = this.selectedObjects.filter(obj => obj.id !== objectId)
 			if (this.selectedObjects.length === 0) {
 				this.closeModal()
 			}
 		},
+		/**
+		 * @spec exclude Wizard forward-navigation guard across migration steps; UI step plumbing.
+		 */
 		nextStep() {
 			if (this.step === 1 && this.selectedObjects.length > 0) {
 				this.step = 2
@@ -464,11 +485,17 @@ export default {
 				this.step = 3
 			}
 		},
+		/**
+		 * @spec exclude Wizard back-navigation across migration steps; UI step plumbing.
+		 */
 		previousStep() {
 			if (this.step > 1) {
 				this.step--
 			}
 		},
+		/**
+		 * @spec exclude Loads source+target schema properties and seeds mappings; UI form-loading plumbing.
+		 */
 		async loadSchemaProperties() {
 			if (!schemaStore.schemaItem || !this.targetSchema) {
 				return
@@ -492,6 +519,9 @@ export default {
 				console.error('Error loading schema properties:', error)
 			}
 		},
+		/**
+		 * @spec exclude Flattens a schema definition into a name/type/required list; UI presentation helper.
+		 */
 		extractSchemaProperties(schema) {
 			// Extract properties from schema definition
 			const properties = []
@@ -506,6 +536,9 @@ export default {
 			}
 			return properties
 		},
+		/**
+		 * @spec exclude Auto-maps same-named source/target properties on load; UI form-init plumbing.
+		 */
 		initializePropertyMappings() {
 			this.mapping = {}
 			this.uiMappings = {}
@@ -527,6 +560,9 @@ export default {
 				}
 			})
 		},
+		/**
+		 * @spec exclude Migrate-confirm handler posting the mapping to the /migrate endpoint and refreshing the list; UI orchestration plumbing.
+		 */
 		async performMigration() {
 			if (!this.canMigrate) {
 				return
@@ -573,13 +609,22 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude Modal close handler resetting navigationStore.modal; UI plumbing.
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 		},
+		/**
+		 * @spec exclude UI-change handler re-syncing the mapping object; UI reactivity plumbing.
+		 */
 		updateMappingFromUI(_sourceProperty) {
 			// Convert UI mappings to our simple mapping format
 			this.convertUIToMapping()
 		},
+		/**
+		 * @spec exclude Converts the UI mapping model to the API mapping shape; UI data-shape helper.
+		 */
 		convertUIToMapping() {
 			// Convert from UI format (source -> target option) to our format (target -> source)
 			this.mapping = {}
@@ -590,6 +635,9 @@ export default {
 				}
 			}
 		},
+		/**
+		 * @spec exclude Converts the API mapping shape back to the UI mapping model; UI data-shape helper.
+		 */
 		convertMappingToUI() {
 			// Convert from our format (target -> source) to UI format (source -> target option)
 			this.uiMappings = {}

--- a/src/modals/organisation/DeleteOrganisation.vue
+++ b/src/modals/organisation/DeleteOrganisation.vue
@@ -94,23 +94,38 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude Computed ownership check gating the delete UI; UI state helper.
+		 */
 		isOwner() {
 			// Check if current user is the owner of the organisation
 			const currentUser = this.getCurrentUser()
 			return organisationStore.organisationItem?.owner === currentUser
 		},
+		/**
+		 * @spec exclude Computed member-presence check for the delete warning; UI state helper.
+		 */
 		hasMembers() {
 		// Check if organisation has members (excluding the owner)
 			return (organisationStore.organisationItem?.users?.length || 0) > 1
 		},
+		/**
+		 * @spec exclude Computed member count for display; UI presentation helper.
+		 */
 		memberCount() {
 			return organisationStore.organisationItem?.users?.length || 0
 		},
+		/**
+		 * @spec exclude Computed check whether this org is the active one; UI state helper.
+		 */
 		isActiveOrganisation() {
 			// Check if this is the currently active organisation
 			return organisationStore.userStats.active
 				   && organisationStore.userStats.active.uuid === organisationStore.organisationItem?.uuid
 		},
+		/**
+		 * @spec exclude Computed delete-enablement guard combining ownership/membership/active checks; UI validation helper.
+		 */
 		canDelete() {
 			// Can only delete if:
 			// 1. Not the default organisation
@@ -131,6 +146,9 @@ export default {
 			// Implementation would depend on how you get current user
 			return 'current-user' // Placeholder
 		},
+		/**
+		 * @spec exclude Modal close handler resetting navigationStore.modal and local state; UI plumbing.
+		 */
 		closeDialog() {
 			navigationStore.setModal(false)
 			clearTimeout(this.closeModalTimeout)
@@ -138,6 +156,9 @@ export default {
 			this.loading = false
 			this.error = false
 		},
+		/**
+		 * @spec exclude Delete-confirm handler delegating to organisationStore.deleteOrganisation; entity mutation lives in the store, this is modal orchestration plumbing.
+		 */
 		async deleteOrganisation() {
 			this.loading = true
 			this.error = null

--- a/src/modals/organisation/EditOrganisation.vue
+++ b/src/modals/organisation/EditOrganisation.vue
@@ -505,10 +505,16 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude Computed byte-to-MB conversion of the storage quota for display; UI presentation helper.
+		 */
 		storageQuotaMB() {
 			if (!this.organisationItem.quota?.storage) return 0
 			return Math.round(this.organisationItem.quota.storage / (1024 * 1024))
 		},
+		/**
+		 * @spec exclude Computed byte-to-MB conversion of the bandwidth quota for display; UI presentation helper.
+		 */
 		bandwidthQuotaMB() {
 			if (!this.organisationItem.quota?.bandwidth) return 0
 			return Math.round(this.organisationItem.quota.bandwidth / (1024 * 1024))
@@ -517,6 +523,7 @@ export default {
 		 * Filter available groups to only show those assigned to the organisation
 		 *
 		 * @return {Array} Filtered array of groups
+		 * @spec exclude Computed filtered group list for the select; UI presentation helper.
 		 */
 		filteredAvailableGroups() {
 			// If no groups assigned yet, show all available groups
@@ -533,6 +540,9 @@ export default {
 	watch: {
 		// Watch for changes in the store's organisationItem (e.g., when clicking edit on different organisations)
 		'organisationStore.organisationItem': {
+			/**
+			 * @spec exclude Watcher re-initializing the form when the edited organisation changes; UI reactivity plumbing.
+			 */
 			handler(newVal, oldVal) {
 				// Only reinitialize if the UUID changed (different organisation) or went from null to something
 				if (newVal && (!oldVal || newVal.uuid !== oldVal?.uuid)) {
@@ -543,6 +553,9 @@ export default {
 			deep: true,
 		},
 	},
+	/**
+	 * @spec exclude Vue mounted() hook loading cached groups and initializing the form; modal init plumbing.
+	 */
 	mounted() {
 		// Use cached Nextcloud groups from store (preloaded on index page)
 		// If not available, they'll be loaded asynchronously
@@ -588,6 +601,7 @@ export default {
 		 *
 		 * @param {string} searchQuery - The search query entered by user
 		 * @return {void}
+		 * @spec exclude Debounced group-autocomplete search; UI search plumbing.
 		 */
 		searchGroups(searchQuery) {
 			// Clear existing debounce timer
@@ -646,6 +660,7 @@ export default {
 		 * Initialize organisation item from store
 		 *
 		 * @return {void}
+		 * @spec exclude Hydrates the local form model and selected groups/users from the store; modal init plumbing.
 		 */
 		initializeOrganisationItem() {
 			if (organisationStore.organisationItem?.uuid) {
@@ -694,6 +709,7 @@ export default {
 		 *
 		 * @param {string} userId - User ID to remove
 		 * @return {void}
+		 * @spec exclude Opens the remove-user confirmation dialog; UI selection plumbing.
 		 */
 		removeUser(userId) {
 			if (!this.organisationItem.uuid || !userId) return
@@ -706,6 +722,7 @@ export default {
 		 * Cancel user removal and close dialog
 		 *
 		 * @return {void}
+		 * @spec exclude Dismisses the remove-user confirmation dialog; UI plumbing.
 		 */
 		cancelRemoveUser() {
 			this.showRemoveUserDialog = false
@@ -716,6 +733,7 @@ export default {
 		 * Confirm and execute user removal
 		 *
 		 * @return {Promise<void>}
+		 * @spec exclude Posts the organisation leave request and refreshes the store; UI orchestration plumbing.
 		 */
 		async confirmRemoveUser() {
 			if (!this.organisationItem.uuid || !this.userToRemove) return
@@ -768,6 +786,7 @@ export default {
 		 * Get current user
 		 *
 		 * @return {string}
+		 * @spec exclude Placeholder current-user accessor; UI helper.
 		 */
 		getCurrentUser() {
 			// Implementation would depend on how you get current user
@@ -779,6 +798,7 @@ export default {
 		 *
 		 * @param {Array} groups - Selected groups
 		 * @return {void}
+		 * @spec exclude Reactive multi-select setter mapping selected groups to IDs; UI plumbing.
 		 */
 		updateGroups(groups) {
 			this.selectedGroups = groups || []
@@ -791,6 +811,7 @@ export default {
 		 *
 		 * @param {object} groupToRemove - Group to remove
 		 * @return {void}
+		 * @spec exclude Removes one group from the selection and re-syncs IDs; UI selection plumbing.
 		 */
 		removeGroup(groupToRemove) {
 			this.selectedGroups = this.selectedGroups.filter(g => g.id !== groupToRemove.id)
@@ -803,6 +824,7 @@ export default {
 		 *
 		 * @param {number} value - Quota in MB
 		 * @return {void}
+		 * @spec exclude Reactive form-field setter converting MB to bytes on the quota model; UI plumbing.
 		 */
 		updateStorageQuota(value) {
 		// Convert MB to bytes (0 = unlimited)
@@ -818,6 +840,7 @@ export default {
 		 *
 		 * @param {number} value - Quota in MB
 		 * @return {void}
+		 * @spec exclude Reactive form-field setter converting MB to bytes on the quota model; UI plumbing.
 		 */
 		updateBandwidthQuota(value) {
 		// Convert MB to bytes (0 = unlimited)
@@ -833,6 +856,7 @@ export default {
 		 *
 		 * @param {number} value - Quota value
 		 * @return {void}
+		 * @spec exclude Reactive form-field setter for the request quota; UI plumbing.
 		 */
 		updateRequestQuota(value) {
 		// 0 = unlimited
@@ -847,6 +871,7 @@ export default {
 		 *
 		 * @param {number} value - Quota value
 		 * @return {void}
+		 * @spec exclude Reactive form-field setter for the user quota; UI plumbing.
 		 */
 		updateUserQuota(value) {
 		// 0 = unlimited
@@ -861,6 +886,7 @@ export default {
 		 *
 		 * @param {number} value - Quota value
 		 * @return {void}
+		 * @spec exclude Reactive form-field setter for the group quota; UI plumbing.
 		 */
 		updateGroupQuota(value) {
 		// 0 = unlimited
@@ -874,6 +900,7 @@ export default {
 		 * Close the modal and reset state
 		 *
 		 * @return {void}
+		 * @spec exclude Modal close handler resetting navigationStore.modal/dialog and local state; UI plumbing.
 		 */
 		closeModal() {
 			this.success = false
@@ -890,6 +917,7 @@ export default {
 		 * Save the organisation
 		 *
 		 * @return {Promise<void>}
+		 * @spec exclude Save handler delegating to organisationStore.saveOrganisation and refreshing lists; entity persistence lives in the store, this is modal orchestration plumbing.
 		 */
 		async saveOrganisation() {
 			this.loading = true
@@ -964,6 +992,7 @@ export default {
 		 *
 		 * @param {boolean} isOpen - Whether the dialog is open
 		 * @return {void}
+		 * @spec exclude Dialog open/close event handler closing the modal on dismiss; UI plumbing.
 		 */
 		handleDialogOpen(isOpen) {
 			// Only close the modal if the dialog is being closed (isOpen = false)
@@ -981,6 +1010,7 @@ export default {
 		 * @param {string} payload.action - The action (create, read, update, delete)
 		 * @param {boolean} payload.hasPermission - Whether to grant or revoke permission
 		 * @return {void}
+		 * @spec exclude Reactive setter toggling a group's entity-permission entry on the local authorization model; UI form plumbing.
 		 */
 		updateEntityPermission({ entityType, groupId, action, hasPermission }) {
 			// Initialize authorization object if it doesn't exist
@@ -1016,6 +1046,7 @@ export default {
 		 * @param {string} right - The special right (object_publish, agent_use, dashboard_view, llm_use)
 		 * @param {Array} groups - Array of group objects with {id, name}
 		 * @return {void}
+		 * @spec exclude Reactive setter writing a special-right's group IDs to the local authorization model; UI form plumbing.
 		 */
 		updateSpecialRight(right, groups) {
 			// Initialize authorization if it doesn't exist
@@ -1037,6 +1068,7 @@ export default {
 		 * Initialize special rights from organization authorization
 		 *
 		 * @return {void}
+		 * @spec exclude Seeds the special-rights UI binding from the authorization model on load; modal init plumbing.
 		 */
 		initializeSpecialRights() {
 			const auth = this.organisationItem.authorization || {}

--- a/src/modals/register/ExportRegister.vue
+++ b/src/modals/register/ExportRegister.vue
@@ -85,22 +85,34 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude Computed register title for display; UI presentation helper.
+		 */
 		registerTitle() {
 			const item = registerStore.registerItem
 			return item?.title || 'Unknown'
 		},
+		/**
+		 * @spec exclude Computed schema title for display; UI presentation helper.
+		 */
 		schemaTitle() {
 			const item = schemaStore.schemaItem
 			return item?.title || 'Unknown'
 		},
 	},
 	methods: {
+		/**
+		 * @spec exclude Modal close handler resetting navigationStore.modal and form state; UI plumbing.
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 			this.loading = false
 			this.error = null
 			this.exportFormat = 'excel'
 		},
+		/**
+		 * @spec exclude Export handler triggering the objects export endpoint download; UI orchestration plumbing.
+		 */
 		async exportObjects() {
 			const register = registerStore.registerItem
 			const schema = schemaStore.schemaItem

--- a/src/modals/schema/DeleteSchemaProperty.vue
+++ b/src/modals/schema/DeleteSchemaProperty.vue
@@ -77,10 +77,16 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude Computed delete-enablement guard (no objects use the property); UI validation helper.
+		 */
 		canDelete() {
 			return this.objects.length === 0
 		},
 	},
+	/**
+	 * @spec exclude Vue updated() hook running one-time dialog init when the modal opens; modal init plumbing.
+	 */
 	updated() {
 		if (!this.isUpdated && navigationStore.modal === 'deleteSchemaProperty') {
 			this.isUpdated = true
@@ -88,6 +94,9 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec exclude Scans registers/objects for usage of the property to populate the warning list; UI form-loading plumbing.
+		 */
 		async initDialog() {
 			await registerStore.refreshRegisterList()
 			if (registerStore.registerList.length === 0) {
@@ -111,6 +120,9 @@ export default {
 				}
 			}
 		},
+		/**
+		 * @spec exclude Modal close handler resetting navigationStore.modal and local state; UI plumbing.
+		 */
 		closeModal() {
 			navigationStore.setModal(null)
 			schemaStore.setSchemaPropertyKey(null)
@@ -120,6 +132,9 @@ export default {
 			this.objects = []
 			this.isUpdated = false
 		},
+		/**
+		 * @spec exclude Delete-confirm handler removing the property and delegating to schemaStore.saveSchema; entity mutation lives in the store, this is modal orchestration plumbing.
+		 */
 		deleteProperty() {
 			this.loading = true
 

--- a/src/modals/settings/CreateConfigSetDialog.vue
+++ b/src/modals/settings/CreateConfigSetDialog.vue
@@ -67,6 +67,9 @@ export default {
 
 	watch: {
 		'navigationStore.dialog': {
+			/**
+			 * @spec exclude Debug-logging watcher on the dialog state; UI reactivity plumbing.
+			 */
 			handler(newValue) {
 				console.info('👁️ CreateConfigSetDialog - navigationStore.dialog changed to:', newValue)
 				console.info('👁️ Should show?', newValue === 'createConfigSet')
@@ -75,6 +78,9 @@ export default {
 		},
 	},
 
+	/**
+	 * @spec exclude Vue mounted() hook logging dialog state; modal init plumbing.
+	 */
 	mounted() {
 		console.info('✅ CreateConfigSetDialog mounted')
 		console.info('✅ navigationStore.dialog:', navigationStore.dialog)
@@ -90,6 +96,9 @@ export default {
 			this.creating = false
 		},
 
+		/**
+		 * @spec exclude Create-button handler posting a new Solr configset to the admin endpoint; platform-admin orchestration plumbing.
+		 */
 		async createConfigSet() {
 			if (!this.configSetName) return
 

--- a/src/modals/settings/DeleteCollectionModal.vue
+++ b/src/modals/settings/DeleteCollectionModal.vue
@@ -211,6 +211,9 @@ export default {
 	},
 
 	watch: {
+		/**
+		 * @spec exclude Watcher resetting modal state when the show prop opens; UI reactivity plumbing.
+		 */
 		show(newValue) {
 			if (newValue) {
 				// Reset state when modal is opened
@@ -266,6 +269,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude Resets the modal to the confirmation step after a failed attempt; UI plumbing.
+		 */
 		handleRetry() {
 			// Reset to confirmation state for retry
 			this.completed = false

--- a/src/modals/settings/MassValidateModal.vue
+++ b/src/modals/settings/MassValidateModal.vue
@@ -411,12 +411,18 @@ export default {
 
 	watch: {
 		config: {
+			/**
+			 * @spec exclude Watcher syncing the incoming config prop into local state; UI reactivity plumbing.
+			 */
 			handler(newConfig) {
 				this.localConfig = { ...newConfig }
 			},
 			deep: true,
 		},
 		localConfig: {
+			/**
+			 * @spec exclude Watcher emitting config changes to the parent; UI reactivity plumbing.
+			 */
 			handler(newConfig) {
 				this.$emit('config-changed', newConfig)
 			},
@@ -432,10 +438,16 @@ export default {
 			this.$emit('start-validate', this.localConfig)
 		},
 
+		/**
+		 * @spec exclude Emits a retry event to the parent; UI plumbing.
+		 */
 		retryValidation() {
 			this.$emit('retry')
 		},
 
+		/**
+		 * @spec exclude Emits a reset event to the parent; UI plumbing.
+		 */
 		resetModal() {
 			this.$emit('reset')
 		},
@@ -444,6 +456,7 @@ export default {
 		 * Estimate validation duration based on configuration
 		 *
 		 * @return {string} Estimated duration in human-readable format
+		 * @spec exclude Heuristic duration estimate for display; UI presentation helper.
 		 */
 		estimateValidationDuration() {
 			if (this.objectStats.totalObjects === 0) {
@@ -478,6 +491,7 @@ export default {
 		 *
 		 * @param {number} milliseconds Execution time in milliseconds
 		 * @return {string} Formatted execution time
+		 * @spec exclude Human-readable duration formatter; UI presentation helper.
 		 */
 		formatExecutionTime(milliseconds) {
 			if (!milliseconds) return 'Unknown'
@@ -497,6 +511,7 @@ export default {
 		 * Format memory prediction for display
 		 *
 		 * @return {string} Formatted memory prediction
+		 * @spec exclude Formats the memory-prediction readout for display; UI presentation helper.
 		 */
 		formatMemoryPrediction() {
 			if (!this.memoryPrediction || this.memoryPrediction.error) {
@@ -516,6 +531,7 @@ export default {
 		 *
 		 * @param {number} percentage Memory usage percentage
 		 * @return {string} CSS class
+		 * @spec exclude Maps memory-usage percentage to a CSS severity class; UI presentation helper.
 		 */
 		getMemoryUsageClass(percentage) {
 			const numPercentage = parseFloat(percentage)
@@ -528,6 +544,7 @@ export default {
 		 * Check if there are detailed error information available
 		 *
 		 * @return {boolean} True if detailed error info is available
+		 * @spec exclude Predicate for whether a detailed-error block should render; UI state helper.
 		 */
 		hasDetailedError() {
 			return !!(this.results?.error_details
@@ -538,6 +555,7 @@ export default {
 		 * Format error details for display
 		 *
 		 * @return {string} Formatted error details
+		 * @spec exclude Stringifies error details for display; UI presentation helper.
 		 */
 		formatErrorDetails() {
 			if (this.results?.error_details) {
@@ -549,6 +567,9 @@ export default {
 			return this.results?.error || 'No detailed error information available'
 		},
 
+		/**
+		 * @spec exclude Computes the success-rate percentage from results stats; UI presentation helper.
+		 */
 		getSuccessRate() {
 			if (!this.results || !this.results.stats) return 0
 			const { successfulSaves, totalObjects } = this.results.stats
@@ -556,6 +577,9 @@ export default {
 			return (successfulSaves / totalObjects) * 100
 		},
 
+		/**
+		 * @spec exclude Maps the success rate to a CSS severity class; UI presentation helper.
+		 */
 		getSuccessRateClass() {
 			const rate = this.getSuccessRate()
 			if (rate >= 95) return 'success'

--- a/src/modals/settings/ObjectVectorizationModal.vue
+++ b/src/modals/settings/ObjectVectorizationModal.vue
@@ -196,12 +196,18 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude Computed batch-count estimate for display; UI presentation helper.
+		 */
 		estimatedBatches() {
 			if (this.stats.objectsToProcess === 0) return 0
 			const objectCount = this.maxObjects > 0 ? Math.min(this.maxObjects, this.stats.objectsToProcess) : this.stats.objectsToProcess
 			return Math.ceil(objectCount / this.batchSize)
 		},
 
+		/**
+		 * @spec exclude Computed duration estimate for display; UI presentation helper.
+		 */
 		estimatedDuration() {
 			const batches = this.estimatedBatches
 			if (batches === 0) return '~0 seconds'
@@ -214,6 +220,9 @@ export default {
 			return `~${Math.ceil(totalSeconds / 3600)} hours`
 		},
 
+		/**
+		 * @spec exclude Computed rough cost estimate for display; UI presentation helper.
+		 */
 		estimatedCost() {
 			// Rough estimate: $0.008 per 1M tokens, ~500 tokens per object
 			const tokens = this.stats.objectsToProcess * 500
@@ -221,6 +230,9 @@ export default {
 			return `$${cost.toFixed(4)}`
 		},
 
+		/**
+		 * @spec exclude Computed progress percentage for the progress bar; UI presentation helper.
+		 */
 		progress() {
 			if (this.stats.objectsToProcess === 0) return 0
 			return Math.round((this.processed / this.stats.objectsToProcess) * 100)
@@ -228,11 +240,16 @@ export default {
 	},
 
 	watch: {
-		// Reload stats when view selection changes
+		/**
+		 * @spec exclude Watcher reloading stats when the all-views toggle changes; UI reactivity plumbing.
+		 */
 		vectorizeAllViews() {
 			this.loadStats()
 		},
 		selectedViews: {
+			/**
+			 * @spec exclude Watcher reloading stats when the view selection changes; UI reactivity plumbing.
+			 */
 			handler() {
 				this.loadStats()
 			},
@@ -240,6 +257,9 @@ export default {
 		},
 	},
 
+	/**
+	 * @spec exclude Vue mounted() hook loading config/views/stats on open; modal init plumbing.
+	 */
 	mounted() {
 		this.loadConfiguration()
 		this.loadViews()
@@ -263,6 +283,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude Loads views to populate the view selector; UI form-loading plumbing.
+		 */
 		async loadViews() {
 			try {
 				const response = await axios.get(generateUrl('/apps/openregister/api/views'))
@@ -272,6 +295,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude Loads object-count stats for the chosen views; UI form-loading plumbing.
+		 */
 		async loadStats() {
 			try {
 				// Determine which views to use for stats
@@ -301,6 +327,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude Start-button handler driving the vectorization job over the chosen views; platform-admin orchestration plumbing.
+		 */
 		async startVectorization() {
 			this.processing = true
 			this.processed = 0

--- a/src/modals/settings/SolrSetupResultsModal.vue
+++ b/src/modals/settings/SolrSetupResultsModal.vue
@@ -239,6 +239,9 @@ export default {
 	emits: ['close', 'retry', 'start-setup'],
 
 	computed: {
+		/**
+		 * @spec exclude Computed predicate matching known configset-propagation error patterns for a tailored hint; UI presentation helper.
+		 */
 		isConfigSetPropagationError() {
 			if (!this.results || this.results.success) {
 				return false
@@ -275,6 +278,9 @@ export default {
 			return 'pending'
 		},
 
+		/**
+		 * @spec exclude Maps a step status to a display icon; UI presentation helper.
+		 */
 		getStepIcon(step) {
 			// Handle both step.success (boolean) and step.status (string) formats
 			if (step.success === true || step.status === 'completed') return '✅'
@@ -282,6 +288,9 @@ export default {
 			return '⏳'
 		},
 
+		/**
+		 * @spec exclude Maps a step status to display text; UI presentation helper.
+		 */
 		getStepStatusText(step) {
 			// Handle both step.success (boolean) and step.status (string) formats
 			if (step.success === true || step.status === 'completed') return 'Completed'
@@ -290,10 +299,16 @@ export default {
 			return 'Pending'
 		},
 
+		/**
+		 * @spec exclude Humanizes a detail key for display; UI presentation helper.
+		 */
 		formatDetailLabel(key) {
 			return key.replace(/_/g, ' ').replace(/([A-Z])/g, ' $1').replace(/^\w/, c => c.toUpperCase())
 		},
 
+		/**
+		 * @spec exclude Stringifies a detail value for display; UI presentation helper.
+		 */
 		formatDetailValue(value) {
 			if (typeof value === 'boolean') {
 				return value ? 'Yes' : 'No'
@@ -304,6 +319,9 @@ export default {
 			return String(value)
 		},
 
+		/**
+		 * @spec exclude Emits a start-setup event to the parent; UI plumbing.
+		 */
 		startSetup() {
 			this.$emit('start-setup')
 		},

--- a/src/modals/source/DeleteSource.vue
+++ b/src/modals/source/DeleteSource.vue
@@ -82,6 +82,9 @@ export default {
 			this.loading = false
 			this.error = false
 		},
+		/**
+		 * @spec exclude Delete-confirm handler delegating to sourceStore.deleteSource; entity mutation lives in the store, this is modal orchestration plumbing.
+		 */
 		async deleteSource() {
 			this.loading = true
 

--- a/src/modals/view/EditView.vue
+++ b/src/modals/view/EditView.vue
@@ -199,6 +199,9 @@ export default {
 	watch: {
 		view: {
 			immediate: true,
+			/**
+			 * @spec exclude Watcher hydrating the local form model from the view prop; UI reactivity plumbing.
+			 */
 			handler(newView) {
 				if (newView) {
 					this.viewData = {
@@ -292,6 +295,7 @@ export default {
 		 *
 		 * @param {string} searchQuery - The search query entered by user
 		 * @return {void}
+		 * @spec exclude Debounced user-autocomplete search via OCS; UI search plumbing.
 		 */
 		searchUsers(searchQuery) {
 			// Clear existing debounce timer
@@ -344,6 +348,9 @@ export default {
 				}
 			}, 300)
 		},
+		/**
+		 * @spec exclude Save handler delegating to viewsStore.updateView and refreshing the list; entity persistence lives in the store, this is modal orchestration plumbing.
+		 */
 		async saveView() {
 			if (!this.viewData.name.trim()) {
 				this.nameTouched = true
@@ -382,6 +389,9 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude Modal close handler resetting local state and emitting close; UI plumbing.
+		 */
 		handleClose() {
 			this.success = false
 			this.error = null

--- a/src/modals/webhook/ViewWebhookLog.vue
+++ b/src/modals/webhook/ViewWebhookLog.vue
@@ -167,11 +167,15 @@ export default {
 		 * Navigation store computed property for template access.
 		 *
 		 * @return {object} Navigation store instance
+		 * @spec exclude Computed passthrough exposing navigationStore to the template; UI plumbing.
 		 */
 		navigationStore() {
 			return navigationStore
 		},
 	},
+	/**
+	 * @spec exclude Vue mounted() hook loading log + webhook data on open; modal init plumbing.
+	 */
 	mounted() {
 		this.loadLogData()
 		this.loadWebhooks()
@@ -200,6 +204,7 @@ export default {
 		 * Load webhooks list for name lookup.
 		 *
 		 * @return {Promise<void>}
+		 * @spec exclude Loads the webhook list for id-to-name lookup; UI form-loading plumbing.
 		 */
 		async loadWebhooks() {
 			try {
@@ -219,6 +224,7 @@ export default {
 		 *
 		 * @param {number} webhookId - Webhook ID
 		 * @return {string} Webhook name or ID
+		 * @spec exclude Resolves a webhook id to its display name; UI presentation helper.
 		 */
 		getWebhookName(webhookId) {
 			const webhook = this.webhooksList.find(w => w.id === webhookId)
@@ -230,6 +236,7 @@ export default {
 		 *
 		 * @param {string} dateString - Date string to format
 		 * @return {string} Formatted date
+		 * @spec exclude Locale date-string formatter for display; UI presentation helper.
 		 */
 		formatDate(dateString) {
 			if (!dateString) {
@@ -248,6 +255,7 @@ export default {
 		 *
 		 * @param {string} jsonString - JSON string to format
 		 * @return {string} Formatted JSON or original string if invalid
+		 * @spec exclude Pretty-prints a JSON payload string for display; UI presentation helper.
 		 */
 		formatJson(jsonString) {
 			if (!jsonString) {
@@ -267,6 +275,7 @@ export default {
 		 *
 		 * @param {boolean} open - Dialog open state
 		 * @return {void}
+		 * @spec exclude Dialog close-event handler closing the modal on dismiss; UI plumbing.
 		 */
 		handleDialogClose(open) {
 			if (!open) {
@@ -278,6 +287,7 @@ export default {
 		 * Retry failed webhook delivery.
 		 *
 		 * @return {Promise<void>}
+		 * @spec exclude Retry handler posting to the webhook-log retry endpoint and refreshing the parent; UI orchestration plumbing.
 		 */
 		async retryWebhook() {
 			if (!this.logItem || !this.logItem.id) {
@@ -312,6 +322,7 @@ export default {
 		 * Close modal.
 		 *
 		 * @return {void}
+		 * @spec exclude Modal close handler resetting navigationStore.modal/transferData; UI plumbing.
 		 */
 		closeModal() {
 			navigationStore.setModal(false)


### PR DESCRIPTION
## Summary

Retrofit annotation pass adding `@spec` traceability to **224 uncovered methods** across `src/modals/` Vue files (chunk 2). These are the leftover methods in modal files that the prior `retrofit-2026-05-24-2b-modals` pass left untagged.

Per ADR-003 and the retrofit playbook, frontend modal plumbing is tagged `@spec exclude <reason>` rather than minting new requirements:
- dialog open/close handlers, reactive form-field setters
- computed/display helpers, value/byte/date/JSON formatters
- multi-step wizard navigation, multi-select toggles
- file-picker handlers, debounced search/autocomplete passthroughs
- operational-job progress/estimate readouts (settings modals)

None introduces a novel user-facing domain contract beyond the existing `entity-management-modals` and `platform-administration-modals` capabilities, so this is a **delta-less, all-exclude** change (no `specs/` delta; skips `--strict`).

**Counts:** 0 spec'd / 224 excluded / 0 new REQs.

Ghost change: `openspec/changes/retrofit-2026-05-25-fe-modals-2/`

## Test plan

- [x] Every batch method ends with a `@spec exclude <reason>` tag (verified: 0 untagged of 224)
- [x] No bare `@spec exclude` without a reason
- [x] Comment-only / JSDoc-only changes — no logic, no refactors, no formatting cleanups