### PR TITLE
docs(openspec): tag-preserving-redaction — structure-aware redaction contract

### DIFF
--- a/openspec/changes/tag-preserving-redaction/.openspec.yaml
+++ b/openspec/changes/tag-preserving-redaction/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/tag-preserving-redaction/design.md
+++ b/openspec/changes/tag-preserving-redaction/design.md
@@ -1,0 +1,235 @@
+## Context
+
+Verified at OpenRegister HEAD (`development` @ 12a52c7fc):
+
+- **PDF manipulation library:** `ddn/sapp` — the Conduction fork of
+  dealfonso/sapp ("Simple and Agnostic PDF Parser"), pinned to
+  `dev-feat/chained-filter-text-replace` from `codeberg.org/Conduction/sapp`
+  (composer.json:99, composer.lock:308). Pure PHP, operates on raw PDF objects
+  and content streams. `PDFDoc::replace_text_in_document()` byte-replaces the
+  text shown by `Tj`/`TJ` operators; `to_pdf_file_s(rebuild: true)`
+  reserialises the object graph.
+- **Other PDF libs:** `smalot/pdfparser ^2.9` is **read-only** text extraction
+  (used for the text-layer probe and residual validation); `dompdf/dompdf ^3.1`
+  is HTML→PDF export. Neither writes structure.
+- **The redaction path:** `DocumentProcessingHandler::anonymizeDocument`
+  (:318) → `replaceWords` (:262) → `replaceWordsInPdfDocument` (:1227) →
+  `PdfTextReplacer::replaceInPdf` (:114) → `PdfMetadataSanitizer::sanitize`
+  (:1341). Result surfaced via `getLastResidualEntities()` /
+  `getLastSanitizationReport()` (:183-216) and the `anonymizeFile` HTTP
+  response (`FileTextController.php:574`).
+
+**The hard constraint:** SAPP has no concept of the logical structure tree.
+There is no `/StructTreeRoot`, `/MarkInfo`, marked-content (`BDC`/`EMC` +
+`/MCID`), `/Alt`, `/ActualText`, `/RoleMap` or reading-order handling anywhere
+in the fork. Text replacement rewrites content-stream bytes and changes the
+number and composition of glyphs behind each `MCID`; even when the
+`/StructTreeRoot` object survives the rebuild, the tag→content correspondence
+it encodes is stale. **This engine cannot re-author or repair a structure
+tree.** Any spec that promised structure *repair* on this stack would be
+speccing magic. This change therefore scopes to what the stack *can* honestly
+do: detect, measure, best-effort pass-through, and truthful explicit
+degradation.
+
+Stakeholders: OpenRegister redaction engine (owner); DocuDesk accessible-
+redaction leaf (consumer of the `structurePreservation` contract); EN 301 549 /
+EAA accessibility obligations.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Detect whether a redaction input is a tagged PDF, and measure its structure-
+  element count before and after redaction — over the SAPP object model, in a
+  unit-testable seam.
+- Preserve the structure-tree object graph through the SAPP rebuild when the
+  engine can, and when it cannot, **degrade explicitly** with machine-readable
+  loss reasons — never a silent flatten.
+- Expose a truthful `structurePreservation` result block (exact field names
+  below) on the processing result and the HTTP seam for the DocuDesk leaf.
+- Keep untagged-PDF redaction output **byte-stable** with today's behaviour.
+
+**Non-Goals:**
+
+- **No structure-tree repair / re-authoring / MCID re-mapping** — impossible on
+  the pure-PHP stack (see D1). Recorded as a deferred alternative.
+- No change to the byte-replace algorithm, the residual validation gate, or
+  metadata sanitisation (consumed unchanged).
+- No DOCX/ODT structure preservation (the Office sanitiser path is out of
+  scope; this change is PDF-only, matching where taggedness lives).
+- No OCR/image-only handling (already deferred to `ocr-document-scanning`).
+- No operator UI — that is the DocuDesk leaf's half; this change ships the
+  engine contract it consumes.
+
+## Decisions
+
+### D1 — The current stack cannot re-author a structure tree; scope to detect + pass-through + honest degradation
+
+`ddn/sapp` exposes a parsed object model but no structure-tree API. The
+achievable v1 posture:
+
+1. **Detect** taggedness: the document Catalog carries `/StructTreeRoot N G R`
+   and/or `/MarkInfo << /Marked true >>`.
+2. **Measure** structure elements: count parsed objects whose dictionary has
+   `/Type /StructElem`. (A raw byte scan is unreliable because PDF 1.5+ packs
+   objects into compressed `/ObjStm` streams; SAPP has already decompressed and
+   parsed them, so counting over the object model is the honest measurement.)
+3. **Pass-through** on rebuild: when `preserveStructure` is active, ensure the
+   `/StructTreeRoot`, `/MarkInfo`, `/RoleMap` and document `/Lang` objects
+   referenced from the Catalog survive `to_pdf_file_s(rebuild: true)` and the
+   subsequent `PdfMetadataSanitizer` pass (the sanitiser strips `/Info` + XMP
+   only, but MUST NOT drop the struct tree — asserted by test).
+4. **Degrade explicitly** otherwise: the engine records `preserved: false` with
+   `lossReasons[]` and returns the redacted bytes anyway (best-effort parity
+   with the existing residual policy — the file is produced, the loss is
+   reported, the operator/leaf decides).
+
+**"Preserved" is claimed conservatively.** Because MCIDs cannot be re-mapped by
+this engine, `preserved: true` is asserted **only** when *all* hold:
+`tagCountAfter === tagCountBefore` (> 0), the `/StructTreeRoot` survived the
+rebuild, and no structured page's marked-content operator count was altered by
+the replacement. In the common case where the redaction mutates marked content
+on a tagged page, the tree is passed through but the correspondence is stale, so
+the engine reports `preserved: false` with
+`marked-content-correspondence-broken` — it does not claim a preservation it
+cannot guarantee. This is the crux of "do not spec magic": the engine tells the
+truth about a degraded result rather than presenting a pass-through as a
+faithful preservation.
+
+*Alternative considered — out-of-process structure-aware repair* (e.g. `qpdf`,
+or an iText/pikepdf-class tool): would enable genuine tag-tree preservation and
+MCID re-mapping, but adds an external binary/service dependency outside the
+pure-PHP stack, a new trust/security surface, and packaging work (ADR-017
+territory). **Rejected for v1**, recorded in Open Questions as the path to true
+preservation. This change's contract is forward-compatible: a future repair
+engine simply raises the rate of `preserved: true` without changing the result
+shape.
+
+### D2 — The `structurePreservation` result contract (field names are contractual)
+
+Every PDF redaction produces exactly this block (consumed verbatim by the
+DocuDesk leaf — field names MUST NOT drift):
+
+```json
+{
+  "structurePreservation": {
+    "requested": true,
+    "preserved": false,
+    "tagCountBefore": 42,
+    "tagCountAfter": 42,
+    "lossReasons": ["marked-content-correspondence-broken"]
+  }
+}
+```
+
+- `requested` (bool) — whether preservation was in effect for this run
+  (resolved `preserveStructure` option; see D3).
+- `preserved` (bool) — whether the engine can attest the tag tree survived
+  faithfully (the conservative rule in D1). `false` whenever `requested` was
+  true but the guarantee could not be met, AND whenever preservation was not
+  applicable (untagged input) — a non-tagged document was not "preserved".
+- `tagCountBefore` (int) — `/StructElem` count of the input (0 for untagged).
+- `tagCountAfter` (int) — `/StructElem` count of the output.
+- `lossReasons` (string[]) — machine-readable reasons, empty when
+  `preserved` is true. Enumerated set (extensible):
+  `engine-cannot-reauthor-structtree`,
+  `marked-content-correspondence-broken`,
+  `structtreeroot-dropped-on-rebuild`,
+  `input-not-tagged` (preservation requested but not applicable),
+  `page-structure-not-preservable`.
+
+`getLastStructurePreservation(): ?StructurePreservation` mirrors the existing
+`getLastResidualEntities()` / `getLastSanitizationReport()` accessor pattern
+(:183-216). The block is emitted for PDF redaction only; for DOCX/ODT/text
+paths the accessor returns null (no PDF structure tree involved) and the HTTP
+response omits the block.
+
+### D3 — `preserveStructure` option resolution (default: preserve when tagged)
+
+A tri-state `?bool $preserveStructure` threaded through
+`anonymizeDocument` / `replaceWords` and read from the `anonymizeFile` HTTP
+param:
+
+- `null` / absent → **auto**: preserve iff the input is tagged
+  (`tagCountBefore > 0`). This is the default.
+- `true` → attempt preservation even if detection is ambiguous; still degrade
+  explicitly if impossible (never fails the redaction on this alone in v1 —
+  best-effort parity).
+- `false` → skip preservation entirely; `requested` is false, `preserved`
+  false, `lossReasons` empty, tag counts still measured for the truthful
+  report.
+
+Rationale for best-effort (produce-and-report) over fail-closed: matches the
+existing residual policy (:1294 "no longer fails closed on residual entity
+text"), and the DocuDesk leaf owns the block/warn decision. A future
+`preserveStructure: 'strict'` that refuses to emit a flattened derivative is an
+Open Question, not v1.
+
+### D4 — Unit-test seams
+
+- `PdfStructureInspector::inspect(PDFDoc $doc): array` (or `->isTagged()` +
+  `->countStructElements()`) — pure over the SAPP object model; unit-tested with
+  a tagged fixture (StructTreeRoot + MarkInfo + N StructElem) and an untagged
+  fixture (`tagCountBefore === 0`, `isTagged === false`). No live NC instance.
+- `PdfTextReplacer::replaceInPdf(..., ?bool $preserveStructure, StructurePreservation &$structureResult)` —
+  unit-tested for: tagged input preserved (counts equal, empty lossReasons only
+  when the conservative rule holds); tagged input with mutated marked content
+  → `preserved:false` + `marked-content-correspondence-broken`; untagged input
+  → `tagCountBefore:0`, `lossReasons:[input-not-tagged]` when requested; and the
+  **byte-stability guard** (untagged redaction output identical to the
+  `preserveStructure:false` / pre-change output).
+- `StructurePreservation` value object with `jsonSerialize()` — asserts the
+  exact field set of D2.
+
+### D5 — ADR / discipline checks
+
+- ADR-005 (PII-free logs): tag counts and loss reasons are structural, never
+  PII — safe to log; the residual-text carve-out is unchanged.
+- ADR-022 (consume-not-rebuild): SAPP, smalot, `PdfMetadataSanitizer` and the
+  residual policy are consumed unchanged; this change adds a measurement seam
+  and a result block, not a parallel PDF engine.
+- Auth: no new route; `anonymizeFile`'s existing file-access gate
+  (`FileTextController.php:105`) is unchanged. The new param is read inside the
+  already-gated method.
+
+## Risks / Trade-offs
+
+- **[`preserved:false` will be the common outcome on tagged PDFs]** — accepted
+  and by design: an honest "we degraded this and here is why" beats a silent
+  flatten. The value is the truthful signal; raising the `true` rate needs the
+  D1 repair engine (deferred).
+- **[Pass-through struct tree with stale MCIDs is not a *valid* PDF/UA tree]** —
+  true; that is exactly why `preserved` is reported `false` in that case. The
+  block never asserts validity it cannot back.
+- **[SAPP rebuild might drop the StructTreeRoot entirely]** — detected by
+  `tagCountAfter < tagCountBefore` / missing root → `structtreeroot-dropped-on-rebuild`;
+  reported, not hidden. A test pins this.
+- **[Tag counting over the object model is approximate]** (nested StructElem in
+  object streams, cross-reference streams) — acceptable: the count is a
+  before/after *comparison* signal, not an absolute audit; equal-count is a
+  necessary-not-sufficient input to the conservative `preserved` rule.
+- **[Extra parse to measure adds latency]** — the document is already parsed by
+  SAPP on the redaction path; inspection reuses that object model, no second
+  load.
+
+## Migration Plan
+
+Additive and back-compatible: new `?bool $preserveStructure` params default to
+`null` (auto) so every existing caller is unaffected; the new result block is
+additive on the accessor and the JSON response. Untagged PDFs are byte-stable
+(REQ-ORTPR-005). No schema, register or route changes. Rollback = drop the new
+param/accessor/block; the redaction pipeline is otherwise untouched.
+
+## Open Questions
+
+- **True structure preservation** needs an out-of-process structure-aware tool
+  (qpdf / pikepdf / iText class) — ADR-017-shaped packaging decision; deferred.
+  The `structurePreservation` contract is forward-compatible with it.
+- **`preserveStructure: 'strict'`** (refuse to emit a flattened derivative,
+  fail-closed) — deferred; v1 is best-effort produce-and-report, matching the
+  residual policy. The DocuDesk leaf can enforce a block on `preserved:false`
+  in the meantime.
+- **DOCX/ODT accessibility structure** (headings, alt text in the OOXML/ODF
+  package) — a separate seam on the Office sanitiser path; out of scope here.
+- **Per-page loss granularity** — v1 reports document-level `lossReasons`; a
+  future `lossPages: int[]` could localise the degradation.

--- a/openspec/changes/tag-preserving-redaction/proposal.md
+++ b/openspec/changes/tag-preserving-redaction/proposal.md
@@ -1,0 +1,130 @@
+## Why
+
+OpenRegister's redaction engine flattens accessibility structure. When a
+**tagged PDF** (PDF/UA, or any PDF carrying a logical structure tree) is
+anonymised, the redacted derivative silently loses its tags, reading order and
+alt text — and today the caller has no way to even know it happened.
+
+Verified at HEAD, the redaction path is a pure-PHP byte pipeline that is
+**structurally blind**:
+
+- `DocumentProcessingHandler::replaceWordsInPdfDocument`
+  (`lib/Service/File/DocumentProcessingHandler.php:1227`) drives
+  `PdfTextReplacer::replaceInPdf` (`lib/Service/File/Pdf/PdfTextReplacer.php:114`),
+  which loads the PDF via the Conduction `ddn/sapp` fork
+  (`PDFDoc::from_string`), calls `replace_text_in_document()` to byte-replace
+  text-showing operators in the content streams, and reserialises with
+  `to_pdf_file_s(rebuild: true)` (`PdfTextReplacer.php:180`).
+- SAPP (`ddn/sapp`, pinned to `dev-feat/chained-filter-text-replace` from
+  `codeberg.org/Conduction/sapp`, composer.json:99) is a raw PDF-object /
+  content-stream library. It has **zero** awareness of the structure tree:
+  no `/StructTreeRoot`, `/MarkInfo`, marked-content (`BDC`/`EMC` + `MCID`),
+  `/Alt`, `/ActualText`, `/Lang` or reading order. `rebuild: true` walks the
+  object graph and reserialises byte offsets; it does not re-author or repair
+  the tag→content correspondence that text mutation breaks.
+- `PdfMetadataSanitizer::sanitize` (`PdfTextReplacer` sibling, run at
+  `DocumentProcessingHandler.php:1341`) then strips `/Info` + XMP fields —
+  again with no structure-tree handling.
+- `smalot/pdfparser ^2.9` (the only other PDF reader in the stack,
+  `DocumentProcessingHandler.php:1257` text-layer probe + `PdfTextReplacer.php:252`
+  residual validation) is **read-only** text extraction; `dompdf/dompdf ^3.1`
+  is HTML→PDF export, not on the redaction path.
+
+The processing result the caller receives back reflects this blindness. After
+`anonymizeDocument` (`DocumentProcessingHandler.php:318`), callers read
+`getLastResidualEntities()` / `getLastSanitizationReport()`
+(`DocumentProcessingHandler.php:183-216`), and the HTTP seam
+`FileTextController::anonymizeFile` (`lib/Controller/FileTextController.php:425`)
+returns `{success, complete, residual_count, residual_entities, …}`
+(`FileTextController.php:574`). **Nothing** in that contract reports whether the
+input was tagged or whether the tags survived — the accessibility regression is
+invisible to the DocuDesk leaf and to the operator.
+
+Why this matters now:
+
+- **Legal (EN 301 549 / WCAG / the European Accessibility Act):** public-sector
+  documents must be accessible. A redaction step that quietly strips PDF/UA
+  structure turns an accessible source document into an inaccessible
+  derivative — an accessibility *regression manufactured by the privacy tool*.
+- **Consumer demand:** the DocuDesk leaf owns the operator-facing
+  "accessible redaction" workflow and must consume a truthful signal from the
+  engine to warn, block, or degrade. It cannot invent that signal client-side;
+  taggedness and tag counts live in the PDF bytes the engine already parses.
+- **Honesty over magic:** the current pure-PHP stack *cannot* re-author a
+  structure tree, so this change does not promise repair it cannot deliver. It
+  delivers **detection, measurement, explicit degradation, and a truthful
+  result contract** — the engine either preserves the tag tree or says, in
+  structured data, exactly what it lost and why.
+
+## What Changes
+
+- **Structure inspection seam.** A new `PdfStructureInspector`
+  (`lib/Service/File/Pdf/`) reads a SAPP-parsed document and reports whether it
+  is tagged (`/StructTreeRoot` present and/or `/MarkInfo` `/Marked true`) and
+  the count of structure elements (`/Type /StructElem` objects) — a pure
+  function over the parsed object model, unit-testable without a live instance.
+- **Preserve-or-degrade-explicitly redaction.** When the input is tagged,
+  `PdfTextReplacer::replaceInPdf` passes the structure-tree object graph
+  (`/StructTreeRoot`, `/MarkInfo`, `/RoleMap`, document `/Lang`) through the
+  SAPP rebuild rather than dropping it, and re-measures afterwards. When the
+  text mutation breaks the tag→content correspondence (the common case: MCIDs
+  can no longer be re-mapped by this engine) or when the tree cannot be carried
+  through an operation/page, the engine records the loss **explicitly** — it
+  never silently flattens.
+- **`structurePreservation` result block** on the processing result, exposed via
+  a new `getLastStructurePreservation()` accessor and the `anonymizeFile` HTTP
+  response — the exact contract the DocuDesk accessible-redaction leaf consumes.
+- **`preserveStructure` option** plumbed through the public seams
+  (`replaceWords` / `anonymizeDocument` options + the `anonymizeFile` HTTP
+  param). Default: **preserve when the input is tagged** (auto); untagged input
+  is unaffected and byte-stable.
+
+## Capabilities
+
+### New Capabilities
+
+- `tag-preserving-redaction`: Detect a tagged PDF, preserve its logical
+  structure tree through text-replacement redaction where the engine can, and
+  where it cannot, degrade explicitly and report the loss through a truthful
+  `structurePreservation` result contract consumed by the DocuDesk accessible-
+  redaction leaf.
+
+### Modified Capabilities
+
+<!-- None at spec level. `pdf-anonymisation`, `file-actions` and
+     `office-document-sanitization` are touched at implementation level only
+     (a new option arg + a new result block on existing seams); their existing
+     spec-level requirements — the byte-replace pipeline, the residual
+     validation gate, metadata sanitisation — are unchanged and are consumed,
+     not re-specified, here. The untagged-PDF byte-stability guard
+     (REQ-ORTPR-005) exists precisely to prove those requirements still hold. -->
+
+## Impact
+
+- **Backend:** new `lib/Service/File/Pdf/PdfStructureInspector.php` (taggedness
+  + StructElem count over the SAPP object model) and a `StructurePreservation`
+  value object (`lib/Service/File/Pdf/`); `PdfTextReplacer::replaceInPdf`
+  gains a `preserveStructure` arg and an out-param carrying the preservation
+  result; `DocumentProcessingHandler::replaceWords` / `anonymizeDocument`
+  gain the `preserveStructure` option and a `lastStructurePreservation`
+  accessor alongside the existing `lastResidualEntities` /
+  `lastSanitizationReport` surfaces.
+- **HTTP seam:** `FileTextController::anonymizeFile`
+  (`lib/Controller/FileTextController.php:425`) reads an optional
+  `preserveStructure` request param and adds a `structurePreservation` block to
+  its `JSONResponse` — no new route, no auth-posture change (existing
+  file-access gate at `FileTextController.php:105` unchanged).
+- **Consumed unchanged (ADR-022):** `ddn/sapp` `PDFDoc` object model,
+  `smalot/pdfparser` (residual validation), `PdfMetadataSanitizer`, the residual
+  best-effort policy, the `AnonymisationLog` write path.
+- **Consumer (leaf, not modified here):** the DocuDesk accessible-redaction
+  change consumes the `structurePreservation` block verbatim (field names are
+  contractual — see design.md) to warn/block/degrade in the operator UI.
+- **Library reality (see design.md D1):** the current stack **cannot re-author**
+  a structure tree. This change deliberately scopes to detection, measurement,
+  best-effort pass-through, and truthful explicit degradation — a repair engine
+  (e.g. an out-of-process `qpdf`/structure-aware path) is recorded as an
+  explicit deferred alternative, not specced here.
+- **Evidence:** EN 301 549 / EAA accessibility obligation on public-sector PDFs;
+  DocuDesk accessible-redaction leaf demand (research-user-wishes); HEAD
+  verification of the structurally-blind pipeline cited above.

--- a/openspec/changes/tag-preserving-redaction/specs/tag-preserving-redaction/spec.md
+++ b/openspec/changes/tag-preserving-redaction/specs/tag-preserving-redaction/spec.md
@@ -1,0 +1,179 @@
+# Capability: `tag-preserving-redaction`
+
+---
+status: proposed
+---
+
+## Purpose
+
+Make OpenRegister's PDF redaction engine honest about accessibility structure.
+When a **tagged PDF** (PDF/UA, or any PDF carrying a logical structure tree) is
+anonymised, the engine MUST preserve that structure tree — tags, reading order,
+alt text — where the pure-PHP stack allows, and where it cannot, MUST degrade
+**explicitly** (a machine-readable loss report) rather than silently flatten the
+document. Every PDF redaction MUST return a truthful `structurePreservation`
+result block that the DocuDesk accessible-redaction leaf consumes verbatim.
+Verified at HEAD, the redaction path (`DocumentProcessingHandler` →
+`PdfTextReplacer` over the `ddn/sapp` fork) is structurally blind; this
+capability adds detection, before/after measurement, best-effort pass-through,
+and the result contract — it does **not** re-author or repair a structure tree,
+which the current stack cannot do.
+
+## ADDED Requirements
+
+### Requirement: The engine MUST detect a tagged PDF and measure its structure-element count before and after redaction (REQ-ORTPR-001)
+
+The redaction engine MUST determine whether a PDF redaction input is a tagged
+PDF and MUST count its logical-structure elements, over the already-parsed
+`ddn/sapp` object model (never a raw byte scan, which misses objects packed in
+compressed object streams). A PDF is tagged when its Catalog references a
+`/StructTreeRoot` and/or carries `/MarkInfo` with `/Marked true`. The structure-
+element count is the number of parsed objects whose dictionary has
+`/Type /StructElem`. The engine MUST record this count for the input
+(`tagCountBefore`) and for the produced output (`tagCountAfter`). Detection and
+counting MUST reuse the document already parsed for redaction — no second load —
+and MUST be exposed as a service seam (`PdfStructureInspector`) that is unit-
+testable without a live Nextcloud instance.
+
+#### Scenario: A tagged PDF is detected with its element count
+
+- **GIVEN** a PDF whose Catalog carries `/StructTreeRoot` and `/MarkInfo << /Marked true >>` and 42 `/Type /StructElem` objects
+- **WHEN** the engine inspects it on the redaction path
+- **THEN** it MUST report the input as tagged with `tagCountBefore` equal to 42
+- @e2e exclude structure-tree detection is pure engine logic over the SAPP object model — covered by PHPUnit (tests/unit/Service/File/Pdf/PdfStructureInspectorTest.php) against a tagged fixture PDF
+
+#### Scenario: An untagged PDF reports a zero element count
+
+- **GIVEN** a PDF with no `/StructTreeRoot` and no `/MarkInfo`
+- **WHEN** the engine inspects it
+- **THEN** it MUST report the input as not tagged with `tagCountBefore` equal to 0
+- @e2e exclude negative detection case — covered by PHPUnit (PdfStructureInspectorTest::testUntaggedPdfHasZeroTags) against an untagged fixture PDF
+
+### Requirement: Redacting a tagged PDF MUST preserve the structure tree or degrade explicitly, never silently flatten (REQ-ORTPR-002)
+
+When redacting a **tagged** PDF with preservation in effect, the engine MUST
+preserve the structure tree or degrade explicitly. `PdfTextReplacer::replaceInPdf`
+MUST carry the structure-tree object graph (`/StructTreeRoot`,
+`/MarkInfo`, `/RoleMap`, document `/Lang`) through the SAPP
+`to_pdf_file_s(rebuild: true)` serialisation and the subsequent
+`PdfMetadataSanitizer` pass rather than dropping it, and MUST re-measure the
+output. The engine MUST attest `preserved: true` **only** when every one of the
+following holds: `tagCountAfter` equals `tagCountBefore` and is greater than 0,
+the `/StructTreeRoot` survived the rebuild, and no structured page's marked-
+content operator count was altered by the replacement. In every other case where
+the input was tagged, the engine MUST set `preserved: false` and MUST record at
+least one machine-readable entry in `lossReasons` — it MUST NOT drop tags
+without reporting the loss, and it MUST NOT claim a preservation it cannot
+guarantee. The redacted bytes MUST still be produced (best-effort parity with
+the existing residual policy); the accessibility regression is reported, not
+concealed, and the caller decides how to act on it.
+
+#### Scenario: Tagged input, faithful preservation attested
+
+- **GIVEN** a tagged PDF whose redaction does not alter marked content on any structured page and whose `/StructTreeRoot` and 42 `/StructElem` objects survive the rebuild
+- **WHEN** it is redacted with preservation in effect
+- **THEN** the result MUST report `preserved: true`, `tagCountBefore` and `tagCountAfter` both 42, and an empty `lossReasons`
+- @e2e exclude preservation attestation is engine byte-level behaviour — covered by PHPUnit (tests/unit/Service/File/Pdf/PdfTextReplacerTest.php::testTaggedPreservationAttested)
+
+#### Scenario: Tagged input, unavoidable loss reported explicitly
+
+- **GIVEN** a tagged PDF whose redaction mutates marked content on a tagged page so the tag→content correspondence can no longer be guaranteed by this engine
+- **WHEN** it is redacted with preservation in effect
+- **THEN** the redacted PDF MUST still be produced, `preserved` MUST be `false`, and `lossReasons` MUST contain `marked-content-correspondence-broken`
+- @e2e exclude explicit-degradation path is engine logic — covered by PHPUnit (PdfTextReplacerTest::testTaggedLossIsReportedNotSilent)
+
+#### Scenario: Structure tree dropped on rebuild is surfaced, not hidden
+
+- **GIVEN** a tagged PDF whose `/StructTreeRoot` does not survive the SAPP rebuild
+- **WHEN** the output is re-measured
+- **THEN** `preserved` MUST be `false` and `lossReasons` MUST contain `structtreeroot-dropped-on-rebuild`
+- @e2e exclude rebuild-loss detection — covered by PHPUnit (PdfTextReplacerTest::testStructTreeDroppedIsReported)
+
+### Requirement: Every PDF redaction MUST return the `structurePreservation` result block with the exact contracted fields (REQ-ORTPR-003)
+
+Every PDF redaction MUST make available a `structurePreservation` block with
+exactly these fields and types: `requested` (boolean — whether preservation was
+in effect), `preserved` (boolean — the conservative attestation of
+REQ-ORTPR-002), `tagCountBefore` (integer), `tagCountAfter` (integer), and
+`lossReasons` (array of strings, empty when `preserved` is true). The field
+names MUST match this contract exactly (the DocuDesk accessible-redaction leaf
+consumes them verbatim; drift breaks the consumer). The block MUST be reachable
+via a `DocumentProcessingHandler::getLastStructurePreservation()` accessor
+mirroring the existing `getLastResidualEntities()` / `getLastSanitizationReport()`
+surfaces, and MUST be included in the `FileTextController::anonymizeFile` HTTP
+`JSONResponse` for PDF inputs. For non-PDF redaction paths (DOCX/ODT/text) the
+accessor MUST return null and the HTTP block MUST be omitted (no PDF structure
+tree is involved). Loss reasons MUST be drawn from a documented enumerated set
+(`engine-cannot-reauthor-structtree`, `marked-content-correspondence-broken`,
+`structtreeroot-dropped-on-rebuild`, `input-not-tagged`,
+`page-structure-not-preservable`) and MUST be PII-free (structural only).
+
+#### Scenario: The block carries exactly the contracted fields
+
+- **GIVEN** a PDF redaction has run
+- **WHEN** the `structurePreservation` block is serialised
+- **THEN** it MUST contain exactly `requested`, `preserved`, `tagCountBefore`, `tagCountAfter` and `lossReasons`, with the documented types, and no additional or renamed field
+- @e2e exclude result-contract shape — covered by PHPUnit (tests/unit/Service/File/Pdf/StructurePreservationTest.php::testJsonSerializeFieldSet)
+
+#### Scenario: A non-PDF redaction omits the block
+
+- **GIVEN** a DOCX file is anonymised
+- **WHEN** the processing result is read
+- **THEN** `getLastStructurePreservation()` MUST return null and the HTTP response MUST NOT contain a `structurePreservation` block
+- @e2e exclude non-PDF branch — covered by PHPUnit (tests/unit/Service/File/DocumentProcessingHandlerTest.php::testNonPdfHasNoStructureBlock)
+
+### Requirement: The `preserveStructure` option MUST be plumbed through the public seams, defaulting to preserve when the input is tagged (REQ-ORTPR-004)
+
+The engine MUST accept a tri-state `preserveStructure` option threaded through
+the public seams — `DocumentProcessingHandler::anonymizeDocument` /
+`replaceWords`, `PdfTextReplacer::replaceInPdf`, and the
+`FileTextController::anonymizeFile` HTTP request param — with this resolution:
+absent/`null` MUST mean **auto** (preserve if and only if the input is tagged,
+i.e. `tagCountBefore > 0`); `true` MUST attempt preservation and still degrade
+explicitly if impossible; `false` MUST skip preservation and set `requested`
+false while still measuring tag counts for the truthful report. The default
+(absent option) MUST be auto, so an existing caller redacting a tagged PDF gets
+preservation without opting in, and a caller redacting an untagged PDF is
+unaffected. Adding the option MUST NOT change the `anonymizeFile` route or its
+existing file-access authorization gate.
+
+#### Scenario: Default auto preserves a tagged input without an explicit opt-in
+
+- **GIVEN** a tagged PDF and an `anonymizeFile` call with no `preserveStructure` param
+- **WHEN** the redaction runs
+- **THEN** `structurePreservation.requested` MUST be true (auto resolved to preserve because the input is tagged)
+- @e2e exclude option-resolution matrix — covered by PHPUnit (PdfTextReplacerTest::testAutoPreservesTaggedByDefault)
+
+#### Scenario: Explicit false skips preservation but still reports counts
+
+- **GIVEN** a tagged PDF and a redaction call with `preserveStructure` false
+- **WHEN** the redaction runs
+- **THEN** `requested` MUST be false, `preserved` MUST be false, `lossReasons` MUST be empty, and `tagCountBefore` MUST still be measured (> 0)
+- @e2e exclude opt-out path — covered by PHPUnit (PdfTextReplacerTest::testExplicitFalseSkipsButMeasures)
+
+### Requirement: Untagged-PDF redaction output MUST remain byte-stable and report preservation as not applicable (REQ-ORTPR-005)
+
+Introducing structure preservation MUST NOT change the redacted output of an
+**untagged** PDF. For an untagged input, the produced bytes MUST be identical to
+the output of the pre-change redaction pipeline (equivalently, identical to the
+output with `preserveStructure` false), so no existing untagged-redaction
+behaviour, residual validation, or metadata sanitisation regresses. The
+`structurePreservation` block for an untagged input MUST report
+`tagCountBefore` 0, `tagCountAfter` 0, and `preserved` false; when preservation
+was requested (auto or `true`) but the input is not tagged, `lossReasons` MUST
+contain `input-not-tagged` to state that preservation was not applicable rather
+than that it failed.
+
+#### Scenario: Untagged redaction output is unchanged
+
+- **GIVEN** an untagged PDF redacted with the pre-change pipeline and the same PDF redacted with structure preservation available
+- **WHEN** the two outputs are compared
+- **THEN** the redacted bytes MUST be identical (structure preservation is inert for untagged input)
+- @e2e exclude byte-stability regression guard — covered by PHPUnit (tests/unit/Service/File/Pdf/PdfTextReplacerTest.php::testUntaggedOutputByteStable) comparing against a golden fixture
+
+#### Scenario: Untagged input reports preservation as not applicable
+
+- **GIVEN** an untagged PDF redacted with preservation requested (default auto)
+- **WHEN** the result block is read
+- **THEN** `tagCountBefore` and `tagCountAfter` MUST both be 0, `preserved` MUST be false, and `lossReasons` MUST contain `input-not-tagged`
+- @e2e exclude not-applicable reporting — covered by PHPUnit (PdfTextReplacerTest::testUntaggedReportsNotApplicable)

--- a/openspec/changes/tag-preserving-redaction/tasks.md
+++ b/openspec/changes/tag-preserving-redaction/tasks.md
@@ -1,0 +1,48 @@
+# Tasks: tag-preserving-redaction
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 12.
+     Acceptance criteria are plain indented bullets, not checkboxes. -->
+
+## 1. Structure inspection seam
+
+- [ ] 1.1 Add `lib/Service/File/Pdf/PdfStructureInspector.php` — taggedness + StructElem count over the SAPP object model (REQ-ORTPR-001)
+  - `inspect(\ddn\sapp\PDFDoc $doc)` (or `isTagged()` + `countStructElements()`): tagged when the Catalog references `/StructTreeRoot` and/or `/MarkInfo` `/Marked true`; count objects whose dict has `/Type /StructElem`; iterate the parsed object model, never a raw byte scan; reuse the already-parsed doc (no second load); no live-instance dependency.
+
+- [ ] 1.2 Add `lib/Service/File/Pdf/StructurePreservation.php` value object (REQ-ORTPR-003)
+  - `final readonly` with `requested` (bool), `preserved` (bool), `tagCountBefore` (int), `tagCountAfter` (int), `lossReasons` (string[]); `jsonSerialize()` emitting exactly those five keys; a class constant enumerating the loss-reason set (design.md D2).
+
+## 2. Preserve-or-degrade redaction
+
+- [ ] 2.1 Thread a tri-state `?bool $preserveStructure` into `PdfTextReplacer::replaceInPdf` + a `StructurePreservation &$structureResult` out-param (REQ-ORTPR-004)
+  - Resolve null→auto (preserve iff `tagCountBefore > 0`), true→attempt, false→skip-but-measure; measure before via the inspector on the loaded `PDFDoc`.
+
+- [ ] 2.2 Pass the structure-tree object graph through the SAPP rebuild + sanitiser and re-measure (REQ-ORTPR-002)
+  - When preserving, ensure `/StructTreeRoot` `/MarkInfo` `/RoleMap` document `/Lang` survive `to_pdf_file_s(rebuild:true)` and the `PdfMetadataSanitizer` pass; measure `tagCountAfter` on the output.
+
+- [ ] 2.3 Apply the conservative `preserved` attestation and populate `lossReasons` (REQ-ORTPR-002)
+  - `preserved:true` only when after==before>0 AND StructTreeRoot survived AND no structured page's marked-content operator count changed; else `preserved:false` with a machine-readable reason (`marked-content-correspondence-broken` / `structtreeroot-dropped-on-rebuild` / `engine-cannot-reauthor-structtree`); always still produce the redacted bytes (best-effort parity, PII-free reasons).
+
+## 3. Result contract on the public seams
+
+- [ ] 3.1 Add `lastStructurePreservation` + `getLastStructurePreservation(): ?StructurePreservation` to `DocumentProcessingHandler` (REQ-ORTPR-003)
+  - Reset alongside the existing `lastResidualEntities`/`lastSanitizationReport` at the top of `anonymizeDocument`; populated on the PDF branch only; null on DOCX/ODT/text branches.
+
+- [ ] 3.2 Thread `preserveStructure` through `anonymizeDocument` / `replaceWords` → `replaceWordsInPdfDocument` → `replaceInPdf` (REQ-ORTPR-004)
+  - New optional param default null (auto) so every existing caller is unaffected; forward it only on the PDF branch.
+
+- [ ] 3.3 Read the `preserveStructure` HTTP param and add the `structurePreservation` block to `FileTextController::anonymizeFile` (REQ-ORTPR-003, REQ-ORTPR-004)
+  - Read optional param inside the already-gated method (no new route, no auth change); include the serialised block for PDF inputs, omit it for non-PDF; block is PII-free (structural counts + reasons only, ADR-005).
+
+## 4. Tests & quality
+
+- [ ] 4.1 PHPUnit `PdfStructureInspectorTest` — tagged fixture (StructTreeRoot+MarkInfo+N StructElem → detected, count N) and untagged fixture (not tagged, count 0) (REQ-ORTPR-001)
+  - Fixtures committed under `tests/unit/.../fixtures/`; no live NC instance; run in the nextcloud:34 container per the OR PHPUnit convention.
+
+- [ ] 4.2 PHPUnit `PdfTextReplacerTest` — preservation matrix (REQ-ORTPR-002, REQ-ORTPR-004, REQ-ORTPR-005)
+  - tagged+attested (`preserved:true`, empty reasons); tagged+loss (`preserved:false`+`marked-content-correspondence-broken`); struct-tree dropped (`structtreeroot-dropped-on-rebuild`); auto-preserves-tagged-by-default; explicit-false-skips-but-measures; untagged reports `input-not-tagged`.
+
+- [ ] 4.3 PHPUnit byte-stability guard + `StructurePreservationTest` field-set + `DocumentProcessingHandlerTest` non-PDF null (REQ-ORTPR-003, REQ-ORTPR-005)
+  - Untagged output identical to a golden pre-change fixture; `jsonSerialize()` emits exactly the five contracted keys; DOCX path returns null accessor + no HTTP block.
+
+- [ ] 4.4 Run `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan, PHPUnit) and `openspec validate tag-preserving-redaction --strict`
+  - SPDX docblocks on new files; if dev-deps are unavailable in the container, `php -l` all new files and note static-analysis/PHPUnit deferred to CI (per the OR convention).


### PR DESCRIPTION
Engine half of accessible redaction from the 2026-07-23 docudesk deep-research round; the docudesk leaf change (accessible-redaction-output, companion PR) consumes the `structurePreservation` contract specced here.

5 requirements: tagged-PDF detection + StructElem measurement · preserve-or-degrade-explicitly (never silent flattening) · contracted `structurePreservation` result block · `preserveStructure` option on public seams · untagged byte-stability regression guard.

Honest scope per HEAD reality: ddn/sapp cannot re-author structure trees — preservation is conservatively attested and the common tagged case reports explicit lossReasons instead of claiming success. Passes `openspec validate --strict`. Markdown-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)