### PR TITLE
feat(flow): per-place item buffers, Merge and Loop (#2067)

### DIFF
--- a/lib/Listener/FlowNodeRegistrationListener.php
+++ b/lib/Listener/FlowNodeRegistrationListener.php
@@ -29,6 +29,8 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Listener;
 
 use OCA\OpenRegister\Service\Flow\Nodes\FilterNode;
+use OCA\OpenRegister\Service\Flow\Nodes\LoopNode;
+use OCA\OpenRegister\Service\Flow\Nodes\MergeNode;
 use OCA\OpenRegister\Service\Flow\Nodes\SetFieldsNode;
 use OCA\OpenRegister\Service\Flow\Nodes\StopNode;
 use OCA\OpenRegister\Service\Flow\Nodes\SwitchNode;
@@ -52,13 +54,17 @@ class FlowNodeRegistrationListener implements IEventListener
      * @param WaitNode      $wait      The built-in "Wait" node.
      * @param SwitchNode    $switch    The built-in "Switch" node.
      * @param StopNode      $stop      The built-in "Stop" node.
+     * @param MergeNode     $merge     The built-in "Merge" node.
+     * @param LoopNode      $loop      The built-in "Loop over items" node.
      */
     public function __construct(
         private readonly SetFieldsNode $setFields,
         private readonly FilterNode $filter,
         private readonly WaitNode $wait,
         private readonly SwitchNode $switch,
-        private readonly StopNode $stop
+        private readonly StopNode $stop,
+        private readonly MergeNode $merge,
+        private readonly LoopNode $loop
     ) {
 
     }//end __construct()
@@ -83,6 +89,8 @@ class FlowNodeRegistrationListener implements IEventListener
         $event->registerNode(node: $this->wait);
         $event->registerNode(node: $this->switch);
         $event->registerNode(node: $this->stop);
+        $event->registerNode(node: $this->merge);
+        $event->registerNode(node: $this->loop);
 
     }//end handle()
 }//end class

--- a/lib/Service/Flow/FlowEngine.php
+++ b/lib/Service/Flow/FlowEngine.php
@@ -41,6 +41,7 @@ namespace OCA\OpenRegister\Service\Flow;
 use DateTime;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
 use Symfony\Component\Workflow\Workflow;
 use Throwable;
@@ -162,6 +163,15 @@ class FlowEngine
         $log      = [];
         $fired    = 0;
 
+        // Per-place item buffers. Items belong to the PLACES a token sits on,
+        // not to the run globally ({@see self::seedPlaceItems()}).
+        $placeItems = $this->seedPlaceItems(
+            workflow: $workflow,
+            subject: $subject,
+            definition: $definition,
+            items: $items
+        );
+
         while (true) {
             $enabled = $workflow->getEnabledTransitions(subject: $subject);
             if (empty($enabled) === true) {
@@ -199,7 +209,7 @@ class FlowEngine
             $transition = $this->selectTransition(
                 enabled: $enabled,
                 flow: $flow,
-                items: $items,
+                placeItems: $placeItems,
                 context: $context
             );
 
@@ -216,12 +226,20 @@ class FlowEngine
                 ];
             }
 
-            $name    = $transition->getName();
-            $step    = $this->stepFor(flow: $flow, transitionName: $name);
-            $itemsIn = $items;
+            $name = $transition->getName();
+            $step = $this->stepFor(flow: $flow, transitionName: $name);
+
+            // A step reads the items on its input place(s). For a join — several
+            // incoming edges converging on one node — that is the concatenation
+            // of every branch's items, in the froms' declared order, which is
+            // exactly what a Merge node then refines. The Petri net already
+            // holds the join until every input place is marked, so wait-for-both
+            // is the default and needs no code here.
+            $itemsIn = $this->itemsForTransition(transition: $transition, placeItems: $placeItems);
+            $items   = $itemsIn;
 
             try {
-                $produced = $dispatcher->dispatch(step: $step, items: $items, context: $context);
+                $produced = $dispatcher->dispatch(step: $step, items: $itemsIn, context: $context);
                 $items    = FlowItems::normalise(value: $produced);
                 $log[]    = [
                     'transition' => $name,
@@ -301,6 +319,10 @@ class FlowEngine
                 }
             }//end try
 
+            // Move the items in lock-step with the token: onto the output
+            // places, off the consumed inputs ({@see self::advanceItems()}).
+            $placeItems = $this->advanceItems(transition: $transition, placeItems: $placeItems, items: $items);
+
             // The marking advances even when a `continue` step failed: the author
             // asked the run to proceed, and leaving the token behind would spin
             // this transition forever.
@@ -349,28 +371,24 @@ class FlowEngine
      *    condition that did not hold, with no default), null is returned and
      *    the run ends at this choice point.
      *
