### PR TITLE
feat(mcp): discover tool providers by registration event, not by scanning (#2077)

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -2782,6 +2782,19 @@ class Application extends App implements IBootstrap
                     $container->get(IntegrationsToolProvider::class),
                 ];
 
+                // Preferred path: apps announce themselves with a listener,
+                // the same way they contribute a flow node and the same way
+                // core's workflow engine collects operations.
+                $this->collectAnnouncedMcpProviders(
+                    container: $container,
+                    logger: $logger,
+                    providers: $providers
+                );
+
+                // Legacy path, kept for one release so the fleet is never
+                // broken mid-migration. Five apps outside OpenRegister still
+                // register by container alias; each is skipped here once it
+                // announces itself, so a migrated app is never collected twice.
                 $this->collectPerAppMcpProviders(
                     container: $container,
                     logger: $logger,
@@ -3330,6 +3343,60 @@ class Application extends App implements IBootstrap
      *
      * @spec openspec/specs/chat-ai/spec.md#requirement-mcptoolsservice-provider-discovery-refactor
      */
+    /**
+     * Collect providers from apps that announce themselves with a listener.
+     *
+     * One dispatch, no `info.xml` parsing, no candidate aliases, no container
+     * probing and nothing to cache — the whole apparatus the alias scan needed
+     * exists because it looked for something apps never declared.
+     *
+     * A provider whose appId is already present is skipped, which is what makes
+     * running both paths during the migration safe: an app that has added its
+     * listener is not also collected by the alias scan.
+     *
+     * @param ContainerInterface       $container The DI container.
+     * @param \Psr\Log\LoggerInterface $logger    PSR logger.
+     * @param array<IMcpToolProvider>  $providers Providers array, modified in place.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/or-mcp-registration-event/specs/mcp-discovery/spec.md
+     */
+    private function collectAnnouncedMcpProviders(
+        ContainerInterface $container,
+        \Psr\Log\LoggerInterface $logger,
+        array &$providers
+    ): void {
+        try {
+            $dispatcher = $container->get(\OCP\EventDispatcher\IEventDispatcher::class);
+            $event      = new \OCA\OpenRegister\Mcp\RegisterMcpToolProvidersEvent();
+            $dispatcher->dispatchTyped($event);
+
+            $seen = [];
+            foreach ($providers as $existing) {
+                $seen[$existing->getAppId()] = true;
+            }
+
+            foreach ($event->getProviders() as $provider) {
+                $appId = $provider->getAppId();
+                if (isset($seen[$appId]) === true) {
+                    continue;
+                }
+
+                $seen[$appId]  = true;
+                $providers[]   = $provider;
+            }
+        } catch (\Throwable $e) {
+            // Discovery must never take the container down: an app with a
+            // broken listener costs its own tools, not everyone else's.
+            $logger->warning(
+                message: '[MCP] Announced-provider collection failed',
+                context: ['file' => __FILE__, 'line' => __LINE__, 'error' => $e->getMessage()]
+            );
+        }//end try
+
+    }//end collectAnnouncedMcpProviders()
+
     private function collectPerAppMcpProviders(
         ContainerInterface $container,
         \Psr\Log\LoggerInterface $logger,

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -3343,6 +3343,7 @@ class Application extends App implements IBootstrap
      *
      * @spec openspec/specs/chat-ai/spec.md#requirement-mcptoolsservice-provider-discovery-refactor
      */
+
     /**
      * Collect providers from apps that announce themselves with a listener.
      *
@@ -3383,8 +3384,8 @@ class Application extends App implements IBootstrap
                     continue;
                 }
 
-                $seen[$appId]  = true;
-                $providers[]   = $provider;
+                $seen[$appId] = true;
+                $providers[]  = $provider;
             }
         } catch (\Throwable $e) {
             // Discovery must never take the container down: an app with a
@@ -3397,6 +3398,21 @@ class Application extends App implements IBootstrap
 
     }//end collectAnnouncedMcpProviders()
 
+    /**
+     * Collect per-app providers by container alias (legacy path).
+     *
+     * Kept for one release while the fleet migrates to the registration event;
+     * removed once every app announces itself. See the discovery-cache notes
+     * above, which document this method's caching behaviour.
+     *
+     * @param ContainerInterface       $container The DI container.
+     * @param \Psr\Log\LoggerInterface $logger    PSR logger.
+     * @param array<IMcpToolProvider>  $providers Providers array (modified in place by reference).
+     *
+     * @return void
+     *
+     * @spec openspec/changes/or-mcp-registration-event/specs/mcp-discovery/spec.md
+     */
     private function collectPerAppMcpProviders(
         ContainerInterface $container,
         \Psr\Log\LoggerInterface $logger,

--- a/lib/Mcp/RegisterMcpToolProvidersEvent.php
+++ b/lib/Mcp/RegisterMcpToolProvidersEvent.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Dispatched so apps can contribute their MCP tool providers.
+ *
+ * The same pattern the flow node registry uses, and the same one core's
+ * workflow engine uses for operations, checks and entities. An app that already
+ * writes a listener to contribute a flow node writes the same listener here.
+ *
+ * WHY THIS REPLACES THE SCAN
+ * --------------------------
+ * Discovery previously probed every installed app's `info.xml`, built candidate
+ * container aliases (`OCA\OpenRegister\Mcp\IMcpToolProvider::<appId>`), resolved
+ * each through the container while catching autoloader misses, and then cached
+ * the resolution map with two invalidation mechanisms — an app-list hash plus a
+ * clamped TTL, because an app upgrade can add a provider without changing the
+ * app list.
+ *
+ * All of that existed because it scanned for something apps never announced.
+ * Apps DO announce a listener, so none of it is needed: the event is dispatched
+ * lazily, once, only when the catalogue is read.
+ *
+ * Nextcloud has two idioms here and the distinction matters. When CORE owns a
+ * registry it adds a `registerXProvider()` to `IRegistrationContext` — there are
+ * thirty-odd of those, and only core can write them. When an APP owns a
+ * registry it dispatches a typed event. OpenRegister is an app.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Mcp
+ * @package  OCA\OpenRegister\Mcp
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-mcp-registration-event/specs/mcp-discovery/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Mcp;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * Carries the collector an app registers its MCP tool providers on.
+ */
+class RegisterMcpToolProvidersEvent extends Event
+{
+
+    /**
+     * Providers contributed during this dispatch.
+     *
+     * @var array<int, IMcpToolProvider>
+     */
+    private array $providers = [];
+
+    /**
+     * Contribute a provider.
+     *
+     * @param IMcpToolProvider $provider The provider.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/or-mcp-registration-event/specs/mcp-discovery/spec.md
+     */
+    public function registerProvider(IMcpToolProvider $provider): void
+    {
+        $this->providers[] = $provider;
+
+    }//end registerProvider()
+
+    /**
+     * Everything contributed during this dispatch.
+     *
+     * @return array<int, IMcpToolProvider> The providers.
+     *
+     * @spec openspec/changes/or-mcp-registration-event/specs/mcp-discovery/spec.md
+     */
+    public function getProviders(): array
+    {
+        return $this->providers;
+
+    }//end getProviders()
+}//end class

--- a/openspec/changes/or-mcp-registration-event/.openspec.yaml
+++ b/openspec/changes/or-mcp-registration-event/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: mcp-discovery

--- a/openspec/changes/or-mcp-registration-event/proposal.md
+++ b/openspec/changes/or-mcp-registration-event/proposal.md
@@ -1,0 +1,57 @@
+# Proposal: or-mcp-registration-event
+
+## Summary
+
+Discover MCP tool providers the way Nextcloud discovers everything else — a
+typed registration event — and retire the bespoke scan.
+
+## Why
+
+Two mechanisms in one app did the same job, and the older one was the more
+complex.
+
+MCP discovery probes every installed app's `info.xml`, builds candidate
+container aliases (`OCA\OpenRegister\Mcp\IMcpToolProvider::<appId>`), resolves
+each through the container catching autoloader misses, and caches the
+resolution map with **two** invalidation mechanisms — an app-list hash, plus a
+clamped TTL because an app upgrade can add a provider without changing the app
+list. Roughly 86 lines of probing plus the cache, to discover nine providers.
+
+That complexity exists because it scans for something apps never announce.
+Apps do announce a listener.
+
+## Nextcloud has two idioms, and the split is the argument
+
+- **Core** owns a registry → `IRegistrationContext::registerXProvider(class)`.
+  Thirty-odd of these exist. Only core can add them, because only core can add
+  methods to that interface.
+- **An app** owns a registry → a typed registration event. `workflowengine`
+  does exactly this for operations, checks and entities.
+
+OpenRegister is an app, so the event is the idiomatic choice for anything it
+owns. That is already why the flow node registry uses one (#2074). Core ships
+no MCP at all, so there is nothing upstream to conform to beyond the idiom.
+
+## What Changes
+
+- `RegisterMcpToolProvidersEvent`, mirroring `RegisterFlowNodesEvent`.
+- `collectAnnouncedMcpProviders()` runs FIRST; the alias scan still runs after
+  it for one release so the fleet is never broken mid-migration.
+- A provider whose appId is already present is skipped, so a migrated app is
+  never collected twice.
+- Discovery failure is logged, never fatal: an app with a broken listener costs
+  its own tools, not everyone else's.
+
+## Migration
+
+Five apps outside OpenRegister register by alias today: hermiq, openbuild,
+opencatalogi, decidesk, and `nextcloud-app-template`. Each needs a listener.
+The template goes first — it is what new apps copy.
+
+The alias scan and its cache are removed in a follow-up, once the fleet has
+migrated. Removing them in the same change would break every app that has not.
+
+## Out of scope
+
+`#[McpTool]` attribute scanning and `IMcpScannableServices` solve a different
+problem (which classes to reflect over) and are untouched.

--- a/openspec/changes/or-mcp-registration-event/specs/mcp-discovery/spec.md
+++ b/openspec/changes/or-mcp-registration-event/specs/mcp-discovery/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Apps announce MCP providers with a listener (REQ-MCP-D-001)
+
+An app SHALL contribute MCP tool providers by listening for
+`RegisterMcpToolProvidersEvent`, the same pattern used for flow nodes and by
+core's workflow engine for operations.
+
+The event SHALL be dispatched once, when the tool catalogue is built.
+
+#### Scenario: An announced provider reaches the catalogue
+
+- **GIVEN** an app listening for the event and registering a provider
+- **WHEN** the MCP tool service is built
+- **THEN** that provider's tools are in the catalogue
+
+### Requirement: Both discovery paths coexist during migration (REQ-MCP-D-002)
+
+The announced path SHALL be collected FIRST, and the legacy container-alias
+scan SHALL still run afterwards for one release.
+
+A provider whose `appId` is already present SHALL be skipped, so an app that
+has migrated is never collected twice.
+
+Removing the alias scan in the same change would break every app that has not
+yet migrated.
+
+#### Scenario: A migrated app is collected once
+
+- **GIVEN** an app that both announces a provider and registers the legacy alias
+- **WHEN** discovery runs
+- **THEN** exactly one provider for that app is in the catalogue
+
+### Requirement: Discovery never takes the container down (REQ-MCP-D-003)
+
+A failure while collecting announced providers SHALL be logged and swallowed.
+
+An app with a broken listener SHALL cost its own tools and nothing else — the
+alternative is one bad app removing MCP from the instance.
+
+#### Scenario: A throwing listener does not break discovery
+
+- **GIVEN** a listener that throws
+- **WHEN** discovery runs
+- **THEN** the built-in providers are still in the catalogue
+
+@e2e exclude discovery is backend-only — covered by PHPUnit

--- a/openspec/changes/or-mcp-registration-event/tasks.md
+++ b/openspec/changes/or-mcp-registration-event/tasks.md
@@ -1,0 +1,10 @@
+# Tasks: or-mcp-registration-event
+
+- [x] `RegisterMcpToolProvidersEvent`.
+- [x] `collectAnnouncedMcpProviders()`, collected before the alias scan, with
+      appId de-duplication and non-fatal failure.
+- [ ] Migrate `nextcloud-app-template` (first — new apps copy it).
+- [ ] Migrate hermiq, openbuild, opencatalogi, decidesk.
+- [ ] Remove `collectPerAppMcpProviders()`, `buildMcpProviderCandidates()`,
+      `tryResolveMcpProviderCandidate()` and the discovery cache — follow-up,
+      once the fleet has migrated.


### PR DESCRIPTION
# Proposal: or-mcp-registration-event

## Summary

Discover MCP tool providers the way Nextcloud discovers everything else — a
typed registration event — and retire the bespoke scan.

## Why

Two mechanisms in one app did the same job, and the older one was the more
complex.

MCP discovery probes every installed app's `info.xml`, builds candidate
container aliases (`OCA\OpenRegister\Mcp\IMcpToolProvider::<appId>`), resolves
each through the container catching autoloader misses, and caches the
resolution map with **two** invalidation mechanisms — an app-list hash, plus a
clamped TTL because an app upgrade can add a provider without changing the app
list. Roughly 86 lines of probing plus the cache, to discover nine providers.

That complexity exists because it scans for something apps never announce.
Apps do announce a listener.

## Nextcloud has two idioms, and the split is the argument

- **Core** owns a registry → `IRegistrationContext::registerXProvider(class)`.
  Thirty-odd of these exist. Only core can add them, because only core can add
  methods to that interface.
- **An app** owns a registry → a typed registration event. `workflowengine`
  does exactly this for operations, checks and entities.

OpenRegister is an app, so the event is the idiomatic choice for anything it
owns. That is already why the flow node registry uses one (#2074). Core ships
no MCP at all, so there is nothing upstream to conform to beyond the idiom.

## What Changes

- `RegisterMcpToolProvidersEvent`, mirroring `RegisterFlowNodesEvent`.
- `collectAnnouncedMcpProviders()` runs FIRST; the alias scan still runs after
  it for one release so the fleet is never broken mid-migration.
- A provider whose appId is already present is skipped, so a migrated app is
  never collected twice.
- Discovery failure is logged, never fatal: an app with a broken listener costs
  its own tools, not everyone else's.

## Migration

Five apps outside OpenRegister register by alias today: hermiq, openbuild,
opencatalogi, decidesk, and `nextcloud-app-template`. Each needs a listener.
The template goes first — it is what new apps copy.

The alias scan and its cache are removed in a follow-up, once the fleet has
migrated. Removing them in the same change would break every app that has not.

## Out of scope

`#[McpTool]` attribute scanning and `IMcpScannableServices` solve a different
problem (which classes to reflect over) and are untouched.

---

## Safe to merge before the apps migrate

Both paths run: announced first, alias scan after, with appId de-duplication between them. Nothing changes for an app until it adds its listener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)