### PR TITLE
feat(config): schema marker makes any schema's objects shareable — no per-app code

### DIFF
--- a/lib/Db/Schema.php
+++ b/lib/Db/Schema.php
@@ -2319,6 +2319,14 @@ class Schema extends Entity implements JsonSerializable
         // a dedicated branch above that validates its shape, and
         // validateConfigurationArray re-throws instead of dropping it.
         self::WRITEONLY_PATHS_ANNOTATION,
+        // Federated configuration sharing (ADR pending): a schema opts its
+        // objects into the shared GitHub sharing engine by carrying either
+        // `true` or an `{id, topic, name}` refinement here. Without this entry
+        // setConfiguration() would silently drop the marker and the schema
+        // would never surface as a shareable type — the same or#460/#462-class
+        // trap the vocabulary exists to catch. Read by
+        // SchemaShareableConfigScanner.
+        'x-openregister-shareable',
     ];
 
     /**

--- a/lib/Listener/ShareableConfigTypeRegistrationListener.php
+++ b/lib/Listener/ShareableConfigTypeRegistrationListener.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Listener;
 
 use OCA\OpenRegister\Service\Config\RegisterShareableConfigTypesEvent;
+use OCA\OpenRegister\Service\Config\SchemaShareableConfigScanner;
 use OCA\OpenRegister\Service\Config\Types\FlowShareableConfigType;
 use OCA\OpenRegister\Service\Config\Types\RegisterSchemaShareableConfigType;
 use OCP\EventDispatcher\Event;
@@ -45,16 +46,18 @@ class ShareableConfigTypeRegistrationListener implements IEventListener
      *
      * @param FlowShareableConfigType           $flows     The built-in "Flows" type.
      * @param RegisterSchemaShareableConfigType $registers The built-in "Registers & schemas" type.
+     * @param SchemaShareableConfigScanner      $scanner   Turns shareable-marked schemas into types.
      */
     public function __construct(
         private readonly FlowShareableConfigType $flows,
-        private readonly RegisterSchemaShareableConfigType $registers
+        private readonly RegisterSchemaShareableConfigType $registers,
+        private readonly SchemaShareableConfigScanner $scanner
     ) {
 
     }//end __construct()
 
     /**
-     * Register the built-in types.
+     * Register the built-in types plus every marked schema's type.
      *
      * @param Event $event The dispatched event.
      *
@@ -70,6 +73,11 @@ class ShareableConfigTypeRegistrationListener implements IEventListener
 
         $event->registerType(type: $this->flows);
         $event->registerType(type: $this->registers);
+
+        // Any schema that marked itself shareable becomes a type — no per-app code.
+        foreach ($this->scanner->scan() as $type) {
+            $event->registerType(type: $type);
+        }
 
     }//end handle()
 }//end class

--- a/lib/Service/Config/SchemaShareableConfigScanner.php
+++ b/lib/Service/Config/SchemaShareableConfigScanner.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * Turns schema markers into shareable configuration types.
+ *
+ * A schema marks itself shareable by setting `shareable` in its `configuration`
+ * (either `true`, or an object refining the `id`, `topic` and `name`). This
+ * scanner finds those schemas, works out which registers hold them, and produces
+ * one {@see GenericObjectShareableConfigType} per register+schema pair — so an
+ * app makes its configuration shareable with a data flag on its schema, never a
+ * line of per-app PHP.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Config
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Config;
+
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Config\Types\GenericObjectShareableConfigType;
+use OCA\OpenRegister\Service\ObjectService;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Discovers shareable-marked schemas and builds a type for each.
+ */
+class SchemaShareableConfigScanner
+{
+    /**
+     * Constructor.
+     *
+     * @param SchemaMapper    $schemaMapper   Enumerates schemas and their markers.
+     * @param RegisterMapper  $registerMapper Finds the registers a schema belongs to.
+     * @param ObjectService   $objectService  Handed to each generated type.
+     * @param LoggerInterface $logger         The logger.
+     */
+    public function __construct(
+        private readonly SchemaMapper $schemaMapper,
+        private readonly RegisterMapper $registerMapper,
+        private readonly ObjectService $objectService,
+        private readonly LoggerInterface $logger
+    ) {
+
+    }//end __construct()
+
+    /**
+     * The shareable types every marked schema declares.
+     *
+     * @return array<int, GenericObjectShareableConfigType> The generated types.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function scan(): array
+    {
+        try {
+            $schemas   = $this->schemaMapper->findAll();
+            $registers = $this->registerMapper->findAll();
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                message: '[SchemaShareableConfigScanner] Could not scan for shareable schemas: '.$e->getMessage(),
+                context: ['file' => __FILE__, 'line' => __LINE__]
+            );
+            return [];
+        }
+
+        $types = [];
+        foreach ($schemas as $schema) {
+            $marker = $this->markerOf(configuration: (array) ($schema->getConfiguration() ?? []));
+            if ($marker === null) {
+                continue;
+            }
+
+            $schemaSlug  = (string) $schema->getSlug();
+            $schemaTitle = (string) $schema->getTitle();
+
+            // A schema may sit in several registers; each register+schema pair is
+            // its own shareable set.
+            foreach ($registers as $register) {
+                if ($this->registerHasSchema(register: $register, schemaId: (int) $schema->getId()) === false) {
+                    continue;
+                }
+
+                $registerSlug  = (string) $register->getSlug();
+                $registerTitle = (string) $register->getTitle();
+
+                $id    = (string) ($marker['id'] ?? ($registerSlug.'.'.$schemaSlug));
+                $topic = (string) ($marker['topic'] ?? ($registerSlug.'-'.$schemaSlug));
+                $name  = (string) ($marker['name'] ?? sprintf('%s (%s)', $schemaTitle, $registerTitle));
+
+                $types[] = new GenericObjectShareableConfigType(
+                    objectService: $this->objectService,
+                    id: $id,
+                    name: $name,
+                    topic: $topic,
+                    register: $registerSlug,
+                    schema: $schemaSlug
+                );
+            }//end foreach
+        }//end foreach
+
+        return $types;
+
+    }//end scan()
+
+    /**
+     * The shareable annotation key on a schema's configuration.
+     *
+     * Follows the `x-openregister-*` vendor-extension convention (sibling of
+     * `x-openregister-lifecycle`, `-mcp`, …). The key must also be declared in
+     * {@see Schema::ANNOTATION_VOCABULARY}, otherwise setConfiguration() drops
+     * it before it ever reaches this scanner.
+     *
+     * @var string
+     */
+    private const MARKER_KEY = 'x-openregister-shareable';
+
+    /**
+     * The shareable marker on a schema's configuration, normalised, or null.
+     *
+     * Accepts `x-openregister-shareable: true` (all defaults derived) or an
+     * object refining `id` / `topic` / `name`. Anything falsy is "not
+     * shareable".
+     *
+     * @param array $configuration The schema configuration.
+     *
+     * @return array<string, mixed>|null The marker, or null when not shareable.
+     */
+    private function markerOf(array $configuration): ?array
+    {
+        $marker = ($configuration[self::MARKER_KEY] ?? null);
+        if ($marker === null || $marker === false) {
+            return null;
+        }
+
+        if (is_array($marker) === true) {
+            return $marker;
+        }
+
+        // A truthy scalar (e.g. `true`) means "shareable with derived defaults".
+        return [];
+
+    }//end markerOf()
+
+    /**
+     * Whether a register includes a schema.
+     *
+     * @param object $register The register.
+     * @param int    $schemaId The schema id.
+     *
+     * @return boolean Whether the register holds the schema.
+     */
+    private function registerHasSchema(object $register, int $schemaId): bool
+    {
+        foreach ((array) ($register->getSchemas() ?? []) as $entry) {
+            if ((int) $entry === $schemaId) {
+                return true;
+            }
+        }
+
+        return false;
+
+    }//end registerHasSchema()
+}//end class

