### PR TITLE
feat(flow): OpenRegister flow engine on symfony/workflow (ADR-065)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,7 @@
 		"symfony/http-kernel": "^6.4",
 		"symfony/process": "^6.4",
 		"symfony/uid": "^6.4",
+		"symfony/workflow": "^6.4",
 		"symfony/yaml": "^6.4 || ^7.0",
 		"theodo-group/llphant": "^0.9.3",
 		"twig/twig": "^3.27.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2ba0fc14c0f30c58ec359432476209a",
+    "content-hash": "2da871c8ad8b8a30e47daff829d8ca73",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -6054,6 +6054,98 @@
                 }
             ],
             "time": "2026-04-18T13:18:21+00:00"
+        },
+        {
+            "name": "symfony/workflow",
+            "version": "v6.4.37",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/workflow.git",
+                "reference": "0624ea5019589fd6a941f0ff11b899c4caca4fc2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/workflow/zipball/0624ea5019589fd6a941f0ff11b899c4caca4fc2",
+                "reference": "0624ea5019589fd6a941f0ff11b899c4caca4fc2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/event-dispatcher": "<5.4"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/security-core": "^5.4|^6.0|^7.0",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0",
+                "symfony/validator": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Workflow\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Grégoire Pineau",
+                    "email": "lyrixx@lyrixx.info"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools for managing a workflow or finite state machine",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "petrinet",
+                "place",
+                "state",
+                "statemachine",
+                "transition",
+                "workflow"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/workflow/tree/v6.4.37"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-13T14:11:12+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/lib/Service/Flow/FlowDefinitionBuilder.php
+++ b/lib/Service/Flow/FlowDefinitionBuilder.php
@@ -1,0 +1,272 @@
+<?php
+
+/**
+ * Builds a symfony/workflow Definition from a stored OpenRegister flow object.
+ *
+ * This is the translation layer between what users author (a graph of nodes and
+ * edges, drawn on CnGraphCanvas) and what executes (a Petri net). It is the only
+ * place that knows both shapes, so the engine never parses user JSON and the
+ * stored document never mentions Symfony.
+ *
+ * Why a Petri net (ADR-065): it is a superset of the two flow models this fleet
+ * already has. A single-token marking is a state machine (procest: `case.status`
+ * is the marking); a multi-token marking expresses parallel splits and
+ * synchronising joins, which no existing fleet engine can do — openconnector's
+ * `order`-indexed step list explicitly cannot, and that limit is why a canvas
+ * could not ship against it.
+ *
+ * The vocabulary maps as:
+ *
+ *   flow node  -> place       (a position in the graph)
+ *   flow edge  -> transition  (a move between positions)
+ *   marking    -> where the run currently is (one token, or several)
+ *
+ * A transition with several `from` places is a **join**: symfony/workflow will
+ * not enable it until every one of them holds a token. A transition with several
+ * `to` places is a **split**: firing it puts a token on each. That is the whole
+ * mechanism behind parallel branches — we do not implement it, we declare it.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use InvalidArgumentException;
+use Symfony\Component\Workflow\Definition;
+use Symfony\Component\Workflow\Transition;
+
+/**
+ * Translates a stored flow document into an executable Petri-net definition.
+ *
+ * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+ */
+class FlowDefinitionBuilder
+{
+    /**
+     * Build a Definition from a stored flow document.
+     *
+     * The document is user data and is therefore treated as hostile: every
+     * reference is resolved against the declared nodes before it reaches
+     * symfony/workflow, which would otherwise fail later and less legibly.
+     *
+     * @param array $flow The flow document: `{nodes: [{id}], edges: [{id, from, to}], initial?}`.
+     *
+     * @return Definition The executable definition.
+     *
+     * @throws InvalidArgumentException When the document does not describe a runnable graph.
+     *
+     * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+     */
+    public function build(array $flow): Definition
+    {
+        $places = $this->extractPlaces(flow: $flow);
+        if (empty($places) === true) {
+            throw new InvalidArgumentException(message: 'Flow declares no nodes; nothing to run.');
+        }
+
+        $transitions = $this->extractTransitions(flow: $flow, places: $places);
+        $initial     = $this->resolveInitialPlaces(flow: $flow, places: $places, transitions: $transitions);
+
+        return new Definition(places: $places, transitions: $transitions, initialPlaces: $initial);
+
+    }//end build()
+
+    /**
+     * Collect the node ids that become Petri-net places.
+     *
+     * @param array $flow The flow document.
+     *
+     * @return array<string> The place names, in declaration order.
+     *
+     * @throws InvalidArgumentException When a node has no usable id, or ids collide.
+     *
+     * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+     */
+    private function extractPlaces(array $flow): array
+    {
+        $places = [];
+        foreach (($flow['nodes'] ?? []) as $index => $node) {
+            $id = trim((string) ($node['id'] ?? ''));
+            if ($id === '') {
+                throw new InvalidArgumentException(
+                    message: sprintf('Flow node at index %d has no id.', $index)
+                );
+            }
+
+            // A duplicate id would silently merge two nodes into one place, so the
+            // graph would run but not be the graph the user drew.
+            if (in_array($id, $places, true) === true) {
+                throw new InvalidArgumentException(
+                    message: sprintf('Flow declares node id "%s" more than once.', $id)
+                );
+            }
+
+            $places[] = $id;
+        }
+
+        return $places;
+
+    }//end extractPlaces()
+
+    /**
+     * Convert edges into Petri-net transitions.
+     *
+     * Edges sharing a `name` are deliberately NOT merged: two edges named "approve"
+     * from different nodes are two transitions, exactly as drawn. Merging them
+     * would turn distinct user intent into an accidental join.
+     *
+     * @param array         $flow   The flow document.
+     * @param array<string> $places The known place names.
+     *
+     * @return array<Transition> The transitions.
+     *
+     * @throws InvalidArgumentException When an edge references an unknown node.
+     *
+     * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+     */
+    private function extractTransitions(array $flow, array $places): array
+    {
+        $transitions = [];
+        foreach (($flow['edges'] ?? []) as $index => $edge) {
+            $from = $this->normaliseEndpoints(value: ($edge['from'] ?? $edge['source'] ?? null));
+            $to   = $this->normaliseEndpoints(value: ($edge['to'] ?? $edge['target'] ?? null));
+
+            if (empty($from) === true || empty($to) === true) {
+                throw new InvalidArgumentException(
+                    message: sprintf('Flow edge at index %d must declare both "from" and "to".', $index)
+                );
+            }
+
+            // Resolve every endpoint now. A dangling edge that reaches
+            // symfony/workflow surfaces as an opaque failure at run time; here we
+            // can name the edge and the missing node.
+            foreach (array_merge($from, $to) as $endpoint) {
+                if (in_array($endpoint, $places, true) === false) {
+                    throw new InvalidArgumentException(
+                        message: sprintf(
+                            'Flow edge "%s" references unknown node "%s".',
+                            (string) ($edge['id'] ?? $index),
+                            $endpoint
+                        )
+                    );
+                }
+            }
+
+            $name = trim((string) ($edge['name'] ?? $edge['id'] ?? ''));
+            if ($name === '') {
+                $name = sprintf('edge-%d', $index);
+            }
+
+            $transitions[] = new Transition(name: $name, froms: $from, tos: $to);
+        }//end foreach
+
+        return $transitions;
+
+    }//end extractTransitions()
+
+    /**
+     * Normalise an edge endpoint to a list of place names.
+     *
+     * A scalar endpoint is an ordinary edge; an array endpoint declares a split
+     * (several `to`) or a join (several `from`).
+     *
+     * @param mixed $value The raw endpoint value.
+     *
+     * @return array<string> The endpoint place names.
+     *
+     * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+     */
+    private function normaliseEndpoints(mixed $value): array
+    {
+        if ($value === null) {
+            return [];
+        }
+
+        $list = [$value];
+        if (is_array($value) === true) {
+            $list = $value;
+        }
+
+        $names = [];
+        foreach ($list as $item) {
+            $name = trim((string) $item);
+            if ($name !== '') {
+                $names[] = $name;
+            }
+        }
+
+        return $names;
+
+    }//end normaliseEndpoints()
+
+    /**
+     * Decide which place(s) a run starts on.
+     *
+     * Explicit `initial` wins. Otherwise the start is inferred as the nodes no
+     * edge points at — the graph's sources. Inference keeps simple flows free of
+     * boilerplate while still letting a user override it.
+     *
+     * @param array             $flow        The flow document.
+     * @param array<string>     $places      The known place names.
+     * @param array<Transition> $transitions The transitions.
+     *
+     * @return array<string> The initial place names.
+     *
+     * @throws InvalidArgumentException When `initial` names an unknown node.
+     *
+     * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+     */
+    private function resolveInitialPlaces(array $flow, array $places, array $transitions): array
+    {
+        $declared = $this->normaliseEndpoints(value: ($flow['initial'] ?? null));
+        if (empty($declared) === false) {
+            foreach ($declared as $place) {
+                if (in_array($place, $places, true) === false) {
+                    throw new InvalidArgumentException(
+                        message: sprintf('Flow initial node "%s" is not a declared node.', $place)
+                    );
+                }
+            }
+
+            return $declared;
+        }
+
+        $targeted = [];
+        foreach ($transitions as $transition) {
+            foreach ($transition->getTos() as $to) {
+                $targeted[$to] = true;
+            }
+        }
+
+        $sources = array_values(
+                array_filter(
+            $places,
+            static fn (string $place): bool => isset($targeted[$place]) === false
+        )
+                );
+
+        // A fully cyclic graph has no source. Rather than refuse to run it, start
+        // on the first declared node: the author drew a loop, which is legitimate,
+        // and declaration order is the only signal available.
+        if (empty($sources) === true) {
+            return [$places[0]];
+        }
+
+        return $sources;
+
+    }//end resolveInitialPlaces()
+}//end class

--- a/lib/Service/Flow/FlowEngine.php
+++ b/lib/Service/Flow/FlowEngine.php
@@ -1,0 +1,239 @@
+<?php
+
+/**
+ * The OpenRegister flow engine.
+ *
+ * OpenRegister is the only home for a flow engine in this fleet (ADR-022,
+ * ADR-065): leaf apps consume this rather than growing their own. openconnector,
+ * procest and openbuild are consumers, not owners.
+ *
+ * The execution core is symfony/workflow — a Petri net, chosen because it is a
+ * superset of both flow models this fleet already has (ADR-065). What Symfony
+ * does NOT provide, and what therefore lives here, is everything that makes a
+ * run real: persistence of the marking, a run lifecycle, an append-only trace,
+ * and a per-step error policy. Those are ported from openconnector's
+ * FlowRunnerService, which had them right.
+ *
+ * This class is deliberately ignorant of what a step *does*. Side effects are
+ * dispatched through a FlowStepDispatcher supplied by the caller, so the engine
+ * can be unit-tested without a Nextcloud container and so a consuming app can
+ * contribute its own step types without touching the engine.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
+use Symfony\Component\Workflow\Workflow;
+use Throwable;
+
+/**
+ * Runs a stored flow document to completion, or until it can go no further.
+ *
+ * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+ */
+class FlowEngine
+{
+
+    /**
+     * Run states, ported from openconnector's flow_run lifecycle.
+     */
+    public const STATUS_COMPLETED = 'completed';
+
+    public const STATUS_STOPPED = 'stopped';
+
+    public const STATUS_DEAD_LETTER = 'dead_letter';
+
+    public const STATUS_FAILED = 'failed';
+
+    /**
+     * Per-step error policies, ported from openconnector's `onError`.
+     */
+    public const ON_ERROR_STOP = 'stop';
+
+    public const ON_ERROR_CONTINUE = 'continue';
+
+    public const ON_ERROR_DEAD_LETTER = 'dead_letter';
+
+    /**
+     * Hard ceiling on transitions fired in one run.
+     *
+     * A Petri net expresses loops, so a user-drawn cycle can run forever. This is
+     * a backstop against a graph that never settles, not a business rule: hitting
+     * it is a failure, reported as one, not a silent truncation.
+     */
+    private const MAX_TRANSITIONS = 1000;
+
+    /**
+     * Constructor.
+     *
+     * @param FlowDefinitionBuilder $builder The document -> Petri-net translator.
+     * @param LoggerInterface       $logger  The logger.
+     */
+    public function __construct(
+        private readonly FlowDefinitionBuilder $builder,
+        private readonly LoggerInterface $logger
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Run a flow document.
+     *
+     * Fires enabled transitions until none remain. Where several are enabled at
+     * once the first is taken, so ordering is the author's (declaration order),
+     * not ours — a genuinely concurrent net is expressed as a split, not as a
+     * race between edges.
+     *
+     * @param array                 $flow       The flow document.
+     * @param MarkingStoreInterface $store      Where the marking lives (an OR object, in production).
+     * @param object                $subject    The object the run is about.
+     * @param FlowStepDispatcher    $dispatcher Performs each step's side effect.
+     * @param array                 $context    Initial context passed to every step.
+     *
+     * @return array The run result: `{status, log: [], context: []}`.
+     *
+     * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+     */
+    public function run(
+        array $flow,
+        MarkingStoreInterface $store,
+        object $subject,
+        FlowStepDispatcher $dispatcher,
+        array $context=[]
+    ): array {
+        try {
+            $definition = $this->builder->build(flow: $flow);
+        } catch (InvalidArgumentException $e) {
+            // A malformed document is the author's error and must be visible.
+            // Unlike x-openregister-flows, this engine does not swallow.
+            $this->logger->warning(
+                message: '[FlowEngine] Refusing to run a malformed flow',
+                context: ['file' => __FILE__, 'line' => __LINE__, 'error' => $e->getMessage()]
+            );
+            return [
+                'status'  => self::STATUS_FAILED,
+                'log'     => [],
+                'context' => $context,
+                'error'   => $e->getMessage(),
+            ];
+        }//end try
+
+        $workflow = new Workflow(definition: $definition, markingStore: $store, name: (string) ($flow['id'] ?? 'flow'));
+        $log      = [];
+        $fired    = 0;
+
+        while (true) {
+            $enabled = $workflow->getEnabledTransitions(subject: $subject);
+            if (empty($enabled) === true) {
+                // No transition is enabled: either the run reached a final marking,
+                // or a join is still waiting on a branch that never arrives. Both
+                // are "as far as this graph goes".
+                return [
+                    'status'  => self::STATUS_COMPLETED,
+                    'log'     => $log,
+                    'context' => $context,
+                ];
+            }
+
+            $fired++;
+            if ($fired > self::MAX_TRANSITIONS) {
+                $this->logger->warning(
+                    message: '[FlowEngine] Flow exceeded the transition ceiling; aborting',
+                    context: ['file' => __FILE__, 'line' => __LINE__, 'flow' => ($flow['id'] ?? null), 'ceiling' => self::MAX_TRANSITIONS]
+                );
+                return [
+                    'status'  => self::STATUS_FAILED,
+                    'log'     => $log,
+                    'context' => $context,
+                    'error'   => sprintf('Flow did not settle within %d transitions; it may contain an unbounded loop.', self::MAX_TRANSITIONS),
+                ];
+            }
+
+            $transition = $enabled[0];
+            $name       = $transition->getName();
+            $step       = $this->stepFor(flow: $flow, transitionName: $name);
+
+            try {
+                $result  = $dispatcher->dispatch(step: $step, subject: $subject, context: $context);
+                $context = array_merge($context, ($result ?? []));
+                $log[]   = ['transition' => $name, 'status' => 'completed'];
+            } catch (Throwable $e) {
+                $policy = (string) ($step['onError'] ?? self::ON_ERROR_STOP);
+                $log[]  = ['transition' => $name, 'status' => 'failed', 'error' => $e->getMessage()];
+
+                $this->logger->warning(
+                    message: '[FlowEngine] Flow step failed',
+                    context: [
+                        'file'       => __FILE__,
+                        'line'       => __LINE__,
+                        'flow'       => ($flow['id'] ?? null),
+                        'transition' => $name,
+                        'policy'     => $policy,
+                        'error'      => $e->getMessage(),
+                    ]
+                );
+
+                if ($policy === self::ON_ERROR_DEAD_LETTER) {
+                    return ['status' => self::STATUS_DEAD_LETTER, 'log' => $log, 'context' => $context];
+                }
+
+                if ($policy !== self::ON_ERROR_CONTINUE) {
+                    // `stop` is the default: an unknown policy stops rather than
+                    // continues, so a typo fails safe instead of running on.
+                    return ['status' => self::STATUS_STOPPED, 'log' => $log, 'context' => $context];
+                }
+            }//end try
+
+            // The marking advances even when a `continue` step failed: the author
+            // asked the run to proceed, and leaving the token behind would spin
+            // this transition forever.
+            $workflow->apply(subject: $subject, transitionName: $name);
+        }//end while
+
+    }//end run()
+
+    /**
+     * Find the step configuration attached to a transition.
+     *
+     * @param array  $flow           The flow document.
+     * @param string $transitionName The transition name.
+     *
+     * @return array The step config, or an empty array when the edge carries none.
+     *
+     * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+     */
+    private function stepFor(array $flow, string $transitionName): array
+    {
+        foreach (($flow['edges'] ?? []) as $index => $edge) {
+            $name = trim((string) ($edge['name'] ?? $edge['id'] ?? ''));
+            if ($name === '') {
+                $name = sprintf('edge-%d', $index);
+            }
+
+            if ($name === $transitionName) {
+                return $edge;
+            }
+        }
+
+        return [];
+
+    }//end stepFor()
+}//end class

--- a/lib/Service/Flow/FlowEngine.php
+++ b/lib/Service/Flow/FlowEngine.php
@@ -102,13 +102,20 @@ class FlowEngine
      * not ours — a genuinely concurrent net is expressed as a split, not as a
      * race between edges.
      *
+     * The data channel is an item LIST ({@see FlowItems}), threaded from step to
+     * step. `$subject` is not that data: it carries the Petri-net marking and
+     * names what the run is about. A run with no explicit seed starts from one
+     * item built out of the subject, so a flow that never fans out behaves
+     * exactly like the single-object model this replaces.
+     *
      * @param array                 $flow       The flow document.
      * @param MarkingStoreInterface $store      Where the marking lives (an OR object, in production).
-     * @param object                $subject    The object the run is about.
+     * @param object                $subject    The object the run is about; holds the marking.
      * @param FlowStepDispatcher    $dispatcher Performs each step's side effect.
-     * @param array                 $context    Initial context passed to every step.
+     * @param array                 $context    Run-level metadata handed to every step.
+     * @param array|null            $items      Seed items; defaults to one item from the subject.
      *
-     * @return array The run result: `{status, log: [], context: []}`.
+     * @return array The run result: `{status, log: [], context: [], items: []}`.
      *
      * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
      */
@@ -117,8 +124,11 @@ class FlowEngine
         MarkingStoreInterface $store,
         object $subject,
         FlowStepDispatcher $dispatcher,
-        array $context=[]
+        array $context=[],
+        ?array $items=null
     ): array {
+        $items = ($items ?? FlowItems::fromSubject(subject: $subject));
+
         try {
             $definition = $this->builder->build(flow: $flow);
         } catch (InvalidArgumentException $e) {
@@ -132,6 +142,7 @@ class FlowEngine
                 'status'  => self::STATUS_FAILED,
                 'log'     => [],
                 'context' => $context,
+                'items'   => $items,
                 'error'   => $e->getMessage(),
             ];
         }//end try
@@ -150,6 +161,7 @@ class FlowEngine
                     'status'  => self::STATUS_COMPLETED,
                     'log'     => $log,
                     'context' => $context,
+                    'items'   => $items,
                 ];
             }
 
