### PR TITLE
feat(leaf): renderMode on LeafDescriptor + discovery + parity (server half of #2127)

### DIFF
--- a/lib/Capabilities/IntegrationsCapability.php
+++ b/lib/Capabilities/IntegrationsCapability.php
@@ -107,9 +107,12 @@ class IntegrationsCapability implements ICapability
                     'providers'       => $rows,
                     // `leaves` — the cross-app leaf catalogue (ADR-066). A
                     // manifest app or admin UI discovers which leaves exist
-                    // (id, label, requiredApp, surfaces, kinds, usability)
-                    // WITHOUT loading any leaf app's JS bundle. Render-surface
-                    // parity to the JS registration is correlated by shared id.
+                    // (id, label, requiredApp, surfaces, kinds, renderMode,
+                    // usability) WITHOUT loading any leaf app's JS bundle.
+                    // `renderMode` (component | mount) reports HOW a render-
+                    // surface leaf renders. Render-surface parity to the JS
+                    // registration — including the renderMode correlation — is
+                    // keyed by the shared id.
                     'leaves'          => $this->leafRegistry->describeForCapabilities(),
                 ],
             ],

--- a/lib/Service/Integration/LeafDescriptor.php
+++ b/lib/Service/Integration/LeafDescriptor.php
@@ -93,6 +93,35 @@ final class LeafDescriptor
     ];
 
     /**
+     * Render mode: the render surface is a Single File Component (tab + widget)
+     * interpreted under the host's own Vue runtime. The default — same-major and
+     * built-in leaves keep the existing SFC contract unchanged.
+     *
+     * @var string
+     */
+    public const RENDER_MODE_COMPONENT = 'component';
+
+    /**
+     * Render mode: the render surface is a `mount(el, props)` / `unmount(el)`
+     * pair the host invokes against a bare, host-owned DOM element, so a leaf
+     * built against a different Vue major than the host still renders (the DOM
+     * element is the neutral hand-off boundary).
+     *
+     * @var string
+     */
+    public const RENDER_MODE_MOUNT = 'mount';
+
+    /**
+     * Every render mode a render-surface descriptor MAY declare.
+     *
+     * @var array<int,string>
+     */
+    public const VALID_RENDER_MODES = [
+        self::RENDER_MODE_COMPONENT,
+        self::RENDER_MODE_MOUNT,
+    ];
+
+    /**
      * Constructor.
      *
      * @param string            $id                 Stable kebab-case id, unique across the registry and
@@ -108,6 +137,14 @@ final class LeafDescriptor
      * @param string|null       $referenceType      Optional marker so a schema reference property can target
      *                                              this leaf's single-entity widget (ADR-019 / AD-18).
      * @param string|null       $requiresPermission Optional permission string gating visibility.
+     * @param string            $renderMode         How a render-surface leaf renders: `component` (default —
+     *                                              an SFC tab/widget interpreted by the host's Vue runtime)
+     *                                              or `mount` (a `mount`/`unmount` pair the host invokes
+     *                                              against a bare DOM element, crossing a Vue major). One of
+     *                                              VALID_RENDER_MODES; validated at registration.
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList) A flat immutable value object: each parameter is one
+     * independent, optional piece of leaf discovery metadata, not a collaborator to bundle into an object.
      *
      * @return void
      */
@@ -121,6 +158,7 @@ final class LeafDescriptor
         private array $surfaces=[],
         private ?string $referenceType=null,
         private ?string $requiresPermission=null,
+        private string $renderMode=self::RENDER_MODE_COMPONENT,
     ) {
     }//end __construct()
 
@@ -237,11 +275,29 @@ final class LeafDescriptor
     }//end requiresPermission()
 
     /**
+     * How a render-surface leaf renders: `component` (default) or `mount`.
+     *
+     * A `component` leaf ships an SFC tab/widget the host interprets under its
+     * own Vue runtime; a `mount` leaf ships a `mount`/`unmount` pair the host
+     * invokes against a bare DOM element so the leaf renders with its own Vue
+     * major. The value is validated against VALID_RENDER_MODES at registration.
+     *
+     * @return string One of the RENDER_MODE_* constants.
+     */
+    public function getRenderMode(): string
+    {
+        return $this->renderMode;
+
+    }//end getRenderMode()
+
+    /**
      * Render the discovery-facing shape for the OCS capabilities surface.
      *
      * Carries only availability + capability metadata (no components, no verb):
-     * id, label, requiredApp, surfaces, kinds. Usability is derived by
-     * `LeafRegistry` from the installed state of `requiredApp`.
+     * id, label, requiredApp, surfaces, kinds, renderMode. Usability is derived
+     * by `LeafRegistry` from the installed state of `requiredApp`. `renderMode`
+     * lets a manifest app or admin UI learn HOW a render-surface leaf renders
+     * (SFC component vs mount hand-off) without loading its JS bundle.
      *
      * @return array<string,mixed> The discovery descriptor.
      */
