### PR TITLE
style(phpcs): clear the 12 baseline errors reintroduced on development

### DIFF
--- a/lib/Command/ReconcileMagicTablesCommand.php
+++ b/lib/Command/ReconcileMagicTablesCommand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * occ command to reconcile magic-table columns against schema definitions.
+ * Occ command to reconcile magic-table columns against schema definitions.
  *
  * @category Command
  * @package  OCA\OpenRegister\Command
@@ -44,7 +44,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ReconcileMagicTablesCommand extends Command
 {
-
     /**
      * Constructor.
      *
@@ -97,15 +96,15 @@ class ReconcileMagicTablesCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $apply         = (bool) $input->getOption('apply');
+        $apply          = (bool) $input->getOption('apply');
         $registerFilter = $input->getOption('register');
 
         $registers = $this->registerMapper->findAll(_rbac: false, _multitenancy: false);
 
-        $driftTables    = 0;
-        $driftColumns   = 0;
-        $repaired       = 0;
-        $failed         = 0;
+        $driftTables  = 0;
+        $driftColumns = 0;
+        $repaired     = 0;
+        $failed       = 0;
 
         foreach ($registers as $register) {
             if ($register instanceof Register === false) {
@@ -134,7 +133,7 @@ class ReconcileMagicTablesCommand extends Command
                     );
 
                     // Table not materialised yet — ensureTable will create it on apply.
-                    $currentColumns = $this->magicMapper->getExistingTableColumns(tableName: $tableName);
+                    $currentColumns  = $this->magicMapper->getExistingTableColumns(tableName: $tableName);
                     $requiredColumns = $this->magicMapper->buildTableColumnsFromSchema(schema: $schema);
                     $missing         = $this->magicMapper->findMissingColumns(
                         currentColumns: $currentColumns,
@@ -151,7 +150,7 @@ class ReconcileMagicTablesCommand extends Command
                         )
                     );
                     continue;
-                }
+                }//end try
 
                 if (empty($missing) === true) {
                     continue;
@@ -215,8 +214,11 @@ class ReconcileMagicTablesCommand extends Command
             )
         );
 
-        return ($failed === 0) ? 0 : 1;
+        if ($failed === 0) {
+            return 0;
+        }
+
+        return 1;
 
     }//end execute()
-
 }//end class

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -4526,7 +4526,7 @@ class MagicMapper extends AbstractObjectMapper
                 // existing rows; otherwise the column is added nullable. Required-ness
                 // is enforced by schema validation at write time, not by the physical
                 // column constraint (see #2082/#2075).
-                $hasDefault = isset($columnDef['default']);
+                $hasDefault  = isset($columnDef['default']);
                 $wantNotNull = (($columnDef['nullable'] ?? true) === false);
 
                 if ($wantNotNull === true && $hasDefault === true) {


### PR DESCRIPTION
phpcs is red on `development` again — 11 errors in `ReconcileMagicTablesCommand`, 1 in `MagicMapper`, from merges after the last cleanup. Mostly alignment plus one inline-`?:` and a lowercase docblock. `phpcbf` + two by hand.

0 errors across 1053 files. Clears the PHP Quality gate for every open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)