### PR TITLE
feat(support-dialog): custom mount + preferences endpoint + nc-vue beta.102

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -50,6 +50,9 @@ return [
         ['name' => 'settings#index', 'url' => '/api/settings', 'verb' => 'GET'],
         ['name' => 'settings#update', 'url' => '/api/settings', 'verb' => 'PUT'],
         ['name' => 'settings#rebase', 'url' => '/api/settings/rebase', 'verb' => 'POST'],
+        // Generic per-user preferences (used by shared nextcloud-vue widgets, e.g. CnSupportDialog).
+        ['name' => 'preferences#getPreference', 'url' => '/api/preferences/{key}', 'verb' => 'GET'],
+        ['name' => 'preferences#setPreference', 'url' => '/api/preferences/{key}', 'verb' => 'PUT'],
         ['name' => 'settings#stats', 'url' => '/api/settings/stats', 'verb' => 'GET'],
 
         // Migration - Move objects between blob storage and magic tables.

--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * OpenRegister PreferencesController.
+ *
+ * Generic per-user key/value preferences, backed by Nextcloud IConfig
+ * user values. Used by shared @conduction/nextcloud-vue widgets (e.g.
+ * CnSupportDialog's "seen" flag) that need to persist a small per-user
+ * UI flag cross-device without a bespoke endpoint per feature.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://github.com/ConductionNL/openregister
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use OCA\OpenRegister\AppInfo\Application;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+/**
+ * Per-user preferences controller.
+ */
+class PreferencesController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param IRequest     $request     The request.
+     * @param IConfig      $config      The Nextcloud config (user values).
+     * @param IUserSession $userSession The user session.
+     */
+    public function __construct(
+        IRequest $request,
+        private readonly IConfig $config,
+        private readonly IUserSession $userSession,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+
+    }//end __construct()
+
+    /**
+     * Read a per-user preference value.
+     *
+     * @param string $key The preference key (kebab/alphanumeric).
+     *
+     * @return JSONResponse `{value: string|null}`.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function getPreference(string $key): JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(data: ['message' => 'Not logged in'], statusCode: Http::STATUS_UNAUTHORIZED);
+        }
+
+        $safeKey = $this->sanitizeKey(key: $key);
+        if ($safeKey === '') {
+            return new JSONResponse(data: ['message' => 'Invalid key'], statusCode: Http::STATUS_BAD_REQUEST);
+        }
+
+        $value = $this->config->getUserValue(
+            userId: $user->getUID(),
+            appName: Application::APP_ID,
+            key: 'pref_'.$safeKey,
+            default: ''
+        );
+
+        $stored = null;
+        if ($value !== '') {
+            $stored = $value;
+        }
+
+        return new JSONResponse(data: ['value' => $stored]);
+
+    }//end getPreference()
+
+    /**
+     * Write a per-user preference value. An empty value clears it.
+     *
+     * @param string $key   The preference key (kebab/alphanumeric).
+     * @param string $value The value to store (empty string clears it).
+     *
+     * @return JSONResponse `{value: string|null}`.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function setPreference(string $key, string $value=''): JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(data: ['message' => 'Not logged in'], statusCode: Http::STATUS_UNAUTHORIZED);
+        }
+
+        $safeKey = $this->sanitizeKey(key: $key);
+        if ($safeKey === '') {
+            return new JSONResponse(data: ['message' => 'Invalid key'], statusCode: Http::STATUS_BAD_REQUEST);
+        }
+
+        $stored = null;
+        if ($value === '') {
+            $this->config->deleteUserValue(
+                userId: $user->getUID(),
+                appName: Application::APP_ID,
+                key: 'pref_'.$safeKey
+            );
+        } else {
+            $this->config->setUserValue(
+                userId: $user->getUID(),
+                appName: Application::APP_ID,
+                key: 'pref_'.$safeKey,
+                value: $value
+            );
+            $stored = $value;
+        }
+
+        return new JSONResponse(data: ['value' => $stored]);
+
+    }//end setPreference()
+
+    /**
+     * Restrict keys to a safe charset so callers cannot reach arbitrary
+     * IConfig user values outside the `pref_` namespace.
+     *
+     * @param string $key The raw key.
+     *
+     * @return string The sanitised key, or '' when nothing safe remains.
+     */
+    private function sanitizeKey(string $key): string
+    {
+        $safe = preg_replace(pattern: '/[^a-z0-9-]/', replacement: '', subject: strtolower($key));
+        return substr((string) $safe, offset: 0, length: 64);
+
+    }//end sanitizeKey()
+}//end class

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/lang-json": "^6.0.1",
-				"@conduction/nextcloud-vue": "^1.0.0-beta.32",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.102",
 				"@fortawesome/fontawesome-svg-core": "^6.5.2",
 				"@fortawesome/free-solid-svg-icons": "^6.5.2",
 				"@nextcloud/axios": "~2.5.1",
@@ -163,9 +163,9 @@
 			}
 		},
 		"node_modules/@babel/eslint-parser": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.28.6.tgz",
