### PR TITLE
docs(openspec): schema-metadata-i18n — translatable schema titles/descriptions

### DIFF
--- a/openspec/changes/schema-metadata-i18n/.openspec.yaml
+++ b/openspec/changes/schema-metadata-i18n/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/schema-metadata-i18n/proposal.md
+++ b/openspec/changes/schema-metadata-i18n/proposal.md
@@ -1,0 +1,76 @@
+# Proposal: schema-metadata-i18n
+
+## Why
+
+OpenRegister ships a rich i18n stack for **object content** — `translatable: true`
+properties whose *values* are stored as per-language maps, negotiated with
+`Accept-Language`, with source-language tracking and out-of-date detection
+(`register-i18n`, `i18n-source-of-truth`, `i18n-api-language-negotiation`).
+
+None of it applies to **schema metadata**. A schema's `title`/`description`, and
+the `title`/`description` of every property, are plain scalars:
+
+- `lib/Db/Schema.php:144` — `protected ?string $title = null;`
+- `oc_openregister_schemas.title` — `character varying(255) NOT NULL`
+- `register-i18n/spec.md` states outright that it is "distinct from the app UI
+  string translations … which handle Nextcloud `IL10N` / `t()` for interface
+  labels"
+
+Those property titles are exactly what consuming apps render as **column headers
+and form labels** on every manifest `type:"index"` page. Because the title is a
+single scalar, whatever language it was authored in is what every user sees.
+
+Live evidence (DocuDesk on the shared dev instance, 2026-07-24, admin account
+`lang=en`, Nextcloud chrome correctly in English):
+
+```
+/apps/docudesk/templates  →  NAAM · CATEGORIE · PAGINAFORMAAT · NAMESPACE · BESCHRIJVING
+/apps/docudesk/signing    →  DOCUMENTNAAM · MODUS · NIVEAU · STATUS · PROVIDER · DEADLINE
+```
+
+because `docudesk_register.json` authors them in Dutch (`"name": {"title": "Naam"}`,
+`"signatureLevel": {"title": "Niveau"}`, …). Tracked as ConductionNL/docudesk#341.
+
+The leaf app cannot fix this properly on its own: authoring the titles in English
+merely inverts the problem and strands Dutch users. ADR-005 mandates NL + EN for
+every Conduction app, and SDG Regulation (EU) 2018/1724 — already cited as the
+driver for `register-i18n` — requires English availability for cross-border
+services. A label is as user-facing as a value; the same guarantee has to cover it.
+
+`Register.languages` (`lib/Db/Register.php:255`) already declares the language set
+per register, so the vocabulary for this exists — it is simply never consulted for
+metadata.
+
+## What Changes
+
+- Accept a **per-language map** for schema `title` and `description`, and for each
+  property's `title` and `description`: `{"nl": "Naam", "en": "Name"}`. A plain
+  string keeps working unchanged and is treated as being in the register's
+  default language.
+- Resolve metadata to a single language on read using the **existing**
+  `Accept-Language` negotiation, with a deterministic fallback chain: requested
+  language → base language (`nl` for `nl-NL`) → register default (first entry of
+  `Register.languages`, else `nl`) → first non-empty entry.
+- Persist the map without a destructive migration: the scalar column keeps the
+  resolved default-language value (so existing readers and the
+  `register_schemas_title_index` btree keep working) while the full map lives in
+  the schema's JSON definition.
+- Expose the unresolved map on demand (`?_metaLanguages=all`) so schema editors
+  and import/export round-trip every language rather than collapsing to one.
+- Validate on write: reject language keys that are not BCP 47 and not present in
+  the register's `languages`, mirroring how content i18n validates.
+
+## Impact
+
+- **Affected code**: `lib/Db/Schema.php` (`title`/`description` hydration +
+  `jsonSerialize`, nested property hydration at `:1614`), the schema read path
+  used by `SchemasController`, and whichever service applies `Accept-Language`
+  for content today (reuse, do not duplicate, `LanguageMiddleware`).
+- **Backwards compatible by construction**: every existing schema keeps a scalar
+  title and resolves to itself. No consumer app is required to change.
+- **Consumers**: DocuDesk can then supply `{"nl": …, "en": …}` titles and close
+  docudesk#341; the same fix lands for every app rendering manifest index pages.
+- **Related**: docudesk#338 (index pages render no visible heading) is a
+  different defect in the shared renderer and is not addressed here.
+- **Risk**: the schema `title` column is `NOT NULL` and indexed — the resolved
+  scalar must always be written, never left null, or schema listing breaks.