-     * The condition is evaluated against the first item as the representative
-     * of the list. Per-item routing — sending each item down a different branch
-     * — is a larger feature (it needs the engine to carry more than one item
-     * list across a split) and is not attempted here.
+     * Each candidate's condition is evaluated against the items on ITS input
+     * place — the data the branch would actually carry — not a single global
+     * list. Per-item routing (each item down a different branch) is a larger
+     * feature and is not attempted here; the condition uses the first item as
+     * the branch's representative.
      *
-     * @param array<int, object>   $enabled The enabled transitions.
-     * @param array<string, mixed> $flow    The flow document.
-     * @param array<int, mixed>    $items   The current item list.
-     * @param array<string, mixed> $context Run-level metadata.
+     * @param array<int, object>   $enabled    The enabled transitions.
+     * @param array<string, mixed> $flow       The flow document.
+     * @param array<string, array> $placeItems Items per place.
+     * @param array<string, mixed> $context    Run-level metadata.
      *
      * @return object|null The transition to fire, or null when none is eligible.
      *
      * @spec openspec/changes/or-flow-logic/specs/flow-logic/spec.md
      */
-    private function selectTransition(array $enabled, array $flow, array $items, array $context): ?object
+    private function selectTransition(array $enabled, array $flow, array $placeItems, array $context): ?object
     {
         $fallback = null;
-        $data     = FlowExpression::dataFor(
-            item: ($items[0] ?? []),
-            itemCount: count($items),
-            context: $context
-        );
 
         foreach ($enabled as $transition) {
             $edge      = $this->stepFor(flow: $flow, transitionName: $transition->getName());
@@ -382,12 +400,115 @@ class FlowEngine
                 continue;
             }
 
+            $items = $this->itemsForTransition(transition: $transition, placeItems: $placeItems);
+            $data  = FlowExpression::dataFor(
+                item: ($items[0] ?? []),
+                itemCount: count($items),
+                context: $context
+            );
+
             if (FlowExpression::isTrue(logic: $condition, data: $data) === true) {
                 return $transition;
             }
-        }
+        }//end foreach
 
         return $fallback;
 
     }//end selectTransition()
+
+    /**
+     * Gather the items a transition reads: every input place's items, in the
+     * froms' declared order.
+     *
+     * For a normal step this is just its one input place. For a join it is the
+     * concatenation of every incoming branch's items — which is what a Merge
+     * node receives and then combines.
+     *
+     * @param object               $transition The transition.
+     * @param array<string, array> $placeItems Items per place.
+     *
+     * @return array<int, mixed> The gathered input items.
+     *
+     * @spec openspec/changes/or-flow-logic/specs/flow-logic/spec.md
+     */
+    private function itemsForTransition(object $transition, array $placeItems): array
+    {
+        $items = [];
+        foreach ($transition->getFroms() as $from) {
+            foreach (($placeItems[(string) $from] ?? []) as $item) {
+                $items[] = $item;
+            }
+        }
+
+        return $items;
+
+    }//end itemsForTransition()
+
+    /**
+     * Seed the per-place item buffers from the current marking.
+     *
+     * Items belong to the PLACES a token sits on, not to the run globally: a
+     * parallel split hands each branch the items from the split point, and a
+     * join reads the items every incoming branch left on it. A single shared
+     * list cannot express either — the second branch to run would overwrite
+     * the first.
+     *
+     * Seeded from the CURRENT marking, which is what makes resume work: a fresh
+     * run's marking is the initial place, a resumed run's is wherever it
+     * suspended, and either way the stored items land on the place that holds
+     * the token.
+     *
+     * @param Workflow   $workflow   The workflow.
+     * @param object     $subject    The subject holding the marking.
+     * @param Definition $definition The definition (for the initial-place fallback).
+     * @param array      $items      The seed items.
+     *
+     * @return array<string, array> Items keyed by place.
+     *
+     * @spec openspec/changes/or-flow-merge/specs/flow-merge/spec.md
+     */
+    private function seedPlaceItems(Workflow $workflow, object $subject, Definition $definition, array $items): array
+    {
+        $placeItems = [];
+        foreach (array_keys($workflow->getMarking(subject: $subject)->getPlaces()) as $place) {
+            $placeItems[(string) $place] = $items;
+        }
+
+        if ($placeItems === []) {
+            foreach ($definition->getInitialPlaces() as $place) {
+                $placeItems[(string) $place] = $items;
+            }
+        }
+
+        return $placeItems;
+
+    }//end seedPlaceItems()
+
+    /**
+     * Move a fired transition's items: onto its output places, off its inputs.
+     *
+     * Clearing the consumed inputs matters for a loop that re-enters the
+     * transition — it must read fresh items, not a stale copy left behind.
+     *
+     * @param object               $transition The fired transition.
+     * @param array<string, array> $placeItems The current per-place buffers.
+     * @param array                $items      What the step produced.
+     *
+     * @return array<string, array> The updated buffers.
+     *
+     * @spec openspec/changes/or-flow-merge/specs/flow-merge/spec.md
+     */
+    private function advanceItems(object $transition, array $placeItems, array $items): array
+    {
+        foreach ($transition->getTos() as $to) {
+            $placeItems[(string) $to] = $items;
+        }
+
+        foreach ($transition->getFroms() as $from) {
+            unset($placeItems[(string) $from]);
+        }
+
+        return $placeItems;
+
+    }//end advanceItems()
 }//end class