--- a/lib/Service/Config/Types/GenericObjectShareableConfigType.php
+++ b/lib/Service/Config/Types/GenericObjectShareableConfigType.php
@@ -1,0 +1,205 @@
+<?php
+
+/**
+ * Any schema's objects as a shareable configuration type — no per-app code.
+ *
+ * Most apps store their shareable configuration as OpenRegister objects: procest
+ * case types, shillinq payroll packs, opencatalogi publication types. Rather than
+ * each app shipping a near-identical {@see FlowShareableConfigType}, a schema
+ * simply marks itself shareable (its `configuration.shareable`), and OpenRegister
+ * registers one of these for it. So making an app's configuration shareable is
+ * data, not code — and carries none of the cross-app namespace/autoload risk a
+ * per-app class does.
+ *
+ * This is the same serialise/deserialise as the flow type, generalised: select
+ * the objects of one register+schema, strip the instance-specific fields, and
+ * write them back on install.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Config\Types
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Config\Types;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Config\IShareableConfigType;
+use OCA\OpenRegister\Service\ObjectService;
+use Throwable;
+
+/**
+ * A shareable type bound to one register + schema, built from a schema marker.
+ */
+class GenericObjectShareableConfigType implements IShareableConfigType
+{
+
+    /**
+     * Instance-specific fields never carried in a portable bundle.
+     *
+     * @var array<int, string>
+     */
+    private const INSTANCE_FIELDS = ['id', 'uuid', '@self', 'owner', 'organisation', 'created', 'updated'];
+
+    /**
+     * Constructor.
+     *
+     * @param ObjectService $objectService Reads and writes the objects.
+     * @param string        $id            The type id (e.g. `procest.casetype`).
+     * @param string        $name          The display name.
+     * @param string        $topic         The discovery topic.
+     * @param string        $register      The register slug the objects live in.
+     * @param string        $schema        The schema slug the objects are of.
+     */
+    public function __construct(
+        private readonly ObjectService $objectService,
+        private readonly string $id,
+        private readonly string $name,
+        private readonly string $topic,
+        private readonly string $register,
+        private readonly string $schema
+    ) {
+
+    }//end __construct()
+
+    /**
+     * The type id.
+     *
+     * @return string The id.
+     */
+    public function getId(): string
+    {
+        return $this->id;
+
+    }//end getId()
+
+    /**
+     * The display name.
+     *
+     * @return string The name.
+     */
+    public function getDisplayName(): string
+    {
+        return $this->name;
+
+    }//end getDisplayName()
+
+    /**
+     * The discovery topic.
+     *
+     * @return string The topic.
+     */
+    public function getTopic(): string
+    {
+        return $this->topic;
+
+    }//end getTopic()
+
+    /**
+     * Package this schema's objects into a portable bundle.
+     *
+     * `$selection` may carry `{ids: [...]}` to share specific objects; absent
+     * that, the whole set of the register/schema is shared. Each object is
+     * reduced to its portable fields.
+     *
+     * @param array $selection `{ids?: [...]}`.
+     *
+     * @return array `{type, version, register, schema, objects: [...]}`.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function serialise(array $selection): array
+    {
+        $wanted = array_map('strval', (array) ($selection['ids'] ?? []));
+
+        $objects = [];
+        try {
+            $found = $this->objectService->findAll(
+                config: ['filters' => ['register' => $this->register, 'schema' => $this->schema]],
+                _rbac: false,
+                _multitenancy: false
+            );
+        } catch (Throwable $e) {
+            $found = [];
+        }
+
+        foreach ($found as $object) {
+            if (($object instanceof ObjectEntity) === false) {
+                continue;
+            }
+
+            if ($wanted !== [] && in_array((string) $object->getUuid(), $wanted, true) === false) {
+                continue;
+            }
+
+            $objects[] = $this->portable(data: $object->getObject());
+        }
+
+        return [
+            'type'     => $this->id,
+            'version'  => '1.0',
+            'register' => $this->register,
+            'schema'   => $this->schema,
+            'objects'  => $objects,
+        ];
+
+    }//end serialise()
+
+    /**
+     * Install a bundle's objects into this instance.
+     *
+     * @param array $bundle A bundle produced by this type.
+     *
+     * @return array `{installed: [uuid, ...]}`.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function deserialise(array $bundle): array
+    {
+        $installed = [];
+        foreach ((array) ($bundle['objects'] ?? []) as $object) {
+            if (is_array($object) === false) {
+                continue;
+            }
+
+            $saved = $this->objectService->saveObject(
+                object: $this->portable(data: $object),
+                register: $this->register,
+                schema: $this->schema
+            );
+
+            $installed[] = (string) $saved->getUuid();
+        }
+
+        return ['installed' => $installed];
+
+    }//end deserialise()
+
+    /**
+     * Strip the instance-specific fields from an object's data.
+     *
+     * @param array $data The object data.
+     *
+     * @return array The portable subset.
+     */
+    private function portable(array $data): array
+    {
+        foreach (self::INSTANCE_FIELDS as $field) {
+            unset($data[$field]);
+        }
+
+        return $data;
+
+    }//end portable()
+}//end class

