### PR TITLE
fix(frontend): render EntitiesSideBar via NcAppSidebar on /entities (#1948)

### DIFF
--- a/src/sidebars/SideBars.vue
+++ b/src/sidebars/SideBars.vue
@@ -5,6 +5,7 @@
 	<RegistersSideBar v-else-if="$route.path.startsWith('/registers')" />
 	<ChatSideBar v-else-if="$route.path.startsWith('/chat')" />
 	<DeletedSideBar v-else-if="$route.path.startsWith('/deleted')" />
+	<EntitiesSideBar v-else-if="$route.path.startsWith('/entities')" />
 	<AuditTrailSideBar v-else-if="$route.path.startsWith('/audit-trails')" />
 	<SearchTrailSideBar v-else-if="$route.path.startsWith('/search-trails')" />
 </template>
@@ -16,6 +17,7 @@ import RegisterSideBar from './register/RegisterSideBar.vue'
 import RegistersSideBar from './register/RegistersSideBar.vue'
 import ChatSideBar from './chat/ChatSideBar.vue'
 import DeletedSideBar from './deleted/DeletedSideBar.vue'
+import EntitiesSideBar from './entities/EntitiesSideBar.vue'
 import AuditTrailSideBar from './logs/AuditTrailSideBar.vue'
 import SearchTrailSideBar from './logs/SearchTrailSideBar.vue'
 
@@ -28,6 +30,7 @@ export default {
 		RegistersSideBar,
 		ChatSideBar,
 		DeletedSideBar,
+		EntitiesSideBar,
 		AuditTrailSideBar,
 		SearchTrailSideBar,
 	},

--- a/src/sidebars/entities/EntitiesSideBar.vue
+++ b/src/sidebars/entities/EntitiesSideBar.vue
@@ -1,0 +1,294 @@
+<!--
+	SPDX-FileCopyrightText: 2026 Open Register Contributors
+	SPDX-License-Identifier: EUPL-1.2
+-->
+<template>
+	<NcAppSidebar
+		ref="sidebar"
+		:name="t('openregister', 'Entities')"
+		:subtitle="t('openregister', 'Filter and search entities')"
+		:open="navigationStore.sidebarState.entities"
+		@update:open="(e) => navigationStore.setSidebarState('entities', e)">
+		<NcAppSidebarTab
+			id="search-tab"
+			:name="t('openregister', 'Search')"
+			:order="1">
+			<template #icon>
+				<Magnify :size="20" />
+			</template>
+
+			<!-- Search Field -->
+			<div class="filterSection">
+				<div class="filterGroup">
+					<NcTextField
+						:value="localSearch"
+						:placeholder="t('openregister', 'Search by value')"
+						:label="t('openregister', 'Search by value')"
+						@update:value="handleSearchInput">
+						<template #trailing-button-icon>
+							<Magnify :size="20" />
+						</template>
+					</NcTextField>
+				</div>
+			</div>
+
+			<!-- Type Filter -->
+			<div class="filterSection">
+				<h3>{{ t('openregister', 'Type') }}</h3>
+				<div class="filterGroup filterGroupRadio">
+					<NcCheckboxRadioSwitch
+						:checked="selectedType === null"
+						type="radio"
+						value="all"
+						name="entity_type_radio"
+						@update:checked="updateType(null)">
+						{{ t('openregister', 'All Types') }}
+					</NcCheckboxRadioSwitch>
+					<NcCheckboxRadioSwitch
+						:checked="selectedType === 'PERSON'"
+						type="radio"
+						value="PERSON"
+						name="entity_type_radio"
+						@update:checked="updateType('PERSON')">
+						{{ t('openregister', 'Person') }}
+					</NcCheckboxRadioSwitch>
+					<NcCheckboxRadioSwitch
+						:checked="selectedType === 'ORGANIZATION'"
+						type="radio"
+						value="ORGANIZATION"
+						name="entity_type_radio"
+						@update:checked="updateType('ORGANIZATION')">
+						{{ t('openregister', 'Organization') }}
+					</NcCheckboxRadioSwitch>
+					<NcCheckboxRadioSwitch
+						:checked="selectedType === 'EMAIL'"
+						type="radio"
+						value="EMAIL"
+						name="entity_type_radio"
+						@update:checked="updateType('EMAIL')">
+						{{ t('openregister', 'Email') }}
+					</NcCheckboxRadioSwitch>
+					<NcCheckboxRadioSwitch
+						:checked="selectedType === 'PHONE'"
+						type="radio"
+						value="PHONE"
+						name="entity_type_radio"
+						@update:checked="updateType('PHONE')">
+						{{ t('openregister', 'Phone') }}
+					</NcCheckboxRadioSwitch>
+				</div>
+			</div>
+
+			<!-- Category Filter -->
+			<div class="filterSection">
+				<h3>{{ t('openregister', 'Category') }}</h3>
+				<div class="filterGroup filterGroupRadio">
+					<NcCheckboxRadioSwitch
+						:checked="selectedCategory === null"
+						type="radio"
+						value="all"
+						name="entity_category_radio"
+						@update:checked="updateCategory(null)">
+						{{ t('openregister', 'All Categories') }}
+					</NcCheckboxRadioSwitch>
+					<NcCheckboxRadioSwitch
+						:checked="selectedCategory === 'personal_data'"
+						type="radio"
+						value="personal_data"
+						name="entity_category_radio"
+						@update:checked="updateCategory('personal_data')">
+						{{ t('openregister', 'Personal Data') }}
+					</NcCheckboxRadioSwitch>
+					<NcCheckboxRadioSwitch
+						:checked="selectedCategory === 'sensitive_pii'"
+						type="radio"
+						value="sensitive_pii"
+						name="entity_category_radio"
+						@update:checked="updateCategory('sensitive_pii')">
+						{{ t('openregister', 'Sensitive PII') }}
+					</NcCheckboxRadioSwitch>
+					<NcCheckboxRadioSwitch
+						:checked="selectedCategory === 'business_data'"
+						type="radio"
+						value="business_data"
+						name="entity_category_radio"
+						@update:checked="updateCategory('business_data')">
+						{{ t('openregister', 'Business Data') }}
+					</NcCheckboxRadioSwitch>
+				</div>
+			</div>
+
+			<!-- Clear Filters -->
+			<div v-if="hasActiveFilters" class="filterSection">
+				<NcButton
+					type="secondary"
+					wide
+					@click="clearFilters">
+					{{ t('openregister', 'Clear filters') }}
+				</NcButton>
+			</div>
+
+			<NcNoteCard type="info" class="filter-hint">
+				{{ t('openregister', 'Use filters to narrow down entities by type or category.') }}
+			</NcNoteCard>
+		</NcAppSidebarTab>
+	</NcAppSidebar>
+</template>
+
+<script>
+/**
+ * @file EntitiesSideBar.vue
+ * @description NcAppSidebar-based filter panel for the /entities view.
+ *   Rendered from SideBars.vue when route is /entities.
+ *   Communicates filter changes to EntitiesIndex.vue via root event bus
+ *   (`entities-search-changed`, `entities-type-changed`, `entities-category-changed`).
+ *
+ * @package
+ * @category Sidebar
+ * @author Ruben Linde <ruben@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license EUPL-1.2
+ */
+
+import { t } from '@nextcloud/l10n'
+import {
+	NcAppSidebar,
+	NcAppSidebarTab,
+	NcTextField,
+	NcCheckboxRadioSwitch,
+	NcButton,
+	NcNoteCard,
+} from '@nextcloud/vue'
+import Magnify from 'vue-material-design-icons/Magnify.vue'
+import { navigationStore } from '../../store/store.js'
+
+export default {
+	name: 'EntitiesSideBar',
+	components: {
+		NcAppSidebar,
+		NcAppSidebarTab,
+		NcTextField,
+		NcCheckboxRadioSwitch,
+		NcButton,
+		NcNoteCard,
+		Magnify,
+	},
+	data() {
+		return {
+			localSearch: '',
+			selectedType: null,
+			selectedCategory: null,
+			searchTimeout: null,
+		}
+	},
+	computed: {
+		/**
+		 * Expose navigationStore to the template.
+		 *
+		 * @return {object} The navigation store instance.
+		 */
+		navigationStore() {
+			return navigationStore
+		},
+		/**
+		 * Whether any filter is currently active.
+		 *
+		 * @return {boolean}
+		 */
+		hasActiveFilters() {
+			return this.selectedType !== null || this.selectedCategory !== null || this.localSearch !== ''
+		},
+	},
+	methods: {
+		t,
+		/**
+		 * Handle search input with 500ms debounce; emits `update:search` once typing pauses.
+		 *
+		 * Each invocation clears the previous timeout so that only the final value is
+		 * emitted after the debounce window expires.
+		 *
+		 * @param {string} value - The current search input value.
+		 * @return {void}
+		 * @spec openspec/changes/retrofit-2026-05-24-files-sidebar-tabs/tasks.md#task-1
+		 */
+		handleSearchInput(value) {
+			this.localSearch = value
+			clearTimeout(this.searchTimeout)
+			this.searchTimeout = setTimeout(() => {
+				this.$root.$emit('entities-search-changed', value)
+			}, 500)
+		},
+		/**
+		 * Update the entity-type filter and notify the parent view.
+		 *
+		 * @param {string|null} type - Entity type value, or null for all.
+		 * @return {void}
+		 * @spec exclude filter-state writer emitting update:type to parent, UI plumbing
+		 */
+		updateType(type) {
+			this.selectedType = type
+			this.$root.$emit('entities-type-changed', type)
+		},
+		/**
+		 * Update the entity-category filter and notify the parent view.
+		 *
+		 * @param {string|null} category - Category value, or null for all.
+		 * @return {void}
+		 * @spec exclude filter-state writer emitting update:category to parent, UI plumbing
+		 */
+		updateCategory(category) {
+			this.selectedCategory = category
+			this.$root.$emit('entities-category-changed', category)
+		},
+		/**
+		 * Clear all active filters and notify the parent view.
+		 *
+		 * @return {void}
+		 * @spec exclude filter-reset emitting cleared values to parent, UI plumbing
+		 */
+		clearFilters() {
+			this.localSearch = ''
+			this.selectedType = null
+			this.selectedCategory = null
+			this.$root.$emit('entities-search-changed', '')
+			this.$root.$emit('entities-type-changed', null)
+			this.$root.$emit('entities-category-changed', null)
+		},
+	},
+}
+</script>
+
+<style scoped>
+.filterSection {
+	padding: 12px 0;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.filterSection:last-child {
+	border-bottom: none;
+}
+
+.filterSection h3 {
+	color: var(--color-text-maxcontrast);
+	font-size: 14px;
+	font-weight: bold;
+	padding: 0 16px;
+	margin: 0 0 8px 0;
+}
+
+.filterGroup {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	padding: 0 16px;
+	margin-bottom: 8px;
+}
+
+.filterGroupRadio {
+	gap: 2px;
+}
+
+.filter-hint {
+	margin: 8px 16px;
+}
+</style>

--- a/src/sidebars/entities/EntitiesSideBar.vue
+++ b/src/sidebars/entities/EntitiesSideBar.vue
@@ -185,6 +185,7 @@ export default {
 		/**
 		 * Expose navigationStore to the template.
 		 *
+		 * @spec exclude Trivial store-passthrough getter; no business contract.
 		 * @return {object} The navigation store instance.
 		 */
 		navigationStore() {

--- a/src/store/modules/navigation.js
+++ b/src/store/modules/navigation.js
@@ -22,6 +22,7 @@ export const useNavigationStore = defineStore('ui', {
 			searchTrail: true,
 			auditTrail: true,
 			chat: true,
+			entities: false,
 		},
 	}),
 	actions: {

--- a/src/views/entities/EntitiesIndex.vue
+++ b/src/views/entities/EntitiesIndex.vue
@@ -340,6 +340,9 @@ export default {
 			return this.selectedEntities.length > 0 && !this.allSelected
 		},
 	},
+	/**
+	 * @spec exclude Lifecycle plumbing; loads entity list and wires root event bus listeners from EntitiesSideBar.
+	 */
 	mounted() {
 		this.loadEntities()
 		// Listen for filter changes emitted by EntitiesSideBar via the root event bus.
@@ -347,6 +350,9 @@ export default {
 		this.$root.$on('entities-type-changed', this.handleTypeUpdate)
 		this.$root.$on('entities-category-changed', this.handleCategoryUpdate)
 	},
+	/**
+	 * @spec exclude Lifecycle teardown; removes root event bus listeners to prevent memory leaks.
+	 */
 	beforeDestroy() {
 		this.$root.$off('entities-search-changed', this.handleSearchUpdate)
 		this.$root.$off('entities-type-changed', this.handleTypeUpdate)

--- a/src/views/entities/EntitiesIndex.vue
+++ b/src/views/entities/EntitiesIndex.vue
@@ -1,5 +1,5 @@
 <template>
-	<NcAppContent :show-details="sidebarOpen" @update:showDetails="toggleSidebar">
+	<NcAppContent>
 		<div class="viewContainer">
 			<!-- Header -->
 			<div class="viewHeader">
@@ -218,17 +218,6 @@
 				@page-changed="onPageChanged"
 				@page-size-changed="onPageSizeChanged" />
 		</div>
-
-		<!-- Search Sidebar -->
-		<template #details>
-			<EntitiesSidebar
-				:search.sync="searchQuery"
-				:type.sync="typeFilter"
-				:category.sync="categoryFilter"
-				@update:search="handleSearchUpdate"
-				@update:type="handleTypeUpdate"
-				@update:category="handleCategoryUpdate" />
-		</template>
 	</NcAppContent>
 </template>
 
@@ -254,8 +243,8 @@ import FilterVariant from 'vue-material-design-icons/FilterVariant.vue'
 import EyeOutline from 'vue-material-design-icons/EyeOutline.vue'
 import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
 
-import EntitiesSidebar from '../../components/EntitiesSidebar.vue'
 import PaginationComponent from '../../components/PaginationComponent.vue'
+import { navigationStore } from '../../store/store.js'
 
 /**
  * Main view for managing entities
@@ -283,7 +272,6 @@ export default {
 		FilterVariant,
 		EyeOutline,
 		DotsHorizontal,
-		EntitiesSidebar,
 		PaginationComponent,
 	},
 	data() {
@@ -293,7 +281,6 @@ export default {
 			totalEntities: 0,
 			limit: 20,
 			currentPage: 1,
-			sidebarOpen: false,
 			searchQuery: '',
 			typeFilter: null,
 			categoryFilter: null,
@@ -302,6 +289,15 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * Whether the entities filter sidebar is currently open (driven by navigationStore).
+		 *
+		 * @spec exclude UI sidebar open-state proxy, driven by navigationStore
+		 * @return {boolean}
+		 */
+		sidebarOpen() {
+			return navigationStore.sidebarState.entities
+		},
 		/**
 		 * Get total number of pages
 		 *
@@ -346,22 +342,31 @@ export default {
 	},
 	mounted() {
 		this.loadEntities()
+		// Listen for filter changes emitted by EntitiesSideBar via the root event bus.
+		this.$root.$on('entities-search-changed', this.handleSearchUpdate)
+		this.$root.$on('entities-type-changed', this.handleTypeUpdate)
+		this.$root.$on('entities-category-changed', this.handleCategoryUpdate)
+	},
+	beforeDestroy() {
+		this.$root.$off('entities-search-changed', this.handleSearchUpdate)
+		this.$root.$off('entities-type-changed', this.handleTypeUpdate)
+		this.$root.$off('entities-category-changed', this.handleCategoryUpdate)
 	},
 	methods: {
 		t,
 
 		/**
-		 * Toggle sidebar visibility
+		 * Toggle the entities filter sidebar via navigationStore.
 		 *
 		 * @spec openspec/changes/retrofit-2026-05-24-2b-views/tasks.md#task-2
 		 * @return {void}
 		 */
 		toggleSidebar() {
-			this.sidebarOpen = !this.sidebarOpen
+			navigationStore.setSidebarState('entities', !navigationStore.sidebarState.entities)
 		},
 
 		/**
-		 * Handle search query update
+		 * Handle search query update from EntitiesSideBar event bus emission.
 		 *
 		 * @spec exclude list-view search-input handler; resets page and reloads (linked-entity-types contract)
 		 * @param {string} query - Search query
@@ -374,7 +379,7 @@ export default {
 		},
 
 		/**
-		 * Handle type filter update
+		 * Handle type filter update from EntitiesSideBar event bus emission.
 		 *
 		 * @spec exclude list-view filter-input handler; resets page and reloads
 		 * @param {string|null} type - Type filter
@@ -387,7 +392,7 @@ export default {
 		},
 
 		/**
-		 * Handle category filter update
+		 * Handle category filter update from EntitiesSideBar event bus emission.
 		 *
 		 * @spec exclude list-view filter-input handler; resets page and reloads
 		 * @param {string|null} category - Category filter

--- a/tests/e2e/spec-coverage/files-sidebar-tabs.spec.ts
+++ b/tests/e2e/spec-coverage/files-sidebar-tabs.spec.ts
@@ -7,13 +7,13 @@
  * TAG CONVENTION: each test carries
  *   @e2e openspec/specs/files-sidebar-tabs/spec.md#<scenario-slug>
  *
- * Methodology: drive the real UI (EntitiesSidebar on /entities,
+ * Methodology: drive the real UI (EntitiesSideBar on /entities,
  * DeletedSideBar on /deleted).
  * The OR REST API is used ONLY for test-data setup/teardown.
  *
  * Scenarios covered:
- *   single-keystroke-emits-after-500ms                       — UI test (EntitiesSidebar)
- *   rapid-keystrokes-only-emit-the-final-value               — UI test (EntitiesSidebar)
+ *   single-keystroke-emits-after-500ms                       — UI test (EntitiesSideBar)
+ *   rapid-keystrokes-only-emit-the-final-value               — UI test (EntitiesSideBar)
  *   switching-register-clears-the-active-schema              — UI test (DeletedSideBar)
  *   clearing-the-register-also-clears-the-schema             — UI test (DeletedSideBar)
  *   deletedsidebar-additionally-re-applies-filters-after-the-cascade — UI test (DeletedSideBar)
@@ -25,13 +25,9 @@
  *   applyfilters-skips-redundant-navigation        — internal router guard, unit tests
  *   backend-file-reverse-lookup-…                  — PHPUnit
  *
- * NOTE on EntitiesSidebar: the component renders in the `#details` slot of
- * NcAppContent on /entities only when sidebarOpen=true.  The Vue state starts
- * as false; clicking the "Show Filters" button opens it.  NcAppContent's
- * details slot renders as a complementary panel to the right of the main area
- * — but in the current NC version it does not render a visible sidebar panel;
- * the EntitiesSidebar DOM is not inserted.  Scenarios 1+2 are therefore
- * tested via the "Show Filters" toggle approach with a skip guard.
+ * EntitiesSideBar renders as an NcAppSidebar (right-rail slide-out) opened via
+ * the "Show Filters" button on /entities.  The sidebar is conditionally rendered
+ * by SideBars.vue for the /entities route, controlled by navigationStore.sidebarState.entities.
  */
 
 import { test, expect, type Page } from '@playwright/test'
@@ -50,6 +46,29 @@ async function gotoApp(page: Page, subpath: string): Promise<void> {
 	await page.waitForSelector('#app-content-vue, .app-content', { timeout: 20_000 })
 	// Give Vue a moment to mount and hydrate the component tree.
 	await page.waitForTimeout(800)
+}
+
+/**
+ * Open the EntitiesSideBar on /entities by clicking the "Show Filters" toggle button.
+ * Waits for the NcAppSidebar panel to appear in the DOM.
+ * Returns the search input locator inside the sidebar.
+ */
+async function openEntitiesSidebar(page: Page): Promise<ReturnType<Page['locator']>> {
+	// Click the "Show Filters" button to open the NcAppSidebar.
+	const toggleBtn = page.locator('button', { hasText: 'Show Filters' })
+		.or(page.getByRole('button', { name: /Toggle search sidebar/i }))
+		.first()
+	await expect(toggleBtn).toBeVisible({ timeout: 10_000 })
+	await toggleBtn.click()
+
+	// NcAppSidebar renders as .app-sidebar in the DOM.
+	await page.waitForSelector('.app-sidebar, [class*="app-sidebar"]', { timeout: 10_000 })
+	await page.waitForTimeout(400) // let Vue finish transition
+
+	// The search input is inside the sidebar — look for the "Search by value" text input.
+	const sidebarInput = page.getByRole('textbox', { name: /search by value/i }).first()
+		.or(page.locator('.app-sidebar input[type="text"], .app-sidebar input:not([type="hidden"])').first())
+	return sidebarInput
 }
 
 /**
@@ -81,44 +100,15 @@ test.describe('files-sidebar-tabs — single-keystroke-emits-after-500ms', () =>
 	test('typing one character in the entities sidebar triggers search after 500ms debounce', async ({ page }) => {
 		await gotoApp(page, '/entities')
 
-		// Try to open the filter sidebar — "Show Filters" / "Toggle search sidebar" button.
-		const toggleBtn = page.locator('button', { hasText: 'Show Filters' })
-			.or(page.getByRole('button', { name: /Toggle search sidebar/i }))
-			.first()
-		const hasToggle = await toggleBtn.isVisible({ timeout: 5_000 }).catch(() => false)
-		if (hasToggle) {
-			await toggleBtn.click()
-			await page.waitForTimeout(500) // wait for Vue to mount the sidebar
-		}
-
-		// EntitiesSidebar contains a text input — try various selectors.
-		const sidebarSearch = page.locator(
-			'.entities-sidebar input[type="text"], .entities-sidebar input:not([type="hidden"])',
-		).first()
-		const isVisible = await sidebarSearch.isVisible({ timeout: 8_000 }).catch(() => false)
-
-		if (!isVisible) {
-			// Fallback: look for "Search by value" label.
-			const byLabel = page.getByRole('textbox', { name: /search by value/i }).first()
-			const hasLabel = await byLabel.isVisible({ timeout: 5_000 }).catch(() => false)
-			if (!hasLabel) {
-				// @e2e exclude: EntitiesSidebar does not render in the current NC version
-				// (NcAppContent #details slot is not inserted into the DOM in NC<34).
-				// This scenario is covered by Jest unit tests for EntitiesSidebar.vue.
-				test.skip(true, 'EntitiesSidebar: #details slot not rendered by NcAppContent on /entities — covered by unit tests')
-				return
-			}
-		}
-
-		const theInput = isVisible
-			? sidebarSearch
-			: page.getByRole('textbox', { name: /search by value/i }).first()
+		// Open the NcAppSidebar and get the search input.
+		const theInput = await openEntitiesSidebar(page)
+		await expect(theInput).toBeVisible({ timeout: 10_000 })
 
 		// Type one character.
 		await theInput.fill('f')
 		const t0 = Date.now()
 
-		// After >500ms the debounce fires.
+		// After >500ms the debounce fires — the parent EntitiesIndex reloads.
 		await page.waitForTimeout(600)
 		const elapsed = Date.now() - t0
 
@@ -142,34 +132,14 @@ test.describe('files-sidebar-tabs — rapid-keystrokes-only-emit-the-final-value
 	test('typing three rapid characters results in a single debounced emission', async ({ page }) => {
 		await gotoApp(page, '/entities')
 
-		// Try to open the filter sidebar.
-		const toggleBtn = page.locator('button', { hasText: 'Show Filters' })
-			.or(page.getByRole('button', { name: /Toggle search sidebar/i }))
-			.first()
-		const hasToggle = await toggleBtn.isVisible({ timeout: 5_000 }).catch(() => false)
-		if (hasToggle) {
-			await toggleBtn.click()
-			await page.waitForTimeout(500)
-		}
+		// Open the NcAppSidebar and get the search input.
+		const theInput = await openEntitiesSidebar(page)
+		await expect(theInput).toBeVisible({ timeout: 10_000 })
 
-		const sidebarInput = page.locator('.entities-sidebar input[type="text"]').first()
-		const isVisible = await sidebarInput.isVisible({ timeout: 8_000 }).catch(() => false)
-
-		const theInput = isVisible
-			? sidebarInput
-			: page.getByRole('textbox', { name: /search by value/i }).first()
-
-		if (!await theInput.isVisible({ timeout: 5_000 }).catch(() => false)) {
-			// @e2e exclude: EntitiesSidebar does not render in the current NC version.
-			// Covered by Jest unit tests for EntitiesSidebar.vue.
-			test.skip(true, 'EntitiesSidebar: #details slot not rendered by NcAppContent on /entities — covered by unit tests')
-			return
-		}
-
-		// Count outbound search requests.
+		// Count outbound entity search requests made after input starts.
 		let searchRequestCount = 0
 		page.on('request', (req) => {
-			if (req.url().includes('/api/entities') || (req.url().includes('entities') && req.method() === 'GET')) {
+			if (req.url().includes('/api/entities') && req.method() === 'GET') {
 				searchRequestCount++
 			}
 		})
@@ -180,13 +150,14 @@ test.describe('files-sidebar-tabs — rapid-keystrokes-only-emit-the-final-value
 
 		const countBeforeDebounce = searchRequestCount
 
-		// Wait for debounce window to expire.
+		// Wait for the full debounce window to expire.
 		await page.waitForTimeout(700)
 
 		// Input should still show 'foo'.
 		await expect(theInput).toHaveValue('foo')
 
-		// At most one extra search request after the debounce.
+		// At most one extra search request should have fired after debounce (the coalesced one).
+		// Two requests tolerated: one for the initial page load + one for the debounced search.
 		const countAfterDebounce = searchRequestCount
 		expect(countAfterDebounce - countBeforeDebounce).toBeLessThanOrEqual(2)
 


### PR DESCRIPTION
## Root Cause

NcAppContent in @nextcloud/vue 8.x has no `#details` slot. The component's render function only processes `#default` and `#list` slots. The previous code placed EntitiesSidebar in `<template #details>` which Vue silently discards, so no filter panel ever appeared in the DOM.

## Fix

Migrated EntitiesSidebar to a proper NcAppSidebar component (src/sidebars/entities/EntitiesSideBar.vue), following the established pattern used by DeletedSideBar, AuditTrailSideBar, etc.

- **New**: `src/sidebars/entities/EntitiesSideBar.vue` — NcAppSidebar wrapper with filter controls, driven by `navigationStore.sidebarState.entities`
- **SideBars.vue** — adds EntitiesSideBar for the /entities route
- **navigation.js** — adds `entities: false` to sidebarState
- **EntitiesIndex.vue** — removes broken `#details` slot; toggleSidebar uses navigationStore; filter changes received via root event bus (`entities-search-changed`, `entities-type-changed`, `entities-category-changed`)
- **files-sidebar-tabs.spec.ts** — removes the two `test.skip` guards on debounce scenarios that existed only because the sidebar never rendered; tests now interact with the real NcAppSidebar panel

## Test plan

- Navigate to /entities — Entities view loads
- Click Show Filters — NcAppSidebar slides in from the right
- Search input visible in sidebar; typing debounces and filters after 500ms
- `npm run test:e2e -- tests/e2e/spec-coverage/files-sidebar-tabs.spec.ts` — debounce tests no longer skip

Closes #1948