--- a/lib/Service/Flow/Nodes/LoopNode.php
+++ b/lib/Service/Flow/Nodes/LoopNode.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * Splits an item list into fixed-size batches.
+ *
+ * A node already acts once per item, so "loop over items" is not needed to
+ * process a collection — that is the item model's whole point. What a batch
+ * node IS for: a downstream step that must be handed a bounded slice at a time
+ * (an API with a page limit, a bulk write with a max payload). This node takes
+ * the item list and emits one item per batch, each carrying its slice under
+ * `items`, so the next step sees N batch-items instead of one long list.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-merge/specs/flow-merge/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Nodes;
+
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
+use UnexpectedValueException;
+
+/**
+ * Batches an item list into slices of a configured size.
+ */
+class LoopNode implements IFlowNode
+{
+    /**
+     * Constructor.
+     *
+     * @param IL10N         $l10n Translations.
+     * @param IURLGenerator $urls For the palette icon.
+     */
+    public function __construct(
+        private readonly IL10N $l10n,
+        private readonly IURLGenerator $urls
+    ) {
+
+    }//end __construct()
+
+    /**
+     * The step type.
+     *
+     * @return string The id.
+     */
+    public function getId(): string
+    {
+        return 'openregister.loop';
+
+    }//end getId()
+
+    /**
+     * Palette name.
+     *
+     * @return string The display name.
+     */
+    public function getDisplayName(): string
+    {
+        return $this->l10n->t('Loop over items');
+
+    }//end getDisplayName()
+
+    /**
+     * Palette description.
+     *
+     * @return string The description.
+     */
+    public function getDescription(): string
+    {
+        return $this->l10n->t('Split the items into fixed-size batches for a step that needs them a slice at a time.');
+
+    }//end getDescription()
+
+    /**
+     * Palette icon.
+     *
+     * @return string The icon URL.
+     */
+    public function getIcon(): string
+    {
+        return $this->urls->imagePath('core', 'actions/play-next.svg');
+
+    }//end getIcon()
+
+    /**
+     * Batching grants no privilege.
+     *
+     * @param int $scope The scope constant.
+     *
+     * @return boolean Whether it is available.
+     */
+    public function isAvailableForScope(int $scope): bool
+    {
+        return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
+
+    }//end isAvailableForScope()
+
+    /**
+     * Reject a non-positive batch size.
+     *
+     * @param array $config The step configuration.
+     *
+     * @return void
+     *
+     * @throws UnexpectedValueException When the batch size is not a positive integer.
+     */
+    public function validateConfig(array $config): void
+    {
+        $size = (int) ($config['batchSize'] ?? 0);
+        if ($size < 1) {
+            throw new UnexpectedValueException($this->l10n->t('A loop needs a batch size of one or more.'));
+        }
+
+    }//end validateConfig()
+
+    /**
+     * Emit one item per batch.
+     *
+     * Each output item carries `batchIndex`, `batchCount` and the slice under
+     * `items`, so a downstream step can act on the slice and know where it is in
+     * the sequence. An empty input yields no batches, which ends the branch.
+     *
+     * @param array $items   The input items.
+     * @param array $config  The step configuration.
+     * @param array $context Run-level metadata.
+     *
+     * @return array One item per batch.
+     */
+    public function execute(array $items, array $config, array $context): array
+    {
+        $size = max(1, (int) ($config['batchSize'] ?? 1));
+        if ($items === []) {
+            return [];
+        }
+
+        $batches = array_chunk($items, $size);
+        $count   = count($batches);
+
+        $out = [];
+        foreach ($batches as $batchIndex => $batch) {
+            $out[] = FlowItems::item(
+                json: [
+                    'batchIndex' => $batchIndex,
+                    'batchCount' => $count,
+                    'items'      => array_map(
+                        static function (array $item): array {
+                            return (array) ($item[FlowItems::JSON] ?? []);
+                        },
+                        $batch
+                    ),
+                ],
+                binary: [],
+                fromItemIndex: ($batchIndex * $size)
+            );
+        }
+
+        return $out;
+
+    }//end execute()
+}//end class

