### PR TITLE
fix(search-sidebar): re-apply route query on register-list arrival; widen e2e waits

### DIFF
--- a/src/sidebars/search/SearchSideBar.vue
+++ b/src/sidebars/search/SearchSideBar.vue
@@ -700,6 +700,25 @@ export default {
 			},
 			deep: true,
 		},
+		// Re-apply the query params once the register list arrives. The mount-
+		// time `applyQueryParamsFromRoute()` retry loop (10 × 200ms) is shorter
+		// than the actual `_extend=schemas&stats` register-list response on
+		// busy dev envs (~5s observed), so deep-links with ?register=… stayed
+		// empty and downstream tables never populated. Reacting to the list
+		// transition closes that race without polling. See the e2e investigation
+		// in tests/e2e/spec-coverage/{entity-management-modals, saved-search-views}.
+		'$root.registerStore.registerList': {
+			/**
+			 * @spec exclude Vue watch handler plumbing; re-runs applyQueryParamsFromRoute when the register list finishes loading on /tables deep-links.
+			 */
+			handler(newList) {
+				if (this.$route.path !== '/tables') return
+				if (Array.isArray(newList) === false || newList.length === 0) return
+				if (this.$route.query.register === undefined) return
+				if (this.selectedRegisters.length > 0) return
+				this.applyQueryParamsFromRoute()
+			},
+		},
 		// Watch for schema changes to initialize properties
 		// Use immediate: true equivalent in mounted
 		// This watcher will update properties when schema changes

--- a/tests/e2e/spec-coverage/entity-management-modals.spec.ts
+++ b/tests/e2e/spec-coverage/entity-management-modals.spec.ts
@@ -340,10 +340,11 @@ test.describe('entity-management-modals — copy-single-object-names-the-duplica
 
 		// Wait for the table to populate (search fires via route watcher).
 		// The CnDataTable tbody rows appear once the API returns results.
-		// 30s budget: in busy dev envs the register list `_extend=schemas&stats`
-		// call alone can take ~5s; the route-watched search then takes another
-		// few seconds. Pairs with the SearchSideBar `registerList` watcher fix.
-		await page.waitForSelector('tbody tr, [role="row"]', { timeout: 30_000 })
+		// 45s budget: in busy dev envs the register list
+		// `_extend=schemas&_extend=@self.stats` call can take >15s; the
+		// route-watched search then takes another few seconds. Test global
+		// budget is 60s. Pairs with the SearchSideBar `registerList` watcher fix.
+		await page.waitForSelector('tbody tr, [role="row"]', { timeout: 45_000 })
 		await page.waitForTimeout(1000)
 
 		// Find the row containing our test object.

--- a/tests/e2e/spec-coverage/entity-management-modals.spec.ts
+++ b/tests/e2e/spec-coverage/entity-management-modals.spec.ts
@@ -340,7 +340,10 @@ test.describe('entity-management-modals — copy-single-object-names-the-duplica
 
 		// Wait for the table to populate (search fires via route watcher).
 		// The CnDataTable tbody rows appear once the API returns results.
-		await page.waitForSelector('tbody tr, [role="row"]', { timeout: 15_000 })
+		// 30s budget: in busy dev envs the register list `_extend=schemas&stats`
+		// call alone can take ~5s; the route-watched search then takes another
+		// few seconds. Pairs with the SearchSideBar `registerList` watcher fix.
+		await page.waitForSelector('tbody tr, [role="row"]', { timeout: 30_000 })
 		await page.waitForTimeout(1000)
 
 		// Find the row containing our test object.

--- a/tests/e2e/spec-coverage/saved-search-views.spec.ts
+++ b/tests/e2e/spec-coverage/saved-search-views.spec.ts
@@ -69,10 +69,11 @@ async function selectRegisterAndSchema(page: Page): Promise<boolean> {
 	if (!hasRegister) return false
 
 	// The combobox is `:disabled="registerLoading"` while the registers list
-	// is fetched (`_extend=schemas&stats` is ~5s on busy dev envs). Await the
-	// `disabled` flag clearing before clicking, otherwise the click no-ops
-	// against the disabled host until the global 30s timeout fires.
-	await expect(registerCombo).toBeEnabled({ timeout: 15_000 })
+	// is fetched (`_extend=schemas&_extend=@self.stats` can take >15s on
+	// busy dev envs with many registers). Await the `disabled` flag clearing
+	// before clicking, otherwise the click no-ops against the disabled host.
+	// 30s budget keeps under the test's global 60s budget.
+	await expect(registerCombo).toBeEnabled({ timeout: 30_000 })
 
 	await registerCombo.click()
 	// Pick LarpingApp Register (register 8).

--- a/tests/e2e/spec-coverage/saved-search-views.spec.ts
+++ b/tests/e2e/spec-coverage/saved-search-views.spec.ts
@@ -68,6 +68,12 @@ async function selectRegisterAndSchema(page: Page): Promise<boolean> {
 	const hasRegister = await registerCombo.isVisible({ timeout: 5_000 }).catch(() => false)
 	if (!hasRegister) return false
 
+	// The combobox is `:disabled="registerLoading"` while the registers list
+	// is fetched (`_extend=schemas&stats` is ~5s on busy dev envs). Await the
+	// `disabled` flag clearing before clicking, otherwise the click no-ops
+	// against the disabled host until the global 30s timeout fires.
+	await expect(registerCombo).toBeEnabled({ timeout: 15_000 })
+
 	await registerCombo.click()
 	// Pick LarpingApp Register (register 8).
 	const opt = page.getByRole('option', { name: /LarpingApp Register/i })


### PR DESCRIPTION
Closes two pre-existing Playwright spec-coverage failures (entity-management-modals copy-object, saved-search-views filter). Both share one root cause: `/api/registers?_extend=schemas&_extend=@self.stats` takes ~5s on busy dev envs (94 registers × schemas × stats), longer than several short timers in the search-sidebar mount path.

## Fixes

- `src/sidebars/search/SearchSideBar.vue` — add a watcher on `registerStore.registerList` that re-runs `applyQueryParamsFromRoute()` when the list transitions empty → populated and the route still carries a `?register=` query. Closes the mount-time race without polling. Additive (existing logic untouched; early-returns when `selectedRegisters.length > 0`).
- `tests/e2e/spec-coverage/entity-management-modals.spec.ts:343` — widen `tbody tr` wait from 15s to 30s. Test global budget is 60s.
- `tests/e2e/spec-coverage/saved-search-views.spec.ts` selectRegisterAndSchema helper — add `await expect(registerCombo).toBeEnabled({timeout:15_000})` between visible-check and click, avoiding no-op clicks against the disabled-during-loading combobox.

## Verification

Build + PW run pending (rebuild in progress to deploy the SearchSideBar watcher; will update + merge after verification).