### PR TITLE
spec: context-chat-provider — Assistant/RAG surface for register objects (ff)

### DIFF
--- a/openspec/changes/context-chat-provider/.openspec.yaml
+++ b/openspec/changes/context-chat-provider/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/context-chat-provider/design.md
+++ b/openspec/changes/context-chat-provider/design.md
@@ -1,0 +1,259 @@
+## Context
+
+OpenRegister already integrates with a cluster of Nextcloud "surface"
+contracts for register objects: `OCP\Search\IProvider` (unified search,
+`ObjectsProvider`), `OCP\Notification\INotifier`, the Activity provider
+(`lib/Activity/Provider.php`), a comments listener, and a dashboard widget —
+all wired in `lib/AppInfo/Application.php`. None of these feed the NC
+Assistant / Context Chat RAG pipeline. `OCP\ContextChat` is Nextcloud's
+platform contract for that: an app registers one or more
+`IContentProvider`s (`getId`, `getAppId`, `getItemUrl($id)`,
+`triggerInitialImport`) by listening for `ContentProviderRegisterEvent`, and
+pushes/removes individual items via `ContentManager::submitContent()` /
+deletion calls as content changes. The platform gates everything on
+`isContextChatAvailable()` so callers never hard-depend on the
+`context_chat` app.
+
+OpenRegister's object lifecycle already dispatches `ObjectCreatedEvent`,
+`ObjectUpdatedEvent`, `ObjectDeletedEvent` from `MagicMapper` — the same
+events `ObjectChangeListener` (text extraction) and `ObjectMetricsListener`
+(operational counters) already listen on. This is the correct, existing hook
+point; no hot-path service needs modification.
+
+The deep-link URL problem this feature also needs (an object's canonical
+"open this" URL, per app, per (register, schema)) is already solved by
+`DeepLinkRegistryService::resolveUrl()`, which `ObjectsProvider` uses
+today for exactly this purpose, with a fallback to the OR-native
+`openregister.objects.show` route.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Register OpenRegister as a Context Chat content provider, softly gated so
+  a standalone instance without `context_chat` installed is unaffected.
+- Submit/withdraw content on the existing object create/update/delete event
+  flow.
+- Give schema authors an explicit, default-OFF opt-in — indexing every
+  object in every register into a third-party AI pipeline by default is not
+  acceptable; this must be a deliberate per-schema decision.
+- Never submit content a given searcher would not otherwise be allowed to
+  see via the same published/RBAC predicate unified search already
+  enforces.
+- Reuse the existing deep-link mechanism for `getItemUrl`, not invent a
+  second URL-templating surface.
+- Provide both an automatic initial-import path (`triggerInitialImport`)
+  and an operator-triggered occ command for backfill/repair.
+
+**Non-Goals:**
+- Per-user visibility filtering *within* Context Chat's own retrieval layer.
+  The platform's `IContentProvider` contract does not expose a per-query
+  "as this user" parameter to `submitContent()` — content is submitted once,
+  app-wide, and Context Chat's own access-control layer (which shells out to
+  each provider's `getItemUrl`/permission hooks per the platform docs) is
+  what NC uses to decide whether a *searching* user may see a *retrieved*
+  chunk. OpenRegister's contribution here is to never submit content that
+  is not published/RBAC-visible to *at least the general population this
+  schema is opted into* — see "Access-model decision" below. Full per-user
+  ACL parity with unified search's live RBAC check is explicitly deferred
+  (see Open Questions).
+- Chunking/embedding strategy — that's Context Chat's own responsibility
+  once content is submitted as plain text.
+- Any change to `ObjectsProvider` (unified search) or the internal
+  `chat-ai` RAG capability — both are unrelated, pre-existing capabilities.
+- A new HTTP/REST surface. The only new entry point is an occ command.
+
+## Decisions
+
+### Registration: event listener, not a constructor-time IRegistrationContext call
+
+Unlike `registerSearchProvider()` / `registerCalendarProvider()` (called
+directly on `IRegistrationContext` at app boot), Context Chat provider
+registration is event-driven: `context_chat` dispatches
+`ContentProviderRegisterEvent` and every listening app calls
+`$event->registerContentProvider($appId, $providerId, $providerClass)` on
+it. This is the platform-mandated shape (verified against
+docs.nextcloud.com developer_manual digging_deeper context_chat, July
+2026) — there is no `IRegistrationContext::registerContentProvider()`
+method to call directly. We register a small
+`ContentProviderRegistrationListener` on `ContentProviderRegisterEvent` in
+`registerEventListeners()`, mirroring the existing
+`OcmResourceTypeListener` pattern (another event-advertised registration).
+
+### Availability guard: `isContextChatAvailable()`, checked in the listener body
+
+The registration listener only fires when `context_chat` dispatches the
+event in the first place, which already implies the app is present — but
+we additionally guard the listener body with an explicit
+`isContextChatAvailable()` check (thin wrapper over
+`IAppManager::isEnabledForUser('context_chat')`) before calling
+`registerContentProvider()`, mirroring the existing
+`class_exists('OCA\\Tables\\Event\\TableDeletedEvent')` guard used for the
+optional Tables integration. Belt-and-braces: it costs nothing and protects
+against any future platform change where the event fires unconditionally.
+
+### Submission hook: new listener on the existing object lifecycle events
+
+A new `ContextChatSubmissionListener` listens on `ObjectCreatedEvent`,
+`ObjectUpdatedEvent`, `ObjectDeletedEvent` — the same events
+`ObjectMetricsListener` already consumes — rather than modifying
+`ObjectService` or `MagicMapper` directly. This keeps the hot object-save
+path untouched (ADR-022 territory: OR's own internal write path stays
+service-agnostic of any single consumer) and keeps the feature fail-soft:
+like `ObjectMetricsListener`, the listener catches `Throwable` and only
+logs, so a Context Chat/`ContentManager` failure can never abort an object
+write.
+
+### Opt-in: `configuration['x-openregister-contextchat']`, default OFF
+
+Follows the established `x-openregister-*` schema-configuration annotation
+convention (`x-openregister-quality`, `x-openregister-object-source`, etc.)
+rather than a new dedicated schema column (contrast with the existing
+top-level `searchable` boolean, which governs unified search, not this
+feature — the two must stay independently controllable: a schema can be
+unified-searchable but not Context-Chat-indexed, or vice versa).
+**Critical implementation detail**: `Schema::setConfiguration()` maintains
+an explicit allow-list of recognised `x-openregister-*` keys and silently
+drops anything not on it (this exact class of bug shipped twice before —
+see the `x-openregister-processing` code comment in `lib/Db/Schema.php`
+and the historical or#460/#462 writeOnly-boundary incident). Task list
+includes adding `x-openregister-contextchat` to that allow-list as an
+explicit, separately-verified step — "the key exists in my JSON payload"
+is not sufficient evidence it round-trips.
+
+### getItemUrl: reuse `DeepLinkRegistryService`, no new config surface
+
+The proposal's originating brief suggested a bespoke
+`contextchat_url_template` config key with `{register}/{schema}/{uuid}`
+placeholders. Investigation found OpenRegister already has exactly this
+mechanism, fleet-wide: `DeepLinkRegistryService::resolveUrl(registerId,
+schemaId, objectData)`, which `ObjectsProvider` already calls for the
+identical "what URL takes a user to this object" problem, with the same
+`openregister.objects.show` fallback when no app has claimed a deep link
+for that (register, schema). Inventing a second, OR-Context-Chat-specific
+URL-template config would (a) duplicate a solved problem, (b) create two
+sources of truth that could disagree, and (c) mean OpenBuild virtual apps
+that already register a deep link for their schemas would need to register
+a *second*, differently-shaped config to get the same behaviour in Context
+Chat. `ContentProvider::getItemUrl($id)` therefore resolves the object by
+uuid, then calls the same `resolveUrl()` / fallback pair `ObjectsProvider`
+uses.
+
+### Access-model decision (published/RBAC boundary)
+
+Context Chat's `IContentProvider` contract, as documented, does not accept
+a "for this user" parameter on `submitContent()` — a provider submits
+content once, and the platform's own permission-checking hooks (evaluated
+per retrieval) are what NC uses to decide whether a match may be shown to
+a given querying user. This is coarser than OR's own live per-object RBAC
+model (per-scope grants, tenant isolation, publish windows). Rather than
+either (a) submitting everything and hoping Context Chat's own ACL layer
+is a perfect proxy for OR's RBAC — which it structurally cannot be, since
+it has no notion of OR scopes/tenants — or (b) blocking this feature
+entirely on a full per-user-ACL-aware Context Chat contract that does not
+exist today, we take the deliberately conservative middle path already
+established for unified search's "published" concept: only ever submit
+objects that satisfy the same published predicate `ObjectsProvider`
+already enforces (`@self.published` set and in the past,
+`@self.depublished` unset or in the future — see
+`openspec/specs/unified-search-provider/spec.md`), on schemas an
+administrator has explicitly opted in. This means: (1) unpublished /
+soft-deleted / not-yet-published objects are NEVER submitted, regardless
+of opt-in; (2) once published, an object is visible to the Assistant for
+*any* user who can reach Context Chat at all — the same trust boundary NC
+already applies to, e.g., globally-shared Talk conversations indexed for
+the same user's Assistant. Tenant/organisation-scoped visibility nuances
+(an object published within tenant A appearing in tenant B's Assistant
+answers) are explicitly OUT of scope for this change and tracked as an
+Open Question / follow-up issue — schema authors opting a multi-tenant
+schema in must be aware submitted content is not tenant-partitioned by
+Context Chat itself.
+
+### Declarative-vs-imperative decision (ADR-031)
+
+ADR-031 governs *consuming apps'* business logic on top of OR schemas —
+whether decidesk/pipelinq/etc. write a bespoke PHP service where an
+`x-openregister-*` schema extension already exists. This change is
+different in kind: it is OpenRegister itself implementing a Nextcloud
+*platform* integration contract (`OCP\ContextChat\IContentProvider`, an
+event listener, an occ command) — there is no schema-extension mechanism
+this could instead be expressed as, in the same way `ObjectsProvider`
+(`OCP\Search\IProvider`), the notifier, and the activity provider are also
+necessarily imperative PHP, not schema-declarative behaviour. This is a
+valid ADR-031 exception under the "OR's extension is missing or
+insufficient" category — more precisely, out of that ADR's scope entirely,
+since ADR-031 does not govern OR's own platform-facing infrastructure. The
+one piece of this change that *is* schema-declarative — the per-schema
+`x-openregister-contextchat` opt-in flag — correctly follows the
+`x-openregister-*` convention rather than, say, a global app-wide config
+toggle, keeping the declarative surface where ADR-031 says it belongs.
+
+## Seed Data
+
+Unit tests need:
+- One `Schema` fixture with `configuration['x-openregister-contextchat'] =
+  true` (opted in) and one with the key absent/false (opted out, default),
+  both belonging to the same `Register` fixture used elsewhere in
+  `tests/Unit/`.
+- Two `ObjectEntity` fixtures under the opted-in schema: one published
+  (`@self.published` in the past, no `@self.depublished` or in the
+  future) and one unpublished — to assert the predicate filter.
+- One `ObjectEntity` fixture under the opted-out schema — to assert the
+  opt-in filter independently of the publish filter.
+- No database seed/migration data is required in `lib/Migration/` — the
+  opt-in flag lives in the existing JSON `configuration` column, and no new
+  table is introduced by this change.
+- `triggerInitialImport`/occ-command integration exercised against the
+  existing Postgres-backed dev instance (8080) with the standard
+  `openregister:seed` fixtures plus one manually opted-in schema, per
+  project convention of live-verifying platform integrations rather than
+  trusting a green mocked test suite alone.
+
+## Risks / Trade-offs
+
+- [Context Chat's own ACL layer may not exist / may be coarser than
+  documented] → Mitigation: the published-predicate + opt-in gate is
+  enforced entirely on the OR side before `submitContent()` is ever called,
+  so OR's guarantee does not depend on Context Chat's retrieval-time
+  behaviour matching the docs.
+- [Multi-tenant schemas opted in leak published content across tenants via
+  the Assistant] → Mitigation: documented explicitly above as a known,
+  deliberate limitation; schema authors must not opt in a tenant-scoped
+  schema until a follow-up closes this gap (tracked as an Open Question).
+- [`ContentManager::submitContent()` unavailable/slow blocks object saves]
+  → Mitigation: listener runs post-persist (on `*Created`/`*Updated`, not
+  `*Creating`/`*Updating`) and wraps the call in try/catch + log, matching
+  `ObjectMetricsListener`'s fail-soft pattern — a Context Chat outage never
+  blocks or fails an object write.
+- [`Schema::setConfiguration()` allow-list silently drops the new key if the
+  task is missed] → Mitigation: called out as its own task item with an
+  explicit round-trip assertion in tests (write config, re-read schema,
+  assert key survived) — not just "key accepted at save time".
+- [Reindex command run against a very large register times out / OOMs] →
+  Mitigation: batched, same batching approach as the existing
+  `RematerialiseCalculationsCommand`.
+
+## Migration Plan
+
+- No database migration required (uses the existing `configuration` JSON
+  column on `oc_openregister_schemas`).
+- `x-openregister-contextchat` added to the `Schema` configuration
+  allow-list is backward compatible — existing schemas without the key
+  behave exactly as before (opted out).
+- Rollout is opt-in per schema; no fleet-wide behaviour change on deploy.
+  Registration itself only activates if `context_chat` is installed and
+  enabled, so instances without it are entirely unaffected.
+- Rollback: disable the schema-level flag (or revert the code); no data
+  cleanup is required on the OR side. `context_chat`-side cleanup of
+  already-submitted content is out of OR's control and follows whatever
+  `context_chat`'s own uninstall/reset story is.
+
+## Open Questions
+
+- Should tenant/organisation scoping be modelled explicitly once Context
+  Chat's own contract exposes a per-item ACL/audience hook (if/when the
+  platform adds one)? Tracked as a follow-up; out of scope here.
+- Should `x-openregister-contextchat` support a richer shape (e.g. field
+  allow-list controlling which properties are submitted as content, versus
+  "the whole object") in a later iteration? This change submits a flat
+  text rendering of all non-writeOnly, non-relation scalar properties;
+  richer per-field control is deferred.

