### PR TITLE
chore(specs): unify text-extraction caps + bring controller REQs to ff structure

### DIFF
--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid2/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid2/proposal.md
@@ -14,8 +14,10 @@ mapped to one new requirement, or `@spec exclude`d as boilerplate.
 
 ## What Changes
 
-- **ADD** capability `text-extraction-sources` with three requirements
-  (REQ-001..003) covering the generic per-source extraction layer:
+- **ADD** the per-source handler requirements to the `text-extraction`
+  capability (consolidated from the former `text-extraction-sources` name) —
+  three requirements (REQ-001..003) covering the generic per-source extraction
+  layer:
   - REQ-001 — common extraction contract (`TextExtractionHandlerInterface::extractText`,
     `FileHandler::getSourceMetadata`, `ObjectHandler::getSourceMetadata`).
   - REQ-002 — normalised extraction + SHA-256 checksum (`FileHandler::extractText`,
@@ -50,15 +52,17 @@ mapped to one new requirement, or `@spec exclude`d as boilerplate.
 ## Counts
 
 - Methods in batch: 52
-- Spec'd against a new requirement: 9 (3 new REQs, `text-extraction-sources`)
+- Spec'd against a new requirement: 9 (3 new REQs, `text-extraction`)
 - Annotated against existing requirements: 40
 - Excluded as boilerplate: 3
-- New capabilities: 1 (`text-extraction-sources`)
+- New capabilities: 1 (`text-extraction`, consolidated from the former
+  `text-extraction-sources` name)
 - New requirements: 3 (well under the ≤5 cap)
 
 ## Impact
 
-- Affected specs: `text-extraction-sources` (new capability, 3 requirements).
+- Affected specs: `text-extraction` (per-source handler requirements, 3
+  requirements; consolidated from the former `text-extraction-sources` name).
 - Capabilities referenced for annotation (no spec change): `mcp-discovery`,
   `oas-validation`, `object-lifecycle`, `faceting-configuration`,
   `avg-verwerkingsregister`.
@@ -76,17 +80,18 @@ mapped to one new requirement, or `@spec exclude`d as boilerplate.
 
 - No cohort frontmatter is added to the five existing capabilities — the cohort
   flag tracks REQ provenance, not annotation provenance (per the retrofit
-  playbook). Only the new `text-extraction-sources` master spec carries
+  playbook). Only the new `text-extraction` master spec carries
   `retrofit: true`.
 - `object-lifecycle#REQ-010` and the `oas-validation` API-46 / request-validation /
   ETag requirements live in active (un-archived) changes; `@spec` is a textual
   reference and remains valid after those changes archive.
