### PR TITLE
feat(flow): native file & user triggers — payload-seeded runs (#2068)

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -2424,6 +2424,16 @@ class Application extends App implements IBootstrap
         $context->registerEventListener(ObjectRevertedEvent::class, \OCA\OpenRegister\Listener\FlowTriggerListener::class);
         $context->registerEventListener(ObjectTransitionedEvent::class, \OCA\OpenRegister\Listener\FlowTriggerListener::class);
 
+        // Non-object native flow triggers: a file or a user is not an OpenRegister
+        // object, so its event rides on the run as a payload the worker seeds the
+        // first item from. A flow wired to file.created / user.created runs on
+        // these just as it does on object events.
+        $context->registerEventListener(\OCP\Files\Events\Node\NodeCreatedEvent::class, \OCA\OpenRegister\Listener\NativeFlowTriggerListener::class);
+        $context->registerEventListener(\OCP\Files\Events\Node\NodeWrittenEvent::class, \OCA\OpenRegister\Listener\NativeFlowTriggerListener::class);
+        $context->registerEventListener(\OCP\Files\Events\Node\NodeDeletedEvent::class, \OCA\OpenRegister\Listener\NativeFlowTriggerListener::class);
+        $context->registerEventListener(\OCP\User\Events\UserCreatedEvent::class, \OCA\OpenRegister\Listener\NativeFlowTriggerListener::class);
+        $context->registerEventListener(\OCP\User\Events\UserDeletedEvent::class, \OCA\OpenRegister\Listener\NativeFlowTriggerListener::class);
+
         // ToolRegistrationListener for agent function tools.
         $context->registerEventListener(ToolRegistrationEvent::class, ToolRegistrationListener::class);
 

--- a/lib/Cron/FlowRunWorker.php
+++ b/lib/Cron/FlowRunWorker.php
@@ -36,6 +36,7 @@ namespace OCA\OpenRegister\Cron;
 use DateTime;
 use OCA\OpenRegister\Db\FlowRun;
 use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Service\Flow\FlowItems;
 use OCA\OpenRegister\Service\Flow\FlowRunService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
@@ -161,12 +162,21 @@ class FlowRunWorker extends TimedJob
 
             // A subjectless run still needs an object to carry the marking; a
             // bare holder does, since the marking store keeps the marking on the
-            // run itself ({@see FlowRunMarkingStore}).
+            // run itself ({@see FlowRunMarkingStore}). Such a run is seeded from
+            // its payload instead of an object: a non-object trigger (a file, a
+            // user) puts what it is about under `payload` on the run context, and
+            // that becomes the first item, so the flow reads a file's path or a
+            // user's id exactly as it would an object's fields.
+            $seed = null;
             if ($subject === null) {
                 $subject = new \stdClass();
+                $payload = (array) (($run->getContext() ?? [])['payload'] ?? []);
+                if ($payload !== []) {
+                    $seed = [FlowItems::item(json: $payload)];
+                }
             }
 
-            $this->runner->execute(run: $run, flow: $flow, subject: $subject);
+            $this->runner->execute(run: $run, flow: $flow, subject: $subject, seedItems: $seed);
         } catch (Throwable $e) {
             $this->logger->error(
                 message: '[FlowRunWorker] Failed to advance a run',

--- a/lib/Listener/NativeFlowTriggerListener.php
+++ b/lib/Listener/NativeFlowTriggerListener.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * Fires non-object Nextcloud events into the flow engine.
+ *
+ * {@see FlowTriggerListener} handles OpenRegister object lifecycle events, whose
+ * subject is an object with a register and schema. This handles the other kind
+ * of native trigger — a file written, a user created — whose subject is not an
+ * OpenRegister object at all. There is nothing to resolve as a subject, so the
+ * event's details ride on the run as a `payload` instead, and the worker seeds
+ * the run's first item from it ({@see FlowRunWorker}). A flow reads a file's
+ * path or a user's id exactly as it would an object's fields.
+ *
+ * These flows match on the trigger id alone (their register/schema are left
+ * empty — a file has neither), so a flow wired to `file.created` runs whenever a
+ * file appears, wherever it appears.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Listener
+ * @package  OCA\OpenRegister\Listener
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-native-triggers/specs/flow-native-triggers/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Listener;
+
+use OCA\OpenRegister\Service\Flow\FlowTriggerService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Files\Events\Node\NodeCreatedEvent;
+use OCP\Files\Events\Node\NodeDeletedEvent;
+use OCP\Files\Events\Node\NodeWrittenEvent;
+use OCP\Files\Node;
+use OCP\IUserSession;
+use OCP\User\Events\UserCreatedEvent;
+use OCP\User\Events\UserDeletedEvent;
+use Throwable;
+
+/**
+ * Queues flow runs on native file and user events.
+ *
+ * @template-implements IEventListener<NodeCreatedEvent|NodeWrittenEvent|NodeDeletedEvent|UserCreatedEvent|UserDeletedEvent>
+ */
+class NativeFlowTriggerListener implements IEventListener
+{
+    /**
+     * Constructor.
+     *
+     * @param FlowTriggerService $triggers    Queues the runs.
+     * @param IUserSession       $userSession The acting user, for attribution.
+     */
+    public function __construct(
+        private readonly FlowTriggerService $triggers,
+        private readonly IUserSession $userSession
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Translate a native event into a trigger, with its details as the payload.
+     *
+     * @param Event $event The dispatched event.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/or-flow-native-triggers/specs/flow-native-triggers/spec.md
+     */
+    public function handle(Event $event): void
+    {
+        [$eventId, $payload] = $this->describe(event: $event);
+        if ($eventId === null) {
+            return;
+        }
+
+        $user = null;
+        if ($this->userSession->getUser() !== null) {
+            $user = $this->userSession->getUser()->getUID();
+        }
+
+        $this->triggers->fire(
+            event: $eventId,
+            subject: [],
+            user: $user,
+            context: ['payload' => $payload]
+        );
+
+    }//end handle()
+
+    /**
+     * The trigger id and payload for a native event, or `[null, []]` when the
+     * event is not one this listener fires.
+     *
+     * @param Event $event The dispatched event.
+     *
+     * @return array{0: string|null, 1: array} The trigger id and its payload.
+     */
+    private function describe(Event $event): array
+    {
+        if ($event instanceof NodeCreatedEvent) {
+            return ['file.created', $this->filePayload(node: $event->getNode())];
+        }
+
+        if ($event instanceof NodeWrittenEvent) {
+            return ['file.updated', $this->filePayload(node: $event->getNode())];
+        }
+
+        if ($event instanceof NodeDeletedEvent) {
+            return ['file.deleted', $this->filePayload(node: $event->getNode())];
+        }
+
+        if ($event instanceof UserCreatedEvent) {
+            return ['user.created', ['uid' => $event->getUid()]];
+        }
+
+        if ($event instanceof UserDeletedEvent) {
+            return ['user.deleted', ['uid' => $event->getUser()->getUID()]];
+        }
+
+        return [null, []];
+
+    }//end describe()
+
+    /**
+     * The payload describing a file event.
+     *
+     * Each field is read defensively: a node in mid-delete can throw on some
+     * accessors, and losing the whole trigger over one unreadable field would be
+     * worse than a payload with a gap.
+     *
+     * @param Node $node The file or folder the event is about.
+     *
+     * @return array<string, mixed> The file payload.
+     */
+    private function filePayload(Node $node): array
+    {
+        $payload = [];
+        foreach ([
+            'fileId'   => static fn (): int => $node->getId(),
+            'path'     => static fn (): string => $node->getPath(),
+            'name'     => static fn (): string => $node->getName(),
+            'mimetype' => static fn (): string => $node->getMimetype(),
+        ] as $key => $read
+        ) {
+            try {
+                $payload[$key] = $read();
+            } catch (Throwable $e) {
+                // Field unavailable for this node; leave it out.
+                continue;
+            }
+        }
+
+        return $payload;
+
+    }//end filePayload()
+}//end class

--- a/lib/Service/Flow/EventCatalogService.php
+++ b/lib/Service/Flow/EventCatalogService.php
@@ -58,6 +58,11 @@ class EventCatalogService
         ['id' => 'object.unlocked', 'label' => 'An object is unlocked', 'group' => 'Object'],
         ['id' => 'object.reverted', 'label' => 'An object is reverted', 'group' => 'Object'],
         ['id' => 'object.transitioned', 'label' => 'An object changes state', 'group' => 'Object'],
+        ['id' => 'file.created', 'label' => 'A file is created', 'group' => 'File'],
+        ['id' => 'file.updated', 'label' => 'A file is written', 'group' => 'File'],
+        ['id' => 'file.deleted', 'label' => 'A file is deleted', 'group' => 'File'],
+        ['id' => 'user.created', 'label' => 'A user is created', 'group' => 'User'],
+        ['id' => 'user.deleted', 'label' => 'A user is deleted', 'group' => 'User'],
     ];
 
     /**

--- a/openspec/changes/or-flow-native-triggers/.openspec.yaml
+++ b/openspec/changes/or-flow-native-triggers/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-native-triggers

--- a/openspec/changes/or-flow-native-triggers/proposal.md
+++ b/openspec/changes/or-flow-native-triggers/proposal.md
@@ -1,0 +1,42 @@
+# Proposal: or-flow-native-triggers
+
+## Summary
+
+Fire flows on Nextcloud events whose subject is not an OpenRegister object — a
+file written, a user created. These need no object to run about; the event's
+details ride on the run as a payload, and the run's first item is seeded from it.
+This is the remaining half of #2068's "a Nextcloud-native trigger set".
+
+## Why
+
+The object-lifecycle triggers (#2104, #2112) cover every event about an
+OpenRegister object. But n8n-parity means triggering on the platform's own
+events too — the moment a file lands, the moment a user is created. Those have no
+register or schema; the object-centric trigger path cannot carry them. The run
+model already anticipated this (the worker comments that a subjectless run is
+"seeded from its payload"), so the missing piece is small: a listener that turns
+the event into a payload, and the worker actually seeding from it.
+
+## What Changes
+
+- **`NativeFlowTriggerListener`** translates file (`NodeCreated` / `NodeWritten`
+  / `NodeDeleted`) and user (`UserCreated` / `UserDeleted`) events into
+  `file.created` / `file.updated` / `file.deleted` / `user.created` /
+  `user.deleted` triggers. The subject is empty — a file is not an OR object — so
+  a flow matches on the trigger id alone. The event's details (a file's id, path,
+  name, mimetype; a user's uid) go on the run context as `payload`, each field
+  read defensively so one unreadable field never loses the whole trigger.
+- **`FlowRunWorker`** seeds a subjectless run's first item from `context.payload`,
+  so a flow reads a file's path or a user's id exactly as it would an object's
+  fields. (A subjectless run already fell back to a bare marking holder; now it
+  also carries its payload.)
+- **The event catalog** gains the File and User trigger groups so the builder can
+  offer them.
+
+## Out of scope
+
+- Share, tag, calendar and scheduled triggers. The mechanism here (payload-seeded
+  subjectless runs) is exactly what they will reuse — each is then a few lines in
+  the same listener — but every event family has its own payload shape and is
+  added on its own. Scheduled triggers are a different shape again (time, not an
+  event) and are their own change.

--- a/openspec/changes/or-flow-native-triggers/specs/flow-native-triggers/spec.md
+++ b/openspec/changes/or-flow-native-triggers/specs/flow-native-triggers/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Flows fire on native file and user events (REQ-NT-001)
+
+OpenRegister SHALL fire flow triggers on Nextcloud file events (`file.created`,
+`file.updated`, `file.deleted`) and user events (`user.created`, `user.deleted`).
+These triggers carry no object subject; the event's details SHALL be placed on
+the run as a `payload`, and each field SHALL be read defensively so one
+unreadable field does not lose the trigger. The catalog SHALL list these triggers.
+
+#### Scenario: A file event fires with its payload
+
+- **GIVEN** a flow wired to `file.created`
+- **WHEN** a file is created
+- **THEN** a run is queued with the file's id, path, name and mimetype as its payload
+
+#### Scenario: The flow reads the payload as its first item
+
+- **GIVEN** a queued subjectless run carrying a payload
+- **WHEN** the worker advances it
+- **THEN** the run's first item is the payload
+
+### Requirement: Native triggers match on the trigger id alone (REQ-NT-002)
+
+A file or user has no register or schema, so a flow wired to a native trigger
+SHALL match on the trigger id alone, regardless of register/schema.
+
+#### Scenario: A file trigger has no object subject
+
+- **WHEN** a file event fires
+- **THEN** the trigger carries an empty subject
+
+@e2e exclude backend triggers — covered by NativeFlowTriggerListenerTest and
+live-verified on 8080 (catalog lists the triggers; a payload-seeded run completed
+with the file path as its first item); driving them from the real Files/User UI
+is covered once a flow store is provisioned

--- a/openspec/changes/or-flow-native-triggers/tasks.md
+++ b/openspec/changes/or-flow-native-triggers/tasks.md
@@ -1,0 +1,13 @@
+# Tasks: or-flow-native-triggers
+
+- [x] `NativeFlowTriggerListener` — file (created/written/deleted) + user
+      (created/deleted) events -> triggers with a defensively-read payload, empty
+      subject.
+- [x] `FlowRunWorker` seeds a subjectless run's first item from context.payload.
+- [x] Event catalog gains the File and User trigger groups.
+- [x] Register the listener on the five events in Application.php.
+- [x] NativeFlowTriggerListenerTest — file.created payload, file.deleted, user
+      uid, empty subject, unrelated event, user attribution (6 tests). phpcs clean.
+- [x] Live-verified on 8080: catalog lists file.*/user.*; listener DI; a
+      subjectless payload-carrying run completed with the file path as item 1.
+- [ ] Share / tag / calendar / scheduled triggers — follow-ups on the same mechanism.

--- a/tests/Unit/Listener/NativeFlowTriggerListenerTest.php
+++ b/tests/Unit/Listener/NativeFlowTriggerListenerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Listener;
+
+use OCA\OpenRegister\Listener\NativeFlowTriggerListener;
+use OCA\OpenRegister\Service\Flow\FlowTriggerService;
+use OCP\EventDispatcher\Event;
+use OCP\Files\Events\Node\NodeCreatedEvent;
+use OCP\Files\Events\Node\NodeDeletedEvent;
+use OCP\Files\Node;
+use OCP\IUser;
+use OCP\IUserSession;
+use OCP\User\Events\UserCreatedEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class NativeFlowTriggerListenerTest extends TestCase
+{
+    private FlowTriggerService&MockObject $triggers;
+
+    private NativeFlowTriggerListener $listener;
+
+    protected function setUp(): void
+    {
+        $this->triggers = $this->createMock(FlowTriggerService::class);
+        $session        = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn(null);
+
+        $this->listener = new NativeFlowTriggerListener($this->triggers, $session);
+    }
+
+    private function node(): Node
+    {
+        $node = $this->createMock(Node::class);
+        $node->method('getId')->willReturn(42);
+        $node->method('getPath')->willReturn('/admin/files/report.pdf');
+        $node->method('getName')->willReturn('report.pdf');
+        $node->method('getMimetype')->willReturn('application/pdf');
+        return $node;
+    }
+
+    public function testAFileCreationFiresWithItsPayload(): void
+    {
+        $this->triggers->expects($this->once())->method('fire')
+            ->with(
+                'file.created',
+                [],
+                null,
+                ['payload' => ['fileId' => 42, 'path' => '/admin/files/report.pdf', 'name' => 'report.pdf', 'mimetype' => 'application/pdf']]
+            )
+            ->willReturn(1);
+
+        $event = $this->createMock(NodeCreatedEvent::class);
+        $event->method('getNode')->willReturn($this->node());
+
+        $this->listener->handle($event);
+    }
+
+    public function testAFileDeletionFiresTheDeletedTrigger(): void
+    {
+        $this->triggers->expects($this->once())->method('fire')
+            ->with('file.deleted', [], null, $this->anything())
+            ->willReturn(1);
+
+        $event = $this->createMock(NodeDeletedEvent::class);
+        $event->method('getNode')->willReturn($this->node());
+
+        $this->listener->handle($event);
+    }
+
+    public function testAUserCreationFiresWithTheUid(): void
+    {
+        $this->triggers->expects($this->once())->method('fire')
+            ->with('user.created', [], null, ['payload' => ['uid' => 'alice']])
+            ->willReturn(1);
+
+        $event = $this->createMock(UserCreatedEvent::class);
+        $event->method('getUid')->willReturn('alice');
+
+        $this->listener->handle($event);
+    }
+
+    public function testAFileEventCarriesNoObjectSubject(): void
+    {
+        // The subject is empty — a file is not an OpenRegister object — so the
+        // flow matches on the trigger id alone.
+        $this->triggers->expects($this->once())->method('fire')
+            ->with($this->anything(), [], $this->anything(), $this->anything())
+            ->willReturn(0);
+
+        $event = $this->createMock(NodeCreatedEvent::class);
+        $event->method('getNode')->willReturn($this->node());
+        $this->listener->handle($event);
+    }
+
+    public function testAnUnrelatedEventFiresNothing(): void
+    {
+        $this->triggers->expects($this->never())->method('fire');
+        $this->listener->handle(new class extends Event {});
+    }
+
+    public function testTheActingUserIsAttributed(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('bob');
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn($user);
+        $listener = new NativeFlowTriggerListener($this->triggers, $session);
+
+        $this->triggers->expects($this->once())->method('fire')
+            ->with('user.created', [], 'bob', $this->anything())
+            ->willReturn(1);
+
+        $event = $this->createMock(UserCreatedEvent::class);
+        $event->method('getUid')->willReturn('carol');
+        $listener->handle($event);
+    }
+}


### PR DESCRIPTION
The remaining half of #2068's Nextcloud-native trigger set: fire flows on events whose subject is **not** an OpenRegister object — a file written, a user created. These need no object to run about; the event's details ride on the run as a payload, and the run's first item is seeded from it.

## Why

The object-lifecycle triggers (#2104, #2112) cover every event about an OpenRegister object. n8n-parity means triggering on the platform's own events too — the moment a file lands, the moment a user is created. Those have no register or schema, so the object-centric path can't carry them. The run model already anticipated this (the worker comments a subjectless run is "seeded from its payload"), so the missing piece is small.

## What

- **`NativeFlowTriggerListener`** turns file (`NodeCreated`/`NodeWritten`/`NodeDeleted`) and user (`UserCreated`/`UserDeleted`) events into `file.created` / `file.updated` / `file.deleted` / `user.created` / `user.deleted` triggers. Subject is empty — a file is not an OR object — so a flow matches on the **trigger id alone**. The event's details (file id/path/name/mimetype; user uid) go on the run context as `payload`, each field read **defensively** so one unreadable field never loses the whole trigger.
- **`FlowRunWorker`** seeds a subjectless run's first item from `context.payload`, so a flow reads a file's path or a user's id exactly as it would an object's fields.
- **The event catalog** gains the File and User trigger groups for the builder.

## Verification

- **Unit** — `NativeFlowTriggerListenerTest`: file.created payload, file.deleted, user uid, empty subject, unrelated event fires nothing, user attribution (6 tests). phpcs clean; 154 flow tests green.
- **Live (8080)** — the catalog lists `file.*` / `user.*`; the listener resolves through DI; a **subjectless payload-carrying run completed with the file path as its first item** (`path=/admin/files/report.pdf`, and a downstream step ran).

## Out of scope (follow-ups on the same mechanism)

Share / tag / calendar triggers (each event family has its own payload shape) and scheduled triggers (time, not an event — a different shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)