### PR TITLE
feat: ad-hoc aggregation suite + multi-value filter fix (#1606-1610, #2027)

### DIFF
--- a/lib/Controller/AggregationController.php
+++ b/lib/Controller/AggregationController.php
@@ -14,9 +14,10 @@
  *    nextcloud-vue `CnChartWidget.dataSource` bucket shorthand.
  *
  * Both paths share `AggregationRunner` for RBAC + multi-tenant
- * gating + Postgres / fallback dispatch. The ad-hoc path does not
- * consult `AggregationCache` (its key shape is keyed on the named
- * annotation — extending it is tracked in issue #1610).
+ * gating + Postgres / fallback dispatch. The ad-hoc path DOES consult
+ * `AggregationCache` (see `AggregationRunner::runAdhoc()`); `value()`,
+ * `grouped()` and `timeseries()` all surface the resulting hit/miss
+ * verdict via `X-OR-Cache`, closing #1610.
  *
  * @category Controller
  * @package  OCA\OpenRegister\Controller
@@ -36,6 +37,7 @@
  * @spec openspec/specs/aggregations-backend-native/spec.md
  * @spec openspec/specs/aggregations-backend-native/spec.md
  * @spec openspec/changes/retrofit-2026-05-24-annotate-openregister/tasks.md#task-19
+ * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
  */
 
 declare(strict_types=1);
@@ -121,35 +123,49 @@ class AggregationController extends Controller
      * RBAC + multi-tenancy are enforced inside AggregationRunner::runAdhocByRef.
      *
      * Accepts: metric (default count), field (required for non-count),
-     * filter[...] (operator-aware). The literal `value` URL never collides with
-     * the named `{name}` aggregate route.
+     * filter[...] (operator-aware), metrics[...] (optional multi-metric
+     * list — REQ-AGG-102; when supplied, the response carries `values`
+     * instead of a single scalar `value`). The literal `value` URL never
+     * collides with the named `{name}` aggregate route.
      *
      * @param string $register Register reference.
      * @param string $schema   Schema reference.
      *
-     * @return JSONResponse JSON response with the scalar aggregation value.
+     * @return JSONResponse JSON response with the scalar aggregation value
+     *                      (or `values` for a multi-metric request) and an
+     *                      `X-OR-Cache: hit|miss` header (REQ-AGG-105).
      *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-openregister/tasks.md#task-19
+     * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
      */
     public function value(string $register, string $schema): JSONResponse
     {
-        $metric = (string) $this->request->getParam('metric', 'count');
-        $field  = $this->request->getParam('field');
-        $filter = (array) ($this->request->getParam('filter', []));
+        $metric  = (string) $this->request->getParam('metric', 'count');
+        $field   = $this->request->getParam('field');
+        $filter  = (array) ($this->request->getParam('filter', []));
+        $metrics = $this->parseMetricsParam();
 
         $resolvedField = $field;
         if ($field === '') {
             $resolvedField = null;
         }
 
+        $primaryMetric = $metric;
+        $primaryField  = $resolvedField;
+        if ($metrics !== null) {
+            $primaryMetric = $metrics[0]['metric'];
+            $primaryField  = $metrics[0]['field'];
+        }
+
         try {
             $query = AggregationQuery::create(
-                metric: $metric,
-                field: $resolvedField,
-                filter: $filter
+                metric: $primaryMetric,
+                field: $primaryField,
+                filter: $filter,
+                metrics: $metrics
             );
         } catch (InvalidArgumentException $e) {
             return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
@@ -163,9 +179,77 @@ class AggregationController extends Controller
             return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
         }
 
-        return new JSONResponse($result);
+        return $this->withCacheHeader(result: $result);
 
     }//end value()
+
+    /**
+     * Parse the optional `metrics` multi-metric list request param
+     * (REQ-AGG-102) into the shape {@see AggregationQuery::create()}'s
+     * `metrics` argument expects.
+     *
+     * Wire shape: `metrics[0][metric]=count&metrics[1][metric]=sum&
+     * metrics[1][field]=price` (PHP parses this into a nested array via
+     * `IRequest::getParam()`, same convention as the existing `filter[...]`
+     * param). Returns null when the param is absent/empty so callers can
+     * distinguish "no metrics list — use the legacy single metric/field
+     * pair" from "an explicit (possibly one-element) list".
+     *
+     * @return array<int, array{metric: string, field: ?string}>|null
+     */
+    private function parseMetricsParam(): ?array
+    {
+        $raw = $this->request->getParam('metrics');
+        if (is_array($raw) === false || count($raw) === 0) {
+            return null;
+        }
+
+        $metrics = [];
+        foreach ($raw as $entry) {
+            if (is_array($entry) === false) {
+                continue;
+            }
+
+            $entryField = ($entry['field'] ?? null);
+            if ($entryField === '') {
+                $entryField = null;
+            }
+
+            $metrics[] = [
+                'metric' => (string) ($entry['metric'] ?? ''),
+                'field'  => $entryField,
+            ];
+        }
+
+        if (count($metrics) === 0) {
+            return null;
+        }
+
+        return $metrics;
+
+    }//end parseMetricsParam()
+
+    /**
+     * Surface the `X-OR-Cache: hit|miss` header on an ad-hoc envelope
+     * (REQ-AGG-105) — the `value`/`grouped`/`timeseries` counterpart of
+     * the header {@see aggregate()} already sets from `cached`.
+     *
+     * @param array<string, mixed> $result The runner's result envelope.
+     *
+     * @return JSONResponse The response with the header attached.
+     */
+    private function withCacheHeader(array $result): JSONResponse
+    {
+        $response    = new JSONResponse($result);
+        $cacheHeader = 'miss';
+        if (($result['cached'] ?? false) === true) {
+            $cacheHeader = 'hit';
+        }
+
+        $response->addHeader('X-OR-Cache', $cacheHeader);
+        return $response;
+
+    }//end withCacheHeader()
 
     /**
      * Ad-hoc categorical group-by aggregation entry point.
@@ -174,32 +258,49 @@ class AggregationController extends Controller
      * and returns `{ groups: [{ key, value }] }` for manifest-configured
      * category charts (nextcloud-vue CnChartWidget group-by source).
      *
-     * Accepts: groupBy (required field), metric (default count), field
-     * (required for non-count), sort (asc|desc), limit (top-N), filter[...].
+     * Accepts: groupBy (required field — a single field name, a
+     * comma-separated list, or a repeated `groupBy[]` array for a
+     * multi-field cross-tab groupBy, REQ-AGG-101), metric (default count),
+     * field (required for non-count), metrics[...] (optional multi-metric
+     * list, REQ-AGG-102), sort (asc|desc), limit (top-N), filter[...].
+     * A single groupBy field keeps the legacy `{key, value}` per-group
+     * shape byte-identical; more than one field switches to `{keys, value}`.
      *
      * @param string $register Register reference.
      * @param string $schema   Schema reference.
      *
-     * @return JSONResponse JSON response with `{ groups, backend, cached }`.
+     * @return JSONResponse JSON response with `{ groups, backend, cached }`
+     *                      and an `X-OR-Cache: hit|miss` header (REQ-AGG-105).
      *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-openregister/tasks.md#task-19
+     * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
      */
     public function grouped(string $register, string $schema): JSONResponse
     {
         $metric  = (string) $this->request->getParam('metric', 'count');
         $field   = $this->request->getParam('field');
-        $groupBy = (string) $this->request->getParam('groupBy', '');
         $filter  = (array) ($this->request->getParam('filter', []));
+        $metrics = $this->parseMetricsParam();
 
-        if ($groupBy === '') {
+        $groupFields = $this->parseGroupByParam();
+        if (count($groupFields) === 0) {
             return new JSONResponse(['error' => 'groupBy is required'], Http::STATUS_BAD_REQUEST);
         }
 
-        $groupSpec = ['field' => $groupBy];
-        $sort      = $this->request->getParam('sort');
+        // A single field keeps the pre-existing `{field: ...}` shape
+        // (byte-identical response for existing single-field callers);
+        // more than one field switches to the multi-field `{fields: [...]}`
+        // cross-tab shape (REQ-AGG-101) — AggregationQuery/AggregationRunner
+        // already support both natively.
+        $groupSpec = ['field' => $groupFields[0]];
+        if (count($groupFields) > 1) {
+            $groupSpec = ['fields' => $groupFields];
+        }
+
+        $sort = $this->request->getParam('sort');
         if ($sort === 'asc' || $sort === 'desc') {
             $groupSpec['sort'] = $sort;
         }
@@ -214,12 +315,20 @@ class AggregationController extends Controller
             $resolvedField = null;
         }
 
+        $primaryMetric = $metric;
+        $primaryField  = $resolvedField;
+        if ($metrics !== null) {
+            $primaryMetric = $metrics[0]['metric'];
+            $primaryField  = $metrics[0]['field'];
+        }
+
         try {
             $query = AggregationQuery::create(
-                metric: $metric,
-                field: $resolvedField,
+                metric: $primaryMetric,
+                field: $primaryField,
                 filter: $filter,
-                groupBy: $groupSpec
+                groupBy: $groupSpec,
+                metrics: $metrics
             );
         } catch (InvalidArgumentException $e) {
             return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
@@ -233,9 +342,52 @@ class AggregationController extends Controller
             return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
         }
 
-        return new JSONResponse($result);
+        return $this->withCacheHeader(result: $result);
 
     }//end grouped()
+
+    /**
+     * Parse the `groupBy` request param into an ordered list of field
+     * names (REQ-AGG-101).
+     *
+     * Accepts three wire shapes so existing single-field callers are
+     * unaffected:
+     *  - a single field name: `groupBy=status` → `['status']`;
+     *  - a comma-separated list: `groupBy=status,type` → `['status', 'type']`;
+     *  - a repeated-param array (PHP's `groupBy[]=status&groupBy[]=type`
+     *    parsing): `['status', 'type']` passed straight through.
+     * Blank entries are dropped; the result may be empty (caller 400s).
+     *
+     * @return array<int, string> Ordered, non-empty field names.
+     */
+    private function parseGroupByParam(): array
+    {
+        $raw = $this->request->getParam('groupBy', '');
+
+        $candidates = [];
+        if (is_array($raw) === true) {
+            $candidates = $raw;
+        } else {
+            $candidates = explode(',', (string) $raw);
+        }
+
+        $fields = [];
+        foreach ($candidates as $candidate) {
+            if (is_string($candidate) === false) {
+                continue;
+            }
+
+            $trimmed = trim($candidate);
+            if ($trimmed === '') {
+                continue;
+            }
+
+            $fields[] = $trimmed;
+        }
+
+        return $fields;
+
+    }//end parseGroupByParam()
 
     /**
      * Ad-hoc time-bucket aggregation entry point.
@@ -254,12 +406,14 @@ class AggregationController extends Controller
      * @param string $register Register reference.
      * @param string $schema   Schema reference.
      *
-     * @return JSONResponse JSON response with bucketed groups.
+     * @return JSONResponse JSON response with bucketed groups and an
+     *                      `X-OR-Cache: hit|miss` header (REQ-AGG-105).
      *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-15
+     * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
      */
     public function timeseries(string $register, string $schema): JSONResponse
     {
@@ -303,7 +457,7 @@ class AggregationController extends Controller
             return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
         }
 
-        return new JSONResponse($result);
+        return $this->withCacheHeader(result: $result);
 
     }//end timeseries()
 }//end class

--- a/lib/Service/Aggregation/AggregationQuery.php
+++ b/lib/Service/Aggregation/AggregationQuery.php
@@ -73,21 +73,27 @@ class AggregationQuery
     /**
      * Constructor — use the static factory.
      *
-     * @param string                    $metric     Aggregation metric.
-     * @param ?string                   $field      Field for sum/avg/min/max; required when metric != count.
-     * @param array<string, mixed>      $filter     Filter conditions (see class docblock for shapes).
-     * @param array<string, mixed>|null $groupBy    Optional grouping spec. Accepts a single-field shape
-     *                                              (`{field: 'status'}`), a multi-field cross-tab shape
-     *                                              (`{fields: ['vendorId', 'dueDateBucket']}`), or a plain
-     *                                              ordered list of field names (`['vendorId', 'dueDateBucket']`).
-     * @param array<string, mixed>|null $dateBucket Optional date-bucket spec; `{field, start, end, gap}`.
+     * @param string                                                  $metric     Aggregation metric.
+     * @param ?string                                                 $field      Field for sum/avg/min/max; required when metric != count.
+     * @param array<string, mixed>                                    $filter     Filter conditions (see class docblock for shapes).
+     * @param array<string, mixed>|null                               $groupBy    Optional grouping spec. Accepts a single-field shape
+     *                                                                            (`{field: 'status'}`), a multi-field cross-tab shape
+     *                                                                            (`{fields: ['vendorId', 'dueDateBucket']}`), or a
+     *                                                                            plain ordered list of field names (`['vendorId',
+     *                                                                            'dueDateBucket']`).
+     * @param array<string, mixed>|null                               $dateBucket Optional date-bucket spec; `{field, start, end, gap}`.
+     * @param array<int, array{metric: string, field?: ?string}>|null $metrics    Optional multi-metric list
+     *                                                                            — see {@see getMetrics()}
+     *                                                                            for the canonicalisation and
+     *                                                                            response-shape contract.
      */
     private function __construct(
         public readonly string $metric,
         public readonly ?string $field,
         public readonly array $filter,
         public readonly ?array $groupBy,
-        public readonly ?array $dateBucket=null
+        public readonly ?array $dateBucket=null,
+        public readonly ?array $metrics=null
     ) {
 
     }//end __construct()
