### PR TITLE
fix(e2e): scope integration-mount inner-tab selector to CnIntegrationWidget

### DIFF
--- a/tests/e2e/integration-mount.spec.ts
+++ b/tests/e2e/integration-mount.spec.ts
@@ -184,20 +184,27 @@ test.describe('Integration tabs MOUNT on the object detail page (K3 / Phase-A re
 		//    is the other half of the Phase-A bug (the dispatch was never
 		//    wired, so the bespoke tabs were dead code).
 		const mountFailures: string[] = []
+		// Scope to the CnIntegrationWidget container — the outer ObjectDetails
+		// BTabs strip ALSO has tabs named "Files" / "Emails" / "Contacts" /
+		// "Audit Trail" alongside the registry, so `role=tab[name="Files"]`
+		// would match the outer strip first and clicking it would close the
+		// Integrations panel (hiding every subsequent inner tab from the
+		// a11y tree). The widget exposes a stable per-provider data-testid
+		// (`cn-integration-widget-tab-{id}`) that we target directly.
+		const widget = page.locator('.cn-integration-widget')
 		for (const id of registeredIds) {
 			const provider = providers.find(p => p.id === id)
 			const tabName = provider?.label || id
-			const innerTab = page.locator(`role=tab[name="${tabName}"]`).first()
+			const innerTab = widget.locator(`[data-testid="cn-integration-widget-tab-${id}"]`)
 			if (await innerTab.count() === 0) {
 				mountFailures.push(`${id}: no inner tab rendered for "${tabName}"`)
 				continue
 			}
 			await innerTab.click()
-			// The active tab panel must contain a mounted child element —
-			// either the bespoke Cn<X>Tab or the generic CnIntegrationTab
-			// fallback. A wired dispatch always renders SOME element; the
-			// dead-code bug rendered an empty panel.
-			const activePanel = page.locator('[role="tabpanel"]:visible, .tab-pane.active').first()
+			// The active panel for the widget lives at `[role="tabpanel"]`
+			// inside the same `.cn-integration-widget`. Scope here too —
+			// outer BTabs panels would otherwise match first.
+			const activePanel = widget.locator('[role="tabpanel"]').first()
 			const mounted = await activePanel.evaluate((el) => {
 				// A mounted Vue component leaves at least one element child
 				// (the integration tab root). Whitespace-only / comment-only


### PR DESCRIPTION
Closes the Tier 2.2 follow-up — the K3 / Phase-A integration-mount regression test reported 22 "no inner tab rendered" failures even though the CnIntegrationWidget IS rendering all 25 provider tabs correctly.

## Root cause: test bug, not product bug

ObjectDetails.vue's outer `<BTabs>` strip has tabs named **"Files", "Emails", "Contacts", "Audit Trail"** — all overlapping with integration-provider labels. The test did:

```ts
const innerTab = page.locator(`role=tab[name="${tabName}"]`).first()
```

For `tabName = "Files"`, this matched BOTH the outer strip's Files BTab AND the inner widget's Files tab. `.first()` picked the outer one (first in DOM). Clicking it switched the active outer tab AWAY from Integrations, putting the widget's panel under `display: none`. Playwright's role-based selectors filter hidden elements out of the a11y tree — so every subsequent provider lookup returned `count === 0`, producing the 22-line failure list.

Manually verified the product is healthy:
1. Navigated to a real object-detail page.
2. Clicked the outer Integrations BTab.
3. All 25 inner `.cn-integration-widget__tab` buttons are visible, with `role="tab"`, with the provider label as accessible name, and with per-provider `data-testid="cn-integration-widget-tab-{id}"`.

## Fix

Scope the inner-tab selector to `.cn-integration-widget` and target the widget's own `data-testid="cn-integration-widget-tab-{id}"` instead of role-by-name. That attribute is per-provider unique, immune to the outer-strip collision, and already exposed by the widget for exactly this purpose.

Also scoped the active-panel locator to `.cn-integration-widget` for consistency (the outer strip's panels would otherwise match first, but in practice they were already wrong).

## Verification

```
tests/e2e/integration-mount.spec.ts:163
Integration tabs MOUNT … › the Integrations tab is present and dispatches
  ✓ 1 passed (19.9s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