--- a/openspec/changes/schema-metadata-i18n/specs/schema-metadata-i18n/spec.md
+++ b/openspec/changes/schema-metadata-i18n/specs/schema-metadata-i18n/spec.md
@@ -1,0 +1,130 @@
+# Capability: schema-metadata-i18n
+
+## Purpose
+
+Make schema **metadata** — the `title` and `description` of a schema and of each
+of its properties — translatable, so the labels consuming apps render as column
+headers and form labels follow the user's language instead of whichever language
+the schema author happened to type. Content i18n (`register-i18n`) already does
+this for property *values*; this capability extends the same guarantee to the
+labels, reusing the existing `Accept-Language` negotiation and the register's
+declared `languages`.
+
+## ADDED Requirements
+
+### Requirement: Schema and property metadata MUST accept a per-language map (REQ-ORSMI-001)
+
+Schema metadata MUST accept either a plain string or a per-language map keyed by
+BCP 47 language code — this applies to a schema's `title` and `description` and
+to the `title` and `description` of every property. A plain string MUST continue
+to be accepted unchanged and MUST be treated as authored in the register's
+default language, so no existing schema requires migration.
+
+The register's default language is the first entry of `Register.languages`,
+falling back to `nl` when that field is empty — the same rule `register-i18n`
+already applies to content.
+
+#### Scenario: A per-language title is accepted and stored
+
+- **GIVEN** a register whose `languages` is `["nl", "en"]`
+- **WHEN** a schema declares a property `name` with `"title": {"nl": "Naam", "en": "Name"}`
+- **THEN** the schema MUST persist both language variants
+- **AND** re-reading the schema definition MUST return both, not just one
+- **@e2e** exclude backend schema metadata storage — asserted by PHPUnit over the Schema entity
+
+#### Scenario: A plain-string title keeps working
+
+- **GIVEN** an existing schema whose property `code` has `"title": "Code"`
+- **WHEN** the schema is read after this change ships
+- **THEN** the title MUST resolve to `Code` for every requested language
+- **AND** the stored definition MUST NOT be rewritten into a map implicitly
+- **@e2e** exclude backwards-compatibility path — asserted by PHPUnit
+
+### Requirement: Metadata MUST resolve to the requested language on read (REQ-ORSMI-002)
+
+Reading a schema MUST resolve every metadata map to a single string using the
+language negotiated for the request, applying this fallback chain in order:
+requested language, its base language (`nl` for `nl-NL`), the register's default
+language, then the first non-empty entry in the map. Resolution MUST reuse the
+existing `Accept-Language` negotiation rather than introducing a second mechanism.
+
+#### Scenario: An English client gets English labels
+
+- **GIVEN** a property whose title is `{"nl": "Niveau", "en": "Level"}`
+- **WHEN** a client requests the schema with `Accept-Language: en`
+- **THEN** the property title MUST be returned as `Level`
+- **@e2e** exclude API-level negotiation — asserted by PHPUnit against the schema read path
+
+#### Scenario: A regional code falls back to its base language
+
+- **GIVEN** the same property and a client requesting `Accept-Language: nl-NL`
+- **WHEN** the map has an `nl` entry but no `nl-NL` entry
+- **THEN** the property title MUST be returned as `Niveau`
+- **@e2e** exclude fallback-chain logic — asserted by PHPUnit
+
+#### Scenario: An unavailable language falls back deterministically
+
+- **GIVEN** the same property and a client requesting `Accept-Language: de`
+- **WHEN** the map has no `de` entry and the register default is `nl`
+- **THEN** the property title MUST be returned as `Niveau`, never an empty string and never the raw map
+- **@e2e** exclude fallback-chain logic — asserted by PHPUnit
+
+### Requirement: The scalar title column MUST always hold the resolved default (REQ-ORSMI-003)
+
+Persisting a schema whose title is a map MUST write the resolved default-language
+string into the scalar `oc_openregister_schemas.title` column, and MUST NOT write
+null, a JSON blob, or an empty string. That column is `NOT NULL` and carries the
+`register_schemas_title_index` btree, so existing listing, sorting and lookup
+paths keep working untouched.
+
+#### Scenario: Saving a map-titled schema keeps the column populated
+
+- **GIVEN** a schema saved with `"title": {"nl": "Sjabloon", "en": "Template"}` in a register defaulting to `nl`
+- **WHEN** the schema is persisted
+- **THEN** the `title` column MUST contain `Sjabloon`
+- **AND** listing schemas MUST return that schema with a non-empty title
+- **@e2e** exclude persistence invariant — asserted by PHPUnit
+
+### Requirement: Callers MUST be able to read the unresolved map (REQ-ORSMI-004)
+
+A schema read MUST be able to return metadata unresolved, as the full
+per-language map, when the caller asks for it (`_metaLanguages=all`). Schema
+editors and import/export MUST use this so a round-trip preserves every language
+instead of collapsing the schema to the reader's language.
+
+#### Scenario: Export round-trips every language
+
+- **GIVEN** a schema whose property titles carry `nl` and `en` variants
+- **WHEN** it is read with `_metaLanguages=all` and re-imported
+- **THEN** both variants MUST survive unchanged
+- **@e2e** exclude import/export round-trip — asserted by PHPUnit
+
+#### Scenario: Default read stays resolved
+
+- **GIVEN** the same schema
+- **WHEN** it is read without `_metaLanguages`
+- **THEN** each title MUST be a plain string, so existing consumers never receive an object where they expect text
+- **@e2e** exclude API shape — asserted by PHPUnit
+
+### Requirement: Invalid language keys MUST be rejected on write (REQ-ORSMI-005)
+
+Validation MUST fail, naming the offending key, when persisted metadata contains
+a language key that is not a well-formed BCP 47 tag, or that is not among the
+register's declared `languages` when that list is non-empty. This mirrors how
+content i18n validates translatable values and stops silent typos (`"eng"`,
+`"NL_nl"`) from producing labels no reader can ever negotiate.
+
+#### Scenario: A malformed language key is refused
+
+- **GIVEN** a register with `languages` `["nl", "en"]`
+- **WHEN** a schema is saved with `"title": {"nl": "Naam", "eng": "Name"}`
+- **THEN** validation MUST fail and the error MUST name `eng`
+- **AND** the schema MUST NOT be persisted
+- **@e2e** exclude validation path — asserted by PHPUnit
+
+#### Scenario: A language outside the register's set is refused
+
+- **GIVEN** the same register
+- **WHEN** a schema is saved with a `de` variant
+- **THEN** validation MUST fail naming `de`, because no reader of that register can negotiate it
+- **@e2e** exclude validation path — asserted by PHPUnit

