### PR TITLE
feat(flow): native share & tag triggers (#2068)

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -2433,6 +2433,10 @@ class Application extends App implements IBootstrap
         $context->registerEventListener(\OCP\Files\Events\Node\NodeDeletedEvent::class, \OCA\OpenRegister\Listener\NativeFlowTriggerListener::class);
         $context->registerEventListener(\OCP\User\Events\UserCreatedEvent::class, \OCA\OpenRegister\Listener\NativeFlowTriggerListener::class);
         $context->registerEventListener(\OCP\User\Events\UserDeletedEvent::class, \OCA\OpenRegister\Listener\NativeFlowTriggerListener::class);
+        $context->registerEventListener(\OCP\Share\Events\ShareCreatedEvent::class, \OCA\OpenRegister\Listener\NativeFlowTriggerListener::class);
+        $context->registerEventListener(\OCP\Share\Events\ShareDeletedEvent::class, \OCA\OpenRegister\Listener\NativeFlowTriggerListener::class);
+        $context->registerEventListener(\OCP\SystemTag\TagAssignedEvent::class, \OCA\OpenRegister\Listener\NativeFlowTriggerListener::class);
+        $context->registerEventListener(\OCP\SystemTag\TagUnassignedEvent::class, \OCA\OpenRegister\Listener\NativeFlowTriggerListener::class);
 
         // ToolRegistrationListener for agent function tools.
         $context->registerEventListener(ToolRegistrationEvent::class, ToolRegistrationListener::class);

--- a/lib/Listener/NativeFlowTriggerListener.php
+++ b/lib/Listener/NativeFlowTriggerListener.php
@@ -42,6 +42,11 @@ use OCP\Files\Events\Node\NodeDeletedEvent;
 use OCP\Files\Events\Node\NodeWrittenEvent;
 use OCP\Files\Node;
 use OCP\IUserSession;
+use OCP\Share\Events\ShareCreatedEvent;
+use OCP\Share\Events\ShareDeletedEvent;
+use OCP\Share\IShare;
+use OCP\SystemTag\TagAssignedEvent;
+use OCP\SystemTag\TagUnassignedEvent;
 use OCP\User\Events\UserCreatedEvent;
 use OCP\User\Events\UserDeletedEvent;
 use Throwable;
@@ -49,7 +54,7 @@ use Throwable;
 /**
  * Queues flow runs on native file and user events.
  *
- * @template-implements IEventListener<NodeCreatedEvent|NodeWrittenEvent|NodeDeletedEvent|UserCreatedEvent|UserDeletedEvent>
+ * @template-implements IEventListener<NodeCreatedEvent|NodeWrittenEvent|NodeDeletedEvent|UserCreatedEvent|UserDeletedEvent|ShareCreatedEvent|ShareDeletedEvent|TagAssignedEvent|TagUnassignedEvent>
  */
 class NativeFlowTriggerListener implements IEventListener
 {
@@ -126,9 +131,84 @@ class NativeFlowTriggerListener implements IEventListener
             return ['user.deleted', ['uid' => $event->getUser()->getUID()]];
         }
 
+        if ($event instanceof ShareCreatedEvent) {
+            return ['share.created', $this->sharePayload(share: $event->getShare())];
+        }
+
+        if ($event instanceof ShareDeletedEvent) {
+            return ['share.deleted', $this->sharePayload(share: $event->getShare())];
+        }
+
+        if ($event instanceof TagAssignedEvent) {
+            return ['tag.assigned', $this->tagPayload(event: $event)];
+        }
+
+        if ($event instanceof TagUnassignedEvent) {
+            return ['tag.unassigned', $this->tagPayload(event: $event)];
+        }
+
         return [null, []];
 
     }//end describe()