@@ -163,6 +175,7 @@ class FlowEngine
                     'status'  => self::STATUS_FAILED,
                     'log'     => $log,
                     'context' => $context,
+                    'items'   => $items,
                     'error'   => sprintf('Flow did not settle within %d transitions; it may contain an unbounded loop.', self::MAX_TRANSITIONS),
                 ];
             }
@@ -170,11 +183,17 @@ class FlowEngine
             $transition = $enabled[0];
             $name       = $transition->getName();
             $step       = $this->stepFor(flow: $flow, transitionName: $name);
+            $itemsIn    = $items;
 
             try {
-                $result  = $dispatcher->dispatch(step: $step, subject: $subject, context: $context);
-                $context = array_merge($context, ($result ?? []));
-                $log[]   = ['transition' => $name, 'status' => 'completed'];
+                $produced = $dispatcher->dispatch(step: $step, items: $items, context: $context);
+                $items    = FlowItems::normalise(value: $produced);
+                $log[]    = [
+                    'transition' => $name,
+                    'status'     => 'completed',
+                    'itemsIn'    => count($itemsIn),
+                    'itemsOut'   => count($items),
+                ];
             } catch (Throwable $e) {
                 $policy = (string) ($step['onError'] ?? self::ON_ERROR_STOP);
                 $log[]  = ['transition' => $name, 'status' => 'failed', 'error' => $e->getMessage()];
@@ -192,13 +211,13 @@ class FlowEngine
                 );
 
                 if ($policy === self::ON_ERROR_DEAD_LETTER) {
-                    return ['status' => self::STATUS_DEAD_LETTER, 'log' => $log, 'context' => $context];
+                    return ['status' => self::STATUS_DEAD_LETTER, 'log' => $log, 'context' => $context, 'items' => $items];
                 }
 
                 if ($policy !== self::ON_ERROR_CONTINUE) {
                     // `stop` is the default: an unknown policy stops rather than
                     // continues, so a typo fails safe instead of running on.
-                    return ['status' => self::STATUS_STOPPED, 'log' => $log, 'context' => $context];
+                    return ['status' => self::STATUS_STOPPED, 'log' => $log, 'context' => $context, 'items' => $items];
                 }
             }//end try
 

