### PR TITLE
feat(flow): persist runs — the critical path for five workstreams (#2076)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -125,6 +125,7 @@ Vrij en open source onder de EUPL-licentie.
 		<job>OCA\OpenRegister\BackgroundJob\ReportRenderJob</job>
 		<job>OCA\OpenRegister\BackgroundJob\NotificationQueueFlushJob</job>
 		<job>OCA\OpenRegister\Cron\ArchivalRetentionTask</job>
+		<job>OCA\OpenRegister\Cron\FlowRunWorker</job>
 		<job>OCA\OpenRegister\Cron\HandoffQueueDrainJob</job>
 		<job>OCA\OpenRegister\BackgroundJob\TemporalCalculationSweepJob</job>
 		<job>OCA\OpenRegister\BackgroundJob\DsarDpiaDetectionJob</job>

--- a/lib/Cron/FlowRunWorker.php
+++ b/lib/Cron/FlowRunWorker.php
@@ -1,0 +1,194 @@
+<?php
+
+/**
+ * Drains the flow-run queue and wakes runs whose wait is over.
+ *
+ * This is what makes a trigger cheap. A Nextcloud Flow rule, an object event
+ * or a file write only records the intent to run a flow; the graph itself
+ * executes here, off the request that caused it. Without this job a trigger
+ * would either block a user action for the length of an arbitrary graph, or
+ * quietly do nothing.
+ *
+ * Runs are claimed in small batches so one pass cannot monopolise the cron
+ * slot, and retention is applied in the same pass because runs are operational
+ * data that grows without bound — this instance has already been taken down
+ * once by a file that nobody was pruning.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Cron
+ * @package  OCA\OpenRegister\Cron
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Cron;
+
+use DateTime;
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+use OCP\IAppConfig;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Executes queued runs, resumes due ones, and prunes old ones.
+ */
+class FlowRunWorker extends TimedJob
+{
+
+    /**
+     * How many runs one pass may claim, per category.
+     *
+     * A ceiling rather than "everything waiting": a cron slot is shared, and a
+     * backlog that cannot be cleared in one pass is cleared over several.
+     *
+     * @var int
+     */
+    private const BATCH = 25;
+
+    /**
+     * Default retention for terminal runs, in days.
+     *
+     * @var int
+     */
+    private const DEFAULT_RETENTION_DAYS = 30;
+
+    /**
+     * Constructor.
+     *
+     * @param ITimeFactory    $time      Job scheduling clock.
+     * @param FlowRunMapper   $mapper    Reads and prunes runs.
+     * @param FlowRunService  $runner    Executes a run.
+     * @param IAppConfig      $appConfig Reads the retention setting.
+     * @param LoggerInterface $logger    The logger.
+     */
+    public function __construct(
+        ITimeFactory $time,
+        private readonly FlowRunMapper $mapper,
+        private readonly FlowRunService $runner,
+        private readonly IAppConfig $appConfig,
+        private readonly LoggerInterface $logger
+    ) {
+        parent::__construct(time: $time);
+        // Every minute: a Wait step's resolution is bounded by this, and a
+        // queued run should feel immediate to the person who triggered it.
+        $this->setInterval(interval: 60);
+
+    }//end __construct()
+
+    /**
+     * One pass: start what is queued, resume what is due, prune what is old.
+     *
+     * @param mixed $argument Job argument (unused).
+     *
+     * @return void
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     */
+    protected function run($argument): void
+    {
+        $now = new DateTime();
+
+        foreach ($this->mapper->findQueued(limit: self::BATCH) as $run) {
+            $this->advance(run: $run);
+        }
+
+        foreach ($this->mapper->findDue(now: $now, limit: self::BATCH) as $run) {
+            $this->advance(run: $run);
+        }
+
+        $this->prune(now: $now);
+
+    }//end run()
+
+    /**
+     * Advance one run, never letting its failure stop the batch.
+     *
+     * @param FlowRun $run The run.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     */
+    private function advance(FlowRun $run): void
+    {
+        try {
+            // TODO(#2067): resolve the flow document and the subject object.
+            // Both arrive with the flow-document store; until then a claimed
+            // run is left for the next pass rather than being failed, so no
+            // run is lost between these two changes landing.
+            $this->logger->debug(
+                message: '[FlowRunWorker] Run awaiting the flow-document store',
+                context: ['file' => __FILE__, 'line' => __LINE__, 'run' => $run->getUuid()]
+            );
+        } catch (Throwable $e) {
+            $this->logger->error(
+                message: '[FlowRunWorker] Failed to advance a run',
+                context: [
+                    'file'  => __FILE__,
+                    'line'  => __LINE__,
+                    'run'   => $run->getUuid(),
+                    'error' => $e->getMessage(),
+                ]
+            );
+        }//end try
+
+    }//end advance()
+
+    /**
+     * Delete terminal runs past their retention window.
+     *
+     * A retention of 0 disables pruning, for an operator who ships runs
+     * somewhere else and wants them kept.
+     *
+     * @param DateTime $now The current time.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     */
+    private function prune(DateTime $now): void
+    {
+        $days = (int) $this->appConfig->getValueString(
+            'openregister',
+            'flow_run_retention_days',
+            (string) self::DEFAULT_RETENTION_DAYS
+        );
+
+        if ($days <= 0) {
+            return;
+        }
+
+        try {
+            $before  = (clone $now)->modify(sprintf('-%d days', $days));
+            $deleted = $this->mapper->pruneBefore(before: $before);
+            if ($deleted > 0) {
+                $this->logger->info(
+                    message: '[FlowRunWorker] Pruned old flow runs',
+                    context: ['file' => __FILE__, 'line' => __LINE__, 'deleted' => $deleted, 'olderThanDays' => $days]
+                );
+            }
+        } catch (Throwable $e) {
+            $this->logger->error(
+                message: '[FlowRunWorker] Retention pass failed',
+                context: ['file' => __FILE__, 'line' => __LINE__, 'error' => $e->getMessage()]
+            );
+        }//end try
+
+    }//end prune()
+}//end class

--- a/lib/Db/FlowRun.php
+++ b/lib/Db/FlowRun.php
@@ -1,0 +1,332 @@
+<?php
+
+/**
+ * One execution of a flow.
+ *
+ * A run is the durable half of `FlowEngine`. The engine walks a Petri net in
+ * memory; without this, a run cannot outlive the request that started it, and
+ * five things become impossible: a Wait step, a sub-flow, run history, retry,
+ * and executing a flow off the request that triggered it.
+ *
+ * The marking is what makes resumption work. It is the Petri net's token
+ * placement — which places currently hold a token — so a suspended run is
+ * restored by handing the stored marking back to `symfony/workflow` rather than
+ * by replaying anything.
+ *
+ * `items` is the data channel at the point the run stopped, so resuming carries
+ * the records forward rather than re-deriving them from the subject.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Class FlowRun
+ *
+ * @method string|null getUuid()
+ * @method void setUuid(?string $uuid)
+ * @method string|null getFlowId()
+ * @method void setFlowId(?string $flowId)
+ * @method string|null getStatus()
+ * @method void setStatus(?string $status)
+ * @method array|null getMarking()
+ * @method void setMarking(?array $marking)
+ * @method array|null getItems()
+ * @method void setItems(?array $items)
+ * @method array|null getContext()
+ * @method void setContext(?array $context)
+ * @method array|null getLog()
+ * @method void setLog(?array $log)
+ * @method string|null getSubjectUuid()
+ * @method void setSubjectUuid(?string $subjectUuid)
+ * @method string|null getSubjectRegister()
+ * @method void setSubjectRegister(?string $subjectRegister)
+ * @method string|null getSubjectSchema()
+ * @method void setSubjectSchema(?string $subjectSchema)
+ * @method string|null getTriggeredBy()
+ * @method void setTriggeredBy(?string $triggeredBy)
+ * @method string|null getTrigger()
+ * @method void setTrigger(?string $trigger)
+ * @method string|null getOrganisation()
+ * @method void setOrganisation(?string $organisation)
+ * @method string|null getError()
+ * @method void setError(?string $error)
+ * @method DateTime|null getResumeAt()
+ * @method void setResumeAt(?DateTime $resumeAt)
+ * @method string|null getParentRunUuid()
+ * @method void setParentRunUuid(?string $parentRunUuid)
+ * @method DateTime|null getCreated()
+ * @method void setCreated(?DateTime $created)
+ * @method DateTime|null getUpdated()
+ * @method void setUpdated(?DateTime $updated)
+ *
+ * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class
+ */
+class FlowRun extends Entity implements JsonSerializable
+{
+
+    /**
+     * Statuses a run can hold.
+     *
+     * `suspended` is the one the engine did not previously have: the run is
+     * mid-graph, waiting for a timer or a child run, and will be resumed. It is
+     * deliberately distinct from `stopped`, which is terminal.
+     */
+    public const STATUS_QUEUED = 'queued';
+
+    public const STATUS_RUNNING = 'running';
+
+    public const STATUS_SUSPENDED = 'suspended';
+
+    public const STATUS_COMPLETED = 'completed';
+
+    public const STATUS_STOPPED = 'stopped';
+
+    public const STATUS_DEAD_LETTER = 'dead_letter';
+
+    public const STATUS_FAILED = 'failed';
+
+    /**
+     * Statuses from which a run will never advance on its own.
+     *
+     * @var array<int, string>
+     */
+    public const TERMINAL = [
+        self::STATUS_COMPLETED,
+        self::STATUS_STOPPED,
+        self::STATUS_DEAD_LETTER,
+        self::STATUS_FAILED,
+    ];
+
+    /**
+     * Public identifier for this run.
+     *
+     * @var string|null
+     */
+    protected ?string $uuid = null;
+
+    /**
+     * The flow this run executes.
+     *
+     * @var string|null
+     */
+    protected ?string $flowId = null;
+
+    /**
+     * Current lifecycle status.
+     *
+     * @var string|null
+     */
+    protected ?string $status = null;
+
+    /**
+     * The Petri-net marking — which places hold a token.
+     *
+     * @var array|null
+     */
+    protected ?array $marking = null;
+
+    /**
+     * The item list as it stood when the run last stopped.
+     *
+     * @var array|null
+     */
+    protected ?array $items = null;
+
+    /**
+     * Run-level metadata handed to every step.
+     *
+     * @var array|null
+     */
+    protected ?array $context = null;
+
+    /**
+     * Append-only per-step trace.
+     *
+     * @var array|null
+     */
+    protected ?array $log = null;
+
+    /**
+     * UUID of the object the run is about.
+     *
+     * @var string|null
+     */
+    protected ?string $subjectUuid = null;
+
+    /**
+     * Register slug of the subject object.
+     *
+     * @var string|null
+     */
+    protected ?string $subjectRegister = null;
+
+    /**
+     * Schema slug of the subject object.
+     *
+     * @var string|null
+     */
+    protected ?string $subjectSchema = null;
+
+    /**
+     * The user whose action started this run.
+     *
+     * @var string|null
+     */
+    protected ?string $triggeredBy = null;
+
+    /**
+     * What started the run (an event id, `manual`, `nc-flow`, `sub-flow`).
+     *
+     * @var string|null
+     */
+    protected ?string $trigger = null;
+
+    /**
+     * Owning organisation.
+     *
+     * @var string|null
+     */
+    protected ?string $organisation = null;
+
+    /**
+     * Failure message, when the run did not complete.
+     *
+     * @var string|null
+     */
+    protected ?string $error = null;
+
+    /**
+     * When a suspended run becomes eligible to resume.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $resumeAt = null;
+
+    /**
+     * The run that started this one, for sub-flows.
+     *
+     * @var string|null
+     */
+    protected ?string $parentRunUuid = null;
+
+    /**
+     * Creation timestamp.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $created = null;
+
+    /**
+     * Last-modified timestamp.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $updated = null;
+
+    /**
+     * Constructor: declare field types so the mapper hydrates them correctly.
+     */
+    public function __construct()
+    {
+        $this->addType(fieldName: 'uuid', type: 'string');
+        $this->addType(fieldName: 'flowId', type: 'string');
+        $this->addType(fieldName: 'status', type: 'string');
+        $this->addType(fieldName: 'marking', type: 'json');
+        $this->addType(fieldName: 'items', type: 'json');
+        $this->addType(fieldName: 'context', type: 'json');
+        $this->addType(fieldName: 'log', type: 'json');
+        $this->addType(fieldName: 'subjectUuid', type: 'string');
+        $this->addType(fieldName: 'subjectRegister', type: 'string');
+        $this->addType(fieldName: 'subjectSchema', type: 'string');
+        $this->addType(fieldName: 'triggeredBy', type: 'string');
+        $this->addType(fieldName: 'trigger', type: 'string');
+        $this->addType(fieldName: 'organisation', type: 'string');
+        $this->addType(fieldName: 'error', type: 'string');
+        $this->addType(fieldName: 'resumeAt', type: 'datetime');
+        $this->addType(fieldName: 'parentRunUuid', type: 'string');
+        $this->addType(fieldName: 'created', type: 'datetime');
+        $this->addType(fieldName: 'updated', type: 'datetime');
+
+    }//end __construct()
+
+    /**
+     * Whether this run has finished for good.
+     *
+     * @return boolean True when no further progress is possible.
+     *
+     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     */
+    public function isTerminal(): bool
+    {
+        return in_array($this->status, self::TERMINAL, true);
+
+    }//end isTerminal()
+
+    /**
+     * Serialise for the API.
+     *
+     * @return array<string, mixed> The run as plain data.
+     *
+     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     */
+    public function jsonSerialize(): array
+    {
+        $resumeAt = null;
+        if ($this->resumeAt !== null) {
+            $resumeAt = $this->resumeAt->format('c');
+        }
+
+        $created = null;
+        if ($this->created !== null) {
+            $created = $this->created->format('c');
+        }
+
+        $updated = null;
+        if ($this->updated !== null) {
+            $updated = $this->updated->format('c');
+        }
+
+        return [
+            'id'              => $this->id,
+            'uuid'            => $this->uuid,
+            'flowId'          => $this->flowId,
+            'status'          => $this->status,
+            'marking'         => ($this->marking ?? []),
+            'items'           => ($this->items ?? []),
+            'context'         => ($this->context ?? []),
+            'log'             => ($this->log ?? []),
+            'subjectUuid'     => $this->subjectUuid,
+            'subjectRegister' => $this->subjectRegister,
+            'subjectSchema'   => $this->subjectSchema,
+            'triggeredBy'     => $this->triggeredBy,
+            'trigger'         => $this->trigger,
+            'organisation'    => $this->organisation,
+            'error'           => $this->error,
+            'resumeAt'        => $resumeAt,
+            'parentRunUuid'   => $this->parentRunUuid,
+            'created'         => $created,
+            'updated'         => $updated,
+        ];
+
+    }//end jsonSerialize()
+}//end class

--- a/lib/Db/FlowRunMapper.php
+++ b/lib/Db/FlowRunMapper.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * Persistence for flow runs.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Reads and writes flow runs.
+ *
+ * @template-extends QBMapper<FlowRun>
+ */
+class FlowRunMapper extends QBMapper
+{
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $db The database connection.
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(db: $db, tableName: 'openregister_flow_runs', entityClass: FlowRun::class);
+
+    }//end __construct()
+
+    /**
+     * Find a run by its public uuid.
+     *
+     * @param string $uuid The run uuid.
+     *
+     * @return FlowRun The run.
+     *
+     * @throws \OCP\AppFramework\Db\DoesNotExistException When no such run exists.
+     *
+     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     */
+    public function findByUuid(string $uuid): FlowRun
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('uuid', $qb->createNamedParameter($uuid)));
+
+        return $this->findEntity(query: $qb);
+
+    }//end findByUuid()
+
+    /**
+     * List runs, newest first.
+     *
+     * @param string|null $flowId Restrict to one flow.
+     * @param string|null $status Restrict to one status.
+     * @param integer     $limit  Page size.
+     * @param integer     $offset Page offset.
+     *
+     * @return array<int, FlowRun> The runs.
+     *
+     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     */
+    public function findAllRuns(?string $flowId=null, ?string $status=null, int $limit=50, int $offset=0): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->orderBy('id', 'DESC')
+            ->setMaxResults($limit)
+            ->setFirstResult($offset);
+
+        if ($flowId !== null && $flowId !== '') {
+            $qb->andWhere($qb->expr()->eq('flow_id', $qb->createNamedParameter($flowId)));
+        }
+
+        if ($status !== null && $status !== '') {
+            $qb->andWhere($qb->expr()->eq('status', $qb->createNamedParameter($status)));
+        }
+
+        return $this->findEntities(query: $qb);
+
+    }//end findAllRuns()
+
+    /**
+     * Suspended runs that are due to resume.
+     *
+     * A run with no `resume_at` is waiting on something other than a clock — a
+     * child run, or a webhook — and is NOT picked up here. Resuming those on a
+     * timer would run them before whatever they are waiting for arrives.
+     *
+     * @param DateTime $now   The current time.
+     * @param integer  $limit Maximum runs to claim in one pass.
+     *
+     * @return array<int, FlowRun> The due runs.
+     *
+     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     */
+    public function findDue(DateTime $now, int $limit=25): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('status', $qb->createNamedParameter(FlowRun::STATUS_SUSPENDED)))
+            ->andWhere($qb->expr()->isNotNull('resume_at'))
+            ->andWhere(
+                $qb->expr()->lte(
+                    'resume_at',
+                    $qb->createNamedParameter($now, IQueryBuilder::PARAM_DATETIME_MUTABLE)
+                )
+            )
+            ->orderBy('resume_at', 'ASC')
+            ->setMaxResults($limit);
+
+        return $this->findEntities(query: $qb);
+
+    }//end findDue()
+
+    /**
+     * Runs waiting in the queue to start.
+     *
+     * @param integer $limit Maximum runs to claim in one pass.
+     *
+     * @return array<int, FlowRun> The queued runs.
+     *
+     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     */
+    public function findQueued(int $limit=25): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('status', $qb->createNamedParameter(FlowRun::STATUS_QUEUED)))
+            ->orderBy('id', 'ASC')
+            ->setMaxResults($limit);
+
+        return $this->findEntities(query: $qb);
+
+    }//end findQueued()
+
+    /**
+     * Delete terminal runs older than a cut-off.
+     *
+     * Runs are operational data and grow without bound; this instance has
+     * already been taken down once by an unbounded log file. Only TERMINAL
+     * runs are eligible — deleting a suspended run would strand whatever it
+     * was waiting for.
+     *
+     * @param DateTime $before Delete terminal runs last updated before this.
+     *
+     * @return integer The number of runs deleted.
+     *
+     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     */
+    public function pruneBefore(DateTime $before): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->in('status', $qb->createNamedParameter(FlowRun::TERMINAL, IQueryBuilder::PARAM_STR_ARRAY)))
+            ->andWhere(
+                $qb->expr()->lt(
+                    'updated',
+                    $qb->createNamedParameter($before, IQueryBuilder::PARAM_DATETIME_MUTABLE)
+                )
+            );
+
+        return (int) $qb->executeStatement();
+
+    }//end pruneBefore()
+}//end class

