### PR TITLE
retrofit: frontend coverage — final 24 residual methods

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-fe-residual-mopup/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-residual-mopup/proposal.md
@@ -1,0 +1,42 @@
+# Retrofit — frontend coverage: residual mop-up (2026-05-25)
+
+Final mop-up over the last 24 uncovered openregister frontend methods. These are
+residual boilerplate added by concurrent work after the main frontend retrofit waves
+(`fe-sidebars`, `fe-components`, `fe-store-*`, `fe-misc`, `fe-views-*`) had already
+landed. They are all UI/store plumbing: computed filter-state bindings, dialog-open
+handlers, a DI constructor, store list-refresh passthroughs, view plumbing, and
+computed v-model accessors.
+
+All 24 methods end tagged with an `@spec exclude <reason>` annotation (reason required
+per ADR-003). No spec delta — every method is excluded, so no `--strict` validation is
+needed. No code-logic changes (comment-only diff).
+
+## Counts
+
+- **24 methods excluded** — residual UI/store plumbing.
+- **0 methods spec'd** — none carry a standalone behavioural contract.
+
+## Excluded (24 methods) — reasons recorded per method
+
+- **Sidebar computed filter-state watchers** — `EntitiesSidebar.vue`
+  (`category`, `search`, `type`), `FilesSidebar.vue` (`riskLevel`, `search`, `status`),
+  `WebhooksSidebar.vue` (`enabled`, `search`): watchers mirroring the two-way-bound
+  filter props into local state. `@spec exclude computed filter-state binding`.
+- **Dialog/handler/computed UI glue** — `RegisterSchemaCard.vue::showEditRegisterDialog`
+  (watcher loading schema options on open), `BulkTranslateDialog.vue::open` (watcher
+  resetting form on open), `UploadFiles.vue::handler` (label-options reactive sync),
+  `EditSchemaProperty.vue::inversedByOptions` (computed option builder — pre-tagged).
+  `@spec exclude UI handler/computed ...`.
+- **DI constructor** — `appInstallService.js::constructor` (RequestError field-copy
+  constructor). `@spec exclude DI constructor`.
+- **Store list-refresh passthroughs** — `agent.js`, `application.js`, `configuration.js`,
+  `organisation.js`, `register.js`, `schema.js`, `source.js` `refreshXList`: thin GET
+  list API passthroughs (pre-tagged in the concurrent store waves).
+  `@spec exclude store list-refresh passthrough`.
+- **View plumbing** — `DeletedIndex.vue::filteredItems` (watcher re-emitting counts),
+  `ObjectsIndex.vue::loadFromRoute` (deep-link prime; pre-tagged).
+  `@spec exclude ... view plumbing`.
+- **Computed v-model accessors** — `SolrConfiguration.vue` `solrEnabled` `get`/`set`
+  (auto-save toggle adapter). `@spec exclude computed v-model accessor`.
+
+Source: `/tmp/or-scan/fw-residual.txt` (24 `path::method` refs).

--- a/openspec/changes/retrofit-2026-05-25-fe-residual-mopup/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-residual-mopup/tasks.md
@@ -1,0 +1,34 @@
+# Tasks — Retrofit fe-residual-mopup (2026-05-25)
+
+Final retrofit annotation pass over the residual `fe-residual` batch (24 methods). Every
+task below is `[x]` because the code already exists — annotating retroactively. All
+methods are residual UI/store plumbing carried as `@spec exclude <reason>`; there is no
+spec delta. No new implementation work and no code-logic changes (comment-only diff).
+
+## Excluded (24 methods)
+
+- [x] task-1: `src/components/EntitiesSidebar.vue` filter-state watchers `category`,
+      `search`, `type` — `@spec exclude computed filter-state binding` (retroactive)
+- [x] task-2: `src/components/FilesSidebar.vue` filter-state watchers `riskLevel`,
+      `search`, `status` — `@spec exclude computed filter-state binding` (retroactive)
+- [x] task-3: `src/components/WebhooksSidebar.vue` filter-state watchers `enabled`,
+      `search` — `@spec exclude computed filter-state binding` (retroactive)
+- [x] task-4: `src/components/cards/RegisterSchemaCard.vue::showEditRegisterDialog`
+      watcher — `@spec exclude UI handler/computed dialog-open trigger` (retroactive)
+- [x] task-5: `src/components/i18n/BulkTranslateDialog.vue::open` watcher —
+      `@spec exclude UI handler/computed dialog-open trigger` (retroactive)
+- [x] task-6: `src/modals/file/UploadFiles.vue::handler` (labelOptions watcher) —
+      `@spec exclude UI handler/computed reactive label-options sync` (retroactive)
+- [x] task-7: `src/modals/schema/EditSchemaProperty.vue::inversedByOptions` computed —
+      `@spec exclude UI display helper` (pre-tagged in concurrent wave)
+- [x] task-8: `src/services/appInstallService.js::constructor` (RequestError) —
+      `@spec exclude DI constructor` (retroactive)
+- [x] task-9: store `refreshXList` passthroughs — `agent.js`, `application.js`,
+      `configuration.js`, `organisation.js`, `register.js`, `schema.js`, `source.js` —
+      `@spec exclude store list-refresh passthrough` (pre-tagged in concurrent store waves)
+- [x] task-10: `src/views/deleted/DeletedIndex.vue::filteredItems` watcher —
+      `@spec exclude list-view watcher re-emitting counts` (retroactive)
+- [x] task-11: `src/views/object/ObjectsIndex.vue::loadFromRoute` —
+      `@spec exclude UI plumbing deep-link prime` (pre-tagged in concurrent wave)
+- [x] task-12: `src/views/settings/sections/SolrConfiguration.vue` `solrEnabled` `get`/`set`
+      — `@spec exclude computed v-model accessor` (retroactive)

