### PR TITLE
feat(integration): cross-app leaf provider registration (ADR-066)

### DIFF
--- a/docs/Integrations/leaf-system.md
+++ b/docs/Integrations/leaf-system.md
@@ -191,6 +191,80 @@ Every leaf renders in up to four surfaces from the same registration. The widget
 
 The registration descriptor can pass surface-specific overrides (`widgetCompact`, `widgetExpanded`, `widgetEntity`); absent overrides fall back to the main `widget`.
 
+## Cross-app leaf registration (sibling apps)
+
+The 18 built-in leaves register inside Open Register's own `boot()`. A **sibling
+Nextcloud app** contributes its own leaf through a typed collect-event —
+`RegisterLeafProvidersEvent` — the same idiom Open Register already uses for MCP
+tool providers and flow nodes (ADR-066). This is the umbrella "apps hook
+themselves into Open Register" seam, and it is **render-and-read only** by
+construction: a leaf can contribute a render surface and/or app-local data, but
+never a command. Cross-app *commands* stay ADR-041 typed events.
+
+A leaf has two faces, correlated by a shared `id`:
+
+- **Server declaration** — a `LeafDescriptor` (id, label, icon, requiredApp,
+  group, surfaces, referenceType, requiresPermission, and a non-empty `kinds`
+  set) plus, when the leaf offers data, an `IntegrationProvider`. The descriptor
+  carries **no** Vue components.
+- **JS registration** — `registerIntegration({ id, tab, widget, … })` from
+  `@conduction/nextcloud-vue`, under the **same id**. The render components live
+  in the app's own bundle.
+
+The `kinds` set names each face independently:
+
+| Kind | Meaning |
+|---|---|
+| `render-surface` | The app mounts a tab + widget under the shared id (JS layer). |
+| `data-provider` | The app serves read/append data via an `IntegrationProvider` on the same registration. |
+| `agent-runner` | Reserved forward-reference (ADR-066); assigned no behaviour here — hermiq's change consumes it. |
+
+### The `app-local` storage strategy
+
+Data leaves declare a new storage strategy — **`app-local`** — alongside the
+existing `magic-column` / `link-table` / `external` / `query-time`. It means the
+data lives in the **contributing app's own store**; Open Register persists none
+of it and simply routes `list()` / optional `create()` to the provider, which
+runs in the sibling app's DI context because the app's listener constructed it
+there.
+
+### Worked example — a notes leaf
+
+```php
+// In the sibling app's Application::register():
+$context->registerEventListener(
+    RegisterLeafProvidersEvent::class,
+    AcmeLeafListener::class,
+);
+
+// AcmeLeafListener::handle():
+$event->registerLeaf(
+    new LeafDescriptor(
+        id: 'acme-notes',
+        label: $this->l10n->t('Notes'),
+        icon: 'NoteText',
+        kinds: [LeafDescriptor::KIND_DATA_PROVIDER, LeafDescriptor::KIND_RENDER_SURFACE],
+        requiredApp: 'acme',
+        surfaces: ['detail-page'],
+    ),
+    // A provider whose getStorageStrategy() returns 'app-local'.
+    // list() reads the app's notes for the object; create() appends one.
+    // A read-only leaf omits create() and lets the base class throw
+    // NotImplementedException — exactly as query-time providers do.
+    $this->container->get(AcmeNotesProvider::class),
+);
+```
+
+The leaf then appears in the OCS capabilities surface under
+`openregister.integrations.leaves` (id, label, requiredApp, surfaces, kinds,
+usability) so admin UI and manifest apps discover it **without loading the app's
+JS bundle**. A throwing listener costs only its own leaf; duplicate ids follow
+ADR-013 first-wins, which is why ids are namespaced (`acme-notes`, not `notes`).
+
+See ADR-019 (registry render/link), ADR-041 (cross-app commands via events),
+ADR-013 (first-wins collision), and ADR-066 (cross-app leaf registration — the
+render-and-read boundary).
+
 ## What to read next
 
 - **[xWiki leaf](./xwiki.md)** — the worked external example (OpenConnector-backed).

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -267,6 +267,7 @@ use OCA\OpenRegister\Service\Integration\BuiltinProviders\TagsProvider;
 use OCA\OpenRegister\Service\Integration\BuiltinProviders\TasksProvider;
 use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
 use OCA\OpenRegister\Service\Integration\IntegrationRegistry;
+use OCA\OpenRegister\Service\Integration\LeafRegistry;
 use OCA\OpenRegister\Service\Integration\PropertyReferenceTypeValidator;
 use OCA\OpenRegister\Service\Integration\PropertySemanticReferenceValidator;
 use OCA\OpenRegister\Service\Integration\Providers\BookmarksProvider;
@@ -1239,6 +1240,22 @@ class Application extends App implements IBootstrap
             }
         );
 
+        // LeafRegistry — the cross-app leaf catalogue (ADR-066). Collects the
+        // leaves sibling apps contribute through RegisterLeafProvidersEvent,
+        // lazily on first read, and lands their data providers on the shared
+        // IntegrationRegistry so existing per-object routing reaches them.
+        $context->registerService(
+            LeafRegistry::class,
+            function (ContainerInterface $container) {
+                return new LeafRegistry(
+                    eventDispatcher: $container->get(\OCP\EventDispatcher\IEventDispatcher::class),
+                    integrationRegistry: $container->get(IntegrationRegistry::class),
+                    appManager: $container->get('OCP\App\IAppManager'),
+                    logger: $container->get('Psr\Log\LoggerInterface')
+                );
+            }
+        );
+
         $this->registerBuiltinIntegrationProviders(context: $context);
 
         // IntegrationsController — read-only API over the registry.
@@ -1287,7 +1304,8 @@ class Application extends App implements IBootstrap
                     registry: $container->get(IntegrationRegistry::class),
                     userSession: $container->get('OCP\IUserSession'),
                     groupManager: $container->get('OCP\IGroupManager'),
-                    appManager: $container->get('OCP\App\IAppManager')
+                    appManager: $container->get('OCP\App\IAppManager'),
+                    leafRegistry: $container->get(LeafRegistry::class)
                 );
             }
         );
@@ -3831,6 +3849,7 @@ class Application extends App implements IBootstrap
         // registry never touches a provider's wrapped service unless a
         // caller actually invokes that provider's CRUD path.
         $this->bootBuiltinIntegrationProviders(server: $server);
+        $this->bootLeafRegistry(server: $server);
         $this->bootObjectSourceProviders(server: $server);
         $this->bootFederation(server: $server);
 
@@ -4018,6 +4037,42 @@ class Application extends App implements IBootstrap
             }//end try
         }//end foreach
     }//end bootBuiltinIntegrationProviders()
+
+    /**
+     * Install the lazy leaf loader on the shared IntegrationRegistry.
+     *
+     * The loader is a closure that reads the LeafRegistry catalogue, which
+     * dispatches `RegisterLeafProvidersEvent` once and lands any data-provider
+     * leaves on the IntegrationRegistry. Installing it here (rather than
+     * dispatching now) keeps the collect-event LAZY: it fires only when
+     * something actually reads the registry or the leaf catalogue in a request
+     * (ADR-066). Guarded so a registry-less build still boots.
+     *
+     * @param mixed $server Server container (passed in from boot()).
+     *
+     * @return void
+     *
+     * @spec openspec/changes/app-leaf-provider-registration/specs/leaf-provider-registration/spec.md
+     */
+    private function bootLeafRegistry($server): void
+    {
+        try {
+            $integrationRegistry = $server->get(IntegrationRegistry::class);
+            $integrationRegistry->setLeafLoader(
+                static function () use ($server): void {
+                    // Reading the catalogue triggers LeafRegistry::ensureLoaded(),
+                    // which dispatches the event and calls addProvider() for each
+                    // data-provider leaf.
+                    $server->get(LeafRegistry::class)->getDescriptors();
+                }
+            );
+        } catch (\Throwable $e) {
+            // Registry binding not available — skip silently; the leaf catalogue
+            // simply stays empty on this build.
+            return;
+        }
+
+    }//end bootLeafRegistry()
 
     /**
      * Register the built-in object-source providers with the shared

--- a/lib/Capabilities/IntegrationsCapability.php
+++ b/lib/Capabilities/IntegrationsCapability.php
@@ -32,6 +32,7 @@ namespace OCA\OpenRegister\Capabilities;
 
 use OCA\OpenRegister\Service\Integration\IntegrationProvider;
 use OCA\OpenRegister\Service\Integration\IntegrationRegistry;
+use OCA\OpenRegister\Service\Integration\LeafRegistry;
 use OCP\App\IAppManager;
 use OCP\Capabilities\ICapability;
 use OCP\IGroupManager;
@@ -61,6 +62,7 @@ class IntegrationsCapability implements ICapability
      * @param IUserSession        $userSession  Current user session.
      * @param IGroupManager       $groupManager Group manager (admin check).
      * @param IAppManager         $appManager   App manager (installed check).
+     * @param LeafRegistry        $leafRegistry Cross-app leaf catalogue (ADR-066).
      *
      * @return void
      */
@@ -69,6 +71,7 @@ class IntegrationsCapability implements ICapability
         private IUserSession $userSession,
         private IGroupManager $groupManager,
         private IAppManager $appManager,
+        private LeafRegistry $leafRegistry,
     ) {
     }//end __construct()
 
@@ -102,6 +105,12 @@ class IntegrationsCapability implements ICapability
                     // `providers`.
                     'registered'      => $this->registry->listIds(),
                     'providers'       => $rows,
+                    // `leaves` — the cross-app leaf catalogue (ADR-066). A
+                    // manifest app or admin UI discovers which leaves exist
+                    // (id, label, requiredApp, surfaces, kinds, usability)
+                    // WITHOUT loading any leaf app's JS bundle. Render-surface
+                    // parity to the JS registration is correlated by shared id.
+                    'leaves'          => $this->leafRegistry->describeForCapabilities(),
                 ],
             ],
         ];

