### PR TITLE
docs(openspec): skos-concept-registers — OR-owned SKOS/NL-SBB vocabulary capability

### DIFF
--- a/openspec/changes/skos-concept-registers/design.md
+++ b/openspec/changes/skos-concept-registers/design.md
@@ -1,0 +1,47 @@
+# Design: skos-concept-registers
+
+## Approach
+Vocabularies are ordinary register data: one bundled vocabulary register with
+`conceptScheme` + `concept` schemas, an idempotent importer, bundled TOOI
+fixtures, and a thin resolution API over the existing object search path. No
+new storage machinery — the whole point is that OR already owns objects,
+relations, RBAC, search and audit.
+
+## Decisions
+
+### D1 — Schema-first, ADR-011 naming
+SKOS core terms map to schema.org-aligned camelCase property names
+(`prefLabel`, `broader`, `inScheme` kept as SKOS terms where schema.org has no
+equivalent — they ARE the standard vocabulary of this domain). Multilingual
+labels are objects keyed by BCP-47 tag (`{"nl": "...", "en": "..."}`) —
+consistent with the register-i18n direction, no parallel i18n mechanism.
+
+### D2 — Relations in the canonical dialect only
+`broader`/`narrower`/`related`/`inScheme` are `format: uuid` + `$ref`
+properties per ADR-062 rules 6/7 (relation-dialect gate). The source SKOS URI
+remains the durable identity; the importer resolves URI→object id at import
+time and maintains both directions of `broader`/`narrower`.
+
+### D3 — Deprecate, never delete (dangling-reference safety)
+Leaf apps hold concept references long-term (a Woo publication's
+informatiecategorie must resolve for its whole retention life). Re-imports
+therefore soft-deprecate missing concepts (a `deprecated: true` property set
+by the importer) instead of deleting.
+
+### D4 — Importer formats: RDF via a small parser, CSV as first-class
+TOOI value lists ship as CSV/JSON fixtures (no network at install). For RDF
+serializations use a lightweight parser (e.g. easyrdf already in the
+dependency tree, else JSON-LD only in v1 with Turtle/RDF-XML follow-up) —
+the acceptance bar is the TOOI + one generic SKOS JSON-LD fixture importing
+green; exotic RDF is not v1 scope.
+
+### D5 — Resolution API = thin controller over ObjectService
+By-URI and by-(scheme, notation) lookups are metadata-filtered
+`searchObjectsPaginated` calls; label search is the standard search path with
+a language-agnostic match over the label maps. Public reads ride the same
+rate-limit posture as other public OR endpoints (ADR-054).
+
+## Leaf reintegration (out of scope here, tracked per leaf)
+OpenCatalogi: `TooiVocabularyService`/`DcatVocabularyService` become readers
+of the vocabulary register (ADR-022 consume change in the opencatalogi repo).
+softwarecatalog (GEMMA), decidesk (ORI) follow the same pattern.

