### PR TITLE
retrofit: frontend coverage — components

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-fe-components/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-components/proposal.md
@@ -1,0 +1,34 @@
+# Retrofit — Frontend coverage: components (all `@spec exclude`)
+
+The coverage scanner flagged 207 uncovered methods across `src/components/` Vue files (batch `fw-fe-components`). This change annotates every one of them with a JSDoc `@spec` tag per ADR-003.
+
+## Why
+
+Bucket 2b ("code exists, no spec to point at") for reusable `src/components/` widgets. After reading the code, every flagged method is reusable-UI plumbing — none defines a new spec-worthy domain contract that is not already captured elsewhere:
+
+- **Computed display / formatter helpers** (`getToolName`, `formatDate`, `riskLabel`, `statusLabel`, `buttonLabel`, `ratioPercent`, `tooltipText`, `repositoryFullName`, `visiblePages`, `getSourceTypeLabel`, …) are pure presentation/derivation of props or store state.
+- **Filter/search state writers** that emit or proxy sidebar filter changes (`updateCategory`, `updateType`, `updateStatus`, `updateRiskLevel`, `updateEnabled`, `clearFilters`, `handleSearchInput`, the whole `FacetComponent` `update*`/`get*`/`is*`/`toggle*` surface) orchestrate the search UI; the underlying facet/search contract lives in the search capability, not in the widget.
+- **Store / API passthrough loaders** (`fetchObjects`, `fetchEmails`, `fetchSchedules`, `fetchExtractionStatus`, `loadSchemaOptions`, `refresh`, `createChain`, `createSchedule`, `runTest`, `save`) delegate to entity stores or backend endpoints; the data contract is owned by the relevant backend capability.
+- **Emit / open-dialog / unlink UI handlers** (`handleEdit`, `handleDelete`, `handleExport`, `openCreateDialog`, `openLinkDialog`, `unlinkContact`, `unlinkCard`, `unlinkEmail`, `unlinkEvent`, `removeSchemaFromRegister`, `toggleExpand`, `toggleFacet`, `toggleType`, …) are pure UI plumbing.
+- **i18n widget helpers** (`TranslationStatusChip`, `TranslationCompletenessBadge`, `TranslationFieldEditor`, `RegisterLanguagesEditor`, `BulkTranslateDialog`) surface behaviour already specified by the `register-i18n` capability; per the 2b-components triage these are dropped from widget-level annotation and excluded here.
+- **Object-relations tab plumbing** (`ContactsTab`, `DeckTab`, `EmailsTab`, `EventsTab`, `RelationsTab`) renders the integration data owned by the per-integration capabilities; the tabs themselves are list/fetch/unlink plumbing.
+- **RBAC table render helpers** (`hasPermission`, `hasAnyPermissions`, `sortedGroups`, `updatePermission`) are computed/emit plumbing over the RBAC capability's data.
+
+The genuinely spec-worthy shared-widget contracts in `src/components/` (pagination bounds-check, ConfigurationCard import detection, collapsible settings card, settings-section HTML escape) were already minted as `shared-ui-components` REQ-001..REQ-004 by `retrofit-2026-05-24-2b-components`; the residual `PaginationComponent` and `ConfigurationCard` methods in this batch are the surrounding display/emit plumbing around those contracts.
+
+Every method therefore received `@spec exclude <reason>` with a specific reason. **Zero new REQs are minted.**
+
+Per the retrofit playbook, an all-exclude change carries no spec delta. `--strict` requires a delta, so this change is intentionally delta-less and should not be validated with `--strict` on a (nonexistent) spec delta.
+
+## What changes
+
+- 207 methods across `src/components/` annotated with JSDoc `@spec exclude <reason>` (ADR-003 two-tool approach: annotation only, comment-only change).
+- No code behaviour changes. No REQs minted, so there is no spec delta.
+
+## Outcome
+
+**0 reverse-spec'd / 207 excluded / 0 new REQs.** Comment-only change.
+
+## Scope of this batch
+
+**Batch source**: `/tmp/or-scan/fw-fe-components.json` — 207 methods across `src/components/` files.

--- a/openspec/changes/retrofit-2026-05-25-fe-components/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-components/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+All tasks are marked `[x]` because the code already exists. This is a retrofit — tasks describe retroactive annotation, not new implementation work.
+
+All-exclude annotation change. No REQs minted, so there is no spec delta and no `--strict` validation step.
+
+## Annotation tasks
+
+- [x] task-1: Tag all 207 batch methods under `src/components/` with JSDoc `@spec exclude <reason>` (ADR-003).
+- [x] task-2: Verify 0 untagged methods remain in the batch.
+- [x] task-3: Confirm every added line is comment-only (no functional code change).

