### PR TITLE
chore(specs): audit+remediate retrofit REQs — group 3

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid2/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid2/proposal.md
@@ -1,82 +1,92 @@
-# Retrofit — backend Service text/oas/schema/mcp (svc-mid2, 2026-05-25)
+# Proposal: Reverse-spec backend Service text/oas/schema/mcp methods (svc-mid2)
 
-Reverse-spec / annotate triage over 52 uncovered methods (`missing @spec`)
-across four `lib/Service/` sub-trees: `TextExtraction/`, `Oas/`, `Schemas/`,
-and `Mcp/`. ADR-003 two-tool pass — every method is either annotated to an
-existing requirement, mapped to one new requirement, or `@spec exclude`d as
-boilerplate. Code already exists; this change retroactively specifies it.
+## Why
 
-Source batch: `/tmp/or-scan/bw-svc-mid2.json` (52 methods).
+A 2026-05-25 coverage scan (`/tmp/or-scan/bw-svc-mid2.json`) flagged 52 uncovered
+public methods (`missing @spec`) across four `lib/Service/` sub-trees —
+`TextExtraction/`, `Oas/`, `Schemas/`, and `Mcp/`. Most implement behaviors that
+already-shipped capabilities describe; a generic per-source text-extraction layer
+(handlers implementing `TextExtractionHandlerInterface`, feeding `ChunkMapper`)
+had no capability owner. This is a reverse-spec retrofit: it documents observed
+behavior of already-shipped code without changing it, applying the ADR-003
+two-tool pass — every method is either annotated to an existing requirement,
+mapped to one new requirement, or `@spec exclude`d as boilerplate.
 
-## Outcome
+## What Changes
 
-- **49 methods spec'd** — 40 annotated to existing requirements in five
-  capabilities (`mcp-discovery`, `oas-validation`, `object-lifecycle`,
-  `faceting-configuration`, `avg-verwerkingsregister`) plus 9 mapped to **one
-  new capability** `text-extraction-sources` (REQ-001..003, 3 new REQs).
-- **3 methods excluded** — the `jsonSerialize()` value-object serialisers on the
-  three EML value objects (pure field-to-array projection boilerplate).
-- **1 new capability**, **3 new REQs** total (well under the ≤5 cap).
+- **ADD** capability `text-extraction-sources` with three requirements
+  (REQ-001..003) covering the generic per-source extraction layer:
+  - REQ-001 — common extraction contract (`TextExtractionHandlerInterface::extractText`,
+    `FileHandler::getSourceMetadata`, `ObjectHandler::getSourceMetadata`).
+  - REQ-002 — normalised extraction + SHA-256 checksum (`FileHandler::extractText`,
+    `ObjectHandler::extractText`).
+  - REQ-003 — freshness-gated re-extraction (`FileHandler::needsExtraction`,
+    `FileHandler::getSourceTimestamp`, `ObjectHandler::needsExtraction`,
+    `ObjectHandler::getSourceTimestamp`).
+- Annotate 40 methods with `@spec` pointers to existing capabilities (no spec
+  change), grouped by capability:
+  - `mcp-discovery` (12) — `McpProtocolService` session/capabilities/audit,
+    `McpResourcesService` resource definitions, `McpToolsService` tool
+    definitions/scoping/audit.
+  - `oas-validation` (13) — `OasETagComputer` (ETag revalidation/performance),
+    `OasRequestValidator::validate` (request validation), `OasValidationReport`
+    (`x-validation-summary` reporting), `ProblemDetailsBuilder` (RFC 7807 /
+    API-46 problem details).
+  - `object-lifecycle#REQ-010` (8) — `SchemaCacheHandler` two-tier schema cache +
+    invalidation (sibling methods of the already-annotated `getSchema`/`invalidate`).
+  - `faceting-configuration` (4) — `FacetCacheHandler` multi-layered facet caching
+    (`openregister_schema_facet_cache` table, cache-statistics shape).
+  - `retrofit-2026-05-24-annotate-openregister#task-13` (1) —
+    `PropertyValidatorHandler::validateProperties` (public loop sibling of the
+    already-annotated `validateProperty`).
+  - `avg-verwerkingsregister` (2) — `EntityRecognitionHandler::extractFromChunk`,
+    `::processSourceChunks` (the PII-detection engine the spec names).
+- **EXCLUDE** 3 methods as boilerplate (`@spec exclude`): the `jsonSerialize()`
+  value-object serialisers on the three EML value objects
+  (`EmlAttachment`, `EmlBody`, `EmlStructure`) — pure field-to-array projection
+  whose shape is already specified by `text-extraction-eml`.
+- No production code behavior changes — annotations and documentation only.
 
