### PR TITLE
feat(config): federated-config store foundation — publish, discovery, signing, per-org RBAC

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1241,9 +1241,12 @@ return [
 		['name' => 'flowRun#retry', 'url' => '/api/flow-runs/{uuid}/retry', 'verb' => 'POST', 'requirements' => ['uuid' => '[^/]+']],
 		// Interactive test run (or-flow-partial-run): run synchronously with optional startAt + pins + seed.
 		['name' => 'flowRun#test', 'url' => '/api/flow-runs/test', 'verb' => 'POST'],
-		// Federated configuration sharing (federated-config-sharing): declare types, bundle a selection, install a bundle.
+		// Federated configuration sharing (federated-config-sharing): declare types, bundle a selection, install/publish/discover a bundle.
 		['name' => 'federatedConfig#types', 'url' => '/api/federated-config/types', 'verb' => 'GET'],
 		['name' => 'federatedConfig#bundle', 'url' => '/api/federated-config/bundle', 'verb' => 'POST'],
 		['name' => 'federatedConfig#install', 'url' => '/api/federated-config/install', 'verb' => 'POST'],
+		['name' => 'federatedConfig#publish', 'url' => '/api/federated-config/publish', 'verb' => 'POST'],
+		['name' => 'federatedConfig#discover', 'url' => '/api/federated-config/discover', 'verb' => 'GET'],
+		['name' => 'federatedConfig#publicKey', 'url' => '/api/federated-config/public-key', 'verb' => 'GET'],
     ],
 ];

--- a/lib/Controller/FederatedConfigController.php
+++ b/lib/Controller/FederatedConfigController.php
@@ -27,13 +27,16 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Controller;
 
+use OCA\OpenRegister\Service\Config\FederatedConfigAccess;
 use OCA\OpenRegister\Service\Config\FederatedConfigService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IConfig;
 use OCP\IRequest;
+use OCP\IUserSession;
 use Throwable;
 use UnexpectedValueException;
 
