### PR TITLE
feat(flow): sub-flow node — run a flow as a step (#2067)

### DIFF
--- a/lib/Listener/FlowNodeRegistrationListener.php
+++ b/lib/Listener/FlowNodeRegistrationListener.php
@@ -33,6 +33,7 @@ use OCA\OpenRegister\Service\Flow\Nodes\LoopNode;
 use OCA\OpenRegister\Service\Flow\Nodes\MergeNode;
 use OCA\OpenRegister\Service\Flow\Nodes\SetFieldsNode;
 use OCA\OpenRegister\Service\Flow\Nodes\StopNode;
+use OCA\OpenRegister\Service\Flow\Nodes\SubFlowNode;
 use OCA\OpenRegister\Service\Flow\Nodes\SwitchNode;
 use OCA\OpenRegister\Service\Flow\Nodes\WaitNode;
 use OCA\OpenRegister\Service\Flow\RegisterFlowNodesEvent;
@@ -56,6 +57,7 @@ class FlowNodeRegistrationListener implements IEventListener
      * @param StopNode      $stop      The built-in "Stop" node.
      * @param MergeNode     $merge     The built-in "Merge" node.
      * @param LoopNode      $loop      The built-in "Loop over items" node.
+     * @param SubFlowNode   $subFlow   The built-in "Run a flow" node.
      */
     public function __construct(
         private readonly SetFieldsNode $setFields,
@@ -64,7 +66,8 @@ class FlowNodeRegistrationListener implements IEventListener
         private readonly SwitchNode $switch,
         private readonly StopNode $stop,
         private readonly MergeNode $merge,
-        private readonly LoopNode $loop
+        private readonly LoopNode $loop,
+        private readonly SubFlowNode $subFlow
     ) {
 
     }//end __construct()
@@ -91,6 +94,7 @@ class FlowNodeRegistrationListener implements IEventListener
         $event->registerNode(node: $this->stop);
         $event->registerNode(node: $this->merge);
         $event->registerNode(node: $this->loop);
+        $event->registerNode(node: $this->subFlow);
 
     }//end handle()
 }//end class

