### PR TITLE
fix(relationhandler): inject RegisterMapper instead of \OC::$server->get()

### DIFF
--- a/lib/Service/Object/RelationHandler.php
+++ b/lib/Service/Object/RelationHandler.php
@@ -22,6 +22,7 @@ use Adbar\Dot;
 use OCA\OpenRegister\Db\MagicMapper\MagicRbacHandler;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Object\PerformanceHandler;
@@ -70,7 +71,8 @@ class RelationHandler
         private readonly SchemaMapper $schemaMapper,
         private readonly PerformanceHandler $performanceHandler,
         private readonly MagicRbacHandler $rbacHandler,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly RegisterMapper $registerMapper
     ) {
     }//end __construct()
 
@@ -586,7 +588,7 @@ class RelationHandler
             $schema   = null;
             if ($_registerId !== null && $_schemaId !== null) {
                 try {
-                    $registerMapper = \OC::$server->get(\OCA\OpenRegister\Db\RegisterMapper::class);
+                    $registerMapper = $this->registerMapper;
                     $register       = $registerMapper->find($_registerId, _rbac: false, _multitenancy: false);
                     $schema         = $this->schemaMapper->find($_schemaId, _rbac: false, _multitenancy: false);
                 } catch (\Exception $e) {
@@ -659,8 +661,8 @@ class RelationHandler
             }
 
             // Get all register+schema pairs that have magic mapping enabled.
-            $registerMapper = \OC::$server->get(\OCA\OpenRegister\Db\RegisterMapper::class);
-            $magicMapper    = \OC::$server->get(\OCA\OpenRegister\Db\MagicMapper::class);
+            $registerMapper = $this->registerMapper;
+            $magicMapper    = $this->objectEntityMapper;
             $registers      = $registerMapper->findAll();
 
             $registerSchemaPairs = [];
@@ -877,7 +879,7 @@ class RelationHandler
             $schema   = null;
             if ($_registerId !== null && $_schemaId !== null) {
                 try {
-                    $registerMapper = \OC::$server->get(\OCA\OpenRegister\Db\RegisterMapper::class);
+                    $registerMapper = $this->registerMapper;
                     $register       = $registerMapper->find($_registerId, _rbac: false, _multitenancy: false);
                     $schema         = $this->schemaMapper->find($_schemaId, _rbac: false, _multitenancy: false);
                 } catch (\Exception $e) {
@@ -898,8 +900,8 @@ class RelationHandler
 
             // Search across all magic tables for objects that reference this UUID in their _relations.
             $results        = [];
-            $magicMapper    = \OC::$server->get(\OCA\OpenRegister\Db\MagicMapper::class);
-            $registerMapper = \OC::$server->get(\OCA\OpenRegister\Db\RegisterMapper::class);
+            $magicMapper    = $this->objectEntityMapper;
+            $registerMapper = $this->registerMapper;
             $magicTables    = $magicMapper->getExistingRegisterSchemaTables();
             $limit          = $query['_limit'] ?? 30;
             $offset         = $query['_offset'] ?? 0;

--- a/tests/Unit/Service/Object/RelationHandlerTest.php
+++ b/tests/Unit/Service/Object/RelationHandlerTest.php
@@ -31,6 +31,7 @@ namespace OCA\OpenRegister\Tests\Unit\Service\Object;
 use OCA\OpenRegister\Db\MagicMapper\MagicRbacHandler;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Object\PerformanceHandler;
@@ -51,6 +52,9 @@ class RelationHandlerTest extends TestCase
 
     /** @var MagicMapper&MockObject */
     private MagicMapper $objectMapper;
+
+    /** @var RegisterMapper&MockObject */
+    private RegisterMapper $registerMapper;
 
     /** @var SchemaMapper&MockObject */
     private SchemaMapper $schemaMapper;
@@ -74,6 +78,7 @@ class RelationHandlerTest extends TestCase
         parent::setUp();
 
         $this->objectMapper = $this->createMock(MagicMapper::class);
+        $this->registerMapper     = $this->createMock(RegisterMapper::class);
         $this->schemaMapper       = $this->createMock(SchemaMapper::class);
         $this->performanceHandler = $this->createMock(PerformanceHandler::class);
         $this->rbacHandler        = $this->createMock(MagicRbacHandler::class);
@@ -84,7 +89,8 @@ class RelationHandlerTest extends TestCase
             schemaMapper: $this->schemaMapper,
             performanceHandler: $this->performanceHandler,
             rbacHandler: $this->rbacHandler,
-            logger: $this->logger
+            logger: $this->logger,
+            registerMapper: $this->registerMapper
         );
     }//end setUp()
 


### PR DESCRIPTION
`RelationHandler::getUses()`/`getUsedBy()` resolved `RegisterMapper` and `MagicMapper` through the **service locator** (`\OC::$server->get(...)`) at call time. Under unit test `\OC::$server` is not a real container → `get()` returns null → `$registerMapper->findAll()` throws `Call to a member function findAll() on null`. Four `RelationHandlerTest` cases errored, and the code was untestable by construction (the test authors left a comment acknowledging the workaround).

`MagicMapper` was already constructor-injected as `$this->objectEntityMapper`, so only `RegisterMapper` needed adding. Both call sites now use the injected instances.

**No behavioural change in production** — the container returns the same singletons — but the dependency is explicit and mockable.

### Verification
- `RelationHandlerTest`: 71 pass / 4 error → **75 pass / 0 error**.
- Full `tests/Unit/Service/Object/`: **4 errors → 0**. The 2 remaining `PermissionHandlerCustomScope` failures are unrelated (tracked in #2023, being addressed separately).
- No manual `new RelationHandler(...)` anywhere — pure DI, auto-wired by type, so the new parameter resolves automatically.

One of the two clusters in #2023.