### PR TITLE
feat(flow): run history and retry (#2070)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1234,5 +1234,10 @@ return [
 		// NoCSRFRequired attribute is declared in the controller for the create method.
 		['name' => 'gitHubIssues#index', 'url' => '/api/github/issues', 'verb' => 'GET'],
 		['name' => 'gitHubIssues#create', 'url' => '/api/github/issues', 'verb' => 'POST'],
+
+		// Flow-run tooling (or-flow-tooling): history, inspection, retry.
+		['name' => 'flowRun#index', 'url' => '/api/flow-runs', 'verb' => 'GET'],
+		['name' => 'flowRun#show', 'url' => '/api/flow-runs/{uuid}', 'verb' => 'GET', 'requirements' => ['uuid' => '[^/]+']],
+		['name' => 'flowRun#retry', 'url' => '/api/flow-runs/{uuid}/retry', 'verb' => 'POST', 'requirements' => ['uuid' => '[^/]+']],
     ],
 ];

--- a/lib/Controller/FlowRunController.php
+++ b/lib/Controller/FlowRunController.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * Run history and retry — the execution-tooling surface over flow runs.
+ *
+ * A run is persisted with everything a person needs to work with it: its
+ * status, its per-step log, the items it carried, its error. This controller
+ * exposes that — list runs (filter by flow and status), inspect one, retry a
+ * finished one, and requeue a dead-lettered one. It is the answer to "what did
+ * my flow do, and can I run it again".
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-tooling/specs/flow-tooling/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * REST surface for inspecting and retrying flow runs.
+ */
+class FlowRunController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param string         $appName The app id.
+     * @param IRequest       $request The request.
+     * @param FlowRunMapper  $mapper  Reads runs.
+     * @param FlowRunService $runner  Retries and requeues.
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly FlowRunMapper $mapper,
+        private readonly FlowRunService $runner
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+
+    }//end __construct()
+
+    /**
+     * List runs, newest first, optionally filtered by flow and status.
+     *
+     * @return JSONResponse The runs plus the paging window.
+     *
+     * @NoAdminRequired
+     *
+     * @spec openspec/changes/or-flow-tooling/specs/flow-tooling/spec.md
+     */
+    #[NoAdminRequired]
+    public function index(): JSONResponse
+    {
+        $flowId = $this->request->getParam('flowId');
+        $status = $this->request->getParam('status');
+        $limit  = min(200, max(1, (int) $this->request->getParam('limit', 50)));
+        $offset = max(0, (int) $this->request->getParam('offset', 0));
+
+        $flowFilter = null;
+        if ($flowId !== null) {
+            $flowFilter = (string) $flowId;
+        }
+
+        $statusFilter = null;
+        if ($status !== null) {
+            $statusFilter = (string) $status;
+        }
+
+        $runs = $this->mapper->findAllRuns(
+            flowId: $flowFilter,
+            status: $statusFilter,
+            limit: $limit,
+            offset: $offset
+        );
+
+        return new JSONResponse(
+            [
+                'results' => array_map(static fn (FlowRun $r): array => $r->jsonSerialize(), $runs),
+                'limit'   => $limit,
+                'offset'  => $offset,
+            ]
+        );
+
+    }//end index()
+
+    /**
+     * One run in full — its log, items, context and error.
+     *
+     * @param string $uuid The run uuid.
+     *
+     * @return JSONResponse The run, or 404.
+     *
+     * @NoAdminRequired
+     *
+     * @spec openspec/changes/or-flow-tooling/specs/flow-tooling/spec.md
+     */
+    #[NoAdminRequired]
+    public function show(string $uuid): JSONResponse
+    {
+        try {
+            $run = $this->mapper->findByUuid($uuid);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'No such run'], Http::STATUS_NOT_FOUND);
+        }
+
+        return new JSONResponse($run->jsonSerialize());
+
+    }//end show()
+
+    /**
+     * Retry a finished run: queue a fresh one, leave the original untouched.
+     *
+     * @param string $uuid The run uuid.
+     *
+     * @return JSONResponse The new run, or a 4xx when the source cannot be retried.
+     *
+     * @NoAdminRequired
+     *
+     * @spec openspec/changes/or-flow-tooling/specs/flow-tooling/spec.md
+     */
+    #[NoAdminRequired]
+    public function retry(string $uuid): JSONResponse
+    {
+        try {
+            $run = $this->mapper->findByUuid($uuid);
+        } catch (DoesNotExistException $e) {
+            return new JSONResponse(['error' => 'No such run'], Http::STATUS_NOT_FOUND);
+        }
+
+        $new = $this->runner->retry($run);
+        if ($new === null) {
+            // The source is not terminal — queued, running, or suspended. Retry
+            // is for finished runs; the others are already progressing.
+            return new JSONResponse(
+                ['error' => 'Only a finished run can be retried; this one is '.$run->getStatus().'.'],
+                Http::STATUS_CONFLICT
+            );
+        }
+
+        return new JSONResponse($new->jsonSerialize(), Http::STATUS_CREATED);
+
+    }//end retry()
+}//end class

