### PR TITLE
feat(flow): synchronous test-run endpoint — POST /api/flow-runs/test (#2070)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1239,5 +1239,7 @@ return [
 		['name' => 'flowRun#index', 'url' => '/api/flow-runs', 'verb' => 'GET'],
 		['name' => 'flowRun#show', 'url' => '/api/flow-runs/{uuid}', 'verb' => 'GET', 'requirements' => ['uuid' => '[^/]+']],
 		['name' => 'flowRun#retry', 'url' => '/api/flow-runs/{uuid}/retry', 'verb' => 'POST', 'requirements' => ['uuid' => '[^/]+']],
+		// Interactive test run (or-flow-partial-run): run synchronously with optional startAt + pins + seed.
+		['name' => 'flowRun#test', 'url' => '/api/flow-runs/test', 'verb' => 'POST'],
     ],
 ];

--- a/lib/Controller/FlowRunController.php
+++ b/lib/Controller/FlowRunController.php
@@ -30,6 +30,8 @@ namespace OCA\OpenRegister\Controller;
 
 use OCA\OpenRegister\Db\FlowRun;
 use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowResolverRegistry;
 use OCA\OpenRegister\Service\Flow\FlowRunService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -37,6 +39,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use stdClass;
 
 /**
  * REST surface for inspecting and retrying flow runs.
@@ -46,16 +49,18 @@ class FlowRunController extends Controller
     /**
      * Constructor.
      *
-     * @param string         $appName The app id.
-     * @param IRequest       $request The request.
-     * @param FlowRunMapper  $mapper  Reads runs.
-     * @param FlowRunService $runner  Retries and requeues.
+     * @param string               $appName   The app id.
+     * @param IRequest             $request   The request.
+     * @param FlowRunMapper        $mapper    Reads runs.
+     * @param FlowRunService       $runner    Retries, requeues and runs.
+     * @param FlowResolverRegistry $resolvers Resolves a flow id to its document.
      */
     public function __construct(
         string $appName,
         IRequest $request,
         private readonly FlowRunMapper $mapper,
-        private readonly FlowRunService $runner
+        private readonly FlowRunService $runner,
+        private readonly FlowResolverRegistry $resolvers
     ) {
         parent::__construct(appName: $appName, request: $request);
 
@@ -162,4 +167,68 @@ class FlowRunController extends Controller
         return new JSONResponse($new->jsonSerialize(), Http::STATUS_CREATED);
 
     }//end retry()
+
+    /**
+     * Run a flow now and return its result — the interactive test run.
+     *
+     * Unlike a trigger, which queues a run for the worker, this runs the flow
+     * synchronously and hands back the whole trace, so an author gets the log and
+     * the items straight away. It carries the two authoring aids: `startAt` runs
+     * from a chosen node (run-from-here), and `pins` supplies stored output for
+     * named steps so the expensive ones are skipped. Together they are the
+     * "iterate on the tail of a flow" loop.
+     *
+     * The run is persisted like any other (trigger `test`), so it also shows up
+     * in the history — a test run is not a throwaway.
+     *
+     * @return JSONResponse The finished run, or a 4xx when the flow is unknown.
+     *
+     * @NoAdminRequired
+     *
+     * @spec openspec/changes/or-flow-partial-run/specs/flow-partial-run/spec.md
+     */
+    #[NoAdminRequired]
+    public function test(): JSONResponse
+    {
+        $flowId = trim((string) $this->request->getParam('flowId', ''));
+        if ($flowId === '') {
+            return new JSONResponse(['error' => 'A test run needs a flowId.'], Http::STATUS_BAD_REQUEST);
+        }
+
+        $flow = $this->resolvers->resolveFlow(flowId: $flowId);
+        if ($flow === null) {
+            return new JSONResponse(['error' => 'No such flow: '.$flowId], Http::STATUS_NOT_FOUND);
+        }
+
+        $startAt = trim((string) $this->request->getParam('startAt', ''));
+        if ($startAt === '') {
+            $startAt = null;
+        }
+
+        $pins = (array) $this->request->getParam('pins', []);
+
+        $seed      = null;
+        $seedParam = $this->request->getParam('seedItems');
+        if ($seedParam !== null) {
+            $seed = FlowItems::normalise(value: $seedParam);
+        }
+
+        $run = $this->runner->queue(
+            flowId: $flowId,
+            subject: [],
+            trigger: 'test',
+            context: ['pins' => $pins]
+        );
+
+        $run = $this->runner->execute(
+            run: $run,
+            flow: $flow,
+            subject: new stdClass(),
+            seedItems: $seed,
+            startAt: $startAt
+        );
+
+        return new JSONResponse($run->jsonSerialize());
+
+    }//end test()
 }//end class

--- a/openspec/changes/or-flow-test-run/.openspec.yaml
+++ b/openspec/changes/or-flow-test-run/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-test-run

