### PR TITLE
chore(specs): audit+remediate retrofit REQs — group 5 (service facades)

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/proposal.md
@@ -39,9 +39,13 @@ Five new requirements, each in its owning capability:
   object-scoped log retrieval with soft-deleted register/schema
   tolerance, multi-format export, and admin-only deletion.
 - **text-extraction** (new capability) — the file→chunk extraction
-  lifecycle (`TextExtractionService`): extract a file/object into chunks
-  with modified-since re-extraction detection, discover untracked files,
-  drain a pending queue, retry failures, and report stats.
+  *orchestration* lifecycle (`TextExtractionService`): extract a
+  file/object into chunks with modified-since re-extraction detection,
+  discover untracked files, drain a pending queue, retry failures, and
+  report stats. This sits above the per-source handler contract in the
+  sibling `text-extraction-sources` cap (bw-svc-mid2) and below
+  `vector-embeddings`; the two text-extraction caps are complementary
+  layers, not duplicates.
 
 Everything else is tagged `@spec exclude` or annotated against an
 existing capability spec / change.
@@ -86,7 +90,8 @@ they are annotated in-place against that capability rather than re-spec'd:
   → `file-actions` REQ-001/004/005.
 - `TextExtractionService::extractFile` / `extractObject` / `chunkDocument` /
   `discoverUntrackedFiles` / `extractPendingFiles` / `retryFailedExtractions` /