--- a/tests/Unit/Db/SchemaAnnotationVocabularyTest.php
+++ b/tests/Unit/Db/SchemaAnnotationVocabularyTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * Schema Annotation Vocabulary Unit Tests
  *
  * Verifies that x-openregister-archival and x-openregister-seed survive
@@ -11,8 +11,8 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Db
  *
- * @author   Conduction Development Team <dev@conduction.nl>
- * @license  EUPL-1.2
+ * @author  Conduction Development Team <dev@conduction.nl>
+ * @license EUPL-1.2
  *
  * @spec openspec/changes/add-archival-annotation-support/tasks.md#task-1.2
  */
@@ -36,7 +36,7 @@ class SchemaAnnotationVocabularyTest extends TestCase
     {
         parent::setUp();
         $this->schema = new Schema();
-    }
+    }//end setUp()
 
     /**
      * ANNOTATION_VOCABULARY constant exists and contains the two new keys.
@@ -63,7 +63,7 @@ class SchemaAnnotationVocabularyTest extends TestCase
         // ProcessingLogService but absent from the vocabulary, so it was
         // silently dropped and per-schema AVG logReads could never be enabled.
         $this->assertContains('x-openregister-processing', $vocabulary);
-    }
+    }//end testAnnotationVocabularyContainsArchivalButNotSeed()
 
     /**
      * x-openregister-archival survives setConfiguration() → getConfiguration() round-trip.
@@ -74,16 +74,18 @@ class SchemaAnnotationVocabularyTest extends TestCase
             'retention' => ['default' => 'P30D'],
         ];
 
-        $this->schema->setConfiguration([
-            'x-openregister-archival' => $archival,
-        ]);
+        $this->schema->setConfiguration(
+                [
+                    'x-openregister-archival' => $archival,
+                ]
+                );
 
         $config = $this->schema->getConfiguration();
 
         $this->assertNotNull($config);
         $this->assertArrayHasKey('x-openregister-archival', $config);
         $this->assertSame($archival, $config['x-openregister-archival']);
-    }
+    }//end testArchivalAnnotationSurvivesRoundTrip()
 
     /**
      * x-openregister-seed is now DROPPED LOUDLY — it has no engine.
@@ -97,9 +99,11 @@ class SchemaAnnotationVocabularyTest extends TestCase
     {
         $seed = ['objects' => [['title' => 'Example']]];
 
-        $this->schema->setConfiguration([
-            'x-openregister-seed' => $seed,
-        ]);
+        $this->schema->setConfiguration(
+                [
+                    'x-openregister-seed' => $seed,
+                ]
+                );
 
         // The key is the only entry, so the configuration ends up empty/null.
         $config = ($this->schema->getConfiguration() ?? []);
@@ -110,7 +114,7 @@ class SchemaAnnotationVocabularyTest extends TestCase
             $this->schema->consumeDroppedAnnotationKeys(),
             'Declaring the engine-less seed key must be reported, not silently accepted'
         );
-    }
+    }//end testSeedAnnotationIsDroppedLoudlyBecauseItHasNoEngine()
 
     /**
      * x-openregister-processing reaches its engine's expected shape.
@@ -125,9 +129,11 @@ class SchemaAnnotationVocabularyTest extends TestCase
     {
         $processing = ['code' => 'demo-activity', 'logReads' => true];
 
-        $this->schema->setConfiguration([
-            ProcessingLogService::ANNOTATION_KEY => $processing,
-        ]);
+        $this->schema->setConfiguration(
+                [
+                    ProcessingLogService::ANNOTATION_KEY => $processing,
+                ]
+                );
 
         $config = $this->schema->getConfiguration();
 
@@ -142,7 +148,7 @@ class SchemaAnnotationVocabularyTest extends TestCase
             ProcessingLogService::ANNOTATION_KEY,
             $this->schema->consumeDroppedAnnotationKeys()
         );
-    }
+    }//end testProcessingAnnotationSurvivesRoundTripAndReachesItsEngine()
 
     /**
      * FAILING PATH (approval-chains-declarative): `x-openregister-approval-chains`
@@ -163,26 +169,56 @@ class SchemaAnnotationVocabularyTest extends TestCase
             ],
         ];
 
-        $this->schema->setConfiguration([
-            'x-openregister-approval-chains' => $chains,
-        ]);
+        $this->schema->setConfiguration(
+                [
+                    'x-openregister-approval-chains' => $chains,
+                ]
+                );
 
         $config = $this->schema->getConfiguration();
 
         $this->assertNotNull($config);
         $this->assertArrayHasKey('x-openregister-approval-chains', $config);
         $this->assertSame($chains, $config['x-openregister-approval-chains']);
-    }
+    }//end testApprovalChainsAnnotationSurvivesRoundTrip()
+
+    /**
+     * FAILING PATH (federated-config-sharing): `x-openregister-shareable`
+     * MUST survive the round-trip. It is the marker
+     * SchemaShareableConfigScanner reads to surface a schema's objects as a
+     * shareable configuration type; absent from the vocabulary the marker
+     * would be silently dropped and the schema could never become shareable.
+     *
+     * Both the boolean form (defaults derived) and the object form (id/topic/
+     * name refined) must reach the configuration column intact.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function testShareableAnnotationSurvivesRoundTrip(): void
+    {
+        $this->schema->setConfiguration(['x-openregister-shareable' => true]);
+        $config = $this->schema->getConfiguration();
+        $this->assertNotNull($config);
+        $this->assertTrue($config['x-openregister-shareable']);
+
+        $refined = ['id' => 'procest.casetype', 'topic' => 'procest-casetype', 'name' => 'Case type'];
+        $this->schema->setConfiguration(['x-openregister-shareable' => $refined]);
+        $config = $this->schema->getConfiguration();
+        $this->assertNotNull($config);
+        $this->assertSame($refined, $config['x-openregister-shareable']);
+    }//end testShareableAnnotationSurvivesRoundTrip()
 
     /**
      * Actual typos (non-vocabulary x-openregister-* keys) are still dropped.
      */
     public function testActualTypoIsDropped(): void
     {
-        $this->schema->setConfiguration([
-            'x-openregister-lifecycl' => ['states' => ['open']],
-            'x-openregister-archival' => ['retention' => ['default' => 'P7D']],
-        ]);
+        $this->schema->setConfiguration(
+                [
+                    'x-openregister-lifecycl' => ['states' => ['open']],
+                    'x-openregister-archival' => ['retention' => ['default' => 'P7D']],
+                ]
+                );
 
         $config = $this->schema->getConfiguration();
 
@@ -191,5 +227,5 @@ class SchemaAnnotationVocabularyTest extends TestCase
 
         // Valid vocabulary key should survive.
         $this->assertArrayHasKey('x-openregister-archival', $config);
-    }
+    }//end testActualTypoIsDropped()
 }//end class

