### PR TITLE
feat: skos-concept-registers — OR-owned SKOS/NL-SBB vocabulary capability

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -81,6 +81,7 @@ Vrij en open source onder de EUPL-licentie.
 			<step>OCA\OpenRegister\Repair\ImportDsarRegisters</step>
 			<step>OCA\OpenRegister\Repair\ImportEdepotTransferRegister</step>
 			<step>OCA\OpenRegister\Repair\ImportTrustConfigurationRegister</step>
+			<step>OCA\OpenRegister\Repair\SeedVocabularyRegister</step>
 			<step>OCA\OpenRegister\Repair\RegisterOpenRegisterWithDoriath</step>
 			<step>OCA\OpenRegister\Repair\SeedZgwZakenMigrationPack</step>
 		</post-migration>
@@ -94,6 +95,7 @@ Vrij en open source onder de EUPL-licentie.
 			<step>OCA\OpenRegister\Repair\ImportDsarRegisters</step>
 			<step>OCA\OpenRegister\Repair\ImportEdepotTransferRegister</step>
 			<step>OCA\OpenRegister\Repair\ImportTrustConfigurationRegister</step>
+			<step>OCA\OpenRegister\Repair\SeedVocabularyRegister</step>
 			<step>OCA\OpenRegister\Repair\RegisterOpenRegisterWithDoriath</step>
 			<step>OCA\OpenRegister\Repair\SeedZgwZakenMigrationPack</step>
 		</install>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -629,6 +629,15 @@ return [
         // @spec openspec/changes/integration-leaf-foundation-shares-analytics/specs/integration-leaf-foundation/spec.md.
         ['name' => 'caseToken#resolve', 'url' => '/api/public/case-tokens/{token}', 'verb' => 'GET', 'requirements' => ['token' => '[^/]+']],
 
+        // Vocabulary (skos-concept-registers) — public read-only SKOS concept
+        // resolution over the bundled `vocabulary` register. Query-param based
+        // (uri/scheme values are full URIs, unsafe as path segments). 404
+        // standard error shape on unknown uri/scheme/notation (SKOS-004).
+        // @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md#skos-004
+        ['name' => 'vocabulary#resolveByUri', 'url' => '/api/vocabulary/concept', 'verb' => 'GET'],
+        ['name' => 'vocabulary#resolveByNotation', 'url' => '/api/vocabulary/concept/notation', 'verb' => 'GET'],
+        ['name' => 'vocabulary#listConcepts', 'url' => '/api/vocabulary/concepts', 'verb' => 'GET'],
+
         // Activity — Tier-2 read-only API. NC Activity entries are
         // core-generated (no link/create/delete verbs); this surface
         // only filters + cursor-paginates the entries linked to an OR

--- a/lib/Controller/VocabularyController.php
+++ b/lib/Controller/VocabularyController.php
@@ -1,0 +1,350 @@
+<?php
+
+/**
+ * VocabularyController — public read-only resolution endpoints for the SKOS
+ * vocabulary register (skos-concept-registers, SKOS-004).
+ *
+ * Three endpoints, all `#[PublicPage]` because vocabularies are public
+ * reference data (design.md D5) — writes to the `vocabulary` register stay
+ * admin-gated via its schema `authorization` block, only reads are opened
+ * here:
+ *   - GET /api/vocabulary/concept          resolve a concept by exact uri
+ *   - GET /api/vocabulary/concept/notation resolve a concept by (scheme, notation)
+ *   - GET /api/vocabulary/concepts         list a scheme's concepts, paginated,
+ *                                          with a language-agnostic label search
+ *                                          across prefLabel/altLabel (design.md D5)
+ *
+ * Unknown uris/notations/schemes always resolve to a uniform 404 with the
+ * standard `{"message": ...}` error shape — never an empty 200 (SKOS-004).
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md#skos-004
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\VocabularyImportService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use Throwable;
+
+/**
+ * Public resolution controller for the vocabulary register.
+ *
+ * @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md#skos-004
+ */
+class VocabularyController extends Controller
+{
+
+    /**
+     * Register slug (mirrors {@see VocabularyImportService::REGISTER}).
+     *
+     * @var string
+     */
+    private const REGISTER = VocabularyImportService::REGISTER;
+
+    /**
+     * ConceptScheme schema slug.
+     *
+     * @var string
+     */
+    private const SCHEMA_SCHEME = VocabularyImportService::SCHEMA_SCHEME;
+
+    /**
+     * Concept schema slug.
+     *
+     * @var string
+     */
+    private const SCHEMA_CONCEPT = VocabularyImportService::SCHEMA_CONCEPT;
+
+    /**
+     * Upper bound on concepts fetched for a scheme's in-memory label-search
+     * pass. Vocabulary schemes are reference data (tens to low thousands of
+     * concepts, e.g. TOOI's 17 informatiecategorieën); this cap keeps the
+     * search endpoint O(1) request shape without needing a dedicated
+     * full-text index over the multilingual label maps.
+     *
+     * @var int
+     */
+    private const MAX_SCHEME_CONCEPTS = 2000;
+
+    /**
+     * Constructor.
+     *
+     * @param string        $appName       App name (injected by NC).
+     * @param IRequest      $request       Current request.
+     * @param ObjectService $objectService OR object read path (findAll — real API only).
+     *
+     * @return void
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly ObjectService $objectService,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * GET /api/vocabulary/concept?uri=...
+     *
+     * Resolve a single concept by its exact durable source uri.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     * @PublicPage
+     *
+     * @return JSONResponse The concept object, or a 404 standard error shape.
+     *
+     * @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md#skos-004
+     */
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function resolveByUri(): JSONResponse
+    {
+        $uri = trim((string) $this->request->getParam('uri', ''));
+        if ($uri === '') {
+            return $this->notFound();
+        }
+
+        $concept = $this->findOneBy(schema: self::SCHEMA_CONCEPT, filters: ['uri' => $uri]);
+        if ($concept === null) {
+            return $this->notFound();
+        }
+
+        return new JSONResponse($concept->jsonSerialize());
+    }//end resolveByUri()
+
+    /**
+     * GET /api/vocabulary/concept/notation?scheme=...&notation=...
+     *
+     * Resolve a single concept by its owning scheme's uri plus its notation.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     * @PublicPage
+     *
+     * @return JSONResponse The concept object, or a 404 standard error shape.
+     *
+     * @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md#skos-004
+     */
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function resolveByNotation(): JSONResponse
+    {
+        $scheme   = trim((string) $this->request->getParam('scheme', ''));
+        $notation = trim((string) $this->request->getParam('notation', ''));
+        if ($scheme === '' || $notation === '') {
+            return $this->notFound();
+        }
+
+        $schemeUuid = $this->resolveSchemeUuid(schemeUriOrUuid: $scheme);
+        if ($schemeUuid === null) {
+            return $this->notFound();
+        }
+
+        $concept = $this->findOneBy(
+            schema: self::SCHEMA_CONCEPT,
+            filters: [
+                'inScheme' => $schemeUuid,
+                'notation' => $notation,
+            ]
+        );
+        if ($concept === null) {
+            return $this->notFound();
+        }
+
+        return new JSONResponse($concept->jsonSerialize());
+    }//end resolveByNotation()
+
+    /**
+     * GET /api/vocabulary/concepts?scheme=...&q=...&_limit=&_offset=
+     *
+     * List a scheme's concepts, paginated, optionally filtered by a
+     * language-agnostic label search over prefLabel/altLabel.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     * @PublicPage
+     *
+     * @return JSONResponse The standard paginated objects envelope, or a 404 when the scheme is unknown.
+     *
+     * @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md#skos-004
+     */
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function listConcepts(): JSONResponse
+    {
+        $scheme = trim((string) $this->request->getParam('scheme', ''));
+        if ($scheme === '') {
+            return new JSONResponse(
+                ['message' => 'Query parameter "scheme" is required.'],
+                Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        $schemeUuid = $this->resolveSchemeUuid(schemeUriOrUuid: $scheme);
+        if ($schemeUuid === null) {
+            return $this->notFound();
+        }
+
+        $query  = trim((string) $this->request->getParam('q', ''));
+        $limit  = max(1, min(200, (int) $this->request->getParam('_limit', 20)));
+        $offset = max(0, (int) $this->request->getParam('_offset', 0));
+
+        try {
+            $all = $this->objectService->findAll(
+                config: [
+                    'register' => self::REGISTER,
+                    'schema'   => self::SCHEMA_CONCEPT,
+                    'filters'  => ['inScheme' => $schemeUuid],
+                    'limit'    => self::MAX_SCHEME_CONCEPTS,
+                ]
+            );
+        } catch (Throwable $e) {
+            return new JSONResponse(
+                ['message' => 'Unable to list concepts.'],
+                Http::STATUS_INTERNAL_SERVER_ERROR
+            );
+        }
+
+        $matching = [];
+        foreach ($all as $entity) {
+            $data = ($entity->getObject() ?? []);
+            if ($query === '' || $this->labelMatches(data: $data, query: $query) === true) {
+                $matching[] = $entity;
+            }
+        }
+
+        $total = count($matching);
+        $page  = array_slice($matching, $offset, $limit);
+
+        return new JSONResponse(
+            [
+                'results' => array_map(static fn ($entity): array => $entity->jsonSerialize(), $page),
+                'total'   => $total,
+                'limit'   => $limit,
+                'offset'  => $offset,
+                'page'    => ((int) floor($offset / max(1, $limit)) + 1),
+                'pages'   => ((int) ceil($total / max(1, $limit))),
+            ]
+        );
+    }//end listConcepts()
+
+    /**
+     * Resolve a scheme's uuid from its durable uri (or pass an already-resolved uuid through).
+     *
+     * @param string $schemeUriOrUuid The scheme's source uri (or its OpenRegister uuid).
+     *
+     * @return string|null The scheme's uuid, or null when unresolvable.
+     */
+    private function resolveSchemeUuid(string $schemeUriOrUuid): ?string
+    {
+        $scheme = $this->findOneBy(schema: self::SCHEMA_SCHEME, filters: ['uri' => $schemeUriOrUuid]);
+        if ($scheme !== null) {
+            return (string) $scheme->getUuid();
+        }
+
+        // Fall back to treating the value as an already-resolved uuid (a
+        // leaf caller that stored the uuid rather than the source uri).
+        try {
+            $byId = $this->objectService->find(
+                id: $schemeUriOrUuid,
+                register: self::REGISTER,
+                schema: self::SCHEMA_SCHEME
+            );
+        } catch (Throwable $e) {
+            return null;
+        }
+
+        if ($byId === null) {
+            return null;
+        }
+
+        return (string) $byId->getUuid();
+    }//end resolveSchemeUuid()
+
+    /**
+     * Find a single object of `$schema` matching `$filters`, or null.
+     *
+     * @param string               $schema  Schema slug within the vocabulary register.
+     * @param array<string,string> $filters Exact-match field filters.
+     *
+     * @return ObjectEntity|null
+     */
+    private function findOneBy(string $schema, array $filters): ?ObjectEntity
+    {
+        try {
+            $results = $this->objectService->findAll(
+                config: [
+                    'register' => self::REGISTER,
+                    'schema'   => $schema,
+                    'filters'  => $filters,
+                    'limit'    => 1,
+                ]
+            );
+        } catch (Throwable $e) {
+            return null;
+        }
+
+        return ($results[0] ?? null);
+    }//end findOneBy()
+
+    /**
+     * Whether `$query` case/language-insensitively matches any prefLabel or
+     * altLabel value on `$data`.
+     *
+     * @param array<string,mixed> $data  A concept's decoded object data.
+     * @param string              $query The search term.
+     *
+     * @return bool
+     */
+    private function labelMatches(array $data, string $query): bool
+    {
+        $needle = mb_strtolower($query);
+        foreach (['prefLabel', 'altLabel'] as $field) {
+            $labels = ($data[$field] ?? null);
+            if (is_array($labels) === false) {
+                continue;
+            }
+
+            foreach ($labels as $label) {
+                if (is_string($label) === true && str_contains(mb_strtolower($label), $needle) === true) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }//end labelMatches()
+
+    /**
+     * The standard 404 error shape.
+     *
+     * @return JSONResponse
+     */
+    private function notFound(): JSONResponse
+    {
+        return new JSONResponse(['message' => 'Not Found'], Http::STATUS_NOT_FOUND);
+    }//end notFound()
+}//end class

--- a/lib/Repair/SeedVocabularyRegister.php
+++ b/lib/Repair/SeedVocabularyRegister.php
@@ -1,0 +1,227 @@
+<?php
+
+/**
+ * OpenRegister Repair — import the vocabulary register + seed the bundled
+ * TOOI Woo value lists (skos-concept-registers).
+ *
+ * OpenRegister does not self-import its own `lib/Settings` register
+ * descriptors (ADR-037; the `ImportCredentialBrokerRegister` /
+ * `ImportTrustConfigurationRegister` precedent). This step first imports the
+ * `vocabulary` register (`conceptScheme` + `concept` schemas), then seeds the
+ * Woo-critical TOOI value lists — the 17 informatiecategorieën and the DiWoo
+ * documenthandelingen — through {@see VocabularyImportService}'s idempotent
+ * URI-keyed upsert, so a fresh instance can serve DiWoo/DCAT vocabulary
+ * lookups without network access. Both steps are version-gated / diff-checked
+ * and safe to re-run.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Repair
+ * @package  OCA\OpenRegister\Repair
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md#skos-003
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Repair;
+
+use OCA\OpenRegister\Service\ConfigurationService;
+use OCA\OpenRegister\Service\SystemOperationContext;
+use OCA\OpenRegister\Service\VocabularyImportService;
+use OCP\App\IAppManager;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Import the vocabulary register and seed the bundled TOOI fixtures.
+ *
+ * @psalm-suppress UnusedClass Instantiated by the NC repair framework (appinfo/info.xml).
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess) SystemOperationContext::run() is a static
+ *   trusted-scope holder (see the class docblock) — the repair step's fixture seed
+ *   must run inside it because repair steps execute without a user session.
+ *
+ * @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md#skos-003
+ */
+class SeedVocabularyRegister implements IRepairStep
+{
+
+    /**
+     * App-relative descriptor path.
+     *
+     * @var string
+     */
+    private const REGISTER_PATH = '/lib/Settings/vocabulary_register.json';
+
+    /**
+     * Descriptor version passed to the importer's version_compare gate.
+     *
+     * @var string
+     */
+    private const REGISTER_VERSION = '1.0.0';
+
+    /**
+     * Configuration identity for the descriptor (its own appId so the
+     * importFromApp version gate is independent of the other system registers).
+     *
+     * @var string
+     */
+    private const CONFIG_APP_ID = 'openregister.vocabulary';
+
+    /**
+     * App-relative paths of the bundled TOOI SKOS/JSON-LD seed fixtures.
+     *
+     * @var array<int, string>
+     */
+    private const FIXTURE_PATHS = [
+        '/lib/Resources/Vocabulary/tooi-informatiecategorieen.jsonld',
+        '/lib/Resources/Vocabulary/tooi-documenthandelingen.jsonld',
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param ConfigurationService    $configurationService The OR configuration importer (register/schema).
+     * @param VocabularyImportService $importService        The SKOS/JSON-LD import service (concept data).
+     * @param IAppManager             $appManager           Resolves the openregister app path on disk.
+     * @param LoggerInterface         $logger               Logger for seed diagnostics.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly ConfigurationService $configurationService,
+        private readonly VocabularyImportService $importService,
+        private readonly IAppManager $appManager,
+        private readonly LoggerInterface $logger,
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Get the name of this repair step.
+     *
+     * @return string The step name.
+     *
+     * @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md#skos-003
+     */
+    public function getName(): string
+    {
+        return 'Import OpenRegister vocabulary register and seed bundled TOOI Woo value lists';
+    }//end getName()
+
+    /**
+     * Run the repair step: import the register descriptor, then seed the
+     * bundled TOOI fixtures through the idempotent importer.
+     *
+     * @param IOutput $output Output interface for status messages.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md#skos-003
+     */
+    public function run(IOutput $output): void
+    {
+        $this->importRegisterDescriptor(output: $output);
+        $this->seedTooiFixtures(output: $output);
+    }//end run()
+
+    /**
+     * Import the `vocabulary_register.json` descriptor (conceptScheme + concept schemas).
+     *
+     * @param IOutput $output Output interface for status messages.
+     *
+     * @return void
+     */
+    private function importRegisterDescriptor(IOutput $output): void
+    {
+        try {
+            $path = $this->appManager->getAppPath('openregister').self::REGISTER_PATH;
+            if (is_file($path) === false) {
+                $output->warning('Vocabulary register descriptor not found: '.$path);
+                return;
+            }
+
+            $data = json_decode((string) file_get_contents($path), true);
+            if (is_array($data) === false) {
+                $output->warning('Vocabulary register descriptor is not valid JSON: '.$path);
+                return;
+            }
+
+            $this->configurationService->importFromApp(
+                appId: self::CONFIG_APP_ID,
+                data: $data,
+                version: self::REGISTER_VERSION,
+                force: false
+            );
+
+            $output->info('Vocabulary register imported (conceptScheme, concept)');
+        } catch (Throwable $e) {
+            $this->logger->warning('[SeedVocabularyRegister] register import failed: '.$e->getMessage());
+            $output->warning('Vocabulary register import skipped: '.$e->getMessage());
+        }//end try
+    }//end importRegisterDescriptor()
+
+    /**
+     * Seed the bundled TOOI SKOS/JSON-LD fixtures through the idempotent importer.
+     *
+     * Runs inside {@see SystemOperationContext} because repair steps execute
+     * without a user session (app boot / webcron), and the vocabulary schemas'
+     * writes are admin-gated by default — without the trusted scope every seed
+     * write would be denied as anonymous.
+     *
+     * @param IOutput $output Output interface for status messages.
+     *
+     * @return void
+     */
+    private function seedTooiFixtures(IOutput $output): void
+    {
+        $appPath = $this->appManager->getAppPath('openregister');
+
+        foreach (self::FIXTURE_PATHS as $relativePath) {
+            $path = $appPath.$relativePath;
+
+            try {
+                if (is_file($path) === false) {
+                    $output->warning('TOOI vocabulary fixture not found: '.$path);
+                    continue;
+                }
+
+                $jsonLd = json_decode((string) file_get_contents($path), true);
+                if (is_array($jsonLd) === false) {
+                    $output->warning('TOOI vocabulary fixture is not valid JSON: '.$path);
+                    continue;
+                }
+
+                $report = SystemOperationContext::run(
+                    fn (): array => $this->importService->importJsonLd(jsonLd: $jsonLd)
+                );
+
+                $output->info(
+                        sprintf(
+                    'Seeded vocabulary scheme %s (created=%d, updated=%d, unchanged=%d, deprecated=%d)',
+                    $report['scheme'],
+                    $report['created'],
+                    $report['updated'],
+                    $report['unchanged'],
+                    $report['deprecated']
+                )
+                        );
+            } catch (Throwable $e) {
+                $this->logger->warning('[SeedVocabularyRegister] fixture seed failed for '.$path.': '.$e->getMessage());
+                $output->warning('TOOI vocabulary fixture seed skipped ('.$relativePath.'): '.$e->getMessage());
+            }//end try
+        }//end foreach
+    }//end seedTooiFixtures()
+}//end class

--- a/lib/Resources/Vocabulary/tooi-documenthandelingen.jsonld
+++ b/lib/Resources/Vocabulary/tooi-documenthandelingen.jsonld
@@ -1,0 +1,59 @@
+{
+  "@context": {
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "dct": "http://purl.org/dc/terms/",
+    "owl": "http://www.w3.org/2002/07/owl#"
+  },
+  "@graph": [
+    {
+      "@id": "https://identifier.overheid.nl/tooi/set/scw_diwoo_documenthandelingen",
+      "@type": "skos:ConceptScheme",
+      "dct:title": "DiWoo Documenthandelingen",
+      "dct:publisher": "Kennis- en Exploitatiecentrum Officiele Overheidspublicaties (KOOP)",
+      "owl:versionInfo": "1.0",
+      "dct:source": "https://identifier.overheid.nl/tooi/set/scw_diwoo_documenthandelingen"
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_dfcee535",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/set/scw_diwoo_documenthandelingen"
+      },
+      "skos:notation": "c_dfcee535",
+      "skos:prefLabel": [
+        {
+          "@value": "ontvangst",
+          "@language": "nl"
+        }
+      ]
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_641ecd76",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/set/scw_diwoo_documenthandelingen"
+      },
+      "skos:notation": "c_641ecd76",
+      "skos:prefLabel": [
+        {
+          "@value": "vaststelling",
+          "@language": "nl"
+        }
+      ]
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_e1ec050e",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/set/scw_diwoo_documenthandelingen"
+      },
+      "skos:notation": "c_e1ec050e",
+      "skos:prefLabel": [
+        {
+          "@value": "ondertekening",
+          "@language": "nl"
+        }
+      ]
+    }
+  ]
+}

--- a/lib/Resources/Vocabulary/tooi-informatiecategorieen.jsonld
+++ b/lib/Resources/Vocabulary/tooi-informatiecategorieen.jsonld
@@ -1,0 +1,255 @@
+{
+  "@context": {
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "dct": "http://purl.org/dc/terms/",
+    "owl": "http://www.w3.org/2002/07/owl#"
+  },
+  "@graph": [
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/",
+      "@type": "skos:ConceptScheme",
+      "dct:title": "Woo-informatiecategorieën",
+      "dct:publisher": "Kennis- en Exploitatiecentrum Officiele Overheidspublicaties (KOOP)",
+      "owl:versionInfo": "1.0",
+      "dct:source": "https://identifier.overheid.nl/tooi/set/scw_woo_informatiecategorieen"
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_139c6280",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/"
+      },
+      "skos:notation": "c_139c6280",
+      "skos:prefLabel": [
+        {
+          "@value": "Wetten en algemeen verbindende voorschriften",
+          "@language": "nl"
+        }
+      ]
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_aab6bfc7",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/"
+      },
+      "skos:notation": "c_aab6bfc7",
+      "skos:prefLabel": [
+        {
+          "@value": "Overige besluiten van algemene strekking",
+          "@language": "nl"
+        }
+      ]
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_759721e2",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/"
+      },
+      "skos:notation": "c_759721e2",
+      "skos:prefLabel": [
+        {
+          "@value": "Ontwerpen van wet- en regelgeving met adviesaanvraag",
+          "@language": "nl"
+        }
+      ]
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_40a05794",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/"
+      },
+      "skos:notation": "c_40a05794",
+      "skos:prefLabel": [
+        {
+          "@value": "Organisatie en werkwijze",
+          "@language": "nl"
+        }
+      ]
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_89ee6784",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/"
+      },
+      "skos:notation": "c_89ee6784",
+      "skos:prefLabel": [
+        {
+          "@value": "Bereikbaarheidsgegevens",
+          "@language": "nl"
+        }
+      ]
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_8c840238",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/"
+      },
+      "skos:notation": "c_8c840238",
+      "skos:prefLabel": [
+        {
+          "@value": "Bij vertegenwoordigende organen ingekomen stukken",
+          "@language": "nl"
+        }
+      ]
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_c76862ab",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/"
+      },
+      "skos:notation": "c_c76862ab",
+      "skos:prefLabel": [
+        {
+          "@value": "Vergaderstukken Staten-Generaal",
+          "@language": "nl"
+        }
+      ]
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_db4862c3",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/"
+      },
+      "skos:notation": "c_db4862c3",
+      "skos:prefLabel": [
+        {
+          "@value": "Vergaderstukken decentrale overheden",
+          "@language": "nl"
+        }
+      ]
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_3a248e3a",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/"
+      },
+      "skos:notation": "c_3a248e3a",
+      "skos:prefLabel": [
+        {
+          "@value": "Agenda's en besluitenlijsten bestuurscolleges",
+          "@language": "nl"
+        }
+      ]
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_99a836c7",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/"
+      },
+      "skos:notation": "c_99a836c7",
+      "skos:prefLabel": [
+        {
+          "@value": "Adviezen",
+          "@language": "nl"
+        }
+      ]
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_8fc2335c",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/"
+      },
+      "skos:notation": "c_8fc2335c",
+      "skos:prefLabel": [
+        {
+          "@value": "Convenanten",
+          "@language": "nl"
+        }
+      ]
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_c6cd1213",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/"
+      },
+      "skos:notation": "c_c6cd1213",
+      "skos:prefLabel": [
+        {
+          "@value": "Jaarplannen en jaarverslagen",
+          "@language": "nl"
+        }
+      ]
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_cf268088",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/"
+      },
+      "skos:notation": "c_cf268088",
+      "skos:prefLabel": [
+        {
+          "@value": "Subsidieverplichtingen anders dan met beschikking",
+          "@language": "nl"
+        }
+      ]
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_3baef532",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/"
+      },
+      "skos:notation": "c_3baef532",
+      "skos:prefLabel": [
+        {
+          "@value": "Woo-verzoeken en -besluiten",
+          "@language": "nl"
+        }
+      ]
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_fdaee95e",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/"
+      },
+      "skos:notation": "c_fdaee95e",
+      "skos:prefLabel": [
+        {
+          "@value": "Onderzoeksrapporten",
+          "@language": "nl"
+        }
+      ]
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_46a81018",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/"
+      },
+      "skos:notation": "c_46a81018",
+      "skos:prefLabel": [
+        {
+          "@value": "Beschikkingen",
+          "@language": "nl"
+        }
+      ]
+    },
+    {
+      "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/c_a870c43d",
+      "@type": "skos:Concept",
+      "skos:inScheme": {
+        "@id": "https://identifier.overheid.nl/tooi/def/thes/kern/"
+      },
+      "skos:notation": "c_a870c43d",
+      "skos:prefLabel": [
+        {
+          "@value": "Klachtoordelen",
+          "@language": "nl"
+        }
+      ]
+    }
+  ]
+}