--- a/lib/Service/Flow/Nodes/SubFlowNode.php
+++ b/lib/Service/Flow/Nodes/SubFlowNode.php
@@ -1,0 +1,350 @@
+<?php
+
+/**
+ * Runs another flow as one step of this one.
+ *
+ * The equivalent of n8n's "Execute Sub-workflow" node, with the same two shapes:
+ *  - Wait (the default): run the named flow now, seeded with this step's items,
+ *    and bring its output items back — the sub-flow behaves like a function the
+ *    parent calls and reads the result of.
+ *  - Fire-and-forget: queue the named flow against the run's subject and carry
+ *    on, so a long or independent flow does not sit on the parent's path.
+ *
+ * A flow is data, so "which flow" is just an id the author picks — the same
+ * resolver the trigger side uses turns it into a document. That means a
+ * sub-flow can live in any consuming app: openconnector calls a hermiq
+ * agentflow, procest calls an openconnector flow, all through this one node.
+ *
+ * Because a flow can call a flow, it can call itself — directly or round a
+ * cycle. The run carries the stack of flow ids it is inside; a sub-flow already
+ * on that stack is refused, and a depth ceiling backstops a chain that grows
+ * without repeating. Neither is a business rule: both are guards against a graph
+ * that would never settle.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-sub-flow/specs/flow-sub-flow/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Nodes;
+
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowResolverRegistry;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
+use RuntimeException;
+use stdClass;
+use UnexpectedValueException;
+
+/**
+ * Executes a named flow as a step, optionally waiting for its result.
+ */
+class SubFlowNode implements IFlowNode
+{
+
+    /**
+     * How deep a chain of sub-flows may go before it is refused.
+     *
+     * A flow calling a flow calling a flow is legitimate; a chain hundreds deep
+     * is a runaway. This is the backstop for a chain that grows without ever
+     * repeating an id (which the stack check would otherwise catch).
+     *
+     * @var integer
+     */
+    private const MAX_DEPTH = 16;
+
+    /**
+     * The context key holding the stack of flow ids the run is inside.
+     *
+     * @var string
+     */
+    private const STACK_KEY = 'flowStack';
+
+    /**
+     * Constructor.
+     *
+     * @param FlowResolverRegistry $resolvers Turns a flow id into a document.
+     * @param FlowRunService       $runs      Queues and executes the sub-run.
+     * @param IL10N                $l10n      Translations.
+     * @param IURLGenerator        $urls      For the palette icon.
+     */
+    public function __construct(
+        private readonly FlowResolverRegistry $resolvers,
+        private readonly FlowRunService $runs,
+        private readonly IL10N $l10n,
+        private readonly IURLGenerator $urls
+    ) {
+
+    }//end __construct()
+
+    /**
+     * The step type.
+     *
+     * @return string The id.
+     */
+    public function getId(): string
+    {
+        return 'openregister.sub-flow';
+
+    }//end getId()
+
+    /**
+     * Palette name.
+     *
+     * @return string The display name.
+     */
+    public function getDisplayName(): string
+    {
+        return $this->l10n->t('Run a flow');
+
+    }//end getDisplayName()
+
+    /**
+     * Palette description.
+     *
+     * @return string The description.
+     */
+    public function getDescription(): string
+    {
+        return $this->l10n->t('Run another flow as a step — wait for its result, or start it and carry on.');
+
+    }//end getDescription()
+
+    /**
+     * Palette icon.
+     *
+     * @return string The icon URL.
+     */
+    public function getIcon(): string
+    {
+        return $this->urls->imagePath('core', 'actions/external.svg');
+
+    }//end getIcon()
+
+    /**
+     * Running a sub-flow grants no privilege of its own; the sub-run enforces
+     * whatever its own steps require.
+     *
+     * @param int $scope The scope constant.
+     *
+     * @return boolean Whether it is available.
+     */
+    public function isAvailableForScope(int $scope): bool
+    {
+        return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
+
+    }//end isAvailableForScope()
+
+    /**
+     * Reject a sub-flow step that names no flow.
+     *
+     * @param array $config The step configuration.
+     *
+     * @return void
+     *
+     * @throws UnexpectedValueException When no flow is named.
+     */
+    public function validateConfig(array $config): void
+    {
+        if ($this->flowIdFrom(config: $config) === '') {
+            throw new UnexpectedValueException($this->l10n->t('A sub-flow step needs a flow to run.'));
+        }
+
+    }//end validateConfig()
+
+    /**
+     * Run (or queue) the named flow.
+     *
+     * With `wait` (the default) the sub-flow runs now, seeded with these items,
+     * and its output items become this step's output — a terminal sub-run that
+     * did not complete cleanly raises, so the parent's `onError` policy decides
+     * what happens. Without `wait` the sub-flow is queued against the run's
+     * subject and these items pass through untouched.
+     *
+     * @param array $items   The input items.
+     * @param array $config  The step configuration.
+     * @param array $context Run-level metadata (carries the sub-flow stack).
+     *
+     * @return array The sub-flow's output items, or the input items when not waiting.
+     *
+     * @throws UnexpectedValueException When the named flow cannot be resolved,
+     *                                  or a sub-flow cycle or depth limit is hit.
+     * @throws RuntimeException         When a waited-on sub-run does not complete.
+     */
+    public function execute(array $items, array $config, array $context): array
+    {
+        $flowId = $this->flowIdFrom(config: $config);
+        if ($flowId === '') {
+            return $items;
+        }
+
+        $stack = $this->guardRecursion(flowId: $flowId, context: $context);
+
+        $flow = $this->resolvers->resolveFlow(flowId: $flowId);
+        if ($flow === null) {
+            throw new UnexpectedValueException(
+                $this->l10n->t('The sub-flow "%s" could not be found.', [$flowId])
+            );
+        }
+
+        $subject  = $this->subjectDescriptor(context: $context);
+        $childCtx = $context;
+        $childCtx[self::STACK_KEY] = $stack;
+
+        // Fire-and-forget: queue against the subject and carry on. The queued
+        // run starts from its subject, not from these items — an independent
+        // flow, kicked off, not a function whose result we read.
+        if (($config['wait'] ?? true) !== true) {
+            $this->runs->queue(
+                flowId: $flowId,
+                subject: $subject,
+                trigger: 'sub-flow',
+                context: $childCtx,
+                user: ($context['triggeredBy'] ?? null)
+            );
+
+            return $items;
+        }
+
+        // Wait: run the sub-flow now, seeded with these items, and return what
+        // it produced. It gets its own persisted run and trace, so a sub-flow
+        // is as inspectable as a top-level one.
+        $run = $this->runs->queue(
+            flowId: $flowId,
+            subject: $subject,
+            trigger: 'sub-flow',
+            context: $childCtx,
+            user: ($context['triggeredBy'] ?? null)
+        );
+
+        $run = $this->runs->execute(
+            run: $run,
+            flow: $flow,
+            subject: new stdClass(),
+            seedItems: $items
+        );
+
+        return $this->itemsFrom(run: $run, flowId: $flowId);
+
+    }//end execute()
+
+    /**
+     * Refuse a sub-flow that would recurse, and return the stack it should push.
+     *
+     * @param string $flowId  The sub-flow's id.
+     * @param array  $context The run context.
+     *
+     * @return array<int, string> The stack to hand the sub-run (this id pushed).
+     *
+     * @throws UnexpectedValueException When the id is already on the stack, or
+     *                                  the stack is at the depth ceiling.
+     */
+    private function guardRecursion(string $flowId, array $context): array
+    {
+        $stack = array_values((array) ($context[self::STACK_KEY] ?? []));
+
+        if (in_array($flowId, $stack, true) === true) {
+            throw new UnexpectedValueException(
+                $this->l10n->t('The flow "%s" is already running as a parent of this step; a flow cannot call itself.', [$flowId])
+            );
+        }
+
+        if (count($stack) >= self::MAX_DEPTH) {
+            throw new UnexpectedValueException(
+                $this->l10n->t('Sub-flows are nested too deeply (more than %s levels).', [(string) self::MAX_DEPTH])
+            );
+        }
+
+        $stack[] = $flowId;
+
+        return $stack;
+
+    }//end guardRecursion()
+
+    /**
+     * Read the sub-run's output items, raising when it did not complete cleanly.
+     *
+     * A completed sub-run hands its items back to the parent. A stopped, failed
+     * or dead-lettered one raises, so it reaches the parent as a step failure
+     * and is handled by the parent step's `onError` policy — exactly as if the
+     * failing work had been inline. A suspended sub-run is treated the same: a
+     * synchronous caller cannot wait indefinitely for a paused branch.
+     *
+     * @param FlowRun $run    The finished sub-run.
+     * @param string  $flowId The sub-flow id (for the message).
+     *
+     * @return array<int, array> The sub-run's output items.
+     *
+     * @throws RuntimeException When the sub-run did not complete.
+     */
+    private function itemsFrom(FlowRun $run, string $flowId): array
+    {
+        $status = (string) $run->getStatus();
+        if ($status !== FlowRun::STATUS_COMPLETED) {
+            $detail = '';
+            if ($run->getError() !== null) {
+                $detail = ': '.$run->getError();
+            }
+
+            throw new RuntimeException(
+                sprintf('Sub-flow "%s" did not complete (status: %s%s).', $flowId, $status, $detail)
+            );
+        }
+
+        return FlowItems::normalise(value: ($run->getItems() ?? []));
+
+    }//end itemsFrom()
+
+    /**
+     * The subject descriptor to run the sub-flow against.
+     *
+     * A sub-flow is about the same object the parent run is about, so the
+     * parent's subject descriptor is carried through. Absent one (a flow with no
+     * subject), an empty descriptor is fine: a waited sub-flow is seeded with
+     * items, not the subject.
+     *
+     * @param array $context The run context.
+     *
+     * @return array<string, string|null> `{uuid, register, schema}`.
+     */
+    private function subjectDescriptor(array $context): array
+    {
+        $subject = (array) ($context['subject'] ?? []);
+
+        return [
+            'uuid'     => ($subject['uuid'] ?? null),
+            'register' => ($subject['register'] ?? null),
+            'schema'   => ($subject['schema'] ?? null),
+        ];
+
+    }//end subjectDescriptor()
+
+    /**
+     * Read the configured flow id, accepting `flowId` or `flow`.
+     *
+     * @param array $config The step configuration.
+     *
+     * @return string The flow id, or an empty string when none is set.
+     */
+    private function flowIdFrom(array $config): string
+    {
+        return trim((string) ($config['flowId'] ?? ($config['flow'] ?? '')));
+
+    }//end flowIdFrom()
+}//end class

