### PR TITLE
fix(schema): scope slug resolution by app/register — stop cross-app schema collisions

### DIFF
--- a/lib/Db/SchemaMapper.php
+++ b/lib/Db/SchemaMapper.php
@@ -417,8 +417,8 @@ class SchemaMapper extends QBMapper
      * same-slug row {@see find()} happens to fetch first. Callers pass the
      * register's own `schemas` id list; the slug is matched only among those.
      *
-     * @param string    $slug      The schema slug (matched case-insensitively).
-     * @param int[]     $schemaIds The candidate schema ids (a register's schemas list).
+     * @param string $slug      The schema slug (matched case-insensitively).
+     * @param int[]  $schemaIds The candidate schema ids (a register's schemas list).
      *
      * @return Schema|null The matching schema within the id set, or null when
      *                     none of the register's schemas carry this slug.

--- a/lib/Db/SchemaMapper.php
+++ b/lib/Db/SchemaMapper.php
@@ -363,6 +363,106 @@ class SchemaMapper extends QBMapper
     }//end find()
 
     /**
+     * Resolve a schema by slug, scoped to a single owning application.
+     *
+     * The plain {@see find()} matches a schema by `LOWER(slug)` GLOBALLY across
+     * every application on the instance and returns the FIRST row it fetches.
+     * On a shared instance where ~20 apps live in one OpenRegister, that lets a
+     * generic slug (e.g. `conversation`, `order`, `task`) from app B silently
+     * bind to — or, on import, OVERWRITE — app A's schema that happens to share
+     * the lower(slug). This scoped lookup is the import-side fix: an app only
+     * ever matches (and therefore updates) a schema IT owns, so importing a
+     * colliding slug creates the app's OWN schema instead of clobbering a
+     * foreign one.
+     *
+     * @param string $slug        The schema slug (matched case-insensitively).
+     * @param string $application The owning application id (exact match).
+     *
+     * @return Schema|null The application-owned schema, or null when the app
+     *                     does not (yet) own a schema with this slug.
+     */
+    public function findByApplicationAndSlug(string $slug, string $application): ?Schema
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from('openregister_schemas')
+            ->where(
+                $qb->expr()->eq(
+                    $qb->func()->lower('slug'),
+                    $qb->createNamedParameter(value: strtolower($slug), type: IQueryBuilder::PARAM_STR)
+                )
+            )
+            ->andWhere(
+                $qb->expr()->eq('application', $qb->createNamedParameter(value: $application, type: IQueryBuilder::PARAM_STR))
+            )
+            ->setMaxResults(1);
+
+        $result = $qb->executeQuery();
+        $row    = $result->fetch();
+        $result->closeCursor();
+
+        if ($row === false) {
+            return null;
+        }
+
+        return $this->resolveSchemaExtension(schema: Schema::fromRow($row));
+    }//end findByApplicationAndSlug()
+
+    /**
+     * Resolve a schema by slug, scoped to a set of schema ids.
+     *
+     * This is the runtime-resolution half of the cross-app slug-collision fix.
+     * When an object operation carries a register context, a schema slug must
+     * resolve to the schema THAT REGISTER references — not to whichever
+     * same-slug row {@see find()} happens to fetch first. Callers pass the
+     * register's own `schemas` id list; the slug is matched only among those.
+     *
+     * @param string    $slug      The schema slug (matched case-insensitively).
+     * @param int[]     $schemaIds The candidate schema ids (a register's schemas list).
+     *
+     * @return Schema|null The matching schema within the id set, or null when
+     *                     none of the register's schemas carry this slug.
+     */
+    public function findBySlugInIds(string $slug, array $schemaIds): ?Schema
+    {
+        // Normalise to a list of positive integers; an empty set can never match.
+        $ids = [];
+        foreach ($schemaIds as $candidate) {
+            if (is_numeric($candidate) === true && (int) $candidate > 0) {
+                $ids[] = (int) $candidate;
+            }
+        }
+
+        if ($ids === []) {
+            return null;
+        }
+
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from('openregister_schemas')
+            ->where(
+                $qb->expr()->eq(
+                    $qb->func()->lower('slug'),
+                    $qb->createNamedParameter(value: strtolower($slug), type: IQueryBuilder::PARAM_STR)
+                )
+            )
+            ->andWhere(
+                $qb->expr()->in('id', $qb->createNamedParameter(value: $ids, type: IQueryBuilder::PARAM_INT_ARRAY))
+            )
+            ->setMaxResults(1);
+
+        $result = $qb->executeQuery();
+        $row    = $result->fetch();
+        $result->closeCursor();
+
+        if ($row === false) {
+            return null;
+        }
+
+        return $this->resolveSchemaExtension(schema: Schema::fromRow($row));
+    }//end findBySlugInIds()
+
+    /**
      * Clear the request-scoped find cache for a specific schema
      *
      * Used by the runtime-schema-api CRUD path to drop the in-memory

--- a/lib/Migration/Version1Date20260723000000.php
+++ b/lib/Migration/Version1Date20260723000000.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * Widen the register/schema slug-uniqueness key from (organisation, slug)
+ * to (organisation, application, slug) so each app can own its own schema
+ * (or register) with a shared, generic slug.
+ *
+ * The old `schemas_organisation_slug_unique` / `registers_organisation_slug_unique`
+ * indexes (added Version1Date20250829120000) made a slug unique per ORGANISATION,
+ * not per app. On a shared OpenRegister instance where ~20 apps live in one
+ * database that turned a generic slug shipped by app B — `conversation`, `order`,
+ * `task`, `notification`, `contact`, … — into a hard collision with app A's
+ * schema of the same slug: the DB physically refused app B its own schema, so the
+ * importer silently BOUND app B to (or OVERWROTE) app A's schema. App B's objects
+ * then landed in the wrong schema/table and A's schema could be corrupted. The
+ * collision was invisible in single-app tests (a clean instance has no competitor
+ * for the slug) and environment-dependent (first-app-wins).
+ *
+ * Adding `application` to the unique key lets every app own a schema/register with
+ * the same slug, while resolution is scoped by app (import) and by register
+ * (runtime) in the accompanying code change so a slug still resolves
+ * deterministically. The new key is STRICTLY MORE PERMISSIVE than the old one —
+ * every row unique under (organisation, slug) is unique under
+ * (organisation, application, slug) — so no data dedup is required and the change
+ * cannot fail on existing rows. Idempotent: swaps each index only when the old one
+ * is present, the new one is absent, and the `application` column exists.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/data-import-export/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Widen slug-uniqueness to (organisation, application, slug) for registers and schemas.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ *
+ * @spec openspec/specs/data-import-export/spec.md
+ */
+class Version1Date20260723000000 extends SimpleMigrationStep
+{
+    /**
+     * Change the database schema.
+     *
+     * @param IOutput                 $output        Output for the migration process.
+     * @param Closure                 $schemaClosure The schema closure.
+     * @param array<array-key, mixed> $options       Migration options.
+     *
+     * @return ISchemaWrapper|null
+     *
+     * @spec openspec/specs/data-import-export/spec.md
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema = $schemaClosure();
+
+        // Registers: (organisation, slug) -> (organisation, application, slug).
+        $this->widenSlugUniqueIndex(
+            schema: $schema,
+            output: $output,
+            tableName: 'openregister_registers',
+            oldIndexName: 'registers_organisation_slug_unique',
+            newIndexName: 'registers_org_app_slug_unique'
+        );
+
+        // Schemas: (organisation, slug) -> (organisation, application, slug).
+        $this->widenSlugUniqueIndex(
+            schema: $schema,
+            output: $output,
+            tableName: 'openregister_schemas',
+            oldIndexName: 'schemas_organisation_slug_unique',
+            newIndexName: 'schemas_org_app_slug_unique'
+        );
+
+        return $schema;
+    }//end changeSchema()
+
+    /**
+     * Swap a (organisation, slug) unique index for a (organisation, application, slug) one.
+     *
+     * Idempotent and self-guarding: does nothing unless the table and the three
+     * columns exist. Drops the old index only when present, and adds the new one
+     * only when absent, so re-runs and partially-applied states converge safely.
+     *
+     * @param ISchemaWrapper $schema       The schema wrapper.
+     * @param IOutput        $output       Migration output.
+     * @param string         $tableName    The table to alter.
+     * @param string         $oldIndexName The (organisation, slug) index to drop.
+     * @param string         $newIndexName The (organisation, application, slug) index to add.
+     *
+     * @return void
+     */
+    private function widenSlugUniqueIndex(
+        ISchemaWrapper $schema,
+        IOutput $output,
+        string $tableName,
+        string $oldIndexName,
+        string $newIndexName
+    ): void {
+        if ($schema->hasTable($tableName) === false) {
+            return;
+        }
+
+        $table = $schema->getTable($tableName);
+
+        // Need all three columns to build the wider key.
+        if ($table->hasColumn('organisation') === false
+            || $table->hasColumn('application') === false
+            || $table->hasColumn('slug') === false
+        ) {
+            $output->warning(
+                "Cannot widen slug-uniqueness on {$tableName}: organisation, application or slug column missing"
+            );
+            return;
+        }
+
+        // Drop the narrow (organisation, slug) index if it is still present.
+        if ($table->hasIndex($oldIndexName) === true) {
+            $table->dropIndex($oldIndexName);
+            $output->info("Dropped narrow unique index {$oldIndexName} on {$tableName}");
+        }
+
+        // Add the wider (organisation, application, slug) index if not already there.
+        if ($table->hasIndex($newIndexName) === false) {
+            $table->addUniqueIndex(['organisation', 'application', 'slug'], $newIndexName);
+            $output->info("Added unique index {$newIndexName} on (organisation, application, slug) for {$tableName}");
+        }
+    }//end widenSlugUniqueIndex()
+}//end class