--- a/lib/Service/Flow/Nodes/MergeNode.php
+++ b/lib/Service/Flow/Nodes/MergeNode.php
@@ -1,0 +1,260 @@
+<?php
+
+/**
+ * Combines the item lists arriving from several branches into one.
+ *
+ * A Merge sits at a join: an edge whose `from` names several nodes. The Petri
+ * net already holds the transition until every one of those branches has
+ * arrived — so "wait for all" is the default, done by the engine, and this node
+ * decides only HOW to combine what arrived. By the time `execute()` runs, the
+ * engine has concatenated every incoming branch's items into `$items`, in the
+ * branches' declared order.
+ *
+ * Modes:
+ *  - `append` (default) — keep them all, in order. The concatenation the engine
+ *    already produced; this is a pass-through.
+ *  - `mergeByKey` — group items that share a value under `key`, and shallow-merge
+ *    each group's records into one. The later branch wins a field collision,
+ *    which matches "enrich the record as it flows through".
+ *  - `unique` — drop later items whose `key` value was already seen, keeping the
+ *    first. Deduplication across branches.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-merge/specs/flow-merge/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Nodes;
+
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
+use UnexpectedValueException;
+
+/**
+ * Merges branch item lists — append, merge-by-key, or unique.
+ */
+class MergeNode implements IFlowNode
+{
+
+    /**
+     * The modes this node understands.
+     *
+     * @var array<int, string>
+     */
+    private const MODES = ['append', 'mergeByKey', 'unique'];
+
+    /**
+     * Constructor.
+     *
+     * @param IL10N         $l10n Translations.
+     * @param IURLGenerator $urls For the palette icon.
+     */
+    public function __construct(
+        private readonly IL10N $l10n,
+        private readonly IURLGenerator $urls
+    ) {
+
+    }//end __construct()
+
+    /**
+     * The step type.
+     *
+     * @return string The id.
+     */
+    public function getId(): string
+    {
+        return 'openregister.merge';
+
+    }//end getId()
+
+    /**
+     * Palette name.
+     *
+     * @return string The display name.
+     */
+    public function getDisplayName(): string
+    {
+        return $this->l10n->t('Merge');
+
+    }//end getDisplayName()
+
+    /**
+     * Palette description.
+     *
+     * @return string The description.
+     */
+    public function getDescription(): string
+    {
+        return $this->l10n->t('Combine the items arriving from several branches into one list.');
+
+    }//end getDescription()
+
+    /**
+     * Palette icon.
+     *
+     * @return string The icon URL.
+     */
+    public function getIcon(): string
+    {
+        return $this->urls->imagePath('core', 'actions/menu.svg');
+
+    }//end getIcon()
+
+    /**
+     * Merging grants no privilege.
+     *
+     * @param int $scope The scope constant.
+     *
+     * @return boolean Whether it is available.
+     */
+    public function isAvailableForScope(int $scope): bool
+    {
+        return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
+
+    }//end isAvailableForScope()
+
+    /**
+     * Reject an unknown mode, or a keyed mode with no key.
+     *
+     * @param array $config The step configuration.
+     *
+     * @return void
+     *
+     * @throws UnexpectedValueException When the mode is unknown or a key is missing.
+     */
+    public function validateConfig(array $config): void
+    {
+        $mode = (string) ($config['mode'] ?? 'append');
+        if (in_array($mode, self::MODES, true) === false) {
+            throw new UnexpectedValueException(
+                $this->l10n->t('Unknown merge mode. Use append, mergeByKey or unique.')
+            );
+        }
+
+        if (($mode === 'mergeByKey' || $mode === 'unique') && trim((string) ($config['key'] ?? '')) === '') {
+            throw new UnexpectedValueException($this->l10n->t('This merge mode needs a key field.'));
+        }
+
+    }//end validateConfig()
+
+    /**
+     * Combine the already-concatenated branch items.
+     *
+     * @param array $items   The input items (all branches, concatenated).
+     * @param array $config  The step configuration.
+     * @param array $context Run-level metadata.
+     *
+     * @return array The combined items.
+     */
+    public function execute(array $items, array $config, array $context): array
+    {
+        $mode = (string) ($config['mode'] ?? 'append');
+        $key  = (string) ($config['key'] ?? '');
+
+        if ($mode === 'mergeByKey') {
+            return $this->mergeByKey(items: $items, key: $key);
+        }
+
+        if ($mode === 'unique') {
+            return $this->unique(items: $items, key: $key);
+        }
+
+        // Append: the engine already concatenated the branches; re-pair each
+        // item to its own position so provenance stays intact.
+        $out = [];
+        foreach ($items as $index => $item) {
+            $out[] = FlowItems::item(
+                json: (array) ($item[FlowItems::JSON] ?? []),
+                binary: (array) ($item[FlowItems::BINARY] ?? []),
+                fromItemIndex: $index
+            );
+        }
+
+        return $out;
+
+    }//end execute()
+
+    /**
+     * Group items by their `key` value and shallow-merge each group's records.
+     *
+     * @param array  $items The input items.
+     * @param string $key   The field to group on.
+     *
+     * @return array<int, array> One item per distinct key value.
+     *
+     * @spec openspec/changes/or-flow-merge/specs/flow-merge/spec.md
+     */
+    private function mergeByKey(array $items, string $key): array
+    {
+        $groups = [];
+        $order  = [];
+        foreach ($items as $index => $item) {
+            $json  = (array) ($item[FlowItems::JSON] ?? []);
+            $value = (string) ($json[$key] ?? '');
+            if (isset($groups[$value]) === false) {
+                $groups[$value] = ['json' => [], 'from' => $index];
+                $order[]        = $value;
+            }
+
+            // A later branch's fields win the collision — enrichment as the
+            // record flows through.
+            $groups[$value]['json'] = array_merge($groups[$value]['json'], $json);
+        }
+
+        $out = [];
+        foreach ($order as $value) {
+            $out[] = FlowItems::item(json: $groups[$value]['json'], binary: [], fromItemIndex: $groups[$value]['from']);
+        }
+
+        return $out;
+
+    }//end mergeByKey()
+
+    /**
+     * Keep the first item for each distinct `key` value; drop later duplicates.
+     *
+     * @param array  $items The input items.
+     * @param string $key   The field to dedupe on.
+     *
+     * @return array<int, array> The deduplicated items.
+     *
+     * @spec openspec/changes/or-flow-merge/specs/flow-merge/spec.md
+     */
+    private function unique(array $items, string $key): array
+    {
+        $seen = [];
+        $out  = [];
+        foreach ($items as $index => $item) {
+            $json  = (array) ($item[FlowItems::JSON] ?? []);
+            $value = (string) ($json[$key] ?? '');
+            if (isset($seen[$value]) === true) {
+                continue;
+            }
+
+            $seen[$value] = true;
+            $out[]        = FlowItems::item(
+                json: $json,
+                binary: (array) ($item[FlowItems::BINARY] ?? []),
+                fromItemIndex: $index
+            );
+        }
+
+        return $out;
+
+    }//end unique()
+}//end class

