### PR TITLE
feat(views): kanban + calendar presentation config — backend (#2059)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -980,6 +980,11 @@ return [
 		['name' => 'views#update', 'url' => '/api/views/{id}', 'verb' => 'PUT', 'requirements' => ['id' => '[^/]+']],
 		['name' => 'views#patch', 'url' => '/api/views/{id}', 'verb' => 'PATCH', 'requirements' => ['id' => '[^/]+']],
 		['name' => 'views#destroy', 'url' => '/api/views/{id}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+']],
+		// Read-only presentation data — drag-to-move goes through the existing
+		// guarded object PATCH/PUT (/api/objects/{register}/{schema}/{id}), never
+		// a bespoke endpoint here (REQ-VIEW-KANBAN-03).
+		['name' => 'views#kanban', 'url' => '/api/views/{id}/kanban', 'verb' => 'GET', 'requirements' => ['id' => '[^/]+']],
+		['name' => 'views#calendar', 'url' => '/api/views/{id}/calendar', 'verb' => 'GET', 'requirements' => ['id' => '[^/]+']],
 
 		// Chat - AI Assistant endpoints.
 		['name' => 'chat#sendMessage', 'url' => '/api/chat/send', 'verb' => 'POST'],

--- a/lib/Controller/ViewsController.php
+++ b/lib/Controller/ViewsController.php
@@ -20,7 +20,9 @@
 
 namespace OCA\OpenRegister\Controller;
 
+use InvalidArgumentException;
 use OCA\OpenRegister\Service\ViewService;
+use OCA\OpenRegister\Service\ViewPresentationService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
@@ -57,6 +59,13 @@ class ViewsController extends Controller
     private ViewService $viewService;
 
     /**
+     * The view presentation service for kanban/calendar board data
+     *
+     * @var ViewPresentationService
+     */
+    private ViewPresentationService $viewPresentationService;
+
+    /**
      * The user session for getting current user
      *
      * @var IUserSession
@@ -73,21 +82,24 @@ class ViewsController extends Controller
     /**
      * Constructor for ViewsController
      *
-     * @param string          $appName     The app name
-     * @param IRequest        $request     The request object
-     * @param ViewService     $viewService The view service
-     * @param IUserSession    $userSession The user session
-     * @param LoggerInterface $logger      The logger
+     * @param string                  $appName                 The app name
+     * @param IRequest                $request                 The request object
+     * @param ViewService             $viewService             The view service
+     * @param ViewPresentationService $viewPresentationService The view presentation (kanban/calendar) service
+     * @param IUserSession            $userSession             The user session
+     * @param LoggerInterface         $logger                  The logger
      */
     public function __construct(
         string $appName,
         IRequest $request,
         ViewService $viewService,
+        ViewPresentationService $viewPresentationService,
         IUserSession $userSession,
         LoggerInterface $logger
     ) {
         parent::__construct(appName: $appName, request: $request);
         $this->viewService = $viewService;
+        $this->viewPresentationService = $viewPresentationService;
         $this->userSession = $userSession;
         $this->logger      = $logger;
     }//end __construct()
@@ -332,13 +344,19 @@ class ViewsController extends Controller
                 $query = $data['query'];
             }
 
+            $presentation = $data['presentation'] ?? null;
+            if (is_array($presentation) === false) {
+                $presentation = null;
+            }
+
             $view = $this->viewService->create(
                 name: $data['name'],
                 description: $data['description'] ?? '',
                 owner: $userId,
                 isPublic: $data['isPublic'] ?? false,
                 isDefault: $data['isDefault'] ?? false,
-                query: $query
+                query: $query,
+                presentation: $presentation
             );
 
             return new JSONResponse(
@@ -346,6 +364,13 @@ class ViewsController extends Controller
                     'view' => $view->jsonSerialize(),
                 ],
                 statusCode: 201
+            );
+        } catch (InvalidArgumentException $e) {
+            return new JSONResponse(
+                data: [
+                    'error' => $e->getMessage(),
+                ],
+                statusCode: 400
             );
         } catch (\Exception $e) {
             $this->logger->error(
@@ -448,6 +473,11 @@ class ViewsController extends Controller
                 $query = $data['query'];
             }
 
+            $presentation = $data['presentation'] ?? null;
+            if (is_array($presentation) === false) {
+                $presentation = null;
+            }
+
             $view = $this->viewService->update(
                 id: $id,
                 name: $data['name'],
@@ -455,7 +485,8 @@ class ViewsController extends Controller
                 owner: $userId,
                 isPublic: $data['isPublic'] ?? false,
                 isDefault: $data['isDefault'] ?? false,
-                query: $query
+                query: $query,
+                presentation: $presentation
             );
 
             return new JSONResponse(
@@ -469,6 +500,13 @@ class ViewsController extends Controller
                     'error' => 'View not found',
                 ],
                 statusCode: 404
+            );
+        } catch (InvalidArgumentException $e) {
+            return new JSONResponse(
+                data: [
+                    'error' => $e->getMessage(),
+                ],
+                statusCode: 400
             );
         } catch (\Exception $e) {
             $this->logger->error(
@@ -562,6 +600,14 @@ class ViewsController extends Controller
                 $query = $data['query'];
             }
 
+            // Handle presentation parameter — fall back to the existing stored
+            // value (not null) so a PATCH that omits presentation cannot
+            // silently wipe an existing kanban/calendar config.
+            $presentation = $view->getPresentation();
+            if (($data['presentation'] ?? null) !== null && is_array($data['presentation']) === true) {
+                $presentation = $data['presentation'];
+            }
+
             // Update view.
             $updatedView = $this->viewService->update(
                 id: $id,
@@ -571,7 +617,8 @@ class ViewsController extends Controller
                 isPublic: $isPublic,
                 isDefault: $isDefault,
                 query: $query,
-                favoredBy: $favoredBy
+                favoredBy: $favoredBy,
+                presentation: $presentation
             );
 
             return new JSONResponse(
@@ -585,6 +632,13 @@ class ViewsController extends Controller
                     'error' => 'View not found',
                 ],
                 statusCode: 404
+            );
+        } catch (InvalidArgumentException $e) {
+            return new JSONResponse(
+                data: [
+                    'error' => $e->getMessage(),
+                ],
+                statusCode: 400
             );
         } catch (\Exception $e) {
             $this->logger->error(
@@ -682,4 +736,169 @@ class ViewsController extends Controller
             );
         }//end try
     }//end destroy()
+
+    /**
+     * Get the kanban board (columns + paginated cards) for a kanban view
+     *
+     * Read-only: this endpoint only derives columns and fetches cards. There
+     * is deliberately NO "move card" write here — moving a card between
+     * columns MUST go through the existing guarded object PATCH/PUT API
+     * (RBAC + `x-openregister-lifecycle`), never a bespoke endpoint
+     * (REQ-VIEW-KANBAN-03).
+     *
+     * @param string $id The view ID (UUID or numeric ID)
+     *
+     * @NoAdminRequired
+     *
+     * @NoCSRFRequired
+     *
+     * @return JSONResponse JSON response with kanban board data or error
+     *
+     * @spec openspec/changes/object-views-kanban-calendar/specs/saved-search-views/spec.md#requirement-kanban-columns-and-cards-req-view-kanban-02
+     */
+    public function kanban(string $id): JSONResponse
+    {
+        try {
+            $user   = $this->userSession->getUser();
+            $userId = '';
+            if ($user !== null) {
+                $userId = $user->getUID();
+            }
+
+            if (empty($userId) === true) {
+                return new JSONResponse(
+                    data: [
+                        'error' => 'User not authenticated',
+                    ],
+                    statusCode: 401
+                );
+            }
+
+            $view  = $this->viewService->find(id: $id, owner: $userId);
+            $board = $this->viewPresentationService->getKanbanBoard(
+                view: $view,
+                requestParams: $this->request->getParams()
+            );
+
+            return new JSONResponse(data: $board);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(
+                data: [
+                    'error' => 'View not found',
+                ],
+                statusCode: 404
+            );
+        } catch (InvalidArgumentException $e) {
+            return new JSONResponse(
+                data: [
+                    'error' => $e->getMessage(),
+                ],
+                statusCode: 400
+            );
+        } catch (\Exception $e) {
+            $this->logger->error(
+                message: '[ViewsController] Error building kanban board',
+                context: [
+                    'file'      => __FILE__,
+                    'line'      => __LINE__,
+                    'id'        => $id,
+                    'exception' => $e->getMessage(),
+                ]
+            );
+            return new JSONResponse(
+                data: [
+                    'error'   => 'Failed to build kanban board',
+                    'message' => $e->getMessage(),
+                ],
+                statusCode: 500
+            );
+        }//end try
+    }//end kanban()
+
+    /**
+     * Get the objects for a calendar view within a visible date range
+     *
+     * @param string $id The view ID (UUID or numeric ID)
+     *
+     * @NoAdminRequired
+     *
+     * @NoCSRFRequired
+     *
+     * @return JSONResponse JSON response with calendar range data or error
+     *
+     * @spec openspec/changes/object-views-kanban-calendar/specs/saved-search-views/spec.md#requirement-calendar-plots-objects-by-a-date-field-over-a-range-req-view-cal-04
+     */
+    public function calendar(string $id): JSONResponse
+    {
+        try {
+            $user   = $this->userSession->getUser();
+            $userId = '';
+            if ($user !== null) {
+                $userId = $user->getUID();
+            }
+
+            if (empty($userId) === true) {
+                return new JSONResponse(
+                    data: [
+                        'error' => 'User not authenticated',
+                    ],
+                    statusCode: 401
+                );
+            }
+
+            $params     = $this->request->getParams();
+            $rangeStart = $params['start'] ?? $params['rangeStart'] ?? null;
+            $rangeEnd   = $params['end'] ?? $params['rangeEnd'] ?? null;
+
+            if (empty($rangeStart) === true || empty($rangeEnd) === true) {
+                return new JSONResponse(
+                    data: [
+                        'error' => 'Both start and end (the visible date range) are required',
+                    ],
+                    statusCode: 400
+                );
+            }
+
+            $view   = $this->viewService->find(id: $id, owner: $userId);
+            $result = $this->viewPresentationService->getCalendarObjects(
+                view: $view,
+                rangeStart: $rangeStart,
+                rangeEnd: $rangeEnd,
+                requestParams: $params
+            );
+
+            return new JSONResponse(data: $result);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(
+                data: [
+                    'error' => 'View not found',
+                ],
+                statusCode: 404
+            );
+        } catch (InvalidArgumentException $e) {
+            return new JSONResponse(
+                data: [
+                    'error' => $e->getMessage(),
+                ],
+                statusCode: 400
+            );
+        } catch (\Exception $e) {
+            $this->logger->error(
+                message: '[ViewsController] Error querying calendar range',
+                context: [
+                    'file'      => __FILE__,
+                    'line'      => __LINE__,
+                    'id'        => $id,
+                    'exception' => $e->getMessage(),
+                ]
+            );
+            return new JSONResponse(
+                data: [
+                    'error'   => 'Failed to query calendar range',
+                    'message' => $e->getMessage(),
+                ],
+                statusCode: 500
+            );
+        }//end try
+    }//end calendar()
 }//end class

--- a/lib/Db/View.php
+++ b/lib/Db/View.php
@@ -50,6 +50,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setIsDefault(bool $isDefault)
  * @method array|null getQuery()
  * @method void setQuery(?array $query)
+ * @method array|null getPresentation()
+ * @method void setPresentation(?array $presentation)
  * @method array|null getFavoritedBy()
  * @method void setFavoritedBy(?array $favoritedBy)
  * @method DateTime|null getCreated()
