### PR TITLE
feat(flow): fire the lock/unlock/revert/state-change triggers (#2068)

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -2402,12 +2402,18 @@ class Application extends App implements IBootstrap
         $context->registerEventListener(ObjectCreatedEvent::class, ObjectChangeListener::class);
         $context->registerEventListener(ObjectUpdatedEvent::class, ObjectChangeListener::class);
 
-        // Object-lifecycle flow triggers: queue a run for every flow wired to
-        // create / update / delete. The first Nextcloud-native trigger; others
-        // register the same way.
+        // Object-lifecycle flow triggers: queue a run for every flow wired to a
+        // lifecycle event. Create / update / delete plus lock / unlock / revert /
+        // state-change — the last four were declared in the event catalog but had
+        // no listener firing them until now, so a flow could select them and never
+        // run.
         $context->registerEventListener(ObjectCreatedEvent::class, \OCA\OpenRegister\Listener\FlowTriggerListener::class);
         $context->registerEventListener(ObjectUpdatedEvent::class, \OCA\OpenRegister\Listener\FlowTriggerListener::class);
         $context->registerEventListener(ObjectDeletedEvent::class, \OCA\OpenRegister\Listener\FlowTriggerListener::class);
+        $context->registerEventListener(ObjectLockedEvent::class, \OCA\OpenRegister\Listener\FlowTriggerListener::class);
+        $context->registerEventListener(ObjectUnlockedEvent::class, \OCA\OpenRegister\Listener\FlowTriggerListener::class);
+        $context->registerEventListener(ObjectRevertedEvent::class, \OCA\OpenRegister\Listener\FlowTriggerListener::class);
+        $context->registerEventListener(ObjectTransitionedEvent::class, \OCA\OpenRegister\Listener\FlowTriggerListener::class);
 
         // ToolRegistrationListener for agent function tools.
         $context->registerEventListener(ToolRegistrationEvent::class, ToolRegistrationListener::class);

--- a/lib/Listener/FlowTriggerListener.php
+++ b/lib/Listener/FlowTriggerListener.php
@@ -3,12 +3,19 @@
 /**
  * Fires object-lifecycle triggers into the flow engine.
  *
- * The first Nextcloud-native trigger: when an OpenRegister object is created,
- * updated or deleted, this hands the event to {@see FlowTriggerService}, which
- * queues a run for every flow wired to it. Other native triggers (files,
- * shares, calendar, users, tags) will register the same way — a small listener
- * that translates a core event into a `FlowTriggerService::fire()` call — so the
- * mechanism is here once and each new trigger is a few lines.
+ * The object-lifecycle triggers: when an OpenRegister object is created,
+ * updated, deleted, locked, unlocked, reverted or changes state, this hands the
+ * event to {@see FlowTriggerService}, which queues a run for every flow wired to
+ * it. Each is one line in the event map here; the mechanism is written once.
+ *
+ * The lock/revert/state triggers were declared in the event catalog from the
+ * start but had no listener firing them — a flow could select "an object is
+ * locked" and it would never run. Wiring them here closes that gap so every
+ * catalog trigger a flow can pick is one the engine actually fires.
+ *
+ * Non-object native triggers (files, shares, calendar, users, tags) carry a
+ * subject that is not an OpenRegister object, so they need a run-seed model this
+ * object-centric listener does not have; they are a separate change.
  *
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  * SPDX-License-Identifier: EUPL-1.2
@@ -31,6 +38,10 @@ namespace OCA\OpenRegister\Listener;
 
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\OpenRegister\Event\ObjectDeletedEvent;
+use OCA\OpenRegister\Event\ObjectLockedEvent;
+use OCA\OpenRegister\Event\ObjectRevertedEvent;
+use OCA\OpenRegister\Event\ObjectTransitionedEvent;
+use OCA\OpenRegister\Event\ObjectUnlockedEvent;
 use OCA\OpenRegister\Event\ObjectUpdatedEvent;
 use OCA\OpenRegister\Service\Flow\FlowTriggerService;
 use OCP\EventDispatcher\Event;
@@ -38,9 +49,9 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\IUserSession;
 
 /**
- * Queues flow runs on object create / update / delete.
+ * Queues flow runs on every object-lifecycle event.
  *
- * @template-implements IEventListener<ObjectCreatedEvent|ObjectUpdatedEvent|ObjectDeletedEvent>
+ * @template-implements IEventListener<ObjectCreatedEvent|ObjectUpdatedEvent|ObjectDeletedEvent|ObjectLockedEvent|ObjectUnlockedEvent|ObjectRevertedEvent|ObjectTransitionedEvent>
  */
 class FlowTriggerListener implements IEventListener
 {
@@ -86,10 +97,38 @@ class FlowTriggerListener implements IEventListener
                 'register' => (string) $object->getRegister(),
                 'schema'   => (string) $object->getSchema(),
             ],
-            user: $user
+            user: $user,
+            context: $this->contextFor(event: $event)
         );
 
     }//end handle()