--- a/openspec/changes/skos-concept-registers/proposal.md
+++ b/openspec/changes/skos-concept-registers/proposal.md
@@ -1,0 +1,53 @@
+---
+kind: code
+---
+
+## Why
+
+Controlled vocabularies are becoming a fleet-wide, legally forced capability:
+NL-SBB (the Dutch SKOS profile for begrippenkaders, on the Forum
+Standaardisatie list) is **mandatory for Federatief Datastelsel participants
+per 1 January 2026**, DiWoo binds Woo publications to TOOI value lists,
+DCAT-AP-NL 3.0 requires EU/NL vocabulary URIs, and ADR-048/049 semantic
+references assume shared concept URIs across apps. Today every leaf hand-rolls
+its own: OpenCatalogi carries `TooiVocabularyService` and
+`DcatVocabularyService` with hardcoded lists, softwarecatalog needs GEMMA
+referentiecomponenten, decidesk needs ORI/organisation URIs. Per ADR-022 a
+capability needed by multiple leaves with schema-shaped data is
+OpenRegister's to own — vocabularies are literally objects in registers.
+This was identified in the 2026-07-23 OpenCatalogi market deep-dive (logged
+in the spectr register, insight "NL-SBB mandatory for Federatief Datastelsel
+participants per 1 Jan 2026") as the highest-leverage cross-app gap.
+
+## What Changes
+
+- Ship canonical **`conceptScheme`** and **`concept`** schemas (SKOS core
+  mapped to schema.org-aligned property names per ADR-011): scheme URI,
+  title, publisher, version; concept URI, prefLabel/altLabel (multilingual
+  map), definition, notation, broader/narrower/related (canonical relation
+  dialect `$ref` within the same register), `inScheme` reference, and NL-SBB
+  conformance fields.
+- Ship a **vocabulary register** definition (`lib/Settings`) that leaf apps
+  can depend on, with `_rbac` public read (vocabularies are public data) and
+  admin-gated writes.
+- **Importer** for SKOS sources: given a SKOS RDF (Turtle/RDF-XML/JSON-LD)
+  or a CSV value-list export, import/refresh a concept scheme idempotently
+  (URI-keyed upsert, no duplicate concepts on re-import). Seed importers for
+  TOOI value lists (informatiecategorieën, organisaties, documentsoorten)
+  as bundled fixtures so a fresh install has the Woo-critical vocabularies.
+- **Resolution API**: resolve a concept by URI or (scheme, notation) pair,
+  and list concepts of a scheme with label search — the lookup surface
+  OpenCatalogi's DCAT/DiWoo rendering and nc-vue concept-picker widgets
+  consume.
+- Leaf reintegration path (follow-up changes in the leaf repos, not here):
+  OpenCatalogi's `TooiVocabularyService`/`DcatVocabularyService` become thin
+  readers of the vocabulary register per ADR-022.
+
+## Impact
+
+- Affected specs: new capability `skos-concept-registers`.
+- Affected code: new register/schema JSON under `lib/Settings`, a
+  `VocabularyImportService`, a resolution endpoint on the existing public
+  API surface, bundled TOOI fixtures, PHPUnit coverage.
+- Not affected: existing leaf vocabularies keep working until each leaf's
+  own consume-change lands (no breaking change in this repo).

--- a/openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md
+++ b/openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+### Requirement: Canonical conceptScheme and concept schemas (SKOS-001)
+
+OpenRegister MUST ship canonical `conceptScheme` and `concept` schemas in a
+vocabulary register definition. `conceptScheme` MUST carry at minimum: `uri`
+(unique, required), `title`, `publisher`, `version`, `source` (where the
+scheme was imported from). `concept` MUST carry at minimum: `uri` (unique
+within the register, required), `prefLabel` (multilingual object keyed by
+BCP-47 language tag, `nl` required), `altLabel` (multilingual, optional),
+`definition`, `notation`, `inScheme` (relation to a `conceptScheme` in the
+canonical relation dialect), and `broader`/`narrower`/`related` relations to
+sibling concepts. Every property MUST carry a human-friendly English `title`
+and `description` (schema-property-titles gate). Reads MUST be public;
+writes MUST be admin-gated.
+
+#### Scenario: concept round-trips with hierarchy intact
+
+- GIVEN a scheme with concepts A (broader of B) and B,
+- WHEN B is fetched via the objects API,
+- THEN B's `broader` MUST resolve to A per the canonical relation dialect,
+- AND A's `narrower` MUST list B,
+- AND B's `inScheme` MUST resolve to the scheme object.
+
+> @e2e exclude Backend schema/relation contract; covered by PHPUnit against the seeded register.
+
+### Requirement: Idempotent SKOS import keyed on URI (SKOS-002)
+
+The system MUST provide an import service that ingests a concept scheme from
+a SKOS serialization (Turtle, RDF/XML or JSON-LD) or a CSV value-list and
+upserts concepts **keyed on their URI**: re-importing the same source MUST
+NOT create duplicates, MUST update changed labels/definitions in place, and
+MUST report counts (created/updated/unchanged). Concepts present in the
+register but absent from the re-imported source MUST be flagged (deprecated
+marker), never hard-deleted, so leaf references cannot dangle.
+
+#### Scenario: re-import is a no-op on unchanged source
+
+- GIVEN a scheme imported from a TOOI value list,
+- WHEN the identical source is imported again,
+- THEN the report MUST show 0 created, 0 updated,
+- AND the concept count in the register MUST be unchanged.
+
+> @e2e exclude Backend import contract; PHPUnit with fixture files.
+
+#### Scenario: removed concept is deprecated, not deleted
+
+- GIVEN a scheme whose re-imported source no longer contains concept X,
+- WHEN the import completes,
+- THEN X MUST remain retrievable with a deprecated marker set,
+- AND resolution of X by URI MUST still succeed.
+
+> @e2e exclude Backend import contract; PHPUnit.
+
+### Requirement: Bundled TOOI seed vocabularies (SKOS-003)
+
+OpenRegister MUST bundle the Woo-critical TOOI value lists
+(informatiecategorieën, documentsoorten, and the overheidsorganisatie scheme
+identifiers) as import fixtures and seed them into the vocabulary register on
+install/repair, so a fresh instance can serve DiWoo/DCAT vocabulary lookups
+without network access. Seeding MUST reuse the idempotent importer (SKOS-002)
+and therefore MUST be safe to run repeatedly.
+
+#### Scenario: fresh install serves the 17 informatiecategorieën
+
+- GIVEN a fresh install after the repair step ran,
+- WHEN the informatiecategorie scheme's concepts are listed,
+- THEN all 17 Woo informatiecategorieën MUST be present with TOOI URIs and
+  Dutch prefLabels.
+
+> @e2e exclude Install/repair backend contract; PHPUnit + existing repair-step test harness.
+
+### Requirement: Concept resolution API (SKOS-004)
+
+The system MUST expose public read endpoints to (a) resolve a single concept
+by exact URI, (b) resolve by `(scheme, notation)` pair, and (c) list a
+scheme's concepts with paginated label search (matching `prefLabel`/`altLabel`
+in any language). Responses MUST use the standard objects envelope. Unknown
+URIs MUST return HTTP 404 with the standard error shape, never an empty 200.
+
+#### Scenario: resolve by URI
+
+- GIVEN the seeded TOOI informatiecategorie scheme,
+- WHEN a concept is requested by its exact TOOI URI,
+- THEN the concept object MUST be returned with prefLabel and inScheme.
+
+> @e2e exclude Public API backend contract; covered by PHPUnit controller tests (leaf-side consumption UIs ship their own e2e in the leaf repos).
+
+#### Scenario: label search within a scheme
+
+- GIVEN the seeded scheme,
+- WHEN concepts are listed with a label query matching one concept's Dutch prefLabel,
+- THEN exactly the matching concepts MUST be returned in the standard
+  paginated envelope.
+
+> @e2e exclude Same backend contract; PHPUnit.

