### PR TITLE
test(newman): fix apphost-observability + magic-mapper-import + register-resolver integration collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,11 @@ phpqa_output.log
 *.csv
 *.xls
 *.xlsx
+# Exception: committed Newman fixture consumed by
+# tests/integration/magic-mapper-import.postman_collection.json — the CI
+# Newman job checks out the app fresh (no dev-container state), so the
+# fixture must be tracked, not generated.
+!tests/integration/magic-mapper-data/*.csv
 
 # Files with unusual names (trailing space, no extension) that are likely mistakes.
 # Patterns listed here must NOT match legitimate PHP source filenames.

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -2817,6 +2817,50 @@ class Application extends App implements IBootstrap
                 );
             }
         );
+
+        // Self-dogfood the GET /api/health and /api/metrics routes at the
+        // generic AppHost controllers. appinfo/routes.php aliases these URLs
+        // to route names 'AppHost\Controller\GenericMetrics#index' /
+        // 'AppHost\Controller\GenericHealth#index' — NC's RouteParser turns
+        // that into the literal DI lookup key
+        // 'AppHost\Controller\GenericHealthController' (buildControllerName()
+        // appends 'Controller' to the route-name segment verbatim; it does
+        // NOT prefix the app namespace for a route name that already
+        // contains a backslash). Without an explicit binding under that
+        // exact key, \OC\AppFramework\App::main() failed to resolve the
+        // controller, was caught as a QueryException, and — because the
+        // string coincidentally contains '\Controller\' — misread as "a
+        // global route pointing at a disabled app", surfacing as a 503
+        // "App controller is not enabled" HTML error page instead of the
+        // health/metrics JSON contract (ADR-006). Every OTHER AppHost route
+        // (dashboard/preferences/settings) is bound this same way, per
+        // controller, by \OCA\OpenRegister\AppHost\Bootstrap for LEAF apps
+        // that call Bootstrap::register(); OpenRegister's own self-adoption
+        // never calls Bootstrap::register() and must bind these two
+        // controllers directly.
+        $context->registerService(
+            'AppHost\\Controller\\GenericHealthController',
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\AppHost\Controller\GenericHealthController(
+                    appName: self::APP_ID,
+                    request: $container->get('OCP\IRequest'),
+                    manifestLoader: $container->get(\OCA\OpenRegister\AppHost\Observability\ManifestLoader::class),
+                    executor: $container->get(\OCA\OpenRegister\AppHost\Observability\HealthCheckExecutor::class)
+                );
+            }
+        );
+
+        $context->registerService(
+            'AppHost\\Controller\\GenericMetricsController',
+            function (ContainerInterface $container) {
+                return new \OCA\OpenRegister\AppHost\Controller\GenericMetricsController(
+                    appName: self::APP_ID,
+                    request: $container->get('OCP\IRequest'),
+                    manifestLoader: $container->get(\OCA\OpenRegister\AppHost\Observability\ManifestLoader::class),
+                    engine: $container->get(\OCA\OpenRegister\AppHost\Observability\MetricsEngine::class)
+                );
+            }
+        );
     }//end registerAppHostObservability()
 
     /**

--- a/lib/Controller/RegistersController.php
+++ b/lib/Controller/RegistersController.php
@@ -485,34 +485,56 @@ class RegistersController extends Controller
      */
     public function show($id): JSONResponse
     {
-        $extend = $this->request->getParam(key: '_extend', default: []);
-        if (is_string($extend) === true) {
-            $extend = [$extend];
-        }
+        try {
+            $extend = $this->request->getParam(key: '_extend', default: []);
+            if (is_string($extend) === true) {
+                $extend = [$extend];
+            }
 
-        $register = $this->registerService->find(id: $id, _extend: [], _multitenancy: false);
+            $register = $this->registerService->find(id: $id, _extend: [], _multitenancy: false);
 
-        // Read-visibility guard (@PublicPage): an anonymous caller may only view
-        // a register whose RBAC authorization grants read access to the `public`
-        // group. Derived from server-side authorization rules, never from
-        // client-supplied parameters.
-        if ($this->isAnonymousRequest() === true
-            && $this->isPublicReadable(authorization: $register->getAuthorization()) === false
-        ) {
-            return new JSONResponse(data: ['error' => 'Authentication required'], statusCode: 401);
-        }
+            // Read-visibility guard (@PublicPage): an anonymous caller may only view
+            // a register whose RBAC authorization grants read access to the `public`
+            // group. Derived from server-side authorization rules, never from
+            // client-supplied parameters.
+            if ($this->isAnonymousRequest() === true
+                && $this->isPublicReadable(authorization: $register->getAuthorization()) === false
+            ) {
+                return new JSONResponse(data: ['error' => 'Authentication required'], statusCode: 401);
+            }
 
-        $registerArr = $register->jsonSerialize();
-        // If '@self.stats' is requested, attach statistics to the register.
-        if (in_array('@self.stats', $extend, true) === true) {
-            $registerArr['stats'] = [
-                'objects' => $this->objectEntityMapper->getStatistics(registerId: $registerArr['id'], schemaId: null),
-                'logs'    => $this->auditTrailMapper->getStatistics(registerId: $registerArr['id'], schemaId: null),
-                'files'   => [ 'total' => 0, 'size' => 0 ],
-            ];
-        }
+            $registerArr = $register->jsonSerialize();
+            // If '@self.stats' is requested, attach statistics to the register.
+            if (in_array('@self.stats', $extend, true) === true) {
+                $registerArr['stats'] = [
+                    'objects' => $this->objectEntityMapper->getStatistics(registerId: $registerArr['id'], schemaId: null),
+                    'logs'    => $this->auditTrailMapper->getStatistics(registerId: $registerArr['id'], schemaId: null),
+                    'files'   => [ 'total' => 0, 'size' => 0 ],
+                ];
+            }
 
-        return new JSONResponse(data: $registerArr);
+            return new JSONResponse(data: $registerArr);
+        } catch (DoesNotExistException $e) {
+            // Unknown id/uuid/slug — a clean 404 JSON error, not an uncaught
+            // exception falling through to Nextcloud's HTML error template
+            // (caught live via the openregister-register-resolver Newman
+            // collection: GET /api/registers/{unknown-slug} was returning a
+            // 500 HTML page instead of a JSON 404, mirroring the pattern
+            // SchemasController::show() already guards against).
+            return new JSONResponse(data: ['error' => 'Register not found'], statusCode: 404);
+        } catch (Exception $e) {
+            $this->logger->error(
+                message: '[RegistersController] Failed to retrieve register',
+                context: [
+                    'file'          => __FILE__,
+                    'line'          => __LINE__,
+                    'register_id'   => $id,
+                    'error_message' => $e->getMessage(),
+                ]
+            );
+
+            return new JSONResponse(data: ['error' => 'Failed to retrieve register: '.$e->getMessage()], statusCode: 500);
+        }//end try
     }//end show()
 
     /**

--- a/tests/Unit/Controller/RegistersControllerTest.php
+++ b/tests/Unit/Controller/RegistersControllerTest.php
@@ -486,15 +486,24 @@ class RegistersControllerTest extends TestCase
         $this->assertArrayHasKey('error', $data);
     }
 
-    public function testShowThrowsWhenNotFound(): void
+    public function testShowReturns404WhenNotFound(): void
     {
-        // show() has no try/catch, so DoesNotExistException propagates
+        // Regression guard: show() previously had no try/catch, so an
+        // unknown id/uuid/slug let DoesNotExistException propagate
+        // uncaught, surfacing to callers as Nextcloud's HTML 500 error
+        // page instead of a clean JSON 404 (caught live via the
+        // openregister-register-resolver Newman collection). show() now
+        // mirrors SchemasController::show()'s catch(DoesNotExistException)
+        // -> 404 pattern.
         $this->request->method('getParam')->willReturn([]);
         $this->registerService->method('find')
             ->willThrowException(new DoesNotExistException('Not found'));
 
-        $this->expectException(DoesNotExistException::class);
-        $this->controller->show(999);
+        $result = $this->controller->show(999);
+
+        $this->assertInstanceOf(\OCP\AppFramework\Http\JSONResponse::class, $result);
+        $this->assertEquals(404, $result->getStatus());
+        $this->assertArrayHasKey('error', $result->getData());
     }
 
     public function testExportReturns400OnException(): void

--- a/tests/integration/apphost-observability.postman_collection.json
+++ b/tests/integration/apphost-observability.postman_collection.json
@@ -8,8 +8,8 @@
         { "key": "base_url", "value": "http://localhost" },
         { "key": "admin_user", "value": "admin" },
         { "key": "admin_password", "value": "admin" },
-        { "key": "health_path", "value": "/apps/openregister/api/apphost/health" },
-        { "key": "metrics_path", "value": "/apps/openregister/api/apphost/metrics" },
+        { "key": "health_path", "value": "/index.php/apps/openregister/api/health" },
+        { "key": "metrics_path", "value": "/index.php/apps/openregister/api/metrics" },
         { "key": "app_prefix", "value": "openregister" }
     ],
     "item": [

--- a/tests/integration/magic-mapper-data/sample-objects.csv
+++ b/tests/integration/magic-mapper-data/sample-objects.csv
@@ -1,0 +1,4 @@
+name,category
+Alpha Widget,Widgets
+Beta Gadget,Gadgets
+Gamma Tool,Tools

--- a/tests/integration/magic-mapper-import.postman_collection.json
+++ b/tests/integration/magic-mapper-import.postman_collection.json
@@ -2,26 +2,9 @@
 	"info": {
 		"_postman_id": "magic-mapper-import-test",
 		"name": "OpenRegister - Magic Mapper CSV Import Test",
-		"description": "Test script for importing CSV data into magic mapper schemas and verifying storage in dedicated tables.",
+		"description": "Self-provisioning CSV import test. Creates its own register + schema (no dependency on dev-only fixtures like a pre-seeded 'voorzieningen' register), imports a small committed CSV fixture through POST /api/registers/{id}/import, and asserts the import status codes documented on RegistersController::import() (200 success with per-row summary, 400 when the required `schema` param is missing, 404 for an unknown register). Object storage is always backed by OpenRegister's dynamic per-schema tables (MagicMapper — SettingsService::getSearchBackendConfig() reports 'database' as the only backend), so a successful import + a follow-up GET /api/objects read is sufficient to prove the magic-mapper storage path end-to-end without needing a special feature flag.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
-	"variable": [
-		{
-			"key": "base_url",
-			"value": "http://nextcloud/index.php/apps/openregister/api",
-			"type": "string"
-		},
-		{
-			"key": "admin_user",
-			"value": "admin",
-			"type": "string"
-		},
-		{
-			"key": "admin_password",
-			"value": "admin",
-			"type": "string"
-		}
-	],
 	"auth": {
 		"type": "basic",
 		"basic": [
@@ -37,26 +20,43 @@
 			}
 		]
 	},
+	"variable": [
+		{
+			"key": "base_url",
+			"value": "http://localhost",
+			"type": "string"
+		},
+		{
+			"key": "admin_user",
+			"value": "admin",
+			"type": "string"
+		},
+		{
+			"key": "admin_password",
+			"value": "admin",
+			"type": "string"
+		}
+	],
 	"item": [
 		{
-			"name": "1. Import Magic Mapper Configuration",
+			"name": "1. Setup: Create Register",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
-							"pm.test('Status code is 200 or 201', function () {",
-							"    pm.expect(pm.response.code).to.be.oneOf([200, 201]);",
+							"pm.test('Status code is 201', function () {",
+							"    pm.response.to.have.status(201);",
 							"});",
 							"",
-							"pm.test('Configuration imported successfully', function () {",
-							"    var jsonData = pm.response.json();",
-							"    pm.expect(jsonData).to.have.property('registers');",
-							"    pm.expect(jsonData).to.have.property('schemas');",
-							"    ",
-							"    console.log('Imported registers:', jsonData.registers.length);",
-							"    console.log('Imported schemas:', jsonData.schemas.length);",
-							"});"
+							"var jsonData = pm.response.json();",
+							"pm.test('Register has id and slug', function () {",
+							"    pm.expect(jsonData).to.have.property('id');",
+							"    pm.expect(jsonData).to.have.property('slug');",
+							"});",
+							"",
+							"pm.collectionVariables.set('register_id', jsonData.id);",
+							"pm.collectionVariables.set('register_slug', jsonData.slug);"
 						],
 						"type": "text/javascript"
 					}
@@ -71,110 +71,61 @@
 					}
 				],
 				"body": {
-					"mode": "file",
-					"file": {
-						"src": "/var/www/html/custom_apps/openregister/tests/integration/softwarecatalogus_register_magic.json"
-					}
+					"mode": "raw",
+					"raw": "{\"title\": \"Magic Mapper Import Register {{$timestamp}}{{$randomInt}}\", \"description\": \"Register for the magic-mapper-import Newman collection\"}"
 				},
 				"url": {
-					"raw": "{{base_url}}/configurations?force=true",
+					"raw": "{{base_url}}/index.php/apps/openregister/api/registers",
 					"host": ["{{base_url}}"],
-					"path": ["configurations"],
-					"query": [
-						{
-							"key": "force",
-							"value": "true"
-						}
-					]
+					"path": ["index.php", "apps", "openregister", "api", "registers"]
 				}
 			},
 			"response": []
 		},
 		{
-			"name": "2. Get Voorzieningen Register",
+			"name": "2. Setup: Create Schema",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
-							"pm.test('Status code is 200', function () {",
-							"    pm.response.to.have.status(200);",
+							"pm.test('Status code is 201', function () {",
+							"    pm.response.to.have.status(201);",
 							"});",
 							"",
-							"pm.test('Register found', function () {",
-							"    var jsonData = pm.response.json();",
-							"    pm.expect(jsonData.results).to.be.an('array');",
-							"    pm.expect(jsonData.results.length).to.be.greaterThan(0);",
-							"    ",
-							"    var register = jsonData.results[0];",
-							"    pm.collectionVariables.set('register_id', register.id);",
-							"    ",
-							"    console.log('Register ID:', register.id);",
-							"    console.log('Register slug:', register.slug);",
-							"    ",
-							"    if (register.configuration && register.configuration.schemas) {",
-							"        console.log('Magic mapping enabled for:', Object.keys(register.configuration.schemas));",
-							"    }",
-							"});"
+							"var jsonData = pm.response.json();",
+							"pm.test('Schema has id and slug', function () {",
+							"    pm.expect(jsonData).to.have.property('id');",
+							"    pm.expect(jsonData).to.have.property('slug');",
+							"});",
+							"",
+							"pm.collectionVariables.set('schema_id', jsonData.id);",
+							"pm.collectionVariables.set('schema_slug', jsonData.slug);"
 						],
 						"type": "text/javascript"
 					}
 				}
 			],
 			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{base_url}}/registers?slug=voorzieningen",
-					"host": ["{{base_url}}"],
-					"path": ["registers"],
-					"query": [
-						{
-							"key": "slug",
-							"value": "voorzieningen"
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "3. Get Module Schema",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test('Status code is 200', function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test('Schema found', function () {",
-							"    var jsonData = pm.response.json();",
-							"    pm.expect(jsonData.results).to.be.an('array');",
-							"    pm.expect(jsonData.results.length).to.be.greaterThan(0);",
-							"    ",
-							"    var schema = jsonData.results[0];",
-							"    pm.collectionVariables.set('module_schema_id', schema.id);",
-							"    ",
-							"    console.log('Module Schema ID:', schema.id);",
-							"});"
-						],
-						"type": "text/javascript"
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
 					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [],
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"title\": \"Magic Mapper Item {{$timestamp}}{{$randomInt}}\", \"description\": \"Schema for the magic-mapper-import Newman collection\", \"properties\": {\"name\": {\"type\": \"string\"}, \"category\": {\"type\": \"string\"}}}"
+				},
 				"url": {
-					"raw": "{{base_url}}/schemas?slug=module",
+					"raw": "{{base_url}}/index.php/apps/openregister/api/schemas?register={{register_id}}",
 					"host": ["{{base_url}}"],
-					"path": ["schemas"],
+					"path": ["index.php", "apps", "openregister", "api", "schemas"],
 					"query": [
 						{
-							"key": "slug",
-							"value": "module"
+							"key": "register",
+							"value": "{{register_id}}"
 						}
 					]
 				}
@@ -182,23 +133,19 @@
 			"response": []
 		},
 		{
-			"name": "4. Import Module CSV",
+			"name": "3. Import: missing schema param returns 400",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
-							"pm.test('Status code is 200', function () {",
-							"    pm.response.to.have.status(200);",
+							"pm.test('Status code is 400 (schema is required for CSV imports)', function () {",
+							"    pm.response.to.have.status(400);",
 							"});",
 							"",
-							"pm.test('Import successful', function () {",
+							"pm.test('Error body names the schema requirement', function () {",
 							"    var jsonData = pm.response.json();",
-							"    pm.expect(jsonData).to.have.property('successCount');",
-							"    pm.expect(jsonData.successCount).to.be.greaterThan(0);",
-							"    ",
-							"    console.log('Imported:', jsonData.successCount);",
-							"    console.log('Failed:', jsonData.failedCount || 0);",
+							"    pm.expect(jsonData).to.have.property('error');",
 							"});"
 						],
 						"type": "text/javascript"
@@ -214,51 +161,150 @@
 						{
 							"key": "file",
 							"type": "file",
-							"src": "/var/www/html/custom_apps/openregister/tests/integration/magic-mapper-data/module.csv"
-						},
-						{
-							"key": "type",
-							"value": "csv",
-							"type": "text"
-						},
-						{
-							"key": "schema",
-							"value": "{{module_schema_id}}",
-							"type": "text"
+							"src": "magic-mapper-data/sample-objects.csv"
 						}
 					]
 				},
 				"url": {
-					"raw": "{{base_url}}/registers/{{register_id}}/import",
+					"raw": "{{base_url}}/index.php/apps/openregister/api/registers/{{register_id}}/import",
 					"host": ["{{base_url}}"],
-					"path": ["registers", "{{register_id}}", "import"]
+					"path": ["index.php", "apps", "openregister", "api", "registers", "{{register_id}}", "import"]
 				}
 			},
 			"response": []
 		},
 		{
-			"name": "5. Verify Objects in Magic Table (DB Query)",
+			"name": "4. Import: unknown register returns 404",
 			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							"// This test will be verified manually via database query"
-						],
-						"type": "text/javascript"
-					}
-				},
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
-							"pm.test('Module objects created', function () {",
-							"    var jsonData = pm.response.json();",
+							"pm.test('Status code is 404 (register does not exist)', function () {",
+							"    pm.response.to.have.status(404);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "file",
+							"type": "file",
+							"src": "magic-mapper-data/sample-objects.csv"
+						},
+						{
+							"key": "schema",
+							"value": "{{schema_slug}}",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "{{base_url}}/index.php/apps/openregister/api/registers/nonexistent-magic-mapper-import-register/import",
+					"host": ["{{base_url}}"],
+					"path": ["index.php", "apps", "openregister", "api", "registers", "nonexistent-magic-mapper-import-register", "import"]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "5. Import: CSV import succeeds (200) with per-row summary",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status code is 200', function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"var jsonData = pm.response.json();",
+							"pm.test('Response has a summary envelope', function () {",
+							"    pm.expect(jsonData).to.have.property('summary');",
+							"});",
+							"",
+							"// The summary is keyed by the CSV's sheet title (PhpSpreadsheet default,",
+							"// e.g. 'Worksheet') alongside 'importJobId' — find the sheet key rather",
+							"// than hardcoding the title.",
+							"var sheetKey = Object.keys(jsonData.summary).find(function (k) { return k !== 'importJobId'; });",
+							"pm.test('Sheet summary key is present', function () {",
+							"    pm.expect(sheetKey).to.be.a('string');",
+							"});",
+							"",
+							"var sheet = jsonData.summary[sheetKey];",
+							"pm.test('All 3 CSV rows were created, none errored', function () {",
+							"    pm.expect(sheet.found).to.eql(3);",
+							"    pm.expect(sheet.created).to.be.an('array').with.lengthOf(3);",
+							"    pm.expect(sheet.errors).to.be.an('array').with.lengthOf(0);",
+							"});",
+							"",
+							"pm.test('importJobId is present', function () {",
+							"    pm.expect(jsonData.summary.importJobId).to.be.a('string').and.not.empty;",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "file",
+							"type": "file",
+							"src": "magic-mapper-data/sample-objects.csv"
+						},
+						{
+							"key": "schema",
+							"value": "{{schema_slug}}",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "{{base_url}}/index.php/apps/openregister/api/registers/{{register_id}}/import",
+					"host": ["{{base_url}}"],
+					"path": ["index.php", "apps", "openregister", "api", "registers", "{{register_id}}", "import"]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "6. Verify: imported objects are queryable (magic-mapper storage)",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status code is 200', function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"var jsonData = pm.response.json();",
+							"pm.test('Results is an array with the 3 imported objects', function () {",
 							"    pm.expect(jsonData.results).to.be.an('array');",
-							"    pm.expect(jsonData.results.length).to.be.greaterThan(0);",
-							"    ",
-							"    console.log('Total module objects:', jsonData.total);",
-							"    console.log('Sample UUID:', jsonData.results[0].uuid);",
+							"    pm.expect(jsonData.results.length).to.be.at.least(3);",
+							"});",
+							"",
+							"pm.test('Imported rows are present with expected property values', function () {",
+							"    // 'name' is a reserved OpenRegister metadata property (ADR object-title",
+							"    // convention) — a schema property literally named 'name' is promoted to",
+							"    // @self.name on the ObjectEntity rather than staying as a top-level custom",
+							"    // property (only 'category', the non-reserved property, stays top-level).",
+							"    var names = jsonData.results.map(function (o) { return o['@self'] && o['@self'].name; });",
+							"    pm.expect(names).to.include.members(['Alpha Widget', 'Beta Gadget', 'Gamma Tool']);",
+							"    var categories = jsonData.results.map(function (o) { return o.category; });",
+							"    pm.expect(categories).to.include.members(['Widgets', 'Gadgets', 'Tools']);",
 							"});"
 						],
 						"type": "text/javascript"
@@ -269,21 +315,85 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{base_url}}/objects?register=voorzieningen&schema=module&_limit=5",
+					"raw": "{{base_url}}/index.php/apps/openregister/api/objects?register={{register_slug}}&schema={{schema_slug}}&_limit=50",
 					"host": ["{{base_url}}"],
-					"path": ["objects"],
+					"path": ["index.php", "apps", "openregister", "api", "objects"],
 					"query": [
 						{
 							"key": "register",
-							"value": "voorzieningen"
+							"value": "{{register_slug}}"
 						},
 						{
 							"key": "schema",
-							"value": "module"
+							"value": "{{schema_slug}}"
 						},
 						{
 							"key": "_limit",
-							"value": "5"
+							"value": "50"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "7. Cleanup: Delete Schema",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status code is 200 or 204', function () {",
+							"    pm.expect([200, 204]).to.include(pm.response.code);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "DELETE",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}/index.php/apps/openregister/api/schemas/{{schema_id}}?deleteObjects=true",
+					"host": ["{{base_url}}"],
+					"path": ["index.php", "apps", "openregister", "api", "schemas", "{{schema_id}}"],
+					"query": [
+						{
+							"key": "deleteObjects",
+							"value": "true"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "8. Cleanup: Delete Register",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status code is 200 or 204', function () {",
+							"    pm.expect([200, 204]).to.include(pm.response.code);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "DELETE",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}/index.php/apps/openregister/api/registers/{{register_id}}?force=true",
+					"host": ["{{base_url}}"],
+					"path": ["index.php", "apps", "openregister", "api", "registers", "{{register_id}}"],
+					"query": [
+						{
+							"key": "force",
+							"value": "true"
 						}
 					]
 				}
@@ -292,4 +402,3 @@
 		}
 	]
 }
-

--- a/tests/integration/openregister-register-resolver.postman_collection.json
+++ b/tests/integration/openregister-register-resolver.postman_collection.json
@@ -13,7 +13,7 @@
     ]
   },
   "variable": [
-    { "key": "base_url", "value": "http://localhost:8080/index.php/apps/openregister" },
+    { "key": "base_url", "value": "http://localhost" },
     { "key": "admin_user", "value": "admin" },
     { "key": "admin_password", "value": "admin" }
   ],
@@ -24,9 +24,9 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "{{base_url}}/api/registers",
+          "raw": "{{base_url}}/index.php/apps/openregister/api/registers",
           "host": ["{{base_url}}"],
-          "path": ["api", "registers"]
+          "path": ["index.php", "apps", "openregister", "api", "registers"]
         }
       },
       "event": [
@@ -48,9 +48,9 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "{{base_url}}/api/registers/nonexistent-resolver-target",
+          "raw": "{{base_url}}/index.php/apps/openregister/api/registers/nonexistent-resolver-target",
           "host": ["{{base_url}}"],
-          "path": ["api", "registers", "nonexistent-resolver-target"]
+          "path": ["index.php", "apps", "openregister", "api", "registers", "nonexistent-resolver-target"]
         }
       },
       "event": [
@@ -59,7 +59,8 @@
           "script": {
             "type": "text/javascript",
             "exec": [
-              "pm.test('Unknown register slug returns 404 or 500 with diagnostic body', function () { pm.expect([404, 500]).to.include(pm.response.code); });"
+              "pm.test('Unknown register slug returns a clean 404 JSON error (not an uncaught 500)', function () { pm.response.to.have.status(404); });",
+              "pm.test('Error body is JSON, not an HTML error page', function () { var j = pm.response.json(); pm.expect(j).to.have.property('error'); });"
             ]
           }
         }
@@ -71,9 +72,9 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "{{base_url}}/api/schemas",
+          "raw": "{{base_url}}/index.php/apps/openregister/api/schemas",
           "host": ["{{base_url}}"],
-          "path": ["api", "schemas"]
+          "path": ["index.php", "apps", "openregister", "api", "schemas"]
         }
       },
       "event": [


### PR DESCRIPTION
## Summary

Fixes the 3 Newman integration collections assigned for remediation (pre-existing red debt on the Code Quality "Integration Tests (Newman)" job against NC stable32). All three were reproduced and fixed live against a disposable `nextcloud:32-apache` instance, run exactly as CI invokes them (PHP built-in server, pgsql, bare `base_url=http://localhost:8080` env-var).

### apphost-observability.postman_collection.json — REAL BUG (fixed)
`GET /api/health` and `GET /api/metrics` both 503'd with `"App controller is not enabled"` instead of serving OpenRegister's own ADR-006/ADR-040 self-dogfooded observability contract.

Root cause: `Application::registerAppHostObservability()` registers every *supporting* AppHost service (`ManifestLoader`, `HealthCheckExecutor`, `MetricsEngine`, metric sources) but never registers the `GenericHealthController`/`GenericMetricsController` DI aliases that `appinfo/routes.php`'s `'AppHost\Controller\GenericHealth#index'` / `'AppHost\Controller\GenericMetrics#index'` route names resolve to. NC's `RouteParser` turns those route names into the literal DI lookup key `AppHost\Controller\GenericHealthController` (no app-namespace prefix, since the route name already contains a backslash); nothing registered that key, so `\OC\AppFramework\App::main()` threw a `QueryException`, which — because the string happens to contain the substring `\Controller\` — was misread by NC's "route points at a disabled global app" fallback, producing the misleading 503 HTML page.

Fix: register both controllers under the exact DI key NC derives (`lib/AppInfo/Application.php`). Also fixed the collection's `health_path`/`metrics_path` variables, which pointed at a path that never existed (`/api/apphost/health`) and used the bare (no `/index.php/`) URL form that 404s on the CI PHP built-in server (no `.htaccess` rewriting).

Every other AppHost-adopting **leaf** app is unaffected — they wire these controllers via `AppHost\Bootstrap::register()`, which already binds this correctly. Only OpenRegister's own self-dogfooding, which never calls `Bootstrap::register()`, was broken.

### magic-mapper-import.postman_collection.json — ENV/SETUP GAP + STALE TEST (rewritten)
The collection referenced dev-only fixtures that were never committed to the repo (`softwarecatalogus_register_magic.json`, `magic-mapper-data/module.csv` — blocked by a blanket `*.csv` `.gitignore` rule) and posted to a route that no longer exists (`/configurations?force=true`; the real route is `/api/configurations/import`).

Rewritten to self-provision its own register + schema and exercise `RegistersController::import()`'s actual status codes (400 missing `schema` param, 404 unknown register, 200 success with per-row summary) against a small committed CSV fixture, then verifies the imported rows via `GET /api/objects`. Object storage is unconditionally backed by OpenRegister's per-schema MagicMapper tables (`SettingsService::getSearchBackendConfig()` reports `'database'` as the only backend now), so a successful import + a follow-up read proves the magic-mapper storage path without needing a special flag. Added a `.gitignore` exception (`!tests/integration/magic-mapper-data/*.csv`) so the fixture ships with the app.

### openregister-register-resolver.postman_collection.json — REAL BUG + URL FIX (fixed)
`GET /api/registers/{unknown-slug}` threw an uncaught `DoesNotExistException`, returning a 500 HTML error page instead of a clean 404 JSON error. The collection's own assertion already tolerated `[404, 500]`, masking the bug.

`RegistersController::show()` had no `try`/`catch` at all — unlike `SchemasController::show()`, which already guards the identical case. Added the same `catch(DoesNotExistException -> 404)` / `catch(Exception -> 500, logged)` pattern, tightened the collection's assertion to require the clean 404, and fixed `tests/Unit/Controller/RegistersControllerTest.php::testShowThrowsWhenNotFound` (renamed `testShowReturns404WhenNotFound`), which had documented the broken behaviour as the expected contract (`"show() has no try/catch, so DoesNotExistException propagates"`).

Also fixed every request URL in the collection: CI overrides `base_url` to a bare host (`http://localhost:8080`, no app path); this collection's `base_url` default baked the `/index.php/apps/openregister` path into the variable itself, which the CI override silently stripped, 404ing every request. Every other working collection in this directory (`openregister-crud.postman_collection.json`, etc.) hardcodes `/index.php/apps/openregister/api/...` directly into each request URL instead — this collection now follows that same convention.

## Verification

All three collections pass 0 failures on a disposable `nextcloud:32-apache` + Postgres instance, run with the exact CI command:
```
newman run "<collection>" --env-var "base_url=http://localhost:8085" --env-var "admin_user=admin" --env-var "admin_password=adminadmin123" --reporters cli
```
Re-run twice to confirm idempotency (timestamp-suffixed fixture names).

`tests/Unit/Controller/RegistersControllerTest.php` (152 tests) and `tests/Unit/AppHost/*` (121 tests) pass in-container. `phpcs` clean on both touched `lib/` files (pre-existing unrelated class-level `@spec` warning on `Application.php` untouched).

## Test plan
- [x] `apphost-observability.postman_collection.json` — 3 requests / 12 assertions, 0 failures
- [x] `magic-mapper-import.postman_collection.json` — 8 requests / 17 assertions, 0 failures
- [x] `openregister-register-resolver.postman_collection.json` — 3 requests / 5 assertions, 0 failures
- [x] `tests/Unit/Controller/RegistersControllerTest.php` — 152/152 pass
- [x] `tests/Unit/AppHost/*` — 121/121 pass
- [x] `phpcs` clean on `lib/AppInfo/Application.php` + `lib/Controller/RegistersController.php`