### PR TITLE
feat(config): registers & schemas as a shareable type — a second consumer

### DIFF
--- a/lib/Listener/ShareableConfigTypeRegistrationListener.php
+++ b/lib/Listener/ShareableConfigTypeRegistrationListener.php
@@ -29,6 +29,7 @@ namespace OCA\OpenRegister\Listener;
 
 use OCA\OpenRegister\Service\Config\RegisterShareableConfigTypesEvent;
 use OCA\OpenRegister\Service\Config\Types\FlowShareableConfigType;
+use OCA\OpenRegister\Service\Config\Types\RegisterSchemaShareableConfigType;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 
@@ -42,10 +43,13 @@ class ShareableConfigTypeRegistrationListener implements IEventListener
     /**
      * Constructor.
      *
-     * @param FlowShareableConfigType $flows The built-in "Flows" type.
+     * @param FlowShareableConfigType           $flows     The built-in "Flows" type.
+     * @param RegisterSchemaShareableConfigType $registers The built-in "Registers & schemas" type.
      */
-    public function __construct(private readonly FlowShareableConfigType $flows)
-    {
+    public function __construct(
+        private readonly FlowShareableConfigType $flows,
+        private readonly RegisterSchemaShareableConfigType $registers
+    ) {
 
     }//end __construct()
 
@@ -65,6 +69,7 @@ class ShareableConfigTypeRegistrationListener implements IEventListener
         }
 
         $event->registerType(type: $this->flows);
+        $event->registerType(type: $this->registers);
 
     }//end handle()
 }//end class