--- a/src/components/EntitiesSidebar.vue
+++ b/src/components/EntitiesSidebar.vue
@@ -148,12 +148,21 @@ export default {
 		},
 	},
 	watch: {
+		/**
+		 * @spec exclude computed filter-state binding
+		 */
 		search(newVal) {
 			this.localSearch = newVal
 		},
+		/**
+		 * @spec exclude computed filter-state binding
+		 */
 		type(newVal) {
 			this.selectedType = newVal
 		},
+		/**
+		 * @spec exclude computed filter-state binding
+		 */
 		category(newVal) {
 			this.selectedCategory = newVal
 		},

--- a/src/components/FilesSidebar.vue
+++ b/src/components/FilesSidebar.vue
@@ -176,12 +176,21 @@ export default {
 	},
 
 	watch: {
+		/**
+		 * @spec exclude computed filter-state binding
+		 */
 		search(newVal) {
 			this.localSearch = newVal
 		},
+		/**
+		 * @spec exclude computed filter-state binding
+		 */
 		status(newVal) {
 			this.selectedStatus = newVal
 		},
+		/**
+		 * @spec exclude computed filter-state binding
+		 */
 		riskLevel(newVal) {
 			this.selectedRiskLevel = newVal
 		},

--- a/src/components/WebhooksSidebar.vue
+++ b/src/components/WebhooksSidebar.vue
@@ -105,9 +105,15 @@ export default {
 	},
 
 	watch: {
+		/**
+		 * @spec exclude computed filter-state binding
+		 */
 		search(newVal) {
 			this.localSearch = newVal
 		},
+		/**
+		 * @spec exclude computed filter-state binding
+		 */
 		enabled(newVal) {
 			this.selectedEnabled = newVal
 		},

--- a/src/components/cards/RegisterSchemaCard.vue
+++ b/src/components/cards/RegisterSchemaCard.vue
@@ -534,6 +534,9 @@ export default {
 		},
 	},
 	watch: {
+		/**
+		 * @spec exclude UI handler/computed dialog-open trigger
+		 */
 		showEditRegisterDialog(val) {
 			if (val) {
 				this.loadSchemaOptions()

--- a/src/components/i18n/BulkTranslateDialog.vue
+++ b/src/components/i18n/BulkTranslateDialog.vue
@@ -131,6 +131,9 @@ export default {
 		},
 	},
 	watch: {
+		/**
+		 * @spec exclude UI handler/computed dialog-open trigger
+		 */
 		open(opened) {
 			if (opened) {
 				// Reset form state on open.

--- a/src/modals/file/UploadFiles.vue
+++ b/src/modals/file/UploadFiles.vue
@@ -364,6 +364,9 @@ export default {
 			deep: true,
 		},
 		labelOptions: {
+			/**
+			 * @spec exclude UI handler/computed reactive label-options sync
+			 */
 			handler() {
 				setTags(this.getLabels())
 			},

--- a/src/services/appInstallService.js
+++ b/src/services/appInstallService.js
@@ -455,6 +455,7 @@ class RequestError extends Error {
 	 * @param {string} message - Error message
 	 * @param {Response} response - The fetch Response object
 	 * @param {any} [data] - The parsed response body (if available)
+	 * @spec exclude DI constructor
 	 */
 	constructor(message, response, data) {
 		super(message)

--- a/src/views/deleted/DeletedIndex.vue
+++ b/src/views/deleted/DeletedIndex.vue
@@ -280,6 +280,9 @@ export default {
 		selectedItems() {
 			this.updateCounts()
 		},
+		/**
+		 * @spec exclude list-view watcher re-emitting counts when filtered items change
+		 */
 		filteredItems() {
 			this.updateCounts()
 		},

--- a/src/views/settings/sections/SolrConfiguration.vue
+++ b/src/views/settings/sections/SolrConfiguration.vue
@@ -1262,9 +1262,15 @@ export default {
 
 		// Computed property for SOLR enabled toggle with auto-save
 		solrEnabled: {
+			/**
+			 * @spec exclude computed v-model accessor
+			 */
 			get() {
 				return Boolean(this.solrOptions?.enabled)
 			},
+			/**
+			 * @spec exclude computed v-model accessor
+			 */
 			async set(newValue) {
 				// Update the store
 				this.solrOptions.enabled = newValue


### PR DESCRIPTION
## Summary

Final mop-up of the last 24 uncovered openregister frontend methods, bringing frontend spec coverage to ~100%. These are residual boilerplate added by concurrent work after the main frontend retrofit waves (`fe-sidebars`, `fe-components`, `fe-store-*`, `fe-misc`, `fe-views-*`) had landed.

All 24 are UI/store plumbing and are tagged with an ADR-003 `@spec exclude <reason>` annotation:

- Sidebar computed filter-state watchers (`EntitiesSidebar`, `FilesSidebar`, `WebhooksSidebar`)
- Dialog-open / reactive handlers (`RegisterSchemaCard`, `BulkTranslateDialog`, `UploadFiles`, `EditSchemaProperty`)
- DI constructor (`appInstallService` RequestError)
- Store `refreshXList` list-refresh passthroughs (7 stores)
- View plumbing (`DeletedIndex`, `ObjectsIndex`)
- Computed v-model accessors (`SolrConfiguration` solrEnabled get/set)

**24 excluded / 0 spec'd.** No spec delta (all-exclude → no `--strict` needed). Comment-only diff, no logic changes.

Ghost change: `openspec/changes/retrofit-2026-05-25-fe-residual-mopup/`.

## Test plan

- [x] All 24 `path::method` refs now carry a `@spec exclude <reason>` annotation (verified: 0 untagged)
- [x] Diff is comment/docblock-only (no behavioural change)