### PR TITLE
fix(rbac): NC-32 IResult lacks fetchAllAssociative() → RBAC fail-closes every internal read

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -893,8 +893,18 @@ class SettingsController extends Controller
                 ->where($qb->expr()->like('o.name', $qb->createNamedParameter('%Samenwerking%')))
                 ->orWhere($qb->expr()->like('o.name', $qb->createNamedParameter('%Community%')));
 
+            // NC's IResult does not expose Doctrine's fetchAllAssociative() on
+            // every supported server (absent on NC 32) — iterate fetch() instead
+            // (see RegisterMapper::getAllRegisterIdsWithSchema / MarkerLookupTrait).
             $stmt = $qb->executeQuery();
-            $rows = $stmt->fetchAllAssociative();
+            $rows = [];
+            $row  = $stmt->fetch();
+            while ($row !== false) {
+                $rows[] = $row;
+                $row    = $stmt->fetch();
+            }
+
+            $stmt->closeCursor();
 
             $results['direct_database_query'] = [
                 'count'         => count($rows),

--- a/lib/Db/RegisterMapper.php
+++ b/lib/Db/RegisterMapper.php
@@ -872,8 +872,24 @@ class RegisterMapper extends QBMapper
         $qb->select('id', 'schemas')
             ->from('openregister_registers');
 
-        $candidates = $qb->executeQuery()->fetchAllAssociative();
-        $needle     = (string) $schemaId;
+        // NC's IResult (OC\DB\ResultAdapter) does not expose Doctrine's
+        // fetchAllAssociative() on every supported server (absent on NC 32) —
+        // calling it throws "undefined method". This method runs inside the
+        // PermissionHandler authorization resolver (getRegisterForSchema), whose
+        // catch re-throws as AuthorizationUnresolvableException and FAIL-CLOSES
+        // the action — so on NC 32 EVERY RBAC-checked read (find(): dashboard
+        // widgets, status-transition engine, single-object reads) is denied,
+        // even for admin. Iterate fetch() instead, matching MarkerLookupTrait.
+        $result     = $qb->executeQuery();
+        $candidates = [];
+        $row        = $result->fetch();
+        while ($row !== false) {
+            $candidates[] = $row;
+            $row          = $result->fetch();
+        }
+
+        $result->closeCursor();
+        $needle = (string) $schemaId;
         $matches    = [];
 
         foreach ($candidates as $row) {


### PR DESCRIPTION
## Problem

On **Nextcloud 32**, `OC\DB\ResultAdapter` (what `IQueryBuilder::executeQuery()` returns) does **not** expose Doctrine's `fetchAllAssociative()` — calling it throws `Call to undefined method`.

`RegisterMapper::getAllRegisterIdsWithSchema()` used it, and that method runs **inside `PermissionHandler`'s authorization resolver** (`getRegisterForSchema()`). Its `catch` re-throws as `AuthorizationUnresolvableException`, which **fail-closes** the action.

**Net effect on NC 32:** every RBAC-checked read via `ObjectService::find()` is denied **even for admin** — dashboard widgets (403), the status-transition engine (`available-transitions` → current status never resolves), and single-object reads. The **list** path still works (it uses `findMultipleOptimized`, no per-row resolver), which masks the root cause: the register lists data but every detail/aggregate read 403s.

## Fix

Iterate `fetch()` instead of `fetchAllAssociative()`, matching the pattern already applied in `MarkerLookupTrait`. Two sites:
- `lib/Db/RegisterMapper.php` — `getAllRegisterIdsWithSchema()` (the RBAC-critical one)
- `lib/Controller/SettingsController.php` — a diagnostic query (same NC-32 bug)

`DbalObjectSourceProvider`'s `fetchAllAssociative()` calls are intentionally left — those run against an **external raw** `\Doctrine\DBAL\Query\QueryBuilder` whose `Result` does expose the method.

## Verification

Reproduced + fixed on a live NC-32 instance (procest + OpenRegister). Before: `available-transitions` returned `current: []` and `loadCase failed / Unable to resolve register for schema N`; procest dashboard widgets 403. After: `current: {statusId, statusName}` resolves and the widgets return 200. Surfaced while running procest's live-NC Playwright e2e suite against NC 32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)