### PR TITLE
fix(security): gate anonymous callers on file visibility (H5, H6)

### DIFF
--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -205,8 +205,11 @@ class FilesController extends Controller
         unset($routeParams);
 
         try {
+            // SECURITY (H6): anonymous callers see only published (shared) files.
+            $isAnonymous = ($this->userSession !== null && $this->userSession->getUser() === null);
+
             // Get the raw files from the file service.
-            $files = $this->fileService->getFiles(object: $id);
+            $files = $this->fileService->getFiles(object: $id, sharedFilesOnly: $isAnonymous);
 
             // Format the files with pagination using request parameters.
             $formattedFiles = $this->fileService->formatFiles(files: $files, requestParams: $this->request->getParams());
@@ -284,6 +287,18 @@ class FilesController extends Controller
                     data: ['error' => 'File not found'],
                     statusCode: 404
                 );
+            }
+
+            // SECURITY (H5): gate anonymous callers on the file being published.
+            // Mirrors the same guard in downloadById() and preview().
+            $isAnonymous = ($this->userSession !== null && $this->userSession->getUser() === null);
+            if ($isAnonymous === true) {
+                if ($this->fileMapper === null || $this->fileMapper->isFilePublished((int) $file->getId()) === false) {
+                    return new JSONResponse(
+                        data: ['error' => 'File not available for anonymous access'],
+                        statusCode: 403
+                    );
+                }
             }
 
             // Stream the file inline so browsers display images/logos directly.


### PR DESCRIPTION
Anonymous callers could previously enumerate all files attached to an object and stream any file by ID. Two guards added:

**H5 (show)**: After resolving the target file, check if the caller is anonymous and reject 403 unless the file has a public share link. Mirrors the identical guard already present in downloadById() and preview().

**H6 (index)**: Pass sharedFilesOnly=true to FileService::getFiles() when the caller is anonymous, so the listing only includes files with a public share link. Authenticated callers are unaffected.

## Test plan
- [ ] Anonymous GET /api/objects/{r}/{s}/{id}/files returns only shared files
- [ ] Anonymous GET /api/objects/{r}/{s}/{id}/files/{fileId} returns 403 for unshared file
- [ ] Anonymous GET /api/objects/{r}/{s}/{id}/files/{fileId} returns 200 for shared file
- [ ] Authenticated GET /api/objects/{r}/{s}/{id}/files returns all files
- [ ] Authenticated GET /api/objects/{r}/{s}/{id}/files/{fileId} returns file content