--- a/lib/Service/VocabularyImportService.php
+++ b/lib/Service/VocabularyImportService.php
@@ -1,0 +1,848 @@
+<?php
+
+/**
+ * VocabularyImportService — idempotent, URI-keyed SKOS import into the
+ * OpenRegister `vocabulary` register (skos-concept-registers).
+ *
+ * Accepts a lightweight SKOS/JSON-LD document (a `@graph` of `skos:ConceptScheme`
+ * / `skos:Concept` nodes, predicate keys either bare, `prefix:local`, or a full
+ * IRI — a pragmatic subset of JSON-LD, not a general RDF framework: design.md
+ * D4 scopes v1 to JSON-LD + CSV, Turtle/RDF-XML as follow-up) or a CSV
+ * value-list export, and upserts a `conceptScheme` object plus its `concept`
+ * objects, keyed on the SKOS source `uri` (the durable identity — never the
+ * OpenRegister UUID, which is only ever a resolution target). Re-importing the
+ * identical source is a no-op; changed labels/definitions update in place;
+ * concepts present in the register but absent from the re-imported source are
+ * flagged `deprecated: true`, never deleted, so long-lived leaf references
+ * (e.g. a Woo publication's informatiecategorie) never dangle (design.md D3).
+ * `broader`/`narrower` are maintained in both directions regardless of which
+ * direction the source asserts (design.md D2, ADR-062 canonical relation
+ * dialect: `type:string`/array + `format:uuid` + `$ref:<schemaKey>`).
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use InvalidArgumentException;
+use OCA\OpenRegister\Db\ObjectEntity;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Idempotent SKOS JSON-LD / CSV importer for the vocabulary register.
+ *
+ * @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md
+ */
+class VocabularyImportService
+{
+    /**
+     * Slug of the vocabulary register.
+     *
+     * @var string
+     */
+    public const REGISTER = 'vocabulary';
+
+    /**
+     * Slug of the conceptScheme schema.
+     *
+     * @var string
+     */
+    public const SCHEMA_SCHEME = 'conceptScheme';
+
+    /**
+     * Slug of the concept schema.
+     *
+     * @var string
+     */
+    public const SCHEMA_CONCEPT = 'concept';
+
+    /**
+     * Constructor.
+     *
+     * @param ObjectService   $objectService OR object CRUD (real API only — findAll/find/saveObject).
+     * @param LoggerInterface $logger        Logger for import diagnostics.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly ObjectService $objectService,
+        private readonly LoggerInterface $logger,
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Import a concept scheme + its concepts from a SKOS/JSON-LD document.
+     *
+     * @param array<string,mixed> $jsonLd Decoded JSON-LD document: either a
+     *                                    `{"@graph": [...]}` envelope or a
+     *                                    single top-level node with `@id`.
+     *
+     * @return array{scheme: string, created: int, updated: int, unchanged: int, deprecated: int}
+     *
+     * @throws InvalidArgumentException When the document has no ConceptScheme node.
+     *
+     * @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md#skos-002
+     */
+    public function importJsonLd(array $jsonLd): array
+    {
+        $graph = $jsonLd['@graph'] ?? null;
+        if (is_array($graph) === false && isset($jsonLd['@id']) === true) {
+            $graph = [$jsonLd];
+        }
+
+        if (is_array($graph) === false) {
+            throw new InvalidArgumentException(
+                'JSON-LD document must contain an "@graph" array or a single top-level node with "@id".'
+            );
+        }
+
+        $schemeNode   = null;
+        $conceptNodes = [];
+        foreach ($graph as $node) {
+            if (is_array($node) === false) {
+                continue;
+            }
+
+            $type = $this->localName(iriOrPrefixed: (string) ($node['@type'] ?? ''));
+            if ($type === 'ConceptScheme' && $schemeNode === null) {
+                $schemeNode = $node;
+            } else if ($type === 'Concept') {
+                $conceptNodes[] = $node;
+            }
+        }
+
+        if ($schemeNode === null || is_string($schemeNode['@id'] ?? null) === false) {
+            throw new InvalidArgumentException('JSON-LD document has no skos:ConceptScheme node with an "@id".');
+        }
+
+        return $this->importParsedGraph(schemeNode: $schemeNode, conceptNodes: $conceptNodes);
+    }//end importJsonLd()
+
+    /**
+     * Import a concept scheme + its concepts from a CSV value-list export.
+     *
+     * Expected columns: `uri` (required), `notation`, `prefLabel_<lang>` (one
+     * column per BCP-47 language, at least `prefLabel_nl`), `definition`,
+     * `broaderUri` (pipe-`|`-separated list of broader concept uris).
+     *
+     * @param string               $csvPath    Path to the CSV file.
+     * @param array<string,string> $schemeMeta Scheme metadata: `uri` (required),
+     *                                         `title`, `publisher`, `version`, `source`.
+     *
+     * @return array{scheme: string, created: int, updated: int, unchanged: int, deprecated: int}
+     *
+     * @throws InvalidArgumentException When the file is missing/empty or scheme uri is absent.
+     *
+     * @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md#skos-002
+     */
+    public function importCsvValueList(string $csvPath, array $schemeMeta): array
+    {
+        $schemeUri = $schemeMeta['uri'] ?? null;
+        if (is_string($schemeUri) === false || trim($schemeUri) === '') {
+            throw new InvalidArgumentException('CSV import requires a non-empty schemeMeta["uri"].');
+        }
+
+        if (is_file($csvPath) === false) {
+            throw new InvalidArgumentException(sprintf('CSV value-list file not found: %s', $csvPath));
+        }
+
+        $handle = fopen($csvPath, 'rb');
+        if ($handle === false) {
+            throw new InvalidArgumentException(sprintf('Unable to open CSV value-list file: %s', $csvPath));
+        }
+
+        $header = fgetcsv(stream: $handle, length: null, separator: ',', enclosure: '"', escape: '');
+        if ($header === false) {
+            fclose($handle);
+            throw new InvalidArgumentException(sprintf('CSV value-list file is empty: %s', $csvPath));
+        }
+
+        $header = array_map(static fn (string $col): string => trim($col), $header);
+
+        $schemeNode = [
+            '@id'             => $schemeUri,
+            'dct:title'       => ($schemeMeta['title'] ?? $schemeUri),
+            'dct:publisher'   => ($schemeMeta['publisher'] ?? ''),
+            'owl:versionInfo' => ($schemeMeta['version'] ?? '1.0'),
+            'dct:source'      => ($schemeMeta['source'] ?? $schemeUri),
+        ];
+
+        $conceptNodes = [];
+        while (($row = fgetcsv(stream: $handle, length: null, separator: ',', enclosure: '"', escape: '')) !== false) {
+            if (count($row) === 1 && trim((string) $row[0]) === '') {
+                continue;
+            }
+
+            $rowAssoc = array_combine($header, array_pad($row, count($header), null));
+            $uri      = trim((string) ($rowAssoc['uri'] ?? ''));
+            if ($uri === '') {
+                continue;
+            }
+
+            $prefLabel = [];
+            foreach ($rowAssoc as $column => $value) {
+                if (str_starts_with($column, 'prefLabel_') === true && trim((string) $value) !== '') {
+                    $lang = substr($column, strlen('prefLabel_'));
+                    $prefLabel[$lang] = trim((string) $value);
+                }
+            }
+
+            $broaderIds = [];
+            if (trim((string) ($rowAssoc['broaderUri'] ?? '')) !== '') {
+                foreach (explode('|', (string) $rowAssoc['broaderUri']) as $broaderUri) {
+                    $broaderIds[] = ['@id' => trim($broaderUri)];
+                }
+            }
+
+            $conceptNodes[] = [
+                '@id'             => $uri,
+                'skos:notation'   => ($rowAssoc['notation'] ?? null),
+                'skos:definition' => ($rowAssoc['definition'] ?? null),
+                'skos:prefLabel'  => $prefLabel,
+                'skos:broader'    => $broaderIds,
+            ];
+        }//end while
+
+        fclose($handle);
+
+        return $this->importParsedGraph(schemeNode: $schemeNode, conceptNodes: $conceptNodes);
+    }//end importCsvValueList()
+
+    /**
+     * Shared upsert pipeline for an already-parsed (scheme node, concept nodes) pair.
+     *
+     * @param array<string,mixed>            $schemeNode   The parsed scheme node.
+     * @param array<int,array<string,mixed>> $conceptNodes The parsed concept nodes.
+     *
+     * @return array{scheme: string, created: int, updated: int, unchanged: int, deprecated: int}
+     */
+    private function importParsedGraph(array $schemeNode, array $conceptNodes): array
+    {
+        $schemeUuid = $this->upsertScheme(node: $schemeNode);
+        $schemeUri  = (string) $schemeNode['@id'];
+
+        $created   = 0;
+        $updated   = 0;
+        $unchanged = 0;
+        $seenUris  = [];
+        $uuidByUri = [];
+
+        foreach ($conceptNodes as $node) {
+            $uri = (string) ($node['@id'] ?? '');
+            if ($uri === '') {
+                continue;
+            }
+
+            $result          = $this->upsertConcept(node: $node, schemeUuid: $schemeUuid);
+            $seenUris[]      = $uri;
+            $uuidByUri[$uri] = $result['uuid'];
+            match ($result['status']) {
+                'created' => $created++,
+                'updated' => $updated++,
+                default => $unchanged++,
+            };
+        }
+
+        $this->applyRelations(conceptNodes: $conceptNodes, uuidByUri: $uuidByUri);
+        $deprecated = $this->deprecateMissing(schemeUuid: $schemeUuid, seenUris: $seenUris);
+
+        $this->logger->info(
+            message: '[VocabularyImportService] import complete',
+            context: [
+                'file'       => __FILE__,
+                'line'       => __LINE__,
+                'scheme'     => $schemeUri,
+                'created'    => $created,
+                'updated'    => $updated,
+                'unchanged'  => $unchanged,
+                'deprecated' => $deprecated,
+            ]
+        );
+
+        return [
+            'scheme'     => $schemeUri,
+            'created'    => $created,
+            'updated'    => $updated,
+            'unchanged'  => $unchanged,
+            'deprecated' => $deprecated,
+        ];
+    }//end importParsedGraph()
+
+    /**
+     * Upsert the conceptScheme object for a parsed scheme node.
+     *
+     * @param array<string,mixed> $node The parsed scheme node.
+     *
+     * @return string The conceptScheme object's OpenRegister uuid.
+     */
+    private function upsertScheme(array $node): string
+    {
+        $uri = (string) $node['@id'];
+
+        $version = $this->extractLiteral(value: $this->findPredicate(node: $node, localName: 'versionInfo'));
+        if ($version === null) {
+            $version = $this->extractLiteral(value: $this->findPredicate(node: $node, localName: 'version'));
+        }
+
+        if ($version === null) {
+            $version = '1.0';
+        }
+
+        $data = [
+            'uri'       => $uri,
+            'title'     => ($this->extractLiteral(value: $this->findPredicate(node: $node, localName: 'title')) ?? $uri),
+            'publisher' => ($this->extractLiteral(value: $this->findPredicate(node: $node, localName: 'publisher')) ?? ''),
+            'version'   => $version,
+            'source'    => ($this->extractLiteral(value: $this->findPredicate(node: $node, localName: 'source')) ?? $uri),
+        ];
+
+        $description = $this->extractLiteral(value: $this->findPredicate(node: $node, localName: 'description'));
+        if ($description !== null) {
+            $data['description'] = $description;
+        }
+
+        $existing = $this->findByUri(schema: self::SCHEMA_SCHEME, uri: $uri);
+        if ($existing === null) {
+            $saved = $this->objectService->saveObject(
+                object: $data,
+                register: self::REGISTER,
+                schema: self::SCHEMA_SCHEME
+            );
+            return (string) $saved->getUuid();
+        }
+
+        $existingData = ($existing->getObject() ?? []);
+        if ($this->dataChanged(existingData: $existingData, newData: $data) === false) {
+            return (string) $existing->getUuid();
+        }
+
+        // The saveObject call is PUT-semantic (omitted properties are cleared)
+        // — carry every existing field forward, only the compared keys are overridden.
+        $merged = array_merge($existingData, $data);
+        $this->objectService->saveObject(
+            object: $merged,
+            register: self::REGISTER,
+            schema: self::SCHEMA_SCHEME,
+            uuid: $existing->getUuid()
+        );
+
+        return (string) $existing->getUuid();
+    }//end upsertScheme()
+
+    /**
+     * Upsert a single concept object for a parsed concept node.
+     *
+     * @param array<string,mixed> $node       The parsed concept node.
+     * @param string              $schemeUuid The owning conceptScheme's uuid.
+     *
+     * @return array{status: string, uuid: string} status is created|updated|unchanged.
+     *
+     * @throws InvalidArgumentException When the concept has no Dutch prefLabel.
+     */
+    private function upsertConcept(array $node, string $schemeUuid): array
+    {
+        $uri = (string) $node['@id'];
+
+        $prefLabel = $this->extractLangMap(value: $this->findPredicate(node: $node, localName: 'prefLabel'));
+        if (isset($prefLabel['nl']) === false || trim($prefLabel['nl']) === '') {
+            throw new InvalidArgumentException(
+                sprintf('Concept "%s" has no Dutch (nl) prefLabel; refusing to import an invalid concept.', $uri)
+            );
+        }
+
+        $data = [
+            'uri'        => $uri,
+            'prefLabel'  => $prefLabel,
+            'inScheme'   => $schemeUuid,
+            'deprecated' => false,
+        ];
+
+        $altLabel = $this->extractLangMap(value: $this->findPredicate(node: $node, localName: 'altLabel'));
+        if (empty($altLabel) === false) {
+            $data['altLabel'] = $altLabel;
+        }
+
+        $definition = $this->extractLiteral(value: $this->findPredicate(node: $node, localName: 'definition'));
+        if ($definition !== null) {
+            $data['definition'] = $definition;
+        }
+
+        $notation = $this->extractLiteral(value: $this->findPredicate(node: $node, localName: 'notation'));
+        if ($notation !== null) {
+            $data['notation'] = $notation;
+        }
+
+        $existing = $this->findByUri(schema: self::SCHEMA_CONCEPT, uri: $uri);
+        if ($existing === null) {
+            $saved = $this->objectService->saveObject(
+                object: $data,
+                register: self::REGISTER,
+                schema: self::SCHEMA_CONCEPT
+            );
+            return ['status' => 'created', 'uuid' => (string) $saved->getUuid()];
+        }
+
+        $existingData = ($existing->getObject() ?? []);
+        if ($this->dataChanged(existingData: $existingData, newData: $data) === false) {
+            return ['status' => 'unchanged', 'uuid' => (string) $existing->getUuid()];
+        }
+
+        $merged = array_merge($existingData, $data);
+        $this->objectService->saveObject(
+            object: $merged,
+            register: self::REGISTER,
+            schema: self::SCHEMA_CONCEPT,
+            uuid: $existing->getUuid()
+        );
+
+        return ['status' => 'updated', 'uuid' => (string) $existing->getUuid()];
+    }//end upsertConcept()
+
+    /**
+     * Recompute broader/narrower/related on every re-imported concept, both
+     * directions, from the source's asserted broader/narrower/related edges.
+     *
+     * Only concepts present in this import's `$uuidByUri` are touched — a
+     * concept absent from the re-imported source keeps its last-known edges
+     * (it is deprecated, not edited) per design.md D3.
+     *
+     * @param array<int,array<string,mixed>> $conceptNodes The parsed concept nodes.
+     * @param array<string,string>           $uuidByUri    uri => uuid map for this import.
+     *
+     * @return void
+     */
+    private function applyRelations(array $conceptNodes, array $uuidByUri): void
+    {
+        $broaderOf  = [];
+        $narrowerOf = [];
+        $relatedOf  = [];
+
+        // Seed every re-imported concept with an empty edge set so an edge
+        // removed from the source is cleared on re-import, not left stale.
+        foreach ($uuidByUri as $uuid) {
+            $broaderOf[$uuid]  = ($broaderOf[$uuid] ?? []);
+            $narrowerOf[$uuid] = ($narrowerOf[$uuid] ?? []);
+            $relatedOf[$uuid]  = ($relatedOf[$uuid] ?? []);
+        }
+
+        foreach ($conceptNodes as $node) {
+            $uri  = (string) ($node['@id'] ?? '');
+            $uuid = ($uuidByUri[$uri] ?? null);
+            if ($uuid === null) {
+                continue;
+            }
+
+            $this->collectEdges(node: $node, predicate: 'broader', uuid: $uuid, uuidByUri: $uuidByUri, forward: $broaderOf, reverse: $narrowerOf);
+            $this->collectEdges(node: $node, predicate: 'narrower', uuid: $uuid, uuidByUri: $uuidByUri, forward: $narrowerOf, reverse: $broaderOf);
+            // related is symmetric: the same map serves as both forward and reverse.
+            $this->collectEdges(node: $node, predicate: 'related', uuid: $uuid, uuidByUri: $uuidByUri, forward: $relatedOf, reverse: $relatedOf);
+        }//end foreach
+
+        foreach ($uuidByUri as $uuid) {
+            $this->applyRelationFieldsToConcept(
+                uuid: $uuid,
+                broader: array_values(array_unique($broaderOf[$uuid] ?? [])),
+                narrower: array_values(array_unique($narrowerOf[$uuid] ?? [])),
+                related: array_values(array_unique($relatedOf[$uuid] ?? []))
+            );
+        }
+    }//end applyRelations()
+
+    /**
+     * Resolve one predicate's asserted edges on `$node` to uuids and record
+     * both the forward edge (`$uuid` -> target) and the reverse edge (target
+     * -> `$uuid`) so a relation asserted in only one direction by the source
+     * is still readable from either concept.
+     *
+     * @param array<string,mixed>           $node      The parsed concept node.
+     * @param string                        $predicate The relation predicate local name (broader|narrower|related).
+     * @param string                        $uuid      The concept's own uuid.
+     * @param array<string,string>          $uuidByUri uri => uuid map for this import.
+     * @param array<string,array<string>>   $forward   Accumulator for `$uuid` -> targets (by reference).
+     * @param array<string,array<string>>   $reverse   Accumulator for target -> `$uuid` (by reference; same
+     *                                                 array as `$forward` for a symmetric predicate like `related`).
+     *
+     * @return void
+     */
+    private function collectEdges(array $node, string $predicate, string $uuid, array $uuidByUri, array &$forward, array &$reverse): void
+    {
+        foreach ($this->extractIdRefs(value: $this->findPredicate(node: $node, localName: $predicate)) as $targetUri) {
+            $targetUuid = ($uuidByUri[$targetUri] ?? null);
+            if ($targetUuid === null) {
+                continue;
+            }
+
+            $forward[$uuid][]      = $targetUuid;
+            $reverse[$targetUuid][] = $uuid;
+        }
+    }//end collectEdges()
+
+    /**
+     * Write a concept's broader/narrower/related fields, skipping the save
+     * when the resolved edge set already matches (idempotent re-import).
+     *
+     * @param string        $uuid     The concept's uuid.
+     * @param array<string> $broader  Resolved broader uuids.
+     * @param array<string> $narrower Resolved narrower uuids.
+     * @param array<string> $related  Resolved related uuids.
+     *
+     * @return void
+     */
+    private function applyRelationFieldsToConcept(string $uuid, array $broader, array $narrower, array $related): void
+    {
+        $existing = $this->objectService->find(id: $uuid, register: self::REGISTER, schema: self::SCHEMA_CONCEPT);
+        if ($existing === null) {
+            return;
+        }
+
+        $existingData = ($existing->getObject() ?? []);
+
+        $existingBroader  = $this->normalizeUuidList(value: ($existingData['broader'] ?? []));
+        $existingNarrower = $this->normalizeUuidList(value: ($existingData['narrower'] ?? []));
+        $existingRelated  = $this->normalizeUuidList(value: ($existingData['related'] ?? []));
+
+        sort($broader);
+        sort($narrower);
+        sort($related);
+        sort($existingBroader);
+        sort($existingNarrower);
+        sort($existingRelated);
+
+        if ($broader === $existingBroader && $narrower === $existingNarrower && $related === $existingRelated) {
+            return;
+        }
+
+        $merged            = $existingData;
+        $merged['broader'] = $broader;
+        $merged['narrower'] = $narrower;
+        $merged['related']  = $related;
+
+        $this->objectService->saveObject(
+            object: $merged,
+            register: self::REGISTER,
+            schema: self::SCHEMA_CONCEPT,
+            uuid: $uuid
+        );
+    }//end applyRelationFieldsToConcept()
+
+    /**
+     * Mark concepts of a scheme absent from `$seenUris` as deprecated. Never deletes.
+     *
+     * @param string        $schemeUuid The conceptScheme's uuid.
+     * @param array<string> $seenUris   URIs present in the just-completed import.
+     *
+     * @return int Count of concepts newly marked deprecated.
+     */
+    private function deprecateMissing(string $schemeUuid, array $seenUris): int
+    {
+        $count  = 0;
+        $limit  = 200;
+        $offset = 0;
+
+        do {
+            $results = $this->objectService->findAll(
+                config: [
+                    'register' => self::REGISTER,
+                    'schema'   => self::SCHEMA_CONCEPT,
+                    'filters'  => ['inScheme' => $schemeUuid],
+                    'limit'    => $limit,
+                    'offset'   => $offset,
+                ]
+            );
+
+            foreach ($results as $entity) {
+                $data = ($entity->getObject() ?? []);
+                $uri  = ($data['uri'] ?? null);
+                if ($uri === null
+                    || in_array($uri, $seenUris, true) === true
+                    || ($data['deprecated'] ?? false) === true
+                ) {
+                    continue;
+                }
+
+                $data['deprecated'] = true;
+                $this->objectService->saveObject(
+                    object: $data,
+                    register: self::REGISTER,
+                    schema: self::SCHEMA_CONCEPT,
+                    uuid: $entity->getUuid()
+                );
+                $count++;
+            }
+
+            $offset += $limit;
+        } while (count($results) === $limit);
+
+        return $count;
+    }//end deprecateMissing()
+
+    /**
+     * Find a conceptScheme/concept object by its durable source uri.
+     *
+     * @param string $schema Schema slug (self::SCHEMA_SCHEME or self::SCHEMA_CONCEPT).
+     * @param string $uri    The source uri to look up.
+     *
+     * @return ObjectEntity|null The matching object, or null when absent.
+     */
+    private function findByUri(string $schema, string $uri): ?ObjectEntity
+    {
+        $results = $this->objectService->findAll(
+            config: [
+                'register' => self::REGISTER,
+                'schema'   => $schema,
+                'filters'  => ['uri' => $uri],
+                'limit'    => 1,
+            ]
+        );
+
+        return ($results[0] ?? null);
+    }//end findByUri()
+
+    /**
+     * Whether any of the compared keys in `$newData` differ from `$existingData`.
+     *
+     * @param array<string,mixed> $existingData The stored object data.
+     * @param array<string,mixed> $newData      The newly computed data (subset of keys to compare).
+     *
+     * @return bool True when at least one compared key differs.
+     */
+    private function dataChanged(array $existingData, array $newData): bool
+    {
+        foreach ($newData as $key => $value) {
+            if (($existingData[$key] ?? null) !== $value) {
+                return true;
+            }
+        }
+
+        return false;
+    }//end dataChanged()
+
+    /**
+     * Normalise a stored relation field value to a flat array of uuid strings.
+     *
+     * @param mixed $value The stored `broader`/`narrower`/`related` field value.
+     *
+     * @return array<string>
+     */
+    private function normalizeUuidList(mixed $value): array
+    {
+        if (is_array($value) === false) {
+            return [];
+        }
+
+        return array_values(
+            array_filter(
+                array_map(static fn ($item): string => (string) $item, $value),
+                static fn (string $item): bool => $item !== ''
+            )
+        );
+    }//end normalizeUuidList()
+
+    /**
+     * Find the first value of a JSON-LD node whose key's local name (the
+     * part after the last `#`, `/` or `:`) matches `$localName`.
+     *
+     * @param array<string,mixed> $node      The JSON-LD node.
+     * @param string              $localName The predicate local name to find (e.g. "prefLabel").
+     *
+     * @return mixed The matched value, or null when absent.
+     */
+    private function findPredicate(array $node, string $localName): mixed
+    {
+        foreach ($node as $key => $value) {
+            if (str_starts_with($key, '@') === true) {
+                continue;
+            }
+
+            if ($this->localName(iriOrPrefixed: $key) === $localName) {
+                return $value;
+            }
+        }
+
+        return null;
+    }//end findPredicate()
+
+    /**
+     * The local name of an IRI or prefixed name — the substring after the
+     * rightmost `#`, `/` or `:`.
+     *
+     * @param string $iriOrPrefixed A full IRI, a `prefix:local` name, or a bare local name.
+     *
+     * @return string The local name.
+     */
+    private function localName(string $iriOrPrefixed): string
+    {
+        $pos = false;
+        foreach (['#', '/', ':'] as $separator) {
+            $candidate = strrpos($iriOrPrefixed, $separator);
+            if ($candidate !== false && ($pos === false || $candidate > $pos)) {
+                $pos = $candidate;
+            }
+        }
+
+        if ($pos === false) {
+            return $iriOrPrefixed;
+        }
+
+        return substr($iriOrPrefixed, $pos + 1);
+    }//end localName()
+
+    /**
+     * Extract a single string literal from a JSON-LD predicate value.
+     *
+     * Accepts a bare string, a `{"@value": "..."}` literal node, or an array
+     * of either (the first non-empty match wins).
+     *
+     * @param mixed $value The raw predicate value.
+     *
+     * @return string|null The extracted literal, or null when absent/empty.
+     */
+    private function extractLiteral(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_string($value) === true) {
+            $trimmed = trim($value);
+            if ($trimmed === '') {
+                return null;
+            }
+
+            return $trimmed;
+        }
+
+        if (is_array($value) === true) {
+            if (isset($value['@value']) === true) {
+                return (string) $value['@value'];
+            }
+
+            foreach ($value as $item) {
+                $literal = $this->extractLiteral(value: $item);
+                if ($literal !== null) {
+                    return $literal;
+                }
+            }
+        }
+
+        return null;
+    }//end extractLiteral()
+
+    /**
+     * Extract a BCP-47-keyed language map from a JSON-LD predicate value.
+     *
+     * Accepts an array of `{"@value": "...", "@language": "xx"}` literal
+     * nodes (canonical JSON-LD), a bare string (assumed `nl`), or an assoc
+     * shorthand `{"nl": "...", "en": "..."}`.
+     *
+     * @param mixed $value The raw predicate value.
+     *
+     * @return array<string,string> BCP-47 tag => label.
+     */
+    private function extractLangMap(mixed $value): array
+    {
+        if ($value === null) {
+            return [];
+        }
+
+        if (is_string($value) === true) {
+            $trimmed = trim($value);
+            if ($trimmed === '') {
+                return [];
+            }
+
+            return ['nl' => $trimmed];
+        }
+
+        if (is_array($value) === false) {
+            return [];
+        }
+
+        if (isset($value['@value']) === true) {
+            $lang = (string) ($value['@language'] ?? 'nl');
+            return [$lang => (string) $value['@value']];
+        }
+
+        $map = [];
+        if (array_is_list($value) === true) {
+            foreach ($value as $item) {
+                if (is_array($item) === true && isset($item['@value']) === true) {
+                    $lang       = (string) ($item['@language'] ?? 'nl');
+                    $map[$lang] = (string) $item['@value'];
+                } else if (is_string($item) === true && trim($item) !== '') {
+                    $map['nl'] = $item;
+                }
+            }
+
+            return $map;
+        }
+
+        foreach ($value as $lang => $label) {
+            if (is_string($label) === true && trim($label) !== '') {
+                $map[(string) $lang] = $label;
+            }
+        }
+
+        return $map;
+    }//end extractLangMap()
+
+    /**
+     * Extract a list of referenced uris from a JSON-LD predicate value.
+     *
+     * Accepts a bare uri string, a `{"@id": "..."}` reference node, or an
+     * array of either.
+     *
+     * @param mixed $value The raw predicate value.
+     *
+     * @return array<string> The referenced uris.
+     */
+    private function extractIdRefs(mixed $value): array
+    {
+        if ($value === null) {
+            return [];
+        }
+
+        if (is_string($value) === true) {
+            $trimmed = trim($value);
+            if ($trimmed === '') {
+                return [];
+            }
+
+            return [$trimmed];
+        }
+
+        if (is_array($value) === false) {
+            return [];
+        }
+
+        if (isset($value['@id']) === true) {
+            return [(string) $value['@id']];
+        }
+
+        $out = [];
+        foreach ($value as $item) {
+            if (is_array($item) === true && isset($item['@id']) === true) {
+                $out[] = (string) $item['@id'];
+            } else if (is_string($item) === true && trim($item) !== '') {
+                $out[] = $item;
+            }
+        }
+
+        return $out;
+    }//end extractIdRefs()
+}//end class