-			"integrity": "sha512-QGmsKi2PBO/MHSQk+AAgA9R6OHQr+VqnniFE0eMWZcVcfBZoA2dKn2hUsl3Csg/Plt9opRUWdY7//VXsrIlEiA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.29.7.tgz",
+			"integrity": "sha512-zxt+UJTOMKvUt3yOg+D58MLuz334pHp93qifMFcjIIO+9hN6t+ufw2gi7vDPMpxvfnHRR+3VVXvIjineCcgyXw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -2078,9 +2078,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.46.tgz",
-			"integrity": "sha512-z6E+m70pQxLvXvgTLKDX7Oc/zkaqB79F3E/APPOjvhnKkbp3+dfX39dcPc7P3/XwWMUgBZG5UvBeKYjZSEtlfw==",
+			"version": "1.0.0-beta.102",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.102.tgz",
+			"integrity": "sha512-wF+bdqphBJXmodtXHewyKK3oEt8EmqocgZIkvN+fMX8h3/TDngs92i+AZsdOTg0vdHXwlzrGEL+ryiO8UE9Ybw==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -2094,16 +2094,21 @@
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.0.0",
 				"@microsoft/fetch-event-source": "^2.0.1",
-				"@nextcloud/dialogs": "^7.3.0",
+				"@nextcloud/dialogs": "^6.4.2",
+				"@nextcloud/event-bus": "^3.3.3",
 				"@nextcloud/notify_push": "^1.0.0",
+				"@types/react": "^18.0.0",
 				"@uiw/codemirror-theme-github": "^4.25.8",
 				"@vueuse/core": "^10.0.0",
+				"ajv": "^8.20.0",
+				"ajv-formats": "^3.0.1",
 				"apexcharts": "^4.7.0",
 				"codemirror": "^6.0.0",
 				"dompurify": "^3.0.0",
 				"gridstack": "^10.3.1",
 				"leaflet": "^1.9.0",
 				"leaflet.markercluster": "^1.5.3",
+				"linkifyjs": "^4.3.3",
 				"lodash": "^4.17.21",
 				"marked": "^15.0.0",
 				"style-mod": "^4.0.0",
@@ -2112,6 +2117,9 @@
 				"vue-color": "^2.8.2",
 				"vue-template-compiler": "^2.7.16"
 			},