--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -1429,12 +1429,13 @@ class ImportHandler
                 // still (correctly) create our own schema below.
                 if ($existingSchema === null) {
                     try {
-                        $foreign = $this->schemaMapper->find($data['slug'], _multitenancy: false);
+                        $foreign    = $this->schemaMapper->find($data['slug'], _multitenancy: false);
                         $foreignApp = $foreign->getApplication();
                         if ($foreignApp !== null && $foreignApp !== '' && $foreignApp !== $appId) {
                             $this->logger->warning(
                                 message: sprintf(
-                                    "[ImportHandler] Schema slug '%s' is already owned by app '%s'; app '%s' will create its OWN schema to avoid a cross-app collision.",
+                                    "[ImportHandler] Schema slug '%s' is already owned by app '%s'; ".
+                                    "app '%s' will create its OWN schema to avoid a cross-app collision.",
                                     $data['slug'],
                                     $foreignApp,
                                     $appId
@@ -3453,12 +3454,12 @@ class ImportHandler
                     }
                 } catch (\Throwable $ignore) {
                     // Missing / undecodable schema id — keep it as-is; nothing to compare against.
-                }
+                }//end try
 
                 if ($keep === true) {
                     $prunedSchemaIds[] = $currentId;
                 }
-            }
+            }//end foreach
 
             // Union the freshly-imported app-owned ids into the pruned list.
             $unionSchemaIds = $prunedSchemaIds;

