### PR TITLE
feat(flow): ship the flow store + Playwright e2e for the flow engine

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -78,6 +78,7 @@ Vrij en open source onder de EUPL-licentie.
 			<step>OCA\OpenRegister\Repair\SeedAppVirtualSchemas</step>
 			<step>OCA\OpenRegister\Repair\SeedTablesVirtualSchemas</step>
 			<step>OCA\OpenRegister\Repair\ImportCredentialBrokerRegister</step>
+			<step>OCA\OpenRegister\Repair\ImportFlowRegister</step>
 			<step>OCA\OpenRegister\Repair\ImportDsarRegisters</step>
 			<step>OCA\OpenRegister\Repair\ImportEdepotTransferRegister</step>
 			<step>OCA\OpenRegister\Repair\ImportTrustConfigurationRegister</step>
@@ -92,6 +93,7 @@ Vrij en open source onder de EUPL-licentie.
 			<step>OCA\OpenRegister\Repair\SeedAppVirtualSchemas</step>
 			<step>OCA\OpenRegister\Repair\SeedTablesVirtualSchemas</step>
 			<step>OCA\OpenRegister\Repair\ImportCredentialBrokerRegister</step>
+			<step>OCA\OpenRegister\Repair\ImportFlowRegister</step>
 			<step>OCA\OpenRegister\Repair\ImportDsarRegisters</step>
 			<step>OCA\OpenRegister\Repair\ImportEdepotTransferRegister</step>
 			<step>OCA\OpenRegister\Repair\ImportTrustConfigurationRegister</step>

--- a/lib/Controller/FlowRunController.php
+++ b/lib/Controller/FlowRunController.php
@@ -37,6 +37,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use stdClass;
@@ -72,10 +73,12 @@ class FlowRunController extends Controller
      * @return JSONResponse The runs plus the paging window.
      *
      * @NoAdminRequired
+     * @NoCSRFRequired
      *
      * @spec openspec/changes/or-flow-tooling/specs/flow-tooling/spec.md
      */
     #[NoAdminRequired]
