### PR TITLE
test(newman): fix i18n (x2) + jsonld integration collections

### DIFF
--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -39,6 +39,7 @@ use OCA\OpenRegister\Exception\CustomValidationException;
 use OCA\OpenRegister\Exception\ExportTooLargeException;
 use OCA\OpenRegister\Exception\FolderAccessDeniedException;
 use OCA\OpenRegister\Exception\ValidationException;
+use OCA\OpenRegister\Exception\TranslationTargetConflictException;
 use OCA\OpenRegister\Exception\RegisterNotFoundException;
 use OCA\OpenRegister\Exception\SchemaNotFoundException;
 use OCA\OpenRegister\Exception\AppendOnlyException;
@@ -2703,6 +2704,13 @@ class ObjectsController extends Controller
             // TODO: Unlock the object after saving using LockingHandler through ObjectService.
             // The unlockObject() method on the old ObjectEntityMapper is deprecated.
             // For now, skipping unlock to allow CRUD operations to complete.
+        } catch (TranslationTargetConflictException $exception) {
+            // Structured 400 per the exception's own documented contract
+            // (i18n-api-language-negotiation): a language-keyed body for a
+            // translatable property collided with X-Translation-Target-Language.
+            // Emitted here so the { "error": { "code": ... } } shape survives
+            // instead of being flattened by the generic validation handler.
+            return new JSONResponse(data: $exception->toErrorBody(), statusCode: 400);
         } catch (ValidationException | CustomValidationException $exception) {
             // Handle validation errors.
                        return new JSONResponse(data: $exception->getMessage(), statusCode: 400);
@@ -2902,6 +2910,13 @@ class ObjectsController extends Controller
         } catch (AppendOnlyException $exception) {
             // Reject update on append-only schema with HTTP 405.
             return new JSONResponse(data: $exception->toResponseBody(), statusCode: Http::STATUS_METHOD_NOT_ALLOWED);
+        } catch (TranslationTargetConflictException $exception) {
+            // Structured 400 per the exception's own documented contract
+            // (i18n-api-language-negotiation): a language-keyed body for a
+            // translatable property collided with X-Translation-Target-Language.
+            // Emitted here so the { "error": { "code": ... } } shape survives
+            // instead of being flattened by the generic validation handler.
+            return new JSONResponse(data: $exception->toErrorBody(), statusCode: 400);
         } catch (ValidationException | CustomValidationException $exception) {
             // Handle validation errors.
             return $objectService->handleValidationException(exception: $exception);
@@ -3109,6 +3124,13 @@ class ObjectsController extends Controller
         } catch (AppendOnlyException $exception) {
             // Reject patch on append-only schema with HTTP 405.
             return new JSONResponse(data: $exception->toResponseBody(), statusCode: Http::STATUS_METHOD_NOT_ALLOWED);
+        } catch (TranslationTargetConflictException $exception) {
+            // Structured 400 per the exception's own documented contract
+            // (i18n-api-language-negotiation): a language-keyed body for a
+            // translatable property collided with X-Translation-Target-Language.
+            // Emitted here so the { "error": { "code": ... } } shape survives
+            // instead of being flattened by the generic validation handler.
+            return new JSONResponse(data: $exception->toErrorBody(), statusCode: 400);
         } catch (ValidationException | CustomValidationException $exception) {
             // Handle validation errors.
             $this->logger->warning(
@@ -3250,6 +3272,13 @@ class ObjectsController extends Controller
         } catch (AppendOnlyException $exception) {
             // Reject post-patch on append-only schema with HTTP 405.
             return new JSONResponse(data: $exception->toResponseBody(), statusCode: Http::STATUS_METHOD_NOT_ALLOWED);
+        } catch (TranslationTargetConflictException $exception) {
+            // Structured 400 per the exception's own documented contract
+            // (i18n-api-language-negotiation): a language-keyed body for a
+            // translatable property collided with X-Translation-Target-Language.
+            // Emitted here so the { "error": { "code": ... } } shape survives
+            // instead of being flattened by the generic validation handler.
+            return new JSONResponse(data: $exception->toErrorBody(), statusCode: 400);
         } catch (ValidationException | CustomValidationException $exception) {
             return $objectService->handleValidationException(exception: $exception);
         } catch (\OCA\OpenRegister\Exception\HookStoppedException $exception) {

--- a/lib/Controller/SchemasController.php
+++ b/lib/Controller/SchemasController.php
@@ -546,6 +546,7 @@ class SchemasController extends Controller
             if (str_contains($e->getMessage(), 'Invalid') === true
                 || str_contains($e->getMessage(), 'must be') === true
                 || str_contains($e->getMessage(), 'required') === true
+                || str_contains($e->getMessage(), 'requires translatable') === true
                 || str_contains($e->getMessage(), 'format') === true
                 || str_contains($e->getMessage(), 'Property at') === true
                 || str_contains($e->getMessage(), 'authorization') === true
@@ -759,6 +760,7 @@ class SchemasController extends Controller
             if (str_contains($e->getMessage(), 'Invalid') === true
                 || str_contains($e->getMessage(), 'must be') === true
                 || str_contains($e->getMessage(), 'required') === true
+                || str_contains($e->getMessage(), 'requires translatable') === true
                 || str_contains($e->getMessage(), 'format') === true
                 || str_contains($e->getMessage(), 'Property at') === true
                 || str_contains($e->getMessage(), 'authorization') === true
@@ -1227,6 +1229,7 @@ class SchemasController extends Controller
             if (str_contains($e->getMessage(), 'Invalid') === true
                 || str_contains($e->getMessage(), 'must be') === true
                 || str_contains($e->getMessage(), 'required') === true
+                || str_contains($e->getMessage(), 'requires translatable') === true
                 || str_contains($e->getMessage(), 'format') === true
                 || str_contains($e->getMessage(), 'Property at') === true
                 || str_contains($e->getMessage(), 'authorization') === true

--- a/lib/Middleware/LanguageMiddleware.php
+++ b/lib/Middleware/LanguageMiddleware.php
@@ -235,7 +235,17 @@ class LanguageMiddleware extends Middleware
      */
     private function resolveSourceLanguageForResponse(): ?string
     {
-        $uuid = $this->request->getParam('uuid');
+        // The canonical object read/write routes bind the identifier to the
+        // `{id}` path segment (objects#show / #update / #patch); only a few
+        // secondary routes name it `{uuid}`. Read `id` first and fall back to
+        // `uuid` so the header is derived on the primary object endpoints —
+        // previously only `uuid` was read, so X-Source-Language was never
+        // emitted on the main object route (i18n-source-of-truth).
+        $uuid = $this->request->getParam('id');
+        if (is_string($uuid) === false || $uuid === '') {
+            $uuid = $this->request->getParam('uuid');
+        }
+
         if (is_string($uuid) === false || $uuid === '') {
             return null;
         }

--- a/lib/Service/Object/ValidateObject.php
+++ b/lib/Service/Object/ValidateObject.php
@@ -1722,6 +1722,48 @@ class ValidateObject
             }//end if
         }//end if
 
+        // Translatable properties accept EITHER the scalar value (source-language
+        // / legacy write, or the X-Translation-Target-Language wrap path) OR a
+        // language-keyed object like {"nl": "Welkom", "en": "Welcome"}. The scalar
+        // branch is validated by the original (null-widened) property schema; the
+        // language-map branch validates every inner language value against that
+        // same scalar schema via additionalProperties. Without this widening a
+        // language-keyed write body is rejected by plain type validation (object
+        // vs string) BEFORE TranslationHandler::normalizeTranslationsForSave() can
+        // split it into per-language translation rows — which broke the entire
+        // i18n write path (see i18n-api-language-negotiation / i18n-source-of-truth).
+        if (property_exists($schemaObject, 'properties') === true
+            && is_object($schemaObject->properties) === true
+        ) {
+            foreach ($schemaObject->properties as $propertyName => $propertySchema) {
+                if (is_object($propertySchema) === false) {
+                    continue;
+                }
+
+                if (($propertySchema->translatable ?? null) !== true) {
+                    continue;
+                }
+
+                // Scalar branch: the property schema minus the custom marker.
+                $valueSchema = json_decode(json_encode($propertySchema));
+                unset($valueSchema->translatable);
+
+                // Language-map branch: an object whose every value matches the
+                // scalar schema (so language values are still type-checked).
+                $languageObjectSchema = (object) [
+                    'type'                 => 'object',
+                    'additionalProperties' => json_decode(json_encode($valueSchema)),
+                ];
+
+                $schemaObject->properties->$propertyName = (object) [
+                    'anyOf' => [
+                        $valueSchema,
+                        $languageObjectSchema,
+                    ],
+                ];
+            }//end foreach
+        }//end if
+
         return [
             'schemaObject' => $schemaObject,
             'computed'     => $computedProperties,

--- a/tests/Unit/Service/Object/ValidateObjectTest.php
+++ b/tests/Unit/Service/Object/ValidateObjectTest.php
@@ -130,6 +130,65 @@ class ValidateObjectTest extends TestCase
         $this->assertTrue($result->isValid());
     }
 
+    /**
+     * Regression: a translatable string property MUST accept a language-keyed
+     * object body ({"nl": ..., "en": ...}) as well as a scalar. Before the
+     * prepareSchemaForValidation widening, the language-map was rejected as
+     * "should be type 'string' but is 'object'" — which broke the entire i18n
+     * write path (objects could never be created with a translated value).
+     *
+     * @return void
+     */
+    public function testValidateObjectTranslatablePropertyAcceptsLanguageKeyedObject(): void
+    {
+        $schema = $this->createSchema([
+            'type'       => 'object',
+            'properties' => ['title' => ['type' => 'string', 'translatable' => true]],
+        ]);
+
+        $schemaObject = new stdClass();
+        $schemaObject->type = 'object';
+        $schemaObject->properties = new stdClass();
+        $schemaObject->properties->title = new stdClass();
+        $schemaObject->properties->title->type = 'string';
+        $schemaObject->properties->title->translatable = true;
+
+        // Language-keyed object shape.
+        $resultMap = $this->handler->validateObject(['title' => ['nl' => 'Welkom', 'en' => 'Welcome']], $schema, $schemaObject);
+        $this->assertTrue($resultMap->isValid(), 'Language-keyed object must be accepted for a translatable property');
+
+        // Scalar shape still valid (legacy / source-language / target-wrap path).
+        $resultScalar = $this->handler->validateObject(['title' => 'Welkom'], $schema, clone $schemaObject);
+        $this->assertTrue($resultScalar->isValid(), 'Scalar value must still be accepted for a translatable property');
+    }
+
+    /**
+     * Regression: the language-map branch still type-checks each language value.
+     * A non-string value inside the language map for a translatable STRING
+     * property must fail validation — the widening must not become an escape
+     * hatch that accepts arbitrary object payloads.
+     *
+     * @return void
+     */
+    public function testValidateObjectTranslatableLanguageValuesAreTypeChecked(): void
+    {
+        $schema = $this->createSchema([
+            'type'       => 'object',
+            'properties' => ['title' => ['type' => 'string', 'translatable' => true]],
+        ]);
+
+        $schemaObject = new stdClass();
+        $schemaObject->type = 'object';
+        $schemaObject->properties = new stdClass();
+        $schemaObject->properties->title = new stdClass();
+        $schemaObject->properties->title->type = 'string';
+        $schemaObject->properties->title->translatable = true;
+
+        // Inner value is an array/object, not a string -> invalid.
+        $result = $this->handler->validateObject(['title' => ['nl' => ['nested' => 'x']]], $schema, $schemaObject);
+        $this->assertFalse($result->isValid(), 'Non-string language values must still fail type validation');
+    }
+
     public function testValidateObjectWithRequiredFieldMissing(): void
     {
         $schema = $this->createSchema([

--- a/tests/integration/openregister-i18n-source-of-truth.postman_collection.json
+++ b/tests/integration/openregister-i18n-source-of-truth.postman_collection.json
@@ -44,6 +44,37 @@
       "name": "Setup",
       "item": [
         {
+          "name": "Force inline translation projection",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// The translation sidecar (openregister_translations, incl. source_language) is",
+                  "// populated by an event-driven projection that defaults to a background job.",
+                  "// Newman runs against a live instance with no cron worker, so we flip the",
+                  "// documented `openregister/listenerDeferral` kill-switch to `inline` to restore",
+                  "// synchronous projection for read-your-writes assertions in this run.",
+                  "pm.test('Deferral kill-switch set to inline (200)', function () { pm.response.to.have.status(200); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "url": "{{base_url}}/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/openregister/listenerDeferral",
+            "header": [
+              { "key": "OCS-APIRequest", "value": "true" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "value=inline"
+            }
+          }
+        },
+        {
           "name": "Create Register",
           "event": [
             {

--- a/tests/integration/openregister-jsonld.postman_collection.json
+++ b/tests/integration/openregister-jsonld.postman_collection.json
@@ -146,6 +146,7 @@
               "pm.test('@type resolves to mapped Schema.org class', function () { pm.expect(d['@type']).to.eql('https://schema.org/Person'); });",
               "pm.test('@self is lifted, not emitted', function () { pm.expect(d).to.not.have.property('@self'); pm.expect(d).to.have.property('or:schema'); });",
               "pm.test('data property present', function () { pm.expect(d.name).to.eql('Jansen'); });",
+              "pm.test('@context is a dereferenceable URL string pointing at the register/schema context', function () { pm.expect(d['@context']).to.be.a('string'); pm.expect(d['@context']).to.include('/api/contexts/' + pm.collectionVariables.get('register_slug') + '/' + pm.collectionVariables.get('schema_slug')); });",
               "pm.collectionVariables.set('context_url', d['@context']);"
             ]
           }
@@ -222,7 +223,7 @@
       "request": {
         "method": "GET",
         "header": [ { "key": "Accept", "value": "application/ld+json" } ],
-        "url": { "raw": "{{context_url}}" }
+        "url": { "raw": "{{base_url}}/index.php/apps/openregister/api/contexts/{{register_slug}}/{{schema_slug}}", "host": ["{{base_url}}"], "path": ["index.php","apps","openregister","api","contexts","{{register_slug}}","{{schema_slug}}"] }
       }
     },
     {


### PR DESCRIPTION
Remediates the 3 red i18n/JSON-LD Newman collections in `tests/integration/`. Reproduced and verified live on a disposable **NC 32.0.12** container; all three now pass **0 failures** from a clean default config (SoT self-provisions its own setup).

Live NC32 result (clean default deferral):
- `openregister-jsonld` — **29 assertions, 0 failed**
- `openregister-i18n-source-of-truth` — **12 assertions, 0 failed**
- `openregister-i18n-api-language-negotiation` — **16 assertions, 0 failed**

## Per-collection root cause

### i18n — API Language Negotiation & Source of Truth (shared root bug)
**REAL lib bug (fixed):** creating an object with a language-keyed value for a translatable property — `{"title":{"nl":"Welkom","en":"Welcome"}}` — was rejected with `400 "Property 'title' should be type 'string' but is 'object'"`. `ObjectService::saveObject()` runs `validateObjectIfRequired()` **before** `SaveObject` calls `TranslationHandler::normalizeTranslationsForSave()`, and the validator had zero translatable-awareness. This broke the *entire* i18n write path (empty UUID → cascade of 404s in both collections).
- Fix: `ValidateObject::prepareSchemaForValidation()` now widens every `translatable: true` property to an `anyOf` of the scalar schema **or** a language-keyed object whose values are validated against that same scalar schema (inner values still type-checked — see the 2 new unit tests). Strictly additive, scoped to translatable props.

### i18n — API Language Negotiation (also)
**REAL serialization drift (fixed):** the `X-Translation-Target-Language` + language-keyed body conflict returned `{status,message,errors:[...]}` instead of the `{error:{code:"TRANSLATION_TARGET_CONFLICT"}}` shape the exception class itself documents. `ObjectsController` now catches `TranslationTargetConflictException` explicitly (before the generic validation catch) and emits `toErrorBody()`.

### i18n — Source of Truth (also)
- **REAL lib bug (fixed):** `X-Source-Language` was never emitted on the primary object endpoint — `LanguageMiddleware::resolveSourceLanguageForResponse()` read `getParam('uuid')` but the object routes bind the identifier to `{id}`. Now reads `id` (with `uuid` fallback).
- **REAL lib bug (fixed):** posting `sourceLanguage` on a **non-translatable** property returned **500** instead of 400. The validation is correct (`PropertyValidatorHandler` rejects it); only the status mapping was wrong. `SchemasController` now maps the `requires translatable` message to 400.
- **ENV/setup gap (test fix):** the translation sidecar (`openregister_translations.source_language`) is populated by an **event-driven projection that defaults to a background job** — never runs under Newman (no cron). Added a self-provisioning Setup step that flips the documented `openregister/listenerDeferral` kill-switch to `inline` via the OCS provisioning API, restoring synchronous projection. No production behaviour changed.

### JSON-LD Output
**STALE test (Newman quirk, fixed):** item 7 dereferenced `{{context_url}}` as a pure-variable raw URL with no `host`/`path` parts → Newman builds an empty request URL. The context endpoint itself works (verified: 200 + proper `@context` object). Rebuilt item 7's URL from `base_url` + register/schema slugs (the same document the object's `@context` advertises) and added an item-4 guard asserting `@context` is a dereferenceable string.

## Regression guards
- 2 new PHPUnit tests in `ValidateObjectTest` (language-map accepted; inner values still type-checked). Full `ValidateObjectTest`: **221 tests green**, no regression.
- The 3 collections run in the CI Newman job.

No deferred/flagged bugs — all root causes fixed or correctly classified.
