### PR TITLE
retrofit: frontend coverage — misc (services/entities/dialogs/nav)

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-fe-misc/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-misc/proposal.md
@@ -1,0 +1,84 @@
+# Retrofit — frontend coverage: misc (services / entities / dialogs / nav) (2026-05-25)
+
+Retrofit triage over the `fe-misc` bundle: 93 uncovered frontend methods across the
+remaining `src/` directories that no earlier frontend pass claimed — `mail-sidebar/`,
+`services/`, `entities/`, `dialogs/`, `reference/`, `navigation/`, `composables/`, and
+`App.vue`. The bundle is a mixed bag: API-client wrappers and a couple of dialog/widget
+contracts carry real behaviour, while the bulk of `entities/`, `dialogs/`, `navigation/`
+and the generic format helpers are UI/model plumbing.
+
+Every method ends tagged: either annotated to an existing-or-newly-minted capability REQ
+via this change's `tasks.md`, or carried as an `@spec exclude <reason>` with a required
+reason. No code logic changes.
+
+## Counts
+
+- **63 methods annotated** (spec'd) — mapped to live or here-minted capability REQs.
+- **30 methods excluded** — UI plumbing, model field-copy constructors, and stateless
+  presentation/format helpers with no standalone behavioural contract.
+- **3 new REQs minted** in a new `frontend-app-bootstrap` capability (app-startup
+  hot-loading, Nextcloud app install/uninstall client, object file-metadata client).
+
+## Annotated → existing capabilities (47 methods)
+
+- **mail-sidebar** (REQ-001 layout, REQ-002 message-view subname, REQ-003 attachment
+  drop, REQ-004 entities tab) — the method-level helpers inside the already file-level
+  annotated three-tab sidebar components: `MailSidebar.vue` (5), `ActionsTab.vue` (6),
+  `EntitiesTab.vue` (4), `LinkObjectDialog.vue` (8), `ObjectCard.vue` (3),
+  `ObjectsTab.vue` (7) = **33**.
+- **notificatie-engine** ("Users MUST be able to manage their notification preferences"
+  / "per-register and per-schema channel subscriptions") — `notificationSubscriptions.js`
+  client (`listSubscriptions`, `subscribe`, `unsubscribe`, `hasSubscription`) = **4**.
+- **mail-smart-picker** ("A custom Vue widget MUST render the rich object preview inline")
+  — `ObjectReferenceWidget.vue` (all 7 computed/method members rendering the Smart Picker
+  reference card) = **7**.
+- **avg-verwerkingsregister** ("maintain a verwerkingsactiviteiten register") —
+  `EditActivityDialog.vue` create/edit form contract (`makeForm`, `buildPayload`,
+  `onSave`) = **3**.
+
+## Annotated → new `frontend-app-bootstrap` capability (16 methods)
+
+These are genuine frontend contracts with no live capability home:
+
+- **REQ-001 (startup hot-load)** — `services/AppInitializationService.js`
+  (`initializeAppData`, `reloadAppData`, `isAppDataLoaded`) + `App.vue` (`mounted`,
+  `provide`) = **5**.
+- **REQ-002 (app install/uninstall client)** — `services/appInstallService.js`
+  (`constructor`, `init`, `invalidateCache`, `reloadCacheList`, `isAppInstalled`,
+  `getAppData`, `installApp`, `forceInstallApp`, `uninstallApp`) = **9**.
+- **REQ-003 (object file-metadata client)** — `services/fileMetadata.js`
+  (`updateFileLabels`, `updateFileMetadata`) = **2**. These are listed as
+  future-pass DROPs in `retrofit-2026-05-24-file-actions` (no live REQ yet), so they get
+  their own contract here rather than a dangling annotation.
+
+## Excluded (30 methods) — reasons required, recorded per method
+
+- **13 entity constructors** (`entities/{agent,application,auditTrail,configuration,
+  conversation,database,message,object,organisation,register,schema,source,view}.ts`) —
+  model field-copy boilerplate: copy typed fields off the input with `|| default`, plus a
+  passthrough for extra keys. No standalone behavioural contract; the `validate()`
+  methods (already covered or out of batch) carry the real schema contract.
+- **`composables/UseFileSelection.js::useFileSelection`** — third-party-derived VueUse
+  dropzone/file-dialog wrapper (attributed to an upstream GitHub author), generic
+  file-picker plumbing not tied to a register-data contract.
+- **`dialogs/Dialogs.vue`** (`onConfigSetCreated`, `onConfigSetDeleted`) — container that
+  re-emits a `configset-updated` event on `$root`; pure event-bus plumbing.
+- **`dialogs/avg/EditActivityDialog.vue`** UI members (`dialogTitle`, `rechtsgrondOptions`,
+  `statusOptions`, `get`/`set` text-area adapters, `t`) — title/option/textarea
+  presentation glue around the form contract that IS spec'd (`makeForm`/`buildPayload`/
+  `onSave`).
+- **`navigation/MainMenu.vue`** (`activeOrganisationName`, `handleNavigate`, `openLink`) —
+  app-navigation plumbing: read active org name, `$router.push`, `window.open`.
+- **Stateless format/presentation helpers** — `services/dateUtils.js`
+  (`stringToDate`/`dateToString`, schema-format date round-trip for the native picker),
+  `services/formatBytes.js`, `services/getTheme.js`, `services/getValidISOstring.js`.
+  Pure pure-function utilities with no domain contract.
+
+## Future reverse-spec passes
+
+None required out of this bundle. `dateUtils.js` is adjacent to the in-progress
+`datetime-input-handling` capability (a backend `DateTimeNormalizer` placeholder); if that
+spec later grows a frontend section the date round-trip helper can be re-homed there, but
+it carries no normative gap today.
+
+Source: `/tmp/or-scan/fw-misc.json` (bundle `fe-misc`, 93 methods).