--- a/openspec/changes/or-flow-test-run/proposal.md
+++ b/openspec/changes/or-flow-test-run/proposal.md
@@ -1,0 +1,39 @@
+# Proposal: or-flow-test-run
+
+## Summary
+
+`POST /api/flow-runs/test` — run a flow now and get its result back. The
+interactive surface that makes pinned output (or-flow-pins) and run-from-here
+(or-flow-partial-run) usable: an author runs a flow synchronously, supplying
+`startAt` and `pins`, and gets the whole trace straight away.
+
+## Why
+
+The engine and service already support pins and run-from-here, but nothing
+exposed them — a UI or agent had no way to ask for a synchronous run. A trigger
+queues a run for the worker and returns nothing to look at; iterating on a flow
+needs the opposite: run it here, now, and show me what each step did. This is
+n8n's "Execute workflow" button.
+
+## What Changes
+
+- `FlowRunController::test` (`POST /api/flow-runs/test`), `@NoAdminRequired`:
+  - `flowId` (required) — resolved through the same `FlowResolverRegistry` the
+    triggers use, so any consuming app's flow can be test-run. Unknown flow → 404;
+    missing flowId → 400.
+  - `startAt` (optional) — run from that node (run-from-here).
+  - `pins` (optional) — step name → item list, put on the run context so pinned
+    steps are skipped.
+  - `seedItems` (optional) — the items to start with, normalised to the item
+    shape.
+  - Runs synchronously via `FlowRunService::queue` + `execute` and returns the
+    finished run (status, per-step log, items).
+- The run is persisted like any other, trigger `test`, so it also appears in the
+  run history — a test run is a first-class run, not a throwaway.
+
+## Out of scope
+
+- A builder affordance (the "Execute" button and the pin/inspect UI). This is the
+  API it calls.
+- An MCP `testFlow` tool. The async `openregister.runFlow` already exists; a
+  synchronous MCP variant can wrap this later if agents need it.

--- a/openspec/changes/or-flow-test-run/specs/flow-test-run/spec.md
+++ b/openspec/changes/or-flow-test-run/specs/flow-test-run/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: A flow can be test-run synchronously (REQ-TR-001)
+
+OpenRegister SHALL expose `POST /api/flow-runs/test` that runs a named flow
+synchronously and returns the finished run. It SHALL accept an optional start
+node (run-from-here), optional pins (step name → items, applied via the run
+context) and optional seed items. A missing flow id SHALL be a 400; an unknown
+flow SHALL be a 404. The run SHALL be persisted with trigger `test`.
+
+#### Scenario: A test run returns the trace
+
+- **GIVEN** a resolvable flow
+- **WHEN** it is test-run
+- **THEN** the response is the finished run with its per-step log and items
+
+#### Scenario: A test run carries startAt and pins
+
+- **GIVEN** a test run with a start node and pins
+- **WHEN** it runs
+- **THEN** it starts at that node
+- **AND** the pinned steps are not executed
+
+#### Scenario: An unknown flow is rejected
+
+- **WHEN** a test run names a flow no resolver owns
+- **THEN** the response is 404
+
+@e2e exclude backend endpoint — covered by FlowRunControllerTest and
+live-verified on 8080 (DI + real queue/execute/persist through the service);
+the builder button that calls it is a separate change

--- a/openspec/changes/or-flow-test-run/tasks.md
+++ b/openspec/changes/or-flow-test-run/tasks.md
@@ -1,0 +1,11 @@
+# Tasks: or-flow-test-run
+
+- [x] `FlowRunController::test` + route `POST /api/flow-runs/test`.
+- [x] Resolve flow via FlowResolverRegistry (404 unknown, 400 no flowId).
+- [x] startAt + pins (on context) + seedItems (normalised) → queue + execute.
+- [x] Persist as trigger `test`; return the finished run.
+- [x] FlowRunControllerTest — bad request, unknown flow, synchronous run passes
+      startAt through, pins land on the context (4 tests). phpcs clean.
+- [x] Live-verified on 8080: real queue+execute+persist with startAt + a pinned
+      step; run reloads from the DB completed.
+- [ ] Builder "Execute" button + pin/inspect UI — follow-up.

