### PR TITLE
spec(auth-system): object-layer RBAC fail-closed hardening (#1955, #1953)

### DIFF
--- a/openspec/changes/object-rbac-fail-closed/.openspec.yaml
+++ b/openspec/changes/object-rbac-fail-closed/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-27

--- a/openspec/changes/object-rbac-fail-closed/proposal.md
+++ b/openspec/changes/object-rbac-fail-closed/proposal.md
@@ -1,0 +1,41 @@
+---
+kind: code
+---
+
+# Object-layer RBAC fail-closed hardening
+
+## Problem
+
+Two object-layer authorization defects were found by a deep security review and **confirmed at runtime** (2026-05-27) on a live instance:
+
+1. **Object writes are default-open through to anonymous callers (#1955).** `PermissionHandler::hasGroupPermission()` returns `true` for everyone when a schema has no `authorization` block (or no entry for the requested action), and `ObjectService::checkSavePermissions()` routes create/update through it; unauthenticated requests fall through to the `public` group. Verified: an **anonymous** `POST /api/objects/decidesk/meeting` returns **201** (object created), as does a non-admin user. The register/schema *model* CRUD was hardened to default-secure in #1949 (`checkSchemaManagePermission`), but object writes were left default-open.
+
+2. **RBAC `match` evaluation fails OPEN on the SQL/list path (#1953).** The PHP/find evaluator (`ConditionMatcher`) denies when a dynamic variable (e.g. `$organisation`) resolves to `null` (fail-closed), but the SQL/list evaluator (`MagicRbacHandler::buildPropertyCondition` → `buildMatchConditions`) returns `null` for the unresolved predicate and **drops it from the AND**, degrading a multi-condition `match` rule to its surviving static predicate. Verified: for an anonymous principal (the genuine null-`$organisation` case — authenticated users auto-receive the Default Organisation), a `public` read rule `{name: …, organisation: "$organisation"}` made `GET /api/objects/{r}/{s}` (LIST) return an object that `GET /api/objects/{r}/{s}/{uuid}` (FIND) denied — a cross-tenant/visibility bypass on the list endpoint. (Single-predicate `match` rules fail closed — the bypass only manifests for multi-condition blocks.)
+
+Both are direct ADR-005 violations (RBAC must be enforced consistently across access methods; authorization must fail closed).
+
+## Context
+
+- `lib/Service/Object/PermissionHandler.php` — `hasGroupPermission()` (~917-925) is the default-open gate; `evaluatePermission()` falls through to the `public` group for unauthenticated requests.
+- `lib/Service/ObjectService.php` — `checkSavePermissions()` (~1320-1360) is the object create/update authorization entry point.
+- `lib/Db/MagicMapper/MagicRbacHandler.php` — `buildMatchConditions()` (~356-377) / `buildPropertyCondition()` (~463-466) build the SQL RBAC predicate; the null-resolution branch drops the predicate instead of emitting an impossible condition.
+- `lib/Service/ConditionMatcher.php` — the fail-closed reference behaviour (`singleConditionMatches` returns false on null dynamic value, ~144-146).
+- #1949 established the **default-secure** precedent for model CRUD; this change extends fail-closed semantics to object writes and to the SQL match evaluator.
+- **Out of scope / preserved:** legitimate public-submission use cases — a schema that *wants* anonymous writes can still declare a `public` `create`/`update` rule; only the *implicit* default for anonymous changes. Object **read** default-open is NOT changed here (separate policy question); this change only makes the SQL match evaluator agree with the PHP one (no new denials for resolvable rules).
+
+## Proposed Solution
+
+1. **Fail-closed object writes for anonymous callers.** In the object create/update authorization path, when the resolved principal is anonymous (no `IUserSession` user) and no authorization rule explicitly grants the `public` group the requested write action, DENY (403). Authenticated users are unaffected by this change (their default-open behaviour is a separate, larger policy decision tracked in #1955). This closes the anonymous write hole while preserving declared public-submission schemas.
+
+2. **Fail-closed SQL match evaluation.** In `buildMatchConditions`/`buildPropertyCondition`, a `match` property whose dynamic value resolves to `null` MUST emit an impossible predicate (`1 = 0`) for that rule rather than being dropped — mirroring `ConditionMatcher`'s fail-closed semantics — so the LIST and FIND paths produce identical verdicts. A shared test asserts list==find for unresolved-variable rules (both single- and multi-condition).
+
+## Capabilities
+
+| Capability | Type | Action |
+|---|---|---|
+| `auth-system` | backend | **Modified** — adds: object writes fail closed for anonymous unless a public-write rule is declared; SQL/list RBAC `match` evaluation fails closed on null-resolved dynamic variables (parity with the PHP/find path) |
+
+## Out of scope
+- Authenticated-user object-write default-open policy (broader decision; tracked in #1955).
+- Object-read published/visibility enforcement (separate finding family).
+- openregister #1952 (downgraded — gated by NC readability) and #1954 (dead branch) — not addressed; both reclassified LOW after runtime verification.

--- a/openspec/changes/object-rbac-fail-closed/specs/auth-system/spec.md
+++ b/openspec/changes/object-rbac-fail-closed/specs/auth-system/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Object write operations MUST fail closed for anonymous callers
+
+Creating or updating an object MUST be denied for an anonymous caller (no resolved Nextcloud user) unless the target schema's `authorization` explicitly grants the `public` group the requested write action. A schema with no `authorization` block, or no entry for the action, MUST NOT permit anonymous writes by default. Authenticated callers are out of scope of this requirement (their write authorization is governed by the existing schema RBAC rules).
+
+#### Scenario: Anonymous write to a schema with no authorization rule is denied
+- **GIVEN** a schema with no `authorization` block (or no `create`/`update` entry)
+- **WHEN** an anonymous caller sends `POST`/`PUT /api/objects/{register}/{schema}`
+- **THEN** the request MUST be rejected with HTTP 403
+- **AND** no object is created or modified
+
+#### Scenario: Anonymous write to a schema that declares public write is allowed
+- **GIVEN** a schema whose `authorization` grants the `public` group the `create` action
+- **WHEN** an anonymous caller sends `POST /api/objects/{register}/{schema}`
+- **THEN** the request MUST be allowed (the schema opted in to public submissions)
+
+#### Scenario: Authenticated write behaviour is unchanged
+- **GIVEN** an authenticated user
+- **WHEN** they create or update an object
+- **THEN** the authorization outcome MUST be identical to before this change (this requirement only constrains anonymous writes)
+
+### Requirement: SQL/list RBAC match evaluation MUST fail closed on unresolved dynamic variables
+
+When a schema `authorization` rule carries a `match` clause referencing a dynamic variable (e.g. `$organisation`, `$userId`, `$now`) that resolves to `null` for the current principal, the SQL/list-path evaluator MUST treat that match property as unsatisfiable (emit an impossible predicate, `1 = 0`) rather than dropping it. The list path and the single-object find path MUST produce identical authorization verdicts for the same rule and principal.
+
+#### Scenario: Multi-condition match with a null dynamic variable denies on both list and find
+- **GIVEN** a read rule `{ "group": "public", "match": { "name": "X", "organisation": "$organisation" } }`
+- **AND** a principal for whom `$organisation` resolves to `null`
+- **WHEN** the principal lists objects (`GET /api/objects/{register}/{schema}`) and fetches the single object (`GET /api/objects/{register}/{schema}/{uuid}`)
+- **THEN** BOTH requests MUST deny access to the object (the unresolved `organisation` predicate is not silently dropped on the list path)
+
+#### Scenario: Rules whose dynamic variables resolve are unaffected
+- **GIVEN** the same rule and a principal for whom `$organisation` resolves to a concrete value
+- **WHEN** the principal lists and finds objects
+- **THEN** access is granted exactly as before — the fail-closed change introduces no new denials for resolvable rules
+
+#### Scenario: Single-condition match parity is preserved
+- **GIVEN** a single-condition `match` rule on a dynamic variable that resolves to null
+- **WHEN** evaluated on the list and find paths
+- **THEN** both paths MUST deny (the SQL path no longer differs from the PHP path)

--- a/openspec/changes/object-rbac-fail-closed/tasks.md
+++ b/openspec/changes/object-rbac-fail-closed/tasks.md
@@ -1,0 +1,45 @@
+# Tasks: Object-layer RBAC fail-closed hardening
+
+## Phase 1 — Fail-closed object writes for anonymous (#1955)
+
+- [ ] In the object create/update authorization path (`ObjectService::checkSavePermissions`
+      and/or `PermissionHandler`), when the resolved principal is anonymous
+      (`IUserSession` has no user) AND no authorization rule explicitly grants the
+      `public` group the requested write action, return/throw a 403 denial.
+- [ ] Preserve declared public-submission: a schema whose `authorization` grants
+      `public` `create`/`update` continues to allow anonymous writes for that action.
+- [ ] Do NOT change authenticated-user write behaviour in this change (tracked
+      separately in #1955) — scope the new denial to anonymous principals.
+
+## Phase 2 — Fail-closed SQL match evaluation (#1953)
+
+- [ ] In `MagicRbacHandler::buildPropertyCondition`/`buildMatchConditions`, when a
+      `match` property's dynamic value resolves to null, emit an impossible
+      predicate (`1 = 0`) for that rule instead of dropping the condition.
+- [ ] Verify single-condition and multi-condition `match` rules now produce the
+      same verdict on LIST as the PHP/find path does (fail-closed), and that
+      rules whose variables DO resolve are unaffected (no new denials).
+
+## Phase 3 — Tests
+
+- [ ] Unit test: anonymous object create/update on a no-rule schema → denied;
+      on a schema with an explicit `public` create rule → allowed; authenticated
+      user unaffected.
+- [ ] Shared RBAC parity test: for a schema with a multi-condition `match` rule on
+      `$organisation`, a principal with null `$organisation` gets identical
+      verdicts from LIST (`searchObjects`) and FIND (`find`) — both deny.
+- [ ] Run the OR unit suite for the touched handlers; ensure no regressions.
+
+## Phase 4 — Runtime verification
+
+- [ ] Anonymous `POST /api/objects/{register}/{schema}` on a no-rule schema → 403
+      (was 201); authenticated create still works; a `public`-create schema still
+      accepts anonymous create.
+- [ ] Reproduce the #1953 setup (multi-condition `$organisation` match, anonymous
+      caller): LIST and FIND now both deny (LIST no longer leaks the object).
+- [ ] Restore the instance + clean up fixtures after verification.
+
+## Acceptance criteria
+- Anonymous writes are denied by default and only allowed where a schema declares a public-write rule.
+- SQL/list and PHP/find RBAC `match` evaluation agree (fail-closed) for null-resolved dynamic variables.
+- No new denials for rules whose variables resolve; authenticated-user write behaviour unchanged.


### PR DESCRIPTION
## Summary

Openspec **design** change (implementation to follow, per the #1950→#1951 pattern) hardening two **runtime-confirmed** object-layer RBAC defects from the deep security review:

- **#1955 — object writes default-open to anonymous.** Verified: anonymous `POST /api/objects/decidesk/meeting` → **201**. This change denies anonymous writes unless the schema declares a `public` write rule (preserving public-submission use cases). Authenticated-write policy is out of scope (broader decision, tracked in #1955).
- **#1953 — SQL/list RBAC `match` fails open on null dynamic vars.** Verified: a multi-condition `public` rule `{name, organisation:$organisation}` for an anonymous principal made LIST return an object FIND denied. This change emits `1=0` for null-resolved match predicates (parity with `ConditionMatcher`), so list==find.

Adds 2 requirements to the `auth-system` capability. `openspec validate --strict` passes.

Note: the sibling findings #1952 (downloadById) and #1954 (hasPermission null grant) were **downgraded to LOW** after runtime verification (gated by NC readability / dead branch respectively) and are deliberately NOT addressed here.