### PR TITLE
fix(dbal): object-source detection as system lookup — cross-org snake_case filters were dead (#2089 follow-on)

### DIFF
--- a/lib/Service/Object/SearchQueryHandler.php
+++ b/lib/Service/Object/SearchQueryHandler.php
@@ -122,6 +122,17 @@ class SearchQueryHandler
      * multi-schema (array) or absent schema, or any resolution failure, yields
      * false so the legacy magic-table behaviour is preserved.
      *
+     * This is a SYSTEM-level structural lookup (does the schema declare an
+     * object-source?), used only to decide how query params are parsed — it
+     * returns no schema data to the caller, so it MUST bypass RBAC and
+     * multitenancy. Otherwise, when saasMode is active and the schema lives in
+     * a different organisation than the caller's active org, the tenant-scoped
+     * find() cannot see it, this returns false, and snake_case column filters
+     * (e.g. `app_id`) are wrongly dot-un-mangled — silently emptying every
+     * per-object filter on a cross-org DBAL register. The actual data read is
+     * still RBAC/tenant-checked downstream in paginateObjectSource() (mirrors
+     * the object-source Source lookup, openregister#2089).
+     *
      * @param int|string|array|null $schema The schema id/slug (single value only).
      *
      * @return bool True when the schema declares an x-openregister-object-source.
@@ -133,7 +144,7 @@ class SearchQueryHandler
         }
 
         try {
-            $entity = $this->schemaMapper->find(id: $schema);
+            $entity = $this->schemaMapper->find(id: $schema, _rbac: false, _multitenancy: false);
         } catch (\Throwable $e) {
             return false;
         }

--- a/tests/Unit/Service/Object/SearchQueryHandlerObjectSourceFilterTest.php
+++ b/tests/Unit/Service/Object/SearchQueryHandlerObjectSourceFilterTest.php
@@ -64,6 +64,38 @@ class SearchQueryHandlerObjectSourceFilterTest extends TestCase
     }
 
     /**
+     * The object-source structural lookup MUST resolve the schema as a system
+     * operation — `find()` called with RBAC and multitenancy disabled — so that
+     * when saasMode is active and the schema lives in another organisation, the
+     * object-source detection still succeeds and snake_case column filters
+     * (e.g. `app_id`) are kept literal instead of being wrongly dot-un-mangled
+     * (openregister#2089 follow-on: cross-org DBAL registers were silently
+     * unfilterable).
+     */
+    public function testObjectSourceLookupBypassesRbacAndMultitenancy(): void
+    {
+        $schema = $this->createMock(Schema::class);
+        $schema->method('getObjectSource')->willReturn(['provider' => 'dbal-source', 'config' => []]);
+        $this->schemaMapper = $this->createMock(SchemaMapper::class);
+        // A tenant-scoped find() (the default) would throw for a cross-org
+        // schema; the handler MUST call it with _rbac=false, _multitenancy=false.
+        $this->schemaMapper->expects($this->once())
+            ->method('find')
+            ->with(777, $this->anything(), false, false)
+            ->willReturn($schema);
+
+        $result = $this->makeHandler()->buildSearchQuery(
+            ['app_id' => '6', '_limit' => '5'],
+            null,
+            777
+        );
+
+        $this->assertArrayHasKey('app_id', $result, 'snake_case column must stay literal for a cross-org object-source schema');
+        $this->assertSame('6', $result['app_id']);
+        $this->assertArrayNotHasKey('app', $result, 'app_id must not be split into a nested array');
+    }//end testObjectSourceLookupBypassesRbacAndMultitenancy()
+
+    /**
      * A magic-table (non-object-source) schema must keep the historical
      * dot-un-mangling: `person_address_street` reconstructs a nested `person`.
      */


### PR DESCRIPTION
## Problem
After restoring `multitenancy.saasMode:true` (once #2088/#2090 fixed the empty-orX and Source-resolution bugs), **every per-object filter on a cross-org DBAL register silently stopped working** — `GET …/spectr-live/v-price-comparison?app_id=6` returned all 31 rows instead of procest, so Spectr's AppDetail widgets and generated report PDFs showed the wrong app's data (procest's price rendered as assetdesk's €34.23 instead of €40).

## Root cause
`SearchQueryHandler::schemaHasObjectSource()` (added in #2043 for the snake_case filter fix) resolves the schema via `SchemaMapper::find()` with **default RBAC + multitenancy**. Under saasMode, a schema whose org ≠ the caller's active org isn't found → the method returns false → `buildSearchQuery()` dot-un-mangles snake_case columns (`app_id` → `['app']['id']`) → the filter never reaches the DBAL provider and is silently dropped.

Same class as #2089 (which fixed the *Source* lookup); this is the *Schema* lookup on the query-parse path.

## Fix
The object-source detection is a **structural check** that returns no schema data to the caller — only decides how query params are parsed. It now runs as a system lookup (`_rbac:false, _multitenancy:false`). The actual data read stays RBAC + tenant checked downstream in `paginateObjectSource()`.

## Tests / verification
- New regression test: asserts `find()` is invoked with RBAC+multitenancy off and `app_id` survives as a literal key. Full `SearchQueryHandlerObjectSourceFilterTest` green (3 tests). `lib` file phpcs clean.
- **Live-verified** on the dev instance under `saasMode:true`: `v-price-comparison?app_id=6` → total 1 (procest, our_price 40 / net 25.20); `v-app-features?app_id=6` → 4,636 (not 38,554); `v-app-competitors?app_id=6` → 134 (not 1,569).

Closes the last blocker to running the fleet with multitenancy enabled.