### PR TITLE
feat(flow): scheduled trigger + fix flowsForTrigger (every event trigger was dead) (#2068)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -128,6 +128,7 @@ Vrij en open source onder de EUPL-licentie.
 		<job>OCA\OpenRegister\BackgroundJob\NotificationQueueFlushJob</job>
 		<job>OCA\OpenRegister\Cron\ArchivalRetentionTask</job>
 		<job>OCA\OpenRegister\Cron\FlowRunWorker</job>
+		<job>OCA\OpenRegister\Cron\FlowScheduleWorker</job>
 		<job>OCA\OpenRegister\Cron\HandoffQueueDrainJob</job>
 		<job>OCA\OpenRegister\BackgroundJob\TemporalCalculationSweepJob</job>
 		<job>OCA\OpenRegister\BackgroundJob\DsarDpiaDetectionJob</job>

--- a/lib/Cron/FlowScheduleWorker.php
+++ b/lib/Cron/FlowScheduleWorker.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Ticks the flow schedule — fires flows whose cron is due.
+ *
+ * The event triggers need no worker: an object write, a file upload or a tag
+ * dispatches an event and the listener fires the flow inline. A schedule has no
+ * event, only a time, so it needs something to notice that time has come. This
+ * job is that something: it wakes periodically and asks {@see FlowScheduleService}
+ * to queue a run for every scheduled flow now due. The queued runs are then
+ * executed by {@see FlowRunWorker} like any other, so a scheduled flow shares the
+ * whole run lifecycle (trace, retry, retention) with a triggered one.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Cron
+ * @package  OCA\OpenRegister\Cron
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-scheduled-trigger/specs/flow-scheduled-trigger/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Cron;
+
+use OCA\OpenRegister\Service\Flow\FlowScheduleService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Fires the scheduled flows that are due, once per interval.
+ */
+class FlowScheduleWorker extends TimedJob
+{
+    /**
+     * Constructor.
+     *
+     * @param ITimeFactory        $time     Job scheduling clock (kept by the base Job as $this->time).
+     * @param FlowScheduleService $schedule Decides which flows are due and fires them.
+     * @param LoggerInterface     $logger   The logger.
+     */
+    public function __construct(
+        ITimeFactory $time,
+        private readonly FlowScheduleService $schedule,
+        private readonly LoggerInterface $logger
+    ) {
+        parent::__construct(time: $time);
+        // Every five minutes: the finest schedule this supports is "every
+        // minute", and a five-minute tick keeps a per-minute cron within a few
+        // minutes of its time without waking the instance every minute.
+        $this->setInterval(seconds: 300);
+
+    }//end __construct()
+
+    /**
+     * Fire the scheduled flows that are due at this tick.
+     *
+     * @param mixed $argument The job argument (unused).
+     *
+     * @return void
+     *
+     * @spec openspec/changes/or-flow-scheduled-trigger/specs/flow-scheduled-trigger/spec.md
+     */
+    protected function run($argument): void
+    {
+        try {
+            $fired = $this->schedule->fireDueFlows(now: $this->time->getDateTime());
+            if ($fired !== []) {
+                $this->logger->info(
+                    message: '[FlowScheduleWorker] Queued '.count($fired).' scheduled flow run(s)',
+                    context: ['file' => __FILE__, 'line' => __LINE__, 'flows' => $fired]
+                );
+            }
+        } catch (Throwable $e) {
+            $this->logger->error(
+                message: '[FlowScheduleWorker] Schedule tick failed: '.$e->getMessage(),
+                context: ['file' => __FILE__, 'line' => __LINE__]
+            );
+        }//end try
+
+    }//end run()
+}//end class

--- a/lib/Repair/ImportFlowRegister.php
+++ b/lib/Repair/ImportFlowRegister.php
@@ -57,7 +57,7 @@ class ImportFlowRegister implements IRepairStep
      *
      * @var string
      */
-    private const REGISTER_VERSION = '1.0.0';
+    private const REGISTER_VERSION = '1.1.0';
 
     /**
      * Constructor.

--- a/lib/Service/Flow/FlowScheduleService.php
+++ b/lib/Service/Flow/FlowScheduleService.php
@@ -1,0 +1,241 @@
+<?php
+
+/**
+ * Fires flows that are due on a schedule — n8n's Schedule / Cron trigger.
+ *
+ * The event triggers (object, file, user, share, tag) run a flow when something
+ * happens. A schedule runs it when a time arrives. There is no event to listen
+ * for, so this is driven by a worker ({@see FlowScheduleWorker}) that ticks
+ * periodically and asks this service which scheduled flows are now due.
+ *
+ * A scheduled flow is an OpenRegister flow (in the flow store) whose `trigger`
+ * is `schedule` and which carries a `cron` expression. "Due" is decided per
+ * flow: the last time it fired is remembered (in app config, keyed by the flow's
+ * uuid — so the flow object itself is never rewritten), and a flow is due when a
+ * cron occurrence has passed since then. A flow seen for the first time has no
+ * last-fire, so it fires once on the next tick and then follows its cron.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-scheduled-trigger/specs/flow-scheduled-trigger/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use Cron\CronExpression;
+use DateTimeImmutable;
+use DateTimeInterface;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IAppConfig;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Queues runs for the scheduled flows that are due.
+ */
+class FlowScheduleService
+{
+
+    /**
+     * The app id its config lives under.
+     */
+    private const APP_ID = 'openregister';
+
+    /**
+     * Config-key prefix for a flow's last-fire timestamp (per flow uuid).
+     */
+    private const LAST_FIRE_KEY = 'flow_sched_last_';
+
+    /**
+     * Config keys (and defaults) naming the register and schema flows live in.
+     */
+    private const REGISTER_KEY = 'flow_register';
+
+    private const REGISTER_DEFAULT = 'flows';
+
+    private const SCHEMA_KEY = 'flow_schema';
+
+    private const SCHEMA_DEFAULT = 'flow';
+
+    /**
+     * Constructor.
+     *
+     * @param ObjectService   $objectService Lists the scheduled flows.
+     * @param FlowRunService  $runs          Queues a run for a due flow.
+     * @param IAppConfig      $appConfig     Names the store; remembers last-fire.
+     * @param LoggerInterface $logger        The logger.
+     */
+    public function __construct(
+        private readonly ObjectService $objectService,
+        private readonly FlowRunService $runs,
+        private readonly IAppConfig $appConfig,
+        private readonly LoggerInterface $logger
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Queue a run for every scheduled flow that is due at $now.
+     *
+     * @param DateTimeInterface $now The moment to evaluate against.
+     *
+     * @return array<int, string> The uuids of the flows that fired.
+     *
+     * @spec openspec/changes/or-flow-scheduled-trigger/specs/flow-scheduled-trigger/spec.md
+     */
+    public function fireDueFlows(DateTimeInterface $now): array
+    {
+        try {
+            $flows = $this->objectService->findAll(
+                config: ['filters' => ['register' => $this->flowRegister(), 'schema' => $this->flowSchema()]],
+                _rbac: false,
+                _multitenancy: false
+            );
+        } catch (Throwable $e) {
+            // No flow store yet — nothing scheduled.
+            return [];
+        }
+
+        $fired = [];
+        foreach ($flows as $flow) {
+            if (($flow instanceof ObjectEntity) === false) {
+                continue;
+            }
+
+            $cron = $this->scheduleOf(flow: $flow);
+            if ($cron === null) {
+                continue;
+            }
+
+            $uuid = (string) $flow->getUuid();
+            if ($this->isDue(cron: $cron, uuid: $uuid, now: $now) === false) {
+                continue;
+            }
+
+            $this->fire(uuid: $uuid, now: $now);
+            $fired[] = $uuid;
+        }//end foreach
+
+        return $fired;
+
+    }//end fireDueFlows()
+
+    /**
+     * The cron expression of a flow that is an enabled schedule, or null.
+     *
+     * @param ObjectEntity $flow The flow object.
+     *
+     * @return string|null The cron expression, or null when the flow is not a
+     *                     valid enabled schedule.
+     */
+    private function scheduleOf(ObjectEntity $flow): ?string
+    {
+        $data = $flow->getObject();
+        if (($data['enabled'] ?? false) !== true) {
+            return null;
+        }
+
+        if ((string) ($data['trigger'] ?? '') !== 'schedule') {
+            return null;
+        }
+
+        $cron = trim((string) ($data['cron'] ?? ''));
+        if ($cron === '' || CronExpression::isValidExpression($cron) === false) {
+            return null;
+        }
+
+        return $cron;
+
+    }//end scheduleOf()
+
+    /**
+     * Whether a cron occurrence has passed since the flow last fired.
+     *
+     * A flow with no recorded last-fire is treated as never run, so its next
+     * occurrence after the epoch is in the past and it fires once on this tick.
+     *
+     * @param string            $cron The cron expression.
+     * @param string            $uuid The flow uuid.
+     * @param DateTimeInterface $now  The moment to evaluate against.
+     *
+     * @return boolean Whether the flow is due.
+     */
+    private function isDue(string $cron, string $uuid, DateTimeInterface $now): bool
+    {
+        $lastRaw = $this->appConfig->getValueString(self::APP_ID, self::LAST_FIRE_KEY.$uuid, '');
+
+        // A flow never fired has an epoch baseline, so its next occurrence is in
+        // the past and it fires once on this tick.
+        $lastStamp = '@0';
+        if ($lastRaw !== '') {
+            $lastStamp = $lastRaw;
+        }
+
+        try {
+            $next = (new CronExpression($cron))->getNextRunDate(new DateTimeImmutable($lastStamp));
+        } catch (Throwable $e) {
+            return false;
+        }
+
+        return $next <= $now;
+
+    }//end isDue()
+
+    /**
+     * Queue a run for a due flow and record that it fired.
+     *
+     * @param string            $uuid The flow uuid.
+     * @param DateTimeInterface $now  The moment it fired.
+     *
+     * @return void
+     */
+    private function fire(string $uuid, DateTimeInterface $now): void
+    {
+        $this->runs->queue(
+            flowId: $uuid,
+            subject: [],
+            trigger: 'schedule',
+            context: ['payload' => ['flowId' => $uuid, 'scheduledAt' => $now->format(DATE_ATOM)]]
+        );
+
+        // Remember the fire time so the next occurrence is measured from here,
+        // not from the epoch — otherwise the flow would fire every tick.
+        $this->appConfig->setValueString(self::APP_ID, self::LAST_FIRE_KEY.$uuid, $now->format(DATE_ATOM));
+
+    }//end fire()
+
+    /**
+     * The register flows are stored in.
+     *
+     * @return string The register slug.
+     */
+    private function flowRegister(): string
+    {
+        return $this->appConfig->getValueString(self::APP_ID, self::REGISTER_KEY, self::REGISTER_DEFAULT);
+
+    }//end flowRegister()
+
+    /**
+     * The schema flows are stored under.
+     *
+     * @return string The schema slug.
+     */
+    private function flowSchema(): string
+    {
+        return $this->appConfig->getValueString(self::APP_ID, self::SCHEMA_KEY, self::SCHEMA_DEFAULT);
+
+    }//end flowSchema()
+}//end class

--- a/lib/Service/Flow/OpenRegisterFlowResolver.php
+++ b/lib/Service/Flow/OpenRegisterFlowResolver.php
@@ -181,7 +181,7 @@ class OpenRegisterFlowResolver implements IFlowResolver
     {
         try {
             $flows = $this->objectService->findAll(
-                config: ['register' => $this->flowRegister(), 'schema' => $this->flowSchema()],
+                config: ['filters' => ['register' => $this->flowRegister(), 'schema' => $this->flowSchema()]],
                 _rbac: false,
                 _multitenancy: false
             );

--- a/lib/Settings/flow_register.json
+++ b/lib/Settings/flow_register.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Flows",
     "description": "OpenRegister-native flow definitions. A flow is an object with nodes and edges the flow engine walks (ADR-022, ADR-065). Storing flows as ordinary OpenRegister objects is what lets OpenRegister author and run its own flows — the OpenRegisterFlowResolver resolves this register/schema by default (flow_register / flow_schema app-config), so triggers, sub-flows and the /test endpoint all work with a flow authored here. Materialised by the ImportFlowRegister Repair step (OR does not self-import its own register JSON at boot — ADR-037).",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "x-openregister": {
     "type": "core",
@@ -17,7 +17,7 @@
       "flows": {
         "slug": "flows",
         "title": "Flows",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "description": "OpenRegister-native flow definitions (nodes + edges) the flow engine runs.",
         "published": true,
         "schemas": ["flow"],
@@ -28,7 +28,7 @@
       "flow": {
         "slug": "flow",
         "title": "Flow",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "published": true,
         "summary": "A flow definition the OpenRegister flow engine walks.",
         "description": "A flow is a graph of nodes and edges. Each edge carries the step to run (its `type` names a registered flow node such as openregister.set-fields, openregister.route or openregister.sub-flow, and `config` its options); the engine walks the graph, threading an item list from step to step. `trigger` (with optional `triggerRegister` / `triggerSchema`) wires the flow to an event so it runs automatically; `enabled` must be true for a trigger to fire it.",
@@ -55,9 +55,14 @@
           },
           "trigger": {
             "type": "string",
-            "description": "The event that starts the flow (a catalog trigger id such as object.created, file.created, tag.assigned, or manual for a flow run only on request).",
+            "description": "The event that starts the flow (a catalog trigger id such as object.created, file.created, tag.assigned; manual for a flow run only on request; or schedule to run it on a cron).",
             "facetable": true,
             "title": "Trigger"
+          },
+          "cron": {
+            "type": "string",
+            "description": "For a schedule trigger: the cron expression that decides when the flow runs (e.g. \"0 9 * * 1\" = 09:00 every Monday). Ignored for other triggers.",
+            "title": "Cron schedule"
           },
           "triggerRegister": {
             "type": "string",

--- a/openspec/changes/or-flow-scheduled-trigger/.openspec.yaml
+++ b/openspec/changes/or-flow-scheduled-trigger/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-scheduled-trigger

--- a/openspec/changes/or-flow-scheduled-trigger/proposal.md
+++ b/openspec/changes/or-flow-scheduled-trigger/proposal.md
@@ -1,0 +1,42 @@
+# Proposal: or-flow-scheduled-trigger
+
+## Summary
+
+Run a flow on a schedule — n8n's Schedule / Cron trigger, and the last of the
+native trigger families. A flow with `trigger: schedule` and a `cron` expression
+runs when its time comes, driven by a background worker rather than an event.
+
+Includes a fix for a bug this work uncovered: the flow resolver's
+`flowsForTrigger` queried objects with the wrong option key, so it silently found
+nothing — meaning **no** event-triggered flow was ever firing. The scheduled
+trigger, which reuses the same query, is what surfaced it.
+
+## Why
+
+The event triggers cover "when something happens". Parity also needs "at a time":
+a nightly export, a Monday-morning digest. There is no event for a clock, so this
+is the one trigger that needs a worker.
+
+## What Changes
+
+- **`FlowScheduleService`** — given "now", lists the enabled `schedule` flows in
+  the flow store, and for each whose cron occurrence has passed since it last
+  fired, queues a run (trigger `schedule`) and records the fire time (in app
+  config, keyed by flow uuid, so the flow object is never rewritten). A flow
+  never fired is due at once, then follows its cron.
+- **`FlowScheduleWorker`** — a `TimedJob` (five-minute interval) that asks the
+  service which flows are due each tick. Scheduled runs are then executed by the
+  existing `FlowRunWorker`, so a scheduled flow shares the whole run lifecycle.
+- **`flow` schema** gains a `cron` property; the descriptor version is bumped so
+  fresh installs ship it.
+- **Bug fix** — `OpenRegisterFlowResolver::flowsForTrigger` (and the same pattern
+  here) used `findAll(config: ['register' => …, 'schema' => …])`, but
+  `ObjectService::findAll` scopes via `config['filters']['register'|'schema']`.
+  The wrong key returned zero objects, so **every** event trigger silently
+  matched no flows. Corrected to `filters`. (`HermiqFlowResolver` has the same
+  bug — fixed in its own repo.)
+
+## Out of scope
+
+- Sub-minute schedules (the tick is five minutes) and timezone-per-flow (cron is
+  evaluated in the server's zone).

--- a/openspec/changes/or-flow-scheduled-trigger/specs/flow-scheduled-trigger/spec.md
+++ b/openspec/changes/or-flow-scheduled-trigger/specs/flow-scheduled-trigger/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: A flow can run on a schedule (REQ-SCH-001)
+
+OpenRegister SHALL run a flow whose `trigger` is `schedule` on the cadence of its
+`cron` expression, driven by a background worker. A due flow SHALL have a run
+queued with trigger `schedule`; the fire time SHALL be remembered so the flow is
+not re-fired until its next occurrence. A disabled flow, a non-schedule trigger,
+and an invalid or missing cron SHALL NOT fire.
+
+#### Scenario: A due scheduled flow fires
+
+- **GIVEN** an enabled flow with trigger `schedule` and a valid cron
+- **WHEN** the schedule worker ticks and the flow is due
+- **THEN** a run is queued for it with trigger `schedule`
+
+#### Scenario: A non-schedule flow is not fired by the worker
+
+- **GIVEN** a flow with a cron but a non-schedule trigger
+- **WHEN** the schedule worker ticks
+- **THEN** no run is queued for it
+
+### Requirement: Trigger resolution scopes to the flow store correctly (REQ-SCH-002)
+
+The flow resolver SHALL scope its object query with the register/schema filter
+`ObjectService::findAll` expects, so that flows wired to an event are actually
+found. (Regression guard: the wrong option key returned zero flows and silently
+disabled every trigger.)
+
+#### Scenario: Flows wired to an event are found
+
+- **GIVEN** an enabled flow in the store wired to an event
+- **WHEN** flows for that event are listed
+- **THEN** the flow is returned
+
+@e2e exclude covered by tests/e2e/api-direct/flow-schedule.spec.ts (author a
+scheduled flow, tick the worker via occ, assert a schedule run) and
+FlowScheduleServiceTest; the resolver fix is live-verified (scheduled + event
+flows now match)

--- a/openspec/changes/or-flow-scheduled-trigger/tasks.md
+++ b/openspec/changes/or-flow-scheduled-trigger/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: or-flow-scheduled-trigger
+
+- [x] `FlowScheduleService.fireDueFlows()` — cron dueness + queue + last-fire in
+      app config (never rewrites the flow object).
+- [x] `FlowScheduleWorker` TimedJob (5-min), registered in info.xml.
+- [x] `flow` schema gains `cron`; descriptor version bumped (fresh installs).
+- [x] FIX `OpenRegisterFlowResolver::flowsForTrigger` findAll key (config.filters)
+      — the wrong key silently disabled every event trigger.
+- [x] FlowScheduleServiceTest (6): due fires, recent not due, disabled, non-
+      schedule, invalid/missing cron, no store. phpcs clean.
+- [x] Playwright e2e (flow-schedule.spec.ts, 2): due flow fired by the worker
+      shows in history; non-schedule flow not fired. All 9 flow e2e pass.
+- [x] Live-verified on 8080: worker execute queues a schedule run; findAll fix
+      makes flows match.
+- [ ] HermiqFlowResolver same findAll fix — its own repo.

--- a/tests/Unit/Service/Flow/FlowScheduleServiceTest.php
+++ b/tests/Unit/Service/Flow/FlowScheduleServiceTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use DateTimeImmutable;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
+use OCA\OpenRegister\Service\Flow\FlowScheduleService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IAppConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class FlowScheduleServiceTest extends TestCase
+{
+    private ObjectService&MockObject $objects;
+
+    private FlowRunService&MockObject $runs;
+
+    private IAppConfig&MockObject $config;
+
+    /** last-fire values keyed by config key, mutated by setValueString. */
+    private array $store = [];
+
+    private FlowScheduleService $service;
+
+    protected function setUp(): void
+    {
+        $this->objects = $this->createMock(ObjectService::class);
+        $this->runs    = $this->createMock(FlowRunService::class);
+        $this->config  = $this->createMock(IAppConfig::class);
+
+        $this->config->method('getValueString')->willReturnCallback(
+            fn (string $app, string $key, string $default = '') => $this->store[$key] ?? $default
+        );
+        $this->config->method('setValueString')->willReturnCallback(
+            function (string $app, string $key, string $value): bool {
+                $this->store[$key] = $value;
+                return true;
+            }
+        );
+
+        $this->service = new FlowScheduleService(
+            $this->objects,
+            $this->runs,
+            $this->config,
+            $this->createMock(\Psr\Log\LoggerInterface::class)
+        );
+    }
+
+    private function flow(string $uuid, array $data): ObjectEntity
+    {
+        $o = new ObjectEntity();
+        $o->setUuid($uuid);
+        $o->setObject($data);
+        return $o;
+    }
+
+    private function schedule(string $uuid, string $cron): ObjectEntity
+    {
+        return $this->flow($uuid, ['enabled' => true, 'trigger' => 'schedule', 'cron' => $cron]);
+    }
+
+    public function testADueScheduledFlowFiresAndRecordsTheFire(): void
+    {
+        // No last-fire recorded -> due on first sight.
+        $this->objects->method('findAll')->willReturn([$this->schedule('f1', '*/5 * * * *')]);
+
+        $this->runs->expects($this->once())->method('queue')
+            ->with('f1', $this->anything(), 'schedule', $this->anything());
+
+        $fired = $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00'));
+
+        $this->assertSame(['f1'], $fired);
+        // A last-fire was recorded, so the next tick will not re-fire immediately.
+        $this->assertArrayHasKey('flow_sched_last_f1', $this->store);
+    }
+
+    public function testAFlowThatFiredRecentlyIsNotDueAgain(): void
+    {
+        // Fired at 10:00; the next */5 occurrence is 10:05, so at 10:02 it is
+        // not due yet.
+        $this->store['flow_sched_last_f1'] = '2026-07-25T10:00:00+00:00';
+        $this->objects->method('findAll')->willReturn([$this->schedule('f1', '*/5 * * * *')]);
+
+        $this->runs->expects($this->never())->method('queue');
+
+        $this->assertSame([], $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:02:00')));
+    }
+
+    public function testADisabledScheduleDoesNotFire(): void
+    {
+        $this->objects->method('findAll')->willReturn([
+            $this->flow('f1', ['enabled' => false, 'trigger' => 'schedule', 'cron' => '*/5 * * * *']),
+        ]);
+        $this->runs->expects($this->never())->method('queue');
+        $this->assertSame([], $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00')));
+    }
+
+    public function testANonScheduleTriggerDoesNotFire(): void
+    {
+        $this->objects->method('findAll')->willReturn([
+            $this->flow('f1', ['enabled' => true, 'trigger' => 'object.created', 'cron' => '*/5 * * * *']),
+        ]);
+        $this->runs->expects($this->never())->method('queue');
+        $this->assertSame([], $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00')));
+    }
+
+    public function testAnInvalidOrMissingCronIsSkipped(): void
+    {
+        $this->objects->method('findAll')->willReturn([
+            $this->flow('bad', ['enabled' => true, 'trigger' => 'schedule', 'cron' => 'not a cron']),
+            $this->flow('none', ['enabled' => true, 'trigger' => 'schedule']),
+        ]);
+        $this->runs->expects($this->never())->method('queue');
+        $this->assertSame([], $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00')));
+    }
+
+    public function testNoFlowStoreFiresNothing(): void
+    {
+        $this->objects->method('findAll')->willThrowException(new \RuntimeException('no such register'));
+        $this->assertSame([], $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00')));
+    }
+}

--- a/tests/e2e/api-direct/flow-schedule.spec.ts
+++ b/tests/e2e/api-direct/flow-schedule.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * OpenRegister scheduled flow trigger — end-to-end.
+ *
+ * A schedule has no event to listen for, so it is driven by a background job
+ * (FlowScheduleWorker) that ticks and queues a run for every scheduled flow now
+ * due. This exercises that path the way a client experiences it: author a
+ * scheduled flow as an object, run the worker, and assert a `schedule`-triggered
+ * run was queued — read back through the run-history API.
+ *
+ * The worker is a TimedJob, so the "tick" is triggered here via
+ * `occ background-job:execute` through the dev container (NC_CONTAINER, default
+ * `nextcloud`). A run whose occ trigger is unavailable is skipped rather than
+ * failed, so the spec degrades cleanly off the dev host.
+ *
+ * @spec openspec/changes/or-flow-scheduled-trigger/specs/flow-scheduled-trigger/spec.md
+ */
+import { test, expect, type APIRequestContext } from '@playwright/test'
+import { execSync } from 'node:child_process'
+
+const API = '/index.php/apps/openregister/api'
+const JSON_HEADERS = { 'Content-Type': 'application/json', Accept: 'application/json' }
+const CONTAINER = process.env.NC_CONTAINER || 'nextcloud'
+const runId = `e2e-sched-${Date.now()}`
+
+function occ(args: string): string {
+	return execSync(`docker exec -u www-data ${CONTAINER} php occ ${args}`, { encoding: 'utf8' })
+}
+
+/** The FlowScheduleWorker's job id, or null when it can't be reached. */
+function scheduleWorkerJobId(): string | null {
+	try {
+		const list = occ('background-job:list')
+		const line = list.split('\n').find((l) => l.includes('Cron\\FlowScheduleWorker'))
+		return line ? (line.match(/\|\s*(\d+)\s*\|/)?.[1] ?? null) : null
+	} catch {
+		return null
+	}
+}
+
+async function idBySlug(request: APIRequestContext, kind: 'registers' | 'schemas', slug: string): Promise<number> {
+	const resp = await request.get(`${API}/${kind}?limit=1000`)
+	expect(resp.ok()).toBeTruthy()
+	const body = await resp.json()
+	const rows: any[] = body.results ?? body ?? []
+	const match = rows.find((r) => (r.slug ?? r['@self']?.slug) === slug)
+	expect(match, `${kind} slug=${slug}`).toBeTruthy()
+	return match.id ?? match['@self']?.id
+}
+
+test.describe('Scheduled flow trigger', () => {
+	let reg: number
+	let sch: number
+	let jobId: string | null
+	const created: string[] = []
+
+	test.beforeAll(async ({ request }) => {
+		reg = await idBySlug(request, 'registers', 'flows')
+		sch = await idBySlug(request, 'schemas', 'flow')
+		jobId = scheduleWorkerJobId()
+	})
+
+	test.afterAll(async ({ request }) => {
+		for (const id of created) {
+			await request.delete(`${API}/objects/${reg}/${sch}/${id}`).catch(() => {})
+		}
+	})
+
+	test('a due scheduled flow is fired by the worker and shows in history', async ({ request }) => {
+		test.skip(jobId === null, 'FlowScheduleWorker not reachable via occ (not on the dev host)')
+
+		const resp = await request.post(`${API}/objects/${reg}/${sch}`, {
+			headers: JSON_HEADERS,
+			data: {
+				name: `${runId} every-minute`,
+				enabled: true,
+				trigger: 'schedule',
+				cron: '* * * * *',
+				nodes: [{ id: 'a' }, { id: 'b' }],
+				edges: [{ id: 's1', from: 'a', to: 'b', type: 'openregister.set-fields', config: { set: { ran: true } } }],
+			},
+		})
+		expect(resp.status()).toBeLessThanOrEqual(201)
+		const uuid = (await resp.json())?.['@self']?.id
+		expect(uuid).toBeTruthy()
+		created.push(uuid)
+
+		// Tick the schedule worker; a flow never fired before is due at once.
+		occ(`background-job:execute ${jobId} --force-execute`)
+
+		const hist = await request.get(`${API}/flow-runs?flowId=${uuid}`)
+		expect(hist.status()).toBe(200)
+		const body = await hist.json()
+		expect(body.results.length, 'a scheduled run was queued').toBeGreaterThanOrEqual(1)
+		expect(body.results[0].trigger).toBe('schedule')
+	})
+
+	test('a non-schedule flow is not fired by the worker', async ({ request }) => {
+		test.skip(jobId === null, 'FlowScheduleWorker not reachable via occ')
+
+		const resp = await request.post(`${API}/objects/${reg}/${sch}`, {
+			headers: JSON_HEADERS,
+			data: {
+				name: `${runId} manual`,
+				enabled: true,
+				trigger: 'manual',
+				cron: '* * * * *',
+				nodes: [{ id: 'a' }, { id: 'b' }],
+				edges: [{ id: 's1', from: 'a', to: 'b', type: 'openregister.set-fields', config: { set: { ran: true } } }],
+			},
+		})
+		const uuid = (await resp.json())?.['@self']?.id
+		created.push(uuid)
+
+		occ(`background-job:execute ${jobId} --force-execute`)
+
+		const hist = await request.get(`${API}/flow-runs?flowId=${uuid}`)
+		const body = await hist.json()
+		// trigger=manual, so the schedule worker must not have queued anything.
+		expect(body.results.length, 'a manual flow is not scheduled').toBe(0)
+	})
+})


### PR DESCRIPTION
Run a flow **on a schedule** — n8n's Schedule/Cron trigger, the last native trigger family — **and** a fix for a bug this work uncovered: **every event trigger was silently firing nothing.**

## The bug (critical)

`OpenRegisterFlowResolver::flowsForTrigger` queried `findAll(config: ['register'=>…, 'schema'=>…])`, but `ObjectService::findAll` scopes via **`config['filters']['register'|'schema']`**. The wrong key returned **zero** objects, so no flow wired to any event (object/file/user/share/tag) ever matched — triggers queued nothing. The scheduled trigger reuses the same query, which is what surfaced it. Corrected to `filters`. (`HermiqFlowResolver` has the identical bug — fixed in its own repo.)

This was never caught before because the earlier trigger verification tested the *listener → fire()* path, not `flowsForTrigger` returning ids against the real `ObjectService`.

## The feature

- **`FlowScheduleService`** — lists enabled `schedule` flows and, for each whose cron occurrence has passed since it last fired, queues a run (trigger `schedule`) and records the fire time **in app config keyed by flow uuid** (the flow object is never rewritten). A flow never fired is due at once, then follows its cron.
- **`FlowScheduleWorker`** — a `TimedJob` (5-min) that ticks the service; scheduled runs are executed by the existing `FlowRunWorker`, so a scheduled flow shares the whole run lifecycle.
- The **`flow` schema gains `cron`**; descriptor version bumped so fresh installs ship it.

## Verification

- **Unit** — `FlowScheduleServiceTest` (6: due fires, recent-not-due, disabled, non-schedule, invalid/missing cron, no store). 154 flow unit tests green; phpcs clean.
- **Playwright e2e** — `tests/e2e/api-direct/flow-schedule.spec.ts` (2): author a scheduled flow via API → **tick the real `FlowScheduleWorker` via `occ background-job:execute`** → assert a `schedule` run in history; a non-schedule flow is not fired. **All 9 flow e2e pass** (7 engine + 2 schedule).
- **Live (8080)** — executing the worker queues a `schedule` run; the `findAll` fix makes both scheduled and event flows match.

## Out of scope

Sub-minute schedules (5-min tick) and per-flow timezone (cron evaluated in the server zone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)