### PR TITLE
Revert tar override (#2128) — it broke the npm audit tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30308,9 +30308,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.22",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
-      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
+      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     "vue-demi": "^0.14.6",
     "minimatch": ">=3.1.5",
     "rollup": ">=2.80.0",
-    "tar": ">=7.5.22",
     "dompurify": "$dompurify",
     "follow-redirects": ">=1.16.0",
     "lodash": ">=4.18.1",


### PR DESCRIPTION
Reverts #2128. The tar `>=7.5.22` override was **unnecessary and harmful**: tar is a dev-only transitive (node-gyp/cacache build tooling) that never ships, so the `Security (npm)` gate (`--audit-level=critical --omit=dev`) already omits it — that job was **green before the override**. Adding the override made npm's retiring `audits/quick` endpoint reject the whole lock with `400 Invalid package tree`, flipping Security (npm) to red (confirmed: green at the pre-override SHA, red at every SHA after). Reverting restores the clean tree. Paired with a shared-workflow change adding `--omit=dev` to the SBOM job's npm audit so dev-tool vulns don't gate there either.