### PR TITLE
fix(npm): npm ci has been failing on every branch — EOVERRIDE on vue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5484,9 +5484,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5509,9 +5506,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5534,9 +5528,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5559,9 +5550,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5584,9 +5572,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5609,9 +5594,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "remark-preset-lint-consistent": "^5.1.1",
     "remark-preset-lint-recommended": "^6.1.2",
     "style-loader": "^3.3.3",
-    "vue": "^2.6 || ^3.0",
+    "vue": "^2.7.16",
     "vue-apexcharts": "^1.7.0",
     "vue-codemirror6": "^1.1.5",
     "vue-draggable-plus": "^0.2.6",


### PR DESCRIPTION
`npm ci` errors before installing anything:

```
npm error code EOVERRIDE
npm error Override for vue@^2.6 || ^3.0 conflicts with direct dependency
```

npm refuses an override for a package that is also a direct dependency unless the two agree. `overrides.vue` pins `^2.7.16` while the devDependency allows `^2.6 || ^3.0`.

## Why this matters more than it looks

That single failure is the root of **five** red checks on every PR here: with no `node_modules`, `validate`, `Vue Quality (eslint)`, `Vue Quality (stylelint)`, `License (npm)` and `Security (npm)` all fail. The eslint one is the most misleading — it reports `eslint-plugin-n` missing, which reads as a lint error but is just the install never having run.

Those checks have been red long enough to be treated as background noise, which is exactly how a real failure gets merged past.

## The fix

The devDependency now declares `^2.7.16`, matching the override's intent. `peerDependencies` stays permissive at `^2.6 || ^3.0` — consumers may be on either major, and peers are not what npm objects to.

Verified: `npm install --package-lock-only` resolves and `npm ci --dry-run` completes with 475 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)