+			"bin": {
+				"manifest-migrate": "src/cli/manifest-migrate.js"
+			},
 			"peerDependencies": {
 				"@nextcloud/auth": "^2.0.0 || ^3.0.0",
 				"@nextcloud/axios": "^2.0.0",
@@ -2119,86 +2127,10 @@
 				"@nextcloud/l10n": "^2.0.0 || ^3.0.0",
 				"@nextcloud/router": "^2.0.0 || ^3.0.0",
 				"@nextcloud/vue": "^8.0.0",
-				"bootstrap-vue": "^2.23.1",
 				"pinia": "^2.0.0",
 				"vue": "^2.7.0",
 				"vue-frag": "^1.4.3",
 				"vue-material-design-icons": "^5.0.0"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@nextcloud/dialogs": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-7.3.0.tgz",
-			"integrity": "sha512-pFuM10Dkvip+wSBaElcbSAN7Jynp41HJUh5kndRYpJipYl0SpNfjIe32+uNfOI43/tln4ScTlrfjIX6cK+3uHg==",
-			"license": "AGPL-3.0-or-later",
-			"dependencies": {
-				"@mdi/js": "^7.4.47",
-				"@nextcloud/auth": "^2.5.3",
-				"@nextcloud/axios": "^2.5.2",
-				"@nextcloud/browser-storage": "^0.5.0",
-				"@nextcloud/event-bus": "^3.3.3",
-				"@nextcloud/files": "^4.0.0",
-				"@nextcloud/initial-state": "^3.0.0",
-				"@nextcloud/l10n": "^3.4.1",
-				"@nextcloud/paths": "^3.0.0",
-				"@nextcloud/router": "^3.1.0",
-				"@nextcloud/sharing": "^0.4.0",
-				"@nextcloud/vue": "^9.5.0",
-				"@types/toastify-js": "^1.12.4",
-				"@vueuse/core": "^14.2.1",
-				"p-queue": "^9.0.1",
-				"toastify-js": "^1.12.0",
-				"vue": "^3.5.28",
-				"webdav": "^5.8.0"
-			},
-			"engines": {
-				"node": "^20 || ^22 || ^24"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@nextcloud/dialogs/node_modules/@nextcloud/sharing": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.4.0.tgz",
-			"integrity": "sha512-1hUNyc7uJdBpnimOnEshJjEtAPAjzDYVl6qmWqF5ZxoN9wOvbExw0QjX3xFIbHbX2dmvbRNLBj0RzLzipmZyeg==",
-			"license": "GPL-3.0-or-later",
-			"dependencies": {
-				"@nextcloud/initial-state": "^3.0.0",
-				"is-svg": "^6.1.0"
-			},
-			"engines": {
-				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
-			},
-			"optionalDependencies": {
-				"@nextcloud/files": "^3.12.2 || ^4.0.0"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@nextcloud/files": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-4.0.0.tgz",
-			"integrity": "sha512-TmecnZIS+PGWGtRh7RpGEboCT4K6iTbHULUcfR6hs3eEzjDVsCc1Ldf8popGY/70lbpdlfYle8xbXnPIo3qaXA==",
-			"license": "AGPL-3.0-or-later",
-			"dependencies": {
-				"@nextcloud/auth": "^2.5.3",
-				"@nextcloud/capabilities": "^1.2.1",
-				"@nextcloud/l10n": "^3.4.1",
-				"@nextcloud/logger": "^3.0.3",
-				"@nextcloud/paths": "^3.0.0",
-				"@nextcloud/router": "^3.1.0",
-				"@nextcloud/sharing": "^0.3.0",
-				"is-svg": "^6.1.0",
-				"typescript-event-target": "^1.1.2",
-				"webdav": "^5.9.0"
-			},
-			"engines": {
-				"node": "^24.0.0"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@nextcloud/initial-state": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-3.0.0.tgz",
-			"integrity": "sha512-cV+HBdkQJGm8FxkBI5rFT/FbMNWNBvpbj6OPrg4Ae4YOOsQ15CL8InPOAw1t4XkOkQK2NEdUGQLVUz/19wXbdQ==",
-			"license": "GPL-3.0-or-later",
-			"engines": {
-				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue/node_modules/@types/web-bluetooth": {
@@ -2208,14 +2140,14 @@
 			"license": "MIT"
 		},
 		"node_modules/@conduction/nextcloud-vue/node_modules/@vueuse/core": {
-			"version": "14.2.1",
-			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.2.1.tgz",
-			"integrity": "sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==",
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
+			"integrity": "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/web-bluetooth": "^0.0.21",
-				"@vueuse/metadata": "14.2.1",
-				"@vueuse/shared": "14.2.1"
+				"@vueuse/metadata": "14.3.0",
+				"@vueuse/shared": "14.3.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
@@ -2225,18 +2157,18 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue/node_modules/@vueuse/metadata": {
-			"version": "14.2.1",
-			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.2.1.tgz",
-			"integrity": "sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==",
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.3.0.tgz",
+			"integrity": "sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue/node_modules/@vueuse/shared": {
-			"version": "14.2.1",
-			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.2.1.tgz",
-			"integrity": "sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==",
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.3.0.tgz",
+			"integrity": "sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
@@ -2244,6 +2176,45 @@
 			"peerDependencies": {
 				"vue": "^3.5.0"
 			}
+		},
+		"node_modules/@conduction/nextcloud-vue/node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@conduction/nextcloud-vue/node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@conduction/nextcloud-vue/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
 		},
 		"node_modules/@conduction/nextcloud-vue/node_modules/marked": {
 			"version": "15.0.12",
@@ -3946,17 +3917,23 @@
 			"license": "MIT"
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "0.2.12",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-			"integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+			"integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"peer": true,
 			"dependencies": {
-				"@emnapi/core": "^1.4.3",
-				"@emnapi/runtime": "^1.4.3",
-				"@tybys/wasm-util": "^0.10.0"
+				"@tybys/wasm-util": "^0.10.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
 			}
 		},
 		"node_modules/@nextcloud/auth": {
@@ -4070,28 +4047,48 @@
 				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
+		"node_modules/@nextcloud/dialogs/node_modules/@types/web-bluetooth": {
+			"version": "0.0.21",
+			"resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+			"integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+			"license": "MIT"
+		},
 		"node_modules/@nextcloud/dialogs/node_modules/@vueuse/core": {
-			"version": "11.3.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-11.3.0.tgz",
-			"integrity": "sha512-7OC4Rl1f9G8IT6rUfi9JrKiXy4bfmHhZ5x2Ceojy0jnd3mHNEvV4JaRygH362ror6/NZ+Nl+n13LPzGiPN8cKA==",
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
+			"integrity": "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/web-bluetooth": "^0.0.20",
-				"@vueuse/metadata": "11.3.0",
-				"@vueuse/shared": "11.3.0",
-				"vue-demi": ">=0.14.10"
+				"@types/web-bluetooth": "^0.0.21",
+				"@vueuse/metadata": "14.3.0",
+				"@vueuse/shared": "14.3.0"
 			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			},
+			"peerDependencies": {
+				"vue": "^3.5.0"
+			}
+		},
+		"node_modules/@nextcloud/dialogs/node_modules/@vueuse/metadata": {
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.3.0.tgz",
+			"integrity": "sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==",
+			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
-		"node_modules/@nextcloud/dialogs/node_modules/@vueuse/metadata": {
-			"version": "11.3.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-11.3.0.tgz",
-			"integrity": "sha512-pwDnDspTqtTo2HwfLw4Rp6yywuuBdYnPYDq+mO38ZYKGebCUQC/nVj/PXSiK9HX5otxLz8Fn7ECPbjiRz2CC3g==",
+		"node_modules/@nextcloud/dialogs/node_modules/@vueuse/shared": {
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.3.0.tgz",
+			"integrity": "sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
+			},
+			"peerDependencies": {
+				"vue": "^3.5.0"
 			}
 		},
 		"node_modules/@nextcloud/eslint-config": {
@@ -4141,9 +4138,9 @@
 			}
 		},
 		"node_modules/@nextcloud/eslint-plugin/node_modules/semver": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -6718,20 +6715,10 @@
 			"version": "8.56.11",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.11.tgz",
 			"integrity": "sha512-sVBpJMf7UPo/wGecYOpk2aQya2VUGeHhe38WG7/mN5FufNSubf5VT9Uh9Uyp8/eLJpu1/tuhJ/qTo4mhSB4V4Q==",
+			"dev": true,
 			"dependencies": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
-			}
-		},
-		"node_modules/@types/eslint-scope": {
-			"version": "3.7.7",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-			"integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/eslint": "*",
-				"@types/estree": "*"
 			}
 		},
 		"node_modules/@types/estree": {
@@ -6958,6 +6945,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/prop-types": {
+			"version": "15.7.15",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+			"license": "MIT"
+		},
 		"node_modules/@types/qs": {
 			"version": "6.15.1",
 			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
@@ -6975,12 +6968,12 @@
 			"peer": true
 		},
 		"node_modules/@types/react": {
-			"version": "19.2.14",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+			"version": "18.3.29",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
+			"integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
+				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
 			}
 		},
