### PR TITLE
feat(ObjectDetails): render integrations via tabbed CnIntegrationWidget

### DIFF
--- a/src/views/integration/IntegrationsView.vue
+++ b/src/views/integration/IntegrationsView.vue
@@ -1,7 +1,6 @@
 <script>
 import { NcAppContent } from '@nextcloud/vue'
-import { CnIntegrationTab, useIntegrationRegistry } from '@conduction/nextcloud-vue'
-import { BTabs, BTab } from 'bootstrap-vue'
+import { CnIntegrationWidget, useIntegrationRegistry } from '@conduction/nextcloud-vue'
 import { computed, ref } from 'vue'
 
 /**
@@ -12,6 +11,13 @@ import { computed, ref } from 'vue'
  * Vue render won't be aborted mid-template by an unrelated race in
  * filesPlugin / auditTrailsPlugin / relationsPlugin.
  *
+ * Renders the tabbed CnIntegrationWidget (nc-vue, ADR-019/024) — the
+ * same app-faithful surface OR's object-detail page now uses — so the
+ * screenshot harness and the live detail page stay visually in sync.
+ * Supersedes the previous hand-rolled BTabs pills + `provider.tab ||
+ * CnIntegrationTab` dispatch, which produced a flat generic surface
+ * that erased each integrated app's identity.
+ *
  * Route: /integrations/:register/:schema/:objectId
  */
 export default {
@@ -19,26 +25,22 @@ export default {
 
 	components: {
 		NcAppContent,
-		CnIntegrationTab,
-		BTabs,
-		BTab,
+		CnIntegrationWidget,
 	},
 
 	/**
 	 * Composition entry wiring the integration registry into the view.
 	 *
 	 * @spec exclude UI plumbing — registry wiring for the screenshot harness; integration contract owned by ADR-019 / generic-integrations.
-	 * @return {object} exposed refs (providers, ready, CnIntegrationTab)
+	 * @return {object} exposed refs (providers, ready)
 	 */
 	setup() {
 		const { integrations } = useIntegrationRegistry()
+		// Used ONLY by the render guard / header count below;
+		// CnIntegrationWidget reads the same singleton itself.
 		const providers = computed(() => (integrations.value || []))
 		const ready = ref(true)
-		// Re-export the fallback tab component so the template's
-		// <component :is="provider.tab || CnIntegrationTab" /> dispatch
-		// can resolve it as a JS identifier (Options API templates can't
-		// reference module-scope imports directly).
-		return { providers, ready, CnIntegrationTab }
+		return { providers, ready }
 	},
 
 	computed: {
@@ -109,25 +111,18 @@ export default {
 					{{ providers.length }} providers
 				</p>
 
-				<BTabs content-class="mt-3" pills>
-					<BTab v-for="provider in providers"
-						:key="provider.id"
-						:title="provider.label || provider.id"
-						:title-attr="`${provider.id} (${provider.group || 'integration'})`">
-						<!--
-							Dispatch to the provider's bespoke Vue component
-							(provider.tab) when one is registered; fall back to
-							the generic CnIntegrationTab otherwise. See ADR-019.
-						-->
-						<component :is="provider.tab || CnIntegrationTab"
-							:provider="provider"
-							:integration-id="provider.id"
-							:register="register"
-							:schema="schema"
-							:object-id="objectId"
-							v-bind="provider.tabProps || {}" />
-					</BTab>
-				</BTabs>
+				<!--
+					Tabbed CnIntegrationWidget — one app-faithful tab per
+					registered IntegrationProvider, app icon + brand accent on
+					the active tab, per-leaf content (provider.tab) in the
+					panel, and an NcEmptyContent set-up state for unavailable /
+					unconfigured integrations (Phase J-B availability).
+				-->
+				<CnIntegrationWidget
+					:register="register"
+					:schema="schema"
+					:object-id="objectId"
+					surface="detail-page" />
 			</div>
 		</div>
 	</NcAppContent>
@@ -152,49 +147,5 @@ export default {
 .integrations-view__empty {
 	padding: 48px 32px;
 	color: var(--color-text-maxcontrast);
-}
-/* Bootstrap-vue pills layout — without these the tabs render as a plain
-   vertical link list because bootstrap CSS isn't loaded in this stack. */
-.integrations-view :deep(.nav-pills) {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 4px;
-	margin: 0 0 16px;
-	padding: 0;
-	list-style: none;
-	border-bottom: 1px solid var(--color-border);
-	padding-bottom: 8px;
-}
-.integrations-view :deep(.nav-pills .nav-item) {
-	margin: 0;
-}
-.integrations-view :deep(.nav-pills .nav-link) {
-	display: inline-block;
-	padding: 6px 12px;
-	border-radius: var(--border-radius-pill, 16px);
-	background: var(--color-background-hover);
-	color: var(--color-main-text);
-	text-decoration: none;
-	font-size: 13px;
-	border: 1px solid transparent;
-	cursor: pointer;
-}
-.integrations-view :deep(.nav-pills .nav-link:hover) {
-	background: var(--color-background-dark);
-}
-.integrations-view :deep(.nav-pills .nav-link.active) {
-	background: var(--color-primary-element);
-	color: var(--color-primary-element-text);
-	font-weight: 600;
-}
-.integrations-view :deep(.tab-content) {
-	min-height: 320px;
-	padding: 16px;
-	border: 1px solid var(--color-border);
-	border-radius: var(--border-radius-large, 8px);
-	background: var(--color-main-background);
-}
-.integrations-view :deep(.tab-content > .tab-pane:not(.active)) {
-	display: none;
 }
 </style>

--- a/src/views/object/ObjectDetails.vue
+++ b/src/views/object/ObjectDetails.vue
@@ -241,35 +241,28 @@
 						</BTab>
 						<BTab v-if="relationContext && (integrationProviders?.length || 0) > 0" :title="t('openregister', 'Integrations')">
 							<!--
-								Registry-driven integration surface. One inner tab per advertised
-								IntegrationProvider (5 built-ins + xwiki + 18 leaves). OR dogfoods
-								the registry on its own object-detail page so every leaf becomes a
-								deterministic Playwright target — no consumer-app wiring needed
-								to verify a provider end-to-end.
+								Registry-driven integration surface. Renders the tabbed
+								CnIntegrationWidget (nc-vue, ADR-019/024) — one app-faithful
+								tab per advertised IntegrationProvider, with the app icon +
+								brand accent on the active tab, the bespoke per-leaf content
+								(provider.tab) in the active panel, and an NcEmptyContent
+								set-up state (app icon + "{App} not available" + docs link)
+								for any integration whose backing app is missing or
+								unconfigured (Phase J-B availability capability).
+
+								This SUPERSEDES the previous hand-rolled BTabs pills +
+								`provider.tab || CnIntegrationTab` dispatch, which rendered a
+								flat generic surface that erased each app's visual identity.
+								The widget reads the same useIntegrationRegistry() singleton
+								that OR's bootstrap (main.js) populates, so every registered
+								leaf (5 built-ins + xwiki + 18 leaves) still becomes a
+								deterministic Playwright target with no consumer-app wiring.
 							-->
-							<BTabs content-class="mt-2" pills small>
-								<BTab v-for="provider in integrationProviders"
-									:key="provider.id"
-									:title="provider.label || provider.id"
-									:title-attr="`${provider.id} (${provider.group || 'integration'})`">
-									<!--
-										Dispatch to a provider-supplied bespoke Vue component
-										(provider.tab) when one is registered (e.g. CnTalkTab,
-										CnCalendarTab, CnDeckTab from the integration-leaves work).
-										Falls back to the generic CnIntegrationTab when the
-										provider only advertised metadata. Without this dispatch,
-										the 11 bespoke Cn<X>Tab components shipped in nc-vue
-										would be unreachable at runtime — see ADR-019.
-									-->
-									<component :is="provider.tab || CnIntegrationTab"
-										:provider="provider"
-										:integration-id="provider.id"
-										:register="String(relationContext.register)"
-										:schema="String(relationContext.schema)"
-										:object-id="String(relationContext.id)"
-										v-bind="provider.tabProps || {}" />
-								</BTab>
-							</BTabs>
+							<CnIntegrationWidget
+								:register="String(relationContext.register)"
+								:schema="String(relationContext.schema)"
+								:object-id="String(relationContext.id)"
+								surface="detail-page" />
 						</BTab>
 						<BTab v-if="objectStore.auditTrails" :title="t('openregister', 'Audit Trails')">
 							<div v-if="objectStore.auditTrails?.results?.length">
@@ -343,7 +336,7 @@ import ContactsTab from '../../components/object-relations/ContactsTab.vue'
 import DeckTab from '../../components/object-relations/DeckTab.vue'
 import RelationsTab from '../../components/object-relations/RelationsTab.vue'
 import { computed } from 'vue'
-import { CnIntegrationTab, useIntegrationRegistry } from '@conduction/nextcloud-vue'
+import { CnIntegrationWidget, useIntegrationRegistry } from '@conduction/nextcloud-vue'
 import { translate as t } from '@nextcloud/l10n'
 import { objectStore, navigationStore } from '../../store/store.js'
 
@@ -373,7 +366,7 @@ export default {
 		ContactsTab,
 		DeckTab,
 		RelationsTab,
-		CnIntegrationTab,
+		CnIntegrationWidget,
 	},
 	/**
 	 * Composition-API setup: expose the integration-provider registry and
@@ -387,8 +380,9 @@ export default {
 		// nc-vue's in-page registry — drained from window.OCA.OpenRegister
 		// once main.js has called installIntegrationRegistry() +
 		// registerBuiltinIntegrations() + registerLeafIntegrations(). Used
-		// by the "Integrations" BTab below to render one inner sub-tab per
-		// advertised provider.
+		// ONLY by the "Integrations" BTab's v-if guard, so the tab is hidden
+		// when no provider is registered; CnIntegrationWidget reads the same
+		// singleton itself to render the tab strip + per-leaf panels.
 		//
 		// IMPORTANT: This setup() block lives in the Options-API <script>
 		// block. A previous version of this file also had a leading
@@ -402,11 +396,6 @@ export default {
 		const integrationProviders = computed(() => integrations.value || [])
 		return {
 			integrationProviders,
-			// Re-export the fallback tab component so the template's
-			// <component :is="provider.tab || CnIntegrationTab" /> dispatch
-			// can resolve it as a JS identifier (Options API templates can't
-			// reference module-scope imports directly).
-			CnIntegrationTab,
 			t,
 			objectStore,
 			navigationStore,


### PR DESCRIPTION
## Summary
Wires the new tabbed **`CnIntegrationWidget`** (nc-vue#407, merged to beta — ADR-019/024) into OpenRegister's integration surfaces, replacing the hand-rolled `BTabs` pills + `provider.tab || CnIntegrationTab` dispatch the user flagged as "a very simple widget covering all integration types — loses visual identification."

- **`src/views/object/ObjectDetails.vue`** — the "Integrations" sub-tab now renders `<CnIntegrationWidget :register :schema :object-id surface="detail-page" />` instead of an inner `BTabs` loop. One app-faithful tab per registered provider (app icon + brand accent on the active tab), bespoke per-leaf content (`provider.tab`) in the active panel, and an `NcEmptyContent` set-up state for unavailable/unconfigured integrations. `integrationProviders` is kept only for the tab's `v-if` guard; `CnIntegrationTab` import dropped.
- **`src/views/integration/IntegrationsView.vue`** — the `/integrations/:register/:schema/:objectId` screenshot harness converted to the same widget, so harness + live detail page stay visually in sync. (Both surfaces hand-rolled the identical BTabs dispatch; consolidating onto one widget is the cleanest long-term path.)

Both surfaces read the same `useIntegrationRegistry()` singleton OR's bootstrap already populates (5 built-ins + xwiki + 18 leaves), so every leaf remains a deterministic Playwright target.

## Architecture review gate
This PR is the architecture review gate before per-app visual-fidelity work. Verified live in the dev container:
- Tabbed widget renders 24 per-integration tabs (Files / Notes / Tags / ... / Time tracker), bespoke content composes per tab (Deck = "Cards", Calendar = "Meetings" with pink accent).
- Single mode (`:only="deck"`) renders one compact-header panel, no tab strip.
- Empty state: disabling the Bookmarks app flips its `available` capability to `false`; its tab shows the `NcEmptyContent` "Bookmarks not available" + "Set up Bookmarks" docs button.

Known follow-up (not blocking the architecture decision): per-app tab **icons** still resolve to the generic help-circle glyph — the `provider.icon` MDI names aren't registered for `CnIcon` in OR yet. That's a visual-fidelity item for the per-app waves; brand **accent color** already works.

## Test plan
- [ ] CI lint/build
- [ ] Open an object detail page -> Integrations tab -> confirm tabbed widget + per-leaf panels
- [ ] Disable a backing app -> confirm that integration's tab shows the empty/set-up state
- [ ] Review screenshots before per-app visual-fidelity work