### PR TITLE
chore(specs): audit+remediate retrofit REQs — group 2

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-bw-svc-index/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-index/proposal.md
@@ -6,7 +6,7 @@ The Bucket-Wide coverage scan (`/tmp/or-scan/bw-svc-index.json`, 2026-05-25) fla
 
 Per ADR-003 (the two-tool approach, just merged), each method ends with EITHER an `@spec` pointer to a real behavior OR an `@spec exclude <reason>` for boilerplate. The overwhelming majority of these 127 methods are backend plumbing: Guzzle HTTP verb wrappers, facade delegations to extracted primitives, interface method declarations, and simplified stubs (`reindexAll`/`warmupIndex`/`fixMismatchedFields` that defer to `IndexService` or return empty). Those are excluded with reasons. A small set of genuinely novel value-transformation and schema-mirroring behaviors — not already in REQ-1..5 — are reverse-spec'd into three new REQs.
 
-## What changes
+## What Changes
 
 - Extend the existing `search-index` capability spec with **three new REQs** (REQ-6, REQ-7, REQ-8):
   - **REQ-6** — `DocumentBuilder` SOLR value coercion, type-compatibility validation, byte-limit truncation, dot-notation array reconstruction, and register/schema ID resolution.

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-index/specs/search-index/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-index/specs/search-index/spec.md
@@ -1,8 +1,10 @@
 # Search Index (delta)
 
-## Why
+## Purpose
 
 The `search-index` capability spec (REQ-1..5) covers the high-level facade and the major orchestration flows but leaves the backend value-transformation, schema-mirroring conflict logic, and file-chunk indexing paths undocumented. The 2026-05-25 Bucket-Wide scan flagged these as uncovered. These three requirements capture observed behavior in `DocumentBuilder`, `SchemaHandler`, and `FileHandler` so future changes to the coercion/conflict/chunking logic are recognised as behavior changes. No production code changes.
+
+**Source**: Reverse-spec retrofit of shipped code — `lib/Service/Index/` backend handlers. Behavior is documented as observed, not changed.
 
 ## ADDED Requirements
 
@@ -103,3 +105,14 @@ Text extraction (OCR, PDF parsing) is expensive and runs on its own schedule, wr
 - **THEN** each chunk MUST become a document carrying `file_id`, `chunk_index`, `total_chunks`, `chunk_text`, owner/organisation/language, and created/updated timestamps
 - **AND** the documents MUST be submitted via `SearchBackendInterface::index()`
 - **AND** the result MUST report `success` and an `indexed` count equal to the document count on success
+
+## Non-Functional
+
+- **i18n (ADR-007)**: No user-facing strings (ADR-007 n/a) — all three behaviors are backend index plumbing; SOLR field names, document keys, and the `...[TRUNCATED]` marker are machine-facing.
+- **Performance**: Byte-limit truncation and per-property coercion run at document-build time to keep one malformed property from failing an entire batch index; chunk indexing is decoupled from text extraction so the index can be (re)built without re-parsing files.
+- **Backward compatibility**: Reverse-spec of already-shipped `DocumentBuilder`/`SchemaHandler`/`FileHandler` code; no production behavior change.
+
+## Acceptance Criteria
+
+- The reverse-spec'd methods (`DocumentBuilder` coercion/validation/truncation/array-reconstruction/ID-resolution, `SchemaHandler::mirrorSchemas`/`ensureVectorFieldType`, `FileHandler::processUnindexedChunks`/`indexFileChunks`) carry `@spec` annotations to REQ-6/REQ-7/REQ-8.
+- The scenarios above hold for the shipped implementation.

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-integration/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-integration/proposal.md
@@ -1,5 +1,7 @@
 # Retrofit — backend coverage: Service/Integration (annotation-only)
 
+## Why
+
 Annotation-only (Bucket 1 style) coverage pass over the
 `lib/Service/Integration/` cluster (ADR-019 pluggable integration
 registry). The scanner flagged 93 uncovered methods across the provider
@@ -31,6 +33,17 @@ flagged methods are retroactively annotated to the change/task that
 already owns them, the single genuinely-uncovered behavior
 (`PaginatedResult`) gets one new REQ, and the repetitive per-provider
 boilerplate is `@spec exclude`d with a reason.
+
+## What Changes
+
+- **ADD** one REQ to the merged `generic-integrations` spec — the
+  "canonical pagination envelope" requirement reverse-specifying
+  `PaginatedResult` envelope normalisation.
+- **ANNOTATE** 55 behavioral methods with `@spec` pointers to the
+  change/task that already owns them (`pluggable-integration-registry`,
+  the per-leaf `integration-*` changes, `retrofit-2026-05-24-activity-provider`).
+- **EXCLUDE** 37 boilerplate methods (`@spec exclude <reason>`).
+- No production code changes — docblock-only edits.
 
 ## Outcome
 
