### PR TITLE
fix(dbal): resolve object-source Source refs as system lookup — tenant filter emptied cross-org registers (fixes #2089)

### DIFF
--- a/lib/Db/SourceMapper.php
+++ b/lib/Db/SourceMapper.php
@@ -245,6 +245,59 @@ class SourceMapper extends QBMapper
     }//end findBySyncEnabled()
 
     /**
+     * Load a Source by id or uuid for a trusted, code-initiated system lookup —
+     * intentionally WITHOUT RBAC verification and WITHOUT the organisation filter.
+     *
+     * A `Source` is shared infrastructure config (a database connection), not
+     * tenant-owned data. Its ONLY current caller,
+     * `DbalObjectSourceProvider::resolveSource()`, resolves the `sourceId`
+     * named in an already-authorized schema's `x-openregister-object-source`
+     * config — `ObjectService::paginateObjectSource()` enforces the schema's
+     * own read RBAC (`checkPermission()`) BEFORE the provider (and therefore
+     * this lookup) ever runs. Filtering this row by the caller's active
+     * organisation adds no isolation — the caller never sees the Source row
+     * itself, only the objects it serves for a schema they were already
+     * cleared to read — and instead breaks every dbal-backed schema whose
+     * Source is configured in a different organisation than the reader's
+     * active one, most visibly under `saasMode: true` where admin override is
+     * unconditionally disabled (openregister#2089: `resolveSource()` returned
+     * null and every downstream find/count on the schema silently emptied,
+     * logged only as a warning).
+     *
+     * Mirrors the same rationale as {@see findBySyncEnabled()} (system-actor
+     * lookup, no tenant scoping) rather than the SystemOperationContext RBAC
+     * bypass: this method skips the ORGANISATION FILTER on the Source row
+     * itself, a query-builder concern `SystemOperationContext` does not touch.
+     *
+     * SECURITY: this method MUST NOT be exposed to any caller that has not
+     * already authorized the request at the schema/object level, and MUST
+     * NOT be used to serve Source data (credentials, connection config)
+     * directly to a client — only to locate the row so its provider can serve
+     * the schema's own RBAC-gated objects.
+     *
+     * @param string $sourceId The Source id (digits) or uuid.
+     *
+     * @return Source|null The source, or null when not found.
+     *
+     * @spec openspec/specs/dbal-virtual-registers/spec.md
+     * @spec openspec/changes/dbal-source-resolution-system-context/specs/dbal-source-resolution-system-context/spec.md
+     */
+    public function findForSystem(string $sourceId): ?Source
+    {
+        $qb = $this->db->getQueryBuilder();
+
+        $qb->select('*')->from('openregister_sources');
+
+        if (ctype_digit($sourceId) === true) {
+            $qb->where($qb->expr()->eq('id', $qb->createNamedParameter((int) $sourceId, IQueryBuilder::PARAM_INT)));
+        } else {
+            $qb->where($qb->expr()->eq('uuid', $qb->createNamedParameter($sourceId)));
+        }
+
+        return $this->findEntity(query: $qb);
+    }//end findForSystem()
+
+    /**
      * Insert a new source
      *
      * @param Entity $entity Source entity to insert

--- a/lib/Service/ObjectSource/DbalObjectSourceProvider.php
+++ b/lib/Service/ObjectSource/DbalObjectSourceProvider.php
@@ -570,10 +570,18 @@ class DbalObjectSourceProvider implements WritableObjectSourceProvider
      * allowlisted columns. Supports equality plus the in/notIn/gt/gte/lt/lte/ne
      * operator vocabulary (same set as the native magic-table path).
      *
-     * @param QueryBuilder         $qb         The query builder (mutated).
-     * @param Connection           $connection The DBAL connection.
-     * @param array<string, mixed> $filter     The filter map.
-     * @param array<int, string>   $columns    The allowlisted scalar columns.
+     * @param QueryBuilder             $qb         The query builder (mutated).
+     * @param Connection               $connection The DBAL connection.
+     * @param array<int|string, mixed> $filter     The filter map — keys are
+     *                                             not guaranteed to be strings
+     *                                             by the caller (e.g. a decoded
+     *                                             JSON object with
+     *                                             numeric-string keys can
+     *                                             surface as int keys); the
+     *                                             runtime `is_string()` guard
+     *                                             below is load-bearing, not
+     *                                             redundant.
+     * @param array<int, string>       $columns    The allowlisted scalar columns.
      *
      * @return void
      *
@@ -734,11 +742,25 @@ class DbalObjectSourceProvider implements WritableObjectSourceProvider
     /**
      * Load the backing database source referenced by the config `sourceId`.
      *
+     * A `Source` referenced this way is a SYSTEM capability lookup, not a
+     * tenant-owned read: `sourceId` names shared infrastructure config (a
+     * database connection) that a schema's own `x-openregister-object-source`
+     * declares, and the schema's read RBAC is already enforced by
+     * `ObjectService::paginateObjectSource()` before this provider ever runs.
+     * Resolving the Source row itself via `SourceMapper::findForSystem()`
+     * deliberately skips the caller's active-organisation filter — scoping the
+     * Source row by the reader's org adds no isolation (the caller never sees
+     * the Source, only the objects it serves for a schema they were already
+     * cleared to read) and previously broke every dbal-backed schema whose
+     * Source lived in a different organisation, most visibly under
+     * `saasMode: true` (openregister#2089).
+     *
      * @param array<string, mixed> $config The object-source config block.
      *
      * @return Source|null The source, or null when not found / not a database source.
      *
      * @spec openspec/specs/dbal-virtual-registers/spec.md
+     * @spec openspec/changes/dbal-source-resolution-system-context/specs/dbal-source-resolution-system-context/spec.md
      */
     private function resolveSource(array $config): ?Source
     {
@@ -748,15 +770,7 @@ class DbalObjectSourceProvider implements WritableObjectSourceProvider
         }
 
         try {
-            $source = null;
-            if (ctype_digit($sourceId) === true) {
-                $source = $this->sourceMapper->find(id: (int) $sourceId);
-            }
-
-            if ($source === null) {
-                $matches = $this->sourceMapper->findAll(filters: ['uuid' => $sourceId]);
-                $source  = ($matches[0] ?? null);
-            }
+            $source = $this->sourceMapper->findForSystem(sourceId: $sourceId);
         } catch (Throwable $e) {
             $this->logger->warning('[ObjectSource:dbal-source] could not load source "'.$sourceId.'": '.$e->getMessage());
             return null;

--- a/openspec/changes/dbal-source-resolution-system-context/.openspec.yaml
+++ b/openspec/changes/dbal-source-resolution-system-context/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/dbal-source-resolution-system-context/proposal.md
+++ b/openspec/changes/dbal-source-resolution-system-context/proposal.md
@@ -1,0 +1,66 @@
+# Proposal: dbal-source-resolution-system-context
+
+## Why
+
+Follow-up to openregister#2084 / PR #2088. That PR fixed a real `orX()` zero-arg
+defect in `MultiTenancyTrait::applyActiveOrgFilter()`, but live-verification on
+the shared dev instance under `saasMode: true` showed dbal-source (query-backed)
+schemas still returned `total: 0` — a second, independent defect, filed as
+openregister#2089.
+
+`DbalObjectSourceProvider::resolveSource()` loaded the backing `Source` entity
+via `SourceMapper::find()` / `SourceMapper::findAll()`, both of which apply
+`MultiTenancyTrait::applyOrganisationFilter()` — the same tenant filter used for
+ordinary tenant-owned rows. A `Source` is shared infrastructure config (an
+external database connection), not tenant-owned data: it is the *provider* a
+dbal-backed schema reads through, not an object that itself belongs to one
+tenant's data set. When the Source's own `organisation` column differs from the
+querying admin's active organisation, and `saasMode: true` unconditionally
+disables admin override (`MultiTenancyTrait::isAdminOverrideEnabled()`), the
+Source row is filtered out of the query entirely — `resolveSource()` returns
+`null`, and every downstream `find`/`findAll`/`count`/`aggregate` on that schema
+silently returns empty, logged only as a `warning`, never surfaced to the
+caller.
+
+## What Changes
+
+- Add `SourceMapper::findForSystem(string $sourceId): ?Source` — a lookup by id
+  or uuid that intentionally skips both RBAC verification and the
+  organisation filter, mirroring the existing `findBySyncEnabled()` system-actor
+  pattern already established in the same mapper. Documented with an explicit
+  security rationale: this method must never be exposed to a caller that has
+  not already authorized the request at the schema/object level, and must never
+  be used to serve Source data (credentials, connection config) directly to a
+  client.
+- `DbalObjectSourceProvider::resolveSource()` now calls
+  `SourceMapper::findForSystem()` instead of `find()`/`findAll()`.
+
+## Why this is safe
+
+Resolving a Source referenced by a schema's `x-openregister-object-source.config.sourceId`
+is a SYSTEM capability lookup, not a user-facing read of the Source itself.
+`ObjectService::paginateObjectSource()` already calls `checkPermission(schema:
+…, action: 'read', …)` — the schema's own read RBAC — **before** the provider
+(and therefore `resolveSource()`) ever runs. A caller who fails that check never
+reaches `resolveSource()` at all. Tenant-filtering the Source row on top of that
+adds no additional isolation (the caller never sees the Source row — only the
+objects it serves for a schema they were already cleared to read) while
+breaking any dbal-backed schema whose Source is configured in a different
+organisation than the reader's active one — exactly the cross-org shared
+registers use case this issue was raised against.
+
+Default org filtering for every other `SourceMapper` caller (the Sources admin
+UI, CRUD, `find()`/`findAll()` as used by controllers) is completely
+unchanged — only the internal system lookup gets the new, narrowly-scoped
+method.
+
+## Impact
+
+- **Affected code**: `lib/Db/SourceMapper.php` (new method),
+  `lib/Service/ObjectSource/DbalObjectSourceProvider.php` (`resolveSource()`).
+- **Tests**: `tests/Unit/Service/ObjectSource/DbalObjectSourceProviderTest.php`
+  gains a cross-org resolution scenario; `SourceMapper` default filtering for
+  ordinary callers is untouched and not weakened.
+- **Deployment**: unblocks re-enabling `saasMode: true` on the shared dev
+  instance without the `{"saasMode":false,"adminOverride":true}` workaround
+  that has been in place since #2084/#2089.

--- a/openspec/changes/dbal-source-resolution-system-context/specs/dbal-source-resolution-system-context/spec.md
+++ b/openspec/changes/dbal-source-resolution-system-context/specs/dbal-source-resolution-system-context/spec.md
@@ -1,0 +1,63 @@
+# Capability: dbal-source-resolution-system-context
+
+## Purpose
+
+Ensure that resolving the `Source` a `dbal-source` schema is configured
+against is treated as a system capability lookup gated by the schema's own
+read RBAC, not as a tenant-owned read subject to the caller's active
+organisation — so a schema whose backing Source is configured in a different
+organisation stays servable, including under `saasMode: true` where admin
+override is unconditionally disabled.
+
+## ADDED Requirements
+
+### Requirement: Resolving a schema's configured Source MUST NOT be filtered by the caller's active organisation (REQ-DSRSC-001)
+
+`DbalObjectSourceProvider::resolveSource()` MUST load the `Source` named by a
+schema's `x-openregister-object-source.config.sourceId` without applying the
+querying user's active-organisation filter to the `Source` row. This MUST hold
+regardless of `saasMode` or `adminOverride` configuration. Ordinary
+`SourceMapper` callers (Sources admin CRUD, listing) MUST continue to apply the
+organisation filter unchanged — only the schema-referenced system lookup is
+exempt.
+
+#### Scenario: A cross-organisation Source still resolves under SaaS mode
+
+- **GIVEN** a `dbal-source` schema whose config names a Source belonging to
+  organisation A
+- **AND** the querying admin's active organisation is B
+- **AND** multitenancy config is `{"saasMode": true, "adminOverride": true}`
+  (admin override disabled by SaaS mode)
+- **WHEN** the schema's objects are listed
+- **THEN** `resolveSource()` MUST return the Source and the provider MUST
+  return the external rows, not an empty result
+- **@e2e** exclude requires a live external database + multi-org fixture;
+  asserted by `DbalObjectSourceProviderTest` with a `SourceMapper` stub whose
+  `findForSystem()` returns a cross-org Source
+
+#### Scenario: Non-system Source reads remain organisation-filtered
+
+- **GIVEN** an admin user with active organisation B
+- **WHEN** they list Sources through the ordinary `SourceMapper::findAll()` /
+  `find()` path (e.g. the Sources admin UI)
+- **THEN** a Source belonging to organisation A MUST NOT be returned, exactly
+  as before this change
+- **@e2e** exclude covered by existing `SourceMapper` / `MultiTenancyTrait`
+  tenant-isolation tests, unmodified
+
+### Requirement: The system lookup MUST remain gated by the schema's own read RBAC (REQ-DSRSC-002)
+
+Removing the organisation filter from Source resolution MUST NOT weaken access
+control: a caller who is denied read access to the schema itself MUST still be
+denied before `resolveSource()` (and the external database) is ever consulted.
+`ObjectService::paginateObjectSource()` MUST continue to enforce
+`checkPermission(schema, 'read', …)` before invoking the provider.
+
+#### Scenario: A user without schema read access is still denied
+
+- **GIVEN** a user lacking read authorization on a `dbal-source` schema
+- **WHEN** they request the schema's objects
+- **THEN** the request MUST fail with the same `NotAuthorizedException` a
+  native schema raises, and the external database MUST NOT be queried
+- **@e2e** exclude covered by existing `paginateObjectSource` / read-access-parity
+  tests, unmodified by this change

--- a/openspec/changes/dbal-source-resolution-system-context/tasks.md
+++ b/openspec/changes/dbal-source-resolution-system-context/tasks.md
@@ -1,0 +1,18 @@
+# Tasks: dbal-source-resolution-system-context
+
+## 1. System lookup seam
+
+- [ ] 1.1 Add `SourceMapper::findForSystem(string $sourceId): ?Source` — id-or-uuid lookup with NO RBAC verify and NO organisation filter, docblock stating the security rationale (REQ-DSRSC-001)
+
+## 2. Provider wiring
+
+- [ ] 2.1 `DbalObjectSourceProvider::resolveSource()` calls `findForSystem()` instead of `find()`/`findAll()` (REQ-DSRSC-001)
+
+## 3. Tests
+
+- [ ] 3.1 Unit test: Source in another organisation + `saasMode: true` → `resolveSource()`/`findAll()` on the provider still resolves and returns objects (REQ-DSRSC-001)
+- [ ] 3.2 Unit test: schema-level RBAC (`checkPermission()` in `ObjectService::paginateObjectSource()`) is untouched and still enforced before the provider runs (REQ-DSRSC-002) — covered by existing `ObjectService`/parity tests, verified not regressed
+
+## 4. Quality
+
+- [ ] 4.1 `php -l` + `composer phpcs` on changed files; run the relevant `DbalObjectSourceProviderTest` subset in the `nextcloud:34` container recipe (host PHP too old)

--- a/tests/Unit/Service/ObjectSource/DbalObjectSourceProviderTest.php
+++ b/tests/Unit/Service/ObjectSource/DbalObjectSourceProviderTest.php
@@ -120,6 +120,7 @@ class DbalObjectSourceProviderTest extends TestCase
         $sourceMapper = $this->createMock(SourceMapper::class);
         $sourceMapper->method('find')->willReturn($source);
         $sourceMapper->method('findAll')->willReturn([$source]);
+        $sourceMapper->method('findForSystem')->willReturn($source);
 
         $store = new class implements CredentialStore {
             /**
@@ -232,6 +233,96 @@ class DbalObjectSourceProviderTest extends TestCase
     {
         $this->assertSame('dbal-source', $this->provider()->getId());
     }//end testGetId()
+
+    /**
+     * Regression for openregister#2089: resolving the schema's configured
+     * Source MUST go through `SourceMapper::findForSystem()` — the
+     * unfiltered, RBAC-free system lookup — never through the
+     * organisation-filtered `find()`/`findAll()` path. A Source that belongs
+     * to a DIFFERENT organisation than the caller's active one (the exact
+     * `saasMode: true` scenario from the issue, where admin override is
+     * unconditionally disabled) MUST still resolve and serve objects.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/dbal-source-resolution-system-context/specs/dbal-source-resolution-system-context/spec.md
+     */
+    public function testResolveSourceUsesSystemLookupAcrossOrganisations(): void
+    {
+        $source = new Source();
+        $source->setId(9);
+        $source->setUuid('00000000-0000-0000-0000-000000000000');
+        $source->setType('database');
+        // Belongs to an organisation different from whatever the caller's
+        // active organisation would be — resolution must not depend on it.
+        $source->setOrganisation('286a9152-4b09-4714-9115-fabbbad342d0');
+        $source->setAuthConfig(['driver' => 'pdo_sqlite', 'path' => self::$dbPath, 'writable' => false]);
+
+        $sourceMapper = $this->createMock(SourceMapper::class);
+        $sourceMapper->expects($this->atLeastOnce())
+            ->method('findForSystem')
+            ->with($this->equalTo('9'))
+            ->willReturn($source);
+        // The organisation-filtered lookups must NEVER be used to resolve a
+        // schema's configured source — that is precisely the #2089 defect.
+        $sourceMapper->expects($this->never())->method('find');
+        $sourceMapper->expects($this->never())->method('findAll');
+
+        $store = new class implements \OCA\OpenRegister\Service\Credential\CredentialStore {
+            /**
+             * {@inheritDoc}
+             *
+             * @param string $uuid   The credential UUID.
+             * @param string $secret The secret.
+             * @param string $scope  The scope.
+             *
+             * @return void
+             */
+            public function put(string $uuid, string $secret, string $scope='personal'): void
+            {
+            }//end put()
+
+            /**
+             * {@inheritDoc}
+             *
+             * @param string $uuid  The credential UUID.
+             * @param string $scope The scope.
+             *
+             * @return string|null Always null.
+             */
+            public function get(string $uuid, string $scope='personal'): ?string
+            {
+                return null;
+            }//end get()
+
+            /**
+             * {@inheritDoc}
+             *
+             * @param string $uuid  The credential UUID.
+             * @param string $scope The scope.
+             *
+             * @return void
+             */
+            public function delete(string $uuid, string $scope='personal'): void
+            {
+            }//end delete()
+        };
+
+        $provider = new DbalObjectSourceProvider(
+            sourceMapper: $sourceMapper,
+            connectionFactory: new DbalConnectionFactory(credentialStore: $store, logger: new NullLogger()),
+            logger: new NullLogger()
+        );
+
+        $objects = $provider->findAll(
+            register: $this->register(),
+            schema: $this->peopleSchema(),
+            query: ['limit' => 5],
+            config: $this->peopleConfig()
+        );
+
+        $this->assertCount(5, $objects);
+    }//end testResolveSourceUsesSystemLookupAcrossOrganisations()
 
     /**
      * findAll() with a filter and a limit applies both in SQL.


### PR DESCRIPTION
## Summary

Fixes #2089 (follow-up to #2084 / PR #2088). `DbalObjectSourceProvider::resolveSource()` loaded the backing `Source` via organisation-filtered `SourceMapper::find()`/`findAll()`. A `Source` is shared infrastructure config (an external DB connection), not tenant-owned data — the schema's own read RBAC is already enforced by `ObjectService::paginateObjectSource()` (`checkPermission()`) **before** the provider ever runs. Filtering the Source row by the caller's active organisation added no additional isolation while breaking every dbal-backed schema whose Source lives in a different organisation, most visibly under `saasMode: true` where admin override is unconditionally disabled — `resolveSource()` returned `null`, and every downstream `find`/`findAll`/`count`/`aggregate` silently returned empty (logged only as a `warning`).

## Design

- Added `SourceMapper::findForSystem(string $sourceId): ?Source` — an id/uuid lookup with **no RBAC verification and no organisation filter**, mirroring the mapper's existing `findBySyncEnabled()` system-actor pattern (same file, same rationale: system-initiated lookup, no tenant scoping). Docblock states the security rationale explicitly and the constraint that it must never be exposed to a caller that hasn't already authorized at the schema/object level.
- `DbalObjectSourceProvider::resolveSource()` now calls `findForSystem()` instead of `find()`/`findAll()`.
- Ordinary `SourceMapper` callers (Sources admin CRUD/listing) are **untouched** — default organisation filtering is not weakened for any other caller.
- Added OpenSpec change `dbal-source-resolution-system-context` (proposal + tasks + spec delta) with `@spec` tags on both changed methods.

## Tests

- New regression test `testResolveSourceUsesSystemLookupAcrossOrganisations` in `DbalObjectSourceProviderTest`: a Source in a different organisation still resolves and serves objects, and asserts `find()`/`findAll()` are **never** called (only `findForSystem()`) — proving the fix path.
- `PaginateObjectSourceTest::testDeniedReadRejectsBeforeProviderIsConsulted` (untouched) continues to cover REQ-DSRSC-002 — schema-level RBAC still gates before the provider runs.
- `php -l`, `composer phpcs` (clean), `phpstan` (clean — also fixed a pre-existing phpstan-only warning on an unrelated method encountered while scoping the file) on both changed lib files.
- Full `DbalObjectSourceProviderTest` (20/20) and `PaginateObjectSourceTest` (8/8) green in the `nextcloud:34.0.0-apache` container.

## Test plan

- [x] Unit tests pass in container (`nextcloud:34.0.0-apache`)
- [x] phpcs / phpstan clean on changed files
- [ ] Live-verify on shared dev instance under `saasMode: true` (tracked in #2089/#2084, done post-merge)