--- a/openspec/changes/or-flow-merge/.openspec.yaml
+++ b/openspec/changes/or-flow-merge/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-merge

--- a/openspec/changes/or-flow-merge/proposal.md
+++ b/openspec/changes/or-flow-merge/proposal.md
@@ -1,0 +1,54 @@
+# Proposal: or-flow-merge
+
+## Summary
+
+Make the item data channel per-place, so parallel branches carry their own
+items and a join can combine them. Adds a Merge node and a Loop (batch) node.
+
+## Why
+
+The engine threaded a single global `$items` list — whatever the last step
+produced. That was subtly wrong for parallel branches: after a split, the
+second branch to run read the FIRST branch's output, not the items from the
+split point. And a join had no way to see both branches' items at all.
+
+## What Changes
+
+- **Per-place item buffers in the engine.** Items belong to the PLACES a token
+  sits on, not to the run globally. A split hands each branch the items from the
+  split point; a join reads the concatenation of every incoming branch's items.
+  Seeded from the current marking, so suspend/resume still lands the stored
+  items on the place that holds the token. Moved in lock-step with the marking:
+  the token and the items advance together, and consumed inputs are cleared so a
+  loop re-reads fresh.
+
+  A condition now evaluates against the items on ITS candidate transition's
+  input place — the data that branch would actually carry — rather than one
+  global list.
+
+- **`MergeNode`.** Sits at a join. The Petri net already holds the transition
+  until every input place is marked (wait-for-all is free), so the node only
+  decides HOW to combine: `append` (keep all), `mergeByKey` (group and
+  shallow-merge, later branch wins a field), or `unique` (dedupe on a key).
+
+- **`LoopNode`.** Splits an item list into fixed-size batches, one output item
+  per batch. NOT for processing a collection — a node already acts once per
+  item — but for a downstream step that must be handed a bounded slice at a
+  time (an API page limit, a bulk-write cap).
+
+## Design decisions
+
+- **The Petri net does the join timing.** wait-for-all is the default because a
+  join transition is not enabled until all its input places are marked. The
+  Merge node never has to wait; it only combines what has already arrived.
+- **`mergeByKey`: later branch wins.** Enrichment as the record flows through —
+  the same shape as `SetFields`.
+- **Loop is batching, not iteration.** The item model already iterates; a
+  separate "for each item" node would be redundant.
+
+## Out of scope (this change)
+
+- **Sub-flows** — calling a flow from a flow. Needs the run queue to suspend the
+  parent while the child runs; a follow-up.
+- **Per-item routing** — sending each item down a different branch. The
+  per-place buffers make this newly possible, but it is its own change.