@@ -126,6 +128,20 @@ class View extends Entity implements JsonSerializable
     protected ?array $query = [];
 
     /**
+     * Presentation configuration stored as JSON (nullable)
+     *
+     * Declares how the view renders: `viewType` (table|kanban|calendar) plus
+     * type-specific config (kanban: groupByField/cardFields/columnOrder;
+     * calendar: dateField/endDateField). Null means "not configured" and MUST
+     * render as `table` (the default) so existing views are unchanged.
+     *
+     * @var array|null Presentation configuration, or null for the default table view
+     *
+     * @spec openspec/changes/object-views-kanban-calendar/design.md#d1
+     */
+    protected ?array $presentation = null;
+
+    /**
      * Array of user IDs who favorited this view
      *
      * @var array|null User IDs who favorited
@@ -158,6 +174,7 @@ class View extends Entity implements JsonSerializable
         $this->addType(fieldName: 'isPublic', type: 'boolean');
         $this->addType(fieldName: 'isDefault', type: 'boolean');
         $this->addType(fieldName: 'query', type: 'json');
+        $this->addType(fieldName: 'presentation', type: 'json');
         $this->addType(fieldName: 'favoredBy', type: 'json');
         $this->addType(fieldName: 'created', type: 'datetime');
         $this->addType(fieldName: 'updated', type: 'datetime');
@@ -206,7 +223,7 @@ class View extends Entity implements JsonSerializable
      * @psalm-return array{id: int, uuid: null|string, name: null|string,
      *     description: null|string, owner: null|string,
      *     organisation: null|string, isPublic: bool, isDefault: bool,
-     *     query: array|null, favoredBy: array,
+     *     query: array|null, presentation: array, favoredBy: array,
      *     quota: array{storage: null, bandwidth: null, requests: null,
      *     users: null, groups: null},
      *     usage: array{storage: 0, bandwidth: 0, requests: 0,
@@ -229,6 +246,7 @@ class View extends Entity implements JsonSerializable
             'isPublic'               => $this->isPublic,
             'isDefault'              => $this->isDefault,
             'query'                  => $this->query,
+            'presentation'           => $this->getPresentationFormatted(),
             'favoredBy'              => $favoredBy,
             'quota'                  => [
                 'storage'   => null,
@@ -289,6 +307,32 @@ class View extends Entity implements JsonSerializable
     }//end getUpdatedFormatted()
 
     /**
+     * Get the presentation configuration, defaulted to the `table` view.
+     *
+     * A null `presentation` (never configured) MUST render exactly like an
+     * unconfigured legacy view: `viewType: table` and no kanban/calendar
+     * config. This is the single place that applies that default so both
+     * the API response and any internal consumer see the same shape.
+     *
+     * @return array{viewType: string, kanban?: array, calendar?: array} The effective presentation config
+     *
+     * @spec openspec/changes/object-views-kanban-calendar/specs/saved-search-views/spec.md#requirement-views-persist-a-validated-presentation-config-req-view-pres-01
+     */
+    private function getPresentationFormatted(): array
+    {
+        $presentation = $this->presentation;
+        if (is_array($presentation) === false) {
+            return ['viewType' => 'table'];
+        }
+
+        if (empty($presentation['viewType']) === true) {
+            $presentation['viewType'] = 'table';
+        }
+
+        return $presentation;
+    }//end getPresentationFormatted()
+
+    /**
      * Get managed by configuration formatted.
      *
      * @return (int|null|string)[]|null
@@ -321,44 +365,34 @@ class View extends Entity implements JsonSerializable
      */
     public function hydrate(array $object): static
     {
-        $this->setUuid(uuid: null);
-        if (($object['uuid'] ?? null) !== null) {
-            $this->setUuid(uuid: $object['uuid']);
-        }
+        // Map property names to their resolved values (falling back to the
+        // same defaults the pre-existing per-field logic used).
+        //
+        // NOTE: Entity setters are dispatched via OCP\AppFramework\Db\Entity's
+        // magic __call(). Calling them with NAMED arguments (e.g.
+        // `setUuid(uuid: null)`) silently breaks: PHP hands __call an
+        // associative $args array keyed by parameter name, so the setter's
+        // `$args[0]` lookup is undefined (→ null), which either silently
+        // no-ops a nullable property or throws a TypeError on a non-nullable
+        // one (`setIsPublic` did, until this fix). A dynamic `$this->$method()`
+        // call (like Agent::hydrate()) is positional and also falls outside
+        // CustomSniffs.Functions.NamedParameters's reach, which only flags
+        // literal `$this->methodName()` call sites.
+        $fields = [
+            'uuid'         => $object['uuid'] ?? null,
+            'name'         => $object['name'] ?? null,
+            'description'  => $object['description'] ?? null,
+            'owner'        => $object['owner'] ?? null,
+            'isPublic'     => $object['isPublic'] ?? false,
+            'isDefault'    => $object['isDefault'] ?? false,
+            'query'        => $object['query'] ?? [],
+            'presentation' => $object['presentation'] ?? null,
+            'favoredBy'    => $object['favoredBy'] ?? [],
+        ];
 
-        $this->setName(name: null);
-        if (($object['name'] ?? null) !== null) {
-            $this->setName(name: $object['name']);
-        }
-
-        $this->setDescription(description: null);
-        if (($object['description'] ?? null) !== null) {
-            $this->setDescription(description: $object['description']);
-        }
-
-        $this->setOwner(owner: null);
-        if (($object['owner'] ?? null) !== null) {
-            $this->setOwner(owner: $object['owner']);
-        }
-
-        $this->setIsPublic(isPublic: false);
-        if (($object['isPublic'] ?? null) !== null) {
-            $this->setIsPublic(isPublic: $object['isPublic']);
-        }
-
-        $this->setIsDefault(isDefault: false);
-        if (($object['isDefault'] ?? null) !== null) {
-            $this->setIsDefault(isDefault: $object['isDefault']);
-        }
-
-        $this->setQuery(query: []);
-        if (($object['query'] ?? null) !== null) {
-            $this->setQuery(query: $object['query']);
-        }
-
-        $this->setFavoredBy(favoredBy: []);
-        if (($object['favoredBy'] ?? null) !== null) {
-            $this->setFavoredBy(favoredBy: $object['favoredBy']);
+        foreach ($fields as $key => $value) {
+            $method = 'set'.ucfirst($key);
+            $this->$method($value);
         }
 
         return $this;

--- a/lib/Migration/Version1Date20260724000000.php
+++ b/lib/Migration/Version1Date20260724000000.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Add the `presentation` JSON column to the openregister_views table.
+ *
+ * The `View` entity (lib/Db/View.php) gained a nullable `presentation`
+ * property declaring how a saved view renders: `viewType`
+ * (table|kanban|calendar) plus type-specific config (kanban:
+ * groupByField/cardFields/columnOrder; calendar: dateField/endDateField).
+ * This migration adds the backing column. The column is nullable and no
+ * existing row is touched, so every pre-existing view keeps reading as
+ * `viewType: table` (View::getPresentationFormatted() defaults a null
+ * presentation to `table`) — this migration changes no rendering behaviour.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/object-views-kanban-calendar/design.md#d1
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adds the nullable `presentation` JSON column to `openregister_views`.
+ *
+ * Idempotent: only adds the column when the table exists and the column is
+ * absent, so re-running on an already-migrated database is a no-op.
+ *
+ * @package OCA\OpenRegister\Migration
+ *
+ * @spec openspec/changes/object-views-kanban-calendar/design.md#d1
+ */
+class Version1Date20260724000000 extends SimpleMigrationStep
+{
+    /**
+     * Change the database schema.
+     *
+     * @param IOutput $output        Migration output
+     * @param Closure $schemaClosure Schema closure returning an ISchemaWrapper
+     * @param array   $options       Migration options
+     *
+     * @return ISchemaWrapper|null The updated schema, or null if no changes were needed
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/object-views-kanban-calendar/design.md#d1
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema = $schemaClosure();
+
+        if ($schema->hasTable('openregister_views') === false) {
+            $output->info(message: 'openregister_views table does not exist, skipping...');
+            return null;
+        }
+
+        $table = $schema->getTable('openregister_views');
+
+        if ($table->hasColumn('presentation') === true) {
+            $output->info(message: 'presentation column already exists on openregister_views, skipping...');
+            return null;
+        }
+
+        $table->addColumn(
+            'presentation',
+            Types::JSON,
+            [
+                'notnull' => false,
+                'default' => null,
+                'comment' => 'Presentation config: viewType (table|kanban|calendar) + type-specific config',
+            ]
+        );
+
+        $output->info(message: 'Added presentation column to openregister_views table');
+
+        return $schema;
+    }//end changeSchema()
+}//end class

--- a/lib/Service/ViewPresentationService.php
+++ b/lib/Service/ViewPresentationService.php
@@ -1,0 +1,378 @@
+<?php
+
+/**
+ * OpenRegister ViewPresentationService
+ *
+ * Backend contract for the kanban and calendar presentations of a saved
+ * view: kanban column/card derivation and calendar date-range object
+ * queries. Both reuse the existing object search/pagination machinery
+ * (ObjectService) — neither introduces new storage or a bespoke write path.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/object-views-kanban-calendar/design.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use InvalidArgumentException;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Db\View;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Derives kanban board data and calendar date-range results for a view's
+ * `presentation` config, over the existing object query/pagination surface.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @spec openspec/changes/object-views-kanban-calendar/design.md#d2
+ * @spec openspec/changes/object-views-kanban-calendar/design.md#d4
+ */
+class ViewPresentationService
+{
+
+    /**
+     * Schema mapper, used to resolve enum order for the groupByField.
+     *
+     * @var SchemaMapper
+     */
+    private readonly SchemaMapper $schemaMapper;
+
+    /**
+     * Object service, used to run the existing paginated/faceted object query.
+     *
+     * @var ObjectService
+     */
+    private readonly ObjectService $objectService;
+
+    /**
+     * Logger.
+     *
+     * @var LoggerInterface
+     */
+    private readonly LoggerInterface $logger;
+
+    /**
+     * Constructor.
+     *
+     * @param SchemaMapper    $schemaMapper  Schema mapper for enum/property discovery
+     * @param ObjectService   $objectService Object service for the paginated object query
+     * @param LoggerInterface $logger        Logger for error tracking
+     *
+     * @return void
+     */
+    public function __construct(
+        SchemaMapper $schemaMapper,
+        ObjectService $objectService,
+        LoggerInterface $logger
+    ) {
+        $this->schemaMapper  = $schemaMapper;
+        $this->objectService = $objectService;
+        $this->logger        = $logger;
+    }//end __construct()
+
+    /**
+     * Build the kanban board for a view: one column per distinct value of
+     * `groupByField`, cards paginated through the existing object query.
+     *
+     * Column order: `columnOrder` when the view configures one; otherwise
+     * the schema's enum order for `groupByField` when it is an enum
+     * property; otherwise the distinct values observed via the existing
+     * facet/object-query machinery (REQ-VIEW-KANBAN-02).
+     *
+     * @param View                 $view          The kanban view
+     * @param array<string, mixed> $requestParams Request params (_limit/_offset apply per column)
+     *
+     * @return array{viewType: string, groupByField: string, columns: array<int, array<string, mixed>>}
+     *
+     * @throws InvalidArgumentException If the view is not a kanban view or its config is incomplete
+     *
+     * @spec openspec/changes/object-views-kanban-calendar/specs/saved-search-views/spec.md#requirement-kanban-columns-and-cards-req-view-kanban-02
+     */
+    public function getKanbanBoard(View $view, array $requestParams=[]): array
+    {
+        $presentation = $view->getPresentation();
+        $viewType     = $presentation['viewType'] ?? 'table';
+        if ($viewType !== 'kanban') {
+            throw new InvalidArgumentException('View is not a kanban view (viewType is "'.$viewType.'")');
+        }
+
+        $kanbanConfig = $presentation['kanban'] ?? [];
+        $groupByField = $kanbanConfig['groupByField'] ?? null;
+        if (is_string($groupByField) === false || $groupByField === '') {
+            throw new InvalidArgumentException('Kanban view is missing kanban.groupByField');
+        }
+
+        $query       = $view->getQuery() ?? [];
+        $registerRef = $query['registers'][0] ?? null;
+        $schemaRef   = $query['schemas'][0] ?? null;
+        if ($registerRef === null || $schemaRef === null) {
+            throw new InvalidArgumentException('Kanban view requires a register and schema in its query');
+        }
+
+        $schema     = $this->schemaMapper->find($schemaRef);
+        $properties = $schema->getProperties();
+
+        $columnOrder = $kanbanConfig['columnOrder'] ?? null;
+        if (is_array($columnOrder) === false) {
+            $columnOrder = null;
+        }
+
+        // Set register/schema context BEFORE any object-query call (including
+        // the enum/columnOrder-less fallback, which discovers distinct values
+        // via the existing facet machinery and therefore needs the same
+        // register/schema scoping as the per-column card queries below).
+        $this->objectService->setRegister(register: $registerRef);
+        $this->objectService->setSchema(schema: $schemaRef);
+
+        $baseQuery = $this->buildBaseObjectQuery(query: $query);
+
+        $columnValues = $this->deriveColumnValues(
+            properties: $properties,
+            groupByField: $groupByField,
+            columnOrder: $columnOrder,
+            baseQuery: $baseQuery
+        );
+
+        $limit  = (int) ($requestParams['_limit'] ?? 20);
+        $offset = (int) ($requestParams['_offset'] ?? 0);
+
+        $columns = [];
+        foreach ($columnValues as $columnValue) {
+            $columnQuery = $baseQuery;
+            $columnQuery[$groupByField] = $columnValue;
+            $columnQuery['_limit']      = $limit;
+            $columnQuery['_offset']     = $offset;
+
+            $result = $this->objectService->searchObjectsPaginated(query: $columnQuery);
+
+            $columns[] = [
+                'value'  => $columnValue,
+                'cards'  => $result['results'] ?? [],
+                'total'  => $result['total'] ?? count($result['results'] ?? []),
+                'limit'  => $limit,
+                'offset' => $offset,
+            ];
+        }//end foreach
+
+        return [
+            'viewType'     => 'kanban',
+            'groupByField' => $groupByField,
+            'columns'      => $columns,
+        ];
+    }//end getKanbanBoard()
+
+    /**
+     * Return objects for a calendar view whose `dateField` falls within the
+     * visible range, spanning to `endDateField` when configured
+     * (REQ-VIEW-CAL-04).
+     *
+     * @param View                 $view          The calendar view
+     * @param string               $rangeStart    Inclusive range start (ISO 8601 date/datetime)
+     * @param string               $rangeEnd      Inclusive range end (ISO 8601 date/datetime)
+     * @param array<string, mixed> $requestParams Additional request params (reserved for future use)
+     *
+     * @return array{viewType: string, dateField: string, endDateField: string|null,
+     *     rangeStart: string, rangeEnd: string, objects: array<int, mixed>, total: int}
+     *
+     * @throws InvalidArgumentException If the view is not a calendar view or its config is incomplete
+     *
+     * @spec openspec/changes/object-views-kanban-calendar/specs/saved-search-views/spec.md#requirement-calendar-plots-objects-by-a-date-field-over-a-range-req-view-cal-04
+     */
+    public function getCalendarObjects(View $view, string $rangeStart, string $rangeEnd, array $requestParams=[]): array
+    {
+        // @spec exclude requestParams reserved for future filter passthrough; unused today.
+        unset($requestParams);
+
+        $presentation = $view->getPresentation();
+        $viewType     = $presentation['viewType'] ?? 'table';
+        if ($viewType !== 'calendar') {
+            throw new InvalidArgumentException('View is not a calendar view (viewType is "'.$viewType.'")');
+        }
+
+        $calendarConfig = $presentation['calendar'] ?? [];
+        $dateField      = $calendarConfig['dateField'] ?? null;
+        if (is_string($dateField) === false || $dateField === '') {
+            throw new InvalidArgumentException('Calendar view is missing calendar.dateField');
+        }
+
+        $endDateField = $calendarConfig['endDateField'] ?? null;
+        if ($endDateField !== null && (is_string($endDateField) === false || $endDateField === '')) {
+            $endDateField = null;
+        }
+
+        $query       = $view->getQuery() ?? [];
+        $registerRef = $query['registers'][0] ?? null;
+        $schemaRef   = $query['schemas'][0] ?? null;
+        if ($registerRef === null || $schemaRef === null) {
+            throw new InvalidArgumentException('Calendar view requires a register and schema in its query');
+        }
+
+        $this->objectService->setRegister(register: $registerRef);
+        $this->objectService->setSchema(schema: $schemaRef);
+
+        $baseQuery = $this->buildBaseObjectQuery(query: $query);
+
+        // Objects that start within the visible range.
+        $startingQuery = $baseQuery;
+        $startingQuery[$dateField] = [
+            'gte' => $rangeStart,
+            'lte' => $rangeEnd,
+        ];
+        $startingResult            = $this->objectService->searchObjectsPaginated(query: $startingQuery);
+
+        $objectsById = [];
+        foreach (($startingResult['results'] ?? []) as $object) {
+            $objectsById[$this->objectIdentity(object: $object)] = $object;
+        }
+
+        // Spanning objects: started at/before the range end and still open at/after the range start.
+        if ($endDateField !== null) {
+            $spanningQuery = $baseQuery;
+            $spanningQuery[$dateField]    = ['lte' => $rangeEnd];
+            $spanningQuery[$endDateField] = ['gte' => $rangeStart];
+            $spanningResult = $this->objectService->searchObjectsPaginated(query: $spanningQuery);
+            foreach (($spanningResult['results'] ?? []) as $object) {
+                $objectsById[$this->objectIdentity(object: $object)] = $object;
+            }
+        }
+
+        return [
+            'viewType'     => 'calendar',
+            'dateField'    => $dateField,
+            'endDateField' => $endDateField,
+            'rangeStart'   => $rangeStart,
+            'rangeEnd'     => $rangeEnd,
+            'objects'      => array_values($objectsById),
+            'total'        => count($objectsById),
+        ];
+    }//end getCalendarObjects()
+
+    /**
+     * Derive the ordered list of kanban column values.
+     *
+     * Precedence: explicit `columnOrder` > schema enum order > distinct
+     * observed values (discovered via the existing facet/object-query
+     * machinery, never by loading the whole table).
+     *
+     * @param array<string, mixed> $properties   The schema's properties
+     * @param string               $groupByField The property grouped on
+     * @param array|null           $columnOrder  Explicit column order, if configured
+     * @param array<string, mixed> $baseQuery    Base object query (filters/sort) to scope discovery
+     *
+     * @return array<int, mixed> The ordered column values
+     */
+    private function deriveColumnValues(array $properties, string $groupByField, ?array $columnOrder, array $baseQuery): array
+    {
+        if ($columnOrder !== null && empty($columnOrder) === false) {
+            return array_values($columnOrder);
+        }
+
+        $enumValues = $properties[$groupByField]['enum'] ?? null;
+        if (is_array($enumValues) === true && empty($enumValues) === false) {
+            return array_values($enumValues);
+        }
+
+        return $this->discoverDistinctValues(groupByField: $groupByField, baseQuery: $baseQuery);
+    }//end deriveColumnValues()
+
+    /**
+     * Discover the distinct observed values of a field via the existing
+     * facet machinery (never a bespoke "SELECT DISTINCT" query, and never a
+     * full-table scan — facets are computed over the existing search index).
+     *
+     * @param string               $groupByField The property to discover distinct values for
+     * @param array<string, mixed> $baseQuery    Base object query (filters/sort) to scope discovery
+     *
+     * @return array<int, mixed> The distinct observed values
+     */
+    private function discoverDistinctValues(string $groupByField, array $baseQuery): array
+    {
+        try {
+            $facetQuery            = $baseQuery;
+            $facetQuery['_facets'] = [$groupByField => ['type' => 'terms']];
+            $facets = $this->objectService->getFacetsForObjects(query: $facetQuery);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                message: '[ViewPresentationService] Failed to discover distinct kanban column values: '.$e->getMessage(),
+                context: ['file' => __FILE__, 'line' => __LINE__, 'groupByField' => $groupByField]
+            );
+            return [];
+        }
+
+        $buckets = $facets['facets'][$groupByField]['data']['buckets'] ?? $facets['facets'][$groupByField]['buckets'] ?? [];
+
+        $values = [];
+        foreach ($buckets as $bucket) {
+            $value = $bucket['value'] ?? $bucket['key'] ?? null;
+            if ($value !== null) {
+                $values[] = $value;
+            }
+        }
+
+        return $values;
+    }//end discoverDistinctValues()
+
+    /**
+     * Build the base object-query filters/sort from a view's stored query,
+     * preserved unchanged (REQ-VIEW-KANBAN-02: "filters and sort preserved").
+     *
+     * @param array<string, mixed> $query The view's stored query
+     *
+     * @return array<string, mixed> The base object-query filters/sort
+     */
+    private function buildBaseObjectQuery(array $query): array
+    {
+        $objectQuery = [];
+
+        if (empty($query['filters']) === false && is_array($query['filters']) === true) {
+            $objectQuery = array_merge($objectQuery, $query['filters']);
+        }
+
+        if (empty($query['sort']) === false) {
+            $objectQuery['_order'] = $query['sort'];
+        }
+
+        return $objectQuery;
+    }//end buildBaseObjectQuery()
+
+    /**
+     * Derive a stable identity for an object result used to de-duplicate
+     * the starting/spanning calendar query merge.
+     *
+     * @param mixed $object A single result row from searchObjectsPaginated()
+     *
+     * @return string The object's identity key
+     */
+    private function objectIdentity(mixed $object): string
+    {
+        if (is_array($object) === true) {
+            $id = $object['id'] ?? $object['uuid'] ?? null;
+            if ($id !== null) {
+                return (string) $id;
+            }
+
+            return md5(serialize($object));
+        }
+
+        if (is_object($object) === true && method_exists($object, 'getId') === true) {
+            return (string) $object->getId();
+        }
+
+        return spl_object_hash((object) $object);
+    }//end objectIdentity()
+}//end class

--- a/lib/Service/ViewService.php
+++ b/lib/Service/ViewService.php
@@ -26,10 +26,12 @@
 namespace OCA\OpenRegister\Service;
 
 use Exception;
+use InvalidArgumentException;
 use stdClass;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCA\OpenRegister\Db\View;
 use OCA\OpenRegister\Db\ViewMapper;
+use OCA\OpenRegister\Db\SchemaMapper;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -73,22 +75,35 @@ class ViewService
     private readonly LoggerInterface $logger;
 
     /**
+     * Schema mapper
+     *
+     * Used to resolve the view's schema when validating a presentation
+     * config's groupByField/dateField against real schema properties.
+     *
+     * @var SchemaMapper Schema mapper instance
+     */
+    private readonly SchemaMapper $schemaMapper;
+
+    /**
      * Constructor
      *
      * Initializes service with view mapper and logger for view operations.
      *
-     * @param ViewMapper      $viewMapper View mapper for database operations
-     * @param LoggerInterface $logger     Logger for error tracking
+     * @param ViewMapper      $viewMapper   View mapper for database operations
+     * @param LoggerInterface $logger       Logger for error tracking
+     * @param SchemaMapper    $schemaMapper Schema mapper for presentation field validation
      *
      * @return void
      */
     public function __construct(
         ViewMapper $viewMapper,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        SchemaMapper $schemaMapper
     ) {
         // Store dependencies for use in service methods.
-        $this->viewMapper = $viewMapper;
-        $this->logger     = $logger;
+        $this->viewMapper   = $viewMapper;
+        $this->logger       = $logger;
+        $this->schemaMapper = $schemaMapper;
     }//end __construct()
 
     /**
@@ -150,17 +165,20 @@ class ViewService
      * Creates a new view entity with specified properties. If view is set as default,
      * clears any existing default view for the user. Validates and stores view in database.
      *
-     * @param string               $name        The name of the view
-     * @param string               $description The description of the view
-     * @param string               $owner       The owner user ID
-     * @param bool                 $isPublic    Whether the view is public (accessible to all users)
-     * @param bool                 $isDefault   Whether the view is the default view for the user
-     * @param array<string, mixed> $query       The query parameters (registers, schemas, filters)
+     * @param string               $name         The name of the view
+     * @param string               $description  The description of the view
+     * @param string               $owner        The owner user ID
+     * @param bool                 $isPublic     Whether the view is public (accessible to all users)
+     * @param bool                 $isDefault    Whether the view is the default view for the user
+     * @param array<string, mixed> $query        The query parameters (registers, schemas, filters)
+     * @param array|null           $presentation Presentation config (viewType + kanban/calendar config); null = table (default)
      *
      * @return View The created view entity
      *
      * @throws Exception If view creation fails (database error, validation error, etc.)
+     * @throws InvalidArgumentException If the presentation config cannot render (REQ-VIEW-PRES-01)
      *
+     * @spec openspec/changes/object-views-kanban-calendar/specs/saved-search-views/spec.md#requirement-views-persist-a-validated-presentation-config-req-view-pres-01
      * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-8
      */
     public function create(
@@ -169,9 +187,13 @@ class ViewService
         string $owner,
         bool $isPublic,
         bool $isDefault,
-        array $query
+        array $query,
+        ?array $presentation=null
     ): View {
         try {
+            // Step 0: Reject a presentation config that cannot render before touching the DB.
+            $this->validatePresentationConfig(presentation: $presentation, query: $query);
+
             // Step 1: If this view is set as default, clear any existing default for this user.
             // Only one default view per user is allowed.
             if ($isDefault === true) {
@@ -186,6 +208,7 @@ class ViewService
             $view->setIsPublic($isPublic);
             $view->setIsDefault($isDefault);
             $view->setQuery($query);
+            $view->setPresentation($presentation);
             $view->setFavoredBy([]);
 
             // Step 3: Insert view into database and return created entity.
@@ -203,19 +226,22 @@ class ViewService
     /**
      * Update an existing view.
      *
-     * @param int|string $id          The ID of the view to update
-     * @param string     $name        The name of the view
-     * @param string     $description The description of the view
-     * @param string     $owner       The owner user ID (for access control)
-     * @param bool       $isPublic    Whether the view is public
-     * @param bool       $isDefault   Whether the view is default
-     * @param array      $query       The query parameters
-     * @param array|null $favoredBy   Array of user IDs who favor this view
+     * @param int|string $id           The ID of the view to update
+     * @param string     $name         The name of the view
+     * @param string     $description  The description of the view
+     * @param string     $owner        The owner user ID (for access control)
+     * @param bool       $isPublic     Whether the view is public
+     * @param bool       $isDefault    Whether the view is default
+     * @param array      $query        The query parameters
+     * @param array|null $favoredBy    Array of user IDs who favor this view
+     * @param array|null $presentation Presentation config (viewType + kanban/calendar config); null leaves the existing value untouched
      *
      * @return View The updated view
      *
      * @throws Exception If update fails
+     * @throws InvalidArgumentException If the presentation config cannot render (REQ-VIEW-PRES-01)
      *
+     * @spec openspec/changes/object-views-kanban-calendar/specs/saved-search-views/spec.md#requirement-views-persist-a-validated-presentation-config-req-view-pres-01
      * @spec openspec/changes/retrofit-2026-05-24-b-svc-urn-sec-edepot-view/tasks.md#task-8
      */
     public function update(
@@ -226,9 +252,13 @@ class ViewService
         bool $isPublic,
         bool $isDefault,
         array $query,
-        ?array $favoredBy=null
+        ?array $favoredBy=null,
+        ?array $presentation=null
     ): View {
         try {
+            // Reject a presentation config that cannot render before touching the DB.
+            $this->validatePresentationConfig(presentation: $presentation, query: $query);
+
             $view = $this->find(id: $id, owner: $owner);
 
             // If this is set as default, schema: unset any existing default for this user.
@@ -245,6 +275,13 @@ class ViewService
             // Update favoredBy if provided.
             if ($favoredBy !== null) {
                 $view->setFavoredBy($favoredBy);
+            }
+
+            // Update presentation if provided; a null presentation leaves the
+            // existing stored value untouched (mirrors favoredBy's semantics)
+            // so a PATCH that doesn't mention presentation can't silently wipe it.
+            if ($presentation !== null) {
+                $view->setPresentation($presentation);
             }
 
             return $this->viewMapper->update($view);
@@ -300,4 +337,112 @@ class ViewService
             }
         }
     }//end clearDefaultForUser()
+
+    /**
+     * Validate a presentation config against the view's schema.
+     *
+     * A null presentation (or an explicit `viewType: table`) is always valid —
+     * `table` has no field to check. A `kanban` presentation must declare a
+     * `groupByField`, and a `calendar` presentation a `dateField` (with an
+     * optional `endDateField`); each declared field MUST be a real property
+     * on the view's (first configured) schema, or the save is rejected.
+     *
+     * @param array|null           $presentation The presentation config to validate, or null
+     * @param array<string, mixed> $query        The view's query (used to resolve its schema)
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException If the presentation cannot render
+     *
+     * @spec openspec/changes/object-views-kanban-calendar/specs/saved-search-views/spec.md#requirement-views-persist-a-validated-presentation-config-req-view-pres-01
+     */
+    private function validatePresentationConfig(?array $presentation, array $query): void
+    {
+        if ($presentation === null) {
+            return;
+        }
+
+        $viewType = $presentation['viewType'] ?? 'table';
+
+        if ($viewType === 'table') {
+            return;
+        }
+
+        if ($viewType === 'kanban') {
+            $groupByField = $presentation['kanban']['groupByField'] ?? null;
+            if (is_string($groupByField) === false || $groupByField === '') {
+                throw new InvalidArgumentException('A kanban presentation requires a non-empty kanban.groupByField');
+            }
+
+            $this->assertFieldExistsOnViewSchema(field: $groupByField, query: $query, label: 'kanban.groupByField');
+            return;
+        }
+
+        if ($viewType === 'calendar') {
+            $dateField = $presentation['calendar']['dateField'] ?? null;
+            if (is_string($dateField) === false || $dateField === '') {
+                throw new InvalidArgumentException('A calendar presentation requires a non-empty calendar.dateField');
+            }
+
+            $this->assertFieldExistsOnViewSchema(field: $dateField, query: $query, label: 'calendar.dateField');
+
+            $endDateField = $presentation['calendar']['endDateField'] ?? null;
+            if ($endDateField !== null) {
+                if (is_string($endDateField) === false || $endDateField === '') {
+                    throw new InvalidArgumentException('calendar.endDateField must be a non-empty string when provided');
+                }
+
+                $this->assertFieldExistsOnViewSchema(field: $endDateField, query: $query, label: 'calendar.endDateField');
+            }
+
+            return;
+        }
+
+        throw new InvalidArgumentException('Unknown presentation viewType: '.(string) $viewType);
+    }//end validatePresentationConfig()
+
+    /**
+     * Assert that a field name is a real property on the view's (first) schema.
+     *
+     * Kanban/calendar are single-schema presentations (per design non-goals:
+     * no cross-register kanban), so the first schema referenced by the view's
+     * query is the one validated against.
+     *
+     * @param string               $field The property name to check
+     * @param array<string, mixed> $query The view's query (holds `schemas`)
+     * @param string               $label Human-readable label for the error message
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException If no schema is configured, the schema can't be
+     *                                   resolved, or the field is not one of its properties
+     *
+     * @spec openspec/changes/object-views-kanban-calendar/specs/saved-search-views/spec.md#requirement-views-persist-a-validated-presentation-config-req-view-pres-01
+     */
+    private function assertFieldExistsOnViewSchema(string $field, array $query, string $label): void
+    {
+        $schemaRef = $query['schemas'][0] ?? null;
+        if ($schemaRef === null || $schemaRef === '') {
+            throw new InvalidArgumentException(
+                'Cannot validate '.$label.': the view has no schema configured to validate against'
+            );
+        }
+
+        try {
+            $schema = $this->schemaMapper->find($schemaRef);
+        } catch (Exception $e) {
+            throw new InvalidArgumentException(
+                'Cannot validate '.$label.': schema "'.$schemaRef.'" could not be resolved',
+                0,
+                $e
+            );
+        }
+
+        $properties = $schema->getProperties();
+        if (array_key_exists($field, $properties) === false) {
+            throw new InvalidArgumentException(
+                'Presentation '.$label.' "'.$field.'" is not a property of the view\'s schema'
+            );
+        }
+    }//end assertFieldExistsOnViewSchema()
 }//end class

--- a/openspec/changes/object-views-kanban-calendar/tasks.md
+++ b/openspec/changes/object-views-kanban-calendar/tasks.md
@@ -4,29 +4,37 @@
 
 ## 1. Presentation config on views
 
-- [ ] 1.1 Add a nullable `presentation` JSON property to `lib/Db/View.php` (`addType('presentation','json')`) + a migration adding the column (REQ-VIEW-PRES-01)
+- [x] 1.1 Add a nullable `presentation` JSON property to `lib/Db/View.php` (`addType('presentation','json')`) + a migration adding the column (REQ-VIEW-PRES-01)
   - `viewType` defaults to `table` when `presentation` is null; existing views render unchanged.
-- [ ] 1.2 In `ViewService.create/update` + `ViewsController`, accept/return `presentation` and validate `groupByField`/`dateField` against the view's schema properties (reject an unrenderable config) (REQ-VIEW-PRES-01)
+  - Done: `View::$presentation` + `getPresentationFormatted()` default; migration `Version1Date20260724000000`.
+- [x] 1.2 In `ViewService.create/update` + `ViewsController`, accept/return `presentation` and validate `groupByField`/`dateField` against the view's schema properties (reject an unrenderable config) (REQ-VIEW-PRES-01)
+  - Done: `ViewService::validatePresentationConfig()` + `assertFieldExistsOnViewSchema()`; controller create/update/patch pass `presentation` through and return 400 on `InvalidArgumentException`.
 
 ## 2. Kanban (backend contract)
 
-- [ ] 2.1 Derive kanban columns from the distinct values of `groupByField` (enum order or `columnOrder`; distinct observed values otherwise); cards come from the existing view `query` with filters/sort preserved (REQ-VIEW-KANBAN-02)
-- [ ] 2.2 Drag-to-move updates `groupByField` via the existing guarded object PATCH/PUT path — RBAC + `x-openregister-lifecycle` enforced; an illegal transition is rejected (card snaps back). No bespoke move endpoint (REQ-VIEW-KANBAN-03)
+- [x] 2.1 Derive kanban columns from the distinct values of `groupByField` (enum order or `columnOrder`; distinct observed values otherwise); cards come from the existing view `query` with filters/sort preserved (REQ-VIEW-KANBAN-02)
+  - Done: `ViewPresentationService::getKanbanBoard()` (+ `deriveColumnValues()`/`discoverDistinctValues()` via the existing facet machinery); cards paginated per column through `ObjectService::searchObjectsPaginated()`. Read-only `GET /api/views/{id}/kanban`.
+- [x] 2.2 Drag-to-move updates `groupByField` via the existing guarded object PATCH/PUT path — RBAC + `x-openregister-lifecycle` enforced; an illegal transition is rejected (card snaps back). No bespoke move endpoint (REQ-VIEW-KANBAN-03)
+  - Done: verified, not built — no move/drag endpoint exists on `ViewsController` or in `routes.php` (asserted by `ViewsControllerTest::testNoBespokeCardMoveEndpointOnController` + `testKanbanAndCalendarRoutesAreReadOnlyGet`). A future drag write goes through the existing `/api/objects/{register}/{schema}/{id}` PATCH/PUT, whose lifecycle guard is unchanged by this backend phase.
 
 ## 3. Calendar (backend contract)
 
-- [ ] 3.1 Calendar view returns objects whose `dateField` falls in the visible range via existing search/filter; optional `endDateField` spans days (REQ-VIEW-CAL-04)
+- [x] 3.1 Calendar view returns objects whose `dateField` falls in the visible range via existing search/filter; optional `endDateField` spans days (REQ-VIEW-CAL-04)
+  - Done: `ViewPresentationService::getCalendarObjects()`; read-only `GET /api/views/{id}/calendar?start=...&end=...`.
 
 ## 4. Frontend + nc-vue
 
 - [ ] 4.1 Ship `CnObjectKanban` + `CnObjectCalendar` in nextcloud-vue (shared components; declared dependency) and dispatch `src/views/` object-list on `presentation.viewType` to them, passing objects/config/write-callback (REQ-VIEW-PRES-05)
   - nc-vue components land in a beta first (or lockstep); backend is verifiable independently.
+  - **PHASE 2 — not started.** Backend contract this phase leaves for the frontend phase to consume: `presentation` on the View API response; `GET /api/views/{id}/kanban` (columns + paginated cards); `GET /api/views/{id}/calendar?start=&end=` (date-range objects); drag-to-move calls the existing object PATCH/PUT endpoint directly (no new endpoint to wire).
 
 ## 5. Verification
 
-- [ ] 5.1 Unit tests: `presentation` persistence + field validation; kanban column-move updates `groupByField` through the guarded path and rejects an illegal lifecycle transition; calendar date-range query (REQ-VIEW-PRES-01, REQ-VIEW-KANBAN-03, REQ-VIEW-CAL-04)
+- [x] 5.1 Unit tests: `presentation` persistence + field validation; kanban column-move updates `groupByField` through the guarded path and rejects an illegal lifecycle transition; calendar date-range query (REQ-VIEW-PRES-01, REQ-VIEW-KANBAN-03, REQ-VIEW-CAL-04)
   - Run in the `nextcloud:34` container: `docker run --rm -v $PWD:/app -w /app <nc-image> php vendor/bin/phpunit`.
+  - Done: `tests/Unit/Db/ViewTest.php`, `tests/Unit/Service/ViewServiceTest.php`, `tests/Unit/Service/ViewPresentationServiceTest.php`, `tests/Unit/Controller/ViewsControllerTest.php` — 123 tests, 270 assertions, green.
 - [ ] 5.2 Live smoke on 8080: create a kanban view grouped by an enum property, drag a card across columns, confirm the object's field changed; create a calendar view and confirm objects plot by date (REQ-VIEW-KANBAN-02, REQ-VIEW-CAL-04)
+  - **PHASE 2 — not started.** Needs the nc-vue components (task 4.1) wired into `src/views/` to exercise end-to-end through the UI; do this alongside 4.1.
 
 Acceptance criteria:
 - A saved view persists a `viewType` of table/kanban/calendar with validated config; `table` remains the default and existing views are unchanged.

--- a/tests/Service/ControllersIntegrationTest.php
+++ b/tests/Service/ControllersIntegrationTest.php
@@ -261,6 +261,7 @@ class ControllersIntegrationTest extends TestCase
             'openregister',
             $this->request,
             \OC::$server->get(ViewService::class),
+            \OC::$server->get(\OCA\OpenRegister\Service\ViewPresentationService::class),
             $this->userSession,
             \OC::$server->get(LoggerInterface::class)
         );

--- a/tests/Unit/Controller/ViewsControllerTest.php
+++ b/tests/Unit/Controller/ViewsControllerTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Tests\Unit\Controller;
 
 use OCA\OpenRegister\Controller\ViewsController;
+use OCA\OpenRegister\Db\View;
+use OCA\OpenRegister\Service\ViewPresentationService;
 use OCA\OpenRegister\Service\ViewService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http\JSONResponse;
@@ -20,6 +22,7 @@ class ViewsControllerTest extends TestCase
     private ViewsController $controller;
     private IRequest&MockObject $request;
     private ViewService&MockObject $viewService;
+    private ViewPresentationService&MockObject $viewPresentationService;
     private IUserSession&MockObject $userSession;
     private LoggerInterface&MockObject $logger;
 
@@ -29,6 +32,7 @@ class ViewsControllerTest extends TestCase
 
         $this->request = $this->createMock(IRequest::class);
         $this->viewService = $this->createMock(ViewService::class);
+        $this->viewPresentationService = $this->createMock(ViewPresentationService::class);
         $this->userSession = $this->createMock(IUserSession::class);
         $this->logger = $this->createMock(LoggerInterface::class);
 
@@ -36,6 +40,7 @@ class ViewsControllerTest extends TestCase
             'openregister',
             $this->request,
             $this->viewService,
+            $this->viewPresentationService,
             $this->userSession,
             $this->logger
         );
@@ -407,7 +412,8 @@ class ViewsControllerTest extends TestCase
                     'searchTerms'   => ['test'],
                     'facetFilters'  => ['status' => 'active'],
                     'enabledFacets' => ['status'],
-                ]
+                ],
+                null
             )
             ->willReturn($view);
 