-## New capability: text-extraction-sources (9 methods, 3 REQs)
+## Counts
 
-The generic per-source text-extraction layer (handlers implementing
-`TextExtractionHandlerInterface`, feeding `ChunkMapper`) had no capability
-owner. It is distinct from `text-extraction-eml` (EML parsing primitives) and
-`text-extraction-office-completeness` (PhpWord/ODT walking), which cover
-format-specific extraction, and from `vector-embeddings`, which consumes the
-chunks produced afterward. One new capability captures the source-handler
-contract:
+- Methods in batch: 52
+- Spec'd against a new requirement: 9 (3 new REQs, `text-extraction-sources`)
+- Annotated against existing requirements: 40
+- Excluded as boilerplate: 3
+- New capabilities: 1 (`text-extraction-sources`)
+- New requirements: 3 (well under the ≤5 cap)
 
-- **REQ-001** — common extraction contract (`TextExtractionHandlerInterface::extractText`, `FileHandler::getSourceMetadata`, `ObjectHandler::getSourceMetadata`)
-- **REQ-002** — normalised extraction + SHA-256 checksum (`FileHandler::extractText`, `ObjectHandler::extractText`)
-- **REQ-003** — freshness-gated re-extraction (`FileHandler::needsExtraction`, `FileHandler::getSourceTimestamp`, `ObjectHandler::needsExtraction`, `ObjectHandler::getSourceTimestamp`)
+## Impact
 
