### PR TITLE
fix(security): SQL injection in MagicMapper UNION search (wave-3 C2, C3)

### DIFF
--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -1210,10 +1210,30 @@ class MagicMapper extends AbstractObjectMapper
                 }
 
                 // Translate field name to column name.
-                $columnName = $this->sanitizeColumnName(name: $field);
+                // Security: every branch MUST route the user-supplied $field through
+                // sanitizeColumnName + quoteIdentifier before concatenating into the
+                // raw ORDER BY clause. The `@self.<suffix>` branch is additionally
+                // allowlist-validated against the known metadata-column set; any
+                // unknown suffix is silently skipped so an attacker cannot inject
+                // arbitrary identifiers or SQL fragments via the order parameter.
                 if (str_starts_with($field, '@self.') === true) {
-                    $columnName = self::METADATA_PREFIX.substr($field, 6);
-                } else if (str_starts_with($field, '_') === false) {
+                    $suffix             = substr($field, 6);
+                    $candidate          = self::METADATA_PREFIX.$this->sanitizeColumnName(name: $suffix);
+                    $allowedMetaColumns = array_keys($this->getMetadataColumns());
+                    if (in_array($candidate, $allowedMetaColumns, true) === false) {
+                        // Unknown metadata suffix: skip rather than risk arbitrary identifier injection.
+                        continue;
+                    }
+
+                    $columnName = $this->quoteIdentifier(name: $candidate, isPostgres: $isPostgres);
+                } else if (str_starts_with($field, '_') === true) {
+                    // Reserved system column reference (e.g. `_relevance` handled above; others
+                    // like `_search_score`). Still sanitise + quote to be safe.
+                    $columnName = $this->quoteIdentifier(
+                        name: $this->sanitizeColumnName(name: $field),
+                        isPostgres: $isPostgres
+                    );
+                } else {
                     // Non-metadata fields - property columns are included in UNION queries.
                     // The column must exist in the SELECT for ordering to work.
                     // Quote to protect against SQL reserved keywords (e.g. "order", "group").
@@ -1240,8 +1260,12 @@ class MagicMapper extends AbstractObjectMapper
         }//end if
 
         // Apply LIMIT/OFFSET to final UNION result.
-        $limit     = $query['_limit'] ?? 100;
-        $offset    = $query['_offset'] ?? 0;
+        // Security: coerce to int + clamp at the boundary. Without this cast the
+        // user-supplied _limit / _offset interpolate as strings directly into
+        // raw SQL, which is a textbook SQL-injection vector. The clamp also
+        // prevents pathological pagination requests from blowing up the DB.
+        $limit     = max(1, min(1000, (int) ($query['_limit'] ?? 100)));
+        $offset    = max(0, (int) ($query['_offset'] ?? 0));
         $unionSql .= " LIMIT {$limit} OFFSET {$offset}";
 
         // Execute the combined query.


### PR DESCRIPTION
## Wave-3 critical security sweep — PR 1 of 4

Fixes two SQL-injection vectors in `lib/Db/MagicMapper.php::searchAcrossMultipleTablesWithUnion()`.

### C2 — _limit / _offset interpolated raw into UNION SQL

`MagicMapper.php:1243-1245` (pre-fix) built `" LIMIT {limit} OFFSET {offset}"` from `query['_limit']` / `query['_offset']` without casting. `SearchQueryHandler` preserves `_`-prefixed system params untouched, so the raw user value flowed from any `GET /api/objects` (incl. `@PublicPage` paths) into a raw prepared SQL string.

**Fix:** cast + clamp at the boundary: (int), then max(1, min(1000, …)) for limit and max(0, …) for offset.

### C3 — ORDER BY accepted unsanitised @self.<field>

`MagicMapper.php:1213-1224` (pre-fix): the `@self.` branch set columnName = METADATA_PREFIX . substr(field, 6) with no sanitizeColumnName + no quoteIdentifier, then concatenated into the ORDER BY clause. Only the non-`_` else-if branch was sanitised + quoted.

**Fix:** allowlist the `@self.<suffix>` candidate against getMetadataColumns(); sanitise + quote in every branch (incl. the `_`-prefixed system-column path); skip unknown suffixes instead of risking arbitrary-identifier injection.

### Why one PR for both

Both are the same class of bug (SQL injection via unfiltered string interpolation in the same method), both reachable via any UNION-search path including anonymous-reachable `@PublicPage` reads. Keeping them together gives reviewers a single diff to audit the entire UNION-clause assembly.

## Test plan

- [x] php -l lib/Db/MagicMapper.php
- [x] composer phpstan against modified file — [OK] No errors
- [x] PHPUnit MagicMapper suite — 85 tests, 217 assertions passing
- [ ] Manual: GET /api/objects/{r}/{s} with crafted _limit / _offset / _order[@self.X] values