### PR TITLE
fix: wire missing backend routes for Templates and Features & Roadmap nav items

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -893,6 +893,8 @@ return [
 		// Rapportage on-demand render endpoints (Phase 2).
 		['name' => 'reports#render',  'url' => '/api/reports/{id}/render',  'verb' => 'POST', 'requirements' => ['id' => '[^/]+']],
 		['name' => 'reports#preview', 'url' => '/api/reports/{id}/preview', 'verb' => 'GET',  'requirements' => ['id' => '[^/]+']],
+		['name' => 'ui#templates', 'url' => '/templates', 'verb' => 'GET'],
+		['name' => 'ui#featuresRoadmap', 'url' => '/features-roadmap', 'verb' => 'GET'],
 		['name' => 'files#page', 'url' => '/files', 'verb' => 'GET'],
 
 		// User - Profile management and authentication.

--- a/lib/Controller/UiController.php
+++ b/lib/Controller/UiController.php
@@ -599,4 +599,50 @@ class UiController extends Controller
     {
         return $this->makeSpaResponse();
     }//end endpointLogs()
+
+    /**
+     * Render templates UI
+     *
+     * Serves the Single Page Application template for the templates management interface.
+     * This route is used when users navigate to the templates section of the application.
+     *
+     * @NoAdminRequired
+     *
+     * @NoCSRFRequired
+     *
+     * @phpstan-return TemplateResponse
+     *
+     * @psalm-return TemplateResponse<200|500, array<string, mixed>>
+     *
+     * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing.
+     */
+    public function templates(): TemplateResponse
+    {
+        return $this->makeSpaResponse();
+    }//end templates()
+
+    /**
+     * Render features & roadmap UI
+     *
+     * Serves the Single Page Application template for the features and roadmap interface.
+     * This route is used when users navigate to the features & roadmap section of the application.
+     *
+     * @NoAdminRequired
+     *
+     * @NoCSRFRequired
+     *
+     * @phpstan-return TemplateResponse
+     *
+     * @psalm-return TemplateResponse<200|500, array<string, mixed>>
+     *
+     * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing.
+     */
+    public function featuresRoadmap(): TemplateResponse
+    {
+        return $this->makeSpaResponse();
+    }//end featuresRoadmap()
 }//end class


### PR DESCRIPTION
## Summary

- Both **Templates** (`/index.php/apps/openregister/templates`) and **Features & Roadmap** (`/index.php/apps/openregister/features-roadmap`) nav items returned 404 because their backend PHP page routes were never registered.
- The Vue router (`src/router/index.js`) and Vue view components (`src/views/templates/TemplatesIndex.vue`, `src/views/roadmap/FeaturesRoadmapIndex.vue`) already existed — the gap was purely on the backend.
- Fixed by adding two entries to `appinfo/routes.php` (`ui#templates` and `ui#featuresRoadmap`) and two corresponding `makeSpaResponse()` stubs in `lib/Controller/UiController.php`, matching the established pattern used by all other SPA nav routes (registers, schemas, avg, reports, etc.).

## Root cause

The view components and frontend routes were added (likely as part of the `add-features-roadmap-menu` and templates work) but the backend catch-all routes that tell Nextcloud to serve the SPA shell for those paths were never added.

## Test plan

- [ ] Navigate to `/index.php/apps/openregister/templates` — should load the SPA (no 404)
- [ ] Navigate to `/index.php/apps/openregister/features-roadmap` — should load the SPA (no 404)
- [ ] Click the **Templates** and **Features & roadmap** left-nav items — both should navigate without a page-not-found error
- [ ] All other nav items continue to work