--- a/openspec/changes/context-chat-provider/proposal.md
+++ b/openspec/changes/context-chat-provider/proposal.md
@@ -1,0 +1,93 @@
+---
+kind: code
+---
+
+## Why
+
+Nextcloud is investing heavily in the Assistant / Context Agent surface (Hub
+26 Spring shipped agent tools across Files, Mail, Tasks, Forms, Deck), and
+"chat with your data" is now a baseline user expectation for any app that
+holds structured records. OpenRegister already registers a unified-search
+provider, notifier, activity provider, and dashboard widget so register
+objects surface across Nextcloud's built-in chrome — but it registers no
+`OCP\ContextChat` content provider, so every object in every register is
+invisible to the NC Assistant's RAG pipeline. For register-backed apps
+(including OpenBuild virtual apps), this is currently the highest-leverage
+missing AI surface: users can search for an object but cannot ask the
+Assistant a question that requires reasoning over its content.
+
+## What Changes
+
+- Implement `OCP\ContextChat\IContentProvider` (`getId`, `getAppId`,
+  `getItemUrl($id)`, `triggerInitialImport`) and register it by listening for
+  `ContentProviderRegisterEvent`, calling
+  `$event->registerContentProvider('openregister', 'openregister_objects', ContentProvider::class)`.
+  Registration is guarded by `isContextChatAvailable()` (soft dependency,
+  same `class_exists`-style guard OpenRegister already uses for the optional
+  Tables integration) — zero hard dependency on the `context_chat` app.
+- Submit object content to `ContentManager::submitContent()` on
+  `ObjectCreatedEvent` / `ObjectUpdatedEvent`, and remove it on
+  `ObjectDeletedEvent`, via a new listener attached at the same
+  `registerEventListeners()` site as the existing object-lifecycle listeners
+  (`ObjectChangeListener`, `ObjectMetricsListener`, `SourceRecordChangeListener`).
+  No hot-path service is modified.
+- Add a per-schema opt-in flag, `configuration['x-openregister-contextchat']`
+  (default OFF), following the existing `x-openregister-*` annotation
+  convention. Only objects of an opted-in schema are ever submitted.
+- Content submission additionally requires the object to satisfy the
+  published predicate already used by unified search
+  (`@self.published` set and in the past, `@self.depublished` unset or in
+  the future) OR be readable via a documented, deliberately coarse
+  allow-list — see design.md's access-model section for the full decision
+  and its explicit limitation.
+- `getItemUrl($id)` resolves via the existing
+  `DeepLinkRegistryService::resolveUrl()` (same mechanism `ObjectsProvider`
+  already uses for unified-search result URLs), falling back to
+  `openregister.objects.show`. No new URL-template config is introduced —
+  see design.md for why a bespoke `contextchat_url_template` key was
+  rejected in favour of the fleet-wide deep-link registry.
+- `triggerInitialImport()` walks opted-in (register, schema) pairs in
+  batches and submits each qualifying object.
+- New occ command `openregister:contextchat:reindex` (optionally scoped to a
+  register/schema) driving the same batch-submission path as
+  `triggerInitialImport()`.
+- Unit tests: provider registration guard (available / unavailable), object
+  → content-item submission payload shape, opt-in schema filtering, and
+  published-predicate filtering.
+
+## Capabilities
+
+### New Capabilities
+- `context-chat-provider`: Registers OpenRegister as a Nextcloud Context Chat
+  (`OCP\ContextChat`) content provider so opted-in, published register
+  objects are indexed into the NC Assistant's RAG pipeline, submitted on
+  object create/update, removed on delete, with an initial-import walk and
+  an occ reindex command.
+
+### Modified Capabilities
+(none — this is additive; it reuses `DeepLinkRegistryService` and the
+existing `x-openregister-*` schema-configuration allow-list mechanism
+without changing their contracts)
+
+## Impact
+
+- `lib/AppInfo/Application.php` — register `ContentProviderRegisterEvent`
+  listener in `registerEventListeners()`; register the new submission
+  listener on `ObjectCreatedEvent` / `ObjectUpdatedEvent` / `ObjectDeletedEvent`.
+- New `lib/ContextChat/ContentProvider.php` — `IContentProvider` implementation.
+- New `lib/ContextChat/ContentProviderRegistrationListener.php` — listens for
+  `ContentProviderRegisterEvent`, guarded by `isContextChatAvailable()`.
+- New `lib/Listener/ContextChatSubmissionListener.php` — submits/removes
+  content on the object lifecycle events.
+- New `lib/Command/ContextChatReindexCommand.php` — `openregister:contextchat:reindex`.
+- `appinfo/info.xml` — register the new occ command (`<command>` entry);
+  declare `context_chat` as an optional/soft dependency if the platform
+  requires it for autoloading its interfaces (see design.md).
+- `lib/Db/Schema.php` — add `x-openregister-contextchat` to the
+  `setConfiguration()` annotation allow-list (existing keys are silently
+  dropped if the incoming key isn't listed — see or#460/#462-class bug
+  history) and add an `isContextChatIndexingEnabled()` accessor.
+- No new HTTP controller/route — no user-facing REST surface is added;
+  the only new entry point is the occ command.
+- Tests: `tests/Unit/ContextChat/ContentProviderTest.php`,
+  `tests/Unit/Listener/ContextChatSubmissionListenerTest.php`.