@@ -7324,9 +7317,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -7431,9 +7424,9 @@
 			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
 		},
 		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-			"integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+			"integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
 			"cpu": [
 				"arm"
 			],
@@ -7446,9 +7439,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-android-arm64": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-			"integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+			"integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -7461,9 +7454,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-darwin-arm64": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-			"integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+			"integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
 			"cpu": [
 				"arm64"
 			],
@@ -7476,9 +7469,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-darwin-x64": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-			"integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+			"integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
 			"cpu": [
 				"x64"
 			],
@@ -7491,9 +7484,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-freebsd-x64": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-			"integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+			"integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
 			"cpu": [
 				"x64"
 			],
@@ -7506,9 +7499,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-			"integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+			"integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
 			"cpu": [
 				"arm"
 			],
@@ -7521,9 +7514,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-			"integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+			"integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
 			"cpu": [
 				"arm"
 			],
@@ -7536,9 +7529,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-			"integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+			"integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
 			"cpu": [
 				"arm64"
 			],
@@ -7554,9 +7547,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-			"integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+			"integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
 			"cpu": [
 				"arm64"
 			],
@@ -7571,10 +7564,46 @@
 			],
 			"peer": true
 		},
+		"node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+			"integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true
+		},
+		"node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+			"integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true
+		},
 		"node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-			"integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+			"integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -7590,9 +7619,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-			"integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+			"integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
 			"cpu": [
 				"riscv64"
 			],
