### PR TITLE
chore(specs): consolidate duplicate frontend store-state capabilities

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-fe-store-2/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-store-2/proposal.md
@@ -12,7 +12,7 @@ does not change runtime behaviour.
 
 ## What Changes
 
-- Mint **one new capability** `frontend-client-state-orchestration` with **3 REQs**
+- Mint **one new capability** `frontend-store-client-state` with **3 REQs**
   (REQ-001..REQ-003) describing genuinely novel client-side behaviour that no
   backend endpoint mirrors:
   - REQ-001 — client-side import heartbeat keeping the session alive during long
@@ -39,7 +39,7 @@ This is a retroactive specification. No code behaviour changes.
 
 After triage:
 
-- **4 methods → spec'd to NEW REQs** (3 REQs in `frontend-client-state-orchestration`):
+- **4 methods → spec'd to NEW REQs** (3 REQs in `frontend-store-client-state`):
   - `src/store/modules/register.js::startImportHeartbeat` → REQ-001
   - `src/store/modules/register.js::stop` (closure returned by startImportHeartbeat) → REQ-001
   - `src/store/modules/views.js::applyView` → REQ-002
@@ -63,7 +63,7 @@ After triage:
 | Excluded (with reason) | 113 |
 | **Total** | **150** |
 
-New REQs minted: **3** (`frontend-client-state-orchestration` REQ-001..REQ-003).
+New REQs minted: **3** (`frontend-store-client-state` REQ-001..REQ-003).
 
 ## Approach
 

--- a/openspec/changes/retrofit-2026-05-25-fe-store-2/specs/frontend-store-client-state/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-store-2/specs/frontend-store-client-state/spec.md
@@ -2,10 +2,12 @@
 retrofit: true
 ---
 
-# Frontend Client-State Orchestration Specification
+# Frontend Store Client State
 
 **Status**: in-progress
 **Scope**: openregister
+
+> Consolidated into the `frontend-store-client-state` capability (was the separate `frontend-client-state-orchestration` cap). This delta adds the import-keepalive heartbeat + saved-view apply/capture orchestration REQs; the sibling `retrofit-2026-05-25-fe-store-1` change adds the store-internal caching/preload/memoisation REQs. Both archive into one capability.
 
 ## Purpose
 
@@ -22,7 +24,7 @@ coverage matcher can resolve `@spec` annotations on those methods.
 
 ## ADDED Requirements
 
-### Requirement: REQ-001 — Long register imports MUST be kept alive by a client-side heartbeat
+### Requirement: Long register imports MUST be kept alive by a client-side heartbeat
 
 Register imports can run far longer than a typical HTTP request, risking gateway and
 session timeouts. The register store (`src/store/modules/register.js`) MUST provide a
@@ -57,7 +59,7 @@ call `stop()` when the import settles (success or error).
 - **THEN** `importRegister` SHALL call the handle's `stop()` in its `finally` block
 - **AND** `stop()` SHALL clear the polling interval so no further heartbeat requests are issued
 
-### Requirement: REQ-002 — A saved view's configuration MUST be applied onto the live search store
+### Requirement: A saved view's configuration MUST be applied onto the live search store
 
 The views store (`src/store/modules/views.js`) MUST be able to project a saved view's
 persisted `configuration` onto a live search-store instance so that selecting a saved
@@ -88,7 +90,7 @@ MUST be rejected as a no-op (with a warning) rather than partially applied.
 - **WHEN** `applyView(view, searchStore)` is called
 - **THEN** the method SHALL warn and return without mutating the search store or the active view
 
-### Requirement: REQ-003 — The live search-store state MUST be capturable into a saveable view configuration
+### Requirement: The live search-store state MUST be capturable into a saveable view configuration
 
 Conversely, the views store MUST be able to snapshot the current search context into a
 view object suitable for persistence. `createViewFromSearchState(searchStore, name,

--- a/openspec/changes/retrofit-2026-05-25-fe-store-2/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-store-2/tasks.md
@@ -3,6 +3,6 @@
 Retroactive annotation of behaviour that already exists in `src/store/`. The code
 already implements each REQ; the only work captured here is the `@spec` pointer.
 
-- [x] task-1: frontend-client-state-orchestration#REQ-001 — Long register imports are kept alive by a client-side heartbeat (retroactive annotation of `src/store/modules/register.js::startImportHeartbeat` and its returned `stop` closure)
-- [x] task-2: frontend-client-state-orchestration#REQ-002 — A saved view's configuration is applied onto the live search store (retroactive annotation of `src/store/modules/views.js::applyView`)
-- [x] task-3: frontend-client-state-orchestration#REQ-003 — The live search-store state is captured into a saveable view configuration (retroactive annotation of `src/store/modules/views.js::createViewFromSearchState`)
+- [x] task-1: frontend-store-client-state#REQ-001 — Long register imports are kept alive by a client-side heartbeat (retroactive annotation of `src/store/modules/register.js::startImportHeartbeat` and its returned `stop` closure)
+- [x] task-2: frontend-store-client-state#REQ-002 — A saved view's configuration is applied onto the live search store (retroactive annotation of `src/store/modules/views.js::applyView`)
+- [x] task-3: frontend-store-client-state#REQ-003 — The live search-store state is captured into a saveable view configuration (retroactive annotation of `src/store/modules/views.js::createViewFromSearchState`)


### PR DESCRIPTION
Two parallel coverage agents minted near-duplicate cap names for complementary client-state REQs. Folds `frontend-client-state-orchestration` (fe-store-2) into the canonical `frontend-store-client-state` (fe-store-1) so both deltas archive into one capability.

- Renamed the spec-delta dir + title; normalized REQ headings to ADR-037 Form A.
- REQ content is distinct (import heartbeat + saved-view apply/capture vs store caching/preload/memoisation) — no dedup, no lost requirements.
- Code `@spec` annotations point at `tasks.md#task-N` (untouched) — no annotations break.