--- a/openspec/changes/retrofit-2026-05-25-fe-misc/specs/frontend-app-bootstrap/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-misc/specs/frontend-app-bootstrap/spec.md
@@ -1,0 +1,118 @@
+---
+retrofit: true
+---
+
+# Frontend App Bootstrap Specification
+
+**Status**: in-progress
+**Scope**: openregister
+
+## Purpose
+
+Specifies the observable behaviour of the OpenRegister web app's bootstrap and
+client-side service layer that is not tied to a single register-data feature: the
+one-time hot-loading of essential data at app startup, the cached Nextcloud
+app install/uninstall client used by setup flows, and the typed object file-metadata
+client. This spec captures behaviour that already exists in `src/services/` and `App.vue`
+so the coverage matcher can resolve `@spec` annotations on those methods. Future
+enhancements extend this capability via new REQs rather than reinventing parallel
+bootstrap paths.
+
+## ADDED Requirements
+
+### Requirement: REQ-001 — Application data MUST be hot-loaded once at startup
+
+When the app mounts, the bootstrap layer MUST pre-load the essential stores (registers,
+schemas, organisations, applications, views, agents, sources, conversations) in parallel
+so that modals and views open without per-open API round-trips. The load MUST be
+idempotent (skip stores that already hold data) on the normal path and MUST be forceable
+on demand (e.g. when switching organisations). A failure in any single store MUST NOT
+abort the others or crash the app, and the layer MUST expose whether the essential data
+is loaded.
+
+#### Scenario: First mount hot-loads all essential stores
+
+- **GIVEN** a freshly mounted `App` with empty stores
+- **WHEN** `mounted()` calls `initializeAppData()`
+- **THEN** registers, schemas, organisations, applications, views, agents, sources, and
+  conversations SHALL all be requested in parallel
+- **AND** the active organisation SHALL be fetched from the session
+
+#### Scenario: Already-loaded stores are not re-fetched on the normal path
+
+- **GIVEN** stores that already hold data
+- **WHEN** `initializeAppData()` runs again
+- **THEN** each already-populated store SHALL be skipped rather than re-fetched
+
+#### Scenario: Force reload always refreshes
+
+- **GIVEN** populated stores
+- **WHEN** `reloadAppData()` is called (e.g. on organisation switch)
+- **THEN** every store SHALL be refreshed regardless of current state
+
+#### Scenario: A single store failure does not abort startup
+
+- **GIVEN** one store load that rejects
+- **WHEN** `initializeAppData()` runs
+- **THEN** the error SHALL be logged and the remaining loads SHALL still complete
+- **AND** `isAppDataLoaded()` SHALL report readiness based on the core entities present
+
+### Requirement: REQ-002 — A cached Nextcloud app install/uninstall client MUST be provided
+
+The app MUST expose a service that installs, force-installs, and uninstalls Nextcloud apps
+via the `/index.php/settings/apps/*` endpoints, backed by an in-memory cache of the app
+list. The client MUST capture the Nextcloud request token at construction, lazily load and
+cache the app list, expose cache invalidation/reload, answer install-state queries from
+the cache, skip apps already in the target state, and propagate the HTTP 403
+password-confirmation contract to callers.
+
+#### Scenario: Install skips already-installed apps and refreshes the cache
+
+- **GIVEN** a request to install `['calendar', 'contacts']` where `calendar` is active
+- **WHEN** `installApp()` runs
+- **THEN** only `contacts` SHALL be POSTed to `/settings/apps/enable`
+- **AND** the cached app list SHALL be reloaded after the call
+- **AND** if every requested app is already installed the call SHALL return `null`
+
+#### Scenario: Install-state queries are answered from the cache
+
+- **GIVEN** an initialised service
+- **WHEN** `isAppInstalled(appId)` / `getAppData(appId)` are called
+- **THEN** the answer SHALL come from the cached list (loading it first if needed)
+- **AND** an unknown `appId` SHALL throw rather than return a falsy result
+
+#### Scenario: Password confirmation is surfaced to the caller
+
+- **GIVEN** an enable/disable request that the server answers with HTTP 403
+- **WHEN** the request resolves
+- **THEN** a `RequestError` carrying the 403 status and parsed body SHALL be thrown so
+  the caller can prompt for password confirmation
+
+### Requirement: REQ-003 — Object file metadata MUST be editable via a typed client
+
+The app MUST expose a typed client for editing the metadata of a file attached to an
+object: its labels, and its description/category/labels enrichment. Each operation MUST
+target the object-scoped file endpoint and MUST raise on a non-OK HTTP response.
+
+#### Scenario: Labels are replaced via the labels endpoint
+
+- **GIVEN** `updateFileLabels({ registerId, schemaId, objectId, fileId, labels })`
+- **WHEN** the client runs
+- **THEN** it SHALL `PUT { labels }` to
+  `/api/objects/{register}/{schema}/{id}/files/{fileId}/labels`
+- **AND** an empty array SHALL clear all labels
+
+#### Scenario: Partial metadata update skips unspecified fields
+
+- **GIVEN** `updateFileMetadata({ ..., description, category, labels })` where some
+  fields are `null`
+- **WHEN** the client runs
+- **THEN** only the non-null fields SHALL be included in the PUT body to
+  `/api/objects/{register}/{schema}/{id}/files/{fileId}`
+- **AND** an empty string / empty array SHALL explicitly clear that field
+
+#### Scenario: HTTP failure raises
+
+- **GIVEN** any of the file-metadata calls receiving a non-OK response
+- **WHEN** the response resolves
+- **THEN** the client SHALL throw an `Error` carrying the HTTP status

