### PR TITLE
fix(security): bump twig/twig to ^3.27.0 — patch 5 sandbox bypass CVEs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,7 @@
 		"symfony/uid": "^6.4",
 		"symfony/yaml": "^6.4 || ^7.0",
 		"theodo-group/llphant": "^0.9.3",
-		"twig/twig": "^3.18",
+		"twig/twig": "^3.27.0",
 		"web-token/jwt-framework": "^3",
 		"webonyx/graphql-php": "^15.0",
 		"zbateson/mail-mime-parser": "^3.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5dde3611bdaf93ffb638254d53beb10",
+    "content-hash": "74fbef263382676f4d61f6f55f0270ef",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -6085,16 +6085,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.26.0",
+            "version": "v3.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc"
+                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
-                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
+                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
                 "shasum": ""
             },
             "require": {
@@ -6149,7 +6149,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.26.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.27.0"
             },
             "funding": [
                 {
@@ -6161,7 +6161,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T07:31:59+00:00"
+            "time": "2026-05-27T13:05:51+00:00"
         },
         {
             "name": "web-token/jwt-framework",


### PR DESCRIPTION
## Summary

- Bumps `twig/twig` from `v3.26.0` (`^3.18`) to `v3.27.0` (`^3.27.0`) to address five sandbox bypass CVEs disclosed 2026-05-27.
- `composer audit` now reports **0 advisories** (was 5).
- No PHP source files changed; phpstan error count unchanged at 13 (pre-existing baseline).

## CVEs fixed

| CVE | Title |
|-----|-------|
| CVE-2026-48805 | Sandbox state regression in deprecated internal wrappers in `src/Resources/core.php` |
| CVE-2026-48806 | Sandbox `__toString()` policy bypass via dynamic mapping keys |
| CVE-2026-48807 | Sandbox `__toString()` policy bypass via `Traversable` in `join`/`replace` and `in`/`not in` operators |
| CVE-2026-48808 | Sandbox property allowlist bypass via the `column` filter under `SourcePolicyInterface` |
| CVE-2026-46636 | Sandbox filter, tag and function allow-list bypass when sandbox state changes between renders |

## Test plan

- [x] `composer audit` → 0 advisories
- [x] `composer phpstan` → 13 errors (identical to development baseline, no regression)
- [x] Only `composer.json` and `composer.lock` changed