--- a/lib/Service/Flow/FlowRunService.php
+++ b/lib/Service/Flow/FlowRunService.php
@@ -104,6 +104,43 @@ class FlowRunService
     }//end queue()
 
     /**
+     * Queue a fresh run that repeats a finished one.
+     *
+     * Retry NEVER re-executes the old run — that would repeat every side effect
+     * it already performed. It creates a NEW queued run against the same flow,
+     * subject and trigger, so the worker executes it from the start. The
+     * original is left exactly as it ended, as the record of what happened.
+     *
+     * Only a terminal run can be retried: a queued or running one is already on
+     * its way, and a suspended one resumes rather than restarts.
+     *
+     * @param FlowRun $run The run to repeat.
+     *
+     * @return FlowRun|null The new queued run, or null when the source is not terminal.
+     *
+     * @spec openspec/changes/or-flow-tooling/specs/flow-tooling/spec.md
+     */
+    public function retry(FlowRun $run): ?FlowRun
+    {
+        if ($run->isTerminal() === false) {
+            return null;
+        }
+
+        return $this->queue(
+            flowId: (string) $run->getFlowId(),
+            subject: [
+                'uuid'     => $run->getSubjectUuid(),
+                'register' => $run->getSubjectRegister(),
+                'schema'   => $run->getSubjectSchema(),
+            ],
+            trigger: 'retry',
+            context: ($run->getContext() ?? []),
+            user: $run->getTriggeredBy()
+        );
+
+    }//end retry()
+
+    /**
      * Execute (or continue) a run to its next stopping point.
      *
      * Called by the queue worker, never by a trigger. Returns the run in

--- a/openspec/changes/or-flow-tooling/.openspec.yaml
+++ b/openspec/changes/or-flow-tooling/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-tooling

--- a/openspec/changes/or-flow-tooling/proposal.md
+++ b/openspec/changes/or-flow-tooling/proposal.md
@@ -1,0 +1,37 @@
+# Proposal: or-flow-tooling
+
+## Summary
+
+Expose the run history that persistence already stores, and let a finished run
+be retried.
+
+## Why
+
+Runs are persisted with their status, per-step log, items and error — but there
+was no way to see them or act on them. "What did my flow do, and can I run it
+again" is the single most-asked question of any automation system, and the data
+to answer it was already in the table.
+
+## What Changes
+
+- **`FlowRunService::retry()`** — queues a NEW run against the same flow,
+  subject and trigger, leaving the original exactly as it ended. It never
+  re-executes the old run: that would repeat every side effect it performed.
+  Only a terminal run can be retried — a queued or running one is already on its
+  way, a suspended one resumes rather than restarts.
+
+- **`FlowRunController`** — `GET /api/flow-runs` (list, newest first, filter by
+  `flowId` and `status`, paged), `GET /api/flow-runs/{uuid}` (one run in full),
+  `POST /api/flow-runs/{uuid}/retry` (201 with the new run, or 409 when the
+  source is not terminal).
+
+## Out of scope (this change)
+
+- **Pin / mock data** — freezing a step's output while authoring. The single
+  biggest authoring-productivity feature, and its own change: it needs an
+  editor surface and a per-step override the engine reads.
+- **Partial execution** — running up to a step against pinned data. Follows
+  pin/mock.
+- **A dead-letter requeue UI** — the retry endpoint already requeues a
+  dead-lettered run (it is terminal); a dedicated dead-letter queue view is
+  presentation, deferred.

--- a/openspec/changes/or-flow-tooling/specs/flow-tooling/spec.md
+++ b/openspec/changes/or-flow-tooling/specs/flow-tooling/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Run history is listable and inspectable (REQ-FTOOL-001)
+
+`GET /api/flow-runs` SHALL return runs newest first, filterable by `flowId` and
+`status`, paged by `limit` (capped) and `offset`. `GET /api/flow-runs/{uuid}`
+SHALL return one run in full — its status, log, items, context and error — or
+404.
+
+#### Scenario: Listing returns runs newest first
+
+- **GIVEN** stored runs
+- **WHEN** the list is requested
+- **THEN** it returns them with the paging window
+
+#### Scenario: An unknown run is 404
+
+- **GIVEN** a uuid no run has
+- **WHEN** it is requested
+- **THEN** the response is 404
+
+### Requirement: A finished run can be retried (REQ-FTOOL-002)
+
+`POST /api/flow-runs/{uuid}/retry` SHALL queue a NEW run against the same flow,
+subject and trigger, and return it (201). The original SHALL be left exactly as
+it ended. Retry SHALL NOT re-execute the original — that would repeat its side
+effects.
+
+Only a terminal run SHALL be retriable; retrying a queued, running or suspended
+run SHALL be refused (409).
+
+#### Scenario: Retry queues a fresh run
+
+- **GIVEN** a failed run
+- **WHEN** it is retried
+- **THEN** a new queued run against the same flow is returned
+- **AND** the original is still failed
+
+#### Scenario: A non-terminal run cannot be retried
+
+- **GIVEN** a running run
+- **WHEN** retry is requested
+- **THEN** the response is 409
+
+@e2e exclude the run-history API is backend-only — covered by PHPUnit and a
+live list/show/retry check; the history UI is a separate change

--- a/openspec/changes/or-flow-tooling/tasks.md
+++ b/openspec/changes/or-flow-tooling/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: or-flow-tooling
+
+- [x] `FlowRunService::retry()` — new run, original untouched, terminal-only,
+      never re-executes.
+- [x] `FlowRunController` — index / show / retry, with paging and status codes.
+- [x] Routes.
+- [x] Tests: retry queues fresh + original untouched, every terminal status
+      retriable, every non-terminal status refused.
+- [x] Live-verified on 8080: list returns runs, show returns the full log +
+      items, retry 201s a fresh queued run with a distinct uuid.
+- [ ] Pin / mock data (follow-up — needs an editor surface + engine override).
+- [ ] Partial execution (follows pin/mock).

--- a/tests/Unit/Service/Flow/FlowRunRetryTest.php
+++ b/tests/Unit/Service/Flow/FlowRunRetryTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Service\Flow\FlowEngine;
+use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class FlowRunRetryTest extends TestCase
+{
+    private FlowRunMapper $mapper;
+    private FlowRunService $service;
+
+    protected function setUp(): void
+    {
+        $this->mapper = $this->createMock(FlowRunMapper::class);
+        $this->mapper->method('insert')->willReturnArgument(0);
+        $this->mapper->method('update')->willReturnArgument(0);
+
+        $this->service = new FlowRunService(
+            $this->mapper,
+            $this->createMock(FlowEngine::class),
+            $this->createMock(FlowNodeRegistry::class),
+            new NullLogger()
+        );
+    }
+
+    private function terminalRun(): FlowRun
+    {
+        $run = new FlowRun();
+        $run->setUuid('orig-uuid');
+        $run->setFlowId('f1');
+        $run->setStatus(FlowRun::STATUS_FAILED);
+        $run->setSubjectUuid('subj-1');
+        $run->setSubjectRegister('reg');
+        $run->setSubjectSchema('sch');
+        $run->setTriggeredBy('alice');
+        $run->setContext(['runUuid' => 'orig-uuid', 'k' => 'v']);
+        return $run;
+    }
+
+    /**
+     * Retry queues a NEW run — same flow, subject and user — and leaves the
+     * original exactly as it ended.
+     */
+    public function testRetryQueuesAFreshRunAgainstTheSameFlow(): void
+    {
+        $source = $this->terminalRun();
+
+        $new = $this->service->retry($source);
+
+        $this->assertNotNull($new);
+        $this->assertNotSame('orig-uuid', $new->getUuid());
+        $this->assertSame('f1', $new->getFlowId());
+        $this->assertSame('subj-1', $new->getSubjectUuid());
+        $this->assertSame('alice', $new->getTriggeredBy());
+        $this->assertSame(FlowRun::STATUS_QUEUED, $new->getStatus());
+        $this->assertSame('retry', $new->getTrigger());
+
+        // The original is untouched — still failed.
+        $this->assertSame(FlowRun::STATUS_FAILED, $source->getStatus());
+    }
+
+    /** @dataProvider terminalStatuses */
+    public function testEveryTerminalStatusCanBeRetried(string $status): void
+    {
+        $run = $this->terminalRun();
+        $run->setStatus($status);
+
+        $this->assertNotNull($this->service->retry($run));
+    }
+
+    public static function terminalStatuses(): array
+    {
+        return [
+            'completed' => [FlowRun::STATUS_COMPLETED],
+            'stopped' => [FlowRun::STATUS_STOPPED],
+            'dead_letter' => [FlowRun::STATUS_DEAD_LETTER],
+            'failed' => [FlowRun::STATUS_FAILED],
+        ];
+    }
+
+    /** @dataProvider nonTerminalStatuses */
+    public function testANonTerminalRunCannotBeRetried(string $status): void
+    {
+        $run = $this->terminalRun();
+        $run->setStatus($status);
+
+        // Queued/running are already progressing; suspended resumes, not restarts.
+        $this->assertNull($this->service->retry($run));
+    }
+
+    public static function nonTerminalStatuses(): array
+    {
+        return [
+            'queued' => [FlowRun::STATUS_QUEUED],
+            'running' => [FlowRun::STATUS_RUNNING],
+            'suspended' => [FlowRun::STATUS_SUSPENDED],
+        ];
+    }
+}


