### PR TITLE
chore(openspec): promote openregister-app-manifest capability to canonical home

### DIFF
--- a/openspec/specs/openregister-app-manifest/spec.md
+++ b/openspec/specs/openregister-app-manifest/spec.md
@@ -1,0 +1,306 @@
+---
+status: implemented
+---
+
+# OpenRegister app-manifest capability
+
+## Purpose
+
+Define OpenRegister's adoption of the JSON-driven app-manifest pattern published
+by `@conduction/nextcloud-vue` (ADR-024). OR ships a single `src/manifest.json`
+that declares its full shell — menu items, route → page mapping, and per-page
+configuration — and mounts that manifest through `CnAppRoot` + `CnPageRenderer`
+so the runtime renders the entire app from data instead of from bespoke
+`App.vue`/`router/index.js` boilerplate.
+
+OR is the fleet's foundation app and therefore the **canonical Tier-4 adopter**:
+its shape (manifest + registry + CnAppRoot + CnAppNav + CnPageRenderer) is the
+reference every other Conduction app mirrors.
+
+Adopted via the archived change
+`2026-05-28-openregister-manifest-shell-swap` (33/33 tasks complete) and the
+preceding `2026-05-27-superseded-openregister-adopt-app-manifest` proposal that
+designed it.
+
+## Requirements
+
+### Requirement: REQ-OR-MAN-001 Manifest file exists at canonical location
+
+OpenRegister SHALL ship a `src/manifest.json` validated against the v2 schema
+published by `@conduction/nextcloud-vue` per ADR-024 §1-2. The file SHALL set
+`$schema` to the published GitHub raw URL of
+`nextcloud-vue/src/schemas/app-manifest-v2.schema.json`. The file MUST NOT
+fork or duplicate the schema.
+
+#### Scenario: Manifest exists and is loadable
+
+- **WHEN** the OpenRegister Vue bundle is built
+- **THEN** `src/manifest.json` is present, parses as valid JSON, and matches
+  the canonical schema (passes the build-time `npm run check:manifest` gate)
+
+#### Scenario: Schema is referenced, not duplicated
+
+- **WHEN** a reviewer inspects `src/manifest.json`
+- **THEN** the `$schema` field points at the canonical v2 schema URL and the
+  OR repo contains no copy of that schema file (a vendored copy is allowed
+  ONLY under `tests/schemas/` as a CI-portability fallback while the package
+  catches up)
+
+---
+
+### Requirement: REQ-OR-MAN-002 Manifest declares zero Conduction-app dependencies
+
+The manifest's `dependencies` field SHALL be an empty array `[]`. OpenRegister
+is the platform foundation; it has no upstream Conduction-app dependencies.
+
+#### Scenario: Foundation declares no dependencies
+
+- **WHEN** `src/manifest.json` is loaded
+- **THEN** `manifest.dependencies` is the empty array `[]`
+
+#### Scenario: Loader skips dependency check on empty deps
+
+- **WHEN** `CnAppRoot` runs and reads `dependencies: []` (passed via
+  `:requires-apps="[]"` in `App.vue`)
+- **THEN** the `dependency-check` phase is a no-op and the shell enters the
+  `loading` → `shell` transition without rendering `CnDependencyMissing`
+
+---
+
+### Requirement: REQ-OR-MAN-003 Manifest declares one entry per route
+
+The manifest's `pages[]` SHALL contain exactly one entry per route OR exposes
+(currently 31, excluding the `*` catch-all). Each entry SHALL set `id` (= route
+name, matched against `$route.name` by `CnPageRenderer`), `route` (= path
+pattern), `type`, and `title` (i18n key).
+
+OR's foundation entities (registers / schemas / sources / organisations /
+applications / endpoints / entities) and the generic objects/tables/audit/
+search-trail/webhook surfaces are **not register-stored objects** — they are
+served by dedicated OR controllers/stores, so the library's built-in
+`index`/`detail`/`dashboard` renderers (which resolve via `useObjectStore`
+against a register+schema slug) cannot drive them. Consequently every OR page
+declares `type:"custom"` with a `component` string resolved against the
+kind-tagged registry. This is the documented D3 fallback in the shell-swap
+design; each page carries an inline `_note` documenting why a built-in was
+not feasible.
+
+#### Scenario: Page count matches the manifest validator
+
+- **WHEN** the build runs `check:manifest`
+- **THEN** `manifest.pages[].length` equals the number of declared menu
+  destinations (currently 31) and every `id` is unique
+
+#### Scenario: Every page resolves to a registry component
+
+- **WHEN** the user navigates to any declared route
+- **THEN** `CnPageRenderer` matches `$route.name === page.id`, reads
+  `page.type === "custom"`, and resolves `page.component` against the v2
+  kind-tagged `registry` prop's `kind:"page"` entries (ADR-036)
+
+#### Scenario: Titles are i18n keys
+
+- **WHEN** an entry's `title` is read
+- **THEN** the value is a translation key resolved via the app's `t()`
+  function in `l10n/{en,nl}.js`
+
+---
+
+### Requirement: REQ-OR-MAN-004 Manifest declares menu split into main and settings sections
+
+The manifest's `menu[]` SHALL declare top-level navigation entries with two
+`section` values: `"main"` for primary navigation and `"settings"` for the
+configuration / log cluster. Each menu entry SHALL set `id`, `label` (i18n
+key), `icon`, `route`, `order`, and `section`.
+
+#### Scenario: Both sections are populated
+
+- **WHEN** the manifest is loaded
+- **THEN** `manifest.menu[]` contains entries with `section: "main"` and
+  entries with `section: "settings"`, with no other section values
+
+#### Scenario: Menu order is monotonic per section
+
+- **WHEN** entries within a section are sorted by `order`
+- **THEN** the visible order in `CnAppNav` matches the manifest order exactly
+
+#### Scenario: Menu labels are i18n keys
+
+- **WHEN** a menu entry's `label` is read
+- **THEN** the value resolves via the app's `t()` function
+
+---
+
+### Requirement: REQ-OR-MAN-005 Bootstrap mounts CnAppRoot with the manifest
+
+`src/main.js` SHALL `import bundledManifest from './manifest.json'` and
+`import registry from './registry.js'`, build the vue-router config via
+`routesFromManifest(bundledManifest)`, and mount `App.vue` (the thin
+`CnAppRoot` wrapper) passing `manifest`, `registry`, and `pageTypes` as props.
+
+`App.vue` SHALL render `<CnAppRoot app-id="openregister" :manifest="manifest"
+:registry="registry" :page-types="pageTypes" :requires-apps="[]"
+:translate="translateForApp">` with `#menu` / `#sidebar` / `#footer` slot
+overrides for `MainMenu`, `SideBars` + `CnObjectSidebar`, and the global
+`Modals`/`Dialogs` hosts.
+
+#### Scenario: Router is built from the manifest
+
+- **WHEN** the bundle initialises
+- **THEN** every `manifest.pages[]` entry becomes a vue-router route with
+  `name === page.id`, `path === page.route`, `component === CnPageRenderer`,
+  and `props: true` for paths containing a `:` parameter; a catch-all
+  `{ path: '*', redirect: '/' }` is appended
+
+#### Scenario: CnAppRoot mounts the shell
+
+- **WHEN** the OR Vue app mounts
+- **THEN** `CnAppRoot` runs its loading → shell phases and renders
+  `<router-view />`; the `#menu` slot renders OR's `MainMenu` (which embeds
+  `CnAppNav` with the active-organisation switcher in `#primary-action`)
+
+---
+
+### Requirement: REQ-OR-MAN-006 CnPageRenderer dispatches every route
+
+`CnPageRenderer` SHALL be the single `component` for every route in the
+manifest-driven router (cloned via `RoutePageRenderer = { ...CnPageRenderer }`
+to keep the lib's barrel export extensible for Vue 2's `_Ctor` cache). For
+each route, the renderer matches `$route.name === page.id` and resolves
+`page.component` against the v2 kind-tagged `registry` prop.
+
+#### Scenario: Index-style routes dispatch via custom registry
+
+- **WHEN** the user navigates to `/registers` (or any list route)
+- **THEN** `CnPageRenderer` matches `id: "registers"` and resolves
+  `component: "RegistersIndex"` against the `registry` prop's
+  `kind:"page"` entries, rendering `RegistersIndex` inside the shell
+
+#### Scenario: Detail-style routes dispatch via custom registry
+
+- **WHEN** the user navigates to `/registers/abc-123`
+- **THEN** `CnPageRenderer` matches `id: "registerDetail"`, props `:id` from
+  the URL, and resolves `component: "RegisterDetail"` from the registry
+
+#### Scenario: Dashboard dispatches via custom registry
+
+- **WHEN** the user navigates to `/`
+- **THEN** `CnPageRenderer` matches `id: "dashboard"` and resolves
+  `component: "Dashboard"`, rendering the OR dashboard with all its
+  KPI / chart widgets
+
+---
+
+### Requirement: REQ-OR-MAN-007 Build gate validates the manifest
+
+The OR `package.json` SHALL declare a `check:manifest` script that runs
+`tests/validate-manifest.js` against `src/manifest.json`. The script SHALL be
+invoked from CI (via `check:specs` → `.github/workflows/spec-validation.yml`)
+and SHALL fail the job on schema errors.
+
+#### Scenario: Valid manifest passes the gate
+
+- **WHEN** CI runs `npm run check:manifest` on a valid `src/manifest.json`
+- **THEN** the script exits 0 and the job continues
+
+#### Scenario: Invalid manifest fails the gate
+
+- **WHEN** CI runs `npm run check:manifest` on a manifest with a schema
+  violation (missing required field, unknown `type`, duplicate `id`, etc.)
+- **THEN** the script exits non-zero, prints the validation error path
+  inside the JSON, and the job fails
+
+#### Scenario: Gate is wired into the composite check
+
+- **WHEN** `npm run check:specs` is invoked
+- **THEN** `check:manifest` runs as part of the composite
+
+---
+
+### Requirement: REQ-OR-MAN-008 Manifest version reflects the adoption tier
+
+The manifest's top-level `version` SHALL be a semver string declaring the
+adoption tier. Tier-4 / full-shell adoption SHALL be expressed as `"1.0.0"`
+(no longer sub-1.0.0 — the original Tier-1/Tier-2 numbering in the superseded
+proposal is superseded by the shell-swap shipping the full shell at once).
+
+#### Scenario: Tier-4 ships at 1.0.0
+
+- **WHEN** the manifest is loaded
+- **THEN** `manifest.version` is `"1.0.0"`
+
+#### Scenario: Validator enforces the field
+
+- **WHEN** the validator runs (Ajv against v2 schema, with structuralLint as
+  a no-Ajv fallback)
+- **THEN** an absent or empty-string `version` fails the gate
+
+---
+
+### Requirement: REQ-OR-MAN-009 Backend `/api/manifest` endpoint is deferred
+
+OpenRegister SHALL NOT implement `GET /index.php/apps/openregister/api/
+manifest`. `useAppManifest`'s silent fallback on 404 makes absence
+non-regressive; the manifest ships statically inside the bundle. A follow-up
+change driven by a real admin-customisation use case (App Builder reorders
+menu / hides pages / overrides locale per tenant) SHALL add the endpoint
+when needed.
+
+#### Scenario: Endpoint returns 404 today
+
+- **WHEN** a request hits `/index.php/apps/openregister/api/manifest`
+- **THEN** the response is HTTP 404 and the loader silently keeps the
+  bundled manifest
+
+---
+
+### Requirement: REQ-OR-MAN-010 Tier-4 shell is adopted
+
+OR `App.vue` SHALL be the `CnAppRoot` wrapper described in REQ-OR-MAN-005,
+NOT a bespoke `NcContent` + `NcAppNavigation` mount. The legacy `src/router/
+index.js` SHALL be deleted; all route construction goes through
+`routesFromManifest` in `main.js`.
+
+This requirement replaces the superseded "Tier 3/Tier 4 are deferred"
+posture in the original proposal — the shell-swap (archive change
+`2026-05-28-openregister-manifest-shell-swap`) adopted both at once.
+
+#### Scenario: App.vue is the CnAppRoot wrapper
+
+- **WHEN** a reviewer inspects `src/App.vue`
+- **THEN** the root template is `<CnAppRoot ...>` with `#menu` / `#sidebar`
+  / `#footer` slot overrides; no direct `NcContent` / `NcAppNavigation`
+  mount is present
+
+#### Scenario: Legacy router file is gone
+
+- **WHEN** a reviewer searches `src/`
+- **THEN** `src/router/index.js` does not exist; only `main.js` imports the
+  router config
+
+---
+
+### Requirement: REQ-OR-MAN-011 Custom-component registry uses the v2 kind-tagged shape
+
+The `registry` prop passed to `CnAppRoot` SHALL be a v2 kind-tagged map per
+ADR-036. Page components MUST be wrapped as `{ kind: "page", component }`
+entries; OR uses a `page(component)` helper in `src/registry.js`. The
+deprecated `customComponents` prop SHALL NOT be passed to `CnAppRoot`.
+
+#### Scenario: Registry uses kind:"page" wrapping
+
+- **WHEN** a reviewer inspects `src/registry.js`
+- **THEN** each entry is `{ kind: "page", component: <imported component> }`,
+  produced via the `page()` helper
+
+#### Scenario: No customComponents prop
+
+- **WHEN** a reviewer inspects `src/App.vue` / `src/main.js`
+- **THEN** neither file passes `customComponents` to `CnAppRoot`; only
+  `registry` is bound
+
+#### Scenario: No deprecation warning at runtime
+
+- **WHEN** the OR shell mounts in a browser
+- **THEN** the lib emits no `CnAppRoot: customComponents prop is deprecated`
+  console warning