--- a/lib/Migration/Version1Date20260724120000.php
+++ b/lib/Migration/Version1Date20260724120000.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Creates the flow-run table.
+ *
+ * A run has to outlive the request that started it, or a Wait step, a
+ * sub-flow, run history, retry, and executing a flow off the triggering
+ * request are all impossible. This is the table that makes those possible.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adds `openregister_flow_runs`.
+ */
+class Version1Date20260724120000 extends SimpleMigrationStep
+{
+    /**
+     * Create the flow-run table.
+     *
+     * @param IOutput $output        Migration output.
+     * @param Closure $schemaClosure Schema closure returning an ISchemaWrapper.
+     * @param array   $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The updated schema, or null when nothing changed.
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema = $schemaClosure();
+
+        if ($schema->hasTable('openregister_flow_runs') === true) {
+            $output->info(message: 'openregister_flow_runs already exists, skipping...');
+            return null;
+        }
+
+        $table = $schema->createTable('openregister_flow_runs');
+
+        $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]);
+        $table->addColumn('uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
+        $table->addColumn('flow_id', Types::STRING, ['notnull' => true, 'length' => 255]);
+        $table->addColumn('status', Types::STRING, ['notnull' => true, 'length' => 32]);
+
+        // The Petri-net marking, the item list and the run-level context are
+        // the three things a resume needs; the log is what a human needs.
+        $table->addColumn('marking', Types::JSON, ['notnull' => false, 'default' => null]);
+        $table->addColumn('items', Types::JSON, ['notnull' => false, 'default' => null]);
+        $table->addColumn('context', Types::JSON, ['notnull' => false, 'default' => null]);
+        $table->addColumn('log', Types::JSON, ['notnull' => false, 'default' => null]);
+
+        $table->addColumn('subject_uuid', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+        $table->addColumn('subject_register', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+        $table->addColumn('subject_schema', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+        $table->addColumn('triggered_by', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+        $table->addColumn('trigger', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+        $table->addColumn('organisation', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+
+        // TEXT rather than STRING: an error is a thrown message and will exceed
+        // any length we pick, and a truncated error is worse than a long one.
+        $table->addColumn('error', Types::TEXT, ['notnull' => false, 'default' => null]);
+
+        $table->addColumn('resume_at', Types::DATETIME, ['notnull' => false, 'default' => null]);
+        $table->addColumn('parent_run_uuid', Types::STRING, ['notnull' => false, 'length' => 36, 'default' => null]);
+        $table->addColumn('created', Types::DATETIME, ['notnull' => false, 'default' => null]);
+        $table->addColumn('updated', Types::DATETIME, ['notnull' => false, 'default' => null]);
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['uuid'], 'or_flowrun_uuid_idx');
+
+        // The queue worker's two hot reads: what is queued, and what is due.
+        // `status` leads both, so one composite index serves each query.
+        $table->addIndex(['status', 'id'], 'or_flowrun_status_idx');
+        $table->addIndex(['status', 'resume_at'], 'or_flowrun_due_idx');
+
+        // Run history is listed per flow, newest first.
+        $table->addIndex(['flow_id', 'id'], 'or_flowrun_flow_idx');
+
+        // Retention prunes terminal runs by age.
+        $table->addIndex(['updated'], 'or_flowrun_updated_idx');
+
+        // A sub-flow's parent, for assembling a run tree.
+        $table->addIndex(['parent_run_uuid'], 'or_flowrun_parent_idx');
+
+        $output->info(message: 'Created openregister_flow_runs table');
+
+        return $schema;
+
+    }//end changeSchema()
+}//end class

--- a/lib/Service/Flow/FlowEngine.php
+++ b/lib/Service/Flow/FlowEngine.php
@@ -38,6 +38,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Service\Flow;
 
+use DateTime;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
@@ -62,6 +63,16 @@ class FlowEngine
     public const STATUS_DEAD_LETTER = 'dead_letter';
 
     public const STATUS_FAILED = 'failed';
+
+    /**
+     * The run stopped mid-graph and will be resumed.
+     *
+     * Distinct from `stopped`, which is terminal. A suspended run keeps its
+     * marking and its items, and the marking is exactly what makes resuming
+     * cheap: the run picks up where it was instead of replaying side effects
+     * it already performed.
+     */
+    public const STATUS_SUSPENDED = 'suspended';
 
     /**
      * Per-step error policies, ported from openconnector's `onError`.
@@ -193,6 +204,26 @@ class FlowEngine
                     'status'     => 'completed',
                     'itemsIn'    => count($itemsIn),
                     'itemsOut'   => count($items),
+                ];
+            } catch (FlowSuspension $suspension) {
+                // A pause, not a failure. Caught before Throwable so the step's
+                // onError policy never sees it — `continue` would otherwise skip
+                // straight past a Wait, which is the opposite of waiting.
+                //
+                // The marking is NOT advanced: the run must resume ON this
+                // transition, re-entering the step that asked to wait.
+                $log[] = [
+                    'transition' => $name,
+                    'status'     => 'suspended',
+                    'reason'     => $suspension->getMessage(),
+                ];
+
+                return [
+                    'status'   => self::STATUS_SUSPENDED,
+                    'log'      => $log,
+                    'context'  => $context,
+                    'items'    => $itemsIn,
+                    'resumeAt' => $suspension->getResumeAt(),
                 ];
             } catch (Throwable $e) {
                 $policy = (string) ($step['onError'] ?? self::ON_ERROR_STOP);

--- a/lib/Service/Flow/FlowRunMarkingStore.php
+++ b/lib/Service/Flow/FlowRunMarkingStore.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Keeps a run's Petri-net marking on its FlowRun row.
+ *
+ * `symfony/workflow` reads and writes the marking through a
+ * `MarkingStoreInterface`, and the in-memory implementations put it on a
+ * property of the subject. That is fine for a run that starts and finishes
+ * inside one request, and useless for one that does not.
+ *
+ * This store puts the marking where it survives: on the run. Resuming a
+ * suspended run is then handing the stored places back to Symfony, not
+ * replaying the graph from the beginning — which matters because replaying
+ * would re-run every side effect the run already performed.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use OCA\OpenRegister\Db\FlowRun;
+use Symfony\Component\Workflow\Marking;
+use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
+
+/**
+ * A marking store backed by a FlowRun row.
+ */
+class FlowRunMarkingStore implements MarkingStoreInterface
+{
+    /**
+     * Constructor.
+     *
+     * @param FlowRun $run The run whose marking this store reads and writes.
+     */
+    public function __construct(private readonly FlowRun $run)
+    {
+
+    }//end __construct()
+
+    /**
+     * Read the marking.
+     *
+     * The subject is ignored: the marking belongs to the RUN, not to the object
+     * the run is about. Two runs over one object hold two independent markings,
+     * which is the whole reason this is not stored on the subject.
+     *
+     * @param object $subject The subject (unused).
+     *
+     * @return Marking The current marking.
+     *
+     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     */
+    public function getMarking(object $subject): Marking
+    {
+        $places = ($this->run->getMarking() ?? []);
+        if (is_array($places) === false || $places === []) {
+            return new Marking();
+        }
+
+        // Stored as `place => tokens`. A list of place names is also accepted,
+        // because that is the shape a hand-authored fixture tends to take.
+        $normalised = [];
+        foreach ($places as $key => $value) {
+            if (is_int($key) === true) {
+                $normalised[(string) $value] = 1;
+                continue;
+            }
+
+            $normalised[(string) $key] = max(1, (int) $value);
+        }
+
+        return new Marking($normalised);
+
+    }//end getMarking()
+
+    /**
+     * Write the marking back onto the run.
+     *
+     * Only mutates the entity; persisting is the caller's job, so a whole hop
+     * (marking, items, log) is written in one update rather than three.
+     *
+     * @param object              $subject The subject (unused).
+     * @param Marking             $marking The new marking.
+     * @param array<string,mixed> $context Transition context (unused).
+     *
+     * @return void
+     *
+     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     */
+    public function setMarking(object $subject, Marking $marking, array $context=[]): void
+    {
+        $this->run->setMarking($marking->getPlaces());
+
+    }//end setMarking()
+}//end class

--- a/lib/Service/Flow/FlowRunService.php
+++ b/lib/Service/Flow/FlowRunService.php
@@ -1,0 +1,230 @@
+<?php
+
+/**
+ * Starts, persists and resumes flow runs.
+ *
+ * `FlowEngine` walks a graph in memory and knows nothing about storage. This
+ * service is the half that makes a run durable: it creates the row, hands the
+ * engine a marking store backed by that row, writes back what the walk
+ * produced, and — when a step asked to wait — leaves the run resumable instead
+ * of finished.
+ *
+ * Keeping the two apart is deliberate. The engine stays unit-testable without
+ * a database, and the decision "when does a run get written" lives in exactly
+ * one place rather than being sprinkled through the walk.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use DateTime;
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * The durable half of flow execution.
+ */
+class FlowRunService
+{
+    /**
+     * Constructor.
+     *
+     * @param FlowRunMapper    $mapper   Persists runs.
+     * @param FlowEngine       $engine   Walks the graph.
+     * @param FlowNodeRegistry $registry Resolves step types.
+     * @param LoggerInterface  $logger   The logger.
+     */
+    public function __construct(
+        private readonly FlowRunMapper $mapper,
+        private readonly FlowEngine $engine,
+        private readonly FlowNodeRegistry $registry,
+        private readonly LoggerInterface $logger
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Queue a run without executing it.
+     *
+     * This is what a trigger calls. A Nextcloud Flow rule, an object event or a
+     * file write runs inside the dispatch of the thing that caused it, and an
+     * arbitrary graph must not sit on that critical path — so the trigger only
+     * records the intent and returns.
+     *
+     * @param string      $flowId  The flow to run.
+     * @param array       $subject `{uuid, register, schema}` of the object.
+     * @param string      $trigger What caused this run.
+     * @param array       $context Run-level metadata.
+     * @param string|null $user    The user whose action caused it.
+     *
+     * @return FlowRun The queued run.
+     *
+     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     */
+    public function queue(
+        string $flowId,
+        array $subject=[],
+        string $trigger='manual',
+        array $context=[],
+        ?string $user=null
+    ): FlowRun {
+        $run = new FlowRun();
+        $run->setUuid($this->newUuid());
+        $run->setFlowId($flowId);
+        $run->setStatus(FlowRun::STATUS_QUEUED);
+        $run->setTrigger($trigger);
+        $run->setContext($context);
+        $run->setLog([]);
+        $run->setSubjectUuid(($subject['uuid'] ?? null));
+        $run->setSubjectRegister(($subject['register'] ?? null));
+        $run->setSubjectSchema(($subject['schema'] ?? null));
+        $run->setTriggeredBy($user);
+        $run->setCreated(new DateTime());
+        $run->setUpdated(new DateTime());
+
+        return $this->mapper->insert($run);
+
+    }//end queue()
+
+    /**
+     * Execute (or continue) a run to its next stopping point.
+     *
+     * Called by the queue worker, never by a trigger. Returns the run in
+     * whatever state the walk left it: terminal, or suspended and resumable.
+     *
+     * @param FlowRun $run       The run to advance.
+     * @param array   $flow      The flow document.
+     * @param object  $subject   The object the run is about.
+     * @param array   $seedItems Items to start from; ignored when resuming.
+     *
+     * @return FlowRun The updated run.
+     *
+     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     */
+    public function execute(FlowRun $run, array $flow, object $subject, ?array $seedItems=null): FlowRun
+    {
+        if ($run->isTerminal() === true) {
+            // Re-executing a finished run would repeat every side effect it
+            // already performed. Retry creates a NEW run instead.
+            return $run;
+        }
+
+        $resuming = ($run->getStatus() === FlowRun::STATUS_SUSPENDED);
+        $run->setStatus(FlowRun::STATUS_RUNNING);
+        $run->setUpdated(new DateTime());
+        $this->mapper->update($run);
+
+        $items = $seedItems;
+        if ($resuming === true) {
+            // On resume the stored items win: they are what the run was
+            // carrying when it paused. Re-seeding from the subject would throw
+            // away everything the earlier steps produced.
+            $items = ($run->getItems() ?? []);
+        }
+
+        $context            = ($run->getContext() ?? []);
+        $context['runUuid'] = $run->getUuid();
+        $context['resuming'] = $resuming;
+
+        try {
+            $result = $this->engine->run(
+                flow: $flow,
+                store: new FlowRunMarkingStore(run: $run),
+                subject: $subject,
+                dispatcher: new RegistryStepDispatcher(registry: $this->registry),
+                context: $context,
+                items: $items
+            );
+        } catch (Throwable $e) {
+            // The engine itself failing (rather than a step) is not something
+            // the run should be left `running` for — that status would make it
+            // look claimed by a worker forever.
+            $this->logger->error(
+                message: '[FlowRunService] Flow run failed outside the walk',
+                context: ['file' => __FILE__, 'line' => __LINE__, 'run' => $run->getUuid(), 'error' => $e->getMessage()]
+            );
+
+            $run->setStatus(FlowRun::STATUS_FAILED);
+            $run->setError($e->getMessage());
+            $run->setUpdated(new DateTime());
+
+            return $this->mapper->update($run);
+        }//end try
+
+        return $this->persistResult(run: $run, result: $result);
+
+    }//end execute()
+
+    /**
+     * Write a completed walk back onto the run.
+     *
+     * @param FlowRun $run    The run.
+     * @param array   $result What the engine returned.
+     *
+     * @return FlowRun The updated run.
+     *
+     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     */
+    private function persistResult(FlowRun $run, array $result): FlowRun
+    {
+        $status = (string) ($result['status'] ?? FlowRun::STATUS_FAILED);
+
+        // The log is appended, not replaced: a resumed run's history is the
+        // whole run, not just the segment since it last woke up.
+        $log = array_merge(($run->getLog() ?? []), (array) ($result['log'] ?? []));
+
+        $run->setStatus($status);
+        $run->setItems((array) ($result['items'] ?? []));
+        $run->setContext((array) ($result['context'] ?? []));
+        $run->setLog($log);
+        $run->setError(($result['error'] ?? null));
+        $run->setUpdated(new DateTime());
+
+        // `resumeAt` is only meaningful while suspended. Clearing it on every
+        // other outcome stops a completed run from being picked up by the
+        // due-runs query on its next pass.
+        $resumeAt = null;
+        if ($status === FlowRun::STATUS_SUSPENDED) {
+            $resumeAt = ($result['resumeAt'] ?? null);
+        }
+
+        $run->setResumeAt($resumeAt);
+
+        return $this->mapper->update($run);
+
+    }//end persistResult()
+
+    /**
+     * A v4 UUID for a new run.
+     *
+     * @return string The uuid.
+     *
+     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     */
+    private function newUuid(): string
+    {
+        $data    = random_bytes(16);
+        $data[6] = chr((ord($data[6]) & 0x0f) | 0x40);
+        $data[8] = chr((ord($data[8]) & 0x3f) | 0x80);
+
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
+
+    }//end newUuid()
+}//end class

--- a/lib/Service/Flow/FlowSuspension.php
+++ b/lib/Service/Flow/FlowSuspension.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Thrown by a step that wants the run paused rather than finished.
+ *
+ * A Wait step and a sub-flow step both need the same thing: stop here, keep
+ * everything, come back later. Neither is a failure and neither is a
+ * completion, so neither fits the existing `onError` policies or the terminal
+ * statuses.
+ *
+ * An exception rather than a return value on purpose. A node returns ITEMS; if
+ * "please suspend" were smuggled into that return, every node author would
+ * have to know about a magic item shape, and a node that forgot would silently
+ * continue. Throwing makes suspension impossible to ignore and keeps the item
+ * contract exactly what it says it is.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use DateTime;
+use RuntimeException;
+
+/**
+ * Signals that the current run should suspend.
+ */
+class FlowSuspension extends RuntimeException
+{
+    /**
+     * Constructor.
+     *
+     * @param DateTime|null $resumeAt When the run becomes eligible to resume;
+     *                                null means it waits for an external
+     *                                signal (a child run, a webhook) instead
+     *                                of a clock.
+     * @param string        $reason   Why it suspended, for the run log.
+     */
+    public function __construct(
+        private readonly ?DateTime $resumeAt=null,
+        string $reason='suspended'
+    ) {
+        parent::__construct(message: $reason);
+
+    }//end __construct()
+
+    /**
+     * When this run may resume.
+     *
+     * @return DateTime|null The resume time, or null when waiting on a signal.
+     *
+     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     */
+    public function getResumeAt(): ?DateTime
+    {
+        return $this->resumeAt;
+
+    }//end getResumeAt()
+}//end class

--- a/openspec/changes/or-flow-runs/.openspec.yaml
+++ b/openspec/changes/or-flow-runs/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-runs

--- a/openspec/changes/or-flow-runs/proposal.md
+++ b/openspec/changes/or-flow-runs/proposal.md
@@ -1,0 +1,58 @@
+# Proposal: or-flow-runs
+
+## Summary
+
+Make a flow run outlive the request that started it.
+
+## Why
+
+`FlowEngine` takes a `MarkingStoreInterface` and the engine change (#2064)
+deferred persisting the marking. That single deferral is what stands between us
+and five separate workstreams:
+
+| Blocked | Why |
+|---|---|
+| **Wait** | A run that pauses must survive the request that started it |
+| **Sub-flows** | A parent must be suspended while a child runs |
+| **Run history** | Nothing to list if runs are not stored |
+| **Retry** | Cannot re-run what was not recorded |
+| **The Nextcloud Flow bridge** | A Flow operation runs inside the dispatch of the event that triggered it — often a file write — and a graph must not block that |
+
+Five things, one dependency. It is built first, not alongside.
+
+## What Changes
+
+- `FlowRun` + `FlowRunMapper` + `openregister_flow_runs`. A run stores its
+  marking, its items, its context and its log.
+- `FlowRunMarkingStore` — a `MarkingStoreInterface` backed by the run row, so
+  the marking survives the request.
+- `FlowSuspension` — thrown by a step that wants the run paused. An exception,
+  not a return value: a node returns ITEMS, and smuggling "please suspend" into
+  that return would mean every node author had to know about a magic item
+  shape, with a forgetful node silently continuing.
+- `FlowEngine::STATUS_SUSPENDED`, caught **before** the generic `Throwable`
+  handler so a step's `onError` policy never sees a pause. `continue` would
+  otherwise skip straight past a Wait, which is the opposite of waiting.
+- `FlowRunService` — queue, execute, resume, persist.
+- `FlowRunWorker` — a per-minute job that starts queued runs, resumes due ones,
+  and prunes old ones.
+
+## Design decisions
+
+- **The marking does not advance past a suspended step.** The run must resume
+  ON that transition, re-entering the step that asked to wait. Advancing would
+  skip it.
+- **Resume uses the stored items, never a re-seed.** Re-seeding from the
+  subject would discard everything earlier steps produced.
+- **A terminal run is never re-executed.** Retry creates a new run; re-running
+  the old one would repeat every side effect it already performed.
+- **Retention ships in this change, not after it.** Runs are operational data
+  and grow without bound; this instance has already been taken down once by a
+  file nobody was pruning. Default 30 days, `0` disables.
+
+## Out of scope (this change)
+
+- **Resolving the flow document and subject in the worker.** Both arrive with
+  the flow-document store. Until then the worker leaves a claimed run for the
+  next pass rather than failing it, so no run is lost between the two changes.
+- **Retry, pin/mock and the run-history UI** — #2070, which this unblocks.

--- a/openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+++ b/openspec/changes/or-flow-runs/specs/flow-runs/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: A run outlives the request that started it (REQ-FR-001)
+
+A flow run SHALL be persisted with its Petri-net marking, its item list, its
+run-level context and its append-only log, so execution can stop and continue
+across requests.
+
+The marking SHALL be stored on the RUN, not on the subject: two runs over one
+object hold two independent markings.
+
+#### Scenario: The marking round-trips through the run
+
+- **GIVEN** a marking of two places
+- **WHEN** it is written and read back through the run's marking store
+- **THEN** both places are returned
+
+### Requirement: A step can suspend a run (REQ-FR-002)
+
+A step SHALL be able to pause the run by throwing `FlowSuspension`, optionally
+naming when it becomes eligible to resume. The engine SHALL report status
+`suspended`, which is NOT terminal.
+
+Suspension SHALL be handled before the step's `onError` policy. A pause is not
+a failure, and `onError: continue` would otherwise skip past a Wait — the
+opposite of waiting.
+
+The marking SHALL NOT advance past a suspended step: the run resumes on that
+transition and re-enters the step that asked to wait.
+
+#### Scenario: A suspended run stays where it was
+
+- **GIVEN** a two-node flow whose step suspends
+- **WHEN** the run executes
+- **THEN** its status is `suspended` and `resumeAt` is set
+- **AND** its marking still holds the place before the suspended step
+
+### Requirement: Resuming carries the run's own items (REQ-FR-003)
+
+Resuming SHALL continue from the stored item list, not from a fresh seed of the
+subject. Re-seeding would discard everything the earlier steps produced.
+
+The run log SHALL accumulate across a suspension, so a resumed run's history is
+the whole run.
+
+`resumeAt` SHALL be cleared once the run is no longer suspended, or the
+due-runs query would keep waking a finished run.
+
+#### Scenario: Items survive the pause
+
+- **GIVEN** a suspended run carrying items no re-seed could produce
+- **WHEN** it resumes
+- **THEN** the step receives exactly those items
+- **AND** the run completes
+
+### Requirement: A terminal run is never re-executed (REQ-FR-004)
+
+Executing a run already in a terminal status SHALL be a no-op. Re-running it
+would repeat every side effect it performed; retry SHALL create a new run.
+
+An engine failure outside the walk SHALL leave the run `failed` with its error,
+never `running` — a run left `running` looks claimed by a worker forever.
+
+#### Scenario: A completed run does not run again
+
+- **GIVEN** a run with status `completed`
+- **WHEN** it is executed
+- **THEN** no step is dispatched
+
+#### Scenario: A malformed flow fails the run
+
+- **GIVEN** a run against a flow with no nodes
+- **WHEN** it is executed
+- **THEN** the run's status is `failed` and its error is set
+
+### Requirement: Runs execute off the triggering request (REQ-FR-005)
+
+A trigger SHALL queue a run and return without executing it. A background job
+SHALL start queued runs, resume due ones, and prune terminal ones.
+
+Only a run with a `resumeAt` SHALL be resumed on a timer. A run waiting on a
+signal — a child run, a webhook — has no `resumeAt` and resuming it on a clock
+would run it before what it waits for arrives.
+
+Terminal runs SHALL be pruned after a configurable retention, defaulting to 30
+days, with `0` disabling it. Runs are operational data and grow without bound.
+
+#### Scenario: Queueing does not execute
+
+- **GIVEN** a queued run
+- **WHEN** the queue call returns
+- **THEN** its status is `queued` and no step has been dispatched
+
+@e2e exclude run persistence is backend-only — covered by PHPUnit; the run-history surface is covered by #2070

--- a/openspec/changes/or-flow-runs/tasks.md
+++ b/openspec/changes/or-flow-runs/tasks.md
@@ -1,0 +1,16 @@
+# Tasks: or-flow-runs
+
+- [x] `FlowRun` entity + statuses (incl. `suspended`) + `isTerminal()`.
+- [x] `FlowRunMapper` — findByUuid, findAllRuns, findQueued, findDue, pruneBefore.
+- [x] Migration `Version1Date20260724120000` with indexes for the worker's two
+      hot reads, per-flow history, retention, and the sub-flow parent link.
+- [x] `FlowRunMarkingStore` — marking on the run, not the subject.
+- [x] `FlowSuspension` + `FlowEngine::STATUS_SUSPENDED`, caught before the
+      `onError` policy.
+- [x] `FlowRunService` — queue / execute / resume / persist.
+- [x] `FlowRunWorker` background job + retention, registered in info.xml.
+- [x] Tests: queue does not execute, suspend leaves it resumable, marking stays
+      put, resume carries stored items, resumeAt cleared, log accumulates,
+      terminal never re-executes, malformed flow fails, marking round-trip.
+- [ ] Resolve the flow document + subject in the worker — needs the
+      flow-document store.

--- a/tests/Unit/Service/Flow/FlowRunServiceTest.php
+++ b/tests/Unit/Service/Flow/FlowRunServiceTest.php
@@ -1,0 +1,258 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use DateTime;
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Service\Flow\FlowDefinitionBuilder;
+use OCA\OpenRegister\Service\Flow\FlowEngine;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
+use OCA\OpenRegister\Service\Flow\FlowRunMarkingStore;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
+use OCA\OpenRegister\Service\Flow\FlowSuspension;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\RegisterFlowNodesEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\WorkflowEngine\IManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Workflow\Marking;
+
+/** Subject carrying nothing — the marking lives on the run, not here. */
+class RunSubject
+{
+    public array $bag = [];
+}
+
+/** A node that suspends the first time and proceeds once resuming. */
+class WaitingNode implements IFlowNode
+{
+    public int $calls = 0;
+
+    public function __construct(private readonly string $id = 'test.wait')
+    {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getDisplayName(): string
+    {
+        return 'Wait';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Waits.';
+    }
+
+    public function getIcon(): string
+    {
+        return 'i.svg';
+    }
+
+    public function isAvailableForScope(int $scope): bool
+    {
+        return true;
+    }
+
+    public function validateConfig(array $config): void
+    {
+    }
+
+    public function execute(array $items, array $config, array $context): array
+    {
+        $this->calls++;
+        if (($context['resuming'] ?? false) !== true) {
+            throw new FlowSuspension(new DateTime('@1900000000'), 'waiting for the clock');
+        }
+
+        return $items;
+    }
+}
+
+class FlowRunServiceTest extends TestCase
+{
+    private FlowRunMapper $mapper;
+    private FlowRunService $service;
+    private WaitingNode $waiter;
+
+    protected function setUp(): void
+    {
+        $this->mapper = $this->createMock(FlowRunMapper::class);
+        // insert/update echo the entity back, so assertions read the real state.
+        $this->mapper->method('insert')->willReturnArgument(0);
+        $this->mapper->method('update')->willReturnArgument(0);
+
+        $this->waiter = new WaitingNode();
+
+        $dispatcher = $this->createMock(IEventDispatcher::class);
+        $dispatcher->method('dispatchTyped')->willReturnCallback(
+            function (Event $event): void {
+                if ($event instanceof RegisterFlowNodesEvent) {
+                    $event->registerNode($this->waiter);
+                }
+            }
+        );
+
+        $registry = new FlowNodeRegistry($dispatcher, $this->createMock(LoggerInterface::class));
+        $engine = new FlowEngine(new FlowDefinitionBuilder(), $this->createMock(LoggerInterface::class));
+
+        $this->service = new FlowRunService(
+            $this->mapper,
+            $engine,
+            $registry,
+            $this->createMock(LoggerInterface::class)
+        );
+    }
+
+    private function waitFlow(): array
+    {
+        return [
+            'id' => 'f1',
+            'nodes' => [['id' => 'a'], ['id' => 'b']],
+            'edges' => [['id' => 'hop', 'from' => 'a', 'to' => 'b', 'type' => 'test.wait']],
+        ];
+    }
+
+    public function testAQueuedRunIsNotExecuted(): void
+    {
+        $run = $this->service->queue('f1', ['uuid' => 'u1'], 'object.created');
+
+        $this->assertSame(FlowRun::STATUS_QUEUED, $run->getStatus());
+        $this->assertSame(0, $this->waiter->calls);
+        $this->assertNotEmpty($run->getUuid());
+    }
+
+    /**
+     * The property the whole issue exists for: a step can pause the run.
+     */
+    public function testAStepThatSuspendsLeavesTheRunResumable(): void
+    {
+        $run = $this->service->queue('f1');
+        $run = $this->service->execute($run, $this->waitFlow(), new RunSubject());
+
+        $this->assertSame(FlowRun::STATUS_SUSPENDED, $run->getStatus());
+        $this->assertInstanceOf(DateTime::class, $run->getResumeAt());
+        $this->assertFalse($run->isTerminal());
+    }
+
+    /**
+     * The marking must NOT have advanced past the suspended step, or resuming
+     * would skip the very step that asked to wait.
+     */
+    public function testASuspendedRunKeepsItsPlaceInTheGraph(): void
+    {
+        $run = $this->service->queue('f1');
+        $run = $this->service->execute($run, $this->waitFlow(), new RunSubject());
+
+        $this->assertSame(['a' => 1], $run->getMarking());
+    }
+
+    public function testResumingCarriesTheStoredItemsRatherThanReseeding(): void
+    {
+        $run = $this->service->queue('f1');
+        $run = $this->service->execute($run, $this->waitFlow(), new RunSubject());
+
+        // Something the subject could never produce — proves the items came
+        // from storage and not from re-seeding.
+        $run->setItems([FlowItems::item(json: ['carried' => 'through-the-pause'])]);
+
+        $run = $this->service->execute($run, $this->waitFlow(), new RunSubject());
+
+        $this->assertSame(FlowRun::STATUS_COMPLETED, $run->getStatus());
+        $this->assertSame('through-the-pause', $run->getItems()[0]['json']['carried']);
+        $this->assertSame(2, $this->waiter->calls);
+    }
+
+    public function testResumeAtIsClearedOnceTheRunIsNoLongerSuspended(): void
+    {
+        $run = $this->service->queue('f1');
+        $run = $this->service->execute($run, $this->waitFlow(), new RunSubject());
+        $this->assertNotNull($run->getResumeAt());
+
+        $run = $this->service->execute($run, $this->waitFlow(), new RunSubject());
+
+        // Otherwise the due-runs query keeps picking up a finished run.
+        $this->assertNull($run->getResumeAt());
+    }
+
+    public function testTheLogAccumulatesAcrossASuspension(): void
+    {
+        $run = $this->service->queue('f1');
+        $run = $this->service->execute($run, $this->waitFlow(), new RunSubject());
+        $afterSuspend = count($run->getLog());
+
+        $run = $this->service->execute($run, $this->waitFlow(), new RunSubject());
+
+        $this->assertGreaterThan($afterSuspend, count($run->getLog()));
+        $this->assertSame('suspended', $run->getLog()[0]['status']);
+    }
+
+    /**
+     * Re-executing a finished run would repeat every side effect it performed.
+     */
+    public function testATerminalRunIsNeverReExecuted(): void
+    {
+        $run = $this->service->queue('f1');
+        $run->setStatus(FlowRun::STATUS_COMPLETED);
+
+        $this->service->execute($run, $this->waitFlow(), new RunSubject());
+
+        $this->assertSame(0, $this->waiter->calls);
+    }
+
+    public function testAMalformedFlowFailsTheRunRatherThanLeavingItRunning(): void
+    {
+        $run = $this->service->queue('f1');
+        $run = $this->service->execute($run, ['nodes' => []], new RunSubject());
+
+        $this->assertSame(FlowRun::STATUS_FAILED, $run->getStatus());
+        $this->assertNotNull($run->getError());
+    }
+}
+
+class FlowRunMarkingStoreTest extends TestCase
+{
+    public function testTheMarkingRoundTripsThroughTheRun(): void
+    {
+        $run = new FlowRun();
+        $store = new FlowRunMarkingStore($run);
+
+        $store->setMarking(new RunSubject(), new Marking(['a' => 1, 'b' => 1]));
+
+        $this->assertSame(['a' => 1, 'b' => 1], $run->getMarking());
+        $this->assertSame(['a' => 1, 'b' => 1], $store->getMarking(new RunSubject())->getPlaces());
+    }
+
+    public function testAnEmptyRunStartsWithAnEmptyMarking(): void
+    {
+        $store = new FlowRunMarkingStore(new FlowRun());
+
+        $this->assertSame([], $store->getMarking(new RunSubject())->getPlaces());
+    }
+
+    /**
+     * A hand-authored fixture tends to be a list of place names rather than a
+     * place => tokens map; accept it rather than silently marking nothing.
+     */
+    public function testAListOfPlaceNamesIsAccepted(): void
+    {
+        $run = new FlowRun();
+        $run->setMarking(['a', 'b']);
+
+        $this->assertSame(['a' => 1, 'b' => 1], (new FlowRunMarkingStore($run))->getMarking(new RunSubject())->getPlaces());
+    }
+}


### PR DESCRIPTION
# Proposal: or-flow-runs

## Summary

Make a flow run outlive the request that started it.

## Why

`FlowEngine` takes a `MarkingStoreInterface` and the engine change (#2064)
deferred persisting the marking. That single deferral is what stands between us
and five separate workstreams:

| Blocked | Why |
|---|---|
| **Wait** | A run that pauses must survive the request that started it |
| **Sub-flows** | A parent must be suspended while a child runs |
| **Run history** | Nothing to list if runs are not stored |
| **Retry** | Cannot re-run what was not recorded |
| **The Nextcloud Flow bridge** | A Flow operation runs inside the dispatch of the event that triggered it — often a file write — and a graph must not block that |

Five things, one dependency. It is built first, not alongside.

## What Changes

- `FlowRun` + `FlowRunMapper` + `openregister_flow_runs`. A run stores its
  marking, its items, its context and its log.
- `FlowRunMarkingStore` — a `MarkingStoreInterface` backed by the run row, so
  the marking survives the request.
- `FlowSuspension` — thrown by a step that wants the run paused. An exception,
  not a return value: a node returns ITEMS, and smuggling "please suspend" into
  that return would mean every node author had to know about a magic item
  shape, with a forgetful node silently continuing.
- `FlowEngine::STATUS_SUSPENDED`, caught **before** the generic `Throwable`
  handler so a step's `onError` policy never sees a pause. `continue` would
  otherwise skip straight past a Wait, which is the opposite of waiting.
- `FlowRunService` — queue, execute, resume, persist.
- `FlowRunWorker` — a per-minute job that starts queued runs, resumes due ones,
  and prunes old ones.

## Design decisions

- **The marking does not advance past a suspended step.** The run must resume
  ON that transition, re-entering the step that asked to wait. Advancing would
  skip it.
- **Resume uses the stored items, never a re-seed.** Re-seeding from the
  subject would discard everything earlier steps produced.
- **A terminal run is never re-executed.** Retry creates a new run; re-running
  the old one would repeat every side effect it already performed.
- **Retention ships in this change, not after it.** Runs are operational data
  and grow without bound; this instance has already been taken down once by a
  file nobody was pruning. Default 30 days, `0` disables.

## Out of scope (this change)

- **Resolving the flow document and subject in the worker.** Both arrive with
  the flow-document store. Until then the worker leaves a claimed run for the
  next pass rather than failing it, so no run is lost between the two changes.
- **Retry, pin/mock and the run-history UI** — #2070, which this unblocks.

---

## Verification

67 unit tests green in `tests/Unit/Service/Flow` (11 new), `phpcs` clean on every new file. The tests cover the properties that actually matter: a suspended run keeps its place in the graph, resuming carries the stored items rather than re-seeding, `resumeAt` is cleared once no longer suspended, the log accumulates across a pause, a terminal run is never re-executed, and a malformed flow fails the run instead of leaving it `running`.

Unblocks #2067 (Wait, sub-flows), #2070 (history, retry), #2068 (triggers), and lets the existing Nextcloud Flow bridge execute instead of running inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)