### PR TITLE
fix(import): reconcile magic tables for every imported schema — closes #2082

### DIFF
--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -3304,6 +3304,25 @@ class ImportHandler
                 result: $result
             );
 
+            // MAGIC-TABLE COLUMN SYNC (fixes #2082): reconcile the physical
+            // table of EVERY imported schema, in every register that holds it.
+            //
+            // The two pre-existing ensureTableForRegisterSchema() call sites
+            // only cover (a) registers that were just auto-created and (b)
+            // schemas that ship seed objects. An EXISTING schema in an
+            // EXISTING register with no seed data — by far the common case for
+            // an app shipping a `register.d` fragment that adds a property —
+            // was never reconciled, so the new column was simply absent until
+            // something happened to write an object of that type.
+            //
+            // Observed 2026-07-24 on softwarecatalog: `beoordeeling` gained a
+            // `status` property and `gebruik` gained TIME fields; neither
+            // column existed afterwards, not even after a FORCED re-import.
+            // Because the schema's own RBAC read rule matched on `status`, the
+            // generated SQL referenced a non-existent column and EVERY read —
+            // including the anonymous public path — returned HTTP 500.
+            $this->ensureMagicTablesForImportedSchemas(schemas: $result['schemas'] ?? []);
+
             return $result;
         } catch (Exception $e) {
             $this->logger->error(
@@ -3313,6 +3332,84 @@ class ImportHandler
             throw new Exception("Failed to import configuration for app {$appId}: ".$e->getMessage());
         }//end try
     }//end importFromApp()