--- a/lib/Service/Flow/FlowItems.php
+++ b/lib/Service/Flow/FlowItems.php
@@ -1,0 +1,206 @@
+<?php
+
+/**
+ * Normalisation for the item array that travels between flow steps.
+ *
+ * The engine's data channel is a LIST of items, not one object. A step receives
+ * items and returns items, and a step that acts per record acts once per item.
+ * This mirrors the model n8n proved out, and it is the reason a flow can express
+ * "fetch 200 rows, act on each" without the author drawing a loop.
+ *
+ * An item is:
+ *
+ *   [
+ *     'json'       => array,       // the record itself
+ *     'binary'     => array,       // file attachments, keyed by name
+ *     'pairedItem' => array|null,  // which input item produced this one
+ *   ]
+ *
+ * `pairedItem` is what makes a run explainable: given an item at the end of a
+ * flow, it is the chain back to the input that caused it. Without it, a step
+ * that fans one item into ten leaves no way to answer "where did this come
+ * from", which is the question every debugging session starts with.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+/**
+ * Helpers for building and normalising flow item lists.
+ */
+final class FlowItems
+{
+
+    /**
+     * The key carrying an item's record.
+     */
+    public const JSON = 'json';
+
+    /**
+     * The key carrying an item's file attachments.
+     */
+    public const BINARY = 'binary';
+
+    /**
+     * The key carrying an item's provenance.
+     */
+    public const PAIRED_ITEM = 'pairedItem';
+
+    /**
+     * Coerce whatever a step returned into a well-formed item list.
+     *
+     * Steps are written by consuming apps, so the engine cannot assume the
+     * shape it gets back. Three authoring shapes are accepted and normalised
+     * rather than rejected, because rejecting them would push the same
+     * boilerplate into every dispatcher:
+     *
+     *   - a full item list             -> used as-is
+     *   - a single item (`['json'=>…]`) -> wrapped into a one-item list
+     *   - a bare record (`['a'=>1]`)    -> wrapped as that item's `json`
+     *
+     * A step that legitimately produces nothing returns an empty list, which
+     * is meaningful: it ends that branch's data, exactly as a filter should.
+     *
+     * @param mixed    $value         What the step returned.
+     * @param int|null $fromItemIndex Input item this output came from, when known.
+     *
+     * @return array<int, array<string, mixed>> A well-formed item list.
+     *
+     * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+     */
+    public static function normalise(mixed $value, ?int $fromItemIndex=null): array
+    {
+        if (is_array($value) === false) {
+            return [];
+        }
+
+        if ($value === []) {
+            return [];
+        }
+
+        // A list whose members are arrays is treated as an item list; each
+        // member is normalised in turn so a half-shaped list still lands well.
+        if (array_is_list($value) === true) {
+            $items = [];
+            foreach ($value as $index => $member) {
+                if (is_array($member) === false) {
+                    continue;
+                }
+
+                $items[] = self::item(
+                    json: (array) ($member[self::JSON] ?? $member),
+                    binary: (array) ($member[self::BINARY] ?? []),
+                    fromItemIndex: self::pairedIndex(member: $member, fallback: ($fromItemIndex ?? $index))
+                );
+            }
+
+            return $items;
+        }
+
+        // A single item, or a bare record standing in for one.
+        return [
+            self::item(
+                json: (array) ($value[self::JSON] ?? $value),
+                binary: (array) ($value[self::BINARY] ?? []),
+                fromItemIndex: self::pairedIndex(member: $value, fallback: $fromItemIndex)
+            ),
+        ];
+
+    }//end normalise()
+
+    /**
+     * Build one well-formed item.
+     *
+     * @param array    $json          The record.
+     * @param array    $binary        File attachments, keyed by name.
+     * @param int|null $fromItemIndex Input item this came from, when known.
+     *
+     * @return array<string, mixed> The item.
+     *
+     * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+     */
+    public static function item(array $json, array $binary=[], ?int $fromItemIndex=null): array
+    {
+        $paired = null;
+        if ($fromItemIndex !== null) {
+            $paired = ['item' => $fromItemIndex];
+        }
+
+        return [
+            self::JSON        => $json,
+            self::BINARY      => $binary,
+            self::PAIRED_ITEM => $paired,
+        ];
+
+    }//end item()
+
+    /**
+     * Seed a run's item list from the object it is about.
+     *
+     * A run always starts with exactly one item, so a flow that never fans out
+     * reads the same as the single-subject model it replaces.
+     *
+     * @param object $subject The object the run is about.
+     *
+     * @return array<int, array<string, mixed>> A one-item list.
+     *
+     * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+     */
+    public static function fromSubject(object $subject): array
+    {
+        $json = [];
+        if (method_exists($subject, 'jsonSerialize') === true) {
+            $json = (array) $subject->jsonSerialize();
+        } else if (method_exists($subject, 'getObject') === true) {
+            $json = (array) $subject->getObject();
+        } else {
+            $json = get_object_vars($subject);
+        }
+
+        return [self::item(json: $json)];
+
+    }//end fromSubject()
+
+    /**
+     * Read an already-set `pairedItem` index, falling back when absent.
+     *
+     * A dispatcher that tracked provenance itself keeps it; one that did not
+     * gets the engine's best guess rather than nothing.
+     *
+     * @param array    $member   The returned member.
+     * @param int|null $fallback The index to use when the member carries none.
+     *
+     * @return int|null The paired input index.
+     *
+     * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+     */
+    private static function pairedIndex(array $member, ?int $fallback): ?int
+    {
+        $paired = ($member[self::PAIRED_ITEM] ?? null);
+        if (is_array($paired) === true && isset($paired['item']) === true) {
+            return (int) $paired['item'];
+        }
+
+        if (is_int($paired) === true) {
+            return $paired;
+        }
+
+        return $fallback;
+
+    }//end pairedIndex()
+}//end class

--- a/lib/Service/Flow/FlowStepDispatcher.php
+++ b/lib/Service/Flow/FlowStepDispatcher.php
@@ -5,7 +5,7 @@
  *
  * The seam between the engine (which owns *when* a step runs) and the app (which
  * owns *what* it does). FlowEngine never learns what a `synchronization` or an
- * `email` is; it hands the step here and takes back context.
+ * `email` is; it hands the step its input items and takes back output items.
  *
  * This exists so the engine is testable without a Nextcloud container, and so a
  * consuming app can contribute step types without an engine change — which is
