### PR TITLE
perf(objectservice): scope the readOnly guard's find() to the resolved register/schema

### DIFF
--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -1528,8 +1528,21 @@ class ObjectService
         // RBAC reject, multitenancy filter) means we're not in a true UPDATE
         // and the engine's normal CREATE path will run — no readOnly check
         // applies.
+        //
+        // Pass the already-resolved register/schema so find() takes the scoped
+        // register/schema-table path directly. Omitting them leaves find() to
+        // rely on the request's URL scope; under a stale scope it falls back to
+        // the deliberate cross-table search (see the resolution-cache note above,
+        // openregister#1520). We are on the save path with both already resolved,
+        // so there is no reason to risk that fallback here.
         try {
-            $existing = $this->objectMapper->find($uuid, _rbac: false, _multitenancy: false);
+            $existing = $this->objectMapper->find(
+                $uuid,
+                register: $this->currentRegister,
+                schema: $this->currentSchema,
+                _rbac: false,
+                _multitenancy: false
+            );
         } catch (\Throwable $e) {
             return;
         }


### PR DESCRIPTION
`enforceReadOnlyOnUpdate()` (the wave-12 readOnly write-path guard landed via #2020) loads the prior record with a bare `$this->objectMapper->find($uuid, _rbac: false, _multitenancy: false)`, leaving `find()` to rely on the request's URL scope. Under a **stale** scope that path falls back to the deliberate cross-table search (openregister#1520).

We are on the save path here with `$this->currentRegister` and `$this->currentSchema` already resolved, so pass them and take the scoped register/schema-table lookup directly.

**Honest severity: defensive hardening, not a hot N+1.** In the common save flow the URL scope matches and the bare `find()` already hits the scoped path — this just removes the dependency on that being true, on a method that runs on every update.

### Provenance
Split out of the now-closed **#470**. That PR ported wave-12 Fix 1 before I realised #2020 had already landed the same enforcement independently (same upstream #2010). Comparing the two, the **only** functional difference was this `find()` call — so rather than duplicate the feature I closed #470 and extracted just this. Convergence context: **#2015** (now resolved — both forges synced at `57c31a8e`).

### Verification
- `Wave12ReadOnlyEnforcementTest` (9 cases, #2020's own suite) still green. `find()` is mocked, so the arguments don't change the tested contract — behaviour is identical, this only changes which query path executes.
- No new test: this is a query-path change with no observable behavioural delta to assert on at the unit level.

Not live-verified against a running instance (shared dev is off-limits).