### PR TITLE
fix(security): scope audit-trail + search-trail to admin (wave-3 C6/C7 cross-tenant leak)

### DIFF
--- a/lib/Controller/AuditTrailController.php
+++ b/lib/Controller/AuditTrailController.php
@@ -47,9 +47,14 @@ use OCP\IRequest;
  *
  * @psalm-suppress UnusedClass
  *
- * @SuppressWarnings(PHPMD.ExcessiveClassLength)   Controller covers audit trail, verification, verwerkingsregister
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Necessary service dependencies
- * @SuppressWarnings(PHPMD.TooManyPublicMethods)   One public method per audit trail route
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength)     Controller covers audit trail, verification, verwerkingsregister
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)   Necessary service dependencies
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)     One public method per audit trail route
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) Audit-trail surface fans out into hash-verify,
+ *     verwerkingsregister, inzageverzoek, export, immutability + admin-gating; the controller's
+ *     overall cyclomatic complexity sits one step above the default threshold (51 vs 50) after
+ *     the wave-3 C6 admin-only gates on index()/show() were added. Splitting the controller
+ *     would force a route-table reshuffle without removing any actual branching.
  */
 class AuditTrailController extends Controller
 {
@@ -77,12 +82,17 @@ class AuditTrailController extends Controller
     }//end __construct()
 
     /**
-     * Gate destructive / bulk-export audit operations on admin membership.
+     * Gate destructive / bulk-export / bulk-read audit operations on admin membership.
      *
      * SECURITY: `clearAll` wipes the entire audit table — a chain of
      * trust for AVG/GDPR Art 30 reviews. `export` dumps every row in
-     * bulk and is an obvious recon path across tenants. Both surfaces
-     * are admin-only at the framework level (the methods carry no
+     * bulk and is an obvious recon path across tenants. `index` and
+     * `show` expose cross-tenant audit-trail rows (per-row diffs of
+     * every object change in every register/schema, frequently PII or
+     * IP-heavy); without this gate any authenticated user — including
+     * users restricted to a single app group — could enumerate every
+     * other tenant's change history (wave-3 C6). All surfaces are
+     * admin-only at the framework level for sensitive routes (no
      * `@NoAdminRequired`) and this body-level helper stays as
      * defence-in-depth so removing the framework gate by accident does
      * not silently open the surface.
@@ -157,8 +167,8 @@ class AuditTrailController extends Controller
         // Extract search parameter.
         $search = $params['search'] ?? $params['_search'] ?? null;
 
-        $sort    = $this->buildSortFromParams($params);
-        $filters = $this->buildFiltersFromParams($params);
+        $sort    = $this->buildSortFromParams(params: $params);
+        $filters = $this->buildFiltersFromParams(params: $params);
 
         return [
             'limit'   => $limit,
@@ -191,12 +201,18 @@ class AuditTrailController extends Controller
         if (is_array($sortRaw) === true) {
             // Bracket format: _sort[created]=DESC.
             foreach ($sortRaw as $field => $direction) {
-                $sort[$field] = strtoupper($direction) === 'ASC' ? 'ASC' : 'DESC';
+                $sort[$field] = 'DESC';
+                if (strtoupper($direction) === 'ASC') {
+                    $sort[$field] = 'ASC';
+                }
             }
         } else if ($sortRaw !== null) {
             // Flat format: sort=created&order=DESC.
             $sortOrder      = $params['order'] ?? $params['_order'] ?? 'DESC';
-            $sort[$sortRaw] = strtoupper($sortOrder) === 'ASC' ? 'ASC' : 'DESC';
+            $sort[$sortRaw] = 'DESC';
+            if (strtoupper($sortOrder) === 'ASC') {
+                $sort[$sortRaw] = 'ASC';
+            }
         }
 
         if (empty($sort) === true) {
@@ -217,9 +233,25 @@ class AuditTrailController extends Controller
     private function buildFiltersFromParams(array $params): array
     {
         $systemKeys = [
-            'limit', '_limit', 'offset', '_offset', 'page', '_page',
-            'search', '_search', 'sort', '_sort', 'order', '_order',
-            '_route', 'id', 'register', 'schema', 'format', 'from', 'to',
+            'limit',
+            '_limit',
+            'offset',
+            '_offset',
+            'page',
+            '_page',
+            'search',
+            '_search',
+            'sort',
+            '_sort',
+            'order',
+            '_order',
+            '_route',
+            'id',
+            'register',
+            'schema',
+            'format',
+            'from',
+            'to',
             'identifier',
         ];
 
@@ -235,22 +267,26 @@ class AuditTrailController extends Controller
     /**
      * Get all audit trail logs
      *
-     * @NoAdminRequired
+     * Admin-only at the framework level (no @NoAdminRequired). Body
+     * `requireAdmin()` stays as defence-in-depth. The cross-tenant
+     * audit-trail index leaks per-row diffs of every object change
+     * across every register/schema — wave-3 C6. Returns 200 on
+     * success, 401 when anonymous, 403 when non-admin.
      *
      * @return JSONResponse JSON response containing list of audit trails
      *
      * @NoCSRFRequired
-     *
-     * @psalm-return JSONResponse<200,
-     *     array{results: array<\OCA\OpenRegister\Db\AuditTrail>,
-     *     total: int<0, max>, page: int|null, pages: float, limit: int,
-     *     offset: int|null}, array<never, never>>
      *
      * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-8
      * @spec openspec/changes/retrofit-2026-04-30-annotate-openregister/tasks.md#task-17
      */
     public function index(): JSONResponse
     {
+        $denial = $this->requireAdmin();
+        if ($denial !== null) {
+            return $denial;
+        }
+
         // Extract common parameters.
         $params = $this->extractRequestParameters();
 
@@ -276,29 +312,30 @@ class AuditTrailController extends Controller
     /**
      * Get a specific audit trail log by ID
      *
+     * Admin-only at the framework level (no @NoAdminRequired). Body
+     * `requireAdmin()` stays as defence-in-depth. Without the gate,
+     * any authed caller could fetch any audit-trail row by ID — and
+     * IDs are sequential, so this is also a trivial enumeration path
+     * across every tenant's change history (wave-3 C6). Returns 200
+     * on success, 401 when anonymous, 403 when non-admin, 404 if
+     * the row does not exist.
+     *
      * @param int $id The audit trail ID
      *
      * @return JSONResponse A JSON response containing the log
      *
-     * @NoAdminRequired
-     *
      * @NoCSRFRequired
-     *
-     * @psalm-return JSONResponse<
-     *     200,
-     *     array<array-key, mixed>,
-     *     array<never, never>
-     * >|JSONResponse<
-     *     404,
-     *     array{error: 'Audit trail not found'},
-     *     array<never, never>
-     * >
      *
      * @spec openspec/changes/retrofit-2026-04-23-annotate-openregister/tasks.md#task-8
      * @spec openspec/changes/retrofit-2026-04-30-annotate-openregister/tasks.md#task-15
      */
     public function show(int $id): JSONResponse
     {
+        $denial = $this->requireAdmin();
+        if ($denial !== null) {
+            return $denial;
+        }
+
         try {
             $log = $this->logService->getLog($id);
             return new JSONResponse(data: $log);

--- a/lib/Controller/SearchTrailController.php
+++ b/lib/Controller/SearchTrailController.php
@@ -30,7 +30,9 @@ use OCA\OpenRegister\Service\SearchTrailService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Class SearchTrailController
@@ -49,14 +51,53 @@ class SearchTrailController extends Controller
      * @param string             $appName            The name of the app
      * @param IRequest           $request            The request object
      * @param SearchTrailService $searchTrailService The search trail service
+     * @param IUserSession       $userSession        Active user session for caller identity
+     * @param IGroupManager      $groupManager       Group manager for admin / role checks
      */
     public function __construct(
         string $appName,
         IRequest $request,
-        private readonly SearchTrailService $searchTrailService
+        private readonly SearchTrailService $searchTrailService,
+        private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
+
+    /**
+     * Gate sensitive search-trail read operations on admin membership.
+     *
+     * SECURITY: search-trail rows record per-search IP address, user
+     * ID, user-agent and full query string for every search across
+     * every register/schema. Returning them to non-admin callers leaks
+     * PII (GDPR) and gives any authenticated user — including users
+     * restricted to a single app group — a recon view of what every
+     * other tenant is searching for (wave-3 C7). Surface stays
+     * admin-only at both the framework level (no `@NoAdminRequired`)
+     * and the body level (defence-in-depth).
+     *
+     * @return JSONResponse|null 401/403 response when blocked, null when allowed.
+     */
+    private function requireAdmin(): ?JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(
+                data: ['error' => 'Authentication required'],
+                statusCode: 401
+            );
+        }
+
+        if ($this->groupManager->isAdmin($user->getUID()) === false) {
+            return new JSONResponse(
+                data: ['error' => 'Forbidden: this search-trail operation is admin-only'],
+                statusCode: 403
+            );
+        }
+
+        return null;
+
+    }//end requireAdmin()
 
     /**
      * Extract pagination, filter, and search parameters from request
@@ -305,7 +346,8 @@ class SearchTrailController extends Controller
     /**
      * Get all search trail logs
      *
-     * @NoAdminRequired
+     * Admin-only at the framework level (no @NoAdminRequired). Body
+     * `requireAdmin()` stays as defence-in-depth — wave-3 C7.
      *
      * @NoCSRFRequired
      *
@@ -315,6 +357,11 @@ class SearchTrailController extends Controller
      */
     public function index(): JSONResponse
     {
+        $denial = $this->requireAdmin();
+        if ($denial !== null) {
+            return $denial;
+        }
+
         try {
             // Get raw request parameters (this is what the service expects).
             $rawParams = $this->request->getParams();
@@ -353,9 +400,13 @@ class SearchTrailController extends Controller
     /**
      * Get a specific search trail log by ID
      *
-     * @param int $id The search trail ID
+     * Admin-only at the framework level (no @NoAdminRequired). Body
+     * `requireAdmin()` stays as defence-in-depth — wave-3 C7. IDs
+     * are sequential so without the gate any authed caller could
+     * enumerate every tenant's recorded searches (IP, user ID,
+     * user-agent, query string).
      *
-     * @NoAdminRequired
+     * @param int $id The search trail ID
      *
      * @NoCSRFRequired
      *
@@ -365,6 +416,11 @@ class SearchTrailController extends Controller
      */
     public function show(int $id): JSONResponse
     {
+        $denial = $this->requireAdmin();
+        if ($denial !== null) {
+            return $denial;
+        }
+
         try {
             $log = $this->searchTrailService->getSearchTrail($id);
             return new JSONResponse(data: $log);

--- a/tests/Service/ControllersIntegrationTest.php
+++ b/tests/Service/ControllersIntegrationTest.php
@@ -54,6 +54,7 @@ use OCP\App\IAppManager;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IDBConnection;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -277,11 +278,15 @@ class ControllersIntegrationTest extends TestCase
             \OC::$server->get(LoggerInterface::class)
         );
 
-        // Build SearchTrailController.
+        // Build SearchTrailController. Reuse the shared userSession mock and
+        // wire a real IGroupManager so the search-trail admin-only gate
+        // (wave-3 C7) reflects production behaviour in integration runs.
         $this->searchTrailController = new SearchTrailController(
             'openregister',
             $this->request,
-            \OC::$server->get(SearchTrailService::class)
+            \OC::$server->get(SearchTrailService::class),
+            $this->userSession,
+            \OC::$server->get(IGroupManager::class)
         );
 
         // Build EndpointsController.
@@ -1780,6 +1785,8 @@ class ControllersIntegrationTest extends TestCase
      */
     public function testSearchTrailIndex(): void
     {
+        // SearchTrail index is admin-only (wave-3 C7).
+        $this->setupAdminUser();
         $this->request->method('getParams')->willReturn([]);
         $this->request->method('getRequestUri')->willReturn('/api/search-trails');
 
@@ -1798,6 +1805,7 @@ class ControllersIntegrationTest extends TestCase
      */
     public function testSearchTrailIndexWithPagination(): void
     {
+        $this->setupAdminUser();
         $this->request->method('getParams')->willReturn([
             '_limit' => 5,
             '_offset' => 0,
@@ -1818,6 +1826,7 @@ class ControllersIntegrationTest extends TestCase
      */
     public function testSearchTrailIndexWithPage(): void
     {
+        $this->setupAdminUser();
         $this->request->method('getParams')->willReturn([
             '_limit' => 10,
             '_page' => 2,
@@ -1838,6 +1847,7 @@ class ControllersIntegrationTest extends TestCase
      */
     public function testSearchTrailShowNotFound(): void
     {
+        $this->setupAdminUser();
         $response = $this->searchTrailController->show(999999);
 
         $this->assertInstanceOf(JSONResponse::class, $response);
@@ -2119,6 +2129,7 @@ class ControllersIntegrationTest extends TestCase
      */
     public function testSearchTrailIndexWithDateFilters(): void
     {
+        $this->setupAdminUser();
         $this->request->method('getParams')->willReturn([
             'from' => '2024-01-01',
             'to' => '2025-12-31',
@@ -2138,6 +2149,7 @@ class ControllersIntegrationTest extends TestCase
      */
     public function testSearchTrailIndexWithSort(): void
     {
+        $this->setupAdminUser();
         $this->request->method('getParams')->willReturn([
             '_sort' => 'created',
             '_order' => 'ASC',

--- a/tests/Unit/Controller/AuditTrailControllerTest.php
+++ b/tests/Unit/Controller/AuditTrailControllerTest.php
@@ -536,4 +536,92 @@ class AuditTrailControllerTest extends TestCase
 
         $this->assertEquals(405, $result->getStatus());
     }
+
+    // ── Wave-3 C6 admin-only gate (cross-tenant audit-trail leak) ──
+
+    /**
+     * Build a fresh controller with a non-admin user for gate tests.
+     *
+     * The shared `setUp()` wires an admin user so the rest of the suite
+     * exercises the happy path. C6 tests need a non-admin (or anon)
+     * user, so we rebuild the controller with overridden mocks rather
+     * than fight the sticky `willReturn` already wired in setUp().
+     *
+     * @param IUser|null $user The user the session returns; null => anon.
+     * @param bool       $isAdmin Whether $user is in the admin group.
+     */
+    private function makeControllerWithUser(?IUser $user, bool $isAdmin): AuditTrailController
+    {
+        $session     = $this->createMock(IUserSession::class);
+        $groupMgr    = $this->createMock(IGroupManager::class);
+        $session->method('getUser')->willReturn($user);
+        if ($user !== null) {
+            $groupMgr->method('isAdmin')->with($user->getUID())->willReturn($isAdmin);
+        }
+
+        return new AuditTrailController(
+            'openregister',
+            $this->request,
+            $this->logService,
+            $this->auditTrailMapper,
+            $this->auditHashService,
+            $session,
+            $groupMgr
+        );
+    }
+
+    public function testIndexReturns401WhenAnonymous(): void
+    {
+        $controller = $this->makeControllerWithUser(null, false);
+
+        $result = $controller->index();
+
+        $this->assertEquals(401, $result->getStatus());
+        $this->assertEquals('Authentication required', $result->getData()['error']);
+    }
+
+    public function testIndexReturns403WhenNonAdmin(): void
+    {
+        $bob = $this->createMock(IUser::class);
+        $bob->method('getUID')->willReturn('bob');
+        $controller = $this->makeControllerWithUser($bob, false);
+
+        $result = $controller->index();
+
+        $this->assertEquals(403, $result->getStatus());
+        $this->assertStringContainsString('admin-only', $result->getData()['error']);
+    }
+
+    public function testShowReturns401WhenAnonymous(): void
+    {
+        $controller = $this->makeControllerWithUser(null, false);
+
+        $result = $controller->show(1);
+
+        $this->assertEquals(401, $result->getStatus());
+    }
+
+    public function testShowReturns403WhenNonAdmin(): void
+    {
+        $bob = $this->createMock(IUser::class);
+        $bob->method('getUID')->willReturn('bob');
+        $controller = $this->makeControllerWithUser($bob, false);
+
+        $result = $controller->show(42);
+
+        $this->assertEquals(403, $result->getStatus());
+    }
+
+    public function testShowDoesNotInvokeServiceWhenForbidden(): void
+    {
+        // Defence-in-depth check: a non-admin call must short-circuit
+        // before the service is touched (no DB hit, no log read).
+        $bob = $this->createMock(IUser::class);
+        $bob->method('getUID')->willReturn('bob');
+        $controller = $this->makeControllerWithUser($bob, false);
+
+        $this->logService->expects($this->never())->method('getLog');
+
+        $controller->show(42);
+    }
 }

--- a/tests/Unit/Controller/SearchTrailControllerCoverageTest.php
+++ b/tests/Unit/Controller/SearchTrailControllerCoverageTest.php
@@ -6,7 +6,10 @@ namespace Unit\Controller;
 
 use OCA\OpenRegister\Controller\SearchTrailController;
 use OCA\OpenRegister\Service\SearchTrailService;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -18,6 +21,8 @@ class SearchTrailControllerCoverageTest extends TestCase
     private SearchTrailController $controller;
     private IRequest&MockObject $request;
     private SearchTrailService&MockObject $searchTrailService;
+    private IUserSession&MockObject $userSession;
+    private IGroupManager&MockObject $groupManager;
 
     protected function setUp(): void
     {
@@ -25,11 +30,20 @@ class SearchTrailControllerCoverageTest extends TestCase
 
         $this->request = $this->createMock(IRequest::class);
         $this->searchTrailService = $this->createMock(SearchTrailService::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->groupManager = $this->createMock(IGroupManager::class);
+
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('admin');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager->method('isAdmin')->with('admin')->willReturn(true);
 
         $this->controller = new SearchTrailController(
             'openregister',
             $this->request,
-            $this->searchTrailService
+            $this->searchTrailService,
+            $this->userSession,
+            $this->groupManager
         );
     }
 

--- a/tests/Unit/Controller/SearchTrailControllerDeepTest.php
+++ b/tests/Unit/Controller/SearchTrailControllerDeepTest.php
@@ -7,7 +7,10 @@ namespace OCA\OpenRegister\Tests\Unit\Controller;
 use OCA\OpenRegister\Controller\SearchTrailController;
 use OCA\OpenRegister\Service\SearchTrailService;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -17,6 +20,8 @@ class SearchTrailControllerDeepTest extends TestCase
     private SearchTrailController $controller;
     private IRequest|MockObject $request;
     private SearchTrailService|MockObject $searchTrailService;
+    private IUserSession|MockObject $userSession;
+    private IGroupManager|MockObject $groupManager;
 
     protected function setUp(): void
     {
@@ -24,11 +29,20 @@ class SearchTrailControllerDeepTest extends TestCase
 
         $this->request = $this->createMock(IRequest::class);
         $this->searchTrailService = $this->createMock(SearchTrailService::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->groupManager = $this->createMock(IGroupManager::class);
+
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('admin');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager->method('isAdmin')->with('admin')->willReturn(true);
 
         $this->controller = new SearchTrailController(
             'openregister',
             $this->request,
-            $this->searchTrailService
+            $this->searchTrailService,
+            $this->userSession,
+            $this->groupManager
         );
     }
 

--- a/tests/Unit/Controller/SearchTrailControllerTest.php
+++ b/tests/Unit/Controller/SearchTrailControllerTest.php
@@ -9,7 +9,10 @@ use OCA\OpenRegister\Controller\SearchTrailController;
 use OCA\OpenRegister\Service\SearchTrailService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -23,6 +26,8 @@ class SearchTrailControllerTest extends TestCase
     private SearchTrailController $controller;
     private IRequest&MockObject $request;
     private SearchTrailService&MockObject $searchTrailService;
+    private IUserSession&MockObject $userSession;
+    private IGroupManager&MockObject $groupManager;
 
     protected function setUp(): void
     {
@@ -30,11 +35,23 @@ class SearchTrailControllerTest extends TestCase
 
         $this->request = $this->createMock(IRequest::class);
         $this->searchTrailService = $this->createMock(SearchTrailService::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->groupManager = $this->createMock(IGroupManager::class);
+
+        // Default: authenticated admin so the requireAdmin() gate on
+        // index()/show() lets the happy-path assertions through. Tests
+        // exercising the non-admin rejection override these expectations.
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('admin');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager->method('isAdmin')->with('admin')->willReturn(true);
 
         $this->controller = new SearchTrailController(
             'openregister',
             $this->request,
-            $this->searchTrailService
+            $this->searchTrailService,
+            $this->userSession,
+            $this->groupManager
         );
     }
 
@@ -1774,5 +1791,86 @@ class SearchTrailControllerTest extends TestCase
         $result = $this->controller->userAgentStats();
 
         $this->assertSame(200, $result->getStatus());
+    }
+
+    // ── Wave-3 C7 admin-only gate (cross-tenant search-trail leak) ──
+
+    /**
+     * Build a fresh controller with a non-admin / anonymous user.
+     *
+     * The shared `setUp()` wires an admin user so the rest of the suite
+     * exercises the happy path. C7 denial tests need to override that.
+     */
+    private function makeControllerWithUser(?IUser $user, bool $isAdmin): SearchTrailController
+    {
+        $session  = $this->createMock(IUserSession::class);
+        $groupMgr = $this->createMock(IGroupManager::class);
+        $session->method('getUser')->willReturn($user);
+        if ($user !== null) {
+            $groupMgr->method('isAdmin')->with($user->getUID())->willReturn($isAdmin);
+        }
+
+        return new SearchTrailController(
+            'openregister',
+            $this->request,
+            $this->searchTrailService,
+            $session,
+            $groupMgr
+        );
+    }
+
+    public function testIndexReturns401WhenAnonymous(): void
+    {
+        $controller = $this->makeControllerWithUser(null, false);
+
+        $result = $controller->index();
+
+        $this->assertEquals(401, $result->getStatus());
+        $this->assertEquals('Authentication required', $result->getData()['error']);
+    }
+
+    public function testIndexReturns403WhenNonAdmin(): void
+    {
+        $bob = $this->createMock(IUser::class);
+        $bob->method('getUID')->willReturn('bob');
+        $controller = $this->makeControllerWithUser($bob, false);
+
+        $result = $controller->index();
+
+        $this->assertEquals(403, $result->getStatus());
+        $this->assertStringContainsString('admin-only', $result->getData()['error']);
+    }
+
+    public function testShowReturns401WhenAnonymous(): void
+    {
+        $controller = $this->makeControllerWithUser(null, false);
+
+        $result = $controller->show(1);
+
+        $this->assertEquals(401, $result->getStatus());
+    }
+
+    public function testShowReturns403WhenNonAdmin(): void
+    {
+        $bob = $this->createMock(IUser::class);
+        $bob->method('getUID')->willReturn('bob');
+        $controller = $this->makeControllerWithUser($bob, false);
+
+        $result = $controller->show(42);
+
+        $this->assertEquals(403, $result->getStatus());
+    }
+
+    public function testShowDoesNotInvokeServiceWhenForbidden(): void
+    {
+        // Defence-in-depth: non-admin must short-circuit before the
+        // search-trail service is touched (no DB hit, no row read).
+        $bob = $this->createMock(IUser::class);
+        $bob->method('getUID')->willReturn('bob');
+        $controller = $this->makeControllerWithUser($bob, false);
+
+        $this->searchTrailService->expects($this->never())->method('getSearchTrail');
+
+        $controller->show(42);
     }
 }


### PR DESCRIPTION
## Summary

Two wave-3 critical findings closed: `AuditTrailController::index`/`show` (**C6**) and `SearchTrailController::index`/`show` (**C7**) were `@NoAdminRequired`, so any authenticated user could enumerate every other tenant's audit-trail rows and search-trail rows — both PII-heavy and recon-grade.

- **C6** — audit-trail rows carry per-row diffs of every object change: register/schema/object UUID, before/after values of every JSON property, actor UID, IP address, processing-activity tag. `LogService::getAllLogs` / `getLog` delegate straight to `AuditTrailMapper::findAll` / `find` with no scope filter, so the surface had no tenant boundary at all. With sequential IDs, `show()` doubled as a trivial enumeration path across the entire instance.
- **C7** — search-trail rows record the full query string, register/schema identifiers, result counts, the caller's IP, user-agent and session id for every search anyone has ever run. Same shape, same leak — plus GDPR-sensitive (IP + user-agent + query terms).

## Fix (Option A — admin-only)

Both surfaces now go through a body-level `requireAdmin()` helper that returns 401 when anonymous and 403 when non-admin, mirroring the existing pattern used by `AuditTrailController::export()` / `clearAll()` and the wave-2 `NotificationHistoryController`. `@NoAdminRequired` is removed at the framework level too, so the gate sits at both layers (defence-in-depth — losing either still keeps the surface closed).

The non-list audit-trail surfaces (`verify`, `verwerkingsregister`, `inzageverzoek`, per-object `objects()`) stay reachable because they already key off identifiers the caller must know up front.

`SearchTrailController` gains `IUserSession` + `IGroupManager` constructor dependencies; NC's DI container auto-wires them, so no `info.xml` change is needed.

## Files

- `lib/Controller/AuditTrailController.php` — `index()` + `show()` gated via existing `requireAdmin()`; helper docblock updated; pre-existing PHPCS run on `buildSortFromParams` / `buildFiltersFromParams` cleaned up in the same commit; new class-level `@SuppressWarnings(PHPMD.ExcessiveClassComplexity)` (the added gate calls bump cyclomatic complexity from 49 to 51).
- `lib/Controller/SearchTrailController.php` — constructor + `requireAdmin()` helper added; `index()` + `show()` gated.
- `tests/Unit/Controller/AuditTrailControllerTest.php` — 5 new denial-path tests covering 401/403 + service-not-invoked on forbidden access.
- `tests/Unit/Controller/SearchTrailControllerTest.php` — 5 new denial-path tests + setUp default-admin so the existing happy paths still pass through the new gate.
- `tests/Unit/Controller/SearchTrailController{Coverage,Deep}Test.php` — constructor sites updated.
- `tests/Service/ControllersIntegrationTest.php` — `SearchTrailController` instantiation wires the shared `userSession` mock + a real `IGroupManager` from DI; `testSearchTrailIndex*` and `testSearchTrailShowNotFound` now call the existing `setupAdminUser()` helper.

## Quality gates (all green on changed files)

| Gate | Result |
| --- | --- |
| `php -l` | clean |
| `composer phpstan` (changed files) | `[OK] No errors` |
| `composer phpcs` (changed files) | clean |
| `composer phpmd` (changed files) | clean |
| `composer phpunit` (4 affected unit suites, 136 tests) | 136 passed, 1 skipped (pre-existing), 1 warning unrelated to this change |

Pre-existing notes (not fixed here, out of hotfix scope):

- `tests/Service/ControllersIntegrationTest.php::testRegisters*` already fails on `development` because `RegistersController::__construct` now expects 19 args (test passes 16) — verified by running the unmodified file from `origin/development`. Worth a follow-up but unrelated to this fix.

## Follow-up issue (Option B)

Filing a separate issue after merge: allow admins to grant an **auditor** group read-only access to audit/search trails without granting full admin (useful for AVG/GDPR Art-30 reviewers and incident-response). Not blocking; admin-only is the safer default for now.

## Test plan

- [ ] CI runs PHPStan/PHPCS/PHPMD/PHPUnit on the changed files and reports green.
- [ ] As a non-admin user in a single-app group, `GET /apps/openregister/api/audit-trail` returns 403.
- [ ] As a non-admin user, `GET /apps/openregister/api/audit-trail/{any-id}` returns 403 — confirming sequential-ID enumeration is closed.
- [ ] As a non-admin user, `GET /apps/openregister/api/search-trail` and `GET /apps/openregister/api/search-trail/{any-id}` return 403.
- [ ] As anonymous, all four return 401 (not 403).
- [ ] As admin, all four return 200 with the existing payload shape (no regression for legitimate users).

Refs: wave-3 triage (`/tmp/triage-openregister.md`) findings **C6** and **C7**. **DO NOT admin-merge.**