--- a/tests/validate-manifest.js
+++ b/tests/validate-manifest.js
@@ -5,13 +5,13 @@
 // validate-manifest.js — schema-validates src/manifest.json against the
 // @conduction/nextcloud-vue app-manifest schema using Ajv.
 //
-// @spec openspec/changes/openregister-adopt-app-manifest/specs/openregister-app-manifest/spec.md#REQ-OR-MAN-007
+// @spec openspec/specs/openregister-app-manifest/spec.md#REQ-OR-MAN-007
 //   (Build gate validates the manifest — `npm run check:manifest` runs this CLI,
 //    is wired into CI via .github/workflows/spec-validation.yml → check:specs,
 //    Ajv-validates against the canonical schema, prints error paths, exits non-zero
 //    on schema violation.)
 //
-// @spec openspec/changes/openregister-adopt-app-manifest/specs/openregister-app-manifest/spec.md#REQ-OR-MAN-002
+// @spec openspec/specs/openregister-app-manifest/spec.md#REQ-OR-MAN-002
 //   (Manifest declares zero Conduction-app dependencies — OpenRegister is the
 //    foundation app, so src/manifest.json carries `"dependencies": []`. The
 //    schema declares `dependencies` as a required array, and CnAppRoot guards
@@ -19,7 +19,7 @@
 //    openregister-manifest-shell-swap, the validator now enforces this end-to-
 //    end on every CI run.)
 //
