### PR TITLE
feat(flow): close the trigger loop — events queue runs, the worker executes (#2068)

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -2383,6 +2383,13 @@ class Application extends App implements IBootstrap
         $context->registerEventListener(ObjectCreatedEvent::class, ObjectChangeListener::class);
         $context->registerEventListener(ObjectUpdatedEvent::class, ObjectChangeListener::class);
 
+        // Object-lifecycle flow triggers: queue a run for every flow wired to
+        // create / update / delete. The first Nextcloud-native trigger; others
+        // register the same way.
+        $context->registerEventListener(ObjectCreatedEvent::class, \OCA\OpenRegister\Listener\FlowTriggerListener::class);
+        $context->registerEventListener(ObjectUpdatedEvent::class, \OCA\OpenRegister\Listener\FlowTriggerListener::class);
+        $context->registerEventListener(ObjectDeletedEvent::class, \OCA\OpenRegister\Listener\FlowTriggerListener::class);
+
         // ToolRegistrationListener for agent function tools.
         $context->registerEventListener(ToolRegistrationEvent::class, ToolRegistrationListener::class);
 

--- a/lib/Cron/FlowRunWorker.php
+++ b/lib/Cron/FlowRunWorker.php
@@ -69,16 +69,18 @@ class FlowRunWorker extends TimedJob
     /**
      * Constructor.
      *
-     * @param ITimeFactory    $time      Job scheduling clock.
-     * @param FlowRunMapper   $mapper    Reads and prunes runs.
-     * @param FlowRunService  $runner    Executes a run.
-     * @param IAppConfig      $appConfig Reads the retention setting.
-     * @param LoggerInterface $logger    The logger.
+     * @param ITimeFactory         $time      Job scheduling clock.
+     * @param FlowRunMapper        $mapper    Reads and prunes runs.
+     * @param FlowRunService       $runner    Executes a run.
+     * @param FlowResolverRegistry $resolvers Loads a run's flow and subject.
+     * @param IAppConfig           $appConfig Reads the retention setting.
+     * @param LoggerInterface      $logger    The logger.
      */
     public function __construct(
         ITimeFactory $time,
         private readonly FlowRunMapper $mapper,
         private readonly FlowRunService $runner,
+        private readonly \OCA\OpenRegister\Service\Flow\FlowResolverRegistry $resolvers,
         private readonly IAppConfig $appConfig,
         private readonly LoggerInterface $logger
     ) {
@@ -128,14 +130,43 @@ class FlowRunWorker extends TimedJob
     private function advance(FlowRun $run): void
     {
         try {
-            // TODO(#2067): resolve the flow document and the subject object.
-            // Both arrive with the flow-document store; until then a claimed
-            // run is left for the next pass rather than being failed, so no
-            // run is lost between these two changes landing.
-            $this->logger->debug(
-                message: '[FlowRunWorker] Run awaiting the flow-document store',
-                context: ['file' => __FILE__, 'line' => __LINE__, 'run' => $run->getUuid()]
-            );
+            $flow = $this->resolvers->resolveFlow((string) $run->getFlowId());
+            if ($flow === null) {
+                // No installed app owns this flow — it was deleted, or the app
+                // that stored it was removed. The run cannot proceed; fail it
+                // with a clear reason rather than leaving it queued forever.
+                $run->setStatus(FlowRun::STATUS_FAILED);
+                $run->setError(sprintf('No app provides flow "%s" (deleted, or its app removed?).', $run->getFlowId()));
+                $this->mapper->update($run);
+                return;
+            }
+
+            // A run may legitimately have no subject (a manual or webhook run
+            // seeded from its payload). Only resolve one when the run names it.
+            $subject = null;
+            if (trim((string) $run->getSubjectUuid()) !== '') {
+                $subject = $this->resolvers->resolveSubject(
+                    (string) $run->getSubjectUuid(),
+                    (string) $run->getSubjectRegister(),
+                    (string) $run->getSubjectSchema()
+                );
+
+                if ($subject === null) {
+                    $run->setStatus(FlowRun::STATUS_FAILED);
+                    $run->setError(sprintf('Subject "%s" no longer exists.', $run->getSubjectUuid()));
+                    $this->mapper->update($run);
+                    return;
+                }
+            }
+
+            // A subjectless run still needs an object to carry the marking; a
+            // bare holder does, since the marking store keeps the marking on the
+            // run itself ({@see FlowRunMarkingStore}).
+            if ($subject === null) {
+                $subject = new \stdClass();
+            }
+
+            $this->runner->execute(run: $run, flow: $flow, subject: $subject);
         } catch (Throwable $e) {
             $this->logger->error(
                 message: '[FlowRunWorker] Failed to advance a run',

--- a/lib/Listener/FlowTriggerListener.php
+++ b/lib/Listener/FlowTriggerListener.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * Fires object-lifecycle triggers into the flow engine.
+ *
+ * The first Nextcloud-native trigger: when an OpenRegister object is created,
+ * updated or deleted, this hands the event to {@see FlowTriggerService}, which
+ * queues a run for every flow wired to it. Other native triggers (files,
+ * shares, calendar, users, tags) will register the same way — a small listener
+ * that translates a core event into a `FlowTriggerService::fire()` call — so the
+ * mechanism is here once and each new trigger is a few lines.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Listener
+ * @package  OCA\OpenRegister\Listener
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Listener;
+
+use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCA\OpenRegister\Event\ObjectDeletedEvent;
+use OCA\OpenRegister\Event\ObjectUpdatedEvent;
+use OCA\OpenRegister\Service\Flow\FlowTriggerService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IUserSession;
+
+/**
+ * Queues flow runs on object create / update / delete.
+ *
+ * @template-implements IEventListener<ObjectCreatedEvent|ObjectUpdatedEvent|ObjectDeletedEvent>
+ */
+class FlowTriggerListener implements IEventListener
+{
+    /**
+     * Constructor.
+     *
+     * @param FlowTriggerService $triggers    Queues the runs.
+     * @param IUserSession       $userSession The acting user, for attribution.
+     */
+    public function __construct(
+        private readonly FlowTriggerService $triggers,
+        private readonly IUserSession $userSession
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Translate an object event into a trigger.
+     *
+     * @param Event $event The dispatched event.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
+     */
+    public function handle(Event $event): void
+    {
+        $eventId = $this->eventIdFor(event: $event);
+        if ($eventId === null) {
+            return;
+        }
+
+        $object = $event->getObject();
+        $user   = null;
+        if ($this->userSession->getUser() !== null) {
+            $user = $this->userSession->getUser()->getUID();
+        }
+
+        $this->triggers->fire(
+            event: $eventId,
+            subject: [
+                'uuid'     => (string) $object->getUuid(),
+                'register' => (string) $object->getRegister(),
+                'schema'   => (string) $object->getSchema(),
+            ],
+            user: $user
+        );
+
+    }//end handle()
+
+    /**
+     * Map an event class to the trigger id flows are wired to.
+     *
+     * @param Event $event The dispatched event.
+     *
+     * @return string|null The trigger id, or null when this is not an object event.
+     *
+     * @spec openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
+     */
+    private function eventIdFor(Event $event): ?string
+    {
+        if ($event instanceof ObjectCreatedEvent) {
+            return 'object.created';
+        }
+
+        if ($event instanceof ObjectUpdatedEvent) {
+            return 'object.updated';
+        }
+
+        if ($event instanceof ObjectDeletedEvent) {
+            return 'object.deleted';
+        }
+
+        return null;
+
+    }//end eventIdFor()
+}//end class

--- a/lib/Service/Flow/FlowResolverRegistry.php
+++ b/lib/Service/Flow/FlowResolverRegistry.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * Holds the flow resolvers apps contributed, and asks each in turn.
+ *
+ * A flow id or a subject may be owned by any installed app, so resolution is
+ * "ask every resolver until one answers". The first non-null wins. A run whose
+ * flow no resolver owns cannot proceed — the worker records that, it does not
+ * crash.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use OCP\EventDispatcher\IEventDispatcher;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Resolves a flow and a subject by asking every contributed resolver.
+ */
+class FlowResolverRegistry
+{
+
+    /**
+     * Collected resolvers, or null before the first lookup.
+     *
+     * @var array<int, IFlowResolver>|null
+     */
+    private ?array $resolvers = null;
+
+    /**
+     * Constructor.
+     *
+     * @param IEventDispatcher $dispatcher Dispatches the contribution event.
+     * @param LoggerInterface  $logger     The logger.
+     */
+    public function __construct(
+        private readonly IEventDispatcher $dispatcher,
+        private readonly LoggerInterface $logger
+    ) {
+
+    }//end __construct()
+
+    /**
+     * The flow document for an id, or null when no app owns it.
+     *
+     * @param string $flowId The flow id.
+     *
+     * @return array|null The flow document.
+     *
+     * @spec openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
+     */
+    public function resolveFlow(string $flowId): ?array
+    {
+        foreach ($this->all() as $resolver) {
+            try {
+                $flow = $resolver->resolveFlow($flowId);
+                if ($flow !== null) {
+                    return $flow;
+                }
+            } catch (\Throwable $e) {
+                $this->logger->warning(
+                    message: '[FlowResolverRegistry] A resolver threw resolving a flow: '.$e->getMessage(),
+                    context: ['file' => __FILE__, 'line' => __LINE__, 'flow' => $flowId]
+                );
+            }//end try
+        }
+
+        return null;
+
+    }//end resolveFlow()
+
+    /**
+     * The subject for a uuid/register/schema, or null when it cannot be found.
+     *
+     * @param string $uuid     The subject uuid.
+     * @param string $register The register slug.
+     * @param string $schema   The schema slug.
+     *
+     * @return object|null The subject.
+     *
+     * @spec openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
+     */
+    public function resolveSubject(string $uuid, string $register, string $schema): ?object
+    {
+        foreach ($this->all() as $resolver) {
+            try {
+                $subject = $resolver->resolveSubject($uuid, $register, $schema);
+                if ($subject !== null) {
+                    return $subject;
+                }
+            } catch (\Throwable $e) {
+                $this->logger->warning(
+                    message: '[FlowResolverRegistry] A resolver threw resolving a subject: '.$e->getMessage(),
+                    context: ['file' => __FILE__, 'line' => __LINE__, 'uuid' => $uuid]
+                );
+            }//end try
+        }
+
+        return null;
+
+    }//end resolveSubject()
+
+    /**
+     * The ids of every flow that should run for an event, across all resolvers.
+     *
+     * @param string $event    The event id.
+     * @param string $register The register slug.
+     * @param string $schema   The schema slug.
+     *
+     * @return array<int, string> Flow ids, de-duplicated.
+     *
+     * @spec openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
+     */
+    public function flowsForTrigger(string $event, string $register, string $schema): array
+    {
+        $ids = [];
+        foreach ($this->all() as $resolver) {
+            try {
+                foreach ($resolver->flowsForTrigger($event, $register, $schema) as $id) {
+                    $ids[(string) $id] = true;
+                }
+            } catch (\Throwable $e) {
+                $this->logger->warning(
+                    message: '[FlowResolverRegistry] A resolver threw listing triggered flows: '.$e->getMessage(),
+                    context: ['file' => __FILE__, 'line' => __LINE__, 'event' => $event]
+                );
+            }//end try
+        }
+
+        return array_keys($ids);
+
+    }//end flowsForTrigger()
+
+    /**
+     * Collect the contributed resolvers once per request.
+     *
+     * @return array<int, IFlowResolver> The resolvers.
+     *
+     * @spec openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
+     */
+    private function all(): array
+    {
+        if ($this->resolvers !== null) {
+            return $this->resolvers;
+        }
+
+        $event = new RegisterFlowResolversEvent();
+        $this->dispatcher->dispatchTyped($event);
+        $this->resolvers = $event->getResolvers();
+
+        return $this->resolvers;
+
+    }//end all()
+}//end class

--- a/lib/Service/Flow/FlowTriggerService.php
+++ b/lib/Service/Flow/FlowTriggerService.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * Turns a Nextcloud event into queued flow runs.
+ *
+ * This is the trigger side of the engine. When something happens — an object is
+ * created, a file changes, a share is declined — this service asks every
+ * resolver which of its flows are wired to that event, and queues a run for
+ * each. It does NOT execute them: a trigger fires inside the dispatch of the
+ * thing that caused it (often a user's save), and an arbitrary graph must not
+ * sit on that critical path. The FlowRunWorker executes the queue off-request.
+ *
+ * A Nextcloud-native trigger is the differentiator the whole programme rests
+ * on: an external automation tool sees Nextcloud over WebDAV and a generic
+ * connector; a flow triggered by a *share being declined*, with the sharee's
+ * identity and the instance's RBAC already resolved, is not something that tool
+ * can reproduce.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Queues a flow run for every flow wired to a fired event.
+ */
+class FlowTriggerService
+{
+    /**
+     * Constructor.
+     *
+     * @param FlowResolverRegistry $resolvers Finds flows wired to an event.
+     * @param FlowRunService       $runner    Queues the runs.
+     * @param LoggerInterface      $logger    The logger.
+     */
+    public function __construct(
+        private readonly FlowResolverRegistry $resolvers,
+        private readonly FlowRunService $runner,
+        private readonly LoggerInterface $logger
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Fire an event: queue a run for every flow wired to it.
+     *
+     * Never throws into the caller. A trigger runs inside the dispatch of a user
+     * action (a save, a share change); a failure to queue must not break that
+     * action, so it is logged and swallowed.
+     *
+     * @param string      $event   The event id (e.g. `object.created`).
+     * @param array       $subject `{uuid, register, schema}` of the object, when there is one.
+     * @param string|null $user    The user whose action fired the event.
+     * @param array       $context Extra run-level metadata (the event payload, say).
+     *
+     * @return int The number of runs queued.
+     *
+     * @spec openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
+     */
+    public function fire(string $event, array $subject=[], ?string $user=null, array $context=[]): int
+    {
+        try {
+            $register = (string) ($subject['register'] ?? '');
+            $schema   = (string) ($subject['schema'] ?? '');
+            $flowIds  = $this->resolvers->flowsForTrigger($event, $register, $schema);
+            if ($flowIds === []) {
+                return 0;
+            }
+
+            $queued = 0;
+            foreach ($flowIds as $flowId) {
+                $this->runner->queue(
+                    flowId: $flowId,
+                    subject: $subject,
+                    trigger: $event,
+                    context: $context,
+                    user: $user
+                );
+                $queued++;
+            }
+
+            $this->logger->debug(
+                message: '[FlowTriggerService] Queued flow runs for an event',
+                context: ['file' => __FILE__, 'line' => __LINE__, 'event' => $event, 'queued' => $queued]
+            );
+
+            return $queued;
+        } catch (Throwable $e) {
+            $this->logger->error(
+                message: '[FlowTriggerService] Failed to queue flow runs for an event: '.$e->getMessage(),
+                context: ['file' => __FILE__, 'line' => __LINE__, 'event' => $event]
+            );
+
+            return 0;
+        }//end try
+
+    }//end fire()
+}//end class

--- a/lib/Service/Flow/IFlowResolver.php
+++ b/lib/Service/Flow/IFlowResolver.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Resolves the two things a queued run needs before it can execute: the flow
+ * document, and the object the run is about.
+ *
+ * The engine deliberately does not know where flows are stored. hermiq keeps
+ * them as `agentflow` objects; a future app might keep them elsewhere; the
+ * worker must not care. So an app that owns flows contributes a resolver —
+ * discovered the same way node types and MCP providers are, through a
+ * registration event — and the worker asks it.
+ *
+ * Returning null for either is not an error the run should crash on: a flow
+ * that was deleted, or a subject that no longer exists, means the run cannot
+ * proceed and should be recorded as such, not throw the worker's whole batch.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+/**
+ * Contract for loading a flow document and its subject.
+ */
+interface IFlowResolver
+{
+    /**
+     * Load a flow document by its id.
+     *
+     * @param string $flowId The flow's id.
+     *
+     * @return array|null The flow document (`{id, nodes, edges, ...}`), or null
+     *                    when this resolver does not own that flow.
+     *
+     * @spec openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
+     */
+    public function resolveFlow(string $flowId): ?array;
+
+    /**
+     * Load the object a run walks against.
+     *
+     * @param string $uuid     The subject object's uuid.
+     * @param string $register The register slug.
+     * @param string $schema   The schema slug.
+     *
+     * @return object|null The subject (carries the marking + is seeded into the
+     *                     item list), or null when it cannot be found.
+     *
+     * @spec openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
+     */
+    public function resolveSubject(string $uuid, string $register, string $schema): ?object;
+
+    /**
+     * Which of this resolver's flows should run for an event.
+     *
+     * Called by the trigger side: when an object event fires, every resolver is
+     * asked which of its enabled flows are wired to that event on that
+     * register/schema, and a run is queued for each. A resolver that owns no
+     * matching flow returns an empty array.
+     *
+     * @param string $event    The event id (e.g. `object.created`).
+     * @param string $register The register slug the event fired on.
+     * @param string $schema   The schema slug the event fired on.
+     *
+     * @return array<int, string> The ids of the flows to run.
+     *
+     * @spec openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
+     */
+    public function flowsForTrigger(string $event, string $register, string $schema): array;
+}//end interface

--- a/lib/Service/Flow/RegisterFlowResolversEvent.php
+++ b/lib/Service/Flow/RegisterFlowResolversEvent.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Dispatched so apps can contribute a flow resolver.
+ *
+ * The same registration-event pattern the node registry and the MCP discovery
+ * use, and the same one core's workflow engine uses for operations. An app that
+ * stores flows (hermiq, with its `agentflow` objects) registers a resolver so
+ * the worker can load and run them.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * Carries the resolvers apps contribute.
+ */
+class RegisterFlowResolversEvent extends Event
+{
+
+    /**
+     * Contributed resolvers.
+     *
+     * @var array<int, IFlowResolver>
+     */
+    private array $resolvers = [];
+
+    /**
+     * Contribute a resolver.
+     *
+     * @param IFlowResolver $resolver The resolver.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
+     */
+    public function registerResolver(IFlowResolver $resolver): void
+    {
+        $this->resolvers[] = $resolver;
+
+    }//end registerResolver()
+
+    /**
+     * Every contributed resolver.
+     *
+     * @return array<int, IFlowResolver> The resolvers.
+     *
+     * @spec openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
+     */
+    public function getResolvers(): array
+    {
+        return $this->resolvers;
+
+    }//end getResolvers()
+}//end class

--- a/openspec/changes/or-flow-triggers/.openspec.yaml
+++ b/openspec/changes/or-flow-triggers/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-triggers

--- a/openspec/changes/or-flow-triggers/proposal.md
+++ b/openspec/changes/or-flow-triggers/proposal.md
@@ -1,0 +1,52 @@
+# Proposal: or-flow-triggers
+
+## Summary
+
+Close the loop: a Nextcloud event queues a flow run, and the worker actually
+executes it. Adds the first native trigger (object create / update / delete).
+
+## Why
+
+Everything was in place except the two ends. The run queue existed but the
+worker could not execute a run — it had a TODO where the flow document and
+subject should be resolved. And nothing turned a Nextcloud event into a run.
+
+A Nextcloud-native trigger is the differentiator the whole programme rests on:
+an external automation tool sees Nextcloud over WebDAV through a generic
+connector; a flow triggered by a *share being declined*, with the sharee's
+identity and RBAC already resolved, is not something that tool can reproduce.
+
+## What Changes
+
+- **`IFlowResolver` + `RegisterFlowResolversEvent` + `FlowResolverRegistry`.**
+  The engine does not know where flows are stored — hermiq keeps them as
+  `agentflow` objects, another app might keep them elsewhere. An app that owns
+  flows contributes a resolver, discovered the same way node types and MCP
+  providers are. The registry asks each in turn: first non-null wins. This is
+  also exactly what hermiq#35 needs to plug its store in.
+
+- **The worker executes.** `FlowRunWorker::advance()` now resolves the flow and
+  subject and runs it. A flow no resolver owns (deleted, its app removed) fails
+  the run with a clear reason rather than looping forever; a subject that no
+  longer exists fails likewise; a subjectless run (manual/webhook) still gets a
+  marking carrier.
+
+- **`FlowTriggerService`.** Turns an event into queued runs: asks every resolver
+  which of its flows are wired to that event, queues one run each. It does NOT
+  execute — a trigger fires inside the dispatch of the user action that caused
+  it, and a graph must not sit on that critical path. Never throws into the
+  caller: a failure to queue must not break the save that fired it.
+
+- **`FlowTriggerListener`** wires object create / update / delete to the trigger
+  service. The first native trigger; files, shares, calendar, users and tags
+  register the same way — a small listener translating a core event into a
+  `fire()` call.
+
+## Out of scope (this change)
+
+- **The other native triggers** — file, share, calendar, user/group, tag,
+  schedule, webhook, manual. The machinery is here; each is a listener plus a
+  `fire()` call, a follow-up per trigger.
+- **A built-in flow store in OpenRegister.** Flows are resolved through the
+  contributed resolver; hermiq provides one for its agentflows (hermiq#35). OR
+  owning a flow schema of its own is a separate decision.

--- a/openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
+++ b/openspec/changes/or-flow-triggers/specs/flow-triggers/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Flows and subjects are resolved through contributed resolvers (REQ-FT-001)
+
+The engine SHALL NOT hard-code where flows are stored. An app that owns flows
+SHALL contribute an `IFlowResolver` through `RegisterFlowResolversEvent`. The
+registry SHALL ask each resolver in turn and take the first non-null answer.
+
+A resolver that throws SHALL NOT stop the others from being asked.
+
+#### Scenario: A flow resolves from its owning resolver
+
+- **GIVEN** two resolvers, each owning a different flow
+- **WHEN** a flow id is resolved
+- **THEN** the owning resolver's document is returned, and an unknown id is null
+
+#### Scenario: A throwing resolver does not block the rest
+
+- **GIVEN** a resolver that throws and one that answers
+- **WHEN** flows are listed for an event
+- **THEN** the answering resolver's flows are still returned
+
+### Requirement: The worker executes a queued run (REQ-FT-002)
+
+`FlowRunWorker` SHALL resolve a run's flow and subject and execute it. A flow no
+resolver owns SHALL fail the run with a clear reason, not loop; a named subject
+that no longer exists SHALL fail it likewise; a run with no subject SHALL still
+receive a marking carrier so it can execute.
+
+### Requirement: An event queues a run for every wired flow (REQ-FT-003)
+
+`FlowTriggerService::fire()` SHALL ask every resolver which flows are wired to
+the event on the given register/schema, and queue one run each. It SHALL NOT
+execute them — a trigger fires inside the dispatch of the action that caused it.
+
+It SHALL NOT throw into the caller: a failure to queue must not break the user
+action that fired the event.
+
+Flow ids SHALL be de-duplicated across resolvers.
+
+#### Scenario: Firing queues one run per wired flow
+
+- **GIVEN** two flows wired to `object.created` on a register/schema
+- **WHEN** the event fires
+- **THEN** two runs are queued, none executed inline
+
+#### Scenario: A queue failure is swallowed
+
+- **GIVEN** queueing throws
+- **WHEN** the event fires
+- **THEN** no exception escapes and zero runs are reported
+
+### Requirement: Object lifecycle is a native trigger (REQ-FT-004)
+
+Object create, update and delete SHALL fire `object.created`, `object.updated`
+and `object.deleted` triggers carrying the object's uuid, register and schema,
+attributed to the acting user.
+
+@e2e exclude trigger wiring is backend-only — covered by PHPUnit and a live
+queue-to-execute check

--- a/openspec/changes/or-flow-triggers/tasks.md
+++ b/openspec/changes/or-flow-triggers/tasks.md
@@ -1,0 +1,17 @@
+# Tasks: or-flow-triggers
+
+- [x] `IFlowResolver` + `RegisterFlowResolversEvent` + `FlowResolverRegistry`
+      (ask-each, first-wins, throwing-resolver-tolerant, id de-dup).
+- [x] `FlowRunWorker::advance()` resolves flow + subject and executes; clear
+      failure for a missing flow or subject; marking carrier for a subjectless run.
+- [x] `FlowTriggerService::fire()` — queue per wired flow, never throw into the
+      caller.
+- [x] `FlowTriggerListener` — object create/update/delete, registered in
+      Application.
+- [x] Tests: fire queues per flow, no-wired-flow queues nothing, queue failure
+      swallowed, id de-dup, first-owner resolution, throwing resolver tolerated.
+- [x] Live-verified on 8080: fire -> queued (persisted) -> resolved -> executed
+      -> completed with the flow's field on the output items.
+- [ ] File / share / calendar / user / tag / schedule / webhook / manual
+      triggers (each a listener + a fire() call).
+- [ ] A resolver for OpenRegister's own flows, if OR gains a flow schema.

--- a/tests/Unit/Service/Flow/FlowTriggerServiceTest.php
+++ b/tests/Unit/Service/Flow/FlowTriggerServiceTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Service\Flow\FlowResolverRegistry;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
+use OCA\OpenRegister\Service\Flow\FlowTriggerService;
+use OCA\OpenRegister\Service\Flow\IFlowResolver;
+use OCA\OpenRegister\Service\Flow\RegisterFlowResolversEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/** A resolver over an in-memory map of flows and their triggers. */
+class ArrayResolver implements IFlowResolver
+{
+    /**
+     * @param array<string, array>              $flows    flowId => document
+     * @param array<string, array<int, string>> $triggers "event|register|schema" => flowIds
+     */
+    public function __construct(
+        private array $flows = [],
+        private array $triggers = []
+    ) {
+    }
+
+    public function resolveFlow(string $flowId): ?array
+    {
+        return $this->flows[$flowId] ?? null;
+    }
+
+    public function resolveSubject(string $uuid, string $register, string $schema): ?object
+    {
+        return null;
+    }
+
+    public function flowsForTrigger(string $event, string $register, string $schema): array
+    {
+        return $this->triggers[$event.'|'.$register.'|'.$schema] ?? [];
+    }
+}
+
+class FlowTriggerServiceTest extends TestCase
+{
+    private function registryWith(IFlowResolver ...$resolvers): FlowResolverRegistry
+    {
+        $dispatcher = $this->createMock(IEventDispatcher::class);
+        $dispatcher->method('dispatchTyped')->willReturnCallback(
+            static function (Event $event) use ($resolvers): void {
+                if ($event instanceof RegisterFlowResolversEvent) {
+                    foreach ($resolvers as $r) {
+                        $event->registerResolver($r);
+                    }
+                }
+            }
+        );
+
+        return new FlowResolverRegistry($dispatcher, new \Psr\Log\NullLogger());
+    }
+
+    public function testFiringQueuesARunForEveryWiredFlow(): void
+    {
+        $resolver = new ArrayResolver(
+            flows: ['f1' => ['id' => 'f1'], 'f2' => ['id' => 'f2']],
+            triggers: ['object.created|hermiq|agent' => ['f1', 'f2']]
+        );
+        $registry = $this->registryWith($resolver);
+
+        $mapper = $this->createMock(FlowRunMapper::class);
+        $mapper->method('insert')->willReturnArgument(0);
+        $queued = [];
+        $mapper->method('insert')->willReturnCallback(function (FlowRun $r) use (&$queued) {
+            $queued[] = $r->getFlowId();
+            return $r;
+        });
+
+        $runner = new FlowRunService(
+            $mapper,
+            $this->createMock(\OCA\OpenRegister\Service\Flow\FlowEngine::class),
+            $this->createMock(\OCA\OpenRegister\Service\Flow\FlowNodeRegistry::class),
+            new \Psr\Log\NullLogger()
+        );
+
+        $service = new FlowTriggerService($registry, $runner, new \Psr\Log\NullLogger());
+
+        $count = $service->fire(
+            event: 'object.created',
+            subject: ['uuid' => 'u1', 'register' => 'hermiq', 'schema' => 'agent'],
+            user: 'alice'
+        );
+
+        $this->assertSame(2, $count);
+        $this->assertSame(['f1', 'f2'], $queued);
+    }
+
+    public function testAnEventWithNoWiredFlowQueuesNothing(): void
+    {
+        $registry = $this->registryWith(new ArrayResolver());
+        $runner = $this->createMock(FlowRunService::class);
+        $runner->expects($this->never())->method('queue');
+
+        $service = new FlowTriggerService($registry, $runner, new \Psr\Log\NullLogger());
+
+        $this->assertSame(0, $service->fire(event: 'object.created', subject: ['register' => 'x', 'schema' => 'y']));
+    }
+
+    /**
+     * A trigger runs inside a user's save; a failure to queue must be swallowed,
+     * never thrown into that action.
+     */
+    public function testAQueueFailureIsSwallowed(): void
+    {
+        $registry = $this->registryWith(
+            new ArrayResolver(triggers: ['object.created||' => ['f1']])
+        );
+        $runner = $this->createMock(FlowRunService::class);
+        $runner->method('queue')->willThrowException(new \RuntimeException('db down'));
+
+        $service = new FlowTriggerService($registry, $runner, new \Psr\Log\NullLogger());
+
+        // No exception escapes; returns 0.
+        $this->assertSame(0, $service->fire(event: 'object.created'));
+    }
+
+    public function testTheRegistryDedupesFlowIdsAcrossResolvers(): void
+    {
+        $a = new ArrayResolver(triggers: ['e||' => ['shared', 'onlyA']]);
+        $b = new ArrayResolver(triggers: ['e||' => ['shared', 'onlyB']]);
+        $registry = $this->registryWith($a, $b);
+
+        $ids = $registry->flowsForTrigger('e', '', '');
+        sort($ids);
+        $this->assertSame(['onlyA', 'onlyB', 'shared'], $ids);
+    }
+
+    public function testTheRegistryResolvesAFlowFromTheFirstOwningResolver(): void
+    {
+        $a = new ArrayResolver(flows: ['x' => ['id' => 'x', 'owner' => 'A']]);
+        $b = new ArrayResolver(flows: ['y' => ['id' => 'y', 'owner' => 'B']]);
+        $registry = $this->registryWith($a, $b);
+
+        $this->assertSame('A', $registry->resolveFlow('x')['owner']);
+        $this->assertSame('B', $registry->resolveFlow('y')['owner']);
+        $this->assertNull($registry->resolveFlow('missing'));
+    }
+
+    /**
+     * One resolver throwing must not stop the others from being asked.
+     */
+    public function testAThrowingResolverDoesNotBlockTheRest(): void
+    {
+        $bad = $this->createMock(IFlowResolver::class);
+        $bad->method('flowsForTrigger')->willThrowException(new \RuntimeException('boom'));
+        $good = new ArrayResolver(triggers: ['e||' => ['f1']]);
+
+        $registry = $this->registryWith($bad, $good);
+
+        $this->assertSame(['f1'], $registry->flowsForTrigger('e', '', ''));
+    }
+}


### PR DESCRIPTION
# Proposal: or-flow-triggers

## Summary

Close the loop: a Nextcloud event queues a flow run, and the worker actually
executes it. Adds the first native trigger (object create / update / delete).

## Why

Everything was in place except the two ends. The run queue existed but the
worker could not execute a run — it had a TODO where the flow document and
subject should be resolved. And nothing turned a Nextcloud event into a run.

A Nextcloud-native trigger is the differentiator the whole programme rests on:
an external automation tool sees Nextcloud over WebDAV through a generic
connector; a flow triggered by a *share being declined*, with the sharee's
identity and RBAC already resolved, is not something that tool can reproduce.

## What Changes

- **`IFlowResolver` + `RegisterFlowResolversEvent` + `FlowResolverRegistry`.**
  The engine does not know where flows are stored — hermiq keeps them as
  `agentflow` objects, another app might keep them elsewhere. An app that owns
  flows contributes a resolver, discovered the same way node types and MCP
  providers are. The registry asks each in turn: first non-null wins. This is
  also exactly what hermiq#35 needs to plug its store in.

- **The worker executes.** `FlowRunWorker::advance()` now resolves the flow and
  subject and runs it. A flow no resolver owns (deleted, its app removed) fails
  the run with a clear reason rather than looping forever; a subject that no
  longer exists fails likewise; a subjectless run (manual/webhook) still gets a
  marking carrier.

- **`FlowTriggerService`.** Turns an event into queued runs: asks every resolver
  which of its flows are wired to that event, queues one run each. It does NOT
  execute — a trigger fires inside the dispatch of the user action that caused
  it, and a graph must not sit on that critical path. Never throws into the
  caller: a failure to queue must not break the save that fired it.

- **`FlowTriggerListener`** wires object create / update / delete to the trigger
  service. The first native trigger; files, shares, calendar, users and tags
  register the same way — a small listener translating a core event into a
  `fire()` call.

## Out of scope (this change)

- **The other native triggers** — file, share, calendar, user/group, tag,
  schedule, webhook, manual. The machinery is here; each is a listener plus a
  `fire()` call, a follow-up per trigger.
- **A built-in flow store in OpenRegister.** Flows are resolved through the
  contributed resolver; hermiq provides one for its agentflows (hermiq#35). OR
  owning a flow schema of its own is a separate decision.

---

## Verification

100 flow tests green (6 new): fire queues per wired flow, no-wired-flow queues nothing, a queue failure is swallowed (a trigger runs inside a user's save), flow-id de-dup across resolvers, first-owner resolution, and a throwing resolver tolerated.

**Live on 8080, full loop against the real DB:** `fire()` → run queued and persisted → resolved via a contributed resolver → executed by the worker path → `completed`, with the flow's field on the output items.

First native trigger (object create/update/delete). The rest — file, share, calendar, user, tag, schedule, webhook, manual — are each a listener plus a `fire()` call now that the machinery exists. The resolver interface is also what hermiq#35 plugs into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)