### PR TITLE
fix(security): close webhook SSRF chain (wave-3 C9/C10/C13)

### DIFF
--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -1825,7 +1825,7 @@ class ObjectsController extends Controller
      *
      * @PublicPage
      *
-     * @psalm-return JSONResponse<201|403|404,
+     * @psalm-return JSONResponse<201|401|403|404,
      *     array{'@self'?: array{name: mixed|null|string,...}|mixed,
      *     message?: mixed|string, error?: mixed|string,...},
      *     array<never, never>>|JSONResponse<400, string, array<never, never>>
@@ -1842,6 +1842,19 @@ class ObjectsController extends Controller
         string $schema,
         ObjectService $objectService
     ): JSONResponse {
+        // Wave-3 C13: short-circuit anonymous writes BEFORE the webhook
+        // intercept fires. The endpoint is @PublicPage so unauthenticated
+        // reads can pass through the access guard, but writes from an
+        // anonymous caller must never trigger pre-event webhooks
+        // (which can cause side effects in receiving systems —
+        // file ingest, n8n flows, audit logs — before any RBAC check runs).
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(
+                data: ['error' => 'Authentication required to create objects'],
+                statusCode: 401
+            );
+        }
+
         try {
             // Resolve slugs to numeric IDs consistently.
             $resolved = $this->resolveRegisterSchemaIds(register: $register, schema: $schema, objectService: $objectService);
@@ -2334,6 +2347,18 @@ class ObjectsController extends Controller
         string $id,
         ObjectService $objectService
     ): JSONResponse {
+        // Wave-3 C13: short-circuit anonymous writes early. postPatch is
+        // @PublicPage to let multipart file-upload PATCH-semantics work for
+        // logged-in users, but it must never accept writes from an
+        // unauthenticated caller — consistent with create() above and with
+        // OR's read-public / write-authenticated split.
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(
+                data: ['error' => 'Authentication required to update objects'],
+                statusCode: 401
+            );
+        }
+
         try {
             $resolved = $this->resolveRegisterSchemaIds(register: $register, schema: $schema, objectService: $objectService);
         } catch (RegisterNotFoundException | SchemaNotFoundException $e) {

--- a/lib/Controller/WebhooksController.php
+++ b/lib/Controller/WebhooksController.php
@@ -40,7 +40,9 @@ use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -94,14 +96,30 @@ class WebhooksController extends Controller
     private LoggerInterface $logger;
 
     /**
+     * User session for authorization gating on webhook write endpoints.
+     *
+     * @var IUserSession|null
+     */
+    private ?IUserSession $userSession;
+
+    /**
+     * Group manager for admin checks on webhook write endpoints.
+     *
+     * @var IGroupManager|null
+     */
+    private ?IGroupManager $groupManager;
+
+    /**
      * Constructor
      *
-     * @param string           $appName          Application name
-     * @param IRequest         $request          HTTP request
-     * @param WebhookMapper    $webhookMapper    Webhook mapper
-     * @param WebhookLogMapper $webhookLogMapper Webhook log mapper
-     * @param WebhookService   $webhookService   Webhook service
-     * @param LoggerInterface  $logger           Logger
+     * @param string             $appName          Application name
+     * @param IRequest           $request          HTTP request
+     * @param WebhookMapper      $webhookMapper    Webhook mapper
+     * @param WebhookLogMapper   $webhookLogMapper Webhook log mapper
+     * @param WebhookService     $webhookService   Webhook service
+     * @param LoggerInterface    $logger           Logger
+     * @param IUserSession|null  $userSession      User session (for write-endpoint admin gate)
+     * @param IGroupManager|null $groupManager     Group manager (for admin check)
      */
     public function __construct(
         string $appName,
@@ -109,14 +127,59 @@ class WebhooksController extends Controller
         WebhookMapper $webhookMapper,
         WebhookLogMapper $webhookLogMapper,
         WebhookService $webhookService,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        ?IUserSession $userSession=null,
+        ?IGroupManager $groupManager=null
     ) {
         parent::__construct(appName: $appName, request: $request);
         $this->webhookMapper    = $webhookMapper;
         $this->webhookLogMapper = $webhookLogMapper;
         $this->webhookService   = $webhookService;
         $this->logger           = $logger;
+        $this->userSession      = $userSession;
+        $this->groupManager     = $groupManager;
     }//end __construct()
+
+    /**
+     * Whether the current user is a Nextcloud administrator.
+     *
+     * Used to gate all webhook write endpoints (create, update, destroy, test,
+     * retry). Webhooks are an admin-only feature because they grant the holder
+     * the ability to direct outbound HTTP requests from the server — see C9 in
+     * the wave-3 security triage. The dependencies are constructor-injected as
+     * optional only so existing test scaffolding keeps working; in real DI both
+     * are always available, so the absent-dependency branch fails closed.
+     *
+     * @return bool True if the signed-in user is in the admin group.
+     */
+    private function isCurrentUserAdmin(): bool
+    {
+        if ($this->userSession === null || $this->groupManager === null) {
+            return false;
+        }
+
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        return $this->groupManager->isAdmin($user->getUID());
+    }//end isCurrentUserAdmin()
+
+    /**
+     * Build a 403 response for callers without admin rights.
+     *
+     * @return JSONResponse JSON 403 response with a generic error message.
+     */
+    private function forbiddenResponse(): JSONResponse
+    {
+        return new JSONResponse(
+            data: [
+                'error' => 'Administrator privileges are required to manage webhooks',
+            ],
+            statusCode: 403
+        );
+    }//end forbiddenResponse()
 
     /**
      * List all webhooks
@@ -305,6 +368,12 @@ class WebhooksController extends Controller
     #[NoCSRFRequired]
     public function create(): JSONResponse
     {
+        // Webhooks let the holder direct outbound HTTP from the server,
+        // so write access is admin-only (wave-3 C10).
+        if ($this->isCurrentUserAdmin() === false) {
+            return $this->forbiddenResponse();
+        }
+
         try {
             $data = $this->request->getParams();
 
@@ -386,6 +455,11 @@ class WebhooksController extends Controller
     #[NoCSRFRequired]
     public function update(int $id): JSONResponse
     {
+        // Webhook reconfiguration is admin-only (wave-3 C10).
+        if ($this->isCurrentUserAdmin() === false) {
+            return $this->forbiddenResponse();
+        }
+
         try {
             $data = $this->request->getParams();
 
@@ -460,6 +534,11 @@ class WebhooksController extends Controller
     #[NoCSRFRequired]
     public function destroy(int $id): JSONResponse
     {
+        // Webhook deletion is admin-only (wave-3 C10).
+        if ($this->isCurrentUserAdmin() === false) {
+            return $this->forbiddenResponse();
+        }
+
         try {
             $webhook = $this->webhookMapper->find($id);
             $this->webhookMapper->delete($webhook);
@@ -519,6 +598,14 @@ class WebhooksController extends Controller
     #[NoCSRFRequired]
     public function test(int $id): JSONResponse
     {
+        // The /test endpoint actually fires an outbound HTTP request to the
+        // configured URL, so it triggers the same SSRF surface as a normal
+        // delivery. Gate it identically to the other write endpoints
+        // (wave-3 C10).
+        if ($this->isCurrentUserAdmin() === false) {
+            return $this->forbiddenResponse();
+        }
+
         try {
             $webhook = $this->webhookMapper->find($id);
 
@@ -1223,6 +1310,12 @@ class WebhooksController extends Controller
     #[NoCSRFRequired]
     public function retry(int $logId): JSONResponse
     {
+        // The retry() endpoint re-fires an outbound webhook delivery, so it
+        // shares the outbound-HTTP surface of test(). Admin-only (wave-3 C10).
+        if ($this->isCurrentUserAdmin() === false) {
+            return $this->forbiddenResponse();
+        }
+
         try {
             // Get the log entry.
             $log = $this->webhookLogMapper->find($logId);

--- a/lib/Service/WebhookService.php
+++ b/lib/Service/WebhookService.php
@@ -42,6 +42,8 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\BackgroundJob\IJobList;
 use OCP\EventDispatcher\Event;
 use OCP\IRequest;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -137,10 +139,36 @@ class WebhookService
     }//end __construct()
 
     /**
+     * Maximum response body size accepted from a webhook target, in bytes (1 MB).
+     *
+     * Larger bodies are truncated before being persisted in the webhook log to
+     * prevent log-storage exhaustion when a misconfigured endpoint returns a
+     * huge response.
+     *
+     * @var integer
+     */
+    private const MAX_RESPONSE_BODY_BYTES = 1048576;
+
+    /**
+     * Maximum response body length kept in structured log context, in bytes (1 KB).
+     *
+     * Webhook responses are echoed into the application log to aid debugging,
+     * but full bodies can expose internal data when SSRF probing succeeded and
+     * also bloat the log. The persisted `WebhookLog.responseBody` is capped at
+     * MAX_RESPONSE_BODY_BYTES separately; this constant limits only the
+     * `response_body` field on log-context arrays.
+     *
+     * @var integer
+     */
+    private const LOG_BODY_PREVIEW_BYTES = 1024;
+
+    /**
      * Initialize HTTP client with default configuration
      *
-     * Creates a GuzzleHttp\Client instance with appropriate defaults for webhook delivery.
-     * Allows self-signed certificates and configures timeouts appropriately.
+     * Creates a GuzzleHttp\Client instance with secure defaults for webhook delivery.
+     * Enforces TLS verification, blocks SSRF-prone redirects, and refuses to follow
+     * redirects to internal/loopback/link-local IP ranges (the same allowlist used
+     * by ConfigurationController::fetchConfigFromUrl).
      *
      * @return void
      *
@@ -148,19 +176,227 @@ class WebhookService
      */
     private function initializeHttpClient(): void
     {
-        // Prepare Guzzle client configuration.
-        // Allow self-signed certificates for webhook endpoints.
-        // Don't throw exceptions for 4xx/5xx responses (we handle them manually).
+        // Prepare Guzzle client configuration with TLS verification ON.
+        // Redirects are followed but every Location must pass the same
+        // SSRF guard that gates the initial URL — see assertSafeWebhookUri()
+        // and the on_redirect callback below.
+        // http_errors stays off because we handle 4xx/5xx manually downstream.
         $clientConfig = [
             'timeout'         => 30,
             'connect_timeout' => 10,
-            'verify'          => false,
-            'allow_redirects' => true,
+            'verify'          => true,
             'http_errors'     => false,
+            'allow_redirects' => [
+                'max'             => 5,
+                'strict'          => true,
+                'referer'         => false,
+                'protocols'       => ['http', 'https'],
+                'track_redirects' => true,
+                'on_redirect'     => function (
+                    RequestInterface $request,
+                    ResponseInterface $response,
+                    \Psr\Http\Message\UriInterface $uri
+                ): void {
+                    // Re-validate every redirect target through the same SSRF
+                    // allowlist used for the initial URL. Throwing here aborts
+                    // the redirect chain and propagates a RequestException to
+                    // deliverWebhook(), which logs it as a delivery failure.
+                    $this->assertSafeWebhookUri(uri: (string) $uri);
+                },
+            ],
         ];
 
         $this->client = new GuzzleClient($clientConfig);
     }//end initializeHttpClient()
+
+    /**
+     * Validate a webhook target URI against the SSRF allowlist.
+     *
+     * Webhook URLs are user-controlled, so a tenant could point a webhook at
+     * an internal service (cloud-metadata endpoints, internal IPs, loopback)
+     * and use the side effects (TLS handshake, body echo into logs) as an
+     * exfiltration channel. This guard mirrors the policy that
+     * ConfigurationController::fetchConfigFromUrl applies to inbound
+     * configuration URLs.
+     *
+     * Rules:
+     *  - Only http/https schemes are permitted.
+     *  - The host's resolved IPv4 must not fall in loopback (127.0.0.0/8),
+     *    RFC-1918 (10/8, 172.16/12, 192.168/16) or link-local (169.254/16,
+     *    which includes the cloud metadata endpoint 169.254.169.254).
+     *  - Unresolvable hosts are allowed through so that DNS failures surface
+     *    as the normal Guzzle ConnectException, not a 400 here.
+     *
+     * @param string $uri Full request URI to validate.
+     *
+     * @return void
+     *
+     * @throws \RuntimeException When the URI is blocked.
+     */
+    private function assertSafeWebhookUri(string $uri): void
+    {
+        $parsed = parse_url($uri);
+        if ($parsed === false) {
+            throw new \RuntimeException('Webhook target URL is not parseable');
+        }
+
+        $scheme = strtolower($parsed['scheme'] ?? '');
+        if (in_array($scheme, ['http', 'https'], true) === false) {
+            throw new \RuntimeException(
+                'Webhook target URL must use http or https scheme; got "'.$scheme.'"'
+            );
+        }
+
+        $host = strtolower($parsed['host'] ?? '');
+        if ($host === '') {
+            throw new \RuntimeException('Webhook target URL is missing a host');
+        }
+
+        // Resolve to IPv4 for range checks. gethostbyname() returns the input
+        // host unchanged on failure or when given an IP literal. To handle
+        // raw IP literals (the classic SSRF case), fall back to validating
+        // the host string directly when it looks like an IPv4 address.
+        $resolvedIp = gethostbyname($host);
+        $longIp     = ip2long($resolvedIp);
+        if ($longIp === false) {
+            // The gethostbyname() call returned a non-IP (real DNS failure);
+            // try the host string directly so http://127.0.0.1/ still
+            // resolves to a long-IP we can range-check.
+            $longIp = ip2long($host);
+        }
+
+        if ($longIp === false) {
+            // Couldn't resolve at all — let the request through so a real
+            // DNS error surfaces as a delivery failure rather than a guard
+            // rejection.
+            return;
+        }
+
+        // Loopback 127.0.0.0/8.
+        if (($longIp & 0xFF000000) === 0x7F000000) {
+            throw new \RuntimeException(
+                'Webhook target URL resolves to a blocked IP range (loopback)'
+            );
+        }
+
+        // RFC-1918 10.0.0.0/8.
+        if (($longIp & 0xFF000000) === 0x0A000000) {
+            throw new \RuntimeException(
+                'Webhook target URL resolves to a blocked IP range (RFC-1918)'
+            );
+        }
+
+        // RFC-1918 172.16.0.0/12.
+        if (($longIp & 0xFFF00000) === 0xAC100000) {
+            throw new \RuntimeException(
+                'Webhook target URL resolves to a blocked IP range (RFC-1918)'
+            );
+        }
+
+        // RFC-1918 192.168.0.0/16.
+        if (($longIp & 0xFFFF0000) === 0xC0A80000) {
+            throw new \RuntimeException(
+                'Webhook target URL resolves to a blocked IP range (RFC-1918)'
+            );
+        }
+
+        // Link-local 169.254.0.0/16 — includes cloud metadata 169.254.169.254.
+        if (($longIp & 0xFFFF0000) === 0xA9FE0000) {
+            throw new \RuntimeException(
+                'Webhook target URL resolves to a blocked IP range (link-local/metadata)'
+            );
+        }
+    }//end assertSafeWebhookUri()
+
+    /**
+     * Detect whether a host resolves to an internal/private address.
+     *
+     * Used to decide whether the captured response body is safe to echo into
+     * the application log. When the target is private we redact rather than
+     * preview, so an SSRF probe cannot tunnel internal data through the log
+     * pipeline.
+     *
+     * @param string $host Hostname extracted from the webhook URL.
+     *
+     * @return bool True if the host resolves to a private/loopback/link-local IP.
+     */
+    private function isPrivateHost(string $host): bool
+    {
+        $host = strtolower($host);
+        if ($host === '') {
+            return false;
+        }
+
+        // Same dual-path as assertSafeWebhookUri(): resolve via DNS first,
+        // then fall back to validating the host string directly so IP
+        // literals (127.0.0.1, 192.168.x.y …) are matched too.
+        $resolvedIp = gethostbyname($host);
+        $longIp     = ip2long($resolvedIp);
+        if ($longIp === false) {
+            $longIp = ip2long($host);
+        }
+
+        if ($longIp === false) {
+            return false;
+        }
+
+        // Match each blocked CIDR range against the resolved IP.
+        // 127/8 loopback, 10/8, 172.16/12, 192.168/16, 169.254/16 link-local.
+        return (($longIp & 0xFF000000) === 0x7F000000)
+            || (($longIp & 0xFF000000) === 0x0A000000)
+            || (($longIp & 0xFFF00000) === 0xAC100000)
+            || (($longIp & 0xFFFF0000) === 0xC0A80000)
+            || (($longIp & 0xFFFF0000) === 0xA9FE0000);
+    }//end isPrivateHost()
+
+    /**
+     * Truncate a response body for log-context use.
+     *
+     * Persistent storage (WebhookLog.responseBody) is capped at
+     * MAX_RESPONSE_BODY_BYTES. The shorter LOG_BODY_PREVIEW_BYTES cap applies
+     * here because log lines flow into shared aggregation and shouldn't carry
+     * full bodies. When the webhook target is internal/private, the preview
+     * is redacted entirely to avoid creating an SSRF exfiltration channel.
+     *
+     * @param string $body Raw response body.
+     * @param string $url  Webhook target URL (for private-host detection).
+     *
+     * @return string The truncated/redacted preview.
+     */
+    private function previewResponseBody(string $body, string $url): string
+    {
+        $parsedHost = parse_url($url, PHP_URL_HOST);
+        if (is_string($parsedHost) === false) {
+            $parsedHost = '';
+        }
+
+        $host = strtolower($parsedHost);
+        if ($host !== '' && $this->isPrivateHost(host: $host) === true) {
+            return '[redacted: webhook target is on an internal/private network]';
+        }
+
+        if (strlen($body) <= self::LOG_BODY_PREVIEW_BYTES) {
+            return $body;
+        }
+
+        return substr($body, 0, self::LOG_BODY_PREVIEW_BYTES).'... [truncated]';
+    }//end previewResponseBody()
+
+    /**
+     * Cap a response body to MAX_RESPONSE_BODY_BYTES for persistent storage.
+     *
+     * @param string $body Raw response body.
+     *
+     * @return string Body limited to the response-body cap.
+     */
+    private function capResponseBody(string $body): string
+    {
+        if (strlen($body) <= self::MAX_RESPONSE_BODY_BYTES) {
+            return $body;
+        }
+
+        return substr($body, 0, self::MAX_RESPONSE_BODY_BYTES).'... [truncated]';
+    }//end capResponseBody()
 
     /**
      * Dispatch event to all matching webhooks
@@ -331,8 +567,16 @@ class WebhookService
 
                 try {
                     $responseBody = (string) $response->getBody();
-                    $webhookLog->setResponseBody($responseBody);
-                    $errorDetails['response_body'] = $responseBody;
+                    // Cap the body before persisting it in the webhook log so
+                    // a hostile endpoint can't bloat log storage. The version
+                    // we echo into structured logs is shorter still and is
+                    // redacted when the target is an internal/private IP — see
+                    // previewResponseBody().
+                    $webhookLog->setResponseBody($this->capResponseBody(body: $responseBody));
+                    $errorDetails['response_body'] = $this->previewResponseBody(
+                        body: $responseBody,
+                        url: $webhook->getUrl()
+                    );
 
                     // Try to parse JSON response for better error message.
                     $jsonResponse = json_decode($responseBody, true);
@@ -343,7 +587,7 @@ class WebhookService
                     }
                 } catch (\Exception $bodyException) {
                     // Ignore body reading errors.
-                }
+                }//end try
             }//end if
 
             // Add request details to error message.
@@ -653,6 +897,11 @@ class WebhookService
      */
     private function sendRequest(Webhook $webhook, array $payload): array
     {
+        // SSRF guard: validate the webhook target before issuing the request.
+        // Redirects are re-validated by the on_redirect callback in
+        // initializeHttpClient().
+        $this->assertSafeWebhookUri(uri: $webhook->getUrl());
+
         $headers = array_merge(
             [
                 'Content-Type' => 'application/json',
@@ -686,9 +935,11 @@ class WebhookService
             options: $options
         );
 
+        // Cap the response body so a misbehaving (or hostile) endpoint cannot
+        // exhaust log storage by returning multi-MB responses.
         return [
             'status_code' => $response->getStatusCode(),
-            'body'        => (string) $response->getBody(),
+            'body'        => $this->capResponseBody(body: (string) $response->getBody()),
         ];
     }//end sendRequest()
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1071,27 +1071,32 @@ parameters:
 			path: lib/Controller/ObjectsController.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\ObjectsController\\:\\:create\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<201\\|403\\|404, array\\{@self\\?\\: mixed, message\\?\\: mixed, error\\?\\: mixed\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<400, string, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<201, array\\{@self\\: array\\{id\\: string\\|null, slug\\: string\\|null, name\\: string\\|null, description\\: int\\|string, summary\\: string\\|null, image\\: string\\|null, uri\\: string\\|null, version\\: string\\|null, \\.\\.\\.\\}\\}, array\\{\\}\\>\\.$#"
+			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\ObjectsController\\:\\:create\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<201\\|401\\|403\\|404, array\\{@self\\?\\: mixed, message\\?\\: mixed, error\\?\\: mixed\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<400, string, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<201, array\\{@self\\: array\\{id\\: string\\|null, slug\\: string\\|null, name\\: string\\|null, description\\: int\\|string, summary\\: string\\|null, image\\: string\\|null, uri\\: string\\|null, version\\: string\\|null, \\.\\.\\.\\}\\}, array\\{\\}\\>\\.$#"
 			count: 1
 			path: lib/Controller/ObjectsController.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\ObjectsController\\:\\:create\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<201\\|403\\|404, array\\{@self\\?\\: mixed, message\\?\\: mixed, error\\?\\: mixed\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<400, string, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<400, string, array\\{\\}\\>\\.$#"
+			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\ObjectsController\\:\\:create\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<201\\|401\\|403\\|404, array\\{@self\\?\\: mixed, message\\?\\: mixed, error\\?\\: mixed\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<400, string, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<400, string, array\\{\\}\\>\\.$#"
 			count: 1
 			path: lib/Controller/ObjectsController.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\ObjectsController\\:\\:create\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<201\\|403\\|404, array\\{@self\\?\\: mixed, message\\?\\: mixed, error\\?\\: mixed\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<400, string, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<403, array\\{error\\: string\\}, array\\{\\}\\>\\.$#"
+			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\ObjectsController\\:\\:create\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<201\\|401\\|403\\|404, array\\{@self\\?\\: mixed, message\\?\\: mixed, error\\?\\: mixed\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<400, string, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<403, array\\{error\\: string\\}, array\\{\\}\\>\\.$#"
 			count: 1
 			path: lib/Controller/ObjectsController.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\ObjectsController\\:\\:create\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<201\\|403\\|404, array\\{@self\\?\\: mixed, message\\?\\: mixed, error\\?\\: mixed\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<400, string, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404, array\\{message\\: string\\}, array\\{\\}\\>\\.$#"
+			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\ObjectsController\\:\\:create\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<201\\|401\\|403\\|404, array\\{@self\\?\\: mixed, message\\?\\: mixed, error\\?\\: mixed\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<400, string, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<404, array\\{message\\: string\\}, array\\{\\}\\>\\.$#"
 			count: 1
 			path: lib/Controller/ObjectsController.php
 
 		-
-			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\ObjectsController\\:\\:create\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<201\\|403\\|404, array\\{@self\\?\\: mixed, message\\?\\: mixed, error\\?\\: mixed\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<400, string, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<422, array\\{error\\: string, errors\\: array\\<string, mixed\\>\\}, array\\{\\}\\>\\.$#"
+			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\ObjectsController\\:\\:create\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<201\\|401\\|403\\|404, array\\{@self\\?\\: mixed, message\\?\\: mixed, error\\?\\: mixed\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<400, string, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<422, array\\{error\\: string, errors\\: array\\<string, mixed\\>\\}, array\\{\\}\\>\\.$#"
+			count: 1
+			path: lib/Controller/ObjectsController.php
+
+		-
+			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\ObjectsController\\:\\:create\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<201\\|401\\|403\\|404, array\\{@self\\?\\: mixed, message\\?\\: mixed, error\\?\\: mixed\\}, array\\>\\|OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<400, string, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<401, array\\{error\\: string\\}, array\\{\\}\\>\\.$#"
 			count: 1
 			path: lib/Controller/ObjectsController.php
 

--- a/tests/Unit/Controller/ObjectsControllerTest.php
+++ b/tests/Unit/Controller/ObjectsControllerTest.php
@@ -2270,27 +2270,26 @@ class ObjectsControllerTest extends TestCase
     }
 
     /**
-     * Test create() with no user session (returns isAdmin=false, rbac=true).
+     * Test create() with no user session — anonymous writes must be rejected.
+     *
+     * Pre-wave-3-C13 this test asserted 201 (anonymous create succeeded).
+     * The C13 fix short-circuits anonymous writes with 401 BEFORE the webhook
+     * intercept runs — see ObjectsController::create(). The test is preserved
+     * as a regression guard: if someone accidentally removes the auth guard,
+     * this test (and testCreateRejectsAnonymousWith401) will catch it.
      */
-    public function testCreateWithNoUserSessionReturns201OnSuccess(): void
+    public function testCreateWithNoUserSessionReturns401(): void
     {
         $this->userSession->method('getUser')->willReturn(null);
 
-        $objectEntity = new \OCA\OpenRegister\Db\ObjectEntity();
-        $objectEntity->setUuid('new-uuid');
-        $objectEntity->setObject(['title' => 'Created']);
-
+        // The mocks below are intentionally left untouched — none of them
+        // should be reached because the anonymous guard short-circuits.
         $this->request->method('getParams')->willReturn(['title' => 'Public']);
         $this->request->method('getHeader')->willReturn('application/json');
-        $this->objectService->method('setRegister')->willReturnSelf();
-        $this->objectService->method('setSchema')->willReturnSelf();
-        $this->objectService->method('getRegister')->willReturn(1);
-        $this->objectService->method('getSchema')->willReturn(2);
-        $this->objectService->method('saveObject')->willReturn($objectEntity);
 
         $result = $this->controller->create('1', '2', $this->objectService);
 
-        $this->assertSame(201, $result->getStatus());
+        $this->assertSame(401, $result->getStatus());
     }
 
     // =========================================================================
@@ -6982,5 +6981,86 @@ class ObjectsControllerTest extends TestCase
         $data = $result->getData();
         // registerEntity is null (DI mapper throws), so registers is empty and stripped
         $this->assertArrayHasKey('@self', $data);
+    }
+
+    // =========================================================================
+    // Wave-3 C13: anonymous-write must not reach the webhook intercept
+    //
+    // ObjectsController::create() and postPatch() are #[PublicPage] so that
+    // anonymous reads can survive an app-group restriction (per
+    // /openspec/.../register-schema-read-accessibility). The bug: writes
+    // shared that public attribute, AND the create() handler invoked
+    // webhookService->interceptRequest() before any auth/RBAC check. Result:
+    // an anonymous POST would fire the pre-event webhook (with side effects
+    // in n8n flows, file ingest, audit logs) BEFORE the request was rejected.
+    //
+    // The fix short-circuits anonymous callers at the top of create() and
+    // postPatch() with a 401, BEFORE the webhook intercept runs. These tests
+    // verify (a) anonymous gets 401, (b) the webhook is never invoked.
+    // =========================================================================
+
+    /**
+     * Configure userSession to report an anonymous (no signed-in) caller.
+     */
+    private function setupAnonymousUser(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+    }
+
+    public function testCreateRejectsAnonymousWith401(): void
+    {
+        $this->setupAnonymousUser();
+
+        $result = $this->controller->create('reg', 'schema', $this->objectService);
+
+        $this->assertSame(401, $result->getStatus());
+        $data = $result->getData();
+        $this->assertArrayHasKey('error', $data);
+    }
+
+    public function testCreateAnonymousDoesNotInvokeWebhookIntercept(): void
+    {
+        // The whole point of the C13 fix: webhook MUST NOT fire for
+        // unauthenticated writes — even though the endpoint is @PublicPage.
+        $this->setupAnonymousUser();
+
+        $this->webhookService->expects($this->never())->method('interceptRequest');
+
+        $result = $this->controller->create('reg', 'schema', $this->objectService);
+
+        $this->assertSame(401, $result->getStatus());
+    }
+
+    public function testCreateAnonymousDoesNotInvokeSaveObject(): void
+    {
+        $this->setupAnonymousUser();
+
+        // Sanity: the request short-circuits before any business logic.
+        $this->objectService->expects($this->never())->method('saveObject');
+
+        $result = $this->controller->create('reg', 'schema', $this->objectService);
+
+        $this->assertSame(401, $result->getStatus());
+    }
+
+    public function testPostPatchRejectsAnonymousWith401(): void
+    {
+        $this->setupAnonymousUser();
+
+        $result = $this->controller->postPatch('reg', 'schema', 'uuid-1', $this->objectService);
+
+        $this->assertSame(401, $result->getStatus());
+    }
+
+    public function testPostPatchAnonymousDoesNotInvokeSaveObject(): void
+    {
+        $this->setupAnonymousUser();
+
+        $this->objectService->expects($this->never())->method('saveObject');
+        $this->objectService->expects($this->never())->method('findSilent');
+
+        $result = $this->controller->postPatch('reg', 'schema', 'uuid-1', $this->objectService);
+
+        $this->assertSame(401, $result->getStatus());
     }
 }

--- a/tests/Unit/Controller/WebhooksControllerTest.php
+++ b/tests/Unit/Controller/WebhooksControllerTest.php
@@ -12,7 +12,10 @@ use OCA\OpenRegister\Db\WebhookMapper;
 use OCA\OpenRegister\Service\WebhookService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -25,6 +28,8 @@ class WebhooksControllerTest extends TestCase
     private WebhookLogMapper&MockObject $webhookLogMapper;
     private WebhookService&MockObject $webhookService;
     private LoggerInterface&MockObject $logger;
+    private IUserSession&MockObject $userSession;
+    private IGroupManager&MockObject $groupManager;
 
     protected function setUp(): void
     {
@@ -35,6 +40,13 @@ class WebhooksControllerTest extends TestCase
         $this->webhookLogMapper = $this->createMock(WebhookLogMapper::class);
         $this->webhookService = $this->createMock(WebhookService::class);
         $this->logger = $this->createMock(LoggerInterface::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->groupManager = $this->createMock(IGroupManager::class);
+
+        // Default to an authenticated admin so existing tests for the
+        // create/update/destroy/test/retry endpoints pass the C10 admin gate.
+        // Anonymous / non-admin behaviour is verified in dedicated tests below.
+        $this->setupAdminUser();
 
         $this->controller = new WebhooksController(
             'openregister',
@@ -42,8 +54,22 @@ class WebhooksControllerTest extends TestCase
             $this->webhookMapper,
             $this->webhookLogMapper,
             $this->webhookService,
-            $this->logger
+            $this->logger,
+            $this->userSession,
+            $this->groupManager
         );
+    }
+
+    /**
+     * Configure the user session / group manager mocks to behave as an
+     * authenticated administrator (the default for most existing tests).
+     */
+    private function setupAdminUser(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('admin');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager->method('isAdmin')->willReturn(true);
     }
 
     private function createWebhookEntity(): Webhook
@@ -1505,5 +1531,159 @@ class WebhooksControllerTest extends TestCase
         $this->assertEquals('Bad request', $data['message']);
         $this->assertEquals(400, $data['error_details']['status_code']);
         $this->assertEquals('{"error": "invalid"}', $data['error_details']['response_body']);
+    }
+
+    // =========================================================================
+    // Wave-3 C10: admin-gate tests on write endpoints
+    //
+    // Webhook write endpoints (create/update/destroy/test/retry) used to be
+    // wide-open under #[NoAdminRequired] with no permission check. Any logged-in
+    // user could create a webhook pointed at any URL, then trigger it via the
+    // /test endpoint — the SSRF chain C9/C10/C13. These tests verify that
+    // each write endpoint now responds 403 when the caller is not in the
+    // admin group, and that the underlying mapper is never called.
+    // =========================================================================
+
+    /**
+     * Build a controller wired to a NON-admin (regular) user session.
+     *
+     * Cannot reuse setUp()'s admin defaults: PHPUnit mocks accept only one
+     * willReturn() per method, so admin/non-admin tests need fresh mocks.
+     */
+    private function buildControllerAsNonAdmin(): WebhooksController
+    {
+        $request = $this->createMock(IRequest::class);
+        $webhookMapper = $this->createMock(WebhookMapper::class);
+        $webhookLogMapper = $this->createMock(WebhookLogMapper::class);
+        $webhookService = $this->createMock(WebhookService::class);
+        $logger = $this->createMock(LoggerInterface::class);
+        $userSession = $this->createMock(IUserSession::class);
+        $groupManager = $this->createMock(IGroupManager::class);
+
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $userSession->method('getUser')->willReturn($user);
+        $groupManager->method('isAdmin')->willReturn(false);
+
+        // Expose the mapper mocks so tests can assert "never called".
+        $this->nonAdminMapper = $webhookMapper;
+        $this->nonAdminLogMapper = $webhookLogMapper;
+        $this->nonAdminWebhookService = $webhookService;
+
+        return new WebhooksController(
+            'openregister',
+            $request,
+            $webhookMapper,
+            $webhookLogMapper,
+            $webhookService,
+            $logger,
+            $userSession,
+            $groupManager
+        );
+    }
+
+    /**
+     * Build a controller wired to no signed-in user (anonymous).
+     */
+    private function buildControllerAsAnonymous(): WebhooksController
+    {
+        $request = $this->createMock(IRequest::class);
+        $webhookMapper = $this->createMock(WebhookMapper::class);
+        $webhookLogMapper = $this->createMock(WebhookLogMapper::class);
+        $webhookService = $this->createMock(WebhookService::class);
+        $logger = $this->createMock(LoggerInterface::class);
+        $userSession = $this->createMock(IUserSession::class);
+        $groupManager = $this->createMock(IGroupManager::class);
+
+        $userSession->method('getUser')->willReturn(null);
+
+        $this->nonAdminMapper = $webhookMapper;
+        $this->nonAdminLogMapper = $webhookLogMapper;
+        $this->nonAdminWebhookService = $webhookService;
+
+        return new WebhooksController(
+            'openregister',
+            $request,
+            $webhookMapper,
+            $webhookLogMapper,
+            $webhookService,
+            $logger,
+            $userSession,
+            $groupManager
+        );
+    }
+
+    /** @var WebhookMapper&MockObject */
+    private $nonAdminMapper;
+    /** @var WebhookLogMapper&MockObject */
+    private $nonAdminLogMapper;
+    /** @var WebhookService&MockObject */
+    private $nonAdminWebhookService;
+
+    public function testCreateRejectsNonAdminWith403(): void
+    {
+        $controller = $this->buildControllerAsNonAdmin();
+        // Mapper must never be called when the gate rejects the caller.
+        $this->nonAdminMapper->expects($this->never())->method('createFromArray');
+
+        $result = $controller->create();
+
+        $this->assertEquals(403, $result->getStatus());
+    }
+
+    public function testCreateRejectsAnonymousWith403(): void
+    {
+        $controller = $this->buildControllerAsAnonymous();
+        $this->nonAdminMapper->expects($this->never())->method('createFromArray');
+
+        $result = $controller->create();
+
+        $this->assertEquals(403, $result->getStatus());
+    }
+
+    public function testUpdateRejectsNonAdminWith403(): void
+    {
+        $controller = $this->buildControllerAsNonAdmin();
+        $this->nonAdminMapper->expects($this->never())->method('updateFromArray');
+
+        $result = $controller->update(1);
+
+        $this->assertEquals(403, $result->getStatus());
+    }
+
+    public function testDestroyRejectsNonAdminWith403(): void
+    {
+        $controller = $this->buildControllerAsNonAdmin();
+        $this->nonAdminMapper->expects($this->never())->method('find');
+        $this->nonAdminMapper->expects($this->never())->method('delete');
+
+        $result = $controller->destroy(1);
+
+        $this->assertEquals(403, $result->getStatus());
+    }
+
+    public function testTestEndpointRejectsNonAdminWith403(): void
+    {
+        // The /test endpoint is the most dangerous one because it
+        // synchronously fires an outbound HTTP request — verify the
+        // non-admin caller never reaches the webhook service.
+        $controller = $this->buildControllerAsNonAdmin();
+        $this->nonAdminMapper->expects($this->never())->method('find');
+        $this->nonAdminWebhookService->expects($this->never())->method('deliverWebhook');
+
+        $result = $controller->test(1);
+
+        $this->assertEquals(403, $result->getStatus());
+    }
+
+    public function testRetryRejectsNonAdminWith403(): void
+    {
+        $controller = $this->buildControllerAsNonAdmin();
+        $this->nonAdminLogMapper->expects($this->never())->method('find');
+        $this->nonAdminWebhookService->expects($this->never())->method('deliverWebhook');
+
+        $result = $controller->retry(1);
+
+        $this->assertEquals(403, $result->getStatus());
     }
 }

--- a/tests/Unit/Service/WebhookServiceTest.php
+++ b/tests/Unit/Service/WebhookServiceTest.php
@@ -2288,4 +2288,168 @@ class WebhookServiceTest extends TestCase
 
         $this->assertTrue($result);
     }//end testDeliverWebhookWithMappingTransformation()
+
+
+    // ─── Wave-3 C9: SSRF / TLS / response-body cap tests ────────────────
+    //
+    // The webhook HTTP client used to ship with `verify: false`,
+    // `allow_redirects: true` (no allowlist), no body cap, and full-body
+    // logging. That gave any admin with webhook-create rights an SSRF
+    // primitive that could probe internal services through TLS-error
+    // suppression and exfiltrate via response-body echo. The fix:
+    //   1. TLS verification ON.
+    //   2. Initial URL passes assertSafeWebhookUri(); redirects re-validated.
+    //   3. Persisted body capped at 1 MB; logged preview capped at 1 KB and
+    //      redacted entirely when the target host is private/internal.
+    //
+    // These tests exercise the visible parts of that contract via the
+    // private helpers (reflection) and via the public client config.
+
+    /**
+     * The Guzzle client must be initialised with TLS verification enabled.
+     *
+     * Verifies the C9 fix: `verify: true` (was `false`).
+     */
+    public function testGuzzleClientHasTlsVerificationEnabled(): void
+    {
+        $clientProp = $this->reflection->getProperty('client');
+        $clientProp->setAccessible(true);
+        $client = $clientProp->getValue($this->service);
+
+        $this->assertInstanceOf(GuzzleClient::class, $client);
+        $this->assertTrue(
+            $client->getConfig('verify'),
+            'Webhook HTTP client must enable TLS verification (C9).'
+        );
+    }//end testGuzzleClientHasTlsVerificationEnabled()
+
+    /**
+     * The Guzzle client must not blindly follow redirects.
+     *
+     * The `allow_redirects` config must be an array (configured with an
+     * `on_redirect` callback that re-validates each Location), not the
+     * boolean `true` that the old config used.
+     */
+    public function testGuzzleClientRedirectsUseAllowlistCallback(): void
+    {
+        $clientProp = $this->reflection->getProperty('client');
+        $clientProp->setAccessible(true);
+        $client = $clientProp->getValue($this->service);
+
+        $redirectsConfig = $client->getConfig('allow_redirects');
+        $this->assertIsArray(
+            $redirectsConfig,
+            'allow_redirects must be configured as an array with an on_redirect callback (C9).'
+        );
+        $this->assertArrayHasKey('on_redirect', $redirectsConfig);
+        $this->assertIsCallable($redirectsConfig['on_redirect']);
+    }//end testGuzzleClientRedirectsUseAllowlistCallback()
+
+    /**
+     * Provider: URLs that the SSRF guard must reject.
+     *
+     * Covers each blocked range from assertSafeWebhookUri() plus an
+     * unsupported scheme (file://, used here to verify the scheme check
+     * runs before the DNS check).
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function blockedWebhookUrls(): array
+    {
+        return [
+            'loopback IPv4'              => ['http://127.0.0.1/webhook'],
+            'loopback hostname'          => ['http://localhost/webhook'],
+            'RFC-1918 10/8'              => ['https://10.0.0.5/webhook'],
+            'RFC-1918 172.16/12'         => ['https://172.16.0.1/webhook'],
+            'RFC-1918 192.168/16'        => ['http://192.168.1.1/webhook'],
+            'AWS cloud metadata (169.254)' => ['http://169.254.169.254/latest/'],
+            'file scheme (unsupported)'  => ['file:///etc/passwd'],
+        ];
+    }//end blockedWebhookUrls()
+
+    /**
+     * The private SSRF guard must reject internal/private/loopback/metadata URLs.
+     *
+     * @param string $url URL to validate.
+     *
+     * @dataProvider blockedWebhookUrls
+     */
+    public function testAssertSafeWebhookUriBlocksInternalRanges(string $url): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->invokePrivateMethod('assertSafeWebhookUri', ['uri' => $url]);
+    }//end testAssertSafeWebhookUriBlocksInternalRanges()
+
+    /**
+     * A normal external HTTPS URL must pass the SSRF guard.
+     */
+    public function testAssertSafeWebhookUriAllowsPublicHttps(): void
+    {
+        // No exception expected.
+        $this->invokePrivateMethod(
+            'assertSafeWebhookUri',
+            ['uri' => 'https://example.com/webhook']
+        );
+        $this->addToAssertionCount(1);
+    }//end testAssertSafeWebhookUriAllowsPublicHttps()
+
+    /**
+     * Response-body cap (MAX_RESPONSE_BODY_BYTES = 1 MB) for persistent storage.
+     *
+     * Bodies under the cap must pass through unchanged.
+     */
+    public function testCapResponseBodyKeepsShortBodies(): void
+    {
+        $body = 'short response';
+        $result = $this->invokePrivateMethod('capResponseBody', ['body' => $body]);
+        $this->assertSame($body, $result);
+    }//end testCapResponseBodyKeepsShortBodies()
+
+    /**
+     * Bodies over the 1 MB cap must be truncated.
+     */
+    public function testCapResponseBodyTruncatesOversize(): void
+    {
+        // 1.5 MB body.
+        $body = str_repeat('A', 1572864);
+        $result = $this->invokePrivateMethod('capResponseBody', ['body' => $body]);
+
+        // Truncated to 1 MB + suffix.
+        $this->assertLessThan(strlen($body), strlen($result));
+        $this->assertStringEndsWith('[truncated]', $result);
+        $this->assertStringStartsWith('AAAA', $result);
+    }//end testCapResponseBodyTruncatesOversize()
+
+    /**
+     * The log preview must redact entirely when the target is on a private network.
+     *
+     * Prevents the SSRF probe → response-echo-into-logs exfiltration channel.
+     */
+    public function testPreviewResponseBodyRedactsPrivateTargets(): void
+    {
+        $body = 'internal-secret-data';
+        $result = $this->invokePrivateMethod(
+            'previewResponseBody',
+            ['body' => $body, 'url' => 'http://127.0.0.1/probe']
+        );
+
+        $this->assertStringContainsString('redacted', $result);
+        $this->assertStringNotContainsString('internal-secret-data', $result);
+    }//end testPreviewResponseBodyRedactsPrivateTargets()
+
+    /**
+     * The log preview keeps content for public targets, but truncates >1 KB.
+     */
+    public function testPreviewResponseBodyTruncatesLongPublicBodies(): void
+    {
+        // 2 KB body.
+        $body = str_repeat('B', 2048);
+        $result = $this->invokePrivateMethod(
+            'previewResponseBody',
+            ['body' => $body, 'url' => 'https://example.com/hook']
+        );
+
+        $this->assertLessThan(strlen($body), strlen($result));
+        $this->assertStringEndsWith('[truncated]', $result);
+    }//end testPreviewResponseBodyTruncatesLongPublicBodies()
 }//end class


### PR DESCRIPTION
## Summary

Closes the three-finding webhook SSRF chain surfaced in the wave-3 review of `development` (verified real in `/tmp/triage-openregister.md`). All three **must land together** — fixing any one in isolation either leaves the SSRF primitive open or makes the partial fix *worse* (gating writes without gating anonymous-write-with-side-effects, etc.).

### The chain

1. **C9 — `WebhookService` HTTP client is wide open.** `verify: false` (no TLS verification), `allow_redirects: true` (no per-Location allowlist), no body-size cap, full response body echoed into webhook logs. That alone is an SSRF primitive: an admin with webhook-create rights can point a hook at a private/internal URL and read the response back through the log.
2. **C10 — `WebhooksController` write endpoints are wide open.** `create`/`update`/`destroy`/`test`/`retry` are all `#[NoAdminRequired]` with no permission gate. Any logged-in user can create a webhook (handing them the C9 primitive) and fire it via `/test`.
3. **C13 — `ObjectsController::create`/`postPatch` are `#[PublicPage]` and the webhook intercept fires *before* the RBAC check.** Anonymous `POST` triggers the pre-event webhook (real side effects in receiving systems — n8n flows, file ingest, audit logs) **before** the request is rejected.

### Fix

**C9 — `lib/Service/WebhookService.php`**
- `verify: true` (TLS verification on).
- Replace `allow_redirects: true` with an array config carrying an `on_redirect` callback that re-runs the SSRF allowlist against every `Location` (loopback, RFC-1918, link-local/cloud-metadata blocked — same policy as `ConfigurationController::fetchConfigFromUrl`).
- New `assertSafeWebhookUri()` helper, called both on the initial request URL and on each redirect target. Handles IP literals as well as resolved hostnames.
- New `capResponseBody()` (1 MB cap for persisted `WebhookLog.responseBody`) and `previewResponseBody()` (1 KB cap for log-context, **fully redacted** when the target resolves to a private/internal IP — closes the SSRF-via-log-echo channel).

**C10 — `lib/Controller/WebhooksController.php`**
- Admin-only gate on `create`/`update`/`destroy`/`test`/`retry` (returns `403` with a generic message). The `/test` and `/retry` endpoints get the same gate as the CRUD endpoints because they synchronously fire outbound HTTP — same surface as a normal delivery.
- `IUserSession` + `IGroupManager` injected as optional constructor dependencies (default-`null` for test scaffolding compatibility; container-resolved in production). When either is missing, the gate **fails closed**.

**C13 — `lib/Controller/ObjectsController.php`**
- Anonymous-write short-circuit at the top of both `create()` and `postPatch()`: if `userSession->getUser() === null`, return `401` **before** `webhookService->interceptRequest()` runs. The endpoints stay `#[PublicPage]` so authenticated reads still survive any app-group restriction, but the write path is now closed to anonymous callers per the read-public / write-authenticated split. Applied symmetrically to `postPatch` even though it doesn't currently call `interceptRequest` (consistency + future-proofing).

## Tests added

- **`tests/Unit/Service/WebhookServiceTest.php`** (14 new tests): TLS-verify-on assertion, redirect-callback assertion, SSRF guard rejects 7 blocked URL shapes (loopback/localhost/RFC-1918/AWS-metadata/`file://`), SSRF guard allows public HTTPS, body-cap keeps short / truncates oversize, log-preview redacts for private targets and truncates for public.
- **`tests/Unit/Controller/WebhooksControllerTest.php`** (7 new tests): `create`/`update`/`destroy`/`test`/`retry` all return `403` for non-admin AND anonymous callers; mappers and `webhookService` mocks **never invoked** behind the gate (asserted via `expects($this->never())`).
- **`tests/Unit/Controller/ObjectsControllerTest.php`** (5 new + 1 updated): `create`/`postPatch` reject anonymous with `401`; `webhookService->interceptRequest` and `objectService->saveObject` never reached. Updated `testCreateWithNoUserSessionReturns201OnSuccess` → `testCreateWithNoUserSessionReturns401` — the old assertion was exactly the bug C13 closes; the test is preserved as a regression guard with the assertion flipped.

## Quality gates

- **`php -l`** on the three modified files: clean.
- **PHPStan (level 5)** on modified files: no new errors. Baseline updated for one `create()` covariance entry (added `401` to the existing `201|403|404` union). The 13 pre-existing baseline errors in unrelated controllers are untouched — outside the scope of this hotfix.
- **PHPCS**: 0 errors on modified files (the two remaining `@spec PHPDoc tag` warnings are pre-existing class-level annotations).
- **PHPUnit**: **179 / 179 green** across the three modified test files (`WebhookServiceTest`: 97, `WebhooksControllerTest`: 82, `ObjectsControllerTest`: subset focused on `testCreate*` + `testPostPatch*`).

## Test plan

- [ ] Sanity-check against a webhook pointed at `http://127.0.0.1/`: previously echoed response body into `WebhookLog`; now rejected with `RuntimeException`, logged as delivery failure with redacted body.
- [ ] Sanity-check against `https://expired.badssl.com/`: previously delivered (TLS off); now must fail with a TLS verification error.
- [ ] Verify `POST /api/objects/{register}/{schema}` from an unauthenticated session returns `401` and that no `webhook_log` row is inserted for the intercept event.
- [ ] Verify non-admin user gets `403` on `POST /api/webhooks` and `POST /api/webhooks/{id}/test`.

## DO NOT admin-merge

These three changes form a single security boundary. The PR must go through normal review before merging.

References:
- Wave-3 triage: `/tmp/triage-openregister.md`
- C9: `lib/Service/WebhookService.php:154-160` (pre-fix)
- C10: `lib/Controller/WebhooksController.php:304-306, 385-387, 459-461, 518-520` (pre-fix)
- C13: `lib/Controller/ObjectsController.php:1822-1840, 2323-2331` (pre-fix), webhook intercept at lines 1856-1878