### PR TITLE
feat(dbal): aggregations for external virtual registers + bytea introspection fix

### DIFF
--- a/lib/Service/Aggregation/AggregationRunner.php
+++ b/lib/Service/Aggregation/AggregationRunner.php
@@ -47,6 +47,7 @@ use OCA\OpenRegister\Exception\NotAuthorizedException;
 use OCA\OpenRegister\Service\LanguageService;
 use OCA\OpenRegister\Service\Object\PermissionHandler;
 use OCA\OpenRegister\Service\Object\TranslationHandler;
+use OCA\OpenRegister\Service\ObjectSource\DbalObjectSourceProvider;
 use OCA\OpenRegister\Service\OrganisationService;
 use OCA\OpenRegister\Service\Search\PlaceholderResolver;
 use OCP\IDBConnection;
@@ -84,18 +85,21 @@ class AggregationRunner
     /**
      * Constructor.
      *
-     * @param MagicMapper          $magicMapper         Magic-table mapper used for the PHP fallback path.
-     * @param RegisterMapper       $registerMapper      Register loader.
-     * @param SchemaMapper         $schemaMapper        Schema loader.
-     * @param PlaceholderResolver  $placeholders        Resolves dynamic placeholders inside filters.
-     * @param IDBConnection        $db                  Database connection for the Postgres-native fast path.
-     * @param AggregationCache     $cache               60s aggregation result cache.
-     * @param PermissionHandler    $permissionHandler   RBAC verdict on the schema's `list` action.
-     * @param IUserSession         $userSession         Active session, for the RBAC + cache-key user scope.
-     * @param OrganisationService  $organisationService Active-organisation lookup for the cache key.
-     * @param TranslationHandler   $translationHandler  Resolves translatable group keys to the negotiated language.
-     * @param LanguageService      $languageService     Request-scoped language negotiation (Accept-Language / _lang).
-     * @param LoggerInterface|null $logger              Optional logger for diagnostics.
+     * @param MagicMapper                   $magicMapper         Magic-table mapper used for the PHP fallback path.
+     * @param RegisterMapper                $registerMapper      Register loader.
+     * @param SchemaMapper                  $schemaMapper        Schema loader.
+     * @param PlaceholderResolver           $placeholders        Resolves dynamic placeholders inside filters.
+     * @param IDBConnection                 $db                  Database connection for the Postgres-native fast path.
+     * @param AggregationCache              $cache               60s aggregation result cache.
+     * @param PermissionHandler             $permissionHandler   RBAC verdict on the schema's `list` action.
+     * @param IUserSession                  $userSession         Active session, for the RBAC + cache-key user scope.
+     * @param OrganisationService           $organisationService Active-organisation lookup for the cache key.
+     * @param TranslationHandler            $translationHandler  Resolves translatable group keys to the negotiated language.
+     * @param LanguageService               $languageService     Request-scoped language negotiation (Accept-Language / _lang).
+     * @param LoggerInterface|null          $logger              Optional logger for diagnostics.
+     * @param DbalObjectSourceProvider|null $dbalSourceProvider  Provider that computes aggregations live against an
+     *                                                           external DBAL virtual register; null disables the
+     *                                                           DBAL path.
      *
      * @return void
      *
@@ -115,7 +119,8 @@ class AggregationRunner
         private readonly OrganisationService $organisationService,
         private readonly TranslationHandler $translationHandler,
         private readonly LanguageService $languageService,
-        private readonly ?LoggerInterface $logger=null
+        private readonly ?LoggerInterface $logger=null,
+        private readonly ?DbalObjectSourceProvider $dbalSourceProvider=null
     ) {
     }//end __construct()
 
@@ -520,6 +525,37 @@ class AggregationRunner
             );
         }
 
+        // External (DBAL virtual) register: the object rows live in an
+        // external database, not the magic table, so the native + PHP paths
+        // below would aggregate an empty magic table and return 0. Delegate
+        // to the DBAL object-source provider, which computes the metric live
+        // in the external DB with the same table/column resolution the reads
+        // use. Returns null when the schema is not DBAL-sourced (→ fall
+        // through to the magic-table paths) or the query shape is unsupported.
+        $dbal = $this->tryDbalAggregation(
+            register: $register,
+            schema: $schema,
+            query: $resolvedQuery
+        );
+        if ($dbal !== null) {
+            $envelope = [
+                'backend' => 'dbal-source',
+                'cached'  => false,
+            ] + $dbal;
+            $this->cache->setAdhoc(
+                registerSlug: (string) $register->getSlug(),
+                schemaSlug: (string) $schema->getSlug(),
+                query: $resolvedQuery,
+                result: $envelope
+            );
+            return $this->projectTranslatableGroupKeys(
+                envelope: $envelope,
+                schema: $schema,
+                register: $register,
+                groupBy: $query->groupBy
+            );
+        }
+
         // Try the Postgres / MySQL / SQLite native fast path. The runner
         // detects the database platform and emits the matching native
         // bucketing expression (date_trunc / DATE_FORMAT / strftime).
@@ -583,6 +619,71 @@ class AggregationRunner
         );
 
     }//end runAdhoc()
+
+    /**
+     * Delegate an ad-hoc aggregation to the DBAL object-source provider when
+     * the schema is backed by an external database (`x-openregister-object-source`
+     * provider `dbal-source`). Returns the `{value}` / `{groups}` fragment, or
+     * null when the schema is not DBAL-sourced, the provider is unavailable, or
+     * the provider cannot serve the query shape (→ caller falls through to the
+     * magic-table native / PHP paths).
+     *
+     * A provider-side failure (unreachable DB / query error) is swallowed to
+     * null here rather than propagated: the aggregation endpoints should
+     * degrade to an empty widget, never 500 the dashboard.
+     *
+     * @param Register         $register The register the schema belongs to.
+     * @param Schema           $schema   The schema being aggregated.
+     * @param AggregationQuery $query    The placeholder-resolved query.
+     *
+     * @return array<string, mixed>|null The result fragment, or null to fall through.
+     *
+     * @spec openspec/specs/dbal-virtual-registers/spec.md
+     */
+    private function tryDbalAggregation(
+        Register $register,
+        Schema $schema,
+        AggregationQuery $query
+    ): ?array {
+        if ($this->dbalSourceProvider === null) {
+            return null;
+        }
+
+        $configuration = $schema->getConfiguration();
+        if (is_array($configuration) === false) {
+            return null;
+        }
+
+        $objectSource = ($configuration['x-openregister-object-source'] ?? null);
+        if (is_array($objectSource) === false
+            || (string) ($objectSource['provider'] ?? '') !== 'dbal-source'
+        ) {
+            return null;
+        }
+
+        $config = ($objectSource['config'] ?? []);
+        if (is_array($config) === false) {
+            return null;
+        }
+
+        try {
+            return $this->dbalSourceProvider->aggregate(
+                register: $register,
+                schema: $schema,
+                metric: $query->metric,
+                field: $query->field,
+                filter: $query->filter,
+                groupBy: $query->groupBy,
+                dateBucket: $query->dateBucket,
+                config: $config
+            );
+        } catch (\Throwable $e) {
+            $this->logger?->warning(
+                '[AggregationRunner] DBAL aggregation failed for schema "'.((string) $schema->getSlug()).'": '.$e->getMessage()
+            );
+            return null;
+        }
+    }//end tryDbalAggregation()
 
     /**
      * Project translatable group keys in a grouped-aggregation envelope to

--- a/lib/Service/Dbal/SqlTypeMapper.php
+++ b/lib/Service/Dbal/SqlTypeMapper.php
@@ -34,6 +34,8 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Translates DBAL column types into JSON-Schema property fragments.
+ *
+ * @spec openspec/specs/dbal-virtual-registers/spec.md
  */
 class SqlTypeMapper
 {
@@ -62,8 +64,8 @@ class SqlTypeMapper
         Types::DATETIMETZ_MUTABLE   => ['string', 'date-time'],
         Types::DATETIMETZ_IMMUTABLE => ['string', 'date-time'],
         Types::JSON                 => ['object', null],
-        Types::BINARY               => ['string', 'binary'],
-        Types::BLOB                 => ['string', 'binary'],
+        Types::BINARY               => ['string', null],
+        Types::BLOB                 => ['string', null],
         Types::SIMPLE_ARRAY         => ['array', null],
         Types::ARRAY                => ['array', null],
     ];

