### PR TITLE
feat(Schema): whitelist `defaultAutoShare` boolean configuration key

### DIFF
--- a/lib/Db/Schema.php
+++ b/lib/Db/Schema.php
@@ -1578,6 +1578,10 @@ class Schema extends Entity implements JsonSerializable
      *   Example: 'profile.avatar' (should contain base64 encoded image data)
      * - 'allowFiles': (bool) Whether this schema allows file attachments
      * - 'allowedTags': (array) Array of allowed file tags/types for file filtering
+     * - 'defaultAutoShare': (bool) Default value for the "Automatically publish"
+     *   toggle on the attachment upload dialog. true seeds the toggle on; absent
+     *   or false keeps it off. Users can always override per upload.
+     *   See: ConductionNL/opencatalogi#577
      *
      * @param array|string|null $configuration The configuration array/string to validate and set
      *
@@ -1648,7 +1652,7 @@ class Schema extends Entity implements JsonSerializable
     {
         $validatedConfig = [];
         $stringFields    = ['objectNameField', 'objectDescriptionField', 'objectSummaryField', 'objectImageField'];
-        $boolFields      = ['allowFiles', 'autoPublish'];
+        $boolFields      = ['allowFiles', 'autoPublish', 'defaultAutoShare'];
         $passThrough     = ['unique', 'facetCacheTtl', 'calendarProvider'];
 
         foreach ($configuration as $key => $value) {


### PR DESCRIPTION
## Summary

- `lib/Db/Schema.php::validateConfigurationArray()` strips any configuration key not in its allow-list. Adds `defaultAutoShare` to the `$boolFields` whitelist so schemas can persist the new key without it being silently dropped on save.
- Also documents the new key in `setConfiguration()`'s PHPDoc.

## Why

Read by the attachment-upload dialog (CnFilesTab in `@conduction/nextcloud-vue`, and the legacy `UploadFiles.vue` in opencatalogi) to seed the "Automatically publish" toggle from per-schema configuration. `true` = toggle on by default; absent / `false` = off (existing behaviour). Users can always override per upload — the schema value never coerces the submitted `share` field.

Without this whitelist entry, every PUT that includes `configuration.defaultAutoShare` returns 200 but the key is dropped server-side, so the consumer never sees the value. Verified by `curl -X PUT … -d '{"configuration": {…, "defaultAutoShare": true}}'`: before this change the response body's `configuration` object had no `defaultAutoShare`; after this change it round-trips intact.

## Companion PRs

- **[ConductionNL/nextcloud-vue#455](https://github.com/ConductionNL/nextcloud-vue/pull/455)** — `CnFilesTab` share toggle (active user-facing surface, rendered inside `CnObjectSidebar`'s Files tab)
- **[ConductionNL/opencatalogi#723](https://github.com/ConductionNL/opencatalogi/pull/723)** — `UploadFiles.vue` legacy modal parity + openspec change

Closes [ConductionNL/opencatalogi#577](https://github.com/ConductionNL/opencatalogi/issues/577) (backend half).

## Backward compatibility

- Strictly additive: adds one entry to an existing whitelist. No semantic change for any other key.
- Existing schemas without `defaultAutoShare` continue to behave exactly as before (validator drop = no key = treated as off downstream).
- No DB migration; the `configuration` column is already JSON. Existing persisted configs are untouched.

## Test plan

- [x] Manual: `PUT /api/schemas/{id}` with `configuration.defaultAutoShare: true` — response body now contains the key (verified locally)
- [ ] Existing PHPUnit suite passes in CI (this change touches a one-line allow-list; no new tests required unless reviewer prefers one)
- [ ] Downstream smoke: with `defaultAutoShare: true` set on a schema, the `CnFilesTab` upload dialog seeds the "Automatically publish" toggle on (verifies end-to-end once the nextcloud-vue PR is released)

🤖 Generated with [Claude Code](https://claude.com/claude-code)