--- a/openspec/changes/or-flow-merge/specs/flow-merge/spec.md
+++ b/openspec/changes/or-flow-merge/specs/flow-merge/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Items belong to places, not to the run (REQ-FM-001)
+
+The engine SHALL carry an item list per PLACE, not one list for the whole run.
+A parallel split SHALL hand each branch the items from the split point; a join
+SHALL read the concatenation of every incoming branch's items, in the froms'
+declared order.
+
+The buffers SHALL be seeded from the current marking, so a resumed run's stored
+items land on the place that holds the token.
+
+#### Scenario: Parallel branches do not see each other
+
+- **GIVEN** a split to two branches from one seed item
+- **WHEN** each branch runs
+- **THEN** each receives the seed item, not the other branch's output
+
+#### Scenario: A join reads every branch
+
+- **GIVEN** two branches that each stamp a distinct marker, converging on a join
+- **WHEN** the join fires
+- **THEN** it receives one item from each branch
+
+### Requirement: Merge combines branch items (REQ-FM-002)
+
+`openregister.merge` SHALL combine the items the join gave it. `append` keeps
+them all; `mergeByKey` groups items sharing a `key` value and shallow-merges
+each group, the later branch winning a field collision; `unique` keeps the
+first item per `key` value.
+
+A keyed mode with no `key`, or an unknown mode, SHALL be refused at save time.
+
+#### Scenario: mergeByKey enriches
+
+- **GIVEN** two items with the same key carrying different fields
+- **WHEN** merged by that key
+- **THEN** one item results, carrying both fields
+
+### Requirement: Loop batches an item list (REQ-FM-003)
+
+`openregister.loop` SHALL split its items into fixed-size batches, emitting one
+item per batch carrying `batchIndex`, `batchCount` and the slice under `items`.
+An empty input SHALL yield no batches. A batch size below one SHALL be refused
+at save time.
+
+#### Scenario: Seven items in batches of three
+
+- **GIVEN** seven items and a batch size of three
+- **WHEN** the loop runs
+- **THEN** three batch-items result, sized 3, 3 and 1
+
+@e2e exclude engine item semantics are backend-only — covered by PHPUnit

--- a/openspec/changes/or-flow-merge/tasks.md
+++ b/openspec/changes/or-flow-merge/tasks.md
@@ -1,0 +1,14 @@
+# Tasks: or-flow-merge
+
+- [x] Per-place item buffers in `FlowEngine` (`seedPlaceItems`, `itemsForTransition`,
+      `advanceItems`), seeded from the marking so resume still works.
+- [x] Conditions evaluate against the candidate transition's input place.
+- [x] `MergeNode` — append / mergeByKey / unique.
+- [x] `LoopNode` — fixed-size batching.
+- [x] Register both through the contribution event.
+- [x] Tests: parallel branches isolated, join reads both, merge modes, loop
+      batching. 105 flow tests green.
+- [x] Live-verified on 8080: a split→join flow merges both branches' items;
+      palette lists all seven built-ins.
+- [ ] Sub-flows — needs run-queue wiring (follow-up).
+- [ ] Per-item routing — now possible on the per-place buffers (follow-up).

