### PR TITLE
feat(flow): pinned step output — n8n's "pin data" (#2070)

### DIFF
--- a/lib/Service/Flow/FlowEngine.php
+++ b/lib/Service/Flow/FlowEngine.php
@@ -238,6 +238,28 @@ class FlowEngine
             $itemsIn = $this->itemsForTransition(transition: $transition, placeItems: $placeItems);
             $items   = $itemsIn;
 
+            // Pinned output (n8n's "pin data"): when a run supplies a pin for
+            // this step, its stored output is used verbatim and the step is NOT
+            // executed — the side effect is skipped. This is what makes iterating
+            // on a flow cheap: pin the node that hits a real API, then re-run the
+            // downstream steps as often as needed without calling it again. A pin
+            // short-circuits before dispatch, so it also can neither stop,
+            // suspend nor fail — a pinned step always "just produces".
+            $pinned = $this->pinnedItems(flow: $flow, context: $context, transitionName: $name);
+            if ($pinned !== null) {
+                $items = $pinned;
+                $log[] = [
+                    'transition' => $name,
+                    'status'     => 'pinned',
+                    'itemsIn'    => count($itemsIn),
+                    'itemsOut'   => count($items),
+                ];
+
+                $placeItems = $this->advanceItems(transition: $transition, placeItems: $placeItems, items: $items);
+                $workflow->apply(subject: $subject, transitionName: $name);
+                continue;
+            }
+
             try {
                 $produced = $dispatcher->dispatch(step: $step, items: $itemsIn, context: $context);
                 $items    = FlowItems::normalise(value: $produced);
@@ -293,29 +315,21 @@ class FlowEngine
                     'resumeAt' => $suspension->getResumeAt(),
                 ];
             } catch (Throwable $e) {
-                $policy = (string) ($step['onError'] ?? self::ON_ERROR_STOP);
-                $log[]  = ['transition' => $name, 'status' => 'failed', 'error' => $e->getMessage()];
-
-                $this->logger->warning(
-                    message: '[FlowEngine] Flow step failed',
-                    context: [
-                        'file'       => __FILE__,
-                        'line'       => __LINE__,
-                        'flow'       => ($flow['id'] ?? null),
-                        'transition' => $name,
-                        'policy'     => $policy,
-                        'error'      => $e->getMessage(),
-                    ]
+                $log[]   = ['transition' => $name, 'status' => 'failed', 'error' => $e->getMessage()];
+                $outcome = $this->outcomeForFailedStep(
+                    step: $step,
+                    error: $e,
+                    name: $name,
+                    flow: $flow,
+                    log: $log,
+                    context: $context,
+                    items: $items
                 );
 
-                if ($policy === self::ON_ERROR_DEAD_LETTER) {
-                    return ['status' => self::STATUS_DEAD_LETTER, 'log' => $log, 'context' => $context, 'items' => $items];
-                }
-
-                if ($policy !== self::ON_ERROR_CONTINUE) {
-                    // `stop` is the default: an unknown policy stops rather than
-                    // continues, so a typo fails safe instead of running on.
-                    return ['status' => self::STATUS_STOPPED, 'log' => $log, 'context' => $context, 'items' => $items];
+                // A terminal outcome ends the run; null means the step's policy
+                // is `continue`, so the walk goes on.
+                if ($outcome !== null) {
+                    return $outcome;
                 }
             }//end try
 
@@ -357,6 +371,89 @@ class FlowEngine
         return [];
 
     }//end stepFor()
+
+    /**
+     * Decide what a failed step does, per its `onError` policy.
+     *
+     * Returns the terminal run result when the policy ends the run
+     * (`dead_letter`, or `stop` — the default, which also catches an unknown
+     * policy so a typo fails safe), or null when the policy is `continue` and
+     * the walk should go on. The failure is logged either way.
+     *
+     * @param array     $step    The step configuration.
+     * @param Throwable $error   The failure.
+     * @param string    $name    The transition name.
+     * @param array     $flow    The flow document (for the log context).
+     * @param array     $log     The run log so far (already holding the failure).
+     * @param array     $context The run context.
+     * @param array     $items   The items in hand at the failure.
+     *
+     * @return array|null The terminal result, or null to continue the walk.
+     *
+     * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
+     */
+    private function outcomeForFailedStep(
+        array $step,
+        Throwable $error,
+        string $name,
+        array $flow,
+        array $log,
+        array $context,
+        array $items
+    ): ?array {
+        $policy = (string) ($step['onError'] ?? self::ON_ERROR_STOP);
+
+        $this->logger->warning(
+            message: '[FlowEngine] Flow step failed',
+            context: [
+                'file'       => __FILE__,
+                'line'       => __LINE__,
+                'flow'       => ($flow['id'] ?? null),
+                'transition' => $name,
+                'policy'     => $policy,
+                'error'      => $error->getMessage(),
+            ]
+        );
+
+        if ($policy === self::ON_ERROR_DEAD_LETTER) {
+            return ['status' => self::STATUS_DEAD_LETTER, 'log' => $log, 'context' => $context, 'items' => $items];
+        }
+
+        if ($policy !== self::ON_ERROR_CONTINUE) {
+            return ['status' => self::STATUS_STOPPED, 'log' => $log, 'context' => $context, 'items' => $items];
+        }
+
+        return null;
+
+    }//end outcomeForFailedStep()
+
+    /**
+     * The pinned output for a step, or null when it is not pinned.
+     *
+     * Pins are a map of step name to an item list. A run carries them in its
+     * `context` under `pins` (a test/authoring run supplies them without
+     * touching the stored flow); a flow may also carry a `pins` map of its own,
+     * used only as the fallback so a run's pins always win. A step whose name is
+     * absent from both is not pinned and runs normally.
+     *
+     * @param array  $flow           The flow document.
+     * @param array  $context        The run context.
+     * @param string $transitionName The step's transition name.
+     *
+     * @return array<int, mixed>|null The pinned items, or null when not pinned.
+     *
+     * @spec openspec/changes/or-flow-pins/specs/flow-pins/spec.md
+     */
+    private function pinnedItems(array $flow, array $context, string $transitionName): ?array
+    {
+        $pins = (array) ($context['pins'] ?? ($flow['pins'] ?? []));
+        if (array_key_exists($transitionName, $pins) === false) {
+            return null;
+        }
+
+        return FlowItems::normalise(value: $pins[$transitionName]);
+
+    }//end pinnedItems()
 
     /**
      * Choose which enabled transition to fire, honouring edge conditions.

--- a/openspec/changes/or-flow-pins/.openspec.yaml
+++ b/openspec/changes/or-flow-pins/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-pins

--- a/openspec/changes/or-flow-pins/proposal.md
+++ b/openspec/changes/or-flow-pins/proposal.md
@@ -1,0 +1,41 @@
+# Proposal: or-flow-pins
+
+## Summary
+
+Pinned step output — n8n's "pin data". A run may carry a map of step name to a
+stored item list; a pinned step is not executed, its stored output is used
+verbatim, and its side effect is skipped. This is the execution-tooling half of
+#2070 that authoring a flow needs most.
+
+## Why
+
+Iterating on a flow means running it over and over. Without pins, every run
+re-executes every step — including the one that hits a real API, sends the
+email, or writes the record. Pinning that step's output lets an author re-run
+the *downstream* steps as often as needed without paying (or repeating) the
+expensive or irreversible one. It is the single biggest quality-of-life feature
+in n8n's editor, and it is small here because the engine already threads items
+step to step.
+
+## What Changes
+
+- `FlowEngine.run` checks a `pins` map before dispatching each step. The map is
+  step name → item list. When the step is pinned, its stored items become the
+  step's output, the step is **not** dispatched (no side effect), and the trace
+  records it as `pinned` rather than `completed`.
+- Pins are read from the run's `context.pins` first (a test/authoring run
+  supplies them without touching the stored flow), falling back to a `pins` map
+  on the flow document itself. A run's pins always win.
+- A pinned step short-circuits before dispatch, so it can neither stop, suspend
+  nor fail — a pinned step always just produces. That is the point: pin the step
+  that would fail or block, and the rest of the flow runs.
+
+## Out of scope (follow-up)
+
+- **Partial execution / run-from-here**: starting a run at a chosen step, seeding
+  the upstream from pins. That needs the initial marking placed mid-graph, which
+  is a larger, riskier change to run seeding — a separate change. Pinning is its
+  prerequisite and lands first.
+- An authoring UI for capturing and storing pins (the builder side). The engine
+  contract is here; a test-run endpoint / MCP parameter that supplies
+  `context.pins` layers on top.

--- a/openspec/changes/or-flow-pins/specs/flow-pins/spec.md
+++ b/openspec/changes/or-flow-pins/specs/flow-pins/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: A run can pin a step's output (REQ-PIN-001)
+
+The flow engine SHALL accept a `pins` map (step name → item list) and, for a
+step whose name is in the map, use the pinned items as the step's output without
+dispatching the step. A pinned step SHALL be traced as `pinned`. Pins SHALL be
+read from the run context first and the flow document second, so a run's pins
+override the flow's.
+
+#### Scenario: A pinned step is not executed
+
+- **GIVEN** a run that pins step "first"
+- **WHEN** the flow runs
+- **THEN** "first" is not dispatched
+- **AND** the next step receives the pinned items
+- **AND** the trace marks "first" as pinned
+
+#### Scenario: A run pin overrides a flow pin
+
+- **GIVEN** a flow that pins "first" and a run that also pins "first"
+- **WHEN** the flow runs
+- **THEN** the run's pinned items are used
+
+### Requirement: A pinned step cannot fail (REQ-PIN-002)
+
+Because a pinned step is not dispatched, it SHALL neither stop, suspend nor fail
+— a pin skips the step that would otherwise have done so.
+
+#### Scenario: Pinning past a failing step
+
+- **GIVEN** a step that would throw, pinned
+- **WHEN** the flow runs
+- **THEN** the run completes using the pinned output
+
+@e2e exclude engine-level — covered by FlowEngineTest and live-verified on 8080;
+the authoring UI that captures pins is a separate change

--- a/openspec/changes/or-flow-pins/tasks.md
+++ b/openspec/changes/or-flow-pins/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: or-flow-pins
+
+- [x] `FlowEngine.run` — pin check before dispatch; pinned output used, side
+      effect skipped, traced as `pinned`.
+- [x] Pins from `context.pins` then `flow.pins`; run pins win.
+- [x] Pinned step short-circuits stop/suspend/fail.
+- [x] Held `run()` cyclomatic complexity at the baseline (12) by extracting the
+      error-policy decision into `outcomeForFailedStep()`.
+- [x] FlowEngineTest — pinned not executed, flow-level pin, run overrides flow,
+      pin past a failing step (4 tests; 20 engine tests total). phpcs clean.
+- [ ] Partial execution / run-from-here (seed the marking mid-graph) — follow-up.
+- [ ] Builder/endpoint that captures and supplies pins — follow-up.

--- a/tests/Unit/Service/Flow/FlowEngineTest.php
+++ b/tests/Unit/Service/Flow/FlowEngineTest.php
@@ -329,6 +329,75 @@ class FlowEngineTest extends TestCase
         $this->assertStringContainsString('unbounded loop', $result['error']);
     }
 
+    public function testAPinnedStepIsNotExecutedAndItsOutputIsUsed(): void
+    {
+        // Pin the first step's output. The dispatcher must never run it, the log
+        // must mark it pinned, and the next step must see the pinned items.
+        $dispatcher = new RecordingDispatcher();
+        $pinned = [FlowItems::item(json: ['pinned' => true])];
+
+        $result = $this->engine->run(
+            $this->linearFlow(),
+            new MethodMarkingStore(false, 'marking'),
+            new FlowSubject(),
+            $dispatcher,
+            ['pins' => ['first' => $pinned]]
+        );
+
+        $this->assertSame(FlowEngine::STATUS_COMPLETED, $result['status']);
+        // Only 'second' ran — 'first' was served from the pin.
+        $this->assertSame(['second'], $dispatcher->dispatched);
+        $this->assertSame('pinned', $result['log'][0]['status']);
+        // The next step saw the pinned output, not a re-execution.
+        $this->assertTrue($dispatcher->seenItems['second'][0]['json']['pinned']);
+    }
+
+    public function testAFlowLevelPinIsUsedWhenTheRunSuppliesNone(): void
+    {
+        $flow = $this->linearFlow();
+        $flow['pins'] = ['first' => [FlowItems::item(json: ['source' => 'flow-pin'])]];
+
+        $dispatcher = new RecordingDispatcher();
+        $result = $this->runFlow($flow, $dispatcher);
+
+        $this->assertSame(['second'], $dispatcher->dispatched);
+        $this->assertSame('flow-pin', $dispatcher->seenItems['second'][0]['json']['source']);
+    }
+
+    public function testARunPinOverridesAFlowPin(): void
+    {
+        $flow = $this->linearFlow();
+        $flow['pins'] = ['first' => [FlowItems::item(json: ['source' => 'flow-pin'])]];
+
+        $dispatcher = new RecordingDispatcher();
+        $result = $this->engine->run(
+            $flow,
+            new MethodMarkingStore(false, 'marking'),
+            new FlowSubject(),
+            $dispatcher,
+            ['pins' => ['first' => [FlowItems::item(json: ['source' => 'run-pin'])]]]
+        );
+
+        // The run's pin wins over the flow's own.
+        $this->assertSame('run-pin', $dispatcher->seenItems['second'][0]['json']['source']);
+    }
+
+    public function testAPinnedStepThatWouldHaveFailedStillSucceeds(): void
+    {
+        // The whole point of a pin: skip the step that blows up (or hits a real
+        // API) and carry on with its stored output.
+        $dispatcher = new RecordingDispatcher(failOn: 'first');
+        $result = $this->engine->run(
+            $this->linearFlow(),
+            new MethodMarkingStore(false, 'marking'),
+            new FlowSubject(),
+            $dispatcher,
+            ['pins' => ['first' => [FlowItems::item(json: ['ok' => true])]]]
+        );
+
+        $this->assertSame(FlowEngine::STATUS_COMPLETED, $result['status']);
+    }
+
     public function testAStepCarriesItsOwnEdgeConfigToTheDispatcher(): void
     {
         $flow = $this->linearFlow();


### PR DESCRIPTION
The execution-tooling half of #2070 that authoring a flow needs most: **pin data**. A run may carry a map of step name → stored item list; a pinned step is **not executed**, its stored output is used verbatim, and its side effect is skipped.

## Why

Iterating on a flow means running it over and over. Without pins every run re-executes every step — including the one that hits a real API, sends the mail, or writes the record. Pinning that step's output lets an author re-run the *downstream* steps as often as needed without paying (or repeating) the expensive or irreversible one. It's the single biggest quality-of-life feature in n8n's editor, and small here because the engine already threads items step to step.

## What

- `FlowEngine.run` checks a `pins` map before dispatching each step. A pinned step's stored items become its output, the step is **not** dispatched, and the trace records it as `pinned`.
- Pins come from the run's `context.pins` first (a test/authoring run supplies them without touching the stored flow), falling back to a `pins` map on the flow document. **A run's pins always win.**
- A pinned step short-circuits before dispatch, so it can neither stop, suspend nor fail — the point of a pin is to skip the step that would.
- Held `run()`'s cyclomatic complexity at the development baseline (12) despite the new branch by extracting the `onError`-policy decision into `outcomeForFailedStep()` — a readability win in its own right.

## Verification

- **Unit** — `FlowEngineTest`: pinned step not executed & its output used, flow-level pin, run pin overrides flow pin, pin past a would-fail step (4 new; 20 engine tests total). phpcs clean; phpmd `run()` at baseline.
- **Live (8080)** — ran a 2-step flow through the real container-wired engine with the first step pinned: only the downstream step dispatched (`ran=second`), the pinned step was traced `pinned`, and its output threaded through. Side effect skipped, exactly as intended.

## Out of scope (follow-ups, noted in the change)

- **Partial execution / run-from-here** — seeding the marking mid-graph; larger and riskier, and pinning is its prerequisite.
- The **builder / endpoint** that captures and supplies pins (the engine contract is here; a test-run endpoint or MCP parameter layers on top).

🤖 Generated with [Claude Code](https://claude.com/claude-code)