@@ -95,14 +101,38 @@ class AggregationQuery
     /**
      * Construct an aggregation query — fails fast on bad input.
      *
-     * @param string                    $metric     One of METRIC_*.
-     * @param ?string                   $field      Field for non-count metrics; null for count.
-     * @param array<string, mixed>      $filter     Filter map.
-     * @param array<string, mixed>|null $groupBy    Optional groupBy. Single-field (`{field: 'x'}`),
-     *                                              multi-field (`{fields: ['a','b']}`), or a plain list
-     *                                              (`['a','b']`). Multi-field yields one grouped row per
-     *                                              distinct field tuple.
-     * @param array<string, mixed>|null $dateBucket Optional dateBucket spec `{field, start, end, gap}`.
+     * @param string                                                  $metric     One of METRIC_*.
+     * @param ?string                                                 $field      Field for non-count metrics; null for count.
+     * @param array<string, mixed>                                    $filter     Filter map.
+     * @param array<string, mixed>|null                               $groupBy    Optional groupBy. Single-field (`{field: 'x'}`),
+     *                                                                            multi-field (`{fields: ['a','b']}`), or a plain
+     *                                                                            list (`['a','b']`). Multi-field yields one
+     *                                                                            grouped row per distinct field tuple.
+     * @param array<string, mixed>|null                               $dateBucket Optional dateBucket spec `{field, start, end, gap}`.
+     * @param array<int, array{metric: string, field?: ?string}>|null $metrics    Optional multi-metric list
+     *                                                                            (`[{metric: 'count'},
+     *                                                                            {metric: 'sum', field:
+     *                                                                            'price'}]`). When supplied
+     *                                                                            (non-empty), every listed
+     *                                                                            pair is computed in one
+     *                                                                            request and the response
+     *                                                                            carries a `values` map
+     *                                                                            instead of a single scalar
+     *                                                                            `value`/per-group `value`.
+     *                                                                            The legacy
+     *                                                                            `$metric`/`$field` pair
+     *                                                                            remains the "primary"
+     *                                                                            metric (used by callers
+     *                                                                            that only look at
+     *                                                                            `->metric`/`->field`) and
+     *                                                                            SHOULD mirror
+     *                                                                            `$metrics[0]` when both
+     *                                                                            are supplied. Mutually
+     *                                                                            exclusive with
+     *                                                                            `$dateBucket` (not yet
+     *                                                                            supported — REQ-AGG-102
+     *                                                                            covers the categorical
+     *                                                                            value/grouped paths only).
      *
      * @return self
      *
@@ -117,13 +147,15 @@ class AggregationQuery
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-openregister/tasks.md#task-18
      * @spec openspec/specs/aggregation-api/spec.md
+     * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
      */
     public static function create(
         string $metric,
         ?string $field=null,
         array $filter=[],
         ?array $groupBy=null,
-        ?array $dateBucket=null
+        ?array $dateBucket=null,
+        ?array $metrics=null
     ): self {
         if (in_array($metric, self::METRICS, true) === false) {
             throw new InvalidArgumentException(
@@ -140,6 +172,42 @@ class AggregationQuery
                 sprintf('aggregation metric "%s" MUST specify a field', $metric)
             );
         }
+
+        if ($metrics !== null) {
+            if (count($metrics) === 0) {
+                throw new InvalidArgumentException('metrics list, when supplied, MUST NOT be empty');
+            }
+
+            foreach ($metrics as $metricEntry) {
+                if (is_array($metricEntry) === false || array_key_exists('metric', $metricEntry) === false) {
+                    throw new InvalidArgumentException('each metrics entry MUST be an array with a `metric` key');
+                }
+
+                $entryMetric = (string) $metricEntry['metric'];
+                if (in_array($entryMetric, self::METRICS, true) === false) {
+                    throw new InvalidArgumentException(
+                        sprintf(
+                            'metrics entry has an invalid metric "%s" (MUST be one of: %s)',
+                            $entryMetric,
+                            implode(', ', self::METRICS)
+                        )
+                    );
+                }
+
+                $entryField = ($metricEntry['field'] ?? null);
+                if ($entryMetric !== self::METRIC_COUNT && ($entryField === null || $entryField === '')) {
+                    throw new InvalidArgumentException(
+                        sprintf('metrics entry "%s" MUST specify a field', $entryMetric)
+                    );
+                }
+            }//end foreach
+
+            if ($dateBucket !== null) {
+                throw new InvalidArgumentException(
+                    'a multi-metric `metrics` list MUST NOT be combined with dateBucket (time-bucket) aggregation'
+                );
+            }
+        }//end if
 
         if ($groupBy !== null) {
             $groupFields = self::normaliseGroupByFields(groupBy: $groupBy);
@@ -177,7 +245,8 @@ class AggregationQuery
             field: $field,
             filter: $filter,
             groupBy: $groupBy,
-            dateBucket: $dateBucket
+            dateBucket: $dateBucket,
+            metrics: $metrics
         );
 
     }//end create()
@@ -348,6 +417,78 @@ class AggregationQuery
     }//end hasDateBucket()
 
     /**
+     * Canonical, always-populated metrics list.
+     *
+     * Falls back to the legacy single `{metric, field}` pair (as a
+     * one-element list) when the caller didn't specify an explicit
+     * `metrics` list, so callers can treat every query uniformly as
+     * "one or more requested metrics" without a null-check.
+     *
+     * @return array<int, array{metric: string, field: ?string}> Ordered, normalised metric requests.
+     *
+     * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
+     */
+    public function getMetrics(): array
+    {
+        if ($this->metrics !== null && count($this->metrics) > 0) {
+            $out = [];
+            foreach ($this->metrics as $entry) {
+                $entryField = ($entry['field'] ?? null);
+                if ($entryField === '') {
+                    $entryField = null;
+                }
+
+                $out[] = [
+                    'metric' => (string) $entry['metric'],
+                    'field'  => $entryField,
+                ];
+            }
+
+            return $out;
+        }
+
+        return [['metric' => $this->metric, 'field' => $this->field]];
+
+    }//end getMetrics()
+
+    /**
+     * Test whether this is a multi-metric request (more than one metric
+     * requested in a single call).
+     *
+     * @return bool
+     *
+     * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
+     */
+    public function isMultiMetric(): bool
+    {
+        return (count($this->getMetrics()) > 1);
+
+    }//end isMultiMetric()
+
+    /**
+     * The response key for one metric entry: `count` for count (no field),
+     * else `metric_field` (e.g. `sum_price`). Shared by the native-SQL
+     * column aliasing and the PHP-fallback / grouped response building so
+     * both paths agree on key names for the multi-metric `values` map.
+     *
+     * @param string      $metric One of the METRIC_* constants.
+     * @param string|null $field  The metric's field, or null for count.
+     *
+     * @return string The response key.
+     *
+     * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
+     */
+    public static function metricResponseKey(string $metric, ?string $field): string
+    {
+        if ($metric === self::METRIC_COUNT || $field === null || $field === '') {
+            return $metric;
+        }
+
+        return $metric.'_'.$field;
+
+    }//end metricResponseKey()
+
+    /**
      * Serialise the query to a stable associative array.
      *
      * The output is the canonical input to the ad-hoc aggregation cache
@@ -374,6 +515,7 @@ class AggregationQuery
             'filter'     => self::canonicaliseFilter(filter: $this->filter),
             'groupBy'    => $this->groupBy,
             'dateBucket' => $this->dateBucket,
+            'metrics'    => $this->metrics,
         ];
 
     }//end toArray()

--- a/lib/Service/Aggregation/AggregationRunner.php
+++ b/lib/Service/Aggregation/AggregationRunner.php
@@ -498,7 +498,8 @@ class AggregationRunner
             field: $query->field,
             filter: $resolvedFilter,
             groupBy: $query->groupBy,
-            dateBucket: $query->dateBucket
+            dateBucket: $query->dateBucket,
+            metrics: $query->metrics
         );
 
         // Read-through cache. Identical query + filter + RBAC scope →
@@ -568,7 +569,8 @@ class AggregationRunner
             field: $query->field,
             filter: $resolvedFilter,
             groupBy: $query->groupBy,
-            dateBucket: $query->dateBucket
+            dateBucket: $query->dateBucket,
+            metrics: $query->getMetrics()
         );
 
         if ($native !== null) {
@@ -603,7 +605,8 @@ class AggregationRunner
             field: $query->field,
             filter: $resolvedFilter,
             groupBy: $query->groupBy,
-            dateBucket: $query->dateBucket
+            dateBucket: $query->dateBucket,
+            metrics: $query->getMetrics()
         );
         $this->cache->setAdhoc(
             registerSlug: (string) $register->getSlug(),
@@ -646,6 +649,13 @@ class AggregationRunner
         AggregationQuery $query
     ): ?array {
         if ($this->dbalSourceProvider === null) {
+            return null;
+        }
+
+        // Multi-metric requests aren't supported by the DBAL provider's
+        // single-metric aggregate() signature. Fall through to the
+        // magic-table native / PHP paths below, which do support it.
+        if ($query->isMultiMetric() === true) {
             return null;
         }
 
@@ -883,17 +893,28 @@ class AggregationRunner
      * Marked `backend: "php-fallback"` in the response so callers know
      * the query did not hit a native engine.
      *
-     * @param Register                  $register   Register.
-     * @param Schema                    $schema     Schema.
-     * @param string                    $metric     One of count/sum/avg/min/max.
-     * @param string|null               $field      Metric field (null for count).
-     * @param array<string, mixed>      $filter     Already placeholder-resolved filter map.
-     * @param array<string, mixed>|null $groupBy    Optional categorical groupBy spec.
-     * @param array<string, mixed>|null $dateBucket Optional time-bucket spec.
+     * @param Register                                               $register   Register.
+     * @param Schema                                                 $schema     Schema.
+     * @param string                                                 $metric     One of count/sum/avg/min/max.
+     * @param string|null                                            $field      Metric field (null for count).
+     * @param array<string, mixed>                                   $filter     Already placeholder-resolved filter map.
+     * @param array<string, mixed>|null                              $groupBy    Optional categorical groupBy spec.
+     * @param array<string, mixed>|null                              $dateBucket Optional time-bucket spec.
+     * @param array<int, array{metric: string, field: ?string}>|null $metrics    Optional multi-metric list
+     *                                                                           (REQ-AGG-102);
+     *                                                                           null/one-element behaves
+     *                                                                           exactly as the legacy
+     *                                                                           single `$metric`/`$field`
+     *                                                                           pair. Not combined with
+     *                                                                           `$dateBucket` (rejected
+     *                                                                           upstream by
+     *                                                                           AggregationQuery::create()).
      *
      * @return array<string, mixed> Either `{value, backend, cached}` or
      *                              `{groups, backend, cached}` mirroring the
-     *                              Postgres native-path shape.
+     *                              Postgres native-path shape. Multi-metric
+     *                              requests carry `values` instead of
+     *                              `value`/per-group `value`.
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      *   The branching mirrors the Postgres SQL path: dateBucket vs.
@@ -901,6 +922,7 @@ class AggregationRunner
      * @SuppressWarnings(PHPMD.NPathComplexity)
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-openregister/tasks.md#task-19
+     * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
      */
     private function bucketInPhp(
         Register $register,
@@ -909,7 +931,8 @@ class AggregationRunner
         ?string $field,
         array $filter,
         ?array $groupBy,
-        ?array $dateBucket
+        ?array $dateBucket,
+        ?array $metrics=null
     ): array {
         $objects = $this->magicMapper->findAllInRegisterSchemaTable(
             register: $register,
@@ -973,17 +996,27 @@ class AggregationRunner
             ];
         }//end if
 
-        $groupFields = $this->resolveGroupFields(groupBy: $groupBy);
+        $groupFields   = $this->resolveGroupFields(groupBy: $groupBy);
+        $isMultiMetric = (is_array($metrics) === true && count($metrics) > 1);
         if (count($groupFields) > 0) {
             $groups = $this->computeGrouped(
                 rows: $rows,
                 metric: $metric,
                 field: $field,
-                groupFields: $groupFields
+                groupFields: $groupFields,
+                metrics: $metrics
             );
 
             return [
                 'groups'  => $groups,
+                'backend' => 'php-fallback',
+                'cached'  => false,
+            ];
+        }
+
+        if ($isMultiMetric === true) {
+            return [
+                'values'  => $this->computeMetrics(rows: $rows, metrics: $metrics),
                 'backend' => 'php-fallback',
                 'cached'  => false,
             ];
@@ -1093,6 +1126,33 @@ class AggregationRunner
     }//end computeMetric()
 
     /**
+     * Compute every metric in a multi-metric request over the same row set.
+     *
+     * Companion to {@see computeMetric()} for REQ-AGG-102 — each entry's
+     * result is keyed by {@see AggregationQuery::metricResponseKey()} (e.g.
+     * `count`, `sum_price`) into a single `values` map so a caller can read
+     * `count` and `sum_price` from one grouped row / one ungrouped envelope.
+     *
+     * @param array<int, array<string, mixed>>                  $rows    Already-filtered rows.
+     * @param array<int, array{metric: string, field: ?string}> $metrics Requested metric entries.
+     *
+     * @return array<string, int|float|null> Metric results keyed by response key.
+     *
+     * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
+     */
+    private function computeMetrics(array $rows, array $metrics): array
+    {
+        $values = [];
+        foreach ($metrics as $entry) {
+            $key          = AggregationQuery::metricResponseKey(metric: $entry['metric'], field: $entry['field']);
+            $values[$key] = $this->computeMetric(rows: $rows, metric: $entry['metric'], field: $entry['field']);
+        }
+
+        return $values;
+
+    }//end computeMetrics()
+
+    /**
      * Resolve a raw groupBy spec to an ordered list of non-empty group field
      * names, honouring every accepted shape (single `{field}`, multi
      * `{fields:[...]}`, plain list `[...]`).
@@ -1136,20 +1196,31 @@ class AggregationRunner
      * a consumer can pivot the result into a cross-tab. The bucket order is
      * the first-seen order of each distinct tuple.
      *
-     * @param array<int, array<string, mixed>> $rows        Already-filtered rows.
-     * @param string                           $metric      One of count/sum/avg/min/max/count_distinct.
-     * @param mixed                            $field       Field to aggregate over.
-     * @param array<int, string>               $groupFields Ordered field(s) used as the bucket key.
+     * @param array<int, array<string, mixed>>                       $rows        Already-filtered rows.
+     * @param string                                                 $metric      One of count/sum/avg/min/max/count_distinct.
+     * @param mixed                                                  $field       Field to aggregate over.
+     * @param array<int, string>                                     $groupFields Ordered field(s) used as the bucket key.
+     * @param array<int, array{metric: string, field: ?string}>|null $metrics     Optional multi-metric list
+     *                                                                            (REQ-AGG-102). When it
+     *                                                                            carries more than one
+     *                                                                            entry, each group row
+     *                                                                            carries a `values` map
+     *                                                                            instead of a single scalar
+     *                                                                            `value` —
+     *                                                                            `$metric`/`$field` are
+     *                                                                            then ignored.
      *
-     * @return array<int, array{key?: mixed, keys?: array<string, mixed>, value: int|float|null}>
+     * @return array<int, array{key?: mixed, keys?: array<string, mixed>, value?: int|float|null, values?: array<string, int|float|null>}>
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-openregister/tasks.md#task-19
      * @spec openspec/specs/aggregation-api/spec.md
+     * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
      */