@@ -37,7 +37,18 @@ namespace OCA\OpenRegister\Service\Flow;
 interface FlowStepDispatcher
 {
     /**
-     * Perform one step.
+     * Perform one step: items in, items out.
+     *
+     * The data channel is a LIST of items ({@see FlowItems}), not a single
+     * object. A step that acts per record acts once per item and returns one
+     * item per result; a step that filters returns fewer items than it got, and
+     * an empty list legitimately ends that branch's data.
+     *
+     * `$context` is run-level metadata (who triggered it, the run id, the
+     * subject) — not the data channel. Putting records there instead of in the
+     * returned items is the mistake this contract exists to prevent: context is
+     * shared by the whole run, so anything written there stops being per-record
+     * the moment a step fans out.
      *
      * Throwing is meaningful: the engine reads the step's `onError` policy to
      * decide whether to stop, continue, or dead-letter. Swallowing an error here
@@ -45,13 +56,14 @@ interface FlowStepDispatcher
      * nothing — the exact failure mode that made OpenRegister's bulk saves write
      * zero audits.
      *
-     * @param array  $step    The step configuration (the edge that carried it).
-     * @param object $subject The object the run is about.
-     * @param array  $context The run context so far.
+     * @param array $step    The step configuration (the edge that carried it).
+     * @param array $items   The input items for this step.
+     * @param array $context Run-level metadata.
      *
-     * @return array|null Context to merge back, or null to leave it unchanged.
+     * @return array The output items. Normalised by the engine, so returning a
+     *               single item or a bare record is accepted.
      *
      * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
      */
-    public function dispatch(array $step, object $subject, array $context): ?array;
+    public function dispatch(array $step, array $items, array $context): array;
 }//end interface

--- a/lib/Service/Flow/FlowStepDispatcher.php
+++ b/lib/Service/Flow/FlowStepDispatcher.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Performs the side effect attached to one flow step.
+ *
+ * The seam between the engine (which owns *when* a step runs) and the app (which
+ * owns *what* it does). FlowEngine never learns what a `synchronization` or an
+ * `email` is; it hands the step here and takes back context.
+ *
+ * This exists so the engine is testable without a Nextcloud container, and so a
+ * consuming app can contribute step types without an engine change — which is
+ * the whole point of the engine living in OpenRegister rather than in the app
+ * that happened to need it first (ADR-022, ADR-065).
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+/**
+ * Contract for performing a flow step's side effect.
+ */
+interface FlowStepDispatcher
+{
+    /**
+     * Perform one step.
+     *
+     * Throwing is meaningful: the engine reads the step's `onError` policy to
+     * decide whether to stop, continue, or dead-letter. Swallowing an error here
+     * defeats that policy and produces a run that reports success while doing
+     * nothing — the exact failure mode that made OpenRegister's bulk saves write
+     * zero audits.
+     *
+     * @param array  $step    The step configuration (the edge that carried it).
+     * @param object $subject The object the run is about.
+     * @param array  $context The run context so far.
+     *
+     * @return array|null Context to merge back, or null to leave it unchanged.
+     *
+     * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+     */
+    public function dispatch(array $step, object $subject, array $context): ?array;
+}//end interface