+
+    /**
+     * Reconcile the magic table of every imported schema, in every register that holds it.
+     *
+     * `ensureTableForRegisterSchema()` creates the table when absent and, when it
+     * already exists, syncs missing/retyped columns via `handleExistingTable()`.
+     * Calling it here closes the gap where an existing schema in an existing
+     * register — with no seed data — never had its physical table reconciled
+     * after a property was added, leaving reads that filter on the new column
+     * throwing a raw SQL error (see #2082).
+     *
+     * A schema may belong to several registers, each with its own physical
+     * table, so every owning register is reconciled.
+     *
+     * Failures are logged and never abort the import: a table that cannot be
+     * reconciled must not lose the rest of an otherwise-successful import.
+     *
+     * @param array $schemas The imported Schema entities.
+     *
+     * @return void
+     */
+    private function ensureMagicTablesForImportedSchemas(array $schemas): void
+    {
+        if ($this->magicMapper === null || empty($schemas) === true) {
+            return;
+        }
+
+        foreach ($schemas as $schema) {
+            if ($schema instanceof Schema === false || $schema->getId() === null) {
+                continue;
+            }
+
+            $schemaId = (int) $schema->getId();
+
+            try {
+                $registerIds = $this->registerMapper->getAllRegisterIdsWithSchema(schemaId: $schemaId);
+            } catch (\Exception $e) {
+                $this->logger->warning(
+                    message: '[ImportHandler] Could not resolve registers for imported schema; magic table not reconciled',
+                    context: [
+                        'file'      => __FILE__,
+                        'line'      => __LINE__,
+                        'schema_id' => $schemaId,
+                        'error'     => $e->getMessage(),
+                    ]
+                );
+                continue;
+            }
+
+            foreach ($registerIds as $registerId) {
+                try {
+                    $register = $this->registerMapper->find(
+                        id: (int) $registerId,
+                        _rbac: false,
+                        _multitenancy: false
+                    );
+
+                    $this->magicMapper->ensureTableForRegisterSchema(
+                        register: $register,
+                        schema: $schema
+                    );
+                } catch (\Exception $e) {
+                    $this->logger->warning(
+                        message: '[ImportHandler] Failed to reconcile magic table for imported schema',
+                        context: [
+                            'file'        => __FILE__,
+                            'line'        => __LINE__,
+                            'schema_id'   => $schemaId,
+                            'schema_slug' => $schema->getSlug(),
+                            'register_id' => $registerId,
+                            'error'       => $e->getMessage(),
+                        ]
+                    );
+                }//end try
+            }//end foreach
+        }//end foreach
+
+    }//end ensureMagicTablesForImportedSchemas()
 
     /**
      * Auto-create or reconcile a Register entity for application-type imports

--- a/tests/Unit/Service/Configuration/ImportHandlerMagicTableSyncTest.php
+++ b/tests/Unit/Service/Configuration/ImportHandlerMagicTableSyncTest.php
@@ -1,0 +1,277 @@
+<?php
+/**
+ * Unit tests for magic-table reconciliation of imported schemas in ImportHandler.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Configuration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Configuration;
+
+use GuzzleHttp\Client;
+use OCA\OpenRegister\Db\ConfigurationMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\MappingMapper;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Configuration\ImportHandler;
+use OCA\OpenRegister\Service\Configuration\UploadHandler;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IAppConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Locks the behaviour of ensureMagicTablesForImportedSchemas().
+ *
+ * Regression cover for #2082: an import updated a schema definition but never
+ * reconciled the physical magic table, so a property added to an EXISTING
+ * schema in an EXISTING register (with no seed data) had no column. Reads that
+ * filtered on it — e.g. a schema RBAC rule matching on the new property — then
+ * failed with a raw "column does not exist" SQL error, and a FORCED re-import
+ * did not repair it either. Observed live on softwarecatalog, where 11 columns
+ * across two schemas were missing.
+ */
+class ImportHandlerMagicTableSyncTest extends TestCase
+{
+
+    private ImportHandler $handler;
+
+    private SchemaMapper|MockObject $schemaMapper;
+
+    private RegisterMapper|MockObject $registerMapper;
+
+    private MagicMapper|MockObject $objectEntityMapper;
+
+    private ConfigurationMapper|MockObject $configurationMapper;
+
+    private MappingMapper|MockObject $mappingMapper;
+
+    private Client|MockObject $client;
+
+    private IAppConfig|MockObject $appConfig;
+
+    private LoggerInterface|MockObject $logger;
+
+    private UploadHandler|MockObject $uploadHandler;
+
+    private ObjectService|MockObject $objectService;
+
+    private MagicMapper|MockObject $magicMapper;
+
+    /**
+     * Build an ImportHandler with fully mocked collaborators.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->schemaMapper        = $this->createMock(SchemaMapper::class);
+        $this->registerMapper      = $this->createMock(RegisterMapper::class);
+        $this->objectEntityMapper  = $this->createMock(MagicMapper::class);
+        $this->configurationMapper = $this->createMock(ConfigurationMapper::class);
+        $this->mappingMapper       = $this->createMock(MappingMapper::class);
+        $this->client              = $this->createMock(Client::class);
+        $this->appConfig           = $this->createMock(IAppConfig::class);
+        $this->logger              = $this->createMock(LoggerInterface::class);
+        $this->uploadHandler       = $this->createMock(UploadHandler::class);
+        $this->objectService       = $this->createMock(ObjectService::class);
+        $this->magicMapper         = $this->createMock(MagicMapper::class);
+
+        $this->handler = new ImportHandler(
+            schemaMapper:        $this->schemaMapper,
+            registerMapper:      $this->registerMapper,
+            objectEntityMapper:  $this->objectEntityMapper,
+            configurationMapper: $this->configurationMapper,
+            mappingMapper:       $this->mappingMapper,
+            client:              $this->client,
+            appConfig:           $this->appConfig,
+            logger:              $this->logger,
+            appDataPath:         '/tmp',
+            uploadHandler:       $this->uploadHandler,
+            objectService:       $this->objectService
+        );
+
+    }//end setUp()
+
+    /**
+     * Invoke the private reconciliation method under test.
+     *
+     * @param array $schemas Imported schema entities.
+     *
+     * @return void
+     */
+    private function invokeSync(array $schemas): void
+    {
+        $reflection = new \ReflectionMethod(ImportHandler::class, 'ensureMagicTablesForImportedSchemas');
+        $reflection->setAccessible(true);
+        $reflection->invoke($this->handler, $schemas);
+
+    }//end invokeSync()
+
+    /**
+     * Build a Schema entity with an id and slug.
+     *
+     * @param int    $id   Schema id.
+     * @param string $slug Schema slug.
+     *
+     * @return Schema
+     */
+    private function makeSchema(int $id, string $slug): Schema
+    {
+        $schema = new Schema();
+        $schema->setId($id);
+        $schema->setSlug($slug);
+        $schema->setTitle($slug);
+
+        return $schema;
+
+    }//end makeSchema()
+
+    /**
+     * Every imported schema is reconciled against every register that holds it.
+     *
+     * This is the case that regressed: without it, a property added to an
+     * existing schema never got a physical column.
+     *
+     * @return void
+     */
+    public function testReconcilesEveryImportedSchemaInEveryOwningRegister(): void
+    {
+        $schema = $this->makeSchema(id: 43, slug: 'beoordeeling');
+
+        $registerA = new Register();
+        $registerA->setId(11);
+        $registerB = new Register();
+        $registerB->setId(12);
+
+        $this->registerMapper->method('getAllRegisterIdsWithSchema')
+            ->with(schemaId: 43)
+            ->willReturn([11, 12]);
+
+        $this->registerMapper->method('find')
+            ->willReturnCallback(
+                static function (string|int $id) use ($registerA, $registerB): Register {
+                    if ((int) $id === 11) {
+                        return $registerA;
+                    }
+
+                    return $registerB;
+                }
+            );
+
+        $seen = [];
+        $this->magicMapper->expects($this->exactly(2))
+            ->method('ensureTableForRegisterSchema')
+            ->willReturnCallback(
+                static function (Register $register, Schema $schema) use (&$seen): bool {
+                    $seen[] = $register->getId().':'.$schema->getId();
+                    return true;
+                }
+            );
+
+        $this->handler->setMagicMapper($this->magicMapper);
+        $this->invokeSync([$schema]);
+
+        $this->assertSame(['11:43', '12:43'], $seen);
+
+    }//end testReconcilesEveryImportedSchemaInEveryOwningRegister()
+
+    /**
+     * A failure on one register must not abort the remaining reconciliations.
+     *
+     * An import that already succeeded must never be lost because one physical
+     * table could not be reconciled.
+     *
+     * @return void
+     */
+    public function testOneFailingRegisterDoesNotAbortTheRest(): void
+    {
+        $schema = $this->makeSchema(id: 43, slug: 'beoordeeling');
+
+        $register = new Register();
+        $register->setId(11);
+
+        $this->registerMapper->method('getAllRegisterIdsWithSchema')->willReturn([11, 12]);
+        $this->registerMapper->method('find')->willReturn($register);
+
+        $calls = 0;
+        $this->magicMapper->expects($this->exactly(2))
+            ->method('ensureTableForRegisterSchema')
+            ->willReturnCallback(
+                static function () use (&$calls): bool {
+                    $calls++;
+                    if ($calls === 1) {
+                        throw new \Exception('table locked');
+                    }
+
+                    return true;
+                }
+            );
+
+        $this->handler->setMagicMapper($this->magicMapper);
+        $this->invokeSync([$schema]);
+
+        $this->assertSame(2, $calls);
+
+    }//end testOneFailingRegisterDoesNotAbortTheRest()
+
+    /**
+     * Without a MagicMapper the reconciliation is a silent no-op.
+     *
+     * @return void
+     */
+    public function testNoMagicMapperIsANoOp(): void
+    {
+        $this->registerMapper->expects($this->never())->method('getAllRegisterIdsWithSchema');
+
+        $this->invokeSync([$this->makeSchema(id: 43, slug: 'beoordeeling')]);
+
+    }//end testNoMagicMapperIsANoOp()
+
+    /**
+     * Non-Schema entries and id-less schemas are skipped without throwing.
+     *
+     * @return void
+     */
+    public function testSkipsNonSchemaEntriesAndSchemasWithoutId(): void
+    {
+        $this->registerMapper->expects($this->never())->method('getAllRegisterIdsWithSchema');
+        $this->magicMapper->expects($this->never())->method('ensureTableForRegisterSchema');
+
+        $this->handler->setMagicMapper($this->magicMapper);
+        $this->invokeSync(['not-a-schema', new Schema()]);
+
+    }//end testSkipsNonSchemaEntriesAndSchemasWithoutId()
+
+    /**
+     * A register-resolution failure is logged and skipped, not fatal.
+     *
+     * @return void
+     */
+    public function testRegisterResolutionFailureIsNotFatal(): void
+    {
+        $this->registerMapper->method('getAllRegisterIdsWithSchema')
+            ->willThrowException(new \Exception('db down'));
+
+        $this->magicMapper->expects($this->never())->method('ensureTableForRegisterSchema');
+
+        $this->handler->setMagicMapper($this->magicMapper);
+        $this->invokeSync([$this->makeSchema(id: 43, slug: 'beoordeeling')]);
+
+    }//end testRegisterResolutionFailureIsNotFatal()
+
+}//end class


