### PR TITLE
docs(config): federated configuration sharing — one fleet standard (design)

### DIFF
--- a/openspec/changes/federated-config-sharing/.openspec.yaml
+++ b/openspec/changes/federated-config-sharing/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: federated-config-sharing

--- a/openspec/changes/federated-config-sharing/proposal.md
+++ b/openspec/changes/federated-config-sharing/proposal.md
@@ -1,0 +1,100 @@
+# Federated configuration sharing — one fleet standard
+
+## Problem
+
+Sharing configuration over GitHub has grown up three times in the fleet, and
+none of it is reusable or user-facing:
+
+1. **OpenRegister's `ConfigurationService`** already bundles heterogeneous OR
+   entities (registers, schemas, objects, views, agents, sources, mappings,
+   applications) as an OAS 3.0 + `x-openregister` document, and already
+   **publishes to and installs from GitHub** (`GitHubHandler::publishConfiguration`,
+   the contents API), with version tracking, preview-diff and cron re-check. But
+   every publish/import/export is **hard-gated to Nextcloud admins**, uses a
+   single shared app-level token, and the export is **register/schema-centric** —
+   an app cannot declare its own shareable object types.
+2. **OpenBuild** built a cleaner object→GitHub model: `AppRepoSerializer`
+   (object + companion schemas → canonical repo files), broker-routed push
+   (`GitHubPushService`, token via the credential broker so it can be **per
+   user**), topic discovery (`GitHubCatalogService`, `topic:openbuild-app`), and
+   a `link / push / pull / status` controller.
+3. **hermiq copied OpenBuild's** for agent templates and skills
+   (`GitHubTemplatePushService`, `topic:hermiq-skill`), and says so in its own
+   spec.
+
+So the mechanism is duplicated, admin-only, and locked to specific object types —
+while **10 of 11 apps store their shareable config as OpenRegister objects** and
+several more (procest, shillinq, softwarecatalog, nldesign) already have local
+OTAP file export that is a natural serialisation seam. There is no one way for a
+**user** to share a flow, a case type, a payroll pack, a publication type, an NL
+Design theme, or a register — over GitHub — and no trust model for installing
+what someone else shared.
+
+## Solution
+
+One OpenRegister-owned service that any app plugs into, unifying the two proven
+mechanisms and opening them to users. It is deliberately **not** built on
+openconnector — the engine is OpenRegister's own `ConfigurationService` plus the
+credential broker; openconnector remains an optional peer that only adds its own
+resource types.
+
+- **`FederatedConfigService`** (OpenRegister) — the engine, extracted from
+  OpenBuild's proven serialiser + broker-routed push + topic discovery, backed by
+  `ConfigurationService`'s existing bundle / version / preview-diff spine.
+- **`IShareableConfigType` + `RegisterShareableConfigTypesEvent`** — the same
+  contribution idiom as flow nodes (#2074) and (soon) MCP tools (#2077). Each app
+  declares a shareable type: how to **select** the config, **serialise** it to
+  canonical files, **deserialise** it on install, **exclude secrets**, and its
+  discovery **topic**. OpenBuild's `AppRepoSerializer` is the reference
+  implementation.
+- **Storage-agnostic by contract.** A type owns serialise/deserialise, so the
+  standard works for OR-object config *and* app-specific storage. **NL Design
+  themes** (`CustomTokenSet`, stored in `IConfig`, exported today by
+  `ConfigBundleService`) are a first-class shareable type that wraps its existing
+  JSON bundle as the payload — no migration onto OR objects required.
+- **User &amp; org sharing, GitHub credentials in Doriath.** Replace the flat
+  NC-admin gate with **per-org RBAC**. GitHub tokens are never a shared app-level
+  secret: they are custodied by the credential broker's **Doriath** vault leaf
+  (per-application EncryptionSuites, ciphertext-only `rsa-oaep-sha256-chunked-v1`,
+  audit on every mutation, rotation), resolved per user/org at publish/pull time.
+  Where Doriath is not installed, the broker's NC-vault leaf is the unchanged
+  fallback. So a normal user can share and install within their org's governance
+  without any shared token.
+- **Trust (v1): org allowlist + version pinning.** An org admin allowlists which
+  GitHub sources/orgs may be installed from; versions are pinned per instance; a
+  type declares and enforces its own secret exclusion; an installed config cannot
+  widen its own grant. Signing/verification is a later hardening, not v1.
+- **Discovery.** GitHub topic search (per type's topic) merged with the existing
+  `x-openregister` code search, plus an optional org-curated source index.
+
+The result: a flow, an OpenBuild app, a procest case type, a shillinq payroll
+pack, an opencatalogi publication type, a docudesk template, a hermiq agent/skill,
+an NL Design theme, or a register/schema — all shared, discovered and installed
+through **one declared seam**. #2065's "flow integration network" becomes the
+first flow-shaped consumer of this, not a separate subsystem.
+
+## Consumers (declared types, phased adoption)
+
+| App | Type(s) | Today |
+|---|---|---|
+| openbuild | Application / Version / Template | Already on GitHub — becomes the reference; migrate onto the shared service |
+| openregister | Registers &amp; schemas, Configurations, **Flows** (#2065) | Admin-only ConfigurationService today |
+| hermiq | Agent / Agentflow / Template / Skill | Already on GitHub (copied OB) — folds onto the shared service |
+| nldesign | **NL Design theme token sets** (`CustomTokenSet`) | `ConfigBundleService` JSON bundle → wrapped as the payload (IConfig storage) |
+| procest | Case types, workflow / decision templates | OTAP file export → redirect at the shared service |
+| shillinq | Payroll / tax / subsidie packs, catalogs | OTAP file export → redirect |
+| opencatalogi | Publication types, DCAT/TOOI waardelijsten | None |
+| docudesk | Document templates, dictionaries | None |
+| softwarecatalog | GEMMA / AMEF compliance definitions | ArchiMate export → seam |
+| pipelinq | Pipeline / deal-stage config, catalogs | None |
+| larpingapp | Character / game templates | None |
+
+## Out of scope (v1)
+
+- **Signing / cryptographic verification** of published configs — v1 relies on org
+  allowlist + pinning; signing is a follow-up hardening.
+- **Deep secret handling beyond exclusion** — secrets stay in the credential
+  broker; a shared config carries credential *requirements*, never values.
+- **A visual sharing UI** beyond the existing Configuration modals — the engine and
+  API first; per-app share buttons layer on.
+- **Migrating nldesign off `IConfig`** — the adapter keeps its bundle as-is.

--- a/openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+++ b/openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Apps declare shareable configuration types (REQ-FCS-001)
+
+OpenRegister SHALL provide `IShareableConfigType` and a
+`RegisterShareableConfigTypesEvent`, so any app contributes a shareable type the
+same way it contributes a flow node. A type SHALL declare how to select its
+configuration, serialise it to canonical repository files, deserialise it on
+install, exclude secrets, and its discovery topic. The contract SHALL be
+storage-agnostic: a type owns (de)serialisation, so it works for OpenRegister
+objects and for app-specific storage alike.
+
+#### Scenario: A type is contributed and listed
+
+- **GIVEN** an app registers an `IShareableConfigType` on the event
+- **WHEN** the shareable-type catalogue is read
+- **THEN** the type appears with its topic and display metadata
+
+#### Scenario: A non-OpenRegister-object type works
+
+- **GIVEN** a type whose config lives in app storage (e.g. NL Design theme token
+  sets in `IConfig`), not OpenRegister objects
+- **WHEN** it is serialised and later deserialised
+- **THEN** the round trip applies the config with no OpenRegister object required
+
+### Requirement: Publish a configuration to GitHub with credentials in Doriath (REQ-FCS-002)
+
+A user with the right to share SHALL publish a configuration of any registered
+type to a GitHub repository — serialise to canonical files, push via the Git
+data/contents API, tag the repository with the type's topic. The GitHub token
+SHALL be resolved through the credential broker's Doriath vault leaf per
+user/org; where Doriath is absent the broker's Nextcloud-vault leaf is used. No
+shared app-level GitHub token SHALL be required for user publishing. Secrets
+SHALL be excluded from the published payload by the type.
+
+#### Scenario: A user publishes without a shared token
+
+- **GIVEN** a user whose GitHub credential is custodied in Doriath
+- **WHEN** they publish a shareable configuration
+- **THEN** it is pushed to their repository using the Doriath-resolved token
+- **AND** no shared app-level token is used
+- **AND** no secret value appears in the published files
+
+### Requirement: Discover and install with preview and pinning (REQ-FCS-003)
+
+OpenRegister SHALL discover shared configurations by GitHub topic (per type) and
+by the `x-openregister` code search, present a preview diff (create/update/skip
+per entity) before applying, install via the type's deserialiser, and let an
+instance pin a version. Version tracking and update checks SHALL reuse the
+existing configuration machinery.
+
+#### Scenario: Preview before install
+
+- **GIVEN** a discovered configuration
+- **WHEN** a user requests to install it
+- **THEN** a preview of what would be created/updated/skipped is shown before anything is written
+
+#### Scenario: A pinned configuration does not auto-advance
+
+- **GIVEN** an installed configuration pinned to a version
+- **WHEN** a newer version is published upstream
+- **THEN** the instance stays on the pinned version until explicitly updated
+
+### Requirement: Trust — org allowlist and pinning (REQ-FCS-004)
+
+Installing a configuration SHALL be governed by an organisation allowlist of
+sources: an install from a source not on the org's allowlist SHALL be refused. An
+installed configuration SHALL NOT be able to widen its own declared grant. (v1
+trust is allowlist + version pinning + secret exclusion; cryptographic signing is
+a later hardening.)
+
+#### Scenario: A non-allowlisted source is refused
+
+- **GIVEN** an organisation with an allowlist of GitHub sources
+- **WHEN** a user tries to install from a source not on the allowlist
+- **THEN** the install is refused
+
+#### Scenario: A config cannot widen its own grant
+
+- **GIVEN** an installed configuration with declared scopes
+- **WHEN** it attempts to touch a register or host outside its declaration
+- **THEN** the engine refuses
+
+### Requirement: Sharing is user/org-scoped, not admin-only (REQ-FCS-005)
+
+Publishing and installing SHALL be available to a user within their
+organisation's governance, not gated to Nextcloud admins. The organisation and
+owner of a configuration SHALL scope who may share and install it.
+
+#### Scenario: A non-admin org member shares
+
+- **GIVEN** a non-admin user permitted to share in their organisation
+- **WHEN** they publish or install a configuration
+- **THEN** the action succeeds within the org's governance
+
+@e2e exclude backend service + fleet contract — covered by unit tests
+(IShareableConfigType registry, allowlist enforcement, secret exclusion) and
+Playwright e2e on the first two consumers (OpenBuild apps + Flows: publish →
+discover → install → run); design-first change, no code in this proposal

--- a/openspec/changes/federated-config-sharing/tasks.md
+++ b/openspec/changes/federated-config-sharing/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: federated-config-sharing
+
+## Phase 1 — design + trust (this change, then a design PR)
+- [ ] `IShareableConfigType` contract (select / serialise / deserialise / exclude
+      secrets / topic), storage-agnostic. Canonical repo layout. Trust model:
+      org allowlist + version pinning + secret exclusion (signing deferred).
+
+## Phase 2 — the engine
+- [ ] `FederatedConfigService` in OpenRegister: extract OpenBuild's serialiser +
+      broker-routed push + topic discovery; back it with ConfigurationService's
+      bundle / version / preview-diff.
+- [ ] `RegisterShareableConfigTypesEvent` + registry (mirror flow nodes).
+- [ ] GitHub credentials via the credential broker's **Doriath** leaf per user/org
+      (NC-vault fallback); retire the shared-token assumption for user publish.
+- [ ] Per-org RBAC replacing the NC-admin gate; org source allowlist enforcement.
+
+## Phase 3 — prove on two types (with Playwright e2e)
+- [ ] OpenBuild apps onto the shared service (reference type).
+- [ ] Flows as a shareable type — the reframed #2065 "integration network".
+- [ ] e2e: publish → discover → install → run, on both.
+
+## Phase 4 — fold in hermiq
+- [ ] Migrate hermiq's duplicated GitHub sync (agent templates + skills) onto the
+      shared service.
+
+## Phase 5 — roll out declared types (parallel)
+- [ ] nldesign: NL Design theme token sets as a type wrapping `ConfigBundleService`.
+- [ ] procest case types / workflow templates (redirect OTAP export).
+- [ ] shillinq payroll/tax packs (redirect OTAP export).
+- [ ] opencatalogi publication types + DCAT/TOOI waardelijsten.
+- [ ] docudesk templates; softwarecatalog GEMMA/AMEF; pipelinq; larpingapp.
+
+## Phase 6 — governance + index
+- [ ] Org source allowlist admin UI; optional curated discovery index over topics.
+- [ ] "How to share a config" docs — publish without a PR to a Conduction repo.
+- [ ] (Later) cryptographic signing / verification.


### PR DESCRIPTION
**Design-only** OpenSpec change (no code) — for review before implementation, like the per-item-routing design.

One OpenRegister-owned standard for any app to **publish / discover / install its configuration over GitHub** — flows, registers & schemas, OpenBuild apps, procest case types, payroll packs, agents & skills, **NL Design themes**. Full write-up + fleet inventory + architecture: the design artifact shared with the team.

## Why this shape (from a fleet scan)

- OpenRegister's `ConfigurationService` is **already** a generic multi-entity, **GitHub-bidirectional** bundle (publish + install, version tracking, preview-diff).
- **OpenBuild already built** the object→GitHub sync (broker-routed tokens, topic discovery, git-data-API push); **hermiq copied it**. 10/11 apps store shareable config as OR objects.
- So this is **unify + generalise + democratise**, not greenfield — and **no openconnector dependency** (engine = OR's ConfigurationService + the credential broker).

## Decisions captured (from review)

- **Engine:** a `FederatedConfigService` in OpenRegister + an `IShareableConfigType` registration event (same idiom as flow nodes). **Storage-agnostic** — app-specific storage works too, so **NL Design themes wrap `ConfigBundleService`** with no migration onto OR objects.
- **GitHub credentials in Doriath** — custodied by the credential broker's Doriath vault leaf (encrypted, audited, rotatable) per user/org; no shared app token; NC-vault fallback where Doriath is absent.
- **Trust v1 = org allowlist + version pinning + secret exclusion**; signing deferred. Sharing is **user/org-scoped, not admin-only**.
- **#2065** collapses into one flow-shaped consumer of this.

## Contents

`proposal.md` (problem, solution, consumer table, out-of-scope) · `spec.md` (5 requirements + scenarios) · `tasks.md` (6 phases with per-app adoption).

Left **open** for review — no code until the design is agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)