--- a/src/components/AgentSelector.vue
+++ b/src/components/AgentSelector.vue
@@ -201,6 +201,9 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * @spec exclude translation function placeholder, no observable behaviour
+		 */
 		t(app, text) {
 			// Translation function placeholder
 			return text
@@ -221,6 +224,7 @@ export default {
 		 *
 		 * @param {object|string} view - The view object or string identifier
 		 * @return {string} The view name
+		 * @spec exclude computed display helper deriving view label from prop
 		 */
 		getViewName(view) {
 			if (typeof view === 'string') {
@@ -234,6 +238,7 @@ export default {
 		 *
 		 * @param {object|string} tool - The tool object or string identifier
 		 * @return {string} The tool name
+		 * @spec exclude computed display helper deriving tool label from prop
 		 */
 		getToolName(tool) {
 			if (typeof tool === 'string') {
@@ -248,6 +253,7 @@ export default {
 		 * Handle start conversation click
 		 *
 		 * @param {object} agent - The agent to start conversation with
+		 * @spec exclude emit/UI handler delegating to parent via select-agent/confirm events
 		 */
 		handleStartConversation(agent) {
 			this.startingAgentId = agent.id
@@ -261,6 +267,7 @@ export default {
 		 *
 		 * @param {string|number} agentId - The agent ID
 		 * @param {string} section - The section to toggle ('views' or 'tools')
+		 * @spec exclude local UI expand-state toggle plumbing
 		 */
 		toggleExpand(agentId, section) {
 			const key = `${agentId}-${section}`
@@ -273,6 +280,7 @@ export default {
 		 * @param {string|number} agentId - The agent ID
 		 * @param {string} section - The section to check ('views' or 'tools')
 		 * @return {boolean} True if section is expanded
+		 * @spec exclude computed read of local UI expand state
 		 */
 		isExpanded(agentId, section) {
 			const key = `${agentId}-${section}`
@@ -284,6 +292,7 @@ export default {
 		 *
 		 * @param {object} agent - The agent object
 		 * @return {Array} Array of visible views
+		 * @spec exclude computed display slice of views by expand state
 		 */
 		getVisibleViews(agent) {
 			if (this.isExpanded(agent.id, 'views')) {
@@ -297,6 +306,7 @@ export default {
 		 *
 		 * @param {object} agent - The agent object
 		 * @return {Array} Array of visible tools
+		 * @spec exclude computed display slice of tools by expand state
 		 */
 		getVisibleTools(agent) {
 			if (this.isExpanded(agent.id, 'tools')) {

--- a/src/components/EntitiesSidebar.vue
+++ b/src/components/EntitiesSidebar.vue
@@ -112,14 +112,23 @@ export default {
 		Magnify,
 	},
 	props: {
+		/**
+		 * @spec exclude two-way-bound search prop, UI plumbing
+		 */
 		search: {
 			type: String,
 			default: '',
 		},
+		/**
+		 * @spec exclude two-way-bound entity-type filter prop, UI plumbing
+		 */
 		type: {
 			type: String,
 			default: null,
 		},
+		/**
+		 * @spec exclude two-way-bound category filter prop, UI plumbing
+		 */
 		category: {
 			type: String,
 			default: null,
@@ -164,14 +173,23 @@ export default {
 				this.$emit('update:search', value)
 			}, 500)
 		},
+		/**
+		 * @spec exclude filter-state writer emitting update:type to parent, UI plumbing
+		 */
 		updateType(type) {
 			this.selectedType = type
 			this.$emit('update:type', type)
 		},
+		/**
+		 * @spec exclude filter-state writer emitting update:category to parent, UI plumbing
+		 */
 		updateCategory(category) {
 			this.selectedCategory = category
 			this.$emit('update:category', category)
 		},
+		/**
+		 * @spec exclude filter-reset emitting cleared values to parent, UI plumbing
+		 */
 		clearFilters() {
 			this.localSearch = ''
 			this.selectedType = null

--- a/src/components/FacetComponent.vue
+++ b/src/components/FacetComponent.vue
@@ -390,6 +390,7 @@ export default {
 		/**
 		 * Get metadata fields that support date range faceting
 		 * These will be shown as date range pickers
+		 * @spec exclude computed filter of store facets for date-range UI, search contract owned by search capability
 		 */
 		metadataDateFields() {
 			// eslint-disable-next-line no-console
@@ -415,6 +416,7 @@ export default {
 		/**
 		 * Get metadata fields that are not date fields (excluding id and uuid)
 		 * These will be shown as checkboxes
+		 * @spec exclude computed filter of store facets for checkbox UI, search contract owned by search capability
 		 */
 		nonDateMetadataFields() {
 			const fields = {}
@@ -436,6 +438,7 @@ export default {
 		/**
 		 * Get object fields that use date_range faceting from current facet results
 		 * @return {object} Date range facet entries keyed by field name
+		 * @spec exclude computed filter of current store facets, search contract owned by search capability
 		 */
 		dateRangeObjectFields() {
 			const fields = {}
@@ -449,6 +452,7 @@ export default {
 		/**
 		 * Get object fields that use date_histogram faceting from current facet results
 		 * @return {object} Date histogram facet entries keyed by field name
+		 * @spec exclude computed filter of current store facets, search contract owned by search capability
 		 */
 		dateHistogramObjectFields() {
 			const fields = {}
@@ -459,6 +463,9 @@ export default {
 			})
 			return fields
 		},
+		/**
+		 * @spec exclude computed filter of store metadata facets for dropdown UI, search contract owned by search capability
+		 */
 		termsMetadataFields() {
 			const fields = {}
 			Object.entries(this.objectStore.availableMetadataFacets).forEach(([fieldName, field]) => {
@@ -478,6 +485,7 @@ export default {
 		 * Check if a facet is currently active
 		 * @param {string} fieldName - Name of the field to check
 		 * @return {boolean} True if facet is active
+		 * @spec exclude computed read of active facet state from store, UI plumbing
 		 */
 		isActiveFacet(fieldName) {
 			if (fieldName.startsWith('@self.')) {
@@ -492,6 +500,7 @@ export default {
 		 * @param {string} fieldName - Name of the field to toggle
 		 * @param {string} facetType - Type of facet
 		 * @param {boolean} enabled - Whether to enable or disable the facet
+		 * @spec exclude store passthrough toggling facet + refreshing list, search contract owned by search capability
 		 */
 		async toggleFacet(fieldName, facetType, enabled) {
 			await this.objectStore.updateActiveFacet(fieldName, facetType, enabled)
@@ -502,6 +511,7 @@ export default {
 		 * Get display name for a facet field
 		 * @param {string} facetField - Name of the facet field
 		 * @return {string} Display name for the facet
+		 * @spec exclude computed display-name helper from store field metadata, UI plumbing
 		 */
 		getFacetDisplayName(facetField) {
 			if (facetField === '@self') {
@@ -525,6 +535,7 @@ export default {
 		 * Get display name for an active facet field
 		 * @param {string} facetField - Name of the facet field
 		 * @return {string} Display name for the active facet
+		 * @spec exclude computed display-name helper, UI plumbing
 		 */
 		getActiveFacetDisplayName(facetField) {
 			// Handle nested facet fields (e.g., '@self' contains multiple sub-facets)
@@ -538,6 +549,7 @@ export default {
 		/**
 		 * Remove a specific filter
 		 * @param {string} facetField - Name of the facet field to remove
+		 * @spec exclude store passthrough removing facet + refreshing list, search contract owned by search capability
 		 */
 		async removeFilter(facetField) {
 			// Remove a specific active filter
@@ -556,6 +568,7 @@ export default {
 		},
 		/**
 		 * Clear all active filters
+		 * @spec exclude store passthrough clearing all facets/filters, search contract owned by search capability
 		 */
 		async clearAllFilters() {
 			// Clear all active facets and filters
@@ -568,6 +581,7 @@ export default {
 		 * Uses facet results if available, otherwise uses sample values
 		 * @param {string} fieldName - Name of the field
 		 * @return {Array} Array of dropdown options
+		 * @spec exclude computed dropdown-option builder from store facet buckets, UI plumbing
 		 */
 		getDropdownOptions(fieldName) {
 			const options = []
@@ -625,6 +639,7 @@ export default {
 		 * Get currently selected values for a dropdown
 		 * @param {string} fieldName - Name of the field
 		 * @return {Array} Array of selected values
+		 * @spec exclude computed read of selected dropdown values from store filters, UI plumbing
 		 */
 		getSelectedDropdownValues(fieldName) {
 			// Get selected values from active filters
@@ -657,6 +672,7 @@ export default {
 		 * Update dropdown selection for a field
 		 * @param {string} fieldName - Name of the field
 		 * @param {Array} selectedOptions - Array of selected options
+		 * @spec exclude store filter writer + list refresh, search contract owned by search capability
 		 */
 		async updateDropdownSelection(fieldName, selectedOptions) {
 			// eslint-disable-next-line no-console
@@ -688,6 +704,7 @@ export default {
 		 * Update a field facet with specific configuration
 		 * @param {string} fieldName - Name of the field
 		 * @param {object} facetConfig - Facet configuration object
+		 * @spec exclude store facet-config writer + list refresh, search contract owned by search capability
 		 */
 		async updateFieldFacet(fieldName, facetConfig) {
 			// eslint-disable-next-line no-console
@@ -721,6 +738,7 @@ export default {
 		 * @param {string} fieldName - Name of the field
 		 * @param {string} bucketValue - The bucket key/value
 		 * @return {boolean} True if selected
+		 * @spec exclude computed read of selected date-range bucket from store filters, UI plumbing
 		 */
 		isDateRangeSelected(fieldName, bucketValue) {
 			const filterKey = `${fieldName}._dateRange`
@@ -730,6 +748,7 @@ export default {
 		 * Select a predefined date range bucket
 		 * @param {string} fieldName - Name of the field
 		 * @param {object} bucket - The bucket with from/to/value/label
+		 * @spec exclude store filter writer for date-range preset + list refresh, search contract owned by search capability
 		 */
 		async selectDateRangeBucket(fieldName, bucket) {
 			const currentFilters = { ...this.objectStore.activeFilters }
@@ -760,6 +779,7 @@ export default {
 		 * @param {string} fieldName - Name of the field
 		 * @param {string} bound - 'from' or 'to'
 		 * @return {string|null} Date value
+		 * @spec exclude computed read of object date-range bound from store filters, UI plumbing
 		 */
 		getObjectDateRangeValue(fieldName, bound) {
 			const operator = bound === 'from' ? '>=' : '<='
@@ -774,6 +794,7 @@ export default {
 		 * @param {string} fieldName - Name of the field
 		 * @param {string} bound - 'from' or 'to'
 		 * @param {string} value - Date value
+		 * @spec exclude store filter writer for object date-range + list refresh, search contract owned by search capability
 		 */
 		async updateObjectDateRange(fieldName, bound, value) {
 			const currentFilters = { ...this.objectStore.activeFilters }
@@ -795,6 +816,7 @@ export default {
 		 * Check if an object date field has an active custom date range
 		 * @param {string} fieldName - Name of the field
 		 * @return {boolean} True if has active date range
+		 * @spec exclude computed read of object date-range presence from store filters, UI plumbing
 		 */
 		hasObjectDateRange(fieldName) {
 			return Boolean(
@@ -805,6 +827,7 @@ export default {
 		/**
 		 * Clear date range for an object date field
 		 * @param {string} fieldName - Name of the field
+		 * @spec exclude store filter writer clearing object date-range + list refresh, search contract owned by search capability
 		 */
 		async clearObjectDateRange(fieldName) {
 			const currentFilters = { ...this.objectStore.activeFilters }
@@ -819,6 +842,7 @@ export default {
 		 * Get dropdown options for a date histogram facet
 		 * @param {string} fieldName - Name of the field
 		 * @return {Array} Array of options with value, label, count, from, to
+		 * @spec exclude computed option builder from store histogram buckets, UI plumbing
 		 */
 		getDateHistogramOptions(fieldName) {
 			const facet = this.objectStore.currentFacets?.[fieldName]
@@ -838,6 +862,7 @@ export default {
 		 * Get currently selected date histogram values
 		 * @param {string} fieldName - Name of the field
 		 * @return {Array} Array of selected options
+		 * @spec exclude computed read of selected histogram buckets from store filters, UI plumbing
 		 */
 		getSelectedDateHistogramValues(fieldName) {
 			// Check for active range filters on this field
@@ -861,6 +886,7 @@ export default {
 		 * Update date histogram selection (using from/to for query params)
 		 * @param {string} fieldName - Name of the field
 		 * @param {Array} selectedOptions - Array of selected options with from/to
+		 * @spec exclude store filter writer for histogram selection + list refresh, search contract owned by search capability
 		 */
 		async updateDateHistogramSelection(fieldName, selectedOptions) {
 			const currentFilters = { ...this.objectStore.activeFilters }
@@ -890,6 +916,7 @@ export default {
 		 * Capitalize field names for display
 		 * @param {string} fieldName - Name of the field to capitalize
 		 * @return {string} Capitalized field name
+		 * @spec exclude pure string-formatting display helper, UI plumbing
 		 */
 		capitalizeFieldName(fieldName) {
 			// Handle common field names and provide proper capitalization
@@ -944,6 +971,7 @@ export default {
 		 * @param {string} fieldName - Name of the field
 		 * @param {string} bound - Bound type ('from' or 'to')
 		 * @return {string|null} Date value or null
+		 * @spec exclude computed read of metadata date-range bound from store facets, UI plumbing
 		 */
 		getDateRangeValue(fieldName, bound) {
 			// eslint-disable-next-line no-console
@@ -977,6 +1005,7 @@ export default {
 		 * @param {string} fieldName - Name of the field
 		 * @param {string} bound - Bound type ('from' or 'to')
 		 * @param {string} value - Date value
+		 * @spec exclude store facet/filter writer for metadata date-range + list refresh, search contract owned by search capability
 		 */
 		async updateDateRange(fieldName, bound, value) {
 			// eslint-disable-next-line no-console
@@ -1043,6 +1072,7 @@ export default {
 		 * Converts range facets to proper filter parameters like @self[created][>=]=2025-06-24T00:00:00+00:00
 		 * @param {string} fieldName - Name of the field
 		 * @param {object} rangeFacet - Range facet configuration object
+		 * @spec exclude internal helper converting range facet to store filter params, UI plumbing
 		 */
 		updateActiveFiltersFromDateRange(fieldName, rangeFacet) {
 			// eslint-disable-next-line no-console
@@ -1091,6 +1121,7 @@ export default {
 		 * Check if a field has an active date range
 		 * @param {string} fieldName - Name of the field to check
 		 * @return {boolean} True if field has an active date range
+		 * @spec exclude computed read of metadata date-range presence from store facets, UI plumbing
 		 */
 		hasDateRange(fieldName) {
 			const activeFacetData = this.objectStore.activeFacets._facets?.['@self']?.[fieldName]
@@ -1103,6 +1134,7 @@ export default {
 		/**
 		 * Clear date range for a field
 		 * @param {string} fieldName - Name of the field to clear date range for
+		 * @spec exclude store facet/filter writer clearing metadata date-range + list refresh, search contract owned by search capability
 		 */
 		async clearDateRange(fieldName) {
 			// Remove the date range facet
@@ -1131,6 +1163,7 @@ export default {
 		 * Uses facet results if available, otherwise uses sample values
 		 * @param {string} fieldName - Name of the metadata field
 		 * @return {Array} Array of dropdown options
+		 * @spec exclude computed dropdown-option builder from store metadata facets, UI plumbing
 		 */
 		getMetadataDropdownOptions(fieldName) {
 			const options = []
@@ -1207,6 +1240,7 @@ export default {
 		 * Get currently selected values for a metadata dropdown
 		 * @param {string} fieldName - Name of the metadata field
 		 * @return {Array} Array of selected dropdown options
+		 * @spec exclude computed read of selected metadata values from store filters, UI plumbing
 		 */
 		getSelectedMetadataDropdownValues(fieldName) {
 			// Metadata filters use @self. prefix
@@ -1240,6 +1274,7 @@ export default {
 		 * Update metadata dropdown selection for a field
 		 * @param {string} fieldName - Name of the metadata field
 		 * @param {Array} selectedOptions - Array of selected options
+		 * @spec exclude store filter writer for metadata selection + list refresh, search contract owned by search capability
 		 */
 		async updateMetadataDropdownSelection(fieldName, selectedOptions) {
 			// eslint-disable-next-line no-console

--- a/src/components/FilesSidebar.vue
+++ b/src/components/FilesSidebar.vue
@@ -132,14 +132,23 @@ export default {
 	},
 
 	props: {
+		/**
+		 * @spec exclude two-way-bound search prop, UI plumbing
+		 */
 		search: {
 			type: String,
 			default: '',
 		},
+		/**
+		 * @spec exclude two-way-bound extraction-status filter prop, UI plumbing
+		 */
 		status: {
 			type: String,
 			default: null,
 		},
+		/**
+		 * @spec exclude two-way-bound risk-level filter prop, UI plumbing
+		 */
 		riskLevel: {
 			type: String,
 			default: null,
@@ -186,6 +195,7 @@ export default {
 		 *
 		 * @param {string} value - The search value
 		 * @return {void}
+		 * @spec exclude debounced search-emit UI plumbing
 		 */
 		handleSearchInput(value) {
 			clearTimeout(this.searchTimeout)
@@ -199,6 +209,7 @@ export default {
 		 *
 		 * @param {string|null} status - The status to filter by
 		 * @return {void}
+		 * @spec exclude filter-state writer emitting update:status, UI plumbing
 		 */
 		updateStatus(status) {
 			this.selectedStatus = status
@@ -210,6 +221,7 @@ export default {
 		 *
 		 * @param {string|null} level - The risk level to filter by
 		 * @return {void}
+		 * @spec exclude filter-state writer emitting update:riskLevel, UI plumbing
 		 */
 		updateRiskLevel(level) {
 			this.selectedRiskLevel = level
@@ -220,6 +232,7 @@ export default {
 		 * Clear all filters
 		 *
 		 * @return {void}
+		 * @spec exclude filter-reset emitting cleared values, UI plumbing
 		 */
 		clearFilters() {
 			this.localSearch = ''

--- a/src/components/NotificationSubscriptionToggle.vue
+++ b/src/components/NotificationSubscriptionToggle.vue
@@ -73,27 +73,42 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude computed numeric coercion of registerId prop, UI plumbing
+		 */
 		registerIdNum() {
 			return this.registerId !== null && this.registerId !== ''
 				? Number(this.registerId)
 				: null
 		},
+		/**
+		 * @spec exclude computed numeric coercion of schemaId prop, UI plumbing
+		 */
 		schemaIdNum() {
 			return this.schemaId !== null && this.schemaId !== ''
 				? Number(this.schemaId)
 				: null
 		},
+		/**
+		 * @spec exclude computed subscription-state read via service helper; subscription contract owned by notificatie-engine
+		 */
 		isSubscribed() {
 			return hasSubscription(this.subscriptions, {
 				registerId: this.registerIdNum,
 				schemaId: this.schemaIdNum,
 			})
 		},
+		/**
+		 * @spec exclude computed button-label display helper, UI plumbing
+		 */
 		buttonLabel() {
 			return this.isSubscribed
 				? t('openregister', 'Subscribed')
 				: t('openregister', 'Subscribe')
 		},
+		/**
+		 * @spec exclude computed tooltip/title display helper, UI plumbing
+		 */
 		title() {
 			return this.isSubscribed
 				? t('openregister', 'Click to unsubscribe from notifications')
@@ -104,6 +119,9 @@ export default {
 		await this.refresh()
 	},
 	methods: {
+		/**
+		 * @spec exclude service passthrough loading subscriptions; subscription contract owned by notificatie-engine
+		 */
 		async refresh() {
 			try {
 				this.subscriptions = await listSubscriptions()
@@ -112,6 +130,9 @@ export default {
 				console.error('Failed to load notification subscriptions:', error)
 			}
 		},
+		/**
+		 * @spec exclude service passthrough toggling subscribe/unsubscribe with optimistic UI; contract owned by notificatie-engine
+		 */
 		async toggle() {
 			if (this.registerIdNum === null && this.schemaIdNum === null) {
 				return

--- a/src/components/PaginationComponent.vue
+++ b/src/components/PaginationComponent.vue
@@ -154,6 +154,7 @@ export default {
 		/**
 		 * Get current page size option object
 		 * @return {object} Current page size option object
+		 * @spec exclude computed lookup of current page-size option, UI plumbing
 		 */
 		currentPageSizeOption() {
 			return this.pageSizeOptions.find(option => option.value === this.currentPageSize) || this.pageSizeOptions[1]
@@ -161,6 +162,7 @@ export default {
 		/**
 		 * Calculate visible page numbers for pagination
 		 * @return {Array} Array of page numbers and ellipsis
+		 * @spec exclude computed ellipsis-aware page-number list for display, UI plumbing
 		 */
 		visiblePages() {
 			const current = this.currentPage
@@ -224,6 +226,7 @@ export default {
 		 * Change page size
 		 * @param {object} option - Selected page size option
 		 * @return {void}
+		 * @spec exclude emit page-size-changed UI plumbing
 		 */
 		changePageSize(option) {
 			if (option.value !== this.currentPageSize) {

--- a/src/components/RbacTable.vue
+++ b/src/components/RbacTable.vue
@@ -179,6 +179,7 @@ export default {
 		 * Get sorted groups (only showing groups assigned to the organisation)
 		 *
 		 * @return {Array} Sorted array of groups
+		 * @spec exclude computed sorted/filtered group list for display, RBAC contract owned by rbac capability
 		 */
 		sortedGroups() {
 			// If no organisation groups specified, show all available groups
@@ -205,6 +206,7 @@ export default {
 		 * Check if any permissions are set for this entity type
 		 *
 		 * @return {boolean} True if permissions are set
+		 * @spec exclude computed read of authorization prop presence, RBAC contract owned by rbac capability
 		 */
 		hasAnyPermissions() {
 		// For applications, authorization is flat (just {create: [], read: [], ...})
@@ -241,6 +243,7 @@ export default {
 	 * @param {string} groupId - The group ID
 	 * @param {string} action - The action (create, read, update, delete)
 	 * @return {boolean} True if group has permission
+	 * @spec exclude permission-check read helper, RBAC contract owned by rbac capability
 	 */
 		hasPermission(groupId, action) {
 		// For applications, authorization is flat (just {create: [], read: [], ...})
@@ -269,6 +272,7 @@ export default {
 		 * @param {string} action - The action (create, read, update, delete)
 		 * @param {boolean} hasPermission - Whether to grant or revoke permission
 		 * @return {void}
+		 * @spec exclude emit update event to parent, RBAC contract owned by rbac capability
 		 */
 		updatePermission(groupId, action, hasPermission) {
 			this.$emit('update', {

--- a/src/components/WebhooksSidebar.vue
+++ b/src/components/WebhooksSidebar.vue
@@ -69,10 +69,16 @@ export default {
 	},
 
 	props: {
+		/**
+		 * @spec exclude two-way-bound search prop, UI plumbing
+		 */
 		search: {
 			type: String,
 			default: '',
 		},
+		/**
+		 * @spec exclude two-way-bound enabled-status filter prop, UI plumbing
+		 */
 		enabled: {
 			type: Boolean,
 			default: null,
@@ -129,6 +135,7 @@ export default {
 		 *
 		 * @param {boolean|null} enabled - The enabled status to filter by
 		 * @return {void}
+		 * @spec exclude filter-state writer emitting update:enabled, UI plumbing
 		 */
 		updateEnabled(enabled) {
 			this.selectedEnabled = enabled
@@ -139,6 +146,7 @@ export default {
 		 * Clear all filters
 		 *
 		 * @return {void}
+		 * @spec exclude filter-reset emitting cleared values, UI plumbing
 		 */
 		clearFilters() {
 			this.localSearch = ''

--- a/src/components/cards/ConfigurationCard.vue
+++ b/src/components/cards/ConfigurationCard.vue
@@ -290,6 +290,7 @@ export default {
 		 * Get the app ID from configuration
 		 *
 		 * @return {string|null}
+		 * @spec exclude computed read of app id from configuration prop, UI plumbing
 		 */
 		appId() {
 			return this.configuration.app || this.configuration.config?.app || null
@@ -299,6 +300,7 @@ export default {
 		 * Uses backend-fetched data, not frontend store (which may be paginated)
 		 *
 		 * @return {boolean}
+		 * @spec exclude computed read of import-status flag set by checkIfImported (REQ-002), UI plumbing
 		 */
 		isAlreadyImported() {
 			if (!this.isDiscovered) return false
@@ -309,6 +311,7 @@ export default {
 		 * Get the existing local configuration if it's already imported
 		 *
 		 * @return {object|null}
+		 * @spec exclude computed lookup/synthesis of local config for display, UI plumbing
 		 */
 		existingConfiguration() {
 			if (!this.importedConfigId) return null
@@ -344,6 +347,7 @@ export default {
 		 * If discovered and already imported, merge with local config
 		 *
 		 * @return {object}
+		 * @spec exclude computed merge of discovered + local config for display, UI plumbing
 		 */
 		displayConfiguration() {
 			if (this.isDiscovered && this.existingConfiguration) {
@@ -374,6 +378,7 @@ export default {
 		 * Check if this is an imported configuration
 		 *
 		 * @return {boolean}
+		 * @spec exclude computed import-state read for display, UI plumbing
 		 */
 		isImported() {
 			// If it's a discovered config, check if it exists locally
@@ -387,6 +392,7 @@ export default {
 		 * Get description from either format
 		 *
 		 * @return {string}
+		 * @spec exclude computed description display helper, UI plumbing
 		 */
 		description() {
 			const config = this.displayConfiguration
@@ -396,6 +402,7 @@ export default {
 		 * Check if configuration is local
 		 *
 		 * @return {boolean}
+		 * @spec exclude computed local-vs-external display flag, UI plumbing
 		 */
 		isLocalConfiguration() {
 			// Check both displayConfiguration and original configuration prop
@@ -426,6 +433,7 @@ export default {
 		 * Check if configuration is remote
 		 *
 		 * @return {boolean}
+		 * @spec exclude computed remote-source display flag, UI plumbing
 		 */
 		isRemoteConfiguration() {
 			const result = this.isImported && this.displayConfiguration.sourceType && this.displayConfiguration.sourceType !== 'local'
@@ -436,6 +444,7 @@ export default {
 		 * Check if update is available
 		 *
 		 * @return {boolean}
+		 * @spec exclude computed version-comparison display flag, UI plumbing
 		 */
 		hasUpdateAvailable() {
 			const config = this.displayConfiguration
@@ -449,6 +458,7 @@ export default {
 		 * Check if configuration is published (local and has GitHub repo info)
 		 *
 		 * @return {boolean}
+		 * @spec exclude computed published-state display flag, UI plumbing
 		 */
 		isPublished() {
 			const config = this.displayConfiguration
@@ -459,6 +469,7 @@ export default {
 		 * Get view source URL
 		 *
 		 * @return {string|null}
+		 * @spec exclude computed source-URL display helper, UI plumbing
 		 */
 		viewSourceUrl() {
 			const config = this.displayConfiguration
@@ -468,6 +479,7 @@ export default {
 		 * Check if configuration has any metadata to display in footer
 		 *
 		 * @return {boolean}
+		 * @spec exclude computed footer-metadata presence flag, UI plumbing
 		 */
 		hasMetadata() {
 			const config = this.displayConfiguration
@@ -485,6 +497,7 @@ export default {
 		 * Get repository full name (owner/repo)
 		 *
 		 * @return {string|null}
+		 * @spec exclude computed repo-name display helper, UI plumbing
 		 */
 		repositoryFullName() {
 			const config = this.displayConfiguration
@@ -513,6 +526,7 @@ export default {
 		 * Get repository URL
 		 *
 		 * @return {string|null}
+		 * @spec exclude computed repo-URL display helper, UI plumbing
 		 */
 		repositoryUrl() {
 			if (!this.repositoryFullName) return null
@@ -536,6 +550,9 @@ export default {
 			}
 		},
 	},
+	/**
+	 * @spec exclude lifecycle hook delegating to checkIfImported (REQ-002), UI plumbing
+	 */
 	mounted() {
 		// For discovered configs, check backend to see if already imported
 		if (this.isDiscovered && this.appId) {
@@ -604,6 +621,7 @@ export default {
 		 *
 		 * @param {string} sourceType Source type
 		 * @return {string}
+		 * @spec exclude source-type label display helper, UI plumbing
 		 */
 		getSourceTypeLabel(sourceType) {
 			const labels = {
@@ -619,6 +637,7 @@ export default {
 		 *
 		 * @param {object} configuration Configuration object
 		 * @return {string}
+		 * @spec exclude sync-status display formatter, UI plumbing
 		 */
 		getSyncStatusText(configuration) {
 			if (configuration.syncStatus === 'success' && configuration.lastSyncDate) {
@@ -646,12 +665,14 @@ export default {
 		 * Open URL in new tab
 		 *
 		 * @param {string} url URL to open
+		 * @spec exclude window.open UI plumbing
 		 */
 		openInNewTab(url) {
 			window.open(url, '_blank')
 		},
 		/**
 		 * Handle view action
+		 * @spec exclude emit/store-dispatch UI handler opening view modal
 		 */
 		handleView() {
 			const config = this.existingConfiguration || this.displayConfiguration
@@ -665,6 +686,7 @@ export default {
 		},
 		/**
 		 * Handle edit action
+		 * @spec exclude emit/store-dispatch UI handler opening edit modal
 		 */
 		handleEdit() {
 			const config = this.existingConfiguration || this.displayConfiguration
@@ -677,6 +699,7 @@ export default {
 		},
 		/**
 		 * Handle export action
+		 * @spec exclude emit/store-dispatch UI handler opening export modal
 		 */
 		handleExport() {
 			const config = this.existingConfiguration || this.displayConfiguration
@@ -689,6 +712,7 @@ export default {
 		},
 		/**
 		 * Handle publish action
+		 * @spec exclude store-dispatch UI handler opening publish modal
 		 */
 		handlePublish() {
 			const config = this.existingConfiguration || this.displayConfiguration
@@ -697,6 +721,7 @@ export default {
 		},
 		/**
 		 * Handle delete action
+		 * @spec exclude emit/store-dispatch UI handler opening delete dialog
 		 */
 		handleDelete() {
 			const config = this.existingConfiguration || this.displayConfiguration
@@ -709,6 +734,7 @@ export default {
 		},
 		/**
 		 * Handle check version action
+		 * @spec exclude emit UI handler dispatching check-version event
 		 */
 		handleCheckVersion() {
 			const config = this.existingConfiguration || this.displayConfiguration
@@ -716,6 +742,7 @@ export default {
 		},
 		/**
 		 * Handle preview update action
+		 * @spec exclude emit/store-dispatch UI handler opening preview modal
 		 */
 		handlePreviewUpdate() {
 			const config = this.existingConfiguration || this.displayConfiguration

--- a/src/components/cards/RegisterSchemaCard.vue
+++ b/src/components/cards/RegisterSchemaCard.vue
@@ -405,6 +405,9 @@ export default {
 		},
 	},
 	emits: ['refresh'],
+	/**
+	 * @spec exclude local data state; showEditRegisterDialog toggles the edit dialog, UI plumbing
+	 */
 	data() {
 		return {
 			itemsExpanded: false,
@@ -415,6 +418,9 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude computed lookup of managing configuration from store, UI plumbing
+		 */
 		managingConfiguration() {
 			if (!this.item || !this.item.id) return null
 			if (this.type === 'register') {
@@ -427,11 +433,17 @@ export default {
 				config => config.schemas && config.schemas.some(s => s.id === this.item.id),
 			) || null
 		},
+		/**
+		 * @spec exclude computed external-management display flag, UI plumbing
+		 */
 		isManagedByExternalConfig() {
 			const config = this.managingConfiguration
 			if (!config) return false
 			return (config.sourceType && ['github', 'gitlab', 'url'].includes(config.sourceType)) || config.isLocal === false
 		},
+		/**
+		 * @spec exclude computed local-management display flag, UI plumbing
+		 */
 		isManagedByLocalConfig() {
 			const config = this.managingConfiguration
 			if (!config) return false
@@ -440,18 +452,27 @@ export default {
 		hasObjects() {
 			return this.item.stats?.objects?.total > 0
 		},
+		/**
+		 * @spec exclude computed delete-disabled display flag from object stats, UI plumbing
+		 */
 		deleteDisabled() {
 			if (this.type === 'register') {
 				return this.item.stats?.total > 0
 			}
 			return this.item.stats?.objects?.total > 0
 		},
+		/**
+		 * @spec exclude computed delete-disabled tooltip display helper, UI plumbing
+		 */
 		deleteDisabledTooltip() {
 			if (this.deleteDisabled) {
 				return 'Cannot delete: objects are still attached'
 			}
 			return ''
 		},
+		/**
+		 * @spec exclude computed paginated schema/property list for display, UI plumbing
+		 */
 		displayedItems() {
 			if (this.type === 'register') {
 				if (!this.item.schemas || this.item.schemas.length === 0) return []
@@ -464,6 +485,9 @@ export default {
 			if (this.itemsExpanded) return sorted
 			return Object.fromEntries(entries.slice(0, 5))
 		},
+		/**
+		 * @spec exclude computed remaining-items count for "view more" display, UI plumbing
+		 */
 		remainingItemsCount() {
 			if (this.type === 'register') {
 				const total = this.item.schemas?.length || 0
@@ -472,6 +496,9 @@ export default {
 			const total = Object.keys(this.item.properties || {}).length
 			return Math.max(0, total - 5)
 		},
+		/**
+		 * @spec exclude computed inline form-schema definition for edit dialog, UI plumbing
+		 */
 		registerSchema() {
 			return {
 				title: t('openregister', 'Register'),
@@ -484,6 +511,9 @@ export default {
 				required: ['title', 'slug'],
 			}
 		},
+		/**
+		 * @spec exclude computed order-sorted property list for display, UI plumbing
+		 */
 		sortedProperties() {
 			const properties = this.item.properties || {}
 			return Object.entries(properties)
@@ -512,6 +542,9 @@ export default {
 	},
 	methods: {
 		// Common methods
+		/**
+		 * @spec exclude store/modal-dispatch UI handler opening edit, register/schema contract owned by register/schema capability
+		 */
 		openEdit() {
 			if (this.type === 'register') {
 				this.showEditRegisterDialog = true
@@ -520,6 +553,9 @@ export default {
 				navigationStore.setModal('editSchema')
 			}
 		},
+		/**
+		 * @spec exclude store passthrough publishing register/schema with toast, contract owned by register/schema capability
+		 */
 		async publish() {
 			try {
 				if (this.type === 'register') {
@@ -534,6 +570,9 @@ export default {
 				showError(t('openregister', 'Failed to publish: {error}', { error: error.message }))
 			}
 		},
+		/**
+		 * @spec exclude store passthrough depublishing register/schema with toast, contract owned by register/schema capability
+		 */
 		async depublish() {
 			try {
 				if (this.type === 'register') {
@@ -548,6 +587,9 @@ export default {
 				showError(t('openregister', 'Failed to depublish: {error}', { error: error.message }))
 			}
 		},
+		/**
+		 * @spec exclude store passthrough loading schema select options, UI plumbing
+		 */
 		async loadSchemaOptions() {
 			this.schemasLoading = true
 			try {
@@ -559,6 +601,9 @@ export default {
 				this.schemasLoading = false
 			}
 		},
+		/**
+		 * @spec exclude computed mapping of schema ids to select options, UI plumbing
+		 */
 		getSchemaSelectValue(schemas) {
 			if (!Array.isArray(schemas)) return []
 			return schemas.map(s => {
@@ -567,6 +612,9 @@ export default {
 					|| { id, label: String(id) }
 			})
 		},
+		/**
+		 * @spec exclude store passthrough saving register from dialog + refresh emit, contract owned by register capability
+		 */
 		async onSaveRegister(formData) {
 			try {
 				await registerStore.saveRegister({
@@ -579,6 +627,9 @@ export default {
 				this.$refs.editRegisterDialog.setResult({ error: error.message })
 			}
 		},
+		/**
+		 * @spec exclude store/dialog-dispatch UI handler opening delete, contract owned by register/schema capability
+		 */
 		openDelete() {
 			if (this.type === 'register') {
 				registerStore.setRegisterItem(this.item)
@@ -595,11 +646,17 @@ export default {
 		},
 
 		// Register-only methods
+		/**
+		 * @spec exclude router-navigation UI handler to register detail, UI plumbing
+		 */
 		viewRegisterDetails() {
 			registerStore.setRegisterItem({ id: this.item.id })
 			this.$router.push(`/registers/${this.item.id}`)
 		},
 
+		/**
+		 * @spec exclude API fetch + browser file-download UI plumbing; OAS contract owned by openapi-generation capability
+		 */
 		async downloadOas() {
 			const baseUrl = window.location.origin
 			const apiUrl = `${baseUrl}/index.php/apps/openregister/api/registers/${this.item.id}/oas`
@@ -619,12 +676,18 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude window.open to external Redoc viewer, UI plumbing
+		 */
 		viewOasDoc() {
 			const baseUrl = window.location.origin
 			const apiUrl = `${baseUrl}/index.php/apps/openregister/api/registers/${this.item.id}/oas`
 			window.open(`https://redocly.github.io/redoc/?url=${encodeURIComponent(apiUrl)}`, '_blank')
 		},
 
+		/**
+		 * @spec exclude computed read of schema property table mapping for icon display, UI plumbing
+		 */
 		hasMagicMapping(schema) {
 			if (!schema || !schema.properties) {
 				return false
@@ -634,6 +697,9 @@ export default {
 			)
 		},
 
+		/**
+		 * @spec exclude computed active-object count from schema stats for display, UI plumbing
+		 */
 		getSchemaObjectCount(schema) {
 			if (!schema || !schema.stats || !schema.stats.objects) {
 				return 0
@@ -643,6 +709,9 @@ export default {
 			return total - deleted
 		},
 
+		/**
+		 * @spec exclude API passthrough triggering magic-table sync with toast; sync contract owned by magic-table capability
+		 */
 		async syncMagicTable(schema) {
 			const baseUrl = window.location.origin
 			const apiUrl = `${baseUrl}/index.php/apps/openregister/api/tables/sync/${this.item.id}/${schema.id}`
@@ -703,6 +772,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude API passthrough toggling schema magic/blob config with toast; schema contract owned by schema capability
+		 */
 		async setSchemaConfiguration(schema, configurationType) {
 			const baseUrl = window.location.origin
 			const apiUrl = `${baseUrl}/index.php/apps/openregister/api/schemas/${schema.id}`
@@ -769,6 +841,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude API passthrough triggering object validation with toast; validation contract owned by oas-validation capability
+		 */
 		async validateSchemaObjects(schema) {
 			const baseUrl = window.location.origin
 			const apiUrl = `${baseUrl}/index.php/apps/openregister/api/objects/validate`
@@ -813,6 +888,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude confirm-dialog + bulk-delete API passthrough with toast; bulk-delete contract owned by scoped-object-delete-api capability
+		 */
 		async deleteSchemaObjects(schema, hardDelete = false) {
 			const totalObjects = schema.stats?.objects?.total || 0
 			const activeObjects = this.getSchemaObjectCount(schema)
@@ -901,6 +979,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude confirm-dialog + schema-delete API passthrough with toast; schema contract owned by schema capability
+		 */
 		async removeSchemaFromRegister(schema) {
 			const objectCount = this.getSchemaObjectCount(schema)
 

--- a/src/components/files-sidebar/ExtractionTab.vue
+++ b/src/components/files-sidebar/ExtractionTab.vue
@@ -192,6 +192,7 @@ export default {
 		 * Human-readable extraction status label.
 		 *
 		 * @return {string}
+		 * @spec exclude computed status-label display helper, UI plumbing
 		 */
 		statusLabel() {
 			const labels = {
@@ -208,6 +209,7 @@ export default {
 		 * Human-readable risk level label.
 		 *
 		 * @return {string}
+		 * @spec exclude computed risk-label display helper, UI plumbing
 		 */
 		riskLabel() {
 			const labels = {
@@ -224,6 +226,7 @@ export default {
 		 * CSS class for risk level badge.
 		 *
 		 * @return {string}
+		 * @spec exclude computed risk-badge CSS-class display helper, UI plumbing
 		 */
 		riskBadgeClass() {
 			const classes = {
@@ -240,6 +243,7 @@ export default {
 		 * Formatted extraction date.
 		 *
 		 * @return {string}
+		 * @spec exclude computed date-format display helper, UI plumbing
 		 */
 		formattedDate() {
 			if (!this.status.extractedAt) {
@@ -255,6 +259,9 @@ export default {
 
 	watch: {
 		fileId: {
+			/**
+			 * @spec exclude watcher refetching extraction status on fileId change, UI plumbing
+			 */
 			handler(newVal) {
 				if (newVal) {
 					this.fetchExtractionStatus()
@@ -269,6 +276,7 @@ export default {
 
 		/**
 		 * Fetch extraction status from the API.
+		 * @spec exclude API passthrough loading extraction status; extraction contract owned by text-extraction capability
 		 */
 		async fetchExtractionStatus() {
 			this.loading = true
@@ -298,6 +306,7 @@ export default {
 
 		/**
 		 * Trigger text extraction for this file.
+		 * @spec exclude API passthrough triggering extraction + refresh; extraction contract owned by text-extraction capability
 		 */
 		async triggerExtraction() {
 			this.extracting = true

--- a/src/components/files-sidebar/RegisterObjectsTab.vue
+++ b/src/components/files-sidebar/RegisterObjectsTab.vue
@@ -85,6 +85,9 @@ export default {
 
 	watch: {
 		fileId: {
+			/**
+			 * @spec exclude watcher refetching objects on fileId change, UI plumbing
+			 */
 			handler(newVal) {
 				if (newVal) {
 					this.fetchObjects()
@@ -99,6 +102,7 @@ export default {
 
 		/**
 		 * Fetch objects referencing this file from the API.
+		 * @spec exclude API passthrough loading file-referencing objects; object contract owned by object capability
 		 */
 		async fetchObjects() {
 			this.loading = true
@@ -132,6 +136,7 @@ export default {
 		 *
 		 * @param {object} obj The object data
 		 * @return {string} The absolute URL to the object detail page
+		 * @spec exclude computed object-detail URL builder, UI plumbing
 		 */
 		getObjectUrl(obj) {
 			return generateUrl(
@@ -149,6 +154,7 @@ export default {
 		 *
 		 * @param {object} obj The object data
 		 * @return {string} Accessible label text
+		 * @spec exclude computed aria-label display helper, UI plumbing
 		 */
 		getAriaLabel(obj) {
 			return t('openregister', '{title} in {register} / {schema}', {

--- a/src/components/i18n/BulkTranslateDialog.vue
+++ b/src/components/i18n/BulkTranslateDialog.vue
@@ -83,6 +83,9 @@ import { useTranslationsStore } from '../../store/modules/translations.js'
 export default {
 	name: 'BulkTranslateDialog',
 	props: {
+		/**
+		 * @spec exclude dialog open/visibility prop, UI plumbing
+		 */
 		open: {
 			type: Boolean,
 			default: false,
@@ -111,6 +114,9 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude computed submit-enabled form-validation flag, UI plumbing
+		 */
 		canSubmit() {
 			return !this.loading
 				&& this.from !== ''
@@ -136,6 +142,9 @@ export default {
 		},
 	},
 	methods: {
+		/**
+		 * @spec exclude store passthrough invoking bulk-translate; bulk-translate contract owned by register-i18n capability
+		 */
 		async onSubmit() {
 			if (!this.canSubmit) return
 			this.loading = true

--- a/src/components/i18n/RegisterLanguagesEditor.vue
+++ b/src/components/i18n/RegisterLanguagesEditor.vue
@@ -130,14 +130,23 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec exclude computed add-enabled form-validation flag, UI plumbing
+		 */
 		canAdd() {
 			return !this.disabled && this.normalizedDraft !== '' && this.validateDraft(this.normalizedDraft) === null
 		},
+		/**
+		 * @spec exclude computed normalized draft input value, UI plumbing
+		 */
 		normalizedDraft() {
 			return (this.draft || '').trim().toLowerCase()
 		},
 	},
 	methods: {
+		/**
+		 * @spec exclude client-side BCP-47/duplicate validation helper, UI plumbing
+		 */
 		validateDraft(candidate) {
 			if (candidate === '') return 'empty'
 			if (!BCP_47_RE.test(candidate)) return 'invalid'
@@ -145,6 +154,9 @@ export default {
 			if (seen.includes(candidate)) return 'duplicate'
 			return null
 		},
+		/**
+		 * @spec exclude list-editor add emitting v-model input; languages contract owned by register-i18n capability
+		 */
 		addCurrent() {
 			const candidate = this.normalizedDraft
 			const reason = this.validateDraft(candidate)
@@ -157,6 +169,9 @@ export default {
 			this.$emit('input', next)
 			this.draft = ''
 		},
+		/**
+		 * @spec exclude computed validation-error message display helper, UI plumbing
+		 */
 		errorMessageFor(reason) {
 			switch (reason) {
 			case 'empty': return 'Enter a BCP 47 language tag.'
@@ -165,12 +180,18 @@ export default {
 			default: return 'Invalid input.'
 			}
 		},
+		/**
+		 * @spec exclude list-editor remove emitting v-model input; languages contract owned by register-i18n capability
+		 */
 		remove(idx) {
 			if (this.disabled) return
 			const next = [...(this.value || [])]
 			next.splice(idx, 1)
 			this.$emit('input', next)
 		},
+		/**
+		 * @spec exclude list-editor reorder emitting v-model input; languages contract owned by register-i18n capability
+		 */
 		move(from, to) {
 			if (this.disabled) return
 			const list = [...(this.value || [])]

--- a/src/components/i18n/TranslationCompletenessBadge.vue
+++ b/src/components/i18n/TranslationCompletenessBadge.vue
@@ -46,6 +46,9 @@ export default {
 		},
 	},
 	computed: {
+		/**
+		 * @spec exclude computed ordered language list from completeness prop, UI plumbing
+		 */
 		languages() {
 			const present = Object.keys(this.completeness)
 			if (this.languageOrder?.length) {
@@ -55,6 +58,9 @@ export default {
 			}
 			return present.slice().sort()
 		},
+		/**
+		 * @spec exclude computed tooltip display helper from completeness prop, UI plumbing
+		 */
 		tooltipText() {
 			const parts = this.languages.map((lang) => {
 				const c = this.completeness[lang]
@@ -64,11 +70,17 @@ export default {
 		},
 	},
 	methods: {
+		/**
+		 * @spec exclude computed percent display helper; completeness contract owned by register-i18n capability
+		 */
 		ratioPercent(lang) {
 			const c = this.completeness[lang]
 			if (!c || typeof c.ratio !== 'number') return '?'
 			return `${Math.round(c.ratio * 100)}%`
 		},
+		/**
+		 * @spec exclude computed pill CSS-class display helper, UI plumbing
+		 */
 		completenessClassFor(lang) {
 			const ratio = this.completeness[lang]?.ratio ?? 0
 			if (ratio >= 1) return 'translation-completeness-badge__pill--complete'

--- a/src/components/i18n/TranslationFieldEditor.vue
+++ b/src/components/i18n/TranslationFieldEditor.vue
@@ -106,12 +106,18 @@ export default {
 		},
 	},
 	computed: {
+		/**
+		 * @spec exclude computed visible-language list filter, UI plumbing
+		 */
 		orderedLanguages() {
 			if (!this.hideEmpty) return this.languages
 			return this.languages.filter((lang) => this.getValue(lang) !== '')
 		},
 	},
 	methods: {
+		/**
+		 * @spec exclude computed read of per-language value from v-model prop, UI plumbing
+		 */
 		getValue(lang) {
 			const v = this.value?.[lang]
 			return typeof v === 'string' ? v : ''
@@ -119,12 +125,21 @@ export default {
 		getStatus(lang) {
 			return this.statuses?.[lang] ?? null
 		},
+		/**
+		 * @spec exclude computed text-direction (rtl/ltr) display helper, UI plumbing
+		 */
 		dirFor(lang) {
 			return isRtlLanguage(lang) ? 'rtl' : 'ltr'
 		},
+		/**
+		 * @spec exclude computed placeholder display helper, UI plumbing
+		 */
 		placeholderFor(lang) {
 			return `Translation in ${lang.toUpperCase()}`
 		},
+		/**
+		 * @spec exclude per-language input emitting v-model input; translatable-field contract owned by register-i18n capability
+		 */
 		onInput(lang, newValue) {
 			const next = { ...this.value, [lang]: newValue }
 			// Drop empty slots so they don't bloat the JSONB nor create

--- a/src/components/i18n/TranslationStatusChip.vue
+++ b/src/components/i18n/TranslationStatusChip.vue
@@ -33,15 +33,27 @@ export default {
 		},
 	},
 	computed: {
+		/**
+		 * @spec exclude computed status-metadata lookup; translation-status contract owned by register-i18n capability
+		 */
 		meta() {
 			return STATUS_META[this.status] ?? { icon: '?', label: this.status }
 		},
+		/**
+		 * @spec exclude computed icon-char display helper, UI plumbing
+		 */
 		iconChar() {
 			return this.meta.icon
 		},
+		/**
+		 * @spec exclude computed status-label display helper, UI plumbing
+		 */
 		labelText() {
 			return this.meta.label
 		},
+		/**
+		 * @spec exclude computed tooltip display helper, UI plumbing
+		 */
 		tooltipText() {
 			const lang = this.language ? ` (${this.language.toUpperCase()})` : ''
 			return `Translation status: ${this.labelText}${lang}`

--- a/src/components/object-relations/ContactsTab.vue
+++ b/src/components/object-relations/ContactsTab.vue
@@ -138,15 +138,27 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude computed store cache-key from register/schema/object, UI plumbing
+		 */
 		key() {
 			return `${this.register}:${this.schema}:${this.objectId}`
 		},
+		/**
+		 * @spec exclude computed read of linked contacts from store; contact-relations contract owned by integration-contacts capability
+		 */
 		contacts() {
 			return this.store.byObject[this.key] || []
 		},
+		/**
+		 * @spec exclude computed read of loading state from store, UI plumbing
+		 */
 		loading() {
 			return !!this.store.loading[this.key]
 		},
+		/**
+		 * @spec exclude computed read of integration-availability flag from store, UI plumbing
+		 */
 		contactsUnavailable() {
 			return this.store.contactsUnavailable
 		},
@@ -155,6 +167,9 @@ export default {
 	watch: {
 		objectId: {
 			immediate: true,
+			/**
+			 * @spec exclude watcher refetching contacts on objectId change, UI plumbing
+			 */
 			handler(newId) {
 				if (newId) {
 					this.fetchContacts()
@@ -188,6 +203,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude store passthrough unlinking contact + change emit; contact-relations contract owned by integration-contacts capability
+		 */
 		async unlinkContact(contact) {
 			const uid = contact.uid || contact.contactUid || contact.id
 			try {
@@ -199,6 +217,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude emit UI handler opening add-contact dialog, UI plumbing
+		 */
 		openCreateDialog() {
 			this.$emit('add-contact')
 		},

--- a/src/components/object-relations/DeckTab.vue
+++ b/src/components/object-relations/DeckTab.vue
@@ -139,15 +139,27 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude computed store cache-key from register/schema/object, UI plumbing
+		 */
 		key() {
 			return `${this.register}:${this.schema}:${this.objectId}`
 		},
+		/**
+		 * @spec exclude computed read of linked deck cards from store; deck-relations contract owned by integration-deck capability
+		 */
 		cards() {
 			return this.store.byObject[this.key] || []
 		},
+		/**
+		 * @spec exclude computed read of loading state from store, UI plumbing
+		 */
 		loading() {
 			return !!this.store.loading[this.key]
 		},
+		/**
+		 * @spec exclude computed read of integration-availability flag from store, UI plumbing
+		 */
 		deckUnavailable() {
 			return this.store.deckUnavailable
 		},
@@ -156,6 +168,9 @@ export default {
 	watch: {
 		objectId: {
 			immediate: true,
+			/**
+			 * @spec exclude watcher refetching deck cards on objectId change, UI plumbing
+			 */
 			handler(newId) {
 				if (newId) {
 					this.fetchCards()
@@ -184,6 +199,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude store passthrough unlinking card + change emit; deck-relations contract owned by integration-deck capability
+		 */
 		async unlinkCard(card) {
 			const ref = card.ref || card.deckRef || card.id
 			try {
@@ -195,10 +213,16 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude emit UI handler opening add-card dialog, UI plumbing
+		 */
 		openCreateDialog() {
 			this.$emit('add-deck-card')
 		},
 
+		/**
+		 * @spec exclude computed date-format display helper, UI plumbing
+		 */
 		formatDate(value) {
 			if (!value) {
 				return ''

--- a/src/components/object-relations/EmailsTab.vue
+++ b/src/components/object-relations/EmailsTab.vue
@@ -134,6 +134,9 @@ export default {
 	watch: {
 		objectId: {
 			immediate: true,
+			/**
+			 * @spec exclude watcher refetching emails on objectId change, UI plumbing
+			 */
 			handler(newId) {
 				if (newId) {
 					this.fetchEmails()
@@ -145,6 +148,9 @@ export default {
 	methods: {
 		t,
 
+		/**
+		 * @spec exclude API passthrough loading linked emails; email-relations contract owned by integration-email capability
+		 */
 		async fetchEmails() {
 			this.loading = true
 			this.error = false
@@ -172,6 +178,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude API passthrough unlinking email + change emit; email-relations contract owned by integration-email capability
+		 */
 		async unlinkEmail(email) {
 			const url = generateUrl('/apps/openregister/api/objects/{register}/{schema}/{id}/emails/{emailId}', {
 				register: this.register,
@@ -190,6 +199,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude computed date-format display helper, UI plumbing
+		 */
 		formatDate(value) {
 			if (!value) {
 				return ''

--- a/src/components/object-relations/EventsTab.vue
+++ b/src/components/object-relations/EventsTab.vue
@@ -150,15 +150,27 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude computed store cache-key from register/schema/object, UI plumbing
+		 */
 		key() {
 			return `${this.register}:${this.schema}:${this.objectId}`
 		},
+		/**
+		 * @spec exclude computed read of linked events from store; event-relations contract owned by integration-calendar capability
+		 */
 		events() {
 			return this.store.byObject[this.key] || []
 		},
+		/**
+		 * @spec exclude computed read of loading state from store, UI plumbing
+		 */
 		loading() {
 			return !!this.store.loading[this.key]
 		},
+		/**
+		 * @spec exclude computed read of integration-availability flag from store, UI plumbing
+		 */
 		calendarUnavailable() {
 			return this.store.calendarUnavailable
 		},
@@ -167,6 +179,9 @@ export default {
 	watch: {
 		objectId: {
 			immediate: true,
+			/**
+			 * @spec exclude watcher refetching events on objectId change, UI plumbing
+			 */
 			handler(newId) {
 				if (newId) {
 					this.fetchEvents()
@@ -195,6 +210,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude store passthrough unlinking event + change emit; event-relations contract owned by integration-calendar capability
+		 */
 		async unlinkEvent(event) {
 			try {
 				await this.store.unlink(this.register, this.schema, this.objectId, event.id)
@@ -205,16 +223,25 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude emit UI handler surfacing create-event intent, UI plumbing
+		 */
 		openCreateDialog() {
 			// Surface intent to the parent so it can mount a calendar-event modal
 			// (the modal lives outside the tab to avoid pulling it into every detail view).
 			this.$emit('create-event')
 		},
 
+		/**
+		 * @spec exclude emit UI handler surfacing link-event intent, UI plumbing
+		 */
 		openLinkDialog() {
 			this.$emit('link-event')
 		},
 
+		/**
+		 * @spec exclude computed date-format display helper, UI plumbing
+		 */
 		formatDate(value) {
 			if (!value) {
 				return ''

--- a/src/components/object-relations/RelationsTab.vue
+++ b/src/components/object-relations/RelationsTab.vue
@@ -145,6 +145,9 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec exclude computed distinct relation-type list for filters, UI plumbing
+		 */
 		availableTypes() {
 			const set = new Set()
 			for (const r of this.relations) {
@@ -156,6 +159,9 @@ export default {
 			return Array.from(set)
 		},
 
+		/**
+		 * @spec exclude computed type-filtered relation list for display, UI plumbing
+		 */
 		visibleRelations() {
 			if (this.selectedTypes.length === 0) {
 				return this.relations
@@ -168,6 +174,9 @@ export default {
 	watch: {
 		objectId: {
 			immediate: true,
+			/**
+			 * @spec exclude watcher refetching relations on objectId change, UI plumbing
+			 */
 			handler(newId) {
 				if (newId) {
 					this.fetchRelations()
@@ -207,6 +216,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude client-side normalisation of timeline/envelope response shapes for display, UI plumbing
+		 */
 		normaliseResponse(data) {
 			// The unified endpoint may return either a flat timeline array
 			// (`view=timeline`) or a typed envelope (`{ emails: [...], events: [...] }`).
@@ -242,6 +254,9 @@ export default {
 			return out
 		},
 
+		/**
+		 * @spec exclude client-side normalisation of a single relation entry for display, UI plumbing
+		 */
 		normaliseEntry(raw) {
 			const type = raw.type || raw.entityType || 'unknown'
 			let title = raw.title || raw.subject || raw.summary || raw.displayName || raw.name || ''
@@ -270,6 +285,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude local type-filter toggle plumbing, UI plumbing
+		 */
 		toggleType(type) {
 			if (this.selectedTypes.includes(type)) {
 				this.selectedTypes = this.selectedTypes.filter(t => t !== type)
@@ -278,6 +296,9 @@ export default {
 			}
 		},
 
+		/**
+		 * @spec exclude computed date-format display helper, UI plumbing
+		 */
 		formatDate(value) {
 			if (!value) {
 				return ''

--- a/src/components/shared/VersionInfoCard.vue
+++ b/src/components/shared/VersionInfoCard.vue
@@ -217,6 +217,7 @@ export default {
 		 * Update button type based on status
 		 *
 		 * @return {string}
+		 * @spec exclude computed button-type display helper, UI plumbing
 		 */
 		updateButtonType() {
 			if (this.isUpToDate) {
@@ -229,6 +230,7 @@ export default {
 		 * Update button should be disabled if up to date or updating
 		 *
 		 * @return {boolean}
+		 * @spec exclude computed button-disabled display flag, UI plumbing
 		 */
 		updateButtonDisabled() {
 			return this.isUpToDate || this.updating
@@ -238,6 +240,7 @@ export default {
 		 * Update button text based on status
 		 *
 		 * @return {string}
+		 * @spec exclude computed button-text display helper, UI plumbing
 		 */
 		updateButtonText() {
 			if (this.updating) {
@@ -255,6 +258,7 @@ export default {
 		 * Handle update button click
 		 *
 		 * @return {void}
+		 * @spec exclude emit UI handler dispatching update event, UI plumbing
 		 */
 		handleUpdateClick() {
 			if (!this.updateButtonDisabled) {

--- a/src/components/workflow/ApprovalChainPanel.vue
+++ b/src/components/workflow/ApprovalChainPanel.vue
@@ -70,6 +70,9 @@ export default {
 				console.error('Failed to fetch chains:', error)
 			}
 		},
+		/**
+		 * @spec exclude API passthrough creating chain + refetch; approval-chain contract owned by approval-workflow capability
+		 */
 		async createChain() {
 			try {
 				const url = generateUrl('/apps/openregister/api/approval-chains')

--- a/src/components/workflow/ApprovalStepList.vue
+++ b/src/components/workflow/ApprovalStepList.vue
@@ -61,9 +61,15 @@ export default {
 				console.error('Failed to fetch steps:', error)
 			}
 		},
+		/**
+		 * @spec exclude computed decide-permission display flag (stub returns true), UI plumbing
+		 */
 		canDecide() {
 			return true
 		},
+		/**
+		 * @spec exclude API passthrough approving step + refetch; approval contract owned by approval-workflow capability
+		 */
 		async approve(step) {
 			try {
 				const url = generateUrl(`/apps/openregister/api/approval-steps/${step.id}/approve`)
@@ -73,6 +79,9 @@ export default {
 				console.error('Failed to approve:', error)
 			}
 		},
+		/**
+		 * @spec exclude API passthrough rejecting step + refetch; approval contract owned by approval-workflow capability
+		 */
 		async reject(step) {
 			try {
 				const url = generateUrl(`/apps/openregister/api/approval-steps/${step.id}/reject`)

--- a/src/components/workflow/HookForm.vue
+++ b/src/components/workflow/HookForm.vue
@@ -86,11 +86,17 @@ export default {
 		isEdit() {
 			return this.hook !== null
 		},
+		/**
+		 * @spec exclude computed select-option mapping from engines prop, UI plumbing
+		 */
 		engineOptions() {
 			return this.engines.map(e => e.engineType || e.name || e)
 		},
 	},
 	methods: {
+		/**
+		 * @spec exclude emit UI handler dispatching save event with form data, UI plumbing
+		 */
 		save() {
 			this.$emit('save', { ...this.form })
 		},

--- a/src/components/workflow/ScheduledWorkflowPanel.vue
+++ b/src/components/workflow/ScheduledWorkflowPanel.vue
@@ -79,6 +79,9 @@ export default {
 		this.fetchSchedules()
 	},
 	methods: {
+		/**
+		 * @spec exclude API passthrough loading schedules; scheduled-workflow contract owned by workflow-operations capability
+		 */
 		async fetchSchedules() {
 			try {
 				const url = generateUrl('/apps/openregister/api/scheduled-workflows')
@@ -88,6 +91,9 @@ export default {
 				console.error('Failed to fetch schedules:', error)
 			}
 		},
+		/**
+		 * @spec exclude API passthrough creating schedule + refetch; scheduled-workflow contract owned by workflow-operations capability
+		 */
 		async createSchedule() {
 			try {
 				const url = generateUrl('/apps/openregister/api/scheduled-workflows')
@@ -98,6 +104,9 @@ export default {
 				console.error('Failed to create schedule:', error)
 			}
 		},
+		/**
+		 * @spec exclude computed interval-format display helper, UI plumbing
+		 */
 		formatInterval(seconds) {
 			if (seconds >= 86400) return `${Math.floor(seconds / 86400)}d`
 			if (seconds >= 3600) return `${Math.floor(seconds / 3600)}h`

--- a/src/components/workflow/TestHookDialog.vue
+++ b/src/components/workflow/TestHookDialog.vue
@@ -60,6 +60,9 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec exclude API passthrough running hook dry-run test; hook-test contract owned by workflow-operations capability
+		 */
 		async runTest() {
 			this.loading = true
 			this.result = null


### PR DESCRIPTION
## Summary

Annotates **207 uncovered methods** across 28 `src/components/` Vue files with JSDoc `@spec exclude <reason>` tags per ADR-003. Closes the `fw-fe-components` coverage batch.

- **0 reverse-spec'd / 207 excluded / 0 new REQs**
- Comment-only change — no behaviour change, every added line is a JSDoc comment.

## Why all-exclude

Reusable UI widgets — filter sidebars, the facet/search control surface, register/schema + configuration cards, file-sidebar tabs, i18n widgets, object-relation tabs, the RBAC table, version card, and workflow panels — are render/format/emit/store-passthrough plumbing. They define no novel widget-level domain contract:

- The genuinely spec-worthy shared-widget contracts (`PaginationComponent.changePage`, `ConfigurationCard.checkIfImported`, settings card/section) were already minted into the `shared-ui-components` capability by `retrofit-2026-05-24-2b-components`; the residual methods here are the surrounding display/emit plumbing.
- Integration tab data (contacts/deck/email/events/relations), i18n widgets, RBAC table, and workflow panels surface behaviour whose contracts live in their owning capabilities (`integration-*`, `register-i18n`, rbac, `approval-workflow`, `workflow-operations`).

Every method received `@spec exclude` with a specific reason (no bare excludes).

Ghost change: `openspec/changes/retrofit-2026-05-25-fe-components/` (proposal + tasks, no spec delta — all-exclude carries no delta, so no `--strict` validation).

## Test plan

- [ ] Diff is comment-only (verified: every added line is `/**`, ` * @spec exclude …`, or ` */`).
- [ ] Coverage re-scan resolves all 207 `fw-fe-components` methods (no longer in Bucket 2b).