-  `getStats` → the new `text-extraction` capability (REQ-001 below).
+  `getStats` → the new `text-extraction` capability ("File and Object
+  Chunk-Extraction Lifecycle" below).
 
 ## Source
 

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/activity-provider/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/activity-provider/spec.md
@@ -16,7 +16,7 @@ which this change anchors.
 
 ## ADDED Requirements
 
-### Requirement: REQ-A1 The Tier-2 activity read surface MUST return filtered, cursor-paginated entries linked to an object and MUST degrade to empty when the Activity app is absent
+### Requirement: Tier-2 Object Activity Read Surface
 The service MUST resolve NC Activity entries linked to an OR object via the `[or:{objectUuid}]` subject marker, apply optional type / actor / date-range filters, return a bounded cursor-paginated page ordered newest-first, and return an empty result set (never throw) when the NC Activity app is not installed or a query fails.
 
 `ActivityFilterService::getActivityEntries()` MUST match entries by the `[or:{objectUuid}]` marker in the `activity.subject` column, MUST apply the optional exact `type`, exact `actor` (`affecteduser`), and `after` (Unix-timestamp lower bound) filters when supplied, MUST clamp the requested page size into `[1, MAX_LIMIT]` defaulting to `DEFAULT_LIMIT`, MUST page descending by `timestamp` then `activity_id` using a strict-less-than cursor, and MUST return `{ results, total, nextCursor }` where `total` is the filter-set count ignoring the cursor and `nextCursor` is null on the last page. When the Activity app is unavailable the result MUST be `{ results: [], total: 0, nextCursor: null }`, and any DB error MUST be logged and degraded to an empty result rather than propagated.

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/audit-trail-immutable/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/audit-trail-immutable/spec.md
@@ -17,7 +17,7 @@ surface.
 
 ## ADDED Requirements
 
-### Requirement: REQ-L1 The audit-trail access surface MUST support object-scoped retrieval tolerant of soft-deleted scope, multi-format export, and administrative deletion
+### Requirement: Audit-Trail Access, Export, and Administrative Deletion Surface
 The service MUST expose audit-trail retrieval scoped to a single object with register/schema membership validation that still succeeds when the register or schema has been soft-deleted, MUST count and list entries with the same filters/pagination, MUST export entries in CSV, JSON, XML, and TXT formats, and MUST support single and filtered bulk deletion as an administrative retention operation.
 
 `LogService::getLogs()` and `LogService::count()` MUST resolve the object across all sources including soft-deleted objects, MUST validate the object belongs to the requested register/schema by comparing stored IDs while tolerating a soft-deleted (unresolvable) register or schema, and MUST restrict results to the object's UUID. `LogService::exportLogs()` MUST emit `{ content, filename, contentType }` for each of the `csv`, `json`, `xml`, and `txt` formats and MUST reject an unsupported format with `InvalidArgumentException`. `LogService::deleteLog()` MUST delete one entry by id (or surface a not-found error), and `LogService::deleteLogs()` MUST delete a filter/id-selected set and MUST report `{ deleted, failed, total }`. Deletion is an administrative retention action and does not relax the per-entry immutability guarantee enforced elsewhere in this capability.

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/generic-integrations/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/generic-integrations/spec.md
@@ -16,7 +16,7 @@ change anchors it so all five services (and future link leaves) conform.
 
 ## ADDED Requirements
 
-### Requirement: REQ-G1 Tier-2 entity link services MUST share a uniform link/create/unlink/list/picker contract with graceful degradation
+### Requirement: Tier-2 Remote-Entity Link Service Contract
 A Tier-2 link service MUST persist object↔remote-entity bindings in its own local link table, resolve its provider/router lazily so the service loads even when the backing app is absent, and expose five operations — link an existing remote entity, create-and-link a new one, unlink (binding only, never deleting the remote), list linked entities with stale-cache refresh, and browse available entities for the picker — each degrading gracefully when the backing app or upstream is unavailable.
 
 Each link service (`XwikiLinkService`, `TalkLinkService`, `OpenProjectLinkService`, `BookmarkLinkService`, `CollectiveLinkService`) MUST:

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/search-index/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/search-index/spec.md
@@ -15,7 +15,7 @@ anchors that adaptive scheduling behavior.
 
 ## ADDED Requirements
 
-### Requirement: REQ-S1 A completed import MUST schedule an adaptive background search-index warmup sized to the import volume
+### Requirement: Adaptive Post-Import Search-Index Warmup Scheduling
 On import completion the service MUST schedule a one-time background Solr warmup job whose warmup mode and maximum-object cap are derived from the number of objects imported, MUST skip scheduling entirely when nothing was imported, and MUST treat a scheduling failure as non-fatal to the import.
 
 `ImportService::scheduleSolrWarmup()` MUST compute the total objects imported across all sheets and MUST return `false` without scheduling when that total is zero. `ImportService::getRecommendedWarmupMode()` MUST select a warmup mode by import-size tier (large imports get the fastest mode, medium imports a balanced mode, small imports the safe mode). `ImportService::scheduleSmartSolrWarmup()` MUST use the recommended mode and a size-derived object cap (bounded by a hard maximum), MUST default to a delayed schedule with an immediate-run override, and MUST delegate to `scheduleSolrWarmup()`. A failure to enqueue the job MUST be logged and MUST NOT abort or roll back the completed import.

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/text-extraction/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/specs/text-extraction/spec.md
@@ -6,18 +6,21 @@ retrofit: true
 
 ## Why
 
-`TextExtractionService` consolidates the file→chunk extraction lifecycle
-that feeds search and vector indexing: it extracts a file or object into
-chunks, detects when re-extraction is needed, discovers files that have
-never been extracted, drains a pending queue, retries failures, and
-reports stats. No capability spec owns this lifecycle (the vector
-embeddings capability begins downstream, once chunks exist). This change
-establishes a `text-extraction` capability anchoring the observed
-behavior.
+`TextExtractionService` is the orchestrator of the file→chunk extraction
+lifecycle that feeds search and vector indexing: it extracts a file or
+object into chunks, detects when re-extraction is needed, discovers files
+that have never been extracted, drains a pending queue, retries failures,
+and reports stats. This orchestration layer sits *above* the per-source
+handler contract specced by `text-extraction-sources`
+(`TextExtractionHandlerInterface`, `FileHandler`, `ObjectHandler`, which
+turn one source into a normalised result) and *below* `vector-embeddings`
+(which consumes the chunks once they exist). No capability spec owns this
+orchestration tier, so this change establishes a `text-extraction`
+capability anchoring the observed behavior.
 
 ## ADDED Requirements
 
-### Requirement: REQ-001 The system MUST extract files and objects into chunks with re-extraction detection and a tracked extraction queue
+### Requirement: File and Object Chunk-Extraction Lifecycle
 The system MUST extract a file or object into stored chunks, MUST skip re-extraction when the source is unchanged unless re-extraction is forced, MUST be able to discover never-extracted (untracked) files, drain a bounded pending-extraction queue, retry previously failed extractions, chunk raw text into bounded segments, and report extraction statistics.
 
 `TextExtractionService::extractFile()` MUST resolve the NC file, determine whether stored chunks are up to date relative to the source modification time, and skip extraction when up to date and not forced; a missing file MUST raise `NotFoundException`. `extractObject()` MUST extract an object's content the same way. `chunkDocument()` MUST split raw text into bounded chunks per the supplied options. `discoverUntrackedFiles()`, `extractPendingFiles()`, and `retryFailedExtractions()` MUST each operate over a bounded batch (`limit`) and return a per-run summary. `getStats()` MUST report aggregate extraction state (e.g. tracked / pending / failed counts).

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md
@@ -7,11 +7,11 @@ capabilities/changes), 36 tagged `@spec exclude`.
 
 ## New requirements (this change)
 
