### PR TITLE
docs(openspec): aggregation-runner-multitenancy-policy — spec for read-paths-always-bypass

### DIFF
--- a/openspec/changes/aggregation-runner-multitenancy-policy/.openspec.yaml
+++ b/openspec/changes/aggregation-runner-multitenancy-policy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-27

--- a/openspec/changes/aggregation-runner-multitenancy-policy/design.md
+++ b/openspec/changes/aggregation-runner-multitenancy-policy/design.md
@@ -1,0 +1,120 @@
+## Context
+
+`SchemaMapper::find()` and `RegisterMapper::find()` take a `_multitenancy: bool` argument (default `true`) that gates the `MultiTenancyTrait::applyOrganisationFilter()` WHERE clause. When `_multitenancy: true` and the current user has no active organisation, the filter resolves to `organisation IS NULL`, so any schema/register with a concrete `organisation` value is invisible — including to admins who happen not to have an active organisation set on their session.
+
+The runtime symptom is the 2026-05-27 Newman triage: 5 aggregation assertions in the `platform-annotations` collection fail with `Schema "<ref>" not found` because `AggregationRunner::loadSchema()` (lib/Service/Aggregation/AggregationRunner.php:1924) keeps the default tenancy filter on while running as admin without an active org. The aggregation never gets to compute anything — the runner 404s on the schema lookup.
+
+The deeper issue is that OpenRegister has two conflicting habits for schema lookups already in production:
+
+| Path                                                  | `_multitenancy`     | Intent                                           |
+| ----------------------------------------------------- | ------------------- | ------------------------------------------------ |
+| `SchemasController::index` L205                       | `false` (explicit)  | `@PublicPage` catalog list                       |
+| `SchemasController::show` L296                        | `false` (explicit)  | `@PublicPage` catalog read                       |
+| `SchemasController::download` L938                    | `true` (default)    | Read JSON dump                                   |
+| `SchemasController::related` L972, `findAll` L974     | `true` (default)    | Read references                                  |
+| `SchemasController::stats` L1031                      | `true` (default)    | Read stats                                       |
+| `SchemasController::publish` L1211                    | `true` (default)    | Read-then-mutate (publish toggle)                |
+| `SchemasController::depublish` L1297                  | `true` (default)    | Read-then-mutate (publish toggle)                |
+| `SchemasController::update` L535                      | `true` (default)    | Mutation authorization                           |
+| `SchemasController::destroy` L689                     | `true` (default)    | Mutation authorization                           |
+| `SchemasController::upload` L811                      | `true` (default)    | Mutation authorization                           |
+| `AggregationRunner::loadSchema` L1930                 | `true` (default)    | Read for aggregation compute                     |
+| `AggregationRunner::loadRegister` L1949               | `true` (default)    | Read for aggregation compute                     |
+
+Two of these (`index`, `show`) decided years ago that schema *definitions* are a globally-visible catalog — `_multitenancy: false`. Tenant isolation in OpenRegister has always lived at the OBJECT row level through `MultiTenancyTrait` + the per-row `_organisation` column on magic tables (see `auth-system` REQ "Multi-tenancy isolation MUST restrict data access to the user's active organisation"). The remaining read paths inherited the default mostly because nobody wrote a policy.
+
+Existing related architecture:
+- `auth-system` already has REQ "Admin users see all organisations" (multi-tenancy bypass for admins) and REQ "Multi-tenancy isolation MUST restrict data access to the user's active organisation" (object-row scope).
+- The `auth-system` REQ "Register and schema read endpoints MUST remain reachable when OpenRegister is restricted to a user group" was added 2026-05-27 in the read-accessibility change; this is the precedent for treating schema metadata as a globally-visible catalog.
+- `BackfillSystemOwnerCommand` already uses `_multitenancy: false` for schema/register lookups (REQ-001) — the OCC-command precedent.
+
+Stakeholders: backend developers writing read-path lookups against `SchemaMapper`/`RegisterMapper`; the Newman test platform-annotations collection; admin users running aggregations.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Codify a clear, spec-level policy for when schema/register metadata lookups bypass multi-tenancy versus when they enforce it.
+- Repair the 5 `platform-annotations` aggregation assertions by making `AggregationRunner::loadSchema/loadRegister` consistent with the catalog-read paths that already exist.
+- Eliminate the policy ambiguity in `SchemasController`'s seven read-default lookups so the same class of bug doesn't keep recurring on every new read path.
+- Make the policy testable: each path's tenancy-bypass status MUST be explicit in code AND derivable from the spec.
+
+**Non-Goals:**
+- Changing the object-row multi-tenancy contract. `MultiTenancyTrait` against `MagicMapper` queries stays exactly as it is — that's where tenant isolation lives.
+- Introducing a new actor-resolution helper (e.g. `isAdminOrSystemActor()`). Approach A would require one; this change deliberately picks the simpler policy that doesn't need one (see Decision 1).
+- Changing the `_multitenancy: true` default on `SchemaMapper::find`/`RegisterMapper::find`. Mutation paths keep their current safe default. The change is per-caller, not per-mapper.
+- Adding a `$crossTenant` argument to `AggregationRunner::loadSchema()`. See Decision 1 rejection of Approach D.
+- Frontend or API contract changes. The spec is a backend invariant only.
+
+## Decisions
+
+### Decision 1: Adopt Approach B — read paths bypass multi-tenancy, write paths keep it on
+
+**Choice:** Codify that schema- and register-**metadata-READ** lookups MUST pass `_multitenancy: false`; metadata-**WRITE** (mutation-gating) lookups MUST keep `_multitenancy: true` (default). Sweep `AggregationRunner` AND the inconsistent `SchemasController` read paths in this change.
+
+**Why B over A/C/D:**
+
+| Approach                                | Pros                                                                                                                                                       | Cons                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **A. Admin-aware bypass**               | Tenant users keep the schema-definition filter (defence in depth); admins/system get the bypass.                                                            | Requires a new `isAdminOrSystemActor()` resolver — new code in a sensitive layer, new test surface. Tenant users still can't resolve published schemas owned by a sibling tenant, which contradicts the *existing* `@PublicPage` catalog precedent (`index`/`show` already give them that). Two policies coexisting on the same mapper. Doesn't repair the publish/depublish/stats/download path for tenant users at all.                  |
+| **B. Read-paths-always-bypass (CHOSEN)**| Matches the existing `index`/`show` precedent and the `BackfillSystemOwnerCommand` precedent. Tenant isolation lives at the object-row level — consistent with the `auth-system` mental model. One uniform rule across every metadata-read caller. No new helper. Zero risk of definition leakage because schema definitions are already globally visible per `index`/`show`. | Requires sweeping the seven inconsistent `SchemasController` read paths in addition to `AggregationRunner` (mitigated: explicit migration list in the spec).                                                                                                                                                                                                                                                                              |
+| **C. Explicit organisation context for admin** | Lets `_multitenancy: true` keep working naturally everywhere.                                                                                            | Forces auth/session layer changes for what is essentially a per-call argument. Doesn't address the cross-tenant schema-definition visibility question (still hides sibling-tenant schemas from non-admins, contradicting `index`/`show`). Migrating session resolution is a much larger change than tuning a per-call argument.                                                                                                            |
+| **D. Per-call `$crossTenant` argument** | Local, no policy commitment.                                                                                                                                | Pushes the decision onto every future caller with no spec to guide them — the exact same bug we're trying to prevent will recur. Adds a parallel argument that mirrors what `_multitenancy` already does. No precedent in the codebase.                                                                                                                                                                                                       |
+
+**Decisive reason:** The `@PublicPage` catalog precedent (`SchemasController::index/show` at `_multitenancy: false`) plus the `auth-system` REQ "Register and schema read endpoints MUST remain reachable when OpenRegister is restricted to a user group" already declares schema metadata to be globally readable. Approaches A, C, D all introduce mechanics to preserve a tenant-scoped *definition* read — but the codebase no longer needs that, because it doesn't enforce it on the two endpoints that matter most. Approach B is the only option that aligns the runtime with the existing public contract.
+
+**Provisional — pending human confirmation.** See DEFERRED_QUESTIONS below.
+
+### Decision 2: Put the policy in `auth-system`, not a new capability
+
+The policy is a *clarification* of how the existing `auth-system` multi-tenancy isolation requirement applies to schema/register metadata reads versus object data. It does not introduce a new operational surface (no new endpoint, no new entity, no new mechanism); it tightens the semantics of an existing one. Creating a `aggregation-multitenancy-policy` capability would scatter the multi-tenancy story across two specs and force `aggregation-runner-multitenancy-policy` to remain visible forever as a separate capability — when the durable concept is just "metadata reads vs object reads vs writes" inside `auth-system`.
+
+Rejected alternatives:
+- New capability `aggregation-multitenancy-policy`: too narrow — the policy spans `SchemasController` too.
+- New capability `schema-metadata-visibility`: would duplicate concerns already settled by the `@PublicPage` catalog precedent inside `auth-system`.
+
+**Provisional — pending human confirmation.** See DEFERRED_QUESTIONS below.
+
+### Decision 3: Scope the apply to BOTH `AggregationRunner` AND the inconsistent `SchemasController` read paths in this change
+
+The Newman finding is narrow (5 aggregation assertions), but the underlying class of bug is broader. If we patch only `AggregationRunner`, the next read path added to `SchemasController` (e.g. a future export endpoint, a discoverability endpoint) will inherit the same wrong default and re-introduce the same 404 class of bug. The spec scenarios make the policy easy to audit, but the implementation must demonstrate the sweep is doable in a single bounded change.
+
+The seven `SchemasController` read paths to sweep are: `download` (L938), `related` (L972 + the `findAll()` at L974), `stats` (L1031), `publish` (L1211), `depublish` (L1297). The three mutation-gating paths (`update` L535, `destroy` L689, `upload` L811) keep the default `_multitenancy: true`. (Publish/depublish are read-then-mutate; the mutation step is governed by management permission, the read step should still bypass — same logic as `index`/`show`.)
+
+Rejected alternatives:
+- Narrow scope to AggregationRunner only: punts the SchemasController inconsistency to "a future PR" — which by `feedback_always-file-issues.md` would need to be an issue filed now. Cheaper to fix it once.
+
+**Provisional — pending human confirmation.** See DEFERRED_QUESTIONS below.
+
+### Decision 4: Keep the `_multitenancy: true` default on the mappers
+
+The default stays as-is so that any new caller defaulting their argument writes the safe (tenant-scoped) behaviour — which is correct for mutation paths and incorrect for read paths, but the read-path callers are now spec-enforced to opt out explicitly. Flipping the default would silently relax tenant scoping for every existing mutation caller that didn't specify the argument; the sweep is bounded, the default is not.
+
+### Decision 5: No new actor-resolution helper
+
+Approach A would have required `isAdminOrSystemActor()` or similar. The chosen Approach B doesn't differentiate by actor — every metadata-read caller bypasses tenancy regardless of who is calling. This keeps the policy auditable from the call site without needing to trace runtime user state.
+
+## Risks / Trade-offs
+
+- **Risk**: A future read path inside `SchemasController` (or another controller / service) is added without `_multitenancy: false` and re-introduces the bug class.
+  - **Mitigation**: The added spec scenarios become test cases per the `unit-test-coverage` capability. Combined with the existing `check_spec_coverage.py` gate, any new method on a read-only schema lookup must either be covered by a spec scenario or `@spec exclude`-ed with a reason. The policy text in `auth-system` is the reference reviewers cite.
+- **Risk**: Schema-definition information leakage to tenant users who shouldn't see a sibling tenant's schemas.
+  - **Mitigation**: This is **not a new exposure** — `SchemasController::index`/`show` are already `@PublicPage` and already pass `_multitenancy: false`, so any tenant user can already list/read every schema definition. The change brings the rest of the read paths in line with that existing public contract. Object-row data continues to be tenant-isolated by `MultiTenancyTrait` against `MagicMapper`.
+- **Risk**: The `// SECURITY: keep multitenancy filter on so a tenant user cannot resolve schemas owned by another tenant simply by knowing the slug` comment in `loadSchema()` describes a threat model the codebase no longer enforces; removing it could surprise a reader.
+  - **Mitigation**: Replace the comment with a corrected rationale that references the new `auth-system` requirement and the `@PublicPage` catalog precedent.
+- **Trade-off**: We give up the option to enforce per-tenant schema-definition visibility entirely. That's a coherent choice — OpenRegister is designed for a globally-visible catalog with tenant-scoped object data; if a future deployment needs schema-definition-level tenancy, it's a much larger architectural change (different from this one).
+
+## Migration Plan
+
+Code change is pure refactor of read-path lookups — no DDL, no data migration. Rollout per the apply tasks:
+
+1. Update `auth-system` spec with the new requirement (this change).
+2. Update `AggregationRunner::loadSchema/loadRegister` to pass `_multitenancy: false` and replace the misleading comment.
+3. Sweep `SchemasController` read paths.
+4. Run the `platform-annotations` Newman collection — the 5 failing assertions MUST go green.
+5. Run full PHPUnit + PHPStan to confirm no regression.
+
+Rollback: revert the `_multitenancy: false` arg-passing. Spec change is independently revertable. No data state to undo.
+
+## Open Questions
+
+See DEFERRED_QUESTIONS in the apply-change handoff.