@@ -443,7 +449,8 @@ class ViewsControllerTest extends TestCase
                     'searchTerms'   => [],
                     'facetFilters'  => [],
                     'enabledFacets' => [],
-                ]
+                ],
+                null
             )
             ->willReturn($view);
 
@@ -562,7 +569,9 @@ class ViewsControllerTest extends TestCase
                     'searchTerms'   => ['foo'],
                     'facetFilters'  => ['type' => 'bar'],
                     'enabledFacets' => ['type'],
-                ]
+                ],
+                null,
+                null
             )
             ->willReturn($view);
 
@@ -688,7 +697,8 @@ class ViewsControllerTest extends TestCase
                     'facetFilters'  => ['cat' => 'dog'],
                     'enabledFacets' => ['cat'],
                 ],
-                []
+                [],
+                null
             )
             ->willReturn($updatedView);
 
@@ -718,7 +728,8 @@ class ViewsControllerTest extends TestCase
                 false,
                 false,
                 ['registers' => [99], 'schemas' => [88]],
-                []
+                [],
+                null
             )
             ->willReturn($updatedView);
 
@@ -749,7 +760,8 @@ class ViewsControllerTest extends TestCase
                 true,
                 true,
                 ['registers' => []],
-                []
+                [],
+                null
             )
             ->willReturn($updatedView);
 