--- a/lib/Service/ObjectSource/DbalObjectSourceProvider.php
+++ b/lib/Service/ObjectSource/DbalObjectSourceProvider.php
@@ -57,6 +57,8 @@ use Throwable;
  *   shapes, allowlisting, error semantics) as one cohesive design-D4 unit.
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)   Bridges the DBAL query stack
  *   and the OR entity/mapper seams the design names explicitly.
+ *
+ * @spec openspec/specs/dbal-virtual-registers/spec.md
  */
 class DbalObjectSourceProvider implements WritableObjectSourceProvider
 {
@@ -292,6 +294,412 @@ class DbalObjectSourceProvider implements WritableObjectSourceProvider
 
         return (int) $total;
     }//end count()
+
+    /**
+     * Compute an aggregation live against the external table.
+     *
+     * The aggregation-endpoint counterpart to {@see count()} / {@see findAll()}:
+     * dashboard KPI / stats-block + chart widgets hit
+     * `/api/objects/aggregations/{register}/{schema}/value|timeseries|grouped`,
+     * which {@see \OCA\OpenRegister\Service\Aggregation\AggregationRunner} routes
+     * here when the schema is `dbal-source`-backed, so the numbers are computed
+     * in the external database rather than over the (empty for a virtual
+     * register) magic table.
+     *
+     * Returns `{value: ...}` for a scalar metric, `{groups: [{key, value}, ...]}`
+     * for a categorical `groupBy` or a `dateBucket` series, or `null` to signal
+     * the caller to fall back (unsupported metric / field / platform / gap).
+     *
+     * @param Register                  $register   The register the schema belongs to.
+     * @param Schema                    $schema     The sourced schema.
+     * @param string                    $metric     count/sum/avg/min/max.
+     * @param string|null               $field      Metric field (required for sum/avg/min/max).
+     * @param array<string, mixed>      $filter     Filter map ({field: scalar} or {field: {op: value}}).
+     * @param array<string, mixed>|null $groupBy    Optional categorical group spec ({field}).
+     * @param array<string, mixed>|null $dateBucket Optional date-bucket spec ({field, start, end, gap}).
+     * @param array<string, mixed>      $config     The object-source `config` block.
+     *
+     * @return array{value: int|float|null}|array{groups: array<int, array{key: mixed, value: int|float|null}>}|null
+     *
+     * @throws DbalObjectSourceException On an unreachable DB (503) or query error (502).
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     *   Three query shapes (date-bucket series / categorical groupBy / scalar
+     *   value) share one connection + filter pipeline; splitting them would
+     *   duplicate the connect-and-fail-closed preamble.
+     *
+     * @spec openspec/specs/dbal-virtual-registers/spec.md
+     */
+    public function aggregate(
+        Register $register,
+        Schema $schema,
+        string $metric,
+        ?string $field,
+        array $filter,
+        ?array $groupBy,
+        ?array $dateBucket,
+        array $config=[]
+    ): ?array {
+        if (in_array($metric, ['count', 'sum', 'avg', 'min', 'max'], true) === false) {
+            return null;
+        }
+
+        $context = $this->resolveContext(config: $config, schema: $schema);
+        if ($context === null) {
+            return null;
+        }
+
+        [$source, $columns] = $context;
+
+        // Value metrics (sum/avg/min/max) operate on a real, allowlisted column.
+        if ($metric !== 'count'
+            && ($field === null || $field === '' || in_array($field, $columns, true) === false)
+        ) {
+            return null;
+        }
+
+        try {
+            $connection = $this->connect(source: $source);
+        } catch (DbalConnectionException $e) {
+            if ($this->driverMissing(source: $source) === true) {
+                return null;
+            }
+
+            throw new DbalObjectSourceException('The external database is unreachable.', 503, $e);
+        }
+
+        $aggExpr = $this->aggregateExpression(connection: $connection, metric: $metric, field: $field);
+        $table   = $this->quote(connection: $connection, identifier: $this->table(config: $config));
+
+        try {
+            // Date-bucket series (chart widgets).
+            if ($dateBucket !== null) {
+                return $this->aggregateDateBucket(
+                    connection: $connection,
+                    table: $table,
+                    aggExpr: $aggExpr,
+                    metric: $metric,
+                    filter: $filter,
+                    columns: $columns,
+                    dateBucket: $dateBucket
+                );
+            }
+
+            // Categorical groupBy.
+            if ($groupBy !== null && (string) ($groupBy['field'] ?? '') !== '') {
+                $groupField = (string) $groupBy['field'];
+                if (in_array($groupField, $columns, true) === false) {
+                    return null;
+                }
+
+                $quotedGroup = $this->quote(connection: $connection, identifier: $groupField);
+                $qb          = $connection->createQueryBuilder();
+                $qb->select($quotedGroup.' AS grpkey', $aggExpr.' AS value')->from($table);
+                $this->applyAggregationFilter(qb: $qb, connection: $connection, filter: $filter, columns: $columns);
+                $qb->groupBy($quotedGroup);
+
+                $groups = [];
+                foreach ($qb->executeQuery()->fetchAllAssociative() as $row) {
+                    $groups[] = [
+                        'key'   => ($row['grpkey'] ?? null),
+                        'value' => $this->numifyMetric(metric: $metric, value: ($row['value'] ?? null)),
+                    ];
+                }
+
+                return ['groups' => $groups];
+            }//end if
+
+            // Scalar value (KPI / stats-block).
+            $qb = $connection->createQueryBuilder();
+            $qb->select($aggExpr)->from($table);
+            $this->applyAggregationFilter(qb: $qb, connection: $connection, filter: $filter, columns: $columns);
+
+            return ['value' => $this->numifyMetric(metric: $metric, value: $qb->executeQuery()->fetchOne())];
+        } catch (DbalException $e) {
+            $this->logger->warning('[ObjectSource:dbal-source] aggregation query failed: '.$e->getMessage());
+            throw new DbalObjectSourceException('The external database returned an error.', 502, $e);
+        }//end try
+    }//end aggregate()
+
+    /**
+     * Run a date-bucketed aggregation series (chart widgets) against the table.
+     *
+     * @param Connection           $connection The DBAL connection.
+     * @param string               $table      The quoted table identifier.
+     * @param string               $aggExpr    The aggregate SELECT expression.
+     * @param string               $metric     The metric name.
+     * @param array<string, mixed> $filter     The filter map.
+     * @param array<int, string>   $columns    The allowlisted scalar columns.
+     * @param array<string, mixed> $dateBucket The date-bucket spec ({field, start, end, gap}).
+     *
+     * @return array{groups: array<int, array{key: string, value: int|float|null}>}|null
+     *
+     * @spec openspec/specs/dbal-virtual-registers/spec.md
+     */
+    private function aggregateDateBucket(
+        Connection $connection,
+        string $table,
+        string $aggExpr,
+        string $metric,
+        array $filter,
+        array $columns,
+        array $dateBucket
+    ): ?array {
+        $bucketField = (string) ($dateBucket['field'] ?? '');
+        if (in_array($bucketField, $columns, true) === false) {
+            return null;
+        }
+
+        $bucketExpr = $this->dateBucketExpression(
+            connection: $connection,
+            field: $bucketField,
+            gap: (string) ($dateBucket['gap'] ?? '')
+        );
+        if ($bucketExpr === null) {
+            return null;
+        }
+
+        // The bounds arrive as ISO-8601 strings; comparing a date/timestamp
+        // column to an untyped param is dialect-fragile, so pin the LHS to
+        // timestamptz on Postgres.
+        $boundLhs = $this->quote(connection: $connection, identifier: $bucketField);
+        if ($connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            $boundLhs .= '::timestamptz';
+        }
+
+        $qb = $connection->createQueryBuilder();
+        $qb->select($bucketExpr.' AS bucket', $aggExpr.' AS value')->from($table);
+        $qb->andWhere($boundLhs.' >= '.$qb->createNamedParameter((string) ($dateBucket['start'] ?? '')));
+        $qb->andWhere($boundLhs.' < '.$qb->createNamedParameter((string) ($dateBucket['end'] ?? '')));
+        $this->applyAggregationFilter(qb: $qb, connection: $connection, filter: $filter, columns: $columns);
+        $qb->groupBy('bucket')->orderBy('bucket', 'ASC');
+
+        $groups = [];
+        foreach ($qb->executeQuery()->fetchAllAssociative() as $row) {
+            $groups[] = [
+                'key'   => $this->isoBucketKey(raw: ($row['bucket'] ?? null)),
+                'value' => $this->numifyMetric(metric: $metric, value: ($row['value'] ?? null)),
+            ];
+        }
+
+        return ['groups' => $groups];
+    }//end aggregateDateBucket()
+
+    /**
+     * Build the aggregate SELECT expression for a metric.
+     *
+     * @param Connection  $connection The DBAL connection (for identifier quoting).
+     * @param string      $metric     count/sum/avg/min/max.
+     * @param string|null $field      Metric column (ignored for count).
+     *
+     * @return string The SQL aggregate expression.
+     *
+     * @spec openspec/specs/dbal-virtual-registers/spec.md
+     */
+    private function aggregateExpression(Connection $connection, string $metric, ?string $field): string
+    {
+        if ($metric === 'count') {
+            return 'COUNT(*)';
+        }
+
+        $col = $this->quote(connection: $connection, identifier: (string) $field);
+        return match ($metric) {
+            'sum'   => 'SUM('.$col.')',
+            'avg'   => 'AVG('.$col.')',
+            'min'   => 'MIN('.$col.')',
+            'max'   => 'MAX('.$col.')',
+            default => 'COUNT(*)',
+        };
+    }//end aggregateExpression()
+
+    /**
+     * The platform-specific date-bucket (truncation) expression, or null when
+     * the platform/gap combination is unsupported (caller falls back).
+     *
+     * @param Connection $connection The DBAL connection.
+     * @param string     $field      The (already-allowlisted) date column.
+     * @param string     $gap        One of minute/hour/day/week/month/quarter/year.
+     *
+     * @return string|null The bucket SQL expression, or null when unsupported.
+     *
+     * @spec openspec/specs/dbal-virtual-registers/spec.md
+     */
+    private function dateBucketExpression(Connection $connection, string $field, string $gap): ?string
+    {
+        if (in_array($gap, ['minute', 'hour', 'day', 'week', 'month', 'quarter', 'year'], true) === false) {
+            return null;
+        }
+
+        $platform = $connection->getDatabasePlatform();
+        $col      = $this->quote(connection: $connection, identifier: $field);
+
+        // Postgres date_trunc handles every supported gap unit natively.
+        if ($platform instanceof PostgreSQLPlatform) {
+            return "date_trunc('".$gap."', ".$col.'::timestamptz)';
+        }
+
+        // MySQL: DATE_FORMAT covers the fixed-width gaps; week/quarter need
+        // bespoke maths, so fall back to PHP for those.
+        if ($platform instanceof AbstractMySQLPlatform) {
+            return match ($gap) {
+                'minute' => "DATE_FORMAT(".$col.", '%Y-%m-%dT%H:%i:00Z')",
+                'hour'   => "DATE_FORMAT(".$col.", '%Y-%m-%dT%H:00:00Z')",
+                'day'    => "DATE_FORMAT(".$col.", '%Y-%m-%dT00:00:00Z')",
+                'month'  => "DATE_FORMAT(".$col.", '%Y-%m-01T00:00:00Z')",
+                'year'   => "DATE_FORMAT(".$col.", '%Y-01-01T00:00:00Z')",
+                default  => null,
+            };
+        }
+
+        return null;
+    }//end dateBucketExpression()
+
+    /**
+     * Apply the aggregation filter map to a query builder, restricted to the
+     * allowlisted columns. Supports equality plus the in/notIn/gt/gte/lt/lte/ne
+     * operator vocabulary (same set as the native magic-table path).
+     *
+     * @param QueryBuilder         $qb         The query builder (mutated).
+     * @param Connection           $connection The DBAL connection.
+     * @param array<string, mixed> $filter     The filter map.
+     * @param array<int, string>   $columns    The allowlisted scalar columns.
+     *
+     * @return void
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/specs/dbal-virtual-registers/spec.md
+     */
+    private function applyAggregationFilter(QueryBuilder $qb, Connection $connection, array $filter, array $columns): void
+    {
+        foreach ($filter as $col => $criterion) {
+            if (is_string($col) === false || in_array($col, $columns, true) === false) {
+                continue;
+            }
+
+            $quoted = $this->quote(connection: $connection, identifier: $col);
+
+            if (is_array($criterion) === false) {
+                $qb->andWhere($quoted.' = '.$qb->createNamedParameter($criterion));
+                continue;
+            }
+
+            $this->applyOperatorCriterion(qb: $qb, quoted: $quoted, criterion: $criterion);
+        }//end foreach
+    }//end applyAggregationFilter()
+
+    /**
+     * Apply a single column's operator criterion (in/notIn/gt/gte/lt/lte/ne).
+     *
+     * @param QueryBuilder         $qb        The query builder (mutated).
+     * @param string               $quoted    The quoted column identifier.
+     * @param array<string, mixed> $criterion The operator → operand map.
+     *
+     * @return void
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/specs/dbal-virtual-registers/spec.md
+     */
+    private function applyOperatorCriterion(QueryBuilder $qb, string $quoted, array $criterion): void
+    {
+        foreach ($criterion as $op => $opValue) {
+            if ((string) $op === 'in' || (string) $op === 'notIn') {
+                $list = [];
+                if (is_array($opValue) === true) {
+                    $list = array_values($opValue);
+                }
+
+                if ($list === []) {
+                    // `in ()` matches nothing; `notIn ()` excludes nothing.
+                    $emptyPredicate = '1 = 1';
+                    if ((string) $op === 'in') {
+                        $emptyPredicate = '1 = 0';
+                    }
+
+                    $qb->andWhere($emptyPredicate);
+                    continue;
+                }
+
+                $params = [];
+                foreach ($list as $item) {
+                    $params[] = $qb->createNamedParameter($item);
+                }
+
+                $keyword = ' NOT IN (';
+                if ((string) $op === 'in') {
+                    $keyword = ' IN (';
+                }
+
+                $qb->andWhere($quoted.$keyword.implode(', ', $params).')');
+                continue;
+            }//end if
+
+            $sqlOp = match ((string) $op) {
+                'gt'  => '>',
+                'gte' => '>=',
+                'lt'  => '<',
+                'lte' => '<=',
+                'ne'  => '<>',
+                default => null,
+            };
+
+            if ($sqlOp === null) {
+                continue;
+            }
+
+            $qb->andWhere($quoted.' '.$sqlOp.' '.$qb->createNamedParameter($opValue));
+        }//end foreach
+    }//end applyOperatorCriterion()
+
+    /**
+     * Coerce a fetched aggregate value to the response numeric shape. `count`
+     * is always an int (0 for an empty set); value metrics are floats, or null
+     * when the set is empty / non-numeric.
+     *
+     * @param string $metric The metric name.
+     * @param mixed  $value  The raw fetched value.
+     *
+     * @return int|float|null The normalised metric value.
+     *
+     * @spec openspec/specs/dbal-virtual-registers/spec.md
+     */
+    private function numifyMetric(string $metric, mixed $value): int|float|null
+    {
+        if ($metric === 'count') {
+            return (int) $value;
+        }
+
+        if ($value === null || is_numeric($value) === false) {
+            return null;
+        }
+
+        return (float) $value;
+    }//end numifyMetric()
+
+    /**
+     * Normalise a bucket label to the ISO-8601-UTC form the PHP fallback emits
+     * (`Y-m-d\TH:i:s\Z`), so chart consumers see one date-key contract across
+     * backends. Non-parseable labels are returned verbatim.
+     *
+     * @param mixed $raw The raw bucket value from the driver.
+     *
+     * @return string The ISO-8601-UTC bucket label.
+     *
+     * @spec openspec/specs/dbal-virtual-registers/spec.md
+     */
+    private function isoBucketKey(mixed $raw): string
+    {
+        $label = (string) $raw;
+        $stamp = strtotime($label);
+        if ($stamp === false) {
+            return $label;
+        }
+
+        return gmdate('Y-m-d\TH:i:s\Z', $stamp);
+    }//end isoBucketKey()
 
     /**
      * Resolve the backing source and the allowlisted scalar column set.


### PR DESCRIPTION
DBAL virtual registers (a `type:database` Source introspected into a register) already serve **object reads** live from the external DB, but had **no aggregation path**: `AggregationRunner` only has the Postgres magic-table fast path + a PHP fallback that hydrates magic-table rows. So every `/api/objects/aggregations/{register}/{schema}/value|timeseries|grouped` call over an external register returned `{"value":0,"backend":"php-fallback"}`, and dashboard KPI/stats-block + chart widgets bound to such a register read **0** while their list/detail pages showed live data.

## Changes
- **`DbalObjectSourceProvider::aggregate()`** — computes `count/sum/avg/min/max`, a categorical `groupBy`, or a `date_trunc` time-bucket series **live in the external DB**, reusing the read path's source/table/column resolution, identifier quoting and column allowlisting. Postgres native; MySQL `DATE_FORMAT` for fixed-width gaps. Filter vocabulary matches the native path (`eq` + `in/notIn/gt/gte/lt/lte/ne`), restricted to allowlisted columns. Fails closed (503/502) like the reads.
- **`AggregationRunner::runAdhoc()`** — delegates to it (`tryDbalAggregation`) before the magic-table paths when the schema carries `x-openregister-object-source` provider `dbal-source`. A provider error degrades to `null` (empty widget, never a 500). The schema-level `list` RBAC gate still applies.
- **`SqlTypeMapper`** — map `bytea` (BINARY/BLOB) to `string` with **no** `format` instead of the unsupported `format: "binary"`, which OR's `PropertyValidatorHandler` rejects. Introspecting any table with a `bytea` column (e.g. `tender_raw_json.raw_json_gz`) previously 502'd. bytea columns are already non-filterable.

## Verification
Live against an external Postgres (spectr → `intelligence-db`): KPI counts and monthly timeseries return `backend: dbal-source` with real values — tenders **81,950**, requirements **157,991**, competitors **1,468**, canonical-features **38,553**, organizations **16,891**. Dashboard renders KPIs + charts. `phpcs` clean.

Scope note: only the ad-hoc endpoints (`runAdhoc`, used by the widgets) are wired; named `x-openregister-aggregations` (`run()`) still uses the magic-table paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)