-// @spec openspec/changes/openregister-adopt-app-manifest/specs/openregister-app-manifest/spec.md#REQ-OR-MAN-008
+// @spec openspec/specs/openregister-app-manifest/spec.md#REQ-OR-MAN-008
 //   (Manifest version reflects the adoption tier — top-level `version: "1.0.0"`
 //    set in src/manifest.json signals Tier-4 / full-shell adoption. The schema's
 //    required `version` field, asserted by Ajv here AND by structuralLint


### PR DESCRIPTION
## Summary

Promotes the \`openregister-app-manifest\` capability spec from inside the superseded change archive to its canonical home at \`openspec/specs/openregister-app-manifest/spec.md\`, so the three \`@spec\` annotations in \`tests/validate-manifest.js\` no longer point into an archive.

Closes the last loose end on the OR manifest migration.

## What this PR ships

- **\`openspec/specs/openregister-app-manifest/spec.md\`** — \`status: implemented\` Tier-4 capability spec, 11 requirements reflecting the shell-swap reality (vs. the superseded Tier-1/Tier-2 proposal).
- **\`tests/validate-manifest.js\`** — \`@spec\` link path moved from \`openspec/changes/openregister-adopt-app-manifest/specs/openregister-app-manifest/spec.md\` → \`openspec/specs/openregister-app-manifest/spec.md\` (3 occurrences).

## Test plan

- [x] \`npm run check:manifest\` — Ajv against v2 schema 2.7.0, 0 errors
- [ ] CI green