-- [x] task-1: activity-provider#REQ-A1 — Tier-2 filtered + cursor-paginated activity read surface (`ActivityFilterService::getActivityEntries`)
-- [x] task-2: generic-integrations#REQ-G1 — Tier-2 entity link-service contract (link/create-and-link/unlink/list/picker across 5 link services, 26 methods)
-- [x] task-3: search-index#REQ-S1 — Adaptive post-import Solr warmup scheduling (`ImportService::scheduleSolrWarmup`, `scheduleSmartSolrWarmup`, `getRecommendedWarmupMode`)
-- [x] task-4: audit-trail-immutable#REQ-L1 — Audit-trail access, export, and admin deletion surface (`LogService::getLogs`, `count`, `exportLogs`, `deleteLog`, `deleteLogs`)
-- [x] task-5: text-extraction#REQ-001 — File→chunk extraction lifecycle (`TextExtractionService::extractFile`, `extractObject`, `chunkDocument`, `discoverUntrackedFiles`, `extractPendingFiles`, `retryFailedExtractions`, `getStats`)
+- [x] task-1: activity-provider "Tier-2 Object Activity Read Surface" — Tier-2 filtered + cursor-paginated activity read surface (`ActivityFilterService::getActivityEntries`)
+- [x] task-2: generic-integrations "Tier-2 Remote-Entity Link Service Contract" — link/create-and-link/unlink/list/picker across 5 link services, 26 methods
+- [x] task-3: search-index "Adaptive Post-Import Search-Index Warmup Scheduling" — `ImportService::scheduleSolrWarmup`, `scheduleSmartSolrWarmup`, `getRecommendedWarmupMode`
+- [x] task-4: audit-trail-immutable "Audit-Trail Access, Export, and Administrative Deletion Surface" — `LogService::getLogs`, `count`, `exportLogs`, `deleteLog`, `deleteLogs`
+- [x] task-5: text-extraction "File and Object Chunk-Extraction Lifecycle" — `TextExtractionService::extractFile`, `extractObject`, `chunkDocument`, `discoverUntrackedFiles`, `extractPendingFiles`, `retryFailedExtractions`, `getStats`
 
 ## Annotated against existing capabilities (no new REQ)
 

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/specs/file-risk-classification/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/specs/file-risk-classification/spec.md
@@ -1,3 +1,20 @@
+---
+retrofit: true
+---
+
+# File Risk Classification
+
+## Why
+
+`RiskLevelService` turns the PII entities that text-extraction detects on a
+file into a single, persisted risk tier and exposes it through Nextcloud's
+files-metadata system for use in the UI and API. This classification concern
+is distinct from entity detection (text-extraction), GDPR processing-register
+bookkeeping (`avg-verwerkingsregister`), and anonymisation: it is the scoring
++ metadata-persistence layer that sits between them, and no existing
+capability owns it. This new capability anchors the observed behaviour. Code
+already exists in production; this is an annotation-only reverse-spec.
+
 ## ADDED Requirements
 
 ### Requirement: RiskLevelService MUST classify a file's PII risk from its detected entities

--- a/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/specs/schema-property-exploration/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-svc-flat-3/specs/schema-property-exploration/spec.md
@@ -1,3 +1,22 @@
+---
+retrofit: true
+---
+
+# Schema Property Exploration
+
+## Why
+
+`SchemaService` carries two methods — `exploreSchemaProperties` and
+`updateSchemaFromExploration` — that implement a schema-authoring aid: they
+analyse the JSON payloads actually stored under a schema to surface
+undeclared or under-specified properties, and apply confirmed suggestions
+back onto the schema. This is a distinct concern from schema CRUD,
+validation, or facet configuration (those are owned by their own
+capabilities), and no existing capability spec captures the
+data-driven discovery loop. This new capability anchors the observed
+behaviour of that loop. Code already exists in production; this is an
+annotation-only reverse-spec.
+
 ## ADDED Requirements
 
 ### Requirement: SchemaService MUST discover undeclared properties by analysing a schema's stored objects


### PR DESCRIPTION
## Summary

Deep-audit + remediation of 3 retrofit service-facade changes (14 REQs total) to /opsx-ff quality. Annotation-only spec deltas; no runtime code changes.

- **bw2-svc-flat-1** (5 REQs: datetime-input-handling, files-sidebar-tabs, generic-integrations, webhook-payload-mapping, zoeken-filteren) — already ADR-037 Form A and well-structured; no edits needed.
- **bw2-svc-flat-2** (5 REQs: activity-provider, audit-trail-immutable, generic-integrations, search-index, text-extraction) — converted all 5 requirement headings from Form B (`REQ-XX` prefix + full-sentence MUST) to **Form A** (concise noun-phrase title; MUST retained in the body first line). Synced tasks.md + proposal.md anchors. Clarified `text-extraction`'s layering relative to the sibling `text-extraction-sources` handler cap.
- **bw2-svc-flat-3** (4 REQs, 2 NEW caps: schema-property-exploration, file-risk-classification) — added `## Why` scoping + `retrofit: true` frontmatter to both new-cap spec files (extra-scrutiny per new-capability rubric).

## Audit findings

- All three changes pass `openspec validate --strict`.
- Form A is now consistent across the group (matches the cleaner fleet siblings).
- **Cross-change flag:** `text-extraction` (this group) and `text-extraction-sources` (bw-svc-mid2, not in this PR) are **complementary layers, not duplicates** — see recommendation in the linked audit thread. No unilateral merge performed.

## Test plan

- [x] `openspec validate retrofit-2026-05-25-bw2-svc-flat-1 --strict`
- [x] `openspec validate retrofit-2026-05-25-bw2-svc-flat-2 --strict`
- [x] `openspec validate retrofit-2026-05-25-bw2-svc-flat-3 --strict`