--- a/openspec/changes/or-flow-sub-flow/.openspec.yaml
+++ b/openspec/changes/or-flow-sub-flow/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-sub-flow

--- a/openspec/changes/or-flow-sub-flow/proposal.md
+++ b/openspec/changes/or-flow-sub-flow/proposal.md
@@ -1,0 +1,41 @@
+# Proposal: or-flow-sub-flow
+
+## Summary
+
+A `openregister.sub-flow` node that runs another flow as a step — n8n's "Execute
+Sub-workflow", closing one of the named gaps in #2067.
+
+## Why
+
+Parity, and reuse. A flow that is worth authoring once (enrich an address,
+score a lead, notify a channel) should be callable from every other flow rather
+than copied into each. n8n has this; without it the fleet's flows cannot be
+composed, only duplicated. The run infrastructure to do it now exists
+(`FlowRunService.queue`/`execute`, the resolver registry), so the node is small.
+
+## What Changes
+
+- **`SubFlowNode`** (`openregister.sub-flow`), a built-in node with two shapes:
+  - **Wait** (default): resolve the named flow, run it *now* seeded with this
+    step's items, and return its output items — the sub-flow is a function the
+    parent calls and reads. The sub-run is a persisted `FlowRun` with its own
+    trace, so it is as inspectable as a top-level run. A sub-run that does not
+    complete cleanly raises, so it reaches the parent step's `onError` policy
+    exactly as inline work would.
+  - **Fire-and-forget** (`wait: false`): queue the named flow against the run's
+    subject and carry on; the parent's items pass through untouched.
+- Which flow is just an id resolved through the same `FlowResolverRegistry` the
+  trigger side uses — so a sub-flow can live in any consuming app (openconnector
+  → a hermiq agentflow, procest → an openconnector flow).
+- **Recursion guards**: the run carries the stack of flow ids it is inside
+  (`context.flowStack`). A sub-flow already on the stack is refused (a flow
+  cannot call itself round a cycle), and a depth ceiling (16) backstops a chain
+  that grows without repeating. Both fail the step, not the process.
+
+## Out of scope
+
+- Passing an explicit subject or a mapped input to the sub-flow (today the
+  waited sub-flow is seeded with the parent's items; the fired one runs against
+  the parent's subject). Input mapping is a later refinement.
+- A visual "open sub-flow" affordance in the builder — this change is the engine
+  node; the builder can add navigation on top of it.

--- a/openspec/changes/or-flow-sub-flow/specs/flow-sub-flow/spec.md
+++ b/openspec/changes/or-flow-sub-flow/specs/flow-sub-flow/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: A flow can run another flow as a step (REQ-SF-001)
+
+OpenRegister SHALL provide a built-in `openregister.sub-flow` node that runs a
+named flow as one step. With `wait` (the default) it SHALL run the named flow
+seeded with the step's items and return the sub-flow's output items. Without
+`wait` it SHALL queue the named flow against the run's subject and pass the
+step's items through unchanged. A sub-flow step naming no flow SHALL be refused
+at save time.
+
+#### Scenario: A waited sub-flow returns its result
+
+- **GIVEN** a flow whose step runs sub-flow "child" with wait on
+- **WHEN** the step executes
+- **THEN** "child" runs seeded with the step's items
+- **AND** its output items become the step's output
+
+#### Scenario: A fired sub-flow does not feed back
+
+- **GIVEN** a sub-flow step with wait off
+- **WHEN** the step executes
+- **THEN** the named flow is queued
+- **AND** the step's input items pass through unchanged
+
+### Requirement: A waited sub-flow's failure reaches the parent (REQ-SF-002)
+
+A waited sub-run that does not complete cleanly SHALL raise, so the parent
+step's `onError` policy decides the outcome — a sub-flow failure is handled
+exactly as an inline step's failure.
+
+#### Scenario: A failed sub-run raises
+
+- **GIVEN** a waited sub-flow that ends failed
+- **WHEN** its result is read
+- **THEN** the sub-flow step raises
+
+### Requirement: A flow cannot recurse without bound (REQ-SF-003)
+
+A sub-flow already among the flow ids the run is inside SHALL be refused, and
+sub-flow nesting SHALL be capped at a fixed depth. Both are step failures, not
+process failures.
+
+#### Scenario: A flow cannot call itself round a cycle
+
+- **GIVEN** a run already inside flow "A"
+- **WHEN** a step tries to run sub-flow "A"
+- **THEN** the step is refused
+
+#### Scenario: Nesting past the ceiling is refused
+
+- **GIVEN** sub-flows nested to the depth ceiling
+- **WHEN** one more sub-flow is entered
+- **THEN** the step is refused
+
+@e2e exclude engine-level node — covered by SubFlowNodeTest and live-verified on
+8080 (palette registration + DI graph); no user-facing page of its own yet

--- a/openspec/changes/or-flow-sub-flow/tasks.md
+++ b/openspec/changes/or-flow-sub-flow/tasks.md
@@ -1,0 +1,11 @@
+# Tasks: or-flow-sub-flow
+
+- [x] `SubFlowNode` (`openregister.sub-flow`) — wait (run + return items) and
+      fire-and-forget (queue + pass through) shapes.
+- [x] Resolve the sub-flow through `FlowResolverRegistry`; refuse an unknown id.
+- [x] Recursion guards — cycle (id on the run's flow stack) and depth ceiling.
+- [x] Register the node on `RegisterFlowNodesEvent` (FlowNodeRegistrationListener).
+- [x] `SubFlowNodeTest` — wait, fire-and-forget, unknown, cycle, depth, failed
+      sub-run, validate, scope (8 tests).
+- [x] phpcs clean; full flow node suite green (127 tests).
+- [ ] Input mapping (explicit subject / mapped input to the sub-flow) — follow-up.

--- a/tests/Unit/Service/Flow/SubFlowNodeTest.php
+++ b/tests/Unit/Service/Flow/SubFlowNodeTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowResolverRegistry;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
+use OCA\OpenRegister\Service\Flow\Nodes\SubFlowNode;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use UnexpectedValueException;
+
+class SubFlowNodeTest extends TestCase
+{
+
+    private FlowResolverRegistry $resolvers;
+
+    private FlowRunService $runs;
+
+    private SubFlowNode $node;
+
+    protected function setUp(): void
+    {
+        $l = $this->createMock(IL10N::class);
+        $l->method('t')->willReturnArgument(0);
+
+        $this->resolvers = $this->createMock(FlowResolverRegistry::class);
+        $this->runs      = $this->createMock(FlowRunService::class);
+
+        $this->node = new SubFlowNode(
+            $this->resolvers,
+            $this->runs,
+            $l,
+            $this->createMock(IURLGenerator::class)
+        );
+    }//end setUp()
+
+    private function finishedRun(string $status, array $items=[]): FlowRun
+    {
+        $run = new FlowRun();
+        $run->setStatus($status);
+        $run->setItems($items);
+        return $run;
+    }//end finishedRun()
+
+    public function testWaitRunsTheSubFlowAndReturnsItsItems(): void
+    {
+        $this->resolvers->method('resolveFlow')->with('child')->willReturn(['id' => 'child', 'edges' => []]);
+
+        $produced = [FlowItems::item(json: ['answer' => 42])];
+        $this->runs->method('queue')->willReturn($this->finishedRun(FlowRun::STATUS_QUEUED));
+        $this->runs->expects($this->once())->method('execute')
+            ->willReturn($this->finishedRun(FlowRun::STATUS_COMPLETED, $produced));
+
+        $out = $this->node->execute([FlowItems::item(json: ['in' => 1])], ['flowId' => 'child'], []);
+
+        $this->assertCount(1, $out);
+        $this->assertSame(42, $out[0]['json']['answer']);
+    }//end testWaitRunsTheSubFlowAndReturnsItsItems()
+
+    public function testFireAndForgetQueuesAndPassesItemsThrough(): void
+    {
+        $input = [FlowItems::item(json: ['in' => 1])];
+
+        $this->resolvers->method('resolveFlow')->willReturn(['id' => 'child']);
+        $this->runs->expects($this->once())->method('queue')->willReturn($this->finishedRun(FlowRun::STATUS_QUEUED));
+        $this->runs->expects($this->never())->method('execute');
+
+        $out = $this->node->execute($input, ['flowId' => 'child', 'wait' => false], []);
+
+        // The parent's items are untouched — a fired sub-flow does not feed back.
+        $this->assertSame($input, $out);
+    }//end testFireAndForgetQueuesAndPassesItemsThrough()
+
+    public function testAnUnknownSubFlowIsRefused(): void
+    {
+        $this->resolvers->method('resolveFlow')->willReturn(null);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->node->execute([], ['flowId' => 'nope'], []);
+    }//end testAnUnknownSubFlowIsRefused()
+
+    public function testAFlowCannotCallItself(): void
+    {
+        // 'child' is already on the stack the run is inside.
+        $this->expectException(UnexpectedValueException::class);
+        $this->node->execute([], ['flowId' => 'child'], ['flowStack' => ['parent', 'child']]);
+    }//end testAFlowCannotCallItself()
+
+    public function testNestingTooDeepIsRefused(): void
+    {
+        $deep = array_map(static fn (int $n): string => 'f'.$n, range(1, 16));
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->node->execute([], ['flowId' => 'one-more'], ['flowStack' => $deep]);
+    }//end testNestingTooDeepIsRefused()
+
+    public function testAWaitedSubRunThatDidNotCompleteRaises(): void
+    {
+        $this->resolvers->method('resolveFlow')->willReturn(['id' => 'child']);
+        $this->runs->method('queue')->willReturn($this->finishedRun(FlowRun::STATUS_QUEUED));
+        $this->runs->method('execute')->willReturn($this->finishedRun(FlowRun::STATUS_FAILED));
+
+        $this->expectException(RuntimeException::class);
+        $this->node->execute([], ['flowId' => 'child'], []);
+    }//end testAWaitedSubRunThatDidNotCompleteRaises()
+
+    public function testASubFlowStepNeedsAFlow(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->node->validateConfig([]);
+    }//end testASubFlowStepNeedsAFlow()
+
+    public function testItIsAvailableInBothScopes(): void
+    {
+        $this->assertTrue($this->node->isAvailableForScope(IManager::SCOPE_ADMIN));
+        $this->assertTrue($this->node->isAvailableForScope(IManager::SCOPE_USER));
+    }//end testItIsAvailableInBothScopes()
+}//end class


### PR DESCRIPTION
Closes one of the named gaps in #2067 (sub-flows). n8n's "Execute Sub-workflow", as the built-in `openregister.sub-flow` node.

## Why

A flow worth authoring once (enrich an address, score a lead, notify a channel) should be callable from every other flow instead of copied into each. The run infrastructure to do it already exists (`FlowRunService.queue`/`execute`, the resolver registry), so the node is small.

## What

Two shapes, matching n8n:

- **Wait** (default): resolve the named flow, run it *now* seeded with this step's items, and return its output items — the sub-flow is a function the parent calls and reads. It gets its own **persisted `FlowRun` and trace**, so a sub-flow is as inspectable as a top-level run. A sub-run that does not complete cleanly **raises**, so it reaches the parent step's `onError` policy exactly as inline work would.
- **Fire-and-forget** (`wait: false`): queue the named flow against the run's subject and carry on; the parent's items pass through untouched.

Which flow is just an id resolved through the same `FlowResolverRegistry` the trigger side uses — so a sub-flow can live in **any consuming app** (openconnector → a hermiq agentflow, procest → an openconnector flow) with no new wiring.

**Recursion guards**: the run carries the stack of flow ids it is inside (`context.flowStack`). A sub-flow already on the stack is refused (a flow cannot call itself round a cycle), and a depth ceiling (16) backstops a chain that grows without repeating. Both fail the step, not the process.

## Verification

- **Unit** — `SubFlowNodeTest`: wait/return, fire-and-forget/passthrough, unknown flow, self-call cycle, depth ceiling, failed sub-run raises, validate, scope (8 tests). Full flow node suite green (127 tests). phpcs clean.
- **Live (8080)** — the things unit tests can't reach: the **DI graph resolves with no cycle** (`SubFlowNode → FlowRunService → FlowNodeRegistry`), and `openregister.sub-flow` **registers in the palette** alongside the other nodes.

Reuses `FlowRunService.queue`/`execute` verbatim — the path merged and live-verified in #2105.

## Out of scope (follow-up)

Input mapping (an explicit subject / mapped input to the sub-flow). Today the waited sub-flow is seeded with the parent's items; the fired one runs against the parent's subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)