@@ -779,7 +791,8 @@ class ViewsControllerTest extends TestCase
                 false,
                 false,
                 ['registers' => []],
-                ['user1', 'user2']
+                ['user1', 'user2'],
+                null
             )
             ->willReturn($updatedView);
 
@@ -812,7 +825,8 @@ class ViewsControllerTest extends TestCase
                 true,
                 true,
                 ['registers' => [42]],
-                ['userX']
+                ['userX'],
+                null
             )
             ->willReturn($updatedView);
 
@@ -849,5 +863,276 @@ class ViewsControllerTest extends TestCase
         $data = $result->getData();
         $this->assertEquals('Failed to delete view', $data['error']);
         $this->assertEquals('Delete failed', $data['message']);
+    }
+
+    // ---------------------------------------------------------------
+    // create()/update() — presentation passthrough + validation errors
+    // ---------------------------------------------------------------
+
+    public function testCreatePassesPresentationThrough(): void
+    {
+        $this->mockAuthenticatedUser();
+        $presentation = ['viewType' => 'kanban', 'kanban' => ['groupByField' => 'status']];
+        $this->request->method('getParams')->willReturn([
+            'name'         => 'Kanban View',
+            'query'        => ['registers' => [1], 'schemas' => [2]],
+            'presentation' => $presentation,
+        ]);
+
+        $view = $this->createViewEntity();
+        $this->viewService->expects($this->once())
+            ->method('create')
+            ->with(
+                'Kanban View',
+                '',
+                'testuser',
+                false,
+                false,
+                ['registers' => [1], 'schemas' => [2]],
+                $presentation
+            )
+            ->willReturn($view);
+
+        $result = $this->controller->create();
+
+        $this->assertEquals(201, $result->getStatus());
+    }
+
+    public function testCreateWithInvalidPresentationReturns400(): void
+    {
+        $this->mockAuthenticatedUser();
+        $this->request->method('getParams')->willReturn([
+            'name'         => 'Kanban View',
+            'query'        => ['registers' => [1], 'schemas' => [2]],
+            'presentation' => ['viewType' => 'kanban', 'kanban' => ['groupByField' => 'status']],
+        ]);
+
+        $this->viewService->method('create')
+            ->willThrowException(new \InvalidArgumentException('Presentation kanban.groupByField "status" is not a property of the view\'s schema'));
+
+        $result = $this->controller->create();
+
+        $this->assertEquals(400, $result->getStatus());
+        $this->assertStringContainsString('groupByField', $result->getData()['error']);
+    }
+
+    public function testUpdateWithInvalidPresentationReturns400(): void
+    {
+        $this->mockAuthenticatedUser();
+        $this->request->method('getParams')->willReturn([
+            'name'         => 'Kanban View',
+            'query'        => ['registers' => [1], 'schemas' => [2]],
+            'presentation' => ['viewType' => 'calendar', 'calendar' => ['dateField' => 'missing']],
+        ]);
+
+        $this->viewService->method('update')
+            ->willThrowException(new \InvalidArgumentException('Presentation calendar.dateField "missing" is not a property of the view\'s schema'));
+
+        $result = $this->controller->update('1');
+
+        $this->assertEquals(400, $result->getStatus());
+        $this->assertStringContainsString('dateField', $result->getData()['error']);
+    }
+
+    public function testPatchPreservesExistingPresentationWhenOmitted(): void
+    {
+        $this->mockAuthenticatedUser();
+        $this->request->method('getParams')->willReturn(['name' => 'Renamed']);
+
+        $existingPresentation = ['viewType' => 'kanban', 'kanban' => ['groupByField' => 'status']];
+        $view = $this->createViewEntity();
+        $view->setPresentation($existingPresentation);
+        $this->viewService->method('find')->willReturn($view);
+
+        $updatedView = $this->createViewEntity();
+        $this->viewService->expects($this->once())
+            ->method('update')
+            ->with(
+                '1',
+                'Renamed',
+                'Desc',
+                'testuser',
+                false,
+                false,
+                ['registers' => []],
+                [],
+                $existingPresentation
+            )
+            ->willReturn($updatedView);
+
+        $result = $this->controller->patch('1');
+
+        $this->assertEquals(200, $result->getStatus());
+    }
+
+    // ---------------------------------------------------------------
+    // kanban() — read-only board data
+    // ---------------------------------------------------------------
+
+    public function testKanbanNotAuthenticated(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $result = $this->controller->kanban('1');
+
+        $this->assertEquals(401, $result->getStatus());
+    }
+
+    public function testKanbanNotFound(): void
+    {
+        $this->mockAuthenticatedUser();
+        $this->viewService->method('find')
+            ->willThrowException(new DoesNotExistException('not found'));
+
+        $result = $this->controller->kanban('999');
+
+        $this->assertEquals(404, $result->getStatus());
+    }
+
+    public function testKanbanSuccess(): void
+    {
+        $this->mockAuthenticatedUser();
+        $this->request->method('getParams')->willReturn([]);
+
+        $view = $this->createViewEntity();
+        $this->viewService->method('find')->willReturn($view);
+
+        $board = [
+            'viewType'     => 'kanban',
+            'groupByField' => 'status',
+            'columns'      => [
+                ['value' => 'todo', 'cards' => [], 'total' => 0, 'limit' => 20, 'offset' => 0],
+            ],
+        ];
+        $this->viewPresentationService->method('getKanbanBoard')->willReturn($board);
+
+        $result = $this->controller->kanban('1');
+
+        $this->assertEquals(200, $result->getStatus());
+        $this->assertEquals($board, $result->getData());
+    }
+
+    public function testKanbanInvalidConfigReturns400(): void
+    {
+        $this->mockAuthenticatedUser();
+        $this->request->method('getParams')->willReturn([]);
+
+        $view = $this->createViewEntity();
+        $this->viewService->method('find')->willReturn($view);
+        $this->viewPresentationService->method('getKanbanBoard')
+            ->willThrowException(new \InvalidArgumentException('View is not a kanban view (viewType is "table")'));
+
+        $result = $this->controller->kanban('1');
+
+        $this->assertEquals(400, $result->getStatus());
+    }
+
+    // ---------------------------------------------------------------
+    // calendar() — date-range object query
+    // ---------------------------------------------------------------
+
+    public function testCalendarNotAuthenticated(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $result = $this->controller->calendar('1');
+
+        $this->assertEquals(401, $result->getStatus());
+    }
+
+    public function testCalendarMissingRangeReturns400(): void
+    {
+        $this->mockAuthenticatedUser();
+        $this->request->method('getParams')->willReturn([]);
+
+        $result = $this->controller->calendar('1');
+
+        $this->assertEquals(400, $result->getStatus());
+    }
+
+    public function testCalendarSuccess(): void
+    {
+        $this->mockAuthenticatedUser();
+        $this->request->method('getParams')->willReturn([
+            'start' => '2026-07-01',
+            'end'   => '2026-07-31',
+        ]);
+
+        $view = $this->createViewEntity();
+        $this->viewService->method('find')->willReturn($view);
+
+        $calendarResult = [
+            'viewType'     => 'calendar',
+            'dateField'    => 'dueDate',
+            'endDateField' => null,
+            'rangeStart'   => '2026-07-01',
+            'rangeEnd'     => '2026-07-31',
+            'objects'      => [],
+            'total'        => 0,
+        ];
+        $this->viewPresentationService->method('getCalendarObjects')->willReturn($calendarResult);
+
+        $result = $this->controller->calendar('1');
+
+        $this->assertEquals(200, $result->getStatus());
+        $this->assertEquals($calendarResult, $result->getData());
+    }
+
+    public function testCalendarNotFound(): void
+    {
+        $this->mockAuthenticatedUser();
+        $this->request->method('getParams')->willReturn([
+            'start' => '2026-07-01',
+            'end'   => '2026-07-31',
+        ]);
+        $this->viewService->method('find')
+            ->willThrowException(new DoesNotExistException('not found'));
+
+        $result = $this->controller->calendar('999');
+
+        $this->assertEquals(404, $result->getStatus());
+    }
+
+    // ---------------------------------------------------------------
+    // Kanban drag-to-move MUST reuse the guarded object PATCH/PUT path
+    // (REQ-VIEW-KANBAN-03, design.md D3) — no bespoke "move card" endpoint.
+    // ---------------------------------------------------------------
+
+    public function testNoBespokeCardMoveEndpointOnController(): void
+    {
+        $reflection  = new \ReflectionClass(ViewsController::class);
+        $methodNames = array_map(
+            fn (\ReflectionMethod $m): string => $m->getName(),
+            $reflection->getMethods(\ReflectionMethod::IS_PUBLIC)
+        );
+
+        $suspicious = array_values(array_filter(
+            $methodNames,
+            fn (string $name): bool => (bool) preg_match('/move|drag/i', $name)
+        ));
+
+        $this->assertSame(
+            [],
+            $suspicious,
+            'Kanban drag-to-move must go through the existing guarded object PATCH/PUT path — '
+                .'ViewsController must not define a bespoke move/drag-card endpoint.'
+        );
+    }
+
+    public function testKanbanAndCalendarRoutesAreReadOnlyGet(): void
+    {
+        $routesFile = dirname(__DIR__, 3).'/appinfo/routes.php';
+        $this->assertFileExists($routesFile);
+        $contents = file_get_contents($routesFile);
+
+        $this->assertMatchesRegularExpression(
+            "/'views#kanban'\s*,\s*'url'\s*=>\s*'\/api\/views\/\{id\}\/kanban'\s*,\s*'verb'\s*=>\s*'GET'/",
+            $contents
+        );
+        $this->assertMatchesRegularExpression(
+            "/'views#calendar'\s*,\s*'url'\s*=>\s*'\/api\/views\/\{id\}\/calendar'\s*,\s*'verb'\s*=>\s*'GET'/",
+            $contents
+        );
+        $this->assertDoesNotMatchRegularExpression("/'views#(moveCard|dragCard|move|drag)'/i", $contents);
     }
 }

