### PR TITLE
fix(tests): seed admin RBAC in DestroySafety tests + expose OCP via composer autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,9 @@
 	],
 	"autoload": {
 		"psr-4": {
-			"OCA\\OpenRegister\\": "lib/"
+			"OCA\\OpenRegister\\": "lib/",
+			"OCP\\": "vendor/nextcloud/ocp/OCP/",
+			"NCU\\": "vendor/nextcloud/ocp/NCU/"
 		}
 	},
 	"repositories": [

--- a/tests/Unit/Controller/RegistersDestroySafetyTest.php
+++ b/tests/Unit/Controller/RegistersDestroySafetyTest.php
@@ -61,34 +61,81 @@ class RegistersDestroySafetyTest extends TestCase
 
     private RegistersController $controller;
 
-    /** @var IRequest&MockObject */
+    /**
+     * @var IRequest&MockObject
+     */
     private IRequest $request;
 
-    /** @var RegisterService&MockObject */
+    /**
+     * @var RegisterService&MockObject
+     */
     private RegisterService $registerService;
 
-    /** @var MagicMapper&MockObject */
+    /**
+     * @var MagicMapper&MockObject
+     */
     private MagicMapper $objectMapper;
 
-    /** @var RegisterCacheHandler&MockObject */
+    /**
+     * @var RegisterCacheHandler&MockObject
+     */
     private RegisterCacheHandler $registerCacheHandler;
 
-    /** @var LoggerInterface&MockObject */
+    /**
+     * @var LoggerInterface&MockObject
+     */
     private LoggerInterface $logger;
 
+    /**
+     * @var IUserSession&MockObject
+     */
+    private IUserSession $userSession;
+
+    /**
+     * @var IGroupManager&MockObject
+     */
+    private IGroupManager $groupManager;
+
+    /**
+     * @var ContainerInterface&MockObject
+     */
+    private ContainerInterface $container;
 
     /**
      * Wire up RegistersController with every dependency mocked.
+     * Default user is an authenticated admin so all permission checks pass.
      */
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->request              = $this->createMock(IRequest::class);
-        $this->registerService      = $this->createMock(RegisterService::class);
-        $this->objectMapper         = $this->createMock(MagicMapper::class);
+        $this->request         = $this->createMock(IRequest::class);
+        $this->registerService = $this->createMock(RegisterService::class);
+        $this->objectMapper    = $this->createMock(MagicMapper::class);
         $this->registerCacheHandler = $this->createMock(RegisterCacheHandler::class);
-        $this->logger               = $this->createMock(LoggerInterface::class);
+        $this->logger       = $this->createMock(LoggerInterface::class);
+        $this->userSession  = $this->createMock(IUserSession::class);
+        $this->groupManager = $this->createMock(IGroupManager::class);
+
+        // Default to an authenticated admin so checkRegisterManagePermission passes.
+        $adminUser = $this->createMock(\OCP\IUser::class);
+        $adminUser->method('getUID')->willReturn('admin');
+        $this->userSession->method('getUser')->willReturn($adminUser);
+        $this->groupManager->method('isAdmin')->willReturn(true);
+        $this->groupManager->method('getUserGroupIds')->willReturn(['admin']);
+
+        // checkRegisterManagePermission() resolves IGroupManager via the container
+        // on its no-authorization (admin-only) branch — return the stubbed one.
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->container->method('get')->willReturnCallback(
+            function ($id) {
+                if ($id === \OCP\IGroupManager::class) {
+                    return $this->groupManager;
+                }
+
+                return null;
+            }
+        );
 
         $this->controller = new RegistersController(
             'openregister',
@@ -97,7 +144,7 @@ class RegistersDestroySafetyTest extends TestCase
             $this->objectMapper,
             $this->createMock(UploadService::class),
             $this->logger,
-            $this->createMock(IUserSession::class),
+            $this->userSession,
             $this->createMock(ConfigurationService::class),
             $this->createMock(AuditTrailMapper::class),
             $this->createMock(ExportService::class),
@@ -107,18 +154,17 @@ class RegistersDestroySafetyTest extends TestCase
             $this->createMock(GitHubHandler::class),
             $this->createMock(IAppManager::class),
             $this->createMock(OasService::class),
-            $this->createMock(ContainerInterface::class),
-            $this->createMock(IGroupManager::class),
+            $this->container,
+            $this->groupManager,
             $this->registerCacheHandler
         );
 
     }//end setUp()
 
-
     /**
      * Build a Register entity with injected id + slug.
      */
