### PR TITLE
chore(specs): audit+remediate retrofit REQs — group 4 (controllers)

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/specs/generic-integrations/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/specs/generic-integrations/spec.md
@@ -16,6 +16,14 @@ eight link controllers implement identically. Reverse-specced from
 `OpenProjectLinksController`, `PollLinksController`, `TalkLinksController`,
 `XwikiLinksController`, and `EmailLinksController`.
 
+The remaining "leaf" link controllers
+(Activity/Bookmark/Cospend/Deck/Flow/Form/Photo/TimeTracker/Share + the
+`EmailsController` leaf) are documented by the companion REQ "Tier-2
+Integration Leaf Link Controller Contract" in the sibling controller-batch
+change `retrofit-2026-05-25-bw2-ctrl-2`. The two REQs describe the *same*
+uniform link contract and partition the controller set with no overlap; they
+were split only because the controller layer was scanned in two batches.
+
 ## ADDED Requirements
 
 ### Requirement: Object-Scoped Integration Link REST Contract

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/generic-integrations/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/generic-integrations/spec.md
@@ -17,6 +17,17 @@ Activity, Shares, Mail) implements identically. Reverse-specced from the live
 shares (the query-time `SharesProvider` documented elsewhere in this spec is
 its backing provider).
 
+This REQ is the **leaf-controller** companion to the "Object-Scoped
+Integration Link REST Contract" REQ added by the sibling controller-batch
+change `retrofit-2026-05-25-bw2-ctrl-1` (which covers the
+Analytics/Collective/Map/OpenProject/Poll/Talk/Xwiki/Email *Links*
+controllers). Both REQs describe the *same* uniform object-scoped link
+contract — they were split only because the controller layer was scanned in
+two batches. The two REQs partition the controller set with no overlap; the
+shared HTTP semantics (route shape, `{results, total}` envelope,
+`501 APP_NOT_AVAILABLE` degradation, exception-code→HTTP mapping) are kept
+deliberately identical so the contract reads as one.
+
 ## ADDED Requirements
 
 ### Requirement: Tier-2 Integration Leaf Link Controller Contract

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md
@@ -60,8 +60,10 @@ and are not individual tasks.
 
 ## oas-generation (NEW REQ — publish / depublish surface)
 
-- [x] **task-5**: oas-generation#REQ-002 "Register and Schema Publication and
-  GitHub OAS Publishing" — `RegistersController`
+- [x] **task-5**: oas-generation ADDED REQ "Register and Schema Publication and
+  GitHub OAS Publishing" (a new requirement; NOT a redefinition of the existing
+  `REQ-002 Generate OpenAPI Specification for a specific register`) —
+  `RegistersController`
   (`publish`/`depublish`/`publishToGitHub`) and `SchemasController`
   (`publish`/`depublish`): register/schema publication lifecycle + OAS-to-GitHub
   push.


### PR DESCRIPTION
## Summary

Deep audit + remediation of two reverse-spec controller retrofit changes to `/opsx-ff` quality:
- `retrofit-2026-05-25-bw2-ctrl-1` — 3 ADDED REQs (generic-integrations, search-index, zoeken-filteren)
- `retrofit-2026-05-25-bw2-ctrl-2` — 5 ADDED REQs (data-import-export, generic-integrations, oas-generation, openapi-generation, production-observability)

Both pass `openspec validate --strict`.

## Audit findings

- **ADR-037**: all 8 ADDED REQs use Form A headings (no REQ-ID prefix) and every REQ body's first line contains MUST. ✓
- **Structure**: proposal.md (real Why/What/Impact), spec.md (Purpose + ADDED Requirements + GIVEN/WHEN/THEN scenarios), all tasks `[x]`. Matches the established `b-ctrl-*` retrofit family convention (which intentionally omits Non-Functional/Acceptance-Criteria sections for reverse-spec of observed behavior). ✓
- **ADR-002**: error envelopes (`{error}`, `{results,total}`, status codes) document observed controller behavior; consistent with sibling registry-views retrofit. ✓

## Remediations applied

- **generic-integrations drift (cross-change)**: ctrl-1 ("Object-Scoped Integration Link REST Contract") and ctrl-2 ("Tier-2 Integration Leaf Link Controller Contract") describe the same uniform link contract, split only by scan batch. Added reciprocal cross-reference notes documenting the no-overlap controller partition.
- **oas-generation task label**: clarified that the new publish/depublish ADDED REQ is not a redefinition of the existing `REQ-002`.

## oas-generation vs openapi-generation dedup recommendation

**Do NOT merge.** They are distinct, independently-extended capabilities: `oas-generation` owns OAS *document* generation + publication lifecycle; `openapi-generation` owns the OpenAPI 3.1.0 *engine* (type mapping, Swagger UI, NL API rules, i18n). The two ctrl-2 REQs target different specs. Minor note: ctrl-2's openapi-generation REQ (schema download/upload/explore/test) is a schema-authoring surface — defensible fit but the weakest thematic match.

## Security/authz concerns surfaced in proposals (not fixed here)

- `ScheduledWorkflowController` — `@NoAdminRequired` on all CRUD verbs + direct mapper call (ADR-003 layering); non-admins can schedule server-side TimedJobs.
- `ObjectsController::postPatch` — `@PublicPage`+`@NoAdminRequired` object create/update widens attack surface.
- `SettingsController::debugTypeFiltering`/`testSchemaMapping` — routed debug endpoints echo object data (info disclosure).
- `RegistersController::rollbackImport` — audit lookup not org-scoped (cross-tenant risk if importer-UID check bypassed).
- `UrnController::bulk` — 1000-URN cap is sole DoS guard, no per-user rate limit.

## Test plan
- [x] `openspec validate retrofit-2026-05-25-bw2-ctrl-1 --strict`
- [x] `openspec validate retrofit-2026-05-25-bw2-ctrl-2 --strict`