+    #[NoCSRFRequired]
     public function index(): JSONResponse
     {
         $flowId = $this->request->getParam('flowId');
@@ -118,10 +121,12 @@ class FlowRunController extends Controller
      * @return JSONResponse The run, or 404.
      *
      * @NoAdminRequired
+     * @NoCSRFRequired
      *
      * @spec openspec/changes/or-flow-tooling/specs/flow-tooling/spec.md
      */
     #[NoAdminRequired]
+    #[NoCSRFRequired]
     public function show(string $uuid): JSONResponse
     {
         try {
@@ -142,10 +147,12 @@ class FlowRunController extends Controller
      * @return JSONResponse The new run, or a 4xx when the source cannot be retried.
      *
      * @NoAdminRequired
+     * @NoCSRFRequired
      *
      * @spec openspec/changes/or-flow-tooling/specs/flow-tooling/spec.md
      */
     #[NoAdminRequired]
+    #[NoCSRFRequired]
     public function retry(string $uuid): JSONResponse
     {
         try {
@@ -184,10 +191,12 @@ class FlowRunController extends Controller
      * @return JSONResponse The finished run, or a 4xx when the flow is unknown.
      *
      * @NoAdminRequired
+     * @NoCSRFRequired
      *
      * @spec openspec/changes/or-flow-partial-run/specs/flow-partial-run/spec.md
      */
     #[NoAdminRequired]
+    #[NoCSRFRequired]
     public function test(): JSONResponse
     {
         $flowId = trim((string) $this->request->getParam('flowId', ''));

--- a/lib/Repair/ImportFlowRegister.php
+++ b/lib/Repair/ImportFlowRegister.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * ImportFlowRegister — materialises the OpenRegister-native flow store.
+ *
+ * OpenRegister owns the flow engine but shipped no store to author a flow in:
+ * only a consuming app could hold one. This repair step imports
+ * `lib/Settings/flow_register.json` via `ConfigurationService::importFromApp()`
+ * so the `flows` register and its `flow` schema land idempotently on install and
+ * `occ upgrade` (matched by slug, version-gated) — the same register-import-via-
+ * Repair convention as {@see ImportCredentialBrokerRegister}. With the store in
+ * place the `OpenRegisterFlowResolver` (which reads this register/schema by
+ * default) resolves flows authored here, so triggers, sub-flows and the /test
+ * endpoint all work with an OpenRegister-native flow. Never throws — a failure
+ * logs a warning and leaves the instance otherwise healthy.
+ *
+ * @category Repair
+ * @package  OCA\OpenRegister\Repair
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/or-flow-store/specs/flow-store/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Repair;
+
+use OCA\OpenRegister\Service\ConfigurationService;
+use OCP\App\IAppManager;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Imports the flow register descriptor idempotently on upgrade/install.
+ */
+class ImportFlowRegister implements IRepairStep
+{
+    /**
+     * App-relative path to the register descriptor imported by this step.
+     *
+     * @var string
+     */
+    private const REGISTER_PATH = '/lib/Settings/flow_register.json';
+
+    /**
+     * Descriptor version passed to the importer's version_compare gate.
+     *
+     * @var string
+     */
+    private const REGISTER_VERSION = '1.0.0';
+
+    /**
+     * Constructor.
+     *
+     * @param ConfigurationService $configurationService The OR configuration importer.
+     * @param IAppManager          $appManager           Resolves the openregister app path on disk.
+     * @param LoggerInterface      $logger               Logger for import diagnostics.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly ConfigurationService $configurationService,
+        private readonly IAppManager $appManager,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Get the name of this repair step.
+     *
+     * @return string The step name.
+     *
+     * @spec openspec/changes/or-flow-store/specs/flow-store/spec.md
+     */
+    public function getName(): string
+    {
+        return 'Import OpenRegister flow register (flows register + flow schema)';
+    }//end getName()
+
+    /**
+     * Run the repair step, importing the flow register descriptor.
+     *
+     * @param IOutput $output Output interface for status messages.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/or-flow-store/specs/flow-store/spec.md
+     */
+    public function run(IOutput $output): void
+    {
+        try {
+            $path = $this->appManager->getAppPath('openregister').self::REGISTER_PATH;
+            if (is_file($path) === false) {
+                $output->warning('Flow register descriptor not found: '.$path);
+                return;
+            }
+
+            // Import the DECODED descriptor via importFromApp() — not
+            // importFromFilePath(), which expects a Nextcloud-root-relative path
+            // and would fail closed on this absolute one.
+            $data = json_decode((string) file_get_contents($path), true);
+            if (is_array($data) === false) {
+                $output->warning('Flow register descriptor is not valid JSON: '.$path);
+                return;
+            }
+
+            $this->configurationService->importFromApp(
+                appId: 'openregister',
+                data: $data,
+                version: self::REGISTER_VERSION,
+                force: false
+            );
+
+            $output->info('Flow register imported (flows register + flow schema)');
+        } catch (Throwable $e) {
+            $this->logger->warning('[ImportFlowRegister] import failed: '.$e->getMessage());
+            $output->warning('Flow register import skipped: '.$e->getMessage());
+        }//end try
+    }//end run()
+}//end class

--- a/lib/Settings/flow_register.json
+++ b/lib/Settings/flow_register.json
@@ -1,0 +1,88 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Flows",
+    "description": "OpenRegister-native flow definitions. A flow is an object with nodes and edges the flow engine walks (ADR-022, ADR-065). Storing flows as ordinary OpenRegister objects is what lets OpenRegister author and run its own flows — the OpenRegisterFlowResolver resolves this register/schema by default (flow_register / flow_schema app-config), so triggers, sub-flows and the /test endpoint all work with a flow authored here. Materialised by the ImportFlowRegister Repair step (OR does not self-import its own register JSON at boot — ADR-037).",
+    "version": "1.0.0"
+  },
+  "x-openregister": {
+    "type": "core",
+    "app": "openregister",
+    "openregister": "^v0.2.10",
+    "description": "Foundational flow-definition register shipped by OpenRegister so a flow can live in OpenRegister itself and not only in a consuming app. The engine, nodes and resolver live in code (lib/Service/Flow); this descriptor is only the store the resolver reads by default."
+  },
+  "paths": {},
+  "components": {
+    "registers": {
+      "flows": {
+        "slug": "flows",
+        "title": "Flows",
+        "version": "1.0.0",
+        "description": "OpenRegister-native flow definitions (nodes + edges) the flow engine runs.",
+        "published": true,
+        "schemas": ["flow"],
+        "folder": "Flows"
+      }
+    },
+    "schemas": {
+      "flow": {
+        "slug": "flow",
+        "title": "Flow",
+        "version": "1.0.0",
+        "published": true,
+        "summary": "A flow definition the OpenRegister flow engine walks.",
+        "description": "A flow is a graph of nodes and edges. Each edge carries the step to run (its `type` names a registered flow node such as openregister.set-fields, openregister.route or openregister.sub-flow, and `config` its options); the engine walks the graph, threading an item list from step to step. `trigger` (with optional `triggerRegister` / `triggerSchema`) wires the flow to an event so it runs automatically; `enabled` must be true for a trigger to fire it.",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Human-readable name of the flow.",
+            "maxLength": 255,
+            "facetable": true,
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "description": "What the flow does.",
+            "title": "Description"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the flow is active. A trigger only fires an enabled flow.",
+            "default": false,
+            "facetable": true,
+            "title": "Enabled"
+          },
+          "trigger": {
+            "type": "string",
+            "description": "The event that starts the flow (a catalog trigger id such as object.created, file.created, tag.assigned, or manual for a flow run only on request).",
+            "facetable": true,
+            "title": "Trigger"
+          },
+          "triggerRegister": {
+            "type": "string",
+            "description": "Restrict an object-event trigger to one register (empty = any).",
+            "title": "Trigger register"
+          },
+          "triggerSchema": {
+            "type": "string",
+            "description": "Restrict an object-event trigger to one schema (empty = any).",
+            "title": "Trigger schema"
+          },
+          "nodes": {
+            "type": "array",
+            "description": "The flow's nodes; each carries an id.",
+            "items": { "type": "object" },
+            "title": "Nodes"
+          },
+          "edges": {
+            "type": "array",
+            "description": "The flow's edges; each carries from/to plus the step type and config to run.",
+            "items": { "type": "object" },
+            "title": "Edges"
+          }
+        }
+      }
+    }
+  }
+}

--- a/openspec/changes/or-flow-store/.openspec.yaml
+++ b/openspec/changes/or-flow-store/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-store

--- a/openspec/changes/or-flow-store/proposal.md
+++ b/openspec/changes/or-flow-store/proposal.md
@@ -1,0 +1,33 @@
+# Proposal: or-flow-store
+
+## Summary
+
+Ship the OpenRegister-native flow store — a `flows` register and a `flow` schema
+— so a flow can be authored in OpenRegister out of the box, not only in a
+consuming app. A repair step imports the descriptor idempotently on install and
+upgrade, the same way OpenRegister ships its other core registers.
+
+## Why
+
+`OpenRegisterFlowResolver` (or-flow-native-store) resolves flows stored as OR
+objects in a configurable register/schema, defaulting to `flows` / `flow`. But
+nothing created that store, so the default resolved nothing until an admin built
+a register and schema by hand. Shipping the store closes that gap: the resolver's
+default now points at a store that exists, so triggers, sub-flows and the `/test`
+endpoint work with an OpenRegister-authored flow immediately.
+
+## What Changes
+
+- **`lib/Settings/flow_register.json`** — the descriptor: a `flows` register and a
+  `flow` schema (name, description, enabled, trigger, triggerRegister,
+  triggerSchema, nodes, edges).
+- **`ImportFlowRegister`** repair step imports it via
+  `ConfigurationService::importFromApp()` — idempotent, slug-matched,
+  version-gated, never throwing — registered in `info.xml` under both `install`
+  and `post-migration`, mirroring `ImportCredentialBrokerRegister`.
+
+## Out of scope
+
+- A bespoke flow-authoring canvas. A flow is an object, so the existing object
+  editor already edits it; the descriptor gives that editor the right fields.
+- Seeding example flows. The store ships empty; authors add flows.

--- a/openspec/changes/or-flow-store/specs/flow-store/spec.md
+++ b/openspec/changes/or-flow-store/specs/flow-store/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: OpenRegister ships a flow store (REQ-FS-001)
+
+OpenRegister SHALL ship a `flows` register and a `flow` schema, imported
+idempotently by a repair step on install and upgrade, so the default flow store
+the resolver reads exists without an admin creating it. The `flow` schema SHALL
+carry the fields a flow needs: name, enabled, trigger (with optional
+triggerRegister/triggerSchema), nodes and edges.
+
+#### Scenario: The flow store exists after install
+
+- **GIVEN** OpenRegister is installed or upgraded
+- **WHEN** the repair steps run
+- **THEN** a `flows` register and a `flow` schema exist
+
+#### Scenario: A flow authored in the store runs
+
+- **GIVEN** a flow object in the flow store
+- **WHEN** it is run through the flow engine
+- **THEN** it executes and returns its result
+
+@e2e exclude covered by tests/e2e/api-direct/flow-engine.spec.ts (creates a flow
+in the store via the API and runs it through /api/flow-runs/test); the repair
+step itself is live-verified on 8080

--- a/openspec/changes/or-flow-store/tasks.md
+++ b/openspec/changes/or-flow-store/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: or-flow-store
+
+- [x] `lib/Settings/flow_register.json` — flows register + flow schema descriptor.
+- [x] `ImportFlowRegister` repair step (importFromApp, idempotent, never throws).
+- [x] Register in info.xml (install + post-migration).
+- [x] Live-verified on 8080: the step runs cleanly ("Flow register imported");
+      the flows register + flow schema are present.
+- [x] Playwright e2e (api-direct/flow-engine.spec.ts): author a flow in the store
+      and run it end-to-end via /api/flow-runs/test.

--- a/tests/e2e/api-direct/flow-engine.spec.ts
+++ b/tests/e2e/api-direct/flow-engine.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * OpenRegister flow engine — end-to-end via the live HTTP API.
+ *
+ * Exercises the flow programme through the surfaces a real client uses, not the
+ * PHP internals: the shipped flow store (`flows` register / `flow` schema, from
+ * the ImportFlowRegister repair step), authoring a flow as an object, and running
+ * it synchronously through `POST /api/flow-runs/test` — which drives the engine,
+ * the node types (set-fields, route), pinned output and run-from-here, then
+ * persists a run that the history endpoint returns.
+ *
+ * Auth is the Basic-auth admin context from playwright.config.ts, so no browser
+ * session is needed. Each flow object is created under a run-unique name and
+ * deleted in afterAll.
+ *
+ * @spec openspec/changes/or-flow-store/specs/flow-store/spec.md
+ */
+import { test, expect, type APIRequestContext } from '@playwright/test'
+
+const API = '/index.php/apps/openregister/api'
+const JSON_HEADERS = { 'Content-Type': 'application/json', Accept: 'application/json' }
+const runId = `e2e-flow-${Date.now()}`
+
+/** Find a shipped register/schema id by slug (the flow store is shipped, not seeded here). */
+async function idBySlug(request: APIRequestContext, kind: 'registers' | 'schemas', slug: string): Promise<number> {
+	const resp = await request.get(`${API}/${kind}?limit=1000`)
+	expect(resp.ok(), `list ${kind}`).toBeTruthy()
+	const body = await resp.json()
+	const rows: any[] = body.results ?? body ?? []
+	const match = rows.find((r) => (r.slug ?? r['@self']?.slug) === slug)
+	expect(match, `${kind} slug=${slug} exists (shipped by ImportFlowRegister)`).toBeTruthy()
+	return match.id ?? match['@self']?.id
+}
+
+/** Author a flow object in the flow store, returning its uuid. */
+async function createFlow(request: APIRequestContext, reg: number, sch: number, flow: Record<string, unknown>): Promise<string> {
+	const resp = await request.post(`${API}/objects/${reg}/${sch}`, { headers: JSON_HEADERS, data: flow })
+	expect(resp.status(), 'create flow object').toBeLessThanOrEqual(201)
+	const body = await resp.json()
+	const id = body?.['@self']?.id ?? body?.id
+	expect(id, 'flow uuid').toBeTruthy()
+	return id
+}
+
+/** Run a flow synchronously via the test endpoint. */
+async function testRun(request: APIRequestContext, payload: Record<string, unknown>) {
+	const resp = await request.post(`${API}/flow-runs/test`, { headers: JSON_HEADERS, data: payload })
+	expect(resp.status(), `test run (${JSON.stringify(payload)})`).toBe(200)
+	return resp.json()
+}
+
+test.describe('Flow engine — end to end', () => {
+	let reg: number
+	let sch: number
+	const created: string[] = []
+
+	test.beforeAll(async ({ request }) => {
+		reg = await idBySlug(request, 'registers', 'flows')
+		sch = await idBySlug(request, 'schemas', 'flow')
+	})
+
+	test.afterAll(async ({ request }) => {
+		for (const id of created) {
+			await request.delete(`${API}/objects/${reg}/${sch}/${id}`).catch(() => {})
+		}
+	})
+
+	test('the flow store is shipped (flows register + flow schema)', async () => {
+		expect(reg, 'flows register id').toBeGreaterThan(0)
+		expect(sch, 'flow schema id').toBeGreaterThan(0)
+	})
+
+	test('a flow authored as an object runs to completion', async ({ request }) => {
+		const uuid = await createFlow(request, reg, sch, {
+			name: `${runId} linear`,
+			enabled: true,
+			trigger: 'manual',
+			nodes: [{ id: 'start' }, { id: 'greet' }, { id: 'done' }],
+			edges: [
+				{ id: 's1', from: 'start', to: 'greet', type: 'openregister.set-fields', config: { set: { greeting: 'hi', step: 1 } } },
+				{ id: 's2', from: 'greet', to: 'done', type: 'openregister.set-fields', config: { set: { step: 2, finished: true } } },
+			],
+		})
+		created.push(uuid)
+
+		const run = await testRun(request, { flowId: uuid })
+		expect(run.status).toBe('completed')
+		const item = (run.items ?? [])[0]?.json ?? {}
+		expect(item.greeting).toBe('hi')
+		expect(item.step).toBe(2)
+		expect(item.finished).toBe(true)
+	})
+
+	test('run-from-here skips the steps before the chosen node', async ({ request }) => {
+		const uuid = await createFlow(request, reg, sch, {
+			name: `${runId} startAt`,
+			enabled: true,
+			trigger: 'manual',
+			nodes: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+			edges: [
+				{ id: 's1', from: 'a', to: 'b', type: 'openregister.set-fields', config: { set: { ran_first: true } } },
+				{ id: 's2', from: 'b', to: 'c', type: 'openregister.set-fields', config: { set: { ran_second: true } } },
+			],
+		})
+		created.push(uuid)
+
+		const run = await testRun(request, { flowId: uuid, startAt: 'b', seedItems: [{ json: { seeded: true } }] })
+		expect(run.status).toBe('completed')
+		// Only s2 ran; the log records exactly one step, and s1's field is absent.
+		const steps = (run.log ?? []).map((l: any) => l.transition)
+		expect(steps).toEqual(['s2'])
+		const item = (run.items ?? [])[0]?.json ?? {}
+		expect(item.ran_second).toBe(true)
+		expect(item.ran_first).toBeUndefined()
+		expect(item.seeded).toBe(true)
+	})
+
+	test('a pinned step is skipped and its stored output used', async ({ request }) => {
+		const uuid = await createFlow(request, reg, sch, {
+			name: `${runId} pin`,
+			enabled: true,
+			trigger: 'manual',
+			nodes: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+			edges: [
+				{ id: 's1', from: 'a', to: 'b', type: 'openregister.set-fields', config: { set: { real: true } } },
+				{ id: 's2', from: 'b', to: 'c', type: 'openregister.set-fields', config: { set: { downstream: true } } },
+			],
+		})
+		created.push(uuid)
+
+		const run = await testRun(request, { flowId: uuid, pins: { s1: [{ json: { pinned: 'yes' } }] } })
+		expect(run.status).toBe('completed')
+		const s1 = (run.log ?? []).find((l: any) => l.transition === 's1')
+		expect(s1?.status, 's1 was served from the pin').toBe('pinned')
+		const item = (run.items ?? [])[0]?.json ?? {}
+		// The real s1 output ({real:true}) never happened; the pin flowed through.
+		expect(item.pinned).toBe('yes')
+		expect(item.real).toBeUndefined()
+		expect(item.downstream).toBe(true)
+	})
+
+	test('a router splits items per-item across branches', async ({ request }) => {
+		const uuid = await createFlow(request, reg, sch, {
+			name: `${runId} route`,
+			enabled: true,
+			trigger: 'manual',
+			nodes: [{ id: 'start' }, { id: 'high' }, { id: 'low' }, { id: 'hEnd' }, { id: 'lEnd' }],
+			edges: [
+				{
+					id: 'route', from: 'start', to: ['high', 'low'], type: 'openregister.route',
+					config: { rules: [{ condition: { '>': [{ var: 'json.n' }, 5] }, output: 'high' }], default: 'low' },
+				},
+				{ id: 'doHigh', from: 'high', to: 'hEnd', type: 'openregister.set-fields', config: { set: { branch: 'high' } } },
+				{ id: 'doLow', from: 'low', to: 'lEnd', type: 'openregister.set-fields', config: { set: { branch: 'low' } } },
+			],
+		})
+		created.push(uuid)
+
+		const run = await testRun(request, {
+			flowId: uuid,
+			seedItems: [{ json: { n: 1 } }, { json: { n: 7 } }, { json: { n: 3 } }],
+		})
+		expect(run.status).toBe('completed')
+		// The router sent one item (n=7) to high and two (n=1,3) to low.
+		const doHigh = (run.log ?? []).find((l: any) => l.transition === 'doHigh')
+		const doLow = (run.log ?? []).find((l: any) => l.transition === 'doLow')
+		expect(doHigh?.itemsIn).toBe(1)
+		expect(doLow?.itemsIn).toBe(2)
+	})
+
+	test('an unknown flow is a 404', async ({ request }) => {
+		const resp = await request.post(`${API}/flow-runs/test`, {
+			headers: JSON_HEADERS,
+			data: { flowId: 'this-flow-does-not-exist' },
+		})
+		expect(resp.status()).toBe(404)
+	})
+
+	test('a test run is persisted in the run history', async ({ request }) => {
+		const uuid = await createFlow(request, reg, sch, {
+			name: `${runId} history`,
+			enabled: true,
+			trigger: 'manual',
+			nodes: [{ id: 'a' }, { id: 'b' }],
+			edges: [{ id: 's1', from: 'a', to: 'b', type: 'openregister.set-fields', config: { set: { done: true } } }],
+		})
+		created.push(uuid)
+
+		await testRun(request, { flowId: uuid })
+
+		const hist = await request.get(`${API}/flow-runs?flowId=${uuid}`)
+		expect(hist.status()).toBe(200)
+		const body = await hist.json()
+		expect(body.results.length, 'the test run shows in history').toBeGreaterThanOrEqual(1)
+		expect(body.results[0].trigger).toBe('test')
+	})
+})


### PR DESCRIPTION
Two things that make the flow programme real for a client, not just internally: an **OpenRegister-native flow store** that ships out of the box, and **end-to-end Playwright coverage** that drives the whole engine through the live HTTP API.

## Flow store (or-flow-store)

- `lib/Settings/flow_register.json` — a `flows` register + `flow` schema (name, enabled, trigger, triggerRegister/triggerSchema, nodes, edges).
- `ImportFlowRegister` repair step imports it idempotently via `ConfigurationService::importFromApp()` (slug-matched, version-gated, never throws), registered in `info.xml` under install + post-migration — the same register-import-via-Repair convention as `ImportCredentialBrokerRegister`.
- `OpenRegisterFlowResolver` already defaults to this register/schema, so **with the store shipped, a flow authored in OpenRegister runs with no admin setup**.

## Fix — FlowRunController was not API-callable

Its endpoints lacked `#[NoCSRFRequired]`, so `/api/flow-runs` and `/api/flow-runs/test` returned **412** to any non-browser client (the rest of OR's API — 120 controllers — uses `NoCSRFRequired`). Added it to index/show/retry/test. This is what let the e2e — and any API/MCP client — call them.

## E2E — `tests/e2e/api-direct/flow-engine.spec.ts`

**Seven Playwright tests** over the live HTTP surface, the first end-to-end coverage of the flow engine (everything before was unit + manual live checks):

1. the flow store is shipped (flows register + flow schema)
2. a flow authored as an object runs to completion
3. run-from-here skips the steps before the chosen node
4. a pinned step is skipped and its stored output used
5. a router splits items per-item across branches
6. an unknown flow is a 404
7. a test run is persisted in the run history

## Verification

- **All 7 e2e tests pass** against 8080 (`npx playwright test` on the api-direct spec).
- The repair step imports the store cleanly (`occ upgrade` ran it; "Flow register imported").
- phpcs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)