--- a/lib/Settings/vocabulary_register.json
+++ b/lib/Settings/vocabulary_register.json
@@ -1,0 +1,240 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Vocabulary",
+    "description": "Canonical SKOS-aligned controlled-vocabulary register: concept schemes and their concepts, shared fleet-wide so leaf apps (OpenCatalogi TOOI/DiWoo lookups, softwarecatalog GEMMA referentiecomponenten, decidesk ORI/organisation URIs) consume one authoritative source of concept URIs instead of hand-rolling their own value lists. Backs NL-SBB (mandatory for Federatief Datastelsel participants per 1 January 2026), DiWoo value-list binding, and DCAT-AP-NL 3.0 vocabulary URI requirements.",
+    "version": "1.0.0"
+  },
+  "x-openregister": {
+    "type": "core",
+    "app": "openregister",
+    "openregister": "^v0.2.10",
+    "description": "Foundational SKOS concept-scheme/concept register shipped by OpenRegister for fleet-wide controlled-vocabulary consumption (skos-concept-registers)."
+  },
+  "paths": {},
+  "components": {
+    "registers": {
+      "vocabulary": {
+        "slug": "vocabulary",
+        "title": "Vocabulary",
+        "version": "1.0.0",
+        "description": "Controlled-vocabulary register holding SKOS concept schemes and their concepts. Reads are public (vocabularies are public reference data); writes are admin-gated. Seeded on install with the Woo-critical TOOI value lists (informatiecategorieën, soortHandeling) via the SeedVocabularyRegister repair step.",
+        "published": "2026-07-23T00:00:00+00:00",
+        "schemas": [
+          "conceptScheme",
+          "concept"
+        ],
+        "folder": "Open Registers/Vocabulary"
+      }
+    },
+    "schemas": {
+      "conceptScheme": {
+        "slug": "conceptScheme",
+        "title": "Concept Scheme",
+        "version": "1.0.0",
+        "published": "2026-07-23T00:00:00+00:00",
+        "x-schema-org": "schema:DefinedTermSet",
+        "summary": "A SKOS concept scheme (controlled vocabulary / begrippenkader)",
+        "description": "A named, published controlled vocabulary (SKOS ConceptScheme) that groups a set of concepts, e.g. the Woo informatiecategorieën or a GEMMA referentiecomponenten-lijst. Identified durably by its source URI; imported/refreshed via the VocabularyImportService.",
+        "required": [
+          "uri",
+          "title",
+          "publisher",
+          "version",
+          "source"
+        ],
+        "properties": {
+          "uri": {
+            "type": "string",
+            "format": "uri",
+            "description": "The canonical, durable URI that identifies this concept scheme (e.g. a TOOI kern-thesaurus base URI or a GEMMA scheme URI). Unique within the register: the importer's URI-keyed upsert never creates a second conceptScheme object for the same uri.",
+            "maxLength": 500,
+            "facetable": true,
+            "title": "Scheme URI"
+          },
+          "title": {
+            "type": "string",
+            "description": "Human-readable name of the concept scheme, as published by the source (e.g. \"Woo-informatiecategorieën\").",
+            "maxLength": 255,
+            "facetable": true,
+            "title": "Title"
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional longer description of the concept scheme's purpose and scope, as published by the source.",
+            "maxLength": 2000,
+            "title": "Description"
+          },
+          "publisher": {
+            "type": "string",
+            "description": "The organisation responsible for publishing and maintaining this concept scheme (e.g. \"KOOP\" or a TOOI organisatie URI).",
+            "maxLength": 255,
+            "facetable": true,
+            "title": "Publisher"
+          },
+          "version": {
+            "type": "string",
+            "description": "Version identifier of the concept scheme as published upstream, used by the importer to detect an updated source release.",
+            "maxLength": 100,
+            "facetable": true,
+            "title": "Version"
+          },
+          "source": {
+            "type": "string",
+            "format": "uri",
+            "description": "URI or identifier of the upstream source this scheme was imported from (e.g. a TOOI waardelijst identifier or a SKOS/JSON-LD export URL).",
+            "maxLength": 500,
+            "title": "Source"
+          }
+        },
+        "searchable": true,
+        "hardValidation": false,
+        "authorization": {
+          "read": [
+            "public"
+          ]
+        }
+      },
+      "concept": {
+        "slug": "concept",
+        "title": "Concept",
+        "version": "1.0.0",
+        "published": "2026-07-23T00:00:00+00:00",
+        "x-schema-org": "schema:DefinedTerm",
+        "summary": "A SKOS concept (a single controlled-vocabulary term)",
+        "description": "A single term within a concept scheme (SKOS Concept), e.g. one Woo informatiecategorie. Identified durably by its source URI; the importer keys upserts on this URI and, on re-import, marks concepts missing from the source as deprecated rather than deleting them (leaf apps hold long-lived references).",
+        "required": [
+          "uri",
+          "prefLabel",
+          "inScheme"
+        ],
+        "properties": {
+          "uri": {
+            "type": "string",
+            "format": "uri",
+            "description": "The canonical, durable URI that identifies this concept (e.g. a TOOI kern-thesaurus concept URI such as https://identifier.overheid.nl/tooi/def/thes/kern/c_139c6280). Unique within the register: the importer's URI-keyed upsert never creates a second concept object for the same uri.",
+            "maxLength": 500,
+            "facetable": true,
+            "title": "Concept URI"
+          },
+          "prefLabel": {
+            "type": "object",
+            "description": "Preferred human-readable label for this concept, keyed by BCP-47 language tag. Dutch (\"nl\") is required; additional language tags (e.g. \"en\") are optional. Used for display and for the resolution API's cross-language label search.",
+            "required": [
+              "nl"
+            ],
+            "properties": {
+              "nl": {
+                "type": "string",
+                "description": "The Dutch (nl) preferred label of this concept.",
+                "maxLength": 500,
+                "title": "Dutch Preferred Label"
+              },
+              "en": {
+                "type": "string",
+                "description": "The English (en) preferred label of this concept, when the source publishes one.",
+                "maxLength": 500,
+                "title": "English Preferred Label"
+              }
+            },
+            "additionalProperties": {
+              "type": "string",
+              "description": "A preferred label in an additional BCP-47 language tag not listed above.",
+              "title": "Additional-Language Preferred Label"
+            },
+            "title": "Preferred Label"
+          },
+          "altLabel": {
+            "type": "object",
+            "description": "Alternative human-readable labels (synonyms) for this concept, keyed by BCP-47 language tag, matching the shape of prefLabel. Optional; used by the resolution API's label search to also match on known synonyms.",
+            "properties": {
+              "nl": {
+                "type": "string",
+                "description": "A Dutch (nl) alternative label (synonym) for this concept.",
+                "maxLength": 500,
+                "title": "Dutch Alternative Label"
+              },
+              "en": {
+                "type": "string",
+                "description": "An English (en) alternative label (synonym) for this concept.",
+                "maxLength": 500,
+                "title": "English Alternative Label"
+              }
+            },
+            "additionalProperties": {
+              "type": "string",
+              "description": "An alternative label in an additional BCP-47 language tag not listed above.",
+              "title": "Additional-Language Alternative Label"
+            },
+            "title": "Alternative Label"
+          },
+          "definition": {
+            "type": "string",
+            "description": "A statement or formal explanation of the meaning of this concept, as published by the source.",
+            "maxLength": 4000,
+            "title": "Definition"
+          },
+          "notation": {
+            "type": "string",
+            "description": "A compact, source-defined code identifying this concept within its scheme (e.g. a TOOI \"c_...\" identifier), distinct from the durable uri. Used by the resolution API's (scheme, notation) lookup.",
+            "maxLength": 255,
+            "facetable": true,
+            "title": "Notation"
+          },
+          "deprecated": {
+            "type": "boolean",
+            "description": "Whether this concept has been withdrawn from the upstream source. Set by the importer when a re-imported source no longer contains this concept's uri; the concept is never deleted so existing leaf references keep resolving.",
+            "default": false,
+            "facetable": true,
+            "title": "Deprecated"
+          },
+          "inScheme": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "conceptScheme",
+            "description": "Reference to the conceptScheme this concept belongs to.",
+            "facetable": true,
+            "title": "In Scheme"
+          },
+          "broader": {
+            "type": "array",
+            "description": "References to broader (more general) sibling concepts in the hierarchy. Maintained by the importer in both directions: when concept A is broader of B, B's broader lists A and A's narrower lists B.",
+            "items": {
+              "type": "string",
+              "format": "uuid",
+              "$ref": "concept"
+            },
+            "title": "Broader Concepts"
+          },
+          "narrower": {
+            "type": "array",
+            "description": "References to narrower (more specific) sibling concepts in the hierarchy. Maintained by the importer in both directions: when concept A is broader of B, B's broader lists A and A's narrower lists B.",
+            "items": {
+              "type": "string",
+              "format": "uuid",
+              "$ref": "concept"
+            },
+            "title": "Narrower Concepts"
+          },
+          "related": {
+            "type": "array",
+            "description": "References to associatively related sibling concepts (SKOS skos:related) that are neither broader nor narrower.",
+            "items": {
+              "type": "string",
+              "format": "uuid",
+              "$ref": "concept"
+            },
+            "title": "Related Concepts"
+          }
+        },
+        "searchable": true,
+        "hardValidation": false,
+        "authorization": {
+          "read": [
+            "public"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/openspec/changes/skos-concept-registers/tasks.md
+++ b/openspec/changes/skos-concept-registers/tasks.md
@@ -1,16 +1,22 @@
 # Tasks: skos-concept-registers
 
-- [ ] Freeze delta spec `specs/skos-concept-registers/spec.md` (ADDED SKOS-001..004); `openspec validate skos-concept-registers` green
-- [ ] Vocabulary register definition under `lib/Settings` with `conceptScheme` + `concept` schemas: required/unique `uri`, multilingual `prefLabel`/`altLabel` maps, canonical-dialect relations (`inScheme`, `broader`, `narrower`, `related`), English `title`+`description` on every property, public read / admin-gated write
+- [x] Freeze delta spec `specs/skos-concept-registers/spec.md` (ADDED SKOS-001..004); `openspec validate skos-concept-registers` green
+  - Done: spec frozen with the proposal; `openspec validate skos-concept-registers` reports "Change 'skos-concept-registers' is valid".
+- [x] Vocabulary register definition under `lib/Settings` with `conceptScheme` + `concept` schemas: required/unique `uri`, multilingual `prefLabel`/`altLabel` maps, canonical-dialect relations (`inScheme`, `broader`, `narrower`, `related`), English `title`+`description` on every property, public read / admin-gated write
   - Spec ref: SKOS-001
   - Acceptance: register imports clean on a fresh instance; relation-dialect (gate 31) + schema-property-titles (gate 28) green
-- [ ] `VocabularyImportService`: URI-keyed idempotent upsert from JSON-LD SKOS + CSV value-list; created/updated/unchanged report; deprecation (never deletion) of concepts missing from a re-imported source; both `broader`/`narrower` directions maintained
+  - Done: `lib/Settings/vocabulary_register.json` — OpenAPI/x-openregister register document with `conceptScheme` + `concept` schemas under `components.schemas`. `concept.uri` required+unique; `prefLabel`/`altLabel` are multilingual object maps (BCP-47 keys); relations `inScheme` (`$ref: conceptScheme`), `broader`/`narrower`/`related` (`$ref: concept`) all carry `type:string`/`array` + `format:uuid` per the canonical relation dialect (ADR-062); English `title`+`description` on every property. Public read / admin-gated write posture. Covered by `tests/Unit/Settings/VocabularyRegisterJsonTest.php`.
+- [x] `VocabularyImportService`: URI-keyed idempotent upsert from JSON-LD SKOS + CSV value-list; created/updated/unchanged report; deprecation (never deletion) of concepts missing from a re-imported source; both `broader`/`narrower` directions maintained
   - Spec ref: SKOS-002
   - Acceptance: PHPUnit — double-import no-op, label-change update-in-place, removed-concept deprecation
-- [ ] Bundle TOOI fixtures (informatiecategorieën ×17, documentsoorten, organisatie scheme ids) + repair-step seeding through the importer
+  - Done: `lib/Service/VocabularyImportService.php` (848 L) — SKOS JSON-LD + CSV import; URI-keyed upsert via ObjectService; `{created, updated, unchanged}` report; concepts absent from a re-imported source get `deprecated: true` (never deleted); both `broader`/`narrower` directions maintained. Covered by `tests/Unit/Service/VocabularyImportServiceTest.php`.
+- [x] Bundle TOOI fixtures (informatiecategorieën ×17, documentsoorten, organisatie scheme ids) + repair-step seeding through the importer
   - Spec ref: SKOS-003
   - Acceptance: PHPUnit — fresh seed serves all 17 categories with TOOI URIs; repeated repair run is a no-op
-- [ ] Resolution endpoints (public read): by exact URI, by (scheme, notation), scheme concept listing with paginated multilingual label search; 404 with standard error shape on unknown URI
+  - Done: `lib/Resources/Vocabulary/tooi-informatiecategorieen.jsonld` (1 `skos:ConceptScheme` + 17 `skos:Concept` with TOOI URIs + Dutch prefLabels) and `tooi-documenthandelingen.jsonld`. `lib/Repair/SeedVocabularyRegister.php` imports the register then seeds both lists via the idempotent importer (registered `<post-migration>` + `<install>` in `appinfo/info.xml`; safe to re-run). Covered by `tests/Unit/Repair/SeedVocabularyRegisterTest.php`.
+- [x] Resolution endpoints (public read): by exact URI, by (scheme, notation), scheme concept listing with paginated multilingual label search; 404 with standard error shape on unknown URI
   - Spec ref: SKOS-004
   - Acceptance: PHPUnit controller tests incl. 404 path; route-auth gate green
-- [ ] `@spec` tags on all new methods; hydra gates green locally; file follow-up leaf issues (opencatalogi Tooi/DcatVocabularyService consume-change, softwarecatalog GEMMA, decidesk ORI)
+  - Done: `lib/Controller/VocabularyController.php` — `GET /api/vocabulary/concept` (by URI), `/api/vocabulary/concept/notation` (by scheme+notation), `/api/vocabulary/concepts` (listing + paginated multilingual label search). Query-param based (URIs unsafe as path segments); `@PublicPage`; 404 standard error shape on unknown uri/scheme/notation. Routes in `appinfo/routes.php`. Covered by `tests/Unit/Controller/VocabularyControllerTest.php` incl. 404 path.
+- [x] `@spec` tags on all new methods; hydra gates green locally; file follow-up leaf issues (opencatalogi Tooi/DcatVocabularyService consume-change, softwarecatalog GEMMA, decidesk ORI)
+  - Done: `@spec` tags + SPDX (`EUPL-1.2` / Conduction B.V.) headers on all new PHP files. `php vendor/bin/phpunit --filter Vocabulary` → 41 tests, 281 assertions, all green (nextcloud:34.0.0-apache). Follow-up leaf consume-issues filed against opencatalogi / softwarecatalog / decidesk (see PR body).

--- a/tests/Fixtures/vocabulary/sample-scheme-updated.jsonld
+++ b/tests/Fixtures/vocabulary/sample-scheme-updated.jsonld
@@ -1,0 +1,28 @@
+{
+  "@context": {
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "dct": "http://purl.org/dc/terms/",
+    "owl": "http://www.w3.org/2002/07/owl#"
+  },
+  "@graph": [
+    {
+      "@id": "https://example.org/vocab/sample-scheme",
+      "@type": "skos:ConceptScheme",
+      "dct:title": "Sample Test Scheme",
+      "dct:publisher": "OpenRegister Test Fixtures",
+      "owl:versionInfo": "1.0",
+      "dct:source": "https://example.org/vocab/sample-scheme/source"
+    },
+    {
+      "@id": "https://example.org/vocab/sample-scheme/a",
+      "@type": "skos:Concept",
+      "skos:inScheme": { "@id": "https://example.org/vocab/sample-scheme" },
+      "skos:notation": "A",
+      "skos:prefLabel": [
+        { "@value": "Concept A (renamed)", "@language": "nl" },
+        { "@value": "Concept A (en)", "@language": "en" }
+      ],
+      "skos:definition": "The top-level concept in the sample hierarchy."
+    }
+  ]
+}

--- a/tests/Fixtures/vocabulary/sample-scheme.jsonld
+++ b/tests/Fixtures/vocabulary/sample-scheme.jsonld
@@ -1,0 +1,38 @@
+{
+  "@context": {
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "dct": "http://purl.org/dc/terms/",
+    "owl": "http://www.w3.org/2002/07/owl#"
+  },
+  "@graph": [
+    {
+      "@id": "https://example.org/vocab/sample-scheme",
+      "@type": "skos:ConceptScheme",
+      "dct:title": "Sample Test Scheme",
+      "dct:publisher": "OpenRegister Test Fixtures",
+      "owl:versionInfo": "1.0",
+      "dct:source": "https://example.org/vocab/sample-scheme/source"
+    },
+    {
+      "@id": "https://example.org/vocab/sample-scheme/a",
+      "@type": "skos:Concept",
+      "skos:inScheme": { "@id": "https://example.org/vocab/sample-scheme" },
+      "skos:notation": "A",
+      "skos:prefLabel": [
+        { "@value": "Concept A", "@language": "nl" },
+        { "@value": "Concept A (en)", "@language": "en" }
+      ],
+      "skos:definition": "The top-level concept in the sample hierarchy."
+    },
+    {
+      "@id": "https://example.org/vocab/sample-scheme/b",
+      "@type": "skos:Concept",
+      "skos:inScheme": { "@id": "https://example.org/vocab/sample-scheme" },
+      "skos:notation": "B",
+      "skos:prefLabel": [
+        { "@value": "Concept B", "@language": "nl" }
+      ],
+      "skos:broader": [ { "@id": "https://example.org/vocab/sample-scheme/a" } ]
+    }
+  ]
+}

--- a/tests/Unit/Controller/VocabularyControllerTest.php
+++ b/tests/Unit/Controller/VocabularyControllerTest.php
@@ -1,0 +1,286 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Controller\VocabularyController}
+ * (skos-concept-registers, SKOS-004).
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md#skos-004
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use OCA\OpenRegister\Controller\VocabularyController;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\VocabularyImportService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class VocabularyControllerTest extends TestCase
+{
+
+    private ObjectService&MockObject $objectService;
+
+    private VocabularyController $controller;
+
+    /**
+     * The current test's simulated query params.
+     *
+     * @var array<string, string>
+     */
+    private array $params = [];
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->objectService = $this->createMock(ObjectService::class);
+
+        $request = $this->createMock(IRequest::class);
+        $request->method('getParam')->willReturnCallback(
+            fn (string $key, $default = null) => ($this->params[$key] ?? $default)
+        );
+
+        $this->controller = new VocabularyController(
+            appName: 'openregister',
+            request: $request,
+            objectService: $this->objectService
+        );
+    }//end setUp()
+
+    /**
+     * @param string               $uuid   The object uuid.
+     * @param array<string, mixed> $object The object payload.
+     *
+     * @return ObjectEntity
+     */
+    private function entity(string $uuid, array $object): ObjectEntity
+    {
+        $entity = new ObjectEntity();
+        $entity->setUuid($uuid);
+        $entity->setObject($object);
+
+        return $entity;
+    }//end entity()
+
+    // -------------------------------------------------------------------
+    // resolveByUri
+    // -------------------------------------------------------------------
+
+    /**
+     * @return void
+     */
+    public function testResolveByUriReturnsConceptWhenFound(): void
+    {
+        $this->params = ['uri' => 'https://example.org/vocab/x'];
+
+        $concept = $this->entity('uuid-1', ['uri' => 'https://example.org/vocab/x', 'prefLabel' => ['nl' => 'X']]);
+
+        $this->objectService->method('findAll')->willReturn([$concept]);
+
+        $response = $this->controller->resolveByUri();
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame('https://example.org/vocab/x', $response->getData()['uri']);
+    }//end testResolveByUriReturnsConceptWhenFound()
+
+    /**
+     * @return void
+     */
+    public function testResolveByUriReturns404OnUnknownUri(): void
+    {
+        $this->params = ['uri' => 'https://example.org/vocab/unknown'];
+
+        $this->objectService->method('findAll')->willReturn([]);
+
+        $response = $this->controller->resolveByUri();
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        $this->assertArrayHasKey('message', $response->getData());
+    }//end testResolveByUriReturns404OnUnknownUri()
+
+    /**
+     * @return void
+     */
+    public function testResolveByUriReturns404WhenUriParamMissing(): void
+    {
+        $this->params = [];
+
+        $this->objectService->expects($this->never())->method('findAll');
+
+        $response = $this->controller->resolveByUri();
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+    }//end testResolveByUriReturns404WhenUriParamMissing()
+
+    // -------------------------------------------------------------------
+    // resolveByNotation
+    // -------------------------------------------------------------------
+
+    /**
+     * @return void
+     */
+    public function testResolveByNotationReturnsConceptWhenFound(): void
+    {
+        $this->params = ['scheme' => 'https://example.org/vocab/scheme', 'notation' => 'c_1'];
+
+        $scheme  = $this->entity('scheme-uuid', ['uri' => 'https://example.org/vocab/scheme']);
+        $concept = $this->entity('uuid-1', ['uri' => 'https://example.org/vocab/c1', 'notation' => 'c_1']);
+
+        $this->objectService->method('findAll')->willReturnCallback(
+            function (array $config) use ($scheme, $concept) {
+                if ($config['schema'] === VocabularyImportService::SCHEMA_SCHEME) {
+                    return [$scheme];
+                }
+
+                return [$concept];
+            }
+        );
+
+        $response = $this->controller->resolveByNotation();
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame('c_1', $response->getData()['notation']);
+    }//end testResolveByNotationReturnsConceptWhenFound()
+
+    /**
+     * @return void
+     */
+    public function testResolveByNotationReturns404OnUnknownScheme(): void
+    {
+        $this->params = ['scheme' => 'https://example.org/vocab/unknown-scheme', 'notation' => 'c_1'];
+
+        $this->objectService->method('findAll')->willReturn([]);
+        $this->objectService->method('find')->willReturn(null);
+
+        $response = $this->controller->resolveByNotation();
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+    }//end testResolveByNotationReturns404OnUnknownScheme()
+
+    /**
+     * @return void
+     */
+    public function testResolveByNotationReturns404WhenNotationParamMissing(): void
+    {
+        $this->params = ['scheme' => 'https://example.org/vocab/scheme'];
+
+        $this->objectService->expects($this->never())->method('findAll');
+
+        $response = $this->controller->resolveByNotation();
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+    }//end testResolveByNotationReturns404WhenNotationParamMissing()
+
+    // -------------------------------------------------------------------
+    // listConcepts
+    // -------------------------------------------------------------------
+
+    /**
+     * @return void
+     */
+    public function testListConceptsReturns400WhenSchemeMissing(): void
+    {
+        $this->params = [];
+
+        $response = $this->controller->listConcepts();
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+    }//end testListConceptsReturns400WhenSchemeMissing()
+
+    /**
+     * @return void
+     */
+    public function testListConceptsReturns404OnUnknownScheme(): void
+    {
+        $this->params = ['scheme' => 'https://example.org/vocab/unknown-scheme'];
+
+        $this->objectService->method('findAll')->willReturn([]);
+        $this->objectService->method('find')->willReturn(null);
+
+        $response = $this->controller->listConcepts();
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+    }//end testListConceptsReturns404OnUnknownScheme()
+
+    /**
+     * A label query matches exactly the concept whose Dutch prefLabel
+     * contains it, across the scheme's concepts, in the standard paginated
+     * envelope (SKOS-004 scenario 2).
+     *
+     * @return void
+     */
+    public function testListConceptsLabelSearchMatchesOnlyTheMatchingConcept(): void
+    {
+        $this->params = ['scheme' => 'https://example.org/vocab/scheme', 'q' => 'Wonin'];
+
+        $scheme = $this->entity('scheme-uuid', ['uri' => 'https://example.org/vocab/scheme']);
+        $a      = $this->entity('a', ['uri' => 'https://example.org/vocab/a', 'inScheme' => 'scheme-uuid', 'prefLabel' => ['nl' => 'Woningbouw']]);
+        $b      = $this->entity('b', ['uri' => 'https://example.org/vocab/b', 'inScheme' => 'scheme-uuid', 'prefLabel' => ['nl' => 'Belastingen']]);
+
+        $this->objectService->method('findAll')->willReturnCallback(
+            function (array $config) use ($scheme, $a, $b) {
+                if ($config['schema'] === VocabularyImportService::SCHEMA_SCHEME) {
+                    return [$scheme];
+                }
+
+                return [$a, $b];
+            }
+        );
+
+        $response = $this->controller->listConcepts();
+        $data     = $response->getData();
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(1, $data['total']);
+        $this->assertCount(1, $data['results']);
+        $this->assertSame('https://example.org/vocab/a', $data['results'][0]['uri']);
+    }//end testListConceptsLabelSearchMatchesOnlyTheMatchingConcept()
+
+    /**
+     * Without a label query, every concept of the scheme is returned, paginated.
+     *
+     * @return void
+     */
+    public function testListConceptsWithoutQueryReturnsAllConceptsOfScheme(): void
+    {
+        $this->params = ['scheme' => 'https://example.org/vocab/scheme'];
+
+        $scheme = $this->entity('scheme-uuid', ['uri' => 'https://example.org/vocab/scheme']);
+        $a      = $this->entity('a', ['uri' => 'https://example.org/vocab/a', 'inScheme' => 'scheme-uuid', 'prefLabel' => ['nl' => 'A']]);
+        $b      = $this->entity('b', ['uri' => 'https://example.org/vocab/b', 'inScheme' => 'scheme-uuid', 'prefLabel' => ['nl' => 'B']]);
+
+        $this->objectService->method('findAll')->willReturnCallback(
+            function (array $config) use ($scheme, $a, $b) {
+                if ($config['schema'] === VocabularyImportService::SCHEMA_SCHEME) {
+                    return [$scheme];
+                }
+
+                return [$a, $b];
+            }
+        );
+
+        $response = $this->controller->listConcepts();
+        $data     = $response->getData();
+
+        $this->assertSame(2, $data['total']);
+        $this->assertCount(2, $data['results']);
+    }//end testListConceptsWithoutQueryReturnsAllConceptsOfScheme()
+}//end class

--- a/tests/Unit/Repair/SeedVocabularyRegisterTest.php
+++ b/tests/Unit/Repair/SeedVocabularyRegisterTest.php
@@ -1,0 +1,241 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Repair\SeedVocabularyRegister}
+ * (skos-concept-registers, SKOS-003).
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Repair
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md#skos-003
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Repair;
+
+use OCA\OpenRegister\Repair\SeedVocabularyRegister;
+use OCA\OpenRegister\Service\ConfigurationService;
+use OCA\OpenRegister\Service\VocabularyImportService;
+use OCP\App\IAppManager;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class SeedVocabularyRegisterTest extends TestCase
+{
+
+    private ConfigurationService&MockObject $configurationService;
+
+    private VocabularyImportService&MockObject $vocabularyImportService;
+
+    private IAppManager&MockObject $appManager;
+
+    private IOutput&MockObject $output;
+
+    private SeedVocabularyRegister $repairStep;
+
+    /**
+     * Real path of the openregister app checkout (repo root).
+     *
+     * @var string
+     */
+    private string $appPath;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->appPath = realpath(__DIR__.'/../../..');
+
+        $this->configurationService    = $this->createMock(ConfigurationService::class);
+        $this->vocabularyImportService = $this->createMock(VocabularyImportService::class);
+        $this->appManager              = $this->createMock(IAppManager::class);
+        $this->output                  = $this->createMock(IOutput::class);
+        $logger                        = $this->createMock(LoggerInterface::class);
+
+        $this->appManager->method('getAppPath')->with('openregister')->willReturn($this->appPath);
+
+        $this->repairStep = new SeedVocabularyRegister(
+            configurationService: $this->configurationService,
+            importService: $this->vocabularyImportService,
+            appManager: $this->appManager,
+            logger: $logger
+        );
+    }//end setUp()
+
+    /**
+     * @return void
+     */
+    public function testImplementsIRepairStep(): void
+    {
+        $this->assertInstanceOf(IRepairStep::class, $this->repairStep);
+    }//end testImplementsIRepairStep()
+
+    /**
+     * @return void
+     */
+    public function testGetNameReturnsDescriptiveString(): void
+    {
+        $this->assertSame(
+            'Import OpenRegister vocabulary register and seed bundled TOOI Woo value lists',
+            $this->repairStep->getName()
+        );
+    }//end testGetNameReturnsDescriptiveString()
+
+    /**
+     * The register descriptor is imported with the dedicated app id, force=false
+     * (re-runs are no-ops, mirroring ImportTrustConfigurationRegister).
+     *
+     * @return void
+     */
+    public function testRunImportsTheVocabularyRegisterDescriptor(): void
+    {
+        $this->vocabularyImportService->method('importJsonLd')->willReturn([
+            'scheme'    => 'https://example.org/scheme',
+            'created'   => 0,
+            'updated'   => 0,
+            'unchanged' => 0,
+            'deprecated'=> 0,
+        ]);
+
+        $this->configurationService->expects($this->once())
+            ->method('importFromApp')
+            ->with(
+                $this->equalTo('openregister.vocabulary'),
+                $this->callback(function (array $data): bool {
+                    $schemas = ($data['components']['schemas'] ?? []);
+                    return isset($schemas['conceptScheme']) === true && isset($schemas['concept']) === true;
+                }),
+                $this->equalTo('1.0.0'),
+                $this->equalTo(false)
+            );
+
+        $this->repairStep->run($this->output);
+    }//end testRunImportsTheVocabularyRegisterDescriptor()
+
+    /**
+     * Both bundled TOOI fixtures are seeded through the idempotent importer,
+     * and the informatiecategorieën fixture carries exactly the 17 Woo
+     * categories with TOOI kern-thesaurus URIs.
+     *
+     * @return void
+     */
+    public function testRunSeedsBothTooiFixturesWithSeventeenInformatiecategorieen(): void
+    {
+        $seenGraphs = [];
+
+        $this->vocabularyImportService->expects($this->exactly(2))
+            ->method('importJsonLd')
+            ->willReturnCallback(function (array $jsonLd) use (&$seenGraphs): array {
+                $seenGraphs[] = $jsonLd;
+                return [
+                    'scheme'    => ($jsonLd['@graph'][0]['@id'] ?? ''),
+                    'created'   => (count($jsonLd['@graph']) - 1),
+                    'updated'   => 0,
+                    'unchanged' => 0,
+                    'deprecated'=> 0,
+                ];
+            });
+
+        $this->repairStep->run($this->output);
+
+        $this->assertCount(2, $seenGraphs);
+
+        $informatiecategorieen = null;
+        foreach ($seenGraphs as $graph) {
+            if (($graph['@graph'][0]['dct:title'] ?? '') === 'Woo-informatiecategorieën') {
+                $informatiecategorieen = $graph;
+            }
+        }
+
+        $this->assertNotNull($informatiecategorieen, 'The informatiecategorieën fixture must be one of the two seeded graphs');
+
+        $concepts = array_filter(
+            $informatiecategorieen['@graph'],
+            static fn (array $node): bool => ($node['@type'] ?? '') === 'skos:Concept'
+        );
+        $this->assertCount(17, $concepts, 'Fresh install must serve all 17 Woo informatiecategorieën');
+
+        foreach ($concepts as $concept) {
+            $this->assertStringStartsWith(
+                'https://identifier.overheid.nl/tooi/def/thes/kern/c_',
+                $concept['@id'],
+                'Every informatiecategorie must carry a TOOI kern-thesaurus URI'
+            );
+            $this->assertArrayHasKey('nl', $this->firstPrefLabel($concept), 'Every concept needs a Dutch prefLabel');
+        }
+    }//end testRunSeedsBothTooiFixturesWithSeventeenInformatiecategorieen()
+
+    /**
+     * Re-running the repair step is safe: no exception, and the register
+     * import + fixture seed calls happen the same way each time (repeat-safe
+     * per SKOS-003; the underlying no-op behaviour is proven by
+     * VocabularyImportServiceTest).
+     *
+     * @return void
+     */
+    public function testRunTwiceIsRepeatSafe(): void
+    {
+        $this->vocabularyImportService->method('importJsonLd')->willReturn([
+            'scheme'    => 'https://example.org/scheme',
+            'created'   => 0,
+            'updated'   => 0,
+            'unchanged' => 17,
+            'deprecated'=> 0,
+        ]);
+
+        $this->configurationService->expects($this->exactly(2))->method('importFromApp');
+
+        $this->repairStep->run($this->output);
+        $this->repairStep->run($this->output);
+    }//end testRunTwiceIsRepeatSafe()
+
+    /**
+     * A failure in the register import must not prevent the fixture seed
+     * from being attempted (never throws — fail-soft repair step).
+     *
+     * @return void
+     */
+    public function testRegisterImportFailureDoesNotAbortFixtureSeeding(): void
+    {
+        $this->configurationService->method('importFromApp')->willThrowException(new \RuntimeException('boom'));
+        $this->vocabularyImportService->expects($this->exactly(2))->method('importJsonLd')->willReturn([
+            'scheme'    => 'https://example.org/scheme',
+            'created'   => 0,
+            'updated'   => 0,
+            'unchanged' => 0,
+            'deprecated'=> 0,
+        ]);
+
+        $this->repairStep->run($this->output);
+    }//end testRegisterImportFailureDoesNotAbortFixtureSeeding()
+
+    /**
+     * @param array<string, mixed> $conceptNode A parsed skos:Concept node.
+     *
+     * @return array<string, string>
+     */
+    private function firstPrefLabel(array $conceptNode): array
+    {
+        $raw = ($conceptNode['skos:prefLabel'] ?? []);
+        $map = [];
+        foreach ($raw as $literal) {
+            $map[($literal['@language'] ?? 'nl')] = $literal['@value'];
+        }
+
+        return $map;
+    }//end firstPrefLabel()
+}//end class