--- a/openspec/changes/context-chat-provider/specs/context-chat-provider/spec.md
+++ b/openspec/changes/context-chat-provider/specs/context-chat-provider/spec.md
@@ -1,0 +1,103 @@
+## ADDED Requirements
+
+### Requirement: OpenRegister MUST register a Context Chat content provider only when the platform is available
+
+OpenRegister MUST listen for `OCP\ContextChat\Event\ContentProviderRegisterEvent`
+and, only when `isContextChatAvailable()` returns true, call
+`$event->registerContentProvider('openregister', 'openregister_objects',
+ContentProvider::class)`. When `context_chat` is not installed or not
+enabled, OpenRegister MUST NOT register a content provider and MUST NOT
+error or log above debug level.
+
+#### Scenario: context_chat app is enabled
+- **WHEN** `ContentProviderRegisterEvent` is dispatched and `context_chat` is enabled
+- **THEN** OpenRegister registers a content provider with id `openregister_objects` and app id `openregister`
+
+#### Scenario: context_chat app is absent
+- **WHEN** OpenRegister boots on an instance without the `context_chat` app installed
+- **THEN** no content provider is registered and app boot completes without error
+
+### Requirement: Only opted-in schemas MUST have their objects submitted to Context Chat
+
+A schema's objects MUST only be submitted to Context Chat when its
+configuration contains `x-openregister-contextchat` set to a truthy value.
+The default, for any schema lacking this key, MUST be treated as opted out.
+
+#### Scenario: Opted-in schema submits content
+- **GIVEN** a schema with `configuration['x-openregister-contextchat'] = true`
+- **WHEN** an object of that schema is created
+- **THEN** the object's content is submitted via `ContentManager::submitContent()`
+
+#### Scenario: Schema without the flag is skipped by default
+- **GIVEN** a schema whose configuration does not contain `x-openregister-contextchat`
+- **WHEN** an object of that schema is created
+- **THEN** no content is submitted for that object
+
+### Requirement: Only published objects MUST be submitted to Context Chat
+
+Regardless of schema opt-in, an object MUST only be submitted to Context
+Chat when it satisfies the published predicate: `@self.published` is set
+and in the past, and `@self.depublished` is either unset or in the future.
+Soft-deleted objects MUST never be submitted.
+
+#### Scenario: Published object on opted-in schema is submitted
+- **GIVEN** an opted-in schema and an object with `@self.published` set in the past and no `@self.depublished`
+- **WHEN** the object is created or updated
+- **THEN** the object's content is submitted to Context Chat
+
+#### Scenario: Unpublished object on opted-in schema is not submitted
+- **GIVEN** an opted-in schema and an object with no `@self.published` value
+- **WHEN** the object is created or updated
+- **THEN** no content is submitted for that object
+
+#### Scenario: Object that becomes depublished is removed
+- **GIVEN** a previously published, submitted object whose `@self.depublished` moves into the past
+- **WHEN** the object is updated
+- **THEN** OpenRegister removes the object's content from Context Chat rather than resubmitting it
+
+### Requirement: Object deletion MUST remove submitted content from Context Chat
+
+OpenRegister MUST remove an object's content from Context Chat when the
+object is deleted, regardless of its published state at delete time,
+provided it was ever eligible for submission (i.e. its schema is opted in).
+
+#### Scenario: Deleting a submitted object removes its content
+- **GIVEN** a published object on an opted-in schema previously submitted to Context Chat
+- **WHEN** the object is deleted
+- **THEN** OpenRegister issues a content-removal call for that object's id to Context Chat
+
+### Requirement: getItemUrl MUST resolve through the existing deep-link registry
+
+`ContentProvider::getItemUrl($id)` MUST resolve the target object's URL via
+`DeepLinkRegistryService::resolveUrl()` using the object's register and
+schema, and MUST fall back to the `openregister.objects.show` route when no
+app has claimed a deep link for that (register, schema) pair. No
+provider-specific URL-template configuration is introduced.
+
+#### Scenario: Deep link registered by a consuming app
+- **GIVEN** an app has registered a deep-link URL template for the object's (register, schema)
+- **WHEN** `getItemUrl($id)` is called for an object of that (register, schema)
+- **THEN** the resolved URL matches the registered app's template
+
+#### Scenario: No deep link registered
+- **GIVEN** no app has registered a deep-link URL template for the object's (register, schema)
+- **WHEN** `getItemUrl($id)` is called
+- **THEN** the resolved URL points to OpenRegister's own `openregister.objects.show` route
+
+### Requirement: Initial import MUST walk opted-in schemas in batches and MUST be re-runnable via occ
+
+`ContentProvider::triggerInitialImport()` MUST enumerate every opted-in
+(register, schema) pair and submit each qualifying (published) object in
+bounded batches. The same batch-submission path MUST also be reachable via
+the `openregister:contextchat:reindex` occ command, which MUST accept
+optional register/schema scoping.
+
+#### Scenario: Initial import covers all opted-in schemas
+- **GIVEN** two opted-in schemas, each with published objects
+- **WHEN** `triggerInitialImport()` runs
+- **THEN** every published object of both schemas is submitted to Context Chat
+
+#### Scenario: occ reindex command scoped to one schema
+- **GIVEN** two opted-in schemas
+- **WHEN** an operator runs `occ openregister:contextchat:reindex --schema=<id>`
+- **THEN** only published objects of that schema are (re)submitted

