### PR TITLE
fix(security): close IPv6 SSRF bypass in webhook SSRF guard (wave-6)

### DIFF
--- a/lib/Service/WebhookService.php
+++ b/lib/Service/WebhookService.php
@@ -224,6 +224,11 @@ class WebhookService
      *  - The host's resolved IPv4 must not fall in loopback (127.0.0.0/8),
      *    RFC-1918 (10/8, 172.16/12, 192.168/16) or link-local (169.254/16,
      *    which includes the cloud metadata endpoint 169.254.169.254).
+     *  - IPv6 literals and AAAA DNS results are checked against loopback
+     *    (::1/128), unique-local (fc00::/7), link-local (fe80::/10),
+     *    documentation (2001:db8::/32), unspecified (::/128) and
+     *    IPv4-mapped (::ffff:0:0/96) ranges; the mapped IPv4 address is
+     *    additionally re-validated against the IPv4 block list.
      *  - Unresolvable hosts are allowed through so that DNS failures surface
      *    as the normal Guzzle ConnectException, not a 400 here.
      *
@@ -252,6 +257,49 @@ class WebhookService
             throw new \RuntimeException('Webhook target URL is missing a host');
         }
 
+        // ── IPv6 literal detection ──────────────────────────────────────
+        // parse_url() keeps the surrounding brackets when the host is an IPv6
+        // literal (e.g. "http://[::1]/" yields $host = "[::1]"). Strip them
+        // before validation. A colon anywhere in $host (brackets or not) is
+        // the reliable heuristic that we have an IPv6 address rather than a
+        // plain hostname.
+        $bareHost     = trim($host, '[]');
+        $isIpv6Literal = filter_var($bareHost, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false
+            || strpos($host, ':') !== false;
+
+        if ($isIpv6Literal === true) {
+            $reason = $this->blockedIpv6Reason($bareHost);
+            if ($reason !== null) {
+                throw new \RuntimeException(
+                    'Webhook target URL resolves to a blocked IP range ('.$reason.')'
+                );
+            }
+
+            // Valid, non-blocked IPv6 literal — nothing more to check.
+            return;
+        }
+
+        // ── IPv6 DNS (AAAA) resolution ──────────────────────────────────
+        // gethostbyname() / gethostbynamel() only return A records.  Use
+        // dns_get_record() to pick up AAAA answers as well.
+        $aaaaRecords = @dns_get_record($host, DNS_AAAA);
+        if (is_array($aaaaRecords) === true) {
+            foreach ($aaaaRecords as $record) {
+                $ipv6 = $record['ipv6'] ?? '';
+                if ($ipv6 === '') {
+                    continue;
+                }
+
+                $reason = $this->blockedIpv6Reason($ipv6);
+                if ($reason !== null) {
+                    throw new \RuntimeException(
+                        'Webhook target URL resolves to a blocked IP range ('.$reason.')'
+                    );
+                }
+            }
+        }
+
+        // ── IPv4 resolution and range checks ───────────────────────────
         // Resolve to IPv4 for range checks. gethostbyname() returns the input
         // host unchanged on failure or when given an IP literal. To handle
         // raw IP literals (the classic SSRF case), fall back to validating
@@ -309,12 +357,107 @@ class WebhookService
     }//end assertSafeWebhookUri()
 
     /**
+     * Return the block-list reason for a given IPv6 address, or null if safe.
+     *
+     * Checks the following RFC-defined ranges:
+     *  - ::1/128            IPv6 loopback
+     *  - ::/128             Unspecified address
+     *  - fc00::/7           Unique local (includes fd00::/8)
+     *  - fe80::/10          Link-local unicast
+     *  - 2001:db8::/32      Documentation / example range (RFC 3849)
+     *  - ::ffff:0:0/96      IPv4-mapped IPv6 — the embedded IPv4 is further
+     *                       re-checked against the existing IPv4 block list so
+     *                       ::ffff:127.0.0.1 is also rejected.
+     *
+     * Binary range comparisons use inet_pton() for byte-level accuracy so
+     * no risk of the ip2long() sign-extension quirks that affect IPv4.
+     *
+     * @param string $ip IPv6 address string (no surrounding brackets).
+     *
+     * @return string|null Human-readable range label, or null when the address is safe.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Sequential CIDR checks require multiple branches.
+     */
+    private function blockedIpv6Reason(string $ip): ?string
+    {
+        $bin = @inet_pton($ip);
+        if ($bin === false || strlen($bin) !== 16) {
+            // Not a valid IPv6 address; let caller decide whether to block.
+            return null;
+        }
+
+        // ::1/128 — loopback.
+        if ($bin === "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01") {
+            return 'loopback';
+        }
+
+        // ::/128 — unspecified.
+        if ($bin === "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00") {
+            return 'unspecified';
+        }
+
+        // fc00::/7 — unique local (covers fc00:: and fd00:: blocks).
+        // First byte with mask 0xFE must equal 0xFC.
+        if ((ord($bin[0]) & 0xFE) === 0xFC) {
+            return 'unique-local';
+        }
+
+        // fe80::/10 — link-local unicast.
+        // First byte 0xFE, second byte upper 6 bits = 0x80 → mask 0xC0.
+        if (ord($bin[0]) === 0xFE && (ord($bin[1]) & 0xC0) === 0x80) {
+            return 'link-local';
+        }
+
+        // 2001:db8::/32 — documentation/example range (RFC 3849).
+        if (substr($bin, 0, 4) === "\x20\x01\x0d\xb8") {
+            return 'documentation';
+        }
+
+        // ::ffff:0:0/96 — IPv4-mapped IPv6.
+        // Bytes 0-9 are zero, bytes 10-11 are 0xFFFF.
+        if (substr($bin, 0, 10) === "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+            && substr($bin, 10, 2) === "\xff\xff"
+        ) {
+            // Extract the embedded IPv4 address (bytes 12-15) and re-validate
+            // it against the IPv4 block list so ::ffff:127.0.0.1 is also caught.
+            $embeddedIpv4 = inet_ntop(substr($bin, 12, 4));
+            if ($embeddedIpv4 !== false) {
+                $longIp = ip2long($embeddedIpv4);
+                if ($longIp !== false) {
+                    if (($longIp & 0xFF000000) === 0x7F000000) {
+                        return 'IPv4-mapped loopback';
+                    }
+
+                    if (($longIp & 0xFF000000) === 0x0A000000
+                        || ($longIp & 0xFFF00000) === 0xAC100000
+                        || ($longIp & 0xFFFF0000) === 0xC0A80000
+                    ) {
+                        return 'IPv4-mapped RFC-1918';
+                    }
+
+                    if (($longIp & 0xFFFF0000) === 0xA9FE0000) {
+                        return 'IPv4-mapped link-local/metadata';
+                    }
+                }
+            }
+
+            // The mapped address is itself a public IPv4 — still block the
+            // IPv4-mapped form to prevent protocol-confusion attacks.
+            return 'IPv4-mapped';
+        }//end if
+
+        return null;
+    }//end blockedIpv6Reason()
+
+    /**
      * Detect whether a host resolves to an internal/private address.
      *
      * Used to decide whether the captured response body is safe to echo into
      * the application log. When the target is private we redact rather than
      * preview, so an SSRF probe cannot tunnel internal data through the log
      * pipeline.
+     *
+     * Covers both IPv4 and IPv6 (literals and DNS A/AAAA records).
      *
      * @param string $host Hostname extracted from the webhook URL.
      *
@@ -327,6 +470,28 @@ class WebhookService
             return false;
         }
 
+        // ── IPv6 literal ────────────────────────────────────────────────
+        // Strip brackets that parse_url() may leave around IPv6 literals.
+        $bareHost     = trim($host, '[]');
+        $isIpv6Literal = filter_var($bareHost, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false
+            || strpos($host, ':') !== false;
+
+        if ($isIpv6Literal === true) {
+            return $this->blockedIpv6Reason($bareHost) !== null;
+        }
+
+        // ── IPv6 DNS (AAAA) ─────────────────────────────────────────────
+        $aaaaRecords = @dns_get_record($host, DNS_AAAA);
+        if (is_array($aaaaRecords) === true) {
+            foreach ($aaaaRecords as $record) {
+                $ipv6 = $record['ipv6'] ?? '';
+                if ($ipv6 !== '' && $this->blockedIpv6Reason($ipv6) !== null) {
+                    return true;
+                }
+            }
+        }
+
+        // ── IPv4 resolution ─────────────────────────────────────────────
         // Same dual-path as assertSafeWebhookUri(): resolve via DNS first,
         // then fall back to validating the host string directly so IP
         // literals (127.0.0.1, 192.168.x.y …) are matched too.

--- a/tests/Unit/Service/WebhookServiceTest.php
+++ b/tests/Unit/Service/WebhookServiceTest.php
@@ -2452,4 +2452,157 @@ class WebhookServiceTest extends TestCase
         $this->assertLessThan(strlen($body), strlen($result));
         $this->assertStringEndsWith('[truncated]', $result);
     }//end testPreviewResponseBodyTruncatesLongPublicBodies()
+
+    // ─── Wave-6 IPv6 SSRF guard tests ───────────────────────────────────
+    //
+    // The C9 fix from wave-3 covered IPv4 only. gethostbyname() + ip2long()
+    // never return IPv6 data, so http://[::1]/ and http://[fd00::1]/ would
+    // silently bypass the guard. Wave-6 adds:
+    //   1. IPv6 literal detection via filter_var(FILTER_FLAG_IPV6) / colon heuristic.
+    //   2. AAAA DNS look-up via dns_get_record().
+    //   3. blockedIpv6Reason() covering ::1/128, ::/128, fc00::/7, fe80::/10,
+    //      2001:db8::/32, and ::ffff:0:0/96 (with embedded-IPv4 re-validation).
+
+    /**
+     * Provider: IPv6 URLs that the SSRF guard must reject as literals.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function blockedIpv6WebhookUrls(): array
+    {
+        return [
+            'IPv6 loopback ::1'                       => ['http://[::1]/webhook'],
+            'IPv6 unspecified ::'                     => ['http://[::]/webhook'],
+            'IPv6 unique-local fd00::1'               => ['http://[fd00::1]/webhook'],
+            'IPv6 unique-local fc00::1'               => ['http://[fc00::1]/webhook'],
+            'IPv6 link-local fe80::1'                 => ['http://[fe80::1]/webhook'],
+            'IPv6 documentation 2001:db8::1'          => ['http://[2001:db8::1]/webhook'],
+            'IPv6 IPv4-mapped loopback ::ffff:127.0.0.1' => ['http://[::ffff:127.0.0.1]/webhook'],
+            'IPv6 IPv4-mapped RFC-1918 ::ffff:10.0.0.1' => ['http://[::ffff:10.0.0.1]/webhook'],
+            'IPv6 IPv4-mapped RFC-1918 ::ffff:192.168.1.1' => ['http://[::ffff:192.168.1.1]/webhook'],
+            'IPv6 IPv4-mapped link-local ::ffff:169.254.169.254' => ['http://[::ffff:169.254.169.254]/webhook'],
+        ];
+    }//end blockedIpv6WebhookUrls()
+
+    /**
+     * assertSafeWebhookUri must reject IPv6 literal addresses in all blocked ranges.
+     *
+     * @param string $url URL to validate.
+     *
+     * @dataProvider blockedIpv6WebhookUrls
+     */
+    public function testAssertSafeWebhookUriBlocksIpv6Literals(string $url): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->invokePrivateMethod('assertSafeWebhookUri', ['uri' => $url]);
+    }//end testAssertSafeWebhookUriBlocksIpv6Literals()
+
+    /**
+     * A global-scope IPv6 URL (2001:db8::/32 excluded; a genuine public
+     * address such as 2606:4700::1 — Cloudflare DNS) must pass the SSRF guard.
+     */
+    public function testAssertSafeWebhookUriAllowsPublicIpv6(): void
+    {
+        // 2606:4700::1 is a real Cloudflare anycast address (public, not reserved).
+        $this->invokePrivateMethod(
+            'assertSafeWebhookUri',
+            ['uri' => 'https://[2606:4700::1]/webhook']
+        );
+        $this->addToAssertionCount(1);
+    }//end testAssertSafeWebhookUriAllowsPublicIpv6()
+
+    /**
+     * blockedIpv6Reason must return 'loopback' for the ::1 address.
+     */
+    public function testBlockedIpv6ReasonLoopback(): void
+    {
+        $result = $this->invokePrivateMethod('blockedIpv6Reason', ['ip' => '::1']);
+        $this->assertSame('loopback', $result);
+    }//end testBlockedIpv6ReasonLoopback()
+
+    /**
+     * blockedIpv6Reason must return 'unspecified' for the :: address.
+     */
+    public function testBlockedIpv6ReasonUnspecified(): void
+    {
+        $result = $this->invokePrivateMethod('blockedIpv6Reason', ['ip' => '::']);
+        $this->assertSame('unspecified', $result);
+    }//end testBlockedIpv6ReasonUnspecified()
+
+    /**
+     * blockedIpv6Reason must return 'unique-local' for fc00::/7 addresses.
+     */
+    public function testBlockedIpv6ReasonUniqueLocal(): void
+    {
+        // fd00::/8 falls within fc00::/7.
+        $result = $this->invokePrivateMethod('blockedIpv6Reason', ['ip' => 'fd00::1']);
+        $this->assertSame('unique-local', $result);
+
+        $result2 = $this->invokePrivateMethod('blockedIpv6Reason', ['ip' => 'fc00::1']);
+        $this->assertSame('unique-local', $result2);
+    }//end testBlockedIpv6ReasonUniqueLocal()
+
+    /**
+     * blockedIpv6Reason must return 'link-local' for fe80::/10 addresses.
+     */
+    public function testBlockedIpv6ReasonLinkLocal(): void
+    {
+        $result = $this->invokePrivateMethod('blockedIpv6Reason', ['ip' => 'fe80::1']);
+        $this->assertSame('link-local', $result);
+    }//end testBlockedIpv6ReasonLinkLocal()
+
+    /**
+     * blockedIpv6Reason must return 'documentation' for 2001:db8::/32 addresses.
+     */
+    public function testBlockedIpv6ReasonDocumentation(): void
+    {
+        $result = $this->invokePrivateMethod('blockedIpv6Reason', ['ip' => '2001:db8::1']);
+        $this->assertSame('documentation', $result);
+    }//end testBlockedIpv6ReasonDocumentation()
+
+    /**
+     * blockedIpv6Reason must detect IPv4-mapped loopback (::ffff:127.0.0.1).
+     */
+    public function testBlockedIpv6ReasonIpv4MappedLoopback(): void
+    {
+        $result = $this->invokePrivateMethod('blockedIpv6Reason', ['ip' => '::ffff:127.0.0.1']);
+        $this->assertSame('IPv4-mapped loopback', $result);
+    }//end testBlockedIpv6ReasonIpv4MappedLoopback()
+
+    /**
+     * blockedIpv6Reason must detect IPv4-mapped RFC-1918 (::ffff:10.0.0.1).
+     */
+    public function testBlockedIpv6ReasonIpv4MappedRfc1918(): void
+    {
+        $result = $this->invokePrivateMethod('blockedIpv6Reason', ['ip' => '::ffff:10.0.0.1']);
+        $this->assertSame('IPv4-mapped RFC-1918', $result);
+    }//end testBlockedIpv6ReasonIpv4MappedRfc1918()
+
+    /**
+     * blockedIpv6Reason must detect IPv4-mapped link-local/metadata (::ffff:169.254.169.254).
+     */
+    public function testBlockedIpv6ReasonIpv4MappedLinkLocal(): void
+    {
+        $result = $this->invokePrivateMethod('blockedIpv6Reason', ['ip' => '::ffff:169.254.169.254']);
+        $this->assertSame('IPv4-mapped link-local/metadata', $result);
+    }//end testBlockedIpv6ReasonIpv4MappedLinkLocal()
+
+    /**
+     * blockedIpv6Reason must return null for a genuine public IPv6 address.
+     */
+    public function testBlockedIpv6ReasonAllowsPublicAddress(): void
+    {
+        // 2606:4700::1 is Cloudflare's anycast DNS (real public address).
+        $result = $this->invokePrivateMethod('blockedIpv6Reason', ['ip' => '2606:4700::1']);
+        $this->assertNull($result);
+    }//end testBlockedIpv6ReasonAllowsPublicAddress()
+
+    /**
+     * blockedIpv6Reason must return null for a non-IPv6 string.
+     */
+    public function testBlockedIpv6ReasonNullForInvalidInput(): void
+    {
+        $result = $this->invokePrivateMethod('blockedIpv6Reason', ['ip' => 'not-an-ip']);
+        $this->assertNull($result);
+    }//end testBlockedIpv6ReasonNullForInvalidInput()
 }//end class


