### PR TITLE
sync: Codeberg development catchup (WOO-517 content-search)

### DIFF
--- a/docs/features/search-and-faceting.md
+++ b/docs/features/search-and-faceting.md
@@ -21,6 +21,19 @@ Triggered via the `_search` query parameter:
 GET /api/objects/meldingen-register/meldingen?_search=geluidsoverlast
 ```
 
+### Widening to attached-file body text (`_content_search`)
+
+`_search` alone only matches object metadata and string schema-properties. Adding the opt-in `_content_search=true` flag additionally matches on the extracted body text of an object's attached files (and object-level text chunks), via the chunk store already populated by the text-extraction pipeline:
+
+```
+GET /api/objects/meldingen-register/meldingen?_search=geluidsoverlast&_content_search=true
+```
+
+- Default `false` (or omitted) — byte-identical to plain `_search` behaviour; no extra query is issued.
+- An object matching on both metadata and attached-file text appears exactly once in the response.
+- The response envelope never leaks chunk-shaped fields (`chunk_id`, `text_content`, `score`, etc.) — every row is a normal object row.
+- On PostgreSQL, chunk matches are `ts_rank`-scored. On backends without a `tsvector` index (e.g. MariaDB), chunk matches are found via an unranked substring scan — the match set is the same, but ordering may differ.
+
 ## Field-Level Filtering
 
 Any schema property can be used as a filter parameter with comparison operators:

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -3090,7 +3090,11 @@ class Application extends App implements IBootstrap
             return null;
         }
 
-        return ($appContainer instanceof ContainerInterface) ? $appContainer : null;
+        if ($appContainer instanceof ContainerInterface) {
+            return $appContainer;
+        }
+
+        return null;
 
     }//end getRegisteredAppContainer()
 

--- a/lib/Controller/UiController.php
+++ b/lib/Controller/UiController.php
@@ -323,7 +323,6 @@ class UiController extends Controller
         return $this->makeSpaResponse();
     }//end tables()
 
-
     /**
      * Returns the configurations page template.
      *

--- a/lib/Db/AuditTrailMapper.php
+++ b/lib/Db/AuditTrailMapper.php
@@ -562,8 +562,8 @@ class AuditTrailMapper extends QBMapper
      * rather than losing the audit records.
      *
      * @param array $entries   Mixed list: ['old' => ?ObjectEntity, 'new' => ?ObjectEntity, 'action' => string,
-     *                          'cascadeContext' => ?array] entries built through {@see buildAuditTrail()}, and/or
-     *                          pre-built AuditTrail entities (each must carry a uuid) persisted as-is
+     *                         'cascadeContext' => ?array] entries built through {@see buildAuditTrail()}, and/or
+     *                         pre-built AuditTrail entities (each must carry a uuid) persisted as-is
      * @param int   $chunkSize Number of rows per multi-row INSERT statement
      *
      * @return AuditTrail[] The persisted audit trail entities (ids populated)
@@ -604,7 +604,7 @@ class AuditTrailMapper extends QBMapper
                 action: ($entry['action'] ?? 'update'),
                 cascadeContext: ($entry['cascadeContext'] ?? null)
             );
-        }
+        }//end foreach
 
         foreach (array_chunk($auditTrails, max(1, $chunkSize)) as $chunk) {
             $this->insertAuditTrailChunk(chunk: $chunk);

--- a/lib/Db/ChunkMapper.php
+++ b/lib/Db/ChunkMapper.php
@@ -500,20 +500,38 @@ class ChunkMapper extends QBMapper
      * keyword path existed before this change on any platform, so this is
      * purely additive).
      *
-     * @param string $query   Search query text
-     * @param int    $limit   Maximum number of results
-     * @param array  $filters Optional filters (source_type)
+     * @param string $query                 Search query text
+     * @param int    $limit                 Maximum number of results
+     * @param array  $filters               Optional filters (source_type)
+     * @param bool   $allowUnrankedFallback When true, non-PostgreSQL platforms run an
+     *                                      unranked `LIKE` scan over `text_content`
+     *                                      instead of returning `[]` (see {@see
+     *                                      searchByKeywordUnranked()}). Defaults to
+     *                                      false so the pre-existing hybrid-search
+     *                                      RRF caller ({@see
+     *                                      \OCA\OpenRegister\Controller\FileSearchController::hybridSearch()})
+     *                                      keeps its documented empty-on-non-Postgres
+     *                                      behaviour unchanged.
      *
      * @return array<int, array{entity_type: string, entity_id: string, score: float,
      *                          chunk_text: string|null, chunk_index: int, metadata: array}>
      *
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Established pattern across this codebase
+     *   for opt-in behaviour flags (see SearchBackendInterface).
+     * @SuppressWarnings(PHPMD.LongVariable)        Descriptive variable name improves readability.
+     *
      * @spec openspec/changes/hybrid-document-search/tasks.md#3.3
+     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-5
      */
-    public function searchByKeyword(string $query, int $limit, array $filters=[]): array
+    public function searchByKeyword(string $query, int $limit, array $filters=[], bool $allowUnrankedFallback=false): array
     {
         $platform = $this->db->getDatabasePlatform();
 
         if (str_contains(get_class($platform), 'PostgreSQL') === false) {
+            if ($allowUnrankedFallback === true) {
+                return $this->searchByKeywordUnranked(query: $query, limit: $limit, filters: $filters);
+            }
+
             $this->logger->warning(
                 message: '[ChunkMapper] Ranked keyword search unavailable: requires PostgreSQL '
                     .'with the tsvector keyword-search index',
@@ -574,4 +592,78 @@ class ChunkMapper extends QBMapper
 
         return $results;
     }//end searchByKeyword()
+
+    /**
+     * Unranked `LIKE` fallback for platforms without a `tsvector` index (e.g. MariaDB).
+     *
+     * Preserves the match set (every chunk whose `text_content` contains the query as a
+     * substring) while degrading ranking — every row scores `0.0` and ordering is by
+     * chunk id rather than relevance. Called only from {@see searchByKeyword()} when
+     * `$allowUnrankedFallback` is true; the pre-existing hybrid-search RRF caller does not
+     * opt in and keeps seeing `[]` on non-PostgreSQL platforms.
+     *
+     * @param string $query   Search query text.
+     * @param int    $limit   Maximum number of results.
+     * @param array  $filters Optional filters (source_type).
+     *
+     * @return array<int, array{entity_type: string, entity_id: string, score: float,
+     *                          chunk_text: string|null, chunk_index: int, metadata: array}>
+     *
+     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-5
+     */
+    private function searchByKeywordUnranked(string $query, int $limit, array $filters=[]): array
+    {
+        $qb            = $this->db->getQueryBuilder();
+        $searchPattern = '%'.$this->db->escapeLikeParameter($query).'%';
+
+        $qb->select('id', 'source_type', 'source_id', 'text_content', 'chunk_index')
+            ->from($this->getTableName())
+            ->where(
+                $qb->expr()->iLike(
+                    'text_content',
+                    $qb->createNamedParameter($searchPattern, IQueryBuilder::PARAM_STR)
+                )
+            )
+            ->orderBy('id', 'ASC')
+            ->setMaxResults(max(1, $limit));
+
+        if (($filters['source_type'] ?? null) !== null) {
+            $qb->andWhere(
+                $qb->expr()->eq(
+                    'source_type',
+                    $qb->createNamedParameter($filters['source_type'], IQueryBuilder::PARAM_STR)
+                )
+            );
+        }
+
+        try {
+            $result = $qb->executeQuery();
+            $rows   = $result->fetchAll();
+            $result->closeCursor();
+        } catch (\Exception $e) {
+            $this->logger->warning(
+                message: '[ChunkMapper] Unranked keyword search query failed; returning empty result',
+                context: [
+                    'file'  => __FILE__,
+                    'line'  => __LINE__,
+                    'error' => $e->getMessage(),
+                ]
+            );
+            return [];
+        }
+
+        $results = [];
+        foreach ($rows as $row) {
+            $results[] = [
+                'entity_type' => (string) ($row['source_type'] ?? 'file'),
+                'entity_id'   => (string) $row['source_id'],
+                'score'       => 0.0,
+                'chunk_text'  => $row['text_content'],
+                'chunk_index' => (int) $row['chunk_index'],
+                'metadata'    => [],
+            ];
+        }
+
+        return $results;
+    }//end searchByKeywordUnranked()
 }//end class

--- a/lib/Db/ChunkMapper.php
+++ b/lib/Db/ChunkMapper.php
@@ -521,7 +521,7 @@ class ChunkMapper extends QBMapper
      * @SuppressWarnings(PHPMD.LongVariable)        Descriptive variable name improves readability.
      *
      * @spec openspec/changes/hybrid-document-search/tasks.md#3.3
-     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-5
+     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md
      */
     public function searchByKeyword(string $query, int $limit, array $filters=[], bool $allowUnrankedFallback=false): array
     {
@@ -609,7 +609,7 @@ class ChunkMapper extends QBMapper
      * @return array<int, array{entity_type: string, entity_id: string, score: float,
      *                          chunk_text: string|null, chunk_index: int, metadata: array}>
      *
-     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-5
+     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md
      */
     private function searchByKeywordUnranked(string $query, int $limit, array $filters=[]): array
     {

--- a/lib/Db/FileMapper.php
+++ b/lib/Db/FileMapper.php
@@ -82,6 +82,9 @@ use OCP\IURLGenerator;
  *
  * @SuppressWarnings(PHPMD.ExcessiveClassLength)
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)     Read-only filecache/oc_share query surface;
+ *   each method is one focused query, splitting the mapper would scatter it without
+ *   reducing complexity.
  */
 class FileMapper extends QBMapper
 {
@@ -689,6 +692,44 @@ class FileMapper extends QBMapper
 
         return $result;
     }//end getFileIdsForObjects()
+
+    /**
+     * Resolve the owning object's UUID for a Nextcloud `filecache.fileid`.
+     *
+     * Inverse of the {@see getFilesForObject()} fallback path: an object's attached
+     * files live under a folder node whose `filecache.name` equals the object's UUID.
+     * This looks up the file's parent folder and returns that folder's name.
+     *
+     * Best-effort only: an object with an explicit `folder` property pointing at a
+     * node whose name is NOT the object UUID (e.g. a manually re-parented folder)
+     * will not resolve here. Callers MUST treat a `null` return as "no owning object
+     * found" and skip silently rather than error — this mirrors the same convention
+     * `getFilesForObject()` already relies on for its own fallback path.
+     *
+     * @param int $fileId The Nextcloud filecache fileid to resolve.
+     *
+     * @return string|null The owning object's UUID, or null when it cannot be resolved.
+     *
+     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-3
+     */
+    public function findOwningObjectUuid(int $fileId): ?string
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('parentNode.name')
+            ->from('filecache', 'file')
+            ->innerJoin('file', 'filecache', 'parentNode', $qb->expr()->eq('file.parent', 'parentNode.fileid'))
+            ->where($qb->expr()->eq('file.fileid', $qb->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
+
+        $result = $qb->executeQuery();
+        $name   = $result->fetchOne();
+        $result->closeCursor();
+
+        if ($name === false || $name === null || $name === '') {
+            return null;
+        }
+
+        return (string) $name;
+    }//end findOwningObjectUuid()
 
     /**
      * Generate a share URL from a share token.

--- a/lib/Db/FileMapper.php
+++ b/lib/Db/FileMapper.php
@@ -711,13 +711,20 @@ class FileMapper extends QBMapper
      * returned UUID is treated as an *unauthenticated candidate*. The RBAC /
      * multitenancy safety net lives ONE layer up in
      * {@see ContentSearchHandler::resolveOwningObject()}, which passes the UUID to
-     * `MagicMapper::find($uuid, _rbac: true, _multitenancy: true)`; a UUID that
-     * belongs to a table the current user cannot see throws `DoesNotExistException`
-     * there and is caught silently. Do NOT reuse this method in contexts that
-     * bypass that follow-up `MagicMapper::find()` call, or a low-privileged user
-     * could probe cross-tenant chunk-content by guessing monotonic fileids.
-     * Defence-in-depth (join in `oc_storages` and filter to accessible storages
-     * up-front) is a follow-up if we ever call this from a hotter path.
+     * `MagicMapper::find($uuid, _rbac: $callerRbac, _multitenancy: $callerMultitenancy)`.
+     * Those flags are propagated from the outer caller (see
+     * `QueryHandler::searchObjectsPaginatedDatabase`) and default to `true` on the
+     * ContentSearchHandler entry point. **When the outer caller opts out of either
+     * flag** (system contexts, batch jobs, some test paths using
+     * `searchObjectsPaginatedDatabase(_rbac: false, _multitenancy: false)`) **this
+     * method's join becomes an unbounded read across tenants and the caller must
+     * supply its own scope guard** — the built-in safety net collapses. Do NOT
+     * reuse this method in contexts that bypass the follow-up `MagicMapper::find()`
+     * call OR that call it with the RBAC/multitenancy flags disabled, or a
+     * low-privileged user could probe cross-tenant chunk-content by guessing
+     * monotonic fileids. Defence-in-depth (join in `oc_storages` and filter to
+     * accessible storages up-front) is a follow-up if we ever call this from a
+     * hotter path or expose it to callers that opt out of RBAC.
      *
      * @param int $fileId The Nextcloud filecache fileid to resolve.
      *

--- a/lib/Db/FileMapper.php
+++ b/lib/Db/FileMapper.php
@@ -706,15 +706,30 @@ class FileMapper extends QBMapper
      * found" and skip silently rather than error — this mirrors the same convention
      * `getFilesForObject()` already relies on for its own fallback path.
      *
+     * SECURITY BOUNDARY: this join is intentionally NOT scoped by storage / tenant /
+     * owner — `filecache.fileid` is globally unique across all storages and any
+     * returned UUID is treated as an *unauthenticated candidate*. The RBAC /
+     * multitenancy safety net lives ONE layer up in
+     * {@see ContentSearchHandler::resolveOwningObject()}, which passes the UUID to
+     * `MagicMapper::find($uuid, _rbac: true, _multitenancy: true)`; a UUID that
+     * belongs to a table the current user cannot see throws `DoesNotExistException`
+     * there and is caught silently. Do NOT reuse this method in contexts that
+     * bypass that follow-up `MagicMapper::find()` call, or a low-privileged user
+     * could probe cross-tenant chunk-content by guessing monotonic fileids.
+     * Defence-in-depth (join in `oc_storages` and filter to accessible storages
+     * up-front) is a follow-up if we ever call this from a hotter path.
+     *
      * @param int $fileId The Nextcloud filecache fileid to resolve.
      *
      * @return string|null The owning object's UUID, or null when it cannot be resolved.
      *
-     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-3
+     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md
      */
     public function findOwningObjectUuid(int $fileId): ?string
     {
         $qb = $this->db->getQueryBuilder();
+        // SECURITY: unscoped filecache join — see docblock. Safety comes from
+        // the MagicMapper::find() call in the sole caller (ContentSearchHandler).
         $qb->select('parentNode.name')
             ->from('filecache', 'file')
             ->innerJoin('file', 'filecache', 'parentNode', $qb->expr()->eq('file.parent', 'parentNode.fileid'))

--- a/lib/Service/Object/ContentSearchHandler.php
+++ b/lib/Service/Object/ContentSearchHandler.php
@@ -1,0 +1,363 @@
+<?php
+
+/**
+ * OpenRegister ContentSearchHandler
+ *
+ * Handler class responsible for the opt-in `_content_search` fan-out that widens
+ * `ObjectService::searchObjectsPaginated()` to match on attached-file body text, not
+ * just object metadata/properties.
+ *
+ * @category Handler
+ * @package  OCA\OpenRegister\Service\Object
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-3
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Object;
+
+use OCA\OpenRegister\Db\ChunkMapper;
+use OCA\OpenRegister\Db\FileMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Widens a metadata-only search result set with objects whose attached-file (or
+ * object-level) chunk body text matches the query, per
+ * `openspec/changes/expose-content-search-in-object-service/specs/zoeken-filteren/spec.md`
+ * (ZKN-CONTENT-001/-002/-003).
+ *
+ * Design (see the change's design.md decisions D1-D5):
+ * - Runs AFTER the metadata-match query, never inline in the same SQL statement.
+ * - Deduplicates on object id; metadata-match rows are never touched or reordered,
+ *   chunk-only matches are appended.
+ * - Skips chunks whose owning object cannot be resolved or falls outside the
+ *   caller's `_register` / `_schemas` scope — silently, never an error.
+ * - Never leaks chunk-shaped fields (id, text_content, score) into the response;
+ *   this handler only ever returns real {@see ObjectEntity} rows.
+ *
+ * @category Handler
+ * @package  OCA\OpenRegister\Service\Object
+ * @author   Conduction Development Team <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://conduction.nl
+ *
+ * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-3
+ */
+class ContentSearchHandler
+{
+    /**
+     * Candidate pool size fetched from the chunk store per call. Opt-in only path
+     * (design.md Risk: "Extra query cost on _content_search=true") — bounded so a
+     * single call cannot force an unbounded chunk-table scan.
+     */
+    private const CHUNK_CANDIDATE_LIMIT = 100;
+
+    /**
+     * Constructor for ContentSearchHandler.
+     *
+     * @param ChunkMapper     $chunkMapper  Chunk store mapper (keyword search over body text).
+     * @param FileMapper      $fileMapper   File mapper, used to resolve a file chunk's owning object.
+     * @param MagicMapper     $objectMapper Unified object mapper, used to resolve chunk hits to ObjectEntity rows.
+     * @param LoggerInterface $logger       Logger for DEBUG-level unresolvable-chunk diagnostics.
+     *
+     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-3
+     */
+    public function __construct(
+        private readonly ChunkMapper $chunkMapper,
+        private readonly FileMapper $fileMapper,
+        private readonly MagicMapper $objectMapper,
+        private readonly LoggerInterface $logger
+    ) {
+    }//end __construct()
+
+    /**
+     * Widen a metadata-match result set with chunk-body-text matches, per ZKN-CONTENT-002.
+     *
+     * No-op (returns `$results`/`$total` unchanged) when: no `_search` term is present,
+     * the page limit is 0 (count/facets-only request), or no chunk hits are found.
+     *
+     * @param array          $query         The original search query (read for `_search` and
+     *                                      register/schema scope; see {@see
+     *                                      resolveScope()}).
+     * @param ObjectEntity[] $results       The metadata-match rows already resolved by the
+     *                                      pre-change search path.
+     * @param int            $total         The metadata-match total already computed by the
+     *                                      pre-change search path.
+     * @param int            $limit         The page's `_limit` (0 = unlimited/count-only).
+     * @param bool           $_rbac         Whether to apply RBAC checks when resolving chunk-hit objects.
+     * @param bool           $_multitenancy Whether to apply multitenancy filtering when resolving chunk-hit objects.
+     *
+     * @return array{results: ObjectEntity[], total: int}
+     *
+     * @psalm-param   array<string, mixed> $query
+     * @phpstan-param array<string, mixed> $query
+     *
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)  RBAC/multitenancy flags mirror the
+     *   established QueryHandler/MagicMapper API pattern.
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Four independent early-exit no-op
+     *   guards (no _search, count-only, no chunk hits, no appends) plus the bounded
+     *   candidate loop; each branch is a single-line guard clause, not nested logic.
+     * @SuppressWarnings(PHPMD.NPathComplexity)      Same early-exit guards multiply paths
+     *   without adding real decision complexity.
+     *
+     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-3
+     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-4
+     */
+    public function augmentWithChunkMatches(
+        array $query,
+        array $results,
+        int $total,
+        int $limit,
+        bool $_rbac=true,
+        bool $_multitenancy=true
+    ): array {
+        $searchTerm = $query['_search'] ?? null;
+        if (is_string($searchTerm) === false || trim($searchTerm) === '') {
+            return ['results' => $results, 'total' => $total];
+        }
+
+        if ($limit === 0) {
+            return ['results' => $results, 'total' => $total];
+        }
+
+        $chunkHits = $this->chunkMapper->searchByKeyword(
+            query: $searchTerm,
+            limit: self::CHUNK_CANDIDATE_LIMIT,
+            filters: [],
+            allowUnrankedFallback: true
+        );
+
+        if (empty($chunkHits) === true) {
+            return ['results' => $results, 'total' => $total];
+        }
+
+        $seenIds = [];
+        foreach ($results as $object) {
+            if ($object instanceof ObjectEntity) {
+                $seenIds[$object->getId()] = true;
+            }
+        }
+
+        $scope    = $this->resolveScope(query: $query);
+        $appended = [];
+        $room     = PHP_INT_MAX;
+        if ($limit > 0) {
+            $room = max(0, $limit - count($results));
+        }
+
+        foreach ($chunkHits as $hit) {
+            if (count($appended) >= $room) {
+                break;
+            }
+
+            $object = $this->resolveAndDedupeHit(
+                hit: $hit,
+                seenIds: $seenIds,
+                scope: $scope,
+                _rbac: $_rbac,
+                _multitenancy: $_multitenancy
+            );
+            if ($object === null) {
+                continue;
+            }
+
+            $seenIds[$object->getId()] = true;
+            $appended[] = $object;
+        }//end foreach
+
+        if (empty($appended) === true) {
+            return ['results' => $results, 'total' => $total];
+        }
+
+        return [
+            'results' => array_merge($results, $appended),
+            'total'   => $total + count($appended),
+        ];
+    }//end augmentWithChunkMatches()
+
+    /**
+     * Resolve one chunk hit and apply the dedupe/scope rules from ZKN-CONTENT-002,
+     * returning the object to append or null when the hit should be skipped.
+     *
+     * Skip reasons (all silent, per D3): already present via the metadata-match arm
+     * (cheap pre-check on 'object' hits, or post-resolve check on 'file' hits — the
+     * owning object id is only known after the file->uuid->object join), unresolvable
+     * owning object, or the object falls outside the caller's register/schema scope.
+     *
+     * @param array $hit           One row from {@see ChunkMapper::searchByKeyword()}.
+     * @param array $seenIds       Object ids already present in the result set, keyed by id.
+     * @param array $scope         The caller's register/schema scope (see {@see resolveScope()}).
+     * @param bool  $_rbac         Whether to apply RBAC checks.
+     * @param bool  $_multitenancy Whether to apply multitenancy filtering.
+     *
+     * @return ObjectEntity|null The object to append, or null to skip this hit.
+     *
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag) RBAC/multitenancy flags mirror the
+     *   established QueryHandler/MagicMapper API pattern.
+     */
+    private function resolveAndDedupeHit(array $hit, array $seenIds, array $scope, bool $_rbac, bool $_multitenancy): ?ObjectEntity
+    {
+        // Cheap pre-dedupe: an 'object' chunk's entity_id IS the object id, so a hit
+        // already present via the metadata-match arm can skip the resolve call entirely.
+        if (($hit['entity_type'] ?? 'file') === 'object'
+            && is_numeric($hit['entity_id'] ?? null) === true
+            && isset($seenIds[(int) $hit['entity_id']]) === true
+        ) {
+            return null;
+        }
+
+        $object = $this->resolveOwningObject(hit: $hit, _rbac: $_rbac, _multitenancy: $_multitenancy);
+        if ($object === null || isset($seenIds[$object->getId()]) === true) {
+            return null;
+        }
+
+        if ($this->matchesScope(object: $object, scope: $scope) === false) {
+            return null;
+        }
+
+        return $object;
+    }//end resolveAndDedupeHit()
+
+    /**
+     * Resolve a single chunk hit to its owning {@see ObjectEntity}, per ZKN-CONTENT-002.
+     *
+     * `source_type='object'` chunks map to the object directly by id; `source_type='file'`
+     * chunks are resolved via {@see FileMapper::findOwningObjectUuid()}. Any failure
+     * (not found, RBAC denial, cross-tenant, unresolvable file->object join) is caught
+     * and logged at DEBUG level — never surfaced as an error to the caller.
+     *
+     * @param array $hit           One row from {@see ChunkMapper::searchByKeyword()}.
+     * @param bool  $_rbac         Whether to apply RBAC checks.
+     * @param bool  $_multitenancy Whether to apply multitenancy filtering.
+     *
+     * @return ObjectEntity|null The owning object, or null when it cannot be resolved.
+     *
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag) RBAC/multitenancy flags mirror the
+     *   established QueryHandler/MagicMapper API pattern.
+     */
+    private function resolveOwningObject(array $hit, bool $_rbac, bool $_multitenancy): ?ObjectEntity
+    {
+        $entityType = $hit['entity_type'] ?? 'file';
+        $entityId   = $hit['entity_id'] ?? null;
+
+        if ($entityId === null || $entityId === '') {
+            return null;
+        }
+
+        try {
+            if ($entityType === 'object') {
+                return $this->objectMapper->find(
+                    identifier: (int) $entityId,
+                    _rbac: $_rbac,
+                    _multitenancy: $_multitenancy
+                );
+            }
+
+            $uuid = $this->fileMapper->findOwningObjectUuid(fileId: (int) $entityId);
+            if ($uuid === null) {
+                return null;
+            }
+
+            return $this->objectMapper->find(
+                identifier: $uuid,
+                _rbac: $_rbac,
+                _multitenancy: $_multitenancy
+            );
+        } catch (\Throwable $e) {
+            $this->logger->debug(
+                message: '[ContentSearchHandler] Unable to resolve owning object for chunk hit; skipping',
+                context: [
+                    'file'       => __FILE__,
+                    'line'       => __LINE__,
+                    'entityType' => $entityType,
+                    'entityId'   => $entityId,
+                    'error'      => $e->getMessage(),
+                ]
+            );
+            return null;
+        }//end try
+    }//end resolveOwningObject()
+
+    /**
+     * Extract the caller's register/schema scope from the search query, mirroring the
+     * key-precedence chain {@see MagicMapper::getSimpleFacets()} already uses.
+     *
+     * @param array $query The search query.
+     *
+     * @return array{registers: int[], schemas: int[]}
+     *
+     * @psalm-param   array<string, mixed> $query
+     * @phpstan-param array<string, mixed> $query
+     */
+    private function resolveScope(array $query): array
+    {
+        $registerId  = $query['@self']['register'] ?? $query['_register'] ?? $query['register'] ?? null;
+        $registerIds = $query['@self']['registers'] ?? $query['_registers'] ?? null;
+        $schemaId    = $query['@self']['schema'] ?? $query['_schema'] ?? $query['schema'] ?? null;
+        $schemaIds   = $query['@self']['schemas'] ?? $query['_schemas'] ?? null;
+
+        $registers = [];
+        if ($registerId !== null) {
+            $registers[] = (int) $registerId;
+        }
+
+        if (is_array($registerIds) === true) {
+            foreach ($registerIds as $id) {
+                $registers[] = (int) $id;
+            }
+        }
+
+        $schemas = [];
+        if ($schemaId !== null) {
+            $schemas[] = (int) $schemaId;
+        }
+
+        if (is_array($schemaIds) === true) {
+            foreach ($schemaIds as $id) {
+                $schemas[] = (int) $id;
+            }
+        }
+
+        return [
+            'registers' => array_values(array_unique($registers)),
+            'schemas'   => array_values(array_unique($schemas)),
+        ];
+    }//end resolveScope()
+
+    /**
+     * Check whether a resolved object falls within the caller's register/schema scope.
+     *
+     * An empty scope list (no `_register`/`_schemas` on the query) matches everything,
+     * consistent with an unscoped cross-schema search.
+     *
+     * @param ObjectEntity                            $object The resolved object.
+     * @param array{registers: int[], schemas: int[]} $scope  The caller's scope.
+     *
+     * @return bool True when the object is in scope.
+     */
+    private function matchesScope(ObjectEntity $object, array $scope): bool
+    {
+        if (empty($scope['registers']) === false
+            && in_array((int) $object->getRegister(), $scope['registers'], true) === false
+        ) {
+            return false;
+        }
+
+        if (empty($scope['schemas']) === false
+            && in_array((int) $object->getSchema(), $scope['schemas'], true) === false
+        ) {
+            return false;
+        }
+
+        return true;
+    }//end matchesScope()
+}//end class

--- a/lib/Service/Object/ContentSearchHandler.php
+++ b/lib/Service/Object/ContentSearchHandler.php
@@ -16,7 +16,7 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-3
+ * @spec openspec/changes/expose-content-search-in-object-service/tasks.md
  */
 
 declare(strict_types=1);
@@ -50,7 +50,7 @@ use Psr\Log\LoggerInterface;
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://conduction.nl
  *
- * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-3
+ * @spec openspec/changes/expose-content-search-in-object-service/tasks.md
  */
 class ContentSearchHandler
 {
@@ -58,8 +58,16 @@ class ContentSearchHandler
      * Candidate pool size fetched from the chunk store per call. Opt-in only path
      * (design.md Risk: "Extra query cost on _content_search=true") — bounded so a
      * single call cannot force an unbounded chunk-table scan.
+     *
+     * Cost note: the constant bounds BOTH the chunk-fetch SQL AND the per-hit
+     * resolve loop below. Each hit costs up to two additional round-trips
+     * (`FileMapper::findOwningObjectUuid()` for file-source chunks, then
+     * `MagicMapper::find($uuid)` for both source branches). Worst case = 2 × N
+     * sequential DB calls. Kept at 50 pending the batch-resolve refactor
+     * discussed on the PR — bulk `findOwningObjectUuidsByFileIds()` /
+     * `findMany($uuids)` variants would let us raise this safely.
      */
-    private const CHUNK_CANDIDATE_LIMIT = 100;
+    private const CHUNK_CANDIDATE_LIMIT = 50;
 
     /**
      * Constructor for ContentSearchHandler.
@@ -69,7 +77,7 @@ class ContentSearchHandler
      * @param MagicMapper     $objectMapper Unified object mapper, used to resolve chunk hits to ObjectEntity rows.
      * @param LoggerInterface $logger       Logger for DEBUG-level unresolvable-chunk diagnostics.
      *
-     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-3
+     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md
      */
     public function __construct(
         private readonly ChunkMapper $chunkMapper,
@@ -109,8 +117,7 @@ class ContentSearchHandler
      * @SuppressWarnings(PHPMD.NPathComplexity)      Same early-exit guards multiply paths
      *   without adding real decision complexity.
      *
-     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-3
-     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-4
+     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md
      */
     public function augmentWithChunkMatches(
         array $query,
@@ -151,6 +158,21 @@ class ContentSearchHandler
             }
         }
 
+        // Stable total across pages: use the distinct-chunk-owner set (grouped
+        // by entity_type+entity_id) as the chunk-arm upper bound BEFORE the
+        // room-clamped resolve loop. Without this, `$total` drifts across
+        // pages (page 1 appends 0 → reports metaTotal; page 3 appends N →
+        // reports metaTotal+N). Accepts over-counting by the metadata/chunk
+        // overlap size and by unresolvable/out-of-scope chunks — the last
+        // page may render short but pagination math stays consistent for the
+        // client. See review discussion on pagination drift concern.
+        $distinctChunkOwners = [];
+        foreach ($chunkHits as $hit) {
+            $key = ($hit['entity_type'] ?? 'file') . ':' . ($hit['entity_id'] ?? '');
+            $distinctChunkOwners[$key] = true;
+        }
+        $chunkOwnerUpperBound = count($distinctChunkOwners);
+
         $scope    = $this->resolveScope(query: $query);
         $appended = [];
         $room     = PHP_INT_MAX;
@@ -178,13 +200,9 @@ class ContentSearchHandler
             $appended[] = $object;
         }//end foreach
 
-        if (empty($appended) === true) {
-            return ['results' => $results, 'total' => $total];
-        }
-
         return [
             'results' => array_merge($results, $appended),
-            'total'   => $total + count($appended),
+            'total'   => $total + $chunkOwnerUpperBound,
         ];
     }//end augmentWithChunkMatches()
 

--- a/lib/Service/Object/ContentSearchHandler.php
+++ b/lib/Service/Object/ContentSearchHandler.php
@@ -66,6 +66,17 @@ class ContentSearchHandler
      * sequential DB calls. Kept at 50 pending the batch-resolve refactor
      * discussed on the PR — bulk `findOwningObjectUuidsByFileIds()` /
      * `findMany($uuids)` variants would let us raise this safely.
+     *
+     * Perf note: the earlier "cheap pre-dedupe on 'object' hits" branch was
+     * intentionally removed when dedup switched to UUID keying (see the
+     * `$seenUuids` block in `augmentWithChunkMatches()` for why — metadata-
+     * arm rows come from `searchObjectsInRegisterSchemaTable` which does not
+     * populate `Entity::$id`). Every 'object' chunk hit therefore now pays
+     * one `MagicMapper::find()` call before dedup even when it fully
+     * overlaps the metadata arm. The clean restore path is to extend
+     * `ChunkMapper::searchByKeyword()` to return the owning-object UUID for
+     * 'object' chunks so the pre-check keys on UUID directly; folds into
+     * the same deferred batch-resolve refactor above.
      */
     private const CHUNK_CANDIDATE_LIMIT = 50;
 
@@ -162,15 +173,26 @@ class ContentSearchHandler
         // by entity_type+entity_id) as the chunk-arm upper bound BEFORE the
         // room-clamped resolve loop. Without this, `$total` drifts across
         // pages (page 1 appends 0 → reports metaTotal; page 3 appends N →
-        // reports metaTotal+N). Accepts over-counting by the metadata/chunk
-        // overlap size and by unresolvable/out-of-scope chunks — the last
-        // page may render short but pagination math stays consistent for the
-        // client. See review discussion on pagination drift concern.
+        // reports metaTotal+N).
+        //
+        // ACCEPTED OVER-COUNT — the upper bound is a THEORETICAL maximum:
+        // scope/register/schema mismatch, tenant/RBAC filtering, and unresolved
+        // file→object joins can each reduce the actually-appended count to zero
+        // without changing `$total`. In a multi-register corpus where the
+        // scope filters out most chunks, the client's `pages = ceil(total/limit)`
+        // will point at pages that render empty. This is the accepted
+        // trade-off for pagination stability across pages of the same query;
+        // the alternative (recompute `$total` per page from the actually-
+        // appended count) reintroduces the drift the fix is meant to close.
+        // Pre-filtering `$chunkHits` by scope + a batch `MagicMapper::findMany`
+        // would tighten the bound but requires the bulk mapper methods
+        // deferred with the batch-resolve refactor.
         $distinctChunkOwners = [];
         foreach ($chunkHits as $hit) {
-            $key = ($hit['entity_type'] ?? 'file') . ':' . ($hit['entity_id'] ?? '');
+            $key = ($hit['entity_type'] ?? 'file').':'.($hit['entity_id'] ?? '');
             $distinctChunkOwners[$key] = true;
         }
+
         $chunkOwnerUpperBound = count($distinctChunkOwners);
 
         $scope    = $this->resolveScope(query: $query);
@@ -211,9 +233,10 @@ class ContentSearchHandler
      * returning the object to append or null when the hit should be skipped.
      *
      * Skip reasons (all silent, per D3): already present via the metadata-match arm
-     * (cheap pre-check on 'object' hits, or post-resolve check on 'file' hits — the
-     * owning object id is only known after the file->uuid->object join), unresolvable
-     * owning object, or the object falls outside the caller's register/schema scope.
+     * (post-resolve dedup on UUID for both source types — chunk `entity_id` is a
+     * numeric id, not a UUID, so the owning UUID is only known after resolve),
+     * unresolvable owning object, or the object falls outside the caller's
+     * register/schema scope.
      *
      * @param array $hit           One row from {@see ChunkMapper::searchByKeyword()}.
      * @param array $seenUuids     Object UUIDs already present in the result set, keyed by uuid.

--- a/lib/Service/Object/ContentSearchHandler.php
+++ b/lib/Service/Object/ContentSearchHandler.php
@@ -140,10 +140,14 @@ class ContentSearchHandler
             return ['results' => $results, 'total' => $total];
         }
 
-        $seenIds = [];
+        // Dedup key is UUID, not getId(): searchObjectsInRegisterSchemaTable
+        // hydrates ObjectEntity without populating Entity::$id (the underlying
+        // column is `_id`, not `id`), so getId() returns null on metadata-arm
+        // rows. UUID is populated and stable across both arms.
+        $seenUuids = [];
         foreach ($results as $object) {
-            if ($object instanceof ObjectEntity) {
-                $seenIds[$object->getId()] = true;
+            if ($object instanceof ObjectEntity && $object->getUuid() !== null) {
+                $seenUuids[$object->getUuid()] = true;
             }
         }
 
@@ -161,7 +165,7 @@ class ContentSearchHandler
 
             $object = $this->resolveAndDedupeHit(
                 hit: $hit,
-                seenIds: $seenIds,
+                seenUuids: $seenUuids,
                 scope: $scope,
                 _rbac: $_rbac,
                 _multitenancy: $_multitenancy
@@ -170,7 +174,7 @@ class ContentSearchHandler
                 continue;
             }
 
-            $seenIds[$object->getId()] = true;
+            $seenUuids[$object->getUuid()] = true;
             $appended[] = $object;
         }//end foreach
 
@@ -194,7 +198,7 @@ class ContentSearchHandler
      * owning object, or the object falls outside the caller's register/schema scope.
      *
      * @param array $hit           One row from {@see ChunkMapper::searchByKeyword()}.
-     * @param array $seenIds       Object ids already present in the result set, keyed by id.
+     * @param array $seenUuids     Object UUIDs already present in the result set, keyed by uuid.
      * @param array $scope         The caller's register/schema scope (see {@see resolveScope()}).
      * @param bool  $_rbac         Whether to apply RBAC checks.
      * @param bool  $_multitenancy Whether to apply multitenancy filtering.
@@ -204,19 +208,10 @@ class ContentSearchHandler
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) RBAC/multitenancy flags mirror the
      *   established QueryHandler/MagicMapper API pattern.
      */
-    private function resolveAndDedupeHit(array $hit, array $seenIds, array $scope, bool $_rbac, bool $_multitenancy): ?ObjectEntity
+    private function resolveAndDedupeHit(array $hit, array $seenUuids, array $scope, bool $_rbac, bool $_multitenancy): ?ObjectEntity
     {
-        // Cheap pre-dedupe: an 'object' chunk's entity_id IS the object id, so a hit
-        // already present via the metadata-match arm can skip the resolve call entirely.
-        if (($hit['entity_type'] ?? 'file') === 'object'
-            && is_numeric($hit['entity_id'] ?? null) === true
-            && isset($seenIds[(int) $hit['entity_id']]) === true
-        ) {
-            return null;
-        }
-
         $object = $this->resolveOwningObject(hit: $hit, _rbac: $_rbac, _multitenancy: $_multitenancy);
-        if ($object === null || isset($seenIds[$object->getId()]) === true) {
+        if ($object === null || $object->getUuid() === null || isset($seenUuids[$object->getUuid()]) === true) {
             return null;
         }
 

--- a/lib/Service/Object/QueryHandler.php
+++ b/lib/Service/Object/QueryHandler.php
@@ -69,19 +69,21 @@ class QueryHandler
     /**
      * Constructor for QueryHandler.
      *
-     * @param MagicMapper                    $objectMapper       Unified mapper for objects.
-     * @param GetObject                      $getHandler         Get handler.
-     * @param RenderObject                   $renderHandler      Render handler.
-     * @param SearchQueryHandler             $searchQueryHandler Search handler.
-     * @param FacetHandler                   $facetHandler       Facet handler.
-     * @param PerformanceOptimizationHandler $performanceHandler Performance handler.
-     * @param IAppContainer                  $container          App container.
-     * @param LoggerInterface                $logger             Logger.
-     * @param IRequest                       $request            Request object.
+     * @param MagicMapper                    $objectMapper         Unified mapper for objects.
+     * @param GetObject                      $getHandler           Get handler.
+     * @param RenderObject                   $renderHandler        Render handler.
+     * @param SearchQueryHandler             $searchQueryHandler   Search handler.
+     * @param FacetHandler                   $facetHandler         Facet handler.
+     * @param PerformanceOptimizationHandler $performanceHandler   Performance handler.
+     * @param ContentSearchHandler           $contentSearchHandler Opt-in `_content_search` chunk fan-out handler.
+     * @param IAppContainer                  $container            App container.
+     * @param LoggerInterface                $logger               Logger.
+     * @param IRequest                       $request              Request object.
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList) Nextcloud DI requires constructor injection
      *
      * @spec openspec/specs/zoeken-filteren/spec.md
+     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-2
      */
     public function __construct(
         private readonly MagicMapper $objectMapper,
@@ -90,6 +92,7 @@ class QueryHandler
         private readonly SearchQueryHandler $searchQueryHandler,
         private readonly FacetHandler $facetHandler,
         private readonly PerformanceOptimizationHandler $performanceHandler,
+        private readonly ContentSearchHandler $contentSearchHandler,
         private readonly IAppContainer $container,
         private readonly LoggerInterface $logger,
         private readonly IRequest $request
@@ -405,6 +408,27 @@ class QueryHandler
         if (isset($searchResult['metrics']) === true) {
             $metrics['db_search'] = $searchResult['metrics']['search_ms'] ?? null;
             $metrics['db_count']  = $searchResult['metrics']['count_ms'] ?? null;
+        }
+
+        // Opt-in `_content_search` fan-out (ZKN-CONTENT-001): widen the metadata-match
+        // result set with objects whose attached-file (or object) chunk body text
+        // matches `_search`. Absent or false is byte-identical to pre-change behaviour —
+        // no additional query is issued against openregister_chunks. Runs BEFORE the
+        // render/extend pipeline below so appended rows get the same `_extend`/`_fields`
+        // treatment as metadata-match rows (ZKN-CONTENT-003).
+        if (($query['_content_search'] ?? false) === true) {
+            $contentSearchStart = microtime(true);
+            $augmented          = $this->contentSearchHandler->augmentWithChunkMatches(
+                query: $query,
+                results: $results,
+                total: $total,
+                limit: $limit,
+                _rbac: $_rbac,
+                _multitenancy: $_multitenancy
+            );
+            $results            = $augmented['results'];
+            $total = $augmented['total'];
+            $metrics['content_search'] = round((microtime(true) - $contentSearchStart) * 1000, 2);
         }
 
         // Detect if complex rendering is needed (extend, fields, filter, unset).

--- a/lib/Service/Object/QueryHandler.php
+++ b/lib/Service/Object/QueryHandler.php
@@ -83,7 +83,7 @@ class QueryHandler
      * @SuppressWarnings(PHPMD.ExcessiveParameterList) Nextcloud DI requires constructor injection
      *
      * @spec openspec/specs/zoeken-filteren/spec.md
-     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-2
+     * @spec openspec/changes/expose-content-search-in-object-service/tasks.md
      */
     public function __construct(
         private readonly MagicMapper $objectMapper,

--- a/lib/Service/Object/QueryHandler.php
+++ b/lib/Service/Object/QueryHandler.php
@@ -416,7 +416,7 @@ class QueryHandler
         // no additional query is issued against openregister_chunks. Runs BEFORE the
         // render/extend pipeline below so appended rows get the same `_extend`/`_fields`
         // treatment as metadata-match rows (ZKN-CONTENT-003).
-        if (($query['_content_search'] ?? false) === true) {
+        if (filter_var($query['_content_search'] ?? false, FILTER_VALIDATE_BOOLEAN) === true) {
             $contentSearchStart = microtime(true);
             $augmented          = $this->contentSearchHandler->augmentWithChunkMatches(
                 query: $query,

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -2400,7 +2400,12 @@ class ObjectService
      *                                   discovery (true/false) - _extend: Properties to
      *                                   extend - _fields: Fields to include - _filter/_unset:
      *                                   Fields to exclude - _queries: Specific fields for
-     *                                   legacy facets
+     *                                   legacy facets - _content_search: opt-in bool
+     *                                   (default false) to widen `_search` matches to
+     *                                   attached-file/object chunk body text via
+     *                                   `ChunkMapper::searchByKeyword()`; absent/false is
+     *                                   byte-identical to pre-change behaviour (see
+     *                                   openspec/changes/expose-content-search-in-object-service)
      * @param bool        $_rbac         Whether to apply RBAC checks (default: true)
      * @param bool        $_multitenancy Whether to apply multitenancy filtering (default: true)
      * @param bool        $deleted       Whether to include deleted objects (default: false)

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -374,11 +374,9 @@ class ObjectService
      *
      * @return mixed Whatever the callable returns.
      *
-     * @SuppressWarnings(PHPMD.StaticAccess) SystemOperationContext is a static execution-context holder by design
+     * @SuppressWarnings(PHPMD.StaticAccess) SystemOperationContext::run is the canonical scoped-elevation API
      *
      * @spec openspec/specs/rbac-scopes/spec.md
-     *
-     * @SuppressWarnings(PHPMD.StaticAccess) SystemOperationContext::run is the canonical scoped-elevation API
      */
     public function runAsSystem(callable $operation)
     {
@@ -2687,11 +2685,9 @@ class ObjectService
      *
      * @return array<string, mixed> The query with provider-contract keys added.
      *
-     * @SuppressWarnings(PHPMD.NPathComplexity) Additive key-by-key mapping; each guard is independent by design
+     * @SuppressWarnings(PHPMD.NPathComplexity) Additive key-by-key mapping; each guard is independent by design, one guard per provider key
      *
      * @spec openspec/specs/dbal-virtual-registers/spec.md
-     *
-     * @SuppressWarnings(PHPMD.NPathComplexity) Additive key-mapping requires one guard per provider key
      */
     private function normaliseObjectSourceQuery(array $query): array
     {

--- a/openspec/changes/expose-content-search-in-object-service/design.md
+++ b/openspec/changes/expose-content-search-in-object-service/design.md
@@ -1,5 +1,7 @@
 # Design: expose-content-search-in-object-service
 
+status: pr-created
+
 ## Context
 
 `ObjectService::searchObjectsPaginated()` is OpenRegister's canonical multi-schema search entry-point — every consumer that wants "objects matching X" goes through it. It delegates to `QueryHandler` → `MagicMapper` → `SearchBackendInterface` and today only matches on metadata + string schema-properties (`_search` param translates to `ILIKE`/`tsvector` over indexed columns; details in `zoeken-filteren` spec).
@@ -58,3 +60,15 @@ Pure code addition. No database migration, no config change, no data transformat
 
 - **Final flag name** — `_content_search` in this proposal is a working name. If bikeshed lands on `_include_content` / `_content` / etc., the OpenCatalogi consumer will translate its `_content=true` query param to whatever wire OR agrees on. Working name is locked in the spec deltas here; changing it later means a follow-up PR that updates the spec + the OC-side consumer.
 - **Dedup ordering** — the current design puts metadata-match rows first and chunk-only rows after. If downstream consumers want relevance-interleaved, a follow-up can add a `_content_search_merge=relevance` option — out of scope here.
+
+## Implementation Notes (added during build, #472)
+
+The builder branched off `main` initially (entrypoint error); the feature branch was reset onto `origin/development` before implementation started, since `main` and `development` have diverged substantially on this repo and `ChunkMapper::searchByKeyword()` only exists on `development` (shipped by the already-merged `hybrid-document-search` change, as this design assumed).
+
+Two assumptions in this design no longer match the current `development` codebase; both are adapted below rather than blocking the build:
+
+1. **"Existing file→object join"** (D2/task 3) — no callable method for resolving a Nextcloud `filecache.fileid` back to its owning `ObjectEntity` existed. Added `FileMapper::findOwningObjectUuid(int $fileId): ?string`, the inverse of `FileMapper::getFilesForObject()`'s own fallback path (an object's attached-file folder is named by the object's UUID in `oc_filecache`). Best-effort per D3: an object with a custom `folder` property pointing at a differently-named node will not resolve via this path and is silently skipped, same as any other unresolvable chunk.
+
+2. **`SearchBackendInterface`** (task 5) — this interface (and its Solr/Elasticsearch implementations) no longer exists on `development`; `QueryHandler` documents "database is the only search backend" after the external index tier was removed. The actual current per-backend seam is `ChunkMapper::searchByKeyword()`'s existing PostgreSQL-vs-other-platform branch. Extended it with an opt-in `bool $allowUnrankedFallback` parameter (default `false`, so the pre-existing `hybrid-document-search` RRF caller in `FileSearchController::hybridSearch()` keeps its documented empty-on-non-Postgres behaviour) that runs an unranked `LIKE` scan on `text_content` when true — satisfying the MariaDB-fallback requirement (ZKN-CONTENT-001 scenario 3) at the seam that actually exists today.
+
+The wire itself lives in a new `ContentSearchHandler` (lib/Service/Object/), invoked from `QueryHandler::searchObjectsPaginatedDatabase()` right after the metadata-match query and before the render/`_extend` pipeline, per D2/D3/D4.

--- a/openspec/changes/expose-content-search-in-object-service/hydra.json
+++ b/openspec/changes/expose-content-search-in-object-service/hydra.json
@@ -8,9 +8,9 @@
       "cycle": 1,
       "trigger": "build:queued",
       "started_at": "2026-07-17T19:07:57Z",
-      "ended_at": null,
-      "outcome": "in-flight",
-      "outcome_reason": null,
+      "ended_at": "2026-07-17T19:08:32Z",
+      "outcome": "needs-input",
+      "outcome_reason": "builder container exited non-zero",
       "pattern_tags": [],
       "stages": [
         {

--- a/openspec/changes/expose-content-search-in-object-service/hydra.json
+++ b/openspec/changes/expose-content-search-in-object-service/hydra.json
@@ -12,7 +12,50 @@
       "outcome": "in-flight",
       "outcome_reason": null,
       "pattern_tags": [],
-      "stages": []
+      "stages": [
+        {
+          "stage": "build",
+          "persona": "Al Gorithm",
+          "model": "sonnet",
+          "container": "hydra-builder",
+          "started_at": "2026-07-17T17:48:43Z",
+          "ended_at": "2026-07-17T19:07:46Z",
+          "exit_code": 1,
+          "turns_used": 0,
+          "turns_budget": 40,
+          "checks_run": [],
+          "checks_skipped": [],
+          "findings": [
+            {
+              "id": "build-failed",
+              "severity": "CRITICAL",
+              "gate": "builder",
+              "rule": "builder container exited non-zero",
+              "status": "open",
+              "note": "Builder container failed to complete. See logs/pipeline-*/builder-build.jsonl for detail.",
+              "autofixable": false
+            }
+          ],
+          "decisions": [],
+          "verdict": "fail",
+          "duration_seconds": 4743
+        }
+      ]
     }
-  ]
+  ],
+  "totals": {
+    "runs": 1,
+    "turns_used": 0,
+    "cost_usd": 0.0,
+    "duration_seconds": 4743,
+    "cycles": 1,
+    "by_stage": {
+      "build": {
+        "runs": 1,
+        "turns_used": 0,
+        "cost_usd": 0.0,
+        "duration_seconds": 4743
+      }
+    }
+  }
 }

--- a/openspec/changes/expose-content-search-in-object-service/hydra.json
+++ b/openspec/changes/expose-content-search-in-object-service/hydra.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 2,
+  "spec_slug": "expose-content-search-in-object-service",
+  "repo": "https://codeberg.org/conduction/openregister",
+  "issue": 472,
+  "cycles": [
+    {
+      "cycle": 1,
+      "trigger": "build:queued",
+      "started_at": "2026-07-17T19:07:57Z",
+      "ended_at": null,
+      "outcome": "in-flight",
+      "outcome_reason": null,
+      "pattern_tags": [],
+      "stages": []
+    }
+  ]
+}

--- a/openspec/changes/expose-content-search-in-object-service/plan.json
+++ b/openspec/changes/expose-content-search-in-object-service/plan.json
@@ -11,7 +11,7 @@
       "id": 1,
       "title": "Freeze the delta spec under `openspec/changes/expose-content-search-in-object-service/specs/zoeken-filteren/spec.md` (ADDED `ZKN-CONTENT-001` / `-002` / `-003`); confirm `openspec validate expose-content-search-in-object-service` is green",
       "description": "",
-      "status": "pending",
+      "status": "done",
       "spec_ref": "specs/zoeken-filteren/spec.md (this change)",
       "acceptance_criteria": [
         "openspec validator reports \"is valid\"; existing `zoeken-filteren` requirements untouched"
@@ -22,7 +22,7 @@
       "id": 2,
       "title": "Extend `ObjectService::searchObjectsPaginated()` signature with `bool $_content_search = false` (or accept it as a `_content_search` key inside `$query`). Default false \u2014 omitted-flag path MUST be byte-identical to today's behaviour",
       "description": "",
-      "status": "pending",
+      "status": "done",
       "spec_ref": "ZKN-CONTENT-001",
       "acceptance_criteria": [
         "PHPUnit test with default (or omitted) flag proves envelope + row order + total are byte-identical to pre-change baseline for a fixed query"
@@ -33,7 +33,7 @@
       "id": 3,
       "title": "When `_content_search=true`, call `ChunkMapper::searchByKeyword($query['_search'])` scoped by the same `_register` / `_schemas` the caller passed; map each hit back to its owning object (source_type='file' \u2192 owning object via existing file\u2192object join; source_type='object' \u2192 source_id is the object id directly)",
       "description": "",
-      "status": "pending",
+      "status": "done",
       "spec_ref": "ZKN-CONTENT-002",
       "acceptance_criteria": [
         "unit test seeds an object with a chunk containing a phrase absent from all metadata columns; assert the object surfaces when `_content_search=true` + `_search=<phrase>` and NOT when `_content_search=false`"
@@ -44,7 +44,7 @@
       "id": 4,
       "title": "Union the metadata-match result set with the chunk-match result set; deduplicate on object id; preserve the existing envelope shape (object rows, not chunks)",
       "description": "",
-      "status": "pending",
+      "status": "done",
       "spec_ref": "ZKN-CONTENT-002, ZKN-CONTENT-003",
       "acceptance_criteria": [
         "object matching on BOTH metadata AND chunk appears exactly once in the response; no chunk id, snippet, or score field leaks into the returned rows"
@@ -55,7 +55,7 @@
       "id": 5,
       "title": "Wire the flag through `SearchBackendInterface` so alternate backends can implement or explicitly fall back. On MariaDB (no tsvector), fall back to `LIKE` on `text_content` without `ts_rank` \u2014 behaviour preserved, ranking degraded; document the fallback in the interface docblock",
       "description": "",
-      "status": "pending",
+      "status": "done",
       "spec_ref": "ZKN-CONTENT-001",
       "acceptance_criteria": [
         "on a MariaDB dev env the endpoint returns matching objects for a body-text query (order may differ from PostgreSQL); on PostgreSQL the results are `ts_rank`-scored"
@@ -66,7 +66,7 @@
       "id": 6,
       "title": "Add PHPUnit coverage: (a) default-off byte-identity, (b) opt-in body-text match found, (c) dedup on both-surface match, (d) no raw chunk payload leakage in response",
       "description": "",
-      "status": "pending",
+      "status": "done",
       "spec_ref": "ZKN-CONTENT-001, -002, -003",
       "acceptance_criteria": [
         "4 new test methods green on both PostgreSQL and MariaDB CI matrices"

--- a/openspec/changes/expose-content-search-in-object-service/tasks.md
+++ b/openspec/changes/expose-content-search-in-object-service/tasks.md
@@ -2,24 +2,31 @@
 
 `kind: code` per ADR-032. Single-service wire; the storage layer (chunk store + tsvector GIN + `ChunkMapper::searchByKeyword()`) already ships from the merged `hybrid-document-search` change.
 
-- [ ] Freeze the delta spec under `openspec/changes/expose-content-search-in-object-service/specs/zoeken-filteren/spec.md` (ADDED `ZKN-CONTENT-001` / `-002` / `-003`); confirm `openspec validate expose-content-search-in-object-service` is green
+- [x] Freeze the delta spec under `openspec/changes/expose-content-search-in-object-service/specs/zoeken-filteren/spec.md` (ADDED `ZKN-CONTENT-001` / `-002` / `-003`); confirm `openspec validate expose-content-search-in-object-service` is green
   - Spec ref: specs/zoeken-filteren/spec.md (this change)
   - Acceptance: openspec validator reports "is valid"; existing `zoeken-filteren` requirements untouched
-- [ ] Extend `ObjectService::searchObjectsPaginated()` signature with `bool $_content_search = false` (or accept it as a `_content_search` key inside `$query`). Default false — omitted-flag path MUST be byte-identical to today's behaviour
+  - Done: `openspec validate expose-content-search-in-object-service` reports "is valid" (already true from the merged proposal PR #471; spec delta unchanged).
+- [x] Extend `ObjectService::searchObjectsPaginated()` signature with `bool $_content_search = false` (or accept it as a `_content_search` key inside `$query`). Default false — omitted-flag path MUST be byte-identical to today's behaviour
   - Spec ref: ZKN-CONTENT-001
   - Acceptance: PHPUnit test with default (or omitted) flag proves envelope + row order + total are byte-identical to pre-change baseline for a fixed query
-- [ ] When `_content_search=true`, call `ChunkMapper::searchByKeyword($query['_search'])` scoped by the same `_register` / `_schemas` the caller passed; map each hit back to its owning object (source_type='file' → owning object via existing file→object join; source_type='object' → source_id is the object id directly)
+  - Done: per design D1, flag lives on `$query['_content_search']` (no signature change). Read in `QueryHandler::searchObjectsPaginatedDatabase()`. Covered by `QueryHandlerContentSearchTest::testContentSearchHandlerIsNeverCalledWhenFlagAbsent`/`...FlagExplicitlyFalse`.
+- [x] When `_content_search=true`, call `ChunkMapper::searchByKeyword($query['_search'])` scoped by the same `_register` / `_schemas` the caller passed; map each hit back to its owning object (source_type='file' → owning object via existing file→object join; source_type='object' → source_id is the object id directly)
   - Spec ref: ZKN-CONTENT-002
   - Acceptance: unit test seeds an object with a chunk containing a phrase absent from all metadata columns; assert the object surfaces when `_content_search=true` + `_search=<phrase>` and NOT when `_content_search=false`
-- [ ] Union the metadata-match result set with the chunk-match result set; deduplicate on object id; preserve the existing envelope shape (object rows, not chunks)
+  - Done: new `ContentSearchHandler::augmentWithChunkMatches()`. The "existing file→object join" did not exist as a callable method — added `FileMapper::findOwningObjectUuid()` (mirrors the uuid-named-folder convention `FileMapper::getFilesForObject()`'s fallback already relies on). See Implementation Notes in design.md.
+- [x] Union the metadata-match result set with the chunk-match result set; deduplicate on object id; preserve the existing envelope shape (object rows, not chunks)
   - Spec ref: ZKN-CONTENT-002, ZKN-CONTENT-003
   - Acceptance: object matching on BOTH metadata AND chunk appears exactly once in the response; no chunk id, snippet, or score field leaks into the returned rows
-- [ ] Wire the flag through `SearchBackendInterface` so alternate backends can implement or explicitly fall back. On MariaDB (no tsvector), fall back to `LIKE` on `text_content` without `ts_rank` — behaviour preserved, ranking degraded; document the fallback in the interface docblock
+  - Done: dedup on `getId()` in `ContentSearchHandler`; appended rows are real `ObjectEntity` instances merged into `$results` before the render/extend pipeline runs, so `_extend`/`_fields` apply uniformly.
+- [x] Wire the flag through `SearchBackendInterface` so alternate backends can implement or explicitly fall back. On MariaDB (no tsvector), fall back to `LIKE` on `text_content` without `ts_rank` — behaviour preserved, ranking degraded; document the fallback in the interface docblock
   - Spec ref: ZKN-CONTENT-001
   - Acceptance: on a MariaDB dev env the endpoint returns matching objects for a body-text query (order may differ from PostgreSQL); on PostgreSQL the results are `ts_rank`-scored
-- [ ] Add PHPUnit coverage: (a) default-off byte-identity, (b) opt-in body-text match found, (c) dedup on both-surface match, (d) no raw chunk payload leakage in response
+  - Done: `SearchBackendInterface` no longer exists on `development` (the Solr/Elasticsearch external index tier was removed; `QueryHandler` documents "database is the only search backend"). The actual current seam is `ChunkMapper::searchByKeyword()`'s existing PostgreSQL-vs-other-platform branch — extended with an opt-in `$allowUnrankedFallback` parameter that runs an unranked `LIKE` scan on non-PostgreSQL platforms. See Implementation Notes in design.md.
+- [x] Add PHPUnit coverage: (a) default-off byte-identity, (b) opt-in body-text match found, (c) dedup on both-surface match, (d) no raw chunk payload leakage in response
   - Spec ref: ZKN-CONTENT-001, -002, -003
   - Acceptance: 4 new test methods green on both PostgreSQL and MariaDB CI matrices
+  - Done: `ContentSearchHandlerTest` (13 tests), `QueryHandlerContentSearchTest` (3 tests), `ChunkMapperKeywordSearchTest` unranked-fallback additions (3 tests), `FileMapperFindOwningObjectUuidTest` (3 tests). No chunk-field leakage is structural (handler only ever returns `ObjectEntity`), asserted via `instanceof`/`assertSame` on the returned rows.
 - [ ] Confirm archive gate: after impl + tests green, run `openspec archive expose-content-search-in-object-service`
   - Spec ref: —
   - Acceptance: change moved under `openspec/changes/archive/YYYY-MM-DD-expose-content-search-in-object-service`; downstream opencatalogi #136 (WOO-517) unblocks
+  - Left unchecked intentionally: archiving happens after this PR merges to `development`, not in the PR itself.

--- a/tests/Unit/Db/ChunkMapperKeywordSearchTest.php
+++ b/tests/Unit/Db/ChunkMapperKeywordSearchTest.php
@@ -175,6 +175,112 @@ class ChunkMapperKeywordSearchTest extends TestCase
     }//end testSearchByKeywordReturnsEmptyWithWarningWhenColumnMissing()
 
     // =========================================================================
+    // searchByKeyword — unranked fallback (expose-content-search-in-object-service, task 5)
+    // =========================================================================
+
+    public function testSearchByKeywordUnrankedFallbackRunsLikeQueryOnMariaDbWhenRequested(): void
+    {
+        $this->db->method('getDatabasePlatform')->willReturn(new MariaDBPlatform());
+        $this->db->method('escapeLikeParameter')->willReturnArgument(0);
+        $this->logger->expects($this->never())->method('warning');
+
+        $expr = $this->createMock(IExpressionBuilder::class);
+        $expr->method('iLike')->willReturnCallback(fn(string $col, $val): string => "$col ILIKE $val");
+        $expr->method('eq')->willReturnCallback(fn(string $col, $val): string => "$col = $val");
+
+        $stmt = $this->createMock(IResult::class);
+        $stmt->method('fetchAll')->willReturn([$this->makeKeywordRow(1, 'quarterly mention in a memo', 0.0)]);
+
+        $qb = $this->createMock(IQueryBuilder::class);
+        $qb->method('select')->willReturnSelf();
+        $qb->method('from')->willReturnSelf();
+        $qb->method('where')->willReturnSelf();
+        $qb->method('andWhere')->willReturnSelf();
+        $qb->method('orderBy')->willReturnSelf();
+        $qb->method('setMaxResults')->willReturnSelf();
+        $qb->method('expr')->willReturn($expr);
+        $qb->method('createNamedParameter')->willReturnArgument(0);
+        $qb->method('executeQuery')->willReturn($stmt);
+
+        $this->db->method('getQueryBuilder')->willReturn($qb);
+        $this->db->expects($this->never())->method('executeQuery');
+
+        $results = $this->mapper->searchByKeyword('quarterly', 10, [], true);
+
+        $this->assertCount(1, $results);
+        $this->assertSame('file', $results[0]['entity_type']);
+        $this->assertSame('101', $results[0]['entity_id']);
+        $this->assertSame(0.0, $results[0]['score']);
+        $this->assertSame([], $results[0]['metadata']);
+    }//end testSearchByKeywordUnrankedFallbackRunsLikeQueryOnMariaDbWhenRequested()
+
+    public function testSearchByKeywordUnrankedFallbackHonoursSourceTypeFilter(): void
+    {
+        $this->db->method('getDatabasePlatform')->willReturn(new MariaDBPlatform());
+        $this->db->method('escapeLikeParameter')->willReturnArgument(0);
+
+        $expr = $this->createMock(IExpressionBuilder::class);
+        $expr->method('iLike')->willReturnCallback(fn(string $col, $val): string => "$col ILIKE $val");
+
+        $capturedFilterCol = null;
+        $expr->method('eq')->willReturnCallback(
+            function (string $col, $val) use (&$capturedFilterCol): string {
+                $capturedFilterCol = $col;
+                return "$col = $val";
+            }
+        );
+
+        $stmt = $this->createMock(IResult::class);
+        $stmt->method('fetchAll')->willReturn([]);
+
+        $qb = $this->createMock(IQueryBuilder::class);
+        $qb->method('select')->willReturnSelf();
+        $qb->method('from')->willReturnSelf();
+        $qb->method('where')->willReturnSelf();
+        $qb->expects($this->once())->method('andWhere')->willReturnSelf();
+        $qb->method('orderBy')->willReturnSelf();
+        $qb->method('setMaxResults')->willReturnSelf();
+        $qb->method('expr')->willReturn($expr);
+        $qb->method('createNamedParameter')->willReturnArgument(0);
+        $qb->method('executeQuery')->willReturn($stmt);
+
+        $this->db->method('getQueryBuilder')->willReturn($qb);
+
+        $this->mapper->searchByKeyword('quarterly', 10, ['source_type' => 'file'], true);
+
+        $this->assertSame('source_type', $capturedFilterCol);
+    }//end testSearchByKeywordUnrankedFallbackHonoursSourceTypeFilter()
+
+    public function testSearchByKeywordUnrankedFallbackDegradesGracefullyOnQueryFailure(): void
+    {
+        $this->db->method('getDatabasePlatform')->willReturn(new MariaDBPlatform());
+        $this->db->method('escapeLikeParameter')->willReturnArgument(0);
+
+        $expr = $this->createMock(IExpressionBuilder::class);
+        $expr->method('iLike')->willReturnCallback(fn(string $col, $val): string => "$col ILIKE $val");
+
+        $qb = $this->createMock(IQueryBuilder::class);
+        $qb->method('select')->willReturnSelf();
+        $qb->method('from')->willReturnSelf();
+        $qb->method('where')->willReturnSelf();
+        $qb->method('orderBy')->willReturnSelf();
+        $qb->method('setMaxResults')->willReturnSelf();
+        $qb->method('expr')->willReturn($expr);
+        $qb->method('createNamedParameter')->willReturnArgument(0);
+        $qb->method('executeQuery')->willThrowException(new \Exception('syntax error'));
+
+        $this->db->method('getQueryBuilder')->willReturn($qb);
+
+        $this->logger->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('Unranked keyword search query failed'), $this->anything());
+
+        $results = $this->mapper->searchByKeyword('quarterly', 10, [], true);
+
+        $this->assertSame([], $results);
+    }//end testSearchByKeywordUnrankedFallbackDegradesGracefullyOnQueryFailure()
+
+    // =========================================================================
     // findUnvectorized — FIFO work queue (task 5.1)
     // =========================================================================
 

--- a/tests/Unit/Db/FileMapperFindOwningObjectUuidTest.php
+++ b/tests/Unit/Db/FileMapperFindOwningObjectUuidTest.php
@@ -15,7 +15,7 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-3
+ * @spec openspec/changes/expose-content-search-in-object-service/tasks.md
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Db/FileMapperFindOwningObjectUuidTest.php
+++ b/tests/Unit/Db/FileMapperFindOwningObjectUuidTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * FileMapperFindOwningObjectUuidTest
+ *
+ * Unit tests covering FileMapper::findOwningObjectUuid() — the fileId -> owning
+ * object UUID reverse join used by the `_content_search` chunk fan-out.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-3
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Db;
+
+use OCA\OpenRegister\Db\FileMapper;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class FileMapperFindOwningObjectUuidTest extends TestCase
+{
+    private IDBConnection&MockObject $db;
+    private IURLGenerator&MockObject $urlGenerator;
+    private FileMapper $mapper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->db           = $this->createMock(IDBConnection::class);
+        $this->urlGenerator = $this->createMock(IURLGenerator::class);
+        $this->mapper       = new FileMapper($this->db, $this->urlGenerator);
+    }//end setUp()
+
+    private function mockQueryBuilder(): IQueryBuilder&MockObject
+    {
+        $expr = $this->createMock(IExpressionBuilder::class);
+        $expr->method('eq')->willReturnCallback(fn(string $col, $val): string => "$col = $val");
+
+        $qb = $this->createMock(IQueryBuilder::class);
+        $qb->method('select')->willReturnSelf();
+        $qb->method('from')->willReturnSelf();
+        $qb->method('innerJoin')->willReturnSelf();
+        $qb->method('where')->willReturnSelf();
+        $qb->method('expr')->willReturn($expr);
+        $qb->method('createNamedParameter')->willReturnArgument(0);
+
+        $this->db->method('getQueryBuilder')->willReturn($qb);
+
+        return $qb;
+    }//end mockQueryBuilder()
+
+    public function testResolvesOwningObjectUuidFromParentFolderName(): void
+    {
+        $qb   = $this->mockQueryBuilder();
+        $stmt = $this->createMock(IResult::class);
+        $stmt->method('fetchOne')->willReturn('object-uuid-123');
+        $qb->method('executeQuery')->willReturn($stmt);
+
+        $uuid = $this->mapper->findOwningObjectUuid(fileId: 42);
+
+        $this->assertSame('object-uuid-123', $uuid);
+    }//end testResolvesOwningObjectUuidFromParentFolderName()
+
+    public function testReturnsNullWhenNoParentFolderMatches(): void
+    {
+        $qb   = $this->mockQueryBuilder();
+        $stmt = $this->createMock(IResult::class);
+        $stmt->method('fetchOne')->willReturn(false);
+        $qb->method('executeQuery')->willReturn($stmt);
+
+        $uuid = $this->mapper->findOwningObjectUuid(fileId: 999);
+
+        $this->assertNull($uuid);
+    }//end testReturnsNullWhenNoParentFolderMatches()
+
+    public function testReturnsNullWhenParentFolderNameIsEmpty(): void
+    {
+        $qb   = $this->mockQueryBuilder();
+        $stmt = $this->createMock(IResult::class);
+        $stmt->method('fetchOne')->willReturn('');
+        $qb->method('executeQuery')->willReturn($stmt);
+
+        $uuid = $this->mapper->findOwningObjectUuid(fileId: 7);
+
+        $this->assertNull($uuid);
+    }//end testReturnsNullWhenParentFolderNameIsEmpty()
+}//end class

--- a/tests/Unit/Service/Object/ContentSearchHandlerTest.php
+++ b/tests/Unit/Service/Object/ContentSearchHandlerTest.php
@@ -14,7 +14,7 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-6
+ * @spec openspec/changes/expose-content-search-in-object-service/tasks.md
  */
 
 declare(strict_types=1);
@@ -210,7 +210,10 @@ class ContentSearchHandlerTest extends TestCase
         );
 
         $this->assertSame([], $result['results']);
-        $this->assertSame(3, $result['total']);
+        // Total is metaTotal + distinct-chunk-owners upper bound (1 chunk hit
+        // even though it turned out to be unresolvable). See "stable total
+        // across pages" fix — over-count is intentional and accepted.
+        $this->assertSame(4, $result['total']);
     }//end testFileChunkWithUnresolvableOwningObjectIsSkippedSilently()
 
     public function testResolveExceptionIsCaughtLoggedAndSkipped(): void
@@ -232,7 +235,9 @@ class ContentSearchHandlerTest extends TestCase
         );
 
         $this->assertSame([], $result['results']);
-        $this->assertSame(0, $result['total']);
+        // Total is upper-bound: chunk-owner set included the doomed id
+        // before the resolve threw. See "stable total across pages" fix.
+        $this->assertSame(1, $result['total']);
     }//end testResolveExceptionIsCaughtLoggedAndSkipped()
 
     // =========================================================================
@@ -262,7 +267,10 @@ class ContentSearchHandlerTest extends TestCase
         );
 
         $this->assertCount(1, $result['results']);
-        $this->assertSame(1, $result['total']);
+        // Total is upper-bound: chunk-owner set had 1 hit even though it
+        // deduped against the metadata arm. Over-count is intentional per
+        // "stable total across pages" fix — pagination stays consistent.
+        $this->assertSame(2, $result['total']);
     }//end testObjectAlreadyMatchedByMetadataArmIsNotDuplicated()
 
     // =========================================================================
@@ -286,7 +294,9 @@ class ContentSearchHandlerTest extends TestCase
         );
 
         $this->assertSame([], $result['results']);
-        $this->assertSame(0, $result['total']);
+        // Total is upper-bound: the out-of-scope chunk is counted before the
+        // scope filter runs. Over-count accepted per "stable total" fix.
+        $this->assertSame(1, $result['total']);
     }//end testObjectOutsideRequestedRegisterIsSkipped()
 
     public function testObjectOutsideRequestedSchemasIsSkipped(): void
@@ -306,7 +316,9 @@ class ContentSearchHandlerTest extends TestCase
         );
 
         $this->assertSame([], $result['results']);
-        $this->assertSame(0, $result['total']);
+        // Total is upper-bound: the out-of-scope chunk is counted before the
+        // scope filter runs. Over-count accepted per "stable total" fix.
+        $this->assertSame(1, $result['total']);
     }//end testObjectOutsideRequestedSchemasIsSkipped()
 
     public function testUnscopedQueryMatchesAnyRegisterOrSchema(): void
@@ -352,7 +364,11 @@ class ContentSearchHandlerTest extends TestCase
         );
 
         $this->assertCount(1, $result['results']);
-        $this->assertSame(1, $result['total']);
+        // Total is upper-bound = metaTotal + distinct chunk-owner count
+        // (1 chunk hit, room=0 so nothing appended). This is the whole point
+        // of the "stable total" fix: page 2 of the same query would then
+        // append this chunk, and the total stays 2 across both pages.
+        $this->assertSame(2, $result['total']);
     }//end testAppendedRowsAreClampedToRemainingRoomOnThePage()
 
     // =========================================================================
@@ -373,4 +389,52 @@ class ContentSearchHandlerTest extends TestCase
             limit: 20
         );
     }//end testAlwaysRequestsUnrankedFallbackFromChunkMapper()
+
+    // =========================================================================
+    // Pagination-total stability (review discussion on drift)
+    // =========================================================================
+
+    /**
+     * Total reported on a page where room=0 (metadata fills the page) is the
+     * SAME as the total reported on a later page where room>0 (metadata
+     * drained, chunk-only rows appended). Without the stable-total fix, the
+     * two would disagree — page 1 = metaTotal, page 3 = metaTotal + appended.
+     *
+     * Both arms use the same chunk-hit set (mock returns the same list); the
+     * caller changes `results`/`limit` to simulate page-1-full vs page-3-open.
+     */
+    public function testTotalIsStableAcrossPagesForSameQuery(): void
+    {
+        $chunkHits = [
+            ['entity_type' => 'object', 'entity_id' => '101', 'score' => 0.9, 'chunk_text' => 'a', 'chunk_index' => 0, 'metadata' => []],
+            ['entity_type' => 'object', 'entity_id' => '102', 'score' => 0.8, 'chunk_text' => 'b', 'chunk_index' => 0, 'metadata' => []],
+            ['entity_type' => 'object', 'entity_id' => '103', 'score' => 0.7, 'chunk_text' => 'c', 'chunk_index' => 0, 'metadata' => []],
+        ];
+        $this->chunkMapper->method('searchByKeyword')->willReturn($chunkHits);
+        $this->objectMapper->method('find')->willReturnCallback(
+            fn(int $id): ObjectEntity => $this->makeObject($id)
+        );
+
+        // Page 1: metadata filled (10 rows, limit=10) → room=0, no chunks
+        // appended, but total still includes the chunk-owner upper bound.
+        $metaPage = array_map(fn(int $id): ObjectEntity => $this->makeObject($id), range(1, 10));
+        $pageOne  = $this->handler->augmentWithChunkMatches(
+            query: ['_search' => 'q'],
+            results: $metaPage,
+            total: 50,
+            limit: 10
+        );
+        $this->assertCount(10, $pageOne['results']);
+        $this->assertSame(53, $pageOne['total']);
+
+        // Page 3 (offset=40, limit=10): metadata returned 10 rows, chunks fill
+        // remaining rows on this page — total stays 53, unchanged.
+        $pageThree = $this->handler->augmentWithChunkMatches(
+            query: ['_search' => 'q'],
+            results: array_slice($metaPage, 0, 5),
+            total: 50,
+            limit: 10
+        );
+        $this->assertSame(53, $pageThree['total']);
+    }//end testTotalIsStableAcrossPagesForSameQuery()
 }//end class

--- a/tests/Unit/Service/Object/ContentSearchHandlerTest.php
+++ b/tests/Unit/Service/Object/ContentSearchHandlerTest.php
@@ -1,0 +1,368 @@
+<?php
+
+/**
+ * ContentSearchHandlerTest
+ *
+ * Unit tests for the opt-in `_content_search` chunk fan-out handler.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-6
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Object;
+
+use OCA\OpenRegister\Db\ChunkMapper;
+use OCA\OpenRegister\Db\FileMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Object\ContentSearchHandler;
+use OCP\AppFramework\Db\DoesNotExistException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Covers ZKN-CONTENT-001/-002/-003:
+ * - default-off byte-identity (no chunk query when `_search`/limit absent).
+ * - chunk hits resolved to owning objects (both source_type='object' and 'file').
+ * - dedup on object id, register/schema scope filtering, silent-skip on failure.
+ */
+class ContentSearchHandlerTest extends TestCase
+{
+    private ChunkMapper&MockObject $chunkMapper;
+    private FileMapper&MockObject $fileMapper;
+    private MagicMapper&MockObject $objectMapper;
+    private LoggerInterface&MockObject $logger;
+    private ContentSearchHandler $handler;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->chunkMapper  = $this->createMock(ChunkMapper::class);
+        $this->fileMapper   = $this->createMock(FileMapper::class);
+        $this->objectMapper = $this->createMock(MagicMapper::class);
+        $this->logger       = $this->createMock(LoggerInterface::class);
+
+        $this->handler = new ContentSearchHandler(
+            $this->chunkMapper,
+            $this->fileMapper,
+            $this->objectMapper,
+            $this->logger
+        );
+    }//end setUp()
+
+    /**
+     * Build an ObjectEntity test double with id/register/schema set.
+     */
+    private function makeObject(int $id, string $register='1', string $schema='1'): ObjectEntity
+    {
+        $object = new ObjectEntity();
+        $object->setId($id);
+        $object->setRegister($register);
+        $object->setSchema($schema);
+
+        return $object;
+    }//end makeObject()
+
+    // =========================================================================
+    // No-op paths (default-off byte-identity, ZKN-CONTENT-001)
+    // =========================================================================
+
+    public function testNoSearchTermReturnsResultsAndTotalUnchanged(): void
+    {
+        $this->chunkMapper->expects($this->never())->method('searchByKeyword');
+
+        $result = $this->handler->augmentWithChunkMatches(
+            query: [],
+            results: [],
+            total: 0,
+            limit: 20
+        );
+
+        $this->assertSame([], $result['results']);
+        $this->assertSame(0, $result['total']);
+    }//end testNoSearchTermReturnsResultsAndTotalUnchanged()
+
+    public function testZeroLimitSkipsChunkFanOut(): void
+    {
+        $this->chunkMapper->expects($this->never())->method('searchByKeyword');
+
+        $result = $this->handler->augmentWithChunkMatches(
+            query: ['_search' => 'quarterly report'],
+            results: [],
+            total: 0,
+            limit: 0
+        );
+
+        $this->assertSame([], $result['results']);
+        $this->assertSame(0, $result['total']);
+    }//end testZeroLimitSkipsChunkFanOut()
+
+    public function testEmptyChunkHitsReturnsResultsAndTotalUnchanged(): void
+    {
+        $this->chunkMapper->method('searchByKeyword')->willReturn([]);
+        $this->objectMapper->expects($this->never())->method('find');
+
+        $existing = [$this->makeObject(1)];
+        $result   = $this->handler->augmentWithChunkMatches(
+            query: ['_search' => 'quarterly report'],
+            results: $existing,
+            total: 1,
+            limit: 20
+        );
+
+        $this->assertSame($existing, $result['results']);
+        $this->assertSame(1, $result['total']);
+    }//end testEmptyChunkHitsReturnsResultsAndTotalUnchanged()
+
+    // =========================================================================
+    // Chunk-hit -> owning-object resolution (ZKN-CONTENT-002)
+    // =========================================================================
+
+    public function testObjectSourceTypeResolvesDirectlyByEntityId(): void
+    {
+        $this->chunkMapper->method('searchByKeyword')->willReturn(
+            [
+                ['entity_type' => 'object', 'entity_id' => '42', 'score' => 0.8, 'chunk_text' => 'x', 'chunk_index' => 0, 'metadata' => []],
+            ]
+        );
+
+        $matchedObject = $this->makeObject(42);
+        $this->objectMapper->expects($this->once())
+            ->method('find')
+            ->with(42)
+            ->willReturn($matchedObject);
+        $this->fileMapper->expects($this->never())->method('findOwningObjectUuid');
+
+        $result = $this->handler->augmentWithChunkMatches(
+            query: ['_search' => 'quarterly report'],
+            results: [],
+            total: 0,
+            limit: 20
+        );
+
+        $this->assertCount(1, $result['results']);
+        $this->assertSame($matchedObject, $result['results'][0]);
+        $this->assertSame(1, $result['total']);
+    }//end testObjectSourceTypeResolvesDirectlyByEntityId()
+
+    public function testFileSourceTypeResolvesViaFileMapperJoin(): void
+    {
+        $this->chunkMapper->method('searchByKeyword')->willReturn(
+            [
+                ['entity_type' => 'file', 'entity_id' => '100', 'score' => 0.8, 'chunk_text' => 'x', 'chunk_index' => 0, 'metadata' => []],
+            ]
+        );
+
+        $this->fileMapper->expects($this->once())
+            ->method('findOwningObjectUuid')
+            ->with(100)
+            ->willReturn('obj-uuid-7');
+
+        $matchedObject = $this->makeObject(7);
+        $this->objectMapper->expects($this->once())
+            ->method('find')
+            ->with('obj-uuid-7')
+            ->willReturn($matchedObject);
+
+        $result = $this->handler->augmentWithChunkMatches(
+            query: ['_search' => 'quarterly report'],
+            results: [],
+            total: 0,
+            limit: 20
+        );
+
+        $this->assertCount(1, $result['results']);
+        $this->assertSame($matchedObject, $result['results'][0]);
+    }//end testFileSourceTypeResolvesViaFileMapperJoin()
+
+    public function testFileChunkWithUnresolvableOwningObjectIsSkippedSilently(): void
+    {
+        $this->chunkMapper->method('searchByKeyword')->willReturn(
+            [
+                ['entity_type' => 'file', 'entity_id' => '999', 'score' => 0.8, 'chunk_text' => 'x', 'chunk_index' => 0, 'metadata' => []],
+            ]
+        );
+
+        $this->fileMapper->method('findOwningObjectUuid')->willReturn(null);
+        $this->objectMapper->expects($this->never())->method('find');
+
+        $result = $this->handler->augmentWithChunkMatches(
+            query: ['_search' => 'quarterly report'],
+            results: [],
+            total: 3,
+            limit: 20
+        );
+
+        $this->assertSame([], $result['results']);
+        $this->assertSame(3, $result['total']);
+    }//end testFileChunkWithUnresolvableOwningObjectIsSkippedSilently()
+
+    public function testResolveExceptionIsCaughtLoggedAndSkipped(): void
+    {
+        $this->chunkMapper->method('searchByKeyword')->willReturn(
+            [
+                ['entity_type' => 'object', 'entity_id' => '55', 'score' => 0.8, 'chunk_text' => 'x', 'chunk_index' => 0, 'metadata' => []],
+            ]
+        );
+
+        $this->objectMapper->method('find')->willThrowException(new DoesNotExistException('not found'));
+        $this->logger->expects($this->once())->method('debug');
+
+        $result = $this->handler->augmentWithChunkMatches(
+            query: ['_search' => 'quarterly report'],
+            results: [],
+            total: 0,
+            limit: 20
+        );
+
+        $this->assertSame([], $result['results']);
+        $this->assertSame(0, $result['total']);
+    }//end testResolveExceptionIsCaughtLoggedAndSkipped()
+
+    // =========================================================================
+    // Dedup on object id (ZKN-CONTENT-002/-003)
+    // =========================================================================
+
+    public function testObjectAlreadyMatchedByMetadataArmIsNotDuplicated(): void
+    {
+        $existing = $this->makeObject(42);
+
+        $this->chunkMapper->method('searchByKeyword')->willReturn(
+            [
+                ['entity_type' => 'object', 'entity_id' => '42', 'score' => 0.8, 'chunk_text' => 'x', 'chunk_index' => 0, 'metadata' => []],
+            ]
+        );
+        $this->objectMapper->expects($this->never())->method('find');
+
+        $result = $this->handler->augmentWithChunkMatches(
+            query: ['_search' => 'quarterly report'],
+            results: [$existing],
+            total: 1,
+            limit: 20
+        );
+
+        $this->assertCount(1, $result['results']);
+        $this->assertSame(1, $result['total']);
+    }//end testObjectAlreadyMatchedByMetadataArmIsNotDuplicated()
+
+    // =========================================================================
+    // Register / schema scope filtering
+    // =========================================================================
+
+    public function testObjectOutsideRequestedRegisterIsSkipped(): void
+    {
+        $this->chunkMapper->method('searchByKeyword')->willReturn(
+            [
+                ['entity_type' => 'object', 'entity_id' => '42', 'score' => 0.8, 'chunk_text' => 'x', 'chunk_index' => 0, 'metadata' => []],
+            ]
+        );
+        $this->objectMapper->method('find')->willReturn($this->makeObject(42, register: '9'));
+
+        $result = $this->handler->augmentWithChunkMatches(
+            query: ['_search' => 'quarterly report', '_register' => 5],
+            results: [],
+            total: 0,
+            limit: 20
+        );
+
+        $this->assertSame([], $result['results']);
+        $this->assertSame(0, $result['total']);
+    }//end testObjectOutsideRequestedRegisterIsSkipped()
+
+    public function testObjectOutsideRequestedSchemasIsSkipped(): void
+    {
+        $this->chunkMapper->method('searchByKeyword')->willReturn(
+            [
+                ['entity_type' => 'object', 'entity_id' => '42', 'score' => 0.8, 'chunk_text' => 'x', 'chunk_index' => 0, 'metadata' => []],
+            ]
+        );
+        $this->objectMapper->method('find')->willReturn($this->makeObject(42, schema: '99'));
+
+        $result = $this->handler->augmentWithChunkMatches(
+            query: ['_search' => 'quarterly report', '_schemas' => [1, 2]],
+            results: [],
+            total: 0,
+            limit: 20
+        );
+
+        $this->assertSame([], $result['results']);
+        $this->assertSame(0, $result['total']);
+    }//end testObjectOutsideRequestedSchemasIsSkipped()
+
+    public function testUnscopedQueryMatchesAnyRegisterOrSchema(): void
+    {
+        $this->chunkMapper->method('searchByKeyword')->willReturn(
+            [
+                ['entity_type' => 'object', 'entity_id' => '42', 'score' => 0.8, 'chunk_text' => 'x', 'chunk_index' => 0, 'metadata' => []],
+            ]
+        );
+        $matched = $this->makeObject(42, register: '9', schema: '77');
+        $this->objectMapper->method('find')->willReturn($matched);
+
+        $result = $this->handler->augmentWithChunkMatches(
+            query: ['_search' => 'quarterly report'],
+            results: [],
+            total: 0,
+            limit: 20
+        );
+
+        $this->assertCount(1, $result['results']);
+        $this->assertSame($matched, $result['results'][0]);
+    }//end testUnscopedQueryMatchesAnyRegisterOrSchema()
+
+    // =========================================================================
+    // Page-limit clamping
+    // =========================================================================
+
+    public function testAppendedRowsAreClampedToRemainingRoomOnThePage(): void
+    {
+        $this->chunkMapper->method('searchByKeyword')->willReturn(
+            [
+                ['entity_type' => 'object', 'entity_id' => '42', 'score' => 0.8, 'chunk_text' => 'x', 'chunk_index' => 0, 'metadata' => []],
+            ]
+        );
+        $this->objectMapper->expects($this->never())->method('find');
+
+        // limit=1, already 1 metadata-match result -> zero room for chunk-only appends.
+        $result = $this->handler->augmentWithChunkMatches(
+            query: ['_search' => 'quarterly report'],
+            results: [$this->makeObject(1)],
+            total: 1,
+            limit: 1
+        );
+
+        $this->assertCount(1, $result['results']);
+        $this->assertSame(1, $result['total']);
+    }//end testAppendedRowsAreClampedToRemainingRoomOnThePage()
+
+    // =========================================================================
+    // Uses the unranked fallback (ZKN-CONTENT-001 MariaDB scenario)
+    // =========================================================================
+
+    public function testAlwaysRequestsUnrankedFallbackFromChunkMapper(): void
+    {
+        $this->chunkMapper->expects($this->once())
+            ->method('searchByKeyword')
+            ->with('quarterly report', $this->anything(), $this->anything(), true)
+            ->willReturn([]);
+
+        $this->handler->augmentWithChunkMatches(
+            query: ['_search' => 'quarterly report'],
+            results: [],
+            total: 0,
+            limit: 20
+        );
+    }//end testAlwaysRequestsUnrankedFallbackFromChunkMapper()
+}//end class

--- a/tests/Unit/Service/Object/ContentSearchHandlerTest.php
+++ b/tests/Unit/Service/Object/ContentSearchHandlerTest.php
@@ -63,12 +63,16 @@ class ContentSearchHandlerTest extends TestCase
     }//end setUp()
 
     /**
-     * Build an ObjectEntity test double with id/register/schema set.
+     * Build an ObjectEntity test double with id/uuid/register/schema set.
+     *
+     * UUID is derived from the numeric id ("obj-uuid-<id>") so tests can dedup
+     * on UUID (production code keys dedup on getUuid() — see ContentSearchHandler).
      */
     private function makeObject(int $id, string $register='1', string $schema='1'): ObjectEntity
     {
         $object = new ObjectEntity();
         $object->setId($id);
+        $object->setUuid('obj-uuid-' . $id);
         $object->setRegister($register);
         $object->setSchema($schema);
 
@@ -244,7 +248,11 @@ class ContentSearchHandlerTest extends TestCase
                 ['entity_type' => 'object', 'entity_id' => '42', 'score' => 0.8, 'chunk_text' => 'x', 'chunk_index' => 0, 'metadata' => []],
             ]
         );
-        $this->objectMapper->expects($this->never())->method('find');
+        // The chunk resolves to the same object that the metadata arm already
+        // returned. objectMapper->find() is called once (dedup happens after
+        // resolve — seenUuids is keyed by getUuid() which is not derivable from
+        // the numeric chunk source_id without loading the object).
+        $this->objectMapper->method('find')->willReturn($existing);
 
         $result = $this->handler->augmentWithChunkMatches(
             query: ['_search' => 'quarterly report'],

--- a/tests/Unit/Service/Object/QueryHandlerContentSearchTest.php
+++ b/tests/Unit/Service/Object/QueryHandlerContentSearchTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * QueryHandlerContentSearchTest
+ *
+ * Unit tests covering the `_content_search` wiring in
+ * QueryHandler::searchObjectsPaginatedDatabase() — the seam that fans out to
+ * ContentSearchHandler only when the caller opts in.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Object;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Object\ContentSearchHandler;
+use OCA\OpenRegister\Service\Object\FacetHandler;
+use OCA\OpenRegister\Service\Object\GetObject;
+use OCA\OpenRegister\Service\Object\PerformanceOptimizationHandler;
+use OCA\OpenRegister\Service\Object\QueryHandler;
+use OCA\OpenRegister\Service\Object\RenderObject;
+use OCA\OpenRegister\Service\Object\SearchQueryHandler;
+use OCP\AppFramework\IAppContainer;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class QueryHandlerContentSearchTest extends TestCase
+{
+    private MagicMapper&MockObject $objectMapper;
+    private ContentSearchHandler&MockObject $contentSearchHandler;
+    private QueryHandler $handler;
+
+    /** @var ObjectEntity[] */
+    private array $metadataMatchResults;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $matched = new ObjectEntity();
+        $matched->setId(1);
+        $this->metadataMatchResults = [$matched];
+
+        $this->objectMapper = $this->createMock(MagicMapper::class);
+        $this->objectMapper->method('searchObjectsPaginated')->willReturn(
+            [
+                'results'   => $this->metadataMatchResults,
+                'total'     => 1,
+                'registers' => [],
+                'schemas'   => [],
+                'facets'    => [],
+                'facetable' => [],
+            ]
+        );
+
+        $this->contentSearchHandler = $this->createMock(ContentSearchHandler::class);
+
+        $this->handler = new QueryHandler(
+            $this->objectMapper,
+            $this->createMock(GetObject::class),
+            $this->createMock(RenderObject::class),
+            $this->createMock(SearchQueryHandler::class),
+            $this->createMock(FacetHandler::class),
+            $this->createMock(PerformanceOptimizationHandler::class),
+            $this->contentSearchHandler,
+            $this->createMock(IAppContainer::class),
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(IRequest::class)
+        );
+    }//end setUp()
+
+    public function testContentSearchHandlerIsNeverCalledWhenFlagAbsent(): void
+    {
+        $this->contentSearchHandler->expects($this->never())->method('augmentWithChunkMatches');
+
+        $result = $this->handler->searchObjectsPaginatedDatabase(
+            query: ['_search' => 'quarterly report'],
+            _rbac: false,
+            _multitenancy: false
+        );
+
+        $this->assertSame($this->metadataMatchResults, $result['results']);
+        $this->assertSame(1, $result['total']);
+    }//end testContentSearchHandlerIsNeverCalledWhenFlagAbsent()
+
+    public function testContentSearchHandlerIsNeverCalledWhenFlagExplicitlyFalse(): void
+    {
+        $this->contentSearchHandler->expects($this->never())->method('augmentWithChunkMatches');
+
+        $this->handler->searchObjectsPaginatedDatabase(
+            query: ['_search' => 'quarterly report', '_content_search' => false],
+            _rbac: false,
+            _multitenancy: false
+        );
+    }//end testContentSearchHandlerIsNeverCalledWhenFlagExplicitlyFalse()
+
+    public function testContentSearchHandlerIsInvokedAndItsResultReplacesResultsAndTotalWhenFlagTrue(): void
+    {
+        $chunkMatch = new ObjectEntity();
+        $chunkMatch->setId(2);
+
+        $this->contentSearchHandler->expects($this->once())
+            ->method('augmentWithChunkMatches')
+            ->with(
+                $this->callback(fn(array $query): bool => ($query['_content_search'] ?? null) === true),
+                $this->metadataMatchResults,
+                1,
+                20,
+                false,
+                false
+            )
+            ->willReturn(
+                [
+                    'results' => array_merge($this->metadataMatchResults, [$chunkMatch]),
+                    'total'   => 2,
+                ]
+            );
+
+        $result = $this->handler->searchObjectsPaginatedDatabase(
+            query: ['_search' => 'quarterly report', '_content_search' => true, '_limit' => 20],
+            _rbac: false,
+            _multitenancy: false
+        );
+
+        $this->assertCount(2, $result['results']);
+        $this->assertSame(2, $result['total']);
+    }//end testContentSearchHandlerIsInvokedAndItsResultReplacesResultsAndTotalWhenFlagTrue()
+}//end class

--- a/tests/Unit/Service/Object/QueryHandlerContentSearchTest.php
+++ b/tests/Unit/Service/Object/QueryHandlerContentSearchTest.php
@@ -16,7 +16,7 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/expose-content-search-in-object-service/tasks.md#task-2
+ * @spec openspec/changes/expose-content-search-in-object-service/tasks.md
  */
 
 declare(strict_types=1);
@@ -139,4 +139,63 @@ class QueryHandlerContentSearchTest extends TestCase
         $this->assertCount(2, $result['results']);
         $this->assertSame(2, $result['total']);
     }//end testContentSearchHandlerIsInvokedAndItsResultReplacesResultsAndTotalWhenFlagTrue()
+
+    /**
+     * Regression: HTTP query params arrive as strings; the flag gate must coerce
+     * so `?_content_search=true` fires the handler. Prior to the fix at
+     * QueryHandler.php:419 (`filter_var(..., FILTER_VALIDATE_BOOLEAN)`) the
+     * check was strict-identity against `true` and every string form was
+     * silently ignored — the whole `_content_search` wire was dead from HTTP.
+     *
+     * @dataProvider provideTruthyStringForms
+     */
+    public function testContentSearchHandlerIsInvokedForTruthyStringForms(mixed $flag): void
+    {
+        $this->contentSearchHandler->expects($this->once())
+            ->method('augmentWithChunkMatches')
+            ->willReturn(['results' => $this->metadataMatchResults, 'total' => 1]);
+
+        $this->handler->searchObjectsPaginatedDatabase(
+            query: ['_search' => 'q', '_content_search' => $flag],
+            _rbac: false,
+            _multitenancy: false
+        );
+    }//end testContentSearchHandlerIsInvokedForTruthyStringForms()
+
+    /**
+     * Regression: falsy string forms must NOT fire the handler.
+     *
+     * @dataProvider provideFalsyStringForms
+     */
+    public function testContentSearchHandlerIsNotInvokedForFalsyStringForms(mixed $flag): void
+    {
+        $this->contentSearchHandler->expects($this->never())->method('augmentWithChunkMatches');
+
+        $this->handler->searchObjectsPaginatedDatabase(
+            query: ['_search' => 'q', '_content_search' => $flag],
+            _rbac: false,
+            _multitenancy: false
+        );
+    }//end testContentSearchHandlerIsNotInvokedForFalsyStringForms()
+
+    public static function provideTruthyStringForms(): array
+    {
+        return [
+            'string "true"' => ['true'],
+            'string "1"'    => ['1'],
+            'int 1'         => [1],
+            'bool true'     => [true],
+        ];
+    }//end provideTruthyStringForms()
+
+    public static function provideFalsyStringForms(): array
+    {
+        return [
+            'string "false"' => ['false'],
+            'string "0"'     => ['0'],
+            'int 0'          => [0],
+            'bool false'     => [false],
+            'empty string'   => [''],
+        ];
+    }//end provideFalsyStringForms()
 }//end class

--- a/tests/Unit/Service/Object/QueryHandlerLimitClampTest.php
+++ b/tests/Unit/Service/Object/QueryHandlerLimitClampTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Unit\Service\Object;
 
 use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Service\Object\ContentSearchHandler;
 use OCA\OpenRegister\Service\Object\FacetHandler;
 use OCA\OpenRegister\Service\Object\GetObject;
 use OCA\OpenRegister\Service\Object\PerformanceOptimizationHandler;
@@ -56,6 +57,7 @@ class QueryHandlerLimitClampTest extends TestCase
             $this->createMock(SearchQueryHandler::class),
             $this->createMock(FacetHandler::class),
             $this->createMock(PerformanceOptimizationHandler::class),
+            $this->createMock(ContentSearchHandler::class),
             $this->createMock(IAppContainer::class),
             $this->createMock(LoggerInterface::class),
             $this->createMock(IRequest::class)

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,6 +22,14 @@ define('PHPUNIT_RUN', 1);
 // Include Composer's autoloader.
 require_once __DIR__ . '/../vendor/autoload.php';
 
+// Breadcrumb: the Doctrine-DBAL / NC-internal / OCP-fallback / Doriath stubs
+// used to be loaded here, before the NC bootstrap. They now live BELOW the
+// real-NC bootstrap block (see lines 132+); each stub is `class_exists()` /
+// `interface_exists()` guarded and safely no-ops when the live NC already
+// supplies the real class. Moving the loads down avoids the "Cannot declare
+// class OC, because the name is already in use" race that could fire when a
+// live NC beat the stubs to declaring `OC`.
+
 /**
  * Resolve the Nextcloud installation root.
  *

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,45 +22,6 @@ define('PHPUNIT_RUN', 1);
 // Include Composer's autoloader.
 require_once __DIR__ . '/../vendor/autoload.php';
 
-// Load minimal Doctrine DBAL stubs so nextcloud/ocp interface constants
-// (IQueryBuilder::PARAM_NULL = ParameterType::NULL, etc.) can be evaluated in
-// the bare php:8.3-cli CI environment where doctrine/dbal is not installed.
-// The stubs are class_exists-guarded, so they are skipped when the real
-// doctrine/dbal is present (e.g. inside a bootstrapped Nextcloud container).
-// Mirrors tests/bootstrap-unit.php; without this, mocking IQueryBuilder in a
-// pure-unit run fatals with "Class Doctrine\DBAL\ParameterType not found".
-require_once __DIR__ . '/stubs/DoctrineDbalStubs.php';
-
-// Load minimal Nextcloud internal-class stubs (OC\Hooks\Emitter, etc.) that
-// the nextcloud/ocp stubs reference but the OCP package does not ship.
-require_once __DIR__ . '/stubs/NextcloudInternalStubs.php';
-
-// Register the nextcloud/ocp stubs for OCP\* / NCU\* — but ONLY here, in the test
-// entry point, and only when no live Nextcloud already supplies them. Registered
-// AFTER the Doctrine stubs above: IQueryBuilder declares constants that reference
-// Doctrine\DBAL\ParameterType, evaluated the moment the file is parsed, so the
-// placeholders must already be in the class table.
-//
-// This mapping must NEVER live in composer.json. `autoload-dev` IS baked into the
-// generated autoloader by a plain `composer install`, and in the dev topology the
-// app checkout IS the served app — Application.php requires vendor/autoload.php, so
-// the stubs would shadow core's OCP on every request. With stubs pinned to a
-// different Nextcloud major than the running server, core's `#[\Override]`
-// attributes then have no matching parent method and PHP raises a COMPILE-TIME
-// fatal that takes down the WHOLE instance (occ dead, 0 apps, every route 404/500).
-// That is the 2026-07-12 outage. Static analysis does not need the mapping either:
-// PHPStan reads the stubs via `scanDirectories`, Psalm via `<extraFiles>`.
-if (interface_exists(\OCP\IUser::class) === false) {
-    $ocpLoader = new \Composer\Autoload\ClassLoader();
-    $ocpLoader->addPsr4('OCP\\', __DIR__ . '/../vendor/nextcloud/ocp/OCP/');
-    $ocpLoader->addPsr4('NCU\\', __DIR__ . '/../vendor/nextcloud/ocp/NCU/');
-    $ocpLoader->register();
-}
-
-// Load the Doriath contract stubs + test fixtures for the credential-broker
-// Doriath custody leaf (class_exists-guarded — a real Doriath install wins).
-require_once __DIR__ . '/stubs/DoriathStubs.php';
-
 /**
  * Resolve the Nextcloud installation root.
  *
@@ -167,3 +128,49 @@ if ($skipNc === false && !defined('OC_CONSOLE')) {
         );
     }
 }
+
+// Load minimal Doctrine DBAL stubs so nextcloud/ocp interface constants
+// (IQueryBuilder::PARAM_NULL = ParameterType::NULL, etc.) can be evaluated in
+// the bare php:8.3-cli CI environment where doctrine/dbal is not installed.
+// The stubs are class_exists-guarded, so they are skipped when the real
+// doctrine/dbal is present (e.g. inside a bootstrapped Nextcloud container).
+// Mirrors tests/bootstrap-unit.php; without this, mocking IQueryBuilder in a
+// pure-unit run fatals with "Class Doctrine\DBAL\ParameterType not found".
+//
+// Loaded AFTER the real-NC bootstrap attempt above (not before): every stub in
+// this block and the two below is individually class_exists()/interface_exists()
+// guarded against the REAL class, so ordering it after the real bootstrap lets
+// those guards see the real classes when a live Nextcloud root was found and
+// correctly no-op, instead of racing the real declarations and fataling with
+// "Cannot declare class OC, because the name is already in use".
+require_once __DIR__ . '/stubs/DoctrineDbalStubs.php';
+
+// Load minimal Nextcloud internal-class stubs (OC\Hooks\Emitter, etc.) that
+// the nextcloud/ocp stubs reference but the OCP package does not ship.
+require_once __DIR__ . '/stubs/NextcloudInternalStubs.php';
+
+// Register the nextcloud/ocp stubs for OCP\* / NCU\* — but ONLY here, in the test
+// entry point, and only when no live Nextcloud already supplies them. Registered
+// AFTER the Doctrine stubs above: IQueryBuilder declares constants that reference
+// Doctrine\DBAL\ParameterType, evaluated the moment the file is parsed, so the
+// placeholders must already be in the class table.
+//
+// This mapping must NEVER live in composer.json. `autoload-dev` IS baked into the
+// generated autoloader by a plain `composer install`, and in the dev topology the
+// app checkout IS the served app — Application.php requires vendor/autoload.php, so
+// the stubs would shadow core's OCP on every request. With stubs pinned to a
+// different Nextcloud major than the running server, core's `#[\Override]`
+// attributes then have no matching parent method and PHP raises a COMPILE-TIME
+// fatal that takes down the WHOLE instance (occ dead, 0 apps, every route 404/500).
+// That is the 2026-07-12 outage. Static analysis does not need the mapping either:
+// PHPStan reads the stubs via `scanDirectories`, Psalm via `<extraFiles>`.
+if (interface_exists(\OCP\IUser::class) === false) {
+    $ocpLoader = new \Composer\Autoload\ClassLoader();
+    $ocpLoader->addPsr4('OCP\\', __DIR__ . '/../vendor/nextcloud/ocp/OCP/');
+    $ocpLoader->addPsr4('NCU\\', __DIR__ . '/../vendor/nextcloud/ocp/NCU/');
+    $ocpLoader->register();
+}
+
+// Load the Doriath contract stubs + test fixtures for the credential-broker
+// Doriath custody leaf (class_exists-guarded — a real Doriath install wins).
+require_once __DIR__ . '/stubs/DoriathStubs.php';


### PR DESCRIPTION
Mirror of merged Codeberg PRs that landed after the 2026-07-16 sync window:

- **Codeberg PR #473**: `feat(search): expose _content_search on searchObjectsPaginated (WOO-517)`
- **Codeberg PR #473 follow-ups**: phpcs auto-fix, content-search re-review & self-review, coerce+dedup on UUID
- Hydra cycle bookkeeping

Codeberg reference: https://codeberg.org/Conduction/openregister/pulls/473
Jira: WOO-517

Automated catchup after Codeberg→GitHub sync (Wed 2026-07-15 evening) — content is already in production via Codeberg.