--- a/openspec/changes/or-flow-engine/.openspec.yaml
+++ b/openspec/changes/or-flow-engine/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/or-flow-engine/proposal.md
+++ b/openspec/changes/or-flow-engine/proposal.md
@@ -42,6 +42,11 @@ Governed by ADR-065 (hydra: `openspec/architecture/adr-065-flow-engine-and-canva
 - `FlowStepDispatcher` — the seam between *when* a step runs (engine) and *what
   it does* (app), so the engine is container-free testable and consumers add
   step types without touching it.
+- `FlowItems` — the data channel. Steps exchange a LIST of items
+  (`{json, binary, pairedItem}`), not one object, so "fetch 200 rows and act on
+  each" needs no author-drawn loop and a fan-out stays explainable. This shape
+  is settled here, before any consumer exists, precisely because changing it
+  later would break every dispatcher in the fleet at once.
 
 ## Out of scope (this change)
 

--- a/openspec/changes/or-flow-engine/proposal.md
+++ b/openspec/changes/or-flow-engine/proposal.md
@@ -1,0 +1,55 @@
+# Proposal: or-flow-engine
+
+## Summary
+
+Give OpenRegister a real flow engine, so the fleet has **one** instead of five
+things called "flow". The execution core is `symfony/workflow` (a Petri net);
+openconnector's run lifecycle is ported on top. Leaf apps become consumers.
+
+Governed by ADR-065 (hydra: `openspec/architecture/adr-065-flow-engine-and-canvas.md`).
+
+## Why
+
+- **Five unrelated systems use the word "flow"** — the NC Flow leaf,
+  `x-openregister-flows`, openconnector's `flow`, procest's `workflowTemplate`,
+  and openbuild's `Automation`. Every app that wants richer flow editing is
+  currently a candidate to grow its own engine: the exact defect ADR-022 exists
+  to prevent.
+- **No fleet engine can express parallel work.** openconnector's model is a
+  linear list where `order` is identity, sequence, and the implicit edge set at
+  once; its spec rules out parallel/fan-out explicitly. procest's engine never
+  walks a graph at all. A canvas invites users to draw a fork the moment they
+  see one.
+- **A Petri net is a superset of both models we already have**, so this unifies
+  execution without forcing a state machine and an action pipeline into one
+  shape. Verified by running it, not from package metadata.
+- **Nothing viable exists to buy for the rest.** There is no PHP DMN engine (the
+  only Packagist hit is an abandoned 2019 *writer*), no PHP FEEL parser at all,
+  and no PHP CMMN anything. `symfony/workflow` is the one maintained,
+  MIT, `php >=8.1` component that does what the execution core needs.
+
+## What Changes
+
+- Add `symfony/workflow: ^6.4`. OpenRegister already requires `symfony/*` at
+  `^6.4` and already vendors `deprecation-contracts` and `event-dispatcher`, so
+  this adds no new class of vendor-shadowing risk; NC core ships Symfony 6.4.x
+  and no `symfony/workflow`, so there is nothing to shadow.
+- `FlowDefinitionBuilder` — translates a stored flow document into a Petri-net
+  `Definition`. Nodes become places; edges become transitions; multi-endpoint
+  edges become splits and synchronising joins.
+- `FlowEngine` — runs a flow, providing everything Symfony does not: run
+  lifecycle, append-only trace, per-step `onError`, and a loop ceiling.
+- `FlowStepDispatcher` — the seam between *when* a step runs (engine) and *what
+  it does* (app), so the engine is container-free testable and consumers add
+  step types without touching it.
+
+## Out of scope (this change)
+
+- **Relocating openconnector's `flow` schema and `FlowRunnerService`.** The
+  engine core lands first; the migration is its own change, and its sharpest
+  edge — `order` is referenced *by value* by `branches[].nextStepOrder`, so it
+  cannot survive a canvas unchanged — deserves separate treatment.
+- **Persisting the marking to an OR object.** The engine takes a
+  `MarkingStoreInterface`; the OR-backed store lands with the relocation.
+- **DMN/CMMN interchange** — parked, openregister#466.
+- **A conformant FEEL implementation** — explicitly not planned.

--- a/openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+++ b/openspec/changes/or-flow-engine/specs/flow-engine/spec.md
@@ -17,8 +17,8 @@ an engine change.
 - **GIVEN** a consumer implementing `FlowStepDispatcher`
 - **WHEN** `FlowEngine::run()` reaches a step
 - **THEN** the engine calls `dispatch()` with that step's own edge
-  configuration (including `type` and `configRef`) and merges any returned
-  array into the run context
+  configuration (including `type` and `configRef`) plus the step's input items,
+  and threads the returned items on to the next step
 - **AND** the engine itself makes no assumption about what the step does
 
 ### Requirement: The execution core is a Petri net (REQ-FE-002)
@@ -143,6 +143,57 @@ openconnector's `FlowRunnerService`:
 - **WHEN** the flow runs
 - **THEN** both steps are dispatched and the run ends `completed`
 - **AND** the run log records the first step as `failed` with its error
+
+### Requirement: The data channel between steps is an item list (REQ-FE-008)
+
+The engine SHALL thread a LIST of items between steps, not a single object.
+A step SHALL receive its input items and SHALL return its output items, so a
+step that acts per record acts once per item, a step that filters returns
+fewer items than it received, and a step that fans out returns more.
+
+- An item SHALL carry `json` (the record), `binary` (attachments keyed by
+  name), and `pairedItem` (which input item produced it).
+- A run SHALL seed exactly one item from the subject when no seed is supplied,
+  so a flow that never fans out behaves exactly like the single-object model.
+- The engine SHALL normalise a dispatcher's return value, accepting a full item
+  list, a single item, or a bare record. Rejecting the looser shapes would push
+  identical boilerplate into every consuming app's dispatcher.
+- An empty returned list SHALL be meaningful — it ends that branch's data — and
+  SHALL NOT be treated as "no change".
+- Run-level metadata SHALL travel in `context`, which is NOT the data channel.
+  Records placed in `context` stop being per-record the moment a step fans out.
+- Each run-log entry SHALL record the item count in and out for that step.
+
+`pairedItem` is what makes a run explainable: given an item at the end of a
+flow it is the chain back to the input that caused it. A fan-out with no
+provenance leaves no way to answer "where did this come from", which is the
+first question asked of any failed run.
+
+#### Scenario: A step's output items become the next step's input
+
+- **GIVEN** a two-step flow
+- **WHEN** the first step returns items it has tagged
+- **THEN** the second step receives exactly those items, not the run's seed
+
+#### Scenario: A fan-out hands every item to the next step
+
+- **GIVEN** a two-step flow whose first step returns three items
+- **WHEN** the flow runs
+- **THEN** the second step receives all three
+- **AND** each output item's `pairedItem` still names the input item it came from
+
+#### Scenario: A step returning no items ends that branch's data
+
+- **GIVEN** a two-step flow whose first step returns an empty list
+- **WHEN** the flow runs
+- **THEN** the second step receives an empty item list
+- **AND** the run's final items are empty
+
+#### Scenario: A run with no seed starts from one item built from the subject
+
+- **GIVEN** a run started without explicit items
+- **WHEN** the first step is dispatched
+- **THEN** it receives exactly one well-formed item
 
 ### Requirement: A run cannot loop forever (REQ-FE-007)
 

--- a/openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+++ b/openspec/changes/or-flow-engine/specs/flow-engine/spec.md
@@ -1,0 +1,160 @@
+## ADDED Requirements
+
+### Requirement: OpenRegister owns the fleet's flow engine (REQ-FE-001)
+
+OpenRegister SHALL provide the only flow-execution engine in the fleet. Leaf
+apps (openconnector, procest, openbuild, and any future consumer) SHALL consume
+it rather than implement their own (ADR-022, ADR-065). A leaf app that adds a
+flow/workflow execution engine is an ADR-022 violation.
+
+The engine SHALL be usable without a Nextcloud container: side effects are
+performed by a caller-supplied `FlowStepDispatcher`, so the engine can be
+unit-tested in isolation and a consuming app can contribute step types without
+an engine change.
+
+#### Scenario: A consuming app supplies its own step behaviour
+
+- **GIVEN** a consumer implementing `FlowStepDispatcher`
+- **WHEN** `FlowEngine::run()` reaches a step
+- **THEN** the engine calls `dispatch()` with that step's own edge
+  configuration (including `type` and `configRef`) and merges any returned
+  array into the run context
+- **AND** the engine itself makes no assumption about what the step does
+
+### Requirement: The execution core is a Petri net (REQ-FE-002)
+
+The engine SHALL execute flows via `symfony/workflow`. `FlowDefinitionBuilder`
+SHALL translate a stored flow document into a `Definition`, mapping each flow
+node to a place and each flow edge to a transition.
+
+A Petri net is required — not merely convenient — because it is a superset of
+both models the fleet already has: a single-token marking is a state machine
+(procest's `case.status`), and a multi-token marking expresses parallel splits
+and synchronising joins, which no existing fleet engine can represent.
+
+#### Scenario: An edge to several nodes is a parallel split
+
+- **GIVEN** a flow with an edge `{ from: 'start', to: ['a', 'b'] }`
+- **WHEN** that transition fires
+- **THEN** both `a` and `b` hold a token, and both branches run
+
+#### Scenario: An edge from several nodes is a synchronising join
+
+- **GIVEN** a flow with an edge `{ from: ['a_done', 'b_done'], to: 'done' }`
+- **WHEN** only `a_done` holds a token
+- **THEN** the join is NOT enabled and does not fire
+- **AND** once `b_done` also holds a token, the join fires exactly once
+
+#### Scenario: A join that can never be satisfied does not fire
+
+- **GIVEN** a join whose second input place can never receive a token
+- **WHEN** the run reaches the join
+- **THEN** the run ends without firing it, rather than firing a
+  half-satisfied join
+
+### Requirement: A flow document is validated before it runs (REQ-FE-003)
+
+A stored flow document is user data and SHALL be treated as untrusted. The
+builder SHALL reject a document that does not describe a runnable graph, naming
+the offending element, rather than allowing `symfony/workflow` to fail later
+and less legibly.
+
+The builder SHALL reject: a document with no nodes; a node with no id; a
+duplicate node id (which would silently merge two nodes into one place, running
+a graph the author did not draw); an edge missing `from` or `to`; an edge whose
+endpoint does not resolve to a declared node; and an `initial` naming an
+unknown node.
+
+Edges sharing a `name` SHALL NOT be merged — two edges named `approve` from
+different nodes are two transitions, as drawn. Merging them would invent a join
+the author never asked for.
+
+#### Scenario: A dangling edge is rejected by name
+
+- **GIVEN** a flow with an edge `{ id: 'ghost', from: 'a', to: 'nowhere' }`
+  where no node `nowhere` is declared
+- **WHEN** the definition is built
+- **THEN** it fails with `Flow edge "ghost" references unknown node "nowhere".`
+
+#### Scenario: A malformed flow fails loudly
+
+- **GIVEN** a malformed flow document
+- **WHEN** `FlowEngine::run()` is called
+- **THEN** it returns `status: 'failed'` with the validation message in
+  `error`
+- **AND** it does NOT swallow the failure — unlike `x-openregister-flows`,
+  whose `run()` deliberately catches to protect the save path, this engine's
+  failures are the caller's to see
+
+### Requirement: Both edge dialects are accepted (REQ-FE-004)
+
+An edge SHALL accept `{from, to}` (the stored document dialect) and
+`{source, target}` (the dialect `CnGraphCanvas` emits). A canvas payload is
+therefore directly runnable without a translation layer in every consumer.
+
+#### Scenario: A canvas-shaped edge builds
+
+- **GIVEN** an edge `{ id: 'go', source: 'a', target: 'b' }`
+- **WHEN** the definition is built
+- **THEN** the transition's froms are `['a']` and tos are `['b']`
+
+### Requirement: Initial places are explicit or inferred (REQ-FE-005)
+
+The run SHALL start on the places named in `initial` when present. Otherwise
+the engine SHALL infer the start as the graph's sources — the nodes no edge
+points at — so simple flows need no boilerplate.
+
+A fully cyclic graph has no source. The engine SHALL start it on the first
+declared node rather than refuse it: a loop is legitimate to draw, and
+declaration order is the only available signal.
+
+#### Scenario: Sources are inferred
+
+- **GIVEN** a flow `a -> b -> c` with no `initial`
+- **WHEN** the definition is built
+- **THEN** the initial places are `['a']`
+
+### Requirement: The run lifecycle governs failures (REQ-FE-006)
+
+The engine SHALL provide a run lifecycle, an append-only trace, and a per-step
+error policy — none of which `symfony/workflow` supplies — ported from
+openconnector's `FlowRunnerService`:
+
+- A run SHALL end in exactly one of `completed`, `stopped`, `dead_letter`, or
+  `failed`.
+- Each step SHALL be recorded in an append-only run log with its transition
+  name, status, and any error.
+- Each step SHALL honour an `onError` policy of `stop`, `continue`, or
+  `dead_letter`.
+- `stop` SHALL be the default, and an **unrecognised** policy SHALL stop —
+  a typo must fail safe rather than silently mean `continue`.
+- Where `onError: continue`, the marking SHALL still advance past the failed
+  step, otherwise the engine would retry that transition forever.
+
+#### Scenario: An unknown error policy stops the run
+
+- **GIVEN** a step with `onError: 'carry-on-regardless'`
+- **WHEN** that step throws
+- **THEN** the run ends `stopped`
+
+#### Scenario: continue advances past a failed step
+
+- **GIVEN** a two-step flow whose first step throws with `onError: continue`
+- **WHEN** the flow runs
+- **THEN** both steps are dispatched and the run ends `completed`
+- **AND** the run log records the first step as `failed` with its error
+
+### Requirement: A run cannot loop forever (REQ-FE-007)
+
+The engine SHALL abort a run that fires more than 1000 transitions and SHALL
+report it as `failed` with an explanatory error. Because a Petri net can
+express cycles, a user-drawn loop can otherwise run indefinitely; a silent
+truncation would report success for a flow that never finished.
+
+#### Scenario: An unbounded loop is aborted and reported
+
+- **GIVEN** a flow `a -> b -> a`
+- **WHEN** it runs
+- **THEN** the run ends `failed` with an error mentioning an unbounded loop
+
+@e2e exclude engine execution is backend-only — covered by PHPUnit, not browser UI; the authoring surface is covered by CnGraphCanvas and its consumers

--- a/openspec/changes/or-flow-engine/tasks.md
+++ b/openspec/changes/or-flow-engine/tasks.md
@@ -1,0 +1,44 @@
+# Tasks: or-flow-engine
+
+## 1. Dependency
+
+- [x] 1.1 Add `symfony/workflow: ^6.4` to composer.json
+- [x] 1.2 Confirm no version churn on OR's existing `symfony/*` packages
+- [x] 1.3 Confirm NC core ships no `symfony/workflow` (nothing to shadow)
+- [x] 1.4 Confirm `composer audit` reports no advisories
+
+## 2. Engine core
+
+- [x] 2.1 `FlowDefinitionBuilder` — document → Petri-net `Definition`
+- [x] 2.2 Accept both `{from,to}` and `{source,target}` edge dialects
+- [x] 2.3 Reject malformed documents by name (dangling edge, duplicate id,
+      missing endpoint, unknown `initial`, no nodes)
+- [x] 2.4 Infer initial places as graph sources; honour explicit `initial`;
+      start a fully cyclic graph on its first node
+- [x] 2.5 `FlowStepDispatcher` interface — the engine/app seam
+- [x] 2.6 `FlowEngine::run()` — fire enabled transitions until none remain
+- [x] 2.7 Port the run lifecycle (`completed`/`stopped`/`dead_letter`/`failed`)
+- [x] 2.8 Port per-step `onError` (`stop`/`continue`/`dead_letter`); unknown
+      policy fails safe by stopping
+- [x] 2.9 Append-only run log
+- [x] 2.10 Loop ceiling, reported as a failure rather than truncating silently
+
+## 3. Verification
+
+- [x] 3.1 Unit tests for the builder (14)
+- [x] 3.2 Unit tests for the engine (12), including parallel split + join
+- [x] 3.3 Prove the join refuses to fire on one token — the claim the engine
+      choice rests on
+- [x] 3.4 Run on the **container's** PHP 8.4, not just the host's 8.2
+      (OR declares `^8.3`; the host cannot run it)
+- [x] 3.5 Confirm pre-existing flow tests still pass (42/42)
+- [x] 3.6 PHPCS clean against the OR standard
+
+## 4. Follow-ups (separate changes)
+
+- [ ] 4.1 OR-backed `MarkingStoreInterface` persisting to a flow-run object
+- [ ] 4.2 Relocate openconnector's `flow` schema + `FlowRunnerService`; resolve
+      `order`-as-identity before a canvas can drive it
+- [ ] 4.3 Move openbuild's `DecisionTableEvaluator` to OR as the shared
+      decision-table service
+- [ ] 4.4 DMN/CMMN interchange (openregister#466) — driver unconfirmed

--- a/openspec/changes/or-flow-engine/tasks.md
+++ b/openspec/changes/or-flow-engine/tasks.md
@@ -42,3 +42,14 @@
 - [ ] 4.3 Move openbuild's `DecisionTableEvaluator` to OR as the shared
       decision-table service
 - [ ] 4.4 DMN/CMMN interchange (openregister#466) — driver unconfirmed
+
+## Item data channel
+
+- [x] `FlowItems` — normalisation, single-item seeding from the subject, and
+      `pairedItem` provenance.
+- [x] `FlowStepDispatcher::dispatch()` takes and returns items; `context` is
+      demoted to run-level metadata.
+- [x] `FlowEngine` threads items between steps and reports per-step item counts
+      in the run log.
+- [x] Tests: threading, fan-out with provenance, filtering to empty, and
+      single-item seeding.

--- a/tests/Unit/Service/Flow/FlowDefinitionBuilderTest.php
+++ b/tests/Unit/Service/Flow/FlowDefinitionBuilderTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * Unit tests for FlowDefinitionBuilder — the flow document -> Petri net translator.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+namespace Unit\Service\Flow;
+
+use InvalidArgumentException;
+use OCA\OpenRegister\Service\Flow\FlowDefinitionBuilder;
+use PHPUnit\Framework\TestCase;
+
+class FlowDefinitionBuilderTest extends TestCase
+{
+    private FlowDefinitionBuilder $builder;
+
+    protected function setUp(): void
+    {
+        $this->builder = new FlowDefinitionBuilder();
+    }
+
+    public function testNodesBecomePlacesAndEdgesBecomeTransitions(): void
+    {
+        $definition = $this->builder->build([
+            'nodes' => [['id' => 'a'], ['id' => 'b']],
+            'edges' => [['id' => 'go', 'from' => 'a', 'to' => 'b']],
+        ]);
+
+        // Definition::getPlaces() is keyed by place name, not a list.
+        $this->assertSame(['a', 'b'], array_keys($definition->getPlaces()));
+        $this->assertCount(1, $definition->getTransitions());
+        $this->assertSame('go', $definition->getTransitions()[0]->getName());
+    }
+
+    public function testAnEdgeMayUseSourceTargetAsWellAsFromTo(): void
+    {
+        // The canvas emits {source, target}; stored documents use {from, to}.
+        // Accepting both keeps CnGraphCanvas's payload directly runnable.
+        $definition = $this->builder->build([
+            'nodes' => [['id' => 'a'], ['id' => 'b']],
+            'edges' => [['id' => 'go', 'source' => 'a', 'target' => 'b']],
+        ]);
+
+        $this->assertSame(['a'], $definition->getTransitions()[0]->getFroms());
+        $this->assertSame(['b'], $definition->getTransitions()[0]->getTos());
+    }
+
+    public function testAnEdgeToSeveralNodesIsAParallelSplit(): void
+    {
+        $definition = $this->builder->build([
+            'nodes' => [['id' => 'start'], ['id' => 'a'], ['id' => 'b']],
+            'edges' => [['id' => 'fork', 'from' => 'start', 'to' => ['a', 'b']]],
+        ]);
+
+        $this->assertSame(['a', 'b'], $definition->getTransitions()[0]->getTos());
+    }
+
+    public function testAnEdgeFromSeveralNodesIsASynchronisingJoin(): void
+    {
+        $definition = $this->builder->build([
+            'nodes' => [['id' => 'a'], ['id' => 'b'], ['id' => 'done']],
+            'edges' => [['id' => 'join', 'from' => ['a', 'b'], 'to' => 'done']],
+        ]);
+
+        $this->assertSame(['a', 'b'], $definition->getTransitions()[0]->getFroms());
+    }
+
+    public function testInitialPlacesAreInferredAsTheGraphSources(): void
+    {
+        $definition = $this->builder->build([
+            'nodes' => [['id' => 'a'], ['id' => 'b'], ['id' => 'c']],
+            'edges' => [
+                ['id' => 'e1', 'from' => 'a', 'to' => 'b'],
+                ['id' => 'e2', 'from' => 'b', 'to' => 'c'],
+            ],
+        ]);
+
+        // Only 'a' is pointed at by nothing.
+        $this->assertSame(['a'], $definition->getInitialPlaces());
+    }
+
+    public function testAnExplicitInitialOverridesInference(): void
+    {
+        $definition = $this->builder->build([
+            'nodes'   => [['id' => 'a'], ['id' => 'b']],
+            'edges'   => [['id' => 'e1', 'from' => 'a', 'to' => 'b']],
+            'initial' => 'b',
+        ]);
+
+        $this->assertSame(['b'], $definition->getInitialPlaces());
+    }
+
+    public function testAFullyCyclicGraphStartsOnItsFirstNodeRatherThanRefusingToBuild(): void
+    {
+        // Every node is targeted, so there is no source. A loop is a legitimate
+        // thing to draw; declaration order is the only signal we have.
+        $definition = $this->builder->build([
+            'nodes' => [['id' => 'a'], ['id' => 'b']],
+            'edges' => [
+                ['id' => 'e1', 'from' => 'a', 'to' => 'b'],
+                ['id' => 'e2', 'from' => 'b', 'to' => 'a'],
+            ],
+        ]);
+
+        $this->assertSame(['a'], $definition->getInitialPlaces());
+    }
+
+    public function testAnEdgeToAnUnknownNodeIsRejectedByNameRatherThanFailingLater(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Flow edge "ghost" references unknown node "nowhere".');
+
+        $this->builder->build([
+            'nodes' => [['id' => 'a']],
+            'edges' => [['id' => 'ghost', 'from' => 'a', 'to' => 'nowhere']],
+        ]);
+    }
+
+    public function testADuplicateNodeIdIsRejected(): void
+    {
+        // Two nodes collapsing into one place would run, but would not be the
+        // graph the user drew.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Flow declares node id "a" more than once.');
+
+        $this->builder->build([
+            'nodes' => [['id' => 'a'], ['id' => 'a']],
+            'edges' => [],
+        ]);
+    }
+
+    public function testANodeWithoutAnIdIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Flow node at index 1 has no id.');
+
+        $this->builder->build(['nodes' => [['id' => 'a'], ['label' => 'oops']], 'edges' => []]);
+    }
+
+    public function testAFlowWithoutNodesIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Flow declares no nodes; nothing to run.');
+
+        $this->builder->build(['nodes' => [], 'edges' => []]);
+    }
+
+    public function testAnEdgeMissingAnEndpointIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Flow edge at index 0 must declare both "from" and "to".');
+
+        $this->builder->build(['nodes' => [['id' => 'a']], 'edges' => [['id' => 'half', 'from' => 'a']]]);
+    }
+
+    public function testEdgesSharingANameAreNotMerged(): void
+    {
+        // Two "approve" edges from different nodes are two transitions, as drawn.
+        // Merging them would invent a join the user never asked for.
+        $definition = $this->builder->build([
+            'nodes' => [['id' => 'a'], ['id' => 'b'], ['id' => 'done']],
+            'edges' => [
+                ['id' => 'e1', 'name' => 'approve', 'from' => 'a', 'to' => 'done'],
+                ['id' => 'e2', 'name' => 'approve', 'from' => 'b', 'to' => 'done'],
+            ],
+        ]);
+
+        $this->assertCount(2, $definition->getTransitions());
+    }
+}

--- a/tests/Unit/Service/Flow/FlowEngineTest.php
+++ b/tests/Unit/Service/Flow/FlowEngineTest.php
@@ -1,0 +1,280 @@
+<?php
+
+/**
+ * Unit tests for FlowEngine — the OpenRegister flow engine (ADR-065).
+ *
+ * These prove the two claims the engine choice rests on: that one Petri net
+ * expresses both a linear pipeline and true parallel split/join, and that the
+ * ported run lifecycle (onError policies, trace, ceiling) actually governs a run.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowDefinitionBuilder;
+use OCA\OpenRegister\Service\Flow\FlowEngine;
+use OCA\OpenRegister\Service\Flow\FlowStepDispatcher;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Symfony\Component\Workflow\MarkingStore\MethodMarkingStore;
+
+/** A subject whose marking is a plain property. */
+class FlowSubject
+{
+    public $marking = [];
+}
+
+/** Records what ran, and can be told to fail on a given step. */
+class RecordingDispatcher implements FlowStepDispatcher
+{
+    public array $dispatched = [];
+
+    public function __construct(private readonly ?string $failOn = null)
+    {
+    }
+
+    public function dispatch(array $step, object $subject, array $context): ?array
+    {
+        $name = (string) ($step['id'] ?? '');
+        $this->dispatched[] = $name;
+
+        if ($this->failOn !== null && $name === $this->failOn) {
+            throw new RuntimeException('step blew up');
+        }
+
+        return [$name => 'ran'];
+    }
+}
+
+class FlowEngineTest extends TestCase
+{
+    private FlowEngine $engine;
+
+    protected function setUp(): void
+    {
+        $this->engine = new FlowEngine(
+            new FlowDefinitionBuilder(),
+            $this->createMock(LoggerInterface::class)
+        );
+    }
+
+    /**
+     * Run a flow against a fresh subject.
+     *
+     * Named runFlow(), not run(): PHPUnit's TestCase::run() is final.
+     */
+    private function runFlow(array $flow, ?FlowStepDispatcher $dispatcher = null): array
+    {
+        $dispatcher ??= new RecordingDispatcher();
+        return $this->engine->run(
+            $flow,
+            new MethodMarkingStore(false, 'marking'),
+            new FlowSubject(),
+            $dispatcher
+        );
+    }
+
+    private function linearFlow(): array
+    {
+        return [
+            'id'    => 'linear',
+            'nodes' => [['id' => 'start'], ['id' => 'middle'], ['id' => 'end']],
+            'edges' => [
+                ['id' => 'first', 'from' => 'start', 'to' => 'middle'],
+                ['id' => 'second', 'from' => 'middle', 'to' => 'end'],
+            ],
+        ];
+    }
+
+    public function testALinearFlowRunsEveryStepInOrderAndCompletes(): void
+    {
+        $dispatcher = new RecordingDispatcher();
+        $result = $this->runFlow($this->linearFlow(), $dispatcher);
+
+        $this->assertSame(FlowEngine::STATUS_COMPLETED, $result['status']);
+        $this->assertSame(['first', 'second'], $dispatcher->dispatched);
+    }
+
+    public function testEachStepIsTracedInTheRunLog(): void
+    {
+        $result = $this->runFlow($this->linearFlow());
+
+        $this->assertSame(
+            [
+                ['transition' => 'first', 'status' => 'completed'],
+                ['transition' => 'second', 'status' => 'completed'],
+            ],
+            $result['log']
+        );
+    }
+
+    public function testAStepsReturnedContextIsVisibleToLaterSteps(): void
+    {
+        $result = $this->runFlow($this->linearFlow());
+
+        $this->assertSame(['first' => 'ran', 'second' => 'ran'], $result['context']);
+    }
+
+    /**
+     * The claim the whole engine choice rests on: a join must not fire until
+     * every inbound branch has arrived. openconnector's order-indexed model
+     * cannot express this at all.
+     */
+    public function testAParallelSplitRunsBothBranchesAndTheJoinWaitsForBoth(): void
+    {
+        $dispatcher = new RecordingDispatcher();
+        $result = $this->runFlow([
+            'id'    => 'parallel',
+            'nodes' => [
+                ['id' => 'start'],
+                ['id' => 'a_pending'], ['id' => 'b_pending'],
+                ['id' => 'a_done'], ['id' => 'b_done'],
+                ['id' => 'done'],
+            ],
+            'edges' => [
+                ['id' => 'fork', 'from' => 'start', 'to' => ['a_pending', 'b_pending']],
+                ['id' => 'do_a', 'from' => 'a_pending', 'to' => 'a_done'],
+                ['id' => 'do_b', 'from' => 'b_pending', 'to' => 'b_done'],
+                ['id' => 'join', 'from' => ['a_done', 'b_done'], 'to' => 'done'],
+            ],
+        ], $dispatcher);
+
+        $this->assertSame(FlowEngine::STATUS_COMPLETED, $result['status']);
+        // Both branches ran, and the join ran exactly once — after both.
+        $this->assertContains('do_a', $dispatcher->dispatched);
+        $this->assertContains('do_b', $dispatcher->dispatched);
+        $this->assertSame(1, count(array_keys($dispatcher->dispatched, 'join')));
+        $this->assertSame('join', end($dispatcher->dispatched));
+    }
+
+    public function testAJoinNeverFiresWhenOnlyOneBranchCanArrive(): void
+    {
+        // 'b' has no inbound edge and is not a source of the taken path, so the
+        // join can never be enabled. The run stops where the graph stops rather
+        // than firing a half-satisfied join.
+        $dispatcher = new RecordingDispatcher();
+        $result = $this->runFlow([
+            'id'      => 'starved-join',
+            'nodes'   => [['id' => 'a'], ['id' => 'b'], ['id' => 'done']],
+            'edges'   => [['id' => 'join', 'from' => ['a', 'b'], 'to' => 'done']],
+            'initial' => 'a',
+        ], $dispatcher);
+
+        $this->assertSame(FlowEngine::STATUS_COMPLETED, $result['status']);
+        $this->assertSame([], $dispatcher->dispatched);
+    }
+
+    public function testOnErrorStopHaltsTheRunAndRecordsTheFailure(): void
+    {
+        $dispatcher = new RecordingDispatcher(failOn: 'first');
+        $flow = $this->linearFlow();
+        $flow['edges'][0]['onError'] = FlowEngine::ON_ERROR_STOP;
+
+        $result = $this->runFlow($flow, $dispatcher);
+
+        $this->assertSame(FlowEngine::STATUS_STOPPED, $result['status']);
+        $this->assertSame(['first'], $dispatcher->dispatched);
+        $this->assertSame('failed', $result['log'][0]['status']);
+        $this->assertSame('step blew up', $result['log'][0]['error']);
+    }
+
+    public function testOnErrorContinueCarriesOnPastAFailedStep(): void
+    {
+        $dispatcher = new RecordingDispatcher(failOn: 'first');
+        $flow = $this->linearFlow();
+        $flow['edges'][0]['onError'] = FlowEngine::ON_ERROR_CONTINUE;
+
+        $result = $this->runFlow($flow, $dispatcher);
+
+        $this->assertSame(FlowEngine::STATUS_COMPLETED, $result['status']);
+        // The marking advanced despite the failure, so the next step ran.
+        $this->assertSame(['first', 'second'], $dispatcher->dispatched);
+    }
+
+    public function testOnErrorDeadLetterEndsTheRunInItsOwnState(): void
+    {
+        $dispatcher = new RecordingDispatcher(failOn: 'first');
+        $flow = $this->linearFlow();
+        $flow['edges'][0]['onError'] = FlowEngine::ON_ERROR_DEAD_LETTER;
+
+        $result = $this->runFlow($flow, $dispatcher);
+
+        $this->assertSame(FlowEngine::STATUS_DEAD_LETTER, $result['status']);
+    }
+
+    public function testAnUnknownErrorPolicyFailsSafeByStopping(): void
+    {
+        // A typo in `onError` must not silently mean "continue".
+        $dispatcher = new RecordingDispatcher(failOn: 'first');
+        $flow = $this->linearFlow();
+        $flow['edges'][0]['onError'] = 'carry-on-regardless';
+
+        $result = $this->runFlow($flow, $dispatcher);
+
+        $this->assertSame(FlowEngine::STATUS_STOPPED, $result['status']);
+    }
+
+    public function testTheDefaultErrorPolicyIsStop(): void
+    {
+        $dispatcher = new RecordingDispatcher(failOn: 'first');
+        $result = $this->runFlow($this->linearFlow(), $dispatcher);
+
+        $this->assertSame(FlowEngine::STATUS_STOPPED, $result['status']);
+    }
+
+    public function testAMalformedFlowFailsLoudlyRatherThanSilently(): void
+    {
+        // x-openregister-flows swallows by design; this engine must not.
+        $result = $this->runFlow(['id' => 'broken', 'nodes' => [], 'edges' => []]);
+
+        $this->assertSame(FlowEngine::STATUS_FAILED, $result['status']);
+        $this->assertSame('Flow declares no nodes; nothing to run.', $result['error']);
+    }
+
+    public function testAnUnboundedLoopIsAbortedAndReportedAsAFailure(): void
+    {
+        // A Petri net can express a cycle, so a drawn loop can run forever.
+        // Hitting the ceiling is a failure, not a silent truncation.
+        $result = $this->runFlow([
+            'id'    => 'loop',
+            'nodes' => [['id' => 'a'], ['id' => 'b']],
+            'edges' => [
+                ['id' => 'there', 'from' => 'a', 'to' => 'b'],
+                ['id' => 'back', 'from' => 'b', 'to' => 'a'],
+            ],
+        ]);
+
+        $this->assertSame(FlowEngine::STATUS_FAILED, $result['status']);
+        $this->assertStringContainsString('unbounded loop', $result['error']);
+    }
+
+    public function testAStepCarriesItsOwnEdgeConfigToTheDispatcher(): void
+    {
+        $flow = $this->linearFlow();
+        $flow['edges'][0]['type'] = 'email';
+        $flow['edges'][0]['configRef'] = 'abc-123';
+
+        $seen = null;
+        $dispatcher = new class($seen) implements FlowStepDispatcher {
+            public array $steps = [];
+
+            public function __construct(&$seen)
+            {
+            }
+
+            public function dispatch(array $step, object $subject, array $context): ?array
+            {
+                $this->steps[] = $step;
+                return null;
+            }
+        };
+
+        $this->engine->run($flow, new MethodMarkingStore(false, 'marking'), new FlowSubject(), $dispatcher);
+
+        $this->assertSame('email', $dispatcher->steps[0]['type']);
+        $this->assertSame('abc-123', $dispatcher->steps[0]['configRef']);
+    }
+}

--- a/tests/Unit/Service/Flow/FlowEngineTest.php
+++ b/tests/Unit/Service/Flow/FlowEngineTest.php
@@ -15,6 +15,7 @@ namespace Unit\Service\Flow;
 
 use OCA\OpenRegister\Service\Flow\FlowDefinitionBuilder;
 use OCA\OpenRegister\Service\Flow\FlowEngine;
+use OCA\OpenRegister\Service\Flow\FlowItems;
 use OCA\OpenRegister\Service\Flow\FlowStepDispatcher;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -32,20 +33,33 @@ class RecordingDispatcher implements FlowStepDispatcher
 {
     public array $dispatched = [];
 
-    public function __construct(private readonly ?string $failOn = null)
+    public function __construct(protected readonly ?string $failOn = null)
     {
     }
 
-    public function dispatch(array $step, object $subject, array $context): ?array
+    /** Items this dispatcher was handed, per step id. */
+    public array $seenItems = [];
+
+    public function dispatch(array $step, array $items, array $context): array
     {
         $name = (string) ($step['id'] ?? '');
         $this->dispatched[] = $name;
+        $this->seenItems[$name] = $items;
 
         if ($this->failOn !== null && $name === $this->failOn) {
             throw new RuntimeException('step blew up');
         }
 
-        return [$name => 'ran'];
+        // One item out per item in, tagged with the step that produced it, so a
+        // test can assert both the threading and the per-item pairing.
+        $out = [];
+        foreach ($items as $index => $item) {
+            $json = (array) ($item['json'] ?? []);
+            $json['ranBy'] = $name;
+            $out[] = FlowItems::item(json: $json, binary: [], fromItemIndex: $index);
+        }
+
+        return $out;
     }
 }
 
@@ -104,18 +118,82 @@ class FlowEngineTest extends TestCase
 
         $this->assertSame(
             [
-                ['transition' => 'first', 'status' => 'completed'],
-                ['transition' => 'second', 'status' => 'completed'],
+                ['transition' => 'first', 'status' => 'completed', 'itemsIn' => 1, 'itemsOut' => 1],
+                ['transition' => 'second', 'status' => 'completed', 'itemsIn' => 1, 'itemsOut' => 1],
             ],
             $result['log']
         );
     }
 
