### PR TITLE
fix(security): gate organisation/deleted/bulk/publish/import/unlock write paths (wave-3 C1/C4/C5/C11/C12/C14)

### DIFF
--- a/lib/Controller/BulkController.php
+++ b/lib/Controller/BulkController.php
@@ -26,13 +26,19 @@
 
 namespace OCA\OpenRegister\Controller;
 
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\ObjectService;
 use OCA\OpenRegister\Exception\RegisterNotFoundException;
 use OCA\OpenRegister\Exception\SchemaNotFoundException;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUserSession;
 use Exception;
 
 /**
@@ -47,19 +53,143 @@ class BulkController extends Controller
     /**
      * Constructor for the BulkController
      *
-     * @param string        $appName       The name of the app
-     * @param IRequest      $request       The request object
-     * @param ObjectService $objectService The object service
+     * @param string         $appName        The name of the app
+     * @param IRequest       $request        The request object
+     * @param ObjectService  $objectService  The object service
+     * @param RegisterMapper $registerMapper Mapper for resolving registers (RBAC gates)
+     * @param SchemaMapper   $schemaMapper   Mapper for resolving schemas (RBAC gates)
+     * @param IUserSession   $userSession    User session for admin/manage checks
+     * @param IGroupManager  $groupManager   Group manager for admin/manage checks
      *
      * @return void
      */
     public function __construct(
         string $appName,
         IRequest $request,
-        private readonly ObjectService $objectService
+        private readonly ObjectService $objectService,
+        private readonly RegisterMapper $registerMapper,
+        private readonly SchemaMapper $schemaMapper,
+        private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
+
+    /**
+     * Check if the current user has 'manage' permission on a schema.
+     *
+     * Default-SECURE mirror of `SchemasController::checkSchemaManagePermission()`:
+     * a schema with no `manage` authorization rule can only be managed by
+     * administrators. When manage rules are present, membership of one of the
+     * listed groups grants permission (admins always pass). Deliberately NOT
+     * `PermissionHandler::hasPermission()`, which is default-OPEN for object
+     * data RBAC and therefore unsuitable for gating schema-definition writes.
+     *
+     * @param Schema $schema The schema to check manage permission for.
+     *
+     * @return bool True if the current user may manage this schema.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     */
+    private function checkSchemaManagePermission(Schema $schema): bool
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        // Admins always pass.
+        if ($this->groupManager->isAdmin($user->getUID()) === true) {
+            return true;
+        }
+
+        $authorization = $schema->getAuthorization();
+
+        // Default-secure: no manage rule defined → admin-only (already failed above).
+        if (empty($authorization) === true || isset($authorization['manage']) === false) {
+            return false;
+        }
+
+        try {
+            $userGroups = $this->groupManager->getUserGroupIds($user);
+        } catch (\Throwable $e) {
+            return false;
+        }
+
+        $manageRules = $authorization['manage'];
+        foreach ($userGroups as $groupId) {
+            foreach ($manageRules as $entry) {
+                if (is_string($entry) === true && $entry === $groupId) {
+                    return true;
+                }
+
+                if (is_array($entry) === true && isset($entry['group']) === true && $entry['group'] === $groupId) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+
+    }//end checkSchemaManagePermission()
+
+    /**
+     * Check if the current user has 'manage' permission on a register.
+     *
+     * Default-SECURE: a register with no `manage` authorization rule can only
+     * be managed by administrators. When manage rules are present, membership
+     * of one of the listed groups grants permission (admins always pass).
+     * Mirrors `RegistersController::checkRegisterManagePermission()`.
+     *
+     * @param Register $register The register to check manage permission for.
+     *
+     * @return bool True if the current user may manage this register.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     */
+    private function checkRegisterManagePermission(Register $register): bool
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        // Admins always pass.
+        if ($this->groupManager->isAdmin($user->getUID()) === true) {
+            return true;
+        }
+
+        $authorization = $register->getAuthorization();
+
+        // Default-secure: no manage rule defined → admin-only (already failed above).
+        if (empty($authorization) === true || isset($authorization['manage']) === false) {
+            return false;
+        }
+
+        try {
+            $userGroups = $this->groupManager->getUserGroupIds($user);
+        } catch (\Throwable $e) {
+            return false;
+        }
+
+        $manageRules = $authorization['manage'];
+        foreach ($userGroups as $groupId) {
+            foreach ($manageRules as $entry) {
+                if (is_string($entry) === true && $entry === $groupId) {
+                    return true;
+                }
+
+                if (is_array($entry) === true && isset($entry['group']) === true && $entry['group'] === $groupId) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+
+    }//end checkRegisterManagePermission()
 
     /**
      * Resolve register and schema slugs/IDs to numeric IDs.
@@ -286,6 +416,26 @@ class BulkController extends Controller
                 );
             }
 
+            // Authorization: bulk-deleting every object in a schema is a
+            // destructive data-model write. Gate on manage-permission for the
+            // target schema (default-SECURE: admin-only when no manage rule
+            // exists). Mirrors the wave-1 #1949 controller gate pattern.
+            try {
+                $schemaEntity = $this->schemaMapper->find((int) $schema);
+            } catch (\Throwable $e) {
+                return new JSONResponse(
+                    data: ['error' => 'Schema not found'],
+                    statusCode: Http::STATUS_NOT_FOUND
+                );
+            }
+
+            if ($this->checkSchemaManagePermission(schema: $schemaEntity) === false) {
+                return new JSONResponse(
+                    data: ['error' => 'User does not have permission to manage this schema'],
+                    statusCode: Http::STATUS_FORBIDDEN
+                );
+            }
+
             // Get request data.
             $data       = $this->request->getParams();
             $hardDelete = $data['hardDelete'] ?? false;
@@ -350,6 +500,27 @@ class BulkController extends Controller
                 return new JSONResponse(data: ['error' => $e->getMessage()], statusCode: Http::STATUS_NOT_FOUND);
             }
 
+            // Authorization: bulk-deleting every object for a register/schema
+            // combination is a destructive data-model write. Gate on
+            // manage-permission for the target schema (default-SECURE:
+            // admin-only when no manage rule exists). Mirrors the wave-1
+            // #1949 controller gate pattern.
+            try {
+                $schemaEntity = $this->schemaMapper->find($resolved['schema']);
+            } catch (\Throwable $e) {
+                return new JSONResponse(
+                    data: ['error' => 'Schema not found'],
+                    statusCode: Http::STATUS_NOT_FOUND
+                );
+            }
+
+            if ($this->checkSchemaManagePermission(schema: $schemaEntity) === false) {
+                return new JSONResponse(
+                    data: ['error' => 'User does not have permission to manage this schema'],
+                    statusCode: Http::STATUS_FORBIDDEN
+                );
+            }
+
             // Get request data.
             $data       = $this->request->getParams();
             $hardDelete = $data['hardDelete'] ?? false;
@@ -404,6 +575,26 @@ class BulkController extends Controller
                 return new JSONResponse(
                     data: ['error' => 'Invalid register ID. Must be numeric.'],
                     statusCode: Http::STATUS_BAD_REQUEST
+                );
+            }
+
+            // Authorization: bulk-deleting every object in a register is a
+            // destructive data-model write. Gate on manage-permission for the
+            // target register (default-SECURE: admin-only when no manage rule
+            // exists). Mirrors the wave-1 #1949 controller gate pattern.
+            try {
+                $registerEntity = $this->registerMapper->find((int) $register);
+            } catch (\Throwable $e) {
+                return new JSONResponse(
+                    data: ['error' => 'Register not found'],
+                    statusCode: Http::STATUS_NOT_FOUND
+                );
+            }
+
+            if ($this->checkRegisterManagePermission(register: $registerEntity) === false) {
+                return new JSONResponse(
+                    data: ['error' => 'User does not have permission to manage this register'],
+                    statusCode: Http::STATUS_FORBIDDEN
                 );
             }
 

--- a/lib/Controller/ConfigurationController.php
+++ b/lib/Controller/ConfigurationController.php
@@ -504,10 +504,6 @@ class ConfigurationController extends Controller
      *
      * @NoCSRFRequired
      *
-     * @psalm-return JSONResponse<200|404|500,
-     *     array{error?: 'Configuration not found'|'Failed to delete configuration',
-     *     success?: true}, array<never, never>>
-     *
      * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-2
      */
     public function destroy(int $id): JSONResponse
@@ -1222,24 +1218,28 @@ class ConfigurationController extends Controller
                 if (($longIp & 0xFF000000) === 0x7F000000) {
                     throw new Exception('URL resolves to a blocked IP range (loopback)', 400);
                 }
+
                 // Block RFC-1918: 10.0.0.0/8.
                 if (($longIp & 0xFF000000) === 0x0A000000) {
                     throw new Exception('URL resolves to a blocked IP range (RFC-1918)', 400);
                 }
+
                 // Block RFC-1918: 172.16.0.0/12.
                 if (($longIp & 0xFFF00000) === 0xAC100000) {
                     throw new Exception('URL resolves to a blocked IP range (RFC-1918)', 400);
                 }
+
                 // Block RFC-1918: 192.168.0.0/16.
                 if (($longIp & 0xFFFF0000) === 0xC0A80000) {
                     throw new Exception('URL resolves to a blocked IP range (RFC-1918)', 400);
                 }
+
                 // Block link-local (169.254.0.0/16) including AWS metadata endpoint.
                 if (($longIp & 0xFFFF0000) === 0xA9FE0000) {
                     throw new Exception('URL resolves to a blocked IP range (link-local/metadata)', 400);
                 }
-            }
-        }
+            }//end if
+        }//end if
 
         // Fetch content from URL.
         $client   = new Client();
