### PR TITLE
chore(specs): audit+remediate retrofit REQs — group 6 (frontend caps)

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-fe-misc/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-misc/proposal.md
@@ -1,15 +1,24 @@
 # Retrofit — frontend coverage: misc (services / entities / dialogs / nav) (2026-05-25)
 
+## Why
+
 Retrofit triage over the `fe-misc` bundle: 93 uncovered frontend methods across the
 remaining `src/` directories that no earlier frontend pass claimed — `mail-sidebar/`,
 `services/`, `entities/`, `dialogs/`, `reference/`, `navigation/`, `composables/`, and
 `App.vue`. The bundle is a mixed bag: API-client wrappers and a couple of dialog/widget
 contracts carry real behaviour, while the bulk of `entities/`, `dialogs/`, `navigation/`
-and the generic format helpers are UI/model plumbing.
+and the generic format helpers are UI/model plumbing. Until every method is either
+annotated to a capability REQ or carries a reasoned `@spec exclude`, the coverage scanner
+keeps flagging the bundle as a gap under ADR-003.
+
+## What Changes
 
 Every method ends tagged: either annotated to an existing-or-newly-minted capability REQ
 via this change's `tasks.md`, or carried as an `@spec exclude <reason>` with a required
-reason. No code logic changes.
+reason. Three new REQs are minted in a new `frontend-app-bootstrap` capability for the
+genuine frontend contracts that have no live capability home (app-startup hot-loading,
+the Nextcloud app install/uninstall client, the object file-metadata client). This is a
+retroactive specification of behaviour that already exists; no code logic changes.
 
 ## Counts
 
@@ -73,6 +82,18 @@ These are genuine frontend contracts with no live capability home:
   (`stringToDate`/`dateToString`, schema-format date round-trip for the native picker),
   `services/formatBytes.js`, `services/getTheme.js`, `services/getValidISOstring.js`.
   Pure pure-function utilities with no domain contract.
+
+## Impact
+
+- **New capability**: `frontend-app-bootstrap` (3 REQs) — the canonical home for
+  app-bootstrap and non-feature-specific client service contracts.
+- **Specs touched**: `specs/frontend-app-bootstrap/spec.md` (ADDED only).
+- **Code**: none — annotation-only retrofit. Existing `src/services/`, `src/App.vue`,
+  `src/mail-sidebar/`, `src/reference/`, and `src/dialogs/avg/` methods gain `@spec`
+  pointers or reasoned `@spec exclude` tags.
+- **Cross-references**: methods mapped to existing capabilities (`mail-sidebar`,
+  `notificatie-engine`, `mail-smart-picker`, `avg-verwerkingsregister`) gain pointers
+  to those owners; no requirement text in those capabilities changes.
 
 ## Future reverse-spec passes
 

--- a/openspec/changes/retrofit-2026-05-25-fe-misc/specs/frontend-app-bootstrap/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-misc/specs/frontend-app-bootstrap/spec.md
@@ -116,3 +116,24 @@ target the object-scoped file endpoint and MUST raise on a non-OK HTTP response.
 - **GIVEN** any of the file-metadata calls receiving a non-OK response
 - **WHEN** the response resolves
 - **THEN** the client SHALL throw an `Error` carrying the HTTP status
+
+## Non-Functional Requirements
+
+- **Resilience:** Startup hot-loading (REQ-001) MUST isolate per-store failures so a
+  single failing fetch never aborts the others or wedges the SPA mount.
+- **Internationalisation (ADR-007):** REQ-001..REQ-003 cover the bootstrap and
+  client-service layer (`AppInitializationService`, `appInstallService`, `fileMetadata`)
+  which carries no user-facing strings; locale does not affect their behaviour. Any
+  user-facing copy lives in the calling Vue components, which already meet the platform's
+  Dutch + English requirement; these service contracts are i18n-agnostic.
+- **Security:** The install client (REQ-002) MUST honour Nextcloud's HTTP 403
+  password-confirmation contract rather than swallowing it, so privileged app-management
+  actions remain gated by re-authentication.
+
+## Acceptance Criteria
+
+- [ ] `@spec` annotations on `AppInitializationService.js`, `App.vue` (`mounted`/`provide`),
+  `appInstallService.js`, and `fileMetadata.js` point at this change's `tasks.md` REQs.
+- [ ] `openspec validate retrofit-2026-05-25-fe-misc --strict` passes.
+- [ ] Coverage scan re-run after archive resolves the 16 annotated methods to their REQ
+  and the 30 excluded methods to reasoned `@spec exclude` tags (no longer uncovered).