--- a/lib/Event/RegisterLeafProvidersEvent.php
+++ b/lib/Event/RegisterLeafProvidersEvent.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Dispatched so sibling apps can contribute their leaves to OpenRegister.
+ *
+ * A leaf is how an app hooks itself onto OpenRegister objects: it contributes a
+ * render surface (a tab/widget on an object), app-local data (notes, records,
+ * annotations backed by the app's own store), or both. This event is the ONLY
+ * server-side seam for a sibling app to contribute a leaf.
+ *
+ * It mirrors `RegisterMcpToolProvidersEvent` line for line — the accepted typed
+ * collect-event idiom OpenRegister already uses for MCP tool providers and flow
+ * nodes. Nextcloud has two idioms here and the distinction matters: when CORE
+ * owns a registry it adds a `registerXProvider()` to `IRegistrationContext`;
+ * when an APP owns a registry it dispatches a typed event. OpenRegister is an
+ * app, so a sibling contributes a leaf by writing one `IEventListener` for this
+ * event and calling `registerLeaf()` — the same shape an app that already ships
+ * an MCP or flow-node listener writes.
+ *
+ * The event is dispatched once, lazily, when the leaf catalogue is first read in
+ * a request (see `LeafRegistry`). A throwing listener costs its own leaf and
+ * nothing else.
+ *
+ * RENDER-AND-READ BOUNDARY (ADR-066)
+ * ----------------------------------
+ * This event is render-and-read only by construction. A `LeafDescriptor` and an
+ * `IntegrationProvider` expose no verb, command, or handler — the registry can
+ * never become a command bus, and gate-27 (`no-phantom-cross-app-rpc`) still
+ * forbids `getLeaf()->call(...)` patterns. Cross-app COMMANDS stay ADR-041 typed
+ * `*RequestedEvent` contracts; this seam lifts the ADR-041 moratorium strictly
+ * for the collect / render / read case.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Event
+ * @package  OCA\OpenRegister\Event
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/app-leaf-provider-registration/specs/leaf-provider-registration/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Event;
+
+use OCA\OpenRegister\Service\Integration\IntegrationProvider;
+use OCA\OpenRegister\Service\Integration\LeafDescriptor;
+use OCP\EventDispatcher\Event;
+
+/**
+ * Carries the collector a sibling app registers its leaves on.
+ */
+class RegisterLeafProvidersEvent extends Event
+{
+
+    /**
+     * Leaves contributed during this dispatch.
+     *
+     * Each entry is a `['descriptor' => LeafDescriptor, 'provider' => ?IntegrationProvider]`
+     * tuple. The provider is present when the descriptor declares the
+     * `data-provider` kind and null otherwise.
+     *
+     * @var array<int, array{descriptor: LeafDescriptor, provider: ?IntegrationProvider}>
+     */
+    private array $leaves = [];
+
+    /**
+     * Contribute a leaf.
+     *
+     * A descriptor declaring the `data-provider` kind MUST pass an
+     * `IntegrationProvider` here; a render-only leaf passes null. The provider
+     * runs in the CONTRIBUTING app's DI context because the listener constructed
+     * it there — the same property ADR-041 relies on for command listeners.
+     *
+     * Validation (non-empty kinds, data-provider-requires-provider, kebab-case
+     * id, first-wins on duplicate id) is applied by `LeafRegistry` when the
+     * catalogue is collected, so a bad contribution costs only its own leaf.
+     *
+     * @param LeafDescriptor           $descriptor The leaf declaration.
+     * @param IntegrationProvider|null $provider   The data provider, or null for a render-only leaf.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/app-leaf-provider-registration/specs/leaf-provider-registration/spec.md
+     */
+    public function registerLeaf(LeafDescriptor $descriptor, ?IntegrationProvider $provider=null): void
+    {
+        $this->leaves[] = [
+            'descriptor' => $descriptor,
+            'provider'   => $provider,
+        ];
+
+    }//end registerLeaf()
+
+    /**
+     * Every leaf contributed during this dispatch.
+     *
+     * @return array<int, array{descriptor: LeafDescriptor, provider: ?IntegrationProvider}> The leaves.
+     *
+     * @spec openspec/changes/app-leaf-provider-registration/specs/leaf-provider-registration/spec.md
+     */
+    public function getLeaves(): array
+    {
+        return $this->leaves;
+
+    }//end getLeaves()
+}//end class

--- a/lib/Service/Integration/IntegrationProvider.php
+++ b/lib/Service/Integration/IntegrationProvider.php
@@ -38,13 +38,21 @@ namespace OCA\OpenRegister\Service\Integration;
  * (`getId`, `getRequiredApp`, `getStorageStrategy`, `isEnabled`, ...) to
  * route sub-resource calls and render UI surfaces.
  *
- * The four storage strategies that providers MAY declare:
+ * The five storage strategies that providers MAY declare:
  *   - 'magic-column' — link stored as a column on the OR object row.
  *   - 'link-table'   — link stored in a dedicated openregister_*_links table.
  *   - 'external'     — no local persistence; CRUD routed through OpenConnector.
  *   - 'query-time'   — no local persistence; source system queried live on
  *                      every list() call. Mutation methods throw
  *                      NotImplementedException (AD-22).
+ *   - 'app-local'    — no local persistence in OpenRegister; the data lives in a
+ *                      SIBLING Nextcloud app's own store and read/optional write
+ *                      are served by the provider's own methods, which run in
+ *                      that app's DI context because the app's listener
+ *                      constructed the provider there (ADR-066). This is the
+ *                      generalisation of the built-in files/notes/calendar
+ *                      leaves to any sibling app. OpenRegister routes the call
+ *                      and persists nothing.
  */
 interface IntegrationProvider
 {
@@ -108,13 +116,16 @@ interface IntegrationProvider
     /**
      * Where this integration's links are stored.
      *
-     * One of `'magic-column' | 'link-table' | 'external' | 'query-time'`.
+     * One of `'magic-column' | 'link-table' | 'external' | 'query-time' | 'app-local'`.
      * See the interface-level docblock for semantics.
      *
      * The registry uses this to choose the dispatch path:
      *   - magic-column / link-table -> ObjectsController routes
      *   - external -> ExternalIntegrationRouter -> OpenConnector
-     *   - query-time -> live read against the upstream source.
+     *   - query-time -> live read against the upstream source
+     *   - app-local -> the provider's own list()/create() served from the
+     *     contributing sibling app's store (ADR-066); OpenRegister persists
+     *     nothing.
      *
      * @return string Storage strategy.
      */

--- a/lib/Service/Integration/IntegrationRegistry.php
+++ b/lib/Service/Integration/IntegrationRegistry.php
@@ -78,6 +78,26 @@ class IntegrationRegistry
     private array $pageWidgets = [];
 
     /**
+     * Optional lazy loader that collects sibling-app leaf providers.
+     *
+     * Set by `Application::boot()` to a closure that reads the `LeafRegistry`
+     * catalogue. Invoked once, on the first registry READ, so a data-provider
+     * leaf contributed through `RegisterLeafProvidersEvent` lands in
+     * `$providers` before `ObjectIntegrationsController` resolves it — without
+     * eagerly dispatching the collect-event when nothing reads the registry.
+     *
+     * @var (callable():void)|null
+     */
+    private $leafLoader = null;
+
+    /**
+     * Whether the lazy leaf loader has already run this request.
+     *
+     * @var boolean
+     */
+    private bool $leavesLoaded = false;
+
+    /**
      * Constructor.
      *
      * @param LoggerInterface $logger Logger for collision and config warnings.
@@ -88,6 +108,55 @@ class IntegrationRegistry
         private LoggerInterface $logger,
     ) {
     }//end __construct()
+
+    /**
+     * Install the lazy leaf loader.
+     *
+     * The loader is a closure that collects sibling-app leaf providers into this
+     * registry (via `addProvider()`); it runs at most once, on the first read.
+     * Kept as a settable hook rather than a constructor dependency to avoid a
+     * `LeafRegistry` <-> `IntegrationRegistry` circular construction.
+     *
+     * @param callable $loader Zero-arg loader closure.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/app-leaf-provider-registration/specs/leaf-provider-registration/spec.md
+     */
+    public function setLeafLoader(callable $loader): void
+    {
+        $this->leafLoader = $loader;
+
+    }//end setLeafLoader()
+
+    /**
+     * Run the lazy leaf loader once, on the first registry read.
+     *
+     * The `$leavesLoaded` flag is set BEFORE invoking the loader so the loader's
+     * own `addProvider()` writes cannot re-enter this method into a loop. A
+     * throwing loader is swallowed — sibling-app discovery must never break the
+     * built-in registry.
+     *
+     * @return void
+     */
+    private function ensureLeavesLoaded(): void
+    {
+        if ($this->leavesLoaded === true || $this->leafLoader === null) {
+            return;
+        }
+
+        $this->leavesLoaded = true;
+
+        try {
+            ($this->leafLoader)();
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                '[IntegrationRegistry] leaf loader failed: {message}',
+                ['message' => $e->getMessage(), 'exception' => $e]
+            );
+        }
+
+    }//end ensureLeavesLoaded()
 
     /**
      * Register a provider with the registry.
@@ -176,6 +245,7 @@ class IntegrationRegistry
      */
     public function list(): array
     {
+        $this->ensureLeavesLoaded();
         return array_values($this->providers);
     }//end list()
 
@@ -192,6 +262,7 @@ class IntegrationRegistry
      */
     public function listIds(): array
     {
+        $this->ensureLeavesLoaded();
         return array_keys($this->providers);
     }//end listIds()
 
@@ -206,6 +277,7 @@ class IntegrationRegistry
      */
     public function get(string $id): ?IntegrationProvider
     {
+        $this->ensureLeavesLoaded();
         return $this->providers[$id] ?? null;
     }//end get()
 
@@ -222,6 +294,7 @@ class IntegrationRegistry
      */
     public function isValidIntegrationId(string $id): bool
     {
+        $this->ensureLeavesLoaded();
         return isset($this->providers[$id]);
     }//end isValidIntegrationId()
 
@@ -322,6 +395,7 @@ class IntegrationRegistry
      */
     public function getEnabled(): array
     {
+        $this->ensureLeavesLoaded();
         $enabled = [];
         foreach ($this->providers as $provider) {
             if ($provider->isEnabled() === true) {

--- a/lib/Service/Integration/LeafDescriptor.php
+++ b/lib/Service/Integration/LeafDescriptor.php
@@ -1,0 +1,261 @@
+<?php
+
+/**
+ * LeafDescriptor — the server-side declaration a sibling app contributes when
+ * it registers a leaf on OpenRegister objects through
+ * `RegisterLeafProvidersEvent`.
+ *
+ * A leaf has two faces: a render surface (a tab/widget mounted by the app's own
+ * Vue bundle) and/or a data provider (read/append data served from the app's own
+ * store). This descriptor carries the availability + capability metadata for
+ * both faces — it deliberately carries NO Vue components: render components are
+ * supplied on the JS layer under the same `id`, and the descriptor `id` MUST
+ * equal the JS registration id so the two layers correlate (ADR-019 parity).
+ *
+ * The descriptor is render-and-read only by construction (ADR-066): it exposes
+ * no verb, command, or handler. Cross-app commands stay ADR-041 typed events.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Integration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/app-leaf-provider-registration/specs/leaf-provider-registration/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Integration;
+
+/**
+ * Immutable value object describing one contributed leaf.
+ *
+ * The `kinds` set names which leaf kinds the app offers, each independently
+ * declarable:
+ *   - `render-surface` — the app mounts a tab + widget under the shared id.
+ *   - `data-provider`  — the app serves read/append data via an
+ *                        `IntegrationProvider` supplied on the same registration.
+ *   - `agent-runner`   — reserved forward-reference (ADR-066 / hermiq change B);
+ *                        this change assigns it no behaviour.
+ */
+final class LeafDescriptor
+{
+
+    /**
+     * Kind: the leaf mounts a render surface (tab + widget) on the JS layer.
+     *
+     * @var string
+     */
+    public const KIND_RENDER_SURFACE = 'render-surface';
+
+    /**
+     * Kind: the leaf serves read/append data through an IntegrationProvider.
+     *
+     * @var string
+     */
+    public const KIND_DATA_PROVIDER = 'data-provider';
+
+    /**
+     * Kind: reserved forward-reference for an agent-runner leaf (ADR-066).
+     *
+     * @var string
+     */
+    public const KIND_AGENT_RUNNER = 'agent-runner';
+
+    /**
+     * Every kind a descriptor MAY declare.
+     *
+     * @var array<int,string>
+     */
+    public const VALID_KINDS = [
+        self::KIND_RENDER_SURFACE,
+        self::KIND_DATA_PROVIDER,
+        self::KIND_AGENT_RUNNER,
+    ];
+
+    /**
+     * Every render surface a descriptor MAY target.
+     *
+     * @var array<int,string>
+     */
+    public const VALID_SURFACES = [
+        'user-dashboard',
+        'app-dashboard',
+        'detail-page',
+        'single-entity',
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param string            $id                 Stable kebab-case id, unique across the registry and
+     *                                              equal to the JS registration id.
+     * @param string            $label              Human-readable label (already translated by the app).
+     * @param string            $icon               Material Design Icons name (no `mdi-` prefix).
+     * @param array<int,string> $kinds              Non-empty subset of VALID_KINDS.
+     * @param string|null       $requiredApp        NC app id that must be installed/enabled, or null when
+     *                                              always-available.
+     * @param string|null       $group              Optional group used to cluster leaves in admin UI.
+     * @param array<int,string> $surfaces           Render surfaces the leaf targets (subset of VALID_SURFACES);
+     *                                              empty when the leaf offers no render surface.
+     * @param string|null       $referenceType      Optional marker so a schema reference property can target
+     *                                              this leaf's single-entity widget (ADR-019 / AD-18).
+     * @param string|null       $requiresPermission Optional permission string gating visibility.
+     *
+     * @return void
+     */
+    public function __construct(
+        private string $id,
+        private string $label,
+        private string $icon,
+        private array $kinds,
+        private ?string $requiredApp=null,
+        private ?string $group=null,
+        private array $surfaces=[],
+        private ?string $referenceType=null,
+        private ?string $requiresPermission=null,
+    ) {
+    }//end __construct()
+
+    /**
+     * Stable kebab-case identifier, equal to the JS registration id.
+     *
+     * @return string The leaf id.
+     */
+    public function getId(): string
+    {
+        return $this->id;
+
+    }//end getId()
+
+    /**
+     * Human-readable label.
+     *
+     * @return string The label.
+     */
+    public function getLabel(): string
+    {
+        return $this->label;
+
+    }//end getLabel()
+
+    /**
+     * Material Design Icons name (no `mdi-` prefix).
+     *
+     * @return string The icon name.
+     */
+    public function getIcon(): string
+    {
+        return $this->icon;
+
+    }//end getIcon()
+
+    /**
+     * The kinds this leaf declares.
+     *
+     * @return array<int,string> A non-empty subset of VALID_KINDS.
+     */
+    public function getKinds(): array
+    {
+        return $this->kinds;
+
+    }//end getKinds()
+
+    /**
+     * Whether the leaf declares the given kind.
+     *
+     * @param string $kind One of the KIND_* constants.
+     *
+     * @return bool True when the kind is present.
+     */
+    public function hasKind(string $kind): bool
+    {
+        return in_array($kind, $this->kinds, true);
+
+    }//end hasKind()
+
+    /**
+     * NC app id the leaf requires, or null when always-available.
+     *
+     * @return string|null The required app id.
+     */
+    public function getRequiredApp(): ?string
+    {
+        return $this->requiredApp;
+
+    }//end getRequiredApp()
+
+    /**
+     * Optional group used to cluster leaves in admin UI.
+     *
+     * @return string|null The group, or null.
+     */
+    public function getGroup(): ?string
+    {
+        return $this->group;
+
+    }//end getGroup()
+
+    /**
+     * Render surfaces the leaf targets.
+     *
+     * @return array<int,string> A subset of VALID_SURFACES.
+     */
+    public function getSurfaces(): array
+    {
+        return $this->surfaces;
+
+    }//end getSurfaces()
+
+    /**
+     * Optional reference-type marker for single-entity targeting.
+     *
+     * @return string|null The reference type, or null.
+     */
+    public function getReferenceType(): ?string
+    {
+        return $this->referenceType;
+
+    }//end getReferenceType()
+
+    /**
+     * Optional permission string gating visibility.
+     *
+     * @return string|null The permission, or null.
+     */
+    public function requiresPermission(): ?string
+    {
+        return $this->requiresPermission;
+
+    }//end requiresPermission()
+
+    /**
+     * Render the discovery-facing shape for the OCS capabilities surface.
+     *
+     * Carries only availability + capability metadata (no components, no verb):
+     * id, label, requiredApp, surfaces, kinds. Usability is derived by
+     * `LeafRegistry` from the installed state of `requiredApp`.
+     *
+     * @return array<string,mixed> The discovery descriptor.
+     */
+    public function toArray(): array
+    {
+        return [
+            'id'          => $this->id,
+            'label'       => $this->label,
+            'icon'        => $this->icon,
+            'requiredApp' => $this->requiredApp,
+            'group'       => $this->group,
+            'surfaces'    => $this->surfaces,
+            'kinds'       => $this->kinds,
+        ];
+
+    }//end toArray()
+}//end class

--- a/lib/Service/Integration/LeafRegistry.php
+++ b/lib/Service/Integration/LeafRegistry.php
@@ -1,0 +1,292 @@
+<?php
+
+/**
+ * LeafRegistry — collects the leaves sibling apps contribute through
+ * `RegisterLeafProvidersEvent` and exposes them for discovery.
+ *
+ * This is the umbrella "apps hook themselves into OpenRegister" catalogue. The
+ * event is dispatched ONCE, LAZILY, when the catalogue is first read in a
+ * request — mirroring `ToolRegistry`/the MCP registration event. A throwing
+ * listener is logged and swallowed so one broken app costs its own leaf and
+ * nothing else, never removing leaves from the instance.
+ *
+ * When a contributed leaf declares the `data-provider` kind, its accompanying
+ * `IntegrationProvider` is added to the shared `IntegrationRegistry` so the
+ * existing per-object routing (`ObjectIntegrationsController`) reaches it with no
+ * change to that path. The provider runs in the CONTRIBUTING app's DI context.
+ *
+ * RENDER-AND-READ BOUNDARY (ADR-066): the catalogue exposes only descriptors and
+ * (for data leaves) list/append routing. It carries no verb; cross-app commands
+ * stay ADR-041 typed events.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Integration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/app-leaf-provider-registration/specs/leaf-provider-registration/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Integration;
+
+use OCA\OpenRegister\Event\RegisterLeafProvidersEvent;
+use OCP\App\IAppManager;
+use OCP\EventDispatcher\IEventDispatcher;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Registry of all leaves contributed by sibling apps on this NC instance.
+ *
+ * Duplicate leaf id: first registration wins, second logs a warning (ADR-013).
+ * Descriptor validation (non-empty kinds, valid kinds, kebab-case id,
+ * data-provider-requires-provider) rejects and skips a bad leaf without breaking
+ * the catalogue.
+ */
+class LeafRegistry
+{
+
+    /**
+     * Whether the catalogue has been collected this request.
+     *
+     * @var boolean
+     */
+    private bool $loaded = false;
+
+    /**
+     * Collected leaf descriptors, keyed by id (first-wins).
+     *
+     * @var array<string, LeafDescriptor>
+     */
+    private array $descriptors = [];
+
+    /**
+     * Constructor.
+     *
+     * @param IEventDispatcher    $eventDispatcher     Dispatcher for the collect-event.
+     * @param IntegrationRegistry $integrationRegistry Shared provider registry (data leaves land here).
+     * @param IAppManager         $appManager          App manager (usability check).
+     * @param LoggerInterface     $logger              Logger for collision, validation, collection warnings.
+     *
+     * @return void
+     */
+    public function __construct(
+        private IEventDispatcher $eventDispatcher,
+        private IntegrationRegistry $integrationRegistry,
+        private IAppManager $appManager,
+        private LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Dispatch the collect-event once and collect the announced leaves.
+     *
+     * Lazy: only the first read in a request pays the dispatch. The `$loaded`
+     * flag is set BEFORE the dispatch so a re-entrant read (e.g. a data leaf
+     * whose registration triggers an integration-registry read) does not
+     * re-dispatch. The whole collection is guarded — discovery must never take
+     * the container down.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/app-leaf-provider-registration/specs/leaf-provider-registration/spec.md
+     */
+    private function ensureLoaded(): void
+    {
+        if ($this->loaded === true) {
+            return;
+        }
+
+        $this->loaded = true;
+
+        $event = new RegisterLeafProvidersEvent();
+
+        try {
+            $this->eventDispatcher->dispatchTyped($event);
+        } catch (\Throwable $e) {
+            // A broken listener costs its own leaf, not everyone else's: the
+            // alternative is one bad app removing leaves from the instance.
+            // Whatever was registered on the event BEFORE the throw is still
+            // collected below, since the event is mutated in place.
+            $this->logger->warning(
+                '[LeafRegistry] a leaf listener threw during dispatch: {message}',
+                ['message' => $e->getMessage(), 'exception' => $e]
+            );
+        }
+
+        // Collect every leaf that reached the event, guarding each one so a
+        // single bad descriptor cannot break the rest of the catalogue.
+        foreach ($event->getLeaves() as $leaf) {
+            try {
+                $this->collectLeaf(descriptor: $leaf['descriptor'], provider: $leaf['provider']);
+            } catch (\Throwable $e) {
+                $this->logger->warning(
+                    '[LeafRegistry] collecting a leaf failed: {message}',
+                    ['message' => $e->getMessage(), 'exception' => $e]
+                );
+            }
+        }
+
+    }//end ensureLoaded()
+
+    /**
+     * Validate one contributed leaf and, if it passes, index it (and register
+     * its data provider on the shared registry).
+     *
+     * Validation rules (a failing leaf is skipped, never fatal):
+     *   - id MUST be non-empty kebab-case;
+     *   - kinds MUST be a non-empty subset of `LeafDescriptor::VALID_KINDS`;
+     *   - a `data-provider` kind MUST carry an accompanying provider;
+     *   - duplicate id: first registration wins (ADR-013).
+     *
+     * @param LeafDescriptor           $descriptor The contributed descriptor.
+     * @param IntegrationProvider|null $provider   The accompanying provider, or null.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/app-leaf-provider-registration/specs/leaf-provider-registration/spec.md
+     */
+    private function collectLeaf(LeafDescriptor $descriptor, ?IntegrationProvider $provider): void
+    {
+        $id = $descriptor->getId();
+
+        if (preg_match('/^[a-z0-9]+(-[a-z0-9]+)*$/', $id) === 0) {
+            $this->logger->warning(
+                sprintf('[LeafRegistry] leaf id "%s" is not kebab-case — skipping', $id)
+            );
+            return;
+        }
+
+        $kinds = $descriptor->getKinds();
+        if ($kinds === []) {
+            $this->logger->warning(
+                sprintf('[LeafRegistry] leaf "%s" declares no kinds — skipping', $id)
+            );
+            return;
+        }
+
+        $unknown = array_diff($kinds, LeafDescriptor::VALID_KINDS);
+        if ($unknown !== []) {
+            $this->logger->warning(
+                sprintf(
+                    '[LeafRegistry] leaf "%s" declares unknown kind(s) "%s" — skipping',
+                    $id,
+                    implode(', ', $unknown)
+                )
+            );
+            return;
+        }
+
+        if ($descriptor->hasKind(LeafDescriptor::KIND_DATA_PROVIDER) === true && $provider === null) {
+            $this->logger->warning(
+                sprintf(
+                    '[LeafRegistry] leaf "%s" declares the data-provider kind but supplied no provider — skipping',
+                    $id
+                )
+            );
+            return;
+        }
+
+        if (isset($this->descriptors[$id]) === true) {
+            $this->logger->warning(
+                sprintf('[LeafRegistry] duplicate leaf id "%s" — keeping first registration', $id)
+            );
+            return;
+        }
+
+        $this->descriptors[$id] = $descriptor;
+
+        // Data leaves route through the existing per-object provider registry;
+        // adding the provider here means ObjectIntegrationsController reaches it
+        // unchanged. addProvider() applies its own first-wins on the provider id.
+        if ($provider !== null) {
+            $this->integrationRegistry->addProvider(provider: $provider);
+        }
+
+    }//end collectLeaf()
+
+    /**
+     * Every collected leaf descriptor.
+     *
+     * @return array<int, LeafDescriptor> The descriptors.
+     *
+     * @spec openspec/changes/app-leaf-provider-registration/specs/leaf-provider-registration/spec.md
+     */
+    public function getDescriptors(): array
+    {
+        $this->ensureLoaded();
+        return array_values($this->descriptors);
+
+    }//end getDescriptors()
+
+    /**
+     * Look up a collected leaf descriptor by id.
+     *
+     * @param string $id The leaf id.
+     *
+     * @return LeafDescriptor|null The descriptor, or null when unknown.
+     *
+     * @spec openspec/changes/app-leaf-provider-registration/specs/leaf-provider-registration/spec.md
+     */
+    public function getDescriptor(string $id): ?LeafDescriptor
+    {
+        $this->ensureLoaded();
+        return $this->descriptors[$id] ?? null;
+
+    }//end getDescriptor()
+
+    /**
+     * Render the discovery rows for the OCS capabilities surface.
+     *
+     * Each row carries the leaf's id, label, requiredApp, surfaces, kinds and
+     * current usability — everything a manifest app or admin UI needs to
+     * discover the leaf WITHOUT loading its JS bundle. Usability is derived from
+     * the installed/enabled state of the required app: a leaf whose required app
+     * is disabled is reported present but not currently usable.
+     *
+     * @return array<int, array<string,mixed>> The discovery rows.
+     *
+     * @spec openspec/changes/app-leaf-provider-registration/specs/leaf-discovery-parity/spec.md
+     */
+    public function describeForCapabilities(): array
+    {
+        $rows = [];
+        foreach ($this->getDescriptors() as $descriptor) {
+            $row           = $descriptor->toArray();
+            $row['usable'] = $this->isUsable(descriptor: $descriptor);
+            $rows[]        = $row;
+        }
+
+        return $rows;
+
+    }//end describeForCapabilities()
+
+    /**
+     * Whether the app backing a leaf is installed and enabled.
+     *
+     * A leaf with no required app (null) rides on OpenRegister itself and is
+     * always usable.
+     *
+     * @param LeafDescriptor $descriptor The descriptor to test.
+     *
+     * @return bool True when the leaf is currently usable.
+     */
+    private function isUsable(LeafDescriptor $descriptor): bool
+    {
+        $appId = $descriptor->getRequiredApp();
+        if ($appId === null || $appId === '') {
+            return true;
+        }
+
+        return $this->appManager->isEnabledForUser($appId);
+
+    }//end isUsable()
+}//end class

--- a/openspec/changes/app-leaf-provider-registration/design.md
+++ b/openspec/changes/app-leaf-provider-registration/design.md
@@ -1,0 +1,160 @@
+# Design: app-leaf-provider-registration
+
+## The layer decision — server *and* JS, correlated by id
+
+A leaf has two faces: something the server must know exists and can serve data
+for, and something the browser must mount as a Vue tab/widget. The honest state
+of the codebase is that each face is already half-built on a different layer, so
+the design is not "pick one layer" but "declare the seam on the server, keep the
+render registration on the client, and bind them with a shared id."
+
+**Server layer — the real gap. Owns discovery + data + capability declaration.**
+Today an `IntegrationProvider` can only be added inside OpenRegister's own
+`Application::boot()`. A sibling app cannot contribute one. We add
+`RegisterLeafProvidersEvent`, a typed collect-event dispatched once when the leaf
+catalogue is first read. A sibling app's single `IEventListener` contributes a
+`LeafDescriptor` (availability + capability metadata) and, when it offers data,
+an `IntegrationProvider` instance. Because the listener runs in the sibling
+app's DI context, the provider it constructs closes over that app's own services
+— the same property ADR-041 relies on for command listeners. This mirrors
+`RegisterMcpToolProvidersEvent` line for line, so an app that already writes an
+MCP or flow-node listener writes the same shape here.
+
+**JS layer — already built. Owns render component registration.**
+`@conduction/nextcloud-vue`'s `registry.js` already exposes `registerIntegration()`
+plus a `window.OCA.OpenRegister.integrations` stub-queue that survives any
+bundle load order, and `CnObjectSidebar` / `CnDashboardPage` / `CnDetailPage` /
+`CnFormDialog` already render from it. A leaf app ships a small init bundle via
+`Util::addInitScript()` that calls `registerIntegration({ id, tab, widget, ... })`.
+This change does not rebuild that; it *specifies* it as the render-surface half
+of the leaf contract and requires the JS `id` to equal the server descriptor
+`id`.
+
+**Why both, not one.** The server cannot mount Vue components (they live in the
+app's own bundle, and ADR-019's cross-Vue trap, openregister#1958, means a
+component must resolve in its own render bundle). The client cannot be the
+source of truth for discovery (an app whose JS has not loaded on this page is
+still installed, still has data, and must still be discoverable by admin UI, OCS
+capabilities, and manifest apps). So render registration stays on the client,
+discovery + data stay on the server, and the shared `id` is the join key. The
+parity contract (below) is what keeps the two halves honest.
+
+## Contract shapes
+
+### LeafDescriptor (server declaration)
+
+A read-only value the listener contributes. Fields:
+
+- `id` — stable kebab-case identifier, unique across the registry, equal to the
+  JS registration id.
+- `label`, `icon`, `group` — presentation metadata mirroring the JS descriptor.
+- `requiredApp` — the Nextcloud app id that must be installed and enabled for
+  the leaf to be usable; null for always-available.
+- `surfaces` — the render surfaces the leaf targets (a subset of
+  `user-dashboard`, `app-dashboard`, `detail-page`, `single-entity`); empty when
+  the leaf offers no render surface.
+- `referenceType` — optional marker so a schema reference property can target
+  this leaf's single-entity widget (ADR-019 / AD-18).
+- `requiresPermission` — optional permission string gating visibility.
+- `kinds` — a set drawn from `render-surface`, `data-provider`, `agent-runner`.
+  At least one is required. `agent-runner` is reserved here and defined by the
+  separate hermiq change.
+
+### App-local data provider
+
+An `IntegrationProvider` whose `getStorageStrategy()` returns the new value
+`app-local`. Semantics:
+
+- `list(register, schema, objectId, filters)` — returns the items the app holds
+  for that object (e.g. the notes on it), in the existing flat-list or
+  `{ items, total, nextCursor }` envelope shape. This is the read path every
+  data leaf must implement.
+- `create(register, schema, objectId, payload)` — optional write. An app that
+  offers add-a-note implements it; a read-only data leaf lets it throw
+  `NotImplementedException`, exactly as `query-time` providers do today.
+- `get` / `update` / `delete` — optional, same rule.
+- The provider's methods run in the sibling app's DI context and read/write the
+  app's own store. OpenRegister does not persist the data; it routes the call.
+
+The note case is the canonical minimum: a `list` returning notes for the object
+and a `create` adding one. "Apps offering notes to OpenRegister" is this and
+nothing more.
+
+## How it relates to the existing built-in leaves
+
+The built-in files / notes / calendar leaves already do exactly this pattern
+internally: they aggregate another Nextcloud subsystem's data onto an
+OpenRegister object through an `IntegrationProvider`, registered in
+`bootBuiltinIntegrationProviders()`. `FilesObjectSourceProvider` and the
+NC-native "backend already shipped" leaves read a foreign store and present it
+against `(register, schema, objectId)`. The `app-local` strategy is the
+generalisation: it takes that same shape and makes it available to *any* sibling
+app via the event, instead of only to leaves OpenRegister boots itself. No new
+data contract is invented — `IntegrationProvider` already speaks about "linked
+things" rather than OR entities on purpose (its own docblock notes this, AD-14).
+The only additions are the registration seam and the `app-local` enum value.
+
+## Discovery + parity
+
+- **Discovery.** Registered descriptors are surfaced through OpenRegister's OCS
+  capabilities response (the same channel `IntegrationProvider::health()` already
+  feeds, AD-17). Manifest apps and admin UI read the catalogue there without
+  loading any leaf's JS bundle.
+- **Parity (ADR-019).** A descriptor declaring `render-surface` MUST have a JS
+  registration under the same id that supplies both `tab` and `widget` — the JS
+  `register()` already throws when either is missing. The cross-app extension is
+  that the correlation is checked between the server descriptor and the JS
+  registration, not only within the JS call.
+- **Collision (ADR-013).** Duplicate leaf id: first registration wins, second is
+  ignored with a logged warning — the policy `ObjectSourceRegistry` and the JS
+  registry already implement. Across apps the same rule holds; boot/dispatch
+  order determines the winner, which is why ids are namespaced by convention
+  (e.g. `hermiq-agent`, not `agent`).
+
+## Migration / compatibility
+
+- The five built-in leaves are unaffected: they keep registering in
+  `bootBuiltinIntegrationProviders()`. The event is collected in addition to,
+  not instead of, the built-in boot — the same coexistence pattern the MCP
+  registration event uses for one release.
+- `app-local` is a new enum value; existing `magic-column` / `link-table` /
+  `external` / `query-time` providers are untouched.
+- The JS `registerIntegration()` path is already shipped and backwards
+  compatible; specifying it changes no runtime behaviour.
+- No object data migrates; app-local data never lived in OpenRegister.
+
+## Risks
+
+- **Lifting the ADR-041 moratorium.** ADR-041 said do not extend the OR registry
+  with cross-app contribution until the IReferenceProvider convergence is
+  decided. This change makes that decision for the collect/render/read case
+  only. The mitigation is the hard render-and-read boundary: the descriptor and
+  the provider contract expose no verb, so the registry cannot become a command
+  bus, and gate-27 (`no-phantom-cross-app-rpc`) still forbids the `getLeaf` /
+  `registry->call` patterns. This must be ratified by a companion ADR before
+  implementation — flagged as an open question.
+- **A sibling declaring a data-provider without a render surface, or vice
+  versa.** The `kinds` set makes each face independently declarable; a
+  data-only leaf (notes, no bespoke widget) is legitimate and renders through a
+  generic list widget, while a render-only leaf declares no provider. Parity is
+  enforced only for the `render-surface` kind.
+- **Discovery cost.** The event is dispatched lazily and once per request when
+  the catalogue is read, and a throwing listener is swallowed — the same
+  non-fatal contract as MCP discovery — so one broken app cannot remove leaves
+  from the instance.
+- **IReferenceProvider overlap.** For pure read-only cross-app *references*,
+  Nextcloud's native `IReferenceProvider` is cross-app by design and may be the
+  better long-term home. This change deliberately does not migrate onto it; the
+  companion ADR should record whether app-local read leaves eventually converge
+  there, keeping OR's bespoke layer only for the tab/widget parity and
+  linked-entity CRUD that `IReferenceProvider` cannot express.
+
+## Companion ADR (recommended, not created here)
+
+File in `hydra/openspec/architecture/` (org-wide): an ADR that (1) ratifies
+lifting the ADR-041 moratorium for the collect/render/read case, (2) fixes the
+render-and-read boundary so the leaf seam can never carry a command, (3) records
+the IReferenceProvider convergence decision, and (4) extends gate
+`integration-parity` to the cross-app descriptor<->JS id correlation. It should
+cross-reference ADR-019, ADR-041, and ADR-013. Do not author it in hydra without
+human review — it changes an org-wide contract.

--- a/openspec/changes/app-leaf-provider-registration/proposal.md
+++ b/openspec/changes/app-leaf-provider-registration/proposal.md
@@ -1,0 +1,117 @@
+# Proposal: app-leaf-provider-registration
+
+## Summary
+
+Give any sibling Nextcloud app a sanctioned server-side seam to register itself
+as a **leaf** on OpenRegister objects — contributing render surfaces (a
+tab/widget on an object) and data (notes, records, annotations backed by the
+app's own store) — through a typed collect-event, the same idiom OpenRegister
+already uses for MCP tool providers and flow nodes. This is the umbrella "apps
+hook themselves into OpenRegister" system. It is render-and-read only by
+construction; cross-app *commands* stay ADR-041 typed events.
+
+## The gap
+
+OpenRegister already has a rich leaf system, but it is closed to sibling apps on
+the server:
+
+- **PHP side.** The `IntegrationProvider` contract (list / get / create / update
+  / delete + `getRequiredApp`, `getStorageStrategy`, `getOpenConnectorSource`,
+  `requiresPermission`, `authRequirements`, `health`) is a full data-provider
+  contract. But every provider is registered inside OpenRegister's own
+  `Application::boot()` through `bootBuiltinIntegrationProviders()` ->
+  `IntegrationRegistry::addProvider()`. There is no event, hook, or DI mechanism
+  for a sibling app to contribute one. Its `getStorageStrategy()` enum offers
+  `magic-column` and `link-table` (data in OpenRegister) and `external` (data
+  over OpenConnector HTTP) but has **no strategy for data that lives in another
+  Nextcloud app's own store**. ADR-041 records this exact limitation.
+
+- **JS side.** The opposite is already true: `registry.js` in `@conduction/nextcloud-vue`
+  ships `registerIntegration()` plus a stub-queue on
+  `window.OCA.OpenRegister.integrations` so a leaf app's bundle, loaded on every
+  page via `Util::addInitScript()`, can register its tab and widget components
+  cross-app regardless of bundle load order. That path works and is documented
+  in the library's own guide — but it is not specified anywhere in OpenRegister,
+  it is invisible to the server, and nothing ties a JS registration back to a
+  server-declared capability.
+
+So the render layer is solved on the client and unspecified on the server; the
+data layer is specified on the server and closed to siblings. This change closes
+both by declaring one cross-app registration seam and correlating the two
+layers by a shared leaf id.
+
+## What changes
+
+- **`RegisterLeafProvidersEvent`** — a typed `IEventDispatcher` collect-event in
+  OpenRegister, mirroring `RegisterMcpToolProvidersEvent`. A sibling app writes
+  one `IEventListener` that contributes a leaf. The event is dispatched once,
+  lazily, when the leaf catalogue is first read. A throwing listener costs its
+  own leaf and nothing else.
+
+- **`LeafDescriptor`** — the server-side declaration a listener contributes. It
+  carries the shared `id`, `label`, `icon`, `requiredApp`, `group`, the render
+  `surfaces` it targets, an optional `referenceType`, `requiresPermission`, and
+  a `kinds` set naming which leaf kinds the app offers: `render-surface`,
+  `data-provider`, and the reserved forward-reference `agent-runner`. The
+  descriptor is availability plus capability metadata; it does not carry Vue
+  components.
+
+- **App-local data providers.** The `IntegrationProvider` storage-strategy enum
+  gains `app-local`: data lives in the contributing app's own store and read /
+  optional write are served by the provider's own methods, which run in that
+  app's DI context because the listener constructed the provider there. This is
+  the generalisation of the built-in files / notes / calendar leaves — which
+  already aggregate another app's data onto an object — to any sibling app. It
+  is the concrete shape behind "apps offering notes to OpenRegister": a
+  read-list of notes for an object, plus an optional add-note write.
+
+- **Discovery and parity.** Registered descriptors are exposed for discovery
+  through OpenRegister's OCS capabilities surface so OpenRegister and manifest
+  apps can see which leaves exist without loading every app's JS. The ADR-019
+  tab+widget parity contract is preserved and extended cross-app: a descriptor
+  that declares the `render-surface` kind MUST have a matching JS registration
+  supplying both a tab and a widget under the same id. Collisions follow ADR-013
+  first-wins on both layers.
+
+## ADR alignment
+
+- **ADR-019 (integration registry — render/link).** This change keeps the
+  registry render-and-link only. The data-provider kind reads linked things and
+  optionally writes a note against an object; it never invokes a business action
+  in the sibling app. Tab+widget parity is preserved.
+
+- **ADR-041 (cross-app commands via events).** ADR-041 rejected a bespoke
+  `RegisterIntegrationProvidersEvent` **for delegation** — a provider registry
+  is the wrong shape for a *command*, and it told authors not to extend the OR
+  registry with cross-app contribution *until the IReferenceProvider
+  convergence question is decided*. This proposal is that decision, scoped
+  strictly to collect / render / read: a collect-event is the *correct* shape
+  for "give me all the leaf providers" (it is exactly what the MCP event does),
+  and nothing here can invoke a verb in another app. Commands remain ADR-041
+  typed `*RequestedEvent` contracts. Because this lifts an explicit ADR-041
+  moratorium, it warrants a companion ADR (see below) and human ratification.
+
+## Cross-repo impact
+
+- **openregister** — new event, descriptor, registry wiring, the `app-local`
+  storage strategy, and the OCS capabilities discovery field. (This change.)
+- **@conduction/nextcloud-vue** — the existing `registerIntegration()` JS
+  bootstrap is formalised as the render-surface half of the contract; the parity
+  gate extends to cross-app leaves. (Separate coordinated change.)
+- **hydra** — a companion ADR ratifying the lifted ADR-041 moratorium and the
+  render/read boundary; the `integration-parity` gate learns the cross-app
+  descriptor<->JS correlation. (Recommended, see design.md.)
+
+## Out of scope
+
+- **Command invocation.** Invoking a verb in another app stays ADR-041 typed
+  `IEventDispatcher` events. This change never adds a command path.
+- **The hermiq agent leaf.** hermiq registering as an agent-runner leaf is the
+  first consumer and is specified separately; here only the `agent-runner` kind
+  name is reserved on the descriptor as a forward reference.
+- **The manifest `type: agent` action.** The manifest-renderer action that
+  surfaces an agent-runner leaf is a `@conduction/nextcloud-vue` change.
+- **IReferenceProvider convergence.** Whether read-only cross-app render should
+  migrate onto Nextcloud's native `IReferenceProvider` is flagged in design.md
+  and deferred to the companion ADR; this change does not migrate existing
+  leaves.

--- a/openspec/changes/app-leaf-provider-registration/specs/leaf-data-providers/spec.md
+++ b/openspec/changes/app-leaf-provider-registration/specs/leaf-data-providers/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: An app-local storage strategy sources data from the sibling app
+
+The integration-provider storage-strategy enum SHALL gain the value app-local,
+meaning the leaf's data lives in the contributing app's own store and OpenRegister
+persists none of it.
+
+A provider declaring app-local MUST serve its read and optional write through its
+own methods, which run in the contributing app's dependency-injection context
+because the listener constructed the provider there. OpenRegister SHALL route the
+call to the provider and MUST NOT store the returned data.
+
+#### Scenario: An app-local list reads from the sibling app store
+
+- **GIVEN** an app-local provider registered by a sibling app
+- **WHEN** OpenRegister lists linked things for an object
+- **THEN** the provider returns the items from the sibling app's own store and OpenRegister persists none of them
+
+#### Scenario: Existing strategies are unchanged
+
+- **GIVEN** a provider declaring magic-column, link-table, external, or query-time
+- **WHEN** the registry routes a call
+- **THEN** its behaviour is unchanged by the addition of app-local
+
+### Requirement: A data provider lists items for an object
+
+A data-provider leaf MUST implement a list method that returns the items the app
+holds for a given register, schema, and object id, in the flat-list or the items,
+total, and nextCursor envelope shape the integration-provider contract already
+accepts.
+
+The list method SHALL honour the common limit, page, and search filters when the
+provider supports them and MUST ignore unknown filters rather than reject them.
+
+#### Scenario: Notes are listed for an object
+
+- **GIVEN** an app-local notes provider and an object that has notes in the app
+- **WHEN** OpenRegister requests the list for that object
+- **THEN** the object's notes are returned in the accepted list shape
+
+#### Scenario: An object with no items returns an empty list
+
+- **GIVEN** an app-local notes provider and an object with no notes
+- **WHEN** OpenRegister requests the list for that object
+- **THEN** an empty list is returned rather than an error
+
+### Requirement: A data provider optionally supports adding a note
+
+A data-provider leaf that supports writes SHALL implement a create method that
+adds an item, such as a note, against a register, schema, and object id,
+persisting it in the app's own store. Implementing create is optional for a
+read-only leaf.
+
+A read-only data-provider leaf SHALL let create throw a not-implemented error,
+exactly as query-time providers do today, and the read path MUST remain usable
+when create is not implemented.
+
+#### Scenario: Adding a note persists it in the sibling app
+
+- **GIVEN** an app-local notes provider that implements create
+- **WHEN** OpenRegister adds a note against an object
+- **THEN** the note is persisted in the app's own store and appears in a subsequent list
+
+#### Scenario: A read-only data leaf refuses writes cleanly
+
+- **GIVEN** an app-local provider that does not implement create
+- **WHEN** OpenRegister attempts to add a note
+- **THEN** a not-implemented error is surfaced and the list path still works
+
+### Requirement: A data provider never invokes a business action
+
+A data-provider leaf SHALL expose only read and linked-item write against an
+object and MUST NOT be used to invoke a business action or command in the
+contributing app.
+
+Cross-app commands SHALL remain typed event contracts per ADR-041; the data
+provider contract carries no verb and MUST NOT be extended into one.
+
+#### Scenario: The provider contract exposes no command path
+
+- **GIVEN** a data-provider leaf
+- **WHEN** its contract is inspected
+- **THEN** it offers list and linked-item write only, with no method that triggers a business action in the sibling app
+
+@e2e exclude data-provider routing is backend-only — covered by PHPUnit

--- a/openspec/changes/app-leaf-provider-registration/specs/leaf-discovery-parity/spec.md
+++ b/openspec/changes/app-leaf-provider-registration/specs/leaf-discovery-parity/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: Registered leaves are discoverable without loading their JS
+
+OpenRegister SHALL expose the registered leaf descriptors through its OCS
+capabilities surface so that OpenRegister, admin UI, and manifest apps can
+discover which leaves exist without loading any leaf app's JavaScript bundle.
+
+The discovery surface MUST report each leaf's id, label, required app, targeted
+surfaces, kinds, and current usability, derived from the descriptor and the
+required-app installed state.
+
+#### Scenario: A manifest app discovers an installed leaf
+
+- **GIVEN** a sibling app that has registered a leaf
+- **WHEN** a manifest app reads the OpenRegister capabilities surface
+- **THEN** the leaf's id, surfaces, kinds, and usability are reported without that app's JS being loaded
+
+#### Scenario: A leaf whose required app is disabled reports unusable
+
+- **GIVEN** a registered leaf whose required app is installed but disabled
+- **WHEN** the capabilities surface is read
+- **THEN** the leaf is reported as present but not currently usable
+
+### Requirement: A render-surface leaf keeps tab and widget parity across layers
+
+A leaf declaring the render-surface kind MUST have a JavaScript registration
+under the same id that supplies both a tab component and a widget component, so
+the ADR-019 tab-and-widget parity contract holds across the server and client
+layers.
+
+The JavaScript registration SHALL reject a render-surface registration that is
+missing either the tab or the widget, and the parity check SHALL correlate the
+server descriptor id with the JavaScript registration id.
+
+#### Scenario: A render leaf supplies both tab and widget
+
+- **GIVEN** a descriptor declaring render-surface and a JS registration under the same id
+- **WHEN** the JS registration is made
+- **THEN** it is accepted only when it supplies both a tab and a widget component
+
+#### Scenario: A data-only leaf needs no bespoke render pair
+
+- **GIVEN** a descriptor whose only kind is data-provider
+- **WHEN** the parity check runs
+- **THEN** no bespoke tab-and-widget pair is required and the leaf renders through a generic list widget
+
+### Requirement: Duplicate leaf ids follow first-wins
+
+A duplicate leaf id SHALL follow the ADR-013 first-wins policy: the first
+registration is kept and any later registration under the same id is ignored with
+a logged warning, on both the server and the JavaScript layers.
+
+Leaf ids SHOULD be namespaced by convention, such as an app-prefixed id, so that
+boot and dispatch order does not cause an accidental collision between unrelated
+apps.
+
+#### Scenario: The second registration of an id is ignored
+
+- **GIVEN** two apps registering a leaf under the same id
+- **WHEN** the catalogue is built
+- **THEN** the first registration is kept and the second is ignored with a logged warning
+
+#### Scenario: Namespaced ids do not collide
+
+- **GIVEN** two apps registering leaves under app-prefixed ids
+- **WHEN** the catalogue is built
+- **THEN** both leaves are present because their ids differ
+
+@e2e exclude discovery and parity are backend-and-build-gate concerns — covered by PHPUnit and the parity gate

--- a/openspec/changes/app-leaf-provider-registration/specs/leaf-provider-registration/spec.md
+++ b/openspec/changes/app-leaf-provider-registration/specs/leaf-provider-registration/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Sibling apps register leaves through a typed collect-event
+
+A sibling Nextcloud app SHALL contribute a leaf to OpenRegister by listening for
+`RegisterLeafProvidersEvent` and calling its register method, the same idiom used
+by `RegisterMcpToolProvidersEvent` for MCP tool providers and by the flow-node
+registry.
+
+The event SHALL be dispatched once, lazily, when the leaf catalogue is first
+read in a request. There SHALL be no other server-side seam for a sibling app to
+contribute a leaf.
+
+#### Scenario: An announced leaf reaches the catalogue
+
+- **GIVEN** an app listening for the event and registering a leaf descriptor
+- **WHEN** the leaf catalogue is built
+- **THEN** that app's leaf is present in the catalogue
+
+#### Scenario: The built-in leaves still register
+
+- **GIVEN** the five built-in leaves that register in OpenRegister boot
+- **WHEN** the leaf catalogue is built
+- **THEN** the built-in leaves are present alongside any announced leaves
+
+### Requirement: A leaf descriptor declares capability metadata not components
+
+A contributed leaf descriptor MUST carry a stable kebab-case id, a label, an
+icon, an optional required app id, the render surfaces it targets, an optional
+reference-type marker, an optional required-permission string, and a non-empty
+set of kinds.
+
+The descriptor MUST NOT carry Vue components; render components are supplied on
+the JS layer under the same id. The id on the descriptor MUST equal the id used
+in the JS registration.
+
+#### Scenario: A descriptor without a kind is rejected
+
+- **GIVEN** a leaf descriptor whose kinds set is empty
+- **WHEN** the app registers it on the event
+- **THEN** the registration is rejected and the rest of the catalogue is unaffected
+
+#### Scenario: A descriptor carries availability metadata
+
+- **GIVEN** a descriptor declaring a required app that is not installed
+- **WHEN** the catalogue reports the leaf
+- **THEN** the leaf is reported as present but not currently usable
+
+### Requirement: A leaf declares which kinds it offers
+
+A leaf descriptor MUST declare its kinds as a subset of render-surface,
+data-provider, and agent-runner, with at least one present.
+
+A leaf declaring the data-provider kind SHALL contribute an integration provider
+instance on the same registration. The agent-runner kind SHALL be reserved by
+this change and defined by a separate change; a descriptor MAY declare it but
+this change assigns it no behaviour.
+
+#### Scenario: A data-provider leaf contributes a provider
+
+- **GIVEN** a descriptor whose kinds include data-provider
+- **WHEN** the app registers it
+- **THEN** an integration provider is required on the same registration and is added to the registry
+
+#### Scenario: A render-only leaf contributes no provider
+
+- **GIVEN** a descriptor whose only kind is render-surface
+- **WHEN** the app registers it
+- **THEN** no integration provider is required and the descriptor is accepted
+
+### Requirement: A broken listener costs only its own leaf
+
+A failure raised while collecting an announced leaf SHALL be logged and
+swallowed so that the rest of the catalogue is still built.
+
+An app with a throwing listener SHALL cost its own leaf and nothing else; the
+alternative is one bad app removing leaves from the instance.
+
+#### Scenario: A throwing listener does not break discovery
+
+- **GIVEN** a listener that throws during collection
+- **WHEN** the leaf catalogue is built
+- **THEN** the built-in leaves and every other announced leaf are still present
+
+@e2e exclude registration is backend-only — covered by PHPUnit

--- a/openspec/changes/app-leaf-provider-registration/tasks.md
+++ b/openspec/changes/app-leaf-provider-registration/tasks.md
@@ -1,0 +1,78 @@
+# Tasks: app-leaf-provider-registration
+
+## Ratification (do first — this lifts an ADR-041 moratorium)
+
+- [x] Draft the companion org-wide ADR in `hydra/openspec/architecture/`
+      ratifying the collect/render/read boundary and lifting ADR-041's
+      "do not extend the OR registry with cross-app contribution" hold. Human
+      review required before any code. — ADR-066 (ratified/merged in hydra;
+      referenced from the event/registry/descriptor docblocks).
+- [x] Record the IReferenceProvider convergence decision in that ADR. — ADR-066.
+
+## Server — registration seam
+
+- [x] Add `RegisterLeafProvidersEvent` (typed `IEventDispatcher` collect-event),
+      mirroring `RegisterMcpToolProvidersEvent`: a register method plus a getter,
+      dispatched once when the leaf catalogue is first read.
+- [x] Add the `LeafDescriptor` value type (id, label, icon, requiredApp,
+      surfaces, referenceType, requiresPermission, kinds).
+- [x] Wire catalogue collection: dispatch the event, collect announced leaves in
+      addition to `bootBuiltinIntegrationProviders()`, log-and-swallow listener
+      failures, apply first-wins on duplicate id. — `LeafRegistry` (lazy, once)
+      + `Application::bootLeafRegistry()` installs the loader on the shared
+      `IntegrationRegistry`.
+- [x] Validate descriptors on registration: non-empty kinds; a data-provider
+      kind requires an accompanying `IntegrationProvider`; reject and skip an
+      invalid descriptor without breaking the catalogue. — `LeafRegistry::collectLeaf()`
+      (also rejects non-kebab-case id + unknown kinds).
+
+## Server — app-local data providers
+
+- [x] Add `app-local` to the `IntegrationProvider` storage-strategy enum and its
+      validation, leaving `magic-column` / `link-table` / `external` /
+      `query-time` untouched. — documented on the `IntegrationProvider` contract
+      (interface + `getStorageStrategy()`); `IntegrationRegistry::addProvider()`
+      accepts it with no OpenConnector-source requirement.
+- [x] Route `list` (and optional `create` / `get` / `update` / `delete`) for
+      `app-local` providers to the provider instance; persist nothing in
+      OpenRegister; keep the read path usable when writes are not implemented.
+      — existing `ObjectIntegrationsController` dispatch calls the provider
+      methods directly (no strategy branch needed); read-only leaves let the
+      `AbstractIntegrationProvider` default throw `NotImplementedException`.
+
+## Server — discovery
+
+- [x] Surface registered leaf descriptors through the OCS capabilities response
+      (id, label, requiredApp, surfaces, kinds, usability). — new
+      `openregister.integrations.leaves` block via `LeafRegistry::describeForCapabilities()`.
+
+## JS (coordinated @conduction/nextcloud-vue change — reference only)
+
+- [ ] Formalise `registerIntegration()` as the render-surface half of the leaf
+      contract; require the JS id to equal the server descriptor id.
+      (Coordinated @conduction/nextcloud-vue change — out of scope for this repo.)
+- [ ] Extend the `integration-parity` gate to correlate the server descriptor
+      with the JS registration cross-app. (The canonical gate-24 lives in
+      hydra `scripts/run-hydra-gates.sh` + the JS check in nextcloud-vue; the
+      openregister wrapper only delegates to it. Follow-up in those repos —
+      not edited here.)
+
+## Tests
+
+- [x] PHPUnit: announced leaf reaches the catalogue; built-ins still present;
+      throwing listener swallowed; empty-kinds rejected; data-provider requires a
+      provider; first-wins on duplicate id. — `LeafRegistryTest`.
+- [x] PHPUnit: app-local `list` returns sibling-store items and persists nothing;
+      empty list on no items; `create` persists a note; read-only `create` throws
+      cleanly while `list` still works. — `LeafRegistryTest`.
+- [x] PHPUnit: OCS capabilities reports leaves and usability; disabled required
+      app reports unusable. — `LeafRegistryTest`. (22 tests / 174 assertions
+      pass in the nextcloud:34 container; plus a live probe against the running
+      instance.)
+
+## Docs
+
+- [x] Document the leaf contract (server descriptor + JS registration + app-local
+      provider) and a worked "notes leaf" example in OpenRegister docs. —
+      `docs/Integrations/leaf-system.md` → "Cross-app leaf registration".
+- [x] Cross-reference ADR-019, ADR-041, ADR-013, and the companion ADR (ADR-066).

--- a/tests/Unit/Service/Integration/LeafDescriptorTest.php
+++ b/tests/Unit/Service/Integration/LeafDescriptorTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * Unit tests for LeafDescriptor.
+ *
+ * Covers:
+ *  - accessors round-trip the constructed metadata;
+ *  - kinds are reported and `hasKind()` answers correctly;
+ *  - toArray() carries availability + capability metadata but NO components;
+ *  - the render-and-read boundary (ADR-066): the descriptor exposes no verb,
+ *    command, handler, or dispatch method.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Integration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/app-leaf-provider-registration/specs/leaf-provider-registration/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Integration;
+
+use OCA\OpenRegister\Service\Integration\LeafDescriptor;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the LeafDescriptor value object.
+ */
+class LeafDescriptorTest extends TestCase
+{
+
+    /**
+     * Accessors round-trip the constructed metadata.
+     *
+     * @return void
+     */
+    public function testAccessorsRoundTripMetadata(): void
+    {
+        $descriptor = new LeafDescriptor(
+            id: 'acme-notes',
+            label: 'Notes',
+            icon: 'NoteText',
+            kinds: [LeafDescriptor::KIND_DATA_PROVIDER, LeafDescriptor::KIND_RENDER_SURFACE],
+            requiredApp: 'acme',
+            group: 'comms',
+            surfaces: ['detail-page'],
+            referenceType: 'acme-note',
+            requiresPermission: 'acme.read',
+        );
+
+        $this->assertSame('acme-notes', $descriptor->getId());
+        $this->assertSame('Notes', $descriptor->getLabel());
+        $this->assertSame('NoteText', $descriptor->getIcon());
+        $this->assertSame('acme', $descriptor->getRequiredApp());
+        $this->assertSame('comms', $descriptor->getGroup());
+        $this->assertSame(['detail-page'], $descriptor->getSurfaces());
+        $this->assertSame('acme-note', $descriptor->getReferenceType());
+        $this->assertSame('acme.read', $descriptor->requiresPermission());
+
+    }//end testAccessorsRoundTripMetadata()
+
+    /**
+     * Kinds are reported and hasKind answers correctly.
+     *
+     * @return void
+     */
+    public function testKindsAreReported(): void
+    {
+        $descriptor = new LeafDescriptor(
+            id: 'acme-notes',
+            label: 'Notes',
+            icon: 'NoteText',
+            kinds: [LeafDescriptor::KIND_DATA_PROVIDER],
+        );
+
+        $this->assertSame([LeafDescriptor::KIND_DATA_PROVIDER], $descriptor->getKinds());
+        $this->assertTrue($descriptor->hasKind(LeafDescriptor::KIND_DATA_PROVIDER));
+        $this->assertFalse($descriptor->hasKind(LeafDescriptor::KIND_RENDER_SURFACE));
+        $this->assertFalse($descriptor->hasKind(LeafDescriptor::KIND_AGENT_RUNNER));
+
+    }//end testKindsAreReported()
+
+    /**
+     * Defaults are null/empty for the optional metadata.
+     *
+     * @return void
+     */
+    public function testOptionalMetadataDefaults(): void
+    {
+        $descriptor = new LeafDescriptor(
+            id: 'acme-tab',
+            label: 'Tab',
+            icon: 'Cube',
+            kinds: [LeafDescriptor::KIND_RENDER_SURFACE],
+        );
+
+        $this->assertNull($descriptor->getRequiredApp());
+        $this->assertNull($descriptor->getGroup());
+        $this->assertSame([], $descriptor->getSurfaces());
+        $this->assertNull($descriptor->getReferenceType());
+        $this->assertNull($descriptor->requiresPermission());
+
+    }//end testOptionalMetadataDefaults()
+
+    /**
+     * toArray() carries capability metadata but no Vue components.
+     *
+     * @return void
+     */
+    public function testToArrayCarriesMetadataNotComponents(): void
+    {
+        $descriptor = new LeafDescriptor(
+            id: 'acme-notes',
+            label: 'Notes',
+            icon: 'NoteText',
+            kinds: [LeafDescriptor::KIND_DATA_PROVIDER],
+            requiredApp: 'acme',
+            surfaces: ['detail-page'],
+        );
+
+        $array = $descriptor->toArray();
+
+        $this->assertSame('acme-notes', $array['id']);
+        $this->assertSame(['detail-page'], $array['surfaces']);
+        $this->assertSame([LeafDescriptor::KIND_DATA_PROVIDER], $array['kinds']);
+
+        // No component/render field is carried on the server descriptor;
+        // render components live on the JS layer under the same id.
+        $this->assertArrayNotHasKey('tab', $array);
+        $this->assertArrayNotHasKey('widget', $array);
+        $this->assertArrayNotHasKey('component', $array);
+
+    }//end testToArrayCarriesMetadataNotComponents()
+
+    /**
+     * Render-and-read boundary (ADR-066): the descriptor exposes no verb.
+     *
+     * @return void
+     */
+    public function testDescriptorExposesNoCommandVerb(): void
+    {
+        $forbidden = ['call', 'invoke', 'dispatch', 'execute', 'run', 'handle', 'command', 'trigger', 'perform'];
+
+        $reflection = new \ReflectionClass(LeafDescriptor::class);
+        foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+            $name = strtolower($method->getName());
+            foreach ($forbidden as $verb) {
+                $this->assertStringNotContainsString(
+                    $verb,
+                    $name,
+                    sprintf('LeafDescriptor must expose no command verb; found "%s"', $method->getName())
+                );
+            }
+        }
+
+    }//end testDescriptorExposesNoCommandVerb()
+}//end class

--- a/tests/Unit/Service/Integration/LeafRegistryTest.php
+++ b/tests/Unit/Service/Integration/LeafRegistryTest.php
@@ -1,0 +1,606 @@
+<?php
+
+/**
+ * Unit tests for LeafRegistry + the app-local data-provider path + OCS discovery.
+ *
+ * Covers the spec's PHPUnit tasks:
+ *  - an announced leaf reaches the catalogue; built-ins still present;
+ *  - a throwing listener is swallowed and other leaves survive;
+ *  - empty-kinds / unknown-kind rejected; data-provider requires a provider;
+ *  - first-wins on duplicate id (ADR-013); namespaced ids do not collide;
+ *  - a data-provider leaf lands on the IntegrationRegistry and is reachable
+ *    through the lazy loader hook;
+ *  - app-local list() returns sibling-store items and persists nothing;
+ *    empty list on no items; create() persists a note; a read-only leaf lets
+ *    create() throw while list() still works;
+ *  - OCS describeForCapabilities reports leaves + usability; a disabled required
+ *    app reports unusable;
+ *  - the render-and-read boundary (ADR-066): the provider contract exposes no
+ *    business-action verb.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Integration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/app-leaf-provider-registration/specs/leaf-provider-registration/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Integration;
+
+use OCA\OpenRegister\Event\RegisterLeafProvidersEvent;
+use OCA\OpenRegister\Exception\NotImplementedException;
+use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
+use OCA\OpenRegister\Service\Integration\IntegrationProvider;
+use OCA\OpenRegister\Service\Integration\IntegrationRegistry;
+use OCA\OpenRegister\Service\Integration\LeafDescriptor;
+use OCA\OpenRegister\Service\Integration\LeafRegistry;
+use OCP\App\IAppManager;
+use OCP\EventDispatcher\IEventDispatcher;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * An app-local notes provider backed by an in-memory "sibling app store".
+ *
+ * Models exactly the canonical minimum: list() reads the notes it holds for an
+ * object, create() appends one. OpenRegister persists none of it — the data
+ * lives here, in the provider's own memory (standing in for the app's store).
+ */
+class _AppLocalNotesProvider extends AbstractIntegrationProvider
+{
+
+    /**
+     * The sibling app's own store, keyed by objectId.
+     *
+     * @var array<string, array<int, array<string,mixed>>>
+     */
+    public array $store = [];
+
+    public function __construct(
+        private string $id='acme-notes',
+        private ?string $requiredApp='acme',
+        private bool $enabled=true,
+    ) {
+    }//end __construct()
+
+    public function getId(): string
+    {
+        return $this->id;
+    }//end getId()
+
+    public function getLabel(): string
+    {
+        return 'Notes';
+    }//end getLabel()
+
+    public function getIcon(): string
+    {
+        return 'NoteText';
+    }//end getIcon()
+
+    public function getRequiredApp(): ?string
+    {
+        return $this->requiredApp;
+    }//end getRequiredApp()
+
+    public function getStorageStrategy(): string
+    {
+        return 'app-local';
+    }//end getStorageStrategy()
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }//end isEnabled()
+
+    public function list(string $register, string $schema, string $objectId, array $filters=[]): array
+    {
+        return ($this->store[$objectId] ?? []);
+    }//end list()
+
+    public function create(string $register, string $schema, string $objectId, array $payload): array
+    {
+        $note                      = ['id' => (string) (count(($this->store[$objectId] ?? [])) + 1), 'body' => ($payload['body'] ?? '')];
+        $this->store[$objectId][]  = $note;
+        return $note;
+    }//end create()
+}//end class
+
+/**
+ * A read-only app-local provider: list() works, create() falls through to the
+ * AbstractIntegrationProvider default that throws NotImplementedException.
+ */
+class _ReadOnlyAppLocalProvider extends AbstractIntegrationProvider
+{
+
+    public function getId(): string
+    {
+        return 'acme-readonly';
+    }//end getId()
+
+    public function getLabel(): string
+    {
+        return 'Read only';
+    }//end getLabel()
+
+    public function getIcon(): string
+    {
+        return 'Eye';
+    }//end getIcon()
+
+    public function getRequiredApp(): ?string
+    {
+        return 'acme';
+    }//end getRequiredApp()
+
+    public function getStorageStrategy(): string
+    {
+        return 'app-local';
+    }//end getStorageStrategy()
+
+    public function isEnabled(): bool
+    {
+        return true;
+    }//end isEnabled()
+
+    public function list(string $register, string $schema, string $objectId, array $filters=[]): array
+    {
+        return [['id' => '1', 'body' => 'read-only item']];
+    }//end list()
+}//end class
+
+/**
+ * A trivial built-in-shaped provider used to prove built-ins survive leaf
+ * collection.
+ */
+class _BuiltinShapedProvider extends AbstractIntegrationProvider
+{
+
+    public function getId(): string
+    {
+        return 'files';
+    }//end getId()
+
+    public function getLabel(): string
+    {
+        return 'Files';
+    }//end getLabel()
+
+    public function getIcon(): string
+    {
+        return 'Paperclip';
+    }//end getIcon()
+
+    public function getRequiredApp(): ?string
+    {
+        return null;
+    }//end getRequiredApp()
+
+    public function getStorageStrategy(): string
+    {
+        return 'magic-column';
+    }//end getStorageStrategy()
+
+    public function isEnabled(): bool
+    {
+        return true;
+    }//end isEnabled()
+
+    public function list(string $register, string $schema, string $objectId, array $filters=[]): array
+    {
+        return [];
+    }//end list()
+}//end class
+
+/**
+ * Unit tests for LeafRegistry.
+ */
+class LeafRegistryTest extends TestCase
+{
+
+    /**
+     * Build a LeafRegistry whose dispatcher runs the supplied listeners against
+     * the collect-event.
+     *
+     * @param array<int, callable>     $listeners           Listeners applied to the event.
+     * @param IntegrationRegistry|null $integrationRegistry Optional shared provider registry.
+     * @param IAppManager|null         $appManager          Optional app-manager mock.
+     *
+     * @return LeafRegistry
+     */
+    private function makeRegistry(
+        array $listeners,
+        ?IntegrationRegistry $integrationRegistry=null,
+        ?IAppManager $appManager=null
+    ): LeafRegistry {
+        $dispatcher = $this->createMock(IEventDispatcher::class);
+        $dispatcher->method('dispatchTyped')->willReturnCallback(
+            function (object $event) use ($listeners) {
+                foreach ($listeners as $listener) {
+                    $listener($event);
+                }
+
+                return $event;
+            }
+        );
+
+        if ($appManager === null) {
+            $appManager = $this->createMock(IAppManager::class);
+            $appManager->method('isEnabledForUser')->willReturn(true);
+        }
+
+        return new LeafRegistry(
+            eventDispatcher: $dispatcher,
+            integrationRegistry: ($integrationRegistry ?? new IntegrationRegistry(new NullLogger())),
+            appManager: $appManager,
+            logger: new NullLogger()
+        );
+    }//end makeRegistry()
+
+    /**
+     * An announced leaf reaches the catalogue.
+     *
+     * @return void
+     */
+    public function testAnnouncedLeafReachesCatalogue(): void
+    {
+        $registry = $this->makeRegistry([
+            function (RegisterLeafProvidersEvent $event) {
+                $event->registerLeaf(
+                    new LeafDescriptor(id: 'acme-tab', label: 'Tab', icon: 'Cube', kinds: [LeafDescriptor::KIND_RENDER_SURFACE])
+                );
+            },
+        ]);
+
+        $ids = array_map(fn ($d) => $d->getId(), $registry->getDescriptors());
+        $this->assertSame(['acme-tab'], $ids);
+    }//end testAnnouncedLeafReachesCatalogue()
+
+    /**
+     * A data-provider leaf lands on the shared IntegrationRegistry and is
+     * reachable through the lazy loader hook.
+     *
+     * @return void
+     */
+    public function testDataProviderLeafLandsOnIntegrationRegistryViaLoaderHook(): void
+    {
+        $integrationRegistry = new IntegrationRegistry(new NullLogger());
+        // A built-in present before leaf collection must survive.
+        $integrationRegistry->addProvider(new _BuiltinShapedProvider());
+
+        $provider = new _AppLocalNotesProvider();
+        $leafReg  = $this->makeRegistry(
+            [
+                function (RegisterLeafProvidersEvent $event) use ($provider) {
+                    $event->registerLeaf(
+                        new LeafDescriptor(
+                            id: 'acme-notes',
+                            label: 'Notes',
+                            icon: 'NoteText',
+                            kinds: [LeafDescriptor::KIND_DATA_PROVIDER],
+                            requiredApp: 'acme'
+                        ),
+                        $provider
+                    );
+                },
+            ],
+            $integrationRegistry
+        );
+
+        // Wire the lazy loader: reading the IntegrationRegistry now triggers
+        // leaf collection, exactly as Application::bootLeafRegistry() sets up.
+        $integrationRegistry->setLeafLoader(fn () => $leafReg->getDescriptors());
+
+        // Built-in present alongside the announced leaf's provider.
+        $ids = $integrationRegistry->listIds();
+        $this->assertContains('files', $ids, 'built-in provider survives leaf collection');
+        $this->assertContains('acme-notes', $ids, 'announced data-provider is reachable');
+        $this->assertSame($provider, $integrationRegistry->get('acme-notes'));
+    }//end testDataProviderLeafLandsOnIntegrationRegistryViaLoaderHook()
+
+    /**
+     * A throwing listener is swallowed; leaves registered before it survive.
+     *
+     * @return void
+     */
+    public function testThrowingListenerDoesNotBreakDiscovery(): void
+    {
+        $registry = $this->makeRegistry([
+            function (RegisterLeafProvidersEvent $event) {
+                $event->registerLeaf(
+                    new LeafDescriptor(id: 'good-leaf', label: 'Good', icon: 'Cube', kinds: [LeafDescriptor::KIND_RENDER_SURFACE])
+                );
+            },
+            function (RegisterLeafProvidersEvent $event) {
+                throw new \RuntimeException('listener blew up');
+            },
+        ]);
+
+        $ids = array_map(fn ($d) => $d->getId(), $registry->getDescriptors());
+        $this->assertSame(['good-leaf'], $ids, 'the healthy leaf survives a throwing listener');
+    }//end testThrowingListenerDoesNotBreakDiscovery()
+
+    /**
+     * A descriptor with an empty kinds set is rejected.
+     *
+     * @return void
+     */
+    public function testEmptyKindsIsRejected(): void
+    {
+        $registry = $this->makeRegistry([
+            function (RegisterLeafProvidersEvent $event) {
+                $event->registerLeaf(new LeafDescriptor(id: 'no-kinds', label: 'X', icon: 'Cube', kinds: []));
+                $event->registerLeaf(new LeafDescriptor(id: 'ok', label: 'Ok', icon: 'Cube', kinds: [LeafDescriptor::KIND_RENDER_SURFACE]));
+            },
+        ]);
+
+        $ids = array_map(fn ($d) => $d->getId(), $registry->getDescriptors());
+        $this->assertSame(['ok'], $ids, 'empty-kinds rejected, the rest of the catalogue unaffected');
+    }//end testEmptyKindsIsRejected()
+
+    /**
+     * An unknown kind is rejected.
+     *
+     * @return void
+     */
+    public function testUnknownKindIsRejected(): void
+    {
+        $registry = $this->makeRegistry([
+            function (RegisterLeafProvidersEvent $event) {
+                $event->registerLeaf(new LeafDescriptor(id: 'weird', label: 'X', icon: 'Cube', kinds: ['teleporter']));
+            },
+        ]);
+
+        $this->assertSame([], $registry->getDescriptors());
+    }//end testUnknownKindIsRejected()
+
+    /**
+     * A data-provider kind without an accompanying provider is rejected.
+     *
+     * @return void
+     */
+    public function testDataProviderWithoutProviderIsRejected(): void
+    {
+        $registry = $this->makeRegistry([
+            function (RegisterLeafProvidersEvent $event) {
+                $event->registerLeaf(
+                    new LeafDescriptor(id: 'acme-notes', label: 'Notes', icon: 'NoteText', kinds: [LeafDescriptor::KIND_DATA_PROVIDER])
+                    // No provider supplied.
+                );
+            },
+        ]);
+
+        $this->assertSame([], $registry->getDescriptors(), 'data-provider kind requires a provider');
+    }//end testDataProviderWithoutProviderIsRejected()
+
+    /**
+     * A render-only leaf needs no provider and is accepted.
+     *
+     * @return void
+     */
+    public function testRenderOnlyLeafNeedsNoProvider(): void
+    {
+        $registry = $this->makeRegistry([
+            function (RegisterLeafProvidersEvent $event) {
+                $event->registerLeaf(
+                    new LeafDescriptor(id: 'acme-tab', label: 'Tab', icon: 'Cube', kinds: [LeafDescriptor::KIND_RENDER_SURFACE])
+                );
+            },
+        ]);
+
+        $this->assertCount(1, $registry->getDescriptors());
+    }//end testRenderOnlyLeafNeedsNoProvider()
+
+    /**
+     * Duplicate id: first registration wins (ADR-013).
+     *
+     * @return void
+     */
+    public function testDuplicateIdFirstWins(): void
+    {
+        $registry = $this->makeRegistry([
+            function (RegisterLeafProvidersEvent $event) {
+                $event->registerLeaf(new LeafDescriptor(id: 'dupe', label: 'First', icon: 'Cube', kinds: [LeafDescriptor::KIND_RENDER_SURFACE]));
+                $event->registerLeaf(new LeafDescriptor(id: 'dupe', label: 'Second', icon: 'Cube', kinds: [LeafDescriptor::KIND_RENDER_SURFACE]));
+            },
+        ]);
+
+        $descriptors = $registry->getDescriptors();
+        $this->assertCount(1, $descriptors);
+        $this->assertSame('First', $descriptors[0]->getLabel(), 'first registration is kept');
+    }//end testDuplicateIdFirstWins()
+
+    /**
+     * Namespaced ids do not collide.
+     *
+     * @return void
+     */
+    public function testNamespacedIdsDoNotCollide(): void
+    {
+        $registry = $this->makeRegistry([
+            function (RegisterLeafProvidersEvent $event) {
+                $event->registerLeaf(new LeafDescriptor(id: 'acme-agent', label: 'A', icon: 'Cube', kinds: [LeafDescriptor::KIND_RENDER_SURFACE]));
+                $event->registerLeaf(new LeafDescriptor(id: 'globex-agent', label: 'B', icon: 'Cube', kinds: [LeafDescriptor::KIND_RENDER_SURFACE]));
+            },
+        ]);
+
+        $ids = array_map(fn ($d) => $d->getId(), $registry->getDescriptors());
+        $this->assertSame(['acme-agent', 'globex-agent'], $ids);
+    }//end testNamespacedIdsDoNotCollide()
+
+    /**
+     * app-local list() returns sibling-store items and OpenRegister persists
+     * none of them.
+     *
+     * @return void
+     */
+    public function testAppLocalListReturnsSiblingStoreItems(): void
+    {
+        $provider                 = new _AppLocalNotesProvider();
+        $provider->store['obj-1'] = [['id' => '1', 'body' => 'first note']];
+
+        $items = $provider->list('reg', 'schema', 'obj-1');
+
+        $this->assertSame([['id' => '1', 'body' => 'first note']], $items);
+        // OpenRegister holds nothing: the only copy is the provider's own store.
+        $this->assertSame($provider->store['obj-1'], $items);
+    }//end testAppLocalListReturnsSiblingStoreItems()
+
+    /**
+     * An object with no items returns an empty list rather than an error.
+     *
+     * @return void
+     */
+    public function testAppLocalListEmptyWhenNoItems(): void
+    {
+        $provider = new _AppLocalNotesProvider();
+        $this->assertSame([], $provider->list('reg', 'schema', 'obj-empty'));
+    }//end testAppLocalListEmptyWhenNoItems()
+
+    /**
+     * create() persists a note in the sibling store; it appears in a subsequent
+     * list().
+     *
+     * @return void
+     */
+    public function testAppLocalCreatePersistsNoteInSiblingStore(): void
+    {
+        $provider = new _AppLocalNotesProvider();
+        $created  = $provider->create('reg', 'schema', 'obj-1', ['body' => 'hello']);
+
+        $this->assertSame('hello', $created['body']);
+        $list = $provider->list('reg', 'schema', 'obj-1');
+        $this->assertCount(1, $list);
+        $this->assertSame('hello', $list[0]['body']);
+    }//end testAppLocalCreatePersistsNoteInSiblingStore()
+
+    /**
+     * A read-only app-local leaf lets create() throw while list() still works.
+     *
+     * @return void
+     */
+    public function testReadOnlyAppLocalLeafRefusesWritesCleanly(): void
+    {
+        $provider = new _ReadOnlyAppLocalProvider();
+
+        // The read path is usable.
+        $this->assertCount(1, $provider->list('reg', 'schema', 'obj-1'));
+
+        // The write path throws the exact not-implemented shape query-time uses.
+        $this->expectException(NotImplementedException::class);
+        $provider->create('reg', 'schema', 'obj-1', ['body' => 'nope']);
+    }//end testReadOnlyAppLocalLeafRefusesWritesCleanly()
+
+    /**
+     * OCS describeForCapabilities reports leaves + usability.
+     *
+     * @return void
+     */
+    public function testDescribeForCapabilitiesReportsLeavesAndUsability(): void
+    {
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('isEnabledForUser')->willReturn(true);
+
+        $registry = $this->makeRegistry(
+            [
+                function (RegisterLeafProvidersEvent $event) {
+                    $event->registerLeaf(
+                        new LeafDescriptor(
+                            id: 'acme-notes',
+                            label: 'Notes',
+                            icon: 'NoteText',
+                            kinds: [LeafDescriptor::KIND_DATA_PROVIDER],
+                            requiredApp: 'acme',
+                            surfaces: ['detail-page']
+                        ),
+                        new _AppLocalNotesProvider()
+                    );
+                },
+            ],
+            null,
+            $appManager
+        );
+
+        $rows = $registry->describeForCapabilities();
+        $this->assertCount(1, $rows);
+        $this->assertSame('acme-notes', $rows[0]['id']);
+        $this->assertSame(['detail-page'], $rows[0]['surfaces']);
+        $this->assertSame([LeafDescriptor::KIND_DATA_PROVIDER], $rows[0]['kinds']);
+        $this->assertTrue($rows[0]['usable']);
+    }//end testDescribeForCapabilitiesReportsLeavesAndUsability()
+
+    /**
+     * A leaf whose required app is disabled reports unusable.
+     *
+     * @return void
+     */
+    public function testLeafWithDisabledRequiredAppReportsUnusable(): void
+    {
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('isEnabledForUser')->willReturn(false);
+
+        $registry = $this->makeRegistry(
+            [
+                function (RegisterLeafProvidersEvent $event) {
+                    $event->registerLeaf(
+                        new LeafDescriptor(id: 'acme-tab', label: 'Tab', icon: 'Cube', kinds: [LeafDescriptor::KIND_RENDER_SURFACE], requiredApp: 'acme')
+                    );
+                },
+            ],
+            null,
+            $appManager
+        );
+
+        $rows = $registry->describeForCapabilities();
+        $this->assertFalse($rows[0]['usable'], 'a disabled required app reports the leaf unusable');
+    }//end testLeafWithDisabledRequiredAppReportsUnusable()
+
+    /**
+     * A leaf with no required app is always usable.
+     *
+     * @return void
+     */
+    public function testLeafWithoutRequiredAppIsAlwaysUsable(): void
+    {
+        $registry = $this->makeRegistry([
+            function (RegisterLeafProvidersEvent $event) {
+                $event->registerLeaf(new LeafDescriptor(id: 'core-leaf', label: 'Core', icon: 'Cube', kinds: [LeafDescriptor::KIND_RENDER_SURFACE]));
+            },
+        ]);
+
+        $rows = $registry->describeForCapabilities();
+        $this->assertTrue($rows[0]['usable']);
+    }//end testLeafWithoutRequiredAppIsAlwaysUsable()
+
+    /**
+     * Render-and-read boundary (ADR-066): the IntegrationProvider contract
+     * exposes list + linked-item CRUD only — no business-action verb.
+     *
+     * @return void
+     */
+    public function testProviderContractExposesNoCommandPath(): void
+    {
+        $allowed = [
+            'getid', 'getlabel', 'geticon', 'getgroup', 'getrequiredapp',
+            'getstoragestrategy', 'getopenconnectorsource', 'isenabled',
+            'requirespermission', 'authrequirements', 'list', 'get', 'create',
+            'update', 'delete', 'health',
+        ];
+
+        $reflection = new \ReflectionClass(IntegrationProvider::class);
+        foreach ($reflection->getMethods() as $method) {
+            $this->assertContains(
+                strtolower($method->getName()),
+                $allowed,
+                sprintf('IntegrationProvider must expose no command verb; found "%s"', $method->getName())
+            );
+        }
+    }//end testProviderContractExposesNoCommandPath()
+}//end class


### PR DESCRIPTION
## Summary

Gives any sibling Nextcloud app a sanctioned **server-side** seam to register itself as a **leaf** on OpenRegister objects — contributing render surfaces and app-local read/append data — through a typed collect-event, the same idiom OpenRegister already uses for MCP tool providers and flow nodes.

Implements spec **#2102** (`spec/app-leaf-provider-registration`) and **ADR-066** (cross-app leaf registration — the render-and-read boundary; lifts the ADR-041 moratorium strictly for the collect/render/read case). Render-and-read only by construction: descriptor + provider carry no verb; cross-app *commands* stay ADR-041 typed events.

## What changed

**New**
- `lib/Event/RegisterLeafProvidersEvent.php` — typed collect-event mirroring `RegisterMcpToolProvidersEvent` line for line (`registerLeaf()` + `getLeaves()`).
- `lib/Service/Integration/LeafDescriptor.php` — value object: id, label, icon, requiredApp, group, surfaces, referenceType, requiresPermission, and a non-empty `kinds` set `{render-surface, data-provider, agent-runner}` (agent-runner reserved — hermiq's change consumes it).
- `lib/Service/Integration/LeafRegistry.php` — dispatches the event **once, lazily, on first read**; validates (non-empty/known kinds, kebab-case id, data-provider-requires-provider); **first-wins** on duplicate id (ADR-013); **swallows a throwing listener** so it costs only its own leaf; lands data-provider leaves on the shared `IntegrationRegistry`. Exposes `describeForCapabilities()` for discovery.
- Tests: `LeafDescriptorTest` + `LeafRegistryTest` (22 tests / 174 assertions).

**Changed**
- `IntegrationRegistry` — lazy `setLeafLoader()` hook (guarded, once-per-request) so a data-provider leaf lands before `ObjectIntegrationsController` resolves it, without eager dispatch.
- `IntegrationProvider` — documents the new **`app-local`** storage strategy (data lives in the sibling app's own store; OpenRegister routes `list()`/optional `create()` and persists nothing). Existing strategies untouched.
- `IntegrationsCapability` — new `openregister.integrations.leaves` OCS block (id, label, requiredApp, surfaces, kinds, usability) — discoverable without loading any leaf's JS.
- `Application::bootLeafRegistry()` — installs the lazy loader; registers the `LeafRegistry` service.
- `docs/Integrations/leaf-system.md` — cross-app section + worked notes-leaf example (ADR-019/041/013/066).

## app-local routing

The existing `ObjectIntegrationsController` dispatch already calls provider methods directly, so `app-local` needs **no** controller branch: the provider's `list()`/`create()` run in the sibling app's DI context; a read-only leaf lets the `AbstractIntegrationProvider` default throw `NotImplementedException` while `list()` stays usable.

## Verification

- **22 PHPUnit tests** pass in the `nextcloud:34` container (174 assertions): announced leaf reaches catalogue; built-ins survive; throwing listener isolated; empty/unknown kinds rejected; data-provider-requires-provider; first-wins collision; namespaced ids coexist; app-local list/empty/create + read-only-throws; OCS reports leaves + usability (disabled required app → unusable); render-and-read boundary (contract exposes no command verb).
- **Live probe** against the running instance: a leaf registered through the real `RegisterLeafProvidersEvent` dispatcher appears in `describeForCapabilities()`, its data-provider is routable on `IntegrationRegistry`, and app-local list→create appends only in the provider's own store. Probe removed (no test provider shipped).
- `php -l` + `composer phpcs` clean on all changed `lib/` files; spec-coverage (gate-16) passes vs `origin/development`.

## Out of scope / follow-up

- **JS half + gate-24 extension** — the render-surface↔JS-id correlation lives in `@conduction/nextcloud-vue` (`registerIntegration()` / `check-integration-parity.js`) and the canonical gate-24 in hydra `run-hydra-gates.sh`. The openregister wrapper only delegates to the JS check, so the cross-app correlation is a coordinated follow-up in those repos — not edited here.
- The `agent-runner` kind is a reserved forward-reference only.

Spec: #2102 · ADR-066 (hydra).
