### PR TITLE
chore(specs): audit+remediate retrofit REQs to ff quality — group 1

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/proposal.md
@@ -1,6 +1,21 @@
 # Retrofit — background jobs / listeners / cron bundle
 
-Reverse-specs a small backend cluster of uncovered background jobs, event listeners, and one cron task: 15 methods across `lib/BackgroundJob/`, `lib/Listener/`, and `lib/Cron/`. Most are the recurring / reactive half of a pipeline whose synchronous half is already specced, so the bias is `--extend` of an existing capability. The code already exists; this change retroactively specifies the observed behaviour and back-annotates each method.
+## Why
+
+A backend cluster of 15 shipped methods across `lib/BackgroundJob/`, `lib/Listener/`, and `lib/Cron/` had no `@spec` coverage, leaving the recurring/reactive half of several pipelines undocumented even though their synchronous half is already specced. Without coverage these methods are invisible to spec-to-test mapping (ADR-008) and the next maintainer cannot tell intended behaviour from incidental implementation. This change closes that gap by reverse-speccing the observed behaviour and back-annotating each method, biased toward `--extend` of existing capabilities so the recurring/reactive code lands next to its synchronous counterpart.
+
+## What Changes
+
+- **3 new REQs** drafted: 1 on `search-index` (asynchronous file text extraction) and 2 on `object-lifecycle` (initial-state listener, update-guard listener).
+- **10 methods** annotated to existing REQs across `notificatie-engine`, `faceting-configuration`, `workflow-operations`, `rapportage-bi-export`, `search-index`, and `retention-management` (no new REQ — `--extend`).
+- **2 methods excluded** via `@spec exclude <reason>` (disabled-by-default migration backfill; dispatch-only event router).
+- No production code behaviour changes — annotations and spec text only.
+
+## Impact
+
+- **Capabilities touched**: `search-index`, `object-lifecycle` (new REQs); `notificatie-engine`, `faceting-configuration`, `workflow-operations`, `rapportage-bi-export`, `retention-management` (existing REQs extended by annotation).
+- **Code**: method-level `@spec` tags added under `lib/BackgroundJob/`, `lib/Listener/`, `lib/Cron/`.
+- **Risk**: low — reverse-spec, no runtime change. Surfaced-but-not-fixed concerns (RBAC/multitenancy system-bypass, the validation listener's hardcoded-English error messages) are documented in Notes for a follow-up functional pass.
 
 Source: `/tmp/or-scan/bw-jobs-listeners.json` (cluster `jobs-listeners`, generated 2026-05-25). See [retrofit playbook](../../../.github/docs/claude/retrofit.md).
 
@@ -33,8 +48,8 @@ Source: `/tmp/or-scan/bw-jobs-listeners.json` (cluster `jobs-listeners`, generat
 | Method | Capability | New REQ |
 |---|---|---|
 | `BackgroundJob/FileTextExtractionJob::run` | `search-index` | Asynchronous file text extraction MUST run as a queued background job |
-| `Listener/LifecycleInitialStateListener::handle` | `object-lifecycle` | REQ-010 — Declared initial lifecycle state MUST be applied on create |
-| `Listener/LifecycleValidationListener::handle` | `object-lifecycle` | REQ-011 — Direct lifecycle-field edits MUST be guarded on update |
+| `Listener/LifecycleInitialStateListener::handle` | `object-lifecycle` | Declared initial lifecycle state applied on create |
+| `Listener/LifecycleValidationListener::handle` | `object-lifecycle` | Direct lifecycle-field edits guarded on update |
 
 ### Excluded (2 methods)
 
@@ -63,8 +78,8 @@ Source: `/tmp/or-scan/bw-jobs-listeners.json` (cluster `jobs-listeners`, generat
 ### object-lifecycle (2 new REQs)
 The object-lifecycle capability already specs the annotation validator (REQ-006), the named-action `TransitionEngine` (REQ-007), and the guard registry / `GuardResult` contract (REQ-008/009). The two listeners in this bundle are the **event-listener enforcement layer** that those REQs do not describe:
 
-- `LifecycleInitialStateListener::handle` force-sets the schema's declared `initial` value on `ObjectCreatingEvent` when the caller left the lifecycle field empty — so apps never have to remember the starting state. → **REQ-010**.
-- `LifecycleValidationListener::handle` guards **direct field edits** (not the named-action `TransitionEngine` path): on `ObjectUpdatingEvent` it rejects any lifecycle-field change that no declared transition allows from the current value, and runs the optional `requires` guard, stopping propagation with a structured error. This is the `saveObject()`-driven complement to REQ-007's explicit-action engine. → **REQ-011**.
+- `LifecycleInitialStateListener::handle` force-sets the schema's declared `initial` value on `ObjectCreatingEvent` when the caller left the lifecycle field empty — so apps never have to remember the starting state. → new REQ **Declared initial lifecycle state applied on create**.
+- `LifecycleValidationListener::handle` guards **direct field edits** (not the named-action `TransitionEngine` path): on `ObjectUpdatingEvent` it rejects any lifecycle-field change that no declared transition allows from the current value, and runs the optional `requires` guard, stopping propagation with a structured error. This is the `saveObject()`-driven complement to REQ-007's explicit-action engine. → new REQ **Direct lifecycle-field edits guarded on update**.
 
 ## Notes
 

--- a/openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/specs/object-lifecycle/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/specs/object-lifecycle/spec.md
@@ -1,8 +1,14 @@
 # Object Lifecycle
 
+## Purpose
+
+The `object-lifecycle` capability already specifies the annotation validator (REQ-006), the named-action `TransitionEngine` (REQ-007), and the guard registry / `GuardResult` contract (REQ-008/009). This delta retroactively captures the **event-listener enforcement layer** those requirements do not describe: the two listeners that apply a schema's declared initial lifecycle state on create and guard direct lifecycle-field edits on update. The code already ships in production; these requirements describe its observed behaviour so the spec reflects the live system.
+
+**Cross-references**: object-lifecycle REQ-006 (annotation validator), REQ-007 (named-action `TransitionEngine`), REQ-008/009 (guard registry / `GuardResult`); [event-driven-architecture](../../../../specs/event-driven-architecture/spec.md).
+
 ## ADDED Requirements
 
-### Requirement: REQ-010 — Declared initial lifecycle state MUST be applied on create
+### Requirement: Declared initial lifecycle state applied on create
 
 `LifecycleInitialStateListener::handle()` MUST, on `ObjectCreatingEvent`, force-set the schema's declared initial lifecycle value when the caller did not supply one. The listener reads the `x-openregister-lifecycle` annotation from the object's schema, takes the annotation's `field` and `initial` keys, and writes `initial` into the object payload under `field` ONLY when that field is currently absent, null, or an empty string. A caller-supplied non-empty value MUST be left untouched (its validity is the validator's / update-guard's concern). The listener MUST be a no-op when the event is not an `ObjectCreatingEvent`, when the schema cannot be resolved, when the schema declares no lifecycle annotation, or when the annotation's `field`/`initial` are empty.
 
@@ -33,7 +39,7 @@ Apps therefore never need to know the starting state — lifecycle is a declarat
 - `loadSchema()` resolves the object's schema via `SchemaMapper::find($ref, _multitenancy: false)` — a system-level lookup because the listener is not user-scoped. An unresolvable or empty schema reference yields a null schema and the listener returns early after logging a warning. See the change Notes for the multitenancy-boundary follow-up.
 - This is the create-time complement to REQ-006's annotation validator; it relies on the annotation already being shape-valid.
 
-### Requirement: REQ-011 — Direct lifecycle-field edits MUST be guarded on update
+### Requirement: Direct lifecycle-field edits guarded on update
 
 `LifecycleValidationListener::handle()` MUST, on `ObjectUpdatingEvent`, reject lifecycle-field edits made through the ordinary save path (`ObjectService::saveObject()`) that no declared transition allows. This is the complement to REQ-007's named-action `TransitionEngine`: it guards the case where a caller edits the lifecycle field value directly rather than invoking a named action. When the old and new value of the annotation's `field` differ, the listener MUST:
 
@@ -75,3 +81,16 @@ Each rejection MUST stamp a structured error onto the event and stop propagation
 #### Notes
 - Trust contract: this listener only fires on `ObjectUpdatingEvent`, dispatched by `ObjectService::saveObject()`. Code paths that mutate an object outside `saveObject()` (direct `MagicMapper::update`, raw SQL, import bypass) skip the listener and can persist an invalid lifecycle value. Callers MUST go through `saveObject()` for the guarantee to hold; a DB-level CHECK constraint is a future hardening step.
 - `loadSchema()` uses `_multitenancy: false` (system-level lookup). The guard receives the loaded object payload, the action name, and the caller's uid via `IUserSession`.
+
+## Non-Functional Requirements
+
+- **i18n (ADR-007)**: The validation listener emits structured rejection messages (`lifecycle-invalid-value`, `lifecycle-invalid-transition`, `lifecycle-guard-denied`) that the controller surfaces to the user as HTTP 422/403 bodies — these are user-facing and SHOULD be translatable (Dutch + English). The shipped messages are hardcoded English via `sprintf()` and do not yet route through `IL10N`; this is captured as an observed gap (see change Notes), not changed in this reverse-spec pass. The initial-state listener emits no user-facing strings (warnings are log-only).
+- **Layering (ADR-003)**: Both listeners react to domain events (`ObjectCreatingEvent`/`ObjectUpdatingEvent`) dispatched by `ObjectService::saveObject()` and resolve schemas via `SchemaMapper` — the service/listener boundary is respected; no controller-to-mapper shortcut is introduced.
+- **Trust boundary**: The update guarantee holds only for mutations that flow through `saveObject()`; out-of-band writes (direct `MagicMapper::update`, raw SQL, import bypass) skip the listener (see REQ Notes).
+
+## Acceptance Criteria
+
+- [x] On create, a declared `initial` lifecycle value is force-set only when the caller leaves the field absent/null/empty; caller-supplied values are preserved.
+- [x] On update, a lifecycle-field change with no declared allowing transition is rejected with `lifecycle-invalid-transition`, a non-string value with `lifecycle-invalid-value`, and a failed `requires` guard with `lifecycle-guard-denied`; each stops propagation.
+- [x] Both listeners are no-ops when the event type, prior state, schema, or lifecycle annotation preconditions are not met.
+- [x] Behaviour annotated in code with `@spec object-lifecycle#...` pointers on `LifecycleInitialStateListener::handle` and `LifecycleValidationListener::handle`.

--- a/openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/specs/search-index/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/specs/search-index/spec.md
@@ -8,7 +8,7 @@ retrofit_extensions:
 
 **Cross-references**: [search-index main spec](../../../../specs/search-index/spec.md).
 
-## Purpose of this delta
+## Purpose
 
 The `search-index` capability covers Solr/document indexing, bulk re-indexing, and backend configuration. It does not yet describe the feeder pipeline that turns uploaded binary files into searchable text. This delta retroactively captures the observed behaviour of `FileTextExtractionJob` — the queued, one-time background job that extracts text from a single file via `TextExtractionService` so the extraction cost is paid off the user request path.
 
@@ -44,3 +44,17 @@ When file text extraction is enabled, the system MUST extract text from uploaded
 
 #### Notes
 - The job is queued from the file create/modify path so extraction never blocks the user request — this is the asynchronous complement to the synchronous Solr indexing covered by the bulk-indexing REQ.
+
+## Non-Functional Requirements
+
+- **i18n (ADR-007)**: No user-facing strings. The job runs in a cron worker and emits only log messages (info/error), which per ADR-007 are not translated. (ADR-007 n/a.)
+- **Resilience**: A failure inside `TextExtractionService::extractFile()` MUST be caught and logged, never re-thrown, so a single bad file cannot crash the cron worker or block the queue.
+- **Performance**: Extraction runs off the request path as a one-time `QueuedJob`, so file create/modify latency is unaffected by extraction cost.
+
+## Acceptance Criteria
+
+- [x] When extraction is disabled (`fileManagement` unset or `extractionScope === 'none'`), the job returns without calling `TextExtractionService`.
+- [x] A missing `file_id` argument is logged and the job returns without attempting extraction.
+- [x] A valid `file_id` triggers `TextExtractionService::extractFile(fileId, forceReExtract: false)` with start/completion log entries including a processing-time metric.
+- [x] An extraction exception is caught, logged at error level with file id and message, and not re-thrown.
+- [x] `FileTextExtractionJob::run` annotated in code with a `@spec search-index#...` pointer.

--- a/openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-jobs-listeners/tasks.md
@@ -33,5 +33,5 @@ Each task back-annotates one method against its target REQ (existing capability 
 
 ## object-lifecycle (new REQs)
 
-- [x] task-12: object-lifecycle#REQ-010 — Declared initial lifecycle state MUST be applied on create — `LifecycleInitialStateListener::handle` force-sets the schema's declared `initial` lifecycle value on `ObjectCreatingEvent` when the caller left it empty (new REQ)
-- [x] task-13: object-lifecycle#REQ-011 — Direct lifecycle-field edits MUST be guarded on update — `LifecycleValidationListener::handle` rejects lifecycle-field changes with no allowing transition and runs the optional `requires` guard on `ObjectUpdatingEvent`, stopping propagation with a structured error (new REQ)
+- [x] task-12: object-lifecycle#Declared initial lifecycle state applied on create — `LifecycleInitialStateListener::handle` force-sets the schema's declared `initial` lifecycle value on `ObjectCreatingEvent` when the caller left it empty (new REQ)
+- [x] task-13: object-lifecycle#Direct lifecycle-field edits guarded on update — `LifecycleValidationListener::handle` rejects lifecycle-field changes with no allowing transition and runs the optional `requires` guard on `ObjectUpdatingEvent`, stopping propagation with a structured error (new REQ)

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-file/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-file/proposal.md
@@ -1,17 +1,33 @@
 # Retrofit — backend coverage, Service/File (bw-svc-file, 2026-05-25)
 
-Reverse-specs the next behavioral slice of OpenRegister's shipped file-action
-surface (`lib/Service/File/*Handler`) by **extending the existing `file-actions`
-capability** with 5 new REQs (REQ-006 … REQ-010). Code already exists and is in
-production — this change retroactively specifies it. Every one of the 45 methods
-in the batch ends tagged either with an `@spec` pointer (annotated to a new or
-existing REQ) or with `@spec exclude <reason>` for boilerplate.
+## Why
 
-This is a follow-up to `retrofit-2026-05-24-file-actions` (REQ-001 … REQ-005),
-which covered CRUD/lock/preview/folder/object-tagging. That change's
-`## DROP — future-pass:next` section listed the publishing/upload/update/read/
-ownership/validation surface as deferred — this change picks up exactly that
-deferred slice for `Service/File/`.
+OpenRegister's shipped per-object file surface (`lib/Service/File/*Handler`)
+includes creation/upsert, retrieval, content+metadata update, publishing/ZIP
+export, sharing, and upload-security validation that the prior
+`retrofit-2026-05-24-file-actions` pass (REQ-001…REQ-005) explicitly deferred to
+a follow-up in its `## DROP — future-pass:next` section. That deferred slice is
+in production but has no `@spec` coverage, so it is invisible to spec-to-test
+mapping (ADR-008) and a maintainer cannot distinguish intended behaviour from
+incidental implementation — including security-relevant behaviour like the
+executable-upload blocklist and the system-user ownership/share model. This
+change closes the gap by reverse-speccing exactly that deferred `Service/File/`
+slice.
+
+## What Changes
+
+- **5 new REQs** added to the existing `file-actions` capability covering: create/upsert pipeline, retrieval + node→metadata projection, content/metadata update, publishing/sharing/batch, and upload security validation.
+- **28 methods** annotated to the 5 new REQs; **8 methods** annotated to existing REQ-004 (folder management) and REQ-005 (object tagging) from the prior pass.
+- **9 boilerplate methods excluded** via `@spec exclude <reason>` (8 `FileCrudHandler` Phase-1B stubs + 1 `FileAuditHandler` no-op).
+- Observed quirks (heuristic base64 detection, all-digit-filename-as-id, `object:`-tag preservation, `FileMapper`-direct share writes, broad executable blocklist, asymmetric file-vs-folder share failure contracts) captured as-is in the REQ text — not silently "fixed".
+- No production code behaviour changes — annotations and spec text only.
+
+## Impact
+
+- **Capability touched**: `file-actions` (extended with REQ-006…REQ-010); existing REQ-004/REQ-005 extended by annotation.
+- **Code**: method-level `@spec` tags added across `lib/Service/File/*Handler.php`.
+- **Risk**: low — reverse-spec, no runtime change. Surfaced-but-not-fixed deviations (notably the `FileMapper`-direct share write bypassing `IManager`, and the un-translated service-layer exception messages) are documented in Notes for a follow-up functional pass.
+- **Coexistence**: the `file-actions` capability is still unarchived (`openspec/changes/file-actions/`, status draft) plus the 2026-05-24 delta; when finalised, REQ-001…REQ-010 should be folded together, biasing toward the retrofit-derived REQs since they describe observed, shipped behaviour.
 
 ## Coexistence with the original `file-actions` change
 
@@ -38,20 +54,20 @@ shipped behavior.
 
 ## New REQs (extend `file-actions`)
 
-### REQ-006 — File creation & upsert pipeline
+### File creation and upsert pipeline
 - `lib/Service/File/CreateFileHandler.php::addFile`
 - `lib/Service/File/CreateFileHandler.php::saveFile`
 
-### REQ-007 — File retrieval (by id, by name/path, per-object listing)
+### File retrieval (by id, by name/path, per-object listing)
 - `lib/Service/File/ReadFileHandler.php::getFile`
 - `lib/Service/File/ReadFileHandler.php::getFileById`
 - `lib/Service/File/ReadFileHandler.php::getFiles`
 
-### REQ-008 — File content & OR-side metadata updates
+### File content and OR-side metadata updates
 - `lib/Service/File/UpdateFileHandler.php::updateFile`
 - `lib/Service/File/UpdateFileHandler.php::updateFileMetadata`
 
-### REQ-009 — File publishing, ZIP export & user/folder sharing
+### File publishing, ZIP export and user/folder sharing
 - `lib/Service/File/FilePublishingHandler.php::publishFile`
 - `lib/Service/File/FilePublishingHandler.php::unpublishFile`
 - `lib/Service/File/FilePublishingHandler.php::createObjectFilesZip`
@@ -60,7 +76,7 @@ shipped behavior.
 - `lib/Service/File/FileSharingHandler.php::shareFileWithUser`
 - `lib/Service/File/FileSharingHandler.php::shareFolderWithUser`
 
-### REQ-010 — Upload security validation (executable blocking, ownership repair)
+### Upload security validation (executable blocking, ownership repair)
 - `lib/Service/File/FileValidationHandler.php::blockExecutableFile`
 - `lib/Service/File/FileValidationHandler.php::detectExecutableMagicBytes`
 - `lib/Service/File/FileValidationHandler.php::checkOwnership`

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-file/specs/file-actions/spec.md
@@ -1,17 +1,20 @@
 # file-actions
 
-## Why
+## Purpose
 
 OpenRegister's per-object file surface (`lib/Service/File/*Handler`) ships
 creation/upsert, retrieval, content+metadata update, publishing/ZIP export,
 sharing, and upload-security behavior that the `retrofit-2026-05-24-file-actions`
-pass explicitly deferred to a follow-up. This delta reverse-specs that deferred
-slice as REQ-006 … REQ-010 so the spec reflects the live, shipped system. No
-code changes — these requirements describe observed behavior.
+pass explicitly deferred to a follow-up (its `## DROP — future-pass:next`
+section). This delta reverse-specs that deferred slice as five new requirements
+so the spec reflects the live, shipped system. No code changes — these
+requirements describe observed behavior.
+
+**Cross-references**: [file-actions main spec](../../../../specs/file-actions/spec.md) (when finalised); `retrofit-2026-05-24-file-actions` (the prior REQ-001…REQ-005 pass covering CRUD/lock/preview/folder/object-tagging); [audit-trail-immutable](../../../../specs/audit-trail-immutable/spec.md).
 
 ## ADDED Requirements
 
-### Requirement: REQ-006 — File creation and upsert MUST run a fixed validate-write-own-tag pipeline
+### Requirement: File creation and upsert run a fixed validate-write-own-tag pipeline
 
 `CreateFileHandler::addFile()` MUST create a Nextcloud file under the object's
 folder following a fixed ordered pipeline, and `CreateFileHandler::saveFile()`
@@ -66,7 +69,7 @@ delegate to `addFile()`. Both methods MUST wrap failures and rethrow as
 - **WHEN** `saveFile(object, "data.json", content)` is called
 - **THEN** the handler MUST delegate to `addFile()`
 
-### Requirement: REQ-007 — File retrieval MUST resolve by id or name and project nodes to metadata
+### Requirement: File retrieval resolves by id or name and projects nodes to metadata
 
 `ReadFileHandler` MUST expose three retrieval paths and `FileFormattingHandler`
 MUST project Nextcloud nodes into the public metadata shape.
@@ -122,7 +125,7 @@ MUST project Nextcloud nodes into the public metadata shape.
 - **WHEN** `formatFile()` builds the metadata
 - **THEN** the `locked`/`lock`/`downloadCount`/`orLock` fields MUST be omitted
 
-### Requirement: REQ-008 — File update MUST guard locks, preserve object tags, and persist OR-side metadata separately
+### Requirement: File update guards locks, preserves object tags, and persists OR-side metadata separately
 
 `UpdateFileHandler::updateFile()` MUST update content and/or tags of an existing
 file resolved by ID or name/path, and `UpdateFileHandler::updateFileMetadata()`
@@ -181,7 +184,7 @@ which defensively clears malformed or expired entries and returns `null`.
 - **WHEN** the current user `alice` triggers a write and `assertCanModify(fileId)` is reached
 - **THEN** the guard MUST throw an `Exception` naming `bob`
 
-### Requirement: REQ-009 — Publishing, ZIP export, sharing and batch operations MUST follow the system-user share model
+### Requirement: Publishing, ZIP export, sharing and batch operations follow the system-user share model
 
 The system MUST expose file publishing, object-files ZIP export, user/folder
 sharing, and a bounded multi-file batch dispatcher, all anchored on the
@@ -252,7 +255,7 @@ OpenRegister system user.
 - **WHEN** `executeBatch()` runs
 - **THEN** the result MUST report `succeeded: 2, failed: 1` with a per-file error entry for the failure
 
-### Requirement: REQ-010 — Uploaded files MUST be screened for executable content and ownership repaired safely
+### Requirement: Uploaded files screened for executable content and ownership repaired safely
 
 `FileValidationHandler` MUST screen uploaded content for executables and repair
 drifted OpenRegister ownership without forcing content reads.
@@ -301,3 +304,19 @@ drifted OpenRegister ownership without forcing content reads.
 - **GIVEN** a readable node whose owner is not the system user
 - **WHEN** `checkOwnership()` runs
 - **THEN** it MUST call `ownFile()`, and a failure inside `ownFile()` MUST be logged and swallowed so the caller is not failed
+
+## Non-Functional Requirements
+
+- **i18n (ADR-007)**: These handlers are a service-layer file surface. The exception messages they throw (e.g. `"Failed to create file <name>"`, `"File <path> does not exist"`, the executable-rejection messages) are propagated by the calling controller as error-response bodies, so they are user-facing and SHOULD be translatable (Dutch + English). The shipped handlers throw plain English `Exception`/`NotPermittedException` messages and do not route through `IL10N`; per the reverse-spec mandate this is captured as observed behaviour, not changed here. Translation belongs to the controller layer that wraps these throws.
+- **Security (ADR-002)**: Upload screening (REQ-010) MUST reject executable content by both extension and magic-byte/shebang/`<?php` content scan of the first 1 KiB before a node is created; ownership probing uses a permission-bitmask check (`isReadable()`) that neither reads content nor acquires an NC lock, keeping it safe in hot listing loops. Lock state (REQ-008) is gated to authenticated callers only.
+- **Layering (ADR-003)**: Behaviour lives in single-responsibility `Service/File/*Handler` classes coordinated by `FileService`; OR-side metadata is persisted via `FileMapper`, NC nodes via `IRootFolder`. No controller-to-mapper shortcut is specified. The `FilePublishingHandler` writes shares directly through `FileMapper` rather than `IManager` — captured as an observed deviation in the change Notes, not endorsed as a target pattern.
+- **Resilience**: `formatFiles` emits a per-file `{id, title, error: "locked"}` stub on `LockedException` rather than failing the whole listing; batch operations continue past per-file failures and report a `{total, succeeded, failed}` summary.
+
+## Acceptance Criteria
+
+- [x] REQ-006: create/upsert runs the fixed resolve-folder → decode → block-executable → create → check-ownership → write → transfer-ownership → tag pipeline; `saveFile()` upserts (update existing same-name file, else add).
+- [x] REQ-007: retrieval resolves numeric/all-digit `$file` as a file id and other values as a name/path (bare then full path), gates lock/OR-side fields to authenticated callers, and filters listings by OR-side category when a `FileMapper` is wired.
+- [x] REQ-008: content is written only when md5 differs; `object:`-prefixed tags are preserved across tag updates; OR-side metadata fields are independently optional; document rewrites produce `_replaced`/`_anonymized` sibling nodes; writes are lock-guarded via `assertCanModify()`.
+- [x] REQ-009: publishing/unpublishing write through `FileMapper`; ZIP export skips non-file nodes; sharing follows the system-user model with the asymmetric file-vs-folder failure contract; batch rejects empty/>100 lists and continues past per-file failures.
+- [x] REQ-010: uploads are screened by extension and content signature; `checkOwnership()` refuses unreadable nodes without repair and repairs drifted ownership best-effort on readable nodes.
+- [x] All 36 in-scope methods annotated with `@spec file-actions#...` pointers; 9 boilerplate methods tagged `@spec exclude <reason>`.

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-file/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-file/tasks.md
@@ -7,11 +7,11 @@ methods from `/tmp/or-scan/bw-svc-file.json`; every method ends tagged with an
 
 ## Covered — new REQs (annotated this run)
 
-- [x] task-1: file-actions#REQ-006 — File creation & upsert pipeline (CreateFileHandler::addFile, ::saveFile; FileOwnershipHandler::transferFileOwnershipIfNeeded)
-- [x] task-2: file-actions#REQ-007 — File retrieval + node→metadata projection (ReadFileHandler::getFile, ::getFileById, ::getFiles; FileFormattingHandler::formatFile, ::formatFiles; FileLockHandler::getLockInfo)
-- [x] task-3: file-actions#REQ-008 — Content + OR-side metadata update, doc rewrite, write-lock guard (UpdateFileHandler::updateFile, ::updateFileMetadata; DocumentProcessingHandler::replaceWords, ::anonymizeDocument; FileLockHandler::assertCanModify)
-- [x] task-4: file-actions#REQ-009 — Publishing, ZIP export, sharing, batch (FilePublishingHandler::publishFile, ::unpublishFile, ::createObjectFilesZip; FileSharingHandler::createShare, ::findShares, ::shareFileWithUser, ::shareFolderWithUser; FileBatchHandler::executeBatch; FileOwnershipHandler::getUser, ::transferFolderOwnershipIfNeeded)
-- [x] task-5: file-actions#REQ-010 — Upload security validation + ownership repair (FileValidationHandler::blockExecutableFile, ::detectExecutableMagicBytes, ::checkOwnership, ::ownFile)
+- [x] task-1: file-actions#File creation and upsert run a fixed validate-write-own-tag pipeline (CreateFileHandler::addFile, ::saveFile; FileOwnershipHandler::transferFileOwnershipIfNeeded)
+- [x] task-2: file-actions#File retrieval resolves by id or name and projects nodes to metadata (ReadFileHandler::getFile, ::getFileById, ::getFiles; FileFormattingHandler::formatFile, ::formatFiles; FileLockHandler::getLockInfo)
+- [x] task-3: file-actions#File update guards locks, preserves object tags, and persists OR-side metadata separately (UpdateFileHandler::updateFile, ::updateFileMetadata; DocumentProcessingHandler::replaceWords, ::anonymizeDocument; FileLockHandler::assertCanModify)
+- [x] task-4: file-actions#Publishing, ZIP export, sharing and batch operations follow the system-user share model (FilePublishingHandler::publishFile, ::unpublishFile, ::createObjectFilesZip; FileSharingHandler::createShare, ::findShares, ::shareFileWithUser, ::shareFolderWithUser; FileBatchHandler::executeBatch; FileOwnershipHandler::getUser, ::transferFolderOwnershipIfNeeded)
+- [x] task-5: file-actions#Uploaded files screened for executable content and ownership repaired safely (FileValidationHandler::blockExecutableFile, ::detectExecutableMagicBytes, ::checkOwnership, ::ownFile)
 
 ## Covered — existing REQs (annotated to the 2026-05-24 pass)
 


### PR DESCRIPTION
## Summary

Deep-audit + remediation of two retrofit changes so they are indistinguishable from `/opsx-ff` (Spectr) output and ready to archive. No code changes, no edits to canonical `openspec/specs/`.

- `retrofit-2026-05-25-bw-jobs-listeners` (object-lifecycle ×2, search-index ×1)
- `retrofit-2026-05-25-bw-svc-file` (file-actions ×5)

## What changed

- **ADR-037**: removed the forbidden `REQ-NNN —` prefix from all 7 `### Requirement:` headings (now Form A `### Requirement: <Title>`); aligned `tasks.md`/`proposal.md` references to the new titles. Every requirement body's first line already / now leads with MUST.
- **ff structure**: added `## Purpose`, `## Non-Functional Requirements`, and `## Acceptance Criteria` to all three specs; restructured both proposals into `## Why` / `## What Changes` / `## Impact`.
- **ADR-007 i18n posture** stated per spec: lifecycle-validation listener + file-handler exception messages are user-facing (surfaced as HTTP 422/403 bodies) and flagged as an observed un-translated gap; the file-text-extraction job is log-only (ADR-007 n/a).
- **ADR-003 layering**: confirmed no controller-to-mapper shortcut is baked into any requirement; the `FileMapper`-direct share write (bypassing `IManager`) is documented as an observed deviation, not endorsed.

Both pass `openspec validate <change> --strict`.

## Test plan

- [x] `openspec validate retrofit-2026-05-25-bw-jobs-listeners --strict`
- [x] `openspec validate retrofit-2026-05-25-bw-svc-file --strict`
- [x] No `### Requirement: REQ-` headings remain
- [x] All tasks.md checkboxes `[x]` (retroactive/already-complete)