--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -1407,24 +1407,62 @@ class ImportHandler
             }//end if
 
             // Check if schema already exists by slug.
-            // Bypass multi-tenancy so we find schemas regardless of organisation context,
-            // preventing duplicate schemas when the active organisation UUID changes.
+            //
+            // CROSS-APP SLUG-COLLISION FIX. Historically this did a GLOBAL slug
+            // lookup (`find($slug, _multitenancy:false)`) — a slug was unique
+            // INSTANCE-WIDE, not per app. On the shared instance that made a
+            // generic slug (e.g. 'conversation', 'order', 'task') shipped by app
+            // B silently BIND to app A's schema, and — if B's version was newer —
+            // OVERWRITE A's live schema via updateFromArray() below. When we have
+            // an app context, resolve the existing schema scoped to THIS app:
+            // an app only ever updates a schema it owns, so importing a colliding
+            // slug creates the app's OWN schema (see the create path below)
+            // instead of clobbering a foreign one. Without an app context
+            // (manual / UI-driven single imports) the historical global behaviour
+            // is preserved for backward compatibility.
             $existingSchema = null;
-            try {
-                $existingSchema = $this->schemaMapper->find($data['slug'], _multitenancy: false);
-            } catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
-                $msg = "Schema '{$data['slug']}' not found, will create new one";
-                $this->logger->info(message: '[ImportHandler] '.$msg, context: ['file' => __FILE__, 'line' => __LINE__]);
-            } catch (\OCA\OpenRegister\Exception\ValidationException $e) {
-                $msg = "Schema '{$data['slug']}' not found (ValidationException), will create new one";
-                $this->logger->info(message: '[ImportHandler] '.$msg, context: ['file' => __FILE__, 'line' => __LINE__]);
-            } catch (\OCP\AppFramework\Db\MultipleObjectsReturnedException $e) {
-                $this->handleDuplicateSchemaError(
-                    slug: $data['slug'],
-                    appId: $appId ?? 'unknown',
-                    version: $version ?? 'unknown'
-                );
-            }
+            if ($appId !== null && $appId !== '') {
+                $existingSchema = $this->schemaMapper->findByApplicationAndSlug(slug: $data['slug'], application: $appId);
+
+                // Visibility: if we own none but a DIFFERENT app already owns the
+                // slug, surface the collision instead of silently forking. We
+                // still (correctly) create our own schema below.
+                if ($existingSchema === null) {
+                    try {
+                        $foreign = $this->schemaMapper->find($data['slug'], _multitenancy: false);
+                        $foreignApp = $foreign->getApplication();
+                        if ($foreignApp !== null && $foreignApp !== '' && $foreignApp !== $appId) {
+                            $this->logger->warning(
+                                message: sprintf(
+                                    "[ImportHandler] Schema slug '%s' is already owned by app '%s'; app '%s' will create its OWN schema to avoid a cross-app collision.",
+                                    $data['slug'],
+                                    $foreignApp,
+                                    $appId
+                                ),
+                                context: ['file' => __FILE__, 'line' => __LINE__, 'slug' => $data['slug']]
+                            );
+                        }
+                    } catch (\Throwable $ignore) {
+                        // No pre-existing schema (or ambiguous) — nothing to warn about.
+                    }
+                }
+            } else {
+                try {
+                    $existingSchema = $this->schemaMapper->find($data['slug'], _multitenancy: false);
+                } catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
+                    $msg = "Schema '{$data['slug']}' not found, will create new one";
+                    $this->logger->info(message: '[ImportHandler] '.$msg, context: ['file' => __FILE__, 'line' => __LINE__]);
+                } catch (\OCA\OpenRegister\Exception\ValidationException $e) {
+                    $msg = "Schema '{$data['slug']}' not found (ValidationException), will create new one";
+                    $this->logger->info(message: '[ImportHandler] '.$msg, context: ['file' => __FILE__, 'line' => __LINE__]);
+                } catch (\OCP\AppFramework\Db\MultipleObjectsReturnedException $e) {
+                    $this->handleDuplicateSchemaError(
+                        slug: $data['slug'],
+                        appId: $appId ?? 'unknown',
+                        version: $version ?? 'unknown'
+                    );
+                }
+            }//end if
 
             if ($existingSchema !== null) {
                 // Compare versions using version_compare for proper semver comparison.

--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -3405,8 +3405,63 @@ class ImportHandler
                 $register->setDescription($description);
             }
 
