### PR TITLE
spec(auth-system): register/schema read accessibility under app-group restriction

### DIFF
--- a/openspec/changes/register-schema-read-accessibility/proposal.md
+++ b/openspec/changes/register-schema-read-accessibility/proposal.md
@@ -1,0 +1,47 @@
+# Register & Schema read accessibility under app-group restriction
+
+## Problem
+
+Deployments want to restrict OpenRegister's **management surface** to a specific Nextcloud user group (e.g. "data engineers") using Nextcloud's built-in *"Limit app to groups"* setting (`occ app:enable openregister --groups <group>`). But OpenRegister is a **data platform**: its register/schema metadata and object data APIs are consumed by *other* Conduction apps (opencatalogi, decidesk, openconnector, …) on behalf of *every* user, not just the management group.
+
+Nextcloud's app-group restriction is **all-or-nothing per user**: it gates route dispatch by `IAppManager::isEnabledForUser()`, which blocks **every non-public route** for any user outside the group — including admins not in the group, and the consuming apps' calls. The only routes that bypass it are those marked `#[PublicPage]`.
+
+Empirically verified on a live instance (OR restricted to a group `rbactest` was not in):
+
+| Endpoint | Attribute | user outside group | anonymous |
+|---|---|---|---|
+| `GET /api/registers` | `@NoAdminRequired` | **412 (blocked)** | 401 |
+| `GET /api/schemas` | `@PublicPage` | 200 | 200 |
+| `GET /api/objects/{register}/{schema}` | `@PublicPage` | 200 | 200 |
+
+So today, when OR is group-restricted, **object reads and schema reads keep working** (already `@PublicPage`) but **register reads break** (`@NoAdminRequired` only) — and any consumer app that lists registers for a non-group user gets a 412.
+
+## Context
+
+- **Object & schema reads are already `@PublicPage`.** `ObjectsController::index/show` and `SchemasController::index/show` carry `#[PublicPage]` and rely on `ObjectService` / `PermissionHandler` to enforce `_rbac` + `_multitenancy` against the *resolved* session user. The register read endpoints (`RegistersController::index/show`) were never made public, so they are the outlier.
+- **`@PublicPage` bypasses BOTH the login requirement AND the app-group restriction.** That is the mechanism we rely on — but it also exposes the endpoint to fully anonymous callers, which is not always desired for register/schema *definitions* (as opposed to published catalogue data).
+- **Write gating is handled separately.** The companion security fix (`fix(security): gate register/schema create/update/delete to admin/manage`, OR PR #1949) keeps create/update/delete on `@NoAdminRequired` and enforces admin/manage authorization. Those write endpoints intentionally stay non-public, so the NC app-group restriction *also* limits management to the group — exactly the desired split. This change covers the **read** half only.
+- **Published visibility already exists in the data model.** Registers and schemas carry `published` / `depublished` timestamp fields (see `Register`/`Schema` entities). This change reuses them as the anonymous-access gate rather than introducing a new flag.
+
+## Proposed Solution
+
+Make the **register read** endpoints `@PublicPage` (objects + schemas already are) so the entire read surface survives NC app-group restriction, and add a uniform **"logged-in unless published"** guard to the register/schema read controllers so the public-page exposure does not leak definitions to the open internet:
+
+1. **`RegistersController::index` / `show`** — add `#[PublicPage]` (alongside existing `#[NoAdminRequired]` + `#[NoCSRFRequired]`).
+2. **Read-visibility guard** (registers and schemas, `index` + `show`):
+   - If a Nextcloud user is resolved on the request → serve normally (subject to existing RBAC / multitenancy scoping).
+   - If the caller is **anonymous** → return only resources whose `published` is set and not `depublished` (a published register/schema). `index` filters the result set to published-only; `show` returns `401` for an unpublished resource and the resource for a published one.
+3. **Writes unchanged** — create/update/delete stay `@NoAdminRequired` (non-public) and keep the admin/manage gating from PR #1949. Under NC app-group restriction they remain blocked for non-group users, which is the intended "management limited to the group" behaviour.
+4. **Document the deployment model** — a short note in the auth/access docs explaining that group-restricting OpenRegister limits *management* to the group while register/schema/object **reads** remain reachable (anonymous only for published resources, logged-in users subject to RBAC).
+
+## Capabilities
+
+| Capability | Type | Action |
+|---|---|---|
+| `auth-system` | backend | **Modified** — adds requirements for register/schema read endpoint accessibility under NC app-group restriction, the `#[PublicPage]` read surface, and the "logged-in unless published" anonymous-access guard |
+
+## Out of scope
+
+- The write-authorization fix (admin/manage gating on create/update/delete) — shipped in OR PR #1949.
+- Any change to object-level RBAC / multitenancy (already enforced by `ObjectService` / `PermissionHandler`).
+- A new per-resource visibility flag — this change reuses the existing `published`/`depublished` fields.

--- a/openspec/changes/register-schema-read-accessibility/specs/auth-system/spec.md
+++ b/openspec/changes/register-schema-read-accessibility/specs/auth-system/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Register and schema read endpoints MUST remain reachable when OpenRegister is restricted to a user group
+
+When an administrator limits OpenRegister to specific Nextcloud groups (the *"Limit app to groups"* setting, i.e. `occ app:enable openregister --groups <group>`), Nextcloud blocks every non-`#[PublicPage]` route for users outside those groups (dispatch is gated by `IAppManager::isEnabledForUser()`). Because OpenRegister's register, schema, and object **read** endpoints are consumed by other apps on behalf of every user, those read endpoints MUST be marked `#[PublicPage]` so they survive the app-group restriction. Write/management endpoints MUST remain non-public so that the same restriction continues to limit management to the group.
+
+#### Scenario: A user outside the restriction group can read registers and schemas
+- **GIVEN** OpenRegister is enabled only for group `data-engineers`
+- **AND** user `alice` is authenticated but is **not** a member of `data-engineers`
+- **WHEN** `alice` calls `GET /api/registers` and `GET /api/schemas`
+- **THEN** both requests MUST succeed (HTTP 200), returning the registers/schemas she is permitted to see under RBAC
+- **AND** `GET /api/objects/{register}/{schema}` MUST also succeed, scoped by `ObjectService` RBAC/multitenancy
+
+#### Scenario: A user outside the restriction group cannot manage registers or schemas
+- **GIVEN** OpenRegister is enabled only for group `data-engineers`
+- **AND** user `alice` is authenticated but is **not** a member of `data-engineers`
+- **WHEN** `alice` calls `POST`, `PUT`, `PATCH`, or `DELETE` on `/api/registers` or `/api/schemas`
+- **THEN** the request MUST NOT succeed — it is either blocked by the Nextcloud app-group restriction (non-public route) or rejected by the register/schema write authorization check (HTTP 403)
+
+### Requirement: Public read endpoints MUST require an authenticated user except for published resources
+
+Marking register/schema read endpoints `#[PublicPage]` also exposes them to fully anonymous callers. Register and schema **definitions** MUST NOT be served to anonymous callers unless the specific resource is published. A resource is *published* when its `published` field is set (non-null) and its `depublished` field is null. Authenticated users are unaffected and continue to receive results scoped by the existing RBAC / multitenancy rules.
+
+#### Scenario: Anonymous list returns only published registers/schemas
+- **GIVEN** no Nextcloud user is resolved on the request (anonymous)
+- **WHEN** the caller requests `GET /api/registers` or `GET /api/schemas`
+- **THEN** the response MUST contain only resources whose `published` is non-null and `depublished` is null
+- **AND** unpublished resources MUST be absent from the result set
+
+#### Scenario: Anonymous show of an unpublished resource is rejected
+- **GIVEN** no Nextcloud user is resolved on the request (anonymous)
+- **AND** register/schema `X` is not published
+- **WHEN** the caller requests `GET /api/registers/X` or `GET /api/schemas/X`
+- **THEN** the response MUST be HTTP 401 (authentication required)
+
+#### Scenario: Anonymous show of a published resource succeeds
+- **GIVEN** no Nextcloud user is resolved on the request (anonymous)
+- **AND** register/schema `Y` is published (`published` set, `depublished` null)
+- **WHEN** the caller requests `GET /api/registers/Y` or `GET /api/schemas/Y`
+- **THEN** the response MUST be HTTP 200 with the resource definition
+
+#### Scenario: Authenticated read is unaffected by the published gate
+- **GIVEN** user `bob` is authenticated
+- **WHEN** `bob` reads registers/schemas
+- **THEN** the published/unpublished gate MUST NOT apply — `bob` receives every resource permitted by his RBAC scope, published or not
+
+### Requirement: The published-visibility gate MUST derive from server-side entity state
+
+The decision to expose a register or schema to an anonymous caller MUST be derived from the persisted `published`/`depublished` fields on the entity, never from client-supplied request parameters. This prevents an anonymous caller from bypassing the gate by asserting visibility in the request.
+
+#### Scenario: Client cannot assert published state
+- **GIVEN** an anonymous caller requests an unpublished register `X` with a query/body parameter claiming `published=true`
+- **WHEN** the read-visibility guard evaluates the request
+- **THEN** the guard MUST ignore the client-supplied value and use the entity's persisted `published`/`depublished` fields
+- **AND** the request MUST be rejected with HTTP 401

--- a/openspec/changes/register-schema-read-accessibility/tasks.md
+++ b/openspec/changes/register-schema-read-accessibility/tasks.md
@@ -1,0 +1,44 @@
+# Tasks: Register & Schema read accessibility under app-group restriction
+
+## Phase 1 — Make the register read surface public
+
+- [ ] Add `#[PublicPage]` to `RegistersController::index` (keep existing
+      `#[NoAdminRequired]` + `#[NoCSRFRequired]`).
+- [ ] Add `#[PublicPage]` to `RegistersController::show`.
+- [ ] Confirm `SchemasController::index/show` and `ObjectsController::index/show`
+      already carry `#[PublicPage]` (no change expected — assert in a test).
+
+## Phase 2 — "Logged-in unless published" read guard
+
+- [ ] Add a private helper (shared shape across both controllers, e.g.
+      `resolveReadVisibility()`): resolves the current `IUserSession` user;
+      returns an enum/bool indicating `authenticated` vs `anonymous`.
+- [ ] `RegistersController::index` + `SchemasController::index`: when the caller
+      is anonymous, constrain the result set to resources where `published` is
+      non-null AND `depublished` is null (published-only). Authenticated callers
+      get the normal RBAC/multitenancy-scoped set.
+- [ ] `RegistersController::show` + `SchemasController::show`: when the caller is
+      anonymous and the resource is not published, return `401`; otherwise serve.
+- [ ] Ensure the guard reads `published`/`depublished` from the entity, not from
+      request params (no client-controlled bypass).
+
+## Phase 3 — Verification
+
+- [ ] Unit/integration test matrix per endpoint (register & schema, index & show):
+      authenticated-in-group, authenticated-out-of-group, anonymous+published,
+      anonymous+unpublished.
+- [ ] Runtime check: with `occ app:enable openregister --groups <group>` and a
+      user outside the group — `GET /api/registers` and `GET /api/schemas` return
+      200 (previously register list 412); object reads unaffected; create/update/
+      delete still 403/412.
+- [ ] Runtime check: anonymous `GET /api/registers` returns only published
+      registers; anonymous `GET /api/registers/{unpublished}` returns 401.
+- [ ] Restore the instance (`occ app:enable openregister`) after testing.
+
+## Phase 4 — Documentation
+
+- [ ] Add a "Restricting OpenRegister to a user group" note to the auth/access
+      docs: group restriction limits **management** to the group; register/schema/
+      object **reads** stay reachable (anonymous only for published resources,
+      logged-in users subject to RBAC). Cross-link the write-gating behaviour
+      (PR #1949).


### PR DESCRIPTION
## Summary

Openspec change capturing the **read-access** design explored with the team: how to keep register/schema/object **read** endpoints reachable when OpenRegister is restricted to a specific user group via Nextcloud's *"Limit app to groups"* setting.

This is the **design/spec** half. The companion **write-gating** security fix is OR #1949. The two together give the desired split: *management limited to the group, reads available to all consumers.*

## What the exploration found (verified live)

NC app-group restriction gates dispatch by `isEnabledForUser()` — it blocks **every non-`#[PublicPage]` route** for users outside the group (incl. admins not in the group and consuming apps):

| Endpoint | Attribute | user outside group | anon |
|---|---|---|---|
| `GET /api/registers` | `@NoAdminRequired` | **412 blocked** | 401 |
| `GET /api/schemas` | `@PublicPage` | 200 | 200 |
| `GET /api/objects/{r}/{s}` | `@PublicPage` | 200 | 200 |

Objects + schemas are already `#[PublicPage]` (RBAC still enforced internally). **Register reads are the outlier** and break under restriction.

## Proposed (this change)

1. Mark `RegistersController::index/show` `#[PublicPage]` so the whole read surface survives the restriction.
2. Add a **"logged-in unless published"** guard to register/schema reads: authenticated users get normal RBAC-scoped results; anonymous callers see only resources where `published` is set and `depublished` is null (reusing existing fields, server-side only).
3. Writes stay non-public → still blocked by the restriction for non-group users + admin/manage-gated by #1949.

## Capability

Modifies `auth-system` (adds 3 requirements: read reachability under app-group restriction; logged-in-unless-published anonymous gate; server-side derivation of the published gate).

`openspec validate --strict` passes.