### PR TITLE
fix(dashboard): one bad schema no longer 500s the whole dashboard (#2087)

### DIFF
--- a/lib/Service/DashboardService.php
+++ b/lib/Service/DashboardService.php
@@ -346,10 +346,10 @@ class DashboardService
                         context: ['file' => __FILE__, 'line' => __LINE__, 'register' => $register->getId()]
                     );
 
-                    $registerArray          = $register->jsonSerialize();
-                    $registerArray['stats'] = [];
+                    $registerArray            = $register->jsonSerialize();
+                    $registerArray['stats']   = [];
                     $registerArray['schemas'] = [];
-                    $registerArray['error'] = $registerError->getMessage();
+                    $registerArray['error']   = $registerError->getMessage();
                     $result[] = $registerArray;
                 }//end try
             }//end foreach

--- a/lib/Service/DashboardService.php
+++ b/lib/Service/DashboardService.php
@@ -26,6 +26,7 @@ namespace OCA\OpenRegister\Service;
 use DateTime;
 use Exception;
 use RuntimeException;
+use Throwable;
 use stdClass;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\SchemaMapper;
@@ -331,35 +332,26 @@ class DashboardService
                 'schemas'     => [],
             ];
 
-            // For each register, get its schemas and statistics.
+            // For each register, get its schemas and statistics. Each register
+            // is processed in its own try/catch: a single register whose
+            // schemas fail to hydrate (e.g. a cross-app schema-format conflict,
+            // openregister#2087) must degrade to a flagged entry, not blank the
+            // whole dashboard for every register and every user.
             foreach ($registers as $register) {
-                $schemas = $this->registerMapper->getSchemasByRegisterId($register->getId());
+                try {
+                    $result[] = $this->buildRegisterEntry(register: $register, schemaId: $schemaId);
+                } catch (Throwable $registerError) {
+                    $this->logger->warning(
+                        message: '[DashboardService] Skipping a register whose schemas could not be loaded: '.$registerError->getMessage(),
+                        context: ['file' => __FILE__, 'line' => __LINE__, 'register' => $register->getId()]
+                    );
 
-                // Get register-level statistics.
-                $registerStats = $this->getStats(registerId: $register->getId());
-
-                // Convert register to array and add statistics.
-                $registerArray          = $register->jsonSerialize();
-                $registerArray['stats'] = $registerStats;
-
-                // Process schemas.
-                $schemasArray = [];
-                foreach ($schemas as $schema) {
-                    if ($schemaId !== null &&  $schema->getId() !== $schemaId) {
-                        continue;
-                    }
-
-                    // Get schema-level statistics.
-                    $schemaStats = $this->getStats(registerId: $register->getId(), schemaId: $schema->getId());
-
-                    // Convert schema to array and add statistics.
-                    $schemaArray          = $schema->jsonSerialize();
-                    $schemaArray['stats'] = $schemaStats;
-                    $schemasArray[]       = $schemaArray;
-                }
-
-                $registerArray['schemas'] = $schemasArray;
-                $result[] = $registerArray;
+                    $registerArray          = $register->jsonSerialize();
+                    $registerArray['stats'] = [];
+                    $registerArray['schemas'] = [];
+                    $registerArray['error'] = $registerError->getMessage();
+                    $result[] = $registerArray;
+                }//end try
             }//end foreach
 
             // Add orphaned items statistics as a special "register".
@@ -381,6 +373,45 @@ class DashboardService
             throw new Exception('Failed to get registers with schemas: '.$e->getMessage());
         }//end try
     }//end getRegistersWithSchemas()