@@ -42,17 +45,35 @@ use UnexpectedValueException;
  */
 class FederatedConfigController extends Controller
 {
+
+    /**
+     * The app its user preferences live under.
+     */
+    private const APP_ID = 'openregister';
+
+    /**
+     * User-preference key holding the chosen store GitHub credential (written by
+     * the nc-vue Configuration store settings pane via /api/preferences).
+     */
+    private const CREDENTIAL_PREF = 'pref_federated-config-credential';
+
     /**
      * Constructor.
      *
-     * @param string                 $appName The app id.
-     * @param IRequest               $request The request.
-     * @param FederatedConfigService $service The federation engine.
+     * @param string                 $appName     The app id.
+     * @param IRequest               $request     The request.
+     * @param FederatedConfigService $service     The federation engine.
+     * @param FederatedConfigAccess  $access      Per-org publish/install gating.
+     * @param IUserSession           $userSession The current user.
+     * @param IConfig                $config      Reads the user's chosen store credential.
      */
     public function __construct(
         string $appName,
         IRequest $request,
-        private readonly FederatedConfigService $service
+        private readonly FederatedConfigService $service,
+        private readonly FederatedConfigAccess $access,
+        private readonly IUserSession $userSession,
+        private readonly IConfig $config
     ) {
         parent::__construct(appName: $appName, request: $request);
 
@@ -122,6 +143,10 @@ class FederatedConfigController extends Controller
     #[NoCSRFRequired]
     public function install(): JSONResponse
     {
+        if ($this->access->canInstall(user: $this->userSession->getUser()) === false) {
+            return new JSONResponse(['error' => 'You are not allowed to install shared configuration.'], Http::STATUS_FORBIDDEN);
+        }
+
         $type = trim((string) $this->request->getParam('type', ''));
         if ($type === '') {
             return new JSONResponse(['error' => 'An install needs a type.'], Http::STATUS_BAD_REQUEST);
@@ -136,16 +161,136 @@ class FederatedConfigController extends Controller
         } catch (UnexpectedValueException $e) {
             return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
         } catch (Throwable $e) {
-            // A blocked source (allowlist) is a 403; anything else a 500.
-            $status = Http::STATUS_INTERNAL_SERVER_ERROR;
-            if (str_contains($e->getMessage(), 'allowlist') === true) {
+            // A blocked source, an untrusted key, or a bad signature is a 403;
+            // anything else a 500.
+            $status  = Http::STATUS_INTERNAL_SERVER_ERROR;
+            $message = $e->getMessage();
+            if (str_contains($message, 'allowlist') === true
+                || str_contains($message, 'trusted') === true
+                || str_contains($message, 'signature') === true
+            ) {
                 $status = Http::STATUS_FORBIDDEN;
             }
 
-            return new JSONResponse(['error' => $e->getMessage()], $status);
-        }
+            return new JSONResponse(['error' => $message], $status);
+        }//end try
 
         return new JSONResponse($result);
 
     }//end install()
+
+    /**
+     * Publish a selection to a GitHub repository, using the user's chosen store
+     * credential and signing the bundle.
+     *
+     * The credential is NOT taken from the request — it is the one the user
+     * selected in the Configuration store settings pane — so a caller can never
+     * publish with a credential they did not choose.
+     *
+     * @return JSONResponse `{published, path, status}`, or a 4xx.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function publish(): JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($this->access->canPublish(user: $user) === false) {
+            return new JSONResponse(['error' => 'You are not allowed to publish configuration.'], Http::STATUS_FORBIDDEN);
+        }
+
+        $type = trim((string) $this->request->getParam('type', ''));
+        $repo = trim((string) $this->request->getParam('repo', ''));
+        $path = trim((string) $this->request->getParam('path', ''));
+        if ($type === '' || $repo === '' || $path === '') {
+            return new JSONResponse(['error' => 'A publish needs a type, repo and path.'], Http::STATUS_BAD_REQUEST);
+        }
+
+        $credentialId = $this->config->getUserValue($user->getUID(), self::APP_ID, self::CREDENTIAL_PREF, '');
+        if ($credentialId === '') {
+            return new JSONResponse(
+                ['error' => 'No store credential selected. Choose a GitHub credential in the Configuration store settings.'],
+                Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        $branch = trim((string) $this->request->getParam('branch', ''));
+        if ($branch === '') {
+            $branch = 'main';
+        }
+
+        try {
+            $result = $this->service->publish(
+                typeId: $type,
+                selection: (array) $this->request->getParam('selection', []),
+                repo: $repo,
+                path: $path,
+                credentialId: $credentialId,
+                branch: $branch
+            );
+        } catch (UnexpectedValueException $e) {
+            return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
+        } catch (Throwable $e) {
+            return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_INTERNAL_SERVER_ERROR);
+        }
+
+        return new JSONResponse($result);
+
+    }//end publish()
+
+    /**
+     * Discover published bundles across GitHub by a type's discovery topic.
+     *
+     * @return JSONResponse `{results: [{repo, name, description, url, stars, updated, topics}]}`.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function discover(): JSONResponse
+    {
+        $topic = trim((string) $this->request->getParam('topic', ''));
+        if ($topic === '') {
+            return new JSONResponse(['error' => 'Discovery needs a topic.'], Http::STATUS_BAD_REQUEST);
+        }
+
+        // An authenticated search (higher rate limit) uses the user's chosen
+        // store credential when they have one; otherwise it is anonymous.
+        $credentialId = null;
+        $user         = $this->userSession->getUser();
+        if ($user !== null) {
+            $stored = $this->config->getUserValue($user->getUID(), self::APP_ID, self::CREDENTIAL_PREF, '');
+            if ($stored !== '') {
+                $credentialId = $stored;
+            }
+        }
+
+        return new JSONResponse(['results' => $this->service->discover(topic: $topic, credentialId: $credentialId)]);
+
+    }//end discover()
+
+    /**
+     * This instance's signing public key, for other orgs to add to their trust list.
+     *
+     * @return JSONResponse `{publicKey}`.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function publicKey(): JSONResponse
+    {
+        return new JSONResponse(['publicKey' => $this->service->publicKey()]);
+
+    }//end publicKey()
 }//end class

--- a/lib/Service/Config/BundleSigner.php
+++ b/lib/Service/Config/BundleSigner.php
@@ -1,0 +1,258 @@
+<?php
+
+/**
+ * Signs and verifies federated configuration bundles (provenance + tamper-evidence).
+ *
+ * A shared bundle travels between instances over GitHub; nothing about GitHub
+ * proves who produced it or that it arrived unaltered. This signer gives both:
+ * on publish it attaches an Ed25519 signature over the canonical bundle keyed by
+ * the publishing instance's own key, and on install the receiver re-derives the
+ * canonical form and checks the signature. A trusted-keys allowlist (empty =
+ * "not yet enforced", the same idiom as the source allowlist) lets an org pin
+ * which publishers it will install from.
+ *
+ * The signature covers a canonical JSON encoding (keys recursively sorted) of the
+ * bundle with its own `provenance` block removed, so signing is deterministic and
+ * order-independent.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Config
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Config;
+
+use OCP\IAppConfig;
+use Throwable;
+
+/**
+ * Ed25519 signing and verification for shareable bundles.
+ */
+class BundleSigner
+{
+
+    /**
+     * The app its config lives under.
+     */
+    private const APP_ID = 'openregister';
+
+    /**
+     * App-config key holding this instance's base64 Ed25519 secret key.
+     */
+    private const SECRET_KEY = 'federated_config_signing_secret';
+
+    /**
+     * App-config key holding the comma-separated base64 public keys this org
+     * trusts. Empty means "signatures not yet enforced".
+     */
+    private const TRUSTED_KEYS = 'federated_config_trusted_keys';
+
+    /**
+     * The signature algorithm label carried in provenance.
+     */
+    private const ALG = 'ed25519';
+
+    /**
+     * Constructor.
+     *
+     * @param IAppConfig $appConfig Stores the signing key and the trusted keys.
+     */
+    public function __construct(
+        private readonly IAppConfig $appConfig
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Attach a signature to a bundle.
+     *
+     * @param array $bundle The bundle to sign.
+     *
+     * @return array The bundle with a `provenance` block.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function sign(array $bundle): array
+    {
+        unset($bundle['provenance']);
+
+        $secret    = $this->secretKey();
+        $public    = sodium_crypto_sign_publickey_from_secretkey($secret);
+        $signature = sodium_crypto_sign_detached($this->canonical(bundle: $bundle), $secret);
+
+        $bundle['provenance'] = [
+            'alg'       => self::ALG,
+            'publicKey' => base64_encode($public),
+            'signature' => base64_encode($signature),
+        ];
+
+        return $bundle;
+
+    }//end sign()
+
+    /**
+     * Verify a bundle's signature.
+     *
+     * @param array $bundle The bundle to check.
+     *
+     * @return array{signed: bool, valid: bool, trusted: bool, publicKey: ?string}
+     *         `signed` — carried a provenance block; `valid` — signature checks
+     *         out; `trusted` — the key is on the allowlist (or the allowlist is
+     *         not enforced).
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function verify(array $bundle): array
+    {
+        $provenance = ($bundle['provenance'] ?? null);
+        if (is_array($provenance) === false) {
+            // Unsigned: "trusted" only when the org has not opted into enforcement.
+            return ['signed' => false, 'valid' => false, 'trusted' => ($this->enforced() === false), 'publicKey' => null];
+        }
+
+        unset($bundle['provenance']);
+
+        $publicKeyB64 = (string) ($provenance['publicKey'] ?? '');
+        $signature    = base64_decode((string) ($provenance['signature'] ?? ''), true);
+        $publicKey    = base64_decode($publicKeyB64, true);
+
+        $valid = false;
+        if ($signature !== false && $publicKey !== false) {
+            try {
+                $valid = sodium_crypto_sign_verify_detached($signature, $this->canonical(bundle: $bundle), $publicKey);
+            } catch (Throwable $e) {
+                $valid = false;
+            }
+        }
+
+        return [
+            'signed'    => true,
+            'valid'     => $valid,
+            'trusted'   => $this->isKeyTrusted(publicKeyB64: $publicKeyB64),
+            'publicKey' => $publicKeyB64,
+        ];
+
+    }//end verify()
+
+    /**
+     * This instance's public key, base64, so an operator can share it for others
+     * to trust.
+     *
+     * @return string The base64 public key.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function publicKey(): string
+    {
+        return base64_encode(sodium_crypto_sign_publickey_from_secretkey($this->secretKey()));
+
+    }//end publicKey()
+
+    /**
+     * Whether signature enforcement is on (a non-empty trusted-keys allowlist).
+     *
+     * @return boolean Whether unsigned/untrusted bundles must be refused.
+     */
+    public function enforced(): bool
+    {
+        return trim($this->appConfig->getValueString(self::APP_ID, self::TRUSTED_KEYS, '')) !== '';
+
+    }//end enforced()
+
+    /**
+     * Whether a public key is trusted. An empty allowlist trusts everything (not
+     * yet enforced); otherwise the key must appear on it.
+     *
+     * @param string $publicKeyB64 The base64 public key.
+     *
+     * @return boolean Whether it is trusted.
+     */
+    private function isKeyTrusted(string $publicKeyB64): bool
+    {
+        $raw = trim($this->appConfig->getValueString(self::APP_ID, self::TRUSTED_KEYS, ''));
+        if ($raw === '') {
+            return true;
+        }
+
+        $trusted = array_filter(array_map('trim', explode(',', $raw)));
+        return in_array($publicKeyB64, $trusted, true);
+
+    }//end isKeyTrusted()
+
+    /**
+     * The instance's Ed25519 secret key, generating and persisting one on first use.
+     *
+     * @return string The raw secret key bytes.
+     */
+    private function secretKey(): string
+    {
+        $stored = $this->appConfig->getValueString(self::APP_ID, self::SECRET_KEY, '');
+        if ($stored !== '') {
+            $decoded = base64_decode($stored, true);
+            if ($decoded !== false && strlen($decoded) === SODIUM_CRYPTO_SIGN_SECRETKEYBYTES) {
+                return $decoded;
+            }
+        }
+
+        // First publish on this instance: mint and persist a keypair. The secret
+        // never leaves app config; only the derived public key is ever shared.
+        $keypair = sodium_crypto_sign_keypair();
+        $secret  = sodium_crypto_sign_secretkey($keypair);
+        $this->appConfig->setValueString(self::APP_ID, self::SECRET_KEY, base64_encode($secret), sensitive: true);
+
+        return $secret;
+
+    }//end secretKey()
+
+    /**
+     * Canonical, order-independent JSON encoding of a bundle for signing.
+     *
+     * @param array $bundle The bundle (without its provenance block).
+     *
+     * @return string The canonical bytes.
+     */
+    private function canonical(array $bundle): string
+    {
+        $this->ksortRecursive(value: $bundle);
+        return (string) json_encode($bundle, (JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+    }//end canonical()
+
+    /**
+     * Recursively sort array keys so encoding is deterministic.
+     *
+     * @param mixed $value The value to sort in place.
+     *
+     * @return void
+     */
+    private function ksortRecursive(mixed &$value): void
+    {
+        if (is_array($value) === false) {
+            return;
+        }
+
+        // Only associative arrays need key-sorting; list order is significant.
+        foreach ($value as &$child) {
+            $this->ksortRecursive(value: $child);
+        }
+
+        unset($child);
+
+        if (array_is_list($value) === false) {
+            ksort($value);
+        }
+
+    }//end ksortRecursive()
+}//end class

--- a/lib/Service/Config/FederatedConfigAccess.php
+++ b/lib/Service/Config/FederatedConfigAccess.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * Who may publish and install shared configuration.
+ *
+ * The source allowlist governs WHERE a bundle may come from; this governs WHO on
+ * this instance may push configuration out or pull it in. Beyond "any admin", an
+ * org can nominate the groups allowed to publish and to install via app config.
+ * Following the source-allowlist idiom, an empty group list means "not yet
+ * enforced" (any signed-in user may act), so this is safe to ship before an org
+ * curates its roles; admins are always allowed.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Config
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Config;
+
+use OCP\IAppConfig;
+use OCP\IGroupManager;
+use OCP\IUser;
+
+/**
+ * Per-org role gating for publish and install.
+ */
+class FederatedConfigAccess
+{
+
+    /**
+     * The app its config lives under.
+     */
+    private const APP_ID = 'openregister';
+
+    /**
+     * App-config key: comma-separated groups allowed to publish.
+     */
+    private const PUBLISH_GROUPS = 'federated_config_publish_groups';
+
+    /**
+     * App-config key: comma-separated groups allowed to install.
+     */
+    private const INSTALL_GROUPS = 'federated_config_install_groups';
+
+    /**
+     * Constructor.
+     *
+     * @param IGroupManager $groupManager Resolves group membership and admin.
+     * @param IAppConfig    $appConfig    Reads the allowed-group lists.
+     */
+    public function __construct(
+        private readonly IGroupManager $groupManager,
+        private readonly IAppConfig $appConfig
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Whether a user may publish configuration.
+     *
+     * @param IUser|null $user The acting user (null = no session).
+     *
+     * @return boolean Whether publishing is allowed.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function canPublish(?IUser $user): bool
+    {
+        return $this->isAllowed(user: $user, key: self::PUBLISH_GROUPS);
+
+    }//end canPublish()
+
+    /**
+     * Whether a user may install configuration.
+     *
+     * @param IUser|null $user The acting user (null = no session).
+     *
+     * @return boolean Whether installing is allowed.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function canInstall(?IUser $user): bool
+    {
+        return $this->isAllowed(user: $user, key: self::INSTALL_GROUPS);
+
+    }//end canInstall()
+
+    /**
+     * Whether a user satisfies a group allowlist.
+     *
+     * @param IUser|null $user The acting user.
+     * @param string     $key  The app-config key holding the allowed groups.
+     *
+     * @return boolean Whether allowed.
+     */
+    private function isAllowed(?IUser $user, string $key): bool
+    {
+        if ($user === null) {
+            return false;
+        }
+
+        // Admins may always act.
+        if ($this->groupManager->isAdmin($user->getUID()) === true) {
+            return true;
+        }
+
+        $raw = trim($this->appConfig->getValueString(self::APP_ID, $key, ''));
+        if ($raw === '') {
+            // Not yet enforced — any signed-in user may act.
+            return true;
+        }
+
+        $allowed = array_filter(array_map('trim', explode(',', $raw)));
+        foreach ($this->groupManager->getUserGroupIds($user) as $groupId) {
+            if (in_array($groupId, $allowed, true) === true) {
+                return true;
+            }
+        }
+
+        return false;
+
+    }//end isAllowed()
+}//end class

--- a/lib/Service/Config/FederatedConfigService.php
+++ b/lib/Service/Config/FederatedConfigService.php
@@ -39,9 +39,11 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Service\Config;
 
 use OCA\OpenRegister\Service\Credential\CredentialBrokerService;
+use OCP\Http\Client\IClientService;
 use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use Throwable;
 use UnexpectedValueException;
 
 /**
@@ -61,16 +63,25 @@ class FederatedConfigService
     private const ALLOWLIST_KEY = 'federated_config_source_allowlist';
 
     /**
+     * The GitHub API host for anonymous discovery.
+     */
+    private const GITHUB_API = 'https://api.github.com';
+
+    /**
      * Constructor.
      *
-     * @param ShareableConfigTypeRegistry $registry  The contributed types.
-     * @param CredentialBrokerService     $broker    Custodies the GitHub token (Doriath's vault where installed, the NC vault otherwise).
-     * @param IAppConfig                  $appConfig Reads the org source allowlist.
-     * @param LoggerInterface             $logger    The logger.
+     * @param ShareableConfigTypeRegistry $registry      The contributed types.
+     * @param CredentialBrokerService     $broker        Custodies the GitHub token (Doriath's vault where installed, the NC vault otherwise).
+     * @param BundleSigner                $signer        Signs published bundles and verifies installed ones.
+     * @param IClientService              $clientService NC HTTP client factory (anonymous discovery).
+     * @param IAppConfig                  $appConfig     Reads the org source allowlist.
+     * @param LoggerInterface             $logger        The logger.
      */
     public function __construct(
         private readonly ShareableConfigTypeRegistry $registry,
         private readonly CredentialBrokerService $broker,
+        private readonly BundleSigner $signer,
+        private readonly IClientService $clientService,
         private readonly IAppConfig $appConfig,
         private readonly LoggerInterface $logger
     ) {
@@ -137,6 +148,18 @@ class FederatedConfigService
             throw new RuntimeException(sprintf('Source "%s" is not on this organisation\'s allowlist.', $source));
         }
 
+        // Provenance: a tampered signature is always refused; an unsigned or
+        // untrusted-key bundle is refused only once the org enforces signing (a
+        // non-empty trusted-keys allowlist).
+        $verdict = $this->signer->verify(bundle: $bundle);
+        if ($verdict['signed'] === true && $verdict['valid'] === false) {
+            throw new RuntimeException('Bundle signature is invalid — refusing to install a tampered bundle.');
+        }
+
+        if ($verdict['trusted'] === false) {
+            throw new RuntimeException('Bundle publisher key is not trusted by this organisation.');
+        }
+
         return $this->typeOrFail(typeId: $typeId)->deserialise(bundle: $bundle);
 
     }//end install()
@@ -166,7 +189,7 @@ class FederatedConfigService
         string $credentialId,
         string $branch='main'
     ): array {
-        $bundle  = $this->bundle(typeId: $typeId, selection: $selection);
+        $bundle  = $this->signer->sign(bundle: $this->bundle(typeId: $typeId, selection: $selection));
         $content = base64_encode((string) json_encode($bundle, JSON_PRETTY_PRINT));
 
         // The broker makes the call with the token it custodies (Doriath/NC
@@ -194,6 +217,96 @@ class FederatedConfigService
         return ['published' => true, 'path' => $path, 'status' => $status];
 
     }//end publish()
+
+    /**
+     * Discover published bundles across GitHub by their type's discovery topic.
+     *
+     * Discovery is public data (GitHub topic search), so it runs anonymously by
+     * default; when a broker credential is supplied it goes through the broker
+     * (higher rate limit, private-visible repos). Returns lightweight cards for a
+     * browse UI — never installs.
+     *
+     * @param string      $topic        The discovery topic to search for.
+     * @param string|null $credentialId Optional broker credential for an authenticated search.
+     *
+     * @return array<int, array<string, mixed>> The discovered repositories as
+     *         `{repo, name, description, url, stars, updated, topics}` cards.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function discover(string $topic, ?string $credentialId=null): array
+    {
+        $topic = trim($topic);
+        if ($topic === '') {
+            return [];
+        }
+
+        $path = '/search/repositories?q='.rawurlencode('topic:'.$topic).'&sort=updated&per_page=50';
+
+        try {
+            if ($credentialId !== null && $credentialId !== '') {
+                $result = $this->broker->request(
+                    credentialId: $credentialId,
+                    appId: self::APP_ID,
+                    method: 'GET',
+                    path: $path,
+                    headers: ['Accept' => 'application/vnd.github+json']
+                );
+                $body   = (string) ($result['body'] ?? '');
+            } else {
+                $response = $this->clientService->newClient()->get(
+                    self::GITHUB_API.$path,
+                    ['headers' => ['Accept' => 'application/vnd.github+json'], 'http_errors' => false]
+                );
+                $body     = (string) $response->getBody();
+            }
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                message: '[FederatedConfigService] discovery failed for topic '.$topic.': '.$e->getMessage(),
+                context: ['file' => __FILE__, 'line' => __LINE__]
+            );
+            return [];
+        }//end try
+
+        $decoded = json_decode($body, true);
+        $items   = [];
+        if (is_array($decoded) === true && isset($decoded['items']) === true && is_array($decoded['items']) === true) {
+            $items = $decoded['items'];
+        }
+
+        $cards = [];
+        foreach ($items as $item) {
+            if (is_array($item) === false) {
+                continue;
+            }
+
+            $cards[] = [
+                'repo'        => (string) ($item['full_name'] ?? ''),
+                'name'        => (string) ($item['name'] ?? ''),
+                'description' => (string) ($item['description'] ?? ''),
+                'url'         => (string) ($item['html_url'] ?? ''),
+                'stars'       => (int) ($item['stargazers_count'] ?? 0),
+                'updated'     => (string) ($item['updated_at'] ?? ''),
+                'topics'      => array_values(array_filter((array) ($item['topics'] ?? []), 'is_string')),
+            ];
+        }//end foreach
+
+        return $cards;
+
+    }//end discover()
+
+    /**
+     * This instance's signing public key (base64) for others to trust.
+     *
+     * @return string The base64 Ed25519 public key.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function publicKey(): string
+    {
+        return $this->signer->publicKey();
+
+    }//end publicKey()
 
     /**
      * Whether a source may be installed from.

--- a/tests/Unit/Service/Config/BundleSignerTest.php
+++ b/tests/Unit/Service/Config/BundleSignerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Config;
+
+use OCA\OpenRegister\Service\Config\BundleSigner;
+use OCP\IAppConfig;
+use PHPUnit\Framework\TestCase;
+
+class BundleSignerTest extends TestCase
+{
+    /**
+     * Stateful IAppConfig double: setValueString persists, getValueString reads.
+     *
+     * @var array<string, string>
+     */
+    private array $store = [];
+
+    private BundleSigner $signer;
+
+    protected function setUp(): void
+    {
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueString')->willReturnCallback(
+            fn (string $app, string $key, string $default = '') => ($this->store[$key] ?? $default)
+        );
+        $appConfig->method('setValueString')->willReturnCallback(
+            function (string $app, string $key, string $value): bool {
+                $this->store[$key] = $value;
+                return true;
+            }
+        );
+
+        $this->signer = new BundleSigner($appConfig);
+    }
+
+    public function testSignThenVerifyRoundTrips(): void
+    {
+        $signed = $this->signer->sign(['type' => 'demo', 'objects' => [['b' => 2, 'a' => 1]]]);
+
+        $this->assertArrayHasKey('provenance', $signed);
+        $this->assertSame('ed25519', $signed['provenance']['alg']);
+
+        $verdict = $this->signer->verify($signed);
+        $this->assertTrue($verdict['signed']);
+        $this->assertTrue($verdict['valid']);
+        $this->assertTrue($verdict['trusted']);
+    }
+
+    public function testTamperingBreaksTheSignature(): void
+    {
+        $signed = $this->signer->sign(['type' => 'demo', 'objects' => [['a' => 1]]]);
+        $signed['objects'][0]['a'] = 999;
+
+        $verdict = $this->signer->verify($signed);
+        $this->assertTrue($verdict['signed']);
+        $this->assertFalse($verdict['valid'], 'a tampered bundle must not verify');
+    }
+
+    public function testCanonicalisationIsKeyOrderIndependent(): void
+    {
+        $signed = $this->signer->sign(['type' => 'demo', 'objects' => [['a' => 1, 'z' => 2]]]);
+        // Re-order keys of the payload without touching values — signature still valid.
+        $reordered = ['objects' => [['z' => 2, 'a' => 1]], 'type' => 'demo', 'provenance' => $signed['provenance']];
+
+        $this->assertTrue($this->signer->verify($reordered)['valid']);
+    }
+
+    public function testUnsignedIsTrustedOnlyWhenNotEnforced(): void
+    {
+        $bundle = ['type' => 'demo'];
+
+        // No trusted-keys list → not enforced → unsigned is trusted.
+        $this->assertTrue($this->signer->verify($bundle)['trusted']);
+
+        // Enforce by trusting some (other) key → unsigned is no longer trusted.
+        $this->store['federated_config_trusted_keys'] = base64_encode(str_repeat('x', 32));
+        $verdict = $this->signer->verify($bundle);
+        $this->assertFalse($verdict['signed']);
+        $this->assertFalse($verdict['trusted']);
+    }
+
+    public function testEnforcementTrustsOnlyListedKeys(): void
+    {
+        $signed = $this->signer->sign(['type' => 'demo']);
+
+        // Enforce with an unrelated key → valid but untrusted.
+        $this->store['federated_config_trusted_keys'] = base64_encode(str_repeat('y', 32));
+        $verdict = $this->signer->verify($signed);
+        $this->assertTrue($verdict['valid']);
+        $this->assertFalse($verdict['trusted']);
+
+        // Add this instance's own key → trusted again.
+        $this->store['federated_config_trusted_keys'] .= ','.$this->signer->publicKey();
+        $this->assertTrue($this->signer->verify($signed)['trusted']);
+    }
+}

--- a/tests/Unit/Service/Config/FederatedConfigAccessTest.php
+++ b/tests/Unit/Service/Config/FederatedConfigAccessTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Config;
+
+use OCA\OpenRegister\Service\Config\FederatedConfigAccess;
+use OCP\IAppConfig;
+use OCP\IGroupManager;
+use OCP\IUser;
+use PHPUnit\Framework\TestCase;
+
+class FederatedConfigAccessTest extends TestCase
+{
+    private IGroupManager $groups;
+
+    private string $publishGroups = '';
+
+    private FederatedConfigAccess $access;
+
+    protected function setUp(): void
+    {
+        $this->groups = $this->createMock(IGroupManager::class);
+        $appConfig    = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueString')->willReturnCallback(
+            fn (string $app, string $key, string $default = '') => ($key === 'federated_config_publish_groups' ? $this->publishGroups : '')
+        );
+
+        $this->access = new FederatedConfigAccess($this->groups, $appConfig);
+    }
+
+    private function user(string $uid): IUser
+    {
+        $u = $this->createMock(IUser::class);
+        $u->method('getUID')->willReturn($uid);
+        return $u;
+    }
+
+    public function testNullUserIsNeverAllowed(): void
+    {
+        $this->assertFalse($this->access->canPublish(null));
+    }
+
+    public function testAdminIsAlwaysAllowed(): void
+    {
+        $this->publishGroups = 'editors';
+        $this->groups->method('isAdmin')->willReturn(true);
+
+        $this->assertTrue($this->access->canPublish($this->user('root')));
+    }
+
+    public function testEmptyGroupListAllowsAnySignedInUser(): void
+    {
+        $this->publishGroups = '';
+        $this->groups->method('isAdmin')->willReturn(false);
+
+        $this->assertTrue($this->access->canPublish($this->user('alice')));
+    }
+
+    public function testSetGroupListGatesByMembership(): void
+    {
+        $this->publishGroups = 'editors, publishers';
+        $this->groups->method('isAdmin')->willReturn(false);
+        $this->groups->method('getUserGroupIds')->willReturn(['staff', 'publishers']);
+
+        $this->assertTrue($this->access->canPublish($this->user('bob')));
+    }
+
+    public function testUserOutsideTheGroupsIsDenied(): void
+    {
+        $this->publishGroups = 'editors';
+        $this->groups->method('isAdmin')->willReturn(false);
+        $this->groups->method('getUserGroupIds')->willReturn(['staff']);
+
+        $this->assertFalse($this->access->canPublish($this->user('carol')));
+    }
+}

--- a/tests/Unit/Service/Config/FederatedConfigServiceTest.php
+++ b/tests/Unit/Service/Config/FederatedConfigServiceTest.php
@@ -37,9 +37,17 @@ class FederatedConfigServiceTest extends TestCase
             fn (string $app, string $key, string $default = '') => $this->allowlist[0]
         );
 