--- a/tests/Unit/Db/ViewTest.php
+++ b/tests/Unit/Db/ViewTest.php
@@ -23,6 +23,7 @@ class ViewTest extends TestCase
         $this->assertSame('boolean', $fieldTypes['isPublic']);
         $this->assertSame('boolean', $fieldTypes['isDefault']);
         $this->assertSame('json', $fieldTypes['query']);
+        $this->assertSame('json', $fieldTypes['presentation']);
         $this->assertSame('json', $fieldTypes['favoredBy']);
         $this->assertSame('datetime', $fieldTypes['created']);
         $this->assertSame('datetime', $fieldTypes['updated']);
@@ -38,6 +39,7 @@ class ViewTest extends TestCase
         $this->assertFalse($this->view->getIsPublic());
         $this->assertFalse($this->view->getIsDefault());
         $this->assertSame([], $this->view->getQuery());
+        $this->assertNull($this->view->getPresentation());
         $this->assertSame([], $this->view->getFavoredBy());
         $this->assertNull($this->view->getCreated());
         $this->assertNull($this->view->getUpdated());
@@ -100,6 +102,20 @@ class ViewTest extends TestCase
         $this->assertSame($query, $this->view->getQuery());
     }
 
+    // --- Presentation (object-views-kanban-calendar, REQ-VIEW-PRES-01) ---
+
+    public function testSetAndGetPresentation(): void
+    {
+        $presentation = ['viewType' => 'kanban', 'kanban' => ['groupByField' => 'status']];
+        $this->view->setPresentation($presentation);
+        $this->assertSame($presentation, $this->view->getPresentation());
+    }
+
+    public function testGetPresentationDefaultsToNull(): void
+    {
+        $this->assertNull($this->view->getPresentation());
+    }
+
     public function testSetAndGetFavoredBy(): void
     {
         $users = ['user1', 'user2', 'admin'];
@@ -151,7 +167,7 @@ class ViewTest extends TestCase
 
         $expectedKeys = [
             'id', 'uuid', 'name', 'description', 'owner', 'organisation',
-            'isPublic', 'isDefault', 'query', 'favoredBy', 'quota', 'usage',
+            'isPublic', 'isDefault', 'query', 'presentation', 'favoredBy', 'quota', 'usage',
             'created', 'updated', 'managedByConfiguration',
         ];
 
@@ -173,6 +189,7 @@ class ViewTest extends TestCase
         $this->assertFalse($json['isPublic']);
         $this->assertFalse($json['isDefault']);
         $this->assertSame([], $json['query']);
+        $this->assertSame(['viewType' => 'table'], $json['presentation']);
         $this->assertSame([], $json['favoredBy']);
         $this->assertNull($json['created']);
         $this->assertNull($json['updated']);
@@ -230,6 +247,65 @@ class ViewTest extends TestCase
         $json = $this->view->jsonSerialize();
         $this->assertNull($json['created']);
         $this->assertNull($json['updated']);
+    }
+
+    // --- Presentation defaulting (REQ-VIEW-PRES-01) ---
+
+    /**
+     * A legacy view (presentation never set, i.e. null) MUST read back with
+     * viewType "table" and render exactly as before this change.
+     */
+    public function testJsonSerializeLegacyViewDefaultsToTablePresentation(): void
+    {
+        $json = $this->view->jsonSerialize();
+        $this->assertSame(['viewType' => 'table'], $json['presentation']);
+    }
+
+    public function testJsonSerializeIncludesExplicitKanbanPresentation(): void
+    {
+        $presentation = ['viewType' => 'kanban', 'kanban' => ['groupByField' => 'status']];
+        $this->view->setPresentation($presentation);
+
+        $json = $this->view->jsonSerialize();
+        $this->assertSame($presentation, $json['presentation']);
+    }
+
+    public function testJsonSerializeIncludesExplicitCalendarPresentation(): void
+    {
+        $presentation = ['viewType' => 'calendar', 'calendar' => ['dateField' => 'dueDate', 'endDateField' => 'endDate']];
+        $this->view->setPresentation($presentation);
+
+        $json = $this->view->jsonSerialize();
+        $this->assertSame($presentation, $json['presentation']);
+    }
+
+    /**
+     * A presentation stored without an explicit viewType key still defaults
+     * to table (defensive: the default only truly matters for a null
+     * presentation, but this guards the merge logic too).
+     */
+    public function testJsonSerializeDefaultsMissingViewTypeToTable(): void
+    {
+        $this->view->setPresentation(['kanban' => ['groupByField' => 'status']]);
+
+        $json = $this->view->jsonSerialize();
+        $this->assertSame('table', $json['presentation']['viewType']);
+    }
+
+    // --- hydrate() ---
+
+    public function testHydrateSetsPresentationWhenProvided(): void
+    {
+        $presentation = ['viewType' => 'kanban', 'kanban' => ['groupByField' => 'status']];
+        $this->view->hydrate(['presentation' => $presentation]);
+        $this->assertSame($presentation, $this->view->getPresentation());
+    }
+
+    public function testHydrateDefaultsPresentationToNullWhenAbsent(): void
+    {
+        $this->view->setPresentation(['viewType' => 'kanban', 'kanban' => ['groupByField' => 'status']]);
+        $this->view->hydrate(['name' => 'No presentation key here']);
+        $this->assertNull($this->view->getPresentation());
     }
 
     // --- getManagedByConfiguration ---

