### PR TITLE
fix(authz): consult the custom-scope veto before the default-open authenticated grant

### DIFF
--- a/lib/Service/Object/PermissionHandler.php
+++ b/lib/Service/Object/PermissionHandler.php
@@ -552,6 +552,37 @@ class PermissionHandler
             return true;
         }
 
+        // Custom action verbs (anything outside the canonical 5) are
+        // routed through a listener-driven dispatch so consuming apps
+        // can contribute verdicts for verbs they own (e.g. ZGW
+        // `besluit_nemen`). Listeners vote via
+        // `CustomScopeEvaluatingEvent::allow() / deny()`; the first
+        // verdict wins. When no listener votes, fall through to the
+        // standard rule chain — most schemas won't have rules for
+        // custom verbs, so this typically denies.
+        //
+        // This dispatch MUST precede the 'authenticated' pseudo-group grant
+        // below. That grant is default-open for a schema with no authorization
+        // block, so evaluating it first short-circuits `return true` before any
+        // listener is consulted — silently killing the veto for exactly the
+        // unconfigured-schema case (a schema that declares no rules for its
+        // custom verb) the mechanism exists to serve. Admin bypass still
+        // precedes this: admins remain un-vetoable, matching the canonical
+        // actions' admin short-circuit above.
+        $isCanonical = in_array(needle: $action, haystack: self::CANONICAL_ACTIONS, strict: true);
+        if ($isCanonical === false && $this->eventDispatcher !== null) {
+            $verdict = $this->dispatchCustomScopeEvaluation(
+                schema: $schema,
+                action: $action,
+                userId: $userId,
+                userGroups: $userGroups,
+                object: $object
+            );
+            if ($verdict !== null) {
+                return $verdict;
+            }
+        }
+
         // 'authenticated' pseudo-group: any logged-in user qualifies,
         // independent of real group membership (so a user with NO groups still
         // matches). Evaluated here — symmetric with the SQL-layer
@@ -569,28 +600,6 @@ class PermissionHandler
             ) === true
         ) {
             return true;
-        }
-
-        // Custom action verbs (anything outside the canonical 5) are
-        // routed through a listener-driven dispatch so consuming apps
-        // can contribute verdicts for verbs they own (e.g. ZGW
-        // `besluit_nemen`). Listeners vote via
-        // `CustomScopeEvaluatingEvent::allow() / deny()`; the first
-        // verdict wins. When no listener votes, fall through to the
-        // standard rule chain — most schemas won't have rules for
-        // custom verbs, so this typically denies.
-        $isCanonical = in_array(needle: $action, haystack: self::CANONICAL_ACTIONS, strict: true);
-        if ($isCanonical === false && $this->eventDispatcher !== null) {
-            $verdict = $this->dispatchCustomScopeEvaluation(
-                schema: $schema,
-                action: $action,
-                userId: $userId,
-                userGroups: $userGroups,
-                object: $object
-            );
-            if ($verdict !== null) {
-                return $verdict;
-            }
         }
 
         // User-level override (delegation) check — evaluated independently of


### PR DESCRIPTION
## The bug

The custom-scope listener dispatch — `CustomScopeEvaluatingEvent`, how a consuming app votes allow/deny on a custom verb it owns (ZGW `besluit_nemen` etc.) — sat **after** the `'authenticated'` pseudo-group grant in `evaluatePermission()`. For a schema with **no authorization block** that grant is default-open, so it returned `true` and short-circuited **before any listener was consulted**.

So on exactly the case the mechanism exists for — a schema that declares no rules for its custom verb — the veto was **dead**. A listener voting `deny()` was silently ignored; the action was granted to any authenticated user.

This is the orphaned-capability shape this repo has been auditing: dispatched, wired, covered by a test, and never reached on the path that mattered. `PermissionHandlerCustomScopeTest` proved it — both listener-voting tests failed with **zero events dispatched**.

## The fix

Move the custom-scope dispatch **above** the `'authenticated'` grant. New order:

```
admin bypass → custom-verb listener vote → authenticated/default-open → delegation → per-group → public-inherit
```

Admin bypass still precedes the veto (admins remain un-vetoable, matching the canonical-action short-circuit).

## ⚠️ Semantic change — please review

A listener verdict now takes precedence over **both** the default-open grant **and** an explicit `'authenticated'` grant — **for custom (non-canonical) verbs only, and only when a listener actively votes**. This is the intended "the app that owns the verb has final say" contract.

**When no listener votes, dispatch returns `null` and evaluation falls through unchanged** — so behaviour is byte-identical for every schema that has no custom-scope listener registered. The blast radius is limited to apps that have opted into the mechanism.

Flagging for a security reviewer because it touches core permission evaluation order. If the "listener overrides explicit grant" semantic isn't wanted, this is a single-commit revert.

## Verification
- `PermissionHandlerCustomScopeTest`: 3/5 → **5/5**.
- All **114** PermissionHandler tests green.
- Full `tests/Unit/Service/Object/`: 2 failures → **0**.
- Not live-verified against a running instance (shared dev off-limits).

Closes the cluster-B half of #2023.