--- a/tests/Unit/Service/Config/GenericObjectShareableConfigTypeTest.php
+++ b/tests/Unit/Service/Config/GenericObjectShareableConfigTypeTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Config;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Config\Types\GenericObjectShareableConfigType;
+use OCA\OpenRegister\Service\ObjectService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class GenericObjectShareableConfigTypeTest extends TestCase
+{
+
+    private ObjectService&MockObject $objects;
+
+    private GenericObjectShareableConfigType $type;
+
+    protected function setUp(): void
+    {
+        $this->objects = $this->createMock(ObjectService::class);
+        $this->type    = new GenericObjectShareableConfigType(
+            $this->objects,
+            'procest.casetype',
+            'Case type (Procest)',
+            'procest-casetype',
+            'procest',
+            'casetype'
+        );
+    }//end setUp()
+
+    private function obj(string $uuid, array $data): ObjectEntity
+    {
+        $o = new ObjectEntity();
+        $o->setUuid($uuid);
+        $o->setObject($data);
+        return $o;
+    }//end obj()
+
+    public function testIdentity(): void
+    {
+        $this->assertSame('procest.casetype', $this->type->getId());
+        $this->assertSame('procest-casetype', $this->type->getTopic());
+        $this->assertSame('Case type (Procest)', $this->type->getDisplayName());
+    }//end testIdentity()
+
+    public function testSerialiseStripsInstanceFields(): void
+    {
+        $this->objects->method('findAll')->willReturn(
+                [
+                    $this->obj('a', ['uuid' => 'a', 'owner' => 'admin', 'organisation' => 'org', 'name' => 'Bezwaar', 'steps' => [1, 2]]),
+                ]
+                );
+
+        $bundle = $this->type->serialise([]);
+        $this->assertSame('procest.casetype', $bundle['type']);
+        $this->assertSame('procest', $bundle['register']);
+        $this->assertCount(1, $bundle['objects']);
+        $o = $bundle['objects'][0];
+        $this->assertSame('Bezwaar', $o['name']);
+        $this->assertSame([1, 2], $o['steps']);
+        $this->assertArrayNotHasKey('uuid', $o);
+        $this->assertArrayNotHasKey('owner', $o);
+        $this->assertArrayNotHasKey('organisation', $o);
+    }//end testSerialiseStripsInstanceFields()
+
+    public function testSerialiseCanFilterBySelectedIds(): void
+    {
+        $this->objects->method('findAll')->willReturn(
+                [
+                    $this->obj('a', ['name' => 'A']),
+                    $this->obj('b', ['name' => 'B']),
+                ]
+                );
+
+        $bundle = $this->type->serialise(['ids' => ['b']]);
+        $this->assertCount(1, $bundle['objects']);
+        $this->assertSame('B', $bundle['objects'][0]['name']);
+    }//end testSerialiseCanFilterBySelectedIds()
+
+    public function testDeserialiseWritesEachObject(): void
+    {
+        $saved = new ObjectEntity();
+        $saved->setUuid('new');
+        $this->objects->expects($this->once())->method('saveObject')
+            ->with($this->isType('array'), [], 'procest', 'casetype')
+            ->willReturn($saved);
+
+        $result = $this->type->deserialise(['objects' => [['name' => 'Imported']]]);
+        $this->assertSame(['new'], $result['installed']);
+    }//end testDeserialiseWritesEachObject()
+}//end class