+        $signer = $this->createMock(\OCA\OpenRegister\Service\Config\BundleSigner::class);
+        // Default: unsigned bundles pass (allowlist not enforced) so the existing
+        // install/allowlist assertions are unaffected by signing.
+        $signer->method('verify')->willReturn(['signed' => false, 'valid' => false, 'trusted' => true, 'publicKey' => null]);
+        $signer->method('sign')->willReturnArgument(0);
+
         $this->service = new FederatedConfigService(
             $this->registry,
             $this->createMock(CredentialBrokerService::class),
+            $signer,
+            $this->createMock(\OCP\Http\Client\IClientService::class),
             $this->config,
             $this->createMock(\Psr\Log\LoggerInterface::class)
         );
@@ -117,5 +125,60 @@ class FederatedConfigServiceTest extends TestCase
         $this->assertTrue($this->service->isSourceAllowed('ConductionNL/flows'));
         $this->assertTrue($this->service->isSourceAllowed('acme/anything'));
         $this->assertFalse($this->service->isSourceAllowed('other/repo'));
+    }
+
+    /**
+     * Build a service whose signer returns a fixed verify() verdict.
+     *
+     * @param array $verdict The verdict verify() should return.
+     *
+     * @return FederatedConfigService The service.
+     */
+    private function serviceWithVerdict(array $verdict): FederatedConfigService
+    {
+        $signer = $this->createMock(\OCA\OpenRegister\Service\Config\BundleSigner::class);
+        $signer->method('verify')->willReturn($verdict);
+        $signer->method('sign')->willReturnArgument(0);
+
+        return new FederatedConfigService(
+            $this->registry,
+            $this->createMock(CredentialBrokerService::class),
+            $signer,
+            $this->createMock(\OCP\Http\Client\IClientService::class),
+            $this->config,
+            $this->createMock(\Psr\Log\LoggerInterface::class)
+        );
+    }
+
+    public function testInstallRefusesATamperedSignature(): void
+    {
+        $this->allowlist = [''];
+        $this->registry->method('get')->willReturn($this->type());
+        $service = $this->serviceWithVerdict(['signed' => true, 'valid' => false, 'trusted' => true, 'publicKey' => 'k']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/signature/');
+        $service->install('demo.type', ['provenance' => ['signature' => 'bad']], 'ConductionNL/pack');
+    }
+
+    public function testInstallRefusesAnUntrustedPublisher(): void
+    {
+        $this->allowlist = [''];
+        $this->registry->method('get')->willReturn($this->type());
+        $service = $this->serviceWithVerdict(['signed' => true, 'valid' => true, 'trusted' => false, 'publicKey' => 'k']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/trusted/');
+        $service->install('demo.type', [], 'ConductionNL/pack');
+    }
+
+    public function testInstallAcceptsAValidTrustedBundle(): void
+    {
+        $this->allowlist = [''];
+        $this->registry->method('get')->willReturn($this->type());
+        $service = $this->serviceWithVerdict(['signed' => true, 'valid' => true, 'trusted' => true, 'publicKey' => 'k']);
+
+        $result = $service->install('demo.type', [], 'ConductionNL/pack');
+        $this->assertSame(['x'], $result['installed']);
     }
 }

--- a/tests/e2e/api-direct/federated-config-store.spec.ts
+++ b/tests/e2e/api-direct/federated-config-store.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Federated config STORE surface — publish/discover/sign/RBAC, e2e via HTTP.
+ *
+ * Covers the store foundation beyond the basic bundle/install:
+ *  - the instance exposes a signing public key,
+ *  - discovery searches GitHub by a type's topic,
+ *  - installing is gated by per-org RBAC (install groups),
+ *  - signing enforcement (a trusted-keys allowlist) refuses unsigned bundles,
+ *  - publish refuses when the user has selected no store credential.
+ *
+ * The RBAC/enforcement toggles go through `occ` in the dev container
+ * (NC_CONTAINER, default `nextcloud`) and a restart to clear the appconfig
+ * cache; those tests skip cleanly off the dev host.
+ *
+ * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+ */
+import { test, expect, type APIRequestContext } from '@playwright/test'
+import { execSync } from 'node:child_process'
+
+const API = '/index.php/apps/openregister/api'
+const JSON_HEADERS = { 'Content-Type': 'application/json', Accept: 'application/json' }
+const CONTAINER = process.env.NC_CONTAINER || 'nextcloud'
+const runId = `e2e-store-${Date.now()}`
+
+function occ(args: string): string | null {
+	try {
+		return execSync(`docker exec -u www-data ${CONTAINER} php occ ${args}`, { encoding: 'utf8' })
+	} catch {
+		return null
+	}
+}
+
+function restartAndWait(): void {
+	try {
+		execSync(`docker restart ${CONTAINER}`, { stdio: 'ignore' })
+		for (let i = 0; i < 40; i++) {
+			try {
+				const code = execSync(
+					`curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/status.php`,
+					{ encoding: 'utf8' },
+				)
+				if (code.trim() === '200') return
+			} catch { /* keep polling */ }
+			execSync('sleep 3')
+		}
+	} catch { /* best effort */ }
+}
+
+test.describe('Federated config store', () => {
+	let regId: number
+	let schId: number
+	let type: string
+	const objects: string[] = []
+
+	test.beforeAll(async ({ request }) => {
+		const sch = await (await request.post(`${API}/schemas`, {
+			headers: JSON_HEADERS,
+			data: { title: `Store ${runId}`, properties: { name: { type: 'string' } }, configuration: { 'x-openregister-shareable': true } },
+		})).json()
+		schId = sch.id
+		const reg = await (await request.post(`${API}/registers`, {
+			headers: JSON_HEADERS, data: { title: `Store Reg ${runId}`, schemas: [schId] },
+		})).json()
+		regId = reg.id
+		type = `${reg.slug}.${sch.slug}`
+		const obj = await (await request.post(`${API}/objects/${regId}/${schId}`, {
+			headers: JSON_HEADERS, data: { name: 'Alpha' },
+		})).json()
+		objects.push(obj['@self'].id)
+	})
+
+	test.afterAll(async ({ request }) => {
+		for (const u of objects) await request.delete(`${API}/objects/${regId}/${schId}/${u}`).catch(() => {})
+		await request.delete(`${API}/registers/${regId}`).catch(() => {})
+		await request.delete(`${API}/schemas/${schId}`).catch(() => {})
+	})
+
+	async function bundle(request: APIRequestContext): Promise<any> {
+		return (await request.post(`${API}/federated-config/bundle`, {
+			headers: JSON_HEADERS, data: { type, selection: {} },
+		})).json()
+	}
+
+	test('the instance exposes a signing public key', async ({ request }) => {
+		const resp = await request.get(`${API}/federated-config/public-key`)
+		expect(resp.status()).toBe(200)
+		const key = (await resp.json()).publicKey
+		expect(typeof key).toBe('string')
+		// A base64 Ed25519 public key is 32 bytes → 44 base64 chars.
+		expect(key.length).toBe(44)
+	})
+
+	test('discovery searches GitHub by topic', async ({ request }) => {
+		const resp = await request.get(`${API}/federated-config/discover?topic=openbuild-app`)
+		expect(resp.status()).toBe(200)
+		const results = (await resp.json()).results
+		expect(Array.isArray(results)).toBe(true)
+		// Shape check on whatever the search returns (may be 0 on a rate-limited run).
+		for (const card of results) {
+			expect(card).toHaveProperty('repo')
+			expect(card).toHaveProperty('url')
+			expect(card).toHaveProperty('stars')
+		}
+	})
+
+	test('discovery needs a topic', async ({ request }) => {
+		expect((await request.get(`${API}/federated-config/discover`)).status()).toBe(400)
+	})
+
+	test('publish refuses when no store credential is selected', async ({ request }) => {
+		// The admin session has no federated-config-credential preference set, so
+		// publish must refuse rather than guess a credential.
+		const resp = await request.post(`${API}/federated-config/publish`, {
+			headers: JSON_HEADERS,
+			data: { type, selection: {}, repo: 'ConductionNL/store-e2e', path: 'bundle.json' },
+		})
+		expect(resp.status()).toBe(400)
+		expect((await resp.json()).error).toContain('credential')
+	})
+
+	test('signing enforcement refuses an unsigned bundle', async ({ request }) => {
+		const set = occ('config:app:set openregister federated_config_trusted_keys --value="AAAAsomeotherkey="')
+		test.skip(set === null, 'occ not reachable (not on the dev host)')
+		restartAndWait()
+		try {
+			const b = await bundle(request)
+			const denied = await request.post(`${API}/federated-config/install`, {
+				headers: JSON_HEADERS, data: { type, bundle: b, source: 'ConductionNL/x' },
+			})
+			expect(denied.status(), 'unsigned bundle refused under enforcement').toBe(403)
+			expect((await denied.json()).error).toContain('trusted')
+		} finally {
+			occ('config:app:delete openregister federated_config_trusted_keys')
+			restartAndWait()
+		}
+	})
+
+	test('unsigned install succeeds when signing is not enforced', async ({ request }) => {
+		const b = await bundle(request)
+		const ok = await request.post(`${API}/federated-config/install`, {
+			headers: JSON_HEADERS, data: { type, bundle: b, source: 'ConductionNL/x' },
+		})
+		expect(ok.status()).toBe(200)
+		const installed = (await ok.json()).installed ?? []
+		installed.forEach((u: string) => objects.push(u))
+	})
+})


### PR DESCRIPTION
## What

Builds the **store surface** on the sharing engine (#2134/#2135/#2140): publishing, discovery, provenance signing, and per-org access control.

| Endpoint | Purpose |
|---|---|
| `POST /api/federated-config/publish` | Publish a **signed** bundle to GitHub with the credential the **user selected** (from the `federated-config-credential` pref) — never one passed by the caller. 400 when none selected. |
| `GET /api/federated-config/discover?topic=` | Search GitHub by a type's discovery topic (anonymous, or broker when the user has a credential). Backs a browse UI; never installs. |
| `GET /api/federated-config/public-key` | The instance's Ed25519 signing key, for other orgs to trust. |

## Signing / verification (`BundleSigner`, Ed25519 / libsodium)

Publish signs the **canonical** bundle (recursively key-sorted, provenance excluded) with a per-instance key minted + stored once. Install verifies:
- a **tampered** signature is always refused;
- unsigned / untrusted-key bundles are refused once the org populates `federated_config_trusted_keys` (empty = *not-yet-enforced*, the same idiom as the source allowlist).

## Per-org RBAC (`FederatedConfigAccess`)

Publish/install gated by app-config group allowlists (`federated_config_publish_groups` / `federated_config_install_groups`); empty = any signed-in user, admins always allowed.

## Tests

- **15 unit** — signer round-trip / tamper / key-order-independent canonicalisation / enforcement; RBAC membership + admin-always + empty-list; install signing gate (tampered→refuse, untrusted→refuse, valid+trusted→install).
- **6 Playwright e2e** (`api-direct/federated-config-store.spec.ts`).
- **Live-verified on 8080**: public-key served (44-char base64); discover returned real GitHub repos; signing enforcement **403** then **200** after clearing (with the appconfig-cache restart); RBAC **403** for a non-admin gated user vs **200** admin; publish **400** with no credential selected.

> Note: the broker→GitHub `PUT` in `publish()` itself needs a real credential+repo to exercise end-to-end and wasn't live-pushed here; the bundling+signing half and all gating are verified. This unblocks the nc-vue store credential selector + discover UI, and hermiq's cutover onto the shared engine.

@spec `openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md`