### PR TITLE
fix(cron): FlowRunWorker setInterval(interval:) → seconds: — fatal that freezes the whole scheduler

### DIFF
--- a/lib/Cron/FlowRunWorker.php
+++ b/lib/Cron/FlowRunWorker.php
@@ -88,7 +88,7 @@ class FlowRunWorker extends TimedJob
         parent::__construct(time: $time);
         // Every minute: a Wait step's resolution is bounded by this, and a
         // queued run should feel immediate to the person who triggered it.
-        $this->setInterval(interval: 60);
+        $this->setInterval(seconds: 60);
 
     }//end __construct()
 


### PR DESCRIPTION
## Impact
`FlowRunWorker` calls `$this->setInterval(interval: 60)`, but `TimedJob::setInterval`'s parameter is `$seconds`. Instantiating this cron job throws a fatal `Unknown named parameter $interval`.

A fatal `Error` (not a caught `Exception`) during job **construction** escapes cron's per-job try/catch, so this **one** job aborts the entire `cron.php` pass — silently freezing background jobs **fleet-wide** (log rotation, retention, text extraction, sync). Observed live: with this job queued, cron drained 0 jobs across repeated passes (frozen at neverrun=543); removing it let the rest drain. This is one of the root causes behind the dead-scheduler → unrotated-log → 163GB disk-fill outage (2026-07-24/25).

## Fix
`setInterval(interval: 60)` → `setInterval(seconds: 60)`. Matches core's signature (`lib/public/BackgroundJob/TimedJob.php`) and the fleet convention — every other `setInterval` caller already uses `seconds:`; this was the lone outlier. One line, no behaviour change (60s interval unchanged). `php -l` clean; repo sweep confirms no other `setInterval(interval:` or bad-OCP-class job remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)