-    private function makeRegister(int $id, string $slug = 'test-register'): Register
+    private function makeRegister(int $id, string $slug='test-register'): Register
     {
         $register = new Register();
         $register->setSlug($slug);
@@ -132,7 +178,6 @@ class RegistersDestroySafetyTest extends TestCase
         return $register;
 
     }//end makeRegister()
-
 
     /**
      * REQ + SCENARIO: "Delete register with attached schemas-with-objects".
@@ -175,7 +220,6 @@ class RegistersDestroySafetyTest extends TestCase
 
     }//end testDestroyWithoutForceReturns409WhenObjectsExist()
 
-
     /**
      * REQ + SCENARIO: Delete register with ?force=true.
      *
@@ -217,10 +261,12 @@ class RegistersDestroySafetyTest extends TestCase
             ->method('warning')
             ->with(
                 $this->stringContains('Force-deleting register with attached objects'),
-                $this->callback(function (array $ctx): bool {
-                    return ($ctx['registerId'] ?? null) === 7
-                        && ($ctx['objectCount'] ?? null) === 4;
-                })
+                $this->callback(
+                        function (array $ctx): bool {
+                            return ($ctx['registerId'] ?? null) === 7
+                            && ($ctx['objectCount'] ?? null) === 4;
+                        }
+                        )
             );
 
         $response = $this->controller->destroy(7);
@@ -228,7 +274,6 @@ class RegistersDestroySafetyTest extends TestCase
         $this->assertSame(200, $response->getStatus());
 
     }//end testDestroyWithForceTrueDeletesAndInvalidatesCache()
-
 
     /**
      * REQ + SCENARIO: Delete unused register (regression baseline).
@@ -265,6 +310,4 @@ class RegistersDestroySafetyTest extends TestCase
         $this->assertSame(200, $response->getStatus());
 
     }//end testDestroyOnUnusedRegisterSucceeds()
-
-
 }//end class

--- a/tests/Unit/Controller/SchemasDestroySafetyTest.php
+++ b/tests/Unit/Controller/SchemasDestroySafetyTest.php
@@ -40,7 +40,9 @@ use OCA\OpenRegister\Service\SchemaService;
 use OCA\OpenRegister\Service\UploadService;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -55,27 +57,44 @@ class SchemasDestroySafetyTest extends TestCase
 
     private SchemasController $controller;
 
-    /** @var IRequest&MockObject */
+    /**
+     * @var IRequest&MockObject
+     */
     private IRequest $request;
 
-    /** @var SchemaMapper&MockObject */
+    /**
+     * @var SchemaMapper&MockObject
+     */
     private SchemaMapper $schemaMapper;
 
-    /** @var MagicMapper&MockObject */
+    /**
+     * @var MagicMapper&MockObject
+     */
     private MagicMapper $objectMapper;
 
-    /** @var SchemaCacheHandler&MockObject */
+    /**
+     * @var SchemaCacheHandler&MockObject
+     */
     private SchemaCacheHandler $schemaCacheService;
 
-    /** @var FacetCacheHandler&MockObject */
+    /**
+     * @var FacetCacheHandler&MockObject
+     */
     private FacetCacheHandler $facetCacheSvc;
 
-    /** @var LoggerInterface&MockObject */
+    /**
+     * @var LoggerInterface&MockObject
+     */
     private LoggerInterface $logger;
 
