### PR TITLE
docs(flow): per-item routing design — the last named #2067 gap

### DIFF
--- a/openspec/changes/or-flow-per-item-routing/.openspec.yaml
+++ b/openspec/changes/or-flow-per-item-routing/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-per-item-routing

--- a/openspec/changes/or-flow-per-item-routing/proposal.md
+++ b/openspec/changes/or-flow-per-item-routing/proposal.md
@@ -1,0 +1,74 @@
+# Proposal: or-flow-per-item-routing (design)
+
+## Status
+
+**Design only — no code.** This records the last named gap in #2067 (per-item
+routing) and the recommended approach, so the decision is made deliberately
+rather than by a rushed engine change. Implementation is a follow-up once the
+approach is agreed.
+
+## Summary
+
+Today a choice point (If/Switch) routes the **whole** item batch down one
+branch, chosen by the first item as the branch's representative
+(`FlowEngine::selectTransition`). n8n instead splits the item stream: each item
+goes to the output whose condition it matches, and every output branch runs with
+its own subset. This proposal is how to get there without breaking the
+Petri-net engine everything else now depends on.
+
+## Why it is not a small change
+
+The engine is a Petri net (symfony/workflow). A Switch is modelled as several
+transitions **from the same place**, each with an edge condition. When one
+fires, the token leaves the input place, so the sibling branches are disabled —
+which is exactly why routing is all-or-nothing today. Firing several of them to
+carry different item subsets would mean firing multiple transitions as one
+logical step, which the token model does not express.
+
+## Options considered
+
+1. **Multi-fire a choice point.** At a conditioned choice, partition the input
+   items and fire *every* edge that received items, each with its subset.
+   - Rejected: needs the engine to fire N transitions atomically from one token,
+     against the Petri-net model. Invasive to the run loop, the marking store
+     and resume.
+
+2. **Per-output item routing on a single transition (recommended).** Model a
+   Switch as *one* transition with several `to` places (its outputs). The node
+   returns items tagged with a target output; `advanceItems` distributes each
+   item to the matching `to` place instead of copying the whole list to all of
+   them (its current behaviour). One transition still fires — no multi-fire — but
+   items fan out per output.
+   - This is n8n's own model (a node has N outputs; items carry an output index).
+   - Contained: the change is to the item/dispatch/advance contract, not the
+     Petri-net firing rule.
+
+3. **Leave batch routing as the documented default.** Per-item routing is
+   authored as an upstream Filter/Split that produces separate branches.
+   - The current behaviour; kept as the fallback if (2) is not pursued.
+
+## Recommended change (option 2)
+
+- Extend the produced-item shape with an optional output key (e.g.
+  `pairedItem` stays as provenance; add `output` or reuse a branch label) that
+  names which of the transition's `to` places the item goes to.
+- `advanceItems`: when items carry an output assignment, distribute per output;
+  when they do not (every existing node), keep today's copy-to-all behaviour, so
+  nothing regresses.
+- A Switch/Filter node opts in by tagging its output items; every other node is
+  unchanged and unaffected.
+- `selectTransition` stays for the true either/or case (a genuine branch, not a
+  split); per-item routing is the *split* case and lives in `advanceItems`.
+
+## Risks
+
+- The item contract is shared with every consuming app's nodes. The opt-in
+  design (untagged items behave exactly as now) is what keeps this safe; it must
+  be covered by a test that an untagged multi-output node still copies to all.
+- Resume: the per-place buffers already persist, so a split that suspends
+  mid-branch resumes correctly — but this needs an explicit test.
+
+## Out of scope
+
+The builder UI for drawing multi-output nodes and labelling their outputs. This
+is the engine contract only.

--- a/openspec/changes/or-flow-per-item-routing/specs/flow-per-item-routing/spec.md
+++ b/openspec/changes/or-flow-per-item-routing/specs/flow-per-item-routing/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: A choice point can route each item to its matching output (REQ-PIR-001)
+
+The flow engine SHALL support routing each item of a step's output to the
+`to` place named by that item, so a Switch/Filter splits its input across its
+outputs rather than sending the whole batch down one branch. An item that names
+no output SHALL be delivered to every `to` place, preserving today's behaviour
+for every existing node.
+
+#### Scenario: A switch splits its items across branches
+
+- **GIVEN** a switch whose items are tagged for output "a" or output "b"
+- **WHEN** the step runs
+- **THEN** the "a" branch receives only the "a" items
+- **AND** the "b" branch receives only the "b" items
+
+#### Scenario: An untagged multi-output step still copies to all
+
+- **GIVEN** a step with several outputs whose items carry no output tag
+- **WHEN** the step runs
+- **THEN** every output receives the full item list
+
+> NOTE: Design-only change. This spec records the intended contract; the
+> implementation is a follow-up (see proposal, option 2).

--- a/openspec/changes/or-flow-per-item-routing/tasks.md
+++ b/openspec/changes/or-flow-per-item-routing/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: or-flow-per-item-routing (design)
+
+- [x] Record the gap, the Petri-net constraint, and the options.
+- [x] Recommend option 2 (per-output routing in advanceItems, opt-in via an
+      item output tag; untagged items unchanged).
+- [ ] DECISION: agree option 2 before writing code.
+- [ ] Implement: item output tag + advanceItems distribution; Switch/Filter opt-in.
+- [ ] Test: split across branches; untagged multi-output copies to all; resume
+      mid-split.


### PR DESCRIPTION
The one named gap in #2067 left unbuilt: **per-item routing** (n8n splitting an item stream across a Switch's outputs). Unlike sub-flows, triggers and pins — all additive — this is a genuine change to the **engine's execution model**, so this PR records the design and recommended approach rather than rushing an engine rewrite through on local verification.

## The constraint

The engine is a Petri net. A Switch is several transitions **from one place**; firing one consumes the token and disables the siblings — which is exactly why routing is all-or-nothing today (`selectTransition` picks one branch by the first item).

## Recommended approach (option 2)

Model a Switch as **one** transition with several `to` places and **distribute items per output in `advanceItems`** — n8n's own model (a node has N outputs; items carry an output index). One transition still fires (no multi-fire against the token model); items fan out per output. **Untagged items behave exactly as now**, so no existing node — in OpenRegister or any consuming app — regresses.

Two other options (multi-fire the choice point; keep batch routing as the documented default) are recorded and rejected/kept-as-fallback in the proposal.

## This PR

Design/spec only — **no code**. It exists so the decision is made deliberately. Implementation is a tracked follow-up once the approach is agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)