### PR TITLE
fix(multitenancy): guard empty orX() in applyActiveOrgFilter — silently-empty object-source reads (fixes #2084)

### DIFF
--- a/lib/Db/MultiTenancyTrait.php
+++ b/lib/Db/MultiTenancyTrait.php
@@ -528,11 +528,8 @@ trait MultiTenancyTrait
             return;
         }
 
-        $orgConditions = $qb->expr()->orX();
-
-        $this->addOrganisationConditions(
+        $orgPredicates = $this->buildOrganisationConditions(
             qb: $qb,
-            orgConditions: $orgConditions,
             activeOrgUuids: $activeOrgUuids,
             organisationColumn: $organisationColumn
         );
@@ -540,36 +537,66 @@ trait MultiTenancyTrait
         // Allow null organisation entities when explicitly permitted by the caller.
         // This is used for system-wide resources like Registers and Schemas.
         if ($allowNullOrg === true) {
-            $orgConditions->add($qb->expr()->isNull($organisationColumn));
+            $orgPredicates[] = $qb->expr()->isNull($organisationColumn);
         }
 
-        $qb->andWhere($orgConditions);
+        // Guard: OCP\DB\QueryBuilder\IExpressionBuilder::orX() documents that calling it
+        // with zero arguments is deprecated and "requires at least one defined when
+        // converting to string" — NC34 already logs a debug-level deprecation exception
+        // on every zero-arg call and has flagged it will throw in a future release.
+        // $orgPredicates is expected to always contain at least one predicate here
+        // (the caller, applyOrganisationFilter(), only reaches this method when
+        // $activeOrgUuids is non-empty), but we defend against that invariant breaking
+        // instead of ever handing orX() an empty argument list.
+        //
+        // Per @spec openspec/specs/tenant-isolation-audit/spec.md ("the system MUST
+        // verify that no Organisation's query filter returns objects belonging to
+        // another Organisation"), an inability to build a positive tenant-match
+        // predicate MUST fail CLOSED (no rows), matching the existing no-active-org
+        // behaviour in applyNoActiveOrgFilter() — never fail open by skipping the
+        // WHERE clause.
+        if ($orgPredicates === []) {
+            if (isset($this->logger) === true) {
+                $this->logger->warning(
+                    message: '[MultiTenancyTrait] applyActiveOrgFilter built zero org predicates '
+                        .'— failing closed (no rows) instead of calling orX() with no arguments',
+                    context: ['file' => __FILE__, 'line' => __LINE__]
+                );
+            }
+
+            $qb->andWhere('1 = 0');
+            return;
+        }
+
+        $qb->andWhere($qb->expr()->orX(...$orgPredicates));
     }//end applyActiveOrgFilter()
 
     /**
-     * Add organisation conditions to the query
+     * Build the organisation predicates for the active organisation(s).
+     *
+     * Returns a plain array of query expressions instead of mutating a composite
+     * expression so the caller can decide how (and whether) to combine them —
+     * see the empty-predicate guard in applyActiveOrgFilter().
      *
      * @param IQueryBuilder $qb                 Query builder
-     * @param mixed         $orgConditions      Organisation conditions object
      * @param array         $activeOrgUuids     Active organisation UUIDs
      * @param string        $organisationColumn Organisation column name
      *
-     * @return void
+     * @return array<int, mixed> The organisation predicates (always at least one entry
+     *                           when $activeOrgUuids is non-empty).
      */