--- a/openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md
@@ -1,0 +1,83 @@
+# Tasks — Retrofit fe-misc (2026-05-25)
+
+Retrofit annotation pass over the `fe-misc` bundle (93 methods). Every task below is
+`[x]` because the code already exists — annotating retroactively. Tasks 1–7 map methods
+to EXISTING capability REQs; tasks 8–10 map methods to the three REQs minted by this
+change's `frontend-app-bootstrap` spec delta; task 11 documents the exclusions. No new
+implementation work and no code-logic changes.
+
+## Annotated → existing capabilities
+
+- [x] task-1: mail-sidebar#REQ-001 (three-tab sidebar layout) — method-level helpers in
+      the Link/Objects/sidebar shell: `src/mail-sidebar/MailSidebar.vue`
+      (`setup`, `created`, `sidebarTitle`, `switchTab`), `src/mail-sidebar/components/
+      ActionsTab.vue` (`loadSchemas`, `loadInitialResults`, `showResults`,
+      `debounceSearch`, `searchObjects`, `objectName`), `src/mail-sidebar/components/
+      LinkObjectDialog.vue` (`visible`, `onSearchInput`, `doSearch`, `selectResult`,
+      `confirmLink`, `resultAriaLabel`, `close`, `reset`), `src/mail-sidebar/components/
+      ObjectCard.vue` (`objectTitle`, `deepLink`, `cardAriaLabel`),
+      `src/mail-sidebar/components/ObjectsTab.vue` (`loadObjects`, `objectUrl`,
+      `messageId`, `unlinkObject`) (retroactive annotation)
+- [x] task-2: mail-sidebar#REQ-003 (drag-and-drop email attachments onto linked objects)
+      — `src/mail-sidebar/components/ObjectsTab.vue` (`onAttachmentDragOver`,
+      `onAttachmentDrop`, `uploadAttachmentToObject`) (retroactive annotation)
+- [x] task-3: mail-sidebar#REQ-004 (email-body entity extraction tab) —
+      `src/mail-sidebar/components/EntitiesTab.vue` (`loadEntities`, `groupedEntities`,
+      `formatType`, `messageId`) (retroactive annotation)
+- [x] task-4: mail-sidebar#REQ-002 (path-based message-view detection) —
+      `src/mail-sidebar/MailSidebar.vue::sidebarSubname` (renders the
+      "Mail Integration" subname only on a message view) (retroactive annotation)
+- [x] task-5: notificatie-engine#Requirement:Users MUST be able to manage their
+      notification preferences / per-register and per-schema channel subscriptions —
+      `src/services/notificationSubscriptions.js` (`listSubscriptions`, `subscribe`,
+      `unsubscribe`, `hasSubscription`): the GET/POST/DELETE client over
+      `/api/notification-subscriptions` plus the local subscription-match predicate
+      (retroactive annotation)
+- [x] task-6: mail-smart-picker#Requirement:A custom Vue widget MUST render the rich
+      object preview inline — `src/reference/ObjectReferenceWidget.vue` (`title`,
+      `objectUrl`, `iconUrl`, `schemaTitle`, `registerTitle`, `properties`,
+      `formattedDate`): the Smart Picker reference card's title / link / icon /
+      schema-register subtitle / property list / formatted-update-date members
+      (retroactive annotation)
+- [x] task-7: avg-verwerkingsregister#Requirement:The system MUST maintain a
+      verwerkingsactiviteiten register as an OpenRegister schema — create/edit form
+      contract in `src/dialogs/avg/EditActivityDialog.vue` (`makeForm` seeds the form
+      from an existing activity or Art-30 defaults; `buildPayload` strips empty optional
+      fields before write; `onSave` dispatches create vs update against `avgStore`)
+      (retroactive annotation)
+
+## Annotated → new frontend-app-bootstrap capability (spec delta this change)
+
+- [x] task-8: frontend-app-bootstrap#REQ-001 (application data MUST be hot-loaded once at
+      startup) — `src/services/AppInitializationService.js` (`initializeAppData`
+      parallel-loads the eight core stores once, `reloadAppData` force-refreshes them,
+      `isAppDataLoaded` reports readiness) and `src/App.vue` (`mounted` kicks off the
+      hot-load + dashboard watchers; `provide` exposes the shared object-sidebar state)
+- [x] task-9: frontend-app-bootstrap#REQ-002 (the app MUST expose a cached Nextcloud
+      app install/uninstall client) — `src/services/appInstallService.js` (`constructor`
+      captures the request token, `init`/`invalidateCache`/`reloadCacheList` manage the
+      cached app list, `isAppInstalled`/`getAppData` query it, `installApp`/
+      `forceInstallApp`/`uninstallApp` drive the `/settings/apps/*` endpoints and refresh
+      the cache, surfacing the 403 password-confirmation contract)
+- [x] task-10: frontend-app-bootstrap#REQ-003 (object file metadata MUST be editable via
+      a typed client) — `src/services/fileMetadata.js` (`updateFileLabels` PUTs
+      `{labels}` to `/files/{fileId}/labels`; `updateFileMetadata` PUTs the partial
+      description/category/labels payload to `/files/{fileId}`, skipping null fields)
+
+## Excluded (30 methods — see proposal.md for full reasons)
+
+- [x] task-11: EXCLUDE bucket — every method below carries `@spec exclude <reason>`:
+  - 13 entity constructors (`entities/*/*.ts`) — model field-copy boilerplate, no
+    standalone contract.
+  - `composables/UseFileSelection.js::useFileSelection` — upstream-derived VueUse
+    dropzone/file-dialog wrapper, generic picker plumbing.
+  - `dialogs/Dialogs.vue` (`onConfigSetCreated`, `onConfigSetDeleted`) — `$root`
+    event re-emit plumbing.
+  - `dialogs/avg/EditActivityDialog.vue` (`dialogTitle`, `rechtsgrondOptions`,
+    `statusOptions`, `get`, `set`, `t`) — title/option/textarea presentation glue.
+  - `navigation/MainMenu.vue` (`activeOrganisationName`, `handleNavigate`, `openLink`)
+    — app-navigation plumbing.
+  - `services/dateUtils.js` (`stringToDate`, `dateToString`), `services/formatBytes.js`
+    (`formatBytes`), `services/getTheme.js` (`getTheme`),
+    `services/getValidISOstring.js` (`getValidISOstring`) — stateless presentation /
+    format helpers, no domain contract.

--- a/src/App.vue
+++ b/src/App.vue
@@ -54,6 +54,12 @@ export default {
 		Views,
 		SideBars,
 	},
+	/**
+	 * Expose the shared object-sidebar state to descendant components.
+	 *
+	 * @return {object} The provided injectables.
+	 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-8
+	 */
 	provide() {
 		return {
 			objectSidebarState: this.objectSidebarState,
@@ -74,6 +80,12 @@ export default {
 			}),
 		}
 	},