--- a/openspec/changes/retrofit-2026-05-25-fe-sidebars/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-sidebars/proposal.md
@@ -6,9 +6,11 @@ The `/opsx-coverage-scan` run on 2026-05-25 reported **149 uncovered methods** a
 
 This change brings every one of the 149 under ADR-003's `@spec` convention via the two-tool approach: **annotate against an existing capability** where the sidebar drives a real domain interaction, **mint a new REQ** only for genuinely novel UI behaviour, and **`@spec exclude <reason>`** for presentation/format/plumbing helpers that should never carry a capability reference.
 
-## What the cluster actually contains
+## What Changes
 
-After reading all eight files, the 149 methods decompose into:
+After reading all eight files, the 149 methods decompose into the buckets below. Each
+method ends tagged — annotated to a REQ (new or existing) or carried as a reasoned
+`@spec exclude`. This is a retroactive specification; no runtime behaviour changes.
 
 ### 1. Genuinely novel behaviour — NEW REQs (3 minted, ≤3 cap)
 
@@ -54,6 +56,14 @@ Pure display helpers, date/byte formatters, tab-switch state, lifecycle `mounted
 - `src/sidebars/register/RegisterSideBar.vue`
 - `src/sidebars/register/RegistersSideBar.vue`
 - `src/sidebars/search/SearchSideBar.vue`
+
+## Impact
+
+- **New capability**: `saved-search-views` (2 REQs) — canonical home for the `/api/views` saved-view UI contract.
+- **Extended capability**: `zoeken-filteren` (+1 REQ, `retrofit_extensions`) — the search-trail analytics-reporting surface previously flagged unspecified.
+- **Specs touched**: `specs/saved-search-views/spec.md` and `specs/zoeken-filteren/spec.md` (ADDED only).
+- **Code**: none — annotation-only retrofit across the eight `src/sidebars/**/*.vue` files.
+- **Cross-references**: sidebar methods mapped to `chat-ai`, `files-sidebar-tabs`, `faceting-configuration`, `entity-management-modals`, `openapi-generation`, and `built-in-dashboards` gain pointers to those owners; no requirement text in those capabilities changes.
 
 ## Out of scope
 

--- a/openspec/changes/retrofit-2026-05-25-fe-sidebars/specs/saved-search-views/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-sidebars/specs/saved-search-views/spec.md
@@ -4,6 +4,10 @@ retrofit: true
 
 # Saved Search Views — Spec Delta
 
+## Purpose
+
+Lets OpenRegister users save the configuration of an object search — selected registers and schemas, free-text search terms, facet filters, and enabled facets — as a reusable, named **view** backed by `/api/views`. Views can be marked public or default, favorited per user, and re-applied to the live search from the search sidebar. This capability describes the observed frontend contract of `src/sidebars/search/SearchSideBar.vue` and the `viewsStore` it drives. It was retrofitted under ADR-003 on 2026-05-25 (cluster `fe-sidebars`); requirements capture observed behavior rather than original intent.
+
 ## ADDED Requirements
 
 ### Requirement: REQ-001 — Saved view lifecycle through the views store and /api/views
@@ -56,3 +60,15 @@ The search sidebar MUST let a signed-in user favorite a view, automatically appl
 - **WHEN** `filteredViews` recomputes
 - **THEN** only views whose name or description contains the query (case-insensitive) MUST be returned
 - **AND** favorited views MUST sort before non-favorited views, alphabetically by name within each group
+
+## Non-Functional Requirements
+
+- **Internationalisation (ADR-007):** The saved-view surface is user-facing — view names/descriptions are user content, while the surrounding UI labels and the "must be logged in" notification (REQ-002) MUST be available in both Dutch and English per the platform's i18n requirement.
+- **Authorisation:** Favoriting (REQ-002) MUST require an authenticated user; an unauthenticated favorite attempt MUST notify and make no request rather than mutating shared view state.
+- **State hygiene:** Persisted view configuration (REQ-001) MUST exclude transient UI state (pagination, sorting, visible columns) so a re-applied view restores only the query context.
+
+## Acceptance Criteria
+
+- [ ] `@spec` annotations on the `SearchSideBar.vue` view-management and favorite/filter members point at this change's `tasks.md` REQs.
+- [ ] `openspec validate retrofit-2026-05-25-fe-sidebars --strict` passes.
+- [ ] Coverage scan re-run after archive resolves the annotated view methods to REQ-001/REQ-002 (no longer uncovered).

--- a/openspec/changes/retrofit-2026-05-25-fe-sidebars/specs/zoeken-filteren/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-sidebars/specs/zoeken-filteren/spec.md
@@ -1,5 +1,9 @@
 # zoeken-filteren — Spec Delta
 
+## Purpose
+
+Extends the canonical `zoeken-filteren` capability with the search-trail **analytics-reporting** surface rendered by `src/sidebars/logs/SearchTrailSideBar.vue`. The canonical spec covers search-trail *persistence* and explicitly flags analytics reporting as unspecified; this delta closes that read/display gap. Retrofitted under ADR-003 on 2026-05-25 (cluster `fe-sidebars`, `retrofit_extensions`); captures observed behaviour rather than original intent.
+
 ## ADDED Requirements
 
 ### Requirement: Search-trail analytics dashboard
@@ -29,3 +33,14 @@ The search-trail sidebar (`SearchTrailSideBar.vue`) MUST render a read-only anal
 - **WHEN** `getComplexityPercentage('simple')` runs
 - **THEN** it MUST return `75`
 - **AND** when the total is `0` it MUST return `0` without dividing by zero
+
+## Non-Functional Requirements
+
+- **Resilience:** Each analytics loader MUST degrade to safe zero/empty defaults on error so a failing aggregate never blanks the dashboard or throws into the mount hook.
+- **Internationalisation (ADR-007):** The dashboard is user-facing; period labels, complexity-bucket labels, and column headings MUST be available in both Dutch and English per the platform's i18n requirement. `formatActivityPeriod` localises bucket labels to the active locale.
+
+## Acceptance Criteria
+
+- [ ] `@spec` annotations on the `SearchTrailSideBar.vue` analytics loaders/formatters point at this change's `tasks.md` REQ.
+- [ ] `openspec validate retrofit-2026-05-25-fe-sidebars --strict` passes.
+- [ ] Coverage scan re-run after archive resolves the analytics methods to this REQ (no longer uncovered).

--- a/openspec/changes/retrofit-2026-05-25-fe-store-1/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-store-1/proposal.md
@@ -10,6 +10,21 @@ getters/setters that mirror an already-specified backend capability; those are
 mutation, per-key cache invalidation, memoised data-source fetching) that has no
 backend equivalent — those are captured by **one new capability** with **3 REQs**.
 
+## What Changes
+
+- Mint one new capability `frontend-store-client-state` with 3 REQs covering the
+  browser-only client-state contracts: cross-store coordination + preload gating
+  (REQ-001), optimistic per-key cache mutation with an app-unavailable fallback
+  (REQ-002), and memoised widget-data fetching by data-source identity (REQ-003).
+- Annotate the 20 store methods that carry real client-state behaviour to those REQs.
+- Carry the remaining 133 store methods as reasoned `@spec exclude` tags (thin API
+  passthroughs, getters/setters, dialog toggles, download helpers).
+
+This is a retroactive specification of behaviour that already exists; no code changes.
+The sibling change `retrofit-2026-05-25-fe-store-2` adds three further REQs (import
+heartbeat, saved-view apply/capture) to the same `frontend-store-client-state`
+capability — the two sets are disjoint and coherent as one capability.
+
 ## Counts
 
 - Methods in batch: **153**
@@ -64,6 +79,13 @@ client-state-management concerns that are not visible server-side:
 - `settings.js` is a 1.6k-line admin store; every action is a 1:1 wrapper over a
   `/api/settings/*` or `/api/solr/*` endpoint already specified server-side, or a
   pure local dialog-visibility toggle. All 67 batch methods are excluded.
+
+## Impact
+
+- **New capability**: `frontend-store-client-state` (REQ-001..REQ-003) — shared with the
+  sibling `retrofit-2026-05-25-fe-store-2` change (disjoint REQ sets, one archive home).
+- **Specs touched**: `specs/frontend-store-client-state/spec.md` (ADDED only).
+- **Code**: none — annotation-only retrofit across the ten `src/store/` files listed above.
 
 Source: `/tmp/or-scan/fw-fe-store-1.json`, generated 2026-05-25. Retrofit
 playbook (ADR-003 two-tool approach).

--- a/openspec/changes/retrofit-2026-05-25-fe-store-1/specs/frontend-store-client-state/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-store-1/specs/frontend-store-client-state/spec.md
@@ -108,3 +108,15 @@ It MUST support a `forceRefresh` flag that bypasses the cache and a
 - **GIVEN** a widget's data is already memoised
 - **WHEN** `fetchWidgetData(widget, true)` is called
 - **THEN** the store MUST re-fetch from the server and overwrite the cached entry
+
+## Non-Functional Requirements
+
+- **Resilience:** The HTTP 501 app-unavailable fallback (REQ-002) MUST render an empty state instead of an error so a missing optional Nextcloud app (Deck, Mail) never breaks the host view.
+- **Cache correctness:** Per-key cache invalidation (REQ-002) and data-source memoisation (REQ-003) MUST be keyed so refreshing one object or widget never invalidates an unrelated one.
+- **Internationalisation (ADR-007):** REQ-001..REQ-003 govern store-internal caching, coordination, and memoisation and carry no user-facing strings; locale does not affect their behaviour. Any user-facing copy lives in the consuming Vue components, which already meet the platform's Dutch + English requirement.
+
+## Acceptance Criteria
+
+- [ ] `@spec` annotations on the 20 in-scope store methods (`dashboard.js`, `deck.js`, `emails.js`, `translations.js`, `deleted.js`, `reports.js`) point at this change's `tasks.md` REQs.
+- [ ] `openspec validate retrofit-2026-05-25-fe-store-1 --strict` passes.
+- [ ] Coverage scan re-run after archive resolves the 20 annotated methods to REQ-001..REQ-003 and the 133 excluded methods to reasoned `@spec exclude` tags (no longer uncovered).

--- a/openspec/changes/retrofit-2026-05-25-fe-store-2/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-store-2/proposal.md
@@ -65,6 +65,16 @@ After triage:
 
 New REQs minted: **3** (`frontend-store-client-state` REQ-001..REQ-003).
 
+## Impact
+
+- **Capability**: `frontend-store-client-state` (REQ-001..REQ-003) — the same capability
+  the sibling `retrofit-2026-05-25-fe-store-1` change extends; this change was reconciled
+  from a duplicate `frontend-client-state-orchestration` cap into the shared one. The two
+  changes' REQ sets are disjoint (this one: heartbeat + saved-view apply/capture; sibling:
+  caching/preload/memoisation) and coherent as a single capability.
+- **Specs touched**: `specs/frontend-store-client-state/spec.md` (ADDED only).
+- **Code**: none — annotation-only retrofit across the eleven `src/store/` files.
+
 ## Approach
 
 For each method: read the body, classify as spec-to-new-REQ, annotate-to-existing,

--- a/openspec/changes/retrofit-2026-05-25-fe-store-2/specs/frontend-store-client-state/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-fe-store-2/specs/frontend-store-client-state/spec.md
@@ -26,11 +26,11 @@ coverage matcher can resolve `@spec` annotations on those methods.
 
 ### Requirement: Long register imports MUST be kept alive by a client-side heartbeat
 
-Register imports can run far longer than a typical HTTP request, risking gateway and
-session timeouts. The register store (`src/store/modules/register.js`) MUST provide a
-client-side heartbeat that, while an import is in flight, periodically issues a
-lightweight `GET /index.php/apps/openregister/api/heartbeat` request to keep the
-session warm. The heartbeat MUST run on a fixed interval (default 15 seconds), MUST
+The register store (`src/store/modules/register.js`) MUST provide a client-side
+heartbeat that, while an import is in flight, periodically issues a lightweight
+`GET /index.php/apps/openregister/api/heartbeat` request to keep the session warm,
+because register imports can run far longer than a typical HTTP request and risk
+gateway and session timeouts. The heartbeat MUST run on a fixed interval (default 15 seconds), MUST
 track consecutive failures, MUST consider itself unhealthy only after 3 consecutive
 failures, MUST NOT stop polling on transient failure, and MUST surface health
 transitions through an optional status callback. The heartbeat MUST return a handle


### PR DESCRIPTION
## Summary

Deep-audit + remediate the 12 OpenSpec REQs across four frontend retrofit changes to `/opsx-ff` quality. Change dirs only — `openspec/specs/` untouched.

- **fe-misc** (`frontend-app-bootstrap`, 3 new REQs): converted proposal to Form A (Why / What Changes / Impact); added Non-Functional (ADR-007 i18n: service layer carries no user-facing strings) + Acceptance Criteria.
- **fe-sidebars** (`saved-search-views` 2 REQs + `zoeken-filteren` +1): renamed proposal section to What Changes, added Impact; added Purpose + Non-Functional (ADR-007: user-facing surfaces require nl+en) + Acceptance Criteria to both spec deltas.
- **fe-store-1** (`frontend-store-client-state`, 3 REQs): added What Changes + Impact to proposal; added Non-Functional + Acceptance Criteria to spec.
- **fe-store-2** (`frontend-store-client-state`, 3 REQs): **fixed the known `--strict` blocker** — reordered the import-heartbeat requirement so its first body line leads with MUST; added Impact to proposal.

## New-capability assessment

- `frontend-app-bootstrap` and `frontend-store-client-state` are well-scoped, correctly named, Purpose-anchored.
- fe-store-1 + fe-store-2 both target `frontend-store-client-state`: all six requirement headings are distinct prose, so they merge cleanly into one capability with no REQ-ID/heading collision — coherent and non-overlapping.

## Test plan

- [x] `openspec validate --strict` passes for all four changes
- [x] All `tasks.md` entries `[x]`
- [x] No `openspec/specs/` modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)