### PR TITLE
feat(flow): per-item routing — RouterNode + per-output distribution (#2067)

### DIFF
--- a/lib/Listener/FlowNodeRegistrationListener.php
+++ b/lib/Listener/FlowNodeRegistrationListener.php
@@ -31,6 +31,7 @@ namespace OCA\OpenRegister\Listener;
 use OCA\OpenRegister\Service\Flow\Nodes\FilterNode;
 use OCA\OpenRegister\Service\Flow\Nodes\LoopNode;
 use OCA\OpenRegister\Service\Flow\Nodes\MergeNode;
+use OCA\OpenRegister\Service\Flow\Nodes\RouterNode;
 use OCA\OpenRegister\Service\Flow\Nodes\SetFieldsNode;
 use OCA\OpenRegister\Service\Flow\Nodes\StopNode;
 use OCA\OpenRegister\Service\Flow\Nodes\SubFlowNode;
@@ -58,6 +59,7 @@ class FlowNodeRegistrationListener implements IEventListener
      * @param MergeNode     $merge     The built-in "Merge" node.
      * @param LoopNode      $loop      The built-in "Loop over items" node.
      * @param SubFlowNode   $subFlow   The built-in "Run a flow" node.
+     * @param RouterNode    $router    The built-in "Route items" node.
      */
     public function __construct(
         private readonly SetFieldsNode $setFields,
@@ -67,7 +69,8 @@ class FlowNodeRegistrationListener implements IEventListener
         private readonly StopNode $stop,
         private readonly MergeNode $merge,
         private readonly LoopNode $loop,
-        private readonly SubFlowNode $subFlow
+        private readonly SubFlowNode $subFlow,
+        private readonly RouterNode $router
     ) {
 
     }//end __construct()
@@ -95,6 +98,7 @@ class FlowNodeRegistrationListener implements IEventListener
         $event->registerNode(node: $this->merge);
         $event->registerNode(node: $this->loop);
         $event->registerNode(node: $this->subFlow);
+        $event->registerNode(node: $this->router);
 
     }//end handle()
 }//end class

--- a/lib/Service/Flow/FlowEngine.php
+++ b/lib/Service/Flow/FlowEngine.php
@@ -619,6 +619,14 @@ class FlowEngine
     /**
      * Move a fired transition's items: onto its output places, off its inputs.
      *
+     * Per-item routing (n8n's If/Switch) lives here. An item that names an output
+     * ({@see FlowItems::OUTPUT}, set by a routing node) goes only to the output
+     * place with that name; an item that names none is broadcast to every output,
+     * which is the ordinary behaviour and what a parallel split relies on. So a
+     * step whose items carry no output tag distributes exactly as before — this
+     * is additive, not a change to any existing flow. The tag is stripped as the
+     * item lands, so it never lingers to misroute a later step.
+     *
      * Clearing the consumed inputs matters for a loop that re-enters the
      * transition — it must read fresh items, not a stale copy left behind.
      *
@@ -628,12 +636,12 @@ class FlowEngine
      *
      * @return array<string, array> The updated buffers.
      *
-     * @spec openspec/changes/or-flow-merge/specs/flow-merge/spec.md
+     * @spec openspec/changes/or-flow-per-item-routing/specs/flow-per-item-routing/spec.md
      */
     private function advanceItems(object $transition, array $placeItems, array $items): array
     {
         foreach ($transition->getTos() as $to) {
-            $placeItems[(string) $to] = $items;
+            $placeItems[(string) $to] = $this->itemsForOutput(items: $items, output: (string) $to);
         }
 
         foreach ($transition->getFroms() as $from) {
@@ -643,4 +651,33 @@ class FlowEngine
         return $placeItems;
 
     }//end advanceItems()
+
+    /**
+     * The items that belong on one output place: those routed to it, plus the
+     * unrouted ones that go everywhere. The output tag is dropped on the way.
+     *
+     * @param array<int, array> $items  The produced items.
+     * @param string            $output The output place's name.
+     *
+     * @return array<int, array> The items for that output, tag removed.
+     *
+     * @spec openspec/changes/or-flow-per-item-routing/specs/flow-per-item-routing/spec.md
+     */
+    private function itemsForOutput(array $items, string $output): array
+    {
+        $out = [];
+        foreach ($items as $item) {
+            $tag = FlowItems::outputOf(member: (array) $item);
+            if ($tag !== null && $tag !== $output) {
+                // Routed elsewhere: not this output's item.
+                continue;
+            }
+
+            unset($item[FlowItems::OUTPUT]);
+            $out[] = $item;
+        }
+
+        return $out;
+
+    }//end itemsForOutput()
 }//end class