+
+    /**
+     * The payload describing a share event.
+     *
+     * @param IShare $share The share the event is about.
+     *
+     * @return array<string, mixed> The share payload.
+     */
+    private function sharePayload(IShare $share): array
+    {
+        $payload = [];
+        foreach ([
+            'shareId'    => static fn (): string => (string) $share->getId(),
+            'nodeId'     => static fn (): int => $share->getNodeId(),
+            'shareType'  => static fn (): int => (int) $share->getShareType(),
+            'sharedWith' => static fn (): string => (string) $share->getSharedWith(),
+            'path'       => static fn (): string => $share->getNode()->getPath(),
+        ] as $key => $read
+        ) {
+            try {
+                $payload[$key] = $read();
+            } catch (Throwable $e) {
+                continue;
+            }
+        }
+
+        return $payload;
+
+    }//end sharePayload()
+
+    /**
+     * The payload describing a tag assign/unassign event.
+     *
+     * @param TagAssignedEvent|TagUnassignedEvent $event The tag event.
+     *
+     * @return array<string, mixed> The tag payload.
+     */
+    private function tagPayload(TagAssignedEvent | TagUnassignedEvent $event): array
+    {
+        $payload = [];
+        foreach ([
+            'objectType' => static fn (): string => $event->getObjectType(),
+            'objectIds'  => static fn (): array => $event->getObjectIds(),
+            'tags'       => static fn (): array => array_map(
+                    static fn ($tag): array => ['id' => $tag->getId(), 'name' => $tag->getName()],
+                    $event->getTags()
+                ),
+        ] as $key => $read
+        ) {
+            try {
+                $payload[$key] = $read();
+            } catch (Throwable $e) {
+                continue;
+            }
+        }
+
+        return $payload;
+
+    }//end tagPayload()
 
     /**
      * The payload describing a file event.

--- a/lib/Service/Flow/EventCatalogService.php
+++ b/lib/Service/Flow/EventCatalogService.php
@@ -63,6 +63,10 @@ class EventCatalogService
         ['id' => 'file.deleted', 'label' => 'A file is deleted', 'group' => 'File'],
         ['id' => 'user.created', 'label' => 'A user is created', 'group' => 'User'],
         ['id' => 'user.deleted', 'label' => 'A user is deleted', 'group' => 'User'],
+        ['id' => 'share.created', 'label' => 'A share is created', 'group' => 'Share'],
+        ['id' => 'share.deleted', 'label' => 'A share is deleted', 'group' => 'Share'],
+        ['id' => 'tag.assigned', 'label' => 'A tag is assigned', 'group' => 'Tag'],
+        ['id' => 'tag.unassigned', 'label' => 'A tag is removed', 'group' => 'Tag'],
     ];
 
     /**

--- a/openspec/changes/or-flow-share-tag-triggers/.openspec.yaml
+++ b/openspec/changes/or-flow-share-tag-triggers/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-share-tag-triggers

--- a/openspec/changes/or-flow-share-tag-triggers/proposal.md
+++ b/openspec/changes/or-flow-share-tag-triggers/proposal.md
@@ -1,0 +1,22 @@
+# Proposal: or-flow-share-tag-triggers
+
+## Summary
+
+Two more native trigger families on the payload mechanism from or-flow-native-
+triggers: shares (`share.created` / `share.deleted`) and tags (`tag.assigned` /
+`tag.unassigned`). Each is a few lines in the existing `NativeFlowTriggerListener`
+— the run-seeding-from-payload work is already done.
+
+## What Changes
+
+- `NativeFlowTriggerListener` also handles `ShareCreated`/`ShareDeleted` (payload:
+  share id, node id, share type, who it is shared with, path) and
+  `TagAssigned`/`TagUnassigned` (payload: object type, object ids, the tags'
+  ids and names). Every field is read defensively, as the file payload is.
+- The event catalog gains the Share and Tag trigger groups.
+
+## Out of scope
+
+Calendar and scheduled triggers. Calendar is another event family (same
+mechanism); a scheduled trigger fires on time rather than an event and is a
+different shape — its own change.

--- a/openspec/changes/or-flow-share-tag-triggers/specs/flow-share-tag-triggers/spec.md
+++ b/openspec/changes/or-flow-share-tag-triggers/specs/flow-share-tag-triggers/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Flows fire on native share and tag events (REQ-ST-001)
+
+OpenRegister SHALL fire flow triggers on Nextcloud share events
+(`share.created`, `share.deleted`) and system-tag events (`tag.assigned`,
+`tag.unassigned`), carrying the event's details as the run payload with each
+field read defensively. The catalog SHALL list these triggers.
+
+#### Scenario: A share event fires with its payload
+
+- **GIVEN** a flow wired to `share.created`
+- **WHEN** a share is created
+- **THEN** a run is queued carrying the share's node, type, recipient and path
+
+#### Scenario: A tag assignment fires with the object and tags
+
+- **GIVEN** a flow wired to `tag.assigned`
+- **WHEN** a tag is assigned to an object
+- **THEN** a run is queued carrying the object type/ids and the tags
+
+@e2e exclude backend triggers — share covered by NativeFlowTriggerListenerTest;
+tag live-verified on 8080 (its OCP event class is absent from the composer test
+stubs); both catalog entries verified live

--- a/openspec/changes/or-flow-share-tag-triggers/tasks.md
+++ b/openspec/changes/or-flow-share-tag-triggers/tasks.md
@@ -1,0 +1,11 @@
+# Tasks: or-flow-share-tag-triggers
+
+- [x] `NativeFlowTriggerListener` handles Share (created/deleted) and Tag
+      (assigned/unassigned) events with defensively-read payloads.
+- [x] Event catalog gains Share and Tag groups.
+- [x] Register the four events in Application.php.
+- [x] Test: share.created payload (unit); tag path live-verified (the OCP tag
+      event is absent from the composer test stubs). 7 listener tests. phpcs clean.
+- [x] Live-verified on 8080: catalog lists share.*/tag.*; tag.assigned maps
+      objectType/objectIds/tags (id+name).
+- [ ] Calendar / scheduled triggers — follow-ups.