@@ -114,6 +127,12 @@ helper) and `SharesProvider`'s anonymous PSR-11 adapter `get` / `has`
 (NC `\OCP\Server::get` shim).
 
 The full per-method classification is in `tasks.md`.
+
+## Impact
+
+- **Specs**: `generic-integrations` gains one REQ (canonical pagination envelope); no other spec changes.
+- **Code**: docblock-only `@spec`/`@spec exclude` edits across the `lib/Service/Integration/` cluster (provider contract, registry, router, helpers, 23 providers); no runtime behavior changes.
+- **Risk**: none — annotation retrofit.
 
 Source: `/tmp/or-scan/bw-svc-integration.json` (93 methods,
 `lib/Service/Integration/`). See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-integration/specs/generic-integrations/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-integration/specs/generic-integrations/spec.md
@@ -6,6 +6,12 @@ retrofit_extensions:
 
 # generic-integrations
 
+## Purpose
+
+This delta extends the merged `generic-integrations` capability with the single genuinely-uncovered behavior in the `lib/Service/Integration/` cluster: the canonical pagination envelope that `PaginatedResult` applies to every provider `list()` response. The provider contract, registry, router, and per-leaf CRUD paths are already owned upstream (`pluggable-integration-registry` and the per-leaf `integration-*` changes) and are only annotated, not re-authored here.
+
+**Source**: Reverse-spec retrofit of shipped code — `lib/Service/Integration/PaginatedResult.php`. Behavior is documented as observed, not changed.
+
 ## ADDED Requirements
 
 ### Requirement: Integration list responses MUST be normalised into a canonical pagination envelope
@@ -45,3 +51,13 @@ Provider `list()` methods MAY return either a flat row array or a partial envelo
 - **WHEN** it is serialised via `toArray()`
 - **THEN** the array MUST contain both `items` and `results` equal to `[row]`
 - **AND** MUST contain `total` and `nextCursor`
+
+## Non-Functional
+
+- **i18n (ADR-007)**: No user-facing strings (ADR-007 n/a) — the envelope keys (`items`, `results`, `total`, `nextCursor`) are machine-facing API contract fields, not display copy.
+- **Backward compatibility**: The serialised envelope mirrors `items` under a `results` key so legacy frontend readers keep working; reverse-spec of already-shipped `PaginatedResult` code, no production behavior change.
+
+## Acceptance Criteria
+
+- `PaginatedResult::fromMixed()` and `toArray()` carry `@spec` annotations to this requirement.
+- The four normalisation scenarios above (flat-list wrap, partial-envelope/`results`-alias preserve, absent-total fallback, non-array empty envelope) plus the serialised mirror hold for the shipped implementation.

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid1/specs/object-lifecycle/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid1/specs/object-lifecycle/spec.md
@@ -4,13 +4,15 @@ retrofit: true
 
 # Object Lifecycle
 
-## Why
+## Purpose
 
 Two object-management behaviors implemented in the `Service\Object` handler layer have no owning requirement. Object **locking** is referenced by other capabilities (content-versioning rollback refuses to revert a locked object) but the lock-state contract itself — how lock presence is determined, how expiry is honored, and what lock metadata is exposed — is unspecified; the write side (`LockHandler::lockObject` / `unlock`) carries only a change-tasks annotation. Object **merge / deduplication** (`MergeHandler::mergeObjects`) — folding a duplicate source object into a target, transferring its files, relations, and inbound references, then soft-deleting the source — is entirely unspecified. This change retroactively documents both observed behaviors so the handler contracts are anchored.
 
+**Source**: Reverse-spec retrofit of shipped code — `LockHandler` and `MergeHandler`. Behavior is documented as observed, not changed.
+
 ## ADDED Requirements
 
-### Requirement: REQ-011 Objects MUST expose an expiry-aware lock-state contract
+### Requirement: Objects MUST expose an expiry-aware lock-state contract
 MUST report whether an object is currently locked, treating an expired lock as unlocked, and MUST expose the lock's metadata (who locked it, when, optional process identifier, and expiry) when a live lock is present.
 
 `LockHandler::isLocked()` MUST resolve the object by id or UUID, read its `locked` metadata, and return `false` when no lock metadata is present. When lock metadata carries an `expiresAt` timestamp that is in the past, `isLocked()` MUST treat the lock as expired and return `false`. `getLockInfo()` MUST return `null` when the object is not locked and otherwise MUST return a normalized array exposing `locked_at`, `locked_by`, `process`, and `expires_at`. Both reads MUST be defensive: a lookup failure MUST be logged and degrade to "not locked" (`false` / `null`) rather than propagating an exception, so a read-side lock probe never breaks the calling flow.
@@ -32,7 +34,7 @@ MUST report whether an object is currently locked, treating an expired lock as u
 - **THEN** the failure MUST be logged
 - **AND** `isLocked()` MUST return `false` and `getLockInfo()` MUST return `null` rather than throwing
 
