### PR TITLE
retrofit: frontend coverage — sidebars

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-fe-sidebars/design.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-sidebars/design.md
@@ -1,0 +1,25 @@
+# Design — retrofit-2026-05-25-fe-sidebars
+
+## Context
+
+Retrofit of the `fe-sidebars` coverage cluster: 149 uncovered methods across eight `src/sidebars/**/*.vue` files. Sidebars are predominantly presentation surfaces (tab switching, filter pickers, statistics display) that drive backend capabilities already specified elsewhere. The two genuinely novel surfaces are saved views and search-trail analytics.
+
+## Decisions
+
+### Annotate-existing over mint
+Most sidebar methods are the frontend half of a backend capability. Rather than mint UI-mirror REQs, they cross-reference the owning capability through this ghost change's tasks:
+- Conversation handlers → `chat-ai` (REQ-002 lifecycle).
+- Register/schema cascade + route-query serialisation → `files-sidebar-tabs` (the prior 2026-05-24 retrofit already minted the canonical REQs for exactly these patterns; we reuse them).
+- Facet UI → `faceting-configuration`. Search execution → `zoeken-filteren`.
+- Register/schema edit modals → `entity-management-modals`. OAS export → `openapi-generation`. Stats display → `built-in-dashboards` (local redirect stub).
+
+### Mint only for novel territory (3 REQs, ≤3 cap)
+- `saved-search-views` (new capability, 2 REQs): named view CRUD + favorite/default/activation. No prior spec describes the `/api/views` UI contract.
+- `zoeken-filteren` +1 REQ: search-trail analytics dashboard. The canonical search-trail REQ covers persistence and explicitly notes analytics reporting is unspecified; this closes the read/display gap.
+
+### Exclude presentation/plumbing
+Date/byte formatters, breakdown formatters, tab-switch state, fire-and-forget `mounted` loaders that only call already-annotated methods, and scanner-captured computed getter/setter/watch-handler nodes (`get`, `set`, `handler`) carry `@spec exclude <reason>` — never a bare exclude.
+
+## Risks
+- The `built-in-dashboards` local spec is a redirect stub; stats methods cross-reference it as their nominal owner. The canonical dashboard spec lives in the root openspec.
+- Observed drift (debug `console.info`, the `OC.getCurrentUser` favoriting TODO) is captured as-is, not corrected.