--- a/lib/Service/Flow/FlowItems.php
+++ b/lib/Service/Flow/FlowItems.php
@@ -62,6 +62,16 @@ final class FlowItems
     public const PAIRED_ITEM = 'pairedItem';
 
     /**
+     * The key naming which output branch an item is routed to.
+     *
+     * Optional and usually absent: only a routing node ({@see Nodes\RouterNode})
+     * sets it, and the engine strips it once it has distributed the item, so it
+     * never lingers on an item a downstream step sees. An item without it is
+     * broadcast to every output, which is the ordinary behaviour.
+     */
+    public const OUTPUT = 'output';
+
+    /**
      * Coerce whatever a step returned into a well-formed item list.
      *
      * Steps are written by consuming apps, so the engine cannot assume the
@@ -105,7 +115,8 @@ final class FlowItems
                 $items[] = self::item(
                     json: (array) ($member[self::JSON] ?? $member),
                     binary: (array) ($member[self::BINARY] ?? []),
-                    fromItemIndex: self::pairedIndex(member: $member, fallback: ($fromItemIndex ?? $index))
+                    fromItemIndex: self::pairedIndex(member: $member, fallback: ($fromItemIndex ?? $index)),
+                    output: self::outputOf(member: $member)
                 );
             }
 
@@ -117,7 +128,8 @@ final class FlowItems
             self::item(
                 json: (array) ($value[self::JSON] ?? $value),
                 binary: (array) ($value[self::BINARY] ?? []),
-                fromItemIndex: self::pairedIndex(member: $value, fallback: $fromItemIndex)
+                fromItemIndex: self::pairedIndex(member: $value, fallback: $fromItemIndex),
+                output: self::outputOf(member: $value)
             ),
         ];
 
@@ -126,28 +138,57 @@ final class FlowItems
     /**
      * Build one well-formed item.
      *
-     * @param array    $json          The record.
-     * @param array    $binary        File attachments, keyed by name.
-     * @param int|null $fromItemIndex Input item this came from, when known.
+     * @param array       $json          The record.
+     * @param array       $binary        File attachments, keyed by name.
+     * @param int|null    $fromItemIndex Input item this came from, when known.
+     * @param string|null $output        The output branch this item routes to, when set.
      *
      * @return array<string, mixed> The item.
      *
      * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
      */