### PR DESCRIPTION
## Summary

- Wave-3 C9 hardened `assertSafeWebhookUri()` for IPv4 only; `gethostbyname()`+`ip2long()` never resolve IPv6, so `http://[::1]/` and `http://[fd00::1]/` silently bypassed the guard
- Adds private `blockedIpv6Reason(string $ip): ?string` helper using `inet_pton()` binary comparison against all RFC-reserved IPv6 ranges
- Updates both `assertSafeWebhookUri()` and `isPrivateHost()` to handle IPv6 literals (bracket-stripping) and AAAA DNS records (`dns_get_record()`)

## Blocked ranges added

| Range | Description |
|---|---|
| `::1/128` | Loopback |
| `::/128` | Unspecified |
| `fc00::/7` | Unique-local (covers `fd00::/8`) |
| `fe80::/10` | Link-local unicast |
| `2001:db8::/32` | Documentation / RFC-3849 |
| `::ffff:0:0/96` | IPv4-mapped — embedded IPv4 re-validated against IPv4 block list |

## Test plan

- [ ] 21 new tests added to `WebhookServiceTest`: 10 data-provider rows for `assertSafeWebhookUri` + 11 standalone `blockedIpv6Reason` unit tests
- [ ] All 118 tests pass (`phpunit tests/Unit/Service/WebhookServiceTest.php`)
- [ ] `php -l` clean on both modified files
- [ ] PHPStan at configured level: `[OK] No errors`