### PR TITLE
fix(deps): override tar >=7.5.22 (clears critical npm audit gate)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30308,9 +30308,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "vue-demi": "^0.14.6",
     "minimatch": ">=3.1.5",
     "rollup": ">=2.80.0",
+    "tar": ">=7.5.22",
     "dompurify": "$dompurify",
     "follow-redirects": ">=1.16.0",
     "lodash": ">=4.18.1",


### PR DESCRIPTION
The Code Quality **npm audit** gate (`npm audit --audit-level=critical`) failed on exactly **1 critical**: `tar <=7.5.20` (node-tar PAX file-smuggling + DoS advisories), resolved transitively to 7.5.11 via node-gyp/cacache — **dev-only build tooling, not in the webpack bundle**. Adds a `tar: >=7.5.22` override; the lock diff is tar-only (7.5.11→7.5.22), zero runtime/bundle impact. Clears the critical so the gate passes. The 16 high / 13 moderate / 21 low advisories are below the gate's `critical` threshold and are left as separate hygiene follow-up.