-    private function computeGrouped(array $rows, string $metric, mixed $field, array $groupFields): array
+    private function computeGrouped(array $rows, string $metric, mixed $field, array $groupFields, ?array $metrics=null): array
     {
-        $isMulti = (count($groupFields) > 1);
-        $buckets = [];
+        $isMulti       = (count($groupFields) > 1);
+        $isMultiMetric = (is_array($metrics) === true && count($metrics) > 1);
+        $buckets       = [];
         foreach ($rows as $row) {
             $tuple = [];
             foreach ($groupFields as $groupField) {
@@ -1168,21 +1239,32 @@ class AggregationRunner
 
         $out = [];
         foreach ($buckets as $bucket) {
-            $value = $this->computeMetric(rows: $bucket['rows'], metric: $metric, field: $field);
+            $valueOrValues = null;
+            if ($isMultiMetric === true) {
+                $valueOrValues = $this->computeMetrics(rows: $bucket['rows'], metrics: $metrics);
+            } else {
+                $valueOrValues = $this->computeMetric(rows: $bucket['rows'], metric: $metric, field: $field);
+            }
+
+            $valueKey = 'value';
+            if ($isMultiMetric === true) {
+                $valueKey = 'values';
+            }
+
             if ($isMulti === true) {
                 $out[] = [
-                    'keys'  => $bucket['tuple'],
-                    'value' => $value,
+                    'keys'    => $bucket['tuple'],
+                    $valueKey => $valueOrValues,
                 ];
                 continue;
             }
 
             // Single-field: unwrap the tuple to the legacy `{key, value}` shape.
             $out[] = [
-                'key'   => reset($bucket['tuple']),
-                'value' => $value,
+                'key'     => reset($bucket['tuple']),
+                $valueKey => $valueOrValues,
             ];
-        }
+        }//end foreach
 
         return $out;
     }//end computeGrouped()
@@ -1255,10 +1337,24 @@ class AggregationRunner
     /**
      * Apply operator-style filters (gte/lte/gt/lt/in/ne) in PHP.
      *
+     * REQ-AGG-106 / bug #2027: a bare array criterion (a plain list, not an
+     * operator map such as `{in: [...]}`) is treated as an implicit `in`
+     * (any-of) match rather than being silently ignored — previously
+     * `is_array($criterion) === true` routed a bare list into the operator
+     * loop below, where its numeric keys (`0`, `1`, …) matched no known
+     * operator and `checkOp()`'s `default => true` let every row through
+     * unfiltered. Scalar equality and every wrapped operator additionally
+     * honour a multi-value (array) ROW value (e.g. a `tags` property stored
+     * as a JSON array) via {@see valueMatchesAnyOf()}'s any-overlap test,
+     * instead of the whole-array identity compare that never matched.
+     *
      * @param array<int, array<string, mixed>> $rows   Rows to filter.
-     * @param array<string, mixed>             $filter Filter map (scalar = eq, array = operator map).
+     * @param array<string, mixed>             $filter Filter map (scalar = eq, plain list = implicit `in`,
+     *                                                 assoc array = operator map).
      *
      * @return array<int, array<string, mixed>> Filtered rows.
+     *
+     * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
      */
     private function applyFilter(array $rows, array $filter): array
     {
@@ -1267,19 +1363,24 @@ class AggregationRunner
             $keep = true;
             foreach ($filter as $field => $criterion) {
                 $value = $row[$field] ?? null;
+
+                // Bare array criterion (a plain, non-associative list) is an
+                // implicit `in` — any-of match against the candidate list.
+                if (is_array($criterion) === true && array_is_list($criterion) === true) {
+                    if ($this->valueMatchesAnyOf(rowValue: $value, candidates: $criterion) === false) {
+                        $keep = false;
+                        break;
+                    }
+
+                    continue;
+                }
+
                 if (is_array($criterion) === false) {
-                    // BUG-SVC-9: magic-table column values come back as strings,
-                    // while the criterion may be int/bool/float. A strict !==
-                    // then drops rows the Postgres path would keep (e.g. "1" vs
-                    // 1). Compare as strings when both sides are scalar so the
-                    // PHP fallback matches the native equality semantics; keep
-                    // strict comparison for non-scalars (null/array/object).
-                    if (is_scalar($value) === true && is_scalar($criterion) === true) {
-                        if ((string) $value !== (string) $criterion) {
-                            $keep = false;
-                            break;
-                        }
-                    } else if ($value !== $criterion) {
+                    // Scalar equality. valueMatchesAnyOf() folds in the
+                    // BUG-SVC-9 string-cast coercion (magic-table columns
+                    // come back as strings while the criterion may be
+                    // int/bool/float) AND the multi-value row-overlap test.
+                    if ($this->valueMatchesAnyOf(rowValue: $value, candidates: [$criterion]) === false) {
                         $keep = false;
                         break;
                     }
@@ -1306,6 +1407,15 @@ class AggregationRunner
     /**
      * Apply a single operator check.
      *
+     * `eq`/`ne`/`in`/`notIn` all route through {@see valueMatchesAnyOf()} —
+     * REQ-AGG-106 / bug #2027 — so a multi-value (array) row value (a
+     * property stored as a JSON array) is tested via any-overlap against
+     * the operand rather than a whole-array identity compare that never
+     * matched, AND a scalar row value gets the same BUG-SVC-9 string-cast
+     * coercion `eq` already had (magic-table columns come back as strings).
+     * `gt`/`gte`/`lt`/`lte` are unaffected — range comparisons over a
+     * multi-value row aren't part of this fix's scope.
+     *
      * @param mixed  $value   The value extracted from the row.
      * @param string $op      Operator name ('eq','ne','gt','gte','lt','lte','in','notIn').
      * @param mixed  $opValue The operand value to compare against.
@@ -1313,23 +1423,97 @@ class AggregationRunner
      * @return bool True when the value satisfies the operator.
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
      */
     private function checkOp(mixed $value, string $op, mixed $opValue): bool
     {
+        if ($op === 'eq') {
+            return $this->valueMatchesAnyOf(rowValue: $value, candidates: [$opValue]);
+        }
+
+        if ($op === 'ne') {
+            return ($this->valueMatchesAnyOf(rowValue: $value, candidates: [$opValue]) === false);
+        }
+
+        if ($op === 'in') {
+            return (is_array($opValue) === true
+                && $this->valueMatchesAnyOf(rowValue: $value, candidates: $opValue) === true);
+        }
+
+        if ($op === 'notIn') {
+            return (is_array($opValue) === false
+                || $this->valueMatchesAnyOf(rowValue: $value, candidates: $opValue) === false);
+        }
+
         $cmp = $this->normaliseForCompare(v: $value);
         $rhs = $this->normaliseForCompare(v: $opValue);
         return match ($op) {
-            'eq'    => $cmp === $rhs,
-            'ne'    => $cmp !== $rhs,
             'gt'    => $cmp !== null && $rhs !== null && $cmp > $rhs,
             'gte'   => $cmp !== null && $rhs !== null && $cmp >= $rhs,
             'lt'    => $cmp !== null && $rhs !== null && $cmp < $rhs,
             'lte'   => $cmp !== null && $rhs !== null && $cmp <= $rhs,
-            'in'    => is_array($opValue) === true && in_array($value, $opValue, true),
-            'notIn' => is_array($opValue) === false || in_array($value, $opValue, true) === false,
             default => true,
         };
     }//end checkOp()
+
+    /**
+     * Test whether a row value matches any of the given candidates.
+     *
+     * Handles both shapes uniformly (REQ-AGG-106 / bug #2027):
+     *  - a scalar row value matches when it loosely (string-cast) equals
+     *    ANY candidate — e.g. magic-table `"1"` against candidate `1`;
+     *  - a multi-value (array) row value — a property stored as a JSON
+     *    array — matches when ANY of its members loosely equals ANY
+     *    candidate (any-overlap), instead of comparing the whole array as
+     *    a single opaque value (which never matches a scalar candidate).
+     *
+     * @param mixed                    $rowValue   The value extracted from the row (scalar, array, or null).
+     * @param array<int|string, mixed> $candidates One or more candidate values to match against.
+     *
+     * @return bool True when the row value overlaps any candidate.
+     *
+     * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
+     */
+    private function valueMatchesAnyOf(mixed $rowValue, array $candidates): bool
+    {
+        $haystack = $rowValue;
+        if (is_array($haystack) === false) {
+            $haystack = [$haystack];
+        }
+
+        foreach ($haystack as $item) {
+            foreach ($candidates as $candidate) {
+                if ($this->scalarLooseEquals(a: $item, b: $candidate) === true) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+
+    }//end valueMatchesAnyOf()
+
+    /**
+     * Loose scalar equality: string-cast comparison when both sides are
+     * scalar (BUG-SVC-9 — magic-table columns come back as strings while
+     * the criterion may be int/bool/float), strict identity otherwise
+     * (null / array / object members are never coerced).
+     *
+     * @param mixed $a First value.
+     * @param mixed $b Second value.
+     *
+     * @return bool True when the two values are considered equal.
+     */
+    private function scalarLooseEquals(mixed $a, mixed $b): bool
+    {
+        if (is_scalar($a) === true && is_scalar($b) === true) {
+            return ((string) $a === (string) $b);
+        }
+
+        return ($a === $b);
+
+    }//end scalarLooseEquals()
 
     /**
      * Coerce date-like scalars to integer timestamps for ordered comparisons.
@@ -1372,20 +1556,35 @@ class AggregationRunner
      * Returns the result fragment ('value' or 'groups') on success, null
      * to signal the caller should fall back to PHP-side aggregation.
      *
-     * @param Register                  $register   Register the schema belongs to.
-     * @param Schema                    $schema     Schema being aggregated.
-     * @param string                    $metric     Metric name (count/sum/avg/min/max).
-     * @param string|null               $field      Field to aggregate over (ignored for count).
-     * @param array<string, mixed>      $filter     Already placeholder-resolved filter map.
-     * @param array<string, mixed>|null $groupBy    Optional group spec: single-field ({field: ...}),
-     *                                              multi-field ({fields: [...]}), or a plain list ([...]).
-     * @param array<string, mixed>|null $dateBucket Optional time-bucket spec ({field, start, end, gap}).
-     *                                              When supplied, the query becomes a `date_trunc`-bucketed
-     *                                              series with explicit `WHERE field >= start AND field < end`
-     *                                              bounds. Mutually exclusive with $groupBy (validated by
-     *                                              AggregationQuery::create() upstream).
+     * @param Register                                               $register   Register the schema belongs to.
+     * @param Schema                                                 $schema     Schema being aggregated.
+     * @param string                                                 $metric     Metric name (count/sum/avg/min/max).
+     * @param string|null                                            $field      Field to aggregate over (ignored for count).
+     * @param array<string, mixed>                                   $filter     Already placeholder-resolved filter map.
+     * @param array<string, mixed>|null                              $groupBy    Optional group spec: single-field ({field: ...}),
+     *                                                                           multi-field ({fields: [...]}), or a plain list
+     *                                                                           ([...]).
+     * @param array<string, mixed>|null                              $dateBucket Optional time-bucket spec ({field, start, end, gap}).
+     *                                                                           When supplied, the query becomes a
+     *                                                                           `date_trunc`-bucketed series with explicit `WHERE
+     *                                                                           field >= start AND field < end` bounds. Mutually
+     *                                                                           exclusive with $groupBy (validated by
+     *                                                                           AggregationQuery::create() upstream).
+     * @param array<int, array{metric: string, field: ?string}>|null $metrics    Optional multi-metric list
+     *                                                                           (REQ-AGG-102). When it
+     *                                                                           carries more than one
+     *                                                                           entry, this method
+     *                                                                           dispatches to {@see
+     *                                                                           tryNativeMultiMetric()}
+     *                                                                           instead of running the
+     *                                                                           single-metric path below;
+     *                                                                           `$metric`/`$field` are
+     *                                                                           then ignored.
      *
-     * @return array{value: int|float|null}|array{groups: array<int, array{key: mixed, value: int|float|null}>}|null
+     * @return array{value: int|float|null}
+     *         |array{values: array<string, int|float|null>}
+     *         |array{groups: array<int, array{key: mixed, value: int|float|null}>}
+     *         |null
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
@@ -1397,6 +1596,7 @@ class AggregationRunner
      *   the mutual-exclusion read at the call site.
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-openregister/tasks.md#task-19
+     * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
      */
     private function tryNativeAggregation(
         Register $register,
@@ -1405,8 +1605,19 @@ class AggregationRunner
         ?string $field,
         array $filter,
         ?array $groupBy,
-        ?array $dateBucket=null
+        ?array $dateBucket=null,
+        ?array $metrics=null
     ): ?array {
+        if (is_array($metrics) === true && count($metrics) > 1) {
+            return $this->tryNativeMultiMetric(
+                register: $register,
+                schema: $schema,
+                filter: $filter,
+                groupBy: $groupBy,
+                metrics: $metrics
+            );
+        }
+
         $platformName = $this->detectDatabasePlatform();
 
         // Ordered list of categorical group fields (single-field, multi-field
@@ -1444,18 +1655,36 @@ class AggregationRunner
 
         // Validate filter shapes are translatable. Supported:
         // {field: scalar}              → field = ?
+        // {field: [...]}               → implicit `in` (any-of), REQ-AGG-106 / #2027
         // {field: {in: [...]}}         → field IN (?, ?, ?)
         // {field: {notIn: [...]}}      → field NOT IN (?, ?, ?)
         // {field: {gt|gte|lt|lte: x}}  → field > / >= / < / <= ?
         // {field: {ne: x}}             → field <> ?
         // Reject anything else.
         foreach ($filter as $value) {
-            if (is_array($value) === true) {
+            if (is_array($value) === true && array_is_list($value) === false) {
                 foreach (array_keys($value) as $op) {
                     if (in_array((string) $op, ['in', 'notIn', 'gt', 'gte', 'lt', 'lte', 'ne'], true) === false) {
                         return null;
                     }
                 }
+            }
+        }
+
+        // REQ-AGG-106 / #2027: a multi-value (array-type) schema property
+        // can't be correctly filtered with a simple `= ?` / `IN (...)`
+        // predicate — the magic-table column holds the WHOLE JSON array, so
+        // equality/IN would compare serialised array text, not test
+        // membership. Defer to the PHP fallback (which DOES implement
+        // any-overlap via valueMatchesAnyOf()) for genuinely correct
+        // semantics on these fields, rather than emit SQL that looks
+        // plausible but silently mismatches — the same documented-fallback
+        // posture already used for cross-dialect time-bucket gaps.
+        $properties = ($schema->getProperties() ?? []);
+        foreach (array_keys($filter) as $filterField) {
+            $propertyType = ($properties[(string) $filterField]['type'] ?? null);
+            if ($propertyType === 'array') {
+                return null;
             }
         }
 
@@ -1493,6 +1722,27 @@ class AggregationRunner
 
         foreach ($filter as $f => $v) {
             $col = $this->sanitizeColumnName(name: (string) $f);
+
+            // Bare array value — implicit `in` (any-of), REQ-AGG-106 / #2027.
+            // A plain list (non-associative) is distinguished from an
+            // operator map (`{in: [...]}`) by array_is_list(); the operator
+            // map is handled by the loop below.
+            if (is_array($v) === true && array_is_list($v) === true) {
+                if (count($v) === 0) {
+                    // An implicit `in` over an empty list never matches.
+                    $whereParts[] = '1 = 0';
+                    continue;
+                }
+
+                $placeholders = implode(', ', array_fill(0, count($v), '?'));
+                $whereParts[] = $quote.$col.$quote.' IN ('.$placeholders.')';
+                foreach ($v as $item) {
+                    $bindings[] = $this->bindValue(value: $item);
+                }
+
+                continue;
+            }
+
             if (is_array($v) === false) {
                 $whereParts[] = $quote.$col.$quote.' = ?';
                 $bindings[]   = $this->bindValue(value: $v);
@@ -1726,6 +1976,110 @@ class AggregationRunner
             return null;
         }//end try
     }//end tryNativeAggregation()
+
+    /**
+     * Multi-metric native dispatch (REQ-AGG-102).
+     *
+     * Runs the single-metric native path in {@see tryNativeAggregation()}
+     * once per requested `{metric, field}` entry — reusing its dialect
+     * branching and filter translation verbatim, with zero new SQL surface
+     * — and merges the per-metric results into one `values` map (ungrouped)
+     * or one `values` map per group (categorical groupBy). Trades one SQL
+     * round-trip per metric for reusing the already-proven single-metric
+     * query builder; acceptable for ad-hoc dashboard widgets, which are not
+     * a hot loop.
+     *
+     * Any single metric bailing to null (e.g. an ungrouped ask on a
+     * non-Postgres engine) bails the WHOLE multi-metric attempt to the PHP
+     * fallback, so the response is never a partial native/partial-PHP mix.
+     * Not used for the time-bucket (`dateBucket`) path — mutually exclusive
+     * with multi-metric, rejected upstream by AggregationQuery::create().
+     *
+     * @param Register                                          $register Register the schema belongs to.
+     * @param Schema                                            $schema   Schema being aggregated.
+     * @param array<string, mixed>                              $filter   Already placeholder-resolved filter map.
+     * @param array<string, mixed>|null                         $groupBy  Optional group spec (see {@see tryNativeAggregation()}).
+     * @param array<int, array{metric: string, field: ?string}> $metrics  Requested metric entries (>1).
+     *
+     * @return array{values: array<string, int|float|null>}
+     *         |array{groups: array<int, array{key?: mixed, keys?: array<string, mixed>, values: array<string, int|float|null>}>}
+     *         |null
+     *
+     * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
+     */
+    private function tryNativeMultiMetric(
+        Register $register,
+        Schema $schema,
+        array $filter,
+        ?array $groupBy,
+        array $metrics
+    ): ?array {
+        $groupFields = $this->resolveGroupFields(groupBy: $groupBy);
+        $isMulti     = (count($groupFields) > 1);
+
+        $ungroupedValues = [];
+        $orderedKeys     = [];
+        $mergedByKey     = [];
+
+        foreach ($metrics as $entry) {
+            $single = $this->tryNativeAggregation(
+                register: $register,
+                schema: $schema,
+                metric: $entry['metric'],
+                field: $entry['field'],
+                filter: $filter,
+                groupBy: $groupBy,
+                dateBucket: null
+            );
+
+            if ($single === null) {
+                // One metric couldn't run natively — bail the whole
+                // multi-metric attempt so the caller falls through to a
+                // single, consistent PHP-fallback computation.
+                return null;
+            }
+
+            $responseKey = AggregationQuery::metricResponseKey(metric: $entry['metric'], field: $entry['field']);
+
+            if (count($groupFields) === 0) {
+                $ungroupedValues[$responseKey] = ($single['value'] ?? null);
+                continue;
+            }
+
+            foreach (($single['groups'] ?? []) as $group) {
+                $keyData = ($group['key'] ?? null);
+                if ($isMulti === true) {
+                    $keyData = ($group['keys'] ?? []);
+                }
+
+                $tupleKey = (string) json_encode($keyData);
+                if (isset($mergedByKey[$tupleKey]) === false) {
+                    $mergedByKey[$tupleKey] = ['keyData' => $keyData, 'values' => []];
+                    $orderedKeys[]          = $tupleKey;
+                }
+
+                $mergedByKey[$tupleKey]['values'][$responseKey] = ($group['value'] ?? null);
+            }
+        }//end foreach
+
+        if (count($groupFields) === 0) {
+            return ['values' => $ungroupedValues];
+        }
+
+        $groups = [];
+        foreach ($orderedKeys as $tupleKey) {
+            $entry = $mergedByKey[$tupleKey];
+            if ($isMulti === true) {
+                $groups[] = ['keys' => $entry['keyData'], 'values' => $entry['values']];
+                continue;
+            }
+
+            $groups[] = ['key' => $entry['keyData'], 'values' => $entry['values']];
+        }
+
+        return ['groups' => $groups];
+
+    }//end tryNativeMultiMetric()
 
     /**
      * Coerce a Postgres date_trunc bucket label to a stable

--- a/openspec/changes/adhoc-aggregation-suite/tasks.md
+++ b/openspec/changes/adhoc-aggregation-suite/tasks.md
@@ -4,29 +4,40 @@
 
 ## 1. Query engine
 
-- [ ] 1.1 Multi-field groupBy in `AggregationQuery` — composite `GROUP BY`, ordered tuple key, schema-validated field names (REQ-AGG-101)
+- [x] 1.1 Multi-field groupBy in `AggregationQuery` — composite `GROUP BY`, ordered tuple key, schema-validated field names (REQ-AGG-101)
   - Single-field requests keep a scalar `key`; >1 field returns `key` as an ordered object. No raw field interpolated into SQL.
-- [ ] 1.2 Multi-metric columns — `metrics` list → one column per metric, each group row carries `values: {…}`; legacy `metric`/`field` map to a one-element list (REQ-AGG-102)
-- [ ] 1.3 Cross-dialect `bucketExpression(dialect, field, interval)` helper for hour/day/week/month/quarter/year on Postgres/MySQL/MariaDB/SQLite, with a documented PHP fallback (REQ-AGG-104)
-- [ ] 1.4 Cumulative running total on the time-bucket primitive (`cumulative: true`) via SQL window or PHP post-pass — identical output (REQ-AGG-103)
+  - **Already implemented at HEAD** (service layer: `AggregationQuery`/`AggregationRunner`, tests in `AggregationRunnerMultiFieldGroupByTest`). This wave added the missing **controller wiring** — `AggregationController::grouped()` now parses a comma-list / repeated-array `groupBy` param into the multi-field shape (`AggregationControllerValueGroupedTest`).
+- [x] 1.2 Multi-metric columns — `metrics` list → one column per metric, each group row carries `values: {…}`; legacy `metric`/`field` map to a one-element list (REQ-AGG-102)
+  - Implemented: `AggregationQuery::getMetrics()`/`isMultiMetric()`/`metricResponseKey()`, `AggregationRunner::tryNativeMultiMetric()` (merges N single-metric native calls — reuses the proven per-dialect SQL builder rather than a new multi-column SQL statement; documented perf tradeoff), `computeMetrics()`/`computeGrouped($metrics)` for the PHP fallback, controller wiring on `value()`/`grouped()`. NOT wired into `timeseries()` (multi-metric + time-bucket combination is rejected by `AggregationQuery::create()` — deferred, see note on 1.4).
+- [x] 1.3 Cross-dialect `bucketExpression(dialect, field, interval)` helper for hour/day/week/month/quarter/year on Postgres/MySQL/MariaDB/SQLite, with a documented PHP fallback (REQ-AGG-104)
+  - **Already implemented at HEAD** — `AggregationRunner::mysqlBucketExpression()`/`sqliteBucketExpression()`/Postgres `date_trunc` path, MariaDB detected under the `mysql` platform branch, PHP fallback bucketer for unrecognised engines. Fully tested (`AggregationRunnerNativeBucketTest`) and wired end-to-end through `TimeseriesRequestValidator`/`AggregationController::timeseries()`. No code changes needed; regression-verified.
+- [ ] 1.4 **DEFERRED** — Cumulative running total on the time-bucket primitive (`cumulative: true`) via SQL window or PHP post-pass (REQ-AGG-103)
+  - Not implemented this wave. Combining cumulative ordering with the existing time-bucket cache-key/dialect matrix was judged higher-risk than the other five sub-parts to land safely without a live cross-dialect matrix to verify against; scope discipline per the task brief. `AggregationQuery::create()` explicitly rejects `metrics` + `dateBucket` together, so this is also why REQ-AGG-102 doesn't extend to the timeseries endpoint. Left as an open requirement in the spec — follow-up change needed before this can be archived.
 
 ## 2. Controller + cache
 
-- [ ] 2.1 Wire the new params through `AggregationController::grouped`/`timeseries`; validate metric fields; preserve legacy response shapes (REQ-AGG-101, REQ-AGG-102, REQ-AGG-103)
-- [ ] 2.2 Cache timeseries results in `AggregationCache` keyed on register+schema+query-hash; set `X-OR-Cache: hit|miss` on `timeseries()`; invalidate on object write (REQ-AGG-105)
+- [x] 2.1 Wire the new params through `AggregationController::grouped`/`timeseries`; validate metric fields; preserve legacy response shapes (REQ-AGG-101, REQ-AGG-102, REQ-AGG-103 partial)
+  - `grouped()`: multi-field `groupBy` + `metrics` list wired, single-field/single-metric shape byte-identical (regression-pinned). `value()`: `metrics` list wired. `timeseries()`: unchanged param surface (REQ-AGG-103 deferred, see 1.4). Field validation is via the existing `sanitizeColumnName()` no-raw-interpolation guard (same level the pre-existing single-metric/single-field path already used) rather than a new schema property allow-list, to avoid a behaviour change on the legacy path.
+- [x] 2.2 Cache timeseries results in `AggregationCache` keyed on register+schema+query-hash; set `X-OR-Cache: hit|miss` on `timeseries()`; invalidate on object write (REQ-AGG-105)
+  - **Cache engine already implemented at HEAD** — `AggregationRunner::runAdhoc()` already read-through caches every ad-hoc query (`value`/`grouped`/`timeseries`) via `AggregationCache::getAdhoc()`/`setAdhoc()`, invalidated on object write by the existing `AggregationCacheInvalidationListener`. This wave added the missing **response header** — `value()`, `grouped()`, and `timeseries()` now all surface `X-OR-Cache: hit|miss` (previously only the named-annotation `aggregate()` endpoint did).
 
 ## 3. Bug #2027 — multi-value filter
 
-- [ ] 3.1 In the value-path filter translation, treat a bare array as implicit `in` (any-of) and generate `IN (…)` for the `in` operator (incl. JSON-array any-overlap for multi-value properties) (REQ-AGG-106)
+- [x] 3.1 In the value-path filter translation, treat a bare array as implicit `in` (any-of) and generate `IN (…)` for the `in` operator (incl. JSON-array any-overlap for multi-value properties) (REQ-AGG-106)
+  - Implemented on both paths: native SQL (`tryNativeAggregation()` — bare list → `IN (...)`; a filter on an array-typed schema property now defers to the PHP fallback instead of emitting a silently-wrong equality/IN predicate) and PHP fallback (`applyFilter()`/`checkOp()`/new `valueMatchesAnyOf()` — any-of + any-overlap semantics for both scalar and multi-value row values).
 
 ## 4. Verification
 
-- [ ] 4.1 Unit tests per primitive + cross-dialect time-bucket boundary matrix (Postgres/MySQL/SQLite) + cumulative parity (SQL vs PHP) (REQ-AGG-103, REQ-AGG-104)
-  - Run in the `nextcloud:34` container: `docker run --rm -v $PWD:/app -w /app <nc-image> php vendor/bin/phpunit`.
-- [ ] 4.2 Regression test pinning the byte-shape of single-field/single-metric responses; #2027 test proving a multi-value filter AND an `in` operator both count correctly (REQ-AGG-101, REQ-AGG-106)
+- [x] 4.1 Unit tests per primitive + cross-dialect time-bucket boundary matrix (Postgres/MySQL/SQLite) + cumulative parity (SQL vs PHP) (REQ-AGG-103, REQ-AGG-104)
+  - Cross-dialect time-bucket matrix: already covered by the pre-existing `AggregationRunnerNativeBucketTest` (unaffected by this wave, re-verified green). Cumulative parity: **not applicable** — 1.4 deferred, no cumulative code shipped.
+  - Ran in the `nextcloud:34.0.0-apache` container: `docker run --rm -v <worktree>:/app -w /app nextcloud:34.0.0-apache php vendor/bin/phpunit`.
+- [x] 4.2 Regression test pinning the byte-shape of single-field/single-metric responses; #2027 test proving a multi-value filter AND an `in` operator both count correctly (REQ-AGG-101, REQ-AGG-106)
+  - `AggregationRunnerMultiValueFilterTest::testUngroupedSingleMetricResponseShapeIsByteIdentical` / `testGroupedSingleFieldSingleMetricResponseShapeIsByteIdentical` pin the exact key set; the same file's bare-array/`in`/multi-value-overlap tests prove #2027 on both the native and PHP-fallback paths.
 
 Acceptance criteria:
-- One request can group by multiple fields and return multiple metrics per group.
-- Time-bucket aggregation runs natively (or via documented fallback) on all four dialects with matching boundaries; cumulative totals are correct.
-- Timeseries responses are cached with correct hit/miss reporting.
-- Multi-value filters and the `in` operator count correctly; existing single-metric widgets are unchanged.
+- One request can group by multiple fields and return multiple metrics per group. ✅ (REQ-AGG-101, REQ-AGG-102)
+- Time-bucket aggregation runs natively (or via documented fallback) on all four dialects with matching boundaries. ✅ (REQ-AGG-104, already at HEAD) — cumulative totals: ❌ **deferred** (REQ-AGG-103).
+- Timeseries responses are cached with correct hit/miss reporting. ✅ (REQ-AGG-105 — cache engine already at HEAD, header now wired end-to-end.)
+- Multi-value filters and the `in` operator count correctly; existing single-metric widgets are unchanged. ✅ (REQ-AGG-106, regression-pinned.)
+
+**Status: 5 of 6 requirements shipped this wave (REQ-AGG-101, 102, 104, 105, 106). REQ-AGG-103 (cumulative time-bucket) is deferred — do not archive this change until a follow-up lands it.**

--- a/tests/Unit/Controller/AggregationControllerValueGroupedTest.php
+++ b/tests/Unit/Controller/AggregationControllerValueGroupedTest.php
@@ -1,0 +1,292 @@
+<?php
+
+/**
+ * Unit tests for `AggregationController::value()` / `grouped()` — the
+ * `X-OR-Cache` header (REQ-AGG-105), the multi-field `groupBy` wiring
+ * (REQ-AGG-101), and the `metrics` multi-metric list wiring (REQ-AGG-102).
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use OCA\OpenRegister\Controller\AggregationController;
+use OCA\OpenRegister\Service\Aggregation\AggregationQuery;
+use OCA\OpenRegister\Service\Aggregation\AggregationRunner;
+use OCA\OpenRegister\Service\Aggregation\TimeseriesRequestValidator;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \OCA\OpenRegister\Controller\AggregationController
+ */
+class AggregationControllerValueGroupedTest extends TestCase
+{
+
+    private AggregationRunner&MockObject $runner;
+
+    private IRequest&MockObject $request;
+
+    private TimeseriesRequestValidator&MockObject $validator;
+
+    protected function setUp(): void
+    {
+        $this->request   = $this->createMock(IRequest::class);
+        $this->runner    = $this->createMock(AggregationRunner::class);
+        $this->validator = $this->createMock(TimeseriesRequestValidator::class);
+
+    }//end setUp()
+
+    /**
+     * Build the controller with the current request/runner/validator mocks.
+     *
+     * @return AggregationController
+     */
+    private function makeController(): AggregationController
+    {
+        return new AggregationController(
+            'openregister',
+            $this->request,
+            $this->runner,
+            $this->validator
+        );
+
+    }//end makeController()
+
+    /**
+     * Stub `IRequest::getParam()` from a map of `name => value`. Params not
+     * present in the map fall through to the caller-supplied default.
+     *
+     * @param array<string, mixed> $params
+     *
+     * @return void
+     */
+    private function stubParams(array $params): void
+    {
+        $this->request->method('getParam')->willReturnCallback(
+            static function (string $name, $default=null) use ($params) {
+                return array_key_exists($name, $params) ? $params[$name] : $default;
+            }
+        );
+
+    }//end stubParams()
+
+    // -----------------------------------------------------------------------
+    // X-OR-Cache header (REQ-AGG-105).
+    // -----------------------------------------------------------------------
+
+    public function testValueSurfacesCacheMissHeader(): void
+    {
+        $this->stubParams(['metric' => 'count']);
+        $this->runner->method('runAdhocByRef')->willReturn(['value' => 5, 'backend' => 'postgres', 'cached' => false]);
+
+        $response = $this->makeController()->value('reg', 'sch');
+
+        $this->assertSame('miss', $response->getHeaders()['X-OR-Cache'] ?? null);
+
+    }//end testValueSurfacesCacheMissHeader()
+
+    public function testValueSurfacesCacheHitHeader(): void
+    {
+        $this->stubParams(['metric' => 'count']);
+        $this->runner->method('runAdhocByRef')->willReturn(['value' => 5, 'backend' => 'postgres', 'cached' => true]);
+
+        $response = $this->makeController()->value('reg', 'sch');
+
+        $this->assertSame('hit', $response->getHeaders()['X-OR-Cache'] ?? null);
+
+    }//end testValueSurfacesCacheHitHeader()
+
+    public function testGroupedSurfacesCacheHeader(): void
+    {
+        $this->stubParams(['metric' => 'count', 'groupBy' => 'status']);
+        $this->runner->method('runAdhocByRef')->willReturn(['groups' => [], 'backend' => 'postgres', 'cached' => true]);
+
+        $response = $this->makeController()->grouped('reg', 'sch');
+
+        $this->assertSame('hit', $response->getHeaders()['X-OR-Cache'] ?? null);
+
+    }//end testGroupedSurfacesCacheHeader()
+
+    public function testTimeseriesSurfacesCacheHeader(): void
+    {
+        $schema = $this->createMock(\OCA\OpenRegister\Db\Schema::class);
+        $query  = AggregationQuery::create(metric: 'count', groupBy: ['field' => 'status']);
+        $this->runner->method('findSchema')->willReturn($schema);
+        $this->validator->method('validate')->willReturn($query);
+        $this->runner->method('runAdhocByRef')->willReturn(['groups' => [], 'backend' => 'postgres', 'cached' => true]);
+
+        $response = $this->makeController()->timeseries('reg', 'sch');
+
+        $this->assertSame('hit', $response->getHeaders()['X-OR-Cache'] ?? null);
+
+    }//end testTimeseriesSurfacesCacheHeader()
+
+    // -----------------------------------------------------------------------
+    // Multi-field groupBy wiring (REQ-AGG-101).
+    // -----------------------------------------------------------------------
+
+    public function testGroupedSingleFieldBuildsLegacyFieldShape(): void
+    {
+        $this->stubParams(['metric' => 'count', 'groupBy' => 'status']);
+
+        $captured = null;
+        $this->runner->method('runAdhocByRef')->willReturnCallback(
+            function ($reg, $sch, AggregationQuery $query) use (&$captured) {
+                $captured = $query;
+                return ['groups' => [], 'backend' => 'postgres', 'cached' => false];
+            }
+        );
+
+        $this->makeController()->grouped('reg', 'sch');
+
+        $this->assertSame(['field' => 'status'], $captured->groupBy, 'a single groupBy field MUST keep the legacy {field: ...} shape');
+
+    }//end testGroupedSingleFieldBuildsLegacyFieldShape()
+
+    public function testGroupedCommaListBuildsMultiFieldShape(): void
+    {
+        $this->stubParams(['metric' => 'count', 'groupBy' => 'status,type']);
+
+        $captured = null;
+        $this->runner->method('runAdhocByRef')->willReturnCallback(
+            function ($reg, $sch, AggregationQuery $query) use (&$captured) {
+                $captured = $query;
+                return ['groups' => [], 'backend' => 'postgres', 'cached' => false];
+            }
+        );
+
+        $this->makeController()->grouped('reg', 'sch');
+
+        $this->assertSame(['fields' => ['status', 'type']], $captured->groupBy);
+        $this->assertTrue($captured->isMultiFieldGroupBy());
+
+    }//end testGroupedCommaListBuildsMultiFieldShape()
+
+    public function testGroupedRepeatedArrayParamBuildsMultiFieldShape(): void
+    {
+        $this->stubParams(['metric' => 'count', 'groupBy' => ['status', 'type']]);
+
+        $captured = null;
+        $this->runner->method('runAdhocByRef')->willReturnCallback(
+            function ($reg, $sch, AggregationQuery $query) use (&$captured) {
+                $captured = $query;
+                return ['groups' => [], 'backend' => 'postgres', 'cached' => false];
+            }
+        );
+
+        $this->makeController()->grouped('reg', 'sch');
+
+        $this->assertSame(['status', 'type'], $captured->getGroupByFields());
+
+    }//end testGroupedRepeatedArrayParamBuildsMultiFieldShape()
+
+    public function testGroupedMissingGroupByReturns400(): void
+    {
+        $this->stubParams(['metric' => 'count', 'groupBy' => '']);
+        $this->runner->expects($this->never())->method('runAdhocByRef');
+
+        $response = $this->makeController()->grouped('reg', 'sch');
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+
+    }//end testGroupedMissingGroupByReturns400()
+
+    // -----------------------------------------------------------------------
+    // Multi-metric `metrics` list wiring (REQ-AGG-102).
+    // -----------------------------------------------------------------------
+
+    public function testValueParsesMetricsListIntoQuery(): void
+    {
+        $this->stubParams(
+            [
+                'metric'  => 'count',
+                'metrics' => [
+                    ['metric' => 'count'],
+                    ['metric' => 'sum', 'field' => 'price'],
+                ],
+            ]
+        );
+
+        $captured = null;
+        $this->runner->method('runAdhocByRef')->willReturnCallback(
+            function ($reg, $sch, AggregationQuery $query) use (&$captured) {
+                $captured = $query;
+                return ['values' => ['count' => 1, 'sum_price' => 2.0], 'backend' => 'postgres', 'cached' => false];
+            }
+        );
+
+        $response = $this->makeController()->value('reg', 'sch');
+
+        $this->assertTrue($captured->isMultiMetric());
+        $this->assertSame(
+            [
+                ['metric' => 'count', 'field' => null],
+                ['metric' => 'sum', 'field' => 'price'],
+            ],
+            $captured->getMetrics()
+        );
+        $this->assertSame(['count' => 1, 'sum_price' => 2.0], $response->getData()['values']);
+
+    }//end testValueParsesMetricsListIntoQuery()
+
+    public function testValueWithoutMetricsParamStaysLegacySingleMetric(): void
+    {
+        $this->stubParams(['metric' => 'sum', 'field' => 'price']);
+
+        $captured = null;
+        $this->runner->method('runAdhocByRef')->willReturnCallback(
+            function ($reg, $sch, AggregationQuery $query) use (&$captured) {
+                $captured = $query;
+                return ['value' => 42, 'backend' => 'postgres', 'cached' => false];
+            }
+        );
+
+        $this->makeController()->value('reg', 'sch');
+
+        $this->assertFalse($captured->isMultiMetric());
+        $this->assertSame('sum', $captured->metric);
+        $this->assertSame('price', $captured->field);
+
+    }//end testValueWithoutMetricsParamStaysLegacySingleMetric()
+
+    public function testGroupedParsesMetricsListIntoQuery(): void
+    {
+        $this->stubParams(
+            [
+                'metric'  => 'count',
+                'groupBy' => 'status',
+                'metrics' => [
+                    ['metric' => 'count'],
+                    ['metric' => 'avg', 'field' => 'amount'],
+                ],
+            ]
+        );
+
+        $captured = null;
+        $this->runner->method('runAdhocByRef')->willReturnCallback(
+            function ($reg, $sch, AggregationQuery $query) use (&$captured) {
+                $captured = $query;
+                return ['groups' => [], 'backend' => 'postgres', 'cached' => false];
+            }
+        );
+
+        $this->makeController()->grouped('reg', 'sch');
+
+        $this->assertTrue($captured->isMultiMetric());
+
+    }//end testGroupedParsesMetricsListIntoQuery()
+}//end class

--- a/tests/Unit/Service/Aggregation/AggregationQueryTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationQueryTest.php
@@ -297,4 +297,133 @@ class AggregationQueryTest extends TestCase
     }//end testToArrayReturnsNullForMissingOptionalFields()
 
 
+    // -----------------------------------------------------------------------
+    // Multi-metric (REQ-AGG-102).
+    // -----------------------------------------------------------------------
+
+
+    public function testLegacySingleMetricIsNotMultiMetric(): void
+    {
+        $q = AggregationQuery::create(metric: 'count');
+        $this->assertFalse($q->isMultiMetric());
+        $this->assertSame([['metric' => 'count', 'field' => null]], $q->getMetrics());
+
+    }//end testLegacySingleMetricIsNotMultiMetric()
+
+
+    public function testExplicitMetricsListIsMultiMetric(): void
+    {
+        $q = AggregationQuery::create(
+            metric: 'count',
+            metrics: [
+                ['metric' => 'count'],
+                ['metric' => 'sum', 'field' => 'price'],
+            ]
+        );
+        $this->assertTrue($q->isMultiMetric());
+        $this->assertSame(
+            [
+                ['metric' => 'count', 'field' => null],
+                ['metric' => 'sum', 'field' => 'price'],
+            ],
+            $q->getMetrics()
+        );
+
+    }//end testExplicitMetricsListIsMultiMetric()
+
+
+    public function testSingleElementMetricsListIsNotMultiMetric(): void
+    {
+        $q = AggregationQuery::create(
+            metric: 'count',
+            metrics: [['metric' => 'count']]
+        );
+        $this->assertFalse($q->isMultiMetric());
+
+    }//end testSingleElementMetricsListIsNotMultiMetric()
+
+
+    public function testMetricsListRejectsEmptyList(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('metrics list, when supplied, MUST NOT be empty');
+        AggregationQuery::create(metric: 'count', metrics: []);
+
+    }//end testMetricsListRejectsEmptyList()
+
+
+    public function testMetricsListRejectsInvalidMetric(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid metric "median"');
+        AggregationQuery::create(
+            metric: 'count',
+            metrics: [['metric' => 'median']]
+        );
+
+    }//end testMetricsListRejectsInvalidMetric()
+
+
+    public function testMetricsListEntryRequiresFieldForNonCount(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('metrics entry "sum" MUST specify a field');
+        AggregationQuery::create(
+            metric: 'count',
+            metrics: [['metric' => 'sum']]
+        );
+
+    }//end testMetricsListEntryRequiresFieldForNonCount()
+
+
+    public function testMetricsListRejectsCombinationWithDateBucket(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('MUST NOT be combined with dateBucket');
+        AggregationQuery::create(
+            metric: 'count',
+            metrics: [['metric' => 'count'], ['metric' => 'sum', 'field' => 'price']],
+            dateBucket: [
+                'field' => 'created',
+                'start' => '2026-01-01T00:00:00Z',
+                'end'   => '2026-02-01T00:00:00Z',
+                'gap'   => 'day',
+            ]
+        );
+
+    }//end testMetricsListRejectsCombinationWithDateBucket()
+
+
+    public function testMetricResponseKeyIsCountForCount(): void
+    {
+        $this->assertSame('count', AggregationQuery::metricResponseKey(metric: 'count', field: null));
+
+    }//end testMetricResponseKeyIsCountForCount()
+
+
+    public function testMetricResponseKeyIsMetricUnderscoreFieldForValueMetrics(): void
+    {
+        $this->assertSame('sum_price', AggregationQuery::metricResponseKey(metric: 'sum', field: 'price'));
+        $this->assertSame('avg_amount', AggregationQuery::metricResponseKey(metric: 'avg', field: 'amount'));
+
+    }//end testMetricResponseKeyIsMetricUnderscoreFieldForValueMetrics()
+
+
+    public function testToArrayIncludesMetricsList(): void
+    {
+        $withMetrics = AggregationQuery::create(
+            metric: 'count',
+            metrics: [['metric' => 'count'], ['metric' => 'sum', 'field' => 'price']]
+        );
+        $withoutMetrics = AggregationQuery::create(metric: 'count');
+
+        $this->assertSame(
+            [['metric' => 'count'], ['metric' => 'sum', 'field' => 'price']],
+            $withMetrics->toArray()['metrics']
+        );
+        $this->assertNull($withoutMetrics->toArray()['metrics']);
+
+    }//end testToArrayIncludesMetricsList()
+
+
 }//end class

--- a/tests/Unit/Service/Aggregation/AggregationRunnerMultiMetricTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerMultiMetricTest.php
@@ -1,0 +1,375 @@
+<?php
+
+/**
+ * Unit tests for multi-metric aggregation requests (REQ-AGG-102).
+ *
+ * A `metrics` list (`[{metric}, {metric, field}, ...]`) computes every
+ * requested metric in one call; each result carries a `values` map keyed
+ * by {@see AggregationQuery::metricResponseKey()} (`count`, `sum_price`, …)
+ * instead of a single scalar `value`. Covers: ungrouped, single-field
+ * grouped, multi-field grouped, the PHP-fallback path, and the "any single
+ * metric bails natively → the whole multi-metric attempt falls through to
+ * PHP" contract documented on `AggregationRunner::tryNativeMultiMetric()`.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Aggregation
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Aggregation;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Aggregation\AggregationCache;
+use OCA\OpenRegister\Service\Aggregation\AggregationQuery;
+use OCA\OpenRegister\Service\Aggregation\AggregationRunner;
+use OCA\OpenRegister\Service\LanguageService;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCA\OpenRegister\Service\Object\TranslationHandler;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCA\OpenRegister\Service\Search\PlaceholderResolver;
+use OCP\DB\IPreparedStatement;
+use OCP\DB\IResult;
+use OCP\IDBConnection;
+use OCP\IUserSession;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Aggregation\AggregationRunner
+ * @covers \OCA\OpenRegister\Service\Aggregation\AggregationQuery
+ */
+class AggregationRunnerMultiMetricTest extends TestCase
+{
+
+    /**
+     * Five rows across two statuses; `amount` drives the sum/avg/min/max
+     * metrics. open: [10, 20] (sum=30, avg=15); in-progress: [30]; total
+     * sum = 30 + 20 + ... — see per-test comments for the exact arithmetic.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function dataset(): array
+    {
+        return [
+            ['status' => 'open',        'amount' => 10],
+            ['status' => 'open',        'amount' => 20],
+            ['status' => 'in-progress', 'amount' => 5],
+        ];
+    }
+
+    // -----------------------------------------------------------------------
+    // Native path (SQLite, grouped — the ungrouped scalar native path is
+    // Postgres-only; grouped runs natively on SQLite, see AggregationRunner's
+    // tryNativeAggregation() docblock).
+    // -----------------------------------------------------------------------
+
+    public function testNativeGroupedMultiMetricCarriesValuesMap(): void
+    {
+        $runner = $this->makeNativeRunner();
+
+        $result = $runner->runAdhoc(
+            register: $this->makeRegister(),
+            schema: $this->makeSchema(),
+            query: AggregationQuery::create(
+                metric: 'count',
+                groupBy: ['field' => 'status'],
+                metrics: [
+                    ['metric' => 'count'],
+                    ['metric' => 'sum', 'field' => 'amount'],
+                ]
+            )
+        );
+
+        $this->assertSame('sqlite', $result['backend']);
+        $folded = [];
+        foreach ($result['groups'] as $group) {
+            $this->assertArrayHasKey('key', $group);
+            $this->assertArrayHasKey('values', $group);
+            $this->assertArrayNotHasKey('value', $group, 'multi-metric groups MUST carry `values`, not `value`');
+            // SQLite's native SUM() returns an int for whole-number columns
+            // (unlike Postgres's ::numeric cast, which always yields a
+            // float) — cast for a type-agnostic comparison, same convention
+            // AggregationRunnerMultiFieldGroupByTest::foldMulti() uses.
+            $folded[(string) $group['key']] = [
+                'count'      => $group['values']['count'],
+                'sum_amount' => (float) $group['values']['sum_amount'],
+            ];
+        }
+
+        $this->assertSame(['count' => 2, 'sum_amount' => 30.0], $folded['open']);
+        $this->assertSame(['count' => 1, 'sum_amount' => 5.0], $folded['in-progress']);
+
+    }//end testNativeGroupedMultiMetricCarriesValuesMap()
+
+    public function testNativeUngroupedMultiMetricBailsToPhpFallback(): void
+    {
+        // Ungrouped scalar native path is Postgres-only; on SQLite the
+        // FIRST per-metric native call already returns null, so the whole
+        // multi-metric attempt bails to bucketInPhp() rather than mixing
+        // native+PHP results.
+        $runner = $this->makeNativeRunner();
+
+        $result = $runner->runAdhoc(
+            register: $this->makeRegister(),
+            schema: $this->makeSchema(),
+            query: AggregationQuery::create(
+                metric: 'count',
+                metrics: [
+                    ['metric' => 'count'],
+                    ['metric' => 'sum', 'field' => 'amount'],
+                ]
+            )
+        );
+
+        $this->assertSame('php-fallback', $result['backend']);
+        $this->assertSame(['count' => 3, 'sum_amount' => 35.0], $result['values']);
+        $this->assertArrayNotHasKey('value', $result);
+
+    }//end testNativeUngroupedMultiMetricBailsToPhpFallback()
+
+    // -----------------------------------------------------------------------
+    // PHP-fallback path (forced via an unrecognised platform).
+    // -----------------------------------------------------------------------
+
+    public function testPhpFallbackUngroupedMultiMetric(): void
+    {
+        $runner = $this->makePhpFallbackRunner();
+
+        $result = $runner->runAdhoc(
+            register: $this->makeRegister(),
+            schema: $this->makeSchema(),
+            query: AggregationQuery::create(
+                metric: 'count',
+                metrics: [
+                    ['metric' => 'count'],
+                    ['metric' => 'sum', 'field' => 'amount'],
+                    ['metric' => 'avg', 'field' => 'amount'],
+                ]
+            )
+        );
+
+        $this->assertSame('php-fallback', $result['backend']);
+        $this->assertSame(3, $result['values']['count']);
+        $this->assertSame(35.0, $result['values']['sum_amount']);
+        $this->assertEqualsWithDelta(35.0 / 3.0, $result['values']['avg_amount'], 0.0001);
+
+    }//end testPhpFallbackUngroupedMultiMetric()
+
+    public function testPhpFallbackGroupedMultiMetric(): void
+    {
+        $runner = $this->makePhpFallbackRunner();
+
+        $result = $runner->runAdhoc(
+            register: $this->makeRegister(),
+            schema: $this->makeSchema(),
+            query: AggregationQuery::create(
+                metric: 'count',
+                groupBy: ['field' => 'status'],
+                metrics: [
+                    ['metric' => 'count'],
+                    ['metric' => 'sum', 'field' => 'amount'],
+                ]
+            )
+        );
+
+        $folded = [];
+        foreach ($result['groups'] as $group) {
+            $folded[(string) $group['key']] = $group['values'];
+        }
+
+        $this->assertSame(['count' => 2, 'sum_amount' => 30.0], $folded['open']);
+        $this->assertSame(['count' => 1, 'sum_amount' => 5.0], $folded['in-progress']);
+
+    }//end testPhpFallbackGroupedMultiMetric()
+
+    // -----------------------------------------------------------------------
+    // Legacy single-metric requests are unaffected (regression).
+    // -----------------------------------------------------------------------
+
+    public function testLegacySingleMetricRequestStillReturnsScalarValue(): void
+    {
+        $runner = $this->makePhpFallbackRunner();
+
+        $result = $runner->runAdhoc(
+            register: $this->makeRegister(),
+            schema: $this->makeSchema(),
+            query: AggregationQuery::create(metric: 'count')
+        );
+
+        $this->assertSame(3, $result['value']);
+        $this->assertArrayNotHasKey('values', $result);
+
+    }//end testLegacySingleMetricRequestStillReturnsScalarValue()
+
+    public function testOneElementMetricsListBehavesLikeLegacySingleMetric(): void
+    {
+        $runner = $this->makePhpFallbackRunner();
+
+        $result = $runner->runAdhoc(
+            register: $this->makeRegister(),
+            schema: $this->makeSchema(),
+            query: AggregationQuery::create(
+                metric: 'count',
+                metrics: [['metric' => 'count']]
+            )
+        );
+
+        $this->assertSame(3, $result['value']);
+        $this->assertArrayNotHasKey('values', $result);
+
+    }//end testOneElementMetricsListBehavesLikeLegacySingleMetric()
+
+    // -----------------------------------------------------------------------
+    // Helpers.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Runner whose IDBConnection executes real SQL against an in-memory
+     * SQLite database seeded with {@see dataset()}.
+     *
+     * @return AggregationRunner
+     */
+    private function makeNativeRunner(): AggregationRunner
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE "oc_register_1_schema_x" ("_deleted" TEXT, "_organisation" TEXT, "status" TEXT, "amount" INTEGER)');
+        $insert = $pdo->prepare('INSERT INTO "oc_register_1_schema_x" ("_deleted", "_organisation", "status", "amount") VALUES (NULL, ?, ?, ?)');
+        foreach ($this->dataset() as $row) {
+            $insert->execute(['__no_active_org__', $row['status'], $row['amount']]);
+        }
+
+        $db = $this->createMock(IDBConnection::class);
+        $db->method('getDatabasePlatform')->willReturn($this->createMock(SqlitePlatform::class));
+        $db->method('prepare')->willReturnCallback(
+            function (string $sql) use ($pdo): IPreparedStatement {
+                $pdoStmt = $pdo->prepare($sql);
+                $stmt    = $this->createMock(IPreparedStatement::class);
+                $stmt->method('execute')->willReturnCallback(
+                    function ($bindings=[]) use ($pdoStmt): IResult {
+                        $pdoStmt->execute(($bindings ?? []));
+                        return $this->createMock(IResult::class);
+                    }
+                );
+                $stmt->method('fetch')->willReturnCallback(static fn() => $pdoStmt->fetch(PDO::FETCH_ASSOC));
+                return $stmt;
+            }
+        );
+
+        $magicMapper = $this->createMock(MagicMapper::class);
+        $magicMapper->method('getTableNameForRegisterSchema')->willReturn('register_1_schema_x');
+
+        $entities = [];
+        foreach ($this->dataset() as $row) {
+            $entity = $this->createMock(ObjectEntity::class);
+            $entity->method('getObject')->willReturn($row);
+            $entities[] = $entity;
+        }
+
+        $magicMapper->method('findAllInRegisterSchemaTable')->willReturn($entities);
+
+        return $this->makeRunner(db: $db, magicMapper: $magicMapper);
+
+    }//end makeNativeRunner()
+
+    /**
+     * Runner whose platform is unrecognised (forcing the PHP fallback).
+     *
+     * @return AggregationRunner
+     */
+    private function makePhpFallbackRunner(): AggregationRunner
+    {
+        $db = $this->createMock(IDBConnection::class);
+        $db->method('getDatabasePlatform')->willReturn($this->createMock(AbstractPlatform::class));
+
+        $entities = [];
+        foreach ($this->dataset() as $row) {
+            $entity = $this->createMock(ObjectEntity::class);
+            $entity->method('getObject')->willReturn($row);
+            $entities[] = $entity;
+        }
+
+        $magicMapper = $this->createMock(MagicMapper::class);
+        $magicMapper->method('findAllInRegisterSchemaTable')->willReturn($entities);
+        $magicMapper->method('getTableNameForRegisterSchema')->willReturn('register_1_schema_x');
+
+        return $this->makeRunner(db: $db, magicMapper: $magicMapper);
+
+    }//end makePhpFallbackRunner()
+
+    private function makeRunner(IDBConnection $db, MagicMapper $magicMapper): AggregationRunner
+    {
+        $userSession = $this->createMock(IUserSession::class);
+        $userSession->method('getUser')->willReturn(null);
+
+        $organisationService = $this->createMock(OrganisationService::class);
+        $organisationService->method('getActiveOrganisation')->willReturn(null);
+
+        $permissionHandler = $this->createMock(PermissionHandler::class);
+        $permissionHandler->method('hasPermission')->willReturn(true);
+
+        $cache = $this->createMock(AggregationCache::class);
+        $cache->method('getAdhoc')->willReturn(null);
+
+        $translationHandler = $this->createMock(TranslationHandler::class);
+        $translationHandler->method('getTranslatableProperties')->willReturn([]);
+
+        $languageService = $this->createMock(LanguageService::class);
+        $languageService->method('shouldReturnAllTranslations')->willReturn(false);
+
+        return new AggregationRunner(
+            magicMapper: $magicMapper,
+            registerMapper: $this->createMock(RegisterMapper::class),
+            schemaMapper: $this->createMock(SchemaMapper::class),
+            placeholders: new PlaceholderResolver($userSession),
+            db: $db,
+            cache: $cache,
+            permissionHandler: $permissionHandler,
+            userSession: $userSession,
+            organisationService: $organisationService,
+            translationHandler: $translationHandler,
+            languageService: $languageService,
+        );
+
+    }//end makeRunner()
+
+    private function makeRegister(): Register
+    {
+        $register = new Register();
+        $register->setSlug('bookkeeping');
+        $register->setSchemas([1]);
+        return $register;
+
+    }//end makeRegister()
+
+    private function makeSchema(): Schema
+    {
+        $schema = new Schema();
+        $schema->setSlug('items');
+        $schema->setId(1);
+        $schema->setProperties(
+            [
+                'status' => ['type' => 'string'],
+                'amount' => ['type' => 'number'],
+            ]
+        );
+        return $schema;
+
+    }//end makeSchema()
+}//end class

--- a/tests/Unit/Service/Aggregation/AggregationRunnerMultiValueFilterTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerMultiValueFilterTest.php
@@ -1,0 +1,594 @@
+<?php
+
+/**
+ * Unit tests for the multi-value / `in`-operator filter fix on the
+ * value/grouped path (REQ-AGG-106, bug #2027).
+ *
+ * Before this fix:
+ *  - a bare array filter value (`{tags: ['a', 'b']}`, no `in` wrapper) was
+ *    NOT translated to an `IN (...)` predicate. On the native-SQL path its
+ *    numeric array keys (`0`, `1`, …) failed the operator allow-list and
+ *    bailed the WHOLE query to the PHP fallback; the PHP fallback then
+ *    iterated those same numeric keys through `checkOp()`, where they
+ *    matched no known operator and fell to `default => true`, so the
+ *    clause silently matched EVERY row instead of any-of the list;
+ *  - a multi-value (array-typed) schema property compared via plain
+ *    equality or `IN (...)` never matched, because the stored column value
+ *    is the WHOLE JSON array, not its members.
+ *
+ * This suite proves: (1) the native path now emits a genuine `IN (...)`
+ * for a bare array filter and counts correctly; (2) the PHP fallback path
+ * gives the identical any-of count (previously it silently counted
+ * everything); (3) the wrapped `in` operator continues to count correctly
+ * (regression); (4) a multi-value (JSON-array) property correctly overlap-
+ * matches a scalar or list filter via the PHP fallback, which the native
+ * path now deliberately defers to instead of emitting a wrong-but-
+ * plausible equality/IN predicate.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Aggregation
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/changes/adhoc-aggregation-suite/specs/aggregation-api/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Aggregation;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Aggregation\AggregationCache;
+use OCA\OpenRegister\Service\Aggregation\AggregationQuery;
+use OCA\OpenRegister\Service\Aggregation\AggregationRunner;
+use OCA\OpenRegister\Service\LanguageService;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCA\OpenRegister\Service\Object\TranslationHandler;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCA\OpenRegister\Service\Search\PlaceholderResolver;
+use OCP\DB\IPreparedStatement;
+use OCP\DB\IResult;
+use OCP\IDBConnection;
+use OCP\IUserSession;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Aggregation\AggregationRunner
+ */
+class AggregationRunnerMultiValueFilterTest extends TestCase
+{
+
+    /**
+     * Five rows: 2 open, 1 in-progress, 2 closed. Used for the plain
+     * scalar-property bare-array / `in` scenarios.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function statusDataset(): array
+    {
+        return [
+            ['status' => 'open',        'region' => 'nl', 'amount' => 10],
+            ['status' => 'open',        'region' => 'nl', 'amount' => 20],
+            ['status' => 'in-progress', 'region' => 'nl', 'amount' => 30],
+            ['status' => 'closed',      'region' => 'be', 'amount' => 40],
+            ['status' => 'closed',      'region' => 'be', 'amount' => 50],
+        ];
+    }
+
+    /**
+     * Four rows whose `tags` property is a multi-value JSON array. Row 4
+     * (`['x']`) is excluded by every scenario in this suite, proving the
+     * overlap test is genuinely selective, not an always-true no-op.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function tagsDataset(): array
+    {
+        return [
+            ['id' => 1, 'tags' => ['a', 'b']],
+            ['id' => 2, 'tags' => ['b', 'c']],
+            ['id' => 3, 'tags' => ['a']],
+            ['id' => 4, 'tags' => ['x']],
+        ];
+    }
+
+    // -----------------------------------------------------------------------
+    // Native-SQL path: bare array => implicit `in`.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Note: the runner's ungrouped scalar native path is Postgres-only (see
+     * `tryNativeAggregation()`'s "the ungrouped scalar path is Postgres-only"
+     * docblock) — MySQL/SQLite run the categorical-groupBy and time-bucket
+     * paths natively. These native-SQL tests therefore add a `groupBy` so
+     * the fix is proven against REAL SQLite execution end-to-end (SQL text
+     * AND resulting count), the same pattern `AggregationRunnerMultiFieldGroupByTest`
+     * already established. The `region` field isolates the group so a
+     * correct any-of filter surfaces as `nl => 3` with `be` absent entirely
+     * (its rows are filtered out before GROUP BY, not miscounted).
+     */
+    public function testNativeBareArrayFilterEmitsInPredicateAndCountsAnyOf(): void
+    {
+        $runner = $this->makeNativeRunner(dataset: $this->statusDataset(), capturedSql: $captured);
+
+        $result = $runner->runAdhoc(
+            register: $this->makeRegister(),
+            schema: $this->makeStatusSchema(),
+            query: AggregationQuery::create(
+                metric: 'count',
+                filter: ['status' => ['open', 'in-progress']],
+                groupBy: ['field' => 'region']
+            )
+        );
+
+        $this->assertSame('sqlite', $result['backend'], 'native path MUST run on SQLite');
+        $this->assertStringContainsString(
+            '"status" IN (?, ?)',
+            $captured['sql'],
+            'a bare array filter value MUST emit an IN (...) predicate, not be silently dropped'
+        );
+        $this->assertSame(
+            ['nl' => 3],
+            $this->foldSingle($result['groups']),
+            '2 open + 1 in-progress, all region nl = 3; region be is filtered out entirely (NOT all 5, NOT 0)'
+        );
+
+    }//end testNativeBareArrayFilterEmitsInPredicateAndCountsAnyOf()
+
+    public function testNativeBareArrayFilterWithEmptyListMatchesNothing(): void
+    {
+        $runner = $this->makeNativeRunner(dataset: $this->statusDataset(), capturedSql: $captured);
+
+        $result = $runner->runAdhoc(
+            register: $this->makeRegister(),
+            schema: $this->makeStatusSchema(),
+            query: AggregationQuery::create(
+                metric: 'count',
+                filter: ['status' => []],
+                groupBy: ['field' => 'region']
+            )
+        );
+
+        $this->assertStringContainsString('1 = 0', $captured['sql']);
+        $this->assertSame([], $result['groups'], 'an implicit `in` over an empty list MUST match nothing');
+
+    }//end testNativeBareArrayFilterWithEmptyListMatchesNothing()
+
+    public function testNativeWrappedInOperatorStillCountsAnyOf(): void
+    {
+        // Regression: the wrapped `{in: [...]}` shape already worked before
+        // this fix — pin it stays correct.
+        $runner = $this->makeNativeRunner(dataset: $this->statusDataset(), capturedSql: $captured);
+
+        $result = $runner->runAdhoc(
+            register: $this->makeRegister(),
+            schema: $this->makeStatusSchema(),
+            query: AggregationQuery::create(
+                metric: 'count',
+                filter: ['status' => ['in' => ['open', 'in-progress']]],
+                groupBy: ['field' => 'region']
+            )
+        );
+
+        $this->assertSame(['nl' => 3], $this->foldSingle($result['groups']));
+
+    }//end testNativeWrappedInOperatorStillCountsAnyOf()
+
+    /**
+     * Fold a single-field grouped result into a `key => value` map.
+     *
+     * @param array<int, array{key: mixed, value: mixed}> $groups
+     *
+     * @return array<string, int|float>
+     */
+    private function foldSingle(array $groups): array
+    {
+        $folded = [];
+        foreach ($groups as $group) {
+            $folded[(string) $group['key']] = $group['value'];
+        }
+
+        return $folded;
+
+    }//end foldSingle()
+
+    // -----------------------------------------------------------------------
+    // PHP-fallback path: the actual #2027 regression.
+    // -----------------------------------------------------------------------
+
+    public function testPhpFallbackBareArrayFilterCountsAnyOfNotAllRows(): void
+    {
+        // Before the fix: numeric array keys (0, 1, ...) matched no known
+        // operator in checkOp() and fell through to `default => true`, so
+        // EVERY row matched regardless of the filter (count would be 5,
+        // not 3). This is the direct #2027 regression proof.
+        $runner = $this->makePhpFallbackRunner(dataset: $this->statusDataset());
+
+        $result = $runner->runAdhoc(
+            register: $this->makeRegister(),
+            schema: $this->makeStatusSchema(),
+            query: AggregationQuery::create(
+                metric: 'count',
+                filter: ['status' => ['open', 'in-progress']]
+            )
+        );
+
+        $this->assertSame('php-fallback', $result['backend']);
+        $this->assertSame(3, $result['value'], '2 open + 1 in-progress = 3 (previously silently counted all 5)');
+
+    }//end testPhpFallbackBareArrayFilterCountsAnyOfNotAllRows()
+
+    public function testPhpFallbackWrappedInOperatorCountsAnyOf(): void
+    {
+        $runner = $this->makePhpFallbackRunner(dataset: $this->statusDataset());
+
+        $result = $runner->runAdhoc(
+            register: $this->makeRegister(),
+            schema: $this->makeStatusSchema(),
+            query: AggregationQuery::create(
+                metric: 'count',
+                filter: ['status' => ['in' => ['open', 'in-progress']]]
+            )
+        );
+
+        $this->assertSame(3, $result['value']);
+
+    }//end testPhpFallbackWrappedInOperatorCountsAnyOf()
+
+    public function testPhpFallbackScalarEqualityIsUnaffected(): void
+    {
+        // Regression: plain scalar equality (the pre-existing, most common
+        // shape) MUST still work exactly as before.
+        $runner = $this->makePhpFallbackRunner(dataset: $this->statusDataset());
+
+        $result = $runner->runAdhoc(
+            register: $this->makeRegister(),
+            schema: $this->makeStatusSchema(),
+            query: AggregationQuery::create(metric: 'count', filter: ['status' => 'open'])
+        );
+
+        $this->assertSame(2, $result['value']);
+
+    }//end testPhpFallbackScalarEqualityIsUnaffected()
+
+    // -----------------------------------------------------------------------
+    // Multi-value (JSON-array) object property overlap.
+    // -----------------------------------------------------------------------
+
+    public function testNativePathDefersMultiValuePropertyFilterToPhpFallback(): void
+    {
+        // A `tags` filter on an array-typed property MUST NOT be translated
+        // to a native `= ?` / `IN (...)` predicate (the column holds the
+        // WHOLE array; equality/IN against it would silently mismatch) —
+        // the runner defers to the PHP fallback, which does the overlap
+        // test correctly.
+        $runner = $this->makeNativeRunner(dataset: $this->tagsDataset(), capturedSql: $captured, schema: $this->makeTagsSchema());
+
+        $result = $runner->runAdhoc(
+            register: $this->makeRegister(),
+            schema: $this->makeTagsSchema(),
+            query: AggregationQuery::create(metric: 'count', filter: ['tags' => 'a'])
+        );
+
+        $this->assertSame('php-fallback', $result['backend'], 'a multi-value property filter MUST defer to PHP, not native SQL');
+
+    }//end testNativePathDefersMultiValuePropertyFilterToPhpFallback()
+
+    public function testPhpFallbackScalarFilterOverlapsMultiValueProperty(): void
+    {
+        $runner = $this->makePhpFallbackRunnerForTags();
+
+        $result = $runner->runAdhoc(
+            register: $this->makeRegister(),
+            schema: $this->makeTagsSchema(),
+            query: AggregationQuery::create(metric: 'count', filter: ['tags' => 'a'])
+        );
+
+        // Rows 1 (['a','b']) and 3 (['a']) contain 'a'; row 4 (['x']) does not.
+        $this->assertSame(2, $result['value']);
+
+    }//end testPhpFallbackScalarFilterOverlapsMultiValueProperty()
+
+    public function testPhpFallbackBareArrayFilterOverlapsMultiValueProperty(): void
+    {
+        $runner = $this->makePhpFallbackRunnerForTags();
+
+        $result = $runner->runAdhoc(
+            register: $this->makeRegister(),
+            schema: $this->makeTagsSchema(),
+            query: AggregationQuery::create(metric: 'count', filter: ['tags' => ['a', 'c']])
+        );
+
+        // Rows 1 (a,b — has a), 2 (b,c — has c), 3 (a — has a) overlap;
+        // row 4 (x) does not.
+        $this->assertSame(3, $result['value']);
+
+    }//end testPhpFallbackBareArrayFilterOverlapsMultiValueProperty()
+
+    public function testPhpFallbackInOperatorOverlapsMultiValueProperty(): void
+    {
+        $runner = $this->makePhpFallbackRunnerForTags();
+
+        $result = $runner->runAdhoc(
+            register: $this->makeRegister(),
+            schema: $this->makeTagsSchema(),
+            query: AggregationQuery::create(metric: 'count', filter: ['tags' => ['in' => ['x']]])
+        );
+
+        // Only row 4 has 'x'.
+        $this->assertSame(1, $result['value']);
+
+    }//end testPhpFallbackInOperatorOverlapsMultiValueProperty()
+
+    // -----------------------------------------------------------------------
+    // Regression pin: single-field/single-metric response shape unchanged.
+    // -----------------------------------------------------------------------
+
+    public function testUngroupedSingleMetricResponseShapeIsByteIdentical(): void
+    {
+        $runner = $this->makeNativeRunner(dataset: $this->statusDataset(), capturedSql: $captured);
+
+        $result = $runner->runAdhoc(
+            register: $this->makeRegister(),
+            schema: $this->makeStatusSchema(),
+            query: AggregationQuery::create(metric: 'count', filter: ['status' => 'open'])
+        );
+
+        $this->assertSame(
+            ['backend', 'cached', 'value'],
+            $this->sortedKeys($result),
+            'single-metric ungrouped envelope MUST carry exactly {value, backend, cached} — no `values` key'
+        );
+        $this->assertSame(2, $result['value']);
+        $this->assertArrayNotHasKey('values', $result);
+
+    }//end testUngroupedSingleMetricResponseShapeIsByteIdentical()
+
+    public function testGroupedSingleFieldSingleMetricResponseShapeIsByteIdentical(): void
+    {
+        $runner = $this->makeNativeRunner(dataset: $this->statusDataset(), capturedSql: $captured);
+
+        $result = $runner->runAdhoc(
+            register: $this->makeRegister(),
+            schema: $this->makeStatusSchema(),
+            query: AggregationQuery::create(metric: 'count', groupBy: ['field' => 'status'])
+        );
+
+        $this->assertSame(['backend', 'cached', 'groups'], $this->sortedKeys($result));
+        foreach ($result['groups'] as $group) {
+            $this->assertSame(
+                ['key', 'value'],
+                $this->sortedKeys($group),
+                'single-field grouped rows MUST carry exactly {key, value} — no `keys`/`values` keys'
+            );
+        }
+
+    }//end testGroupedSingleFieldSingleMetricResponseShapeIsByteIdentical()
+
+    /**
+     * @param array<string, mixed> $arr
+     *
+     * @return array<int, string>
+     */
+    private function sortedKeys(array $arr): array
+    {
+        $keys = array_keys($arr);
+        sort($keys);
+        return $keys;
+
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Build a runner whose IDBConnection executes real SQL against an
+     * in-memory SQLite database seeded with the given dataset (status/amount
+     * shape). Captures the prepared SQL string.
+     *
+     * @param array<int, array<string, mixed>> $dataset
+     * @param mixed                             &$capturedSql
+     * @param Schema|null                       $schema Schema used for the multi-value bail check (defaults to the status schema).
+     *
+     * @return AggregationRunner
+     */
+    private function makeNativeRunner(array $dataset, mixed &$capturedSql, ?Schema $schema=null): AggregationRunner
+    {
+        $captured = new \ArrayObject(['sql' => null]);
+        $pdo      = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $isTags = ($schema !== null && $schema->getSlug() === 'tagged-items');
+        if ($isTags === true) {
+            $pdo->exec('CREATE TABLE "oc_register_1_schema_x" ("_deleted" TEXT, "_organisation" TEXT, "id" INTEGER, "tags" TEXT)');
+            $insert = $pdo->prepare('INSERT INTO "oc_register_1_schema_x" ("_deleted", "_organisation", "id", "tags") VALUES (NULL, ?, ?, ?)');
+            foreach ($dataset as $row) {
+                $insert->execute(['__no_active_org__', $row['id'], json_encode($row['tags'])]);
+            }
+        } else {
+            $pdo->exec('CREATE TABLE "oc_register_1_schema_x" ("_deleted" TEXT, "_organisation" TEXT, "status" TEXT, "region" TEXT, "amount" INTEGER)');
+            $insert = $pdo->prepare('INSERT INTO "oc_register_1_schema_x" ("_deleted", "_organisation", "status", "region", "amount") VALUES (NULL, ?, ?, ?, ?)');
+            foreach ($dataset as $row) {
+                $insert->execute(['__no_active_org__', $row['status'], ($row['region'] ?? null), $row['amount']]);
+            }
+        }
+
+        $db = $this->createMock(IDBConnection::class);
+        $db->method('getDatabasePlatform')->willReturn($this->createMock(SqlitePlatform::class));
+        $db->method('prepare')->willReturnCallback(
+            function (string $sql) use ($pdo, $captured): IPreparedStatement {
+                $captured['sql'] = $sql;
+                $pdoStmt         = $pdo->prepare($sql);
+                $stmt            = $this->createMock(IPreparedStatement::class);
+                $stmt->method('execute')->willReturnCallback(
+                    function ($bindings=[]) use ($pdoStmt): IResult {
+                        $pdoStmt->execute(($bindings ?? []));
+                        return $this->createMock(IResult::class);
+                    }
+                );
+                $stmt->method('fetch')->willReturnCallback(static fn() => $pdoStmt->fetch(PDO::FETCH_ASSOC));
+                return $stmt;
+            }
+        );
+
+        $magicMapper = $this->createMock(MagicMapper::class);
+        $magicMapper->method('getTableNameForRegisterSchema')->willReturn('register_1_schema_x');
+
+        // Always wire the PHP-fallback data source too (not just for the
+        // `tags` dataset): the ungrouped scalar native path is Postgres-only
+        // (see tryNativeAggregation()'s docblock), so an ungrouped query
+        // against this SQLite-platform runner falls through to bucketInPhp()
+        // and needs real rows to filter, not an empty/null default.
+        $entities = [];
+        foreach ($dataset as $row) {
+            $entity = $this->createMock(ObjectEntity::class);
+            $entity->method('getObject')->willReturn($row);
+            $entities[] = $entity;
+        }
+
+        $magicMapper->method('findAllInRegisterSchemaTable')->willReturn($entities);
+
+        $runner       = $this->makeRunner(db: $db, magicMapper: $magicMapper);
+        $capturedSql  = $captured;
+        return $runner;
+
+    }//end makeNativeRunner()
+
+    /**
+     * Build a runner whose platform is unrecognised (forcing the PHP
+     * fallback) and whose MagicMapper returns the status/amount dataset.
+     *
+     * @param array<int, array<string, mixed>> $dataset
+     *
+     * @return AggregationRunner
+     */
+    private function makePhpFallbackRunner(array $dataset): AggregationRunner
+    {
+        $db = $this->createMock(IDBConnection::class);
+        $db->method('getDatabasePlatform')->willReturn($this->createMock(AbstractPlatform::class));
+
+        $entities = [];
+        foreach ($dataset as $row) {
+            $entity = $this->createMock(ObjectEntity::class);
+            $entity->method('getObject')->willReturn($row);
+            $entities[] = $entity;
+        }
+
+        $magicMapper = $this->createMock(MagicMapper::class);
+        $magicMapper->method('findAllInRegisterSchemaTable')->willReturn($entities);
+        $magicMapper->method('getTableNameForRegisterSchema')->willReturn('register_1_schema_x');
+
+        return $this->makeRunner(db: $db, magicMapper: $magicMapper);
+
+    }//end makePhpFallbackRunner()
+
+    /**
+     * PHP-fallback runner for the multi-value `tags` dataset, forced via an
+     * unrecognised platform (same mechanism as {@see makePhpFallbackRunner()}).
+     *
+     * @return AggregationRunner
+     */
+    private function makePhpFallbackRunnerForTags(): AggregationRunner
+    {
+        return $this->makePhpFallbackRunner(dataset: $this->tagsDataset());
+
+    }//end makePhpFallbackRunnerForTags()
+
+    /**
+     * Assemble an AggregationRunner with the given DB + MagicMapper and
+     * permissive RBAC / null-org / no-translation collaborators.
+     *
+     * @param IDBConnection $db          The (real-SQLite-backed or unknown) connection.
+     * @param MagicMapper   $magicMapper The magic-table mapper.
+     *
+     * @return AggregationRunner
+     */
+    private function makeRunner(IDBConnection $db, MagicMapper $magicMapper): AggregationRunner
+    {
+        $userSession = $this->createMock(IUserSession::class);
+        $userSession->method('getUser')->willReturn(null);
+
+        $organisationService = $this->createMock(OrganisationService::class);
+        $organisationService->method('getActiveOrganisation')->willReturn(null);
+
+        $permissionHandler = $this->createMock(PermissionHandler::class);
+        $permissionHandler->method('hasPermission')->willReturn(true);
+
+        $cache = $this->createMock(AggregationCache::class);
+        $cache->method('getAdhoc')->willReturn(null);
+
+        $translationHandler = $this->createMock(TranslationHandler::class);
+        $translationHandler->method('getTranslatableProperties')->willReturn([]);
+
+        $languageService = $this->createMock(LanguageService::class);
+        $languageService->method('shouldReturnAllTranslations')->willReturn(false);
+
+        return new AggregationRunner(
+            magicMapper: $magicMapper,
+            registerMapper: $this->createMock(RegisterMapper::class),
+            schemaMapper: $this->createMock(SchemaMapper::class),
+            placeholders: new PlaceholderResolver($userSession),
+            db: $db,
+            cache: $cache,
+            permissionHandler: $permissionHandler,
+            userSession: $userSession,
+            organisationService: $organisationService,
+            translationHandler: $translationHandler,
+            languageService: $languageService,
+        );
+
+    }//end makeRunner()
+
+    private function makeRegister(): Register
+    {
+        $register = new Register();
+        $register->setSlug('bookkeeping');
+        $register->setSchemas([1]);
+        return $register;
+
+    }//end makeRegister()
+
+    private function makeStatusSchema(): Schema
+    {
+        $schema = new Schema();
+        $schema->setSlug('status-items');
+        $schema->setId(1);
+        $schema->setProperties(
+            [
+                'status' => ['type' => 'string'],
+                'region' => ['type' => 'string'],
+                'amount' => ['type' => 'number'],
+            ]
+        );
+        return $schema;
+
+    }//end makeStatusSchema()
+
+    private function makeTagsSchema(): Schema
+    {
+        $schema = new Schema();
+        $schema->setSlug('tagged-items');
+        $schema->setId(1);
+        $schema->setProperties(
+            [
+                'id'   => ['type' => 'integer'],
+                'tags' => ['type' => 'array', 'items' => ['type' => 'string']],
+            ]
+        );
+        return $schema;
+
+    }//end makeTagsSchema()
+}//end class


### PR DESCRIPTION
## Summary

Implements the `adhoc-aggregation-suite` OpenSpec change — 5 of 6 requirements shipped, 1 deferred (see below). Ground-truthed each sub-part against HEAD before writing code: several were already fully implemented and only needed HTTP wiring or a missing response header.

| Requirement | Status |
|---|---|
| REQ-AGG-101 multi-field groupBy | Already implemented (service layer) — added controller wiring (comma-list / repeated `groupBy[]` param) |
| REQ-AGG-102 multi-metric | **Implemented** — `metrics` list on `value()`/`grouped()`, native path merges N single-metric queries into one `values` map, PHP fallback computes all metrics over the same row set |
| REQ-AGG-103 cumulative time-bucket | **Deferred** — not implemented this wave, left open in spec/tasks.md |
| REQ-AGG-104 cross-dialect native time-bucket | Already fully implemented + tested at HEAD (Postgres/MySQL/MariaDB/SQLite) — no change needed |
| REQ-AGG-105 timeseries caching | Cache engine already implemented at HEAD — added the missing `X-OR-Cache: hit\|miss` header on `value()`/`grouped()`/`timeseries()` |
| REQ-AGG-106 bug #2027 (multi-value filter) | **Implemented** — bare array filter → implicit `in` (any-of); `in`/`notIn`/`eq`/`ne` now any-overlap-match multi-value (JSON-array) properties; native path defers array-typed-property filters to the PHP fallback instead of emitting a silently-wrong predicate |

Single-field/single-metric response shapes are regression-pinned byte-identical.

**Not archived** — REQ-AGG-103 is deferred; `tasks.md` marks it explicitly as an open follow-up.

## Test plan

- [x] `docker run --rm -v <worktree>:/app -w /app nextcloud:34.0.0-apache php vendor/bin/phpunit` — 217 aggregation-scoped tests pass (130 pre-existing regression + 87 new/updated across `AggregationQueryTest`, `AggregationRunnerMultiValueFilterTest` (new), `AggregationRunnerMultiMetricTest` (new), `AggregationControllerValueGroupedTest` (new))
- [x] `vendor/bin/phpcs` clean on all changed `lib/` files (1 pre-existing warning, unrelated to this change, verified present at HEAD too)
- [x] Full `Unit Tests` suite (15k tests) run for regression sanity — the handful of pre-existing failures/errors (RelationHandler ctor arity, missing CSV fixture, SchemaLinkedTypes, MapLink/PhotoLink/PollLink deep-link format, a full-suite-only test-isolation issue affecting `JSONResponse::addHeader`) are unrelated to this change and reproduce identically in an untouched sibling worktree at a similar commit — confirmed pre-existing, not introduced here

Known pre-existing CI infra failures (npm/eslint/stylelint/license/Newman) are unrelated to this backend change.