### PR TITLE
test(newman): fix relations + referential-integrity API test drift

### DIFF
--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -57,6 +57,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\AnonRateLimit;
+use OCP\AppFramework\Http\Attribute\UserRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\DB\Exception;
@@ -2593,7 +2594,21 @@ class ObjectsController extends Controller
      * @suppressWarnings(PHPMD.NPathComplexity) Object creation requires many validation and processing steps
      *
      * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
+     *
+     * BUG-RATE-1: this endpoint is `@PublicPage` so anonymous callers (e.g.
+     * public form submissions via CaseToken/FormLink) need throttling —
+     * that is what #[AnonRateLimit] is for (added for the public-create
+     * path, see commit 044faee7d). But Nextcloud's RateLimitingMiddleware
+     * applies an Anon-only limit to EVERY caller, authenticated or not,
+     * when no #[UserRateLimit] is present ("If only an AnonRateThrottle is
+     * specified that one will also be applied to logged-in users" —
+     * lib/private/AppFramework/Middleware/Security/RateLimitingMiddleware.php).
+     * Without this explicit, more generous authenticated-user limit, every
+     * logged-in API caller — including bulk imports/integrations and this
+     * app's own CI test suite — was capped at the same 30 requests/minute
+     * meant only for anonymous abuse prevention.
      */
+    #[UserRateLimit(limit: 300, period: 60)]
     #[AnonRateLimit(limit: 30, period: 60)]
     public function create(
         string $register,

--- a/lib/Db/AuditTrailMapper.php
+++ b/lib/Db/AuditTrailMapper.php
@@ -649,13 +649,21 @@ class AuditTrailMapper extends QBMapper
             }
         }
 
+        $qb       = $this->db->getQueryBuilder();
+        $platform = $this->db->getDatabasePlatform();
+
         $fieldTypes = $chunk[0]->getFieldTypes();
         $columns    = [];
         foreach ($properties as $property) {
-            $columns[] = $chunk[0]->propertyToColumn($property);
+            // `user` is a reserved word in PostgreSQL (it doubles as the
+            // CURRENT_USER function) — an unquoted `user` column in an
+            // INSERT column list raises SQLSTATE 42601 ("syntax error at
+            // or near \"user\""). The QueryBuilder-based single-row insert
+            // path quotes identifiers automatically; this hand-built
+            // multi-row INSERT must do the same for every column.
+            $columns[] = $platform->quoteIdentifier($chunk[0]->propertyToColumn($property));
         }
 
-        $qb        = $this->db->getQueryBuilder();
         $tableName = $qb->getTableName($this->getTableName());
 
         $valuesClauses = [];

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -6793,6 +6793,16 @@ class MagicMapper extends AbstractObjectMapper
 
         $qb = $this->db->getQueryBuilder();
 
+        // PostgreSQL's CASE type-resolution infers the expression's overall
+        // type from its WHEN/THEN literals (here: text), so assigning the
+        // result straight into a jsonb column fails with SQLSTATE 42804
+        // ("column is of type jsonb but expression is of type text"). An
+        // explicit `::jsonb` cast on the whole CASE result fixes the
+        // mismatch; MySQL's JSON column accepts the string form as-is and
+        // does not need (nor understand) a Postgres-style cast.
+        $platform   = $this->db->getDatabasePlatform();
+        $isPostgres = stripos($platform::class, 'PostgreSQL') !== false;
+
         $caseSql = '(CASE '.$uuidCol;
         $uuids   = [];
         foreach ($items as $item) {
@@ -6804,6 +6814,9 @@ class MagicMapper extends AbstractObjectMapper
         }
 
         $caseSql .= ' END)';
+        if ($isPostgres === true) {
+            $caseSql .= '::jsonb';
+        }
 
         $qb->update($tableName)
             ->set($deletedCol, $qb->createFunction($caseSql))

--- a/tests/Unit/Db/AuditTrailMapperBulkInsertTest.php
+++ b/tests/Unit/Db/AuditTrailMapperBulkInsertTest.php
@@ -92,6 +92,16 @@ class AuditTrailMapperBulkInsertTest extends TestCase
         $queryBuilder->method('getTableName')->willReturn('"oc_openregister_audit_trails"');
         $this->db->method('getQueryBuilder')->willReturn($queryBuilder);
 