--- a/tests/Unit/Service/Config/SchemaShareableConfigScannerTest.php
+++ b/tests/Unit/Service/Config/SchemaShareableConfigScannerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Config;
+
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Config\SchemaShareableConfigScanner;
+use OCA\OpenRegister\Service\ObjectService;
+use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\TestCase;
+
+class SchemaShareableConfigScannerTest extends TestCase
+{
+
+    private SchemaMapper $schemaMapper;
+
+    private RegisterMapper $registerMapper;
+
+    private SchemaShareableConfigScanner $scanner;
+
+    protected function setUp(): void
+    {
+        $this->schemaMapper   = $this->createMock(SchemaMapper::class);
+        $this->registerMapper = $this->createMock(RegisterMapper::class);
+        $this->scanner        = new SchemaShareableConfigScanner(
+            $this->schemaMapper,
+            $this->registerMapper,
+            $this->createMock(ObjectService::class),
+            $this->createMock(LoggerInterface::class)
+        );
+    }//end setUp()
+
+    private function schema(int $id, string $slug, string $title, ?array $config): Schema
+    {
+        $s = new Schema();
+        $s->setId($id);
+        $s->setSlug($slug);
+        $s->setTitle($title);
+        $s->setConfiguration($config);
+        return $s;
+    }//end schema()
+
+    private function register(string $slug, string $title, array $schemaIds): Register
+    {
+        $r = new Register();
+        $r->setSlug($slug);
+        $r->setTitle($title);
+        $r->setSchemas($schemaIds);
+        return $r;
+    }//end register()
+
+    public function testUnmarkedSchemasProduceNoTypes(): void
+    {
+        $this->schemaMapper->method('findAll')->willReturn(
+                [
+                    $this->schema(1, 'thing', 'Thing', null),
+                    $this->schema(2, 'other', 'Other', ['x-openregister-shareable' => false]),
+                ]
+                );
+        $this->registerMapper->method('findAll')->willReturn(
+                [
+                    $this->register('reg', 'Reg', [1, 2]),
+                ]
+                );
+
+        $this->assertSame([], $this->scanner->scan());
+    }//end testUnmarkedSchemasProduceNoTypes()
+
+    public function testBooleanMarkerDerivesDefaults(): void
+    {
+        $this->schemaMapper->method('findAll')->willReturn(
+                [
+                    $this->schema(1, 'casetype', 'Case type', ['x-openregister-shareable' => true]),
+                ]
+                );
+        $this->registerMapper->method('findAll')->willReturn(
+                [
+                    $this->register('procest', 'Procest', [1]),
+                ]
+                );
+
+        $types = $this->scanner->scan();
+        $this->assertCount(1, $types);
+        $this->assertSame('procest.casetype', $types[0]->getId());
+        $this->assertSame('procest-casetype', $types[0]->getTopic());
+        $this->assertSame('Case type (Procest)', $types[0]->getDisplayName());
+    }//end testBooleanMarkerDerivesDefaults()
+
+    public function testObjectMarkerRefinesIdentity(): void
+    {
+        $this->schemaMapper->method('findAll')->willReturn(
+                [
+                    $this->schema(3, 'pack', 'Pack', ['x-openregister-shareable' => ['id' => 'shillinq.pack', 'topic' => 'shillinq-payroll', 'name' => 'Payroll pack']]),
+                ]
+                );
+        $this->registerMapper->method('findAll')->willReturn(
+                [
+                    $this->register('shillinq', 'Shillinq', [3]),
+                ]
+                );
+
+        $types = $this->scanner->scan();
+        $this->assertCount(1, $types);
+        $this->assertSame('shillinq.pack', $types[0]->getId());
+        $this->assertSame('shillinq-payroll', $types[0]->getTopic());
+        $this->assertSame('Payroll pack', $types[0]->getDisplayName());
+    }//end testObjectMarkerRefinesIdentity()
+
+    public function testOnlyRegistersHoldingTheSchemaProduceTypes(): void
+    {
+        $this->schemaMapper->method('findAll')->willReturn(
+                [
+                    $this->schema(1, 'casetype', 'Case type', ['x-openregister-shareable' => true]),
+                ]
+                );
+        $this->registerMapper->method('findAll')->willReturn(
+                [
+                    $this->register('procest', 'Procest', [1]),
+                    $this->register('unrelated', 'Unrelated', [9]),
+                ]
+                );
+
+        $types = $this->scanner->scan();
+        $this->assertCount(1, $types);
+        $this->assertSame('procest.casetype', $types[0]->getId());
+    }//end testOnlyRegistersHoldingTheSchemaProduceTypes()
+}//end class