+
+    /**
+     * Build one register's dashboard entry: its stats plus each schema's stats.
+     *
+     * Split out of {@see self::getRegistersWithSchemas()} so a failure here is
+     * caught per register rather than aborting the whole dashboard. Any throw
+     * (a schema-hydration conflict, a stats query error) is the caller's to
+     * turn into a flagged entry.
+     *
+     * @param \OCA\OpenRegister\Db\Register $register The register.
+     * @param int|null                      $schemaId Restrict to one schema, or null for all.
+     *
+     * @return array<string, mixed> The register entry, with `stats` and `schemas`.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-5
+     */
+    private function buildRegisterEntry(\OCA\OpenRegister\Db\Register $register, ?int $schemaId): array
+    {
+        $schemas = $this->registerMapper->getSchemasByRegisterId($register->getId());
+
+        $registerArray          = $register->jsonSerialize();
+        $registerArray['stats'] = $this->getStats(registerId: $register->getId());
+
+        $schemasArray = [];
+        foreach ($schemas as $schema) {
+            if ($schemaId !== null && $schema->getId() !== $schemaId) {
+                continue;
+            }
+
+            $schemaArray          = $schema->jsonSerialize();
+            $schemaArray['stats'] = $this->getStats(registerId: $register->getId(), schemaId: $schema->getId());
+            $schemasArray[]       = $schemaArray;
+        }
+
+        $registerArray['schemas'] = $schemasArray;
+
+        return $registerArray;
+
+    }//end buildRegisterEntry()
 
     /**
      * Recalculate sizes for objects in specified registers and/or schemas

--- a/tests/Unit/Service/DashboardServiceTest.php
+++ b/tests/Unit/Service/DashboardServiceTest.php
@@ -473,6 +473,62 @@ class DashboardServiceTest extends TestCase
         $this->assertSame('Orphaned Items', $result[$lastIndex]['title']);
     }
 
+    /**
+     * A register whose schemas cannot be loaded (e.g. the cross-app
+     * schema-format conflict in openregister#2087) must NOT blank the whole
+     * dashboard. It degrades to a flagged entry, and every other register
+     * still renders.
+     *
+     * @return void
+     */
+    public function testABadRegisterIsFlaggedRatherThanAbortingTheDashboard(): void
+    {
+        $good = $this->createRegisterEntity(1, 'Healthy Register');
+        $bad  = $this->createRegisterEntity(2, 'Broken Register');
+        $schema = $this->createSchemaEntity(10, 'Test Schema');
+
+        $this->registerMapper
+            ->method('findAll')
+            ->willReturn([$good, $bad]);
+
+        // The broken register throws on schema hydration, exactly as the
+        // format-constraint conflict does; the healthy one returns normally.
+        $this->registerMapper
+            ->method('getSchemasByRegisterId')
+            ->willReturnCallback(function (int $registerId) use ($schema) {
+                if ($registerId === 2) {
+                    throw new \RuntimeException("Schema '1119': Property 'orderDate' cannot change format from 'date-time' to 'date'");
+                }
+
+                return [$schema];
+            });
+
+        $this->setupStatsMappers();
+
+        $result = $this->service->getRegistersWithSchemas();
+
+        // The whole call still succeeds — no throw.
+        $byId = [];
+        foreach ($result as $entry) {
+            $byId[$entry['id']] = $entry;
+        }
+
+        // Healthy register renders in full.
+        $this->assertArrayHasKey(1, $byId);
+        $this->assertCount(1, $byId[1]['schemas']);
+        $this->assertArrayNotHasKey('error', $byId[1]);
+
+        // Broken register is present but flagged, not missing and not fatal.
+        $this->assertArrayHasKey(2, $byId);
+        $this->assertArrayHasKey('error', $byId[2]);
+        $this->assertStringContainsString('cannot change format', $byId[2]['error']);
+        $this->assertSame([], $byId[2]['schemas']);
+
+        // Totals and orphaned bookends still present.
+        $this->assertSame('totals', $result[0]['id']);
+        $this->assertSame('orphaned', $result[count($result) - 1]['id']);
+    }
+
     public function testGetRegistersWithSchemasFiltersByRegisterId(): void
     {
         $register = $this->createRegisterEntity(5, 'Filtered Register');


### PR DESCRIPTION
The resilience half of #2087.

## The failure

`getRegistersWithSchemas()` wrapped every register in a single try/catch, so one register whose schemas failed to hydrate threw the whole method and blanked the OpenRegister UI — every register, every user — with a 500.

That is exactly what took a dev instance down: three schemas across **two apps** (shillinq's SalesOrder + OrderPrimitive, decidesk's order) all declare `x-schema-org: schema:Order`, OR treated the shared marker as an inheritance edge, and the format-constraint validator refused shillinq's `date` against the sibling's `date-time`. One conflict → total UI outage.

## The fix

Each register is built in its own try/catch (`buildRegisterEntry()`). A register that throws degrades to a **flagged entry** — its own data plus an `error` field — and every other register still renders. The dashboard stays up and names the broken register instead of showing nothing.

## Scope

This is deliberately only the resilience half. The root cause — schema inheritance being scoped to a shared `x-schema-org` marker rather than to same-app or explicitly-declared relationships — stays open on #2087. That one is the same cross-app collision class as the slug bug (#2047), on a different key.

## Verification

- 59 tests green, 1 new: a register that throws on schema hydration is flagged not fatal, and the healthy register beside it still renders in full.
- phpcs clean.
- Live: dashboard 200 with schemas consistent. The degradation path is carried by the unit test — the original first-load org context that produced the 500 could not be reproduced on demand, so I did not fake a live repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)