### PR TITLE
fix(routing): serve SPA for /objects, /applications/{id}, /mijn-account; rename ui#objects deep-link

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -755,6 +755,8 @@ return [
         ['name' => 'userSettings#removeGitHubToken', 'url' => '/api/user-settings/github/token', 'verb' => 'DELETE'],
         // Applications.
         ['name' => 'applications#page', 'url' => '/applications', 'verb' => 'GET'],
+        // SPA detail route — see ConductionNL/openregister#1962.
+        ['name' => 'ui#applicationDetails', 'url' => '/applications/{id}', 'verb' => 'GET', 'requirements' => ['id' => '[^/]+']],
         // Agents.
         ['name' => 'agents#page', 'url' => '/agents', 'verb' => 'GET'],
         ['name' => 'agents#stats', 'url' => '/api/agents/stats', 'verb' => 'GET'],
@@ -869,7 +871,12 @@ return [
 		// parses the {register, schema, id} params and ObjectsIndex
 		// fetches the object so its detail tabs (including the registry-
 		// driven Integrations tab) render directly.
-		['name' => 'ui#objects', 'url' => '/objects/{register}/{schema}/{id}', 'verb' => 'GET', 'requirements' => ['register' => '[^/]+', 'schema' => '[^/]+', 'id' => '[^/]+']],
+		//
+		// Distinct action name (`ui#objectDetail`) so OC's `OC\Route\Router`
+		// duplicate-route-name guard does not drop one of the two `/objects*`
+		// declarations — same pattern as `ui#integrationsView` below. See
+		// ConductionNL/openregister#1962.
+		['name' => 'ui#objectDetail', 'url' => '/objects/{register}/{schema}/{id}', 'verb' => 'GET', 'requirements' => ['register' => '[^/]+', 'schema' => '[^/]+', 'id' => '[^/]+']],
 		// Standalone integrations view (per-leaf screenshot harness target).
 		// Bypasses ObjectDetails; Vue Router resolves to IntegrationsView.vue.
 		// Has its own action `ui#integrationsView` so the duplicate-route-name
@@ -895,6 +902,8 @@ return [
 		['name' => 'reports#preview', 'url' => '/api/reports/{id}/preview', 'verb' => 'GET',  'requirements' => ['id' => '[^/]+']],
 		['name' => 'ui#templates', 'url' => '/templates', 'verb' => 'GET'],
 		['name' => 'ui#featuresRoadmap', 'url' => '/features-roadmap', 'verb' => 'GET'],
+		// SPA my-account route — see ConductionNL/openregister#1962.
+		['name' => 'ui#myAccount', 'url' => '/mijn-account', 'verb' => 'GET'],
 		['name' => 'files#page', 'url' => '/files', 'verb' => 'GET'],
 
 		// User - Profile management and authentication.

--- a/lib/Controller/UiController.php
+++ b/lib/Controller/UiController.php
@@ -645,4 +645,79 @@ class UiController extends Controller
     {
         return $this->makeSpaResponse();
     }//end featuresRoadmap()
+
+    /**
+     * Render My-account UI
+     *
+     * Serves the Single Page Application template for the per-user account page
+     * (`/mijn-account`). Mounted by the manifest as `myAccount` and reached via
+     * the settings menu. Without this route the hard-load and deep-link 404
+     * server-side. See ConductionNL/openregister#1962.
+     *
+     * @NoAdminRequired
+     *
+     * @NoCSRFRequired
+     *
+     * @phpstan-return TemplateResponse
+     *
+     * @psalm-return TemplateResponse<200|500, array<string, mixed>>
+     *
+     * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing.
+     */
+    public function myAccount(): TemplateResponse
+    {
+        return $this->makeSpaResponse();
+    }//end myAccount()
+
+    /**
+     * Render Application-detail UI
+     *
+     * Serves the Single Page Application template for `/applications/{id}`.
+     * Without this route the hard-load and deep-link 404 server-side. See
+     * ConductionNL/openregister#1962.
+     *
+     * @NoAdminRequired
+     *
+     * @NoCSRFRequired
+     *
+     * @phpstan-return TemplateResponse
+     *
+     * @psalm-return TemplateResponse<200|500, array<string, mixed>>
+     *
+     * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing.
+     */
+    public function applicationDetails(): TemplateResponse
+    {
+        return $this->makeSpaResponse();
+    }//end applicationDetails()
+
+    /**
+     * Render Object-detail (deep-link) UI
+     *
+     * Serves the Single Page Application template for
+     * `/objects/{register}/{schema}/{id}`. Has its own action name (distinct
+     * from `ui#objects`) so OC's `OC\Route\Router` duplicate-route-name guard
+     * does not drop one of the two — same trick as `ui#integrationsView` at
+     * `appinfo/routes.php`. See ConductionNL/openregister#1962.
+     *
+     * @NoAdminRequired
+     *
+     * @NoCSRFRequired
+     *
+     * @phpstan-return TemplateResponse
+     *
+     * @psalm-return TemplateResponse<200|500, array<string, mixed>>
+     *
+     * @return TemplateResponse The SPA template response
+     *
+     * @spec exclude Trivial SPA-mount route stub: delegates to makeSpaResponse() for client-side routing.
+     */
+    public function objectDetail(): TemplateResponse
+    {
+        return $this->makeSpaResponse();
+    }//end objectDetail()
 }//end class


### PR DESCRIPTION
Closes #1962.

Five OpenRegister SPA paths returned HTTP 404 server-side on hard load. The Vue SPA never mounted, so client-side vue-router could not rescue. Surfaced by walking every manifest route after the CnAppRoot shell swap (PR #1961) merged.

### Fixes per path

- **`/objects`**: Was 404ing because `appinfo/routes.php` declared `ui#objects` twice. OC's `OC\Route\Router` deduplicates by route name, so only the deep-link variant (`/objects/{register}/{schema}/{id}`) was registered. Renamed the deep-link to `ui#objectDetail` + added one-line `UiController::objectDetail()` (same trick the file already uses for `ui#integrationsView`).
- **`/applications/{id}`**: No SPA route at all. Added `ui#applicationDetails` + `UiController::applicationDetails()`.
- **`/mijn-account`**: No SPA route at all. Added `ui#myAccount` + `UiController::myAccount()`.

`/templates` and `/features-roadmap` were already fixed on `development`.

### Verification

All five paths now return 200 and serve the SPA. Verified locally after `apcu_clear_cache` + `apache2ctl graceful`:

```
/objects                  200
/objects/1/1/1            200
/applications/1           200
/templates                200
/mijn-account             200
/features-roadmap         200
```

### Scope

PHP-only. Three new controller methods, each a one-liner delegating to the existing `makeSpaResponse()` (same pattern as ~25 other SPA-mount methods).