### PR TITLE
test(newman): fix schema-import + schema-migration + crud collections

### DIFF
--- a/lib/Controller/SchemaImportController.php
+++ b/lib/Controller/SchemaImportController.php
@@ -80,6 +80,8 @@ class SchemaImportController extends Controller
      *
      * @return JSONResponse The discovery results.
      *
+     * @NoCSRFRequired
+     *
      * @spec openspec/specs/schema-import/spec.md
      */
     public function types(string $dialect): JSONResponse
@@ -101,6 +103,8 @@ class SchemaImportController extends Controller
      *
      * @return JSONResponse The snapshot info.
      *
+     * @NoCSRFRequired
+     *
      * @spec openspec/specs/schema-import/spec.md
      */
     public function snapshot(string $dialect): JSONResponse
@@ -120,6 +124,8 @@ class SchemaImportController extends Controller
      * @param string $dialect The dialect key (schema.org | ggm).
      *
      * @return JSONResponse The created schema, or a structured error.
+     *
+     * @NoCSRFRequired
      *
      * @spec openspec/specs/schema-import/spec.md
      */
@@ -169,6 +175,8 @@ class SchemaImportController extends Controller
      * @param int $id The schema id.
      *
      * @return JSONResponse The classified diff (preview) or the updated schema.
+     *
+     * @NoCSRFRequired
      *
      * @spec openspec/specs/schema-import/spec.md
      *
@@ -247,12 +255,11 @@ class SchemaImportController extends Controller
      */
     private function persistNewSchema(ImportedSchema $imported): Schema
     {
-        $payload = $imported->toSchemaArray();
-
-        $schema = new Schema();
-        $schema->hydrate($payload);
-
-        return $this->schemaMapper->insert($schema);
+        // Use the canonical creation path so the schema gets its uuid, slug,
+        // version, facet configuration and delta extraction. Hand-rolling
+        // hydrate()+insert() bypasses cleanObject() and inserts a NULL uuid,
+        // which the NOT NULL constraint on oc_openregister_schemas rejects.
+        return $this->schemaMapper->createFromArray($imported->toSchemaArray());
 
     }//end persistNewSchema()
 

--- a/lib/Controller/SchemaMigrationController.php
+++ b/lib/Controller/SchemaMigrationController.php
@@ -92,6 +92,8 @@ class SchemaMigrationController extends Controller
      *
      * @return JSONResponse The changelog entries.
      *
+     * @NoCSRFRequired
+     *
      * @spec openspec/specs/schema-migration/spec.md
      */
     public function changelog(int $id): JSONResponse
@@ -111,6 +113,8 @@ class SchemaMigrationController extends Controller
      * @param int $id The schema id.
      *
      * @return JSONResponse The created run, or an error.
+     *
+     * @NoCSRFRequired
      *
      * @spec openspec/specs/schema-migration/spec.md
      */
@@ -156,6 +160,8 @@ class SchemaMigrationController extends Controller
      *
      * @return JSONResponse The runs.
      *
+     * @NoCSRFRequired
+     *
      * @spec openspec/specs/schema-migration/spec.md
      */
     public function runs(int $id): JSONResponse
@@ -177,6 +183,8 @@ class SchemaMigrationController extends Controller
      * @param int $run The run id.
      *
      * @return JSONResponse The run + entries.
+     *
+     * @NoCSRFRequired
      *
      * @spec openspec/specs/schema-migration/spec.md
      */
@@ -218,6 +226,8 @@ class SchemaMigrationController extends Controller
      *
      * @return JSONResponse Before/after pairs, or a plan-validation error.
      *
+     * @NoCSRFRequired
+     *
      * @spec openspec/specs/schema-migration/spec.md
      */
     public function previewMigration(int $id): JSONResponse
@@ -257,6 +267,8 @@ class SchemaMigrationController extends Controller
      * @param int $id The schema id.
      *
      * @return JSONResponse The created run, or an error.
+     *
+     * @NoCSRFRequired
      *
      * @spec openspec/specs/schema-migration/spec.md
      */
@@ -310,6 +322,8 @@ class SchemaMigrationController extends Controller
      * @param int $run The migration run id.
      *
      * @return JSONResponse The rolled-back run, or an error.
+     *
+     * @NoCSRFRequired
      *
      * @spec openspec/specs/schema-migration/spec.md
      */

--- a/lib/Db/Schema.php
+++ b/lib/Db/Schema.php
@@ -1920,7 +1920,13 @@ class Schema extends Entity implements JsonSerializable
         // `handoffContract` is the ADR-051 provider-side binding block
         // (contract field → own property, per kind URI); its shape is
         // validated at save time by HandoffContractBindingValidator.