-    public static function item(array $json, array $binary=[], ?int $fromItemIndex=null): array
+    public static function item(array $json, array $binary=[], ?int $fromItemIndex=null, ?string $output=null): array
     {
         $paired = null;
         if ($fromItemIndex !== null) {
             $paired = ['item' => $fromItemIndex];
         }
 
-        return [
+        $item = [
             self::JSON        => $json,
             self::BINARY      => $binary,
             self::PAIRED_ITEM => $paired,
         ];
 
+        // The output tag is added only when set, so an ordinary item keeps its
+        // exact three-key shape and nothing downstream has to know about routing.
+        if ($output !== null && $output !== '') {
+            $item[self::OUTPUT] = $output;
+        }
+
+        return $item;
+
     }//end item()
+
+    /**
+     * Read a member's output tag, if it carries one.
+     *
+     * @param array $member A returned item.
+     *
+     * @return string|null The output branch, or null when the item is unrouted.
+     *
+     * @spec openspec/changes/or-flow-per-item-routing/specs/flow-per-item-routing/spec.md
+     */
+    public static function outputOf(array $member): ?string
+    {
+        $output = ($member[self::OUTPUT] ?? null);
+        if (is_string($output) === true && $output !== '') {
+            return $output;
+        }
+
+        return null;
+
+    }//end outputOf()
 
     /**
      * Seed a run's item list from the object it is about.

--- a/lib/Service/Flow/Nodes/RouterNode.php
+++ b/lib/Service/Flow/Nodes/RouterNode.php
@@ -1,0 +1,228 @@
+<?php
+
+/**
+ * Routes each item to an output branch — per-item If / Switch.
+ *
+ * {@see SwitchNode} branches the whole batch: the engine picks one outgoing edge
+ * by its condition and every item follows it. This node is the other kind of
+ * branch, the one n8n's If and Switch actually are — it decides *per item*. Each
+ * item is tested against the node's rules in order and tagged for the output of
+ * the first rule it matches (or the fallback); items matching nothing with no
+ * fallback are dropped. The engine then delivers each item only to the output
+ * place it was tagged for ({@see FlowEngine::advanceItems()}).
+ *
+ * So a Router with rules -> "high" / "low" and an edge from each output splits
+ * one stream of items into two, and both branches run with their own share.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-per-item-routing/specs/flow-per-item-routing/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Nodes;
+
+use OCA\OpenRegister\Service\Flow\FlowExpression;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
+use UnexpectedValueException;
+
+/**
+ * Tags each item with the output branch it should go to.
+ */
+class RouterNode implements IFlowNode
+{
+    /**
+     * Constructor.
+     *
+     * @param IL10N         $l10n Translations.
+     * @param IURLGenerator $urls For the palette icon.
+     */
+    public function __construct(
+        private readonly IL10N $l10n,
+        private readonly IURLGenerator $urls
+    ) {
+
+    }//end __construct()
+
+    /**
+     * The step type.
+     *
+     * @return string The id.
+     */
+    public function getId(): string
+    {
+        return 'openregister.route';
+
+    }//end getId()
+
+    /**
+     * Palette name.
+     *
+     * @return string The display name.
+     */
+    public function getDisplayName(): string
+    {
+        return $this->l10n->t('Route items');
+
+    }//end getDisplayName()
+
+    /**
+     * Palette description.
+     *
+     * @return string The description.
+     */
+    public function getDescription(): string
+    {
+        return $this->l10n->t('Send each item down a different branch, chosen per item by a rule.');
+
+    }//end getDescription()
+
+    /**
+     * Palette icon.
+     *
+     * @return string The icon URL.
+     */
+    public function getIcon(): string
+    {
+        return $this->urls->imagePath('core', 'actions/arrow-right.svg');
+
+    }//end getIcon()
+
+    /**
+     * Routing grants no privilege.
+     *
+     * @param int $scope The scope constant.
+     *
+     * @return boolean Whether it is available.
+     */
+    public function isAvailableForScope(int $scope): bool
+    {
+        return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
+
+    }//end isAvailableForScope()
+
+    /**
+     * Reject a router with no rules — it would route nothing.
+     *
+     * @param array $config The step configuration.
+     *
+     * @return void
+     *
+     * @throws UnexpectedValueException When no rules are configured.
+     */
+    public function validateConfig(array $config): void
+    {
+        if ($this->rulesOf(config: $config) === []) {
+            throw new UnexpectedValueException($this->l10n->t('A router needs at least one rule.'));
+        }
+
+    }//end validateConfig()
+
+    /**
+     * Tag each item with the output it matches.
+     *
+     * Rules are tried in order; the first whose condition holds for the item wins
+     * and the item is tagged for that rule's output. An item matching no rule
+     * takes the fallback (`default`) when one is set, and is otherwise dropped —
+     * the same as a Switch case with no match and no default.
+     *
+     * @param array $items   The input items.
+     * @param array $config  The step configuration.
+     * @param array $context Run-level metadata.
+     *
+     * @return array The items, each tagged (or dropped when unmatched).
+     */
+    public function execute(array $items, array $config, array $context): array
+    {
+        $rules    = $this->rulesOf(config: $config);
+        $fallback = trim((string) ($config['default'] ?? ''));
+        $count    = count($items);
+
+        $out = [];
+        foreach ($items as $index => $item) {
+            $data   = FlowExpression::dataFor(
+                item: (array) $item,
+                itemCount: $count,
+                context: $context
+            );
+            $output = $this->outputFor(rules: $rules, data: $data, fallback: $fallback);
+            if ($output === null) {
+                // No rule matched and no fallback: this item goes nowhere.
+                continue;
+            }
+
+            $out[] = FlowItems::item(
+                json: (array) ($item[FlowItems::JSON] ?? []),
+                binary: (array) ($item[FlowItems::BINARY] ?? []),
+                fromItemIndex: $index,
+                output: $output
+            );
+        }//end foreach
+
+        return $out;
+
+    }//end execute()
+
+    /**
+     * The output branch an item's data selects, or null when it selects none.
+     *
+     * @param array<int, array> $rules    The routing rules.
+     * @param array             $data     The item's expression data.
+     * @param string            $fallback The default output, empty for none.
+     *
+     * @return string|null The chosen output, or null.
+     */
+    private function outputFor(array $rules, array $data, string $fallback): ?string
+    {
+        foreach ($rules as $rule) {
+            $output = trim((string) ($rule['output'] ?? ''));
+            if ($output === '') {
+                continue;
+            }
+
+            if (FlowExpression::isTrue(logic: ($rule['condition'] ?? null), data: $data) === true) {
+                return $output;
+            }
+        }
+
+        if ($fallback !== '') {
+            return $fallback;
+        }
+
+        return null;
+
+    }//end outputFor()
+
+    /**
+     * The configured rules, as a clean list.
+     *
+     * @param array $config The step configuration.
+     *
+     * @return array<int, array> The rules.
+     */
+    private function rulesOf(array $config): array
+    {
+        $rules = ($config['rules'] ?? []);
+        if (is_array($rules) === false) {
+            return [];
+        }
+
+        return array_values(array_filter($rules, static fn ($rule): bool => is_array($rule) === true));
+
+    }//end rulesOf()
+}//end class

--- a/openspec/changes/or-flow-per-item-routing/.openspec.yaml
+++ b/openspec/changes/or-flow-per-item-routing/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-per-item-routing

--- a/openspec/changes/or-flow-per-item-routing/proposal.md
+++ b/openspec/changes/or-flow-per-item-routing/proposal.md
@@ -1,0 +1,44 @@
+# Proposal: or-flow-per-item-routing
+
+## Summary
+
+Per-item routing — n8n's If / Switch that splits an item stream across branches,
+each item taking the branch its own data selects. This closes the last named gap
+in #2067. It is additive: a step whose items carry no routing tag distributes
+exactly as before, so no existing flow changes behaviour.
+
+## Why
+
+The existing `SwitchNode` branches the *whole batch*: the engine picks one
+outgoing edge by its condition and every item follows it. That is a real routing
+mode, but it is not what n8n's If/Switch do — those decide per item, and a flow
+that (say) sends approved records one way and the rest another needs exactly
+that.
+
+## What Changes
+
+- **The item gains an optional `output` tag** (`FlowItems::OUTPUT`), naming the
+  branch it is routed to. It is present only when a routing node sets it, so an
+  ordinary item keeps its exact `{json, binary, pairedItem}` shape.
+- **`FlowEngine::advanceItems` distributes per output**: an item tagged for an
+  output goes only to that output place; an untagged item is broadcast to every
+  output — the ordinary behaviour, and what a parallel split relies on. The tag
+  is stripped as the item lands, so it never lingers to misroute a later step. A
+  step whose items carry no tag routes exactly as before: additive, not a change
+  to the firing rule.
+- **`RouterNode`** (`openregister.route`, "Route items") tags each item. Its
+  rules are tried in order; the first whose JSONLogic condition holds wins and
+  tags the item for that rule's output. An item matching nothing takes the
+  `default` output when set, and is otherwise dropped — the same as a Switch case
+  with no match and no default.
+
+## Relationship to SwitchNode
+
+Both stay. `SwitchNode` + edge conditions is whole-batch routing (any node can
+branch, the decision is on the edge). `RouterNode` is per-item routing (the
+decision is in the node, on each item). They are the two branch kinds n8n has;
+an author picks by whether the split is of the path or of the items.
+
+## Out of scope
+
+The builder affordance for drawing a router's outputs and labelling them.

--- a/openspec/changes/or-flow-per-item-routing/specs/flow-per-item-routing/spec.md
+++ b/openspec/changes/or-flow-per-item-routing/specs/flow-per-item-routing/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: A step can route each item to its own output (REQ-PIR-001)
+
+The flow engine SHALL deliver a produced item that names an output
+(`FlowItems::OUTPUT`) only to the output place with that name, and SHALL
+broadcast an item that names no output to every output place. The output tag
+SHALL be removed as the item is delivered. A step whose items carry no tag SHALL
+distribute exactly as it did before this change.
+
+#### Scenario: A router splits its items across branches
+
+- **GIVEN** a step routing items to outputs "high" and "low"
+- **WHEN** it tags some items "high" and the rest "low"
+- **THEN** the "high" branch receives only the "high" items
+- **AND** the "low" branch receives only the "low" items
+- **AND** neither branch's items still carry the routing tag
+
+#### Scenario: An untagged split still broadcasts to every branch
+
+- **GIVEN** a fork whose items carry no output tag
+- **WHEN** it fires
+- **THEN** every output receives every item
+
+### Requirement: The router tags items by rule (REQ-PIR-002)
+
+OpenRegister SHALL provide a `openregister.route` node that tags each item for
+the output of the first rule whose condition holds, falling back to a configured
+default, and dropping an item that matches neither. A router with no rules SHALL
+be refused at save time.
+
+#### Scenario: The first matching rule wins
+
+- **GIVEN** an item that satisfies two rules
+- **WHEN** it is routed
+- **THEN** it is tagged for the earlier rule's output
+
+#### Scenario: An unmatched item with no default is dropped
+
+- **GIVEN** an item matching no rule and no default is set
+- **WHEN** it is routed
+- **THEN** it is not emitted
+
+@e2e exclude engine + node — covered by FlowEngineTest and RouterNodeTest and
+live-verified on 8080 (real dispatcher split 3 items 1/2 across two branches);
+the builder affordance for router outputs is a separate change

--- a/openspec/changes/or-flow-per-item-routing/tasks.md
+++ b/openspec/changes/or-flow-per-item-routing/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: or-flow-per-item-routing
+
+- [x] Item `output` tag (FlowItems::OUTPUT), present only when set; normalise
+      preserves it; `outputOf()` reads it.
+- [x] `FlowEngine::advanceItems` distributes per output (untagged broadcasts,
+      tagged goes to its output only, tag stripped on delivery) via
+      `itemsForOutput()`. run() CC unchanged at baseline 12.
+- [x] `RouterNode` (`openregister.route`) — rules in order, first match wins,
+      `default` fallback, unmatched dropped; registered on the node event.
+- [x] Tests: engine split + no-regression broadcast (FlowEngineTest);
+      RouterNode tag/first-match/drop/validate/scope (RouterNodeTest). 142 flow
+      tests green; phpcs clean; phpmd run() at baseline.
+- [x] Live-verified on 8080: `openregister.route` in the palette; a real
+      RegistryStepDispatcher run split 3 seed items into high=1 / low=2 branches.
+- [ ] Builder affordance for router outputs — follow-up.

--- a/tests/Unit/Service/Flow/FlowEngineTest.php
+++ b/tests/Unit/Service/Flow/FlowEngineTest.php
@@ -398,6 +398,91 @@ class FlowEngineTest extends TestCase
         $this->assertSame(FlowEngine::STATUS_COMPLETED, $result['status']);
     }
 
