### PR TITLE
feat(flow): run-from-here — start a flow at a chosen node (#2070)

### DIFF
--- a/lib/Service/Flow/FlowEngine.php
+++ b/lib/Service/Flow/FlowEngine.php
@@ -120,12 +120,20 @@ class FlowEngine
      * item built out of the subject, so a flow that never fans out behaves
      * exactly like the single-object model this replaces.
      *
+     * `$startAt` runs the flow from a chosen node instead of its start — n8n's
+     * "run from here". The seed items land on that node, and the steps before it
+     * do not run; an author pins their output ({@see self::pinnedItems()}) and
+     * re-runs only the part being worked on. It is the initial place overridden,
+     * so a resume — whose marking is already mid-graph and comes from the store —
+     * is unaffected.
+     *
      * @param array                 $flow       The flow document.
      * @param MarkingStoreInterface $store      Where the marking lives (an OR object, in production).
      * @param object                $subject    The object the run is about; holds the marking.
      * @param FlowStepDispatcher    $dispatcher Performs each step's side effect.
      * @param array                 $context    Run-level metadata handed to every step.
      * @param array|null            $items      Seed items; defaults to one item from the subject.
+     * @param string|null           $startAt    Node to start from; defaults to the flow's own start.
      *
      * @return array The run result: `{status, log: [], context: [], items: []}`.
      *
@@ -137,9 +145,11 @@ class FlowEngine
         object $subject,
         FlowStepDispatcher $dispatcher,
         array $context=[],
-        ?array $items=null
+        ?array $items=null,
+        ?string $startAt=null
     ): array {
         $items = ($items ?? FlowItems::fromSubject(subject: $subject));
+        $flow  = $this->withStartNode(flow: $flow, startAt: $startAt);
 
         try {
             $definition = $this->builder->build(flow: $flow);
@@ -344,6 +354,31 @@ class FlowEngine
         }//end while
 
     }//end run()
+
+    /**
+     * Override where a flow starts, for "run from here".
+     *
+     * A non-empty start node replaces the flow's `initial`; the builder then
+     * validates it exists, so an unknown node fails the run exactly as a bad
+     * document does. An empty or absent start leaves the flow untouched, so the
+     * ordinary path is unaffected.
+     *
+     * @param array       $flow    The flow document.
+     * @param string|null $startAt The node to start from, or null/empty for none.
+     *
+     * @return array The flow document, with `initial` overridden when asked.
+     *
+     * @spec openspec/changes/or-flow-partial-run/specs/flow-partial-run/spec.md
+     */
+    private function withStartNode(array $flow, ?string $startAt): array
+    {
+        if (($startAt ?? '') !== '') {
+            $flow['initial'] = $startAt;
+        }
+
+        return $flow;
+
+    }//end withStartNode()
 
     /**
      * Find the step configuration attached to a transition.

--- a/lib/Service/Flow/FlowRunService.php
+++ b/lib/Service/Flow/FlowRunService.php
@@ -146,16 +146,17 @@ class FlowRunService
      * Called by the queue worker, never by a trigger. Returns the run in
      * whatever state the walk left it: terminal, or suspended and resumable.
      *
-     * @param FlowRun $run       The run to advance.
-     * @param array   $flow      The flow document.
-     * @param object  $subject   The object the run is about.
-     * @param array   $seedItems Items to start from; ignored when resuming.
+     * @param FlowRun     $run       The run to advance.
+     * @param array       $flow      The flow document.
+     * @param object      $subject   The object the run is about.
+     * @param array       $seedItems Items to start from; ignored when resuming.
+     * @param string|null $startAt   Node to start from (run-from-here); ignored when resuming.
      *
      * @return FlowRun The updated run.
      *
      * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
      */