+    /**
+     * @var ContainerInterface&MockObject
+     */
+    private ContainerInterface $container;
 
     /**
      * Wire up SchemasController with every dependency mocked.
+     * Default user is an authenticated admin so all permission checks pass.
      */
     protected function setUp(): void
     {
@@ -86,7 +105,35 @@ class SchemasDestroySafetyTest extends TestCase
         $this->objectMapper       = $this->createMock(MagicMapper::class);
         $this->schemaCacheService = $this->createMock(SchemaCacheHandler::class);
         $this->facetCacheSvc      = $this->createMock(FacetCacheHandler::class);
-        $this->logger             = $this->createMock(LoggerInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        // SchemasController resolves IUserSession + IGroupManager lazily via the
+        // container (checkSchemaManagePermission). Default to an authenticated admin
+        // so all write-permission checks pass.
+        $adminUser = $this->createMock(\OCP\IUser::class);
+        $adminUser->method('getUID')->willReturn('admin');
+
+        $userSession = $this->createMock(IUserSession::class);
+        $userSession->method('getUser')->willReturn($adminUser);
+
+        $groupManager = $this->createMock(IGroupManager::class);
+        $groupManager->method('isAdmin')->willReturn(true);
+        $groupManager->method('getUserGroupIds')->willReturn(['admin']);
+
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->container->method('get')->willReturnCallback(
+            function ($id) use ($userSession, $groupManager) {
+                if ($id === \OCP\IUserSession::class) {
+                    return $userSession;
+                }
+
+                if ($id === \OCP\IGroupManager::class) {
+                    return $groupManager;
+                }
+
+                return null;
+            }
+        );
 
         $this->controller = new SchemasController(
             'openregister',
@@ -101,16 +148,15 @@ class SchemasDestroySafetyTest extends TestCase
             $this->facetCacheSvc,
             $this->createMock(SchemaService::class),
             $this->logger,
-            $this->createMock(ContainerInterface::class)
+            $this->container
         );
 
     }//end setUp()
 
-
     /**
      * Build a Schema entity with injected id + slug.
      */
-    private function makeSchema(int $id, string $slug = 'test-schema'): Schema
+    private function makeSchema(int $id, string $slug='test-schema'): Schema
     {
         $schema = new Schema();
         $schema->setSlug($slug);
@@ -124,7 +170,6 @@ class SchemasDestroySafetyTest extends TestCase
         return $schema;
 
     }//end makeSchema()
-
 
     /**
      * REQ + SCENARIO: "Delete a schema with objects, no force flag".
@@ -170,7 +215,6 @@ class SchemasDestroySafetyTest extends TestCase
         $this->assertSame(5, $data['objectCount']);
 
     }//end testDestroyWithoutForceReturns409WhenObjectsExist()
-
 
     /**
      * REQ + SCENARIO: "Delete a schema with objects and force=true".
@@ -218,10 +262,12 @@ class SchemasDestroySafetyTest extends TestCase
             ->method('warning')
             ->with(
                 $this->stringContains('Force-deleting schema with attached objects'),
-                $this->callback(function (array $ctx): bool {
-                    return ($ctx['schemaId'] ?? null) === 42
-                        && ($ctx['objectCount'] ?? null) === 7;
-                })
+                $this->callback(
+                        function (array $ctx): bool {
+                            return ($ctx['schemaId'] ?? null) === 42
+                            && ($ctx['objectCount'] ?? null) === 7;
+                        }
+                        )
             );
 
         $response = $this->controller->destroy(42);
@@ -230,7 +276,6 @@ class SchemasDestroySafetyTest extends TestCase
         $this->assertSame(200, $response->getStatus());
 
     }//end testDestroyWithForceTrueDeletesAndInvalidatesCache()
-
 
     /**
      * REQ + SCENARIO: "Delete an unused schema" (regression baseline).
@@ -269,6 +314,4 @@ class SchemasDestroySafetyTest extends TestCase
         $this->assertSame(200, $response->getStatus());
 
     }//end testDestroyOnUnusedSchemaSucceeds()
-
-
 }//end class


### PR DESCRIPTION
## Summary

- **RegistersDestroySafetyTest** and **SchemasDestroySafetyTest** were returning 403 on all test scenarios after PR #1949 tightened RBAC (`checkRegisterManagePermission` / `checkSchemaManagePermission` now default-secure). The test `setUp()` wired the mocks but never configured them to represent an authenticated admin, so the permission check always fell through to `false → 403`.
- Fix mirrors the repair pattern from PR #1951 (which fixed `RegistersControllerTest` / `SchemasControllerTest`): `setUp()` now creates an `adminUser` mock, seeds `userSession.getUser()`, `groupManager.getUserGroupIds(['admin'])`, `isAdmin(true)`, and wires `container.get(IGroupManager|IUserSession)` to return the stubbed managers.
- Added `OCP` and `NCU` PSR-4 entries to `composer.json` autoload so PHPUnit can mock OCP types (`IRequest`, `IGroupManager`, etc.) in pure unit mode without a Nextcloud root. `phpstan-bootstrap.php` already used the same `addPsr4` call — this aligns the test runner with it.

## Test results

- `RegistersDestroySafetyTest`: 3/3 green (was 3 failures: 403 ≠ 200/409)
- `SchemasDestroySafetyTest`: 3/3 green (was 3 failures: 403 ≠ 200/409)
- `RegistersControllerTest` + `SchemasControllerTest`: still 177/177 passing
- `PHPStan`: 0 errors (unchanged)

## Out of scope (pre-existing infra debt)

- `SolrNightlyWarmupJobTest` / `CalendarEventServiceTest` / `CalendarLinkServiceTest` / `ContactServiceTest` — require a real NC runtime (`OCA\DAV`, `Doctrine\DBAL`, `OC` server class); these are infrastructure-bound and not affected by this change.