--- a/tests/Unit/Service/Flow/FlowMergeTest.php
+++ b/tests/Unit/Service/Flow/FlowMergeTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowDefinitionBuilder;
+use OCA\OpenRegister\Service\Flow\FlowEngine;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowStepDispatcher;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Workflow\MarkingStore\MethodMarkingStore;
+
+/** Subject carrying the marking. */
+class MergeSubject
+{
+    public array $marking = [];
+}
+
+/**
+ * Dispatcher that, per step type, stamps a field so a test can see which
+ * branch's items reached the merge. Type `merge` applies MergeNode-append,
+ * `passthrough` returns items unchanged, and `stamp:<field>=<value>` sets a
+ * field on every item.
+ */
+class BranchDispatcher implements FlowStepDispatcher
+{
+    /** @var array<string, array> Items seen per step type. */
+    public array $seen = [];
+
+    public function dispatch(array $step, array $items, array $context): array
+    {
+        $type = (string) ($step['type'] ?? '');
+        $this->seen[$type] = $items;
+
+        if (str_starts_with($type, 'stamp:')) {
+            [$field, $value] = explode('=', substr($type, 6));
+            $out = [];
+            foreach ($items as $i => $item) {
+                $json = (array) ($item['json'] ?? []);
+                $json[$field] = $value;
+                $out[] = FlowItems::item(json: $json, binary: [], fromItemIndex: $i);
+            }
+            return $out;
+        }
+
+        return $items;
+    }
+}
+
+class FlowMergeTest extends TestCase
+{
+    private FlowEngine $engine;
+
+    protected function setUp(): void
+    {
+        $this->engine = new FlowEngine(new FlowDefinitionBuilder(), $this->createMock(LoggerInterface::class));
+    }
+
+    private function walk(array $flow, array $items, FlowStepDispatcher $d): array
+    {
+        return $this->engine->run(
+            flow: $flow,
+            store: new MethodMarkingStore(false, 'marking'),
+            subject: new MergeSubject(),
+            dispatcher: $d,
+            context: [],
+            items: $items
+        );
+    }
+
+    /**
+     * The property the per-place item buffers exist for: two parallel branches
+     * each carry their own items from the split, and the join reads BOTH.
+     */
+    public function testAJoinReadsTheItemsFromEveryBranch(): void
+    {
+        $flow = [
+            'id' => 'split-join',
+            'nodes' => [['id' => 's'], ['id' => 'a'], ['id' => 'b'], ['id' => 'm']],
+            'edges' => [
+                // Split: s fans out to a and b.
+                ['id' => 'split', 'from' => 's', 'to' => ['a', 'b'], 'type' => 'passthrough'],
+                // Each branch stamps a different marker.
+                ['id' => 'ea', 'from' => 'a', 'to' => 'a2', 'type' => 'stamp:branch=A'],
+                ['id' => 'eb', 'from' => 'b', 'to' => 'b2', 'type' => 'stamp:branch=B'],
+                // Join: a2 and b2 converge on the merge.
+                ['id' => 'join', 'from' => ['a2', 'b2'], 'to' => 'm', 'type' => 'merge'],
+            ],
+            'nodes2' => [],
+        ];
+        // a2 and b2 must be declared nodes.
+        $flow['nodes'] = [['id' => 's'], ['id' => 'a'], ['id' => 'b'], ['id' => 'a2'], ['id' => 'b2'], ['id' => 'm']];
+
+        $d = new BranchDispatcher();
+        $this->walk($flow, [FlowItems::item(json: ['n' => 1])], $d);
+
+        // The merge saw both branches' items — one from A, one from B.
+        $branches = array_column(array_column($d->seen['merge'], 'json'), 'branch');
+        sort($branches);
+        $this->assertSame(['A', 'B'], $branches);
+    }
+
+    /**
+     * A parallel branch must NOT see the other branch's items — each carries
+     * its own from the split. This is the bug the single global list had.
+     */
+    public function testParallelBranchesDoNotSeeEachOther(): void
+    {
+        $flow = [
+            'id' => 'parallel',
+            'nodes' => [['id' => 's'], ['id' => 'a'], ['id' => 'b']],
+            'edges' => [
+                ['id' => 'split', 'from' => 's', 'to' => ['a', 'b'], 'type' => 'passthrough'],
+                ['id' => 'ea', 'from' => 'a', 'to' => 'aEnd', 'type' => 'stamp:x=fromA'],
+                ['id' => 'eb', 'from' => 'b', 'to' => 'bEnd', 'type' => 'stamp:x=fromB'],
+            ],
+        ];
+        $flow['nodes'] = [['id' => 's'], ['id' => 'a'], ['id' => 'b'], ['id' => 'aEnd'], ['id' => 'bEnd']];
+
+        $d = new BranchDispatcher();
+        $this->walk($flow, [FlowItems::item(json: ['seed' => true])], $d);
+
+        // Each branch received the seed item (one item), not the other branch's.
+        $this->assertCount(1, $d->seen['stamp:x=fromA']);
+        $this->assertCount(1, $d->seen['stamp:x=fromB']);
+        $this->assertTrue($d->seen['stamp:x=fromA'][0]['json']['seed']);
+        $this->assertTrue($d->seen['stamp:x=fromB'][0]['json']['seed']);
+    }
+}

--- a/tests/Unit/Service/Flow/LoopNodeTest.php
+++ b/tests/Unit/Service/Flow/LoopNodeTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\Nodes\LoopNode;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
+
+class LoopNodeTest extends TestCase
+{
+    private LoopNode $node;
+
+    protected function setUp(): void
+    {
+        $l = $this->createMock(IL10N::class);
+        $l->method('t')->willReturnArgument(0);
+        $this->node = new LoopNode($l, $this->createMock(IURLGenerator::class));
+    }
+
+    private function items(int $count): array
+    {
+        $out = [];
+        for ($i = 0; $i < $count; $i++) {
+            $out[] = FlowItems::item(json: ['n' => $i]);
+        }
+        return $out;
+    }
+
+    public function testItSplitsIntoBatchesOfTheConfiguredSize(): void
+    {
+        $out = $this->node->execute($this->items(7), ['batchSize' => 3], []);
+
+        // 7 items in batches of 3 -> 3 batches (3, 3, 1).
+        $this->assertCount(3, $out);
+        $this->assertSame(3, $out[0]['json']['batchCount']);
+        $this->assertCount(3, $out[0]['json']['items']);
+        $this->assertCount(1, $out[2]['json']['items']);
+        $this->assertSame(0, $out[0]['json']['batchIndex']);
+        $this->assertSame(2, $out[2]['json']['batchIndex']);
+    }
+
+    public function testNoItemsYieldsNoBatches(): void
+    {
+        $this->assertSame([], $this->node->execute([], ['batchSize' => 5], []));
+    }
+
+    public function testANonPositiveBatchSizeIsRefused(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->node->validateConfig(['batchSize' => 0]);
+    }
+
+    public function testItIsAvailableInBothScopes(): void
+    {
+        $this->assertTrue($this->node->isAvailableForScope(IManager::SCOPE_ADMIN));
+        $this->assertTrue($this->node->isAvailableForScope(IManager::SCOPE_USER));
+    }
+}