--- a/openspec/changes/skos-concept-registers/tasks.md
+++ b/openspec/changes/skos-concept-registers/tasks.md
@@ -1,0 +1,16 @@
+# Tasks: skos-concept-registers
+
+- [ ] Freeze delta spec `specs/skos-concept-registers/spec.md` (ADDED SKOS-001..004); `openspec validate skos-concept-registers` green
+- [ ] Vocabulary register definition under `lib/Settings` with `conceptScheme` + `concept` schemas: required/unique `uri`, multilingual `prefLabel`/`altLabel` maps, canonical-dialect relations (`inScheme`, `broader`, `narrower`, `related`), English `title`+`description` on every property, public read / admin-gated write
+  - Spec ref: SKOS-001
+  - Acceptance: register imports clean on a fresh instance; relation-dialect (gate 31) + schema-property-titles (gate 28) green
+- [ ] `VocabularyImportService`: URI-keyed idempotent upsert from JSON-LD SKOS + CSV value-list; created/updated/unchanged report; deprecation (never deletion) of concepts missing from a re-imported source; both `broader`/`narrower` directions maintained
+  - Spec ref: SKOS-002
+  - Acceptance: PHPUnit — double-import no-op, label-change update-in-place, removed-concept deprecation
+- [ ] Bundle TOOI fixtures (informatiecategorieën ×17, documentsoorten, organisatie scheme ids) + repair-step seeding through the importer
+  - Spec ref: SKOS-003
+  - Acceptance: PHPUnit — fresh seed serves all 17 categories with TOOI URIs; repeated repair run is a no-op
+- [ ] Resolution endpoints (public read): by exact URI, by (scheme, notation), scheme concept listing with paginated multilingual label search; 404 with standard error shape on unknown URI
+  - Spec ref: SKOS-004
+  - Acceptance: PHPUnit controller tests incl. 404 path; route-auth gate green
+- [ ] `@spec` tags on all new methods; hydra gates green locally; file follow-up leaf issues (opencatalogi Tooi/DcatVocabularyService consume-change, softwarecatalog GEMMA, decidesk ORI)


### PR DESCRIPTION
Cross-app change from the OpenCatalogi market deep-dive (2026-07-23, logged in the spectr register). NL-SBB (Forum Standaardisatie) is mandatory for Federatief Datastelsel participants per 1 Jan 2026; DiWoo binds publications to TOOI value lists; DCAT-AP-NL 3.0 requires vocabulary URIs; ADR-048/049 semantic references assume shared concept URIs.

Adds capability `skos-concept-registers` (SKOS-001..004): canonical `conceptScheme`/`concept` schemas in a bundled vocabulary register, URI-keyed idempotent SKOS/CSV importer with deprecate-never-delete semantics, bundled TOOI seed fixtures (17 informatiecategorieën), and a public concept-resolution API. Leaves (opencatalogi TooiVocabularyService/DcatVocabularyService, softwarecatalog GEMMA, decidesk ORI) reintegrate as consumers per ADR-022 in follow-up changes in their own repos.

Specs only — implementation follows on a wip/ branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)