### PR TITLE
feat(dbal): query-backed virtual schemas + snake_case filter fix

### DIFF
--- a/lib/Service/Object/SearchQueryHandler.php
+++ b/lib/Service/Object/SearchQueryHandler.php
@@ -113,6 +113,35 @@ class SearchQueryHandler
     ) {
     }//end __construct()
 
+
+    /**
+     * Whether the target schema is served by an external object-source (DBAL
+     * virtual register), whose columns are flat snake_case and must not be run
+     * through the dot-un-mangling in {@see buildSearchQuery()}.
+     *
+     * Resolves the schema id/slug via the mapper (request-cached). A
+     * multi-schema (array) or absent schema, or any resolution failure, yields
+     * false so the legacy magic-table behaviour is preserved.
+     *
+     * @param int|string|array|null $schema The schema id/slug (single value only).
+     *
+     * @return bool True when the schema declares an x-openregister-object-source.
+     */
+    private function schemaHasObjectSource(int | string | array | null $schema): bool
+    {
+        if ($schema === null || is_array($schema) === true) {
+            return false;
+        }
+
+        try {
+            $entity = $this->schemaMapper->find(id: $schema);
+        } catch (\Throwable $e) {
+            return false;
+        }
+
+        return ($entity->getObjectSource() !== null);
+    }//end schemaHasObjectSource()
+
     /**
      * Build search query from request parameters
      *
@@ -142,6 +171,17 @@ class SearchQueryHandler
         int | string | array | null $schema=null,
         ?array $ids=null
     ): array {
+        // A schema served from an external object-source (DBAL virtual register)
+        // has FLAT, snake_case columns — `product_line`, `app_slug`,
+        // `competitor_id`. The dot-un-mangling in STEP 1 (which rebuilds
+        // `@self.register` from PHP's mangled `@self_register`) would wrongly
+        // split those column names into nested arrays
+        // (`product_line` → ['product' => ['line' => …]]), silently dropping the
+        // filter. Detect object-source schemas so their snake_case object-field
+        // keys stay literal; `@self.*` metadata keys still un-mangle. Magic-table
+        // schemas are unaffected.
+        $isObjectSourceSchema = $this->schemaHasObjectSource(schema: $schema);
+
         // STEP 1: Fix PHP's dot-to-underscore mangling in query parameter names.
         // PHP converts dots to underscores in parameter names, e.g.:.
         // @self.register → @self_register.
@@ -156,7 +196,11 @@ class SearchQueryHandler
             }
 
             // Check if key contains underscores (indicating PHP mangled dots).
-            if (str_contains($key, '_') === true) {
+            // For object-source schemas, only un-mangle `@…` metadata keys and
+            // keep snake_case object-field keys (real DBAL columns) literal.
+            if (str_contains($key, '_') === true
+                && ($isObjectSourceSchema === false || str_starts_with(haystack: $key, needle: '@') === true)
+            ) {
                 // Split by underscore to reconstruct nested structure.
                 $parts = explode('_', $key);
 

--- a/lib/Service/Object/SearchQueryHandler.php
+++ b/lib/Service/Object/SearchQueryHandler.php
@@ -113,7 +113,6 @@ class SearchQueryHandler
     ) {
     }//end __construct()
 
-
     /**
      * Whether the target schema is served by an external object-source (DBAL
      * virtual register), whose columns are flat snake_case and must not be run

--- a/lib/Service/ObjectSource/DbalObjectSourceProvider.php
+++ b/lib/Service/ObjectSource/DbalObjectSourceProvider.php
@@ -77,6 +77,15 @@ class DbalObjectSourceProvider implements WritableObjectSourceProvider
     private const DEFAULT_LIMIT = 200;
 
     /**
+     * Alias for the derived table wrapping a query-backed schema's definition
+     * (`FROM (<query>) <alias>`). Distinctive to avoid colliding with any table
+     * alias that appears inside the query definition itself.
+     *
+     * @var string
+     */
+    private const DERIVED_ALIAS = 'or_src';
+
+    /**
      * Constructor.
      *
      * @param SourceMapper          $sourceMapper      Loads the backing database source.
@@ -168,7 +177,7 @@ class DbalObjectSourceProvider implements WritableObjectSourceProvider
         }
 
         try {
-            $qb = $this->baseSelect(connection: $connection, table: $this->table(config: $config), columns: $columns);
+            $qb = $this->baseSelect(connection: $connection, config: $config, columns: $columns);
             $this->applyIdPredicate(qb: $qb, connection: $connection, idColumns: $idColumns, id: $id);
             $qb->setMaxResults(1);
 
@@ -222,7 +231,7 @@ class DbalObjectSourceProvider implements WritableObjectSourceProvider
         }
 
         try {
-            $qb = $this->baseSelect(connection: $connection, table: $this->table(config: $config), columns: $columns);
+            $qb = $this->baseSelect(connection: $connection, config: $config, columns: $columns);
             $this->applyFilters(qb: $qb, connection: $connection, query: $query, columns: $columns, config: $config);
             $this->applySort(qb: $qb, connection: $connection, query: $query, columns: $columns);
 
@@ -283,7 +292,7 @@ class DbalObjectSourceProvider implements WritableObjectSourceProvider
 
         try {
             $qb = $connection->createQueryBuilder();
-            $qb->select('COUNT(*)')->from($this->quote(connection: $connection, identifier: $this->table(config: $config)));
+            $qb->select('COUNT(*)')->from($this->fromExpression(connection: $connection, config: $config));
             $this->applyFilters(qb: $qb, connection: $connection, query: $query, columns: $columns, config: $config);
 
             $total = $qb->executeQuery()->fetchOne();
@@ -371,7 +380,7 @@ class DbalObjectSourceProvider implements WritableObjectSourceProvider
         }
 
         $aggExpr = $this->aggregateExpression(connection: $connection, metric: $metric, field: $field);
-        $table   = $this->quote(connection: $connection, identifier: $this->table(config: $config));
+        $table   = $this->fromExpression(connection: $connection, config: $config);
 
         try {
             // Date-bucket series (chart widgets).
@@ -793,17 +802,20 @@ class DbalObjectSourceProvider implements WritableObjectSourceProvider
     }//end driverMissing()
 
     /**
-     * Build a `SELECT <cols> FROM <table>` query with quoted identifiers.
+     * Build a `SELECT <cols> FROM <source>` query with quoted identifiers.
      *
-     * @param Connection         $connection The DBAL connection.
-     * @param string             $table      The backing table name.
-     * @param array<int, string> $columns    The scalar columns to select.
+     * The FROM source is a quoted base table, or a `(<query>) src` derived table
+     * for a query-backed schema (see {@see fromExpression()}).
+     *
+     * @param Connection           $connection The DBAL connection.
+     * @param array<string, mixed> $config     The object-source config block.
+     * @param array<int, string>   $columns    The scalar columns to select.
      *
      * @return QueryBuilder The query builder.
      *
      * @spec openspec/specs/dbal-virtual-registers/spec.md
      */
