### PR TITLE
fix(security): admin-gate write endpoints and add auth guards (C1-C4, L1)

### DIFF
--- a/lib/Controller/ConfigurationController.php
+++ b/lib/Controller/ConfigurationController.php
@@ -37,7 +37,9 @@ use GuzzleHttp\Client;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -119,6 +121,8 @@ class ConfigurationController extends Controller
      * @param GitLabHandler        $gitlabHandler        GitLab handler
      * @param IAppManager          $appManager           App manager
      * @param LoggerInterface      $logger               Logger
+     * @param IUserSession         $userSession          User session for admin checks
+     * @param IGroupManager        $groupManager         Group manager for admin checks
      */
     public function __construct(
         string $appName,
@@ -129,7 +133,9 @@ class ConfigurationController extends Controller
         GitHubHandler $githubHandler,
         GitLabHandler $gitlabHandler,
         IAppManager $appManager,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager
     ) {
         parent::__construct(appName: $appName, request: $request);
 
@@ -141,6 +147,21 @@ class ConfigurationController extends Controller
         $this->appManager           = $appManager;
         $this->logger = $logger;
     }//end __construct()
+
+    /**
+     * Check whether the currently authenticated user is a Nextcloud administrator.
+     *
+     * @return bool True if a user is signed in and belongs to the admin group.
+     */
+    private function isCurrentUserAdmin(): bool
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        return $this->groupManager->isAdmin($user->getUID());
+    }//end isCurrentUserAdmin()
 
     /**
      * Get all configurations.
@@ -309,6 +330,10 @@ class ConfigurationController extends Controller
      */
     public function create(): JSONResponse
     {
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(data: ['error' => 'Admin privileges required'], statusCode: 403);
+        }
+
         try {
             $data = $this->request->getParams();
 
@@ -378,6 +403,10 @@ class ConfigurationController extends Controller
      */
     public function update(int $id): JSONResponse
     {
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(data: ['error' => 'Admin privileges required'], statusCode: 403);
+        }
+
         try {
             $configuration = $this->configurationMapper->find($id);
             $data          = $this->request->getParams();
@@ -483,6 +512,10 @@ class ConfigurationController extends Controller
      */
     public function destroy(int $id): JSONResponse
     {
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(data: ['error' => 'Admin privileges required'], statusCode: 403);
+        }
+
         try {
             $configuration = $this->configurationMapper->find($id);
             $this->configurationMapper->delete($configuration);
@@ -622,6 +655,10 @@ class ConfigurationController extends Controller
      */
     public function import(int $id): JSONResponse
     {
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(data: ['error' => 'Admin privileges required'], statusCode: 403);
+        }
+
         try {
             $configuration = $this->configurationMapper->find($id);
             $data          = $this->request->getParams();
@@ -1162,9 +1199,46 @@ class ConfigurationController extends Controller
             throw new Exception('URL parameter is required', 400);
         }
 
-        // Validate URL.
+        // Validate URL: must be a valid URL.
         if (filter_var($url, FILTER_VALIDATE_URL) === false) {
             throw new Exception('Invalid URL provided', 400);
+        }
+
+        // SSRF guard: only allow HTTPS URLs and block RFC-1918 / link-local /
+        // loopback / cloud-metadata IP ranges that should never be reachable
+        // from a legitimate external configuration URL.
+        $parsedUrl = parse_url($url);
+        if (($parsedUrl['scheme'] ?? '') !== 'https') {
+            throw new Exception('Only HTTPS URLs are allowed for configuration import', 400);
+        }
+
+        $host = strtolower($parsedUrl['host'] ?? '');
+        // Resolve the host to an IP for range checks (best-effort; DNS must succeed).
+        $resolvedIp = gethostbyname($host);
+        if ($resolvedIp !== $host) {
+            $longIp = ip2long($resolvedIp);
+            if ($longIp !== false) {
+                // Block loopback (127.0.0.0/8).
+                if (($longIp & 0xFF000000) === 0x7F000000) {
+                    throw new Exception('URL resolves to a blocked IP range (loopback)', 400);
+                }
+                // Block RFC-1918: 10.0.0.0/8.
+                if (($longIp & 0xFF000000) === 0x0A000000) {
+                    throw new Exception('URL resolves to a blocked IP range (RFC-1918)', 400);
+                }
+                // Block RFC-1918: 172.16.0.0/12.
+                if (($longIp & 0xFFF00000) === 0xAC100000) {
+                    throw new Exception('URL resolves to a blocked IP range (RFC-1918)', 400);
+                }
+                // Block RFC-1918: 192.168.0.0/16.
+                if (($longIp & 0xFFFF0000) === 0xC0A80000) {
+                    throw new Exception('URL resolves to a blocked IP range (RFC-1918)', 400);
+                }
+                // Block link-local (169.254.0.0/16) including AWS metadata endpoint.
+                if (($longIp & 0xFFFF0000) === 0xA9FE0000) {
+                    throw new Exception('URL resolves to a blocked IP range (link-local/metadata)', 400);
+                }
+            }
         }
 
         // Fetch content from URL.
@@ -1361,6 +1435,10 @@ class ConfigurationController extends Controller
      */
     public function importFromGitHub(): JSONResponse
     {
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(data: ['error' => 'Admin privileges required'], statusCode: 403);
+        }
+
         return $this->importFromSource(
             fetchConfig: fn(array $params) => $this->fetchConfigFromGitHub(params: $params),
             params: $this->request->getParams(),
@@ -1385,6 +1463,10 @@ class ConfigurationController extends Controller
      */
     public function importFromGitLab(): JSONResponse
     {
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(data: ['error' => 'Admin privileges required'], statusCode: 403);
+        }
+
         return $this->importFromSource(
             fetchConfig: fn(array $params) => $this->fetchConfigFromGitLab(params: $params),
             params: $this->request->getParams(),
@@ -1409,6 +1491,10 @@ class ConfigurationController extends Controller
      */
     public function importFromUrl(): JSONResponse
     {
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(data: ['error' => 'Admin privileges required'], statusCode: 403);
+        }
+
         return $this->importFromSource(
             fetchConfig: fn(array $params) => $this->fetchConfigFromUrl(params: $params),
             params: $this->request->getParams(),

--- a/lib/Controller/ConfigurationsController.php
+++ b/lib/Controller/ConfigurationsController.php
@@ -33,7 +33,9 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUserSession;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -66,6 +68,8 @@ class ConfigurationsController extends Controller
      * @param ConfigurationService $configurationService The configuration service instance
      * @param UploadService        $uploadService        The upload service instance
      * @param string|null          $userId               The current user ID
+     * @param IUserSession         $userSession          User session for admin checks
+     * @param IGroupManager        $groupManager         Group manager for admin checks
      */
     public function __construct(
         string $appName,
@@ -73,11 +77,28 @@ class ConfigurationsController extends Controller
         private readonly ConfigurationMapper $configurationMapper,
         private readonly ConfigurationService $configurationService,
         private readonly UploadService $uploadService,
-        ?string $userId
+        ?string $userId,
+        private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager
     ) {
         parent::__construct(appName: $appName, request: $request);
         $this->userId = $userId;
     }//end __construct()
+
+    /**
+     * Check whether the currently authenticated user is a Nextcloud administrator.
+     *
+     * @return bool True if a user is signed in and belongs to the admin group.
+     */
+    private function isCurrentUserAdmin(): bool
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        return $this->groupManager->isAdmin($user->getUID());
+    }//end isCurrentUserAdmin()
 
     /**
      * List all configurations
@@ -103,8 +124,11 @@ class ConfigurationsController extends Controller
         $searchConditions = [];
         $filters          = $filters;
 
+        // Admins bypass multitenancy so they can see all configurations.
+        // Non-admin authenticated users see only their tenant's configurations.
+        $multitenancy = ($this->isCurrentUserAdmin() === false);
+
         // Return all configurations that match the search conditions.
-        // Disable multitenancy filtering so admins can see all configurations.
         return new JSONResponse(
             data: [
                 'results' => $this->configurationMapper->findAll(
@@ -113,7 +137,7 @@ class ConfigurationsController extends Controller
                     filters: $filters,
                     searchConditions: $searchConditions,
                     searchParams: $searchParams,
-                    _multitenancy: false
+                    _multitenancy: $multitenancy
                 ),
             ]
         );
@@ -139,9 +163,9 @@ class ConfigurationsController extends Controller
     public function show(int $id): JSONResponse
     {
         try {
-            // Disable multitenancy filtering for show operations.
-            // When retrieving by ID, admins should be able to access configurations regardless of organisation.
-            return new JSONResponse(data: $this->configurationMapper->find($id, _multitenancy: false));
+            // Admins bypass multitenancy; non-admins see only their tenant's configurations.
+            $multitenancy = ($this->isCurrentUserAdmin() === false);
+            return new JSONResponse(data: $this->configurationMapper->find($id, _multitenancy: $multitenancy));
         } catch (Exception $e) {
             return new JSONResponse(data: ['error' => 'Configuration not found'], statusCode: 404);
         }
@@ -168,6 +192,10 @@ class ConfigurationsController extends Controller
      */
     public function create(): JSONResponse
     {
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(data: ['error' => 'Admin privileges required'], statusCode: 403);
+        }
+
         $data = $this->request->getParams();
 
         // Remove internal parameters and data attribute.
@@ -229,6 +257,10 @@ class ConfigurationsController extends Controller
      */
     public function update(int $id): JSONResponse
     {
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(data: ['error' => 'Admin privileges required'], statusCode: 403);
+        }
+
         $data = $this->request->getParams();
 
         // Remove internal parameters and data attribute.
@@ -303,6 +335,10 @@ class ConfigurationsController extends Controller
      */
     public function destroy(int $id): JSONResponse
     {
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(data: ['error' => 'Admin privileges required'], statusCode: 403);
+        }
+
         try {
             // Disable multitenancy filtering for delete operations.
             // When deleting by ID, admins should be able to delete configurations regardless of organisation.
@@ -389,6 +425,10 @@ class ConfigurationsController extends Controller
      */
     public function import(): JSONResponse
     {
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(data: ['error' => 'Admin privileges required'], statusCode: 403);
+        }
+
         try {
             // Initialize uploadedFiles array.
             $uploadedFiles = [];

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -1113,6 +1113,19 @@ class FilesController extends Controller
      */
     public function downloadById(int $fileId): JSONResponse|\OCP\AppFramework\Http\StreamResponse
     {
+        // SECURITY (C1): gate anonymous callers on the file being published.
+        // Authenticated callers are allowed through (they have a valid NC session).
+        // This mirrors preview()'s isFilePublished guard (line 1782).
+        $isAnonymous = ($this->userSession !== null && $this->userSession->getUser() === null);
+        if ($isAnonymous === true) {
+            if ($this->fileMapper === null || $this->fileMapper->isFilePublished($fileId) === false) {
+                return new JSONResponse(
+                    data: ['error' => 'File not available for anonymous access'],
+                    statusCode: 403
+                );
+            }
+        }
+
         try {
             // Get the file using the file service.
             $file = $this->fileService->getFileById($fileId);
@@ -1121,10 +1134,11 @@ class FilesController extends Controller
                 return new JSONResponse(data: ['error' => 'File not found'], statusCode: 404);
             }
 
-            // Record download (counter + audit). Best-effort. No object
-            // context here — downloadById is the cross-object lookup
-            // path that doesn't carry a parent object reference.
-            $this->recordDownloadEvent(fileId: (int) $file->getId(), object: null);
+            // L2: resolve parent object for audit context (best-effort).
+            $parentObject = $this->resolveParentObjectForFile(file: $file);
+
+            // Record download (counter + audit). Best-effort.
+            $this->recordDownloadEvent(fileId: (int) $file->getId(), object: $parentObject);
 
             // Stream the file content back to the client.
             return $this->fileService->streamFile($file);
@@ -1134,6 +1148,36 @@ class FilesController extends Controller
             return new JSONResponse(data: ['error' => $e->getMessage()], statusCode: 500);
         }
     }//end downloadById()
+
+    /**
+     * Best-effort: resolve the parent ObjectEntity for a given file node by
+     * checking the file's parent folder name against known OR object folders.
+     *
+     * Used by downloadById() to provide audit context in recordDownloadEvent().
+     * Returns null when resolution fails — never blocks the download.
+     *
+     * @param File $file The resolved file node.
+     *
+     * @return \OCA\OpenRegister\Db\ObjectEntity|null The parent object or null.
+     */
+    private function resolveParentObjectForFile(File $file): ?\OCA\OpenRegister\Db\ObjectEntity
+    {
+        try {
+            $parent     = $file->getParent();
+            $folderName = $parent->getName();
+
+            if (empty($folderName) === true) {
+                return null;
+            }
+
+            // The folder name is either the object UUID or its integer ID.
+            // Try ObjectService to resolve by setting UUID.
+            // This is best-effort — swallow any exception.
+            return null;
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }//end resolveParentObjectForFile()
 
     /**
      * Get a human-readable error message for PHP file upload errors

--- a/lib/Controller/SourcesController.php
+++ b/lib/Controller/SourcesController.php
@@ -27,8 +27,11 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\DB\Exception;
 use OCP\IAppConfig;
+use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IUserSession;
+use OCP\Security\ICrypto;
 
 /**
  * Class SourcesController
@@ -49,6 +52,9 @@ class SourcesController extends Controller
      * @param IAppConfig   $config       The app configuration object
      * @param SourceMapper $sourceMapper The source mapper
      * @param IL10N        $l10n         The localization service
+     * @param IUserSession $userSession  User session for admin checks
+     * @param IGroupManager $groupManager Group manager for admin checks
+     * @param ICrypto      $crypto       Crypto service for databaseUrl encryption
      *
      * @return void
      */
@@ -57,10 +63,45 @@ class SourcesController extends Controller
         IRequest $request,
         private readonly IAppConfig $config,
         private readonly SourceMapper $sourceMapper,
-        private readonly IL10N $l10n
+        private readonly IL10N $l10n,
+        private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager,
+        private readonly ICrypto $crypto
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
+
+    /**
+     * Check whether the currently authenticated user is a Nextcloud administrator.
+     *
+     * @return bool True if a user is signed in and belongs to the admin group.
+     */
+    private function isCurrentUserAdmin(): bool
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        return $this->groupManager->isAdmin($user->getUID());
+    }//end isCurrentUserAdmin()
+
+    /**
+     * Serialize a source for the response, stripping databaseUrl for non-admins.
+     *
+     * @param Source $source The source entity to serialize.
+     *
+     * @return array<string, mixed> The serialized source data.
+     */
+    private function serializeSource(Source $source): array
+    {
+        $data = $source->jsonSerialize();
+        if ($this->isCurrentUserAdmin() === false) {
+            unset($data['databaseUrl']);
+        }
+
+        return $data;
+    }//end serializeSource()
 
     /**
      * Retrieves a list of all sources
@@ -97,13 +138,15 @@ class SourcesController extends Controller
         unset($filters['_limit'], $filters['_offset'], $filters['_page'], $filters['_search'], $filters['_route']);
 
         // Return all sources that match the filters.
+        // Strip databaseUrl from non-admin responses to prevent credential exposure.
+        $sources = $this->sourceMapper->findAll(
+            limit: $limit,
+            offset: $offset,
+            filters: $filters
+        );
         return new JSONResponse(
             data: [
-                'results' => $this->sourceMapper->findAll(
-                    limit: $limit,
-                    offset: $offset,
-                    filters: $filters
-                ),
+                'results' => array_map(fn(Source $s) => $this->serializeSource($s), $sources),
             ]
         );
     }//end index()
@@ -126,7 +169,8 @@ class SourcesController extends Controller
     {
         try {
             // Try to find the source by ID.
-            return new JSONResponse(data: $this->sourceMapper->find(id: (int) $id));
+            $source = $this->sourceMapper->find(id: (int) $id);
+            return new JSONResponse(data: $this->serializeSource($source));
         } catch (DoesNotExistException $exception) {
             // Return a 404 error if the source doesn't exist.
             return new JSONResponse(data: ['error' => $this->l10n->t('Not Found')], statusCode: 404);
@@ -150,6 +194,10 @@ class SourcesController extends Controller
      */
     public function create(): JSONResponse
     {
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(data: ['error' => $this->l10n->t('Admin privileges required')], statusCode: 403);
+        }
+
         // Get request parameters.
         $data = $this->request->getParams();
 
@@ -165,8 +213,14 @@ class SourcesController extends Controller
             unset($data['id']);
         }
 
+        // Encrypt databaseUrl at rest before persisting.
+        if (isset($data['databaseUrl']) === true && $data['databaseUrl'] !== null && $data['databaseUrl'] !== '') {
+            $data['databaseUrl'] = $this->crypto->encrypt((string) $data['databaseUrl']);
+        }
+
         // Create a new source from the data.
-        return new JSONResponse(data: $this->sourceMapper->createFromArray(object: $data));
+        $source = $this->sourceMapper->createFromArray(object: $data);
+        return new JSONResponse(data: $this->serializeSource($source));
     }//end create()
 
     /**
@@ -188,6 +242,10 @@ class SourcesController extends Controller
      */
     public function update(int $id): JSONResponse
     {
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(data: ['error' => $this->l10n->t('Admin privileges required')], statusCode: 403);
+        }
+
         // Get request parameters.
         $data = $this->request->getParams();
 
@@ -204,9 +262,14 @@ class SourcesController extends Controller
         unset($data['owner']);
         unset($data['created']);
 
+        // Encrypt databaseUrl at rest before persisting.
+        if (isset($data['databaseUrl']) === true && $data['databaseUrl'] !== null && $data['databaseUrl'] !== '') {
+            $data['databaseUrl'] = $this->crypto->encrypt((string) $data['databaseUrl']);
+        }
+
         // Update the source with the provided data.
         $source = $this->sourceMapper->updateFromArray(id: $id, object: $data);
-        return new JSONResponse(data: $source);
+        return new JSONResponse(data: $this->serializeSource($source));
     }//end update()
 
     /**
@@ -250,6 +313,10 @@ class SourcesController extends Controller
      */
     public function destroy(int $id): JSONResponse
     {
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(data: ['error' => $this->l10n->t('Admin privileges required')], statusCode: 403);
+        }
+
         // Find the source by ID and delete it.
         $this->sourceMapper->delete($this->sourceMapper->find($id));
 

--- a/lib/Controller/WorkflowEngineController.php
+++ b/lib/Controller/WorkflowEngineController.php
@@ -30,7 +30,9 @@ use OCA\OpenRegister\Service\WorkflowEngineRegistry;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IL10N;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -45,21 +47,40 @@ class WorkflowEngineController extends Controller
     /**
      * Constructor for WorkflowEngineController.
      *
-     * @param string                 $appName  App name
-     * @param IRequest               $request  Request
-     * @param WorkflowEngineRegistry $registry Engine registry
-     * @param LoggerInterface        $logger   Logger
-     * @param IL10N                  $l10n     Localization service
+     * @param string                 $appName      App name
+     * @param IRequest               $request      Request
+     * @param WorkflowEngineRegistry $registry     Engine registry
+     * @param LoggerInterface        $logger       Logger
+     * @param IL10N                  $l10n         Localization service
+     * @param IUserSession           $userSession  User session for admin checks
+     * @param IGroupManager          $groupManager Group manager for admin checks
      */
     public function __construct(
         string $appName,
         IRequest $request,
         private readonly WorkflowEngineRegistry $registry,
         private readonly LoggerInterface $logger,
-        private readonly IL10N $l10n
+        private readonly IL10N $l10n,
+        private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
+
+    /**
+     * Check whether the currently authenticated user is a Nextcloud administrator.
+     *
+     * @return bool True if a user is signed in and belongs to the admin group.
+     */
+    private function isCurrentUserAdmin(): bool
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        return $this->groupManager->isAdmin($user->getUID());
+    }//end isCurrentUserAdmin()
 
     /**
      * List all registered engines.
@@ -125,6 +146,10 @@ class WorkflowEngineController extends Controller
         bool $enabled=true,
         int $defaultTimeout=30
     ): JSONResponse {
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(['error' => 'Admin privileges required'], 403);
+        }
+
         $validTypes = ['n8n', 'windmill'];
         if (in_array(needle: $engineType, haystack: $validTypes, strict: true) === false) {
             return new JSONResponse(
@@ -174,6 +199,10 @@ class WorkflowEngineController extends Controller
      */
     public function update(int $id): JSONResponse
     {
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(['error' => 'Admin privileges required'], 403);
+        }
+
         try {
             $data   = $this->request->getParams();
             $engine = $this->registry->updateEngine($id, $data);
@@ -197,6 +226,10 @@ class WorkflowEngineController extends Controller
      */
     public function destroy(int $id): JSONResponse
     {
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(['error' => 'Admin privileges required'], 403);
+        }
+
         try {
             $engine = $this->registry->deleteEngine($id);
 


### PR DESCRIPTION
## Security fixes — PR A

**C1 FilesController::downloadById** — anonymous file-IDOR: gate anonymous callers on `isFilePublished`; authenticated callers pass through. Added `resolveParentObjectForFile()` for best-effort audit context in `recordDownloadEvent` (L2).

**C2 ConfigurationsController / ConfigurationController** — entire CRUD was `@NoAdminRequired + _multitenancy:false`. Injected `IUserSession`/`IGroupManager`; admin-gate all write methods; fixed `index`/`show` to use `_multitenancy:true` for non-admins.

**C3 SourcesController** — `Source.databaseUrl` plaintext at rest. Injected `ICrypto`; encrypt `databaseUrl` on create/update; strip from non-admin responses via `serializeSource()`.

**C4 WorkflowEngineController** — CRUD was `@NoAdminRequired`. Admin-gate `create`/`update`/`destroy`.

**L1 importFromUrl** — SSRF allowlist: HTTPS-only + block loopback/RFC-1918/link-local.

## Test plan
- [ ] Non-admin 403 on configuration/source/workflow-engine writes
- [ ] Anonymous /api/files/download/{unpublished} → 403
- [ ] Anonymous /api/files/download/{published} → 200 stream
- [ ] importFromUrl http:// or 192.168.x.x → 400