--- a/tests/Unit/Service/ViewPresentationServiceTest.php
+++ b/tests/Unit/Service/ViewPresentationServiceTest.php
@@ -1,0 +1,313 @@
+<?php
+
+/**
+ * ViewPresentationService Unit Test
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/object-views-kanban-calendar/design.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use InvalidArgumentException;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Db\View;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\ViewPresentationService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for ViewPresentationService (kanban board + calendar range queries).
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @spec openspec/changes/object-views-kanban-calendar/design.md
+ */
+class ViewPresentationServiceTest extends TestCase
+{
+
+    private ViewPresentationService $service;
+
+    private SchemaMapper&MockObject $schemaMapper;
+
+    private ObjectService&MockObject $objectService;
+
+    private LoggerInterface&MockObject $logger;
+
+    protected function setUp(): void
+    {
+        $this->schemaMapper  = $this->createMock(originalClassName: SchemaMapper::class);
+        $this->objectService = $this->createMock(originalClassName: ObjectService::class);
+        $this->logger        = $this->createMock(originalClassName: LoggerInterface::class);
+
+        $this->service = new ViewPresentationService(
+            schemaMapper: $this->schemaMapper,
+            objectService: $this->objectService,
+            logger: $this->logger
+        );
+    }//end setUp()
+
+    /**
+     * Build a view with the given presentation + query.
+     *
+     * @param array|null           $presentation The presentation config
+     * @param array<string, mixed> $query        The view's query
+     *
+     * @return View
+     */
+    private function createView(?array $presentation, array $query): View
+    {
+        $view = new View();
+        $view->setPresentation($presentation);
+        $view->setQuery($query);
+        return $view;
+    }//end createView()
+
+    private function createSchema(array $properties): Schema
+    {
+        $schema = new Schema();
+        $schema->setProperties($properties);
+        return $schema;
+    }//end createSchema()
+
+    // ── getKanbanBoard() — guard rails ──
+
+    public function testGetKanbanBoardThrowsWhenViewTypeIsNotKanban(): void
+    {
+        $view = $this->createView(['viewType' => 'table'], ['registers' => [1], 'schemas' => [2]]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->service->getKanbanBoard(view: $view);
+    }//end testGetKanbanBoardThrowsWhenViewTypeIsNotKanban()
+
+    public function testGetKanbanBoardThrowsWhenGroupByFieldMissing(): void
+    {
+        $view = $this->createView(['viewType' => 'kanban', 'kanban' => []], ['registers' => [1], 'schemas' => [2]]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->service->getKanbanBoard(view: $view);
+    }//end testGetKanbanBoardThrowsWhenGroupByFieldMissing()
+
+    public function testGetKanbanBoardThrowsWhenRegisterOrSchemaMissing(): void
+    {
+        $view = $this->createView(
+            ['viewType' => 'kanban', 'kanban' => ['groupByField' => 'status']],
+            []
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->service->getKanbanBoard(view: $view);
+    }//end testGetKanbanBoardThrowsWhenRegisterOrSchemaMissing()
+
+    // ── getKanbanBoard() — column derivation + pagination (REQ-VIEW-KANBAN-02) ──
+
+    public function testGetKanbanBoardDerivesColumnsFromEnumOrder(): void
+    {
+        $view = $this->createView(
+            ['viewType' => 'kanban', 'kanban' => ['groupByField' => 'status']],
+            ['registers' => [1], 'schemas' => [2]]
+        );
+
+        $this->schemaMapper->method('find')->willReturn(
+            $this->createSchema(['status' => ['type' => 'string', 'enum' => ['todo', 'doing', 'done']]])
+        );
+
+        $this->objectService->expects($this->once())->method('setRegister')->with(1);
+        $this->objectService->expects($this->once())->method('setSchema')->with(2);
+
+        $this->objectService->method('searchObjectsPaginated')->willReturnCallback(
+            function (array $query) {
+                return [
+                    'results' => [['id' => 'obj-'.$query['status']]],
+                    'total'   => 1,
+                ];
+            }
+        );
+
+        $board = $this->service->getKanbanBoard(view: $view, requestParams: ['_limit' => 10, '_offset' => 0]);
+
+        $this->assertSame('kanban', $board['viewType']);
+        $this->assertSame('status', $board['groupByField']);
+        $this->assertCount(3, $board['columns']);
+        $this->assertSame('todo', $board['columns'][0]['value']);
+        $this->assertSame('doing', $board['columns'][1]['value']);
+        $this->assertSame('done', $board['columns'][2]['value']);
+        $this->assertSame(10, $board['columns'][0]['limit']);
+        $this->assertSame([['id' => 'obj-todo']], $board['columns'][0]['cards']);
+    }//end testGetKanbanBoardDerivesColumnsFromEnumOrder()
+
+    public function testGetKanbanBoardRespectsExplicitColumnOrderOverEnum(): void
+    {
+        $view = $this->createView(
+            [
+                'viewType' => 'kanban',
+                'kanban'   => ['groupByField' => 'status', 'columnOrder' => ['done', 'todo', 'doing']],
+            ],
+            ['registers' => [1], 'schemas' => [2]]
+        );
+
+        $this->schemaMapper->method('find')->willReturn(
+            $this->createSchema(['status' => ['type' => 'string', 'enum' => ['todo', 'doing', 'done']]])
+        );
+        $this->objectService->method('searchObjectsPaginated')->willReturn(['results' => [], 'total' => 0]);
+
+        $board = $this->service->getKanbanBoard(view: $view);
+
+        $this->assertSame(['done', 'todo', 'doing'], array_column($board['columns'], 'value'));
+    }//end testGetKanbanBoardRespectsExplicitColumnOrderOverEnum()
+
+    public function testGetKanbanBoardFallsBackToFacetDiscoveryWithoutEnumOrColumnOrder(): void
+    {
+        $view = $this->createView(
+            ['viewType' => 'kanban', 'kanban' => ['groupByField' => 'category']],
+            ['registers' => [1], 'schemas' => [2]]
+        );
+
+        $this->schemaMapper->method('find')->willReturn(
+            $this->createSchema(['category' => ['type' => 'string']])
+        );
+
+        $this->objectService->method('getFacetsForObjects')->willReturn(
+            [
+                'facets' => [
+                    'category' => [
+                        'data' => [
+                            'buckets' => [
+                                ['value' => 'alpha', 'count' => 2],
+                                ['value' => 'beta', 'count' => 1],
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->objectService->method('searchObjectsPaginated')->willReturn(['results' => [], 'total' => 0]);
+
+        $board = $this->service->getKanbanBoard(view: $view);
+
+        $this->assertSame(['alpha', 'beta'], array_column($board['columns'], 'value'));
+    }//end testGetKanbanBoardFallsBackToFacetDiscoveryWithoutEnumOrColumnOrder()
+
+    public function testGetKanbanBoardCardsUsePaginationParamsPerColumn(): void
+    {
+        $view = $this->createView(
+            ['viewType' => 'kanban', 'kanban' => ['groupByField' => 'status']],
+            ['registers' => [1], 'schemas' => [2]]
+        );
+
+        $this->schemaMapper->method('find')->willReturn(
+            $this->createSchema(['status' => ['type' => 'string', 'enum' => ['todo']]])
+        );
+
+        $capturedQuery = null;
+        $this->objectService->method('searchObjectsPaginated')->willReturnCallback(
+            function (array $query) use (&$capturedQuery) {
+                $capturedQuery = $query;
+                return ['results' => [], 'total' => 0];
+            }
+        );
+
+        $this->service->getKanbanBoard(view: $view, requestParams: ['_limit' => 5, '_offset' => 15]);
+
+        $this->assertSame(5, $capturedQuery['_limit']);
+        $this->assertSame(15, $capturedQuery['_offset']);
+        $this->assertSame('todo', $capturedQuery['status']);
+    }//end testGetKanbanBoardCardsUsePaginationParamsPerColumn()
+
+    // ── getCalendarObjects() — guard rails ──
+
+    public function testGetCalendarObjectsThrowsWhenViewTypeIsNotCalendar(): void
+    {
+        $view = $this->createView(['viewType' => 'kanban'], ['registers' => [1], 'schemas' => [2]]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->service->getCalendarObjects(view: $view, rangeStart: '2026-07-01', rangeEnd: '2026-07-31');
+    }//end testGetCalendarObjectsThrowsWhenViewTypeIsNotCalendar()
+
+    public function testGetCalendarObjectsThrowsWhenDateFieldMissing(): void
+    {
+        $view = $this->createView(
+            ['viewType' => 'calendar', 'calendar' => []],
+            ['registers' => [1], 'schemas' => [2]]
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->service->getCalendarObjects(view: $view, rangeStart: '2026-07-01', rangeEnd: '2026-07-31');
+    }//end testGetCalendarObjectsThrowsWhenDateFieldMissing()
+
+    // ── getCalendarObjects() — date-range query (REQ-VIEW-CAL-04) ──
+
+    public function testGetCalendarObjectsReturnsOnlyObjectsInRange(): void
+    {
+        $view = $this->createView(
+            ['viewType' => 'calendar', 'calendar' => ['dateField' => 'dueDate']],
+            ['registers' => [1], 'schemas' => [2]]
+        );
+
+        $capturedQuery = null;
+        $this->objectService->method('searchObjectsPaginated')->willReturnCallback(
+            function (array $query) use (&$capturedQuery) {
+                $capturedQuery = $query;
+                return [
+                    'results' => [['id' => 'obj-1', 'dueDate' => '2026-07-15']],
+                    'total'   => 1,
+                ];
+            }
+        );
+
+        $result = $this->service->getCalendarObjects(view: $view, rangeStart: '2026-07-01', rangeEnd: '2026-07-31');
+
+        $this->assertSame('calendar', $result['viewType']);
+        $this->assertSame('dueDate', $result['dateField']);
+        $this->assertNull($result['endDateField']);
+        $this->assertSame(['gte' => '2026-07-01', 'lte' => '2026-07-31'], $capturedQuery['dueDate']);
+        $this->assertCount(1, $result['objects']);
+        $this->assertSame('obj-1', $result['objects'][0]['id']);
+    }//end testGetCalendarObjectsReturnsOnlyObjectsInRange()
+
+    public function testGetCalendarObjectsMergesSpanningObjectsWithEndDateField(): void
+    {
+        $view = $this->createView(
+            ['viewType' => 'calendar', 'calendar' => ['dateField' => 'startDate', 'endDateField' => 'endDate']],
+            ['registers' => [1], 'schemas' => [2]]
+        );
+
+        $callCount = 0;
+        $this->objectService->method('searchObjectsPaginated')->willReturnCallback(
+            function (array $query) use (&$callCount) {
+                $callCount++;
+                if ($callCount === 1) {
+                    // Starting-within-range query.
+                    return ['results' => [['id' => 'obj-starts-in-range']], 'total' => 1];
+                }
+
+                // Spanning query.
+                return ['results' => [['id' => 'obj-spans-in'], ['id' => 'obj-starts-in-range']], 'total' => 2];
+            }
+        );
+
+        $result = $this->service->getCalendarObjects(view: $view, rangeStart: '2026-07-01', rangeEnd: '2026-07-31');
+
+        $ids = array_column($result['objects'], 'id');
+        sort($ids);
+        $this->assertSame(['obj-spans-in', 'obj-starts-in-range'], $ids);
+        $this->assertSame('endDate', $result['endDateField']);
+    }//end testGetCalendarObjectsMergesSpanningObjectsWithEndDateField()
+}//end class

--- a/tests/Unit/Service/ViewServiceTest.php
+++ b/tests/Unit/Service/ViewServiceTest.php
@@ -23,6 +23,9 @@ declare(strict_types=1);
 namespace Unit\Service;
 
 use Exception;
+use InvalidArgumentException;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Db\View;
 use OCA\OpenRegister\Db\ViewMapper;
 use OCA\OpenRegister\Service\ViewService;
@@ -63,17 +66,43 @@ class ViewServiceTest extends TestCase
     private LoggerInterface&MockObject $logger;
 
     /**
+     * Mock schema mapper (used for presentation field validation).
+     *
+     * @var SchemaMapper&MockObject
+     */
+    private SchemaMapper&MockObject $schemaMapper;
+
+    /**
      * Set up test fixtures.
      *
      * @return void
      */
     protected function setUp(): void
     {
-        $this->viewMapper = $this->createMock(originalClassName: ViewMapper::class);
-        $this->logger     = $this->createMock(originalClassName: LoggerInterface::class);
+        $this->viewMapper   = $this->createMock(originalClassName: ViewMapper::class);
+        $this->logger       = $this->createMock(originalClassName: LoggerInterface::class);
+        $this->schemaMapper = $this->createMock(originalClassName: SchemaMapper::class);
 
-        $this->service = new ViewService(viewMapper: $this->viewMapper, logger: $this->logger);
+        $this->service = new ViewService(
+            viewMapper: $this->viewMapper,
+            logger: $this->logger,
+            schemaMapper: $this->schemaMapper
+        );
     }//end setUp()
+
+    /**
+     * Build a Schema entity with the given properties (for presentation validation tests).
+     *
+     * @param array<string, mixed> $properties The schema's JSON-schema properties
+     *
+     * @return Schema The configured schema entity
+     */
+    private function createSchema(array $properties): Schema
+    {
+        $schema = new Schema();
+        $schema->setProperties($properties);
+        return $schema;
+    }//end createSchema()
 
     /**
      * Create a test View entity with the given properties.
@@ -471,4 +500,319 @@ class ViewServiceTest extends TestCase
 
         $this->service->delete(id: 999, owner: 'user1');
     }//end testDeleteThrowsAndLogsOnFailure()
+
+    // ── presentation config (REQ-VIEW-PRES-01) ──
+
+    /**
+     * Test that create() persists a valid kanban presentation and returns it.
+     *
+     * @return void
+     */
+    public function testCreatePersistsValidKanbanPresentation(): void
+    {
+        $this->schemaMapper->method('find')->willReturn(
+            value: $this->createSchema(['status' => ['type' => 'string', 'enum' => ['todo', 'doing', 'done']]])
+        );
+        $this->viewMapper->method('insert')->willReturnCallback(
+            function (View $view) {
+                return $view;
+            }
+        );
+
+        $presentation = ['viewType' => 'kanban', 'kanban' => ['groupByField' => 'status']];
+
+        $result = $this->service->create(
+            name: 'Kanban View',
+            description: 'Desc',
+            owner: 'user1',
+            isPublic: false,
+            isDefault: false,
+            query: ['schemas' => ['status-schema']],
+            presentation: $presentation
+        );
+
+        $this->assertSame(expected: $presentation, actual: $result->getPresentation());
+    }//end testCreatePersistsValidKanbanPresentation()
+
+    /**
+     * Test that create() rejects a kanban presentation whose groupByField is
+     * not a property of the view's schema.
+     *
+     * @return void
+     */
+    public function testCreateRejectsKanbanGroupByFieldNotOnSchema(): void
+    {
+        $this->schemaMapper->method('find')->willReturn(
+            value: $this->createSchema(['title' => ['type' => 'string']])
+        );
+        $this->viewMapper->expects($this->never())->method('insert');
+
+        $this->expectException(exception: InvalidArgumentException::class);
+
+        $this->service->create(
+            name: 'Kanban View',
+            description: 'Desc',
+            owner: 'user1',
+            isPublic: false,
+            isDefault: false,
+            query: ['schemas' => ['some-schema']],
+            presentation: ['viewType' => 'kanban', 'kanban' => ['groupByField' => 'status']]
+        );
+    }//end testCreateRejectsKanbanGroupByFieldNotOnSchema()
+
+    /**
+     * Test that create() rejects a calendar presentation whose dateField is
+     * not a property of the view's schema.
+     *
+     * @return void
+     */
+    public function testCreateRejectsCalendarDateFieldNotOnSchema(): void
+    {
+        $this->schemaMapper->method('find')->willReturn(
+            value: $this->createSchema(['title' => ['type' => 'string']])
+        );
+        $this->viewMapper->expects($this->never())->method('insert');
+
+        $this->expectException(exception: InvalidArgumentException::class);
+
+        $this->service->create(
+            name: 'Calendar View',
+            description: 'Desc',
+            owner: 'user1',
+            isPublic: false,
+            isDefault: false,
+            query: ['schemas' => ['some-schema']],
+            presentation: ['viewType' => 'calendar', 'calendar' => ['dateField' => 'dueDate']]
+        );
+    }//end testCreateRejectsCalendarDateFieldNotOnSchema()
+
+    /**
+     * Test that create() accepts a valid calendar presentation with an endDateField.
+     *
+     * @return void
+     */
+    public function testCreatePersistsValidCalendarPresentationWithEndDateField(): void
+    {
+        $this->schemaMapper->method('find')->willReturn(
+            value: $this->createSchema(
+                [
+                    'startDate' => ['type' => 'string', 'format' => 'date'],
+                    'endDate'   => ['type' => 'string', 'format' => 'date'],
+                ]
+            )
+        );
+        $this->viewMapper->method('insert')->willReturnCallback(
+            function (View $view) {
+                return $view;
+            }
+        );
+
+        $presentation = [
+            'viewType' => 'calendar',
+            'calendar' => ['dateField' => 'startDate', 'endDateField' => 'endDate'],
+        ];
+
+        $result = $this->service->create(
+            name: 'Calendar View',
+            description: 'Desc',
+            owner: 'user1',
+            isPublic: false,
+            isDefault: false,
+            query: ['schemas' => ['event-schema']],
+            presentation: $presentation
+        );
+
+        $this->assertSame(expected: $presentation, actual: $result->getPresentation());
+    }//end testCreatePersistsValidCalendarPresentationWithEndDateField()
+
+    /**
+     * Test that create() rejects a calendar presentation whose configured
+     * endDateField is not a property of the view's schema.
+     *
+     * @return void
+     */
+    public function testCreateRejectsCalendarEndDateFieldNotOnSchema(): void
+    {
+        $this->schemaMapper->method('find')->willReturn(
+            value: $this->createSchema(['startDate' => ['type' => 'string', 'format' => 'date']])
+        );
+        $this->viewMapper->expects($this->never())->method('insert');
+
+        $this->expectException(exception: InvalidArgumentException::class);
+
+        $this->service->create(
+            name: 'Calendar View',
+            description: 'Desc',
+            owner: 'user1',
+            isPublic: false,
+            isDefault: false,
+            query: ['schemas' => ['event-schema']],
+            presentation: ['viewType' => 'calendar', 'calendar' => ['dateField' => 'startDate', 'endDateField' => 'missingField']]
+        );
+    }//end testCreateRejectsCalendarEndDateFieldNotOnSchema()
+
+    /**
+     * Test that create() rejects a kanban presentation when the view has no schema configured.
+     *
+     * @return void
+     */
+    public function testCreateRejectsPresentationWithNoSchemaConfigured(): void
+    {
+        $this->viewMapper->expects($this->never())->method('insert');
+
+        $this->expectException(exception: InvalidArgumentException::class);
+
+        $this->service->create(
+            name: 'Kanban View',
+            description: 'Desc',
+            owner: 'user1',
+            isPublic: false,
+            isDefault: false,
+            query: [],
+            presentation: ['viewType' => 'kanban', 'kanban' => ['groupByField' => 'status']]
+        );
+    }//end testCreateRejectsPresentationWithNoSchemaConfigured()
+
+    /**
+     * Test that a null presentation is always accepted (default table view, REQ-VIEW-PRES-01).
+     *
+     * @return void
+     */
+    public function testCreateAcceptsNullPresentation(): void
+    {
+        $this->schemaMapper->expects($this->never())->method('find');
+        $this->viewMapper->method('insert')->willReturnCallback(
+            function (View $view) {
+                return $view;
+            }
+        );
+
+        $result = $this->service->create(
+            name: 'Plain View',
+            description: 'Desc',
+            owner: 'user1',
+            isPublic: false,
+            isDefault: false,
+            query: [],
+            presentation: null
+        );
+
+        $this->assertNull(actual: $result->getPresentation());
+    }//end testCreateAcceptsNullPresentation()
+
+    /**
+     * Test that update() persists a valid presentation change.
+     *
+     * @return void
+     */
+    public function testUpdatePersistsValidPresentation(): void
+    {
+        $view = $this->createView(id: 1, owner: 'user1');
+        $view->setQuery(['schemas' => ['status-schema']]);
+        $this->viewMapper->method('find')->willReturn(value: $view);
+        $this->schemaMapper->method('find')->willReturn(
+            value: $this->createSchema(['status' => ['type' => 'string', 'enum' => ['todo', 'done']]])
+        );
+        $this->viewMapper->method('update')->willReturnCallback(
+            function (View $v) {
+                return $v;
+            }
+        );
+
+        $presentation = ['viewType' => 'kanban', 'kanban' => ['groupByField' => 'status']];
+
+        $result = $this->service->update(
+            id: 1,
+            name: 'View',
+            description: 'Desc',
+            owner: 'user1',
+            isPublic: false,
+            isDefault: false,
+            query: ['schemas' => ['status-schema']],
+            presentation: $presentation
+        );
+
+        $this->assertSame(expected: $presentation, actual: $result->getPresentation());
+    }//end testUpdatePersistsValidPresentation()
+
+    /**
+     * Test that update() rejects an invalid presentation before touching the mapper.
+     *
+     * @return void
+     */
+    public function testUpdateRejectsInvalidPresentation(): void
+    {
+        $view = $this->createView(id: 1, owner: 'user1');
+        $this->viewMapper->method('find')->willReturn(value: $view);
+        $this->schemaMapper->method('find')->willReturn(
+            value: $this->createSchema(['title' => ['type' => 'string']])
+        );
+        $this->viewMapper->expects($this->never())->method('update');
+
+        $this->expectException(exception: InvalidArgumentException::class);
+
+        $this->service->update(
+            id: 1,
+            name: 'View',
+            description: 'Desc',
+            owner: 'user1',
+            isPublic: false,
+            isDefault: false,
+            query: ['schemas' => ['some-schema']],
+            presentation: ['viewType' => 'kanban', 'kanban' => ['groupByField' => 'status']]
+        );
+    }//end testUpdateRejectsInvalidPresentation()
+
+    /**
+     * Test that update() with a null presentation leaves the existing stored
+     * presentation untouched (mirrors favoredBy's preserve-if-null semantics).
+     *
+     * @return void
+     */
+    public function testUpdateWithNullPresentationPreservesExisting(): void
+    {
+        $existingPresentation = ['viewType' => 'kanban', 'kanban' => ['groupByField' => 'status']];
+        $view                 = $this->createView(id: 1, owner: 'user1');
+        $view->setPresentation($existingPresentation);
+        $this->viewMapper->method('find')->willReturn(value: $view);
+        $this->viewMapper->method('update')->willReturnCallback(
+            function (View $v) {
+                return $v;
+            }
+        );
+
+        $result = $this->service->update(
+            id: 1,
+            name: 'View',
+            description: 'Desc',
+            owner: 'user1',
+            isPublic: false,
+            isDefault: false,
+            query: []
+        );
+
+        $this->assertSame(expected: $existingPresentation, actual: $result->getPresentation());
+    }//end testUpdateWithNullPresentationPreservesExisting()
+
+    /**
+     * Test that an unknown viewType is rejected.
+     *
+     * @return void
+     */
+    public function testCreateRejectsUnknownViewType(): void
+    {
+        $this->viewMapper->expects($this->never())->method('insert');
+
+        $this->expectException(exception: InvalidArgumentException::class);
+
+        $this->service->create(
+            name: 'View',
+            description: 'Desc',
+            owner: 'user1',
+            isPublic: false,
+            isDefault: false,
+            query: [],
+            presentation: ['viewType' => 'gallery']
+        );
+    }//end testCreateRejectsUnknownViewType()
 }//end class


### PR DESCRIPTION
## Summary

Backend phase of `openspec/changes/object-views-kanban-calendar` (#2059). This is **NOT the full feature** — it lands the server-side contract only; the nc-vue component phase (`CnObjectKanban`/`CnObjectCalendar` + `src/views/` dispatch on `presentation.viewType`) is phase 2 and remains after this PR. Do not close #2059.

- `lib/Db/View.php`: nullable `presentation` JSON property (`viewType`: table|kanban|calendar + kanban/calendar config), defaulted to `table` when null so existing views are unchanged. Migration `Version1Date20260724000000` adds the column (idempotent, nullable).
- `lib/Service/ViewService.php`: `create()`/`update()` accept/validate/persist `presentation`; `groupByField`/`dateField`/`endDateField` are validated against the view's schema properties and an unrenderable config is rejected with `InvalidArgumentException`.
- `lib/Controller/ViewsController.php`: create/update/patch pass `presentation` through (400 on validation failure); two new read-only endpoints — `GET /api/views/{id}/kanban` and `GET /api/views/{id}/calendar?start=&end=`.
- `lib/Service/ViewPresentationService.php` (new): kanban column derivation (explicit `columnOrder` > schema enum order > facet-discovered distinct values) with cards paginated per column through the existing `ObjectService::searchObjectsPaginated()`; calendar date-range query (+ optional `endDateField` spanning) over the same existing object-query surface.
- Drag-to-move deliberately has no new endpoint — it continues to go through the existing guarded object PATCH/PUT (RBAC + `x-openregister-lifecycle`), asserted by a dedicated test rather than re-implemented.
- Fixed a pre-existing bug surfaced by the new tests: `View::hydrate()` called Entity's magic-`__call` setters with named arguments (`setUuid(uuid: null)`), which silently resolves to an undefined `$args[0]` and crashes on the non-nullable `isPublic` field. Rewritten to the field-map + dynamic-method-call pattern already used elsewhere (e.g. `Agent::hydrate()`).

## Test plan

- [x] `tests/Unit/Db/ViewTest.php`, `tests/Unit/Service/ViewServiceTest.php`, `tests/Unit/Service/ViewPresentationServiceTest.php`, `tests/Unit/Controller/ViewsControllerTest.php` — 123 tests / 270 assertions, green in `nextcloud:34.0.0-apache`.
- [x] `phpcs` clean on all changed/added `lib/` files.
- [x] Legacy-view-unchanged, validation-rejects-unrenderable-config, enum/columnOrder/facet column derivation, pagination-per-column, and calendar range+spanning behavior all covered by unit tests.
- [ ] Phase 2 (tasks 4.1, 5.2 — nc-vue components + live smoke on 8080) — left unchecked in tasks.md for the follow-up change.