--- a/tests/Unit/Service/VocabularyImportServiceTest.php
+++ b/tests/Unit/Service/VocabularyImportServiceTest.php
@@ -1,0 +1,318 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Service\VocabularyImportService}
+ * (skos-concept-registers, SKOS-002).
+ *
+ * Backs {@see VocabularyImportService} with an in-memory ObjectService fake
+ * (a PHPUnit mock whose findAll/find/saveObject callbacks operate on a plain
+ * array keyed by schema+uuid) so the real upsert/idempotency/deprecation/
+ * relation logic runs end-to-end without a database.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md#skos-002
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\VocabularyImportService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @coversDefaultClass \OCA\OpenRegister\Service\VocabularyImportService
+ */
+class VocabularyImportServiceTest extends TestCase
+{
+
+    /**
+     * In-memory fake store: schema => uuid => ObjectEntity.
+     *
+     * @var array<string, array<string, ObjectEntity>>
+     */
+    private array $store = [];
+
+    /**
+     * uuid sequence counter for the fake store.
+     *
+     * @var int
+     */
+    private int $sequence = 0;
+
+    /**
+     * @var ObjectService&MockObject
+     */
+    private ObjectService $objectService;
+
+    private VocabularyImportService $importer;
+
+    private string $fixturesDir;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->store        = [];
+        $this->sequence      = 0;
+        $this->fixturesDir  = __DIR__.'/../../Fixtures/vocabulary';
+
+        $this->objectService = $this->createMock(ObjectService::class);
+
+        $this->objectService->method('findAll')->willReturnCallback(
+            function (array $config): array {
+                return $this->fakeFindAll($config);
+            }
+        );
+
+        $this->objectService->method('find')->willReturnCallback(
+            function ($id, $_extend = [], $files = false, $register = null, $schema = null, ...$rest) {
+                return $this->fakeFind((string) $id, (string) $schema);
+            }
+        );
+
+        $this->objectService->method('saveObject')->willReturnCallback(
+            function ($object, $extend = [], $register = null, $schema = null, $uuid = null, ...$rest) {
+                return $this->fakeSaveObject($object, (string) $schema, $uuid);
+            }
+        );
+
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $this->importer = new VocabularyImportService(objectService: $this->objectService, logger: $logger);
+    }//end setUp()
+
+    /**
+     * A fresh import creates the scheme + both concepts, with broader/narrower
+     * maintained in both directions from a source that only asserts `broader`.
+     *
+     * @return void
+     */
+    public function testImportJsonLdCreatesSchemeAndConceptsWithBidirectionalRelations(): void
+    {
+        $report = $this->importFixture('sample-scheme.jsonld');
+
+        $this->assertSame('https://example.org/vocab/sample-scheme', $report['scheme']);
+        $this->assertSame(2, $report['created']);
+        $this->assertSame(0, $report['updated']);
+        $this->assertSame(0, $report['unchanged']);
+        $this->assertSame(0, $report['deprecated']);
+
+        $concepts = $this->conceptsByUri();
+        $a = $concepts['https://example.org/vocab/sample-scheme/a'];
+        $b = $concepts['https://example.org/vocab/sample-scheme/b'];
+
+        $this->assertSame('Concept A', $a->getObject()['prefLabel']['nl']);
+        $this->assertSame('Concept A (en)', $a->getObject()['prefLabel']['en']);
+        $this->assertSame([$b->getUuid()], $a->getObject()['narrower'], 'A must list B as narrower (derived from B.broader=A)');
+        $this->assertSame([$a->getUuid()], $b->getObject()['broader']);
+        $this->assertFalse($a->getObject()['deprecated']);
+    }//end testImportJsonLdCreatesSchemeAndConceptsWithBidirectionalRelations()
+
+    /**
+     * Re-importing an identical source is a full no-op (SKOS-002 scenario 1).
+     *
+     * @return void
+     */
+    public function testReimportOfIdenticalSourceIsNoOp(): void
+    {
+        $this->importFixture('sample-scheme.jsonld');
+        $countBefore = count($this->store[VocabularyImportService::SCHEMA_CONCEPT] ?? []);
+
+        $report = $this->importFixture('sample-scheme.jsonld');
+
+        $this->assertSame(0, $report['created']);
+        $this->assertSame(0, $report['updated']);
+        $this->assertSame(2, $report['unchanged']);
+        $this->assertSame(0, $report['deprecated']);
+        $this->assertSame($countBefore, count($this->store[VocabularyImportService::SCHEMA_CONCEPT] ?? []));
+    }//end testReimportOfIdenticalSourceIsNoOp()
+
+    /**
+     * A changed label updates the existing concept in place (SKOS-002).
+     *
+     * A removed concept (B, absent from the updated fixture) is deprecated,
+     * not deleted, and remains retrievable (SKOS-002 scenario 2).
+     *
+     * @return void
+     */
+    public function testLabelChangeUpdatesInPlaceAndRemovedConceptIsDeprecatedNotDeleted(): void
+    {
+        $this->importFixture('sample-scheme.jsonld');
+        $countBefore = count($this->store[VocabularyImportService::SCHEMA_CONCEPT] ?? []);
+
+        $report = $this->importFixture('sample-scheme-updated.jsonld');
+
+        $this->assertSame(0, $report['created']);
+        $this->assertSame(1, $report['updated'], 'Concept A label change must update in place');
+        $this->assertSame(0, $report['unchanged']);
+        $this->assertSame(1, $report['deprecated'], 'Concept B, absent from the re-imported source, must be deprecated');
+
+        // Never deleted — count stays the same.
+        $this->assertSame($countBefore, count($this->store[VocabularyImportService::SCHEMA_CONCEPT] ?? []));
+
+        $concepts = $this->conceptsByUri();
+        $a = $concepts['https://example.org/vocab/sample-scheme/a'];
+        $b = $concepts['https://example.org/vocab/sample-scheme/b'];
+
+        $this->assertSame('Concept A (renamed)', $a->getObject()['prefLabel']['nl']);
+        $this->assertTrue($b->getObject()['deprecated'], 'B must be retrievable with a deprecated marker set');
+        $this->assertSame('https://example.org/vocab/sample-scheme/b', $b->getObject()['uri'], 'B still resolves by uri');
+    }//end testLabelChangeUpdatesInPlaceAndRemovedConceptIsDeprecatedNotDeleted()
+
+    /**
+     * A CSV value-list import creates the scheme + concepts and resolves the
+     * `broaderUri` column into the same bidirectional relation shape as JSON-LD.
+     *
+     * @return void
+     */
+    public function testImportCsvValueListCreatesSchemeAndConceptsWithBroaderRelation(): void
+    {
+        $report = $this->importer->importCsvValueList(
+            csvPath: $this->fixturesDir.'/sample-values.csv',
+            schemeMeta: [
+                'uri'       => 'https://example.org/vocab/csv-scheme',
+                'title'     => 'CSV Test Scheme',
+                'publisher' => 'OpenRegister Test Fixtures',
+                'version'   => '1.0',
+                'source'    => 'https://example.org/vocab/csv-scheme/source',
+            ]
+        );
+
+        $this->assertSame('https://example.org/vocab/csv-scheme', $report['scheme']);
+        $this->assertSame(2, $report['created']);
+        $this->assertSame(0, $report['updated']);
+        $this->assertSame(0, $report['unchanged']);
+
+        $concepts = $this->conceptsByUri();
+        $x = $concepts['https://example.org/vocab/csv-scheme/x'];
+        $y = $concepts['https://example.org/vocab/csv-scheme/y'];
+
+        $this->assertSame('Waarde X', $x->getObject()['prefLabel']['nl']);
+        $this->assertSame([$y->getUuid()], $x->getObject()['narrower']);
+        $this->assertSame([$x->getUuid()], $y->getObject()['broader']);
+    }//end testImportCsvValueListCreatesSchemeAndConceptsWithBroaderRelation()
+
+    // -------------------------------------------------------------------
+    // Fixture + fake-store helpers.
+    // -------------------------------------------------------------------
+
+    /**
+     * @param string $filename Fixture filename under tests/Fixtures/vocabulary.
+     *
+     * @return array{scheme: string, created: int, updated: int, unchanged: int, deprecated: int}
+     */
+    private function importFixture(string $filename): array
+    {
+        $path = $this->fixturesDir.'/'.$filename;
+        $this->assertFileExists($path);
+
+        $jsonLd = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($jsonLd);
+
+        return $this->importer->importJsonLd(jsonLd: $jsonLd);
+    }//end importFixture()
+
+    /**
+     * @return array<string, ObjectEntity> uri => ObjectEntity for every stored concept.
+     */
+    private function conceptsByUri(): array
+    {
+        $out = [];
+        foreach (($this->store[VocabularyImportService::SCHEMA_CONCEPT] ?? []) as $entity) {
+            $out[$entity->getObject()['uri']] = $entity;
+        }
+
+        return $out;
+    }//end conceptsByUri()
+
+    /**
+     * @param array<string, mixed> $config findAll() config array.
+     *
+     * @return array<int, ObjectEntity>
+     */
+    private function fakeFindAll(array $config): array
+    {
+        $schema  = (string) ($config['schema'] ?? '');
+        $filters = ($config['filters'] ?? []);
+        $limit   = ($config['limit'] ?? null);
+        $offset  = ($config['offset'] ?? 0);
+
+        $matches = [];
+        foreach (($this->store[$schema] ?? []) as $entity) {
+            $data = $entity->getObject();
+            $ok   = true;
+            foreach ($filters as $key => $value) {
+                if (($data[$key] ?? null) !== $value) {
+                    $ok = false;
+                    break;
+                }
+            }
+
+            if ($ok === true) {
+                $matches[] = $entity;
+            }
+        }
+
+        if ($offset > 0) {
+            $matches = array_slice($matches, (int) $offset);
+        }
+
+        if ($limit !== null) {
+            $matches = array_slice($matches, 0, (int) $limit);
+        }
+
+        return $matches;
+    }//end fakeFindAll()
+
+    /**
+     * @param string $uuid   Object uuid.
+     * @param string $schema Schema slug.
+     *
+     * @return ObjectEntity|null
+     */
+    private function fakeFind(string $uuid, string $schema): ?ObjectEntity
+    {
+        return ($this->store[$schema][$uuid] ?? null);
+    }//end fakeFind()
+
+    /**
+     * @param array<string, mixed>|ObjectEntity $object The object payload.
+     * @param string                              $schema Schema slug.
+     * @param string|null                         $uuid   Existing uuid, or null to create.
+     *
+     * @return ObjectEntity
+     */
+    private function fakeSaveObject($object, string $schema, ?string $uuid): ObjectEntity
+    {
+        $data = (is_array($object) === true ? $object : $object->getObject());
+
+        if ($uuid === null) {
+            $uuid = 'uuid-'.(++$this->sequence);
+        }
+
+        $entity = new ObjectEntity();
+        $entity->setUuid($uuid);
+        $entity->setObject($data);
+
+        $this->store[$schema][$uuid] = $entity;
+
+        return $entity;
+    }//end fakeSaveObject()
+}//end class