--- a/tests/e2e/api-direct/federated-config-marker.spec.ts
+++ b/tests/e2e/api-direct/federated-config-marker.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * Federated configuration sharing — the schema-marker generic path, e2e via HTTP.
+ *
+ * Proves that an app makes its objects shareable with DATA, not code: a schema
+ * carrying `configuration['x-openregister-shareable']` is auto-surfaced by
+ * OpenRegister as a shareable type (no per-app IShareableConfigType class), and
+ * that type bundles its objects into a portable, instance-independent shape and
+ * installs them back as fresh objects.
+ *
+ * This is the leverage that collapses the per-app rollout — procest case types,
+ * shillinq payroll packs, opencatalogi publication types — into a one-line
+ * marker each.
+ *
+ * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+ */
+import { test, expect, type APIRequestContext } from '@playwright/test'
+
+const API = '/index.php/apps/openregister/api'
+const JSON_HEADERS = { 'Content-Type': 'application/json', Accept: 'application/json' }
+const runId = `e2e-fedmarker-${Date.now()}`
+
+test.describe('Federated config — schema marker (generic type)', () => {
+	let regId: number
+	let schId: number
+	let regSlug: string
+	let schSlug: string
+	let typeId: string
+	const objects: string[] = []
+
+	test.beforeAll(async ({ request }) => {
+		// A schema that opts in with the marker only — no PHP anywhere.
+		const schResp = await request.post(`${API}/schemas`, {
+			headers: JSON_HEADERS,
+			data: {
+				title: `Marker Casetype ${runId}`,
+				properties: { name: { type: 'string' }, steps: { type: 'array' } },
+				configuration: { 'x-openregister-shareable': true },
+			},
+		})
+		expect(schResp.status()).toBeLessThan(300)
+		const sch = await schResp.json()
+		schId = sch.id ?? sch['@self']?.id
+		schSlug = sch.slug ?? sch['@self']?.slug
+
+		const regResp = await request.post(`${API}/registers`, {
+			headers: JSON_HEADERS,
+			data: { title: `Marker Register ${runId}`, schemas: [schId] },
+		})
+		expect(regResp.status()).toBeLessThan(300)
+		const reg = await regResp.json()
+		regId = reg.id ?? reg['@self']?.id
+		regSlug = reg.slug ?? reg['@self']?.slug
+
+		typeId = `${regSlug}.${schSlug}`
+	})
+
+	test.afterAll(async ({ request }) => {
+		for (const u of objects) {
+			await request.delete(`${API}/objects/${regId}/${schId}/${u}`).catch(() => {})
+		}
+		await request.delete(`${API}/registers/${regId}`).catch(() => {})
+		await request.delete(`${API}/schemas/${schId}`).catch(() => {})
+	})
+
+	async function makeObject(request: APIRequestContext, name: string): Promise<string> {
+		const resp = await request.post(`${API}/objects/${regId}/${schId}`, {
+			headers: JSON_HEADERS,
+			data: { name, steps: ['intake', 'besluit'] },
+		})
+		const uuid = (await resp.json())?.['@self']?.id
+		objects.push(uuid)
+		return uuid
+	}
+
+	test('the marked schema is auto-surfaced as a shareable type', async ({ request }) => {
+		const resp = await request.get(`${API}/federated-config/types`)
+		expect(resp.status()).toBe(200)
+		const types = (await resp.json()).types ?? []
+		const mine = types.find((t: any) => t.id === typeId)
+		expect(mine, `a marked schema becomes type ${typeId} with no per-app code`).toBeTruthy()
+		expect(mine.topic).toBe(`${regSlug}-${schSlug}`)
+	})
+
+	test('its objects bundle portably and install as fresh objects', async ({ request }) => {
+		await makeObject(request, `${runId} bezwaar`)
+
+		// Bundle — instance fields stripped, only portable data.
+		const bundleResp = await request.post(`${API}/federated-config/bundle`, {
+			headers: JSON_HEADERS,
+			data: { type: typeId, selection: {} },
+		})
+		expect(bundleResp.status()).toBe(200)
+		const bundle = await bundleResp.json()
+		expect(bundle.type).toBe(typeId)
+		expect(bundle.register).toBe(regSlug)
+		expect(bundle.objects.length).toBe(1)
+		expect(bundle.objects[0].name).toBe(`${runId} bezwaar`)
+		expect(bundle.objects[0].steps).toEqual(['intake', 'besluit'])
+		expect(bundle.objects[0].uuid, 'no instance uuid in the bundle').toBeUndefined()
+		expect(bundle.objects[0].owner, 'no owner in the bundle').toBeUndefined()
+
+		// Install — a fresh object with a new uuid, same portable data.
+		const installResp = await request.post(`${API}/federated-config/install`, {
+			headers: JSON_HEADERS,
+			data: { type: typeId, bundle, source: 'ConductionNL/casetype-pack' },
+		})
+		expect(installResp.status()).toBe(200)
+		const installed = (await installResp.json()).installed ?? []
+		expect(installed.length).toBe(1)
+		objects.push(installed[0])
+
+		// The register now holds both the source and the freshly installed copy.
+		const listResp = await request.get(`${API}/objects/${regId}/${schId}?_limit=100`)
+		const rows = (await listResp.json()).results ?? []
+		const names = rows.map((o: any) => o.name)
+		expect(rows.length).toBe(2)
+		expect(names.every((n: string) => n === `${runId} bezwaar`)).toBe(true)
+	})
+
+	test('an unknown marker-derived type is a 404', async ({ request }) => {
+		const resp = await request.post(`${API}/federated-config/bundle`, {
+			headers: JSON_HEADERS,
+			data: { type: 'never-registered.nope', selection: {} },
+		})
+		expect(resp.status()).toBe(404)
+	})
+})


