### PR TITLE
feat(adr-036): migrate App.vue to v2 kind-tagged registry prop

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -40,7 +40,7 @@ Open Register drijft apps zoals OpenCatalogi, Procest, Pipelinq en Software Cata
 
 Vrij en open source onder de EUPL-licentie.
     ]]></description>
-    <version>0.2.13-unstable.81</version>
+    <version>0.2.13-unstable.82</version>
     <licence>agpl</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>OpenRegister</namespace>

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
 	<CnAppRoot
 		app-id="openregister"
 		:manifest="manifest"
-		:custom-components="customComponents"
+		:registry="registry"
 		:page-types="pageTypes"
 		:requires-apps="[]"
 		:translate="translateForApp">
@@ -90,10 +90,13 @@ export default {
 			required: true,
 		},
 		/**
-		 * Flat registry of OpenRegister's view components, resolved by
-		 * CnPageRenderer for every `type:"custom"` page.
+		 * V2 kind-tagged registry (ADR-036) — each entry is
+		 * `{ kind: "page", component: ... }`. CnPageRenderer resolves
+		 * every `type:"custom"` page's `component` string against the
+		 * `kind: "page"` entries here. Replaces the deprecated
+		 * `customComponents` prop.
 		 */
-		customComponents: {
+		registry: {
 			type: Object,
 			default: () => ({}),
 		},

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,7 @@ import '@conduction/nextcloud-vue/css/index.css'
 import { Fragment } from 'vue-frag'
 import { ensureIntegrationRegistry } from './integrations/bootstrap.js'
 import bundledManifest from './manifest.json'
-import customComponents from './customComponents.js'
+import registry from './registry.js'
 
 import AccountGroupOutline from 'vue-material-design-icons/AccountGroupOutline.vue'
 import FileDocumentOutline from 'vue-material-design-icons/FileDocumentOutline.vue'
@@ -156,13 +156,13 @@ const router = new VueRouter({
 })
 
 // Pass shallow copies of the registry maps to App.vue → CnAppRoot. The lib
-// exports `defaultPageTypes` (and the consumer's `customComponents`) as frozen
-// module objects in some bundle shapes — Vue 2's `Vue.extend()` mutates
-// component definitions to attach an internal `_Ctor` cache, which throws
-// "Cannot add property _Ctor, object is not extensible" against a frozen source
-// map. Cloning here yields extensible objects without changing the values the
-// lib resolves at render time.
-const customComponentsProp = { ...customComponents }
+// exports `defaultPageTypes` (and our `registry`) as frozen module objects in
+// some bundle shapes — Vue 2's `Vue.extend()` mutates component definitions to
+// attach an internal `_Ctor` cache, which throws "Cannot add property _Ctor,
+// object is not extensible" against a frozen source map. Cloning here yields
+// extensible objects without changing the values the lib resolves at render
+// time.
+const registryProp = { ...registry }
 const pageTypesProp = { ...defaultPageTypes }
 
 new Vue(
@@ -172,7 +172,7 @@ new Vue(
 		render: h => h(App, {
 			props: {
 				manifest: bundledManifest,
-				customComponents: customComponentsProp,
+				registry: registryProp,
 				pageTypes: pageTypesProp,
 			},
 		}),

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,9 +1,10 @@
 /**
- * OpenRegister custom-component registry.
+ * OpenRegister v2 component registry (ADR-036).
  *
- * Flat `{ ComponentName: Component }` map (decidesk convention) passed as the
- * `customComponents` prop to CnAppRoot. CnPageRenderer resolves each manifest
- * page's `component` string against this map for `type:"custom"` pages.
+ * Kind-tagged map passed as the `registry` prop to CnAppRoot. CnPageRenderer
+ * resolves each manifest page's `component` string against entries whose
+ * `kind === "page"` (with precedence over the deprecated `customComponents`
+ * prop, which OpenRegister no longer ships).
  *
  * OpenRegister is the data-platform foundation: its registers, schemas,
  * sources, applications, endpoints and entities are native foundation entities
@@ -11,7 +12,7 @@
  * library's built-in `index`/`detail` renderers (which resolve via
  * useObjectStore against a register+schema slug) cannot drive them. Every OR
  * page therefore stays a bespoke view referenced here by name — a pure shell
- * swap with no page-rendering behaviour change.
+ * dispatch with no page-rendering behaviour change.
  *
  * SPDX-License-Identifier: EUPL-1.2
  * SPDX-FileCopyrightText: 2026 Conduction B.V.
@@ -48,35 +49,50 @@ import ReportView from './views/reports/ReportView.vue'
 import FeaturesRoadmapIndex from './views/roadmap/FeaturesRoadmapIndex.vue'
 import IntegrationsView from './views/integration/IntegrationsView.vue'
 
+/**
+ * Wrap a Vue component into the v2 registry shape required by CnAppRoot's
+ * `registry` prop (`kind: "page"` is the discriminator CnPageRenderer keys
+ * page dispatch off — `kind: "widget"`/`"modal"`/`"form-field"`/
+ * `"cell-renderer"` entries with the same name are NOT used for page
+ * dispatch).
+ *
+ * @param {object} component Vue component options.
+ *
+ * @return {object} A `{ kind: "page", component }` registry entry.
+ */
+function page(component) {
+	return { kind: 'page', component }
+}
+
 export default {
-	Dashboard,
-	RegistersIndex,
-	RegisterDetail,
-	SchemasIndex,
-	SchemaDetails,
-	SourcesIndex,
-	OrganisationsIndex,
-	ApplicationsIndex,
-	ApplicationDetails,
-	ObjectsIndex,
-	SearchIndex,
-	ChatIndex,
-	FilesIndex,
-	AgentsIndex,
-	ConfigurationsIndex,
-	DeletedIndex,
-	AuditTrailIndex,
-	SearchTrailIndex,
-	WebhooksIndex,
-	WebhookLogsIndex,
-	EndpointsIndex,
-	EntitiesIndex,
-	EntityDetail,
-	TemplatesIndex,
-	MyAccount,
-	AvgIndex,
-	ReportsIndex,
-	ReportView,
-	FeaturesRoadmapIndex,
-	IntegrationsView,
+	Dashboard: page(Dashboard),
+	RegistersIndex: page(RegistersIndex),
+	RegisterDetail: page(RegisterDetail),
+	SchemasIndex: page(SchemasIndex),
+	SchemaDetails: page(SchemaDetails),
+	SourcesIndex: page(SourcesIndex),
+	OrganisationsIndex: page(OrganisationsIndex),
+	ApplicationsIndex: page(ApplicationsIndex),
+	ApplicationDetails: page(ApplicationDetails),
+	ObjectsIndex: page(ObjectsIndex),
+	SearchIndex: page(SearchIndex),
+	ChatIndex: page(ChatIndex),
+	FilesIndex: page(FilesIndex),
+	AgentsIndex: page(AgentsIndex),
+	ConfigurationsIndex: page(ConfigurationsIndex),
+	DeletedIndex: page(DeletedIndex),
+	AuditTrailIndex: page(AuditTrailIndex),
+	SearchTrailIndex: page(SearchTrailIndex),
+	WebhooksIndex: page(WebhooksIndex),
+	WebhookLogsIndex: page(WebhookLogsIndex),
+	EndpointsIndex: page(EndpointsIndex),
+	EntitiesIndex: page(EntitiesIndex),
+	EntityDetail: page(EntityDetail),
+	TemplatesIndex: page(TemplatesIndex),
+	MyAccount: page(MyAccount),
+	AvgIndex: page(AvgIndex),
+	ReportsIndex: page(ReportsIndex),
+	ReportView: page(ReportView),
+	FeaturesRoadmapIndex: page(FeaturesRoadmapIndex),
+	IntegrationsView: page(IntegrationsView),
 }


### PR DESCRIPTION
## Summary

Migrate OpenRegister's own frontend to use the v2 `registry` prop on `CnAppRoot` instead of the deprecated `customComponents` prop, per [ADR-036](https://github.com/ConductionNL/nextcloud-vue).

- `src/customComponents.js` → `src/registry.js`: each page component is now wrapped as `{ kind: 'page', component }` via a small `page()` helper.
- `src/main.js`: imports `registry` and passes `registry: registryProp` to `App`.
- `src/App.vue`: declares the `registry` prop, binds `:registry="registry"` on `CnAppRoot`.
- `appinfo/info.xml`: bump `0.2.13-unstable.81` → `.82` to bust NC's `Cache-Control: immutable` URL hash so consumer browsers re-fetch the new bundle.

Lib-side resolution was shipped in [@conduction/nextcloud-vue#458](https://github.com/ConductionNL/nextcloud-vue/pull/458) (`CnPageRenderer` resolves `type:"custom"` `page.component` against the new `kind:"page"` registry entries first, with fallback to the legacy `customComponents` map for backward compatibility).

## Test plan

- [x] Browser-tested at `localhost:8080`: 0 deprecation warnings (was: `CnAppRoot: \`customComponents\` prop is deprecated when using v2 manifests…`)
- [x] Vue tree probe confirms App now declares `[manifest, registry, pageTypes]` (no `customComponents`); receives 30 registry entries
- [x] Dashboard renders, page navigation works
- [ ] CI: lint + tests green

## Next

Once this lands, fan out the same migration to the other fleet apps that adopted the manifest shell (decidesk, docudesk, procest, pipelinq, mydash, opencatalogi).