### PR TITLE
fix(ui): bump @nextcloud/vue to ^8.39.0 (nav corner sliver on NC<34)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@nextcloud/initial-state": "^2.2.0",
 				"@nextcloud/l10n": "^3.2.0",
 				"@nextcloud/router": "^3.0.0",
-				"@nextcloud/vue": "^8.16.0",
+				"@nextcloud/vue": "^8.39.0",
 				"@vueuse/core": "^10.7.2",
 				"apexcharts": "^4.0.0",
 				"axios": "^1.7.3",
@@ -4323,9 +4323,9 @@
 			}
 		},
 		"node_modules/@nextcloud/vue": {
-			"version": "8.38.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.38.0.tgz",
-			"integrity": "sha512-8wfTXUhks8e5KVtmyc66bH8+IeVMSGyV0PZmZQD/ctQwuWdH53c8vA1V4voHJ8cPHrN2pXq6WF8++4/RoW1eMw==",
+			"version": "8.39.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.39.0.tgz",
+			"integrity": "sha512-TJgrFeVr82CN8ng4y+IxMBb7mKlww7Fot22z33+Q0zKgWvi5EoQ0vYescA3Drl8cIRSGktUdFm3xO2gAqvnwoA==",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@floating-ui/dom": "^1.7.6",
@@ -4346,7 +4346,7 @@
 				"blurhash": "^2.0.5",
 				"clone": "^2.1.2",
 				"debounce": "^2.2.0",
-				"dompurify": "^3.4.1",
+				"dompurify": "^3.4.2",
 				"emoji-mart-vue-fast": "^15.0.5",
 				"escape-html": "^1.0.3",
 				"floating-vue": "^1.0.0-beta.19",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@nextcloud/initial-state": "^2.2.0",
 		"@nextcloud/l10n": "^3.2.0",
 		"@nextcloud/router": "^3.0.0",
-		"@nextcloud/vue": "^8.16.0",
+		"@nextcloud/vue": "^8.39.0",
 		"@vueuse/core": "^10.7.2",
 		"apexcharts": "^4.0.0",
 		"axios": "^1.7.3",
@@ -117,7 +117,7 @@
 	},
 	"overrides": {
 		"vue": "^2.7.16",
-		"@nextcloud/vue": "^8.16.0",
+		"@nextcloud/vue": "^8.39.0",
 		"@nextcloud/axios": "~2.5.1",
 		"stylelint": "^15.11.0",
 		"eslint": "^8.56.0",


### PR DESCRIPTION
## Problem

A small white curved sliver appears at the top of the app navigation, next to the collapse toggle, on Nextcloud < 34 (this dev server is NC 32).

## Root cause

NC 34 introduced a new app layout where `.app-content` is a rounded card (`border-radius: 16px 0 0 16px`). `@nextcloud/vue` **8.39.0** added a server-version guard (`isLegacy34 = NC major < 34`) that applies `content--legacy` / `app-navigation--legacy` to keep the old flush, square layout on NC < 34. Versions **≤ 8.38.0 lack this guard** and unconditionally render the rounded layout, so the white `.app-content` corner pokes past the still-square translucent `.app-navigation` → the sliver.

Verified live: openconnector (8.39.0) renders `app-navigation--legacy` + `border-radius: 0` and is clean; openregister/opencatalogi/pipelinq/doriath (≤8.38) show the sliver.

## Fix

Bump `@nextcloud/vue` to `^8.39.0` in both the direct dependency and the `overrides` pin (the override was the binding constraint). No code changes — the guard lives in the library. `js/` is gitignored, so CI rebuilds the bundle on release.

Part of a fleet-wide sweep across all apps built against @nextcloud/vue < 8.39.0.