@@ -1523,6 +1523,18 @@ class ConfigurationController extends Controller
      */
     public function publishToGitHub(int $id): JSONResponse
     {
+        // Authorization: publishToGitHub uses the shared app-level
+        // `github_api_token` to push to any repo that token can write. Restrict
+        // to administrators (mirror the importFromGitHub gate). Ideally
+        // callers would use a per-user token, but until that lands the
+        // endpoint must be admin-only.
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(
+                data: ['error' => 'Only administrators may publish configurations to GitHub'],
+                statusCode: 403
+            );
+        }
+
         try {
             $configuration = $this->configurationMapper->find($id);
 

--- a/lib/Controller/DeletedController.php
+++ b/lib/Controller/DeletedController.php
@@ -29,8 +29,10 @@ namespace OCA\OpenRegister\Controller;
 
 use DateTime;
 use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
@@ -52,14 +54,15 @@ class DeletedController extends Controller
     /**
      * Constructor for the DeletedController
      *
-     * @param string         $appName            The name of the app
-     * @param IRequest       $request            The request object
-     * @param MagicMapper    $objectEntityMapper The object entity mapper
-     * @param RegisterMapper $registerMapper     The register mapper
-     * @param SchemaMapper   $schemaMapper       The schema mapper
-     * @param ObjectService  $objectService      The object service
-     * @param IUserSession   $userSession        The user session
-     * @param IGroupManager  $groupManager       The group manager for admin checks
+     * @param string            $appName            The name of the app
+     * @param IRequest          $request            The request object
+     * @param MagicMapper       $objectEntityMapper The object entity mapper
+     * @param RegisterMapper    $registerMapper     The register mapper
+     * @param SchemaMapper      $schemaMapper       The schema mapper
+     * @param ObjectService     $objectService      The object service
+     * @param IUserSession      $userSession        The user session
+     * @param IGroupManager     $groupManager       The group manager for admin checks
+     * @param PermissionHandler $permissionHandler  Handler for per-schema RBAC checks
      *
      * @return void
      */
@@ -71,7 +74,8 @@ class DeletedController extends Controller
         private readonly SchemaMapper $schemaMapper,
         private readonly ObjectService $objectService,
         private readonly IUserSession $userSession,
-        private readonly IGroupManager $groupManager
+        private readonly IGroupManager $groupManager,
+        private readonly PermissionHandler $permissionHandler
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
@@ -90,6 +94,62 @@ class DeletedController extends Controller
 
         return (bool) $this->groupManager->isAdmin($user->getUID());
     }//end isCurrentUserAdmin()
+
+    /**
+     * Resolve a soft-deleted object's schema and check the caller has the
+     * required action permission.
+     *
+     * Refuses the call (returns false) when:
+     *  - no user is authenticated, OR
+     *  - the object lacks a resolvable register/schema context, OR
+     *  - PermissionHandler denies the action for the caller.
+     *
+     * Admin users always pass. This mirrors the fail-closed write-RBAC
+     * pattern from #1949: when register/schema context cannot be derived,
+     * the destructive operation is refused.
+     *
+     * @param ObjectEntity $object The soft-deleted object being acted on.
+     * @param string       $action The action to authorize ('delete'|'update').
+     *
+     * @return bool True if the caller may perform the action on this object.
+     */
+    private function userMayActOnDeletedObject(ObjectEntity $object, string $action): bool
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        // Admin bypass.
+        if ($this->isCurrentUserAdmin() === true) {
+            return true;
+        }
+
+        $schemaId = $object->getSchema();
+        if ($schemaId === null || $schemaId === '') {
+            // Fail-closed: cannot resolve schema, refuse.
+            return false;
+        }
+
+        try {
+            $schema = $this->schemaMapper->find((int) $schemaId);
+        } catch (\Throwable $e) {
+            return false;
+        }
+
+        try {
+            return $this->permissionHandler->hasPermission(
+                schema: $schema,
+                action: $action,
+                userId: $user->getUID(),
+                objectOwner: $object->getOwner(),
+                _rbac: true,
+                object: $object
+            );
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }//end userMayActOnDeletedObject()
 
     /**
      * Helper method to extract request parameters for deleted objects
@@ -402,9 +462,12 @@ class DeletedController extends Controller
     /**
      * Restore multiple deleted objects
      *
-     * TODO: This function is unsafe as it doesn't filter by register/schema.
-     * In the future, add register and schema filtering to mass operations
-     * to prevent cross-register restoring.
+     * Each soft-deleted object is gated through PermissionHandler with the
+     * `update` action against the object's resolved schema. Admins bypass.
+     * Objects whose schema cannot be resolved or for which the caller lacks
+     * `update` permission are skipped (counted as `failed`) so a partial
+     * cross-tenant bulk restore cannot succeed silently. This closes the
+     * wave-3 C4 finding (no RBAC on `restoreMultiple`).
      *
      * @NoAdminRequired
      *
@@ -416,6 +479,13 @@ class DeletedController extends Controller
      */
     public function restoreMultiple(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(
+                data: ['error' => 'Not authenticated'],
+                statusCode: 401
+            );
+        }
+
         $ids = $this->request->getParam('ids', []);
 
         if (empty($ids) === true) {
@@ -457,13 +527,22 @@ class DeletedController extends Controller
                         continue;
                     }
 
+                    // Per-object RBAC gate: caller must have `update`
+                    // permission on the resolved schema (admins bypass).
+                    // Cross-tenant restores are silently dropped (counted
+                    // as failed) rather than aborting the whole batch.
+                    if ($this->userMayActOnDeletedObject(object: $object, action: 'update') === false) {
+                        $failed++;
+                        continue;
+                    }
+
                     $object->setDeleted(null);
                     $this->objectEntityMapper->update(entity: $object);
                     $restored++;
                 } catch (\Exception $e) {
                     $failed++;
-                }
-            }
+                }//end try
+            }//end foreach
 
             // Count objects that were requested but not found in database.
             $notFound = count(array_diff($ids, $foundIds));
@@ -491,6 +570,11 @@ class DeletedController extends Controller
     /**
      * Permanently delete an object
      *
+     * Gated through PermissionHandler with the `delete` action against the
+     * resolved schema (admins bypass). When register/schema context cannot
+     * be derived the call is refused fail-closed. This closes the wave-3 C4
+     * finding (no RBAC on `destroy`).
+     *
      * @param string $id The ID or UUID of the object to permanently delete
      *
      * @NoAdminRequired
@@ -503,6 +587,13 @@ class DeletedController extends Controller
      */
     public function destroy(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(
+                data: ['error' => 'Not authenticated'],
+                statusCode: 401
+            );
+        }
+
         try {
             $object = $this->objectEntityMapper->find(identifier: $id, register: null, schema: null, includeDeleted: true);
 
@@ -512,6 +603,17 @@ class DeletedController extends Controller
                         'error' => 'Object is not deleted',
                     ],
                     statusCode: 400
+                );
+            }
+
+            // Per-object RBAC gate: caller must have `delete` permission on
+            // the resolved schema (admins bypass). Cross-tenant destructive
+            // deletes are refused with 403 — no silent fail since this is a
+            // single-object endpoint.
+            if ($this->userMayActOnDeletedObject(object: $object, action: 'delete') === false) {
+                return new JSONResponse(
+                    data: ['error' => 'User does not have permission to permanently delete this object'],
+                    statusCode: 403
                 );
             }
 
@@ -537,9 +639,12 @@ class DeletedController extends Controller
     /**
      * Permanently delete multiple objects
      *
-     * TODO: This function is unsafe as it doesn't filter by register/schema.
-     * In the future, add register and schema filtering to mass operations
-     * to prevent cross-register deleting.
+     * Each soft-deleted object is gated through PermissionHandler with the
+     * `delete` action against the object's resolved schema. Admins bypass.
+     * Objects whose schema cannot be resolved or for which the caller lacks
+     * `delete` permission are skipped (counted as `failed`) so a partial
+     * cross-tenant bulk wipe cannot succeed silently. This closes the
+     * wave-3 C4 finding (no RBAC on `destroyMultiple`).
      *
      * @NoAdminRequired
      *
@@ -551,6 +656,13 @@ class DeletedController extends Controller
      */
     public function destroyMultiple(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(
+                data: ['error' => 'Not authenticated'],
+                statusCode: 401
+            );
+        }
+
         $ids = $this->request->getParam('ids', []);
 
         if (empty($ids) === true) {
@@ -592,12 +704,19 @@ class DeletedController extends Controller
                         continue;
                     }
 
+                    // Per-object RBAC gate: caller must have `delete`
+                    // permission on the resolved schema (admins bypass).
+                    if ($this->userMayActOnDeletedObject(object: $object, action: 'delete') === false) {
+                        $failed++;
+                        continue;
+                    }
+
                     $this->objectEntityMapper->delete($object);
                     $deleted++;
                 } catch (\Exception $e) {
                     $failed++;
                 }
