### PR TITLE
retrofit: frontend coverage — store (chunk 2)

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-fe-store-2/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-store-2/proposal.md
@@ -1,0 +1,76 @@
+# Retrofit — frontend coverage, store (chunk 2)
+
+## Why
+
+The 2026-05-25 coverage scan surfaced 150 public methods across 11 `src/store/`
+files that carry no `@spec` annotation linking them to a capability. This change
+brings every one of those methods under ADR-003's annotation convention using the
+two-tool approach: each method ends tagged with either a `@spec` pointer to a REQ
+it implements, or a `@spec exclude <reason>` tag documenting why it is deliberately
+unspecified. Code already exists — this change describes observed behaviour, it
+does not change runtime behaviour.
+
+## What Changes
+
+- Mint **one new capability** `frontend-client-state-orchestration` with **3 REQs**
+  (REQ-001..REQ-003) describing genuinely novel client-side behaviour that no
+  backend endpoint mirrors:
+  - REQ-001 — client-side import heartbeat keeping the session alive during long
+    register imports (`register.js::startImportHeartbeat` + its returned `stop`).
+  - REQ-002 — applying a saved view's configuration onto a live search-store
+    instance (`views.js::applyView`).
+  - REQ-003 — capturing the live search-store state into a saveable view
+    configuration object (`views.js::createViewFromSearchState`).
+- **Annotate** methods that map to an existing REQ to that REQ's task pointer
+  (search-trail store → the existing `retrofit-2026-04-23-annotate-openregister`
+  task-89; per-object contact/event relation stores → their existing file-level
+  task pointers).
+- **Exclude** every other method — thin CRUD/import API passthroughs whose
+  observable contract is owned by the mirrored backend capability spec, plus
+  getters/setters/UI-state mutators, no-op compatibility stubs, and delegation to
+  the `@conduction/nextcloud-vue` package object store. Each exclude carries a
+  required reason.
+
+This is a retroactive specification. No code behaviour changes.
+
+## Scope of this batch
+
+**Batch source**: `/tmp/or-scan/fw-fe-store-2.json` — 150 methods / 11 files.
+
+After triage:
+
+- **4 methods → spec'd to NEW REQs** (3 REQs in `frontend-client-state-orchestration`):
+  - `src/store/modules/register.js::startImportHeartbeat` → REQ-001
+  - `src/store/modules/register.js::stop` (closure returned by startImportHeartbeat) → REQ-001
+  - `src/store/modules/views.js::applyView` → REQ-002
+  - `src/store/modules/views.js::createViewFromSearchState` → REQ-003
+
+- **33 methods → annotated to EXISTING REQs**:
+  - `src/store/modules/searchTrail.js` (22 methods) → `retrofit-2026-04-23-annotate-openregister/tasks.md#task-89` (search-trail capability the file already references at file scope).
+  - `src/store/modules/object-relations/contacts.js` (5 methods) → `retrofit-2026-05-24-contacts-actions/tasks.md#task-5` (contact-relations capability the file already references at file scope).
+  - `src/store/modules/object-relations/events.js` (6 methods) → `retrofit-2026-05-24-data-integrity-relations/tasks.md#task-5` (event-relations capability the file already references at file scope).
+
+- **113 methods → `@spec exclude <reason>`**:
+  - `application.js` (11), `avg.js` (12), `configuration.js` (16), `conversation.ts` (18), `navigation.js` (4), `organisation.js` (21), `register.js` (16 of 18 — the two heartbeat methods are spec'd), `views.js` (8 of 10 — applyView/createViewFromSearchState are spec'd), `object.js` (5).
+  - Reasons fall into four families: (a) thin API passthrough mirrored by a backend capability spec (avg-verwerkingsregister, data-import-export, chat-ai, tenant-lifecycle, zoeken-filteren, register lifecycle); (b) pure client UI-state getter/setter/mutator with no backend contract; (c) no-op compatibility stub (`object.js::initializeColumnFilters`/`initializeProperties`); (d) delegation to the shared `@conduction/nextcloud-vue` package object store.
+
+## Counts
+
+| Outcome | Methods |
+|---|---|
+| Spec'd to NEW REQs | 4 |
+| Annotated to EXISTING REQs | 33 |
+| Excluded (with reason) | 113 |
+| **Total** | **150** |
+
+New REQs minted: **3** (`frontend-client-state-orchestration` REQ-001..REQ-003).
+
+## Approach
+
+For each method: read the body, classify as spec-to-new-REQ, annotate-to-existing,
+or exclude-with-reason. Methods that are API passthroughs whose contract is the
+backend's are excluded (the backend capability spec already owns the observable
+behaviour); methods that hold novel client-only orchestration get a REQ; methods
+that mirror an already-specified store surface inherit that surface's REQ.
+
+See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-25-fe-store-2/specs/frontend-client-state-orchestration/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-store-2/specs/frontend-client-state-orchestration/spec.md
@@ -1,0 +1,132 @@
+---
+retrofit: true
+---
+
+# Frontend Client-State Orchestration Specification
+
+**Status**: in-progress
+**Scope**: openregister
+
+## Purpose
+
+Specifies observable client-side behaviour in OpenRegister's Pinia stores that is
+**not** a mirror of any backend endpoint — orchestration that lives only in the
+browser. Most store actions are thin passthroughs to the REST API and inherit their
+contract from the backend capability that owns the endpoint; those are excluded from
+spec coverage via `@spec exclude`. This capability captures the handful of store
+behaviours that have no backend counterpart and therefore need their own REQs: the
+import-keepalive heartbeat that prevents gateway timeouts, and the saved-view
+apply/capture bridge between the persisted view store and the live search store.
+This spec describes behaviour that already exists in `src/store/modules/` so the
+coverage matcher can resolve `@spec` annotations on those methods.
+
+## ADDED Requirements
+
+### Requirement: REQ-001 — Long register imports MUST be kept alive by a client-side heartbeat
+
+Register imports can run far longer than a typical HTTP request, risking gateway and
+session timeouts. The register store (`src/store/modules/register.js`) MUST provide a
+client-side heartbeat that, while an import is in flight, periodically issues a
+lightweight `GET /index.php/apps/openregister/api/heartbeat` request to keep the
+session warm. The heartbeat MUST run on a fixed interval (default 15 seconds), MUST
+track consecutive failures, MUST consider itself unhealthy only after 3 consecutive
+failures, MUST NOT stop polling on transient failure, and MUST surface health
+transitions through an optional status callback. The heartbeat MUST return a handle
+exposing a `stop()` method that clears the interval, and `importRegister` MUST always
+call `stop()` when the import settles (success or error).
+
+#### Scenario: Heartbeat pings on its interval during an import
+
+- **GIVEN** an import started via `importRegister(file)` for the selected register
+- **WHEN** `startImportHeartbeat(15000, onStatusChange)` is invoked
+- **THEN** the store SHALL issue `GET …/api/heartbeat` every 15 seconds with `Cache-Control: no-cache` and a 10-second per-request abort timeout
+- **AND** the returned handle SHALL expose `stop()` and `getStatus()`
+
+#### Scenario: Transient failures do not stop the heartbeat
+
+- **GIVEN** a running heartbeat whose first two pings fail
+- **WHEN** the failures occur
+- **THEN** the heartbeat SHALL keep polling (the interval is not cleared)
+- **AND** it SHALL remain "healthy" until a third consecutive failure flips it to unhealthy
+- **AND** a recovered ping SHALL reset the failure count back to zero and report `healthy: true` via the status callback
+
+#### Scenario: Import settlement stops the heartbeat
+
+- **GIVEN** an in-flight import with an active heartbeat
+- **WHEN** the import resolves or rejects
+- **THEN** `importRegister` SHALL call the handle's `stop()` in its `finally` block
+- **AND** `stop()` SHALL clear the polling interval so no further heartbeat requests are issued
+
+### Requirement: REQ-002 — A saved view's configuration MUST be applied onto the live search store
+
+The views store (`src/store/modules/views.js`) MUST be able to project a saved view's
+persisted `configuration` onto a live search-store instance so that selecting a saved
+view restores the full search context. `applyView(view, searchStore)` MUST apply each
+present configuration facet — selected registers, schemas, source, search terms, facet
+filters, enabled facets, advanced filters, pagination, sorting, and columns — to the
+provided search store via that store's setters, skip facets that are absent from the
+configuration, and mark the applied view as active. A view without a `configuration`
+MUST be rejected as a no-op (with a warning) rather than partially applied.
+
+#### Scenario: Applying a complete saved view
+
+- **GIVEN** a saved view whose `configuration` contains registers, schemas, source, searchTerms, facetFilters, enabledFacets, advancedFilters, pagination, sorting, and columns
+- **WHEN** `applyView(view, searchStore)` is called
+- **THEN** each corresponding `searchStore.set*` setter SHALL be invoked with the configuration value
+- **AND** `setActiveView(view)` SHALL be called so the view becomes the active view
+
+#### Scenario: Partial configuration applies only present facets
+
+- **GIVEN** a saved view whose `configuration` only contains `registers` and `searchTerms`
+- **WHEN** `applyView` is called
+- **THEN** only `setSelectedRegisters` and `setSearchTerms` SHALL be invoked
+- **AND** the other search-store facets SHALL be left untouched
+
+#### Scenario: View without configuration is a guarded no-op
+
+- **GIVEN** a `view` that is null or lacks a `configuration` object
+- **WHEN** `applyView(view, searchStore)` is called
+- **THEN** the method SHALL warn and return without mutating the search store or the active view
+
+### Requirement: REQ-003 — The live search-store state MUST be capturable into a saveable view configuration
+
+Conversely, the views store MUST be able to snapshot the current search context into a
+view object suitable for persistence. `createViewFromSearchState(searchStore, name,
+description, isDefault, isPublic)` MUST return a plain object carrying the supplied
+metadata (name, description, default/public flags) and a `configuration` block built
+from the search store's current selectors — registers, schemas, source, search terms,
+facet filters, enabled facets, advanced filters, pagination, sorting, and columns —
+applying sensible defaults for any selector that is empty or unset (e.g. `source`
+defaults to `'auto'`, pagination to `{ page: 1, limit: 20 }`).
+
+#### Scenario: Capturing the current search state
+
+- **GIVEN** a search store with selected registers, a source of `'graphql'`, and custom pagination
+- **WHEN** `createViewFromSearchState(searchStore, 'My view', 'desc', false, true)` is called
+- **THEN** the returned object SHALL carry `name: 'My view'`, `description: 'desc'`, `isDefault: false`, `isPublic: true`
+- **AND** its `configuration` SHALL mirror the search store's current registers, schemas, source, searchTerms, facetFilters, enabledFacets, advancedFilters, pagination, sorting, and columns
+
+#### Scenario: Empty selectors fall back to defaults
+
+- **GIVEN** a freshly-initialised search store with no source and no pagination set
+- **WHEN** `createViewFromSearchState(searchStore, 'Blank', '', false, false)` is called
+- **THEN** the returned `configuration.source` SHALL be `'auto'`
+- **AND** `configuration.pagination` SHALL be `{ page: 1, limit: 20 }`
+- **AND** array selectors SHALL default to `[]` and object selectors to `{}`
+
+## Non-Functional Requirements
+
+- **Resilience:** The heartbeat (REQ-001) MUST be fault-tolerant — a flaky network during a long import must not abort the import or wedge the SPA. Failures are logged and counted, never thrown out of the interval callback.
+- **Separation of concerns:** REQ-002/REQ-003 keep the persisted view store and the live search store decoupled — the views store reads/writes the search store only through its public setters and selectors, never its internal state.
+- **Internationalisation:** These store methods carry no user-facing strings; locale does not affect their behaviour (ADR-007).
+
+## Acceptance Criteria
+
+- [ ] `@spec` annotations exist on `register.js::startImportHeartbeat` (+ its `stop` closure), `views.js::applyView`, and `views.js::createViewFromSearchState`, pointing at `openspec/changes/retrofit-2026-05-25-fe-store-2/tasks.md#task-N`.
+- [ ] `npm run lint -- src/store/modules/register.js src/store/modules/views.js` passes.
+- [ ] Coverage scan re-run after archive resolves these methods to their REQ (no longer uncovered).
+
+## Notes
+
+- The heartbeat's health threshold (3 consecutive failures) and interval (15s) are the observed defaults; they are captured as the contract, not hardened — tuning is out of scope for this retrofit.
+- `applyView`/`createViewFromSearchState` take the search store as an argument rather than importing it, because the views store predates a stable cross-store import path; the REQs capture the current argument-injection contract.