+            // Reconcile schema references. Union the freshly-imported (app-owned)
+            // ids in, but first PRUNE any currently-listed id that is now
+            // SHADOWED by a newly-imported schema sharing the same slug. This
+            // self-heals a register that — before the cross-app slug-collision
+            // fix — had a FOREIGN app's same-slug schema bound into it (e.g.
+            // pipelinq's 'conversation' #701 living in hermiq's register). Once
+            // the app imports its OWN 'conversation', the foreign shadow is
+            // dropped from THIS app's register so a slug resolves unambiguously
+            // to the app's own schema.
             $currentSchemaIds = $register->getSchemas() ?? [];
-            $unionSchemaIds   = $currentSchemaIds;
+
+            // Map lower(slug) -> app-owned id for everything we just imported.
+            $newSlugToId = [];
+            foreach ($schemas as $schema) {
+                if ($schema instanceof Schema
+                    && $schema->getId() !== null
+                    && $schema->getSlug() !== null
+                ) {
+                    $newSlugToId[strtolower($schema->getSlug())] = (int) $schema->getId();
+                }
+            }
+
+            // Drop any currently-listed id whose slug matches a freshly-imported
+            // schema but whose id differs (the shadowed, foreign/stale one).
+            $prunedSchemaIds = [];
+            foreach ($currentSchemaIds as $currentId) {
+                $currentId = (int) $currentId;
+                $keep      = true;
+                try {
+                    $existingSlug = $this->schemaMapper->find($currentId, _multitenancy: false)->getSlug();
+                    if ($existingSlug !== null) {
+                        $slugKey = strtolower($existingSlug);
+                        if (isset($newSlugToId[$slugKey]) === true && $newSlugToId[$slugKey] !== $currentId) {
+                            $keep = false;
+                            $this->logger->info(
+                                message: sprintf(
+                                    "[ImportHandler] Auto-Register '%s': pruning shadowed schema id %d (slug '%s') in favour of app-owned id %d",
+                                    $slug,
+                                    $currentId,
+                                    $existingSlug,
+                                    $newSlugToId[$slugKey]
+                                ),
+                                context: ['file' => __FILE__, 'line' => __LINE__]
+                            );
+                        }
+                    }
+                } catch (\Throwable $ignore) {
+                    // Missing / undecodable schema id — keep it as-is; nothing to compare against.
+                }
+
+                if ($keep === true) {
+                    $prunedSchemaIds[] = $currentId;
+                }
+            }
+
+            // Union the freshly-imported app-owned ids into the pruned list.
+            $unionSchemaIds = $prunedSchemaIds;
             foreach ($newSchemaIds as $newId) {
                 if (in_array($newId, $unionSchemaIds, true) === false) {
                     $unionSchemaIds[] = $newId;

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -423,6 +423,30 @@ class ObjectService
     public function setSchema(Schema | string | int $schema): static
     {
         if (is_string($schema) === true || is_int($schema) === true) {
+            // REGISTER-SCOPED SLUG RESOLUTION (cross-app collision fix).
+            // SchemaMapper::find() resolves a slug by LOWER(slug) GLOBALLY across
+            // every app on the instance and returns the FIRST row it fetches. On
+            // the shared instance that lets a generic slug (e.g. 'conversation',
+            // 'order', 'task') resolve to another app's schema that shares the
+            // lower(slug). When a register context is present, the slug must
+            // resolve to the schema THAT REGISTER references. Try that first; it
+            // is a no-op (null) for numeric ids, uuids, or slugs the register
+            // does not carry, so we transparently fall back to the global find
+            // for every legacy / register-less caller.
+            if (is_string($schema) === true
+                && is_numeric($schema) === false
+                && $this->currentRegister !== null
+            ) {
+                $scoped = $this->schemaMapper->findBySlugInIds(
+                    slug: $schema,
+                    schemaIds: ($this->currentRegister->getSchemas() ?? [])
+                );
+                if ($scoped !== null) {
+                    $this->currentSchema = $scoped;
+                    return $this;
+                }
+            }
+
             // Resolve the identifier through the mapper. SchemaMapper::find()
             // already provides request-scoped caching (findCache) and supports
             // numeric IDs, UUIDs, and slugs via orX(id, uuid, slug).
@@ -2181,19 +2205,29 @@ class ObjectService
             );
         }
 
-        // Resolve schema slug → numeric ID, scoped to the same multi-tenancy
-        // boundary. A schema that exists in another organisation MUST throw,
-        // not return the foreign-org entity (principle of least surprise).
-        try {
-            $schema = $this->schemaMapper->find(
-                id: $schemaSlug,
-                _rbac: $_rbac,
-                _multitenancy: $_multitenancy
-            );
-        } catch (OcpDoesNotExistException $e) {
-            throw new OcpDoesNotExistException(
-                'searchObjectsBySlug: schema slug not found in caller organisation: '.$schemaSlug
-            );
+        // Resolve schema slug → numeric ID. REGISTER-SCOPED first (cross-app
+        // collision fix): a generic slug must resolve to the schema THIS
+        // register references, not to whichever same-slug row find() fetches
+        // first across the shared instance. Fall back to the multi-tenancy
+        // scoped global find when the register does not carry the slug — a
+        // schema in another organisation MUST then throw, not return the
+        // foreign-org entity (principle of least surprise).
+        $schema = $this->schemaMapper->findBySlugInIds(
+            slug: $schemaSlug,
+            schemaIds: ($register->getSchemas() ?? [])
+        );
+        if ($schema === null) {
+            try {
+                $schema = $this->schemaMapper->find(
+                    id: $schemaSlug,
+                    _rbac: $_rbac,
+                    _multitenancy: $_multitenancy
+                );
+            } catch (OcpDoesNotExistException $e) {
+                throw new OcpDoesNotExistException(
+                    'searchObjectsBySlug: schema slug not found in caller organisation: '.$schemaSlug
+                );
+            }
         }
 
         // Merge resolved numeric IDs into the @self block of the filters.

--- a/openspec/changes/schema-slug-cross-app-scoping/.openspec.yaml
+++ b/openspec/changes/schema-slug-cross-app-scoping/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/schema-slug-cross-app-scoping/proposal.md
+++ b/openspec/changes/schema-slug-cross-app-scoping/proposal.md
@@ -1,0 +1,69 @@
+---
+kind: code
+---
+
+## Why
+
+Schema (and register) slugs are unique per **organisation**, not per **application**.
+The DB enforces this with a `(organisation, slug)` unique index, and
+`SchemaMapper::find()` resolves a slug by `LOWER(slug)` GLOBALLY across every app
+on the instance, returning the first row it fetches.
+
+On the shared OpenRegister instance — ~20 Conduction apps living in one database —
+that turns a generic slug shipped by app B (`conversation`, `order`, `task`,
+`notification`, `contact`, `message`, …) into a hard collision with app A's schema
+of the same slug:
+
+- The DB physically refuses app B its own schema, so `ImportHandler::importSchema()`
+  silently **binds** app B to app A's schema — or, if B's version is newer,
+  **overwrites** A's live schema.
+- App B's objects then land in the wrong schema/table, and A's schema can be
+  corrupted.
+- It is **first-app-wins** and therefore environment-dependent, and **invisible in
+  single-app tests** (a clean instance has no competitor for the slug).
+
+Live example: `hermiq` ships bare `conversation`/`message`; `pipelinq` already owns
+`conversation` (#701, required `channel` enum) and `message` (#700). hermiq's import
+bound to #701/#700, so **every** hermiq agent run — which does
+`saveObject(register: 'hermiq', schema: 'conversation')` — resolved to pipelinq's
+#701 and failed validation on the missing `channel`. Agent execution was 100% broken.
+
+Convention (namespacing every app's slugs) does not hold across ~20 teams. The
+durable fix is to make the slug namespace **per application**, and to resolve slugs
+within the **register** context that runtime callers already carry.
+
+## What Changes
+
+- **Widen slug-uniqueness** (migration): replace the `(organisation, slug)` unique
+  index on `openregister_schemas` and `openregister_registers` with
+  `(organisation, application, slug)`. Strictly more permissive than the old key —
+  no data dedup, cannot fail on existing rows. Idempotent + self-guarding.
+- **App-scoped import** (`ImportHandler::importSchema()`): when an app context is
+  present, resolve the existing schema via
+  `SchemaMapper::findByApplicationAndSlug($slug, $appId)`. An app only ever updates
+  a schema it **owns**, so importing a colliding slug creates the app's **own**
+  schema instead of binding to / overwriting a foreign one. A foreign owner is
+  logged. App-less (manual/UI) imports keep the historical global behaviour.
+- **Register-scoped runtime resolution** (`ObjectService::setSchema()` and
+  `searchObjectsBySlug()`): when a register context is present, resolve a slug among
+  the register's own schemas via `SchemaMapper::findBySlugInIds($slug, $ids)` so a
+  slug resolves to the schema **that register references** — not whichever same-slug
+  row is fetched first. Falls back to the global find for numeric ids, uuids, and
+  slugs the register does not carry (register-less callers unchanged).
+- **Self-heal polluted registers** (`ImportHandler::autoCreateRegisterIfApplication()`):
+  when reconciling an app's auto-register, **prune** any listed schema id that is now
+  shadowed by a freshly-imported same-slug schema, so a register that had a foreign
+  app's schema bound in before this fix is cleaned up on the next import.
+
+## Impact
+
+- Backward compatible: the new resolution paths are no-ops without an app/register
+  context; the wider unique key accepts everything the old one did.
+- Behaviour changes **only** in genuine cross-app collision cases (which were bugs):
+  the second app now gets its own schema and resolves to it.
+- Affected code: `lib/Db/SchemaMapper.php`, `lib/Service/ObjectService.php`,
+  `lib/Service/Configuration/ImportHandler.php`,
+  `lib/Migration/Version1Date20260723000000.php`.
+- Live-verified on the shared 8080 instance: hermiq now imports its own
+  `conversation`/`message` schemas, its register is healed of the foreign ids, a
+  slug resolves to the app's own schema, and a conversation object persists.

--- a/openspec/changes/schema-slug-cross-app-scoping/specs/data-import-export/spec.md
+++ b/openspec/changes/schema-slug-cross-app-scoping/specs/data-import-export/spec.md
@@ -1,0 +1,65 @@
+---
+status: proposed
+---
+
+# Data Import & Export
+
+## ADDED Requirements
+
+### Requirement: Schema slugs are unique per application, not per organisation
+The system SHALL scope schema and register slug-uniqueness by
+`(organisation, application, slug)` rather than `(organisation, slug)`, so two
+applications sharing one OpenRegister instance MAY each own a schema (or register)
+with the same generic slug. The `Version1Date20260723000000` migration MUST replace
+the `(organisation, slug)` unique indexes on `openregister_schemas` and
+`openregister_registers` with `(organisation, application, slug)` indexes, and MUST
+be idempotent (swap each index only when the old one is present and the new one is
+absent).
+
+#### Scenario: Two apps import a schema with the same slug
+- **GIVEN** application `pipelinq` already owns a schema with slug `conversation`
+- **WHEN** application `hermiq` imports its own schema with slug `conversation`
+- **THEN** the database MUST accept both rows
+- **AND** each schema MUST retain its own `application` (`pipelinq` and `hermiq`)
+- **AND** neither schema's definition is overwritten by the other's import
+
+### Requirement: Schema import binds only to schemas the importing app owns
+When `ImportHandler::importSchema()` runs with an application context, it MUST
+resolve the existing schema by `(slug, application)` — an application only ever
+updates a schema it owns. If a schema with the same slug exists but is owned by a
+different application, the import MUST create the importing application's own schema
+(and SHOULD log the foreign owner) rather than binding to or overwriting the foreign
+schema. Imports without an application context (manual/UI single imports) retain the
+historical global slug behaviour.
+
+#### Scenario: Importing a slug owned by another app creates your own schema
+- **GIVEN** slug `conversation` is owned by application `pipelinq`
+- **WHEN** application `hermiq` imports a schema with slug `conversation`
+- **THEN** a new schema owned by `hermiq` MUST be created
+- **AND** `pipelinq`'s `conversation` schema MUST be left unchanged
+
+### Requirement: A slug resolves within its register context
+When an object operation carries a register context, `ObjectService` MUST resolve a
+schema slug among the schemas that register references, so a generic slug resolves to
+the schema the register owns rather than an arbitrary same-slug row from another
+application. When the register does not reference a schema with that slug, resolution
+MUST fall back to the global lookup so register-less callers are unaffected.
+
+#### Scenario: Saving an object resolves the app's own schema
+- **GIVEN** register `hermiq` references schema `conversation` owned by `hermiq`
+- **AND** another application owns a different schema with slug `conversation`
+- **WHEN** a caller does `saveObject(register: 'hermiq', schema: 'conversation')`
+- **THEN** the object MUST be validated and stored against `hermiq`'s `conversation`
+  schema, not the other application's
+
+### Requirement: Re-import heals a register polluted with a foreign schema
+When `ImportHandler` reconciles an application's auto-created register, it MUST prune
+any referenced schema id that is shadowed by a freshly-imported schema sharing the
+same slug, so a register that had a foreign application's same-slug schema bound into
+it before this change is cleaned up on the next import.
+
+#### Scenario: Re-import drops a foreign shadowed schema id
+- **GIVEN** register `hermiq` still lists `pipelinq`'s `conversation` schema id
+- **WHEN** `hermiq` re-imports and creates its own `conversation` schema
+- **THEN** the register MUST list `hermiq`'s `conversation` schema id
+- **AND** the register MUST NOT list `pipelinq`'s `conversation` schema id

--- a/openspec/changes/schema-slug-cross-app-scoping/tasks.md
+++ b/openspec/changes/schema-slug-cross-app-scoping/tasks.md
@@ -1,0 +1,29 @@
+# Tasks
+
+## 1. Widen slug-uniqueness to (organisation, application, slug)
+- [x] Migration `Version1Date20260723000000` drops
+      `schemas_organisation_slug_unique` / `registers_organisation_slug_unique`
+      and adds `schemas_org_app_slug_unique` / `registers_org_app_slug_unique`
+      over `(organisation, application, slug)`.
+- [x] Idempotent + self-guarding (checks table + columns + index presence).
+
+## 2. App-scoped schema import
+- [x] `SchemaMapper::findByApplicationAndSlug($slug, $application)` — scoped lookup.
+- [x] `ImportHandler::importSchema()` uses it when `$appId` is present; app-less
+      imports keep the global find. Foreign owner is logged.
+
+## 3. Register-scoped runtime resolution
+- [x] `SchemaMapper::findBySlugInIds($slug, $schemaIds)` — resolve within an id set.
+- [x] `ObjectService::setSchema()` resolves within the current register first.
+- [x] `ObjectService::searchObjectsBySlug()` resolves within the register first.
+
+## 4. Self-heal already-polluted registers
+- [x] `ImportHandler::autoCreateRegisterIfApplication()` prunes schema ids shadowed
+      by a freshly-imported same-slug app-owned schema during reconcile.
+
+## 5. Verification
+- [x] Live-verified on shared 8080: hermiq imports own `conversation` #5018 /
+      `message` #5019; register #2428 healed of pipelinq #701/#700; slug resolves
+      to #5018; conversation object persists (no `channel` enum error).
+- [ ] CI: full PHPUnit suite green (update any test asserting the old global-find
+      import behaviour to the app-scoped behaviour).


### PR DESCRIPTION
## Problem

Schema/register slugs are unique per **organisation**, not per **application**. The DB enforces `(organisation, slug)` and `SchemaMapper::find()` resolves a slug by `LOWER(slug)` **globally**, returning the first row. On the shared instance (~20 apps, one DB) a generic slug shipped by app B (`conversation`, `order`, `task`, `notification`, `message`, …) collides with app A's schema of the same slug:

- The DB refuses app B its own schema → `importSchema()` silently **binds** B to A's schema, or **overwrites** it when B's version is newer.
- B's objects land in the wrong schema/table; A's schema can be corrupted.
- First-app-wins → environment-dependent, and **invisible in single-app tests**.

**Live example:** `hermiq` ships bare `conversation`/`message`; `pipelinq` owns `conversation` #701 (required `channel` enum) / `message` #700. hermiq bound to #701, so **every** hermiq agent run (`saveObject(register:'hermiq', schema:'conversation')`) resolved to #701 and failed on the missing `channel`. Agent execution was 100% broken.

## Fix

1. **Migration `Version1Date20260723000000`** — widen the unique index on `openregister_schemas` **and** `openregister_registers` from `(organisation, slug)` to `(organisation, application, slug)`. Strictly more permissive (no dedup, cannot fail on existing rows); idempotent + self-guarding.
2. **App-scoped import** — `importSchema()` resolves the existing schema via new `SchemaMapper::findByApplicationAndSlug()` when an app context is present, so an app only ever updates a schema it **owns**; a colliding slug creates the app's own schema. App-less imports keep global behaviour.
3. **Register-scoped resolution** — `ObjectService::setSchema()` and `searchObjectsBySlug()` resolve a slug among the register's own schemas via new `SchemaMapper::findBySlugInIds()`, falling back to the global find for numeric ids / uuids / slugs the register does not carry.
4. **Self-heal** — `autoCreateRegisterIfApplication()` prunes schema ids shadowed by a freshly-imported same-slug schema, cleaning registers polluted before this fix.

## Backward compatibility

The new resolution paths are no-ops without an app/register context; the wider unique key accepts everything the old one did. Behaviour changes **only** in genuine cross-app collision cases (which were bugs).

## Verification (live, shared 8080)

- hermiq re-import now creates its **own** `conversation` #5018 / `message` #5019 (app=hermiq); pipelinq #701/#700 untouched.
- register #2428 healed — pipelinq #701/#700 **pruned**, hermiq #5018/#5019 present.
- `setSchema('conversation')` under register `hermiq` resolves to **#5018** (was #701).
- A `conversation` object **persists** in #5018 — the `channel`-enum `ValidationException` is gone.

OpenSpec change `schema-slug-cross-app-scoping` included (validated).

> CI: if any existing ImportHandler test asserts the old global-find import behaviour, it should be updated to the app-scoped behaviour.