@@ -7608,9 +7637,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-			"integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+			"integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
 			"cpu": [
 				"riscv64"
 			],
@@ -7626,9 +7655,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-			"integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+			"integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
 			"cpu": [
 				"s390x"
 			],
@@ -7644,9 +7673,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-			"integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+			"integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
 			"cpu": [
 				"x64"
 			],
@@ -7662,9 +7691,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-linux-x64-musl": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-			"integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+			"integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
 			"cpu": [
 				"x64"
 			],
@@ -7679,10 +7708,25 @@
 			],
 			"peer": true
 		},
+		"node_modules/@unrs/resolver-binding-openharmony-arm64": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+			"integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"peer": true
+		},
 		"node_modules/@unrs/resolver-binding-wasm32-wasi": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-			"integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+			"integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
 			"cpu": [
 				"wasm32"
 			],
@@ -7691,16 +7735,18 @@
 			"optional": true,
 			"peer": true,
 			"dependencies": {
-				"@napi-rs/wasm-runtime": "^0.2.11"
+				"@emnapi/core": "1.10.0",
+				"@emnapi/runtime": "1.10.0",
+				"@napi-rs/wasm-runtime": "^1.1.4"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-			"integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+			"integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
 			"cpu": [
 				"arm64"
 			],
@@ -7713,9 +7759,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-			"integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+			"integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
 			"cpu": [
 				"ia32"
 			],
@@ -7728,9 +7774,9 @@
 			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-			"integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+			"integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
 			"cpu": [
 				"x64"
 			],
@@ -9180,9 +9226,9 @@
 			"peer": true
 		},
 		"node_modules/bonjour-service": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
-			"integrity": "sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.0.tgz",
+			"integrity": "sha512-fGQtj1qdR9vIKjFiWPQd52qIqwjaYqhcI40JEiDuvlZ86E7ZBPBwY9fPgHy9r2rYGIjiRfctNPYz6OQU73ww2w==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -9320,14 +9366,14 @@
 			}
 		},
 		"node_modules/browserify-sign": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.5.tgz",
-			"integrity": "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==",
+			"version": "4.2.6",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz",
+			"integrity": "sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
 			"dependencies": {
-				"bn.js": "^5.2.2",
+				"bn.js": "^5.2.3",
 				"browserify-rsa": "^4.1.1",
 				"create-hash": "^1.2.0",
 				"create-hmac": "^1.1.7",
@@ -11452,13 +11498,13 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
-			"integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.0.tgz",
+			"integrity": "sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==",
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
-				"tapable": "^2.3.0"
+				"tapable": "^2.3.3"
 			},
 			"engines": {
 				"node": ">=10.13.0"
@@ -11876,6 +11922,7 @@
 			"version": "1.0.0-beta.5",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-exports/-/eslint-import-resolver-exports-1.0.0-beta.5.tgz",
 			"integrity": "sha512-o6t0w7muUpXr7MkUVzD5igQoDfAQvTmcPp8HEAJdNF8eOuAO+yn6I/TTyMxz9ecCwzX7e02vzlkHURoScUuidg==",
+			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -12082,9 +12129,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -14644,9 +14691,9 @@
 			}
 		},
 		"node_modules/is-bun-module/node_modules/semver": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -17356,8 +17403,7 @@
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
 			"integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/load-plugin": {
 			"version": "5.1.0",
@@ -27956,14 +28002,14 @@
 			"devOptional": true
 		},
 		"node_modules/sass": {
-			"version": "1.99.0",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
-			"integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
+			"version": "1.100.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.100.0.tgz",
+			"integrity": "sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"chokidar": "^4.0.0",
+				"chokidar": "^5.0.0",
 				"immutable": "^5.1.5",
 				"source-map-js": ">=0.6.2 <2.0.0"
 			},