--- a/lib/Service/Config/Types/RegisterSchemaShareableConfigType.php
+++ b/lib/Service/Config/Types/RegisterSchemaShareableConfigType.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * Registers and schemas as a shareable configuration type.
+ *
+ * The foundational case: a register and its schemas are themselves shareable
+ * configuration. OpenRegister already knows how to package them — the
+ * `ConfigurationService` exports a register (and its schemas) as a portable,
+ * slug-keyed OpenAPI document, and imports one back. This type is a thin adapter
+ * that exposes that proven export/import through the one federated-config seam,
+ * so a register travels the same way a flow, a case type or a theme does.
+ *
+ * Publishing a register carries its structure, not its data: objects are
+ * included only when the selection asks for it, and never any secret.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Config\Types
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Config\Types;
+
+use OCA\OpenRegister\Service\Config\IShareableConfigType;
+use OCA\OpenRegister\Service\ConfigurationService;
+use OCA\OpenRegister\Service\RegisterService;
+use Throwable;
+use UnexpectedValueException;
+
+/**
+ * Serialises and installs registers (with their schemas) through the engine.
+ */
+class RegisterSchemaShareableConfigType implements IShareableConfigType
+{
+    /**
+     * Constructor.
+     *
+     * @param RegisterService      $registerService Loads the register to share.
+     * @param ConfigurationService $configService   Exports and imports the bundle.
+     */
+    public function __construct(
+        private readonly RegisterService $registerService,
+        private readonly ConfigurationService $configService
+    ) {
+
+    }//end __construct()
+
+    /**
+     * The type id.
+     *
+     * @return string The id.
+     */
+    public function getId(): string
+    {
+        return 'openregister.registers';
+
+    }//end getId()
+
+    /**
+     * The display name.
+     *
+     * @return string The name.
+     */
+    public function getDisplayName(): string
+    {
+        return 'Registers & schemas';
+
+    }//end getDisplayName()
+
+    /**
+     * The discovery topic.
+     *
+     * @return string The topic.
+     */
+    public function getTopic(): string
+    {
+        return 'openregister-register';
+
+    }//end getTopic()
+
+    /**
+     * Package a register (and its schemas) into a portable bundle.
+     *
+     * `$selection` is `{register: id|slug, includeObjects?: bool}`. The bundle is
+     * the slug-keyed OpenAPI document the ConfigurationService already produces —
+     * portable and instance-independent by construction.
+     *
+     * @param array $selection `{register, includeObjects?}`.
+     *
+     * @return array The exported configuration bundle.
+     *
+     * @throws UnexpectedValueException When no register is named or found.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function serialise(array $selection): array
+    {
+        $ref = trim((string) ($selection['register'] ?? ''));
+        if ($ref === '') {
+            throw new UnexpectedValueException('Sharing registers needs a register.');
+        }
+
+        try {
+            $register = $this->registerService->find(id: $ref);
+        } catch (Throwable $e) {
+            throw new UnexpectedValueException(sprintf('No register "%s".', $ref));
+        }
+
+        return $this->configService->exportConfig(
+            input: $register,
+            includeObjects: (bool) ($selection['includeObjects'] ?? false)
+        );
+
+    }//end serialise()
+
+    /**
+     * Install a register bundle into this instance.
+     *
+     * Reuses the app-import path (idempotent, slug-matched, version-gated) — the
+     * same one the shipped register descriptors use.
+     *
+     * @param array $bundle A configuration bundle produced by this type.
+     *
+     * @return array The import result (`{registers, schemas, ...}`).
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function deserialise(array $bundle): array
+    {
+        $version = (string) ($bundle['info']['version'] ?? '1.0.0');
+
+        return $this->configService->importFromApp(
+            appId: 'openregister',
+            data: $bundle,
+            version: $version,
+            force: false
+        );
+
+    }//end deserialise()
+}//end class

--- a/tests/Unit/Service/Config/RegisterSchemaShareableConfigTypeTest.php
+++ b/tests/Unit/Service/Config/RegisterSchemaShareableConfigTypeTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Config;
+
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Service\Config\Types\RegisterSchemaShareableConfigType;
+use OCA\OpenRegister\Service\ConfigurationService;
+use OCA\OpenRegister\Service\RegisterService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
+
+class RegisterSchemaShareableConfigTypeTest extends TestCase
+{
+    private RegisterService&MockObject $registers;
+
+    private ConfigurationService&MockObject $config;
+
+    private RegisterSchemaShareableConfigType $type;
+
+    protected function setUp(): void
+    {
+        $this->registers = $this->createMock(RegisterService::class);
+        $this->config    = $this->createMock(ConfigurationService::class);
+        $this->type      = new RegisterSchemaShareableConfigType($this->registers, $this->config);
+    }
+
+    public function testIdentity(): void
+    {
+        $this->assertSame('openregister.registers', $this->type->getId());
+        $this->assertSame('openregister-register', $this->type->getTopic());
+    }
+
+    public function testSerialiseExportsTheNamedRegister(): void
+    {
+        $this->registers->method('find')->with('flows')->willReturn($this->createMock(Register::class));
+        $this->config->expects($this->once())->method('exportConfig')
+            ->willReturn(['openapi' => '3.0.0', 'components' => ['registers' => ['flows' => []]]]);
+
+        $bundle = $this->type->serialise(['register' => 'flows']);
+        $this->assertArrayHasKey('registers', $bundle['components']);
+    }
+
+    public function testSerialiseNeedsARegister(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->type->serialise([]);
+    }
+
+    public function testSerialiseUnknownRegisterIsRefused(): void
+    {
+        $this->registers->method('find')->willThrowException(new \RuntimeException('nope'));
+        $this->expectException(UnexpectedValueException::class);
+        $this->type->serialise(['register' => 'ghost']);
+    }
+
+    public function testDeserialiseImportsWithTheBundleVersion(): void
+    {
+        $this->config->expects($this->once())->method('importFromApp')
+            ->with('openregister', $this->anything(), '2.3.0', false)
+            ->willReturn(['registers' => ['flows'], 'schemas' => ['flow']]);
+
+        $result = $this->type->deserialise([
+            'info'       => ['version' => '2.3.0'],
+            'components' => ['registers' => ['flows' => []]],
+        ]);
+        $this->assertContains('flows', $result['registers']);
+    }
+}

--- a/tests/e2e/api-direct/federated-config.spec.ts
+++ b/tests/e2e/api-direct/federated-config.spec.ts
@@ -68,13 +68,31 @@ test.describe('Federated configuration sharing', () => {
 		return uuid
 	}
 
-	test('the shareable types include Flows', async ({ request }) => {
+	test('the shareable types include Flows and Registers', async ({ request }) => {
 		const resp = await request.get(`${API}/federated-config/types`)
 		expect(resp.status()).toBe(200)
 		const types = (await resp.json()).types ?? []
 		const flows = types.find((t: any) => t.id === 'openregister.flows')
 		expect(flows, 'Flows is a shareable type').toBeTruthy()
 		expect(flows.topic).toBe('openregister-flow')
+		// A second, very different consumer proves the standard generalises.
+		const registers = types.find((t: any) => t.id === 'openregister.registers')
+		expect(registers, 'Registers & schemas is a shareable type').toBeTruthy()
+		expect(registers.topic).toBe('openregister-register')
+	})
+
+	test('a register bundles into a portable OpenAPI document', async ({ request }) => {
+		// Read-only: bundle the shipped `flows` register; do not install (that
+		// would re-import a shared register).
+		const resp = await request.post(`${API}/federated-config/bundle`, {
+			headers: JSON_HEADERS,
+			data: { type: 'openregister.registers', selection: { register: 'flows' } },
+		})
+		expect(resp.status()).toBe(200)
+		const bundle = await resp.json()
+		expect(bundle.openapi, 'the bundle is an OpenAPI document').toBeTruthy()
+		expect(bundle.components?.registers?.flows, 'it carries the flows register').toBeTruthy()
+		expect(bundle.components?.schemas?.flow, 'and its flow schema').toBeTruthy()
 	})
 
 	test('a flow bundles into a portable shape and installs as a fresh flow that runs', async ({ request }) => {


### PR DESCRIPTION
Adds the foundational consumer you named — **"registers and schemas themselves"** — proving the federated-config standard generalises beyond flows, entirely within OpenRegister.

## What

- **`RegisterSchemaShareableConfigType`** (`openregister.registers`) — a thin adapter over the proven `ConfigurationService` export/import. `serialise()` exports a register + its schemas as the slug-keyed OpenAPI bundle; `deserialise()` imports it back via `importFromApp` (idempotent, slug-matched, version-gated — the same path the shipped register descriptors use). Objects only when the selection asks; never a secret.
- Registered alongside Flows on the shareable-type event.

**Two very different types now ride the one seam:** a flow (an OR object in the flow store) and a register (the OpenAPI configuration bundle). That is the whole point of the standard.

## Verification

- **Unit** — `RegisterSchemaShareableConfigTypeTest` (5). 18 config unit tests total; phpcs clean.
- **Playwright e2e** — the types list includes both **Flows and Registers**, and a register **bundles into a portable OpenAPI document** carrying the register + its schema.
- **Live (8080)** — types = `openregister.flows` + `openregister.registers`; bundling `flows` yields `components.registers.flows` + `components.schemas.flow`.

Builds on #2134. Follow-ups remain the cross-app rollout (hermiq fold-in; procest/shillinq/opencatalogi/docudesk/softwarecatalog/pipelinq/larpingapp/**NL Design themes**), the publish/discover UI, per-org RBAC beyond admin, and signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)