-        $passThrough = ['unique', 'facetCacheTtl', 'calendarProvider', 'jsonld', 'implements', 'x-schema-org', 'handoffContract'];
+        // `importSource` is the schema-import provenance block (dialect,
+        // reference, snapshot version, baseline) written by
+        // SchemaImportService and read back by the reimport / update-from-
+        // source endpoint; without it in the allowlist the provenance is
+        // silently dropped on save and the entire update-from-source feature
+        // is dead (the schema reports "not imported from a standard").
+        $passThrough = ['unique', 'facetCacheTtl', 'calendarProvider', 'jsonld', 'implements', 'x-schema-org', 'handoffContract', 'importSource'];
 
         foreach ($configuration as $key => $value) {
             // Per-key isolation (#419): a bad VALUE for one config key must never

--- a/tests/Unit/Db/SchemaImportSourceConfigTest.php
+++ b/tests/Unit/Db/SchemaImportSourceConfigTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Schema importSource Provenance Config Round-Trip Test
+ *
+ * Regression guard for the schema-import provenance block. The `importSource`
+ * configuration fragment (dialect, reference, snapshot version, baseline) is
+ * written by SchemaImportService when a schema is imported from an external
+ * standard (Schema.org / GGM) and read back by the reimport / update-from-
+ * source endpoint. It MUST be in the setConfiguration() passThrough allowlist
+ * or it is silently discarded on save — which persists the schema without any
+ * provenance and makes the entire update-from-source feature dead (the schema
+ * reports "not imported from a standard"). See the schema-import + schema-
+ * migration Newman integration collections for the end-to-end coverage.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ *
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2
+ *
+ * @spec openspec/specs/schema-import/spec.md
+ */
+
+namespace Unit\Db;
+
+use OCA\OpenRegister\Db\Schema;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the importSource provenance persistence path.
+ */
+class SchemaImportSourceConfigTest extends TestCase
+{
+
+
+    /**
+     * An `importSource` block supplied under `configuration` survives the
+     * hydrate round-trip unchanged (passThrough allowlist).
+     *
+     * @return void
+     */
+    public function testImportSourceSurvivesHydrate(): void
+    {
+        $importSource = [
+            'dialect'         => 'schema.org',
+            'reference'       => 'https://schema.org/Person',
+            'snapshotVersion' => '2026-01',
+            'baseline'        => ['email' => ['type' => 'string']],
+        ];
+
+        $schema = new Schema();
+        $schema->hydrate(
+            object: [
+                'title'         => 'Person',
+                'properties'    => ['email' => ['type' => 'string']],
+                'configuration' => [
+                    'jsonld'       => ['@vocab' => 'https://schema.org/'],
+                    'importSource' => $importSource,
+                ],
+            ]
+        );
+
+        $config = $schema->getConfiguration();
+
+        $this->assertNotNull($config);
+        $this->assertArrayHasKey('importSource', $config);
+        $this->assertSame($importSource, $config['importSource']);
+        // The sibling jsonld block must also survive alongside it.
+        $this->assertArrayHasKey('jsonld', $config);
+    }//end testImportSourceSurvivesHydrate()
+
+
+    /**
+     * The provenance block round-trips through jsonSerialize() so the reimport
+     * endpoint can read `configuration.importSource` back off a persisted schema.
+     *
+     * @return void
+     */
+    public function testImportSourceSurvivesSerialization(): void
+    {
+        $schema = new Schema();
+        $schema->hydrate(
+            object: [
+                'configuration' => [
+                    'importSource' => ['dialect' => 'ggm', 'reference' => 'ZAAK'],
+                ],
+            ]
+        );
+
+        $serialized = $schema->jsonSerialize();
+
+        $this->assertIsArray($serialized['configuration']);
+        $this->assertArrayHasKey('importSource', $serialized['configuration']);
+        $this->assertSame('ggm', $serialized['configuration']['importSource']['dialect']);
+    }//end testImportSourceSurvivesSerialization()
+}//end class


### PR DESCRIPTION
## Summary
Remediates the red debt in three integration Newman collections. Reproduced and live-verified on a disposable NC **stable32** container (the env the CI "Integration Tests (Newman)" job uses). All three now pass with **0 failures**.

| Collection | Before | After |
|---|---|---|
| openregister-schema-import | 14+ failures | 26 assertions, 0 failed |
| openregister-schema-migration | 5 failures | 21 assertions, 0 failed |
| openregister-crud | (clean on fresh DB) | 194 assertions, 0 failed |

## Root causes & fixes (all REAL API/lib bugs — no assertions were weakened)

### 1. Every schema-import & schema-migration endpoint was unreachable (412 CSRF)
`SchemaImportController` (4 methods) and `SchemaMigrationController` (7 methods) omitted `@NoCSRFRequired`. Unlike every working controller in the app, these returned **412 "CSRF check failed"** for any API client, so the entire schema-import and schema-migration REST surfaces were dead over the API. Added `@NoCSRFRequired` to all public methods. Admin-gating is intentional and unchanged (no `@NoAdminRequired` added), so the endpoints stay admin-only.

### 2. Schema import returned 500 (NOT NULL uuid violation)
`SchemaImportController::persistNewSchema()` hand-rolled `new Schema() + hydrate() + insert()`, bypassing `SchemaMapper::cleanObject()`, so it inserted a **NULL `uuid`** → `SQLSTATE[23502]` → 500. Routed it through the canonical `SchemaMapper::createFromArray()` which sets uuid/slug/version + facet config.

### 3. Import provenance silently discarded — update-from-source feature was dead
`Schema::setConfiguration()`'s `passThrough` allowlist included `jsonld` but **not `importSource`**, so the provenance block written on import was silently dropped on save. Imported schemas persisted without provenance, and the reimport / update-from-source endpoint always answered *"not imported from a standard"* (422). Added `importSource` to the allowlist + a unit-test guard (`tests/Unit/Db/SchemaImportSourceConfigTest.php`) for the round-trip. The Newman collections cover it end-to-end.

## Notes
- **crud collection** already passes on a fresh database — its prior red was environment pollution on the shared instance, not a code bug. No change needed.
- No deferred/flagged bugs — all failures were real and fixed.

## Verification
Live NC32 (`nextcloud:32-apache`), app deployed from this branch, run exactly as CI does (`newman run <collection> --env-var base_url=... admin_user=admin admin_password=...`). All three collections: 0 failures. New PHPUnit guard: 2 tests / 7 assertions green. phpcs (`lib/`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)