--- a/openspec/changes/schema-metadata-i18n/tasks.md
+++ b/openspec/changes/schema-metadata-i18n/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: schema-metadata-i18n
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 8.
+     Acceptance criteria are plain bullets, not checkboxes. -->
+
+## 1. Metadata resolution seam (the unit seam)
+
+- [ ] 1.1 Implement `SchemaMetadataTranslator` with `resolve(string|array $value, string $requested, string $default): string` and `isMap()` (REQ-ORSMI-001, REQ-ORSMI-002)
+  - Pure over its inputs (no DB, no request) so it is provable by PHPUnit: requested → base language → register default → first non-empty; a plain string returns itself; never returns an empty string or the raw map.
+
+## 2. Entity + persistence
+
+- [ ] 2.1 Hydrate and serialise map-valued `title`/`description` on `Schema` and on nested properties (REQ-ORSMI-001)
+  - `lib/Db/Schema.php` — keep the full map in the properties/definition JSON; `hydrate()` must not flatten it (mirror the nested-property handling around `:1614`).
+- [ ] 2.2 Always write the resolved default-language string to the scalar `title` column (REQ-ORSMI-003)
+  - `NOT NULL` + `register_schemas_title_index` must keep working; never null/empty/JSON. Add a regression test that lists schemas after saving a map-titled one.
+
+## 3. Read path
+
+- [ ] 3.1 Resolve metadata using the existing `Accept-Language` negotiation (REQ-ORSMI-002)
+  - Reuse the mechanism `LanguageMiddleware` / the content-i18n read path already applies; do NOT introduce a second negotiation. Default reads return plain strings.
+- [ ] 3.2 Support `_metaLanguages=all` to return maps unresolved (REQ-ORSMI-004)
+  - Used by schema editors and import/export so a round-trip preserves every language.
+
+## 4. Validation
+
+- [ ] 4.1 Reject non-BCP-47 keys and keys outside the register's `languages` (REQ-ORSMI-005)
+  - Error message names the offending key; schema is not persisted. Empty `languages` disables the membership check but not the BCP 47 check.
+
+## 5. Quality
+
+- [ ] 5.1 PHPUnit for the translator, hydration/serialisation, the NOT NULL invariant and validation — min 75% on new code
+  - Run in the `nextcloud:34.0.0-apache` container (host PHP is too old); all pre-existing tests stay green.
+- [ ] 5.2 Documentation + `openspec validate schema-metadata-i18n --strict`
+  - Document the accepted shapes, the fallback chain and the `_metaLanguages=all` escape hatch; note that leaf apps (e.g. DocuDesk, ConductionNL/docudesk#341) can then author `{"nl": …, "en": …}` titles.


### PR DESCRIPTION
### The gap

OpenRegister's i18n stack covers object **content** (translatable property *values*, `Accept-Language` negotiation, source-language tracking). It does **not** cover schema **metadata**:

- `lib/Db/Schema.php:144` → `protected ?string $title = null;`
- `oc_openregister_schemas.title` → `varchar(255) NOT NULL`
- `register-i18n/spec.md` scopes itself as "distinct from the app UI string translations … for interface labels"

Property titles are exactly what consuming apps render as **index column headers and form labels**, so whatever language the schema was authored in is what every user sees.

### Live evidence

Admin account `lang=en`, Nextcloud chrome correctly in English, DocuDesk on the shared dev instance (2026-07-24):

```
/apps/docudesk/templates  →  NAAM · CATEGORIE · PAGINAFORMAAT · NAMESPACE · BESCHRIJVING
/apps/docudesk/signing    →  DOCUMENTNAAM · MODUS · NIVEAU · STATUS · PROVIDER · DEADLINE
```

…because `docudesk_register.json` authors those titles in Dutch (ConductionNL/docudesk#341). A leaf app can't fix it alone — authoring in English just strands Dutch users, while ADR-005 mandates NL+EN and SDG 2018/1724 (already the driver for `register-i18n`) requires English for cross-border services.

### What this specs

Per-language maps for schema/property `title`+`description`; resolution through the **existing** Accept-Language negotiation with a deterministic fallback chain (requested → base → register default → first non-empty); the `NOT NULL` scalar-column invariant so listing/sorting/indexing keep working; an unresolved `_metaLanguages=all` read so editors and import/export round-trip every language; and BCP 47 + register-`languages` validation.

**Backwards compatible by construction** — plain strings keep working and resolve to themselves, so no existing schema needs migration and no consumer app is forced to change.

5 requirements, 11 scenarios. `openspec validate --strict` clean. Markdown-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)