-## Annotated to existing requirements (40 methods)
-
-### Mcp/ → `mcp-discovery` (12 methods)
-The `mcp-discovery` spec (status `implemented`) names these services and methods
-explicitly in its scenarios, so the annotations are faithful retroactive maps:
-- `McpProtocolService` — `initialize`, `createSession`, `validateSession`, `destroySession`, `ping` → "MCP Session Management", "MCP Capabilities Negotiation", "MCP Audit Logging"
-- `McpResourcesService` — `listResources`, `listTemplates`, `readResource` → "MCP Resource Definitions"
-- `McpToolsService` — `listTools`, `callTool`, `invokeTool`, `addProvider` → "MCP Tool Definitions", "Multi-Register Tool Scoping", "MCP Audit Logging"
-
-### Oas/ → `oas-validation` (13 methods)
-The active `oas-validation` change spec covers runtime request/response
-validation, validation reporting, performance/ETag caching, and RFC 7807
-problem details. The four helper classes implement those requirements:
-- `OasETagComputer` — `computeETag`, `hash`, `matches` → "Performance Impact of Validation" (ETag revalidation scenario)
-- `OasRequestValidator` — `validate` → "Request Validation Against OAS Schema"
-- `OasValidationReport` — `addError`, `addWarning`, `addAutoCorrection`, `passed`, `toSummary` → "Validation Error Reporting" (`x-validation-summary`)
-- `ProblemDetailsBuilder` — `build`, `validationFailed`, `notFound`, `conflict` → "Error responses include problem details (API-46 / RFC 7807)"
-
-### Schemas/ → `object-lifecycle` + `faceting-configuration` + annotate-openregister (13 methods)
-- `SchemaCacheHandler` (8) — `cacheSchema`, `cacheSchemaConfiguration`, `cacheSchemaProperties`, `cleanExpiredEntries`, `clearAllCaches`, `clearSchemaCache`, `getCacheStatistics`, `invalidateForSchemaChange` → `object-lifecycle#REQ-010` ("Schema reads MUST use a two-tier cache with explicit invalidation"; sibling methods of the already-annotated `getSchema`/`invalidate`, both carrying `retrofit-2026-05-24-b-svc-object-facade` task-5)
-- `FacetCacheHandler` (4) — `cacheFacetableFields`, `cleanExpiredEntries`, `clearAllCaches`, `getCacheStatistics` → `faceting-configuration` "Multi-layered facet caching" (names `FacetCacheHandler`, the `openregister_schema_facet_cache` table, the cache-statistics shape)
-- `PropertyValidatorHandler` (1) — `validateProperties` → `retrofit-2026-05-24-annotate-openregister` task-13 (the public loop sibling of the already-annotated `validateProperty`)
-
-### TextExtraction/ → `avg-verwerkingsregister` (2 methods)
-- `EntityRecognitionHandler` — `extractFromChunk`, `processSourceChunks` → `avg-verwerkingsregister` "Automated PII detection MUST flag unregistered personal data processing" (the spec names `EntityRecognitionHandler` as the PII-detection engine and specifies the regex/Presidio/LLM/hybrid method configuration these methods implement)
-
-## Excluded (3 methods)
-
-Pure value-object serialisation boilerplate — `jsonSerialize()` projects the
-VO's public readonly properties into an array with no behavioural contract
-beyond the field shape already specified by `text-extraction-eml`:
-- `EmlAttachment::jsonSerialize`, `EmlBody::jsonSerialize`, `EmlStructure::jsonSerialize`
-
-## Mode
-Mixed: `--cluster text-extraction-sources` (1 new cap, REQ-001..003) plus
-cross-capability annotation to five existing capabilities. No existing
-requirements are modified.
+- Affected specs: `text-extraction-sources` (new capability, 3 requirements).
+- Capabilities referenced for annotation (no spec change): `mcp-discovery`,
+  `oas-validation`, `object-lifecycle`, `faceting-configuration`,
+  `avg-verwerkingsregister`.
+- Affected code (annotations only): `lib/Service/TextExtraction/FileHandler.php`,
+  `ObjectHandler.php`, `TextExtractionHandlerInterface.php`,
+  `EntityRecognitionHandler.php`; `lib/Service/Oas/OasETagComputer.php`,
+  `OasRequestValidator.php`, `OasValidationReport.php`, `ProblemDetailsBuilder.php`;
+  `lib/Service/Schemas/SchemaCacheHandler.php`, `FacetCacheHandler.php`,
+  `PropertyValidatorHandler.php`; `lib/Service/Mcp/McpProtocolService.php`,
+  `McpResourcesService.php`, `McpToolsService.php`; and the three EML value
+  objects (`@spec exclude`).
+- No migrations, no API changes, no behavioral change.
 
 ## Notes
+
 - No cohort frontmatter is added to the five existing capabilities — the cohort
   flag tracks REQ provenance, not annotation provenance (per the retrofit
-  playbook's documentation-only sub-patterns). Only the new
-  `text-extraction-sources` master spec carries `retrofit: true`.
-- `object-lifecycle#REQ-010` and the `oas-validation` API-46/request-validation/
+  playbook). Only the new `text-extraction-sources` master spec carries
+  `retrofit: true`.
+- `object-lifecycle#REQ-010` and the `oas-validation` API-46 / request-validation /
   ETag requirements live in active (un-archived) changes; `@spec` is a textual
   reference and remains valid after those changes archive.
