### PR TITLE
chore(quality): resolve pre-existing psalm InvalidTemplateParam on JSONResponse<int,…> annotations (#1960)

### DIFF
--- a/lib/Controller/EndpointsController.php
+++ b/lib/Controller/EndpointsController.php
@@ -532,6 +532,11 @@ class EndpointsController extends Controller
      *
      * @psalm-suppress InvalidReturnType
      * @psalm-suppress InvalidReturnStatement
+     * @psalm-suppress InvalidTemplateParam The status code is the int echoed back from the
+     *     tested endpoint's response (`$result['statusCode']`), so it is genuinely the
+     *     full HTTP range — narrowing it would be a lie. The narrow-or-baseline
+     *     guidance from #1960 lands here on the "baseline" side; we use a focused
+     *     `@psalm-suppress` annotation to keep the noise scoped to this one method.
      *
      * @return JSONResponse JSON response with test result or error
      *

--- a/lib/Controller/RegistersController.php
+++ b/lib/Controller/RegistersController.php
@@ -470,7 +470,7 @@ class RegistersController extends Controller
      * @return JSONResponse JSON response with created register or error
      *
      * @psalm-return JSONResponse<201, Register,
-     *     array<never, never>>|JSONResponse<int, array{error: string},
+     *     array<never, never>>|JSONResponse<403|409|500, array{error: string},
      *     array<never, never>>
      *
      * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
@@ -553,7 +553,7 @@ class RegistersController extends Controller
      * @return JSONResponse JSON response with updated register or error
      *
      * @psalm-return JSONResponse<200, Register,
-     *     array<never, never>>|JSONResponse<int, array{error: string},
+     *     array<never, never>>|JSONResponse<403|404|409, array{error: string},
      *     array<never, never>>
      *
      * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
@@ -669,7 +669,7 @@ class RegistersController extends Controller
      * @return JSONResponse JSON response with patched register or error
      *
      * @psalm-return JSONResponse<200, Register,
-     *     array<never, never>>|JSONResponse<int, array{error: string},
+     *     array<never, never>>|JSONResponse<403|404|409, array{error: string},
      *     array<never, never>>
      *
      * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
@@ -696,7 +696,7 @@ class RegistersController extends Controller
      *
      * @return JSONResponse JSON response on success or error
      *
-     * @psalm-return JSONResponse<int, array{error?: string},
+     * @psalm-return JSONResponse<200|403|404|409|500, array{error?: string, objectCount?: int},
      *     array<never, never>>
      *
      * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7

--- a/lib/Controller/SchemasController.php
+++ b/lib/Controller/SchemasController.php
@@ -368,7 +368,7 @@ class SchemasController extends Controller
      * @return JSONResponse JSON response with created schema or error
      *
      * @psalm-return JSONResponse<201, Schema,
-     *     array<never, never>>|JSONResponse<int, array{error: string},
+     *     array<never, never>>|JSONResponse<400|403|409|500, array{error: string},
      *     array<never, never>>
      *
      * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
@@ -505,7 +505,7 @@ class SchemasController extends Controller
      * @return JSONResponse JSON response with updated schema or error
      *
      * @psalm-return JSONResponse<200, Schema,
-     *     array<never, never>>|JSONResponse<int, array{error: string},
+     *     array<never, never>>|JSONResponse<400|403|404|409|500, array{error: string},
      *     array<never, never>>
      *
      * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
@@ -645,7 +645,7 @@ class SchemasController extends Controller
      * @return JSONResponse JSON response with patched schema or error
      *
      * @psalm-return JSONResponse<200, Schema,
-     *     array<never, never>>|JSONResponse<int, array{error: string},
+     *     array<never, never>>|JSONResponse<400|403|404|409|500, array{error: string},
      *     array<never, never>>
      *
      * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7

--- a/lib/Controller/UserSettingsController.php
+++ b/lib/Controller/UserSettingsController.php
@@ -153,7 +153,7 @@ class UserSettingsController extends Controller
      *
      * @return JSONResponse JSON response containing result of token save operation
      *
-     * @psalm-return JSONResponse<int,
+     * @psalm-return JSONResponse<200|400|401|500,
      *     array{error?: string, success?: true,
      *     message?: 'GitHub token saved successfully'},
      *     array<never, never>>


### PR DESCRIPTION
Psalm emitted 9 `InvalidTemplateParam` errors across `lib/Controller/` because the `JSONResponse<S, …>` template `S` expects the literal HTTP status-code union (`100|101|…|511`), not the generic `int`. Issue #1960's guidance: narrow if findings are ≤ ~30, baseline if > 30. With 9 total, narrowing is the right call.

## Changes

### Narrowed (8 sites)

Each `@psalm-return JSONResponse<int, …>` was replaced with the actual status union the method can return, read off the `return new JSONResponse(…, statusCode: N)` call sites:

**RegistersController.php**
- `create()` — error branch -> `403|409|500` (admin-only 403, `DBException` → `DatabaseConstraintException::fromDatabaseException` which always emits 409, catch-all 500).
- `update()` + `patch()` — error branch -> `403|404|409` (find→404, permission→403, `DBException`/`DatabaseConstraintException`→409; no broad `Exception` catch in this path).
- `destroy()` — narrowed to `200|403|404|409|500` (200 on success, permission→403, find→404, has-objects / `ValidationException` → 409, catch-all 500). Data key `objectCount?` made optional in the array shape so the cascade-protection branch type-checks.

**SchemasController.php**
- `create()` — error branch -> `400|403|409|500` (admin-only 403, validation-heuristic 400, constraint 409, catch-all 500).
- `update()` + `patch()` — error branch -> `400|403|404|409|500` (find→404, permission→403, validation 400, DB 409, catch-all 500).

**UserSettingsController.php**
- `setGitHubToken()` — narrowed to `200|400|401|500` (auth→401, missing-or-invalid-token→400, success→200, catch-all→500).

### Focused suppress (1 site)

**EndpointsController.php `test()`** is genuinely unbounded — `$result['statusCode']` is the literal int echoed back from the tested endpoint's response, so the method really can return any HTTP status. Narrowing here would be a lie.

Per the issue's "narrow OR baseline, document the rationale" guidance, I added a focused `@psalm-suppress InvalidTemplateParam` (with the rationale inline) instead of polluting `psalm-baseline.xml` with a single entry. Suppression is scoped to this one method, not the whole class.

## Verification

- `vendor/bin/psalm lib/Controller/` reports **0 `InvalidTemplateParam`**.
- Full-project `vendor/bin/psalm` reports **0 `InvalidTemplateParam`**.
- No new psalm errors of any other kind introduced in the changed files.
- `php -l` clean on all four files.
- `phpcs` on the four files: **0 errors**, 1 pre-existing class-level `@spec`-tag warning unrelated to this diff.
- Smoke test: `GET /api/registers` and `GET /api/schemas` still return 200.

Closes #1960