-    public function testAStepsReturnedContextIsVisibleToLaterSteps(): void
+    public function testItemsAreThreadedFromEachStepIntoTheNext(): void
     {
-        $result = $this->runFlow($this->linearFlow());
+        $dispatcher = new RecordingDispatcher();
+        $result = $this->runFlow($this->linearFlow(), $dispatcher);
 
-        $this->assertSame(['first' => 'ran', 'second' => 'ran'], $result['context']);
+        // The second step sees what the first produced, not the run's seed.
+        $this->assertSame('first', $dispatcher->seenItems['second'][0]['json']['ranBy']);
+        $this->assertSame('second', $result['items'][0]['json']['ranBy']);
+    }
+
+    public function testARunSeedsExactlyOneItemFromTheSubject(): void
+    {
+        $dispatcher = new RecordingDispatcher();
+        $this->runFlow($this->linearFlow(), $dispatcher);
+
+        $this->assertCount(1, $dispatcher->seenItems['first']);
+        $this->assertArrayHasKey('json', $dispatcher->seenItems['first'][0]);
+        $this->assertArrayHasKey('binary', $dispatcher->seenItems['first'][0]);
+        $this->assertArrayHasKey('pairedItem', $dispatcher->seenItems['first'][0]);
+    }
+
+    public function testAStepThatFansOutIsFollowedByOneCallPerItem(): void
+    {
+        // A step returning three items must hand all three to the next step:
+        // this is the property the whole item model exists for.
+        $fanOut = new class extends RecordingDispatcher {
+            public function dispatch(array $step, array $items, array $context): array
+            {
+                $name = (string) ($step['id'] ?? '');
+                $this->dispatched[] = $name;
+                $this->seenItems[$name] = $items;
+
+                if ($name !== 'first') {
+                    return $items;
+                }
+
+                return [
+                    FlowItems::item(json: ['n' => 1], binary: [], fromItemIndex: 0),
+                    FlowItems::item(json: ['n' => 2], binary: [], fromItemIndex: 0),
+                    FlowItems::item(json: ['n' => 3], binary: [], fromItemIndex: 0),
+                ];
+            }
+        };
+
+        $result = $this->runFlow($this->linearFlow(), $fanOut);
+
+        $this->assertCount(3, $fanOut->seenItems['second']);
+        $this->assertCount(3, $result['items']);
+        // Provenance survives the hop: every item still points at input item 0.
+        $this->assertSame(['item' => 0], $result['items'][0]['pairedItem']);
+    }
+
+    public function testAStepReturningNothingEndsThatBranchesData(): void
+    {
+        $filter = new class extends RecordingDispatcher {
+            public function dispatch(array $step, array $items, array $context): array
+            {
+                $name = (string) ($step['id'] ?? '');
+                $this->dispatched[] = $name;
+                $this->seenItems[$name] = $items;
+
+                return ($name === 'first') ? [] : $items;
+            }
+        };
+
+        $result = $this->runFlow($this->linearFlow(), $filter);
+
+        $this->assertSame([], $filter->seenItems['second']);
+        $this->assertSame([], $result['items']);
     }
 
     /**
@@ -265,10 +343,10 @@ class FlowEngineTest extends TestCase
             {
             }
 
-            public function dispatch(array $step, object $subject, array $context): ?array
+            public function dispatch(array $step, array $items, array $context): array
             {
                 $this->steps[] = $step;
-                return null;
+                return $items;
             }
         };
 


### PR DESCRIPTION
# Proposal: or-flow-engine

## Summary

Give OpenRegister a real flow engine, so the fleet has **one** instead of five
things called "flow". The execution core is `symfony/workflow` (a Petri net);
openconnector's run lifecycle is ported on top. Leaf apps become consumers.

Governed by ADR-065 (hydra: `openspec/architecture/adr-065-flow-engine-and-canvas.md`).

## Why

- **Five unrelated systems use the word "flow"** — the NC Flow leaf,
  `x-openregister-flows`, openconnector's `flow`, procest's `workflowTemplate`,
  and openbuild's `Automation`. Every app that wants richer flow editing is
  currently a candidate to grow its own engine: the exact defect ADR-022 exists
  to prevent.
- **No fleet engine can express parallel work.** openconnector's model is a
  linear list where `order` is identity, sequence, and the implicit edge set at
  once; its spec rules out parallel/fan-out explicitly. procest's engine never
  walks a graph at all. A canvas invites users to draw a fork the moment they
  see one.
- **A Petri net is a superset of both models we already have**, so this unifies
  execution without forcing a state machine and an action pipeline into one
  shape. Verified by running it, not from package metadata.
- **Nothing viable exists to buy for the rest.** There is no PHP DMN engine (the
  only Packagist hit is an abandoned 2019 *writer*), no PHP FEEL parser at all,
  and no PHP CMMN anything. `symfony/workflow` is the one maintained,
  MIT, `php >=8.1` component that does what the execution core needs.

## What Changes

- Add `symfony/workflow: ^6.4`. OpenRegister already requires `symfony/*` at
  `^6.4` and already vendors `deprecation-contracts` and `event-dispatcher`, so
  this adds no new class of vendor-shadowing risk; NC core ships Symfony 6.4.x
  and no `symfony/workflow`, so there is nothing to shadow.
- `FlowDefinitionBuilder` — translates a stored flow document into a Petri-net
  `Definition`. Nodes become places; edges become transitions; multi-endpoint
  edges become splits and synchronising joins.
- `FlowEngine` — runs a flow, providing everything Symfony does not: run
  lifecycle, append-only trace, per-step `onError`, and a loop ceiling.
- `FlowStepDispatcher` — the seam between *when* a step runs (engine) and *what
  it does* (app), so the engine is container-free testable and consumers add
  step types without touching it.
- `FlowItems` — the data channel. Steps exchange a LIST of items
  (`{json, binary, pairedItem}`), not one object, so "fetch 200 rows and act on
  each" needs no author-drawn loop and a fan-out stays explainable. This shape
  is settled here, before any consumer exists, precisely because changing it
  later would break every dispatcher in the fleet at once.

## Out of scope (this change)

- **Relocating openconnector's `flow` schema and `FlowRunnerService`.** The
  engine core lands first; the migration is its own change, and its sharpest
  edge — `order` is referenced *by value* by `branches[].nextStepOrder`, so it
  cannot survive a canvas unchanged — deserves separate treatment.
- **Persisting the marking to an OR object.** The engine takes a
  `MarkingStoreInterface`; the OR-backed store lands with the relocation.
- **DMN/CMMN interchange** — parked, openregister#466.
- **A conformant FEEL implementation** — explicitly not planned.

---

## Amended before merge: the data channel is an item list

The dispatcher contract originally took one `object $subject` and returned context to merge. It now takes and returns an **item list** — `{json, binary, pairedItem}` — settled here rather than in a follow-up, because changing it after consumers exist would break every dispatcher in the fleet at once.

`$subject` stays: it carries the Petri-net marking and names what the run is about. It was never the data.

This is the foundation of the flow-parity programme:

| # | Workstream |
|---|---|
| #2067 | Flow logic — If/Switch, Merge, Loop, Wait, error branch, sub-flows |
| #2068 | Nextcloud-native trigger set |
| #2069 | JSONLogic expressions (reusing openconnector's existing dependency) |
| #2070 | Execution tooling — history, retry, pin/mock data, partial runs |
| #2071 | MCP surface at parity with n8n's |
| #2065 | Shareable integration network, distributed via GitHub |
| #2066 | Optional Node sidecar — the route to a real Code node |
| hermiq#35 | Retire hermiq's GraphExecutor onto this engine |

## Verification

41 unit tests green, including four new ones covering item threading, fan-out with surviving provenance, filtering to an empty list, and single-item seeding from the subject. `phpcs` clean on all five files under `lib/Service/Flow/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)