+- **Dedup flag:** the sibling change `retrofit-2026-05-25-bw2-svc-flat-2` mints a
+  capability literally named `text-extraction` for the `TextExtractionService`
+  orchestration layer (extractFile/extractObject/chunkDocument/queue). That layer
+  delegates to the per-source handlers this capability specifies. The two are
+  adjacent layers of the same subsystem and are candidates to be unified under one
+  `text-extraction` capability. Reconciliation is deferred to a central owner — not
+  resolved here.
 
 See [retrofit playbook](../../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid2/specs/text-extraction-sources/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid2/specs/text-extraction-sources/spec.md
@@ -23,7 +23,7 @@ Code already exists — this change retroactively specifies observed behaviour.
 
 ## ADDED Requirements
 
-### Requirement: REQ-001 — Source handlers MUST implement a common extraction contract
+### Requirement: Source handlers MUST implement a common extraction contract (REQ-001)
 The system MUST expose a `TextExtractionHandlerInterface` that every
 source-type handler implements, so the orchestrating service can extract text
 from any registered source type without knowing its concrete type. The
@@ -50,7 +50,7 @@ be resolved.
 - **WHEN** `getSourceMetadata($sourceId)` is called
 - **THEN** the handler MUST throw `DoesNotExistException`
 
-### Requirement: REQ-002 — Handlers MUST extract normalised text and a stable checksum from their source
+### Requirement: Handlers MUST extract normalised text and a stable checksum from their source (REQ-002)
 Each handler's `extractText()` MUST load the source by ID, derive a plain-text
 projection of its content, and return the normalised result array. The `text`
 field MUST be a non-empty string — when no text can be derived the handler MUST
@@ -83,7 +83,7 @@ into `key: value` lines with a bounded recursion depth.
 - **THEN** the handler MUST throw an exception naming the source ID rather than
   returning an empty `text`
 
-### Requirement: REQ-003 — Handlers MUST gate re-extraction on source freshness
+### Requirement: Handlers MUST gate re-extraction on source freshness (REQ-003)
 Each handler MUST expose `needsExtraction(int $sourceId, int $sourceTimestamp,
 bool $force): bool` and `getSourceTimestamp(int $sourceId): int` so the
 orchestrator can skip work when previously-produced chunks are still
@@ -114,3 +114,30 @@ falling back to the current time when the source cannot be resolved.
 - **GIVEN** a source ID that does not resolve
 - **WHEN** `getSourceTimestamp($sourceId)` is called
 - **THEN** it MUST return the current Unix timestamp instead of throwing
+
+## Non-Functional
+
+- **i18n (ADR-007):** This capability is a backend extraction layer with no
+  user-facing strings of its own. The detected source `language` and
+  `language_confidence` it records are propagated to downstream search and
+  PII detection; the layer MUST NOT hardcode a language assumption and MUST
+  preserve the detected `language`/`language_level`/`detection_method` keys
+  verbatim so localised presentation remains the caller's concern.
+- **Error surfaces** raised here (`DoesNotExistException`, "no extractable
+  text" failures) are developer/operator diagnostics, not end-user copy, and
+  are exempt from translation.
+- **Determinism:** the SHA-256 `checksum` MUST be stable for identical input
+  text so freshness gating and re-extraction skipping are reproducible.
+- **Bounded work:** object flattening MUST honour a fixed recursion-depth bound
+  to keep extraction cost bounded on deeply nested payloads.
+
+## Acceptance Criteria
+
+- Every concrete handler implements `TextExtractionHandlerInterface` and returns
+  the full normalised key set from `extractText()`.
+- `getSourceMetadata` throws `DoesNotExistException` on an unresolvable source.
+- `checksum` equals `hash('sha256', $text)` for the extracted text.
+- `needsExtraction` returns `true` on force, on no existing chunks, and on stale
+  chunks; `false` only when chunks are at or newer than the source timestamp.
+- `getSourceTimestamp` falls back to the current time (never throws) on an
+  unresolvable source.

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid3/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid3/proposal.md
@@ -4,6 +4,27 @@
 
 The 2026-05-25 coverage scan (`/tmp/or-scan/bw-svc-mid3.json`) flagged 37 uncovered methods spread across nine `lib/Service/` sub-trees. Most are siblings or read/write twins of methods already annotated by earlier retrofit passes (the 2026-04-23 / 2026-04-30 / 2026-05-24 annotate changes and the `aggregations-backend-native`, `vector-embeddings`, `object-lifecycle`, `geo-metadata-kaart` reverse-spec changes). A handful describe genuine, observable behavior that no existing REQ covers. This change drains the batch with the ADR-003 two-tool approach: extend the matching capability where there is a real gap, cross-reference an existing task where the method is a twin/wrapper of an already-spec'd one, and `@spec exclude` the pure plumbing.
 
+## What Changes
+
+- **MODIFY** capability `vector-embeddings`: add REQ-006 — vector *query*
+  execution (semantic KNN/cosine + hybrid Reciprocal-Rank-Fusion search).
+- **MODIFY** capability `aggregations-backend-native`: add REQ-ABN-006 (REST
+  timeseries-request + `x-openregister-widgets` annotation validation) and
+  REQ-ABN-007 (the time/session placeholder DSL the runner resolves filters
+  through).
+- **MODIFY** capability `data-import-export`: add REQ-CFG-TRACK-001 — the
+  import-tracking `Configuration` entity (`createOrUpdateConfiguration`):
+  OAS→`x-openregister`→legacy metadata fallback and entity-ID merge for
+  idempotent re-import.
+- Cross-reference 11 method groups (no new REQs) to existing tasks in prior
+  changes — cache write/evict, query-builder `build`, ad-hoc-by-ref, geo
+  parser/evaluator, graphql relation resolver, lifecycle available-actions,
+  webhook formatter, Fireworks adapter, file strategy.
+- **EXCLUDE** as boilerplate (`@spec exclude`): the six `StreamYieldChannel`
+  pub-sub forwarder methods, `GitHubGuards::runGuards` (generic guard runner),
+  and `AggregationRunner::findSchema` (thin `loadSchema` wrapper).
+- No production code behavior changes — annotations and documentation only.
+
 ## What the batch contains
 
 | Sub-tree | Methods | Disposition |
@@ -28,6 +49,32 @@ The 2026-05-25 coverage scan (`/tmp/or-scan/bw-svc-mid3.json`) flagged 37 uncove
 - **Exclude (boilerplate):** the six `StreamYieldChannel` pub-sub methods, `GitHubGuards::runGuards` (generic short-circuit guard runner), `AggregationRunner::findSchema` (thin `loadSchema` convenience wrapper).
 
 **4 new REQs total** (under the ≤5 cap).
+
+## Counts
+
+- Methods in batch: 37
+- Spec'd against a new requirement: 9 (4 new REQs across 3 capabilities)
+- Cross-referenced to existing requirements: 19
+- Excluded as boilerplate: 9
+- New requirements: 4 (`vector-embeddings` REQ-006; `aggregations-backend-native`
+  REQ-ABN-006, REQ-ABN-007; `data-import-export` REQ-CFG-TRACK-001)
+
+## Impact
+
+- Affected specs (new requirements): `vector-embeddings`,
+  `aggregations-backend-native`, `data-import-export`.
+- Capabilities referenced for cross-annotation (no spec change):
+  `geo-metadata-kaart`, `graphql-api`, `object-lifecycle`,
+  `webhook-payload-mapping`.
+- Affected code (annotations only): `lib/Service/Vectorization/` (VectorEmbeddings,
+  VectorSearchHandler, EmbeddingGeneratorHandler, FileVectorizationStrategy),
+  `lib/Service/Aggregation/` (TimeseriesRequestValidator, WidgetAnnotationValidator,
+  PlaceholderResolver, AggregationCache, AggregationQuery, AggregationRunner,
+  Elasticsearch/SolrAggregationQueryBuilder), `lib/Service/Configuration/ImportHandler.php`,
+  `lib/Service/Chat/StreamYieldChannel.php` (excludes), `lib/Service/Geo/`,
+  `lib/Service/GraphQL/GraphQLResolver.php`, `lib/Service/Lifecycle/TransitionEngine.php`,
+  `lib/Service/Search/PlaceholderResolver.php`, `lib/Service/Webhook/CloudEventFormatter.php`.
+- No migrations, no API changes, no behavioral change.
 
 ## Out of scope
 

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid3/specs/aggregations-backend-native/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid3/specs/aggregations-backend-native/spec.md
@@ -72,3 +72,29 @@ retrofit_extensions:
 - **THEN** `status` MUST remain `'open'`
 - **AND** `createdAfter` MUST be the Monday-anchored `DateTimeImmutable` for the current week
 - **AND** `nested.by` MUST be the resolved session UID
+
+## Non-Functional
+
+- **i18n (ADR-007):** This delta covers backend validators and a placeholder
+  resolver with no user-facing copy of its own. Validation errors
+  (`InvalidArgumentException` messages, the `{code, message}` widget error
+  descriptors) are developer/operator diagnostics; the stable machine-readable
+  `code` (e.g. `widget-bad-type`) is the contract, leaving the human `message`
+  free for the caller to localise. The DSL MUST NOT assume a locale — week
+  boundaries are anchored on Monday (ISO-8601), independent of display locale.
+- **Determinism:** placeholder resolution MUST be applied exactly once per
+  request, before cache-key derivation, so identical filters yield identical
+  cache keys.
+- **Safety:** field allow-listing against declared schema properties MUST gate
+  every timeseries request to prevent unbounded/arbitrary-field aggregation.
+
+## Acceptance Criteria
+
+- `TimeseriesRequestValidator::validate` rejects undeclared fields, enforces the
+  closed interval vocabulary, requires `date-time` fields for sub-day intervals,
+  and produces exactly one of `dateBucket` / `groupBy`.
+- `WidgetAnnotationValidator::validate` returns `[]` for absent annotations and a
+  coded error per violated rule otherwise.
+- `PlaceholderResolver::resolve` handles `$currentUser`, the date anchors, signed
+  offset arithmetic with unit defaulting, and passes unknown/non-string values
+  through unchanged; `resolveArray` recurses preserving keys.

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid3/specs/data-import-export/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid3/specs/data-import-export/spec.md
@@ -46,3 +46,29 @@ Any failure MUST be logged and re-thrown wrapped as `Failed to create or update 
 - **WHEN** the new-configuration branch runs
 - **THEN** `githubRepo`/`githubBranch`/`githubPath` MUST be populated from the nested keys
 - **AND** an import using the legacy flat `githubRepo`/`githubBranch`/`githubPath` keys MUST populate the same fields
+
+## Non-Functional
+
+- **i18n (ADR-007):** This delta tracks import bookkeeping with no user-facing
+  copy of its own. The default title/description strings
+  (`"Configuration for {appId}"`) are administrative fallbacks for untitled
+  imports, not localised end-user labels; when the import data carries
+  `info.title`/`description` those caller-supplied (already-localised) values
+  take precedence. The wrapped failure message
+  (`Failed to create or update configuration: {message}`) is an
+  operator/log diagnostic and is exempt from translation.
+- **Idempotency:** re-importing the same app MUST reconcile into a single
+  tracking record and MUST NOT lose previously tracked entity IDs
+  (`array_unique(array_merge(...))`).
+
+## Acceptance Criteria
+
+- One `Configuration` per app: re-import updates the existing record (union,
+  de-duplicated IDs); first import inserts a `isLocal=true`, `syncEnabled=false`,
+  `syncStatus='never'` record.
+- Metadata resolves via the OAS `info` → `x-openregister` → top-level → default
+  fallback chain, `info.title` winning when present.
+- GitHub coordinates populate identically from the nested
+  `x-openregister.github.{repo,branch,path}` and the legacy flat shape.
+- Any failure is logged and re-thrown wrapped as
+  `Failed to create or update configuration: {message}`.

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid3/specs/vector-embeddings/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid3/specs/vector-embeddings/spec.md
@@ -53,3 +53,29 @@ Each result entry MUST carry `vector_id`, `entity_type`, `entity_id`, `similarit
 - **WHEN** `hybridSearch(...)` normalises them
 - **THEN** the effective weights MUST be `['solr' => 0.75, 'vector' => 0.25]`
 - **AND** the returned `weights` field MUST reflect the normalised values
+
+## Non-Functional
+
+- **i18n (ADR-007):** This delta covers backend vector-query execution with no
+  user-facing copy of its own. The query string is opaque pass-through content
+  embedded by the model and is locale-agnostic; result entries carry only
+  machine fields (`vector_id`, `similarity`, `chunk_text`, etc.) and no
+  presentation labels. Error strings (`Solr service is not available`,
+  `Semantic search failed: {message}`) are operator/log diagnostics and are
+  exempt from translation.
+- **Graceful degradation:** a failing vector leg in `hybridSearch` MUST be
+  logged and tolerated; the Solr leg MUST still fuse and return results.
+- **Resilience:** an unparseable stored embedding MUST be skipped (warning),
+  never fatal, on the database path.
+
+## Acceptance Criteria
+
+- `semanticSearch` embeds the query, routes by backend, computes cosine
+  similarity on the DB path, sorts descending, and caps at `limit`; an empty
+  vector table returns `[]`.
+- Each result entry carries the full key set (`vector_id`, `entity_type`,
+  `entity_id`, `similarity`, `chunk_index`, `total_chunks`, `chunk_text`,
+  `metadata`, `model`, `dimensions`).
+- `hybridSearch` normalises weights to sum to 1, fuses via Reciprocal Rank
+  Fusion, tolerates a failing vector leg, and returns `results`, `total`,
+  `search_time_ms`, `source_breakdown`, and the normalised `weights`.


### PR DESCRIPTION
## Summary

Deep-audit + remediate 7 REQs across 2 svc-mid retrofit changes to `/opsx-ff` quality. Change dirs only — `openspec/specs/` untouched.

- **mid2** (`retrofit-2026-05-25-bw-svc-mid2`, new cap `text-extraction-sources`, 3 REQs):
  - Rewrote REQ headings to **ADR-037 Form A** (`### Requirement: <Title> (REQ-001)` — removed the `REQ-001 —` title prefix, Form B violation).
  - Restructured proposal to canonical `## Why / ## What Changes / ## Counts / ## Impact`.
  - Added `## Non-Functional` (ADR-007 i18n posture) + `## Acceptance Criteria`.
- **mid3** (`retrofit-2026-05-25-bw-svc-mid3`, 4 REQs across aggregations-backend-native / data-import-export / vector-embeddings):
  - Added canonical `## What Changes / ## Counts / ## Impact` to proposal.
  - Added `## Non-Functional` (ADR-007 i18n) + `## Acceptance Criteria` to all three spec deltas.

Both pass `openspec validate --strict`. All tasks `[x]`.

## Cross-change dedup flag

`text-extraction-sources` (this PR) specifies the per-source extraction **handlers** (`FileHandler`/`ObjectHandler`/`TextExtractionHandlerInterface`). The sibling change `retrofit-2026-05-25-bw2-svc-flat-2` (different owner) mints `text-extraction` for the `TextExtractionService` **orchestration** layer that delegates to those handlers. These are adjacent layers of one subsystem and are strong candidates to be **unified under a single `text-extraction` capability**. Not merged here — flagged for central reconciliation.

## Test plan

- [x] `openspec validate retrofit-2026-05-25-bw-svc-mid2 --strict`
- [x] `openspec validate retrofit-2026-05-25-bw-svc-mid3 --strict`
- [x] All tasks.md entries `[x]`
- [x] No `openspec/specs/` files modified