+        // BUG-SQL-1 fix coverage: insertAuditTrailChunk() now quotes every
+        // INSERT column via the platform (e.g. `user` is a reserved word in
+        // PostgreSQL and breaks an unquoted multi-row INSERT). Reuse the
+        // same platform mock pattern as the QueryBuilder above.
+        $platform = $this->createMock(\Doctrine\DBAL\Platforms\AbstractPlatform::class);
+        $platform->method('quoteIdentifier')->willReturnCallback(
+            static fn (string $identifier): string => '"'.$identifier.'"'
+        );
+        $this->db->method('getDatabasePlatform')->willReturn($platform);
+
         $this->statements = [];
         $this->db->method('executeStatement')
             ->willReturnCallback(

--- a/tests/Unit/Db/MagicMapper/MagicMapperBatchSoftDeleteTest.php
+++ b/tests/Unit/Db/MagicMapper/MagicMapperBatchSoftDeleteTest.php
@@ -67,6 +67,14 @@ class MagicMapperBatchSoftDeleteTest extends TestCase
     {
         parent::setUp();
         $this->db = $this->createMock(IDBConnection::class);
+        // BUG-DB-8 fix coverage: executeBatchSoftDeleteUpdate() now reads the
+        // platform to decide whether the CASE result needs a Postgres
+        // `::jsonb` cast. A mock platform whose class name does not contain
+        // "PostgreSQL" keeps these tests on the pre-fix (no-cast) code path,
+        // matching what they assert.
+        $this->db->method('getDatabasePlatform')->willReturn(
+            $this->createMock(\Doctrine\DBAL\Platforms\AbstractPlatform::class)
+        );
         $this->eventDispatcher  = $this->createMock(IEventDispatcher::class);
         $this->dispatchedEvents = [];
     }//end setUp()


### PR DESCRIPTION
## Summary

Fixes the two failing Newman domains in the api-test-coverage orchestrator: `relations` and `referential-integrity`. Both turned out to be genuine production bugs, not stale test collections.

### referential-integrity — real bug, two fixes

- **`lib/Db/MagicMapper.php` (`executeBatchSoftDeleteUpdate`)**: the CASCADE-delete batched soft-delete builds a raw `CASE _uuid WHEN ... THEN ... END` SQL expression assigned into the `_deleted` column. On PostgreSQL, the CASE expression's WHEN/THEN parameter literals resolve to `text`, and assigning that straight into the `jsonb` column fails with `SQLSTATE[42804]: Datatype mismatch`. That failure poisons the surrounding transaction, so every subsequent query in the same request (including the magic-table existence check) fails with `SQLSTATE[25P02]: current transaction is aborted`, and `DeleteObject` rolls the whole CASCADE delete back — the client sees a bare 403 with no useful detail. Fixed by appending an explicit `::jsonb` cast to the CASE result on Postgres (MySQL's JSON column already accepts the string form and doesn't understand the cast).
- **`lib/Db/AuditTrailMapper.php` (`insertAuditTrailChunk`)**: the bulk cascade audit-trail INSERT hand-builds `INSERT INTO tbl (col1, col2, ...) VALUES (...)` with unquoted column names. `user` is a reserved word in PostgreSQL, so the statement fails with `SQLSTATE[42601]: syntax error at or near "user"` whenever a cascade-deleted object's audit row includes the `user`/`user_name` columns — which is every row. Fixed by quoting every column through `$platform->quoteIdentifier()` (the same approach the single-row insert path gets for free via the query builder).

Confirmed via live 403 body + `nextcloud.log` on a disposable NC 34 + Postgres instance, then confirmed the fix by reproducing the CASCADE delete before/after.

### relations — real bug (rate limiting), not a collection issue

`ObjectsController::create()` carries `#[AnonRateLimit(limit: 30, period: 60)]` (added for the public/anonymous CaseToken form-create path — commit `044faee7d`). Nextcloud's `RateLimitingMiddleware` documents that an `AnonRateThrottle` with no matching `UserRateThrottle` **also throttles logged-in users**. In CI, `crud` and `graphql` run before `relations` in the same 60s window and already spend most of that 30-request budget, so `relations`' own object-creates start returning 429 — which then cascades into empty extracted UUIDs and double-slash 404s downstream (matches the actual CI failure log exactly). Added `#[UserRateLimit(limit: 300, period: 60)]` alongside the existing `AnonRateLimit` so authenticated bulk API usage (imports, integrations, this suite) is no longer capped at the anonymous-abuse tier, while anonymous public-form submissions keep the original 30/60s protection.

The `relations` Postman collection itself needed no changes — it was already correct.

### Test-only changes

`tests/Unit/Db/MagicMapper/MagicMapperBatchSoftDeleteTest.php` and `tests/Unit/Db/AuditTrailMapperBulkInsertTest.php` mock `IDBConnection` and now need a `getDatabasePlatform()` stub to match the new platform-aware code paths (mirrors the pattern `AuditTrailMapperBulkTest.php` already used).

## Test plan

- [x] Stood up a disposable NC 34 + Postgres instance (not the shared dev :8080), deployed this worktree + vendor into `custom_apps/openregister`
- [x] Reproduced both failures live: referential-integrity's 403 traced through `nextcloud.log` to the two SQL bugs above; relations' 429s reproduced by running `crud`+`graphql`+`relations` in sequence
- [x] Applied fixes, redeployed, re-ran `bash tests/newman/run-all.sh` with `COLLECTIONS="crud graphql relations auth-matrix error-matrix referential-integrity"` (the exact CI invocation, `NEWMAN_RUNNER=host`) — **6/6 domains pass, 0 failures**
- [x] Full existing PHPUnit suite (6080 tests) still green — no regressions
- [x] `phpcs` clean on all three touched `lib/` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)