--- a/tests/Unit/Service/Flow/MergeNodeTest.php
+++ b/tests/Unit/Service/Flow/MergeNodeTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\Nodes\MergeNode;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
+
+class MergeNodeTest extends TestCase
+{
+    private MergeNode $node;
+
+    protected function setUp(): void
+    {
+        $l = $this->createMock(IL10N::class);
+        $l->method('t')->willReturnArgument(0);
+        $this->node = new MergeNode($l, $this->createMock(IURLGenerator::class));
+    }
+
+    private function items(array $records): array
+    {
+        return array_map(static fn (array $r): array => FlowItems::item(json: $r), $records);
+    }
+
+    public function testAppendKeepsEveryItem(): void
+    {
+        $out = $this->node->execute($this->items([['n' => 1], ['n' => 2]]), ['mode' => 'append'], []);
+        $this->assertSame([1, 2], array_column(array_column($out, 'json'), 'n'));
+    }
+
+    public function testMergeByKeyGroupsAndEnriches(): void
+    {
+        $out = $this->node->execute(
+            $this->items([
+                ['id' => 'x', 'a' => 1],
+                ['id' => 'y', 'a' => 9],
+                ['id' => 'x', 'b' => 2],
+            ]),
+            ['mode' => 'mergeByKey', 'key' => 'id'],
+            []
+        );
+
+        $this->assertCount(2, $out);
+        // x's two records merged; the later branch's fields are present.
+        $this->assertSame(['id' => 'x', 'a' => 1, 'b' => 2], $out[0]['json']);
+        $this->assertSame(['id' => 'y', 'a' => 9], $out[1]['json']);
+    }
+
+    public function testUniqueDropsLaterDuplicates(): void
+    {
+        $out = $this->node->execute(
+            $this->items([['id' => 'x', 'v' => 1], ['id' => 'x', 'v' => 2], ['id' => 'y', 'v' => 3]]),
+            ['mode' => 'unique', 'key' => 'id'],
+            []
+        );
+
+        $this->assertCount(2, $out);
+        $this->assertSame(1, $out[0]['json']['v']); // first x kept
+        $this->assertSame('y', $out[1]['json']['id']);
+    }
+
+    public function testAnUnknownModeIsRefused(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->node->validateConfig(['mode' => 'sideways']);
+    }
+
+    public function testAKeyedModeWithoutAKeyIsRefused(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->node->validateConfig(['mode' => 'mergeByKey']);
+    }
+}


### PR DESCRIPTION
# Proposal: or-flow-merge

## Summary

Make the item data channel per-place, so parallel branches carry their own
items and a join can combine them. Adds a Merge node and a Loop (batch) node.

## Why

The engine threaded a single global `$items` list — whatever the last step
produced. That was subtly wrong for parallel branches: after a split, the
second branch to run read the FIRST branch's output, not the items from the
split point. And a join had no way to see both branches' items at all.

## What Changes

- **Per-place item buffers in the engine.** Items belong to the PLACES a token
  sits on, not to the run globally. A split hands each branch the items from the
  split point; a join reads the concatenation of every incoming branch's items.
  Seeded from the current marking, so suspend/resume still lands the stored
  items on the place that holds the token. Moved in lock-step with the marking:
  the token and the items advance together, and consumed inputs are cleared so a
  loop re-reads fresh.

  A condition now evaluates against the items on ITS candidate transition's
  input place — the data that branch would actually carry — rather than one
  global list.

- **`MergeNode`.** Sits at a join. The Petri net already holds the transition
  until every input place is marked (wait-for-all is free), so the node only
  decides HOW to combine: `append` (keep all), `mergeByKey` (group and
  shallow-merge, later branch wins a field), or `unique` (dedupe on a key).

- **`LoopNode`.** Splits an item list into fixed-size batches, one output item
  per batch. NOT for processing a collection — a node already acts once per
  item — but for a downstream step that must be handed a bounded slice at a
  time (an API page limit, a bulk-write cap).

## Design decisions

- **The Petri net does the join timing.** wait-for-all is the default because a
  join transition is not enabled until all its input places are marked. The
  Merge node never has to wait; it only combines what has already arrived.
- **`mergeByKey`: later branch wins.** Enrichment as the record flows through —
  the same shape as `SetFields`.
- **Loop is batching, not iteration.** The item model already iterates; a
  separate "for each item" node would be redundant.

## Out of scope (this change)

- **Sub-flows** — calling a flow from a flow. Needs the run queue to suspend the
  parent while the child runs; a follow-up.
- **Per-item routing** — sending each item down a different branch. The
  per-place buffers make this newly possible, but it is its own change.

---

## Verification

105 flow tests green (11 new). The load-bearing ones: parallel branches proven isolated (each gets the seed, not the other's output) and a join proven to read both branches' items. Merge modes (append/mergeByKey/unique) and Loop batching covered. phpcs clean; `run()` complexity held at the development baseline (12) by extracting the seeding and item-advance to helpers.

**Live on 8080:** a split→join flow merges both branches' items; the palette lists all seven built-ins.

Completes the bulk of #2067. Sub-flows (needs run-queue wiring) and per-item routing (now possible on these buffers) are noted as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)