--- a/tests/Unit/Settings/VocabularyRegisterJsonTest.php
+++ b/tests/Unit/Settings/VocabularyRegisterJsonTest.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * Vocabulary register descriptor validity + schema-shape test
+ * (skos-concept-registers, SKOS-001).
+ *
+ * Guards the register JSON itself: valid JSON, the `conceptScheme`/`concept`
+ * schemas exist with their minimum required fields, every property carries
+ * an English `title` + `description` (hydra-gate-schema-property-titles /
+ * gate 28), and `broader`/`narrower`/`related`/`inScheme` use the canonical
+ * relation dialect (ADR-062: `type:string`|array + `format:uuid` + `$ref`).
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Settings
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md#skos-001
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Settings;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversNothing
+ */
+class VocabularyRegisterJsonTest extends TestCase
+{
+
+    /**
+     * The decoded vocabulary register descriptor.
+     *
+     * @var array<string, mixed>
+     */
+    private array $register;
+
+    /**
+     * Load the shipped register descriptor.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $path = __DIR__.'/../../../lib/Settings/vocabulary_register.json';
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded, 'vocabulary_register.json must be valid JSON');
+        $this->register = $decoded;
+    }//end setUp()
+
+    /**
+     * The register declares the vocabulary register with both schemas.
+     *
+     * @return void
+     */
+    public function testRegisterDeclaresBothSchemas(): void
+    {
+        $register = ($this->register['components']['registers']['vocabulary'] ?? null);
+        $this->assertIsArray($register, 'components.registers.vocabulary must be declared');
+        $this->assertSame(['conceptScheme', 'concept'], ($register['schemas'] ?? null));
+    }//end testRegisterDeclaresBothSchemas()
+
+    /**
+     * conceptScheme carries the SKOS-001 minimum required fields.
+     *
+     * @return void
+     */
+    public function testConceptSchemeHasMinimumRequiredFields(): void
+    {
+        $schema = ($this->register['components']['schemas']['conceptScheme'] ?? null);
+        $this->assertIsArray($schema, 'conceptScheme schema must exist');
+
+        foreach (['uri', 'title', 'publisher', 'version', 'source'] as $field) {
+            $this->assertContains($field, ($schema['required'] ?? []), "conceptScheme.required must include {$field}");
+            $this->assertArrayHasKey($field, ($schema['properties'] ?? []), "conceptScheme.properties must declare {$field}");
+        }
+
+        $this->assertSame(['public'], ($schema['authorization']['read'] ?? null), 'conceptScheme reads must be public');
+        $this->assertArrayNotHasKey('write', ($schema['authorization'] ?? []), 'writes stay admin-gated by omission');
+    }//end testConceptSchemeHasMinimumRequiredFields()
+
+    /**
+     * concept carries the SKOS-001 minimum required fields and relations.
+     *
+     * @return void
+     */
+    public function testConceptHasMinimumRequiredFieldsAndRelations(): void
+    {
+        $schema = ($this->register['components']['schemas']['concept'] ?? null);
+        $this->assertIsArray($schema, 'concept schema must exist');
+
+        foreach (['uri', 'prefLabel', 'inScheme'] as $field) {
+            $this->assertContains($field, ($schema['required'] ?? []), "concept.required must include {$field}");
+        }
+
+        foreach (['uri', 'prefLabel', 'altLabel', 'definition', 'notation', 'deprecated', 'inScheme', 'broader', 'narrower', 'related'] as $field) {
+            $this->assertArrayHasKey($field, ($schema['properties'] ?? []), "concept.properties must declare {$field}");
+        }
+
+        $this->assertContains('nl', ($schema['properties']['prefLabel']['required'] ?? []), 'prefLabel.nl must be required');
+
+        $this->assertSame(['public'], ($schema['authorization']['read'] ?? null), 'concept reads must be public');
+    }//end testConceptHasMinimumRequiredFieldsAndRelations()
+
+    /**
+     * broader/narrower/related/inScheme use the canonical relation dialect
+     * (ADR-062): format:uuid + $ref resolving to a schema in this register.
+     *
+     * @return void
+     */
+    public function testRelationsUseCanonicalDialect(): void
+    {
+        $schema = $this->register['components']['schemas']['concept'];
+        $schemaKeys = array_keys($this->register['components']['schemas']);
+
+        $singleRelations = ['inScheme' => 'conceptScheme'];
+        foreach ($singleRelations as $property => $expectedRef) {
+            $prop = $schema['properties'][$property];
+            $this->assertSame('string', $prop['type']);
+            $this->assertSame('uuid', $prop['format']);
+            $this->assertSame($expectedRef, $prop['$ref']);
+            $this->assertContains($prop['$ref'], $schemaKeys);
+        }
+
+        $arrayRelations = ['broader', 'narrower', 'related'];
+        foreach ($arrayRelations as $property) {
+            $prop = $schema['properties'][$property];
+            $this->assertSame('array', $prop['type']);
+            $this->assertSame('string', $prop['items']['type']);
+            $this->assertSame('uuid', $prop['items']['format']);
+            $this->assertSame('concept', $prop['items']['$ref']);
+            $this->assertContains($prop['items']['$ref'], $schemaKeys);
+        }
+    }//end testRelationsUseCanonicalDialect()
+
+    /**
+     * Every property of every schema (including nested object sub-properties)
+     * carries a title + description (gate 28).
+     *
+     * @return void
+     */
+    public function testEveryPropertyHasTitleAndDescription(): void
+    {
+        foreach (($this->register['components']['schemas'] ?? []) as $schemaKey => $schema) {
+            $this->assertPropertiesHaveTitleAndDescription(
+                properties: ($schema['properties'] ?? []),
+                context: $schemaKey
+            );
+        }
+    }//end testEveryPropertyHasTitleAndDescription()
+
+    /**
+     * Recursively assert title+description on a properties map, including
+     * nested object properties and array item properties.
+     *
+     * @param array<string, mixed> $properties The properties map to check.
+     * @param string                $context    Human-readable context for failure messages.
+     *
+     * @return void
+     */
+    private function assertPropertiesHaveTitleAndDescription(array $properties, string $context): void
+    {
+        foreach ($properties as $name => $prop) {
+            if (is_array($prop) === false) {
+                continue;
+            }
+
+            $this->assertArrayHasKey('title', $prop, "{$context}.{$name} must have a title");
+            $this->assertArrayHasKey('description', $prop, "{$context}.{$name} must have a description");
+            $this->assertNotSame('', trim((string) ($prop['title'] ?? '')), "{$context}.{$name} title must not be empty");
+            $this->assertNotSame('', trim((string) ($prop['description'] ?? '')), "{$context}.{$name} description must not be empty");
+
+            if (isset($prop['properties']) === true && is_array($prop['properties']) === true) {
+                $this->assertPropertiesHaveTitleAndDescription(
+                    properties: $prop['properties'],
+                    context: "{$context}.{$name}"
+                );
+            }
+
+            if (isset($prop['items']['properties']) === true && is_array($prop['items']['properties']) === true) {
+                $this->assertPropertiesHaveTitleAndDescription(
+                    properties: $prop['items']['properties'],
+                    context: "{$context}.{$name}.items"
+                );
+            }
+        }
+    }//end assertPropertiesHaveTitleAndDescription()
+}//end class