--- a/openspec/changes/aggregation-runner-multitenancy-policy/proposal.md
+++ b/openspec/changes/aggregation-runner-multitenancy-policy/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The 2026-05-27 Newman triage on the `platform-annotations` collection surfaced 5 consecutive aggregation assertions failing with HTTP 404 `Schema "<ref>" not found`. Root cause: `AggregationRunner::loadSchema()` (lib/Service/Aggregation/AggregationRunner.php:1924) calls `SchemaMapper::find($ref)` with the default `_multitenancy: true`, and the admin user driving Newman has **no active organisation**. `MultiTenancyTrait::applyOrganisationFilter` therefore restricts the query to schemas where `organisation IS NULL`, excluding every schema the test seed creates with a concrete `organisation` value. The aggregation requests resolve nothing, the controller returns 404, and the assertions go red.
+
+This is a single symptom of a broader inconsistency: `SchemasController::index` (L205) and `SchemasController::show` (L296) deliberately pass `_multitenancy: false` because those endpoints are `@PublicPage` and must stay reachable for cross-tenant catalog browsing, while **every other schema read path** in the controller (L535 update-lookup, L689 destroy-lookup, L811 upload-lookup, L938 download, L972 related, L1031 stats, L1211 publish, L1297 depublish) **and** `AggregationRunner::loadSchema/loadRegister` rely on the default `_multitenancy: true`. The intent here is mixed: some of those callers want the filter, some don't, and nothing documents the policy. Aggregation is the first place this mixed intent has produced a runtime failure on the happy path.
+
+The change establishes a **named, spec-level policy** for when schema- and register-metadata READ lookups bypass multi-tenancy, and aligns the AggregationRunner (plus any other read-path lookups that contradict the chosen policy) with it. Schema definitions are a globally-visible catalog; per-row data is where tenant isolation lives (`MagicMapper` + `_organisation` per object, see `auth-system` REQ "Multi-tenancy isolation MUST restrict data access to the user's active organisation"). Codifying that explicitly closes the ambiguity, repairs Newman, and prevents the same class of bug in future read paths.
+
+## What Changes
+
+- Add a **schema/register read-vs-write multi-tenancy policy** to the `auth-system` capability: metadata READ lookups bypass multi-tenancy; metadata WRITE lookups keep it on. Tenant isolation is enforced at the OBJECT level via `MultiTenancyTrait` against `MagicMapper` queries, not at the schema-definition level.
+- Define the policy precisely in terms of the existing `SchemaMapper::find` / `RegisterMapper::find` `_multitenancy` argument: every caller whose purpose is to **resolve a schema/register entity for reading metadata or computing over its rows** MUST pass `_multitenancy: false`. Every caller whose purpose is to **authorize an administrative mutation against the entity** MUST keep `_multitenancy: true` (default).
+- Align `AggregationRunner::loadSchema()` and `AggregationRunner::loadRegister()` (lib/Service/Aggregation/AggregationRunner.php:1930, :1949) with the policy: both are read-path lookups that feed aggregation computation and MUST pass `_multitenancy: false`. The existing in-code `// SECURITY: keep multitenancy filter on` comment is wrong about the threat model — schema *definitions* are public; tenant isolation lives at the row level — and MUST be replaced with a corrected rationale.
+- Sweep the read-path inconsistencies in `SchemasController` (`download` L938, `related` L972, `stats` L1031, `publish` L1211, `depublish` L1297) to match the policy (read = bypass). The mutation-gating lookups (`update` L535, `destroy` L689, `upload` L811) keep the filter on because their explicit purpose is to validate the caller's right to mutate.
+- Add the `Schema "%s" not found.` 404 response semantics to the spec: unknown ref still returns 404 (caught by `AggregationController`) regardless of tenancy state.
+- **No backward-incompatible behaviour change** for tenant users that already have an active organisation: their schemas were already resolvable. The only observable change is that admin/system-actor callers with no active organisation can now resolve schemas owned by any tenant — which is what they should already have been able to do (admins are documented to bypass multi-tenancy, see `auth-system` REQ "Admin users see all organisations").
+
+## Capabilities
+
+### New Capabilities
+<!-- None — the policy belongs in auth-system, which already owns the multi-tenancy isolation requirements. -->
+
+### Modified Capabilities
+- `auth-system`: Add a new requirement that disambiguates the *schema/register metadata read* path from the *object data* path within multi-tenancy isolation. The existing REQ "Multi-tenancy isolation MUST restrict data access to the user's active organisation" already covers OBJECT rows via `MultiTenancyTrait`; this change adds a sibling REQ that schema/register definition reads bypass multi-tenancy, and metadata writes keep it on. This is a spec-level clarification of an existing capability, not a new capability.
+
+## Impact
+
+- **Affected code**:
+  - `lib/Service/Aggregation/AggregationRunner.php` — `loadSchema()` L1924-L1934, `loadRegister()` L1945-L1953: pass `_multitenancy: false`, replace misleading SECURITY comment.
+  - `lib/Controller/SchemasController.php` — five read-path lookups (download L938, related L972 + L974 `findAll()`, stats L1031, publish L1211, depublish L1297) MUST pass `_multitenancy: false`. The three mutation-gating lookups (update L535, destroy L689, upload L811) MUST keep the default. Audit-only sweep; no API contract change.
+- **Affected APIs**: No request/response schema changes. The only behaviour change is that the affected endpoints become reachable for admin/system-actor callers with no active organisation, matching the documented `auth-system` admin-bypass contract.
+- **Affected dependencies**: None — internal to OpenRegister.
+- **Newman / verification**: The 5 failing `platform-annotations` aggregation assertions on the 2026-05-27 triage MUST go green. No other Newman collection is expected to shift status.
+- **Seed Data**: NONE — this is pure backend policy. No schema definitions or register definitions change. No migration.
+- **Database**: NONE — `_multitenancy` is a runtime argument; no DDL.
+- **Frontend**: NONE — no UI contract change.