+    public function testPerItemRoutingSendsEachItemDownItsTaggedBranch(): void
+    {
+        // A router edge start -> [high, low], then a step off each. The router
+        // tags n>5 for 'high', the rest for 'low'. Each branch must see only its
+        // own items — this is what per-item routing means.
+        $router = new class extends RecordingDispatcher {
+            public function dispatch(array $step, array $items, array $context): array
+            {
+                $name = (string) ($step['id'] ?? '');
+                $this->dispatched[] = $name;
+                $this->seenItems[$name] = $items;
+
+                if ($name !== 'route') {
+                    return $items;
+                }
+
+                $out = [];
+                foreach ($items as $i => $item) {
+                    $n = (int) ($item['json']['n'] ?? 0);
+                    $out[] = FlowItems::item(
+                        json: $item['json'],
+                        binary: [],
+                        fromItemIndex: $i,
+                        output: ($n > 5 ? 'high' : 'low')
+                    );
+                }
+
+                return $out;
+            }
+        };
+
+        $flow = [
+            'id'    => 'route',
+            'nodes' => [['id' => 'start'], ['id' => 'high'], ['id' => 'low'], ['id' => 'hEnd'], ['id' => 'lEnd']],
+            'edges' => [
+                ['id' => 'route', 'from' => 'start', 'to' => ['high', 'low']],
+                ['id' => 'doHigh', 'from' => 'high', 'to' => 'hEnd'],
+                ['id' => 'doLow', 'from' => 'low', 'to' => 'lEnd'],
+            ],
+        ];
+
+        $seed = [
+            FlowItems::item(json: ['n' => 1]),
+            FlowItems::item(json: ['n' => 7]),
+            FlowItems::item(json: ['n' => 3]),
+        ];
+
+        $result = $this->engine->run(
+            $flow,
+            new MethodMarkingStore(false, 'marking'),
+            new FlowSubject(),
+            $router,
+            [],
+            $seed
+        );
+
+        $this->assertSame(FlowEngine::STATUS_COMPLETED, $result['status']);
+        // High branch saw only n=7; low branch saw n=1 and n=3.
+        $this->assertSame([7], array_map(static fn (array $i): int => $i['json']['n'], $router->seenItems['doHigh']));
+        $this->assertSame([1, 3], array_map(static fn (array $i): int => $i['json']['n'], $router->seenItems['doLow']));
+        // The routing tag does not linger on the items the branch step sees.
+        $this->assertArrayNotHasKey('output', $router->seenItems['doHigh'][0]);
+    }
+
+    public function testAnUntaggedSplitStillBroadcastsToEveryBranch(): void
+    {
+        // The no-regression guarantee: a fork whose items carry no output tag
+        // delivers every item to every branch, exactly as before per-item routing.
+        $dispatcher = new RecordingDispatcher();
+        $result = $this->runFlow([
+            'id'    => 'fork',
+            'nodes' => [['id' => 'start'], ['id' => 'a'], ['id' => 'b'], ['id' => 'aEnd'], ['id' => 'bEnd']],
+            'edges' => [
+                ['id' => 'fork', 'from' => 'start', 'to' => ['a', 'b']],
+                ['id' => 'doA', 'from' => 'a', 'to' => 'aEnd'],
+                ['id' => 'doB', 'from' => 'b', 'to' => 'bEnd'],
+            ],
+        ], $dispatcher);
+
+        $this->assertSame(FlowEngine::STATUS_COMPLETED, $result['status']);
+        // Both branches saw the (single, untagged) item.
+        $this->assertCount(1, $dispatcher->seenItems['doA']);
+        $this->assertCount(1, $dispatcher->seenItems['doB']);
+    }
+
     public function testRunFromHereStartsAtTheChosenNodeAndSkipsWhatIsBefore(): void
     {
         // A three-step line start -> middle -> end. Starting at 'middle' must

--- a/tests/Unit/Service/Flow/RouterNodeTest.php
+++ b/tests/Unit/Service/Flow/RouterNodeTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\Nodes\RouterNode;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
+
+class RouterNodeTest extends TestCase
+{
+    private RouterNode $node;
+
+    protected function setUp(): void
+    {
+        $l = $this->createMock(IL10N::class);
+        $l->method('t')->willReturnArgument(0);
+        $this->node = new RouterNode($l, $this->createMock(IURLGenerator::class));
+    }
+
+    private function items(array $ns): array
+    {
+        return array_map(static fn (int $n): array => FlowItems::item(json: ['n' => $n]), $ns);
+    }
+
+    private function config(): array
+    {
+        // n > 5 -> "high", otherwise the "low" fallback.
+        return [
+            'rules'   => [['condition' => ['>' => [['var' => 'json.n'], 5]], 'output' => 'high']],
+            'default' => 'low',
+        ];
+    }
+
+    public function testItTagsEachItemForTheOutputItMatches(): void
+    {
+        $out = $this->node->execute($this->items([1, 7, 3]), $this->config(), []);
+
+        $this->assertCount(3, $out);
+        $this->assertSame('low', $out[0][FlowItems::OUTPUT]);
+        $this->assertSame('high', $out[1][FlowItems::OUTPUT]);
+        $this->assertSame('low', $out[2][FlowItems::OUTPUT]);
+        // The record is carried through untouched.
+        $this->assertSame(7, $out[1]['json']['n']);
+    }
+
+    public function testTheFirstMatchingRuleWins(): void
+    {
+        $config = [
+            'rules' => [
+                ['condition' => ['>' => [['var' => 'json.n'], 0]], 'output' => 'positive'],
+                ['condition' => ['>' => [['var' => 'json.n'], 5]], 'output' => 'big'],
+            ],
+        ];
+
+        $out = $this->node->execute($this->items([7]), $config, []);
+        // 7 matches both, but the first rule (positive) wins.
+        $this->assertSame('positive', $out[0][FlowItems::OUTPUT]);
+    }
+
+    public function testAnItemMatchingNothingWithNoFallbackIsDropped(): void
+    {
+        $config = [
+            'rules' => [['condition' => ['>' => [['var' => 'json.n'], 5]], 'output' => 'high']],
+        ];
+
+        // 1 matches no rule and there is no default -> it is dropped.
+        $out = $this->node->execute($this->items([1, 7]), $config, []);
+
+        $this->assertCount(1, $out);
+        $this->assertSame('high', $out[0][FlowItems::OUTPUT]);
+    }
+
+    public function testARouterNeedsAtLeastOneRule(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->node->validateConfig(['rules' => []]);
+    }
+
+    public function testItIsAvailableInBothScopes(): void
+    {
+        $this->assertTrue($this->node->isAvailableForScope(IManager::SCOPE_ADMIN));
+        $this->assertTrue($this->node->isAvailableForScope(IManager::SCOPE_USER));
+    }
+
+    public function testTheTypeIsStable(): void
+    {
+        $this->assertSame('openregister.route', $this->node->getId());
+    }
+}


### PR DESCRIPTION
Closes the **last named gap in #2067**: n8n's If/Switch that splits an item stream across branches, each item taking the branch its own data selects. **Additive** — a step whose items carry no routing tag distributes exactly as before, so no existing flow changes behaviour.

This is the implementation of **option 2** from the design in #2115 (which can now be closed).

## Why

The existing `SwitchNode` branches the *whole batch* (the engine picks one outgoing edge by its condition and every item follows). That is a real mode but not what n8n's If/Switch do — those decide *per item*. **Both stay**: `SwitchNode` + edge conditions is whole-batch routing (any node can branch, decision on the edge); `RouterNode` is per-item (decision in the node, on each item).

## What

- **Item gains an optional `output` tag** (`FlowItems::OUTPUT`), present only when a routing node sets it, so an ordinary item keeps its exact `{json, binary, pairedItem}` shape.
- **`FlowEngine::advanceItems` distributes per output**: a tagged item goes only to its output place; an untagged item **broadcasts to every output** (the ordinary behaviour a parallel split relies on). The tag is stripped as the item lands, so it never lingers to misroute a later step. Held `run()` CC at baseline 12 (the change is in `advanceItems` + a new `itemsForOutput` helper).
- **`RouterNode`** (`openregister.route`, "Route items") tags each item: rules tried in order, first matching JSONLogic condition wins, `default` fallback, unmatched dropped.

## Verification

- **Unit** — `FlowEngineTest`: per-item split sends each item down its branch and the tag does not linger; **an untagged split still broadcasts to every branch** (the no-regression guarantee). `RouterNodeTest`: tag by rule, first-match-wins, drop unmatched, needs a rule, scope. 142 flow tests green; phpcs clean; phpmd `run()` at baseline 12.
- **Live (8080)** — `openregister.route` in the palette; a **real `RegistryStepDispatcher` run split 3 seed items into high=1 / low=2 branches**, each branch step receiving exactly its share.

## Out of scope

The builder affordance for drawing a router's outputs and labelling them.

Supersedes #2115 (design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)