-    private function addOrganisationConditions(
+    private function buildOrganisationConditions(
         IQueryBuilder $qb,
-        mixed $orgConditions,
         array $activeOrgUuids,
         string $organisationColumn
-    ): void {
+    ): array {
         $directActiveOrgUuid = $this->getActiveOrganisationUuid();
 
         if ($directActiveOrgUuid !== null) {
-            $orgConditions->add(
-                $qb->expr()->eq(
-                    $organisationColumn,
-                    $qb->createNamedParameter($directActiveOrgUuid, IQueryBuilder::PARAM_STR)
-                )
+            $conditions   = [];
+            $conditions[] = $qb->expr()->eq(
+                $organisationColumn,
+                $qb->createNamedParameter($directActiveOrgUuid, IQueryBuilder::PARAM_STR)
             );
 
             $parentOrgs = array_filter(
@@ -580,24 +607,26 @@ trait MultiTenancyTrait
             );
 
             if (count($parentOrgs) > 0) {
-                $orgConditions->add(
-                    $qb->expr()->in(
-                        $organisationColumn,
-                        $qb->createNamedParameter($parentOrgs, IQueryBuilder::PARAM_STR_ARRAY)
-                    )
+                $conditions[] = $qb->expr()->in(
+                    $organisationColumn,
+                    $qb->createNamedParameter($parentOrgs, IQueryBuilder::PARAM_STR_ARRAY)
                 );
             }
 
-            return;
+            return $conditions;
         }//end if
 
-        $orgConditions->add(
+        if (empty($activeOrgUuids) === true) {
+            return [];
+        }
+
+        return [
             $qb->expr()->in(
                 $organisationColumn,
                 $qb->createNamedParameter($activeOrgUuids, IQueryBuilder::PARAM_STR_ARRAY)
-            )
-        );
-    }//end addOrganisationConditions()
+            ),
+        ];
+    }//end buildOrganisationConditions()
 
     /**
      * Set organisation on an entity during creation.

--- a/tests/Unit/Db/MultiTenancyTraitApplyActiveOrgFilterTest.php
+++ b/tests/Unit/Db/MultiTenancyTraitApplyActiveOrgFilterTest.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * Unit tests for MultiTenancyTrait::applyActiveOrgFilter() empty-predicate guard
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Db;
+
+use OCA\OpenRegister\Db\OrganisationMapper;
+use OCA\OpenRegister\Db\WebhookMapper;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IAppConfig;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Regression test for openregister#2084.
+ *
+ * MultiTenancyTrait::applyActiveOrgFilter() used to always call
+ * `$qb->expr()->orX()` with zero initial arguments and rely on every code
+ * path adding at least one predicate before the query ran. OCP's own
+ * IExpressionBuilder::orX() docblock says a zero-argument call "requires at
+ * least one defined when converting to string" and NC34 already logs a
+ * deprecation exception on every zero-argument call, flagging it will throw
+ * in a future release.
+ *
+ * These tests drive applyActiveOrgFilter() directly (via reflection, since
+ * it is private) with an empty $activeOrgUuids array — the one input that
+ * defeats the "always at least one predicate" invariant the rest of the
+ * class relies on — and assert:
+ *  - orX() is never invoked with zero arguments (in fact never invoked at
+ *    all on this path, since there are no predicates to combine);
+ *  - the query fails CLOSED (`1 = 0`, i.e. no rows), matching the
+ *    tenant-isolation guarantee in
+ *    openspec/specs/tenant-isolation-audit/spec.md ("the system MUST verify
+ *    that no Organisation's query filter returns objects belonging to
+ *    another Organisation") rather than failing open by skipping the WHERE
+ *    clause entirely.
+ */
+class MultiTenancyTraitApplyActiveOrgFilterTest extends TestCase
+{
+    private IDBConnection&MockObject $db;
+    private OrganisationMapper&MockObject $organisationMapper;
+    private IUserSession&MockObject $userSession;
+    private IGroupManager&MockObject $groupManager;
+    private IAppConfig&MockObject $appConfig;
+    private WebhookMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->db                 = $this->createMock(IDBConnection::class);
+        $this->organisationMapper = $this->createMock(OrganisationMapper::class);
+        $this->userSession        = $this->createMock(IUserSession::class);
+        $this->groupManager       = $this->createMock(IGroupManager::class);
+        $this->appConfig          = $this->createMock(IAppConfig::class);
+
+        $this->mapper = new WebhookMapper(
+            $this->db,
+            $this->organisationMapper,
+            $this->userSession,
+            $this->groupManager,
+            $this->appConfig
+        );
+    }//end setUp()
+
+    /**
+     * Invoke the private applyActiveOrgFilter() method via reflection.
+     *
+     * @param IQueryBuilder $qb                 Query builder mock
+     * @param mixed         $user               User object (or null)
+     * @param array         $activeOrgUuids     Active organisation UUIDs
+     * @param bool          $allowNullOrg       Allow NULL organisation
+     * @param string        $organisationColumn Organisation column name
+     *
+     * @return void
+     */
+    private function invokeApplyActiveOrgFilter(
+        IQueryBuilder $qb,
+        mixed $user,
+        array $activeOrgUuids,
+        bool $allowNullOrg,
+        string $organisationColumn
+    ): void {
+        $method = new ReflectionMethod(WebhookMapper::class, 'applyActiveOrgFilter');
+        $method->setAccessible(true);
+        $method->invoke($this->mapper, $qb, $user, $activeOrgUuids, $allowNullOrg, $organisationColumn);
+    }//end invokeApplyActiveOrgFilter()
+
+    /**
+     * A non-admin user with zero active organisation UUIDs must fail CLOSED
+     * (no rows) and must NEVER trigger a zero-argument orX() call.
+     */
+    public function testEmptyActiveOrgUuidsFailsClosedWithoutZeroArgOrX(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+
+        // Non-admin: isUserAdmin() must return false so the admin-override
+        // early-return branch is never taken.
+        $this->groupManager->method('getUserGroupIds')->willReturn(['users']);
+
+        // getActiveOrganisationUuid() (used inside buildOrganisationConditions
+        // for the "direct active org" fast path) resolves via the session +
+        // OrganisationMapper fallback; return null so the empty-array branch
+        // in buildOrganisationConditions() is what produces zero predicates.
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->organisationMapper->method('getActiveOrganisationWithFallback')->willReturn(null);
+
+        $expr = $this->createMock(IExpressionBuilder::class);
+        // orX() must never be called on this path — there are no predicates
+        // to combine, so the guard must short-circuit before reaching it.
+        $expr->expects($this->never())->method('orX');
+
+        $qb = $this->createMock(IQueryBuilder::class);
+        $qb->method('expr')->willReturn($expr);
+
+        // Fail-closed: the guard must add an unconditional "no rows" predicate.
+        $qb->expects($this->once())->method('andWhere')->with('1 = 0');
+
+        $this->invokeApplyActiveOrgFilter(
+            qb: $qb,
+            user: $user,
+            activeOrgUuids: [],
+            allowNullOrg: false,
+            organisationColumn: 'organisation'
+        );
+    }//end testEmptyActiveOrgUuidsFailsClosedWithoutZeroArgOrX()
+
+    /**
+     * Sanity check on the happy path: a single active organisation UUID
+     * still produces a real filter (orX() called with a non-empty argument
+     * list, never with zero arguments), preserving existing behaviour.
+     */
+    public function testSingleActiveOrgUuidBuildsOrXWithPredicates(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $this->groupManager->method('getUserGroupIds')->willReturn(['users']);
+
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->organisationMapper->method('getActiveOrganisationWithFallback')
+            ->willReturn('11111111-1111-1111-1111-111111111111');
+
+        $expr = $this->createMock(IExpressionBuilder::class);
+        $expr->method('eq')->willReturn('eq-expr');
+        $expr->expects($this->once())
+            ->method('orX')
+            ->with($this->logicalAnd($this->isType('string')))
+            ->willReturnCallback(function (...$args) {
+                // orX() must be called WITH arguments — never zero-arg.
+                $this->assertNotEmpty($args);
+                return $this->createMock(\OCP\DB\QueryBuilder\ICompositeExpression::class);
+            });
+
+        $qb = $this->createMock(IQueryBuilder::class);
+        $qb->method('expr')->willReturn($expr);
+        $qb->method('createNamedParameter')->willReturn(':param1');
+        $qb->expects($this->once())->method('andWhere');
+
+        $this->invokeApplyActiveOrgFilter(
+            qb: $qb,
+            user: $user,
+            activeOrgUuids: ['11111111-1111-1111-1111-111111111111'],
+            allowNullOrg: false,
+            organisationColumn: 'organisation'
+        );
+    }//end testSingleActiveOrgUuidBuildsOrXWithPredicates()
+}//end class


