### PR TITLE
chore(deps): bump nextcloud-vue to beta.220 (OpenBuild glyph fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "^1.0.0-beta.213",
+    "@conduction/nextcloud-vue": "^1.0.0-beta.220",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@nextcloud/axios": "~2.5.1",


### PR DESCRIPTION
Bumps `@conduction/nextcloud-vue` to `^1.0.0-beta.220`, picking up the OpenBuild edit-button glyph fix (package/cube → OpenBuild stacked-layers icon), shipped in beta.218.

This app's currently-shipped bundle binds the **old cube** glyph (confirmed by scanning the built `js/` for the path bound to `cn-openbuild-edit__glyph`), so it needs this bump for its next CI/release build to ship the correct icon.

Dependency-only change — no source edits.