### PR TITLE
fix(validate): strip $ref from array items given as an associative array

### DIFF
--- a/lib/Service/Object/ValidateObject.php
+++ b/lib/Service/Object/ValidateObject.php
@@ -527,6 +527,15 @@ class ValidateObject
         $isArrayType = ($propertySchema->type ?? null) !== null
             && $propertySchema->type === 'array';
         $hasItems    = ($propertySchema->items ?? null) !== null;
+        // `items` may decode as an associative array rather than a stdClass depending on the
+        // schema source; normalise it to an object so the $ref-strip below runs. Without this,
+        // an array-items $ref (e.g. `installedOn.items {"$ref":"Agent"}`) is left intact and
+        // Opis JSON Schema fails with "Unresolved reference: schema:///Agent#" — unlike a scalar
+        // string $ref, which is stripped by a separate branch that needs no object cast.
+        if ($isArrayType === true && $hasItems === true && is_array($propertySchema->items) === true) {
+            $propertySchema->items = (object) $propertySchema->items;
+        }
+
         if ($isArrayType === true && $hasItems === true && is_object($propertySchema->items) === true) {
             $itemsSchema = $propertySchema->items;
 

--- a/tests/Unit/Service/Object/ValidateObjectArrayRefTest.php
+++ b/tests/Unit/Service/Object/ValidateObjectArrayRefTest.php
@@ -191,4 +191,35 @@ class ValidateObjectArrayRefTest extends TestCase
 
         $this->assertTrue($result->isValid(), 'nested array-of-objects must keep its object items');
     }//end testNestedArrayOfObjectsStillValidates()
+
+    /**
+     * Regression: when a property's `items` decodes as an associative ARRAY rather
+     * than a stdClass (as `Schema::getSchemaObject()` produces for some sources —
+     * e.g. hermiq `Skill.installedOn.items {"$ref":"Agent"}`), the array-items
+     * $ref-strip must still run. Before the fix the `is_object($items)` guard
+     * skipped it, leaving the bare `$ref` for Opis and raising
+     * "Unresolved reference: schema:///Agent#" (HTTP 500) on every install.
+     *
+     * @return void
+     */
+    public function testArrayItemsAsAssociativeArrayStillStripsRef(): void
+    {
+        // Build the schema with `items` as a PHP array (NOT a stdClass), the shape
+        // that triggered the bug — json_decode() would otherwise yield an object.
+        $schemaObject             = new stdClass();
+        $schemaObject->type       = 'object';
+        $property                 = new stdClass();
+        $property->type           = 'array';
+        $property->items          = ['$ref' => 'Agent', 'type' => 'string', 'format' => 'uuid'];
+        $schemaObject->properties = (object) ['installedOn' => $property];
+
+        $object = ['installedOn' => ['00000000-0000-0000-0000-000000000000']];
+
+        $result = $this->handler->validateObject($object, $this->schema('agentskill'), $schemaObject);
+
+        $this->assertTrue(
+            $result->isValid(),
+            'array items given as an associative array must still have their $ref stripped'
+        );
+    }//end testArrayItemsAsAssociativeArrayStillStripsRef()
 }//end class


### PR DESCRIPTION
An array property whose `items` decode as an associative array (not a stdClass) skipped the array-items `$ref`-strip in `transformPropertyForOpenRegister` (the `is_object($items)` guard), so a bare relation `$ref` reached Opis and raised **`Unresolved reference: schema:///<slug>#`** (HTTP 500) on save.

Reproduced live on hermiq: `Skill.installedOn.items {"$ref":"Agent"}` came back from `Schema::getSchemaObject()` with `items` as a PHP array → **every skill install 500'd**. Scalar string `$ref` was fine (separate branch). Verified with a live `validateObject()` probe (was throwing → now `valid=true`).

Fix: normalise an array-shaped `items` to an object before the strip. Regression test added to `ValidateObjectArrayRefTest`.