### PR DESCRIPTION
Closes #2082.

### Root cause
`ensureTableForRegisterSchema()` was reachable from only two import paths:
- `autoCreateRegisterIfApplication()` — **newly auto-created registers only**
- `importSeedData()` — **schemas that ship seed objects only**

An app shipping a `register.d` fragment that adds a property to an **existing** schema in an **existing** register hits neither, so the physical column is never created — **not even by a forced re-import**. It only appears if something later happens to write an object of that type, because the *save* path does call `ensureTableForRegisterSchema()`.

The sync logic itself was fine — it simply was never invoked from import.

### Why it's worse than a silent no-op
When the schema's own RBAC read rule matches on the new property, the generated SQL references a non-existent column, so **every read throws**:
```
GET /apps/openregister/api/objects/11/beoordeeling → 500
SQLSTATE[42703]: Undefined column: column t.status does not exist
```
Fail-closed still holds (nothing leaks), but the public read path is a hard error.

### Observed live (softwarecatalog, 2026-07-24)
`beoordeeling` gained `status` (public read rule matched on it → anonymous 500) and `gebruik` gained the TIME fields. **11 columns across two schemas were missing**, so three already-merged features could not persist their data at all.

### Fix
After import, reconcile every imported schema against **every register that holds it** (a schema can belong to several, each with its own table). Failures are logged and never fatal — an otherwise-successful import must not be lost because one table could not be reconciled.

### Verification
- **Live, end-to-end**: with the patch, a single import created all 11 previously-missing columns — `gebruik.time_classification/time_rationale/time_review_date`, `module.bbn_level/dpia_status/dpia_date/dpia_volgende_beoordeling/dpia_document_ref/verwerkingsregister_ref/eol_product_slug` — and the anonymous read that had been throwing returned **200**. Baseline captured before/after; environment restored afterwards.
- **Unit**: 5 new tests (reconciles every schema × every owning register; one failing register doesn't abort the rest; no-MagicMapper no-op; non-Schema/id-less entries skipped; register-resolution failure non-fatal). 5/5 pass.

Note: `tests/Unit/AppHost/BootstrapFactoryChainTest.php` breaks full-suite discovery on `phpunit-unit.xml` — confirmed **pre-existing** (reproduced with my changes stashed), so the new test was run directly.

Built in a worktree off `development` to avoid disturbing other in-flight openregister work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)