+
+    /**
+     * Extra run context an event carries beyond the object it is about.
+     *
+     * A state change is the one lifecycle event that is *about* a change rather
+     * than a moment: which action ran and the places it moved between are what a
+     * flow wired to "an object changes state" needs to branch on, so they are
+     * put on the run context where the flow's conditions can read them. Every
+     * other lifecycle event adds nothing beyond its subject.
+     *
+     * @param Event $event The dispatched event.
+     *
+     * @return array<string, string> The extra context, empty for most events.
+     */
+    private function contextFor(Event $event): array
+    {
+        if ($event instanceof ObjectTransitionedEvent) {
+            return [
+                'action' => $event->getAction(),
+                'from'   => $event->getFrom(),
+                'to'     => $event->getTo(),
+            ];
+        }
+
+        return [];
+
+    }//end contextFor()
 
     /**
      * Map an event class to the trigger id flows are wired to.
@@ -112,6 +151,22 @@ class FlowTriggerListener implements IEventListener
 
         if ($event instanceof ObjectDeletedEvent) {
             return 'object.deleted';
+        }
+
+        if ($event instanceof ObjectLockedEvent) {
+            return 'object.locked';
+        }
+
+        if ($event instanceof ObjectUnlockedEvent) {
+            return 'object.unlocked';
+        }
+
+        if ($event instanceof ObjectRevertedEvent) {
+            return 'object.reverted';
+        }
+
+        if ($event instanceof ObjectTransitionedEvent) {
+            return 'object.transitioned';
         }
 
         return null;

--- a/tests/Unit/Listener/FlowTriggerListenerTest.php
+++ b/tests/Unit/Listener/FlowTriggerListenerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Listener;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCA\OpenRegister\Event\ObjectLockedEvent;
+use OCA\OpenRegister\Event\ObjectRevertedEvent;
+use OCA\OpenRegister\Event\ObjectTransitionedEvent;
+use OCA\OpenRegister\Event\ObjectUnlockedEvent;
+use OCA\OpenRegister\Listener\FlowTriggerListener;
+use OCA\OpenRegister\Service\Flow\FlowTriggerService;
+use OCP\EventDispatcher\Event;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+
+class FlowTriggerListenerTest extends TestCase
+{
+    private FlowTriggerService $triggers;
+
+    private FlowTriggerListener $listener;
+
+    protected function setUp(): void
+    {
+        $this->triggers = $this->createMock(FlowTriggerService::class);
+        $session        = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn(null);
+
+        $this->listener = new FlowTriggerListener($this->triggers, $session);
+    }
+
+    private function object(): ObjectEntity
+    {
+        $o = new ObjectEntity();
+        $o->setUuid('obj-1');
+        $o->setRegister('reg');
+        $o->setSchema('sch');
+        return $o;
+    }
+
+    public function testLockFiresTheLockedTrigger(): void
+    {
+        $this->triggers->expects($this->once())->method('fire')
+            ->with('object.locked', $this->anything(), null, [])
+            ->willReturn(1);
+
+        $this->listener->handle(new ObjectLockedEvent($this->object()));
+    }
+
+    public function testUnlockFiresTheUnlockedTrigger(): void
+    {
+        $this->triggers->expects($this->once())->method('fire')
+            ->with('object.unlocked', $this->anything(), null, [])
+            ->willReturn(1);
+
+        $this->listener->handle(new ObjectUnlockedEvent($this->object()));
+    }
+
+    public function testRevertFiresTheRevertedTrigger(): void
+    {
+        $this->triggers->expects($this->once())->method('fire')
+            ->with('object.reverted', $this->anything(), null, [])
+            ->willReturn(1);
+
+        $this->listener->handle(new ObjectRevertedEvent($this->object(), 'v1'));
+    }
+
+    public function testTransitionFiresAndCarriesTheStateChangeAsContext(): void
+    {
+        $this->triggers->expects($this->once())->method('fire')
+            ->with(
+                'object.transitioned',
+                $this->callback(static fn (array $s): bool => ($s['uuid'] ?? null) === 'obj-1'),
+                null,
+                ['action' => 'approve', 'from' => 'draft', 'to' => 'published']
+            )
+            ->willReturn(1);
+
+        $this->listener->handle(
+            new ObjectTransitionedEvent($this->object(), 'approve', 'draft', 'published', null, 'reg', 'sch')
+        );
+    }
+
+    public function testAnUnrelatedEventFiresNothing(): void
+    {
+        $this->triggers->expects($this->never())->method('fire');
+        $this->listener->handle(new class extends Event {});
+    }
+
+    public function testCreateStillCarriesNoExtraContext(): void
+    {
+        $this->triggers->expects($this->once())->method('fire')
+            ->with('object.created', $this->anything(), null, [])
+            ->willReturn(1);
+
+        $this->listener->handle(new ObjectCreatedEvent($this->object()));
+    }
+}


### PR DESCRIPTION
Closes a gap in #2068. The event catalog declared `object.locked`, `object.unlocked`, `object.reverted` and `object.transitioned` from the start, but the trigger listener only fired create/update/delete — **a flow could select "an object is locked" and it would never run.** This wires the four declared-but-dead triggers so every catalog trigger a flow can pick is one the engine actually fires.

## What

- Extend `FlowTriggerListener`'s event map with the four events, and register them in `Application.php`. Each is one line; the mechanism was already there.
- All four events are **genuinely dispatched** by OpenRegister — `MagicMapper` (lock/unlock), `RevertHandler` (revert), `TransitionEngine` (state change) — so wiring them is live, not speculative.
- `object.transitioned` is the one lifecycle event that is *about a change*, so it carries the **action** and the **from/to** places on the run context, where a flow wired to "an object changes state" can branch on them.

## Not in scope

Non-object native triggers (files, shares, calendar, users, tags) carry a subject that is **not** an OpenRegister object, so they need a run-seed model this object-centric listener does not have. That is a separate, larger change (a non-object run subject) rather than a few lines here — called out so the boundary is explicit.

## Verification

- **Unit** — `FlowTriggerListenerTest`: each new event maps to its trigger id, the transition carries its state-change context, create still carries none, an unrelated event fires nothing (6 tests). phpcs clean.
- **Live (8080)** — the listener resolves through DI and all four events map to their trigger ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)