@@ -255,6 +311,7 @@ final class LeafDescriptor
             'group'       => $this->group,
             'surfaces'    => $this->surfaces,
             'kinds'       => $this->kinds,
+            'renderMode'  => $this->renderMode,
         ];
 
     }//end toArray()

--- a/lib/Service/Integration/LeafRegistry.php
+++ b/lib/Service/Integration/LeafRegistry.php
@@ -47,9 +47,9 @@ use Psr\Log\LoggerInterface;
  * Registry of all leaves contributed by sibling apps on this NC instance.
  *
  * Duplicate leaf id: first registration wins, second logs a warning (ADR-013).
- * Descriptor validation (non-empty kinds, valid kinds, kebab-case id,
- * data-provider-requires-provider) rejects and skips a bad leaf without breaking
- * the catalogue.
+ * Descriptor validation (non-empty kinds, valid kinds, kebab-case id, valid
+ * renderMode, data-provider-requires-provider) rejects and skips a bad leaf
+ * without breaking the catalogue.
  */
 class LeafRegistry
 {
@@ -144,6 +144,8 @@ class LeafRegistry
      * Validation rules (a failing leaf is skipped, never fatal):
      *   - id MUST be non-empty kebab-case;
      *   - kinds MUST be a non-empty subset of `LeafDescriptor::VALID_KINDS`;
+     *   - renderMode MUST be one of `LeafDescriptor::VALID_RENDER_MODES`
+     *     (`component` — the default — or `mount`);
      *   - a `data-provider` kind MUST carry an accompanying provider;
      *   - duplicate id: first registration wins (ADR-013).
      *
@@ -180,6 +182,18 @@ class LeafRegistry
                     '[LeafRegistry] leaf "%s" declares unknown kind(s) "%s" — skipping',
                     $id,
                     implode(', ', $unknown)
+                )
+            );
+            return;
+        }
+
+        $renderMode = $descriptor->getRenderMode();
+        if (in_array($renderMode, LeafDescriptor::VALID_RENDER_MODES, true) === false) {
+            $this->logger->warning(
+                sprintf(
+                    '[LeafRegistry] leaf "%s" declares unknown renderMode "%s" — skipping',
+                    $id,
+                    $renderMode
                 )
             );
             return;
@@ -246,9 +260,10 @@ class LeafRegistry
     /**
      * Render the discovery rows for the OCS capabilities surface.
      *
-     * Each row carries the leaf's id, label, requiredApp, surfaces, kinds and
-     * current usability — everything a manifest app or admin UI needs to
-     * discover the leaf WITHOUT loading its JS bundle. Usability is derived from
+     * Each row carries the leaf's id, label, requiredApp, surfaces, kinds,
+     * renderMode and current usability — everything a manifest app or admin UI
+     * needs to discover the leaf (including HOW a render-surface leaf renders)
+     * WITHOUT loading its JS bundle. Usability is derived from
      * the installed/enabled state of the required app: a leaf whose required app
      * is disabled is reported present but not currently usable.
      *

--- a/tests/Unit/Service/Integration/LeafDescriptorTest.php
+++ b/tests/Unit/Service/Integration/LeafDescriptorTest.php
@@ -6,7 +6,9 @@
  * Covers:
  *  - accessors round-trip the constructed metadata;
  *  - kinds are reported and `hasKind()` answers correctly;
- *  - toArray() carries availability + capability metadata but NO components;
+ *  - renderMode defaults to `component` and round-trips a `mount` value;
+ *  - toArray() carries availability + capability metadata (incl. renderMode)
+ *    but NO components;
  *  - the render-and-read boundary (ADR-066): the descriptor exposes no verb,
  *    command, handler, or dispatch method.
  *
@@ -105,8 +107,33 @@ class LeafDescriptorTest extends TestCase
         $this->assertSame([], $descriptor->getSurfaces());
         $this->assertNull($descriptor->getReferenceType());
         $this->assertNull($descriptor->requiresPermission());
+        // renderMode defaults to `component` — the existing SFC contract, so
+        // every descriptor that does not opt in keeps rendering as before.
+        $this->assertSame(LeafDescriptor::RENDER_MODE_COMPONENT, $descriptor->getRenderMode());
+        $this->assertSame('component', $descriptor->getRenderMode());
 
     }//end testOptionalMetadataDefaults()
+
+    /**
+     * A descriptor may declare the `mount` render mode; the getter round-trips it.
+     *
+     * @return void
+     */
+    public function testRenderModeMountIsRoundTripped(): void
+    {
+        $descriptor = new LeafDescriptor(
+            id: 'hermiq-agent',
+            label: 'Agent',
+            icon: 'Robot',
+            kinds: [LeafDescriptor::KIND_RENDER_SURFACE],
+            surfaces: ['single-entity'],
+            renderMode: LeafDescriptor::RENDER_MODE_MOUNT,
+        );
+
+        $this->assertSame('mount', $descriptor->getRenderMode());
+        $this->assertSame('mount', $descriptor->toArray()['renderMode']);
+
+    }//end testRenderModeMountIsRoundTripped()
 
     /**
      * toArray() carries capability metadata but no Vue components.
@@ -129,6 +156,10 @@ class LeafDescriptorTest extends TestCase
         $this->assertSame('acme-notes', $array['id']);
         $this->assertSame(['detail-page'], $array['surfaces']);
         $this->assertSame([LeafDescriptor::KIND_DATA_PROVIDER], $array['kinds']);
+        // renderMode is carried as discovery metadata (HOW a render leaf
+        // renders), defaulting to `component`; it is a mode string, not a
+        // shipped Vue component.
+        $this->assertSame('component', $array['renderMode']);
 
         // No component/render field is carried on the server descriptor;
         // render components live on the JS layer under the same id.

--- a/tests/Unit/Service/Integration/LeafRegistryTest.php
+++ b/tests/Unit/Service/Integration/LeafRegistryTest.php
@@ -7,6 +7,8 @@
  *  - an announced leaf reaches the catalogue; built-ins still present;
  *  - a throwing listener is swallowed and other leaves survive;
  *  - empty-kinds / unknown-kind rejected; data-provider requires a provider;
+ *  - a `mount` renderMode leaf is accepted; an unknown renderMode is rejected;
+ *    discovery reports each leaf's renderMode;
  *  - first-wins on duplicate id (ADR-013); namespaced ids do not collide;
  *  - a data-provider leaf lands on the IntegrationRegistry and is reachable
  *    through the lazy loader hook;
@@ -362,6 +364,64 @@ class LeafRegistryTest extends TestCase
     }//end testUnknownKindIsRejected()
 
     /**
+     * A render-surface leaf declaring renderMode `mount` is accepted with no
+     * bespoke tab/widget expectation (the mount/unmount pair lives on the JS
+     * layer, so the server only records the mode).
+     *
+     * @return void
+     */
+    public function testMountRenderModeLeafIsAccepted(): void
+    {
+        $registry = $this->makeRegistry([
+            function (RegisterLeafProvidersEvent $event) {
+                $event->registerLeaf(
+                    new LeafDescriptor(
+                        id: 'hermiq-agent',
+                        label: 'Agent',
+                        icon: 'Robot',
+                        kinds: [LeafDescriptor::KIND_RENDER_SURFACE],
+                        surfaces: ['single-entity'],
+                        renderMode: LeafDescriptor::RENDER_MODE_MOUNT
+                    )
+                );
+            },
+        ]);
+
+        $descriptors = $registry->getDescriptors();
+        $this->assertCount(1, $descriptors);
+        $this->assertSame('mount', $descriptors[0]->getRenderMode());
+    }//end testMountRenderModeLeafIsAccepted()
+
+    /**
+     * An unknown renderMode is rejected and skipped, leaving the rest of the
+     * catalogue unaffected — mirroring the unknown-kind rule.
+     *
+     * @return void
+     */
+    public function testUnknownRenderModeIsRejected(): void
+    {
+        $registry = $this->makeRegistry([
+            function (RegisterLeafProvidersEvent $event) {
+                $event->registerLeaf(
+                    new LeafDescriptor(
+                        id: 'bad-mode',
+                        label: 'X',
+                        icon: 'Cube',
+                        kinds: [LeafDescriptor::KIND_RENDER_SURFACE],
+                        renderMode: 'teleport'
+                    )
+                );
+                $event->registerLeaf(
+                    new LeafDescriptor(id: 'ok', label: 'Ok', icon: 'Cube', kinds: [LeafDescriptor::KIND_RENDER_SURFACE])
+                );
+            },
+        ]);
+
+        $ids = array_map(fn ($d) => $d->getId(), $registry->getDescriptors());
+        $this->assertSame(['ok'], $ids, 'unknown renderMode rejected, the rest of the catalogue unaffected');
+    }//end testUnknownRenderModeIsRejected()
+
+    /**
      * A data-provider kind without an accompanying provider is rejected.
      *
      * @return void
@@ -533,8 +593,39 @@ class LeafRegistryTest extends TestCase
         $this->assertSame('acme-notes', $rows[0]['id']);
         $this->assertSame(['detail-page'], $rows[0]['surfaces']);
         $this->assertSame([LeafDescriptor::KIND_DATA_PROVIDER], $rows[0]['kinds']);
+        // renderMode defaults to `component` on the discovery surface.
+        $this->assertSame('component', $rows[0]['renderMode']);
         $this->assertTrue($rows[0]['usable']);
     }//end testDescribeForCapabilitiesReportsLeavesAndUsability()
+
+    /**
+     * OCS discovery reports a mount-mode render-surface leaf's renderMode so a
+     * manifest app / admin UI learns HOW it renders without loading its JS.
+     *
+     * @return void
+     */
+    public function testDescribeForCapabilitiesReportsMountRenderMode(): void
+    {
+        $registry = $this->makeRegistry([
+            function (RegisterLeafProvidersEvent $event) {
+                $event->registerLeaf(
+                    new LeafDescriptor(
+                        id: 'hermiq-agent',
+                        label: 'Agent',
+                        icon: 'Robot',
+                        kinds: [LeafDescriptor::KIND_RENDER_SURFACE],
+                        surfaces: ['single-entity'],
+                        renderMode: LeafDescriptor::RENDER_MODE_MOUNT
+                    )
+                );
+            },
+        ]);
+
+        $rows = $registry->describeForCapabilities();
+        $this->assertCount(1, $rows);
+        $this->assertSame('hermiq-agent', $rows[0]['id']);
+        $this->assertSame('mount', $rows[0]['renderMode']);
+    }//end testDescribeForCapabilitiesReportsMountRenderMode()
 
     /**
      * A leaf whose required app is disabled reports unusable.


### PR DESCRIPTION
## Summary

Server (OpenRegister) half of the **leaf-mount-render-escape-hatch** contract (spec: `spec/leaf-mount-render-escape-hatch`, openregister#2127). Adds an optional `renderMode` to the cross-app leaf registry so a render-surface leaf can declare it renders via a `mount(el, props)` / `unmount(el)` hand-off (Vue-major-agnostic) instead of an SFC `tab`/`widget`. This is the field the nc-vue host + parity gate correlate on; the actual mount lifecycle is a client-side concern.

## renderMode contract (so the nc-vue side matches)

- Enum: `'component'` (default) | `'mount'`. Constants `LeafDescriptor::RENDER_MODE_COMPONENT` / `RENDER_MODE_MOUNT`, set `VALID_RENDER_MODES`.
- Constructor param `renderMode` defaults to `'component'` (back-compat: existing descriptors behave exactly as today).
- Getter `LeafDescriptor::getRenderMode(): string`.
- Emitted in `toArray()` under key `renderMode`, so it flows onto the OCS `openregister.integrations.leaves` discovery block (`describeForCapabilities()` -> each `leaves[]` row now carries `renderMode`). A manifest app / admin UI learns HOW a leaf renders without loading its JS.
- Validation at registration (`LeafRegistry::collectLeaf`): a descriptor whose `renderMode` is not in `VALID_RENDER_MODES` is rejected and skipped -- same shape as the unknown-kind rule; one bad leaf never breaks the catalogue.
- A `mount`-mode render-surface leaf is accepted with **no** bespoke tab/widget expectation (the server carries no components -- the mount/unmount pair lives on the JS layer under the shared id).

## Parity note

Server-side there is no tab/widget completeness check to relax (the descriptor carries no components). The cross-layer correlation -- server `renderMode` MUST equal the JS registration `renderMode` under the shared id -- is the nc-vue gate-24 (`check-integration-parity`) concern; this change gives that gate the field to correlate by emitting `renderMode` on discovery.

## Files changed

- `lib/Service/Integration/LeafDescriptor.php` -- constants, constructor param, `getRenderMode()`, `toArray()` field.
- `lib/Service/Integration/LeafRegistry.php` -- renderMode validation in `collectLeaf`; docblocks.
- `lib/Capabilities/IntegrationsCapability.php` -- discovery comment (renderMode + parity role).
- `tests/Unit/Service/Integration/LeafDescriptorTest.php` -- default `component`, `mount` round-trip, `toArray` renderMode.
- `tests/Unit/Service/Integration/LeafRegistryTest.php` -- mount-mode accepted, unknown renderMode rejected, discovery reports renderMode.

## Verification (nextcloud:34 container)

- Leaf tests: `LeafDescriptorTest` + `LeafRegistryTest` -- **26 tests, 195 assertions, OK**.
- `IntegrationsCapabilityTest` -- **5 tests, 19 assertions, OK**.
- phpcs (`--standard=phpcs.xml`, full lib) -- **clean, 74/74**.
- phpstan (changed files) -- **No errors**. phpmd (changed files, baseline) -- **clean** (10-param DTO ctor annotated `@SuppressWarnings(PHPMD.ExcessiveParameterList)`, matching codebase convention).
- Purely additive; no `new LeafDescriptor(` call sites in `lib/`.
