### PR TITLE
fix(lifecycle): initial-only x-openregister-lifecycle must not fail-closed every status change

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -893,8 +893,18 @@ class SettingsController extends Controller
                 ->where($qb->expr()->like('o.name', $qb->createNamedParameter('%Samenwerking%')))
                 ->orWhere($qb->expr()->like('o.name', $qb->createNamedParameter('%Community%')));
 
+            // NC's IResult does not expose Doctrine's fetchAllAssociative() on
+            // every supported server (absent on NC 32) — iterate fetch() instead
+            // (see RegisterMapper::getAllRegisterIdsWithSchema / MarkerLookupTrait).
             $stmt = $qb->executeQuery();
-            $rows = $stmt->fetchAllAssociative();
+            $rows = [];
+            $row  = $stmt->fetch();
+            while ($row !== false) {
+                $rows[] = $row;
+                $row    = $stmt->fetch();
+            }
+
+            $stmt->closeCursor();
 
             $results['direct_database_query'] = [
                 'count'         => count($rows),

--- a/lib/Db/RegisterMapper.php
+++ b/lib/Db/RegisterMapper.php
@@ -872,8 +872,24 @@ class RegisterMapper extends QBMapper
         $qb->select('id', 'schemas')
             ->from('openregister_registers');
 
-        $candidates = $qb->executeQuery()->fetchAllAssociative();
-        $needle     = (string) $schemaId;
+        // NC's IResult (OC\DB\ResultAdapter) does not expose Doctrine's
+        // fetchAllAssociative() on every supported server (absent on NC 32) —
+        // calling it throws "undefined method". This method runs inside the
+        // PermissionHandler authorization resolver (getRegisterForSchema), whose
+        // catch re-throws as AuthorizationUnresolvableException and FAIL-CLOSES
+        // the action — so on NC 32 EVERY RBAC-checked read (find(): dashboard
+        // widgets, status-transition engine, single-object reads) is denied,
+        // even for admin. Iterate fetch() instead, matching MarkerLookupTrait.
+        $result     = $qb->executeQuery();
+        $candidates = [];
+        $row        = $result->fetch();
+        while ($row !== false) {
+            $candidates[] = $row;
+            $row          = $result->fetch();
+        }
+
+        $result->closeCursor();
+        $needle = (string) $schemaId;
         $matches    = [];
 
         foreach ($candidates as $row) {

--- a/lib/Listener/LifecycleValidationListener.php
+++ b/lib/Listener/LifecycleValidationListener.php
@@ -151,7 +151,22 @@ class LifecycleValidationListener implements IEventListener
         }
 
         $transitions = ($annotation['transitions'] ?? []);
-        $matched     = $this->findTransitionByTarget(
+
+        // Initial-only lifecycle: a schema may declare `x-openregister-lifecycle`
+        // solely to derive the START state (e.g. procest's `case` schema —
+        // `{ field: status, initial: { from: caseType, field: initialStatus } }`)
+        // while OWNING transition validation itself (procest routes every status
+        // change through its workflow-template state engine). With no declared
+        // `transitions` there is nothing for OR to enforce, so validating here
+        // fail-closes EVERY status change (findTransitionByTarget([]) === null →
+        // reject), silently breaking those apps' status advancement. Treat an
+        // empty/absent transition set as "app-managed" and skip enforcement; the
+        // initial state is still pinned by LifecycleInitialStateListener.
+        if (empty($transitions) === true) {
+            return;
+        }
+
+        $matched = $this->findTransitionByTarget(
             transitions: $transitions,
             oldValue: (string) $oldValue,
             newValue: $newValue


### PR DESCRIPTION
## Problem

`LifecycleValidationListener` validates a status change against the schema annotation's `transitions` and rejects when no transition matches (`findTransitionByTarget(...) === null`). But there is **no guard for an empty/absent transition set**.

A schema may legitimately declare `x-openregister-lifecycle` with only an `initial` block and **no `transitions`** — to have OR derive the *start* state while the app owns transition validation itself. procest's `case` schema does exactly this:

```json
{ "field": "status", "initial": { "from": "caseType", "field": "initialStatus" } }
```

procest routes every advance through its own workflow-template state engine. With no declared transitions, `findTransitionByTarget([])` returns null, so the listener **rejected every status change** (`lifecycle-invalid-transition`) — silently breaking case status advancement app-wide. procest's transition engine surfaces it as a 500 (`No transition allows moving "status" from … to …`).

## Fix

Treat an empty/absent `transitions` set as **app-managed**: skip transition enforcement (early return). The initial state is still pinned by `LifecycleInitialStateListener`, and schemas that DO declare `transitions` are still fully enforced, including their guards.

## Verification

Reproduced + fixed on a live NC-32 instance (procest + OpenRegister). Before: procest `executeTransition` → 500 `No transition allows moving …`. After: procest's case state-machine e2e specs pass — the *advance* transition succeeds **and** an invalid transition (missing required field) is still correctly blocked.

Companion to #2035 (both surfaced running procest's live-NC e2e on NC 32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)