### PR TITLE
spec: market-gap wave 2026-07-23 (4 changes)

### DIFF
--- a/openspec/changes/adhoc-aggregation-suite/.openspec.yaml
+++ b/openspec/changes/adhoc-aggregation-suite/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/adhoc-aggregation-suite/design.md
+++ b/openspec/changes/adhoc-aggregation-suite/design.md
@@ -1,0 +1,85 @@
+# Design: adhoc-aggregation-suite
+
+## Context
+
+The ad-hoc aggregation stack today: `AggregationController` exposes
+`value(register, schema)` (single metric), `grouped(register, schema)` (single
+`groupBy` field → `{ groups, backend, cached }`), and `timeseries(...)` (a
+time-bucket primitive). SQL is built by `AggregationQuery`; results can be
+served from `AggregationCache` (the `aggregate()` route already sets
+`X-OR-Cache`). Validators exist for annotations, timeseries requests and
+widgets. Execution runs natively on the object's magic table.
+
+This change extends the three endpoints with the primitives dashboards need,
+and fixes the multi-value filter defect on the value/count path.
+
+## Decisions
+
+### D1 — Multi-field groupBy (#1606) is a list, single stays scalar
+
+`grouped` accepts `groupBy` as either a single field (current behaviour) or a
+comma-list / repeated param → an ordered list of fields. `AggregationQuery`
+emits a composite `GROUP BY f1, f2, …` and returns groups keyed by an ordered
+tuple (`key` becomes an object `{f1: …, f2: …}` when >1 field; stays a scalar
+`key` for one field, preserving today's shape). Field names are validated
+against the schema before interpolation (no raw field into SQL).
+
+### D2 — Multi-metric (#1608) via a metrics list
+
+A `metrics` param (list of `{metric, field?}`) produces one column per metric;
+each group row carries `values: {count: …, sum_price: …}`. The legacy single
+`metric`/`field` params remain and map to a one-element list. `count` needs no
+field; `sum`/`avg`/`min`/`max` require a numeric field (validated).
+
+### D3 — Cumulative (#1607) is a post-pass over ordered buckets
+
+`cumulative: true` on the timeseries/time-bucket primitive orders buckets
+ascending by bucket start and emits a running total of the chosen metric
+alongside the per-bucket value (`value` + `cumulative`). Implemented as a SQL
+window (`SUM(...) OVER (ORDER BY bucket)`) where the dialect supports it, else a
+PHP post-pass over the ordered result — identical output either way (pinned by
+test).
+
+### D4 — Cross-dialect time-bucket (#1609)
+
+Bucket expression is dialect-selected: PostgreSQL `DATE_TRUNC`, MySQL/MariaDB
+`DATE_FORMAT` truncation (or `DATE_TRUNC` on MariaDB ≥ the supporting version),
+SQLite `strftime`. A single `bucketExpression(dialect, field, interval)` helper
+centralises this so boundaries agree across dialects. Supported intervals:
+`hour|day|week|month|quarter|year`. A dialect/interval combination with no
+native expression falls back to a documented PHP-side bucketer rather than
+emitting wrong SQL.
+
+### D5 — Timeseries cache (#1610)
+
+`AggregationCache` gains timeseries entries keyed on
+`register + schema + normalized-query-hash` (query includes field, interval,
+metrics, filters, cumulative). `timeseries()` sets `X-OR-Cache: hit|miss` like
+`aggregate()` already does. Cache invalidation rides the existing object-write
+invalidation for the register+schema.
+
+### D6 — #2027 multi-value filter / `in` fix on the value path
+
+The value/count path currently passes a filter value straight through: a bare
+array is compared as a scalar (raw count), and the `in` operator yields `0`.
+Fix: in the filter translation used by `value()`/`grouped()`, a bare array
+value is treated as an implicit `in` (any-of); the `in` operator generates an
+`IN (…)` predicate (or, for multi-value object properties stored as JSON
+arrays, an any-overlap test). Scalars are unchanged. This aligns the aggregation
+filter semantics with the main object-search filter semantics.
+
+## Risks / Trade-offs
+
+- **Dialect drift** — the cross-dialect matrix test is the guard; if a dialect
+  can't match Postgres boundaries natively, D4's PHP fallback keeps output
+  correct at some performance cost (logged, not silent).
+- **Cache staleness** — bounded by riding existing write-invalidation; a
+  timeseries over a hot schema may serve a slightly stale bucket, acceptable for
+  dashboards and explicitly bypassable with a no-cache param.
+- **Response-shape compatibility** — the single-field/single-metric shape is
+  frozen by a regression test so existing widgets don't break.
+
+## Migration / Rollout
+
+No migration. Additive request params; corrected counts. Frontend adopts
+multi-field/multi-metric opportunistically.

--- a/openspec/changes/adhoc-aggregation-suite/proposal.md
+++ b/openspec/changes/adhoc-aggregation-suite/proposal.md
@@ -1,0 +1,78 @@
+# adhoc-aggregation-suite
+
+## Why
+
+OpenRegister's ad-hoc aggregation API (`AggregationController` →
+`value` / `grouped` / `timeseries`, backed by `AggregationQuery`,
+`AggregationRunner`-equivalent execution and `AggregationCache`) covers the
+single-metric, single-dimension cases but stops short of the shapes real
+dashboards need. Five open issues plus one correctness bug describe the gap:
+
+- **#1606** multi-field `groupBy` (group by more than one property in one call)
+- **#1607** running / cumulative aggregates over the time-bucket primitive
+- **#1608** multi-metric requests (e.g. `count` + `sum` in a single response)
+- **#1609** native time-bucket on MySQL / SQLite (not just PostgreSQL
+  `DATE_TRUNC`)
+- **#1610** cache ad-hoc time-bucket aggregations in `AggregationCache`
+- **#2027** (bug) the stat-widget count endpoint ignores multi-value filters —
+  a bare array value is counted raw and the `in` operator returns `0` instead
+  of matching any-of
+
+Demand evidence: aggregations/BI/dashboards is a recurring roadmap theme
+(#1675 BI export, #1729 built-in dashboards, #1662 role-scoped aggregations),
+and these six are the concrete, ready-to-build primitives beneath it. #2027 is a
+live correctness defect that silently under- or over-counts dashboard widgets.
+
+## What Changes
+
+- **Multi-field groupBy (#1606):** `grouped` accepts a `groupBy` list (multiple
+  fields), returning nested or composite-key groups. Single-field requests keep
+  their current shape (backward compatible).
+- **Multi-metric (#1608):** requests may specify several metrics
+  (`count`, `sum`, `avg`, `min`, `max`) in one call; each group carries all
+  requested metric values.
+- **Cumulative/running aggregates (#1607):** the time-bucket primitive accepts a
+  `cumulative: true` flag producing a running total across ordered buckets.
+- **Cross-dialect time-bucket (#1609):** time-bucket grouping executes natively
+  on MySQL/MariaDB and SQLite (not only PostgreSQL), with identical bucket
+  boundaries and an explicit fallback path when a dialect lacks a native
+  function.
+- **Time-bucket cache (#1610):** time-bucket/timeseries results are cached in
+  `AggregationCache` keyed on register+schema+query, with the existing
+  `X-OR-Cache: hit|miss` header semantics extended to the timeseries endpoint.
+- **Multi-value filter fix (#2027):** the value/count path treats a bare array
+  filter value as an implicit `in` (any-of) match, and the `in` operator
+  matches when the object's value is contained in the list — for both scalar and
+  multi-value object properties.
+
+**BREAKING:** none intended. Multi-field/multi-metric are additive request
+shapes; the #2027 fix corrects counts that were already wrong. A regression test
+pins that single-field/single-metric responses are byte-shape identical.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `aggregation-api`: gains requirements for multi-field groupBy, multi-metric
+  responses, cumulative time-bucket aggregates, cross-dialect native
+  time-bucket execution, timeseries result caching, and correct multi-value /
+  `in`-operator filter handling on the value/count path.
+
+## Impact
+
+**Affected code:** `lib/Controller/AggregationController.php`
+(`value`/`grouped`/`timeseries` param parsing + response assembly),
+`lib/Service/AggregationQuery.php` (SQL generation: composite group keys,
+multiple metric columns, dialect-specific time-bucket expressions, cumulative
+window), `lib/Service/AggregationCache.php` (timeseries keys), the filter
+translation used by the value path (multi-value / `in`).
+
+**Tests:** unit tests per primitive + a cross-dialect matrix (Postgres/MySQL/
+SQLite) for time-bucket boundaries; a regression test pinning the unchanged
+single-field/single-metric response shape; a #2027 test proving a multi-value
+filter and an `in` operator both count correctly. Runnable in the `nextcloud:34`
+container.
+
+**Dependencies:** no new packages; no schema/migration change (cache table
+already exists). Frontend stat-widgets consume the corrected counts with no API
+break.

--- a/openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
+++ b/openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
@@ -1,0 +1,108 @@
+# aggregation-api Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose delta
+
+The ad-hoc aggregation API gains the primitives dashboards require —
+multi-field grouping, multi-metric responses, cumulative time-bucket totals,
+cross-dialect native time-bucket execution, and timeseries caching — and the
+value/count path is corrected to honour multi-value and `in`-operator filters.
+
+## ADDED Requirements
+
+### Requirement: Multi-field group-by (REQ-AGG-101)
+
+The grouped aggregation endpoint MUST accept `groupBy` as either a single field
+(unchanged behaviour) or an ordered list of fields, emitting a composite
+`GROUP BY` and returning each group keyed by an ordered tuple. A single-field
+request MUST return the same response shape as before this change (scalar
+`key`); a multi-field request MUST return `key` as an ordered object of
+field→value. Field names MUST be validated against the schema and MUST NOT be
+interpolated raw into SQL.
+
+#### Scenario: Group by two fields
+
+- **GIVEN** objects with `status` and `type` properties
+- **WHEN** a client requests `groupBy=status,type` with `metric=count`
+- **THEN** each returned group is keyed by both `status` and `type` and carries
+  the count of objects in that combination.
+
+#### Scenario: Single-field shape is unchanged
+
+- **WHEN** a client requests `groupBy=status`
+- **THEN** the response shape is identical to the pre-change single-field shape.
+
+### Requirement: Multi-metric responses (REQ-AGG-102)
+
+The aggregation endpoints MUST accept a list of metrics
+(`count`, `sum`, `avg`, `min`, `max`) in one request and return every requested
+metric per group under a `values` object. Non-`count` metrics MUST require a
+numeric field, validated before execution. The legacy single `metric`/`field`
+params MUST remain valid and map to a one-element metrics list.
+
+#### Scenario: Count and sum in one call
+
+- **WHEN** a client requests `metrics=[{count},{sum,price}]` grouped by `status`
+- **THEN** each group carries both the count and the summed `price`.
+
+### Requirement: Cumulative time-bucket aggregates (REQ-AGG-103)
+
+The time-bucket primitive MUST accept a `cumulative: true` flag that orders
+buckets ascending by bucket start and returns a running total of the selected
+metric alongside each per-bucket value. The cumulative result MUST be identical
+whether computed by a SQL window function or a PHP post-pass.
+
+#### Scenario: Running total over months
+
+- **GIVEN** a monthly time-bucket over `createdAt`
+- **WHEN** a client requests it with `cumulative=true`
+- **THEN** each bucket carries its own value and the running total up to and
+  including that bucket.
+
+### Requirement: Cross-dialect native time-bucket (REQ-AGG-104)
+
+Time-bucket grouping MUST execute natively on PostgreSQL, MySQL/MariaDB and
+SQLite for the intervals `hour`, `day`, `week`, `month`, `quarter`, `year`, with
+bucket boundaries that agree across dialects. A dialect/interval combination
+with no native expression MUST fall back to a documented PHP-side bucketer
+rather than emit incorrect SQL.
+
+#### Scenario: Same boundaries on every dialect
+
+- **GIVEN** the same objects loaded on Postgres, MySQL and SQLite
+- **WHEN** a monthly time-bucket aggregation runs on each
+- **THEN** the bucket boundaries and per-bucket counts are identical.
+
+### Requirement: Timeseries result caching (REQ-AGG-105)
+
+Timeseries/time-bucket results MUST be cacheable in `AggregationCache`, keyed on
+register, schema and a normalized query hash (field, interval, metrics, filters,
+cumulative). The timeseries endpoint MUST report `X-OR-Cache: hit` or
+`X-OR-Cache: miss`, and cached entries MUST be invalidated when an object in the
+register+schema is written.
+
+#### Scenario: Second identical request is a cache hit
+
+- **WHEN** the same timeseries request is issued twice with no intervening write
+- **THEN** the first responds `X-OR-Cache: miss` and the second
+  `X-OR-Cache: hit` with an identical body.
+
+### Requirement: Multi-value and in-operator filters on the value path (REQ-AGG-106)
+
+On the value/count and grouped paths, a bare array filter value MUST be treated
+as an implicit `in` (any-of) match, and the `in` operator MUST generate an
+`IN (…)` predicate — including an any-overlap test for multi-value object
+properties stored as JSON arrays. Scalar filter values MUST be unchanged. This
+aligns aggregation filter semantics with the main object-search filter
+semantics.
+
+#### Scenario: Count with a multi-value filter
+
+- **GIVEN** objects whose `tags` property holds arrays
+- **WHEN** a client counts with a filter `tags=[a,b]`
+- **THEN** objects whose tags include `a` or `b` are counted (not a raw
+  array-equality that matches none), and the `in` operator over a scalar field
+  returns the any-of count rather than `0`.

--- a/openspec/changes/adhoc-aggregation-suite/tasks.md
+++ b/openspec/changes/adhoc-aggregation-suite/tasks.md
@@ -1,0 +1,32 @@
+# Tasks: adhoc-aggregation-suite
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 9. -->
+
+## 1. Query engine
+
+- [ ] 1.1 Multi-field groupBy in `AggregationQuery` — composite `GROUP BY`, ordered tuple key, schema-validated field names (REQ-AGG-101)
+  - Single-field requests keep a scalar `key`; >1 field returns `key` as an ordered object. No raw field interpolated into SQL.
+- [ ] 1.2 Multi-metric columns — `metrics` list → one column per metric, each group row carries `values: {…}`; legacy `metric`/`field` map to a one-element list (REQ-AGG-102)
+- [ ] 1.3 Cross-dialect `bucketExpression(dialect, field, interval)` helper for hour/day/week/month/quarter/year on Postgres/MySQL/MariaDB/SQLite, with a documented PHP fallback (REQ-AGG-104)
+- [ ] 1.4 Cumulative running total on the time-bucket primitive (`cumulative: true`) via SQL window or PHP post-pass — identical output (REQ-AGG-103)
+
+## 2. Controller + cache
+
+- [ ] 2.1 Wire the new params through `AggregationController::grouped`/`timeseries`; validate metric fields; preserve legacy response shapes (REQ-AGG-101, REQ-AGG-102, REQ-AGG-103)
+- [ ] 2.2 Cache timeseries results in `AggregationCache` keyed on register+schema+query-hash; set `X-OR-Cache: hit|miss` on `timeseries()`; invalidate on object write (REQ-AGG-105)
+
+## 3. Bug #2027 — multi-value filter
+
+- [ ] 3.1 In the value-path filter translation, treat a bare array as implicit `in` (any-of) and generate `IN (…)` for the `in` operator (incl. JSON-array any-overlap for multi-value properties) (REQ-AGG-106)
+
+## 4. Verification
+
+- [ ] 4.1 Unit tests per primitive + cross-dialect time-bucket boundary matrix (Postgres/MySQL/SQLite) + cumulative parity (SQL vs PHP) (REQ-AGG-103, REQ-AGG-104)
+  - Run in the `nextcloud:34` container: `docker run --rm -v $PWD:/app -w /app <nc-image> php vendor/bin/phpunit`.
+- [ ] 4.2 Regression test pinning the byte-shape of single-field/single-metric responses; #2027 test proving a multi-value filter AND an `in` operator both count correctly (REQ-AGG-101, REQ-AGG-106)
+
+Acceptance criteria:
+- One request can group by multiple fields and return multiple metrics per group.
+- Time-bucket aggregation runs natively (or via documented fallback) on all four dialects with matching boundaries; cumulative totals are correct.
+- Timeseries responses are cached with correct hit/miss reporting.
+- Multi-value filters and the `in` operator count correctly; existing single-metric widgets are unchanged.

--- a/openspec/changes/object-views-kanban-calendar/.openspec.yaml
+++ b/openspec/changes/object-views-kanban-calendar/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/object-views-kanban-calendar/design.md
+++ b/openspec/changes/object-views-kanban-calendar/design.md
@@ -1,0 +1,94 @@
+# Design: object-views-kanban-calendar
+
+## Context
+
+The `View` entity (`lib/Db/View.php`) persists saved searches: `uuid`, `name`,
+`description`, `owner`, `organisation`, `isPublic`, `isDefault`, and a `query`
+JSON holding registers/schemas/filters/sort, plus `favoredBy`. `ViewService`
+(`find`/`findAll`/`create`/`update`/`delete`) and `ViewsController` manage them;
+`ViewCreated/Updated/DeletedEvent` fire on mutation. There is no presentation
+metadata — a view is always rendered as a list. This change adds a
+presentation dimension and the kanban/calendar MVP over it.
+
+Per fleet convention, shared Vue components live in nextcloud-vue; OpenRegister
+consumes them. So the data contract (this spec) is authored OR-side, and the
+rendering components (`CnObjectKanban`, `CnObjectCalendar`) are a nc-vue
+dependency.
+
+## Goals / Non-goals
+
+**Goals:** persist a `presentation` config on a view; render a register as
+kanban (grouped by an enum/status field, drag = guarded status write) or
+calendar (plotted by a date field); keep `table` the default with zero change to
+existing views.
+
+**Non-goals (phase-2):** gallery and timeline view types; cross-register
+kanban; calendar recurrence; per-user presentation overrides on a shared view;
+inline card editing beyond the status move.
+
+## Decisions
+
+### D1 — `presentation` JSON column on `View`
+
+Add a nullable `presentation` JSON property to `View` (with `addType('presentation','json')`)
+and a migration adding the column. Shape:
+```
+{ "viewType": "table|kanban|calendar",
+  "kanban":   { "groupByField": "status", "cardFields": ["title","assignee"], "columnOrder": ["todo","doing","done"] },
+  "calendar": { "dateField": "dueDate", "endDateField": "endDate" } }
+```
+`viewType` defaults to `table` when `presentation` is null → existing views
+unchanged. `ViewService.create/update` validate that `groupByField`/`dateField`
+name real properties on the view's schema (reject otherwise), so a view can't
+persist a presentation that can't render.
+
+### D2 — Kanban columns from distinct group values
+
+Columns are the distinct values of `groupByField`. For an enum property the enum
+values give a stable, ordered column set (respect `columnOrder` when supplied,
+else enum order); for a free field, distinct observed values. Cards are the
+objects, fetched through the existing view `query` (filters/sort preserved).
+
+### D3 — Drag = guarded object write, not a bespoke endpoint
+
+Moving a card to another column issues an object update setting
+`groupByField` to the target column value via the existing object PATCH/PUT API.
+This inherits RBAC, validation and `x-openregister-lifecycle`: an illegal
+status transition is **rejected by the write path** and the UI snaps the card
+back. No new "move card" controller — the kanban is a thin presentation over the
+guarded write. (Consumes the object write path; benefits from
+`put-preserve-key-order` but does not depend on it.)
+
+### D4 — Calendar is a date-range object query
+
+The calendar view asks the object store for objects whose `dateField` falls in
+the visible range, reusing existing search/filter (a range filter on the date
+property). `endDateField` (optional) lets an object span days. No new storage;
+the calendar is another presentation over the same magic-table query.
+
+### D5 — Frontend dispatch on `viewType`
+
+The `src/views/` object-list surface dispatches on `view.presentation.viewType`:
+`table` → current list; `kanban` → `CnObjectKanban`; `calendar` →
+`CnObjectCalendar`, passing the objects, the config, and the write callback. The
+components are nc-vue's; OR only wires props/events.
+
+## Risks / Trade-offs
+
+- **nc-vue dependency ordering** — the components must land in a nc-vue beta
+  first (or lockstep); the OR change is testable server-side (persistence +
+  validation + drag-write contract) independent of the components, so the
+  backend can merge and be verified before the UI is wired.
+- **Kanban over huge groups** — columns page their cards through the existing
+  object query pagination; a column with thousands of cards is bounded, not
+  loaded whole (the explicit contrast with Tables' whole-table-in-memory
+  ceiling).
+- **Lifecycle rejection UX** — the snap-back on a rejected transition must
+  surface the reason; the write path already returns the rejection, the
+  component shows it.
+
+## Migration / Rollout
+
+One additive DB migration (nullable `presentation` column). Existing views
+default to `table`. Ship the nc-vue components, then enable the kanban/calendar
+options in the OR view UI. Verify on live 8080.

--- a/openspec/changes/object-views-kanban-calendar/proposal.md
+++ b/openspec/changes/object-views-kanban-calendar/proposal.md
@@ -1,0 +1,74 @@
+# object-views-kanban-calendar
+
+## Why
+
+Multiple view types (kanban / calendar / gallery / timeline) are 2026
+table-stakes for structured-data platforms — Airtable, Baserow, NocoDB, Grist
+and SeaTable all ship them, and they are the headline reason non-technical users
+choose those tools. OpenRegister today renders objects only as a list/table; its
+saved-view entity (`View`, with a `query` JSON of registers/schemas/filters/sort
+and `isDefault`/`isPublic`) has **no presentation dimension** — there is no way
+to say "show this register as a kanban grouped by status" or "as a calendar by
+due-date".
+
+This is also the concrete first step of the strategic "Tables that scales"
+positioning (research 2026-07-23): Nextcloud Tables collapses at ~2k rows, so a
+kanban/calendar UI over OpenRegister's dedicated-magic-table storage is a lane
+no competitor in the Nextcloud ecosystem occupies. This change delivers the
+**kanban** and **calendar** MVP; gallery/timeline are explicit phase-2
+follow-ups.
+
+## What Changes
+
+- **Presentation config on saved views:** the `View` entity gains a
+  `presentation` block declaring a `viewType`
+  (`table` (default) | `kanban` | `calendar`) plus type-specific config:
+  - `kanban`: a `groupByField` (an enum/status property) whose distinct values
+    become columns; card ordering; which fields render on the card.
+  - `calendar`: a `dateField` (a date/datetime property) to plot objects on, and
+    an optional `endDateField` for spanning events.
+- **Kanban status change via drag = object write:** moving a card between
+  columns issues an object update setting `groupByField` to the target column's
+  value, through the existing object PATCH/PUT API and its RBAC + lifecycle
+  guards (an illegal lifecycle transition is rejected and the card snaps back).
+- **Calendar plotting:** objects are placed by `dateField`; the view returns the
+  objects for a visible date range using existing object search/filter.
+- **Shared Vue components in nextcloud-vue:** `CnObjectKanban` and
+  `CnObjectCalendar` live in the shared design-system library (fleet rule: Vue
+  logic and shared components belong in nextcloud-vue); OpenRegister consumes
+  them and wires them to its object store and the `presentation` config. This
+  change's OpenRegister scope is the **`presentation` config persistence + view
+  wiring**; the nc-vue component work is a declared dependency.
+
+**BREAKING:** none. `viewType` defaults to `table`; existing views render
+exactly as today. The `presentation` block is additive to the `View` `query`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `saved-search-views`: saved views gain a `presentation` dimension
+  (`viewType` + kanban/calendar config) persisted on the `View` entity, a
+  kanban drag-to-change-status contract that routes through the guarded object
+  write path, and a calendar date-range object query.
+
+## Impact
+
+**Affected code (OpenRegister):** `lib/Db/View.php` (+ its DB table/migration:
+add a `presentation` JSON column), `lib/Service/ViewService.php` and
+`lib/Controller/ViewsController.php` (accept/return `presentation`; validate
+`groupByField`/`dateField` against the view's schema), the object list surface
+in `src/views/` that renders a view (dispatch on `viewType` to the nc-vue
+component), and the object store call for the kanban drag-write.
+
+**Affected code (nextcloud-vue):** new `CnObjectKanban` and `CnObjectCalendar`
+components (declared dependency; shipped via a nc-vue beta and consumed here).
+
+**Tests:** `ViewService`/`ViewsController` unit tests for `presentation`
+persistence + field validation; an object-write test proving a kanban column
+move updates `groupByField` through the guarded path and that an illegal
+lifecycle transition is rejected; a calendar date-range query test. Runnable in
+the `nextcloud:34` container. Frontend: component render smoke on live 8080.
+
+**Dependencies:** the nc-vue `CnObjectKanban`/`CnObjectCalendar` components must
+land first (or in lockstep). A DB migration adds the `presentation` column.

--- a/openspec/changes/object-views-kanban-calendar/specs/saved-search-views/spec.md
+++ b/openspec/changes/object-views-kanban-calendar/specs/saved-search-views/spec.md
@@ -1,0 +1,111 @@
+# saved-search-views Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose delta
+
+Saved views gain a presentation dimension: a `viewType` (table / kanban /
+calendar) with type-specific config persisted on the view, a kanban
+drag-to-change-status contract that routes through the guarded object write
+path, and a calendar date-range object query. `table` remains the default so
+existing views are unchanged.
+
+## ADDED Requirements
+
+### Requirement: Views persist a validated presentation config (REQ-VIEW-PRES-01)
+
+A saved view MUST support a nullable `presentation` block declaring a `viewType`
+of `table`, `kanban`, or `calendar`, plus type-specific config
+(kanban: `groupByField`, optional `cardFields`, optional `columnOrder`;
+calendar: `dateField`, optional `endDateField`). When `presentation` is null the
+view MUST render as `table` (default), leaving existing views unchanged. On
+create/update the service MUST validate that `groupByField`/`dateField` name
+real properties on the view's schema and MUST reject a presentation that cannot
+render.
+
+#### Scenario: Save a kanban view
+
+- **WHEN** a client saves a view with `presentation.viewType = kanban` and
+  `groupByField = status` where `status` exists on the schema
+- **THEN** the view persists the presentation and returns it on read.
+
+#### Scenario: Reject an unrenderable presentation
+
+- **WHEN** a client saves a kanban view whose `groupByField` is not a property
+  of the view's schema
+- **THEN** the save is rejected with a validation error.
+
+#### Scenario: Legacy view still renders as table
+
+- **GIVEN** a view saved before this change (no `presentation`)
+- **WHEN** it is read
+- **THEN** its `viewType` is `table` and it renders exactly as before.
+
+### Requirement: Kanban columns and cards (REQ-VIEW-KANBAN-02)
+
+A kanban view MUST render one column per distinct value of `groupByField` —
+using enum order (or `columnOrder` when supplied) for enum properties, and
+distinct observed values otherwise — and MUST populate cards from the objects
+returned by the view's existing `query` (filters and sort preserved). Cards MUST
+be paginated through the existing object-query pagination rather than loading a
+whole column at once.
+
+#### Scenario: Columns from an enum status
+
+- **GIVEN** a `status` enum property with values `todo`, `doing`, `done`
+- **WHEN** a kanban view groups by `status`
+- **THEN** three columns render in enum (or configured) order, each holding the
+  objects with that status, paginated.
+
+### Requirement: Kanban drag changes status via the guarded write path (REQ-VIEW-KANBAN-03)
+
+Moving a card to another column MUST update the object's `groupByField` to the
+target column's value through the existing guarded object update API, enforcing
+RBAC, validation and `x-openregister-lifecycle`. There MUST NOT be a bespoke
+"move card" endpoint. An update that violates a lifecycle transition MUST be
+rejected by the write path, and the view MUST reflect the rejection (the card
+returns to its origin column with the reason surfaced).
+
+#### Scenario: Legal move persists
+
+- **WHEN** a user drags a card from `todo` to `doing` and the transition is
+  permitted
+- **THEN** the object's `status` is updated to `doing` through the guarded write
+  path and the card stays in the `doing` column.
+
+#### Scenario: Illegal transition snaps back
+
+- **GIVEN** a lifecycle that forbids `done` → `todo`
+- **WHEN** a user drags a `done` card to `todo`
+- **THEN** the write is rejected and the card returns to `done` with the reason
+  shown.
+
+### Requirement: Calendar plots objects by a date field over a range (REQ-VIEW-CAL-04)
+
+A calendar view MUST place objects by their `dateField` value and MUST return
+the objects whose `dateField` falls within the visible date range using the
+existing object search/filter. When an `endDateField` is configured, an object
+MUST span from `dateField` to `endDateField`.
+
+#### Scenario: Objects appear on their date
+
+- **GIVEN** objects with a `dueDate` property
+- **WHEN** a calendar view over `dueDate` shows a given month
+- **THEN** each object appears on its `dueDate` and only objects within the
+  visible range are returned.
+
+### Requirement: Presentation components are shared and wired, not owned by OR (REQ-VIEW-PRES-05)
+
+The kanban and calendar rendering components MUST be shared nextcloud-vue
+components (`CnObjectKanban`, `CnObjectCalendar`); OpenRegister MUST consume them
+and dispatch its object-list surface on `presentation.viewType`, passing the
+objects, the presentation config, and the write callback. OpenRegister MUST NOT
+re-implement the rendering locally.
+
+#### Scenario: OR dispatches to the shared component
+
+- **WHEN** a view with `viewType = kanban` is opened in OpenRegister
+- **THEN** OpenRegister renders it via the nextcloud-vue `CnObjectKanban`
+  component wired to the object store, not a bespoke OR-local kanban.

--- a/openspec/changes/object-views-kanban-calendar/tasks.md
+++ b/openspec/changes/object-views-kanban-calendar/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: object-views-kanban-calendar
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 8. -->
+
+## 1. Presentation config on views
+
+- [ ] 1.1 Add a nullable `presentation` JSON property to `lib/Db/View.php` (`addType('presentation','json')`) + a migration adding the column (REQ-VIEW-PRES-01)
+  - `viewType` defaults to `table` when `presentation` is null; existing views render unchanged.
+- [ ] 1.2 In `ViewService.create/update` + `ViewsController`, accept/return `presentation` and validate `groupByField`/`dateField` against the view's schema properties (reject an unrenderable config) (REQ-VIEW-PRES-01)
+
+## 2. Kanban (backend contract)
+
+- [ ] 2.1 Derive kanban columns from the distinct values of `groupByField` (enum order or `columnOrder`; distinct observed values otherwise); cards come from the existing view `query` with filters/sort preserved (REQ-VIEW-KANBAN-02)
+- [ ] 2.2 Drag-to-move updates `groupByField` via the existing guarded object PATCH/PUT path — RBAC + `x-openregister-lifecycle` enforced; an illegal transition is rejected (card snaps back). No bespoke move endpoint (REQ-VIEW-KANBAN-03)
+
+## 3. Calendar (backend contract)
+
+- [ ] 3.1 Calendar view returns objects whose `dateField` falls in the visible range via existing search/filter; optional `endDateField` spans days (REQ-VIEW-CAL-04)
+
+## 4. Frontend + nc-vue
+
+- [ ] 4.1 Ship `CnObjectKanban` + `CnObjectCalendar` in nextcloud-vue (shared components; declared dependency) and dispatch `src/views/` object-list on `presentation.viewType` to them, passing objects/config/write-callback (REQ-VIEW-PRES-05)
+  - nc-vue components land in a beta first (or lockstep); backend is verifiable independently.
+
+## 5. Verification
+
+- [ ] 5.1 Unit tests: `presentation` persistence + field validation; kanban column-move updates `groupByField` through the guarded path and rejects an illegal lifecycle transition; calendar date-range query (REQ-VIEW-PRES-01, REQ-VIEW-KANBAN-03, REQ-VIEW-CAL-04)
+  - Run in the `nextcloud:34` container: `docker run --rm -v $PWD:/app -w /app <nc-image> php vendor/bin/phpunit`.
+- [ ] 5.2 Live smoke on 8080: create a kanban view grouped by an enum property, drag a card across columns, confirm the object's field changed; create a calendar view and confirm objects plot by date (REQ-VIEW-KANBAN-02, REQ-VIEW-CAL-04)
+
+Acceptance criteria:
+- A saved view persists a `viewType` of table/kanban/calendar with validated config; `table` remains the default and existing views are unchanged.
+- Kanban renders columns from a status/enum field; dragging a card changes the object's value through the guarded write path (illegal transitions rejected).
+- Calendar plots objects by a date field over a visible range.
+- Shared components live in nextcloud-vue; OpenRegister only wires them.

--- a/openspec/changes/put-preserve-key-order/.openspec.yaml
+++ b/openspec/changes/put-preserve-key-order/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/put-preserve-key-order/design.md
+++ b/openspec/changes/put-preserve-key-order/design.md
@@ -1,0 +1,56 @@
+# Design: put-preserve-key-order
+
+## Context
+
+OpenRegister stores object data as JSON in the magic table. On write, the
+payload is JSON-decoded to a PHP array, validated, normalised and re-encoded.
+PHP associative arrays preserve insertion order, so the loss reported in #1720
+comes from a normalisation/merge step that rebuilds an object property's array
+without preserving submitted key order (e.g. iterating schema property
+definitions rather than submitted keys, or a `+`/`array_merge` that reorders,
+or a `json_decode(..., true)` followed by a canonicalising re-key).
+
+## Goals / Non-goals
+
+**Goal:** submitted key order of JSON object-typed properties survives
+verbatim through validate → store → read-back.
+
+**Non-goals:** ordering of *array* items (already positional); sorting or
+canonicalising keys for any reason; changing the storage column type.
+
+## Decisions
+
+### D1 — Locate and neutralise the reordering step
+
+Trace the write path for object-typed properties and identify where an object
+property's keys are rebuilt. The fix keeps the submitted associative array's
+order: iterate submitted keys (not schema-declared property order) when merging
+defaults, and avoid any `ksort`/canonicalisation on object-typed values.
+Defaults for absent keys are appended after submitted keys, never interleaved
+in a way that reorders existing ones.
+
+### D2 — Order-preserving encode on read
+
+The serializer MUST re-encode with keys in stored order. PHP `json_encode` of an
+associative array already preserves order; the requirement is simply that no
+read-side normalisation re-keys object properties.
+
+### D3 — PUT-semantic interaction
+
+OpenRegister `saveObject` is PUT-semantic (carries all fields forward). This
+change does not alter which keys are present — only their order. The
+round-trip test also asserts a non-changed sibling field survives (guards
+against a regression in the PUT-semantic carry-forward while touching the write
+path).
+
+## Risks / Trade-offs
+
+- **Hidden second reorder site** — mitigated by testing the full HTTP
+  round-trip (not just the unit under test), so any downstream re-key is caught.
+- **Performance** — negligible; order preservation is the natural PHP array
+  behaviour, the fix removes work rather than adding it.
+
+## Migration / Rollout
+
+No migration. Stored objects keep their current order until next write, which
+then preserves submitted order.

--- a/openspec/changes/put-preserve-key-order/proposal.md
+++ b/openspec/changes/put-preserve-key-order/proposal.md
@@ -1,0 +1,53 @@
+# put-preserve-key-order
+
+## Why
+
+**#1720** — the object write path (PUT/update) does not preserve the key
+ordering of JSON object-typed properties. When a schema stores an ordered map
+(an object whose keys are meaningful, e.g. a drag-reorderable list rendered as
+`{ "step-1": …, "step-2": … }` or a manifest whose property order drives UI
+row order), a round-trip through PUT re-serialises the object with keys in a
+different (hash/alphabetical) order, so the drag-reorder the user just performed
+is silently lost on save.
+
+This is a correctness/UX defect: the user drags a row, saves, and the order
+snaps back. It affects any object-keyed schema that relies on insertion order —
+a pattern OpenBuild manifests and several leaf apps use.
+
+## What Changes
+
+- The object save/update path MUST preserve the insertion order of keys in
+  JSON object-typed properties exactly as submitted, through validation,
+  storage and read-back.
+- JSON decode/encode on the write path MUST NOT reorder object keys (no
+  associative-array reshuffling, no `ksort`, no key-canonicalisation that
+  reorders).
+- The stored representation and the serialized read response MUST return object
+  keys in the submitted order.
+
+**BREAKING:** none. This only makes preserved order match submitted order;
+callers that did not depend on order are unaffected.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `objects-crud`: the update/PUT (and create) contract gains a requirement that
+  key ordering of JSON object-typed properties is preserved end-to-end
+  (submit → validate → store → read).
+
+## Impact
+
+**Affected code:** the object write path in `lib/Service/Object*` /
+`ObjectEntityService` save/update (JSON decode/encode and property
+normalisation), and the serializer used on read-back. The fix is to ensure
+JSON is decoded and re-encoded order-preservingly and that no normalisation step
+reorders object keys.
+
+**Tests:** a round-trip test that PUTs an object with a known key order into an
+object-keyed property, reads it back, and asserts the exact key sequence
+survives; a drag-reorder simulation (reverse the keys, save, re-read, assert
+reversed). Runnable in the `nextcloud:34` container.
+
+**Dependencies:** none; no migration. Existing stored objects are unaffected;
+their next write preserves whatever order is submitted.

--- a/openspec/changes/put-preserve-key-order/specs/objects-crud/spec.md
+++ b/openspec/changes/put-preserve-key-order/specs/objects-crud/spec.md
@@ -1,0 +1,38 @@
+# objects-crud Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose delta
+
+The object create/update contract preserves the insertion order of keys in
+JSON object-typed properties end-to-end, so that order-significant maps (e.g.
+drag-reorderable rows) survive a save round-trip.
+
+## ADDED Requirements
+
+### Requirement: Preserve JSON object key order on write and read (REQ-OBJ-KO-01)
+
+The object create/update path MUST preserve the insertion order of keys within
+any JSON object-typed property exactly as submitted, through validation,
+storage, and read-back. The write path MUST NOT reorder,
+alphabetise, or canonicalise object keys; default values for absent keys MUST be
+appended after the submitted keys without reordering existing ones. The read
+serializer MUST return object keys in stored order. Preserving key order MUST
+NOT alter the PUT-semantic carry-forward of unchanged fields.
+
+#### Scenario: Drag-reorder persists across save
+
+- **GIVEN** an object with an object-keyed property `{ "a": 1, "b": 2, "c": 3 }`
+- **WHEN** the client reorders it to `{ "c": 3, "b": 2, "a": 1 }` and PUTs the
+  object
+- **THEN** reading the object back returns the keys in the order
+  `c`, `b`, `a`
+- **AND** a sibling property that was not changed retains its value.
+
+#### Scenario: No implicit reordering
+
+- **WHEN** an object with an object-keyed property is saved unchanged
+- **THEN** the stored and returned key order is identical to the submitted
+  order, with no alphabetisation or canonicalisation applied.

--- a/openspec/changes/put-preserve-key-order/tasks.md
+++ b/openspec/changes/put-preserve-key-order/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: put-preserve-key-order
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 4. -->
+
+## 1. Fix the write path
+
+- [ ] 1.1 Trace the object save/update path and locate where JSON object-typed property keys are reordered; neutralise it so submitted key order is preserved (iterate submitted keys on default-merge, no `ksort`/canonicalisation on object values) (REQ-OBJ-KO-01)
+  - Absent-key defaults are appended after submitted keys, never interleaved to reorder existing ones.
+
+- [ ] 1.2 Ensure the read serializer re-encodes object-typed properties in stored order (no read-side re-keying) (REQ-OBJ-KO-01)
+
+## 2. Verification
+
+- [ ] 2.1 HTTP round-trip test: PUT an object with a known key order into an object-keyed property, read back, assert the exact key sequence; then reverse the keys, save, re-read, assert reversed (drag-reorder simulation) (REQ-OBJ-KO-01)
+  - Run in the `nextcloud:34` container: `docker run --rm -v $PWD:/app -w /app <nc-image> php vendor/bin/phpunit`.
+
+- [ ] 2.2 PUT-semantic guard: assert a non-changed sibling field survives the write while key order is being preserved (REQ-OBJ-KO-01)
+
+Acceptance criteria:
+- A drag-reorder of an object-keyed property persists across save and re-read.
+- No object-typed property keys are reordered by validate/store/serialize.
+- PUT-semantic carry-forward of unchanged fields is unaffected.

--- a/openspec/changes/register-import-auto-create/.openspec.yaml
+++ b/openspec/changes/register-import-auto-create/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/register-import-auto-create/design.md
+++ b/openspec/changes/register-import-auto-create/design.md
@@ -1,0 +1,69 @@
+# Design: register-import-auto-create
+
+## Context
+
+`ImportService` has `importFromJson(..., ?Register $register = null)` plus
+`importFromExcel`/`importFromCsv`, all taking an optional register. Register and
+schema creation already exists via the configuration/register-import path (the
+Repair-step register import and `ConfigurationService::importFromApp()` create
+registers and schemas from a JSON envelope). Today `importFromJson` assumes the
+register is resolved by the caller; when it is not, objects import without a
+proper register home or the flow errors opaquely (#1487).
+
+## Goals / Non-goals
+
+**Goals:** a register bundle imports cleanly into an instance that lacks the
+register (auto-create), and any un-createable missing-register case fails with a
+clear, actionable message; re-import stays idempotent.
+
+**Non-goals:** changing the object upsert semantics; inventing a new bundle
+format (reuse the existing register/schema envelope); cross-instance transport
+(that is the caller's concern).
+
+## Decisions
+
+### D1 — Detect bundle vs plain object array
+
+`importFromJson` inspects the payload: a **bundle** carries a register
+definition (envelope with register slug/title/description and a `schemas`
+section, the same shape the register-import path already understands); a **plain
+object list** is just objects for an already-resolved register. Only the bundle
+form can auto-create.
+
+### D2 — Reuse the existing register/schema creation path
+
+When the target register is absent and the payload is a bundle, delegate
+register + schema creation to the existing configuration/register-import
+machinery (no duplicated creation logic — ADR-011 reuse). Then import objects
+into the freshly-created register. This keeps a single source of truth for how
+registers/schemas are materialised (union-merge, slug rules, magic-table
+creation all handled there).
+
+### D3 — Clear failure when auto-create is impossible
+
+If the payload references a register that does not exist and is not a bundle
+(no creatable register metadata), throw a domain error whose message names the
+missing register slug and states the two remedies: create the register first,
+or supply a full bundle. The controller surfaces this as an actionable
+4xx, not a 500.
+
+### D4 — Idempotency
+
+If the register already exists, skip creation and proceed to the existing
+schema/object upsert. Re-importing a bundle MUST NOT create a second register
+with the same slug (guard on slug lookup before create). This matches the
+existing idempotent import behaviour for schemas/objects.
+
+## Risks / Trade-offs
+
+- **Partial-bundle ambiguity** — a payload that half-describes a register is
+  treated as un-creatable and takes the clear-error path (D3), never a
+  best-effort partial create that could produce a malformed register.
+- **Union-merge on existing register** — reusing the existing path inherits its
+  union-merge semantics (and its known "diff vs merge base" caveat); this change
+  does not alter them, only routes to them.
+
+## Migration / Rollout
+
+No migration. Additive create path; clearer errors. Existing
+import-into-existing-register flows unchanged.

--- a/openspec/changes/register-import-auto-create/proposal.md
+++ b/openspec/changes/register-import-auto-create/proposal.md
@@ -1,0 +1,58 @@
+# register-import-auto-create
+
+## Why
+
+**#1487** — the register import workflow (`ImportService::importFromJson` and
+the spreadsheet variants, which all accept an optional `?Register $register`)
+requires the target register to already exist. When a user imports a register
+bundle (a JSON envelope describing a register plus its schemas and objects) into
+an instance that does not yet have that register, the import either silently
+associates objects with no register or fails in a confusing, low-signal way
+instead of either (a) creating the register from the bundle metadata or
+(b) failing clearly with an actionable message.
+
+This is a repeated onboarding papercut: moving a register between instances
+(dev → test → prod, or sharing a bundle) should "just work" or tell the user
+exactly what to do. Today it does neither reliably.
+
+## What Changes
+
+- **Auto-create from bundle:** when an import payload is a register bundle whose
+  envelope carries the register definition (slug, title, description, schemas)
+  and the target register does not exist, `importFromJson` MUST create the
+  register (and its referenced schemas, reusing the existing register/schema
+  import path) before importing objects into it.
+- **Fail clearly otherwise:** when the payload references a register that does
+  not exist AND the payload does not carry enough metadata to create it, the
+  import MUST fail with a clear, actionable error (which register slug is
+  missing, and that either the register must be created first or a full bundle
+  supplied) — not a silent no-op or an opaque exception.
+- **Idempotent:** re-importing a bundle whose register already exists MUST NOT
+  duplicate the register; it upserts schemas/objects as today.
+
+**BREAKING:** none. Existing imports into an existing register are unchanged;
+this adds a create path and replaces silent/opaque failure with a clear error.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `data-import-export`: the JSON/bundle import contract gains requirements to
+  auto-create a missing register from bundle metadata, to fail with an
+  actionable error when auto-create is not possible, and to remain idempotent on
+  re-import.
+
+## Impact
+
+**Affected code:** `lib/Service/ImportService.php` (`importFromJson`, and the
+`?Register` handling shared by the Excel/CSV paths), reusing the existing
+register/schema import/creation path (`ConfigurationService` /
+register-import-via-repair machinery) rather than duplicating creation logic.
+
+**Tests:** import a bundle for a non-existent register → asserts the register +
+schemas are created and objects land in it; import referencing a missing
+register with no creatable metadata → asserts a clear error naming the slug;
+re-import an existing-register bundle → asserts no duplicate register.
+Runnable in the `nextcloud:34` container.
+
+**Dependencies:** none; no migration. Reuses existing register/schema creation.

--- a/openspec/changes/register-import-auto-create/specs/data-import-export/spec.md
+++ b/openspec/changes/register-import-auto-create/specs/data-import-export/spec.md
@@ -1,0 +1,58 @@
+# data-import-export Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose delta
+
+Register-bundle import auto-creates a missing register from the bundle metadata,
+fails with an actionable error when auto-create is not possible, and stays
+idempotent on re-import.
+
+## ADDED Requirements
+
+### Requirement: Auto-create a missing register from a bundle (REQ-IMP-AC-01)
+
+The register-bundle import MUST create a missing register and its referenced
+schemas from the bundle metadata before importing objects into it, when the
+target register does not already exist and the payload is a bundle — an envelope
+carrying the register definition (slug, title, description) and its schemas.
+Register/schema creation MUST reuse the existing configuration/register-import
+machinery rather than duplicate creation logic.
+
+#### Scenario: Bundle imports into an instance without the register
+
+- **GIVEN** an instance that does not have register `products`
+- **WHEN** a client imports a `products` bundle (register + schemas + objects)
+- **THEN** the `products` register and its schemas are created and the objects
+  are imported into it.
+
+### Requirement: Clear failure when auto-create is impossible (REQ-IMP-AC-02)
+
+The import MUST fail with a clear, actionable error when it references a register
+that does not exist and the payload does not carry enough metadata to create it
+(not a bundle); the error MUST name the missing register slug and state that
+either the register must be created first or a full bundle supplied, and MUST
+surface as an actionable 4xx response, not a silent no-op and not an opaque 500.
+
+#### Scenario: Plain object list for a missing register
+
+- **GIVEN** an instance without register `orders`
+- **WHEN** a client imports a plain object list targeting `orders` with no
+  register metadata
+- **THEN** the import fails with an error naming `orders` and describing the two
+  remedies, returned as a 4xx.
+
+### Requirement: Idempotent register-bundle re-import (REQ-IMP-AC-03)
+
+Re-importing a register bundle whose register already exists MUST NOT create a
+duplicate register; it MUST skip register creation (slug lookup before create)
+and proceed to the existing idempotent schema/object upsert.
+
+#### Scenario: Re-import does not duplicate
+
+- **GIVEN** register `products` already exists from a prior import
+- **WHEN** the same `products` bundle is imported again
+- **THEN** no second `products` register is created and schemas/objects are
+  upserted, not duplicated.

--- a/openspec/changes/register-import-auto-create/tasks.md
+++ b/openspec/changes/register-import-auto-create/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: register-import-auto-create
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 5. -->
+
+## 1. Import path
+
+- [ ] 1.1 In `ImportService::importFromJson`, detect bundle (register envelope + schemas) vs plain object list; when the target register is absent and the payload is a bundle, create the register + schemas via the existing register/schema import path, then import objects into it (REQ-IMP-AC-01)
+  - Reuse the configuration/register-import machinery — no duplicated creation logic (ADR-011).
+
+- [ ] 1.2 Idempotency: look up the register by slug before create; if it exists, skip creation and proceed to the existing schema/object upsert (no duplicate register) (REQ-IMP-AC-03)
+
+- [ ] 1.3 Clear failure: when a missing register is referenced and the payload is not a creatable bundle, throw a domain error naming the missing slug and stating the two remedies; surface as an actionable 4xx, not a 500 (REQ-IMP-AC-02)
+
+## 2. Verification
+
+- [ ] 2.1 Test: import a bundle for a non-existent register → register + schemas created, objects land in it; re-import same bundle → no duplicate register (REQ-IMP-AC-01, REQ-IMP-AC-03)
+  - Run in the `nextcloud:34` container: `docker run --rm -v $PWD:/app -w /app <nc-image> php vendor/bin/phpunit`.
+
+- [ ] 2.2 Test: import referencing a missing register with no creatable metadata → clear error naming the slug, mapped to a 4xx by the controller (REQ-IMP-AC-02)
+
+Acceptance criteria:
+- A register bundle imports cleanly into an instance that lacks the register.
+- An un-createable missing-register import fails with an actionable message, never a silent no-op or opaque 500.
+- Re-importing an existing-register bundle does not duplicate the register.


### PR DESCRIPTION
Four OpenSpec changes from an OpenRegister **market-position deep-research + gap analysis** (competitors, Nextcloud ecosystem, user wishes, intelligence-db mining, repo inventory — 2026-07-23).

| Change | Issues | What |
|---|---|---|
| `adhoc-aggregation-suite` | #1606 #1607 #1608 #1609 #1610 #2027 | Multi-field groupBy, multi-metric, cumulative time-bucket, cross-dialect native time-bucket, timeseries cache, + fix stat-widget multi-value/`in` filter counts |
| `put-preserve-key-order` | #1720 | Preserve JSON object key order through write/read (fixes drag-reorder loss) |
| `register-import-auto-create` | #1487 | Auto-create a missing register from a bundle, or fail clearly; idempotent |
| `object-views-kanban-calendar` | — | Kanban + calendar view types over OR storage ("Tables that scales": NC Tables collapses at ~2k rows). Shared `CnObjectKanban`/`CnObjectCalendar` in nc-vue; OR persists presentation config + guarded drag-write |

**Positioning read:** OR's moat is the Dutch compliance stack (Archiefwet/AVG/audit) + VNG Objecten-API alignment + no-per-seat EUPL; parity gaps vs Airtable/Baserow/Directus are richer views, multi-metric aggregation, and no-code affordances — this wave takes the ready-to-build subset.

**Dropped:** a proposed `rbac-fail-open-hardening` change — already covered by the in-flight `rbac-default-deny-on-configured-authorization`.

All four validate under `openspec change validate --strict`. Spec-only; no code in this PR.