### PR TITLE
fix(security): gate endpoint/approval writes, schema upload, notif read-check (H3, H7, M1, M2)

### DIFF
--- a/lib/Controller/ApprovalController.php
+++ b/lib/Controller/ApprovalController.php
@@ -33,6 +33,7 @@ use OCA\OpenRegister\Db\ApprovalStepMapper;
 use OCA\OpenRegister\Service\ApprovalService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -56,6 +57,7 @@ class ApprovalController extends Controller
      * @param ApprovalService     $approvalService Approval service
      * @param IUserSession        $userSession     User session
      * @param LoggerInterface     $logger          Logger
+     * @param IGroupManager       $groupManager    Group manager for admin checks
      */
     public function __construct(
         string $appName,
@@ -64,10 +66,26 @@ class ApprovalController extends Controller
         private readonly ApprovalStepMapper $stepMapper,
         private readonly ApprovalService $approvalService,
         private readonly IUserSession $userSession,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly IGroupManager $groupManager
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
+
+    /**
+     * Determine whether the current user is a Nextcloud admin.
+     *
+     * @return bool True when the active session user belongs to the admin group.
+     */
+    private function isCurrentUserAdmin(): bool
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        return $this->groupManager->isAdmin($user->getUID());
+    }//end isCurrentUserAdmin()
 
     /**
      * List all approval chains.
@@ -118,6 +136,11 @@ class ApprovalController extends Controller
      */
     public function create(): JSONResponse
     {
+        // SECURITY (M1): approval chain writes are admin-only.
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(['error' => 'Admin privileges required'], 403);
+        }
+
         $data = $this->request->getParams();
 
         try {
@@ -140,6 +163,11 @@ class ApprovalController extends Controller
      */
     public function update(int $id): JSONResponse
     {
+        // SECURITY (M1): approval chain writes are admin-only.
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(['error' => 'Admin privileges required'], 403);
+        }
+
         try {
             $data  = $this->request->getParams();
             $chain = $this->chainMapper->updateFromArray($id, $data);
@@ -163,6 +191,11 @@ class ApprovalController extends Controller
      */
     public function destroy(int $id): JSONResponse
     {
+        // SECURITY (M1): approval chain writes are admin-only.
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(['error' => 'Admin privileges required'], 403);
+        }
+
         try {
             $chain = $this->chainMapper->find($id);
             $this->chainMapper->delete($chain);

--- a/lib/Controller/EndpointsController.php
+++ b/lib/Controller/EndpointsController.php
@@ -33,7 +33,9 @@ use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -104,6 +106,20 @@ class EndpointsController extends Controller
     private readonly LoggerInterface $logger;
 
     /**
+     * User session for authentication checks.
+     *
+     * @var IUserSession User session instance
+     */
+    private readonly IUserSession $userSession;
+
+    /**
+     * Group manager for admin-role checks.
+     *
+     * @var IGroupManager Group manager instance
+     */
+    private readonly IGroupManager $groupManager;
+
+    /**
      * Constructor
      *
      * Initializes controller with required dependencies for endpoint management.
@@ -115,6 +131,8 @@ class EndpointsController extends Controller
      * @param EndpointLogMapper $endpointLogMapper Endpoint log mapper for log operations
      * @param EndpointService   $endpointService   Endpoint service for business logic
      * @param LoggerInterface   $logger            Logger for error tracking
+     * @param IUserSession      $userSession       User session for auth checks
+     * @param IGroupManager     $groupManager      Group manager for admin checks
      *
      * @return void
      */
@@ -124,7 +142,9 @@ class EndpointsController extends Controller
         EndpointMapper $endpointMapper,
         EndpointLogMapper $endpointLogMapper,
         EndpointService $endpointService,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        IUserSession $userSession,
+        IGroupManager $groupManager
     ) {
         // Call parent constructor to initialize base controller.
         parent::__construct(appName: $appName, request: $request);
@@ -134,7 +154,24 @@ class EndpointsController extends Controller
         $this->endpointLogMapper = $endpointLogMapper;
         $this->endpointService   = $endpointService;
         $this->logger            = $logger;
+        $this->userSession       = $userSession;
+        $this->groupManager      = $groupManager;
     }//end __construct()
+
+    /**
+     * Determine whether the current user is a Nextcloud admin.
+     *
+     * @return bool True when the active session user belongs to the admin group.
+     */
+    private function isCurrentUserAdmin(): bool
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        return $this->groupManager->isAdmin($user->getUID());
+    }//end isCurrentUserAdmin()
 
     /**
      * List all endpoints
@@ -276,6 +313,11 @@ class EndpointsController extends Controller
     #[NoCSRFRequired]
     public function create(): JSONResponse
     {
+        // SECURITY (H7): endpoint writes are admin-only.
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(data: ['error' => 'Admin privileges required'], statusCode: 403);
+        }
+
         try {
             // Get endpoint data from request parameters.
             $data = $this->request->getParams();
@@ -354,6 +396,11 @@ class EndpointsController extends Controller
     #[NoCSRFRequired]
     public function update(int $id): JSONResponse
     {
+        // SECURITY (H7): endpoint writes are admin-only.
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(data: ['error' => 'Admin privileges required'], statusCode: 403);
+        }
+
         try {
             // Get update data from request parameters.
             $data = $this->request->getParams();
@@ -467,6 +514,11 @@ class EndpointsController extends Controller
     #[NoCSRFRequired]
     public function destroy(int $id): JSONResponse
     {
+        // SECURITY (H7): endpoint writes are admin-only.
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(data: ['error' => 'Admin privileges required'], statusCode: 403);
+        }
+
         try {
             // Find endpoint by ID to ensure it exists before deletion.
             $endpoint = $this->endpointMapper->find($id);

--- a/lib/Controller/NotificationSubscriptionsController.php
+++ b/lib/Controller/NotificationSubscriptionsController.php
@@ -130,18 +130,13 @@ class NotificationSubscriptionsController extends Controller
         $registerId = $this->coerceNullableInt(value: ($params['registerId'] ?? null));
         $schemaId   = $this->coerceNullableInt(value: ($params['schemaId'] ?? null));
 
-        // Validate the referenced register/schema exists before persisting
-        // the subscription. Metadata-read bypass per the auth-system
-        // requirement "Schema and register METADATA-READ lookups MUST
-        // bypass multi-tenancy" — register/schema definitions are a
-        // globally-visible catalog (admin without an active organisation
-        // would otherwise 404 here). Tenant isolation for the eventual
-        // notification delivery is enforced downstream by the dispatcher,
-        // which filters object-row events by the subscriber's organisation
-        // before fan-out.
+        // SECURITY (M2): verify the caller has read access to the referenced
+        // register/schema before persisting the subscription.
+        // Use _multitenancy: true to enforce tenant-scope — a user in org A
+        // must not be allowed to subscribe to org B's register/schema events.
         if ($registerId !== null) {
             try {
-                $this->registerMapper->find($registerId, _multitenancy: false);
+                $this->registerMapper->find($registerId, _multitenancy: true);
             } catch (\Throwable $e) {
                 return new JSONResponse(
                     data: ['error' => 'Register not found or not accessible'],
@@ -152,7 +147,7 @@ class NotificationSubscriptionsController extends Controller
 
         if ($schemaId !== null) {
             try {
-                $this->schemaMapper->find($schemaId, _multitenancy: false);
+                $this->schemaMapper->find($schemaId, _multitenancy: true);
             } catch (\Throwable $e) {
                 return new JSONResponse(
                     data: ['error' => 'Schema not found or not accessible'],

--- a/lib/Controller/SchemasController.php
+++ b/lib/Controller/SchemasController.php
@@ -826,6 +826,25 @@ class SchemasController extends Controller
             $schema = $this->schemaMapper->find($id);
         }
 
+        // SECURITY (H3): gate schema uploads on appropriate permissions.
+        // Updating an existing schema requires manage-permission (same as update/destroy).
+        // Creating a new schema requires admin (same as create).
+        if ($id !== null) {
+            if ($this->checkSchemaManagePermission(schema: $schema) === false) {
+                return new JSONResponse(
+                    data: ['error' => 'You do not have permission to update this schema'],
+                    statusCode: 403
+                );
+            }
+        } else {
+            if ($this->isCurrentUserAdmin() === false) {
+                return new JSONResponse(
+                    data: ['error' => 'Admin privileges required to upload new schemas'],
+                    statusCode: 403
+                );
+            }
+        }
+
         // Get the uploaded JSON data.
         $phpArray = $this->uploadService->getUploadedJson($this->request->getParams());
         if ($phpArray instanceof JSONResponse) {


### PR DESCRIPTION
Four security findings addressed: H3 SchemasController::upload gated (new=admin, existing=manage-permission). H7 EndpointsController create/update/patch/destroy admin-gated (reads open). M1 ApprovalController create/update/destroy admin-gated (reads open). M2 NotificationSubscriptionsController::create switched from _multitenancy:false to _multitenancy:true to prevent cross-tenant subscriptions.