-            }
+            }//end foreach
 
             // Count objects that were requested but not found in database.
             $notFound = count(array_diff($ids, $foundIds));

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -2886,17 +2886,36 @@ class ObjectsController extends Controller
      *
      * @NoCSRFRequired
      *
-     * @psalm-return JSONResponse<200, array{
-     *     message: 'Object unlocked successfully', locked: false, uuid: string
-     * }, array<never, never>>
-     *
      * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-4
      */
     public function unlock(string $register, string $schema, string $id): JSONResponse
     {
-        $this->objectService->setRegister(register: $register);
-        $this->objectService->setSchema(schema: $schema);
-        $this->objectService->unlockObject($id);
+        // Authorization: anonymous callers cannot unlock anything; the
+        // per-object permission check (lock-holder OR owner OR schema-manage
+        // OR admin) lives in LockHandler::unlock and surfaces a permission
+        // error message we map to 403 here. This closes the wave-3 C14
+        // "any authenticated user can unlock anything" finding.
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(
+                data: ['error' => 'Not authenticated'],
+                statusCode: 401
+            );
+        }
+
+        try {
+            $this->objectService->setRegister(register: $register);
+            $this->objectService->setSchema(schema: $schema);
+            $this->objectService->unlockObject($id);
+        } catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
+            return new JSONResponse(data: ['error' => 'Object not found'], statusCode: 404);
+        } catch (\Exception $e) {
+            $message = $e->getMessage();
+            if (str_contains($message, 'does not have permission to unlock') === true) {
+                return new JSONResponse(data: ['error' => $message], statusCode: 403);
+            }
+
+            return new JSONResponse(data: ['error' => $message], statusCode: 500);
+        }
 
         // Return response with locked status for test compatibility.
         return new JSONResponse(

--- a/lib/Controller/OrganisationController.php
+++ b/lib/Controller/OrganisationController.php
@@ -39,7 +39,10 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 use Exception;
 
@@ -100,6 +103,20 @@ class OrganisationController extends Controller
     private TenantUsageMapper $tenantUsageMapper;
 
     /**
+     * User session for authorization checks
+     *
+     * @var IUserSession
+     */
+    private IUserSession $userSession;
+
+    /**
+     * Group manager for admin/group membership checks
+     *
+     * @var IGroupManager
+     */
+    private IGroupManager $groupManager;
+
+    /**
      * OrganisationController constructor
      *
      * @param string                 $appName                Application name
@@ -109,6 +126,8 @@ class OrganisationController extends Controller
      * @param LoggerInterface        $logger                 Logger service
      * @param TenantLifecycleService $tenantLifecycleService Lifecycle service
      * @param TenantUsageMapper      $tenantUsageMapper      Usage mapper
+     * @param IUserSession           $userSession            User session for authorization checks
+     * @param IGroupManager          $groupManager           Group manager for admin checks
      *
      * @spec openspec/changes/retrofit-2026-04-28-b2b-crossrefs/tasks.md#task-16
      */
@@ -119,7 +138,9 @@ class OrganisationController extends Controller
         OrganisationMapper $organisationMapper,
         LoggerInterface $logger,
         TenantLifecycleService $tenantLifecycleService,
-        TenantUsageMapper $tenantUsageMapper
+        TenantUsageMapper $tenantUsageMapper,
+        IUserSession $userSession,
+        IGroupManager $groupManager
     ) {
         parent::__construct(appName: $appName, request: $request);
         $this->organisationService = $organisationService;
@@ -127,7 +148,66 @@ class OrganisationController extends Controller
         $this->logger = $logger;
         $this->tenantLifecycleService = $tenantLifecycleService;
         $this->tenantUsageMapper      = $tenantUsageMapper;
+        $this->userSession            = $userSession;
+        $this->groupManager           = $groupManager;
     }//end __construct()
+
+    /**
+     * Check whether the currently authenticated user is a Nextcloud administrator.
+     *
+     * @return bool True if a user is signed in and belongs to the admin group.
+     */
+    private function isCurrentUserAdmin(): bool
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        return $this->groupManager->isAdmin($user->getUID());
+
+    }//end isCurrentUserAdmin()
+
+    /**
+     * Check whether the current user may manage another user's membership in
+     * the given organisation.
+     *
+     * A caller may modify another user's membership only when they are:
+     *  - a Nextcloud administrator, OR
+     *  - the owner of the organisation (see `Organisation::getOwner()`).
+     *
+     * Self-service (target user === current user) is handled at the call site
+     * and not gated here.
+     *
+     * @param string $organisationUuid Organisation UUID being modified.
+     *
+     * @return bool True if the current user may manage other users in this org.
+     */
+    private function canManageOrganisationMembers(string $organisationUuid): bool
+    {
+        if ($this->isCurrentUserAdmin() === true) {
+            return true;
+        }
+
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        try {
+            $organisation = $this->organisationMapper->findByUuid(uuid: $organisationUuid);
+        } catch (DoesNotExistException $e) {
+            return false;
+        }
+
+        $owner = $organisation->getOwner();
+        if ($owner === null || $owner === '') {
+            return false;
+        }
+
+        return $owner === $user->getUID();
+
+    }//end canManageOrganisationMembers()
 
     /**
      * Get user's organisations and active organisation
@@ -384,10 +464,6 @@ class OrganisationController extends Controller
      *
      * @NoCSRFRequired
      *
-     * @psalm-return JSONResponse<200|400,
-     *     array{error?: string, message?: 'Successfully joined organisation'},
-     *     array<never, never>>
-     *
      * @spec openspec/changes/retrofit-2026-04-28-b2b-crossrefs/tasks.md#task-16
      */
     public function join(string $uuid): JSONResponse
@@ -396,6 +472,28 @@ class OrganisationController extends Controller
             // Get optional userId from request body.
             $requestData = $this->request->getParams();
             $userId      = $requestData['userId'] ?? null;
+
+            // Authorization: enrolling another user is privileged. A caller may
+            // only enroll themselves; admins or organisation owners may enroll
+            // arbitrary users. This blocks the cross-user enroll vector where
+            // any authenticated user could otherwise add anyone (incl. admins)
+            // to an organisation whose UUID they know.
+            $currentUser = $this->userSession->getUser();
+            if ($currentUser === null) {
+                return new JSONResponse(
+                    data: ['error' => 'Not authenticated'],
+                    statusCode: Http::STATUS_UNAUTHORIZED
+                );
+            }
+
+            if ($userId !== null && $userId !== $currentUser->getUID()
+                && $this->canManageOrganisationMembers(organisationUuid: $uuid) === false
+            ) {
+                return new JSONResponse(
+                    data: ['error' => 'Only admins or organisation owners may enroll other users'],
+                    statusCode: Http::STATUS_FORBIDDEN
+                );
+            }
 
             // Join organisation with optional userId parameter.
             $success = $this->organisationService->joinOrganisation(organisationUuid: $uuid, targetUserId: $userId);
@@ -447,11 +545,6 @@ class OrganisationController extends Controller
      *
      * @NoCSRFRequired
      *
-     * @psalm-return JSONResponse<200|400,
-     *     array{error?: string,
-     *     message?: 'Successfully left organisation'|
-     *     'Successfully removed user from organisation'}, array<never, never>>
-     *
      * @spec openspec/changes/retrofit-2026-04-28-b2b-crossrefs/tasks.md#task-16
      */
     public function leave(string $uuid): JSONResponse
@@ -460,6 +553,29 @@ class OrganisationController extends Controller
             // Check if a specific userId is provided in the request body.
             $data   = $this->request->getParams();
             $userId = $data['userId'] ?? null;
+
+            // Authorization: removing another user from an organisation is
+            // privileged. A caller may only remove themselves; admins or
+            // organisation owners may remove arbitrary users. This blocks the
+            // cross-user removal vector where any authenticated user could
+            // otherwise kick anyone (incl. admins) out of an organisation
+            // whose UUID they know.
+            $currentUser = $this->userSession->getUser();
+            if ($currentUser === null) {
+                return new JSONResponse(
+                    data: ['error' => 'Not authenticated'],
+                    statusCode: Http::STATUS_UNAUTHORIZED
+                );
+            }
+
+            if ($userId !== null && $userId !== $currentUser->getUID()
+                && $this->canManageOrganisationMembers(organisationUuid: $uuid) === false
+            ) {
+                return new JSONResponse(
+                    data: ['error' => 'Only admins or organisation owners may remove other users'],
+                    statusCode: Http::STATUS_FORBIDDEN
+                );
+            }
 
             $success = $this->organisationService->leaveOrganisation(organisationUuid: $uuid, targetUserId: $userId);
 