--- a/openspec/changes/retrofit-2026-05-25-fe-store-2/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-store-2/tasks.md
@@ -1,0 +1,8 @@
+# Tasks — Retrofit frontend store (chunk 2)
+
+Retroactive annotation of behaviour that already exists in `src/store/`. The code
+already implements each REQ; the only work captured here is the `@spec` pointer.
+
+- [x] task-1: frontend-client-state-orchestration#REQ-001 — Long register imports are kept alive by a client-side heartbeat (retroactive annotation of `src/store/modules/register.js::startImportHeartbeat` and its returned `stop` closure)
+- [x] task-2: frontend-client-state-orchestration#REQ-002 — A saved view's configuration is applied onto the live search store (retroactive annotation of `src/store/modules/views.js::applyView`)
+- [x] task-3: frontend-client-state-orchestration#REQ-003 — The live search-store state is captured into a saveable view configuration (retroactive annotation of `src/store/modules/views.js::createViewFromSearchState`)

--- a/src/store/modules/application.js
+++ b/src/store/modules/application.js
@@ -23,10 +23,16 @@ export const useApplicationStore = defineStore('application', {
 		getViewMode: (state) => state.viewMode,
 	},
 	actions: {
+		/**
+		 * @spec exclude Pure client UI-state setter — list/card view-mode toggle. No backend contract.
+		 */
 		setViewMode(mode) {
 			this.viewMode = mode
 			console.log('View mode set to:', mode)
 		},
+		/**
+		 * @spec exclude Client state mutator — wraps the active application in an entity. No backend contract.
+		 */
 		setApplicationItem(applicationItem) {
 			try {
 				this.loading = true
@@ -40,6 +46,9 @@ export const useApplicationStore = defineStore('application', {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude Client state mutator — maps the application list to entities. No backend contract.
+		 */
 		setApplicationList(applicationList) {
 			this.applicationList = applicationList.map(
 				(applicationItem) => new Application(applicationItem),
@@ -50,6 +59,8 @@ export const useApplicationStore = defineStore('application', {
 		 * Set pagination details
 		 * @param {number} page - The current page number for pagination
 		 * @param {number} limit - The number of items to display per page
+		 *
+		 * @spec exclude Pure client UI-state setter — list pagination cursor. No backend contract.
 		 */
 		setPagination(page, limit = 20) {
 			this.pagination = { page, limit }
@@ -58,6 +69,8 @@ export const useApplicationStore = defineStore('application', {
 		/**
 		 * Set query filters for application list
 		 * @param {object} filters - The filter criteria to apply to the application list
+		 *
+		 * @spec exclude Pure client UI-state setter — list filter criteria. No backend contract.
 		 */
 		setFilters(filters) {
 			this.filters = { ...this.filters, ...filters }
@@ -69,6 +82,8 @@ export const useApplicationStore = defineStore('application', {
 		 * @param {string|null} search - Optional search term
 		 * @param {boolean} soft - If true, don't show loading state (default: false)
 		 * @return {Promise} Promise with response and data
+		 *
+		 * @spec exclude Thin API passthrough — GET /api/applications list; observable contract owned by the applications backend capability.
 		 */
 		/* istanbul ignore next */
 		async refreshApplicationList(search = null, soft = false) {
@@ -110,6 +125,9 @@ export const useApplicationStore = defineStore('application', {
 				}
 			}
 		},
+		/**
+		 * @spec exclude Thin API passthrough — GET /api/applications/{id}; observable contract owned by the applications backend capability.
+		 */
 		async getApplication(id) {
 			const endpoint = `/index.php/apps/openregister/api/applications/${id}`
 			try {
@@ -133,6 +151,9 @@ export const useApplicationStore = defineStore('application', {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude Thin API passthrough — DELETE /api/applications/{id}; observable contract owned by the applications backend capability.
+		 */
 		async deleteApplication(applicationItem) {
 			if (!applicationItem.id) {
 				throw new Error('No application to delete')
@@ -164,6 +185,9 @@ export const useApplicationStore = defineStore('application', {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude Thin API passthrough — POST/PUT /api/applications; observable contract owned by the applications backend capability.
+		 */
 		async saveApplication(applicationItem) {
 			if (!applicationItem) {
 				throw new Error('No application to save')
@@ -213,6 +237,9 @@ export const useApplicationStore = defineStore('application', {
 			}
 		},
 		// Clean application data for saving - remove read-only fields
+		/**
+		 * @spec exclude Client-side payload sanitiser — strips read-only fields before save. No standalone backend contract.
+		 */
 		cleanApplicationForSave(applicationItem) {
 			const cleaned = { ...applicationItem }
 
@@ -236,6 +263,8 @@ export const useApplicationStore = defineStore('application', {
 		 * This should be called on the applications index page to preload groups
 		 *
 		 * @return {Promise<void>}
+		 *
+		 * @spec exclude Thin passthrough to the Nextcloud OCS groups API; observable contract owned by Nextcloud core, not OpenRegister.
 		 */
 		async loadNextcloudGroups() {
 			try {

--- a/src/store/modules/avg.js
+++ b/src/store/modules/avg.js
@@ -73,6 +73,9 @@ export const useAvgStore = defineStore('avg', {
 			state.activities.find((a) => a.uuid === uuid) ?? null,
 	},
 	actions: {
+		/**
+		 * @spec exclude Pure client UI-state mutator — clears the store error flag. No backend contract.
+		 */
 		clearError() {
 			this.error = null
 		},
@@ -81,6 +84,8 @@ export const useAvgStore = defineStore('avg', {
 		 * Fetch all verwerkingsactiviteiten.
 		 *
 		 * @param {object} params Optional `?status=` and `?organisation=` query filters.
+		 *
+		 * @spec exclude Thin API passthrough — GET /api/avg/verwerkingsactiviteiten; observable contract owned by avg-verwerkingsregister.
 		 */
 		async fetchActivities(params = {}) {
 			this.loading = true
@@ -102,6 +107,8 @@ export const useAvgStore = defineStore('avg', {
 		 * Fetch one activity by id (numeric), uuid, or short readable code.
 		 *
 		 * @param {string|number} identifier
+		 *
+		 * @spec exclude Thin API passthrough — GET /api/avg/verwerkingsactiviteiten/{id}; observable contract owned by avg-verwerkingsregister.
 		 */
 		async fetchActivity(identifier) {
 			if (!identifier) return null
@@ -126,6 +133,8 @@ export const useAvgStore = defineStore('avg', {
 		 * Create a new verwerkingsactiviteit. Admin-only on the backend.
 		 *
 		 * @param {object} payload Mirrors the entity's `set*` accepting fields.
+		 *
+		 * @spec exclude Thin API passthrough — POST /api/avg/verwerkingsactiviteiten; observable contract owned by avg-verwerkingsregister.
 		 */
 		async createActivity(payload) {
 			this.loading = true
@@ -153,6 +162,8 @@ export const useAvgStore = defineStore('avg', {
 		 *
 		 * @param {string|number} identifier id|uuid|code
 		 * @param {object}        payload    Fields to overwrite.
+		 *
+		 * @spec exclude Thin API passthrough — PUT /api/avg/verwerkingsactiviteiten/{id}; observable contract owned by avg-verwerkingsregister.
 		 */
 		async updateActivity(identifier, payload) {
 			this.loading = true
@@ -184,6 +195,8 @@ export const useAvgStore = defineStore('avg', {
 		 * audit-trail FKs need the row to remain resolvable.
 		 *
 		 * @param {string|number} identifier id|uuid|code
+		 *
+		 * @spec exclude Thin API passthrough — DELETE /api/avg/verwerkingsactiviteiten/{id} (soft-archive); observable contract owned by avg-verwerkingsregister.
 		 */
 		async archiveActivity(identifier) {
 			this.loading = true
@@ -211,6 +224,8 @@ export const useAvgStore = defineStore('avg', {
 		/**
 		 * Fetch the Art 30 §4 verantwoordingsdocument — joins activities
 		 * with audit-trail row counts per processing activity.
+		 *
+		 * @spec exclude Thin API passthrough — GET /api/avg/verantwoording (Art 30 §4); observable contract owned by avg-verwerkingsregister.
 		 */
 		async fetchVerantwoording() {
 			this.loading = true
@@ -232,6 +247,8 @@ export const useAvgStore = defineStore('avg', {
 		 * Run a DSAR inzageverzoek (Art 15) for the given subject.
 		 *
 		 * @param {object} params {subject, type?, mode?}
+		 *
+		 * @spec exclude Thin API passthrough — GET /api/avg/inzage (Art 15 DSAR); observable contract owned by avg-verwerkingsregister.
 		 */
 		async runInzage({ subject, type, mode }) {
 			if (!subject) return null
@@ -258,6 +275,8 @@ export const useAvgStore = defineStore('avg', {
 		 * preview the matched set before committing.
 		 *
 		 * @param {object} params {subject, type?, dryRun?}
+		 *
+		 * @spec exclude Thin API passthrough — POST /api/avg/vergetelheid (Art 17 erasure); observable contract owned by avg-verwerkingsregister.
 		 */
 		async runVergetelheid({ subject, type, dryRun = false }) {
 			if (!subject) return null
@@ -283,6 +302,8 @@ export const useAvgStore = defineStore('avg', {
 		 * Fetch the Art 20 portabiliteit envelope for the given subject.
 		 *
 		 * @param {object} params {subject, type?}
+		 *
+		 * @spec exclude Thin API passthrough — GET /api/avg/portabiliteit (Art 20 portability); observable contract owned by avg-verwerkingsregister.
 		 */
 		async runPortabiliteit({ subject, type }) {
 			if (!subject) return null
@@ -306,6 +327,8 @@ export const useAvgStore = defineStore('avg', {
 		 * Apply a rectificatie change set to a single object.
 		 *
 		 * @param {object} payload {objectId, changes}
+		 *
+		 * @spec exclude Thin API passthrough — POST /api/avg/rectificatie (Art 16 rectification); observable contract owned by avg-verwerkingsregister.
 		 */
 		async runRectificatie(payload) {
 			this.loading = true
@@ -325,6 +348,8 @@ export const useAvgStore = defineStore('avg', {
 		/**
 		 * Fetch the compliance report (currently: schemas with PII but
 		 * no `x-openregister-processing-activity` annotation).
+		 *
+		 * @spec exclude Thin API passthrough — GET /api/avg/compliance; observable contract owned by avg-verwerkingsregister.
 		 */
 		async fetchCompliance() {
 			this.loading = true

--- a/src/store/modules/configuration.js
+++ b/src/store/modules/configuration.js
@@ -13,10 +13,16 @@ export const useConfigurationStore = defineStore('configuration', {
 		},
 	}),
 	actions: {
+		/**
+		 * @spec exclude Client state mutator — wraps the active configuration in an entity. No backend contract.
+		 */
 		setConfigurationItem(configurationItem) {
 			this.configurationItem = configurationItem ? new ConfigurationEntity(configurationItem) : null
 			console.log('Active configuration item set to ' + (configurationItem?.title || 'null'))
 		},
+		/**
+		 * @spec exclude Client state mutator — maps the configuration list to entities. No backend contract.
+		 */
 		setConfigurationList(configurationList) {
 			this.configurationList = configurationList.map(
 				(configurationItem) => new ConfigurationEntity(configurationItem),
@@ -27,6 +33,8 @@ export const useConfigurationStore = defineStore('configuration', {
 		 * Set pagination details
 		 * @param {number} page - The current page number for pagination
 		 * @param {number} limit - The number of items to display per page
+		 *
+		 * @spec exclude Pure client UI-state setter — list pagination cursor. No backend contract.
 		 */
 		setPagination(page, limit = 14) {
 			this.pagination = { page, limit }
@@ -35,6 +43,8 @@ export const useConfigurationStore = defineStore('configuration', {
 		/**
 		 * Set query filters for configuration list
 		 * @param {object} filters - The filter criteria to apply to the configuration list
+		 *
+		 * @spec exclude Pure client UI-state setter — list filter criteria. No backend contract.
 		 */
 		setFilters(filters) {
 			this.filters = { ...this.filters, ...filters }
@@ -46,6 +56,8 @@ export const useConfigurationStore = defineStore('configuration', {
 		 * @param {string|null} search - Optional search term
 		 * @param {boolean} soft - If true, don't show loading state (default: false)
 		 * @return {Promise} Promise with response and data
+		 *
+		 * @spec exclude Thin API passthrough — GET /api/configurations list; observable contract owned by data-import-export.
 		 */
 		/* istanbul ignore next */ // ignore this for Jest until moved into a service
 		async refreshConfigurationList(search = null, soft = false) {
@@ -66,6 +78,9 @@ export const useConfigurationStore = defineStore('configuration', {
 
 			return { response, data }
 		},
+		/**
+		 * @spec exclude Thin API passthrough — GET /api/configurations/{id}; observable contract owned by data-import-export.
+		 */
 		async getConfiguration(id) {
 			const endpoint = `/index.php/apps/openregister/api/configurations/${id}`
 			try {
@@ -80,6 +95,9 @@ export const useConfigurationStore = defineStore('configuration', {
 				throw err
 			}
 		},
+		/**
+		 * @spec exclude Thin API passthrough — DELETE /api/configurations/{id}; observable contract owned by data-import-export.
+		 */
 		async deleteConfiguration(configurationItem) {
 			if (!configurationItem.id) {
 				throw new Error('No configuration item to delete')
@@ -107,6 +125,9 @@ export const useConfigurationStore = defineStore('configuration', {
 				throw new Error(`Failed to delete configuration: ${error.message}`)
 			}
 		},
+		/**
+		 * @spec exclude Thin API passthrough — POST/PUT /api/configurations; observable contract owned by data-import-export.
+		 */
 		async saveConfiguration(configurationItem) {
 			if (!configurationItem) {
 				throw new Error('No configuration item to save')
@@ -157,6 +178,9 @@ export const useConfigurationStore = defineStore('configuration', {
 			}
 		},
 		// Clean configuration data for saving - remove read-only fields
+		/**
+		 * @spec exclude Client-side payload sanitiser — strips read-only fields before save. No standalone backend contract.
+		 */
 		cleanConfigurationForSave(configurationItem) {
 			const cleaned = { ...configurationItem }
 
@@ -168,6 +192,9 @@ export const useConfigurationStore = defineStore('configuration', {
 
 			return cleaned
 		},
+		/**
+		 * @spec exclude Thin API passthrough — POST/PUT /api/configurations/upload; observable contract owned by data-import-export.
+		 */
 		async uploadConfiguration(configuration) {
 			if (!configuration) {
 				throw new Error('No configuration item to upload')
@@ -214,6 +241,9 @@ export const useConfigurationStore = defineStore('configuration', {
 				throw new Error(`Failed to upload configuration: ${error.message}`)
 			}
 		},
+		/**
+		 * @spec exclude Thin API passthrough — POST /api/configurations/import; observable contract owned by data-import-export.
+		 */
 		async importConfiguration(file, includeObjects = false) {
 			if (!file) {
 				throw new Error('No file to import')
@@ -257,6 +287,9 @@ export const useConfigurationStore = defineStore('configuration', {
 				throw error // Pass through the original error message
 			}
 		},
+		/**
+		 * @spec exclude Thin API passthrough — GET /api/configurations/discover; observable contract owned by data-import-export.
+		 */
 		async discoverConfigurations(source, search = '') {
 			console.log(`ConfigurationStore: Discovering configurations on ${source}`)
 			const endpoint = '/index.php/apps/openregister/api/configurations/discover'
@@ -285,6 +318,9 @@ export const useConfigurationStore = defineStore('configuration', {
 				throw error
 			}
 		},
+		/**
+		 * @spec exclude Thin API passthrough — GET /api/configurations/{source}/branches; observable contract owned by data-import-export.
+		 */
 		async getBranches(source, params) {
 			console.log(`ConfigurationStore: Fetching branches from ${source}`)
 			const endpoint = `/index.php/apps/openregister/api/configurations/${source}/branches`
@@ -306,6 +342,9 @@ export const useConfigurationStore = defineStore('configuration', {
 				throw error
 			}
 		},
+		/**
+		 * @spec exclude Thin API passthrough — GET /api/configurations/{source}/files; observable contract owned by data-import-export.
+		 */
 		async getConfigurationFiles(source, params) {
 			console.log(`ConfigurationStore: Fetching configuration files from ${source}`)
 			const endpoint = `/index.php/apps/openregister/api/configurations/${source}/files`
@@ -327,6 +366,9 @@ export const useConfigurationStore = defineStore('configuration', {
 				throw error
 			}
 		},
+		/**
+		 * @spec exclude Thin API passthrough — POST /api/configurations/import/github; observable contract owned by data-import-export.
+		 */
 		async importFromGitHub(params) {
 			console.log('ConfigurationStore: Importing from GitHub')
 			const endpoint = '/index.php/apps/openregister/api/configurations/import/github'
@@ -353,6 +395,9 @@ export const useConfigurationStore = defineStore('configuration', {
 				throw error
 			}
 		},
+		/**
+		 * @spec exclude Thin API passthrough — POST /api/configurations/import/gitlab; observable contract owned by data-import-export.
+		 */
 		async importFromGitLab(params) {
 			console.log('ConfigurationStore: Importing from GitLab')
 			const endpoint = '/index.php/apps/openregister/api/configurations/import/gitlab'
@@ -379,6 +424,9 @@ export const useConfigurationStore = defineStore('configuration', {
 				throw error
 			}
 		},
+		/**
+		 * @spec exclude Thin API passthrough — POST /api/configurations/import/url; observable contract owned by data-import-export.
+		 */
 		async importFromUrl(params) {
 			console.log('ConfigurationStore: Importing from URL')
 			const endpoint = '/index.php/apps/openregister/api/configurations/import/url'

--- a/src/store/modules/conversation.ts
+++ b/src/store/modules/conversation.ts
@@ -57,6 +57,8 @@ export const useConversationStore = defineStore('conversation', {
 	actions: {
 		/**
 		 * Toggle sidebar collapsed state
+		 *
+		 * @spec exclude Pure client UI-state toggle — chat sidebar collapse. No backend contract.
 		 */
 		toggleSidebar() {
 			this.sidebarCollapsed = !this.sidebarCollapsed
@@ -65,6 +67,8 @@ export const useConversationStore = defineStore('conversation', {
 
 		/**
 		 * Toggle archive view
+		 *
+		 * @spec exclude Pure client UI-state toggle — archive view switch (lazily refreshes archived list). No backend contract.
 		 */
 		toggleArchive() {
 			this.showArchive = !this.showArchive
@@ -78,6 +82,8 @@ export const useConversationStore = defineStore('conversation', {
 		 * Set active conversation
 		 *
 		 * @param {object | null} conversation - The conversation to set as active
+		 *
+		 * @spec exclude Client state mutator — wraps the active conversation in an entity. No backend contract.
 		 */
 		setActiveConversation(conversation: TConversation | null) {
 			this.activeConversation = conversation ? new Conversation(conversation) : null
@@ -88,6 +94,8 @@ export const useConversationStore = defineStore('conversation', {
 		 * Set messages for active conversation
 		 *
 		 * @param {Array} messages - Array of messages
+		 *
+		 * @spec exclude Client state mutator — maps the active conversation's messages to entities. No backend contract.
 		 */
 		setActiveMessages(messages: TMessage[]) {
 			this.activeConversationMessages = messages.map((msg) => new Message(msg))
@@ -98,6 +106,8 @@ export const useConversationStore = defineStore('conversation', {
 		 * Add a message to the active conversation
 		 *
 		 * @param {object} message - Message to add
+		 *
+		 * @spec exclude Client state mutator — appends a message entity to the active conversation. No backend contract.
 		 */
 		addMessage(message: TMessage) {
 			const newMessage = new Message(message)
@@ -109,6 +119,8 @@ export const useConversationStore = defineStore('conversation', {
 		 * Set conversation list
 		 *
 		 * @param {Array} conversations - Array of conversations
+		 *
+		 * @spec exclude Client state mutator — maps the conversation list to entities. No backend contract.
 		 */
 		setConversationList(conversations: TConversation[]) {
 			this.conversationList = conversations.map((conv) => new Conversation(conv))
@@ -120,6 +132,8 @@ export const useConversationStore = defineStore('conversation', {
 		 *
 		 * @param {boolean} soft - If true, don't show loading state
 		 * @return {Promise} Promise with response and data
+		 *
+		 * @spec exclude Thin API passthrough — GET /api/conversations list; observable contract owned by chat-ai.
 		 */
 		async refreshConversationList(soft = false) {
 			console.log('ConversationStore: Starting refreshConversationList (soft=' + soft + ')')
@@ -165,6 +179,8 @@ export const useConversationStore = defineStore('conversation', {
 		 * Refresh archived conversations
 		 *
 		 * @return {Promise} Promise with response and data
+		 *
+		 * @spec exclude Thin API passthrough — GET /api/conversations?_deleted=true; observable contract owned by chat-ai.
 		 */
 		async refreshArchivedConversations() {
 			console.log('ConversationStore: Starting refreshArchivedConversations')
@@ -207,6 +223,8 @@ export const useConversationStore = defineStore('conversation', {
 		 *
 		 * @param {string} uuid - Conversation UUID
 		 * @return {Promise} Promise with conversation data
+		 *
+		 * @spec exclude Thin API passthrough — GET /api/conversations/{uuid}; observable contract owned by chat-ai.
 		 */
 		async loadConversation(uuid: string) {
 			console.log('ConversationStore: Loading conversation', uuid)
@@ -253,6 +271,8 @@ export const useConversationStore = defineStore('conversation', {
 		 * @param {number} limit - Number of messages to load (default: 50)
 		 * @param {number} offset - Offset for pagination (default: 0)
 		 * @return {Promise} Promise with messages data
+		 *
+		 * @spec exclude Thin API passthrough — GET /api/conversations/{uuid}/messages; observable contract owned by chat-ai.
 		 */
 		async loadMessages(uuid: string, limit = 50, offset = 0) {
 			console.log('ConversationStore: Loading messages', { uuid, limit, offset })
@@ -306,6 +326,8 @@ export const useConversationStore = defineStore('conversation', {
 		 * @param {string} agentUuid - Agent UUID
 		 * @param {string} title - Optional conversation title
 		 * @return {Promise} Promise with new conversation data
+		 *
+		 * @spec exclude Thin API passthrough — POST /api/conversations; observable contract owned by chat-ai.
 		 */
 		async createConversation(agentUuid: string, title?: string) {
 			console.log('ConversationStore: Creating conversation with agent', agentUuid)
@@ -355,6 +377,8 @@ export const useConversationStore = defineStore('conversation', {
 		 * @param {string} uuid - Conversation UUID
 		 * @param {object} updates - Fields to update
 		 * @return {Promise} Promise with updated conversation data
+		 *
+		 * @spec exclude Thin API passthrough — PATCH /api/conversations/{uuid}; observable contract owned by chat-ai.
 		 */
 		async updateConversation(uuid: string, updates: Partial<TConversation>) {
 			console.log('ConversationStore: Updating conversation', uuid)
@@ -403,6 +427,8 @@ export const useConversationStore = defineStore('conversation', {
 		 *
 		 * @param {string} uuid - Conversation UUID
 		 * @return {Promise} Promise with response
+		 *
+		 * @spec exclude Thin API passthrough — DELETE /api/conversations/{uuid} (soft-archive); observable contract owned by chat-ai.
 		 */
 		async archiveConversation(uuid: string) {
 			console.log('ConversationStore: Archiving conversation', uuid)
@@ -448,6 +474,8 @@ export const useConversationStore = defineStore('conversation', {
 		 *
 		 * @param {string} uuid - Conversation UUID
 		 * @return {Promise} Promise with response
+		 *
+		 * @spec exclude Client-side alias of archiveConversation; delegates to a chat-ai passthrough. No standalone backend contract.
 		 */
 		async deleteConversation(uuid: string) {
 			return this.archiveConversation(uuid)
@@ -458,6 +486,8 @@ export const useConversationStore = defineStore('conversation', {
 		 *
 		 * @param {string} uuid - Conversation UUID
 		 * @return {Promise} Promise with restored conversation data
+		 *
+		 * @spec exclude Thin API passthrough — POST /api/conversations/{uuid}/restore; observable contract owned by chat-ai.
 		 */
 		async restoreConversation(uuid: string) {
 			console.log('ConversationStore: Restoring conversation', uuid)
@@ -498,6 +528,8 @@ export const useConversationStore = defineStore('conversation', {
 		 *
 		 * @param {string} uuid - Conversation UUID
 		 * @return {Promise} Promise with response
+		 *
+		 * @spec exclude Thin API passthrough — DELETE /api/conversations/{uuid}/permanent; observable contract owned by chat-ai.
 		 */
 		async deleteConversationPermanent(uuid: string) {
 			console.log('ConversationStore: Permanently deleting conversation', uuid)
@@ -679,6 +711,8 @@ export const useConversationStore = defineStore('conversation', {
 
 		/**
 		 * Clear active conversation
+		 *
+		 * @spec exclude Pure client UI-state mutator — resets active conversation/messages. No backend contract.
 		 */
 		clearActiveConversation() {
 			this.setActiveConversation(null)
@@ -691,6 +725,8 @@ export const useConversationStore = defineStore('conversation', {
 		 *
 		 * @param {number} page - Page number
 		 * @param {number} limit - Items per page
+		 *
+		 * @spec exclude Pure client UI-state setter — conversation list pagination cursor. No backend contract.
 		 */
 		setPagination(page: number, limit = 50) {
 			this.pagination = { ...this.pagination, page, limit }

--- a/src/store/modules/navigation.js
+++ b/src/store/modules/navigation.js
@@ -37,19 +37,31 @@ export const useNavigationStore = defineStore('ui', {
 		setModal(modal) {
 			this.modal = modal
 		},
+		/**
+		 * @spec exclude Pure client UI-state setter — toggles the single active dialog. No backend contract.
+		 */
 		setDialog(dialog) {
 			console.log('NavigationStore - setDialog() called with:', dialog)
 			this.dialog = dialog
 		},
+		/**
+		 * @spec exclude Pure client UI-state setter — stashes cross-component transfer payload. No backend contract.
+		 */
 		setTransferData(data) {
 			console.log('NavigationStore - setTransferData() called with:', data)
 			this.transferData = data
 			console.log('NavigationStore - transferData set to:', this.transferData)
 		},
+		/**
+		 * @spec exclude Pure client UI-state getter — returns the stashed transfer payload. No backend contract.
+		 */
 		getTransferData() {
 			console.log('NavigationStore - getTransferData() called, returning:', this.transferData)
 			return this.transferData
 		},
+		/**
+		 * @spec exclude Pure client UI-state mutator — clears the stashed transfer payload. No backend contract.
+		 */
 		clearTransferData() {
 			console.log('NavigationStore - clearTransferData() called')
 			this.transferData = null

--- a/src/store/modules/object-relations/contacts.js
+++ b/src/store/modules/object-relations/contacts.js
@@ -29,6 +29,9 @@ export const useContactRelationsStore = defineStore('contactRelations', {
 	}),
 
 	actions: {
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-24-contacts-actions/tasks.md#task-5
+		 */
 		_url(register, schema, id, suffix = '') {
 			return generateUrl('/apps/openregister/api/objects/{register}/{schema}/{id}/contacts' + suffix, {
 				register,
@@ -37,6 +40,9 @@ export const useContactRelationsStore = defineStore('contactRelations', {
 			})
 		},
 
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-24-contacts-actions/tasks.md#task-5
+		 */
 		async fetch(register, schema, id) {
 			const k = `${register}:${schema}:${id}`
 			this.loading = { ...this.loading, [k]: true }
@@ -68,12 +74,18 @@ export const useContactRelationsStore = defineStore('contactRelations', {
 			}
 		},
 
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-24-contacts-actions/tasks.md#task-5
+		 */
 		async createOrLink(register, schema, id, payload) {
 			const response = await axios.post(this._url(register, schema, id), payload)
 			await this.fetch(register, schema, id)
 			return response.data
 		},
 
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-24-contacts-actions/tasks.md#task-5
+		 */
 		async unlink(register, schema, id, contactUid) {
 			await axios.delete(this._url(register, schema, id, '/' + encodeURIComponent(contactUid)))
 			const k = `${register}:${schema}:${id}`
@@ -82,6 +94,9 @@ export const useContactRelationsStore = defineStore('contactRelations', {
 			return next
 		},
 
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-24-contacts-actions/tasks.md#task-5
+		 */
 		get(register, schema, id) {
 			return this.byObject[`${register}:${schema}:${id}`] || []
 		},

--- a/src/store/modules/object-relations/events.js
+++ b/src/store/modules/object-relations/events.js
@@ -32,6 +32,9 @@ export const useEventRelationsStore = defineStore('eventRelations', {
 	}),
 
 	actions: {
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-24-data-integrity-relations/tasks.md#task-5
+		 */
 		_url(register, schema, id, suffix = '') {
 			return generateUrl('/apps/openregister/api/objects/{register}/{schema}/{id}/events' + suffix, {
 				register,
@@ -40,6 +43,9 @@ export const useEventRelationsStore = defineStore('eventRelations', {
 			})
 		},
 
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-24-data-integrity-relations/tasks.md#task-5
+		 */
 		async fetch(register, schema, id) {
 			const k = `${register}:${schema}:${id}`
 			this.loading = { ...this.loading, [k]: true }
@@ -65,18 +71,27 @@ export const useEventRelationsStore = defineStore('eventRelations', {
 			}
 		},
 
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-24-data-integrity-relations/tasks.md#task-5
+		 */
 		async create(register, schema, id, payload) {
 			const response = await axios.post(this._url(register, schema, id), payload)
 			await this.fetch(register, schema, id)
 			return response.data
 		},
 
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-24-data-integrity-relations/tasks.md#task-5
+		 */
 		async link(register, schema, id, payload) {
 			const response = await axios.post(this._url(register, schema, id, '/link'), payload)
 			await this.fetch(register, schema, id)
 			return response.data
 		},
 
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-24-data-integrity-relations/tasks.md#task-5
+		 */
 		async unlink(register, schema, id, eventId) {
 			await axios.delete(this._url(register, schema, id, '/' + encodeURIComponent(eventId)))
 			const k = `${register}:${schema}:${id}`
@@ -85,6 +100,9 @@ export const useEventRelationsStore = defineStore('eventRelations', {
 			return next
 		},
 
+		/**
+		 * @spec openspec/changes/retrofit-2026-05-24-data-integrity-relations/tasks.md#task-5
+		 */
 		get(register, schema, id) {
 			return this.byObject[`${register}:${schema}:${id}`] || []
 		},

--- a/src/store/modules/object.js
+++ b/src/store/modules/object.js
@@ -43,10 +43,16 @@ function openregisterObjectPlugin() {
 		}),
 
 		getters: {
+			/**
+			 * @spec exclude Derived client-state getter — composes a type slug from the register/schema stores. No backend contract.
+			 */
 			currentType() {
 				return getCurrentType(getActivePinia())
 			},
 
+			/**
+			 * @spec exclude Derived client-state getter — proxies the active schema from the schema store. No backend contract.
+			 */
 			activeSchema() {
 				const pinia = getActivePinia()
 				if (!pinia) return null
@@ -58,6 +64,8 @@ function openregisterObjectPlugin() {
 			/**
 			 * Ensure the current register/schema type is registered in the package store, then fetch collection.
 			 * @param options
+			 *
+			 * @spec exclude Adapter delegating to the @conduction/nextcloud-vue package object store (fetchCollection); the data-fetch contract is owned by the shared library, not this app.
 			 */
 			async refreshObjectList(options = {}) {
 				const pinia = getActivePinia()
@@ -106,6 +114,9 @@ function openregisterObjectPlugin() {
 			// A no-op stub lets the SPA finish mounting; the original
 			// behaviour (per-column filter init) is now handled inline by
 			// the filter components themselves.
+			/**
+			 * @spec exclude Intentional no-op compatibility stub — keeps stale call sites safe; behaviour moved into the filter components.
+			 */
 			initializeColumnFilters() {
 				// Intentionally empty.
 			},
@@ -114,6 +125,9 @@ function openregisterObjectPlugin() {
 			// the same code paths in DashboardSideBar.vue when a schema
 			// becomes available. The new schema-aware property store
 			// handles this elsewhere; a no-op keeps the call site safe.
+			/**
+			 * @spec exclude Intentional no-op compatibility stub — keeps stale call sites safe; behaviour moved into the schema-aware property store.
+			 */
 			initializeProperties(_schema) {
 				// Intentionally empty.
 			},

--- a/src/store/modules/organisation.js
+++ b/src/store/modules/organisation.js
@@ -26,22 +26,37 @@ export const useOrganisationStore = defineStore('organisation', {
 		getUserOrganisations: (state) => state.userStats.list,
 	},
 	actions: {
+		/**
+		 * @spec exclude Pure client UI-state setter — list/card view-mode toggle. No backend contract.
+		 */
 		setViewMode(mode) {
 			this.viewMode = mode
 			console.log('View mode set to:', mode)
 		},
+		/**
+		 * @spec exclude Client state mutator — wraps the active organisation in an entity. No backend contract.
+		 */
 		setOrganisationItem(organisationItem) {
 			this.organisationItem = organisationItem && new Organisation(organisationItem)
 			console.log('Active organisation item set to ' + (organisationItem?.name || 'null'))
 		},
+		/**
+		 * @spec exclude Client state mutator — maps the organisation list to entities. No backend contract.
+		 */
 		setOrganisationList(organisations) {
 			this.organisationList = organisations.map(organisation => new Organisation(organisation))
 			console.log('Organisation list set to ' + organisations.length + ' items')
 		},
+		/**
+		 * @spec exclude Client state mutator — wraps the active organisation in an entity. No backend contract.
+		 */
 		setActiveOrganisation(activeOrganisation) {
 			this.activeOrganisation = activeOrganisation && new Organisation(activeOrganisation)
 			console.log('Active organisation set to ' + (activeOrganisation?.name || 'null'))
 		},
+		/**
+		 * @spec exclude Client state mutator — maps the user-org stats response into entities. No backend contract.
+		 */
 		setUserStats(stats) {
 			this.userStats = {
 				total: stats.total || 0,
@@ -54,6 +69,8 @@ export const useOrganisationStore = defineStore('organisation', {
 		 * Set pagination details
 		 * @param {number} page - The current page number for pagination
 		 * @param {number} limit - The number of items to display per page
+		 *
+		 * @spec exclude Pure client UI-state setter — list pagination cursor. No backend contract.
 		 */
 		setPagination(page, limit = 14) {
 			this.pagination = { page, limit }
@@ -62,11 +79,16 @@ export const useOrganisationStore = defineStore('organisation', {
 		/**
 		 * Set query filters for organisation list
 		 * @param {object} filters - The filter criteria to apply to the organisation list
+		 *
+		 * @spec exclude Pure client UI-state setter — list filter criteria. No backend contract.
 		 */
 		setFilters(filters) {
 			this.filters = { ...this.filters, ...filters }
 			console.info('Query filters set to', this.filters)
 		},
+		/**
+		 * @spec exclude Thin API passthrough — GET /api/organisations list; observable contract owned by tenant-lifecycle.
+		 */
 		/* istanbul ignore next */ // ignore this for Jest until moved into a service
 		async refreshOrganisationList() {
 			const endpoint = '/index.php/apps/openregister/api/organisations'
@@ -85,6 +107,9 @@ export const useOrganisationStore = defineStore('organisation', {
 			return { response, data }
 		},
 		// Get active organisation
+		/**
+		 * @spec exclude Thin API passthrough — GET /api/organisations/active; observable contract owned by tenant-lifecycle.
+		 */
 		async getActiveOrganisation() {
 			const endpoint = '/index.php/apps/openregister/api/organisations/active'
 			try {
@@ -104,6 +129,9 @@ export const useOrganisationStore = defineStore('organisation', {
 			}
 		},
 		// Function to get a single organisation
+		/**
+		 * @spec exclude Thin API passthrough — GET /api/organisations/{uuid}; observable contract owned by tenant-lifecycle.
+		 */
 		async getOrganisation(uuid, options = { setItem: false }) {
 			const endpoint = `/index.php/apps/openregister/api/organisations/${uuid}`
 			try {
@@ -123,6 +151,9 @@ export const useOrganisationStore = defineStore('organisation', {
 			}
 		},
 		// Set active organisation
+		/**
+		 * @spec exclude Thin API passthrough — POST /api/organisations/{uuid}/set-active; observable contract owned by tenant-lifecycle.
+		 */
 		async setActiveOrganisationById(uuid) {
 			const endpoint = `/index.php/apps/openregister/api/organisations/${uuid}/set-active`
 			try {
@@ -155,6 +186,8 @@ export const useOrganisationStore = defineStore('organisation', {
 		 * @param {string} uuid - Organisation UUID to join
 		 * @param {string|null} userId - Optional user ID to join the organisation. If null, current user joins.
 		 * @return {Promise<{response: Response, data: object}>} API response
+		 *
+		 * @spec exclude Thin API passthrough — POST /api/organisations/{uuid}/join; observable contract owned by tenant-lifecycle.
 		 */
 		async joinOrganisation(uuid, userId = null) {
 			const endpoint = `/index.php/apps/openregister/api/organisations/${uuid}/join`
@@ -186,6 +219,9 @@ export const useOrganisationStore = defineStore('organisation', {
 			}
 		},
 		// Leave an organisation
+		/**
+		 * @spec exclude Thin API passthrough — POST /api/organisations/{uuid}/leave; observable contract owned by tenant-lifecycle.
+		 */
 		async leaveOrganisation(uuid) {
 			const endpoint = `/index.php/apps/openregister/api/organisations/${uuid}/leave`
 			try {
@@ -210,6 +246,9 @@ export const useOrganisationStore = defineStore('organisation', {
 			}
 		},
 		// Delete an organisation (owner only)
+		/**
+		 * @spec exclude Thin API passthrough — DELETE /api/organisations/{uuid}; observable contract owned by tenant-lifecycle.
+		 */
 		async deleteOrganisation(organisationItem) {
 			if (!organisationItem.uuid) {
 				throw new Error('No organisation UUID to delete')
@@ -232,6 +271,9 @@ export const useOrganisationStore = defineStore('organisation', {
 			return { response }
 		},
 		// Create a new organisation
+		/**
+		 * @spec exclude Thin API passthrough — POST /api/organisations; observable contract owned by tenant-lifecycle.
+		 */
 		async createOrganisation(organisationData) {
 			console.log('Creating organisation...', organisationData)
 
@@ -269,6 +311,9 @@ export const useOrganisationStore = defineStore('organisation', {
 		},
 
 		// Update an existing organisation
+		/**
+		 * @spec exclude Thin API passthrough — PUT /api/organisations/{uuid}; observable contract owned by tenant-lifecycle.
+		 */
 		async updateOrganisation(organisationData) {
 			console.log('Updating organisation...', organisationData)
 
@@ -325,6 +370,9 @@ export const useOrganisationStore = defineStore('organisation', {
 		},
 
 		// Create or update an organisation (legacy method for backward compatibility)
+		/**
+		 * @spec exclude Client-side create/update dispatcher — delegates to createOrganisation/updateOrganisation passthroughs. No standalone backend contract.
+		 */
 		async saveOrganisation(organisationItem) {
 			const isNewOrganisation = !organisationItem.uuid && !organisationItem.id
 
@@ -335,6 +383,9 @@ export const useOrganisationStore = defineStore('organisation', {
 			}
 		},
 		// Clean organisation data for saving - remove read-only fields
+		/**
+		 * @spec exclude Client-side payload sanitiser — strips read-only fields before save. No standalone backend contract.
+		 */
 		cleanOrganisationForSave(organisationItem) {
 			const cleaned = { ...organisationItem }
 
@@ -371,6 +422,8 @@ export const useOrganisationStore = defineStore('organisation', {
 		 * @param {number} limit - Maximum number of results to return
 		 * @param {number} offset - Number of results to skip
 		 * @return {Promise<Array>} List of organisations
+		 *
+		 * @spec exclude Thin API passthrough — GET /api/organisations/search; observable contract owned by tenant-lifecycle.
 		 */
 		async searchOrganisations(query = '', limit = 50, offset = 0) {
 			// Build query parameters
@@ -401,6 +454,9 @@ export const useOrganisationStore = defineStore('organisation', {
 			}
 		},
 		// Clear cache
+		/**
+		 * @spec exclude Thin API passthrough — POST /api/organisations/clear-cache; observable contract owned by tenant-lifecycle.
+		 */
 		async clearCache() {
 			const endpoint = '/index.php/apps/openregister/api/organisations/clear-cache'
 			try {
@@ -425,6 +481,8 @@ export const useOrganisationStore = defineStore('organisation', {
 		 * This should be called on the organisations index page to preload groups
 		 *
 		 * @return {Promise<void>}
+		 *
+		 * @spec exclude Thin passthrough to the Nextcloud OCS groups API; observable contract owned by Nextcloud core, not OpenRegister.
 		 */
 		async loadNextcloudGroups() {
 			try {

--- a/src/store/modules/register.js
+++ b/src/store/modules/register.js
@@ -24,14 +24,23 @@ export const useRegisterStore = defineStore('register', {
 		getViewMode: (state) => state.viewMode,
 	},
 	actions: {
+		/**
+		 * @spec exclude Pure client UI-state setter — active detail tab. No backend contract.
+		 */
 		setActiveTab(tab) {
 			this.activeTab = tab
 			console.log('Active tab set to:', tab)
 		},
+		/**
+		 * @spec exclude Pure client UI-state setter — list/card view-mode toggle. No backend contract.
+		 */
 		setViewMode(mode) {
 			this.viewMode = mode
 			console.log('View mode set to:', mode)
 		},
+		/**
+		 * @spec exclude Client state mutator — wraps the active register in an entity. No backend contract.
+		 */
 		setRegisterItem(registerItem) {
 			try {
 				this.loading = true
@@ -45,6 +54,9 @@ export const useRegisterStore = defineStore('register', {
 				this.loading = false
 			}
 		},
+		/**
+		 * @spec exclude Client state mutator — maps the register list to entities. No backend contract.
+		 */
 		setRegisterList(registerList) {
 			this.registerList = registerList.map(
 				(registerItem) => new Register(registerItem),
@@ -55,6 +67,8 @@ export const useRegisterStore = defineStore('register', {
 		 * Set pagination details
 		 * @param {number} page - The current page number for pagination
 		 * @param {number} limit - The number of items to display per page
+		 *
+		 * @spec exclude Pure client UI-state setter — list pagination cursor. No backend contract.
 		 */
 		setPagination(page, limit = 14) {
 			this.pagination = { page, limit }
@@ -63,11 +77,16 @@ export const useRegisterStore = defineStore('register', {
 		/**
 		 * Set query filters for register list
 		 * @param {object} filters - The filter criteria to apply to the register list
+		 *
+		 * @spec exclude Pure client UI-state setter — list filter criteria. No backend contract.
 		 */
 		setFilters(filters) {
 			this.filters = { ...this.filters, ...filters }
 			console.info('Query filters set to', this.filters) // Logging the filters
 		},
+		/**
+		 * @spec exclude Thin API passthrough — GET /api/registers list; observable contract owned by the register lifecycle backend capability.
+		 */
 		/* istanbul ignore next */ // ignore this for Jest until moved into a service
 		async refreshRegisterList(search = null) {
 			console.log('RegisterStore: Starting refreshRegisterList')
@@ -87,6 +106,9 @@ export const useRegisterStore = defineStore('register', {
 			return { response, data }
 		},
 		// New function to get a single register
+		/**
+		 * @spec exclude Thin API passthrough — GET /api/registers/{id}; observable contract owned by the register lifecycle backend capability.
+		 */
 		async getRegister(id) {
 			const endpoint = `/index.php/apps/openregister/api/registers/${id}`
 			try {
@@ -102,6 +124,9 @@ export const useRegisterStore = defineStore('register', {
 			}
 		},
 		// New function to get register statistics
+		/**
+		 * @spec exclude Thin API passthrough — GET /api/registers/{id}/stats; observable contract owned by the register lifecycle backend capability.
+		 */
 		async getRegisterStats(id) {
 			const endpoint = `/index.php/apps/openregister/api/registers/${id}/stats`
 			try {
@@ -116,6 +141,9 @@ export const useRegisterStore = defineStore('register', {
 			}
 		},
 		// Delete a register
+		/**
+		 * @spec exclude Thin API passthrough — DELETE /api/registers/{id}; observable contract owned by the register lifecycle backend capability.
+		 */
 		async deleteRegister(registerItem) {
 			if (!registerItem.id) {
 				throw new Error('No register item to delete')
@@ -150,6 +178,9 @@ export const useRegisterStore = defineStore('register', {
 			}
 		},
 		// Publish a register
+		/**
+		 * @spec exclude Thin API passthrough — POST /api/registers/{id}/publish; observable contract owned by the register lifecycle backend capability.
+		 */
 		async publishRegister(registerId, date = null) {
 			if (!registerId) {
 				throw new Error('No register ID provided')
@@ -187,6 +218,9 @@ export const useRegisterStore = defineStore('register', {
 			}
 		},
 		// Depublish a register
+		/**
+		 * @spec exclude Thin API passthrough — POST /api/registers/{id}/depublish; observable contract owned by the register lifecycle backend capability.
+		 */
 		async depublishRegister(registerId, date = null) {
 			if (!registerId) {
 				throw new Error('No register ID provided')
@@ -224,6 +258,9 @@ export const useRegisterStore = defineStore('register', {
 			}
 		},
 		// Create or save a register from store
+		/**
+		 * @spec exclude Thin API passthrough — POST/PUT /api/registers; observable contract owned by the register lifecycle backend capability.
+		 */
 		async saveRegister(registerItem) {
 			if (!registerItem) {
 				throw new Error('No register item to save')
@@ -274,6 +311,9 @@ export const useRegisterStore = defineStore('register', {
 			}
 		},
 		// Clean register data for saving - remove read-only fields
+		/**
+		 * @spec exclude Client-side payload sanitiser — strips read-only fields before save. No standalone backend contract.
+		 */
 		cleanRegisterForSave(registerItem) {
 			const cleaned = { ...registerItem }
 
@@ -286,6 +326,9 @@ export const useRegisterStore = defineStore('register', {
 			return cleaned
 		},
 		// Create or save a register from store
+		/**
+		 * @spec exclude Thin API passthrough — POST/PUT /api/registers/upload; observable contract owned by the register lifecycle backend capability.
+		 */
 		async uploadRegister(register) {
 			if (!register) {
 				throw new Error('No register item to upload')
@@ -333,6 +376,8 @@ export const useRegisterStore = defineStore('register', {
 		 * @param {number} intervalMs - Heartbeat interval in milliseconds (default: 15 seconds)
 		 * @param {Function} onStatusChange - Callback for heartbeat status changes
 		 * @return {object} - Object with stop() method and status property
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-store-2/tasks.md#task-1
 		 */
 		startImportHeartbeat(intervalMs = 15000, onStatusChange = null) {
 			console.log('RegisterStore: Starting import heartbeat every', intervalMs, 'ms')
@@ -392,6 +437,9 @@ export const useRegisterStore = defineStore('register', {
 			}, intervalMs)
 
 			return {
+				/**
+				 * @spec openspec/changes/retrofit-2026-05-25-fe-store-2/tasks.md#task-1
+				 */
 				stop() {
 					console.log(`RegisterStore: Stopping import heartbeat after ${heartbeatCount} attempts (${failureCount} failures)`)
 					clearInterval(heartbeatInterval)
@@ -402,6 +450,9 @@ export const useRegisterStore = defineStore('register', {
 			}
 		},
 
+		/**
+		 * @spec exclude Thin API passthrough — POST /api/registers/{id}/import; observable contract owned by data-import-export (the heartbeat it spins up is spec'd separately under frontend-client-state-orchestration REQ-001).
+		 */
 		async importRegister(file, heartbeatCallback = null) {
 			if (!file) {
 				throw new Error('No file to import')
@@ -487,6 +538,9 @@ export const useRegisterStore = defineStore('register', {
 				heartbeat.stop()
 			}
 		},
+		/**
+		 * @spec exclude Pure client UI-state mutator — resets the active register and error. No backend contract.
+		 */
 		clearRegisterItem() {
 			this.registerItem = null
 			this.error = null

--- a/src/store/modules/searchTrail.js
+++ b/src/store/modules/searchTrail.js
@@ -74,6 +74,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		/**
 		 * Set search trail list
 		 * @param {Array} searchTrailList - The search trail list to set
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		setSearchTrailList(searchTrailList) {
 			// Ensure we have a clean array without reactive references
@@ -84,6 +86,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		/**
 		 * Set search trail item
 		 * @param {object} searchTrailItem - The search trail item to set
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		setSearchTrailItem(searchTrailItem) {
 			this.searchTrailItem = searchTrailItem
@@ -93,6 +97,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		/**
 		 * Set search trail pagination
 		 * @param {object} pagination - The pagination object
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		setSearchTrailPagination(pagination) {
 			this.searchTrailPagination = {
@@ -105,6 +111,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		/**
 		 * Set statistics
 		 * @param {object} stats - The statistics object
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		setStatistics(stats) {
 			this.statistics = {
@@ -130,6 +138,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		/**
 		 * Set popular terms
 		 * @param {object} response - The popular terms response object
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		setPopularTerms(response) {
 			// Handle response structure from API
@@ -141,6 +151,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		/**
 		 * Set activity data
 		 * @param {object} activityResponse - The activity data response
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		setActivity(activityResponse) {
 			// Handle response structure from API
@@ -166,6 +178,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		/**
 		 * Set register schema statistics
 		 * @param {object} response - The register schema statistics response
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		setRegisterSchemaStats(response) {
 			// Handle response structure from API
@@ -177,6 +191,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		/**
 		 * Set user agent statistics
 		 * @param {object} response - The user agent statistics response
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		setUserAgentStats(response) {
 			// Handle response structure from API
@@ -188,6 +204,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		/**
 		 * Set search trail filters
 		 * @param {object} filters - The filters to set
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		setSearchTrailFilters(filters) {
 			this.searchTrailFilters = filters
@@ -197,6 +215,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		/**
 		 * Set search trail search
 		 * @param {string} search - The search term
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		setSearchTrailSearch(search) {
 			this.searchTrailSearch = search
@@ -285,6 +305,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		/**
 		 * Fetch search trail statistics
 		 * @return {Promise<object>} The statistics data
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		async fetchStatistics() {
 			this.statisticsLoading = true
@@ -321,6 +343,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		 * Fetch popular search terms
 		 * @param {number} limit - Number of terms to fetch
 		 * @return {Promise<Array>} The popular terms data
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		async fetchPopularTerms(limit = 10) {
 			this.popularTermsLoading = true
@@ -357,6 +381,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		 * Fetch search activity data
 		 * @param {string} period - The period to fetch (hourly, daily, weekly, monthly)
 		 * @return {Promise<Array>} The activity data
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		async fetchActivity(period = 'daily') {
 			this.activityLoading = true
@@ -392,6 +418,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		/**
 		 * Fetch register schema statistics
 		 * @return {Promise<Array>} The register schema statistics
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		async fetchRegisterSchemaStats() {
 			try {
@@ -423,6 +451,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		/**
 		 * Fetch user agent statistics
 		 * @return {Promise<Array>} The user agent statistics
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		async fetchUserAgentStats() {
 			try {
@@ -488,6 +518,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		/**
 		 * Refresh search trail list with current filters
 		 * @return {Promise} The refresh promise
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		async refreshSearchTrailList() {
 			return this.fetchSearchTrails({
@@ -499,6 +531,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		/**
 		 * Get search trail statistics
 		 * @return {Promise<object>} The statistics
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		async getStatistics() {
 			try {
@@ -528,6 +562,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		 * Get popular search terms
 		 * @param {number} limit - Number of terms to get
 		 * @return {Promise<Array>} The popular terms
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		async getPopularTerms(limit = 10) {
 			try {
@@ -543,6 +579,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		 * Get search activity data
 		 * @param {string} period - The period to get data for
 		 * @return {Promise<Array>} The activity data
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		async getActivity(period = 'daily') {
 			try {
@@ -557,6 +595,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		/**
 		 * Get register schema usage statistics
 		 * @return {Promise<Array>} The register schema statistics
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		async getRegisterSchemaStats() {
 			try {
@@ -571,6 +611,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 		/**
 		 * Get user agent statistics
 		 * @return {Promise<Array>} The user agent statistics
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		async getUserAgentStats() {
 			try {
@@ -584,6 +626,8 @@ export const useSearchTrailStore = defineStore('searchTrail', {
 
 		/**
 		 * Clear all search trail store data
+		 *
+		 * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-89
 		 */
 		clearSearchTrailStore() {
 			this.searchTrailList = []

--- a/src/store/modules/views.js
+++ b/src/store/modules/views.js
@@ -98,6 +98,8 @@ export const useViewsStore = defineStore('views', {
 		 * Set the active view
 		 * @param {object|null} view - The view to set as active
 		 * @return {void}
+		 *
+		 * @spec exclude Pure client UI-state setter — active saved view. No backend contract.
 		 */
 		setActiveView(view) {
 			this.activeView = view
@@ -107,6 +109,8 @@ export const useViewsStore = defineStore('views', {
 		/**
 		 * Clear the active view
 		 * @return {void}
+		 *
+		 * @spec exclude Pure client UI-state mutator — clears the active saved view. No backend contract.
 		 */
 		clearActiveView() {
 			this.activeView = null
@@ -116,6 +120,8 @@ export const useViewsStore = defineStore('views', {
 		/**
 		 * Fetch all views from the API
 		 * @return {Promise<void>}
+		 *
+		 * @spec exclude Thin API passthrough — GET /api/views list; observable contract owned by zoeken-filteren.
 		 */
 		async fetchViews() {
 			this.loading = true
@@ -150,6 +156,8 @@ export const useViewsStore = defineStore('views', {
 		 * Fetch a specific view by ID
 		 * @param {string} id - The view ID
 		 * @return {Promise<object>}
+		 *
+		 * @spec exclude Thin API passthrough — GET /api/views/{id}; observable contract owned by zoeken-filteren.
 		 */
 		async fetchView(id) {
 			this.loading = true
@@ -187,6 +195,8 @@ export const useViewsStore = defineStore('views', {
 		 * Create a new view
 		 * @param {object} viewData - The view data
 		 * @return {Promise<object>}
+		 *
+		 * @spec exclude Thin API passthrough — POST /api/views; observable contract owned by zoeken-filteren.
 		 */
 		async createView(viewData) {
 			this.loading = true
@@ -229,6 +239,8 @@ export const useViewsStore = defineStore('views', {
 		 * @param {string} id - The view ID
 		 * @param {object} viewData - The updated view data
 		 * @return {Promise<object>}
+		 *
+		 * @spec exclude Thin API passthrough — PUT /api/views/{id}; observable contract owned by zoeken-filteren.
 		 */
 		async updateView(id, viewData) {
 			this.loading = true
@@ -281,6 +293,8 @@ export const useViewsStore = defineStore('views', {
 		 * Clean view data for saving - remove read-only fields
 		 * @param {object} viewData - The view data to clean
 		 * @return {object} Cleaned view data
+		 *
+		 * @spec exclude Client-side payload sanitiser — strips read-only fields before save. No standalone backend contract.
 		 */
 		cleanViewForSave(viewData) {
 			const cleaned = { ...viewData }
@@ -298,6 +312,8 @@ export const useViewsStore = defineStore('views', {
 		 * Delete a view
 		 * @param {string} id - The view ID
 		 * @return {Promise<void>}
+		 *
+		 * @spec exclude Thin API passthrough — DELETE /api/views/{id}; observable contract owned by zoeken-filteren.
 		 */
 		async deleteView(id) {
 			this.loading = true
@@ -338,6 +354,8 @@ export const useViewsStore = defineStore('views', {
 		 * @param {object} view - The view to apply
 		 * @param {object} searchStore - The search store instance
 		 * @return {void}
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-store-2/tasks.md#task-2
 		 */
 		applyView(view, searchStore) {
 			if (!view || !view.configuration) {
@@ -408,6 +426,8 @@ export const useViewsStore = defineStore('views', {
 		 * @param {boolean} isDefault - Whether this should be the default view
 		 * @param {boolean} isPublic - Whether this view should be public
 		 * @return {object} The view configuration
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-fe-store-2/tasks.md#task-3
 		 */
 		createViewFromSearchState(searchStore, name, description = '', isDefault = false, isPublic = false) {
 			return {


### PR DESCRIPTION
## Summary

Brings 150 previously-uncovered `src/store/` Pinia store methods under ADR-003's `@spec` convention using the two-tool approach — every method now ends tagged with either a `@spec` pointer to a REQ it implements or a `@spec exclude <reason>` documenting why it is deliberately unspecified.

| Outcome | Methods |
|---|---|
| Spec'd to NEW REQs | 4 |
| Annotated to EXISTING REQs | 33 |
| Excluded (with reason) | 113 |
| **Total** | **150** |

- **3 new REQs** in a new `frontend-client-state-orchestration` capability for genuinely novel client-only behaviour with no backend mirror:
  - REQ-001 — import heartbeat keepalive (`register.js::startImportHeartbeat` + its `stop` closure)
  - REQ-002 — applying a saved view onto the live search store (`views.js::applyView`)
  - REQ-003 — capturing live search state into a view config (`views.js::createViewFromSearchState`)
- **Annotated to existing REQs**: `searchTrail.js` (22 → search-trail task-89), `object-relations/contacts.js` (5 → contacts-actions task-5), `object-relations/events.js` (6 → data-integrity-relations task-5).
- **Excluded with reasons**: thin backend-mirrored API passthroughs (avg-verwerkingsregister, data-import-export, chat-ai, tenant-lifecycle, zoeken-filteren, register lifecycle), pure client UI-state getters/setters/mutators, no-op compatibility stubs, and delegation to the `@conduction/nextcloud-vue` package object store.

Ghost change: `openspec/changes/retrofit-2026-05-25-fe-store-2/`. Retroactive specification only — **no runtime behaviour changes**.

## Test plan

- [ ] `npm run lint -- src/store/modules/` passes (additive docblock comments only; all `.js` files pass `node --check`).
- [ ] Re-run `/opsx-coverage-scan openregister` confirms the 150 methods are no longer uncovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)