@@ -27971,7 +28017,7 @@
 				"sass": "sass.js"
 			},
 			"engines": {
-				"node": ">=14.0.0"
+				"node": ">=20.19.0"
 			},
 			"optionalDependencies": {
 				"@parcel/watcher": "^2.4.1"
@@ -28017,31 +28063,31 @@
 			}
 		},
 		"node_modules/sass/node_modules/chokidar": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+			"integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"readdirp": "^4.0.1"
+				"readdirp": "^5.0.0"
 			},
 			"engines": {
-				"node": ">= 14.16.0"
+				"node": ">= 20.19.0"
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/sass/node_modules/readdirp": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+			"integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"engines": {
-				"node": ">= 14.18.0"
+				"node": ">= 20.19.0"
 			},
 			"funding": {
 				"type": "individual",
@@ -28426,9 +28472,9 @@
 			}
 		},
 		"node_modules/shell-quote": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-			"integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+			"integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -29418,9 +29464,9 @@
 			}
 		},
 		"node_modules/stylelint-config-recommended-vue/node_modules/semver": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -29642,9 +29688,9 @@
 			"dev": true
 		},
 		"node_modules/tapable": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-			"integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+			"integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -29740,9 +29786,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.47.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
-			"integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
+			"version": "5.48.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+			"integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
 			"license": "BSD-2-Clause",
 			"peer": true,
 			"dependencies": {
@@ -31305,39 +31351,42 @@
 			}
 		},
 		"node_modules/unrs-resolver": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