-    public function execute(FlowRun $run, array $flow, object $subject, ?array $seedItems=null): FlowRun
+    public function execute(FlowRun $run, array $flow, object $subject, ?array $seedItems=null, ?string $startAt=null): FlowRun
     {
         if ($run->isTerminal() === true) {
             // Re-executing a finished run would repeat every side effect it
@@ -169,11 +170,14 @@ class FlowRunService
         $this->mapper->update($run);
 
         $items = $seedItems;
+        $start = $startAt;
         if ($resuming === true) {
             // On resume the stored items win: they are what the run was
             // carrying when it paused. Re-seeding from the subject would throw
-            // away everything the earlier steps produced.
+            // away everything the earlier steps produced. A start node is a
+            // fresh-run concern too — the marking already holds where to resume.
             $items = ($run->getItems() ?? []);
+            $start = null;
         }
 
         $context            = ($run->getContext() ?? []);
@@ -187,7 +191,8 @@ class FlowRunService
                 subject: $subject,
                 dispatcher: new RegistryStepDispatcher(registry: $this->registry),
                 context: $context,
-                items: $items
+                items: $items,
+                startAt: $start
             );
         } catch (Throwable $e) {
             // The engine itself failing (rather than a step) is not something

--- a/openspec/changes/or-flow-partial-run/.openspec.yaml
+++ b/openspec/changes/or-flow-partial-run/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-partial-run

--- a/openspec/changes/or-flow-partial-run/proposal.md
+++ b/openspec/changes/or-flow-partial-run/proposal.md
@@ -1,0 +1,35 @@
+# Proposal: or-flow-partial-run
+
+## Summary
+
+Run-from-here — start a flow at a chosen node instead of its beginning, seeding
+that node with supplied items. Together with pinned output (or-flow-pins) this is
+n8n's authoring loop: pin the expensive upstream step, then re-run only the part
+being worked on.
+
+## Why
+
+The other half of #2070's execution tooling. Pinning skips a step's side effect;
+run-from-here skips whole upstream *sections*, so an author iterating on the tail
+of a flow does not re-run (or re-pin) everything before it. Neither is useful
+without the other — this completes the pair.
+
+## What Changes
+
+- `FlowEngine::run` gains an optional `startAt` node. When set, it overrides the
+  flow's `initial` place, so the run begins there and the seed items land on that
+  node; the steps before it do not run. The builder already validates `initial`,
+  so an unknown start node fails the run exactly as a malformed document does.
+- The override is a fresh-run concern only. A resume's marking is already
+  mid-graph and comes from the store, so `FlowRunService::execute` drops
+  `startAt` when resuming — the same rule it already applies to seed items.
+- `run()`'s cyclomatic complexity is held at the baseline (12) by extracting the
+  override into `withStartNode()`.
+
+## Out of scope (follow-up)
+
+- The **endpoint / MCP tool** that offers run-from-here interactively (supplying
+  `startAt`, seed items and pins, and returning the result synchronously). The
+  engine and service support are here; the interactive surface layers on top,
+  and — because a partial run is an editor action, not a background trigger — it
+  is a synchronous test-run endpoint rather than the async queue.

--- a/openspec/changes/or-flow-partial-run/specs/flow-partial-run/spec.md
+++ b/openspec/changes/or-flow-partial-run/specs/flow-partial-run/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: A flow can run from a chosen node (REQ-PR-001)
+
+The flow engine SHALL accept an optional start node. When given, the run SHALL
+begin at that node with the supplied seed items, and the steps before it SHALL
+NOT run. An empty or absent start node SHALL leave the flow's own start
+unchanged. An unknown start node SHALL fail the run.
+
+#### Scenario: Running from a mid-graph node skips what is before it
+
+- **GIVEN** a flow start -> middle -> end
+- **WHEN** it is run starting at "middle" with seed items
+- **THEN** only the middle -> end step runs
+- **AND** it receives the seed items
+
+#### Scenario: An unknown start node fails the run
+
+- **WHEN** a flow is run starting at a node it does not declare
+- **THEN** the run fails
+
+### Requirement: Run-from-here does not disturb resume (REQ-PR-002)
+
+A resumed run's marking already holds where it left off, so a start node SHALL be
+ignored when resuming.
+
+#### Scenario: A resume ignores a start node
+
+- **GIVEN** a suspended run being resumed
+- **WHEN** execution continues
+- **THEN** the run resumes from its stored marking, not from any start node
+
+@e2e exclude engine-level — covered by FlowEngineTest and live-verified on 8080;
+the interactive run-from-here surface is a separate change

--- a/openspec/changes/or-flow-partial-run/tasks.md
+++ b/openspec/changes/or-flow-partial-run/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: or-flow-partial-run
+
+- [x] `FlowEngine::run` optional `startAt` overriding `initial` (via
+      `withStartNode()`, holding run() CC at baseline 12).
+- [x] Unknown start node fails the run (builder validation).
+- [x] `FlowRunService::execute` threads `startAt`, dropping it on resume.
+- [x] FlowEngineTest — run-from-here skips upstream, unknown start fails, empty
+      start ignored (3 tests; 23 engine tests total). phpcs clean; phpmd baseline.
+- [x] Live-verified on 8080: run-from a mid node ran only the downstream step;
+      unknown start failed.
+- [ ] Interactive endpoint / MCP tool (startAt + seed + pins, synchronous) —
+      follow-up.

--- a/tests/Unit/Service/Flow/FlowEngineTest.php
+++ b/tests/Unit/Service/Flow/FlowEngineTest.php
@@ -398,6 +398,61 @@ class FlowEngineTest extends TestCase
         $this->assertSame(FlowEngine::STATUS_COMPLETED, $result['status']);
     }
 