--- a/openspec/changes/aggregation-runner-multitenancy-policy/specs/auth-system/spec.md
+++ b/openspec/changes/aggregation-runner-multitenancy-policy/specs/auth-system/spec.md
@@ -1,0 +1,88 @@
+## ADDED Requirements
+
+### Requirement: Schema and register METADATA-READ lookups MUST bypass multi-tenancy; metadata WRITE lookups MUST enforce it
+
+OpenRegister's multi-tenancy isolation lives at the OBJECT-row level via `MultiTenancyTrait` on `MagicMapper` queries (see existing requirement "Multi-tenancy isolation MUST restrict data access to the user's active organisation"). Schema and register **definitions** are a globally-visible catalog — this is already the established contract via `@PublicPage` on `SchemasController::index`/`show`, both of which pass `_multitenancy: false` to `SchemaMapper::find`/`findAll`.
+
+To eliminate inconsistent inheritance of the `_multitenancy: true` default, every code path whose **purpose** is to **resolve a schema or register entity for reading metadata, computing over its data, or rendering it to a consumer** MUST pass `_multitenancy: false` to `SchemaMapper::find` / `SchemaMapper::findAll` / `RegisterMapper::find` / `RegisterMapper::findAll`. Conversely, every code path whose **purpose** is to **authorize an administrative mutation against the entity** (create, update, patch, delete, upload-as-update) MUST keep the default `_multitenancy: true`. The mapper's default of `true` is intentionally the safe-for-mutation default; the policy is per-caller, not per-mapper.
+
+The `Schema "%s" not found.` / `Register "%s" not found.` 404 path is preserved: an unknown ref still results in `DoesNotExistException` regardless of the tenancy argument; nothing else about lookup semantics changes.
+
+#### Scenario: Tenant user lists schemas via the public catalog endpoint
+- **GIVEN** user `jan` has active organisation `org-uuid-1`
+- **AND** schemas exist with `organisation = 'org-uuid-1'`, `organisation = 'org-uuid-2'`, and `organisation IS NULL`
+- **WHEN** `jan` calls `GET /api/schemas`
+- **THEN** the request MUST succeed (HTTP 200)
+- **AND** the response MUST contain schemas from all three groups, scoped only by the existing read-accessibility published gate (not by tenancy)
+- **AND** `SchemaMapper::findAll(..., _multitenancy: false)` MUST be the underlying call
+
+#### Scenario: Admin without active organisation runs an aggregation that resolves a schema by ref
+- **GIVEN** an admin user (in the `admin` Nextcloud group) with NO active organisation set
+- **AND** a schema `meldingen` exists with `organisation = 'org-uuid-1'`
+- **WHEN** the admin calls an aggregation endpoint whose runner invokes `AggregationRunner::loadSchema(schemaRef: 'meldingen')`
+- **THEN** the schema MUST resolve via `SchemaMapper::find('meldingen', _multitenancy: false)`
+- **AND** the aggregation runner MUST proceed (no `Schema "meldingen" not found.` 404)
+- **AND** any object-row enumeration the runner performs subsequently MUST still be tenant-filtered by `MultiTenancyTrait` against `MagicMapper`, per the existing object-row multi-tenancy requirement
+
+#### Scenario: Background job (system actor) resolves a register for aggregation
+- **GIVEN** a scheduled job running as the system actor (no Nextcloud session, no active organisation)
+- **AND** a register `zaken` exists with `organisation = 'org-uuid-2'`
+- **WHEN** the job invokes `AggregationRunner::loadRegister(registerRef: 'zaken')`
+- **THEN** the register MUST resolve via `RegisterMapper::find('zaken', _multitenancy: false)`
+- **AND** the job MUST proceed without a `Register "zaken" not found.` 404
+
+#### Scenario: Tenant user reads a single schema (download, related, stats, publish/depublish lookups)
+- **GIVEN** user `jan` has active organisation `org-uuid-1`
+- **AND** schema `producten` exists with `organisation = 'org-uuid-2'`
+- **WHEN** `jan` calls `GET /api/schemas/producten/download`, `/related`, `/stats`, or hits the GET lookup inside the publish/depublish flow
+- **THEN** the schema MUST resolve via `SchemaMapper::find('producten', ..., _multitenancy: false)`
+- **AND** the response MUST be HTTP 200 (subject to the existing read-accessibility published gate when the caller is anonymous)
+
+#### Scenario: Tenant user attempts to UPDATE a schema owned by another tenant
+- **GIVEN** user `jan` has active organisation `org-uuid-1`
+- **AND** schema `producten` exists with `organisation = 'org-uuid-2'`
+- **AND** `jan` does NOT have schema-manage permission on `producten`
+- **WHEN** `jan` calls `PUT /api/schemas/producten`
+- **THEN** the underlying lookup MUST be `SchemaMapper::find('producten')` with default `_multitenancy: true` (mutation-gating lookup MUST NOT bypass tenancy)
+- **AND** the mutation MUST be rejected with HTTP 404 (the schema is not in `jan`'s tenant scope and is therefore unresolvable for the purpose of authorizing a mutation) OR HTTP 403 (if the schema is resolvable but `checkSchemaManagePermission` denies)
+- **AND** no schema record MUST be modified
+
+#### Scenario: Tenant user attempts to DELETE a schema owned by another tenant
+- **GIVEN** user `jan` has active organisation `org-uuid-1`
+- **AND** schema `interne-notities` exists with `organisation = 'org-uuid-2'`
+- **WHEN** `jan` calls `DELETE /api/schemas/interne-notities`
+- **THEN** the underlying lookup MUST be `SchemaMapper::find('interne-notities')` with default `_multitenancy: true`
+- **AND** the mutation MUST be rejected (404 or 403 per `checkSchemaManagePermission`)
+- **AND** no schema record MUST be deleted
+
+#### Scenario: Tenant user attempts to UPLOAD-AS-UPDATE a schema owned by another tenant
+- **GIVEN** user `jan` has active organisation `org-uuid-1`
+- **AND** schema `bezwaarschriften` exists with `organisation = 'org-uuid-2'`
+- **WHEN** `jan` calls `POST /api/schemas/bezwaarschriften/upload` with a JSON body
+- **THEN** the underlying existing-schema lookup MUST be `SchemaMapper::find($id)` with default `_multitenancy: true`
+- **AND** the mutation MUST be rejected (the existing-schema branch fails to resolve, OR the manage-permission check denies)
+
+#### Scenario: Unknown schema ref returns 404 regardless of tenancy state
+- **GIVEN** no schema with ref `does-not-exist` is persisted
+- **WHEN** any caller (tenant user, admin, or background job) invokes `AggregationRunner::loadSchema(schemaRef: 'does-not-exist')`
+- **THEN** `SchemaMapper::find('does-not-exist', _multitenancy: false)` MUST throw `DoesNotExistException`
+- **AND** the runner MUST rethrow as `RuntimeException` with message `Schema "does-not-exist" not found.`
+- **AND** `AggregationController` MUST translate that into HTTP 404
+
+#### Scenario: Object-row data remains tenant-isolated independently of metadata read
+- **GIVEN** user `jan` has active organisation `org-uuid-1`
+- **AND** schema `meldingen` is resolvable to `jan` via the metadata-read bypass (regardless of the schema's own `organisation`)
+- **WHEN** `jan` lists objects under that schema (`GET /api/objects/{register}/meldingen`)
+- **THEN** the OBJECT-row query MUST be tenant-filtered by `MultiTenancyTrait` (see the existing object-row multi-tenancy requirement)
+- **AND** only objects with `_organisation = 'org-uuid-1'` (plus RBAC matches) MUST be returned
+- **AND** schema-definition metadata reads (now bypassing tenancy) MUST NOT widen object-row access in any way
+
+#### Scenario: The metadata-read bypass MUST NOT change the in-memory mapper default
+- **GIVEN** a new caller is added that calls `SchemaMapper::find($id)` without specifying `_multitenancy`
+- **THEN** the call MUST continue to use the default `_multitenancy: true` (the safe-for-mutation default)
+- **AND** the new caller MUST explicitly opt into `_multitenancy: false` if it is a metadata-read path, per this requirement
+
+## Standards & References (additions)
+- This requirement specialises the existing `auth-system` requirement "Multi-tenancy isolation MUST restrict data access to the user's active organisation" for schema and register metadata reads.
+- Precedent for the catalog-read bypass: existing requirement "Register and schema read endpoints MUST remain reachable when OpenRegister is restricted to a user group" (added by the `register-schema-read-accessibility` change, archived).
+- Operational precedent: `BackfillSystemOwnerCommand` (REQ-001) already passes `_rbac: false, _multitenancy: false` for schema/register lookups when running maintenance.

--- a/openspec/changes/aggregation-runner-multitenancy-policy/tasks.md
+++ b/openspec/changes/aggregation-runner-multitenancy-policy/tasks.md
@@ -1,0 +1,42 @@
+## 1. Align AggregationRunner with the metadata-read bypass policy
+
+- [ ] 1.1 Update `lib/Service/Aggregation/AggregationRunner.php::loadSchema()` (around L1924-L1934) to call `$this->schemaMapper->find($schemaRef, _multitenancy: false)`.
+- [ ] 1.2 Replace the misleading `// SECURITY: keep multitenancy filter on so a tenant user cannot resolve schemas owned by another tenant simply by knowing the slug.` comment with a corrected rationale that references the new `auth-system` requirement and notes that tenant isolation lives at the object-row level via `MultiTenancyTrait`.
+- [ ] 1.3 Update `lib/Service/Aggregation/AggregationRunner.php::loadRegister()` (around L1945-L1953) to call `$this->registerMapper->find($registerRef, _multitenancy: false)` and replace the `// SECURITY: keep multitenancy filter on (see loadSchema).` comment with the corrected rationale.
+- [ ] 1.4 Confirm via grep that `loadSchema` / `loadRegister` are the only schema/register lookups inside `lib/Service/Aggregation/` and that no other in-runner read path needs updating.
+
+## 2. Sweep SchemasController read paths for consistency
+
+- [ ] 2.1 Update `lib/Controller/SchemasController.php::download()` (L938) to call `$this->schemaMapper->find($id, _multitenancy: false)`.
+- [ ] 2.2 Update `lib/Controller/SchemasController.php::related()` (L972 for the target lookup AND L974 for the `findAll()`) to pass `_multitenancy: false`.
+- [ ] 2.3 Update `lib/Controller/SchemasController.php::stats()` (L1031) to call `$this->schemaMapper->find($id, _multitenancy: false)`.
+- [ ] 2.4 Update `lib/Controller/SchemasController.php::publish()` (L1211) to call `$this->schemaMapper->find($id, _multitenancy: false)` for the read step. The subsequent mutation (`$this->schemaMapper->update($schema)`) is unchanged.
+- [ ] 2.5 Update `lib/Controller/SchemasController.php::depublish()` (L1297) to call `$this->schemaMapper->find($id, _multitenancy: false)` for the read step. The subsequent mutation is unchanged.
+- [ ] 2.6 Leave `lib/Controller/SchemasController.php::update()` (L535) at default `_multitenancy: true` — mutation-gating lookup MUST enforce tenancy per the spec.
+- [ ] 2.7 Leave `lib/Controller/SchemasController.php::destroy()` (L689) at default `_multitenancy: true` — mutation-gating lookup MUST enforce tenancy per the spec.
+- [ ] 2.8 Leave `lib/Controller/SchemasController.php::upload()` (L811) at default `_multitenancy: true` — mutation-gating lookup MUST enforce tenancy per the spec.
+- [ ] 2.9 Add an inline comment on each updated read-path lookup referencing the `auth-system` requirement name so future readers know why the bypass is intentional.
+
+## 3. PHPUnit coverage
+
+- [ ] 3.1 Add a PHPUnit test under `tests/Unit/Service/Aggregation/AggregationRunnerTest.php` (create if missing) asserting that `loadSchema` invokes `SchemaMapper::find` with `_multitenancy === false`. Use a mock SchemaMapper and verify the argument.
+- [ ] 3.2 Add a parallel test for `loadRegister` against a mock RegisterMapper.
+- [ ] 3.3 Add a PHPUnit test under `tests/Unit/Controller/SchemasControllerTest.php` for each of the five read paths (`download`, `related`, `stats`, `publish`, `depublish`) asserting `_multitenancy === false` is passed to `SchemaMapper::find`.
+- [ ] 3.4 Add a PHPUnit test asserting `update`, `destroy`, and `upload` still pass the default `_multitenancy: true` to `SchemaMapper::find` so the safe-mutation default is locked in by a test.
+- [ ] 3.5 Add a PHPUnit test for the unknown-ref 404 path: `AggregationRunner::loadSchema('does-not-exist')` MUST throw `RuntimeException` with message exactly `Schema "does-not-exist" not found.` after `SchemaMapper::find` raises `DoesNotExistException`.
+
+## 4. Quality gates
+
+- [ ] 4.1 Run `composer check:strict` and resolve any new PHPCS / PHPMD / PHPStan / Psalm findings introduced by the change. Per `feedback_fix-all-issues-encountered.md`, also fix any pre-existing issues that surface on the touched files.
+- [ ] 4.2 Run the full PHPUnit suite and ensure the new tests pass alongside the existing suite (no regressions). Per `feedback_no-mock-fixes-real-functionality.md`, no shared stub edits to make existing tests pass — fix code or change assertions to behaviour.
+
+## 5. Newman verification (the original triage finding)
+
+- [ ] 5.1 Run the `platform-annotations` Newman collection against the dev environment and confirm the 5 aggregation assertions previously failing with `Schema "<ref>" not found` now go GREEN.
+- [ ] 5.2 Capture the before/after Newman assertion counts (count of failing assertions before this change vs after) in the apply summary.
+- [ ] 5.3 Spot-check one aggregation endpoint manually as the admin user against a schema with a concrete `organisation` value to confirm the runtime behaviour matches the spec scenarios (`Admin without active organisation runs an aggregation that resolves a schema by ref`).
+
+## 6. Spec coverage and archival prep
+
+- [ ] 6.1 Run `python .github/check_spec_coverage.py` (or the project's equivalent gate-16 invocation) to confirm new code references are spec-linked. Annotate any genuinely-plumbing helpers with `@spec exclude <reason>` per the strict-coverage policy.
+- [ ] 6.2 Re-read `openspec/specs/auth-system/spec.md` after the delta is archived (post-merge) to confirm the new requirement reads correctly inline with the existing multi-tenancy requirements.


### PR DESCRIPTION
Spec-only PR (no PHP changes). Implementation will follow via `/opsx-apply` once the design is approved.

## Why

The 8-domain Newman triage (2026-05-27) found 5 platform-annotations `/api/objects/aggregations/decidesk/action-item/{name}` assertions return HTTP 404 with `{"error":"Schema \"action-item\" not found."}` for the admin user. Root cause: `AggregationRunner::loadSchema()` calls `schemaMapper->find($ref)` with the default `_multitenancy: true`, which adds `WHERE organisation IS NULL` for users without an active organisation context.

The trivial `_multitenancy: false` patch is rejected on its own because the cross-tenant concern in the existing comment is real. But OR has no coherent policy — `SchemasController` already passes `_multitenancy: false` on lines 205 and 296 (index/show) while many other methods in the same controller keep the default.

## Design (Approach B — read-paths-always-bypass)

Four candidates evaluated; design picks **B** and locks in:

1. **Approach B**: schema-metadata READS bypass multitenancy; WRITES keep the filter. Tenant isolation is enforced at the object-row level (`MultiTenancyTrait`).
2. **Spec home**: extend `auth-system`.
3. **Apply scope**: sweep `AggregationRunner::loadSchema` + the 5 inconsistent `SchemasController` read paths (download / related / stats / publish / depublish) together.
4. **Mapper default**: keep `_multitenancy: true` (mutation-safe).

## Artifacts

- `openspec/changes/aggregation-runner-multitenancy-policy/proposal.md`
- `.../design.md` — context table of every `_multitenancy` call site, 5 Decisions, risks, migration.
- `.../specs/auth-system/spec.md` — 1 ADDED requirement, 9 scenarios.
- `.../tasks.md` — 6 task groups; no PR/merge tasks per project policy.

Passes `openspec validate --strict`.