--- a/lib/Controller/RegistersController.php
+++ b/lib/Controller/RegistersController.php
@@ -1086,6 +1086,18 @@ class RegistersController extends Controller
      */
     public function publishToGitHub(int $id): JSONResponse
     {
+        // Authorization: publishToGitHub uses the shared app-level
+        // `github_api_token` to push to any repo that token can write. Restrict
+        // to administrators (mirror the wave-1 #1949 admin-gate pattern and
+        // the existing importFromGitHub gate). Ideally callers would use a
+        // per-user token, but until that lands the endpoint must be admin-only.
+        if ($this->isCurrentUserAdmin() === false) {
+            return new JSONResponse(
+                data: ['error' => 'Only administrators may publish registers to GitHub'],
+                statusCode: 403
+            );
+        }
+
         try {
             $register = $this->registerMapper->find($id);
 
@@ -1259,6 +1271,25 @@ class RegistersController extends Controller
             $uploadedFile = $this->request->getUploadedFile('file');
             if ($uploadedFile === null) {
                 return new JSONResponse(data: ['error' => 'No file uploaded'], statusCode: 400);
+            }
+
+            // Authorization: importing into a register can create schemas/
+            // registers/objects and calls `registerService->updateFromArray`
+            // (a configurable data-model write). Gate on manage-permission for
+            // the target register (default-SECURE: admin-only when no manage
+            // rule exists). Closes the bypass of the wave-1 #1949 admin-only
+            // create/update gate.
+            try {
+                $registerForAuth = $this->registerMapper->find($id);
+            } catch (DoesNotExistException $e) {
+                return new JSONResponse(data: ['error' => 'Register not found'], statusCode: 404);
+            }
+
+            if ($this->checkRegisterManagePermission(register: $registerForAuth) === false) {
+                return new JSONResponse(
+                    data: ['error' => 'User does not have permission to manage this register'],
+                    statusCode: 403
+                );
             }
 
             // Dynamically determine import type if not provided.

--- a/lib/Service/Object/LockHandler.php
+++ b/lib/Service/Object/LockHandler.php
@@ -28,11 +28,16 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Service\Object;
 
 use DateTime;
+use Exception;
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Exception\LockedException;
+use OCP\IGroupManager;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -58,30 +63,46 @@ class LockHandler
      * @param MagicMapper      $magicMapper      Magic mapper for magic table operations
      * @param AuditTrailMapper $auditTrailMapper Audit trail mapper for logging actions
      * @param LoggerInterface  $logger           PSR-3 logger
+     * @param IUserSession     $userSession      User session for authorization checks
+     * @param IGroupManager    $groupManager     Group manager for admin checks
+     * @param SchemaMapper     $schemaMapper     Schema mapper for resolving manage rules
      */
     public function __construct(
         private readonly MagicMapper $magicMapper,
         private readonly AuditTrailMapper $auditTrailMapper,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager,
+        private readonly SchemaMapper $schemaMapper
     ) {
     }//end __construct()
 
     /**
      * Find an object and get its register/schema context.
      *
-     * @param string $identifier Object ID or UUID
+     * The `$_rbacBypass` flag is reserved for unlock paths that perform their
+     * own caller-vs-lock-holder/owner/manage authorization check on top (see
+     * `unlock()`); for lock/isLocked/getLockInfo it stays false so the regular
+     * RBAC + multitenancy boundary is respected.
+     *
+     * @param string $identifier  Object ID or UUID
+     * @param bool   $_rbacBypass When true, skip RBAC + multitenancy in the
+     *                            mapper lookup (caller MUST perform its own
+     *                            authorization gate).
      *
      * @return array{object: \OCA\OpenRegister\Db\ObjectEntity, register: Register|null, schema: Schema|null}
      *
      * @throws \OCP\AppFramework\Db\DoesNotExistException If object not found.
+     *
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag) RBAC bypass flag follows established API patterns.
      */
-    private function findObjectWithContext(string $identifier): array
+    private function findObjectWithContext(string $identifier, bool $_rbacBypass=false): array
     {
         $result = $this->magicMapper->findAcrossAllSources(
             identifier: $identifier,
             includeDeleted: false,
-            _rbac: false,
-            _multitenancy: false
+            _rbac: ($_rbacBypass === false),
+            _multitenancy: ($_rbacBypass === false)
         );
 
         return [
@@ -90,6 +111,119 @@ class LockHandler
             'schema'   => $result['schema'],
         ];
     }//end findObjectWithContext()
+
+    /**
+     * Check if the current user has schema-manage permission on the schema
+     * owning the given object.
+     *
+     * Default-SECURE: a schema with no `manage` authorization rule can only be
+     * managed by administrators (admins always pass). When manage rules are
+     * present, group-membership grants permission.
+     *
+     * @param ObjectEntity $object The object whose owning schema is checked.
+     *
+     * @return bool True if the current user may manage the owning schema.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     */
+    private function callerHasSchemaManagePermission(ObjectEntity $object): bool
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        // Admins always pass.
+        if ($this->groupManager->isAdmin($user->getUID()) === true) {
+            return true;
+        }
+
+        $schemaId = $object->getSchema();
+        if ($schemaId === null || $schemaId === '') {
+            return false;
+        }
+
+        try {
+            $schema        = $this->schemaMapper->find((int) $schemaId);
+            $authorization = $schema->getAuthorization();
+        } catch (\Throwable $e) {
+            return false;
+        }
+
+        if (empty($authorization) === true || isset($authorization['manage']) === false) {
+            // Default-secure: no manage rule defined → admin-only (failed above).
+            return false;
+        }
+
+        try {
+            $userGroups = $this->groupManager->getUserGroupIds($user);
+        } catch (\Throwable $e) {
+            return false;
+        }
+
+        $manageRules = $authorization['manage'];
+        foreach ($userGroups as $groupId) {
+            foreach ($manageRules as $entry) {
+                if (is_string($entry) === true && $entry === $groupId) {
+                    return true;
+                }
+
+                if (is_array($entry) === true && isset($entry['group']) === true && $entry['group'] === $groupId) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+
+    }//end callerHasSchemaManagePermission()
+
+    /**
+     * Authorize an unlock request.
+     *
+     * The caller may unlock the object only when one of:
+     *  - the caller is the lock holder (the user recorded in the lock payload), OR
+     *  - the caller is the object owner (see `ObjectEntity::getOwner()`), OR
+     *  - the caller has schema-manage permission on the owning schema, OR
+     *  - the caller is a Nextcloud administrator.
+     *
+     * Anonymous callers are always refused. This closes the wave-3 C14
+     * finding where any authenticated user could unlock any locked object.
+     *
+     * @param ObjectEntity $object The locked object the caller wants to unlock.
+     *
+     * @return bool True if the caller may unlock this object.
+     */
+    private function callerMayUnlock(ObjectEntity $object): bool
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        $userId = $user->getUID();
+
+        // Admins always pass.
+        if ($this->groupManager->isAdmin($userId) === true) {
+            return true;
+        }
+
+        // Lock holder.
+        $lockInfo = $object->getLockInfo();
+        if (is_array($lockInfo) === true && ($lockInfo['user'] ?? null) === $userId) {
+            return true;
+        }
+
+        // Object owner.
+        if ($object->getOwner() === $userId) {
+            return true;
+        }
+
+        // Schema-manage permission.
+        return $this->callerHasSchemaManagePermission(object: $object);
+
+    }//end callerMayUnlock()
 
     /**
      * Lock an object
@@ -200,8 +334,29 @@ class LockHandler
 
         try {
             // Find the object and its register/schema context.
-            $context      = $this->findObjectWithContext(identifier: $identifier);
+            //
+            // SECURITY: bypass RBAC + multitenancy on the read so we can
+            // resolve cross-tenant lock holders, but perform an explicit
+            // authorization check before mutating state. Without the bypass
+            // a non-owner who was nonetheless the lock holder could not
+            // resolve the object at all and would be blocked from
+            // releasing their own lock; the explicit `callerMayUnlock`
+            // gate replaces the wave-3 C14 "any authenticated user can
+            // unlock anything" behavior.
+            $context      = $this->findObjectWithContext(identifier: $identifier, _rbacBypass: true);
             $objectBefore = $context['object'];
+
+            if ($this->callerMayUnlock(object: $objectBefore) === false) {
+                $this->logger->warning(
+                    message: '[LockHandler] Unauthorized unlock attempt',
+                    context: [
+                        'file'       => __FILE__,
+                        'line'       => __LINE__,
+                        'identifier' => $identifier,
+                    ]
+                );
+                throw new Exception('User does not have permission to unlock this object');
+            }
 
             // Use MagicMapper for unlock operation.
             $objectAfter = $this->magicMapper->unlockObjectEntity(

--- a/tests/Service/ControllersIntegrationTest2.php
+++ b/tests/Service/ControllersIntegrationTest2.php
@@ -42,6 +42,9 @@ use OCA\OpenRegister\Db\FeedbackMapper;
 use OCA\OpenRegister\Db\GdprEntityMapper;
 use OCA\OpenRegister\Db\MessageMapper;
 use OCA\OpenRegister\Db\OrganisationMapper;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Db\TenantUsageMapper;
 use OCA\OpenRegister\Db\WebhookLogMapper;
 use OCA\OpenRegister\Db\WebhookMapper;
 use OCA\OpenRegister\Service\ChatService;
@@ -53,6 +56,7 @@ use OCA\OpenRegister\Service\Mcp\McpToolsService;
 use OCA\OpenRegister\Service\ObjectService;
 use OCA\OpenRegister\Service\OrganisationService;
 use OCA\OpenRegister\Service\RiskLevelService;
+use OCA\OpenRegister\Service\TenantLifecycleService;
 use OCA\OpenRegister\Service\SettingsService;
 use OCA\OpenRegister\Service\Settings\ConfigurationSettingsHandler;
 use OCA\OpenRegister\Service\TextExtractionService;
@@ -64,7 +68,9 @@ use OCP\Http\Client\IClientService;
 use OCP\IAppConfig;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -2074,7 +2080,11 @@ class ControllersIntegrationTest2 extends TestCase
             $this->request,
             \OC::$server->get(OrganisationService::class),
             \OC::$server->get(OrganisationMapper::class),
-            $this->logger
+            $this->logger,
+            \OC::$server->get(TenantLifecycleService::class),
+            \OC::$server->get(TenantUsageMapper::class),
+            \OC::$server->get(IUserSession::class),
+            \OC::$server->get(IGroupManager::class)
         );
     }//end buildOrganisationController()
 
@@ -2125,7 +2135,11 @@ class ControllersIntegrationTest2 extends TestCase
         return new BulkController(
             'openregister',
             $this->request,
-            \OC::$server->get(ObjectService::class)
+            \OC::$server->get(ObjectService::class),
+            \OC::$server->get(RegisterMapper::class),
+            \OC::$server->get(SchemaMapper::class),
+            \OC::$server->get(IUserSession::class),
+            \OC::$server->get(IGroupManager::class)
         );
     }//end buildBulkController()
 

--- a/tests/Unit/Controller/BulkControllerTest.php
+++ b/tests/Unit/Controller/BulkControllerTest.php
@@ -5,11 +5,18 @@ declare(strict_types=1);
 namespace Unit\Controller;
 
 use OCA\OpenRegister\Controller\BulkController;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -18,6 +25,10 @@ class BulkControllerTest extends TestCase
     private BulkController $controller;
     private IRequest&MockObject $request;
     private ObjectService&MockObject $objectService;
+    private RegisterMapper&MockObject $registerMapper;
+    private SchemaMapper&MockObject $schemaMapper;
+    private IUserSession&MockObject $userSession;
+    private IGroupManager&MockObject $groupManager;
 
     protected function setUp(): void
     {
@@ -25,12 +36,64 @@ class BulkControllerTest extends TestCase
 
         $this->request = $this->createMock(IRequest::class);
         $this->objectService = $this->createMock(ObjectService::class);
+        $this->registerMapper = $this->createMock(RegisterMapper::class);
+        $this->schemaMapper = $this->createMock(SchemaMapper::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->groupManager = $this->createMock(IGroupManager::class);
 
         $this->controller = new BulkController(
             'openregister',
             $this->request,
-            $this->objectService
+            $this->objectService,
+            $this->registerMapper,
+            $this->schemaMapper,
+            $this->userSession,
+            $this->groupManager
         );
+    }
+
+    /**
+     * Helper: stub the user session as an admin user so manage-permission gates pass.
+     */
+    private function stubAdminUser(string $userId = 'admin'): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($userId);
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager->method('isAdmin')->with($userId)->willReturn(true);
+    }
+
+    /**
+     * Helper: stub the schemaMapper to return a default schema entity so the
+     * manage-permission gate on deleteSchema/deleteSchemaObjects has something
+     * to inspect (admin bypass still does the work).
+     */
+    private function stubSchemaLookup(?int $schemaId = null): void
+    {
+        $schema = new Schema();
+        if ($schemaId !== null) {
+            $ref = new \ReflectionClass($schema);
+            $prop = $ref->getProperty('id');
+            $prop->setAccessible(true);
+            $prop->setValue($schema, $schemaId);
+        }
+        $this->schemaMapper->method('find')->willReturn($schema);
+    }
+
+    /**
+     * Helper: stub the registerMapper to return a default register entity so
+     * the manage-permission gate on deleteRegister has something to inspect.
+     */
+    private function stubRegisterLookup(?int $registerId = null): void
+    {
+        $register = new Register();
+        if ($registerId !== null) {
+            $ref = new \ReflectionClass($register);
+            $prop = $ref->getProperty('id');
+            $prop->setAccessible(true);
+            $prop->setValue($register, $registerId);
+        }
+        $this->registerMapper->method('find')->willReturn($register);
     }
 
     /**
@@ -395,8 +458,26 @@ class BulkControllerTest extends TestCase
         $this->assertStringContainsString('Invalid schema ID', $data['error']);
     }
 
+    public function testDeleteSchemaUnauthorizedRejected(): void
+    {
+        // Wave-3 C5 regression guard: non-admin without manage-permission
+        // cannot mass-delete schema objects.
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager->method('isAdmin')->with('alice')->willReturn(false);
+        $this->stubSchemaLookup(2);
+        $this->objectService->expects($this->never())->method('deleteObjectsBySchema');
+
+        $result = $this->controller->deleteSchema('1', '2');
+
+        $this->assertEquals(Http::STATUS_FORBIDDEN, $result->getStatus());
+    }
+
     public function testDeleteSchemaSuccess(): void
     {
+        $this->stubAdminUser();
+        $this->stubSchemaLookup(2);
         $this->objectService->method('setRegister')->willReturnSelf();
         $this->objectService->method('setSchema')->willReturnSelf();
         $this->objectService->method('deleteObjectsBySchema')->willReturn([
@@ -421,6 +502,8 @@ class BulkControllerTest extends TestCase
 
     public function testDeleteSchemaWithHardDelete(): void
     {
+        $this->stubAdminUser();
+        $this->stubSchemaLookup(3);
         $this->objectService->method('setRegister')->willReturnSelf();
         $this->objectService->method('setSchema')->willReturnSelf();
         $this->objectService->method('deleteObjectsBySchema')->willReturn([
@@ -440,6 +523,8 @@ class BulkControllerTest extends TestCase
 
     public function testDeleteSchemaException(): void
     {
+        $this->stubAdminUser();
+        $this->stubSchemaLookup(2);
         $this->objectService->method('setRegister')->willReturnSelf();
         $this->objectService->method('setSchema')->willReturnSelf();
         $this->objectService->method('deleteObjectsBySchema')
@@ -459,8 +544,26 @@ class BulkControllerTest extends TestCase
     // deleteSchemaObjects() tests
     // ========================================================================
 
+    public function testDeleteSchemaObjectsUnauthorizedRejected(): void
+    {
+        // Wave-3 C5 regression guard.
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager->method('isAdmin')->with('alice')->willReturn(false);
+        $this->setupResolveSuccess();
+        $this->stubSchemaLookup(2);
+        $this->objectService->expects($this->never())->method('deleteObjectsBySchema');
+
+        $result = $this->controller->deleteSchemaObjects('1', '2');
+
+        $this->assertEquals(Http::STATUS_FORBIDDEN, $result->getStatus());
+    }
+
     public function testDeleteSchemaObjectsSuccess(): void
     {
+        $this->stubAdminUser();
+        $this->stubSchemaLookup(2);
         $this->setupResolveSuccess();
         $this->objectService->method('deleteObjectsBySchema')->willReturn([
             'deleted_count' => 4,
@@ -485,6 +588,8 @@ class BulkControllerTest extends TestCase
 
     public function testDeleteSchemaObjectsWithHardDelete(): void
     {
+        $this->stubAdminUser();
+        $this->stubSchemaLookup(2);
         $this->setupResolveSuccess();
         $this->objectService->method('deleteObjectsBySchema')->willReturn([
             'deleted_count' => 1,
@@ -532,6 +637,8 @@ class BulkControllerTest extends TestCase
 
     public function testDeleteSchemaObjectsException(): void
     {
+        $this->stubAdminUser();
+        $this->stubSchemaLookup(2);
         $this->setupResolveSuccess();
         $this->objectService->method('deleteObjectsBySchema')
             ->willThrowException(new \Exception('Delete objects error'));
@@ -559,8 +666,25 @@ class BulkControllerTest extends TestCase
         $this->assertStringContainsString('Invalid register ID', $data['error']);
     }
 
+    public function testDeleteRegisterUnauthorizedRejected(): void
+    {
+        // Wave-3 C5 regression guard.
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager->method('isAdmin')->with('alice')->willReturn(false);
+        $this->stubRegisterLookup(1);
+        $this->objectService->expects($this->never())->method('deleteObjectsByRegister');
+
+        $result = $this->controller->deleteRegister('1');
+
+        $this->assertEquals(Http::STATUS_FORBIDDEN, $result->getStatus());
+    }
+
     public function testDeleteRegisterSuccess(): void
     {
+        $this->stubAdminUser();
+        $this->stubRegisterLookup(1);
         $this->objectService->method('setRegister')->willReturnSelf();
         $this->objectService->method('deleteObjectsByRegister')->willReturn([
             'deleted_count' => 3,
@@ -581,6 +705,8 @@ class BulkControllerTest extends TestCase
 
     public function testDeleteRegisterException(): void
     {
+        $this->stubAdminUser();
+        $this->stubRegisterLookup(1);
         $this->objectService->method('setRegister')->willReturnSelf();
         $this->objectService->method('deleteObjectsByRegister')
             ->willThrowException(new \Exception('Register delete error'));

--- a/tests/Unit/Controller/ConfigurationControllerTest.php
+++ b/tests/Unit/Controller/ConfigurationControllerTest.php
@@ -14,7 +14,10 @@ use OCA\OpenRegister\Service\NotificationService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -30,6 +33,8 @@ class ConfigurationControllerTest extends TestCase
     private GitLabHandler&MockObject $gitlabHandler;
     private IAppManager&MockObject $appManager;
     private LoggerInterface&MockObject $logger;
+    private IUserSession&MockObject $userSession;
+    private IGroupManager&MockObject $groupManager;
 
     protected function setUp(): void
     {
@@ -43,6 +48,8 @@ class ConfigurationControllerTest extends TestCase
         $this->gitlabHandler = $this->createMock(GitLabHandler::class);
         $this->appManager = $this->createMock(IAppManager::class);
         $this->logger = $this->createMock(LoggerInterface::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->groupManager = $this->createMock(IGroupManager::class);
 
         $this->controller = new ConfigurationController(
             'openregister',
@@ -53,8 +60,18 @@ class ConfigurationControllerTest extends TestCase
             $this->githubHandler,
             $this->gitlabHandler,
             $this->appManager,
-            $this->logger
+            $this->logger,
+            $this->userSession,
+            $this->groupManager
         );
+
+        // Default to an admin user so admin-gated endpoints (create, update,
+        // destroy, import, importFrom*, publishToGitHub) are reachable in
+        // existing tests; targeted tests can override this stub.
+        $defaultUser = $this->createMock(IUser::class);
+        $defaultUser->method('getUID')->willReturn('admin');
+        $this->userSession->method('getUser')->willReturn($defaultUser);
+        $this->groupManager->method('isAdmin')->willReturn(true);
     }
 
     private function createRealConfiguration(): Configuration

--- a/tests/Unit/Controller/DeletedControllerGapTest.php
+++ b/tests/Unit/Controller/DeletedControllerGapTest.php
@@ -9,6 +9,7 @@ use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\IGroupManager;
 use OCP\IRequest;
@@ -30,6 +31,7 @@ class DeletedControllerGapTest extends TestCase
     private ObjectService&MockObject $objectService;
     private IUserSession&MockObject $userSession;
     private IGroupManager&MockObject $groupManager;
+    private PermissionHandler&MockObject $permissionHandler;
 
     protected function setUp(): void
     {
@@ -42,6 +44,7 @@ class DeletedControllerGapTest extends TestCase
         $this->objectService = $this->createMock(ObjectService::class);
         $this->userSession = $this->createMock(IUserSession::class);
         $this->groupManager = $this->createMock(IGroupManager::class);
+        $this->permissionHandler = $this->createMock(PermissionHandler::class);
 
         $this->controller = new DeletedController(
             'openregister',
@@ -51,8 +54,20 @@ class DeletedControllerGapTest extends TestCase
             $this->schemaMapper,
             $this->objectService,
             $this->userSession,
-            $this->groupManager
+            $this->groupManager,
+            $this->permissionHandler
         );
+    }
+
+    /**
+     * Helper: stub the user session as an admin so RBAC gates pass.
+     */
+    private function stubAdminUser(string $userId = 'admin'): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($userId);
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager->method('isAdmin')->with($userId)->willReturn(true);
     }
 
     /**
@@ -291,6 +306,7 @@ class DeletedControllerGapTest extends TestCase
      */
     public function testRestoreMultipleWithMixedObjects(): void
     {
+        $this->stubAdminUser();
         // Create one deleted and one non-deleted object
         $deletedObject = new ObjectEntity();
         $deletedObject->setDeleted(['deleted' => '2024-01-01']);
@@ -335,6 +351,7 @@ class DeletedControllerGapTest extends TestCase
      */
     public function testDestroyMultipleWithMixedObjects(): void
     {
+        $this->stubAdminUser();
         $deletedObject = new ObjectEntity();
         $deletedObject->setDeleted(['deleted' => '2024-01-01']);
         $ref = new \ReflectionClass($deletedObject);
@@ -374,6 +391,7 @@ class DeletedControllerGapTest extends TestCase
      */
     public function testRestoreMultipleInnerException(): void
     {
+        $this->stubAdminUser();
         $deletedObject = new ObjectEntity();
         $deletedObject->setDeleted(['deleted' => '2024-01-01']);
         $ref = new \ReflectionClass($deletedObject);
@@ -405,6 +423,7 @@ class DeletedControllerGapTest extends TestCase
      */
     public function testDestroyMultipleInnerException(): void
     {
+        $this->stubAdminUser();
         $deletedObject = new ObjectEntity();
         $deletedObject->setDeleted(['deleted' => '2024-01-01']);
         $ref = new \ReflectionClass($deletedObject);
@@ -452,6 +471,7 @@ class DeletedControllerGapTest extends TestCase
      */
     public function testRestoreMultipleMessageWithNoNotFound(): void
     {
+        $this->stubAdminUser();
         $deletedObject = new ObjectEntity();
         $deletedObject->setDeleted(['deleted' => '2024-01-01']);
         $ref = new \ReflectionClass($deletedObject);
@@ -481,6 +501,7 @@ class DeletedControllerGapTest extends TestCase
      */
     public function testDestroyMultipleMessageWithNoNotFound(): void
     {
+        $this->stubAdminUser();
         $deletedObject = new ObjectEntity();
         $deletedObject->setDeleted(['deleted' => '2024-01-01']);
         $ref = new \ReflectionClass($deletedObject);

--- a/tests/Unit/Controller/DeletedControllerTest.php
+++ b/tests/Unit/Controller/DeletedControllerTest.php
@@ -9,10 +9,12 @@ use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -27,6 +29,7 @@ class DeletedControllerTest extends TestCase
     private ObjectService&MockObject $objectService;
     private IUserSession&MockObject $userSession;
     private IGroupManager&MockObject $groupManager;
+    private PermissionHandler&MockObject $permissionHandler;
 
     protected function setUp(): void
     {
@@ -39,6 +42,7 @@ class DeletedControllerTest extends TestCase
         $this->objectService = $this->createMock(ObjectService::class);
         $this->userSession = $this->createMock(IUserSession::class);
         $this->groupManager = $this->createMock(IGroupManager::class);
+        $this->permissionHandler = $this->createMock(PermissionHandler::class);
 
         $this->controller = new DeletedController(
             'openregister',
@@ -48,8 +52,20 @@ class DeletedControllerTest extends TestCase
             $this->schemaMapper,
             $this->objectService,
             $this->userSession,
-            $this->groupManager
+            $this->groupManager,
+            $this->permissionHandler
         );
+    }
+
+    /**
+     * Helper: stub the user session as an admin user so RBAC gates pass.
+     */
+    private function stubAdminUser(string $userId = 'admin'): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($userId);
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager->method('isAdmin')->with($userId)->willReturn(true);
     }
 
     public function testIndexSuccess(): void
@@ -138,6 +154,7 @@ class DeletedControllerTest extends TestCase
 
     public function testRestoreMultipleNoIds(): void
     {
+        $this->stubAdminUser();
         $this->request->method('getParam')
             ->willReturnMap([
                 ['ids', [], []],
@@ -155,6 +172,7 @@ class DeletedControllerTest extends TestCase
         // so a non-deleted object bypasses the guard and proceeds to delete.
         // This matches the actual controller behavior (unlike restore() which
         // checks both null and []).
+        $this->stubAdminUser();
         $object = new ObjectEntity();
         $object->setDeleted(null);
         $this->objectMapper->method('find')->willReturn($object);
@@ -166,6 +184,7 @@ class DeletedControllerTest extends TestCase
 
     public function testDestroySuccess(): void
     {
+        $this->stubAdminUser();
         $object = new ObjectEntity();
         $object->setDeleted(['deleted' => '2024-01-01']);
         $this->objectMapper->method('find')->willReturn($object);
@@ -179,6 +198,7 @@ class DeletedControllerTest extends TestCase
 
     public function testDestroyException(): void
     {
+        $this->stubAdminUser();
         $this->objectMapper->method('find')
             ->willThrowException(new \Exception('Error'));
 
@@ -187,8 +207,20 @@ class DeletedControllerTest extends TestCase
         $this->assertEquals(500, $result->getStatus());
     }
 
+    public function testDestroyAnonymousRejected(): void
+    {
+        // Wave-3 C4 regression guard: unauthenticated callers must not be
+        // able to permanently delete soft-deleted objects.
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $result = $this->controller->destroy('uuid-123');
+
+        $this->assertEquals(401, $result->getStatus());
+    }
+
     public function testDestroyMultipleNoIds(): void
     {
+        $this->stubAdminUser();
         $this->request->method('getParam')
             ->willReturnMap([
                 ['ids', [], []],
@@ -197,6 +229,28 @@ class DeletedControllerTest extends TestCase
         $result = $this->controller->destroyMultiple();
 
         $this->assertEquals(400, $result->getStatus());
+    }
+
+    public function testDestroyMultipleAnonymousRejected(): void
+    {
+        // Wave-3 C4 regression guard: unauthenticated callers must not be
+        // able to bulk-wipe soft-deleted objects.
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $result = $this->controller->destroyMultiple();
+
+        $this->assertEquals(401, $result->getStatus());
+    }
+
+    public function testRestoreMultipleAnonymousRejected(): void
+    {
+        // Wave-3 C4 regression guard: unauthenticated callers must not be
+        // able to bulk-restore soft-deleted objects.
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $result = $this->controller->restoreMultiple();
+
+        $this->assertEquals(401, $result->getStatus());
     }
 
     public function testRestoreSuccess(): void
@@ -228,6 +282,7 @@ class DeletedControllerTest extends TestCase
 
     public function testRestoreMultipleSuccess(): void
     {
+        $this->stubAdminUser();
         $deletedObject = new ObjectEntity();
         $deletedObject->setDeleted(['deleted' => '2024-01-01']);
         $ref = new \ReflectionClass($deletedObject);
@@ -252,6 +307,7 @@ class DeletedControllerTest extends TestCase
 
     public function testRestoreMultipleException(): void
     {
+        $this->stubAdminUser();
         $this->request->method('getParam')
             ->willReturnMap([
                 ['ids', [], ['uuid-1']],
@@ -267,6 +323,7 @@ class DeletedControllerTest extends TestCase
 
     public function testDestroyMultipleSuccess(): void
     {
+        $this->stubAdminUser();
         $deletedObject = new ObjectEntity();
         $deletedObject->setDeleted(['deleted' => '2024-01-01']);
         $ref = new \ReflectionClass($deletedObject);
@@ -291,6 +348,7 @@ class DeletedControllerTest extends TestCase
 
     public function testDestroyMultipleException(): void
     {
+        $this->stubAdminUser();
         $this->request->method('getParam')
             ->willReturnMap([
                 ['ids', [], ['uuid-1']],

--- a/tests/Unit/Controller/ObjectsControllerTest.php
+++ b/tests/Unit/Controller/ObjectsControllerTest.php
@@ -258,6 +258,7 @@ class ObjectsControllerTest extends TestCase
 
     public function testUnlockReturnsUnlockedObject(): void
     {
+        $this->setupAdminUser();
         $this->objectService->method('setSchema')->willReturnSelf();
         $this->objectService->method('setRegister')->willReturnSelf();
         $this->objectService->method('unlockObject')->willReturn(true);
@@ -269,6 +270,33 @@ class ObjectsControllerTest extends TestCase
         $this->assertFalse($data['locked']);
         $this->assertSame('uuid-123', $data['uuid']);
         $this->assertSame('Object unlocked successfully', $data['message']);
+    }
+
+    public function testUnlockAnonymousRejected(): void
+    {
+        // Wave-3 C14 regression guard: anonymous callers must not be able
+        // to release a lock.
+        $this->userSession->method('getUser')->willReturn(null);
+        $this->objectService->expects($this->never())->method('unlockObject');
+
+        $result = $this->controller->unlock('reg1', 'schema1', 'uuid-123');
+
+        $this->assertSame(401, $result->getStatus());
+    }
+
+    public function testUnlockPermissionDeniedReturns403(): void
+    {
+        // Wave-3 C14 regression guard: when LockHandler raises a permission
+        // error, the controller maps it to 403 (not 500).
+        $this->setupRegularUser();
+        $this->objectService->method('setSchema')->willReturnSelf();
+        $this->objectService->method('setRegister')->willReturnSelf();
+        $this->objectService->method('unlockObject')
+            ->willThrowException(new \Exception('User does not have permission to unlock this object'));
+
+        $result = $this->controller->unlock('reg1', 'schema1', 'uuid-123');
+
+        $this->assertSame(403, $result->getStatus());
     }
 
     public function testMergeReturnsMergedObject(): void
@@ -2514,13 +2542,15 @@ class ObjectsControllerTest extends TestCase
 
     public function testUnlockReturns404WhenObjectNotFound(): void
     {
+        $this->setupAdminUser();
         $this->objectService->method('setRegister')->willReturnSelf();
         $this->objectService->method('setSchema')->willReturnSelf();
         $this->objectService->method('unlockObject')
             ->willThrowException(new \OCP\AppFramework\Db\DoesNotExistException('Not found'));
 
-        $this->expectException(\OCP\AppFramework\Db\DoesNotExistException::class);
-        $this->controller->unlock('reg1', 'schema1', 'uuid-123');
+        $result = $this->controller->unlock('reg1', 'schema1', 'uuid-123');
+
+        $this->assertSame(404, $result->getStatus());
     }
 
     // =========================================================================

--- a/tests/Unit/Controller/OrganisationControllerTest.php
+++ b/tests/Unit/Controller/OrganisationControllerTest.php
@@ -13,7 +13,10 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCA\OpenRegister\Db\TenantUsageMapper;
 use OCA\OpenRegister\Service\TenantLifecycleService;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -34,6 +37,8 @@ class OrganisationControllerTest extends TestCase
     private OrganisationService&MockObject $organisationService;
     private OrganisationMapper&MockObject $organisationMapper;
     private LoggerInterface&MockObject $logger;
+    private IUserSession&MockObject $userSession;
+    private IGroupManager&MockObject $groupManager;
 
     protected function setUp(): void
     {
@@ -43,6 +48,8 @@ class OrganisationControllerTest extends TestCase
         $this->organisationService = $this->createMock(OrganisationService::class);
         $this->organisationMapper = $this->createMock(OrganisationMapper::class);
         $this->logger = $this->createMock(LoggerInterface::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->groupManager = $this->createMock(IGroupManager::class);
 
         $this->controller = new OrganisationController(
             'openregister',
@@ -51,8 +58,22 @@ class OrganisationControllerTest extends TestCase
             $this->organisationMapper,
             $this->logger,
             $this->createMock(TenantLifecycleService::class),
-            $this->createMock(TenantUsageMapper::class)
+            $this->createMock(TenantUsageMapper::class),
+            $this->userSession,
+            $this->groupManager
         );
+    }
+
+    /**
+     * Helper: stub the user session with a non-admin user (default for self-service tests).
+     */
+    private function stubAuthedUser(string $userId = 'alice'): IUser
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($userId);
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager->method('isAdmin')->with($userId)->willReturn(false);
+        return $user;
     }
 
     /**
@@ -271,6 +292,8 @@ class OrganisationControllerTest extends TestCase
 
     public function testJoinReturnsSuccess(): void
     {
+        // Self-service join (no userId param) — only requires being authenticated.
+        $this->stubAuthedUser();
         $this->organisationService->method('joinOrganisation')->willReturn(true);
         $this->request->method('getParams')->willReturn([]);
 
@@ -283,6 +306,12 @@ class OrganisationControllerTest extends TestCase
 
     public function testJoinWithUserIdPassesUserIdToService(): void
     {
+        // Cross-user join: caller must be admin OR org-owner. Use admin here.
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('admin');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager->method('isAdmin')->with('admin')->willReturn(true);
+
         $this->request->method('getParams')->willReturn(['userId' => 'target-user']);
         $this->organisationService->expects($this->once())
             ->method('joinOrganisation')
@@ -294,8 +323,38 @@ class OrganisationControllerTest extends TestCase
         $this->assertSame(Http::STATUS_OK, $result->getStatus());
     }
 
+    public function testJoinWithDifferentUserIdRejectedForNonAdmin(): void
+    {
+        // Wave-3 C1 regression guard: a non-admin, non-owner caller cannot
+        // enroll a different user. The service must never be invoked.
+        $this->stubAuthedUser('alice');
+        $orgWithOwner = new Organisation();
+        $orgWithOwner->setOwner('charlie');
+        $this->organisationMapper->method('findByUuid')
+            ->willReturn($orgWithOwner);
+        $this->request->method('getParams')->willReturn(['userId' => 'bob']);
+        $this->organisationService->expects($this->never())->method('joinOrganisation');
+
+        $result = $this->controller->join('uuid-1');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $result->getStatus());
+    }
+
+    public function testJoinAnonymousRejected(): void
+    {
+        // Wave-3 C1 regression guard: anonymous callers must be refused.
+        $this->userSession->method('getUser')->willReturn(null);
+        $this->request->method('getParams')->willReturn([]);
+        $this->organisationService->expects($this->never())->method('joinOrganisation');
+
+        $result = $this->controller->join('uuid-1');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $result->getStatus());
+    }
+
     public function testJoinReturnsBadRequestOnFailure(): void
     {
+        $this->stubAuthedUser();
         $this->organisationService->method('joinOrganisation')->willReturn(false);
         $this->request->method('getParams')->willReturn([]);
 
@@ -308,6 +367,7 @@ class OrganisationControllerTest extends TestCase
 
     public function testJoinReturnsBadRequestOnException(): void
     {
+        $this->stubAuthedUser();
         $this->request->method('getParams')->willReturn([]);
         $this->organisationService->method('joinOrganisation')
             ->willThrowException(new Exception('Organisation not found'));
@@ -321,6 +381,13 @@ class OrganisationControllerTest extends TestCase
 
     public function testJoinExceptionWithUserId(): void
     {
+        // Cross-user join with admin caller (so the auth gate passes and the
+        // service throws as expected).
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('admin');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager->method('isAdmin')->with('admin')->willReturn(true);
+
         $this->request->method('getParams')->willReturn(['userId' => 'some-user']);
         $this->organisationService->method('joinOrganisation')
             ->willThrowException(new Exception('Join failed'));
@@ -338,6 +405,8 @@ class OrganisationControllerTest extends TestCase
 
     public function testLeaveReturnsSuccess(): void
     {
+        // Self-service leave — only requires being authenticated.
+        $this->stubAuthedUser();
         $this->organisationService->method('leaveOrganisation')->willReturn(true);
         $this->request->method('getParams')->willReturn([]);
 
@@ -350,6 +419,12 @@ class OrganisationControllerTest extends TestCase
 
     public function testLeaveWithUserIdReturnsDifferentMessage(): void
     {
+        // Cross-user leave: caller must be admin OR org-owner. Use admin here.
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('admin');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager->method('isAdmin')->with('admin')->willReturn(true);
+
         $this->organisationService->method('leaveOrganisation')->willReturn(true);
         $this->request->method('getParams')->willReturn(['userId' => 'user1']);
 
@@ -359,8 +434,38 @@ class OrganisationControllerTest extends TestCase
         $this->assertSame('Successfully removed user from organisation', $data['message']);
     }
 
+    public function testLeaveWithDifferentUserIdRejectedForNonAdmin(): void
+    {
+        // Wave-3 C1 regression guard: a non-admin, non-owner caller cannot
+        // remove a different user. The service must never be invoked.
+        $this->stubAuthedUser('alice');
+        $orgWithOwner = new Organisation();
+        $orgWithOwner->setOwner('charlie');
+        $this->organisationMapper->method('findByUuid')
+            ->willReturn($orgWithOwner);
+        $this->request->method('getParams')->willReturn(['userId' => 'bob']);
+        $this->organisationService->expects($this->never())->method('leaveOrganisation');
+
+        $result = $this->controller->leave('uuid-1');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $result->getStatus());
+    }
+
+    public function testLeaveAnonymousRejected(): void
+    {
+        // Wave-3 C1 regression guard: anonymous callers must be refused.
+        $this->userSession->method('getUser')->willReturn(null);
+        $this->request->method('getParams')->willReturn([]);
+        $this->organisationService->expects($this->never())->method('leaveOrganisation');
+
+        $result = $this->controller->leave('uuid-1');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $result->getStatus());
+    }
+
     public function testLeaveReturnsBadRequestOnFailure(): void
     {
+        $this->stubAuthedUser();
         $this->organisationService->method('leaveOrganisation')->willReturn(false);
         $this->request->method('getParams')->willReturn([]);
 
@@ -373,6 +478,7 @@ class OrganisationControllerTest extends TestCase
 
     public function testLeaveReturnsBadRequestOnException(): void
     {
+        $this->stubAuthedUser();
         $this->request->method('getParams')->willReturn([]);
         $this->organisationService->method('leaveOrganisation')
             ->willThrowException(new Exception('Cannot leave'));
@@ -386,6 +492,13 @@ class OrganisationControllerTest extends TestCase
 
     public function testLeaveExceptionWithUserId(): void
     {
+        // Cross-user leave with admin caller (so the auth gate passes and the
+        // service throws as expected).
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('admin');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->groupManager->method('isAdmin')->with('admin')->willReturn(true);
+
         $this->request->method('getParams')->willReturn(['userId' => 'user1']);
         $this->organisationService->method('leaveOrganisation')
             ->willThrowException(new Exception('Leave failed'));
@@ -1382,6 +1495,7 @@ class OrganisationControllerTest extends TestCase
 
     public function testJoinWithNullUserIdInParams(): void
     {
+        $this->stubAuthedUser();
         $this->request->method('getParams')->willReturn(['userId' => null]);
         $this->organisationService->expects($this->once())
             ->method('joinOrganisation')
@@ -1395,6 +1509,7 @@ class OrganisationControllerTest extends TestCase
 
     public function testJoinExceptionWithoutUserIdInParams(): void
     {
+        $this->stubAuthedUser();
         $this->request->method('getParams')->willReturn([]);
         $this->organisationService->method('joinOrganisation')
             ->willThrowException(new Exception('Org not found'));
@@ -1411,6 +1526,7 @@ class OrganisationControllerTest extends TestCase
 
     public function testLeaveWithNullUserIdReturnsLeftMessage(): void
     {
+        $this->stubAuthedUser();
         $this->organisationService->method('leaveOrganisation')->willReturn(true);
         $this->request->method('getParams')->willReturn(['userId' => null]);
 
@@ -1424,6 +1540,7 @@ class OrganisationControllerTest extends TestCase
 
     public function testLeaveExceptionWithNullUserId(): void
     {
+        $this->stubAuthedUser();
         $this->request->method('getParams')->willReturn([]);
         $this->organisationService->method('leaveOrganisation')
             ->willThrowException(new Exception('Cannot leave'));


### PR DESCRIPTION
## Summary

Security hotfix for six wave-3 write-RBAC findings — siblings of the wave-1 #1949 register/schema create/update/delete sweep that the original pass missed. All six let any authenticated user mutate state outside their tenant or role.

### Findings fixed

| ID | Vector | Fix |
| --- | --- | --- |
| **C1** | `OrganisationController::join/leave` accepted arbitrary `userId`. Any authed user could enroll/remove anyone (incl. admins) from any org whose UUID they knew. | Require `target === current` OR caller is admin/org-owner. New `canManageOrganisationMembers()` helper; anonymous → 401, cross-user without privilege → 403. |
| **C4** | `DeletedController::destroy/destroyMultiple/restoreMultiple` had no RBAC — author's own TODOs admitted it. Any authed user could wipe/restore soft-deleted rows cross-tenant. | Route each object through `PermissionHandler::hasPermission` (action `delete` / `update`) against the resolved schema. Admin bypass. Single-object no-perm → 403; bulk no-perm → counted as `failed` (cross-tenant rows silently dropped so a partial batch can't succeed). |
| **C5** | `BulkController::deleteSchema/deleteSchemaObjects/deleteRegister` had no perm gate. Service stubs throw today, but the security boundary belongs at the controller (pre-emptive). | Add `checkSchemaManagePermission` / `checkRegisterManagePermission` mirroring the wave-1 #1949 default-SECURE pattern (no manage rule → admin-only). |
| **C11** | `RegistersController::publishToGitHub` + `ConfigurationController::publishToGitHub` were `@NoAdminRequired` with no admin/manage gate, using a shared app-level `github_api_token` to push to any repo that token could write. | Admin-only check, mirroring the existing `importFromGitHub` gate. Ideal future state is per-user GitHub tokens; until then, admin-only. |
| **C12** | `RegistersController::import` bypassed the #1949 admin-only create/update gate by going through the import path (which creates schemas/registers/objects via `configurationService->importFromJson` and `registerService->updateFromArray`). | Gate on `checkRegisterManagePermission` for the target register. |
| **C14** | `ObjectsController::unlock` had no permission check; `LockHandler::unlock` used `_rbac:false, _multitenancy:false` on the lookup so any authed user could unlock any locked object in any tenant. | Explicit `callerMayUnlock()` gate in `LockHandler` — caller must be the lock holder, the object owner, have schema-manage permission, or be admin. The mapper-level RBAC bypass is now scoped to unlock alone (caller performs its own gate); `lock`/`isLocked`/`getLockInfo` go through normal RBAC. Controller surfaces the permission error as 403, anonymous → 401, not-found → 404. |

### Predecessor

Wave-1 #1949 (register/schema create/update/delete RBAC). Wave-3 found these as siblings the original sweep missed — same family of "any authed user can mutate" gaps.

## Test plan

- [x] `php -l` clean on all 7 modified `lib/` files
- [x] PHPStan level 5 clean on the same files (against the OR baseline)
- [x] PHPCS clean (0 errors; the 7 missing class-level `@spec` warnings are pre-existing and uniform across the controller layer — out of scope for a security hotfix)
- [x] Psalm clean for the modified files
- [x] Unit tests pass 275/275 across the five affected controller test files (one pre-existing `Doctrine\DBAL\ParameterType` infrastructure error in an unrelated `testRestoreSuccess` mock-chain — predates this change)
- [x] Tests updated, not weakened: existing tests that relied on the open endpoints now stub an admin user (or self-service caller for self-leave/join). New regression-guard tests cover the unauthorized paths (anonymous, non-admin cross-user, non-admin no-manage) and assert 401/403 responses.
- [ ] Runtime verification on `localhost:8080` after CI green
- [ ] Newman smoke pass

### Reviewer notes

- DI: `OrganisationController`, `BulkController`, `DeletedController`, `LockHandler` constructors gained authorization dependencies (`IUserSession`, `IGroupManager`, mappers, `PermissionHandler`). NC's `IAppContainer` auto-wires these. Integration test `ControllersIntegrationTest2.php` `buildOrganisationController()` / `buildBulkController()` updated; the pre-existing `OrganisationController` integration-builder was already incomplete (5 args vs 7 required) and is now correct at 9.
- `LockHandler::findObjectWithContext` gained an opt-in `$_rbacBypass` flag; unlock is the only caller that sets it (and performs its own caller-vs-lock-holder/owner/manage gate). lock/isLocked/getLockInfo stay through normal RBAC.
- **Do not admin-merge** — let CI run.