### PR TITLE
fix(security): bump symfony/http-foundation 6.4.35→6.4.41 (CVE-2026-48736)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,6 +103,7 @@
 		"react/promise": "^3.2",
 		"smalot/pdfparser": "^2.9",
 		"symfony/console": "^6.4",
+		"symfony/http-foundation": "^6.4.41",
 		"symfony/http-kernel": "^6.4",
 		"symfony/process": "^6.4",
 		"symfony/uid": "^6.4",
@@ -126,7 +127,6 @@
 		"roave/security-advisories": "dev-latest",
 		"sabre/vobject": "^4.5",
 		"squizlabs/php_codesniffer": "^3.9",
-		"symfony/http-foundation": "^6.4",
 		"vimeo/psalm": "^5.26"
 	},
 	"config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3fa3b89cb72c898fc69adb35a63e848a",
+    "content-hash": "d5dde3611bdaf93ffb638254d53beb10",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -4306,16 +4306,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.4.35",
+            "version": "v6.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "cffffd0a2c037117b742b4f8b379a22a2a33f6d2"
+                "reference": "48d76c29a67a301e0f7779a512bf76417395ffef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/cffffd0a2c037117b742b4f8b379a22a2a33f6d2",
-                "reference": "cffffd0a2c037117b742b4f8b379a22a2a33f6d2",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/48d76c29a67a301e0f7779a512bf76417395ffef",
+                "reference": "48d76c29a67a301e0f7779a512bf76417395ffef",
                 "shasum": ""
             },
             "require": {
@@ -4363,7 +4363,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.4.35"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.4.41"
             },
             "funding": [
                 {
@@ -4383,7 +4383,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-06T11:15:58+00:00"
+            "time": "2026-05-24T10:54:17+00:00"
         },
         {
             "name": "symfony/http-kernel",


### PR DESCRIPTION
## Summary

- Bumps `symfony/http-foundation` from `v6.4.35` to `v6.4.41` to resolve **CVE-2026-48736**
- CVE: SSRF bypass in `NoPrivateNetworkHttpClient` via IPv6 transition forms (6to4, NAT64, Teredo, IPv4-compatible) omitted from `IpUtils::PRIVATE_SUBNETS`
- Also corrects a pre-existing placement bug: `symfony/http-foundation` was in `require-dev` but is used in production code (`TenantLifecycleService`, `MultiTenancyTrait`, `AuthenticationService`); moved to `require`

## Verification

- `composer audit` → **No security vulnerability advisories found**
- `phpcs` → clean (71/71 files)
- `phpstan` → **[OK] No errors**
- `psalm` → 141 errors before and after (no regression; pre-existing baseline)

## Test plan

- [ ] `composer audit` returns clean
- [ ] `composer check:strict` (phpcs/phpstan) passes in CI