-			"integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+			"integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"napi-postinstall": "^0.3.0"
+				"napi-postinstall": "^0.3.4"
 			},
 			"funding": {
 				"url": "https://opencollective.com/unrs-resolver"
 			},
 			"optionalDependencies": {
-				"@unrs/resolver-binding-android-arm-eabi": "1.11.1",
-				"@unrs/resolver-binding-android-arm64": "1.11.1",
-				"@unrs/resolver-binding-darwin-arm64": "1.11.1",
-				"@unrs/resolver-binding-darwin-x64": "1.11.1",
-				"@unrs/resolver-binding-freebsd-x64": "1.11.1",
-				"@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
-				"@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
-				"@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
-				"@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
-				"@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
-				"@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
-				"@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
-				"@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
-				"@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
-				"@unrs/resolver-binding-linux-x64-musl": "1.11.1",
-				"@unrs/resolver-binding-wasm32-wasi": "1.11.1",
-				"@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
-				"@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
-				"@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+				"@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+				"@unrs/resolver-binding-android-arm64": "1.12.2",
+				"@unrs/resolver-binding-darwin-arm64": "1.12.2",
+				"@unrs/resolver-binding-darwin-x64": "1.12.2",
+				"@unrs/resolver-binding-freebsd-x64": "1.12.2",
+				"@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+				"@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+				"@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+				"@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+				"@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+				"@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+				"@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+				"@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+				"@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+				"@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+				"@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
 			}
 		},
 		"node_modules/update-browserslist-db": {
@@ -32479,13 +32528,12 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.106.2",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
-			"integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
+			"version": "5.107.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
+			"integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
 				"@types/json-schema": "^7.0.15",
 				"@webassemblyjs/ast": "^1.14.1",
@@ -32495,20 +32543,20 @@
 				"acorn-import-phases": "^1.0.3",
 				"browserslist": "^4.28.1",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.20.0",
-				"es-module-lexer": "^2.0.0",
+				"enhanced-resolve": "^5.22.0",
+				"es-module-lexer": "^2.1.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.2.11",
-				"loader-runner": "^4.3.1",
+				"loader-runner": "^4.3.2",
 				"mime-db": "^1.54.0",
 				"neo-async": "^2.6.2",
 				"schema-utils": "^4.3.3",
 				"tapable": "^2.3.0",
-				"terser-webpack-plugin": "^5.3.17",
+				"terser-webpack-plugin": "^5.5.0",
 				"watchpack": "^2.5.1",
-				"webpack-sources": "^3.3.4"
+				"webpack-sources": "^3.5.0"
 			},
 			"bin": {
 				"webpack": "bin/webpack.js"
@@ -32676,9 +32724,9 @@
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.1.tgz",
-			"integrity": "sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
+			"integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 	},
 	"dependencies": {
 		"@codemirror/lang-json": "^6.0.1",
-		"@conduction/nextcloud-vue": "^1.0.0-beta.32",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.102",
 		"@fortawesome/fontawesome-svg-core": "^6.5.2",
 		"@fortawesome/free-solid-svg-icons": "^6.5.2",
 		"@nextcloud/axios": "~2.5.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -27,6 +27,21 @@
 			@update:open="objectSidebarState.open = $event" />
 		<Modals />
 		<Dialogs />
+		<!--
+			First-open support note. OpenRegister mounts its own root
+			(not CnAppRoot yet), so the dialog is wired manually here:
+			useSupportDialog resolves the per-user "seen" flag from
+			/api/preferences/support-dialog-seen (localStorage fallback).
+			Swap to CnAppRoot's built-in auto-mount once the shell
+			migration lands and drop this block.
+		-->
+		<CnSupportDialog
+			v-if="supportVisible"
+			app-name="OpenRegister"
+			app-slug="openregister"
+			app-store-url="https://apps.nextcloud.com/apps/openregister"
+			feature-request-url="https://github.com/ConductionNL/openregister/issues/new"
+			@close="supportHide" />
 	</NcContent>
 </template>
 
@@ -34,7 +49,7 @@
 
 import Vue from 'vue'
 import { NcContent } from '@nextcloud/vue'
-import { CnObjectSidebar } from '@conduction/nextcloud-vue'
+import { CnObjectSidebar, CnSupportDialog, useSupportDialog } from '@conduction/nextcloud-vue'
 import MainMenu from './navigation/MainMenu.vue'
 import Modals from './modals/Modals.vue'
 import Dialogs from './dialogs/Dialogs.vue'
@@ -48,11 +63,23 @@ export default {
 	components: {
 		NcContent,
 		CnObjectSidebar,
+		CnSupportDialog,
 		MainMenu,
 		Modals,
 		Dialogs,
 		Views,
 		SideBars,
+	},
+	/**
+	 * Wire the first-open support note's per-user persistence (server
+	 * preferences endpoint, localStorage fallback). Manual mount because
+	 * OpenRegister does not use CnAppRoot yet.
+	 *
+	 * @return {object} `{ supportVisible, supportHide }`.
+	 */
+	setup() {
+		const { visible, hide } = useSupportDialog('openregister', { persistence: 'server' })
+		return { supportVisible: visible, supportHide: hide }
 	},
 	/**
 	 * Expose the shared object-sidebar state to descendant components.


### PR DESCRIPTION
## Summary

Brings the fleet support dialog to **OpenRegister** without waiting on the (deferred) CnAppRoot shell migration — wired manually in `App.vue`.

- **Manual mount** in `src/App.vue`: `useSupportDialog('openregister', { persistence: 'server' })` + `<CnSupportDialog>` (app name/slug/App-Store/feature-request props). A `<!-- … -->` note marks it to be removed in favour of `CnAppRoot`'s built-in auto-mount once the shell migration lands.
- **Preferences endpoint** `GET/PUT /api/preferences/{key}` (IConfig user values, `pref_*` namespace, key-sanitised) — per-user "seen" flag, cross-device, localStorage fallback. Canonical controller (mirrors pipelinq#553 / nat#68).
- **Lib bump** `@conduction/nextcloud-vue` `beta.32` → `beta.102` — pulls in `CnSupportDialog`/`useSupportDialog`.

## Gates
- `npm run build` — **green** (webpack 5.107.2 compiled, 28 pre-existing warnings, no errors). The 70-version lib jump compiles OR's source cleanly.
- `php -l` clean; `phpcs --standard=phpcs.xml` — 0 errors (3 advisory `@spec` warnings).

## Notes
- **Foundation app — not auto-merged; for review.** The lib jump is large (beta.32→102); please smoke-test in an env before merge.
- package-lock churn is from the lib bump (full install resolving the updated tree).