### PR DESCRIPTION
# Proposal: or-flow-tooling

## Summary

Expose the run history that persistence already stores, and let a finished run
be retried.

## Why

Runs are persisted with their status, per-step log, items and error — but there
was no way to see them or act on them. "What did my flow do, and can I run it
again" is the single most-asked question of any automation system, and the data
to answer it was already in the table.

## What Changes

- **`FlowRunService::retry()`** — queues a NEW run against the same flow,
  subject and trigger, leaving the original exactly as it ended. It never
  re-executes the old run: that would repeat every side effect it performed.
  Only a terminal run can be retried — a queued or running one is already on its
  way, a suspended one resumes rather than restarts.

- **`FlowRunController`** — `GET /api/flow-runs` (list, newest first, filter by
  `flowId` and `status`, paged), `GET /api/flow-runs/{uuid}` (one run in full),
  `POST /api/flow-runs/{uuid}/retry` (201 with the new run, or 409 when the
  source is not terminal).

## Out of scope (this change)

- **Pin / mock data** — freezing a step's output while authoring. The single
  biggest authoring-productivity feature, and its own change: it needs an
  editor surface and a per-step override the engine reads.
- **Partial execution** — running up to a step against pinned data. Follows
  pin/mock.
- **A dead-letter requeue UI** — the retry endpoint already requeues a
  dead-lettered run (it is terminal); a dedicated dead-letter queue view is
  presentation, deferred.

---

## Verification

102 flow tests green (8 new): retry queues a fresh run and leaves the original untouched, every terminal status is retriable, every non-terminal status is refused.

**Live on 8080:** `GET /api/flow-runs` lists the persisted runs; `GET /api/flow-runs/{uuid}` returns the full log and items; `POST .../retry` 201s a fresh queued run (trigger `retry`, distinct uuid) with the original untouched. phpcs clean.

Pin/mock data and partial execution are the remaining #2070 pieces (each needs an editor surface + engine override), deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)