### PR DESCRIPTION
## Summary

Fixes #2084.

`MultiTenancyTrait::applyActiveOrgFilter()` always constructed
`$qb->expr()->orX()` with zero initial arguments and relied on every
downstream code path to `->add()` at least one predicate afterwards.
OCP's `IExpressionBuilder::orX()` docblock documents that a zero-argument
call "requires at least one defined when converting to string", and this
NC34 instance already logs a deprecation `Exception` on every such call,
warning that it "will throw soon" in a future release.

- `buildOrganisationConditions()` (replacing the former
  `addOrganisationConditions()`) now returns a plain array of predicates
  instead of mutating a composite expression in place.
- `applyActiveOrgFilter()` only calls `$qb->expr()->orX(...$predicates)`
  once at least one real predicate exists.
- If the predicate list is ever empty (an invariant break — today's only
  caller, `applyOrganisationFilter()`, already guards against an empty
  `$activeOrgUuids` before reaching this method), the guard fails
  **CLOSED** with an unconditional `1 = 0` rather than calling `orX()`
  with no arguments, or skipping the `WHERE` clause and failing open.
  This matches the tenant-isolation guarantee in
  `openspec/specs/tenant-isolation-audit/spec.md` ("the system MUST
  verify that no Organisation's query filter returns objects belonging to
  another Organisation") and mirrors the existing no-active-org behaviour
  in `applyNoActiveOrgFilter()`.

### Root-cause note (see issue for full investigation)

Live-reproduced on the shared dev instance: flipping
`multitenancy` to `{"saasMode":true,"adminOverride":true}` and querying
the `v-app-market` dbal-source (`x-openregister-object-source`) schema
under register 2479 returned `total: 0` instead of real rows. The
`nextcloud.log` trace showed the `orX()` zero-arg deprecation warning
firing repeatedly (confirming this defect is real and present), but the
actual emptiness came from a **second**, related defect one layer up:
`DbalObjectSourceProvider::resolveSource()` calls
`SourceMapper::findAll(filters: ['uuid' => $sourceId])`, which applies
the same organisation-scoped filter (with `allowNullOrg: false`) to the
shared `Source` entity. Because the `spectr intelligence-db` `Source`
row's own `organisation` differs from the querying admin's active
organisation, SaaS mode (which disables admin override) excludes the
`Source` row entirely, `resolveSource()` returns `null`, and every
downstream `find`/`findAll`/`count`/`aggregate` on that schema silently
returns empty with only a `warning`-level log line
(`[ObjectSource:dbal-source] no source resolved for schema ...`) — no
exception ever surfaces.

**This PR fixes the `orX()` defect exactly as reported and adds a
regression test for it**, but does **not** by itself restore dbal-source
results while `saasMode` is `true`, because that second defect (shared
system `Source` rows being subject to per-tenant org filtering at all) is
a separate design question. Filing a follow-up issue for that; the
`{"saasMode":false,"adminOverride":true}` workaround should stay in place
on the shared instance until it's resolved.

## Test plan
- [x] `php -l lib/Db/MultiTenancyTrait.php`
- [x] `composer phpcs` (project-wide, `lib/` scope) — clean, 0 errors
- [x] New regression test `tests/Unit/Db/MultiTenancyTraitApplyActiveOrgFilterTest.php`:
      drives `applyActiveOrgFilter()` directly via reflection with an
      empty active-org list, asserts `orX()` is never invoked (let alone
      with zero args) and the query fails closed (`andWhere('1 = 0')`);
      a second test confirms the happy path still builds a real `orX()`
      filter with predicates.
- [x] Full unit suite (`composer test:unit`, 15149 tests) run for
      regressions — the 111 errors / 18 failures present are pre-existing
      and unrelated to this change (Maps/Photos/Polls deep-link URL
      format, SqlTypeMapper, SchemaLinkedTypes `InvalidArgumentException`
      assertions); none reference `MultiTenancyTrait`,
      `applyActiveOrgFilter`, or `WebhookMapper`.