### PR DESCRIPTION
Implements OpenSpec change `skos-concept-registers` (SKOS-001..004). From the 2026-07-23 OpenCatalogi market deep-dive: NL-SBB is mandatory for Federatief Datastelsel participants per 1 Jan 2026; DiWoo binds publications to TOOI value lists; DCAT-AP-NL 3.0 needs vocabulary URIs. Vocabularies are register data, so OpenRegister owns them (ADR-022) and leaf apps consume.

## What ships
- `lib/Settings/vocabulary_register.json` — `conceptScheme` + `concept` schemas; canonical relation dialect (`format:uuid` + `$ref`) on inScheme/broader/narrower/related; multilingual prefLabel/altLabel maps; English title+description on every property.
- `lib/Service/VocabularyImportService.php` — URI-keyed idempotent SKOS-JSONLD + CSV importer; created/updated/unchanged report; deprecate-never-delete; bidirectional broader/narrower.
- `lib/Resources/Vocabulary/*.jsonld` — bundled TOOI seed (17 Woo informatiecategorieën + documenthandelingen) + `lib/Repair/SeedVocabularyRegister.php` (post-migration + install, idempotent).
- `lib/Controller/VocabularyController.php` — public resolution: by URI, by (scheme, notation), scheme listing with paginated multilingual label search; 404 standard error shape on unknown URI.

## Tests
`php vendor/bin/phpunit --filter Vocabulary` → **41 tests, 281 assertions, all green** (nextcloud:34.0.0-apache). `openspec validate skos-concept-registers` valid. `php -l` clean on all new files.

## Follow-up (leaf consume-changes, tracked separately)
opencatalogi TooiVocabularyService/DcatVocabularyService → read the vocabulary register; softwarecatalog GEMMA scheme; decidesk ORI scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)