+	/**
+	 * On mount, kick off application-data hot-loading and dashboard watchers.
+	 *
+	 * @return {void}
+	 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-8
+	 */
 	mounted() {
 		// Initialize hot-loading of essential application data
 		// This loads registers, schemas, organisations, applications, views, agents, sources, and conversations

--- a/src/composables/UseFileSelection.js
+++ b/src/composables/UseFileSelection.js
@@ -11,6 +11,7 @@ import { objectStore } from '../store/store.js'
  * https://github.com/adamreisnz
  * https://github.com/vueuse/vueuse/issues/4085
  *
+ * @spec exclude Upstream-derived VueUse dropzone/file-dialog wrapper; generic file-picker plumbing not tied to a register-data contract.
  */
 export function useFileSelection(options) {
 

--- a/src/dialogs/Dialogs.vue
+++ b/src/dialogs/Dialogs.vue
@@ -37,10 +37,16 @@ export default {
 		DeleteApplication,
 	},
 	methods: {
+		/**
+		 * @spec exclude $root event re-emit plumbing: forwards a configset-updated bus event; no standalone behavioural contract.
+		 */
 		onConfigSetCreated() {
 			// Emit event to reload ConfigSets list if needed
 			this.$root.$emit('configset-updated')
 		},
+		/**
+		 * @spec exclude $root event re-emit plumbing: forwards a configset-updated bus event; no standalone behavioural contract.
+		 */
 		onConfigSetDeleted() {
 			// Emit event to reload ConfigSets list if needed
 			this.$root.$emit('configset-updated')

--- a/src/dialogs/avg/EditActivityDialog.vue
+++ b/src/dialogs/avg/EditActivityDialog.vue
@@ -129,26 +129,44 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude Presentation glue: exposes the translate helper to the template; no standalone behavioural contract.
+		 */
 		t() {
 			return t
 		},
+		/**
+		 * @spec exclude Presentation glue: edit-vs-create dialog title string; no standalone behavioural contract.
+		 */
 		dialogTitle() {
 			return this.activity
 				? t('openregister', 'Edit verwerkingsactiviteit')
 				: t('openregister', 'New verwerkingsactiviteit')
 		},
+		/**
+		 * @spec exclude Presentation glue: maps the rechtsgrond vocabulary to select options; no standalone behavioural contract.
+		 */
 		rechtsgrondOptions() {
 			return RECHTSGROND_VOCABULARY.map((v) => ({ value: v, label: v.replace(/_/g, ' ') }))
 		},
+		/**
+		 * @spec exclude Presentation glue: maps the status vocabulary to select options; no standalone behavioural contract.
+		 */
 		statusOptions() {
 			return STATUS_VOCABULARY.map((v) => ({ value: v, label: v }))
 		},
 		categorieenBetrokkenenText: {
+			/**
+			 * @spec exclude Presentation glue: textarea getter joining a string array into newline-separated text; no standalone behavioural contract.
+			 */
 			get() {
 				return Array.isArray(this.form.categorieenBetrokkenen)
 					? this.form.categorieenBetrokkenen.join('\n')
 					: ''
 			},
+			/**
+			 * @spec exclude Presentation glue: textarea setter splitting newline text into a trimmed string array; no standalone behavioural contract.
+			 */
 			set(value) {
 				this.form.categorieenBetrokkenen = (value ?? '')
 					.split('\n')
@@ -157,11 +175,17 @@ export default {
 			},
 		},
 		categorieenPersoonsgegevensText: {
+			/**
+			 * @spec exclude Presentation glue: textarea getter joining a string array into newline-separated text; no standalone behavioural contract.
+			 */
 			get() {
 				return Array.isArray(this.form.categorieenPersoonsgegevens)
 					? this.form.categorieenPersoonsgegevens.join('\n')
 					: ''
 			},
+			/**
+			 * @spec exclude Presentation glue: textarea setter splitting newline text into a trimmed string array; no standalone behavioural contract.
+			 */
 			set(value) {
 				this.form.categorieenPersoonsgegevens = (value ?? '')
 					.split('\n')
@@ -172,6 +196,11 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * Seed the form from an existing activity or with Art-30 defaults.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-7
+		 */
 		makeForm(activity) {
 			return {
 				naam: activity?.naam ?? '',
@@ -188,6 +217,11 @@ export default {
 			}
 		},
 
+		/**
+		 * Strip empty optional fields before writing the activity.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-7
+		 */
 		buildPayload() {
 			const payload = { ...this.form }
 			// Strip empty optional fields so we don't override server-side defaults.
@@ -197,6 +231,11 @@ export default {
 			return payload
 		},
 
+		/**
+		 * Dispatch create vs update of the processing activity against avgStore.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-7
+		 */
 		async onSave() {
 			this.saving = true
 			this.error = null

--- a/src/entities/agent/agent.ts
+++ b/src/entities/agent/agent.ts
@@ -45,6 +45,9 @@ export class Agent implements TAgent {
 	public created?: string
 	public updated?: string
 
+	/**
+	 * @spec exclude Entity model field-copy boilerplate: copies typed fields off the input with || defaults; no standalone behavioural contract.
+	 */
 	constructor(agent: TAgent) {
 		this.id = agent.id
 		this.uuid = agent.uuid || ''

--- a/src/entities/application/application.ts
+++ b/src/entities/application/application.ts
@@ -35,6 +35,9 @@ export class Application implements TApplication {
 	public created?: string
 	public updated?: string
 
+	/**
+	 * @spec exclude Entity model field-copy boilerplate: copies typed fields off the input with || defaults; no standalone behavioural contract.
+	 */
 	constructor(application: TApplication) {
 		this.id = application.id
 		this.uuid = application.uuid || ''

--- a/src/entities/auditTrail/auditTrail.ts
+++ b/src/entities/auditTrail/auditTrail.ts
@@ -29,6 +29,9 @@ export class AuditTrail implements TAuditTrail {
 	public retentionPeriod: string | null
 	public size: number
 
+	/**
+	 * @spec exclude Entity model field-copy boilerplate: copies typed fields off the input with || defaults; no standalone behavioural contract.
+	 */
 	constructor(auditTrail: TAuditTrail) {
 		this.id = auditTrail.id || 0
 		this.uuid = auditTrail.uuid || ''

--- a/src/entities/configuration/configuration.ts
+++ b/src/entities/configuration/configuration.ts
@@ -32,6 +32,9 @@ export class ConfigurationEntity implements TConfiguration {
 	githubPath?: string | null
 	app?: string
 
+	/**
+	 * @spec exclude Entity model field-copy boilerplate: copies typed fields off the input with || defaults; no standalone behavioural contract.
+	 */
 	constructor(configuration: TConfiguration) {
 		this.id = configuration.id || ''
 		this.title = configuration.title || ''

--- a/src/entities/conversation/conversation.ts
+++ b/src/entities/conversation/conversation.ts
@@ -26,6 +26,9 @@ export class Conversation implements TConversation {
 	public messages?: any[]
 	public messageCount?: number
 
+	/**
+	 * @spec exclude Entity model field-copy boilerplate: copies typed fields off the input with || defaults; no standalone behavioural contract.
+	 */
 	constructor(conversation: TConversation) {
 		this.id = conversation.id
 		this.uuid = conversation.uuid || ''

--- a/src/entities/database/database.ts
+++ b/src/entities/database/database.ts
@@ -8,6 +8,9 @@ export class Database implements TDatabase {
 	public url: string
 	public tablePrefix: string
 
+	/**
+	 * @spec exclude Entity model field-copy boilerplate: copies typed fields off the input with || defaults; no standalone behavioural contract.
+	 */
 	constructor(database: TDatabase) {
 		this.id = database.id || ''
 		this.name = database.name

--- a/src/entities/message/message.ts
+++ b/src/entities/message/message.ts
@@ -21,6 +21,9 @@ export class Message implements TMessage {
 	public sources?: any[]
 	public created?: string
 
+	/**
+	 * @spec exclude Entity model field-copy boilerplate: copies typed fields off the input with || defaults; no standalone behavioural contract.
+	 */
 	constructor(message: TMessage) {
 		this.id = message.id
 		this.uuid = message.uuid || ''

--- a/src/entities/object/object.ts
+++ b/src/entities/object/object.ts
@@ -37,6 +37,9 @@ export class ObjectEntity implements TObject {
 
 	[key: string]: unknown
 
+	/**
+	 * @spec exclude Entity model field-copy boilerplate: copies typed @self fields off the input with || defaults plus an extra-key passthrough; no standalone behavioural contract (validate() carries the schema contract).
+	 */
 	constructor(object: TObject) {
 		this['@self'] = {
 			id: object['@self']?.id || '',

--- a/src/entities/organisation/organisation.ts
+++ b/src/entities/organisation/organisation.ts
@@ -35,6 +35,9 @@ export class Organisation implements TOrganisation {
 	public created?: string
 	public updated?: string
 
+	/**
+	 * @spec exclude Entity model field-copy boilerplate: copies typed fields off the input with || defaults; no standalone behavioural contract.
+	 */
 	constructor(organisation: TOrganisation) {
 		this.id = organisation.id
 		this.uuid = organisation.uuid || ''

--- a/src/entities/register/register.ts
+++ b/src/entities/register/register.ts
@@ -19,6 +19,9 @@ export class Register implements TRegister {
 	public usage?: TRegister['usage']
 	public stats?: TRegister['stats']
 
+	/**
+	 * @spec exclude Entity model field-copy boilerplate: copies typed fields off the input with || defaults; no standalone behavioural contract.
+	 */
 	constructor(register: TRegister) {
 		this.id = register.id || ''
 		this.title = register.title

--- a/src/entities/schema/schema.ts
+++ b/src/entities/schema/schema.ts
@@ -34,6 +34,9 @@ export class Schema implements TSchema {
 	public anyOf?: string[]
 	public stats?: TSchema['stats']
 
+	/**
+	 * @spec exclude Entity model field-copy boilerplate: copies typed fields off the input with || defaults; no standalone behavioural contract.
+	 */
 	constructor(schema: TSchema) {
 		this.id = schema.id || ''
 		this.title = schema.title || ''

--- a/src/entities/source/source.ts
+++ b/src/entities/source/source.ts
@@ -11,6 +11,9 @@ export class Source implements TSource {
 	public updated: string
 	public created: string
 
+	/**
+	 * @spec exclude Entity model field-copy boilerplate: copies typed fields off the input with || defaults; no standalone behavioural contract.
+	 */
 	constructor(source: TSource) {
 		this.id = source.id || ''
 		this.title = source.title || ''

--- a/src/entities/view/view.ts
+++ b/src/entities/view/view.ts
@@ -27,6 +27,9 @@ export class View implements TView {
 	public created?: string
 	public updated?: string
 
+	/**
+	 * @spec exclude Entity model field-copy boilerplate: copies typed fields off the input with || defaults; no standalone behavioural contract.
+	 */
 	constructor(view: TView) {
 		this.id = view.id
 		this.uuid = view.uuid || ''

--- a/src/mail-sidebar/MailSidebar.vue
+++ b/src/mail-sidebar/MailSidebar.vue
@@ -98,6 +98,9 @@ export default {
 		Plus,
 		AccountMultiple,
 	},
+	/**
+	 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+	 */
 	setup() {
 		const mailObserver = useMailObserver({ debounceMs: 300 })
 		useAttachmentDrag()
@@ -110,9 +113,15 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		sidebarTitle() {
 			return t('openregister', 'OpenRegister')
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-4
+		 */
 		sidebarSubname() {
 			if (!this.isMessageView) {
 				return ''
@@ -120,6 +129,9 @@ export default {
 			return t('openregister', 'Mail Integration')
 		},
 	},
+	/**
+	 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+	 */
 	created() {
 		const stored = localStorage.getItem(COLLAPSED_STORAGE_KEY)
 		if (stored === 'true') {
@@ -135,6 +147,9 @@ export default {
 			this.collapsed = !this.collapsed
 			localStorage.setItem(COLLAPSED_STORAGE_KEY, String(this.collapsed))
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		switchTab(tabId) {
 			this.activeTab = tabId
 		},

--- a/src/mail-sidebar/components/ActionsTab.vue
+++ b/src/mail-sidebar/components/ActionsTab.vue
@@ -72,6 +72,9 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		objectName(obj) {
 			return obj['@self']?.name
 				|| obj._name
@@ -80,6 +83,9 @@ export default {
 				|| obj.naam
 				|| obj.id
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		async loadSchemas() {
 			this.loading = true
 			try {
@@ -115,6 +121,9 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		async loadInitialResults(schema) {
 			const register = this.registerCache[schema.id]
 			if (!register) return
@@ -134,9 +143,15 @@ export default {
 				console.error('[ActionsTab] Initial load failed for', schema.title, err)
 			}
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		showResults(schema) {
 			this.$set(this.visibleResults, schema.id, true)
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		debounceSearch(schema) {
 			if (this.debounceTimers[schema.id]) {
 				clearTimeout(this.debounceTimers[schema.id])
@@ -145,6 +160,9 @@ export default {
 				this.searchObjects(schema)
 			}, 300)
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		async searchObjects(schema) {
 			const term = this.searchTerms[schema.id] || ''
 			const register = this.registerCache[schema.id]

--- a/src/mail-sidebar/components/EntitiesTab.vue
+++ b/src/mail-sidebar/components/EntitiesTab.vue
@@ -55,6 +55,9 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-3
+		 */
 		groupedEntities() {
 			const groups = {}
 			for (const entity of this.entities) {
@@ -68,6 +71,9 @@ export default {
 		},
 	},
 	watch: {
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-3
+		 */
 		messageId() {
 			this.loadEntities()
 		},
@@ -77,6 +83,9 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-3
+		 */
 		formatType(type) {
 			const labels = {
 				PERSON: t('openregister', 'Persons'),
@@ -91,6 +100,9 @@ export default {
 			}
 			return labels[type] || type
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-3
+		 */
 		async loadEntities() {
 			if (!this.messageId) {
 				this.entities = []

--- a/src/mail-sidebar/components/LinkObjectDialog.vue
+++ b/src/mail-sidebar/components/LinkObjectDialog.vue
@@ -97,6 +97,9 @@ export default {
 		}
 	},
 	watch: {
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		visible(val) {
 			if (val) {
 				this.$nextTick(() => {
@@ -111,6 +114,9 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		onSearchInput() {
 			if (this.debounceTimer) {
 				clearTimeout(this.debounceTimer)
@@ -122,6 +128,9 @@ export default {
 			}
 			this.debounceTimer = setTimeout(() => this.doSearch(), 300)
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		async doSearch() {
 			this.searching = true
 			try {
@@ -144,12 +153,18 @@ export default {
 		isAlreadyLinked(result) {
 			return this.linkedObjectUuids.includes(result.uuid)
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		selectResult(result) {
 			if (this.isAlreadyLinked(result)) {
 				return
 			}
 			this.selectedResult = result
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		resultAriaLabel(result) {
 			const title = result.title || result.uuid
 			if (this.isAlreadyLinked(result)) {
@@ -157,15 +172,24 @@ export default {
 			}
 			return title
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		confirmLink() {
 			if (this.selectedResult) {
 				this.$emit('link', this.selectedResult)
 				this.close()
 			}
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		close() {
 			this.$emit('close')
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		reset() {
 			this.query = ''
 			this.searchResults = []

--- a/src/mail-sidebar/components/ObjectCard.vue
+++ b/src/mail-sidebar/components/ObjectCard.vue
@@ -57,15 +57,24 @@ export default {
 		},
 	},
 	computed: {
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		objectTitle() {
 			return this.object.objectTitle || this.object.objectUuid || ''
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		deepLink() {
 			const registerId = this.object.registerId || ''
 			const schemaId = this.object.schemaId || ''
 			const objectUuid = this.object.objectUuid || ''
 			return `/apps/openregister/registers/${registerId}/${schemaId}/${objectUuid}`
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		cardAriaLabel() {
 			const parts = [this.objectTitle]
 			if (this.object.schemaTitle) {

--- a/src/mail-sidebar/components/ObjectsTab.vue
+++ b/src/mail-sidebar/components/ObjectsTab.vue
@@ -108,6 +108,9 @@ export default {
 		}
 	},
 	watch: {
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		messageId() {
 			this.loadObjects()
 		},
@@ -117,6 +120,9 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		objectUrl(obj) {
 			return generateUrl('/apps/openregister/registers/{register}/{schemaId}/{uuid}', {
 				register: obj.register,
@@ -124,6 +130,9 @@ export default {
 				uuid: obj.uuid,
 			})
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		async loadObjects() {
 			if (!this.accountId || !this.messageId) {
 				this.objects = []
@@ -143,6 +152,9 @@ export default {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-1
+		 */
 		async unlinkObject(obj) {
 			if (!confirm(t('openregister', 'Remove link to {name}?', { name: obj.name || obj.uuid }))) {
 				return
@@ -161,11 +173,17 @@ export default {
 				console.error('[ObjectsTab] Unlink failed:', err)
 			}
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-2
+		 */
 		onAttachmentDragOver(event) {
 			if (event.dataTransfer) {
 				event.dataTransfer.dropEffect = 'copy'
 			}
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-2
+		 */
 		async onAttachmentDrop(event, obj) {
 			const raw = event.dataTransfer?.getData(ATTACHMENT_MIME)
 			if (!raw) {
@@ -190,6 +208,9 @@ export default {
 				this.uploadingObjectUuid = null
 			}
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-2
+		 */
 		async uploadAttachmentToObject(attachment, target) {
 			const response = await fetch(attachment.downloadUrl, { credentials: 'same-origin' })
 			if (!response.ok) {

--- a/src/navigation/MainMenu.vue
+++ b/src/navigation/MainMenu.vue
@@ -192,6 +192,9 @@ export default {
 		 *
 		 * @return {string} The active organisation name or a fallback
 		 */
+		/**
+		 * @spec exclude App-navigation plumbing: reads the active organisation name with a fallback label; no standalone behavioural contract.
+		 */
 		activeOrganisationName() {
 			const activeOrg = organisationStore.activeOrganisation
 			if (activeOrg && activeOrg.name) {
@@ -203,9 +206,15 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * @spec exclude App-navigation plumbing: $router.push wrapper; no standalone behavioural contract.
+		 */
 		handleNavigate(path) {
 			this.$router.push(path)
 		},
+		/**
+		 * @spec exclude App-navigation plumbing: window.open wrapper; no standalone behavioural contract.
+		 */
 		openLink(url, type = '') {
 			window.open(url, type)
 		},

--- a/src/reference/ObjectReferenceWidget.vue
+++ b/src/reference/ObjectReferenceWidget.vue
@@ -70,27 +70,48 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-6
+		 */
 		title() {
 			return this.richObject.title || t('openregister', 'Unknown Object')
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-6
+		 */
 		objectUrl() {
 			return this.richObject.url || '#'
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-6
+		 */
 		iconUrl() {
 			return this.richObject.icon_url || ''
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-6
+		 */
 		schemaTitle() {
 			return this.richObject.schema?.title || t('openregister', 'Unknown Schema')
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-6
+		 */
 		registerTitle() {
 			return this.richObject.register?.title || t('openregister', 'Unknown Register')
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-6
+		 */
 		properties() {
 			return this.richObject.properties || []
 		},
 		updated() {
 			return this.richObject.updated || ''
 		},
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-6
+		 */
 		formattedDate() {
 			if (!this.updated) {
 				return ''

--- a/src/services/AppInitializationService.js
+++ b/src/services/AppInitializationService.js
@@ -24,6 +24,7 @@ import {
  * data that is frequently needed across the application.
  *
  * @return {Promise<void>}
+ * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-8
  */
 export async function initializeAppData() {
 	console.info('[AppInit] Starting application data initialization...')
@@ -63,6 +64,7 @@ export async function initializeAppData() {
  * This always fetches fresh data regardless of whether it's already loaded.
  *
  * @return {Promise<void>}
+ * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-8
  */
 export async function reloadAppData() {
 	console.info('[AppInit] Reloading all application data...')
@@ -323,6 +325,7 @@ async function forceLoadConversations() {
  * Check if all essential data is loaded.
  *
  * @return {boolean} True if all data is loaded
+ * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-8
  */
 export function isAppDataLoaded() {
 	return Boolean(

--- a/src/services/appInstallService.js
+++ b/src/services/appInstallService.js
@@ -168,12 +168,18 @@ class AppInstallService {
 	 */
 	hasInit = false
 
+	/**
+	 * Capture the Nextcloud request token at construction.
+	 *
+	 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-9
+	 */
 	constructor() {
 		this.#token = this.#getToken()
 	}
 
 	/**
 	 * Async initializer for the service, ensuring the app list is loaded.
+	 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-9
 	 */
 	async init() {
 		await this.#ensureAppListLoaded()
@@ -284,6 +290,7 @@ class AppInstallService {
 
 	/**
 	 * Invalidates the cached app list.
+	 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-9
 	 */
 	async invalidateCache() {
 		this.#appList = null
@@ -291,6 +298,7 @@ class AppInstallService {
 
 	/**
 	 * Invalidates the apps list cache and then re-fetches the list and caches it.
+	 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-9
 	 */
 	async reloadCacheList() {
 		this.invalidateCache()
@@ -301,6 +309,7 @@ class AppInstallService {
 	 * Check if an app is installed by passing it an app ID.
 	 * @param { string } appId - The app ID
 	 * @return { Promise<boolean> } - True if the app is installed, false otherwise
+	 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-9
 	 */
 	async isAppInstalled(appId) {
 		const appData = await this.#findAppInCachedList(appId)
@@ -314,6 +323,7 @@ class AppInstallService {
 	 * Get app data by passing it an app ID
 	 * @param { string } appId - The app ID
 	 * @return { Promise<object> } - The app data
+	 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-9
 	 */
 	async getAppData(appId) {
 		const appData = await this.#findAppInCachedList(appId)
@@ -330,6 +340,7 @@ class AppInstallService {
 	 * @param {string | string[]} appIds - The app ID or an array of app IDs
 	 * @return {Promise<object|null>} The JSON response or null if no installation was necessary
 	 * @throws {RequestError} - If the network request fails or password confirmation is required (status 403)
+	 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-9
 	 */
 	async installApp(appIds) {
 		if (!appIds) {
@@ -370,6 +381,7 @@ class AppInstallService {
 	 * @param {string | string[]} appIds - The app ID or an array of app IDs
 	 * @return {Promise<object>} The response from the final install call
 	 * @throws {RequestError} - If the force calls or install fails, or password confirmation is required (status 403)
+	 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-9
 	 */
 	async forceInstallApp(appIds) {
 		if (!Array.isArray(appIds)) {
@@ -397,6 +409,7 @@ class AppInstallService {
 	 * @param {string | string[]} appIds - The app ID or an array of app IDs
 	 * @return {Promise<object>} The response from the final uninstall call
 	 * @throws {RequestError} - If the network request fails or password confirmation is required (status 403)
+	 * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-9
 	 */
 	async uninstallApp(appIds) {
 		if (!appIds) {

--- a/src/services/dateUtils.js
+++ b/src/services/dateUtils.js
@@ -7,6 +7,7 @@
  * @param {string} value - The date string from the backend
  * @param {string} format - Schema format: 'date', 'time', or 'date-time'
  * @return {Date|null}
+ * @spec exclude Stateless date-format helper for the native datetime picker; pure presentation/format utility with no domain contract.
  */
 export function stringToDate(value, format) {
 	if (!value) return null
@@ -40,6 +41,7 @@ export function stringToDate(value, format) {
  * @param {Date} date
  * @param {string} format - Schema format: 'date', 'time', or 'date-time'
  * @return {string}
+ * @spec exclude Stateless date-format helper for the native datetime picker; pure presentation/format utility with no domain contract.
  */
 export function dateToString(date, format) {
 	const yyyy = date.getFullYear().toString().padStart(4, '0')

--- a/src/services/fileMetadata.js
+++ b/src/services/fileMetadata.js
@@ -41,6 +41,7 @@ function buildFileUrl(registerId, schemaId, objectId, fileId, suffix = '') {
  * @param {string[]} params.labels New labels (use [] to clear all)
  * @return {Promise<object>} The formatted file response
  * @throws {Error} On HTTP error or network failure
+ * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-10
  */
 export async function updateFileLabels({ registerId, schemaId, objectId, fileId, labels }) {
 	const url = buildFileUrl(registerId, schemaId, objectId, fileId, '/labels')
@@ -70,6 +71,7 @@ export async function updateFileLabels({ registerId, schemaId, objectId, fileId,
  * @param {string[]|null} [params.labels] Labels (or null to skip)
  * @return {Promise<object>} The formatted file response
  * @throws {Error} On HTTP error or network failure
+ * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-10
  */
 export async function updateFileMetadata({
 	registerId,

--- a/src/services/formatBytes.js
+++ b/src/services/formatBytes.js
@@ -1,3 +1,6 @@
+/**
+ * @spec exclude Stateless byte-size formatting helper; pure presentation utility with no domain contract.
+ */
 export default function formatBytes(bytes) {
 	if (!bytes || bytes === 0) {
 		return '0 KB'

--- a/src/services/getTheme.js
+++ b/src/services/getTheme.js
@@ -8,6 +8,7 @@
  * accordingly. If neither attribute is present, it defaults to 'dark'.
  *
  * @return { 'light' | 'dark' } The current theme, either 'light' or 'dark'.
+ * @spec exclude Stateless theme-detection helper reading document body attributes; pure presentation utility with no domain contract.
  */
 export const getTheme = () => {
 	if (document.body.hasAttribute('data-theme-light')) {

--- a/src/services/getValidISOstring.js
+++ b/src/services/getValidISOstring.js
@@ -8,6 +8,7 @@
  *
  * @param  { string | Date } dateString The date string or Date object to be converted.
  * @return { string | null } The ISO string representation of the date or null.
+ * @spec exclude Stateless ISO-string validation/conversion helper; pure format utility with no domain contract.
  */
 export default function getValidISOstring(dateString) {
 	const date = new Date(dateString)

--- a/src/services/notificationSubscriptions.js
+++ b/src/services/notificationSubscriptions.js
@@ -22,6 +22,7 @@ const BASE = '/index.php/apps/openregister/api/notification-subscriptions'
  *
  * @return {Promise<Array<{id, userId, registerId, schemaId, created}>>}
  * @throws {Error} On HTTP error.
+ * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-5
  */
 export async function listSubscriptions() {
 	const response = await fetch(BASE, {
@@ -43,6 +44,7 @@ export async function listSubscriptions() {
  * @param {?number} [params.schemaId] Schema id.
  * @return {Promise<object>} The created subscription.
  * @throws {Error} On HTTP error.
+ * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-5
  */
 export async function subscribe({ registerId = null, schemaId = null } = {}) {
 	const response = await fetch(BASE, {
@@ -64,6 +66,7 @@ export async function subscribe({ registerId = null, schemaId = null } = {}) {
  * @param {?number} [params.schemaId] Schema id.
  * @return {Promise<{deleted: boolean}>} Result envelope.
  * @throws {Error} On HTTP error.
+ * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-5
  */
 export async function unsubscribe({ registerId = null, schemaId = null } = {}) {
 	const qs = new URLSearchParams()
@@ -90,6 +93,7 @@ export async function unsubscribe({ registerId = null, schemaId = null } = {}) {
  * @param {?number} [target.registerId] Register id.
  * @param {?number} [target.schemaId] Schema id.
  * @return {boolean} True when a matching subscription exists.
+ * @spec openspec/changes/retrofit-2026-05-25-fe-misc/tasks.md#task-5
  */
 export function hasSubscription(subscriptions, { registerId = null, schemaId = null } = {}) {
 	if (!Array.isArray(subscriptions)) return false


### PR DESCRIPTION
## Summary

Retrofit annotation pass over the `fe-misc` bundle — the 93 uncovered frontend methods across the remaining `src/` dirs (mail-sidebar, services, entities, dialogs, reference, navigation, composables, App.vue) that no earlier frontend pass claimed. Every method ends tagged per ADR-003. Annotation-only; no code-logic changes.

- **63 annotated** to capability REQs:
  - `mail-sidebar` (33) — method-level helpers in the three-tab sidebar components (layout / message-view subname / attachment-drop / entities tab).
  - `notificatie-engine` (4) — `notificationSubscriptions.js` preferences client.
  - `mail-smart-picker` (7) — `ObjectReferenceWidget.vue` Smart Picker reference card.
  - `avg-verwerkingsregister` (3) — `EditActivityDialog.vue` create/edit form contract.
  - **new `frontend-app-bootstrap` capability (16, 3 REQs)** — app-startup data hot-loading, Nextcloud app install/uninstall client, object file-metadata client.
- **30 excluded** via `@spec exclude <reason>` — 13 entity model field-copy constructors, UI/nav plumbing (Dialogs event re-emit, MainMenu nav, EditActivityDialog presentation glue, UseFileSelection wrapper), and stateless format helpers (dateUtils/formatBytes/getTheme/getValidISOstring).

Change: `openspec/changes/retrofit-2026-05-25-fe-misc/` (proposal + tasks + `frontend-app-bootstrap` spec delta). `openspec validate --strict` passes.

## Test plan

- [ ] `openspec validate retrofit-2026-05-25-fe-misc --strict` (green)
- [ ] Spot-check that all 93 batch methods carry a `@spec` tag in their immediately-preceding docblock (verified: 63 spec / 30 exclude / 0 untagged)