--- a/openspec/changes/retrofit-2026-05-25-fe-sidebars/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-sidebars/proposal.md
@@ -1,0 +1,64 @@
+# Retrofit — frontend coverage cluster `fe-sidebars`
+
+## Why
+
+The `/opsx-coverage-scan` run on 2026-05-25 reported **149 uncovered methods** across the eight `src/sidebars/**/*.vue` files (bundle `fe-sidebars` — `fw-fe-sidebars.json`). The cluster is named after the `src/sidebars/` directory, not a real capability: it bundles tab-switching, register/schema filter pickers, route-query serialisation, statistics display, and a handful of genuinely novel domain surfaces (saved views, search analytics) that drive backend behaviour.
+
+This change brings every one of the 149 under ADR-003's `@spec` convention via the two-tool approach: **annotate against an existing capability** where the sidebar drives a real domain interaction, **mint a new REQ** only for genuinely novel UI behaviour, and **`@spec exclude <reason>`** for presentation/format/plumbing helpers that should never carry a capability reference.
+
+## What the cluster actually contains
+
+After reading all eight files, the 149 methods decompose into:
+
+### 1. Genuinely novel behaviour — NEW REQs (3 minted, ≤3 cap)
+
+- **saved-search-views** (NEW capability spec, 2 REQs) — `SearchSideBar.vue` exposes a full saved-view surface backed by `/api/views`: list/activate/load/create/update/delete named views, plus public/default/favorite flags. A "view" persists a query configuration (registers, schemas, search terms, facet filters, enabled facets) and re-applies it to the live search. No existing capability describes this UI contract.
+  - REQ-001 — Saved view lifecycle (create / update / activate / load / delete) through `viewsStore` + `/api/views`.
+  - REQ-002 — View favoriting, default-view auto-apply, and search-scoped filtering of the view list.
+- **zoeken-filteren** extension (1 REQ, `retrofit_extensions`) — `SearchTrailSideBar.vue` renders a search-analytics dashboard (popular terms, register/schema breakdown, user-agent stats, activity-period buckets, query-complexity distribution) sourced from the search-trail store. The canonical `zoeken-filteren` spec records search-trail *persistence* but explicitly notes analytics reporting is unspecified. This REQ closes that gap for the read/display surface.
+  - REQ — Search-trail analytics dashboard (period-bucketed activity, popular terms, user-agent and register/schema aggregation).
+
+### 2. Methods that drive EXISTING capabilities — cross-reference annotation (no new REQs)
+
+These sidebar methods surface behaviour already specified elsewhere; they are annotated against this ghost change's cross-reference tasks, which point at the owning capability:
+
+| Sidebar behaviour | Owning capability |
+|---|---|
+| Conversation create / select / archive / restore / permanent-delete (`ChatSideBar` handlers) | `chat-ai` (REQ-002 conversation lifecycle) |
+| Register-selection cascade + dependent schema reset (`handleRegisterChange`/`handleSchemaChange` across Dashboard / Deleted / SearchTrail / Registers / Search) | `files-sidebar-tabs` (Register selection cascade) |
+| Route-query serialisation of filter state (`applyFilters`, `buildQueryFromState`, `queriesEqual`, `updateRouteQueryFromState`, `applyQueryParamsFromRoute`, `applyFiltersToStore`, `clearFilters`/`clearAllFilters`, debounced filter input) | `files-sidebar-tabs` (Deleted sidebar serialises filter state into the route query) |
+| Facet discovery / configuration / filtering UI (`discoverFacets`, `buildFacetConfiguration`, `toggleFacet`, `getFacetOptions`, `getFacetLabel`, `capitalizeFieldName`, `applyFacetFilters`, `applyFiltersToObjectStore`, `updateFacetFilter`, `resetFacets`, `performSearchWithFacets`) | `faceting-configuration` (`_facetable` discovery + `_facets` request config) |
+| Object search execution + search-term plumbing (`performSearch`, `onSearchInput`, `onFilterChange`, `onColumnsChange`, `addSearchTerms`, `removeSearchTerm`, `handleSearchInput`, `syncSearchParamsAndRefetch`, `resolveInheritedProperties`) | `zoeken-filteren` (full-text search + filtering) |
+| Register edit / schema-edit modal launch + save (`onSaveRegister`, `editSchema`, `loadSchemaOptions`, `getSchemaSelectValue`, `register`, `registerSchema`, `showEditDialog`) | `entity-management-modals` (create/edit modals submit through the store) |
+| OAS download / view (`downloadOas`, `viewOasDoc`) | `openapi-generation` (downloadable OAS per register) |
+| Statistics display + register/schema dropdown options (`systemTotals`, `orphanedItems`, `filteredRegisters`, `totalSchemas`, `metadataColumns`, `registerOptions`, `schemaOptions`, `selectedRegisterValue`, `selectedSchemaValue`, `userOptions`, `calculateSizes`, `onDateRangeChange`, deletion + audit + search-trail stat loaders) | `built-in-dashboards` (stats overview surface) |
+
+### 3. Presentation / format / plumbing — `@spec exclude`
+
+Pure display helpers, date/byte formatters, tab-switch state, lifecycle `mounted` hooks that only fire-and-forget already-annotated loaders, and scanner-captured computed getter/setter/watch-handler nodes (`get`, `set`, `handler`). Each carries `@spec exclude <reason>` — never a bare exclude.
+
+## Counts
+
+- **Total methods**: 149
+- **Spec'd** (new REQ or cross-reference to existing capability): 133
+- **Excluded** (`@spec exclude <reason>`): 16
+- **New REQs minted**: 3 (saved-search-views ×2, zoeken-filteren extension ×1)
+
+## Affected files
+
+- `src/sidebars/chat/ChatSideBar.vue`
+- `src/sidebars/dashboard/DashboardSideBar.vue`
+- `src/sidebars/deleted/DeletedSideBar.vue`
+- `src/sidebars/logs/AuditTrailSideBar.vue`
+- `src/sidebars/logs/SearchTrailSideBar.vue`
+- `src/sidebars/register/RegisterSideBar.vue`
+- `src/sidebars/register/RegistersSideBar.vue`
+- `src/sidebars/search/SearchSideBar.vue`
+
+## Out of scope
+
+- Any reshaping of observed behaviour. Drift (e.g. `console.info` debug noise in `SearchSideBar.handleRegisterChange`, the `OC.getCurrentUser` favoriting TODO) is captured as observed, not corrected.
+- The canonical `built-in-dashboards` spec (root openspec) — the local slug is a redirect stub; stats-display methods cross-reference it as their owner.
+- Methods outside this batch's eight files.
+
+Source: `/tmp/or-scan/fw-fe-sidebars.json`. See [retrofit playbook](../../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-25-fe-sidebars/specs/saved-search-views/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-sidebars/specs/saved-search-views/spec.md
@@ -1,0 +1,58 @@
+---
+retrofit: true
+---
+
+# Saved Search Views — Spec Delta
+
+## ADDED Requirements
+
+### Requirement: REQ-001 — Saved view lifecycle through the views store and /api/views
+
+The search sidebar (`SearchSideBar.vue`) MUST expose a saved-view surface backed by `viewsStore` and the `/api/views` endpoints. A "view" persists a reusable query configuration — `registers`, `schemas`, `searchTerms`, `facetFilters`, and `enabledFacets` — under a user-supplied `name` and optional `description`, with `isPublic` and `isDefault` flags. The sidebar MUST support: listing available views (`viewOptions` / `selectedViewValue` computeds drawn from `viewsStore.getAllViews`), creating a view (`saveView` → `viewsStore.createView`), updating the active view (`updateActiveView` → `viewsStore.updateView`), activating a view (`handleViewChange` / `loadView` → `viewsStore.fetchView` then `applyViewConfiguration`), and deleting a view (`confirmDeleteView` / `confirmDeleteActiveView` stage `viewToDelete`; `handleDeleteClose` refreshes the list and clears the active view if it was deleted). Applying a view (`applyViewConfiguration`) MUST read the stored config (supporting both the new `query` and legacy `configuration` key), repopulate the sidebar's selection state, set it as the active view via `viewsStore.setActiveView`, and re-run the search when `canSearch` is satisfied. Only query parameters MUST be persisted — never transient UI state such as pagination, sorting, or visible columns.
+
+#### Scenario: Saving the current search as a new view persists only query parameters
+- **GIVEN** the user has selected registers, schemas, search terms, and facet filters and entered a view name
+- **WHEN** `saveView()` runs
+- **THEN** `viewsStore.createView` MUST be called with `{ name, description, isPublic, isDefault, configuration: { registers, schemas, searchTerms, facetFilters, enabledFacets } }`
+- **AND** the new view MUST become the active view and the save form MUST be reset
+- **AND** pagination, sorting, and visible-column state MUST NOT be included in the persisted configuration
+
+#### Scenario: Activating a view re-applies its configuration to the live search
+- **GIVEN** a saved view with a stored `query` (or legacy `configuration`) block
+- **WHEN** the user selects it and `handleViewChange(option)` resolves `viewsStore.fetchView`
+- **THEN** `applyViewConfiguration(view)` MUST repopulate `selectedRegisters`, `selectedSchemas`, `searchTerms`, `facetFilters`, and `enabledFacets` from the stored config
+- **AND** the view MUST be set active via `viewsStore.setActiveView`
+- **AND** when `canSearch` is true the search MUST be re-run via `performSearchWithFacets()`
+
+#### Scenario: Deleting the active view clears the active selection
+- **GIVEN** the active view is staged for deletion via `confirmDeleteActiveView`
+- **WHEN** the delete dialog closes through `handleDeleteClose()`
+- **THEN** `viewsStore.fetchViews` MUST refresh the list
+- **AND** because the deleted view was active, `viewsStore.activeView` MUST be cleared and `activeViewName` reset to an empty string
+
+### Requirement: REQ-002 — View favoriting, default-view auto-apply, and list filtering
+
+The search sidebar MUST let a signed-in user favorite a view, automatically apply the configured default view on mount, and filter/sort the view list. `isFavorited(view)` MUST return true when the current user's uid appears in `view.favoredBy`. `toggleFavorite(view)` MUST add or remove the current user's uid from `favoredBy` via a `PATCH /api/views/{id}` request carrying only the updated `favoredBy` array, then refresh the list; when no user is signed in it MUST surface a notification and make no request. On mount, when `viewsStore.getDefaultView` returns a view, the sidebar MUST apply it via `applyViewConfiguration`. `filteredViews` MUST filter the list by a case-insensitive substring match against name and description, then sort favorited views first and alphabetically by name within each group.
+
+#### Scenario: Toggling favorite patches only the favoredBy array
+- **GIVEN** a signed-in user viewing a view they have not favorited
+- **WHEN** `toggleFavorite(view)` runs
+- **THEN** a `PATCH /api/views/{id}` request MUST be sent with a body containing only `favoredBy` extended by the current user's uid
+- **AND** after a successful response `viewsStore.fetchViews` MUST refresh the list and a confirmation notification MUST be shown
+
+#### Scenario: Favoriting requires an authenticated user
+- **GIVEN** no current user is available from `OC.getCurrentUser()`
+- **WHEN** `toggleFavorite(view)` runs
+- **THEN** a "must be logged in" notification MUST be shown
+- **AND** no PATCH request MUST be issued
+
+#### Scenario: The default view is applied on mount
+- **GIVEN** `viewsStore.getDefaultView` returns a view
+- **WHEN** the sidebar's `mounted()` hook runs
+- **THEN** `applyViewConfiguration(defaultView)` MUST be invoked
+
+#### Scenario: The view list is filtered and favorite-sorted
+- **GIVEN** the user types a query into the view search box and some views are favorited
+- **WHEN** `filteredViews` recomputes
+- **THEN** only views whose name or description contains the query (case-insensitive) MUST be returned
+- **AND** favorited views MUST sort before non-favorited views, alphabetically by name within each group

--- a/openspec/changes/retrofit-2026-05-25-fe-sidebars/specs/zoeken-filteren/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-sidebars/specs/zoeken-filteren/spec.md
@@ -1,0 +1,31 @@
+# zoeken-filteren — Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Search-trail analytics dashboard
+
+The search-trail sidebar (`SearchTrailSideBar.vue`) MUST render a read-only analytics dashboard over persisted `SearchTrail` data, sourced from `searchTrailStore`. The canonical `zoeken-filteren` spec covers search-trail *persistence*; this requirement covers the *analytics reporting* surface that the persistence-spec Notes section flags as unspecified. On mount the sidebar MUST load the trail list (`loadSearchTrailData`), aggregate statistics (`loadStatistics` → totals, averages, success rate, unique terms/users/organisations, per-session averages, and a `queryComplexity` distribution), popular terms (`loadPopularTerms`), register/schema usage (`loadRegisterSchemaStats`), user-agent usage (`loadUserAgentStats`), and period-bucketed activity (`loadActivityData` for the selected `hourly`/`daily`/`weekly`/`monthly` period). Each loader MUST degrade gracefully to safe empty/zero defaults on error. Display helpers MUST format the aggregates for the panel: `getComplexityPercentage(type)` returns the share of a complexity bucket, `formatActivityPeriod(period)` localises a bucket label per the selected period, `getRegisterSchemaName(stat)` resolves register/schema ids to titles, `getBrowserName(agent)` derives a browser label from the user-agent record, and `updateFilteredCount()` reflects the current list length. Changing the activity period MUST reload activity data and reflect the period in the route query.
+
+#### Scenario: Mounting the sidebar loads every analytics dataset
+- **GIVEN** the search-trail sidebar is mounted
+- **WHEN** the `mounted()` hook runs
+- **THEN** `loadSearchTrailData`, `loadStatistics`, `loadPopularTerms`, `loadRegisterSchemaStats`, `loadUserAgentStats`, and `loadActivityData` MUST each be invoked
+- **AND** the filtered count MUST be initialised from the store list length
+
+#### Scenario: A failing analytics loader degrades to safe defaults
+- **GIVEN** `searchTrailStore.getStatistics()` rejects
+- **WHEN** `loadStatistics()` handles the error
+- **THEN** all statistic fields MUST be reset to zero defaults (totals `0`, `queryComplexity = { simple: 0, medium: 0, complex: 0 }`)
+- **AND** no exception MUST propagate to the caller
+
+#### Scenario: Changing the activity period reloads bucketed activity
+- **GIVEN** the user selects a different activity period (e.g. `monthly`)
+- **WHEN** `loadActivityData()` runs
+- **THEN** `searchTrailStore.getActivity(period)` MUST be called with the selected period
+- **AND** the selected period MUST be reflected in the `/search-trails` route query via `updateRouteQueryFromState()`
+
+#### Scenario: Complexity percentage is computed against the bucket total
+- **GIVEN** `queryComplexity = { simple: 3, medium: 1, complex: 0 }`
+- **WHEN** `getComplexityPercentage('simple')` runs
+- **THEN** it MUST return `75`
+- **AND** when the total is `0` it MUST return `0` without dividing by zero

--- a/openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: retrofit-2026-05-25-fe-sidebars
+
+## New REQs (spec delta)
+
+- [x] task-1 — saved-search-views#REQ-001 "Saved view lifecycle": annotate `SearchSideBar` view-management methods (`handleViewChange`, `applyViewConfiguration`, `saveView`, `updateActiveView`, `loadView`, `confirmDeleteView`, `confirmDeleteActiveView`, `openEditDialogForActiveView`, `openEditDialog`, `cancelEditView`, `cancelSaveView`, `handleDeleteClose`, `isActiveView`) + view computeds (`viewOptions`, `selectedViewValue`).
+- [x] task-2 — saved-search-views#REQ-002 "View favoriting, default auto-apply, and list filtering": annotate `SearchSideBar.isFavorited`, `SearchSideBar.toggleFavorite`, `SearchSideBar.filteredViews`.
+- [x] task-3 — zoeken-filteren#REQ "Search-trail analytics dashboard": annotate `SearchTrailSideBar` analytics loaders/formatters (`loadStatistics`, `loadPopularTerms`, `loadRegisterSchemaStats`, `loadUserAgentStats`, `loadActivityData`, `loadSearchTrailData`, `getComplexityPercentage`, `formatActivityPeriod`, `getRegisterSchemaName`, `getBrowserName`, `updateFilteredCount`, `mounted`).
+
+## Cross-reference annotation (existing capabilities — no new REQs)
+
+- [x] task-4 — chat-ai#REQ-002 (conversation lifecycle): annotate `ChatSideBar` conversation handlers (`handleNewConversation`, `handleSelectConversation`, `handleArchiveConversation`, `handleRestoreConversation`, `handleDeleteConversation`).
+- [x] task-5 — files-sidebar-tabs "Register selection cascade resets dependent schema state": annotate the `handleRegisterChange` / `handleSchemaChange` cascade across `DashboardSideBar`, `DeletedSideBar`, `SearchTrailSideBar`, `RegistersSideBar`, `SearchSideBar`.
+- [x] task-6 — files-sidebar-tabs "Deleted sidebar serialises filter state into the route query": annotate route-query serialisation + filter-apply plumbing (`applyFilters`, `buildQueryFromState`, `queriesEqual`, `updateRouteQueryFromState`, `applyQueryParamsFromRoute`, `applyFiltersToStore`, `clearAllFilters`, `clearFilters`, `debouncedApplyFilters`, `handleSearchTermFilterChange`, `handleExecutionTimeChange`, `handleResultCountChange`, `handleSearch`) across `DeletedSideBar`, `SearchTrailSideBar`, `SearchSideBar`, `DashboardSideBar`.
+- [x] task-7 — faceting-configuration (`_facetable` discovery + `_facets` request config): annotate `SearchSideBar` facet UI methods (`discoverFacets`, `buildFacetConfiguration`, `toggleFacet`, `getFacetOptions`, `getFacetLabel`, `capitalizeFieldName`, `applyFacetFilters`, `applyFiltersToObjectStore`, `updateFacetFilter`, `resetFacets`, `performSearchWithFacets`).
+- [x] task-8 — zoeken-filteren (full-text search + filtering): annotate `SearchSideBar` search execution + term plumbing (`performSearch`, `onSearchInput`, `onFilterChange`, `onColumnsChange`, `addSearchTerms`, `removeSearchTerm`, `handleSearchInput`, `syncSearchParamsAndRefetch`, `resolveInheritedProperties`, `searchValueForSidebar`, `searchPlaceholder`, `canSearch`, `selectedSchemasWithProperties`, `toggleSchemaGroup`).
+- [x] task-9 — entity-management-modals (create/edit modals submit through the store): annotate `RegisterSideBar` register-edit + schema-edit modal methods (`onSaveRegister`, `editSchema`, `loadSchemaOptions`, `getSchemaSelectValue`, `register`, `registerSchema`, `showEditDialog` watch).
+- [x] task-10 — openapi-generation (downloadable OAS per register): annotate `RegisterSideBar.downloadOas`, `RegisterSideBar.viewOasDoc`.
+- [x] task-11 — built-in-dashboards (stats overview surface): annotate statistics-display computeds + stat loaders + register/schema dropdown options (`systemTotals`, `orphanedItems`, `filteredRegisters`, `totalSchemas`, `metadataColumns`, `registerOptions`, `schemaOptions`, `selectedRegisterValue`, `selectedSchemaValue`, `userOptions`, `calculateSizes`, `onDateRangeChange`, `loadStatistics`, `loadTopDeleters`, `canSaveView`) across `DashboardSideBar`, `RegistersSideBar`, `RegisterSideBar`, `DeletedSideBar`, `AuditTrailSideBar`.
+
+## Excludes
+
+- [x] task-12 — presentation/format/plumbing helpers carry `@spec exclude <reason>` (date/byte formatters, breakdown formatters, tab-switch state, fire-and-forget `mounted` loaders, scanner-captured getter/setter/watch-handler nodes).

--- a/openspec/specs/saved-search-views/spec.md
+++ b/openspec/specs/saved-search-views/spec.md
@@ -1,0 +1,63 @@
+---
+status: implemented
+retrofit: true
+---
+
+# Saved Search Views
+
+## Purpose
+
+Lets OpenRegister users save the configuration of an object search — selected registers and schemas, free-text search terms, facet filters, and enabled facets — as a reusable, named **view** backed by `/api/views`. Views can be marked public or default, favorited per user, and re-applied to the live search from the search sidebar. This capability describes the observed frontend contract of `src/sidebars/search/SearchSideBar.vue` and the `viewsStore` it drives. It was retrofitted under ADR-003 on 2026-05-25 (cluster `fe-sidebars`); requirements capture observed behavior rather than original intent.
+
+## Requirements
+
+### Requirement: REQ-001 — Saved view lifecycle through the views store and /api/views
+
+The search sidebar (`SearchSideBar.vue`) MUST expose a saved-view surface backed by `viewsStore` and the `/api/views` endpoints. A "view" persists a reusable query configuration — `registers`, `schemas`, `searchTerms`, `facetFilters`, and `enabledFacets` — under a user-supplied `name` and optional `description`, with `isPublic` and `isDefault` flags. The sidebar MUST support: listing available views (`viewOptions` / `selectedViewValue` computeds drawn from `viewsStore.getAllViews`), creating a view (`saveView` → `viewsStore.createView`), updating the active view (`updateActiveView` → `viewsStore.updateView`), activating a view (`handleViewChange` / `loadView` → `viewsStore.fetchView` then `applyViewConfiguration`), and deleting a view (`confirmDeleteView` / `confirmDeleteActiveView` stage `viewToDelete`; `handleDeleteClose` refreshes the list and clears the active view if it was deleted). Applying a view (`applyViewConfiguration`) MUST read the stored config (supporting both the new `query` and legacy `configuration` key), repopulate the sidebar's selection state, set it as the active view via `viewsStore.setActiveView`, and re-run the search when `canSearch` is satisfied. Only query parameters MUST be persisted — never transient UI state such as pagination, sorting, or visible columns.
+
+#### Scenario: Saving the current search as a new view persists only query parameters
+- **GIVEN** the user has selected registers, schemas, search terms, and facet filters and entered a view name
+- **WHEN** `saveView()` runs
+- **THEN** `viewsStore.createView` MUST be called with `{ name, description, isPublic, isDefault, configuration: { registers, schemas, searchTerms, facetFilters, enabledFacets } }`
+- **AND** the new view MUST become the active view and the save form MUST be reset
+- **AND** pagination, sorting, and visible-column state MUST NOT be included in the persisted configuration
+
+#### Scenario: Activating a view re-applies its configuration to the live search
+- **GIVEN** a saved view with a stored `query` (or legacy `configuration`) block
+- **WHEN** the user selects it and `handleViewChange(option)` resolves `viewsStore.fetchView`
+- **THEN** `applyViewConfiguration(view)` MUST repopulate `selectedRegisters`, `selectedSchemas`, `searchTerms`, `facetFilters`, and `enabledFacets` from the stored config
+- **AND** the view MUST be set active via `viewsStore.setActiveView`
+- **AND** when `canSearch` is true the search MUST be re-run via `performSearchWithFacets()`
+
+#### Scenario: Deleting the active view clears the active selection
+- **GIVEN** the active view is staged for deletion via `confirmDeleteActiveView`
+- **WHEN** the delete dialog closes through `handleDeleteClose()`
+- **THEN** `viewsStore.fetchViews` MUST refresh the list
+- **AND** because the deleted view was active, `viewsStore.activeView` MUST be cleared and `activeViewName` reset to an empty string
+
+### Requirement: REQ-002 — View favoriting, default-view auto-apply, and list filtering
+
+The search sidebar MUST let a signed-in user favorite a view, automatically apply the configured default view on mount, and filter/sort the view list. `isFavorited(view)` MUST return true when the current user's uid appears in `view.favoredBy`. `toggleFavorite(view)` MUST add or remove the current user's uid from `favoredBy` via a `PATCH /api/views/{id}` request carrying only the updated `favoredBy` array, then refresh the list; when no user is signed in it MUST surface a notification and make no request. On mount, when `viewsStore.getDefaultView` returns a view, the sidebar MUST apply it via `applyViewConfiguration`. `filteredViews` MUST filter the list by a case-insensitive substring match against name and description, then sort favorited views first and alphabetically by name within each group.
+
+#### Scenario: Toggling favorite patches only the favoredBy array
+- **GIVEN** a signed-in user viewing a view they have not favorited
+- **WHEN** `toggleFavorite(view)` runs
+- **THEN** a `PATCH /api/views/{id}` request MUST be sent with a body containing only `favoredBy` extended by the current user's uid
+- **AND** after a successful response `viewsStore.fetchViews` MUST refresh the list and a confirmation notification MUST be shown
+
+#### Scenario: Favoriting requires an authenticated user
+- **GIVEN** no current user is available from `OC.getCurrentUser()`
+- **WHEN** `toggleFavorite(view)` runs
+- **THEN** a "must be logged in" notification MUST be shown
+- **AND** no PATCH request MUST be issued
+
+#### Scenario: The default view is applied on mount
+- **GIVEN** `viewsStore.getDefaultView` returns a view
+- **WHEN** the sidebar's `mounted()` hook runs
+- **THEN** `applyViewConfiguration(defaultView)` MUST be invoked
+
+#### Scenario: The view list is filtered and favorite-sorted
+- **GIVEN** the user types a query into the view search box and some views are favorited
+- **WHEN** `filteredViews` recomputes
+- **THEN** only views whose name or description contains the query (case-insensitive) MUST be returned
+- **AND** favorited views MUST sort before non-favorited views, alphabetically by name within each group

--- a/openspec/specs/zoeken-filteren/spec.md
+++ b/openspec/specs/zoeken-filteren/spec.md
@@ -1,5 +1,7 @@
 ---
 status: implemented
+retrofit_extensions:
+  - search-trail-analytics-dashboard
 ---
 # Zoeken en Filteren
 

--- a/src/sidebars/chat/ChatSideBar.vue
+++ b/src/sidebars/chat/ChatSideBar.vue
@@ -187,6 +187,13 @@ export default {
 		isActive(conversation) {
 			return conversationStore.activeConversation?.uuid === conversation.uuid
 		},
+		/**
+		 * Format a conversation timestamp for compact display in the list row.
+		 *
+		 * @spec exclude Presentation-only relative-date formatter; carries no domain behavior.
+		 * @param {string} dateString - ISO timestamp of the conversation's last update
+		 * @return {string} Localised compact date/time label
+		 */
 		formatDate(dateString) {
 			if (!dateString) return ''
 
@@ -202,11 +209,25 @@ export default {
 				return date.toLocaleDateString([], { month: 'short', day: 'numeric' })
 			}
 		},
+		/**
+		 * Start a fresh conversation by clearing the active conversation and messages,
+		 * which surfaces the agent selector.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-4
+		 * @return {void}
+		 */
 		handleNewConversation() {
 			// Clear active conversation to show the agent selector
 			conversationStore.setActiveConversation(null)
 			conversationStore.setActiveMessages([])
 		},
+		/**
+		 * Load and activate the selected conversation (chat-ai conversation read).
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-4
+		 * @param {object} conversation - The conversation to load (by uuid)
+		 * @return {Promise<void>}
+		 */
 		async handleSelectConversation(conversation) {
 			try {
 				await conversationStore.loadConversation(conversation.uuid)
@@ -215,6 +236,13 @@ export default {
 				showError(this.t('openregister', 'Failed to load conversation'))
 			}
 		},
+		/**
+		 * Soft-delete (archive) a conversation (chat-ai conversation lifecycle).
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-4
+		 * @param {object} conversation - The conversation to archive (by uuid)
+		 * @return {Promise<void>}
+		 */
 		async handleArchiveConversation(conversation) {
 			try {
 				await conversationStore.archiveConversation(conversation.uuid)
@@ -224,6 +252,13 @@ export default {
 				showError(this.t('openregister', 'Failed to archive conversation'))
 			}
 		},
+		/**
+		 * Permanently delete a conversation (chat-ai conversation lifecycle).
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-4
+		 * @param {object} conversation - The conversation to delete (by uuid)
+		 * @return {Promise<void>}
+		 */
 		async handleDeleteConversation(conversation) {
 			try {
 				await conversationStore.deleteConversation(conversation.uuid)
@@ -233,6 +268,13 @@ export default {
 				showError(this.t('openregister', 'Failed to delete conversation'))
 			}
 		},
+		/**
+		 * Restore a soft-deleted conversation to the active list (chat-ai lifecycle).
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-4
+		 * @param {object} conversation - The conversation to restore (by uuid)
+		 * @return {Promise<void>}
+		 */
 		async handleRestoreConversation(conversation) {
 			try {
 				await conversationStore.restoreConversation(conversation.uuid)

--- a/src/sidebars/dashboard/DashboardSideBar.vue
+++ b/src/sidebars/dashboard/DashboardSideBar.vue
@@ -189,6 +189,12 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Build the register dropdown options for the dashboard filter.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object} NcSelect options bag for registers
+		 */
 		registerOptions() {
 			return {
 				options: registerStore.registerList.map(register => ({
@@ -204,6 +210,12 @@ export default {
 				},
 			}
 		},
+		/**
+		 * Build the schema dropdown options scoped to the selected register.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object} NcSelect options bag for schemas
+		 */
 		schemaOptions() {
 			if (!registerStore.registerItem) return { options: [] }
 
@@ -223,6 +235,12 @@ export default {
 				},
 			}
 		},
+		/**
+		 * Resolve the currently-selected register into NcSelect value shape.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object|null} Selected register option, or null
+		 */
 		selectedRegisterValue() {
 			if (!registerStore.registerItem) return null
 			const register = registerStore.registerItem
@@ -233,6 +251,12 @@ export default {
 				register,
 			}
 		},
+		/**
+		 * Resolve the currently-selected schema into NcSelect value shape.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object|null} Selected schema option, or null
+		 */
 		selectedSchemaValue() {
 			if (!schemaStore.schemaItem) return null
 			const schema = schemaStore.schemaItem
@@ -243,6 +267,12 @@ export default {
 				schema,
 			}
 		},
+		/**
+		 * Flatten the object metadata map into column descriptors for display.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {Array} Metadata column descriptors
+		 */
 		metadataColumns() {
 			return Object.entries(objectStore.metadata).map(([id, meta]) => ({
 				id,
@@ -251,6 +281,7 @@ export default {
 		},
 		/**
 		 * Get system totals from dashboardStore
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
 		 * @return {object | null}
 		 */
 		systemTotals() {
@@ -258,6 +289,7 @@ export default {
 		},
 		/**
 		 * Get orphaned items from dashboardStore
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
 		 * @return {object | null}
 		 */
 		orphanedItems() {
@@ -265,6 +297,7 @@ export default {
 		},
 		/**
 		 * Get filtered registers (excluding system and orphaned)
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
 		 * @return {Array}
 		 */
 		filteredRegisters() {
@@ -275,6 +308,7 @@ export default {
 		},
 		/**
 		 * Get total number of schemas in filtered registers
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
 		 * @return {number}
 		 */
 		totalSchemas() {
@@ -304,6 +338,9 @@ export default {
 		// Use immediate: true equivalent in mounted
 		// This watcher will update properties when schema changes
 		'$root.schemaStore.schemaItem': {
+			/**
+			 * @spec exclude Vue watch handler plumbing; re-initialises object properties when the selected schema changes.
+			 */
 			handler(newSchema) {
 				if (newSchema) {
 					objectStore.initializeProperties(newSchema)
@@ -315,6 +352,9 @@ export default {
 			deep: true,
 		},
 	},
+	/**
+	 * @spec exclude Lifecycle plumbing; fire-and-forget load of register/schema/object lists for the dashboard filter, no domain logic.
+	 */
 	mounted() {
 		objectStore.initializeColumnFilters()
 		this.registerLoading = true
@@ -352,6 +392,14 @@ export default {
 			registerStore.setRegisterItem(option)
 			schemaStore.setSchemaItem(null)
 		},
+		/**
+		 * Apply a schema selection: set the schema, initialise its properties, and
+		 * refresh the object list for the new filter context.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-5
+		 * @param {object|null} option - The selected schema (or null to clear)
+		 * @return {Promise<void>}
+		 */
 		async handleSchemaChange(option) {
 			schemaStore.setSchemaItem(option)
 			if (option) {
@@ -359,6 +407,12 @@ export default {
 				objectStore.refreshObjectList()
 			}
 		},
+		/**
+		 * Re-run the object search for the current register/schema with the search term.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
+		 * @return {void}
+		 */
 		handleSearch() {
 			if (registerStore.registerItem && schemaStore.schemaItem) {
 				objectStore.refreshObjectList({

--- a/src/sidebars/deleted/DeletedSideBar.vue
+++ b/src/sidebars/deleted/DeletedSideBar.vue
@@ -195,6 +195,11 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Build the register dropdown options for the deleted-items filter.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object} NcSelect options bag for registers
+		 */
 		registerOptions() {
 			return {
 				options: registerStore.registerList.map(register => ({
@@ -210,6 +215,11 @@ export default {
 				},
 			}
 		},
+		/**
+		 * Build the schema dropdown options scoped to the selected register.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object} NcSelect options bag for schemas
+		 */
 		schemaOptions() {
 			if (!registerStore.registerItem) return { options: [] }
 
@@ -229,6 +239,11 @@ export default {
 				},
 			}
 		},
+		/**
+		 * Resolve the currently-selected register into NcSelect value shape.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object|null} Selected register option, or null
+		 */
 		selectedRegisterValue() {
 			if (!registerStore.registerItem) return null
 			const register = registerStore.registerItem
@@ -239,6 +254,11 @@ export default {
 				register,
 			}
 		},
+		/**
+		 * Resolve the currently-selected schema into NcSelect value shape.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object|null} Selected schema option, or null
+		 */
 		selectedSchemaValue() {
 			if (!schemaStore.schemaItem) return null
 			const schema = schemaStore.schemaItem
@@ -249,6 +269,11 @@ export default {
 				schema,
 			}
 		},
+		/**
+		 * Derive the "deleted by" user filter options from the deleted-items list.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {Array} User filter options
+		 */
 		userOptions() {
 			// Get unique users from deleted items or provide default options
 			const users = new Set()
@@ -277,6 +302,9 @@ export default {
 	watch: {
 		// Keep component/store in sync with URL query params (single source of truth)
 		'$route.query': {
+			/**
+			 * @spec exclude Vue watch handler plumbing; re-syncs sidebar state from the route query on /deleted.
+			 */
 			handler() {
 				if (this.$route.path !== '/deleted') return
 				this.applyQueryParamsFromRoute()
@@ -291,6 +319,9 @@ export default {
 			this.applyFilters()
 		},
 	},
+	/**
+	 * @spec exclude Lifecycle plumbing; loads lists/statistics and seeds state from the route, delegating to already-annotated methods.
+	 */
 	async mounted() {
 		// Load required data
 		if (!registerStore.registerList.length) {
@@ -331,6 +362,7 @@ export default {
 		},
 		/**
 		 * Load deletion statistics
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
 		 * @return {Promise<void>}
 		 */
 		async loadStatistics() {
@@ -342,6 +374,7 @@ export default {
 		},
 		/**
 		 * Load top deleters statistics
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
 		 * @return {Promise<void>}
 		 */
 		async loadTopDeleters() {
@@ -352,7 +385,8 @@ export default {
 			}
 		},
 		/**
-		 * Handle register change
+		 * Handle register change (cascade: set register, clear schema, re-apply filters).
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-5
 		 * @param {object} register - The selected register object
 		 * @return {void}
 		 */
@@ -362,7 +396,8 @@ export default {
 			this.applyFilters()
 		},
 		/**
-		 * Handle schema change
+		 * Handle schema change (set schema, re-apply filters into the route query).
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-5
 		 * @param {object} schema - The selected schema object
 		 * @return {void}
 		 */
@@ -372,6 +407,7 @@ export default {
 		},
 		/**
 		 * Build URL query object from current sidebar state
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
 		 * @return {object}
 		 */
 		buildQueryFromState() {
@@ -392,6 +428,7 @@ export default {
 		},
 		/**
 		 * Compare two shallow query objects (keys and stringified values)
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
 		 * @param {object} a - First query object to compare
 		 * @param {object} b - Second query object to compare
 		 * @return {boolean} Whether the two query objects are equal
@@ -408,6 +445,7 @@ export default {
 		},
 		/**
 		 * Write current state to the router query (only on /deleted)
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
 		 * @return {void}
 		 */
 		updateRouteQueryFromState() {
@@ -421,6 +459,7 @@ export default {
 		},
 		/**
 		 * Apply URL query params to component/store state and emit filters
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
 		 * @return {void}
 		 */
 		applyQueryParamsFromRoute() {
@@ -470,6 +509,7 @@ export default {
 		},
 		/**
 		 * Build filters from state and emit to parent (legacy compatibility)
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
 		 * @return {void}
 		 */
 		applyFiltersToStore() {

--- a/src/sidebars/logs/AuditTrailSideBar.vue
+++ b/src/sidebars/logs/AuditTrailSideBar.vue
@@ -391,6 +391,9 @@ export default {
 			this.applyFilters()
 		},
 	},
+	/**
+	 * @spec exclude Lifecycle plumbing; fire-and-forget load of lists/audit-trail data and route-seed, delegating to already-annotated methods.
+	 */
 	mounted() {
 		// Load required data
 		if (!registerStore.registerList.length) {

--- a/src/sidebars/logs/SearchTrailSideBar.vue
+++ b/src/sidebars/logs/SearchTrailSideBar.vue
@@ -485,6 +485,11 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Build the register dropdown options for the search-trail filter.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object} NcSelect options bag for registers
+		 */
 		registerOptions() {
 			return {
 				options: registerStore.registerList.map(register => ({
@@ -500,6 +505,11 @@ export default {
 				},
 			}
 		},
+		/**
+		 * Build the schema dropdown options scoped to the selected register.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object} NcSelect options bag for schemas
+		 */
 		schemaOptions() {
 			if (!registerStore.registerItem) return { options: [] }
 
@@ -519,6 +529,11 @@ export default {
 				},
 			}
 		},
+		/**
+		 * Resolve the currently-selected register into NcSelect value shape.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object|null} Selected register option, or null
+		 */
 		selectedRegisterValue() {
 			if (!registerStore.registerItem) return null
 			const register = registerStore.registerItem
@@ -529,6 +544,11 @@ export default {
 				register,
 			}
 		},
+		/**
+		 * Resolve the currently-selected schema into NcSelect value shape.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object|null} Selected schema option, or null
+		 */
 		selectedSchemaValue() {
 			if (!schemaStore.schemaItem) return null
 			const schema = schemaStore.schemaItem
@@ -539,6 +559,11 @@ export default {
 				schema,
 			}
 		},
+		/**
+		 * Derive the user filter options from the search-trail list.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {Array} User filter options
+		 */
 		userOptions() {
 			if (!searchTrailStore.searchTrailList || !searchTrailStore.searchTrailList.length) {
 				return []
@@ -554,6 +579,9 @@ export default {
 	watch: {
 		// Keep component/store in sync with URL query params (single source of truth)
 		'$route.query': {
+			/**
+			 * @spec exclude Vue watch handler plumbing; re-syncs sidebar state from the route query on /search-trails.
+			 */
 			handler() {
 				if (this.$route.path !== '/search-trails') return
 				this.applyQueryParamsFromRoute()
@@ -571,6 +599,12 @@ export default {
 			this.applyFilters()
 		},
 	},
+	/**
+	 * Load every search-trail analytics dataset on mount and seed state from the route.
+	 *
+	 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-3
+	 * @return {void}
+	 */
 	mounted() {
 		// Load required data
 		if (!registerStore.registerList.length) {
@@ -606,6 +640,7 @@ export default {
 	methods: {
 		/**
 		 * Load search trail data and update filtered count
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-3
 		 * @return {Promise<void>}
 		 */
 		async loadSearchTrailData() {
@@ -618,6 +653,7 @@ export default {
 		},
 		/**
 		 * Clear all filters
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
 		 * @return {void}
 		 */
 		clearAllFilters() {
@@ -647,6 +683,7 @@ export default {
 		},
 		/**
 		 * Clear filters (alias for clearAllFilters for template compatibility)
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
 		 * @return {void}
 		 */
 		clearFilters() {
@@ -654,6 +691,7 @@ export default {
 		},
 		/**
 		 * Handle search term filter change with debouncing
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
 		 * @param {string} value - The filter value
 		 * @return {void}
 		 */
@@ -663,6 +701,7 @@ export default {
 		},
 		/**
 		 * Handle execution time filter change with debouncing
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
 		 * @return {void}
 		 */
 		handleExecutionTimeChange() {
@@ -670,6 +709,7 @@ export default {
 		},
 		/**
 		 * Handle result count filter change with debouncing
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
 		 * @return {void}
 		 */
 		handleResultCountChange() {
@@ -677,6 +717,7 @@ export default {
 		},
 		/**
 		 * Apply filters and emit to parent components
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
 		 * @return {void}
 		 */
 		applyFilters() {
@@ -746,6 +787,7 @@ export default {
 		},
 		/**
 		 * Debounced version of applyFilters for text input
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
 		 * @return {void}
 		 */
 		debouncedApplyFilters() {
@@ -756,6 +798,7 @@ export default {
 		},
 		/**
 		 * Update filtered count from store
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-3
 		 * @return {void}
 		 */
 		updateFilteredCount() {
@@ -763,6 +806,7 @@ export default {
 		},
 		/**
 		 * Load statistics
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-3
 		 * @return {Promise<void>}
 		 */
 		async loadStatistics() {
@@ -797,6 +841,7 @@ export default {
 		},
 		/**
 		 * Load popular search terms
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-3
 		 * @return {Promise<void>}
 		 */
 		async loadPopularTerms() {
@@ -810,6 +855,7 @@ export default {
 		},
 		/**
 		 * Load register schema statistics
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-3
 		 * @return {Promise<void>}
 		 */
 		async loadRegisterSchemaStats() {
@@ -823,6 +869,7 @@ export default {
 		},
 		/**
 		 * Load user agent statistics
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-3
 		 * @return {Promise<void>}
 		 */
 		async loadUserAgentStats() {
@@ -836,6 +883,7 @@ export default {
 		},
 		/**
 		 * Load activity data for selected period
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-3
 		 * @return {Promise<void>}
 		 */
 		async loadActivityData() {
@@ -852,6 +900,7 @@ export default {
 		},
 		/**
 		 * Get complexity percentage for progress bar
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-3
 		 * @param {string} type - The complexity type
 		 * @return {number} The percentage
 		 */
@@ -862,6 +911,7 @@ export default {
 		},
 		/**
 		 * Format activity period for display
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-3
 		 * @param {string} period - The period string
 		 * @return {string} Formatted period
 		 */
@@ -883,7 +933,8 @@ export default {
 			}
 		},
 		/**
-		 * Handle register change
+		 * Handle register change (cascade: set register, clear schema, re-apply filters).
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-5
 		 * @param {object} register - Selected register
 		 * @return {void}
 		 */
@@ -893,7 +944,8 @@ export default {
 			this.applyFilters()
 		},
 		/**
-		 * Handle schema change
+		 * Handle schema change (set schema, re-apply filters).
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-5
 		 * @param {object} schema - Selected schema
 		 * @return {void}
 		 */
@@ -903,6 +955,7 @@ export default {
 		},
 		/**
 		 * Get register/schema name for display
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-3
 		 * @param {object} stat - The register/schema stat object
 		 * @return {string} The display name
 		 */
@@ -917,6 +970,7 @@ export default {
 		},
 		/**
 		 * Get browser name for display
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-3
 		 * @param {object} agent - The user agent stat object
 		 * @return {string} The browser name
 		 */
@@ -928,7 +982,11 @@ export default {
 			}
 			return agent.user_agent || 'Unknown Browser'
 		},
-		// Build URL query from current component/store state
+		/**
+		 * Build URL query from current component/store state.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
+		 * @return {object} Query object derived from sidebar filter state
+		 */
 		buildQueryFromState() {
 			const query = {}
 			// Filters
@@ -946,7 +1004,13 @@ export default {
 			if (this.resultCountTo) query.resultCountTo = String(this.resultCountTo)
 			return query
 		},
-		// Shallow compare queries
+		/**
+		 * Shallow-compare two query objects (keys and stringified values).
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
+		 * @param {object} a - First query object
+		 * @param {object} b - Second query object
+		 * @return {boolean} Whether the queries are equal
+		 */
 		queriesEqual(a, b) {
 			const ka = Object.keys(a).sort()
 			const kb = Object.keys(b || {}).sort()
@@ -958,14 +1022,22 @@ export default {
 			}
 			return true
 		},
-		// Write current state into URL
+		/**
+		 * Write current sidebar state into the URL query (only on /search-trails).
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
+		 * @return {void}
+		 */
 		updateRouteQueryFromState() {
 			if (this.$route.path !== '/search-trails') return
 			const nextQuery = this.buildQueryFromState()
 			if (this.queriesEqual(nextQuery, this.$route.query)) return
 			this.$router.replace({ path: this.$route.path, query: nextQuery })
 		},
-		// Read URL query and apply to component/store
+		/**
+		 * Read the URL query and apply it to component/store state.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
+		 * @return {void}
+		 */
 		applyQueryParamsFromRoute() {
 			if (this.$route.path !== '/search-trails') return
 			const q = this.$route.query || {}

--- a/src/sidebars/register/RegisterSideBar.vue
+++ b/src/sidebars/register/RegisterSideBar.vue
@@ -253,19 +253,34 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Resolve the active register (with stats) from the dashboard store.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-9
+		 * @return {object|undefined} The active register record
+		 */
 		register() {
 			// Find the register in the dashboard store using the ID from register store
 			const registerId = registerStore.getRegisterItem?.id
 			return dashboardStore.registers.find(r => r.id === registerId)
 		},
 		activeTab: {
+			/**
+			 * @spec exclude Tab-switch state accessor; proxies the active tab to/from the register store, no domain behavior.
+			 */
 			get() {
 				return registerStore.getActiveTab
 			},
+			/**
+			 * @spec exclude Tab-switch state mutator; proxies the active tab to the register store, no domain behavior.
+			 */
 			set(value) {
 				registerStore.setActiveTab(value)
 			},
 		},
+		/**
+		 * @spec exclude Presentation-only formatter; builds the object stats breakdown (size/invalid/deleted/locked) for display.
+		 * @return {object} Breakdown descriptor for the objects stats block
+		 */
 		objectsBreakdown() {
 			const stats = this.register?.stats?.objects
 			const breakdown = {
@@ -276,6 +291,11 @@ export default {
 			}
 			return breakdown
 		},
+		/**
+		 * Build the schema definition used by the inline register-edit form dialog.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-9
+		 * @return {object} JSON-schema-like definition for the edit form
+		 */
 		registerSchema() {
 			return {
 				title: t('openregister', 'Register'),
@@ -291,6 +311,12 @@ export default {
 		},
 	},
 	watch: {
+		/**
+		 * Load schema options when the register-edit dialog opens.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-9
+		 * @param {boolean} val - Whether the edit dialog is open
+		 * @return {void}
+		 */
 		showEditDialog(val) {
 			if (val) {
 				this.loadSchemaOptions()
@@ -298,11 +324,21 @@ export default {
 		},
 	},
 	methods: {
+		/**
+		 * @spec exclude Presentation-only formatter; renders a byte size as a stats breakdown descriptor.
+		 * @param {number} size - Byte size
+		 * @return {object|null} Breakdown descriptor or null
+		 */
 		sizeBreakdown(size) {
 			if (!size) return null
 			return { size: formatBytes(size) }
 		},
 
+		/**
+		 * Load the schema list and build select options for the register-edit form.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-9
+		 * @return {Promise<void>}
+		 */
 		async loadSchemaOptions() {
 			this.schemasLoading = true
 			try {
@@ -315,6 +351,12 @@ export default {
 			}
 		},
 
+		/**
+		 * Resolve persisted schema references into select-option shape for the edit form.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-9
+		 * @param {Array} schemas - Schema ids or objects
+		 * @return {Array} Select options
+		 */
 		getSchemaSelectValue(schemas) {
 			if (!Array.isArray(schemas)) return []
 			return schemas.map(s => {
@@ -324,6 +366,12 @@ export default {
 			})
 		},
 
+		/**
+		 * Submit the register-edit form through the register store and refresh dashboard stats.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-9
+		 * @param {object} formData - Edited register fields
+		 * @return {Promise<void>}
+		 */
 		async onSaveRegister(formData) {
 			try {
 				await registerStore.saveRegister({
@@ -337,6 +385,11 @@ export default {
 			}
 		},
 
+		/**
+		 * Trigger a server-side size recalculation for the register and refresh stats.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {Promise<void>}
+		 */
 		async calculateSizes() {
 			if (!this.register) return
 
@@ -349,6 +402,11 @@ export default {
 			}
 		},
 
+		/**
+		 * Fetch the register's generated OpenAPI spec and download it as a JSON file.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-10
+		 * @return {Promise<void>}
+		 */
 		async downloadOas() {
 			if (!this.register) return
 
@@ -370,6 +428,11 @@ export default {
 			}
 		},
 
+		/**
+		 * Open the register's generated OpenAPI spec in an interactive ReDoc viewer.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-10
+		 * @return {void}
+		 */
 		viewOasDoc() {
 			if (!this.register) return
 
@@ -378,6 +441,12 @@ export default {
 			window.open(`https://redocly.github.io/redoc/?url=${encodeURIComponent(apiUrl)}`, '_blank')
 		},
 
+		/**
+		 * Stage a schema for editing and open the schema-edit modal.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-9
+		 * @param {object} schema - The schema to edit
+		 * @return {void}
+		 */
 		editSchema(schema) {
 			registerStore.setSchemaItem(schema)
 			navigationStore.setModal('editSchema')

--- a/src/sidebars/register/RegistersSideBar.vue
+++ b/src/sidebars/register/RegistersSideBar.vue
@@ -204,23 +204,48 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * System totals stats from the dashboard store.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object|null}
+		 */
 		systemTotals() {
 			return dashboardStore.getSystemTotals
 		},
+		/**
+		 * Orphaned-items stats from the dashboard store.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object|null}
+		 */
 		orphanedItems() {
 			return dashboardStore.getOrphanedItems
 		},
+		/**
+		 * Registers excluding the synthetic System Totals / Orphaned Items rows.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {Array}
+		 */
 		filteredRegisters() {
 			return dashboardStore.registers.filter(register =>
 				register.title !== 'System Totals'
 				&& register.title !== 'Orphaned Items',
 			)
 		},
+		/**
+		 * Total schema count across the filtered registers.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {number}
+		 */
 		totalSchemas() {
 			return this.filteredRegisters.reduce((total, register) => {
 				return total + (register.schemas?.length || 0)
 			}, 0)
 		},
+		/**
+		 * Build the register dropdown options for the registers-overview filter.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object} NcSelect options bag for registers
+		 */
 		registerOptions() {
 			return {
 				options: registerStore.registerList.map(register => ({
@@ -236,6 +261,11 @@ export default {
 				},
 			}
 		},
+		/**
+		 * Build the schema dropdown options scoped to the selected register.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object} NcSelect options bag for schemas
+		 */
 		schemaOptions() {
 			if (!registerStore.registerItem) return { options: [] }
 
@@ -255,6 +285,11 @@ export default {
 				},
 			}
 		},
+		/**
+		 * Resolve the currently-selected register into NcSelect value shape.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object|null} Selected register option, or null
+		 */
 		selectedRegisterValue() {
 			if (!registerStore.registerItem) return null
 			const register = registerStore.registerItem
@@ -265,6 +300,11 @@ export default {
 				register,
 			}
 		},
+		/**
+		 * Resolve the currently-selected schema into NcSelect value shape.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object|null} Selected schema option, or null
+		 */
 		selectedSchemaValue() {
 			if (!schemaStore.schemaItem) return null
 			const schema = schemaStore.schemaItem
@@ -277,10 +317,22 @@ export default {
 		},
 	},
 	methods: {
+		/**
+		 * Apply a register selection and reset dependent schema state (cascade).
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-5
+		 * @param {object|null} option - Selected register (or null to clear)
+		 * @return {void}
+		 */
 		handleRegisterChange(option) {
 			registerStore.setRegisterItem(option)
 			schemaStore.setSchemaItem(null)
 		},
+		/**
+		 * Apply a schema selection, initialise properties, and refresh the object list.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-5
+		 * @param {object|null} option - Selected schema (or null to clear)
+		 * @return {void}
+		 */
 		handleSchemaChange(option) {
 			schemaStore.setSchemaItem(option)
 			if (option) {
@@ -288,9 +340,19 @@ export default {
 				objectStore.refreshObjectList()
 			}
 		},
+		/**
+		 * Push the selected date range into the dashboard store for stats scoping.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {void}
+		 */
 		onDateRangeChange() {
 			dashboardStore.setDateRange(this.dateRange.from, this.dateRange.till)
 		},
+		/**
+		 * @spec exclude Presentation-only formatter; builds the objects stats breakdown descriptor for a stats source.
+		 * @param {object} source - Stats-bearing record
+		 * @return {object|null} Breakdown descriptor or null
+		 */
 		objectsBreakdown(source) {
 			const stats = source?.stats?.objects
 			if (!stats) return null
@@ -301,6 +363,11 @@ export default {
 			if (stats.locked) breakdown.locked = stats.locked
 			return Object.keys(breakdown).length > 0 ? breakdown : null
 		},
+		/**
+		 * @spec exclude Presentation-only formatter; renders a byte size as a stats breakdown descriptor.
+		 * @param {number} size - Byte size
+		 * @return {object|null} Breakdown descriptor or null
+		 */
 		sizeBreakdown(size) {
 			if (!size) return null
 			return { size: formatBytes(size) }

--- a/src/sidebars/search/SearchSideBar.vue
+++ b/src/sidebars/search/SearchSideBar.vue
@@ -499,10 +499,19 @@ export default {
 		}
 	},
 	computed: {
-		/** Search string for CnIndexSidebar; synced to store and used for fetch. */
+		/**
+		 * Search string for CnIndexSidebar; synced to store and used for fetch.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-8
+		 * @return {string} Current search string
+		 */
 		searchValueForSidebar() {
 			return objectStore.searchParams.search || ''
 		},
+		/**
+		 * Build the register dropdown options (multi-select) for the search sidebar.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object} NcSelect options bag for registers
+		 */
 		registerOptions() {
 			return {
 				options: registerStore.registerList.map(register => ({
@@ -519,6 +528,11 @@ export default {
 				},
 			}
 		},
+		/**
+		 * Build the schema dropdown options (multi-select) for the selected registers.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {object} NcSelect options bag for schemas
+		 */
 		schemaOptions() {
 			// Get all schemas from selected registers
 			if (this.selectedRegisters.length === 0) return { options: [] }
@@ -548,6 +562,11 @@ export default {
 				},
 			}
 		},
+		/**
+		 * Map saved views into NcSelect options for the view picker.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-1
+		 * @return {Array} View options
+		 */
 		viewOptions() {
 			return viewsStore.getAllViews.map(view => ({
 				value: view.id || view.uuid,
@@ -557,6 +576,11 @@ export default {
 				isPublic: view.isPublic,
 			}))
 		},
+		/**
+		 * Resolve the active saved view into NcSelect value shape.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-1
+		 * @return {object|null} Active view option, or null
+		 */
 		selectedViewValue() {
 			if (!viewsStore.activeView) return null
 			const view = viewsStore.activeView
@@ -566,6 +590,11 @@ export default {
 			}
 		},
 
+		/**
+		 * Filter the saved-view list by search query and sort favorites first.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-2
+		 * @return {Array} Filtered, favorite-sorted views
+		 */
 		filteredViews() {
 			// Filter views based on search query
 			let views = viewsStore.getAllViews
@@ -590,20 +619,40 @@ export default {
 			})
 		},
 
+		/**
+		 * Whether a search can run (requires at least one register and one schema).
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-8
+		 * @return {boolean}
+		 */
 		canSearch() {
 			// Allow search if at least one register and one schema are selected
 			return this.selectedRegisters.length > 0 && this.selectedSchemas.length > 0
 		},
+		/**
+		 * Whether the current search configuration can be saved as a view.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {boolean}
+		 */
 		canSaveView() {
 			// Can save view if we have search configuration
 			return this.canSearch
 		},
+		/**
+		 * Placeholder text for the search input, varying by current term state.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-8
+		 * @return {string}
+		 */
 		searchPlaceholder() {
 			return this.searchTerms.length > 0 ? 'Add more search terms...' : 'Type to search...'
 		},
 		hasEnabledFacets() {
 			return Object.values(this.enabledFacets).some(enabled => enabled)
 		},
+		/**
+		 * Flatten the object metadata map into column descriptors for display.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-11
+		 * @return {Array} Metadata column descriptors
+		 */
 		metadataColumns() {
 			return Object.entries(objectStore.metadata).map(([id, meta]) => ({
 				id,
@@ -615,6 +664,7 @@ export default {
 		 *
 		 * Returns an array of objects containing schema info and properties
 		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-8
 		 * @return {Array} Array of schema data with properties
 		 */
 		selectedSchemasWithProperties() {
@@ -641,6 +691,9 @@ export default {
 	watch: {
 		// React to query param changes as single source of truth (only on /tables)
 		'$route.query': {
+			/**
+			 * @spec exclude Vue watch handler plumbing; re-syncs sidebar state from the route query on /tables.
+			 */
 			handler() {
 				if (this.$route.path !== '/tables') return
 				this.applyQueryParamsFromRoute()
@@ -651,6 +704,9 @@ export default {
 		// Use immediate: true equivalent in mounted
 		// This watcher will update properties when schema changes
 		'$root.schemaStore.schemaItem': {
+			/**
+			 * @spec exclude Vue watch handler plumbing; re-initialises object properties when the selected schema changes.
+			 */
 			handler(newSchema) {
 				if (newSchema) {
 					objectStore.initializeProperties(newSchema)
@@ -663,6 +719,9 @@ export default {
 		},
 		// Watch for selected schemas changes to auto-expand new schemas
 		selectedSchemas: {
+			/**
+			 * @spec exclude Vue watch handler plumbing; auto-expands newly selected schema groups in the UI.
+			 */
 			handler(newSchemas, oldSchemas) {
 				// Auto-expand newly selected schemas
 				if (newSchemas && newSchemas.length > 0) {
@@ -680,6 +739,9 @@ export default {
 		},
 		// Watch for active view changes to sync the name input
 		'viewsStore.activeView': {
+			/**
+			 * @spec exclude Vue watch handler plumbing; mirrors the active view's name into the editable name input.
+			 */
 			handler(newView) {
 				if (newView && newView.name) {
 					this.activeViewName = newView.name
@@ -690,6 +752,9 @@ export default {
 			deep: true,
 		},
 	},
+	/**
+	 * @spec exclude Lifecycle plumbing; fetches views/lists, applies the default view, and seeds state from the route via already-annotated methods.
+	 */
 	mounted() {
 		// objectStore.initializeColumnFilters()
 		this.registerLoading = true
@@ -733,6 +798,7 @@ export default {
 		t,
 		/**
 		 * CnIndexSidebar @search: update store, keep searchTerms in sync for URL, and refetch.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-8
 		 * @param value
 		 */
 		onSearchInput(value) {
@@ -743,6 +809,7 @@ export default {
 		},
 		/**
 		 * CnIndexSidebar @filter-change: update store filters, keep facetFilters in sync, and refetch.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-8
 		 * @param root0
 		 * @param root0.key
 		 * @param root0.values
@@ -755,12 +822,17 @@ export default {
 		},
 		/**
 		 * CnIndexSidebar @columns-change: persist visible columns.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-8
 		 * @param columns
 		 */
 		onColumnsChange(columns) {
 			objectStore.setSearchVisibleColumns(columns)
 		},
-		// Build query params from current sidebar state
+		/**
+		 * Build URL query params from current sidebar state.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
+		 * @return {object} Query object
+		 */
 		buildQueryFromState() {
 			const query = {}
 			if (this.selectedRegisters.length > 0) {
@@ -774,7 +846,13 @@ export default {
 			}
 			return query
 		},
-		// Compare two query objects for equality (shallow, keys/values as strings)
+		/**
+		 * Shallow-compare two query objects (keys/values as strings).
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
+		 * @param {object} a - First query object
+		 * @param {object} b - Second query object
+		 * @return {boolean} Whether the queries are equal
+		 */
 		queriesEqual(a, b) {
 			const ka = Object.keys(a).sort()
 			const kb = Object.keys(b).sort()
@@ -785,7 +863,11 @@ export default {
 			}
 			return true
 		},
-		// Write current state to URL query (only on /tables)
+		/**
+		 * Write current sidebar state to the URL query (only on /tables).
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
+		 * @return {void}
+		 */
 		updateRouteQueryFromState() {
 			if (this.$route.path !== '/tables') return
 			const nextQuery = this.buildQueryFromState()
@@ -795,7 +877,11 @@ export default {
 				query: nextQuery,
 			})
 		},
-		// Apply URL query params into component/store state
+		/**
+		 * Apply URL query params into component/store state and run the initial search.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-6
+		 * @return {void}
+		 */
 		applyQueryParamsFromRoute() {
 			if (this.$route.path !== '/tables') return
 			const { register, schema, q } = this.$route.query || {}
@@ -840,6 +926,12 @@ export default {
 			}
 			tryApply()
 		},
+		/**
+		 * Apply a multi-select register change, prune now-invalid schemas, and sync the route.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-5
+		 * @param {Array|number} options - Selected register ids
+		 * @return {void}
+		 */
 		handleRegisterChange(options) {
 			// Handle multi-select - options is an array of values
 			console.info('Register change - raw options:', options)
@@ -875,6 +967,12 @@ export default {
 			// Only update URL; route watcher will trigger applyQueryParamsFromRoute -> performSearchWithFacets once
 			this.updateRouteQueryFromState()
 		},
+		/**
+		 * Apply a multi-select schema change and sync the route.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-5
+		 * @param {Array|number} options - Selected schema ids
+		 * @return {Promise<void>}
+		 */
 		async handleSchemaChange(options) {
 			// Handle multi-select - options is an array of values
 			if (!options || options.length === 0) {
@@ -892,7 +990,12 @@ export default {
 			// Only update URL; route watcher will trigger applyQueryParamsFromRoute -> performSearchWithFacets once
 			this.updateRouteQueryFromState()
 		},
-		/** Push sidebar state into objectStore.searchParams and refetch type 'search'. Sets register/schema context for dialogs and discoverFacets. */
+		/**
+		 * Push sidebar state into objectStore.searchParams and refetch type 'search'. Sets
+		 * register/schema context for dialogs and discoverFacets.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-8
+		 * @return {void}
+		 */
 		syncSearchParamsAndRefetch() {
 			const registerId = this.selectedRegisters.length > 0 ? this.selectedRegisters[0] : null
 			const schemaId = this.selectedSchemas.length > 0 ? this.selectedSchemas[0] : null
@@ -918,6 +1021,11 @@ export default {
 			})
 			objectStore.refetchSearchCollection()
 		},
+		/**
+		 * Parse the search input into de-duplicated search terms.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-8
+		 * @return {void}
+		 */
 		handleSearchInput() {
 			// Parse search terms from input (support comma and space separation)
 			const inputTerms = this.searchQuery
@@ -933,6 +1041,11 @@ export default {
 				this.searchTerms = [...this.searchTerms, ...newTerms]
 			}
 		},
+		/**
+		 * Commit input terms to the search-term set, clear the input, and sync the route.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-8
+		 * @return {void}
+		 */
 		addSearchTerms() {
 			// This method adds terms from the input to the existing search terms
 			this.handleSearchInput()
@@ -941,6 +1054,12 @@ export default {
 			// Reflect change in URL
 			this.updateRouteQueryFromState()
 		},
+		/**
+		 * Remove a search term, re-run the search if possible, and sync the route.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-8
+		 * @param {number} index - Index of the term to remove
+		 * @return {Promise<void>}
+		 */
 		async removeSearchTerm(index) {
 			this.searchTerms.splice(index, 1)
 			this.searchQuery = this.searchTerms.join(', ')
@@ -954,6 +1073,11 @@ export default {
 			// Reflect change in URL
 			this.updateRouteQueryFromState()
 		},
+		/**
+		 * Run the object search for the current configuration and record timing stats.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-8
+		 * @return {Promise<void>}
+		 */
 		async performSearch() {
 			if (!this.canSearch) return
 
@@ -999,6 +1123,7 @@ export default {
 		/**
 		 * Merge inherited properties from allOf parent schemas into the given schema's own properties.
 		 * Own properties take precedence over inherited ones.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-8
 		 * @param {object} schema - Schema object with optional allOf and properties
 		 * @return {object} Merged properties object
 		 */
@@ -1017,7 +1142,11 @@ export default {
 			return { ...inherited, ...(schema?.properties || {}) }
 		},
 
-		/** Load facet options for type 'search' via _facets=extend; facet data then comes from objectStore.searchFacets. */
+		/**
+		 * Load facet options for type 'search' via _facets=extend; facet data then comes from objectStore.searchFacets.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-7
+		 * @return {Promise<void>}
+		 */
 		async discoverFacets() {
 			if (!objectStore.searchParams.register || !objectStore.searchParams.schema) return
 			try {
@@ -1038,7 +1167,13 @@ export default {
 			}
 		},
 
-		// Toggle individual facet on/off
+		/**
+		 * Toggle an individual facet on/off, clearing its filter when disabled.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-7
+		 * @param {string} fieldName - Facet field name
+		 * @param {object} _fieldInfo - Unused field metadata
+		 * @return {void}
+		 */
 		toggleFacet(fieldName, _fieldInfo) {
 			// When toggling facet, clear any existing data for that field
 			if (this.enabledFacets[fieldName]) {
@@ -1049,7 +1184,11 @@ export default {
 			// The v-model will handle the enabledFacets update
 		},
 
-		// Build facet configuration from enabled facets
+		/**
+		 * Build the `_facets` request configuration from the enabled facets.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-7
+		 * @return {object} Facet request configuration
+		 */
 		buildFacetConfiguration() {
 			const config = {}
 
@@ -1084,7 +1223,11 @@ export default {
 			return { _facets: config }
 		},
 
-		/** Reset all facet/filter state (local and store) so CnIndexSidebar and Advanced Filters UI are cleared. */
+		/**
+		 * Reset all facet/filter state (local and store) so CnIndexSidebar and Advanced Filters UI are cleared.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-7
+		 * @return {void}
+		 */
 		resetFacets() {
 			this.enabledFacets = {}
 			this.facetFilters = {}
@@ -1096,6 +1239,11 @@ export default {
 			}
 		},
 
+		/**
+		 * Run a faceted search by syncing params and refetching, then mirror store facets locally.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-7
+		 * @return {Promise<void>}
+		 */
 		async performSearchWithFacets() {
 			if (!this.canSearch) return
 			try {
@@ -1110,6 +1258,14 @@ export default {
 			}
 		},
 
+		/**
+		 * Resolve a human-readable label for a facet field.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-7
+		 * @param {string} field - Facet field name
+		 * @param {object} facet - Facet data
+		 * @param {boolean} isMetadata - Whether the facet is a @self metadata facet
+		 * @return {string} Display label
+		 */
 		getFacetLabel(field, facet, isMetadata) {
 			// Get human-readable label for facet
 			if (isMetadata) {
@@ -1121,6 +1277,12 @@ export default {
 			}
 		},
 
+		/**
+		 * Normalise a facet (terms/range/date_histogram, new or legacy shape) into select options.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-7
+		 * @param {object} facet - Facet data
+		 * @return {Array} Select options for the facet
+		 */
 		getFacetOptions(facet) {
 			// CnIndexSidebar / package store format: { values: [{ value, count }] }
 			if (facet?.values?.length) {
@@ -1186,6 +1348,11 @@ export default {
 			return []
 		},
 
+		/**
+		 * @spec exclude Presentation-only helper; humanises a camelCase facet field name for the label.
+		 * @param {string} fieldName - Raw field name
+		 * @return {string} Humanised label
+		 */
 		capitalizeFieldName(fieldName) {
 			// Convert field names like 'tooiCategorieNaam' to 'Tooi Categorie Naam'
 			return fieldName
@@ -1196,6 +1363,7 @@ export default {
 		/**
 		 * Toggle schema group expanded/collapsed state
 		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-8
 		 * @param {number} schemaId - The schema ID
 		 * @return {void}
 		 */
@@ -1207,7 +1375,12 @@ export default {
 			}
 		},
 
-		// View Management Methods
+		/**
+		 * Activate a selected saved view by fetching it and applying its configuration.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-1
+		 * @param {object|null} option - Selected view option (or null to clear)
+		 * @return {Promise<void>}
+		 */
 		async handleViewChange(option) {
 			if (!option) {
 				viewsStore.clearActiveView()
@@ -1225,6 +1398,12 @@ export default {
 			}
 		},
 
+		/**
+		 * Apply a saved view's stored query config to the live search state and re-run search.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-1
+		 * @param {object} view - The saved view (with query/configuration block)
+		 * @return {void}
+		 */
 		applyViewConfiguration(view) {
 			if (!view) return
 
@@ -1266,6 +1445,11 @@ export default {
 			}
 		},
 
+		/**
+		 * Persist the current search configuration as a new saved view.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-1
+		 * @return {Promise<void>}
+		 */
 		async saveView() {
 			if (!this.viewName.trim()) return
 
@@ -1311,6 +1495,11 @@ export default {
 			}
 		},
 
+		/**
+		 * Reset and hide the save-view form without persisting.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-1
+		 * @return {void}
+		 */
 		cancelSaveView() {
 			// Reset form and hide it
 			this.viewName = ''
@@ -1319,6 +1508,11 @@ export default {
 			this.showSaveForm = false
 		},
 
+		/**
+		 * Persist the current search configuration onto the active saved view.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-1
+		 * @return {Promise<void>}
+		 */
 		async updateActiveView() {
 			if (!viewsStore.activeView || !this.activeViewName.trim()) return
 
@@ -1355,17 +1549,33 @@ export default {
 			}
 		},
 
+		/**
+		 * Open the view-edit dialog for the currently active view.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-1
+		 * @return {void}
+		 */
 		openEditDialogForActiveView() {
 			if (!viewsStore.activeView) return
 			this.openEditDialog(viewsStore.activeView)
 		},
 
+		/**
+		 * Stage the active view for deletion and open the confirm dialog.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-1
+		 * @return {void}
+		 */
 		confirmDeleteActiveView() {
 			if (!viewsStore.activeView) return
 			this.viewToDelete = viewsStore.activeView
 			this.showDeleteDialog = true
 		},
 
+		/**
+		 * Fetch and activate a saved view, apply its config, and switch to the search tab.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-1
+		 * @param {object} view - The view to load
+		 * @return {Promise<void>}
+		 */
 		async loadView(view) {
 			try {
 				// Fetch the full view details
@@ -1386,11 +1596,23 @@ export default {
 			}
 		},
 
+		/**
+		 * Stage a view for deletion and open the confirm dialog.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-1
+		 * @param {object} view - The view to delete
+		 * @return {void}
+		 */
 		confirmDeleteView(view) {
 			this.viewToDelete = view
 			this.showDeleteDialog = true
 		},
 
+		/**
+		 * Whether the given view is the currently active view.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-1
+		 * @param {object} view - The view to test
+		 * @return {boolean}
+		 */
 		isActiveView(view) {
 			if (!viewsStore.activeView) return false
 			const activeId = viewsStore.activeView.id || viewsStore.activeView.uuid
@@ -1398,6 +1620,12 @@ export default {
 			return activeId === viewId
 		},
 
+		/**
+		 * Whether the current user has favorited the given view.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-2
+		 * @param {object} view - The view to test
+		 * @return {boolean}
+		 */
 		isFavorited(view) {
 			// Check if current user has favorited this view
 			// TODO: Remove this once we have a proper user store
@@ -1407,6 +1635,12 @@ export default {
 			return view.favoredBy.includes(currentUser)
 		},
 
+		/**
+		 * Add or remove the current user from a view's favoredBy via PATCH, then refresh.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-2
+		 * @param {object} view - The view to favorite/unfavorite
+		 * @return {Promise<void>}
+		 */
 		async toggleFavorite(view) {
 			try {
 				// TODO: Remove this once we have a proper user store
@@ -1455,16 +1689,32 @@ export default {
 			}
 		},
 
+		/**
+		 * Open the view-edit dialog for a given view.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-1
+		 * @param {object} view - The view to edit
+		 * @return {void}
+		 */
 		openEditDialog(view) {
 			this.editingView = view
 			this.showEditDialog = true
 		},
 
+		/**
+		 * Close the view-edit dialog without saving.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-1
+		 * @return {void}
+		 */
 		cancelEditView() {
 			this.showEditDialog = false
 			this.editingView = null
 		},
 
+		/**
+		 * After a delete dialog closes, refresh the view list and clear the active view if deleted.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-1
+		 * @return {Promise<void>}
+		 */
 		async handleDeleteClose() {
 			const wasActiveView = this.viewToDelete && viewsStore.activeView
 				&& (this.viewToDelete.id === viewsStore.activeView.id || this.viewToDelete.uuid === viewsStore.activeView.uuid)
@@ -1482,6 +1732,13 @@ export default {
 			}
 		},
 
+		/**
+		 * Update a single facet filter's selected values and re-run the faceted search.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-7
+		 * @param {string} field - Facet field name
+		 * @param {Array} selectedValues - Selected facet values
+		 * @return {void}
+		 */
 		updateFacetFilter(field, selectedValues) {
 			// Update facet filter and refresh search
 			this.facetFilters = {
@@ -1493,7 +1750,11 @@ export default {
 			this.applyFacetFilters()
 		},
 
-		/** Sync facet filters into search params (used before refetch when custom facet UI changes). */
+		/**
+		 * Sync facet filters into search params (used before refetch when custom facet UI changes).
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-7
+		 * @return {void}
+		 */
 		applyFiltersToObjectStore() {
 			const activeFilters = {}
 			Object.entries(this.facetFilters).forEach(([field, values]) => {
@@ -1508,6 +1769,11 @@ export default {
 			})
 		},
 
+		/**
+		 * Apply facet filters and refresh the faceted search, managing the loading state.
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-sidebars/tasks.md#task-7
+		 * @return {Promise<void>}
+		 */
 		async applyFacetFilters() {
 			// Apply facet filters and refresh search with facets
 			// Note: performSearchWithFacets manages its own searchLoading state


### PR DESCRIPTION
## Summary

Brings the **149 uncovered methods** across the eight `src/sidebars/**/*.vue` files under ADR-003's `@spec` convention (coverage cluster `fe-sidebars`), using the two-tool retrofit approach: annotate-existing where the sidebar drives a real domain interaction, mint a new REQ only for genuinely novel behaviour, and `@spec exclude <reason>` for presentation/plumbing helpers.

- **133** methods annotated — cross-referenced to existing capabilities (`chat-ai`, `files-sidebar-tabs`, `faceting-configuration`, `zoeken-filteren`, `entity-management-modals`, `openapi-generation`, `built-in-dashboards`) or to the 3 newly minted REQs.
- **16** methods carry `@spec exclude <reason>` (date/byte formatters, breakdown formatters, tab-switch accessors, fire-and-forget `mounted` loaders, Vue watch-handler plumbing) — never a bare exclude.
- **3 new REQs** (≤3 cap):
  - `saved-search-views` (NEW capability) — REQ-001 saved-view lifecycle through `viewsStore` + `/api/views`; REQ-002 favoriting, default-view auto-apply, and list filtering.
  - `zoeken-filteren` extension — search-trail analytics dashboard (the canonical search-trail REQ covers persistence but explicitly flags analytics reporting as unspecified).

Ghost change: `openspec/changes/retrofit-2026-05-25-fe-sidebars/` (proposal + counts + tasks + spec delta). Validated with `openspec validate --strict` (passes). Only docblock additions — no code-line changes (confirmed by diff; script-block braces remain balanced).

## Test plan

- [ ] `openspec validate retrofit-2026-05-25-fe-sidebars --strict` passes
- [ ] Every batch method ends tagged (verified: 0 untagged / 0 bare excludes)
- [ ] Sidebars render and behave unchanged in the dev container (annotation-only)