### PR TITLE
fix(security): clamp _limit/_offset + sanitize @self.<field> ORDER BY (wave-3 C2/C3 SQL injection)

### DIFF
--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -1212,7 +1212,23 @@ class MagicMapper extends AbstractObjectMapper
                 // Translate field name to column name.
                 $columnName = $this->sanitizeColumnName(name: $field);
                 if (str_starts_with($field, '@self.') === true) {
-                    $columnName = self::METADATA_PREFIX.substr($field, 6);
+                    // Metadata fields: sanitize the bare name, then validate against
+                    // the known METADATA_PREFIX column allowlist before quoting.
+                    // Without this allowlist, raw user input was concatenated into
+                    // the UNION SQL (SQL injection via ORDER BY).
+                    $rawMetaName     = substr($field, 6);
+                    $sanitizedMeta   = $this->sanitizeColumnName(name: $rawMetaName);
+                    $candidateColumn = self::METADATA_PREFIX.$sanitizedMeta;
+                    $allowedMetadata = array_keys($this->getMetadataColumns());
+                    if (in_array($candidateColumn, $allowedMetadata, true) === false) {
+                        // Unknown metadata column - skip this ORDER BY clause entirely.
+                        continue;
+                    }
+
+                    $columnName = $this->quoteIdentifier(
+                        name: $candidateColumn,
+                        isPostgres: $isPostgres
+                    );
                 } else if (str_starts_with($field, '_') === false) {
                     // Non-metadata fields - property columns are included in UNION queries.
                     // The column must exist in the SELECT for ordering to work.
@@ -1240,8 +1256,10 @@ class MagicMapper extends AbstractObjectMapper
         }//end if
 
         // Apply LIMIT/OFFSET to final UNION result.
-        $limit     = $query['_limit'] ?? 100;
-        $offset    = $query['_offset'] ?? 0;
+        // Cast + clamp at the boundary so raw user input cannot reach the
+        // interpolated SQL string (SQL injection via _limit / _offset).
+        $limit     = max(1, min(1000, (int) ($query['_limit'] ?? 100)));
+        $offset    = max(0, (int) ($query['_offset'] ?? 0));
         $unionSql .= " LIMIT {$limit} OFFSET {$offset}";
 
         // Execute the combined query.


### PR DESCRIPTION
## Summary

Two SQL injection vectors in `MagicMapper::searchAcrossMultipleTablesWithUnion` reachable from any authenticated `GET /api/objects/{register}/{schema}` call. Identified in the wave-3 re-review triage.

### C2 — `lib/Db/MagicMapper.php:1243-1245` (raw `_limit` / `_offset` interpolation)

Before:
```php
$limit  = $query['_limit'] ?? 100;
$offset = $query['_offset'] ?? 0;
$unionSql .= " LIMIT {$limit} OFFSET {$offset}";
```

`$query` originates from request data — a string payload like `"1; DROP TABLE ..."` was interpolated directly into the final SQL string. Fixed by casting to int and clamping at the boundary (`limit` 1..1000, `offset >= 0`) before interpolation, so the values reaching the SQL are guaranteed integers in safe ranges.

### C3 — `lib/Db/MagicMapper.php:1213-1224` (`@self.<field>` ORDER BY)

The `@self.` branch of the ORDER BY translator skipped the `sanitizeColumnName` + `quoteIdentifier` path that the property-column and `_*` branches use, concatenating raw user input directly:

```php
} else if (str_starts_with($field, '@self.') === true) {
    $columnName = self::METADATA_PREFIX.substr($field, 6);
}
```

An attacker could pass `_order[@self.foo;DROP TABLE x]=ASC` and the substring after `@self.` would be interpolated raw into the final `ORDER BY` clause of the UNION SQL.

Fixed by:
1. Routing the metadata branch through `sanitizeColumnName`.
2. Validating the resulting column against the `getMetadataColumns()` allowlist (the 30 known `_*` metadata columns: `_id`, `_uuid`, `_uri`, `_register`, `_schema`, `_owner`, `_organisation`, `_created`, `_updated`, etc.).
3. Skipping the ORDER BY clause entirely if the metadata column is unknown.
4. `quoteIdentifier`-quoting the result before interpolation, matching the property-column branch.

## Impact

SQL injection reachable from any authenticated `GET /api/objects/{register}/{schema}` call that triggers the multi-table UNION search path (i.e. searches spanning more than one register+schema pair). No new tests in this PR — the existing 56 MagicMapper unit tests still pass; reproducing the vulnerable path in a unit test would require a substantial DB / platform / schema mock harness.

## Verification

- `php -l lib/Db/MagicMapper.php` — clean
- `composer phpstan` against `lib/Db/MagicMapper.php` — `[OK] No errors`
- `composer phpunit tests/Unit/Db/MagicMapper/ tests/Unit/Service/MagicMapperTest.php` — 56 tests, 155 assertions, all passing
- Pre-existing failing tests in the full unit suite (ContactService missing `OCA\DAV\CardDAV\CardDavBackend`, SolrNightlyWarmupJob DB-recovery output, ManifestController 404s) confirmed against the unmodified baseline file — unrelated to this change.

## Test plan
- [ ] Sanity-check the diff against the wave-3 triage findings
- [ ] Confirm no other call sites in `MagicMapper.php` build SQL with un-sanitized user input around the modified lines
- [ ] Smoke `GET /api/objects/{register}/{schema}?_order[@self.unknown]=ASC` returns results (clause skipped, not 500)
- [ ] Smoke `GET /api/objects/{register}/{schema}?_order[@self.created]=DESC&_limit=9999` returns at most 1000 rows