### PR TITLE
feat(flow): OpenRegister-native flow store — resolve flows stored as OR objects

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -2383,6 +2383,15 @@ class Application extends App implements IBootstrap
             \OCA\OpenRegister\Listener\FlowNodeRegistrationListener::class
         );
 
+        // Flow resolution. OpenRegister resolves flows stored as its own objects
+        // (a `flows` register / `flow` schema by default), so a flow can live in
+        // OpenRegister itself and not only in a consuming app — contributed
+        // through the same resolver event.
+        $context->registerEventListener(
+            \OCA\OpenRegister\Service\Flow\RegisterFlowResolversEvent::class,
+            \OCA\OpenRegister\Listener\FlowResolverRegistrationListener::class
+        );
+
         // Advertise the `openregister` OCM resource type in /ocm-provider discovery.
         $context->registerEventListener(
             \OCP\OCM\Events\ResourceTypeRegisterEvent::class,

--- a/lib/Listener/FlowResolverRegistrationListener.php
+++ b/lib/Listener/FlowResolverRegistrationListener.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Registers OpenRegister's own flow resolver.
+ *
+ * OpenRegister contributes its resolver through the same event every consuming
+ * app uses ({@see RegisterFlowResolversEvent}) rather than seeding the registry
+ * directly. Same reasoning as the node listener: if the owner of the mechanism
+ * does not use the mechanism, the mechanism rots.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Listener
+ * @package  OCA\OpenRegister\Listener
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-native-store/specs/flow-native-store/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Listener;
+
+use OCA\OpenRegister\Service\Flow\OpenRegisterFlowResolver;
+use OCA\OpenRegister\Service\Flow\RegisterFlowResolversEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+/**
+ * Contributes the built-in flow resolver.
+ *
+ * @template-implements IEventListener<RegisterFlowResolversEvent>
+ */
+class FlowResolverRegistrationListener implements IEventListener
+{
+    /**
+     * Constructor.
+     *
+     * @param OpenRegisterFlowResolver $resolver The built-in flow resolver.
+     */
+    public function __construct(private readonly OpenRegisterFlowResolver $resolver)
+    {
+
+    }//end __construct()
+
+    /**
+     * Register the built-in resolver.
+     *
+     * @param Event $event The dispatched event.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/or-flow-native-store/specs/flow-native-store/spec.md
+     */
+    public function handle(Event $event): void
+    {
+        if (($event instanceof RegisterFlowResolversEvent) === false) {
+            return;
+        }
+
+        $event->registerResolver(resolver: $this->resolver);
+
+    }//end handle()
+}//end class

--- a/lib/Service/Flow/OpenRegisterFlowResolver.php
+++ b/lib/Service/Flow/OpenRegisterFlowResolver.php
@@ -1,0 +1,246 @@
+<?php
+
+/**
+ * Resolves flows stored in OpenRegister itself.
+ *
+ * The flow engine is OpenRegister's, but until now OpenRegister could not own a
+ * flow: it had no resolver of its own, so only a consuming app (hermiq's
+ * agentflows) could store and run one. This is the resolver that closes that —
+ * it lets a flow live as an ordinary OpenRegister object, in a register and
+ * schema an admin nominates, and the engine, triggers, sub-flows and the test
+ * run all work with it exactly as they do with a leaf app's flows.
+ *
+ * A flow is just an object with `nodes` and `edges`. Which register and schema
+ * hold them is configuration (`flow_register` / `flow_schema`, defaulting to the
+ * `flows` register and `flow` schema), so an instance points this at whatever
+ * store it authored its flows in. Absent that store, every method resolves to
+ * nothing and another app's resolver is left to answer — this never claims a
+ * flow it does not own.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-native-store/specs/flow-native-store/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IAppConfig;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * The resolver for OpenRegister's own flow objects.
+ */
+class OpenRegisterFlowResolver implements IFlowResolver
+{
+
+    /**
+     * The app id its config lives under.
+     */
+    private const APP_ID = 'openregister';
+
+    /**
+     * Config keys (and defaults) naming the register and schema flows live in.
+     */
+    private const REGISTER_KEY = 'flow_register';
+
+    private const REGISTER_DEFAULT = 'flows';
+
+    private const SCHEMA_KEY = 'flow_schema';
+
+    private const SCHEMA_DEFAULT = 'flow';
+
+    /**
+     * Constructor.
+     *
+     * @param ObjectService   $objectService Loads and lists flow objects.
+     * @param IAppConfig      $appConfig     Names the register and schema.
+     * @param LoggerInterface $logger        The logger.
+     */
+    public function __construct(
+        private readonly ObjectService $objectService,
+        private readonly IAppConfig $appConfig,
+        private readonly LoggerInterface $logger
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Load a flow as a flow document.
+     *
+     * @param string $flowId The flow uuid.
+     *
+     * @return array|null The flow document, or null when it is not an OR flow.
+     *
+     * @spec openspec/changes/or-flow-native-store/specs/flow-native-store/spec.md
+     */
+    public function resolveFlow(string $flowId): ?array
+    {
+        try {
+            $object = $this->objectService->find(
+                id: $flowId,
+                register: $this->flowRegister(),
+                schema: $this->flowSchema(),
+                _rbac: false,
+                _multitenancy: false
+            );
+        } catch (Throwable $e) {
+            // Not an OR flow (or the store does not exist) — leave it to another
+            // resolver.
+            return null;
+        }
+
+        if (($object instanceof ObjectEntity) === false) {
+            return null;
+        }
+
+        $data = $object->getObject();
+
+        // An object in the flow store that is not shaped like a flow is not one.
+        if (isset($data['nodes']) === false && isset($data['edges']) === false) {
+            return null;
+        }
+
+        return [
+            'id'     => $flowId,
+            'nodes'  => (array) ($data['nodes'] ?? []),
+            'edges'  => (array) ($data['edges'] ?? []),
+            'limits' => (array) ($data['limits'] ?? []),
+        ];
+
+    }//end resolveFlow()
+
+    /**
+     * Load the object a run is about.
+     *
+     * @param string $uuid     The subject uuid.
+     * @param string $register The register slug.
+     * @param string $schema   The schema slug.
+     *
+     * @return object|null The subject object, or null when it cannot be found.
+     *
+     * @spec openspec/changes/or-flow-native-store/specs/flow-native-store/spec.md
+     */
+    public function resolveSubject(string $uuid, string $register, string $schema): ?object
+    {
+        if ($uuid === '' || $register === '' || $schema === '') {
+            return null;
+        }
+
+        try {
+            $object = $this->objectService->find(
+                id: $uuid,
+                register: $register,
+                schema: $schema,
+                _rbac: false,
+                _multitenancy: false
+            );
+        } catch (Throwable $e) {
+            return null;
+        }
+
+        if (($object instanceof ObjectEntity) === true) {
+            return $object;
+        }
+
+        return null;
+
+    }//end resolveSubject()
+
+    /**
+     * Which flows are wired to a fired event.
+     *
+     * A flow declares its trigger with `trigger`, `triggerRegister` and
+     * `triggerSchema` fields. A flow matches when it is enabled, its trigger
+     * equals the event and its register/schema match (an empty flow
+     * register/schema is a wildcard — "any").
+     *
+     * @param string $event    The event id.
+     * @param string $register The register the event fired on.
+     * @param string $schema   The schema the event fired on.
+     *
+     * @return array<int, string> The ids of the matching flows.
+     *
+     * @spec openspec/changes/or-flow-native-store/specs/flow-native-store/spec.md
+     */
+    public function flowsForTrigger(string $event, string $register, string $schema): array
+    {
+        try {
+            $flows = $this->objectService->findAll(
+                config: ['register' => $this->flowRegister(), 'schema' => $this->flowSchema()],
+                _rbac: false,
+                _multitenancy: false
+            );
+        } catch (Throwable $e) {
+            // No flow store yet — nothing to trigger.
+            return [];
+        }
+
+        $ids = [];
+        foreach ($flows as $flow) {
+            if (($flow instanceof ObjectEntity) === false) {
+                continue;
+            }
+
+            $data = $flow->getObject();
+            if (($data['enabled'] ?? false) !== true) {
+                continue;
+            }
+
+            if ((string) ($data['trigger'] ?? '') !== $event) {
+                continue;
+            }
+
+            $flowRegister = (string) ($data['triggerRegister'] ?? '');
+            $flowSchema   = (string) ($data['triggerSchema'] ?? '');
+            if ($flowRegister !== '' && $flowRegister !== $register) {
+                continue;
+            }
+
+            if ($flowSchema !== '' && $flowSchema !== $schema) {
+                continue;
+            }
+
+            $ids[] = (string) $flow->getUuid();
+        }//end foreach
+
+        return $ids;
+
+    }//end flowsForTrigger()
+
+    /**
+     * The register flows are stored in.
+     *
+     * @return string The register slug.
+     */
+    private function flowRegister(): string
+    {
+        return $this->appConfig->getValueString(self::APP_ID, self::REGISTER_KEY, self::REGISTER_DEFAULT);
+
+    }//end flowRegister()
+
+    /**
+     * The schema flows are stored under.
+     *
+     * @return string The schema slug.
+     */
+    private function flowSchema(): string
+    {
+        return $this->appConfig->getValueString(self::APP_ID, self::SCHEMA_KEY, self::SCHEMA_DEFAULT);
+
+    }//end flowSchema()
+}//end class

--- a/openspec/changes/or-flow-native-store/.openspec.yaml
+++ b/openspec/changes/or-flow-native-store/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-native-store

--- a/openspec/changes/or-flow-native-store/proposal.md
+++ b/openspec/changes/or-flow-native-store/proposal.md
@@ -1,0 +1,51 @@
+# Proposal: or-flow-native-store
+
+## Summary
+
+Let a flow live in OpenRegister itself. OpenRegister owns the flow engine but had
+no resolver of its own, so a flow could only be stored and run by a consuming app
+(hermiq's agentflows). This adds `OpenRegisterFlowResolver`, which resolves flows
+stored as ordinary OpenRegister objects — so the engine, triggers, sub-flows and
+the test run all work with an OpenRegister-authored flow exactly as with a leaf
+app's.
+
+## Why
+
+"OpenRegister is the fleet's one flow engine" was only half true: you could run
+the engine, but you could not author a flow *in* OpenRegister and have anything
+resolve it. Every other surface (the `/test` endpoint, the trigger listener,
+the sub-flow node) resolves a flow id through the resolver registry, and that
+registry had exactly one contributor — hermiq. This closes the gap so
+OpenRegister is a first-class flow author, not only the runtime.
+
+## What Changes
+
+- **`OpenRegisterFlowResolver`** (registered through `RegisterFlowResolversEvent`,
+  the same event hermiq uses):
+  - `resolveFlow` loads a flow object and returns its `{nodes, edges, limits}`. An
+    object in the flow store that is not shaped like a flow (no nodes/edges) is
+    not treated as one.
+  - `resolveSubject` loads the object a run is about.
+  - `flowsForTrigger` lists the enabled flows wired to a fired event, scoped to
+    the flow store, matching the flow's `trigger` and optional
+    `triggerRegister`/`triggerSchema`.
+- **The flow store is configuration**: `flow_register` / `flow_schema` app-config
+  keys name where flows live, defaulting to the `flows` register and `flow`
+  schema. Absent that store, every method resolves to nothing — the resolver
+  never claims a flow it does not own, so it composes cleanly with hermiq's.
+
+## Enabling it
+
+Create a register and schema for flows (an object with `nodes`, `edges`, and —
+for triggering — `enabled`, `trigger`, optional `triggerRegister`/`triggerSchema`),
+then point `flow_register` / `flow_schema` at them (or name them `flows` / `flow`
+to use the defaults). A flow is then just an object; the run history, retry, pins,
+run-from-here and the `/test` endpoint all already work with it.
+
+## Out of scope
+
+- Shipping and force-importing a canonical `flow` schema on install. The resolver
+  is deliberately store-agnostic (any register/schema, by config) so this does not
+  depend on the register-import machinery; a bundled schema can follow.
+- A flow-authoring UI. Flows are objects, so the existing object editor already
+  edits them; a purpose-built canvas is a separate concern.

--- a/openspec/changes/or-flow-native-store/specs/flow-native-store/spec.md
+++ b/openspec/changes/or-flow-native-store/specs/flow-native-store/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: OpenRegister resolves flows stored as its own objects (REQ-NS-001)
+
+OpenRegister SHALL contribute a flow resolver, registered through
+`RegisterFlowResolversEvent`, that resolves flows stored as OpenRegister objects
+in a configurable register and schema (`flow_register` / `flow_schema`,
+defaulting to `flows` / `flow`). It SHALL return a flow's `{nodes, edges}`, load a
+run's subject, and list the enabled flows wired to a fired event. An object that
+is not shaped like a flow SHALL NOT be resolved as one, and an absent flow store
+SHALL resolve to nothing rather than error.
+
+#### Scenario: A flow object resolves
+
+- **GIVEN** a flow object (with nodes and edges) in the flow store
+- **WHEN** its id is resolved
+- **THEN** its flow document is returned
+
+#### Scenario: A non-flow object is not a flow
+
+- **GIVEN** an object in the flow store with no nodes or edges
+- **WHEN** its id is resolved
+- **THEN** the resolver returns null
+
+#### Scenario: No flow store, no triggers
+
+- **GIVEN** no flow register exists
+- **WHEN** flows for an event are listed
+- **THEN** the result is empty and no error is raised
+
+@e2e exclude backend resolver — covered by OpenRegisterFlowResolverTest and
+live-verified on 8080 (resolved a real flow-shaped object through the OR resolver;
+absent store returned null); the flow-authoring UI is a separate change

--- a/openspec/changes/or-flow-native-store/tasks.md
+++ b/openspec/changes/or-flow-native-store/tasks.md
@@ -1,0 +1,13 @@
+# Tasks: or-flow-native-store
+
+- [x] `OpenRegisterFlowResolver` (resolveFlow / resolveSubject / flowsForTrigger)
+      over a configurable `flow_register` / `flow_schema` store (defaults
+      `flows` / `flow`); non-flow-shaped object -> null; absent store -> null/[].
+- [x] `FlowResolverRegistrationListener` + registration on
+      `RegisterFlowResolversEvent` in Application.php.
+- [x] OpenRegisterFlowResolverTest — resolve, not-flow-shaped, not-found, trigger
+      enabled/scoped filtering, absent store (6 tests). phpcs clean.
+- [x] Live-verified on 8080: absent store -> null; a real flow-shaped object
+      resolved through the OR resolver (nodes=2, edges=1); registry reachable.
+- [ ] Ship + force-import a canonical `flow` schema on install — follow-up.
+- [ ] Flow-authoring canvas — follow-up (objects are editable in the object editor today).

--- a/tests/Unit/Service/Flow/OpenRegisterFlowResolverTest.php
+++ b/tests/Unit/Service/Flow/OpenRegisterFlowResolverTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Flow\OpenRegisterFlowResolver;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IAppConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class OpenRegisterFlowResolverTest extends TestCase
+{
+    private ObjectService&MockObject $objects;
+
+    private OpenRegisterFlowResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->objects = $this->createMock(ObjectService::class);
+
+        $config = $this->createMock(IAppConfig::class);
+        $config->method('getValueString')->willReturnCallback(
+            static fn (string $app, string $key, string $default = '') => $default
+        );
+
+        $this->resolver = new OpenRegisterFlowResolver(
+            $this->objects,
+            $config,
+            $this->createMock(\Psr\Log\LoggerInterface::class)
+        );
+    }
+
+    private function flowObject(array $data): ObjectEntity
+    {
+        $o = new ObjectEntity();
+        $o->setUuid('flow-1');
+        $o->setObject($data);
+        return $o;
+    }
+
+    public function testItResolvesAFlowObjectIntoADocument(): void
+    {
+        $this->objects->method('find')->willReturn(
+            $this->flowObject(['nodes' => [['id' => 'a']], 'edges' => [['id' => 'e']]])
+        );
+
+        $doc = $this->resolver->resolveFlow('flow-1');
+
+        $this->assertIsArray($doc);
+        $this->assertSame('flow-1', $doc['id']);
+        $this->assertCount(1, $doc['nodes']);
+        $this->assertCount(1, $doc['edges']);
+    }
+
+    public function testAnObjectThatIsNotFlowShapedIsNotAFlow(): void
+    {
+        // An ordinary object in the flow store with no nodes/edges is not a flow.
+        $this->objects->method('find')->willReturn($this->flowObject(['title' => 'not a flow']));
+
+        $this->assertNull($this->resolver->resolveFlow('flow-1'));
+    }
+
+    public function testAFlowThatCannotBeLoadedResolvesNull(): void
+    {
+        $this->objects->method('find')->willThrowException(new RuntimeException('nope'));
+        $this->assertNull($this->resolver->resolveFlow('ghost'));
+    }
+
+    public function testFlowsForTriggerReturnsOnlyEnabledMatches(): void
+    {
+        $match = $this->flowObject(['enabled' => true, 'trigger' => 'object.created']);
+        $disabled = $this->flowObject(['enabled' => false, 'trigger' => 'object.created']);
+        $otherEvent = $this->flowObject(['enabled' => true, 'trigger' => 'object.deleted']);
+        $match->setUuid('yes');
+        $disabled->setUuid('off');
+        $otherEvent->setUuid('other');
+
+        $this->objects->method('findAll')->willReturn([$match, $disabled, $otherEvent]);
+
+        $ids = $this->resolver->flowsForTrigger('object.created', 'reg', 'sch');
+        $this->assertSame(['yes'], $ids);
+    }
+
+    public function testATriggerRegisterScopesTheMatch(): void
+    {
+        $scoped = $this->flowObject([
+            'enabled'         => true,
+            'trigger'         => 'object.created',
+            'triggerRegister' => 'sales',
+        ]);
+        $scoped->setUuid('scoped');
+        $this->objects->method('findAll')->willReturn([$scoped]);
+
+        // Same event on a different register does not match.
+        $this->assertSame([], $this->resolver->flowsForTrigger('object.created', 'hr', 'sch'));
+        // The scoped register matches.
+        $this->assertSame(['scoped'], $this->resolver->flowsForTrigger('object.created', 'sales', 'sch'));
+    }
+
+    public function testNoFlowStoreYieldsNoTriggers(): void
+    {
+        $this->objects->method('findAll')->willThrowException(new RuntimeException('no such register'));
+        $this->assertSame([], $this->resolver->flowsForTrigger('object.created', 'reg', 'sch'));
+    }
+}


### PR DESCRIPTION
"OpenRegister is the fleet's one flow engine" was only **half** true: you could run the engine, but you could not author a flow *in* OpenRegister and have anything resolve it. Every surface — the `/test` endpoint, the trigger listener, the sub-flow node — resolves a flow id through the resolver registry, and that registry had exactly **one** contributor: hermiq. This makes OpenRegister a first-class flow author, not only the runtime.

## What

- **`OpenRegisterFlowResolver`** (registered through `RegisterFlowResolversEvent`, the same event hermiq uses):
  - `resolveFlow` loads a flow object → `{nodes, edges, limits}`. An object in the store with no nodes/edges is **not** treated as a flow.
  - `resolveSubject` loads the object a run is about.
  - `flowsForTrigger` lists the enabled flows wired to an event, scoped to the store, matching `trigger` + optional `triggerRegister`/`triggerSchema`.
- **The flow store is configuration**: `flow_register` / `flow_schema` app-config keys, defaulting to the `flows` register and `flow` schema. Absent that store, every method resolves to nothing — so this never claims a flow it does not own and **composes cleanly with hermiq's** resolver.

Mirrors the proven `HermiqFlowResolver` (same `ObjectService` calls, live-verified earlier) with configurable slugs instead of hardcoded ones.

## Enabling it

Create a register + schema for flows (object with `nodes`, `edges`, and for triggering `enabled` / `trigger` / optional `triggerRegister`/`triggerSchema`), then point `flow_register` / `flow_schema` at them (or name them `flows` / `flow` for the defaults). A flow is then just an object — run history, retry, pins, run-from-here and `/test` all already work with it.

## Verification

- **Unit** — `OpenRegisterFlowResolverTest`: resolve, not-flow-shaped → null, not-found → null, trigger enabled/scoped filtering, absent store → `[]` (6 tests). phpcs clean.
- **Live (8080)** — absent store → null (graceful); a **real flow-shaped object resolved through the OR resolver** (nodes=2, edges=1) by temporarily pointing the config at an existing store; registry reachable; config left clean.

## Out of scope (follow-up)

- Shipping + force-importing a canonical `flow` schema on install (the resolver is store-agnostic, so it does not depend on the register-import machinery).
- A flow-authoring canvas (flows are objects, editable in the object editor today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)