### PR DESCRIPTION
## What

A schema opts its objects into the federated GitHub sharing engine with a single **data flag** — `configuration['x-openregister-shareable']` (`true`, or an `{id, topic, name}` refinement) — instead of each app shipping a near-identical `IShareableConfigType`. OpenRegister auto-surfaces the schema as a shareable type.

This is the leverage move for the fleet rollout: procest case types, shillinq payroll packs, opencatalogi publication types, docudesk, softwarecatalog, pipelinq, larpingapp all become **one-line markers** rather than seven copy-paste per-app classes — and it removes the cross-app namespace/autoload risk a per-app class carries (see nldesign #192's `NLDesign`-case trap that cost hours).

## How

- **`GenericObjectShareableConfigType`** — a shareable type bound to one register+schema, built from a marker. `serialise()` selects the set, strips instance fields (`id/uuid/@self/owner/organisation/created/updated`), returns a portable bundle; `deserialise()` writes each back as a fresh object. Same shape as `FlowShareableConfigType`, generalised.
- **`SchemaShareableConfigScanner`** — finds marked schemas, resolves which registers hold each, emits one generic type per register+schema pair.
- **`ShareableConfigTypeRegistrationListener`** — registers every scanned type alongside the built-in Flows + Registers types.
- **`Schema::ANNOTATION_VOCABULARY`** — adds `x-openregister-shareable`. Without this entry `setConfiguration()` **silently drops** the marker (the or#460/#462-class trap the vocabulary exists to catch) — a dedicated round-trip test covers it.

## Tests

- **15 unit** — generic type serialise/deserialise/identity; scanner marker normalisation (boolean vs object form), register-membership filtering, unmarked-skip; vocabulary round-trip.
- **3 Playwright e2e** (`api-direct/federated-config-marker.spec.ts`) — marked schema auto-surfaces as a type → bundle strips instance fields → install creates a fresh object; unknown type 404.
- **Live-verified on 8080**: created a marked schema → generic type appeared in `/api/federated-config/types` → bundle→install round-trip produced a fresh copy with distinct uuid and identical portable data, **zero per-app PHP**. Test data torn down.

Builds on #2134 (engine + Flows) and #2135 (Registers & schemas).

@spec `openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md`