--- a/tests/Unit/Listener/NativeFlowTriggerListenerTest.php
+++ b/tests/Unit/Listener/NativeFlowTriggerListenerTest.php
@@ -17,6 +17,8 @@ use OCP\Files\Events\Node\NodeDeletedEvent;
 use OCP\Files\Node;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\Share\Events\ShareCreatedEvent;
+use OCP\Share\IShare;
 use OCP\User\Events\UserCreatedEvent;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -99,6 +101,36 @@ class NativeFlowTriggerListenerTest extends TestCase
         $event->method('getNode')->willReturn($this->node());
         $this->listener->handle($event);
     }
+
+    public function testAShareCreationFiresWithItsPayload(): void
+    {
+        $node = $this->createMock(Node::class);
+        $node->method('getPath')->willReturn('/admin/files/shared.txt');
+
+        $share = $this->createMock(IShare::class);
+        $share->method('getId')->willReturn('7');
+        $share->method('getNodeId')->willReturn(99);
+        $share->method('getShareType')->willReturn(0);
+        $share->method('getSharedWith')->willReturn('bob');
+        $share->method('getNode')->willReturn($node);
+
+        $this->triggers->expects($this->once())->method('fire')
+            ->with(
+                'share.created',
+                [],
+                null,
+                ['payload' => ['shareId' => '7', 'nodeId' => 99, 'shareType' => 0, 'sharedWith' => 'bob', 'path' => '/admin/files/shared.txt']]
+            )
+            ->willReturn(1);
+
+        $event = $this->createMock(ShareCreatedEvent::class);
+        $event->method('getShare')->willReturn($share);
+        $this->listener->handle($event);
+    }
+
+    // Tag events (TagAssignedEvent / TagUnassignedEvent) are newer OCP classes
+    // absent from the composer-only test stubs, so they cannot be mocked here;
+    // the tag path is live-verified on an instance where the class exists.
 
     public function testAnUnrelatedEventFiresNothing(): void
     {


### PR DESCRIPTION
Two more native trigger families on the payload mechanism from #2121: **shares** (`share.created` / `share.deleted`) and **tags** (`tag.assigned` / `tag.unassigned`). Each is a few lines in the existing `NativeFlowTriggerListener` — the run-seeding-from-payload work is already done.

## What

- Share events carry the share id, node id, share type, recipient and path.
- Tag events carry the object type, object ids, and the tags' ids and names.
- Every field read defensively, as the file payload is; the catalog gains the **Share** and **Tag** groups.

## Verification

- **Unit** — `share.created` payload (7 listener tests). The tag OCP event classes are newer than the composer-only test stubs, so they can't be mocked there; the tag path is live-verified instead. phpcs clean.
- **Live (8080)** — the catalog lists `share.*`/`tag.*`; `tag.assigned` maps `objectType`/`objectIds`/`tags` (with each tag's id and name).

## Out of scope (follow-ups)

Calendar (same mechanism) and scheduled (fires on time, not an event — a different shape) triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)