-### Requirement: REQ-012 The system MUST support merging a duplicate object into a target within the same register and schema
+### Requirement: The system MUST support merging a duplicate object into a target within the same register and schema
 MUST merge a source object into a target object — applying property overrides, transferring or deleting the source's files, transferring or dropping its relations, updating inbound references from other objects, and soft-deleting the source — while rejecting merges across mismatched register or schema, and MUST return a structured report of the actions taken.
 
 `MergeHandler::mergeObjects()` MUST require a non-empty target identifier and MUST throw an `InvalidArgumentException` when it is missing. It MUST resolve both source and target across all magic-table sources, throwing a not-found exception when either cannot be located. It MUST reject the merge with an `InvalidArgumentException` when the source and target belong to a different register or a different schema. Merge behavior MUST be configurable per call: `fileAction` of `transfer` (default) or `delete`, `relationAction` of `transfer` (default) or `drop`, and a reference action governing how inbound references to the source are rewritten to the target. After applying property overrides and the configured file/relation/reference handling, the source object MUST be soft-deleted. The method MUST return a merge report containing the original source and target, the merged result, the per-category actions taken, aggregate statistics (properties changed, files transferred/deleted, relations transferred/dropped, references updated), and any warnings or errors — rather than throwing on partial, recoverable problems.
@@ -52,3 +54,13 @@ MUST merge a source object into a target object — applying property overrides,
 - **WHEN** `mergeObjects()` is called with property overrides
 - **THEN** the target MUST receive the property overrides, the source's files and relations MUST be transferred, inbound references MUST be rewritten to the target, and the source MUST be soft-deleted
 - **AND** the returned report MUST include the merged object and statistics for the actions taken
+
+## Non-Functional
+
+- **i18n (ADR-007)**: No user-facing strings (ADR-007 n/a) — both behaviors are backend handler contracts; lock metadata keys and merge-report keys are machine-facing, and any operator-facing surfacing is owned by the controller/UI specs.
+- **Backward compatibility**: Reverse-spec of already-shipped `LockHandler`/`MergeHandler` code; no production behavior change.
+
+## Acceptance Criteria
+
+- `LockHandler::isLocked()` / `getLockInfo()` carry `@spec` annotations to the locking requirement, and `MergeHandler::mergeObjects()` to the merge requirement.
+- The scenarios above hold for the shipped implementation (expiry honored, lookup failure degrades to not-locked, cross-register/schema merge rejected before soft-delete).


### PR DESCRIPTION
## Summary

Deep-audit + remediate three 2026-05-25 backend-coverage retrofit changes to `/opsx-ff` (Spectr) quality. Audit-only edits inside each change's own dirs — no canonical `openspec/specs/` files touched.

- **bw-svc-index** (search-index, 3 REQs): DocumentBuilder coercion, SchemaHandler conflict/vector, FileHandler chunk indexing.
- **bw-svc-integration** (generic-integrations, 1 REQ): PaginatedResult canonical pagination envelope.
- **bw-svc-mid1** (object-lifecycle, 2 REQs): lock-state contract + object merge/dedup.

## Fixes per change

- **bw-svc-mid1**: ADR-037 violation — dropped forbidden `REQ-011`/`REQ-012` prefixes from `### Requirement:` headings; added `## Purpose`, `## Non-Functional` (i18n ADR-007 n/a — backend only), `## Acceptance Criteria`.
- **bw-svc-index**: `## Why` → `## Purpose` + Source note; added `## Non-Functional` (i18n n/a) + `## Acceptance Criteria`; proposal heading normalised to `## What Changes`.
- **bw-svc-integration**: added `## Purpose` + Source; `## Non-Functional` (i18n n/a) + `## Acceptance Criteria`; gave the proposal real `## Why` / `## What Changes` / `## Impact` headings.

All three pass `openspec validate <change> --strict`. ADR-037 (MUST-first-line + no REQ-ID prefix), ADR-007 (i18n posture stated), and ADR-002/003 verified per REQ.

## Cross-change flag

- The single `generic-integrations` REQ here ("canonical pagination envelope") is coherent and non-overlapping with the upstream `pluggable-integration-registry` REQs (contract/registry/router are annotated, not re-authored). No naming drift within my scope.
- **Sibling drift (out of my scope):** `retrofit-2026-05-25-bw-svc-mid2` and `bw-svc-file` still use the ADR-037-forbidden `### Requirement: REQ-00N — ...` prefix style. Other audit groups should strip those.

## Test plan

- [x] `openspec validate retrofit-2026-05-25-bw-svc-index --strict`
- [x] `openspec validate retrofit-2026-05-25-bw-svc-integration --strict`
- [x] `openspec validate retrofit-2026-05-25-bw-svc-mid1 --strict`