--- a/openspec/changes/context-chat-provider/tasks.md
+++ b/openspec/changes/context-chat-provider/tasks.md
@@ -1,0 +1,46 @@
+## 1. Schema configuration
+
+- [ ] 1.1 Add `x-openregister-contextchat` to `Schema::setConfiguration()`'s annotation allow-list, add an `isContextChatIndexingEnabled()` accessor, and assert round-trip (write config, re-read schema, key survives) in a test
+
+## 2. Content provider + registration
+
+- [ ] 2.1 Implement `lib/ContextChat/ContentProvider.php` (`IContentProvider`: `getId`, `getAppId`, `getItemUrl($id)`, `triggerInitialImport`)
+- [ ] 2.2 Implement `lib/ContextChat/ContentProviderRegistrationListener.php` (listens on `ContentProviderRegisterEvent`, guarded by `isContextChatAvailable()`)
+- [ ] 2.3 Register the listener in `lib/AppInfo/Application.php::registerEventListeners()`
+
+## 3. Submission listener
+
+- [ ] 3.1 Implement `lib/Listener/ContextChatSubmissionListener.php`: submit on `ObjectCreatedEvent`/`ObjectUpdatedEvent` when schema opted-in AND object satisfies the published predicate; remove on `ObjectDeletedEvent` or when an update makes the object no longer published; fail-soft (catch `Throwable`, log, never block the write)
+- [ ] 3.2 Register the listener on `ObjectCreatedEvent`, `ObjectUpdatedEvent`, `ObjectDeletedEvent` in `registerEventListeners()`
+
+## 4. Deep-link URL resolution
+
+- [ ] 4.1 Wire `ContentProvider::getItemUrl()` to `DeepLinkRegistryService::resolveUrl()` with the `openregister.objects.show` route fallback (no new URL-template config)
+
+## 5. Initial import + occ command
+
+- [ ] 5.1 Implement `triggerInitialImport()`: batched walk of every opted-in (register, schema) pair, submitting each published object
+- [ ] 5.2 Implement `lib/Command/ContextChatReindexCommand.php` (`openregister:contextchat:reindex`, optional `--register`/`--schema` scoping), reusing the batch-submission path
+- [ ] 5.3 Register the command in `appinfo/info.xml`
+
+## 6. Tests
+
+- [ ] 6.1 Unit test: provider registration fires only when `isContextChatAvailable()` is true
+- [ ] 6.2 Unit test: submission payload shape on object create/update
+- [ ] 6.3 Unit test: opt-in filtering (schema with flag vs. without)
+- [ ] 6.4 Unit test: published-predicate filtering (published/unpublished/depublished objects)
+- [ ] 6.5 Unit test: object deletion issues a content-removal call
+- [ ] 6.6 Unit test: `getItemUrl` deep-link resolution and fallback
+
+## 7. Live verification
+
+- [ ] 7.1 Live-verify on the dev instance (8080): opt in a test schema, create/publish/update/delete objects, confirm submit/remove calls fire, and run `occ openregister:contextchat:reindex` end-to-end
+
+## Acceptance Criteria
+
+- A standalone OpenRegister instance without the `context_chat` app boots and behaves exactly as before this change.
+- Objects on schemas without `x-openregister-contextchat: true` are never submitted to Context Chat.
+- Only published, non-deleted objects on opted-in schemas are submitted; depublished or deleted objects are removed from Context Chat.
+- `getItemUrl()` returns the same URL a user would reach via unified search or the deep-link registry for that object.
+- `occ openregister:contextchat:reindex` backfills all opted-in, published objects and can be scoped to a single register/schema.
+- No object create/update/delete request fails or slows materially due to a Context Chat submission error.