-    private function baseSelect(Connection $connection, string $table, array $columns): QueryBuilder
+    private function baseSelect(Connection $connection, array $config, array $columns): QueryBuilder
     {
         $qb = $connection->createQueryBuilder();
 
@@ -816,7 +828,7 @@ class DbalObjectSourceProvider implements WritableObjectSourceProvider
             $selects = ['*'];
         }
 
-        $qb->select(...$selects)->from($this->quote(connection: $connection, identifier: $table));
+        $qb->select(...$selects)->from($this->fromExpression(connection: $connection, config: $config));
 
         return $qb;
     }//end baseSelect()
@@ -1055,6 +1067,49 @@ class DbalObjectSourceProvider implements WritableObjectSourceProvider
     {
         return (string) ($config['table'] ?? '');
     }//end table()
+
+    /**
+     * Whether the schema is backed by a query definition (a virtual "view of
+     * tables" authored in OpenRegister config) rather than a single base table.
+     *
+     * When `config.query` holds a non-empty SELECT, the provider reads from it
+     * as a derived table — `FROM (<query>) src` — so a join/projection over the
+     * source's tables is exposed as a flat, read-only schema. Filters, sort,
+     * pagination and aggregation push down onto the derived table exactly as for
+     * a base table.
+     *
+     * @param array<string, mixed> $config The object-source config block.
+     *
+     * @return bool True when a query definition is present.
+     */
+    private function isQueryBacked(array $config): bool
+    {
+        $query = ($config['query'] ?? null);
+        return (is_string($query) === true && trim($query) !== '');
+    }//end isQueryBacked()
+
+    /**
+     * The FROM expression for a read query: a quoted base-table identifier, or a
+     * `(<query>) src` derived table when the schema is query-backed.
+     *
+     * The query definition is emitted verbatim as a sub-select (DBAL's
+     * QueryBuilder::from() does not quote a raw expression), so it MUST be
+     * trusted config authored by an administrator — never request input. It is
+     * read-only: writes are rejected in {@see writeContext()}.
+     *
+     * @param Connection           $connection The DBAL connection.
+     * @param array<string, mixed> $config     The object-source config block.
+     *
+     * @return string The FROM expression (quoted table, or aliased sub-select).
+     */
+    private function fromExpression(Connection $connection, array $config): string
+    {
+        if ($this->isQueryBacked(config: $config) === true) {
+            return '('.trim((string) $config['query']).') '.self::DERIVED_ALIAS;
+        }
+
+        return $this->quote(connection: $connection, identifier: $this->table(config: $config));
+    }//end fromExpression()
 
     /**
      * The scalar (non-relation) columns of a schema — the query allowlist.
@@ -1309,7 +1364,7 @@ class DbalObjectSourceProvider implements WritableObjectSourceProvider
             $this->getId()
         );
 
-        if (($config['isView'] ?? false) === true) {
+        if (($config['isView'] ?? false) === true || $this->isQueryBacked(config: $config) === true) {
             throw new \RuntimeException($readOnlyError);
         }
 

--- a/tests/Unit/Service/Object/SearchQueryHandlerObjectSourceFilterTest.php
+++ b/tests/Unit/Service/Object/SearchQueryHandlerObjectSourceFilterTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Service\Object;
+
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Db\ViewMapper;
+use OCA\OpenRegister\Service\Object\SearchQueryHandler;
+use OCA\OpenRegister\Service\SearchTrailService;
+use OCA\OpenRegister\Service\SettingsService;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Guards the object-source snake_case filter fix in SearchQueryHandler::buildSearchQuery().
+ *
+ * PHP mangles dots in query-param names to underscores, and STEP 1 rebuilds the
+ * nested structure (`@self.register` from `@self_register`). For a schema backed
+ * by an external object-source (DBAL virtual register) whose columns are flat
+ * snake_case (`product_line`, `app_slug`), that reconstruction wrongly split the
+ * column into a nested array and the filter was silently dropped. The fix skips
+ * the reconstruction for object-source schemas' non-`@` keys, keeping them
+ * literal, while leaving the magic-table (nested-JSON) behaviour unchanged.
+ */
+class SearchQueryHandlerObjectSourceFilterTest extends TestCase
+{
+    private SchemaMapper $schemaMapper;
+
+    private function makeHandler(): SearchQueryHandler
+    {
+        return new SearchQueryHandler(
+            $this->createMock(ViewMapper::class),
+            $this->schemaMapper,
+            $this->createMock(SettingsService::class),
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(IRequest::class),
+            $this->createMock(SearchTrailService::class)
+        );
+    }
+
+    /**
+     * A snake_case object-field filter on an object-source schema must survive
+     * as a literal top-level key, not be split into a nested array.
+     */
+    public function testObjectSourceSchemaKeepsSnakeCaseColumnLiteral(): void
+    {
+        $schema = $this->createMock(Schema::class);
+        $schema->method('getObjectSource')->willReturn(['provider' => 'dbal-source', 'config' => []]);
+        $this->schemaMapper = $this->createMock(SchemaMapper::class);
+        $this->schemaMapper->method('find')->willReturn($schema);
+
+        $result = $this->makeHandler()->buildSearchQuery(
+            ['product_line' => 'shillinq', '_limit' => '5'],
+            null,
+            777
+        );
+
+        $this->assertArrayHasKey('product_line', $result, 'snake_case column must stay a literal key');
+        $this->assertSame('shillinq', $result['product_line']);
+        $this->assertArrayNotHasKey('product', $result, 'snake_case column must not be split into a nested array');
+    }
+
+    /**
+     * A magic-table (non-object-source) schema must keep the historical
+     * dot-un-mangling: `person_address_street` reconstructs a nested `person`.
+     */
+    public function testMagicTableSchemaStillUnmanglesUnderscores(): void
+    {
+        $this->schemaMapper = $this->createMock(SchemaMapper::class);
+
+        $result = $this->makeHandler()->buildSearchQuery(
+            ['person_address_street' => 'Main St'],
+            null,
+            null
+        );
+
+        $this->assertArrayHasKey('person', $result, 'nested reconstruction must be preserved for magic-table schemas');
+        $this->assertArrayNotHasKey('person_address_street', $result);
+    }
+}