--- a/tests/Unit/Controller/FlowRunControllerTest.php
+++ b/tests/Unit/Controller/FlowRunControllerTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Controller;
+
+use OCA\OpenRegister\Controller\FlowRunController;
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Service\Flow\FlowResolverRegistry;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class FlowRunControllerTest extends TestCase
+{
+    private IRequest&MockObject $request;
+
+    private FlowRunMapper&MockObject $mapper;
+
+    private FlowRunService&MockObject $runner;
+
+    private FlowResolverRegistry&MockObject $resolvers;
+
+    private FlowRunController $controller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->request   = $this->createMock(IRequest::class);
+        $this->mapper    = $this->createMock(FlowRunMapper::class);
+        $this->runner    = $this->createMock(FlowRunService::class);
+        $this->resolvers = $this->createMock(FlowResolverRegistry::class);
+
+        $this->controller = new FlowRunController(
+            'openregister',
+            $this->request,
+            $this->mapper,
+            $this->runner,
+            $this->resolvers
+        );
+    }
+
+    /** Map a params array onto the request mock's getParam(name, default). */
+    private function params(array $values): void
+    {
+        $this->request->method('getParam')->willReturnCallback(
+            static fn (string $name, $default = null) => $values[$name] ?? $default
+        );
+    }
+
+    public function testTestWithoutAFlowIdIsABadRequest(): void
+    {
+        $this->params([]);
+        $res = $this->controller->test();
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $res->getStatus());
+    }
+
+    public function testTestWithAnUnknownFlowIsNotFound(): void
+    {
+        $this->params(['flowId' => 'ghost']);
+        $this->resolvers->method('resolveFlow')->willReturn(null);
+
+        $res = $this->controller->test();
+        $this->assertSame(Http::STATUS_NOT_FOUND, $res->getStatus());
+    }
+
+    public function testTestRunsSynchronouslyAndReturnsTheResult(): void
+    {
+        $this->params([
+            'flowId'  => 'f1',
+            'startAt' => 'middle',
+            'pins'    => ['first' => [['json' => ['x' => 1]]]],
+        ]);
+        $this->resolvers->method('resolveFlow')->with('f1')->willReturn(['id' => 'f1', 'edges' => []]);
+
+        $queued = new FlowRun();
+        $queued->setStatus(FlowRun::STATUS_QUEUED);
+        $this->runner->method('queue')->willReturn($queued);
+
+        $done = new FlowRun();
+        $done->setStatus(FlowRun::STATUS_COMPLETED);
+        $done->setLog([['transition' => 'second', 'status' => 'completed']]);
+
+        // The controller must pass the parsed startAt through to execute().
+        $this->runner->expects($this->once())->method('execute')
+            ->with(
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                'middle'
+            )
+            ->willReturn($done);
+
+        $res  = $this->controller->test();
+        $body = $res->getData();
+
+        $this->assertSame(Http::STATUS_OK, $res->getStatus());
+        $this->assertSame(FlowRun::STATUS_COMPLETED, $body['status']);
+    }
+
+    public function testTestPassesPinsOnTheRunContext(): void
+    {
+        $pins = ['first' => [['json' => ['pinned' => true]]]];
+        $this->params(['flowId' => 'f1', 'pins' => $pins]);
+        $this->resolvers->method('resolveFlow')->willReturn(['id' => 'f1']);
+
+        // queue() must receive the pins on the context so the engine can read them.
+        $this->runner->expects($this->once())->method('queue')
+            ->with(
+                'f1',
+                $this->anything(),
+                'test',
+                ['pins' => $pins]
+            )
+            ->willReturn(new FlowRun());
+        $done = new FlowRun();
+        $done->setStatus(FlowRun::STATUS_COMPLETED);
+        $this->runner->method('execute')->willReturn($done);
+
+        $this->controller->test();
+    }
+}


### PR DESCRIPTION
The interactive surface that makes pinned output (#2114) and run-from-here (#2116) usable. The engine and service already supported both, but nothing exposed them — a UI or agent had no way to ask for a synchronous run. A trigger queues a run for the worker and returns nothing to look at; iterating on a flow needs the opposite: **run it here, now, and show me what each step did** (n8n's "Execute workflow").

## What

`FlowRunController::test` — `POST /api/flow-runs/test`, `@NoAdminRequired`:

- **`flowId`** (required) — resolved through the same `FlowResolverRegistry` the triggers use, so any consuming app's flow can be test-run. Unknown flow → 404; missing flowId → 400.
- **`startAt`** (optional) — run from that node (run-from-here).
- **`pins`** (optional) — step name → item list, put on the run context so pinned steps are skipped.
- **`seedItems`** (optional) — the items to start with, normalised to the item shape.
- Runs synchronously via `FlowRunService::queue` + `execute` and returns the finished run (status, per-step log, items). Persisted like any other run, trigger `test`, so it also appears in the history.

## Verification

- **Unit** — `FlowRunControllerTest`: bad request (no flowId), unknown flow (404), synchronous run passes `startAt` through to `execute()`, pins land on the queue context (4 tests). phpcs clean.
- **Live (8080)** — real `queue` + `execute` + persist with `startAt="b"` and a pinned step: only the downstream step ran, it was traced `pinned`, and the run **reloads from the DB completed**. Exercises startAt + pins + seed + persistence together.

## Notes / out of scope

- OpenRegister ships **no flow resolver of its own** — flows are stored and resolved by consuming apps (hermiq's agentflows today). The endpoint resolves through whatever resolvers are registered; an OR-native flow store is a separate concern.
- Follow-up: the builder "Execute" button + pin/inspect UI (this is the API it calls), and a synchronous MCP `testFlow` tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)