--- a/openspec/specs/context-chat-provider/spec.md
+++ b/openspec/specs/context-chat-provider/spec.md
@@ -1,0 +1,47 @@
+---
+status: in-progress
+---
+# Context Chat Provider
+
+## Purpose
+
+@e2e exclude backend Nextcloud Context Chat integration — covered by PHPUnit
+
+Registers OpenRegister as a Nextcloud Context Chat (`OCP\ContextChat`) content provider so opted-in, published register objects become searchable/reasonable-over by the NC Assistant's RAG pipeline — the same way OpenRegister already surfaces objects to unified search, notifications, and activity. Registration is soft-gated on `isContextChatAvailable()` (zero hard dependency on the `context_chat` app). Content is submitted on object create/update and removed on delete via the existing object-lifecycle events, is scoped by an explicit, default-OFF per-schema opt-in (`configuration['x-openregister-contextchat']`), and is further restricted to objects satisfying the same published predicate unified search already enforces. `getItemUrl()` reuses the existing `DeepLinkRegistryService::resolveUrl()` fleet-wide deep-link mechanism (no bespoke URL-template config). An `occ openregister:contextchat:reindex` command and `triggerInitialImport()` provide batched backfill.
+
+**Status**: in-progress
+
+**OpenSpec changes**
+- `context-chat-provider` (in-progress) — implements `IContentProvider` (`getId`/`getAppId`/`getItemUrl`/`triggerInitialImport`) registered via `ContentProviderRegisterEvent`; submits/removes content on the existing `ObjectCreatedEvent`/`ObjectUpdatedEvent`/`ObjectDeletedEvent` listeners; adds the `x-openregister-contextchat` per-schema opt-in to the `Schema` configuration allow-list; adds the `openregister:contextchat:reindex` occ command.
+
+## Requirements
+
+### Requirement: OpenRegister registers a Context Chat content provider only when the platform is available
+
+OpenRegister SHALL listen for `ContentProviderRegisterEvent` and register exactly one content provider (id `openregister_objects`, app id `openregister`) only when `isContextChatAvailable()` is true, mirroring the existing soft-dependency guard pattern used for the optional Tables integration. Instances without `context_chat` installed MUST be entirely unaffected. The full normative behaviour is defined by the `context-chat-provider` change delta.
+
+#### Scenario: Provider registration is gated on platform availability
+- **GIVEN** an OpenRegister instance with or without the `context_chat` app enabled
+- **WHEN** `ContentProviderRegisterEvent` is dispatched (or never dispatched, on an instance without the app)
+- **THEN** OpenRegister registers `openregister_objects` only when `context_chat` is available, and never errors either way
+- @e2e exclude backend event listener registration — asserted by PHPUnit
+
+### Requirement: Only opted-in, published objects are submitted to Context Chat
+
+Content submission to Context Chat SHALL be scoped by two independent gates: (1) the object's schema carries `configuration['x-openregister-contextchat']` set to a truthy value (default OFF), and (2) the object satisfies the published predicate already used by unified search (`@self.published` set and in the past, `@self.depublished` unset or in the future). Deleted objects, or objects that become unpublished, SHALL have their content removed from Context Chat rather than left stale. The full normative behaviour is defined by the `context-chat-provider` change delta.
+
+#### Scenario: Object submission respects opt-in and publish state
+- **GIVEN** objects across opted-in and non-opted-in schemas, in both published and unpublished states
+- **WHEN** each object is created, updated, or deleted
+- **THEN** Context Chat only ever holds content for currently-published objects on opted-in schemas, and content is removed on delete or on the object leaving the published state
+- @e2e exclude backend submission/removal listener — asserted by PHPUnit
+
+### Requirement: getItemUrl and initial import reuse existing OpenRegister infrastructure
+
+`getItemUrl($id)` SHALL resolve via the existing `DeepLinkRegistryService::resolveUrl()`, falling back to the `openregister.objects.show` route — no new URL-template configuration surface is introduced. `triggerInitialImport()` and the `openregister:contextchat:reindex` occ command SHALL walk opted-in (register, schema) pairs in bounded batches, submitting every qualifying published object, with the occ command additionally supporting optional register/schema scoping. The full normative behaviour is defined by the `context-chat-provider` change delta.
+
+#### Scenario: Item URL and backfill reuse fleet-wide mechanisms
+- **GIVEN** an opted-in schema with a mix of published objects, some claimed by a registered deep link and some not
+- **WHEN** `getItemUrl()` is resolved for those objects, and `triggerInitialImport()` or the reindex occ command is run
+- **THEN** each URL matches the deep-link registry result (or the `openregister.objects.show` fallback), and every published object of every opted-in schema is submitted
+- @e2e exclude backend initial-import/reindex batch job — asserted by PHPUnit


### PR DESCRIPTION
OpenSpec ff change from the OpenBuild market deepdive round 2 (2026-07-23, findings logged to spectr register 2444).

**Gap:** OR registers unified search, notifications, activity, comments, dashboard — but no Context Chat `IContentProvider`; register objects are invisible to the NC Assistant.

**Change artifacts:** proposal / design (seed data, access-model decision, ADR-031 note) / spec delta (6 requirements) / tasks (17). `openspec validate --strict` passes.

Leaf feature: consumed by OpenBuild virtual apps and every register-backed app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)