-- **Dedup flag:** the sibling change `retrofit-2026-05-25-bw2-svc-flat-2` mints a
-  capability literally named `text-extraction` for the `TextExtractionService`
-  orchestration layer (extractFile/extractObject/chunkDocument/queue). That layer
-  delegates to the per-source handlers this capability specifies. The two are
-  adjacent layers of the same subsystem and are candidates to be unified under one
-  `text-extraction` capability. Reconciliation is deferred to a central owner — not
-  resolved here.
+- **Unified (2026-05-25):** the sibling change `retrofit-2026-05-25-bw2-svc-flat-2`
+  carries the `text-extraction` capability for the `TextExtractionService`
+  orchestration layer (extractFile/extractObject/chunkDocument/queue), which
+  delegates to the per-source handlers this delta specifies. The two were adjacent
+  layers of the same subsystem, so they have been unified: this delta was renamed
+  from `text-extraction-sources` to `text-extraction` and both changes now archive
+  into one `text-extraction` capability (handler REQs from here, orchestrator REQs
+  from the sibling).
 
 See [retrofit playbook](../../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid2/specs/text-extraction/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid2/specs/text-extraction/spec.md
@@ -3,7 +3,14 @@ status: implemented
 retrofit: true
 ---
 
-# Text Extraction Sources
+# Text Extraction
+
+> **Consolidation note:** this delta adds the per-source HANDLER requirements
+> (`FileHandler`, `ObjectHandler`, `TextExtractionHandlerInterface`) of the
+> `text-extraction` capability, while the sibling `retrofit-2026-05-25-bw2-svc-flat-2`
+> change adds the orchestrator (`TextExtractionService`) requirements — both
+> archive into one `text-extraction` capability. This delta was consolidated
+> from the former `text-extraction-sources` name.
 
 ## Purpose
 Provides a generic, source-type-agnostic text-extraction layer that turns

--- a/openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md
@@ -1,10 +1,14 @@
 # Tasks
 
-## New capability: text-extraction-sources (reverse-spec)
+## Capability: text-extraction — per-source handler layer (reverse-spec)
 
-- [x] task-1: text-extraction-sources#REQ-001 — Common extraction contract (`TextExtractionHandlerInterface::extractText`, `FileHandler::getSourceMetadata`, `ObjectHandler::getSourceMetadata`) (retroactive annotation)
-- [x] task-2: text-extraction-sources#REQ-002 — Normalised extraction + SHA-256 checksum (`FileHandler::extractText`, `ObjectHandler::extractText`) (retroactive annotation)
-- [x] task-3: text-extraction-sources#REQ-003 — Freshness-gated re-extraction (`FileHandler::needsExtraction`, `FileHandler::getSourceTimestamp`, `ObjectHandler::needsExtraction`, `ObjectHandler::getSourceTimestamp`) (retroactive annotation)
+> Consolidated from the former `text-extraction-sources` name; the handler REQs
+> below archive into the shared `text-extraction` capability alongside the
+> orchestrator REQs from `retrofit-2026-05-25-bw2-svc-flat-2`.
+
+- [x] task-1: text-extraction#REQ-001 — Common extraction contract (`TextExtractionHandlerInterface::extractText`, `FileHandler::getSourceMetadata`, `ObjectHandler::getSourceMetadata`) (retroactive annotation)
+- [x] task-2: text-extraction#REQ-002 — Normalised extraction + SHA-256 checksum (`FileHandler::extractText`, `ObjectHandler::extractText`) (retroactive annotation)
+- [x] task-3: text-extraction#REQ-003 — Freshness-gated re-extraction (`FileHandler::needsExtraction`, `FileHandler::getSourceTimestamp`, `ObjectHandler::needsExtraction`, `ObjectHandler::getSourceTimestamp`) (retroactive annotation)
 
 ## Cross-capability annotations to existing requirements
 

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/specs/generic-integrations/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/specs/generic-integrations/spec.md
@@ -86,3 +86,27 @@ inherit this contract's session-only default.
 - **WHEN** the controller catches it via its `mapException()` helper
 - **THEN** the response status MUST be `409`
 - **AND** an exception code outside `{400,401,404,409,503}` MUST default to HTTP `400`
+
+## Non-Functional Requirements
+
+- **i18n (ADR-007)**: These are JSON REST endpoints. The error bodies they emit
+  (`{error: "Object not found"}`, `{error, code: "APP_NOT_AVAILABLE"}`) are
+  machine-readable diagnostics keyed by a stable `code`; the human-readable
+  `error` text is developer/operator copy and is exempt from translation.
+  Resource payloads carry only provider-supplied data, no app-authored
+  user-facing strings, so nl+en localisation does not apply here. (ADR-007 n/a.)
+- **REST/error contract (ADR-002)**: The contract follows the OpenRegister REST
+  conventions — the `{results, total}` list envelope, HTTP-status-by-meaning
+  (`201` create, `404` unresolved object, `409` conflict, `501`
+  `APP_NOT_AVAILABLE`), and a stable `code` on degraded responses so callers can
+  branch without parsing prose. The richer RFC 7807 problem-details shape is
+  governed by the separate `oas-validation` requirement and is not redefined
+  here.
+
+## Acceptance Criteria
+
+- [x] All eight object-scoped link controllers carry `@spec generic-integrations#...` annotations pointing at this requirement.
+- [x] List/picker endpoints return the `{results, total}` envelope; link and create-and-link return `201`; unlink returns `{success: true}`.
+- [x] A missing backing app yields `501` with `{error, code: "APP_NOT_AVAILABLE"}`; an unresolvable object yields `404` with `{error: "Object not found"}`.
+- [x] Service exception codes map to HTTP status (`400/401/404/409/503`), defaulting to `400`.
+- [x] `openspec validate retrofit-2026-05-25-bw2-ctrl-1 --strict` passes.

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/specs/search-index/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/specs/search-index/spec.md
@@ -71,3 +71,26 @@ anonymised or have no detected entities.
 - **GIVEN** a file whose name already contains `_anonymized`
 - **WHEN** the anonymise endpoint is invoked
 - **THEN** the response MUST be HTTP `400` and no new anonymised copy MUST be created
+
+## Non-Functional Requirements
+
+- **i18n (ADR-007)**: These are JSON REST endpoints for the Files UI and
+  administrators. The status/error strings they emit (`"Text extraction
+  disabled"`, `"Query parameter is required"`) are operator-facing diagnostics
+  paired with a stable `success:false` flag and HTTP status, and are exempt from
+  translation. Search results echo file content and metadata, not app-authored
+  user-facing copy, so nl+en localisation does not apply here. (ADR-007 n/a.)
+- **REST/error contract (ADR-002)**: Responses follow OpenRegister REST
+  conventions — the `{success, query, total, results, search_type}` search
+  envelope, HTTP-status-by-meaning (`400` empty query, `501` extraction
+  disabled), and bounded bulk operations (batch cap ≤ 500). Disabled-feature and
+  validation failures are reported with HTTP status plus a `{success:false,
+  message}` body rather than the full RFC 7807 shape.
+
+## Acceptance Criteria
+
+- [x] `FileTextController`, `FileSearchController`, `FileSidebarController`, and `FileSettingsController` carry `@spec search-index#...` annotations.
+- [x] Per-file and bounded bulk extraction work; extraction returns `501` when file management/extraction is disabled.
+- [x] Semantic/hybrid file search returns the `{success, query, total, results, search_type}` envelope and rejects an empty `query` with `400`.
+- [x] Anonymisation creates a new copy and guards already-anonymised / no-entity files.
+- [x] `openspec validate retrofit-2026-05-25-bw2-ctrl-1 --strict` passes.

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/specs/zoeken-filteren/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-1/specs/zoeken-filteren/spec.md
@@ -55,3 +55,24 @@ shared parameter-extraction helper, and system/query parameters (`_route`,
 - **GIVEN** stale search-trail entries
 - **WHEN** the cleanup, single-delete, or clear-all endpoint is invoked
 - **THEN** the matching entries MUST be removed and the operation result MUST be reported
+
+## Non-Functional Requirements
+
+- **i18n (ADR-007)**: This is an operator-facing analytics/audit JSON API. The
+  only app-authored string is the `{error: "Search trail not found"}` 404
+  diagnostic, which is operator copy and exempt from translation; trail rows and
+  aggregates carry recorded search terms and counts, not localisable UI copy. CSV
+  and JSON exports emit raw recorded data. (ADR-007 n/a.)
+- **REST/error contract (ADR-002)**: Follows OpenRegister REST conventions —
+  the shared `{results, total, page, pages, limit, offset}` pagination envelope
+  (identical to the objects list endpoint), `404` for a missing entry, and the
+  shared parameter-extraction helper that strips system params (`_route`, `id`)
+  before they reach the service.
+
+## Acceptance Criteria
+
+- [x] `SearchTrailController` carries `@spec zoeken-filteren#...` annotations pointing at this requirement.
+- [x] The list endpoint returns the shared pagination envelope and strips `_route`/`id`; a missing entry returns `404`.
+- [x] Statistics endpoints honour the optional `from`/`to` window; popular-terms, time-series, per-(register,schema), and user-agent stats are exposed.
+- [x] Export (CSV/JSON) and retention (cleanup/delete/clear-all) operations behave as specified.
+- [x] `openspec validate retrofit-2026-05-25-bw2-ctrl-1 --strict` passes.

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/data-import-export/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/data-import-export/spec.md
@@ -63,3 +63,25 @@ register portability" requirement and are not redefined here.
 - **WHEN** `GET /api/configurations/github/files` is called for a repository
 - **THEN** the response MUST list the configuration files in that repository
 - **AND** repositories or files the caller cannot access MUST NOT be returned
+
+## Non-Functional Requirements
+
+- **i18n (ADR-007)**: These are administrator-facing configuration/Git-sync JSON
+  REST endpoints. The only app-authored strings are `{error}` diagnostics on
+  unknown ids and failures, which are operator copy and exempt from translation.
+  Configuration payloads and remote file listings carry external/portability
+  data, not localisable UI copy. (ADR-007 n/a.)
+- **REST/error contract (ADR-002)**: Follows OpenRegister REST conventions —
+  resource CRUD with `404` for unknown ids and `201` on explicit create. The
+  Git-discovery endpoints MUST resolve the caller's credentials from
+  configuration and MUST NOT leak repositories/files the caller cannot access
+  (no cross-account enumeration). The portability file format itself remains
+  governed by the existing register-portability requirement.
+
+## Acceptance Criteria
+
+- [x] `ConfigurationController` and `ConfigurationsController` carry `@spec data-import-export#...` annotations pointing at this requirement.
+- [x] Configuration CRUD returns `404` for unknown ids and `201` on explicit create; `patch` applies a partial update via the `update` write path.
+- [x] `checkVersion`/`preview`/`enrichDetails` operate against the configured remote source; the GitHub/GitLab discovery endpoints list only files the caller can access.
+- [x] `export`/`import` continue to defer to the existing register-portability requirement (not redefined here).
+- [x] `openspec validate retrofit-2026-05-25-bw2-ctrl-2 --strict` passes.

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/generic-integrations/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/generic-integrations/spec.md
@@ -94,3 +94,27 @@ all authenticated users.
 - **WHEN** a non-admin attempts a mutating verb
 - **THEN** the Activity leaf MUST expose no link/create/unlink verb at all
 - **AND** the Flow leaf MUST reject the mutating verb for non-admins while still serving its list verb read-only
+
+## Non-Functional Requirements
+
+- **i18n (ADR-007)**: These are JSON REST link controllers. The error bodies
+  (`{error}`, `{error, code: "APP_NOT_AVAILABLE"}`) are machine-readable
+  diagnostics keyed by a stable `code`; the human-readable text is
+  developer/operator copy and exempt from translation. Linked-entity payloads
+  carry only backing-app data, no app-authored user-facing strings, so nl+en
+  localisation does not apply here. (ADR-007 n/a.)
+- **REST/error contract (ADR-002)**: Deliberately identical to the sibling
+  `retrofit-2026-05-25-bw2-ctrl-1` "Object-Scoped Integration Link REST Contract"
+  so the contract reads as one — `{results, total}` list envelope, `201` on
+  link/create, `400` for a missing reference id, `404` for an unresolved object,
+  `501 APP_NOT_AVAILABLE` degradation, and exception-code→HTTP mapping
+  (`409/404/503/400`). The full RFC 7807 problem-details shape is out of scope
+  for these link controllers.
+
+## Acceptance Criteria
+
+- [x] Every Tier-2 leaf link controller (`*LinksController` / `EmailsController` family) carries `@spec generic-integrations#...` annotations pointing at this requirement.
+- [x] List returns `{results, total}`; link/create returns `201`; a missing reference id returns `400`; an unresolved object returns `404`.
+- [x] A missing backing app yields `501` with `{error, code: "APP_NOT_AVAILABLE"}` on every verb.
+- [x] Read-only (Activity) and admin-gated (Flow) leaves restrict mutating verbs as specified; the contract stays byte-identical to the ctrl-1 sibling REQ with no controller overlap.
+- [x] `openspec validate retrofit-2026-05-25-bw2-ctrl-2 --strict` passes.

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/oas-generation/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/oas-generation/spec.md
@@ -53,3 +53,24 @@ The endpoint MAY accept `path`, `branch` (default `main`), and
 - **WHEN** `POST /api/registers/{id}/publish/github` is called without `owner` or `repo`
 - **THEN** the response MUST be HTTP 400 with an `{error}` body
 - **AND** a request with valid `owner` and `repo` MUST commit the generated OAS document to the target repository
+
+## Non-Functional Requirements
+
+- **i18n (ADR-007)**: These are administrator-facing publication/publishing JSON
+  REST endpoints. The only app-authored strings are `{error}` diagnostics on
+  unknown ids, missing `owner`/`repo`, and publish failures, which are operator
+  copy and exempt from translation. The published artefact is a machine-readable
+  OAS document, not localisable UI copy. (ADR-007 n/a.)
+- **REST/error contract (ADR-002)**: Follows OpenRegister REST conventions —
+  publish/depublish return the updated entity, `404` for unknown ids, `400` for
+  missing required `owner`/`repo`. The GitHub publish path MUST surface failures
+  as a `500` with a descriptive `{error}` body rather than leaking the
+  underlying exception trace.
+
+## Acceptance Criteria
+
+- [x] `RegistersController` and `SchemasController` publish/depublish verbs carry `@spec oas-generation#...` annotations.
+- [x] Publish/depublish toggle the entity's published state and return the updated entity; an unknown id returns `404`.
+- [x] `publishToGitHub` requires `owner` and `repo` (`400` when missing) and commits the generated OAS to the target repository on success.
+- [x] A GitHub publish failure returns `500` with a descriptive `{error}` body and no leaked trace.
+- [x] `openspec validate retrofit-2026-05-25-bw2-ctrl-2 --strict` passes.

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/openapi-generation/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/openapi-generation/spec.md
@@ -71,3 +71,26 @@ mapper/service.
 - **WHEN** its `test` endpoint is called with sample input
 - **THEN** the response MUST return the execution result
 - **AND** no entity or audit side effect MUST be persisted
+
+## Non-Functional Requirements
+
+- **i18n (ADR-007)**: These are administrator/authoring JSON REST endpoints. The
+  only app-authored strings are `{error}` diagnostics (e.g. `{error: "Schema
+  not found"}`), which are operator copy and exempt from translation. Schema
+  documents, `$ref` relationship maps, and dry-run results are machine-readable
+  artefacts, not localisable UI copy. (ADR-007 n/a.)
+- **REST/error contract (ADR-002)**: Follows OpenRegister REST conventions —
+  `404` with an `{error}` body for unknown ids, the `{results, total}` envelope
+  on sub-resource lookups, and `{incoming, outgoing, total}` on the relationship
+  endpoint. The `test` dry-run endpoints MUST return the execution result
+  (status / transformed output / structured error) WITHOUT persisting any side
+  effect, and all endpoints MUST respect the underlying mapper/service RBAC +
+  multi-tenancy filters.
+
+## Acceptance Criteria
+
+- [x] `SchemasController`, `RegistersController`, `EndpointsController`, and `MappingsController` carry `@spec openapi-generation#...` annotations for these verbs.
+- [x] `download`/`upload`/`uploadUpdate`/`related`/`explore`/`updateFromExploration` behave as specified; unknown ids return `404`.
+- [x] Register `schemas`/`objects` sub-resource lookups return their envelopes; `related` returns `{incoming, outgoing, total}`.
+- [x] `EndpointsController::test` and `MappingsController::test` run a dry-run with no persisted side effect and respect RBAC/multi-tenancy.
+- [x] `openspec validate retrofit-2026-05-25-bw2-ctrl-2 --strict` passes.

--- a/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/production-observability/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/specs/production-observability/spec.md
@@ -56,3 +56,24 @@ entries across tenants.
 - **THEN** the response MUST return that endpoint's delivery-log entries
 - **AND** `GET /api/endpoints/logs` MUST return entries across all endpoints
 - **AND** `GET /api/endpoints/{id}/logs/stats` MUST return aggregate statistics over the endpoint's log
+
+## Non-Functional Requirements
+
+- **i18n (ADR-007)**: These are operator-facing statistics/log JSON REST
+  endpoints. The only app-authored strings are `{error}` diagnostics on unknown
+  ids, which are operator copy and exempt from translation. Statistics envelopes
+  and delivery-log entries carry counts and recorded call data, not localisable
+  UI copy. (ADR-007 n/a.)
+- **REST/error contract (ADR-002)**: Follows OpenRegister REST conventions —
+  `404` with an `{error}` body for unknown ids and a consistent statistics
+  envelope. The statistics and log endpoints MUST respect the same RBAC +
+  multi-tenancy filters as the underlying mappers so counts and log entries
+  cannot be enumerated across tenants.
+
+## Acceptance Criteria
+
+- [x] `RegistersController::stats`, `SchemasController::stats`, and the `EndpointsController` log verbs carry `@spec production-observability#...` annotations.
+- [x] Register/schema `stats` return the aggregate envelope (object counts incl. total/invalid/deleted/locked/size + audit-log stats) scoped to the entity; unknown ids return `404`.
+- [x] `logs`/`logStats`/`allLogs` return per-endpoint and cross-endpoint delivery-log data as specified.
+- [x] Statistics and log endpoints respect RBAC + multi-tenancy (no cross-tenant enumeration).
+- [x] `openspec validate retrofit-2026-05-25-bw2-ctrl-2 --strict` passes.


### PR DESCRIPTION
## Summary

Two reconcile tasks on already-merged openregister retrofit changes (no canonical `openspec/specs/` files touched — archiving is separate).

- **Unify `text-extraction`**: `git mv` the `bw-svc-mid2` per-source HANDLER delta from `text-extraction-sources` -> `text-extraction` so it archives alongside the `bw2-svc-flat-2` orchestrator REQs under one `text-extraction` capability. H1 + consolidation note added; `tasks.md`/`proposal.md` references updated with a historical note. No REQ-title collision (handler REQ-001..003 vs orchestrator "File and Object Chunk-Extraction Lifecycle").
- **ff structure for controller changes**: added `## Non-Functional Requirements` (ADR-007 i18n posture + ADR-002 REST/error notes) and `## Acceptance Criteria` checklists to all 8 capability spec deltas in `bw2-ctrl-1` (generic-integrations, search-index, zoeken-filteren) and `bw2-ctrl-2` (data-import-export, generic-integrations, oas-generation, openapi-generation, production-observability).

## Test plan

- [x] `openspec validate retrofit-2026-05-25-bw-svc-mid2 --strict`
- [x] `openspec validate retrofit-2026-05-25-bw2-svc-flat-2 --strict`
- [x] `openspec validate retrofit-2026-05-25-bw2-ctrl-1 --strict`
- [x] `openspec validate retrofit-2026-05-25-bw2-ctrl-2 --strict`
- [x] No `openspec/specs/` canonical files touched