+    public function testRunFromHereStartsAtTheChosenNodeAndSkipsWhatIsBefore(): void
+    {
+        // A three-step line start -> middle -> end. Starting at 'middle' must
+        // run only the 'second' step (middle -> end); 'first' never runs.
+        $dispatcher = new RecordingDispatcher();
+        $seed = [FlowItems::item(json: ['from' => 'run-from-here'])];
+
+        $result = $this->engine->run(
+            $this->linearFlow(),
+            new MethodMarkingStore(false, 'marking'),
+            new FlowSubject(),
+            $dispatcher,
+            [],
+            $seed,
+            'middle'
+        );
+
+        $this->assertSame(FlowEngine::STATUS_COMPLETED, $result['status']);
+        $this->assertSame(['second'], $dispatcher->dispatched);
+        // The chosen start's step saw the supplied seed, not a subject item.
+        $this->assertSame('run-from-here', $dispatcher->seenItems['second'][0]['json']['from']);
+    }
+
+    public function testRunFromAnUnknownNodeFailsLoudly(): void
+    {
+        $result = $this->engine->run(
+            $this->linearFlow(),
+            new MethodMarkingStore(false, 'marking'),
+            new FlowSubject(),
+            new RecordingDispatcher(),
+            [],
+            null,
+            'no-such-node'
+        );
+
+        $this->assertSame(FlowEngine::STATUS_FAILED, $result['status']);
+    }
+
+    public function testAnEmptyStartAtIsIgnoredAndTheFlowRunsFromItsStart(): void
+    {
+        $dispatcher = new RecordingDispatcher();
+        $result = $this->engine->run(
+            $this->linearFlow(),
+            new MethodMarkingStore(false, 'marking'),
+            new FlowSubject(),
+            $dispatcher,
+            [],
+            null,
+            ''
+        );
+
+        $this->assertSame(FlowEngine::STATUS_COMPLETED, $result['status']);
+        $this->assertSame(['first', 'second'], $dispatcher->dispatched);
+    }
+
     public function testAStepCarriesItsOwnEdgeConfigToTheDispatcher(): void
     {
         $flow = $this->linearFlow();


### PR DESCRIPTION
The other half of #2070's execution tooling, and the partner to pinned output (#2114): **run-from-here** — start a flow at a chosen node instead of its beginning, seeding that node with supplied items.

Pin the expensive upstream step, then run-from-here to re-run only the tail being worked on — n8n's authoring loop. Neither is useful without the other; this completes the pair.

## What

- `FlowEngine::run` gains an optional `startAt` node that overrides the flow's `initial` place, so the run begins there and the seed items land on it; the steps before do **not** run. The builder already validates `initial`, so an unknown start node fails the run exactly as a malformed document does.
- The override is a **fresh-run concern only**: a resume's marking is already mid-graph and comes from the store, so `FlowRunService::execute` drops `startAt` when resuming — the same rule it already applies to seed items.
- Held `run()`'s cyclomatic complexity at the baseline (12) by extracting the override into `withStartNode()` (single-condition, so NPath stays under threshold too).

## Verification

- **Unit** — `FlowEngineTest`: run-from-here skips upstream and the start step gets the seed, unknown start fails, empty start ignored (3 new; 23 engine tests total). phpcs clean; phpmd `run()` at baseline 12.
- **Live (8080)** — through the real engine: starting a `start → middle → end` flow at `middle` ran only the downstream step (`ran=second`); an unknown start node failed.

## Out of scope (follow-up)

The interactive **endpoint / MCP tool** that offers run-from-here synchronously (`startAt` + seed + pins, returning the result). The engine and service support are here; a partial run is an editor action, not a background trigger, so that surface is a synchronous test-run endpoint rather than the async queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)