### PR DESCRIPTION
## Summary
Two OpenRegister DBAL object-source changes, both **live-verified against the `spectr-live` external register** (they power new pure-manifest competitive/feature/market widgets on Spectr's AppDetail page).

### OR-2 — query-backed virtual schema ("view of tables, exposed as a table")
OR already introspects DB *views* as read-only schemas but could not **define** one. A schema's `x-openregister-object-source.config` may now carry a **`query`** (a SELECT/join over the source's tables). `DbalObjectSourceProvider` reads it as a derived table — `SELECT <props> FROM (<query>) or_src WHERE <pushed-down filters>` — via new `isQueryBacked()` / `fromExpression()`, wired into `findAll`/`find`/`count`/`aggregate`. Read-only (writes rejected like a view). The view definition lives in OR config, not the foreign DB, and filters/sort/pagination/aggregation push down normally.

Config shape:
```json
"x-openregister-object-source": { "provider": "dbal-source", "readOnly": true,
  "config": { "sourceId": "<uuid>", "idColumn": "id", "query": "SELECT … FROM a JOIN b …" } }
```
The schema `properties` list the query's output columns (drives SELECT + filter/sort allowlist).

### OR-1 — snake_case filter fix
Direct snake_case field filters (`?product_line=x`, `?app_slug=x`) were **silently dropped** on external DBAL registers. Root cause: `SearchQueryHandler::buildSearchQuery` STEP 1 un-mangles PHP's dot→underscore params (`@self.register`→`@self_register`) by splitting **every** `_`-containing key into a nested array — corrupting real columns (`product_line`→`['product']['line']`). Only the nested `?filters[product_line]=x` form worked, but `CnObjectListWidget` sends the direct form. `schemaHasObjectSource()` now restricts the split to `@`-keys for object-source schemas, keeping snake_case columns literal. Magic-table (nested-JSON) filters are unchanged. This also fixes already-shipped spectr detail-page widgets that were showing unfiltered data.

## Tests
- Adds `SearchQueryHandlerObjectSourceFilterTest` (object-source keeps snake_case literal; magic-table still un-mangles).
- Live-verified: `product_line`/`app_slug`/`app_id` filters + 3 query-backed views (`v_app_competitors`/`v_app_features`/`v_app_market`) rendering on the spectr AppDetail page.

## Risk
Read-path change on a shared service. Scoped by `schemaHasObjectSource()` so internal magic-table registers are unaffected; query-backed behaviour only triggers when `config.query` is present.