### PR TITLE
feat(config): config-set shareable type + repo-creation & topic-tagging on publish

### DIFF
--- a/lib/Listener/ShareableConfigTypeRegistrationListener.php
+++ b/lib/Listener/ShareableConfigTypeRegistrationListener.php
@@ -29,6 +29,7 @@ namespace OCA\OpenRegister\Listener;
 
 use OCA\OpenRegister\Service\Config\RegisterShareableConfigTypesEvent;
 use OCA\OpenRegister\Service\Config\SchemaShareableConfigScanner;
+use OCA\OpenRegister\Service\Config\Types\ConfigSetShareableConfigType;
 use OCA\OpenRegister\Service\Config\Types\FlowShareableConfigType;
 use OCA\OpenRegister\Service\Config\Types\RegisterSchemaShareableConfigType;
 use OCP\EventDispatcher\Event;
@@ -46,11 +47,13 @@ class ShareableConfigTypeRegistrationListener implements IEventListener
      *
      * @param FlowShareableConfigType           $flows     The built-in "Flows" type.
      * @param RegisterSchemaShareableConfigType $registers The built-in "Registers & schemas" type.
+     * @param ConfigSetShareableConfigType      $configSet The built-in "Configuration set" type.
      * @param SchemaShareableConfigScanner      $scanner   Turns shareable-marked schemas into types.
      */
     public function __construct(
         private readonly FlowShareableConfigType $flows,
         private readonly RegisterSchemaShareableConfigType $registers,
+        private readonly ConfigSetShareableConfigType $configSet,
         private readonly SchemaShareableConfigScanner $scanner
     ) {
 
@@ -73,6 +76,7 @@ class ShareableConfigTypeRegistrationListener implements IEventListener
 
         $event->registerType(type: $this->flows);
         $event->registerType(type: $this->registers);
+        $event->registerType(type: $this->configSet);
 
         // Any schema that marked itself shareable becomes a type — no per-app code.
         foreach ($this->scanner->scan() as $type) {

--- a/lib/Service/Config/FederatedConfigService.php
+++ b/lib/Service/Config/FederatedConfigService.php
@@ -189,7 +189,16 @@ class FederatedConfigService
         string $credentialId,
         string $branch='main'
     ): array {
-        $bundle  = $this->signer->sign(bundle: $this->bundle(typeId: $typeId, selection: $selection));
+        $type = $this->typeOrFail(typeId: $typeId);
+
+        // Make the target repo exist and carry the type's discovery topic, so a
+        // freshly published config is findable via discover() (both single-config
+        // and config-set repos rely on this). Best-effort: a failure here still
+        // lets the contents write surface a clear error.
+        $this->ensureRepo(repo: $repo, credentialId: $credentialId);
+        $this->setTopics(repo: $repo, topics: [$type->getTopic()], credentialId: $credentialId);
+
+        $bundle  = $this->signer->sign(bundle: $type->serialise(selection: $selection));
         $content = base64_encode((string) json_encode($bundle, JSON_PRETTY_PRINT));
 
         // The broker makes the call with the token it custodies (Doriath/NC
@@ -214,9 +223,110 @@ class FederatedConfigService
             throw new RuntimeException(sprintf('GitHub publish failed (%d).', $status));
         }
 
-        return ['published' => true, 'path' => $path, 'status' => $status];
+        return [
+            'published' => true,
+            'repo'      => $repo,
+            'path'      => $path,
+            'topic'     => $type->getTopic(),
+            'status'    => $status,
+        ];
 
     }//end publish()
+
+    /**
+     * Ensure a GitHub repository exists, creating it when absent.
+     *
+     * A config store is often published into a fresh, per-set repo. Creation is
+     * best-effort: when the owner is an organisation the org-repo endpoint is
+     * used, otherwise the authenticated user's; a failure is logged, not fatal
+     * (the subsequent contents write reports a missing repo clearly).
+     *
+     * @param string $repo         The `owner/repo`.
+     * @param string $credentialId The broker credential.
+     *
+     * @return void
+     */
+    private function ensureRepo(string $repo, string $credentialId): void
+    {
+        [$owner, $name] = array_pad(explode('/', $repo, 2), 2, '');
+        if ($owner === '' || $name === '') {
+            return;
+        }
+
+        try {
+            $existing = $this->broker->request(
+                credentialId: $credentialId,
+                appId: self::APP_ID,
+                method: 'GET',
+                path: sprintf('/repos/%s/%s', $owner, $name),
+                headers: ['Accept' => 'application/vnd.github+json']
+            );
+            if ((int) ($existing['status'] ?? 0) === 200) {
+                return;
+            }
+        } catch (Throwable $e) {
+            // Fall through to creation.
+        }
+
+        // Try an org repo first, then the authenticated user's namespace.
+        foreach ([sprintf('/orgs/%s/repos', $owner), '/user/repos'] as $createPath) {
+            try {
+                $created = $this->broker->request(
+                    credentialId: $credentialId,
+                    appId: self::APP_ID,
+                    method: 'POST',
+                    path: $createPath,
+                    headers: ['Accept' => 'application/vnd.github+json'],
+                    body: (string) json_encode(['name' => $name, 'private' => false, 'auto_init' => true])
+                );
+                if ((int) ($created['status'] ?? 0) >= 200 && (int) ($created['status'] ?? 0) < 300) {
+                    return;
+                }
+            } catch (Throwable $e) {
+                continue;
+            }
+        }
+
+        $this->logger->warning(
+            message: '[FederatedConfigService] could not ensure repo '.$repo.' exists; relying on the write to report it.',
+            context: ['file' => __FILE__, 'line' => __LINE__]
+        );
+
+    }//end ensureRepo()
+
+    /**
+     * Set a repository's discovery topics (best-effort).
+     *
+     * @param string             $repo         The `owner/repo`.
+     * @param array<int, string> $topics       The topics to set.
+     * @param string             $credentialId The broker credential.
+     *
+     * @return void
+     */
+    private function setTopics(string $repo, array $topics, string $credentialId): void
+    {
+        $names = array_values(array_filter(array_map('trim', $topics)));
+        if ($names === []) {
+            return;
+        }
+
+        try {
+            $this->broker->request(
+                credentialId: $credentialId,
+                appId: self::APP_ID,
+                method: 'PUT',
+                path: sprintf('/repos/%s/topics', $repo),
+                headers: ['Accept' => 'application/vnd.github+json'],
+                body: (string) json_encode(['names' => $names])
+            );
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                message: '[FederatedConfigService] could not set topics on '.$repo.': '.$e->getMessage(),
+                context: ['file' => __FILE__, 'line' => __LINE__]
+            );
+        }
+
+    }//end setTopics()
 
     /**
      * Discover published bundles across GitHub by their type's discovery topic.

--- a/lib/Service/Config/Types/ConfigSetShareableConfigType.php
+++ b/lib/Service/Config/Types/ConfigSetShareableConfigType.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * A whole configuration SET as a shareable configuration type.
+ *
+ * Where {@see RegisterSchemaShareableConfigType} shares one register, a
+ * configuration set is an app's worth of configuration at once — registers,
+ * schemas, objects, views, flows, sources and mappings — the same multi-entity
+ * bundle OpenBuild ships as an "app". OpenRegister already models this as a
+ * {@see \OCA\OpenRegister\Db\Configuration}, and `ConfigurationService` already
+ * exports it as one portable, slug-keyed OpenAPI document and imports it back.
+ * This type exposes that through the federated-config seam, so a config set
+ * travels — signed, broker-published, discoverable — the same way a single flow
+ * or a marked schema does.
+ *
+ * A set is published as one file in a repo; a repo may hold many such files (many
+ * sets), which is exactly the "config-set repo" shape. The repo may also carry an
+ * app's own scaffolding (info.xml, bundle) — this type only reads/writes the
+ * configuration document, never the surrounding app files.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Config\Types
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Config\Types;
+
+use OCA\OpenRegister\Db\ConfigurationMapper;
+use OCA\OpenRegister\Service\Config\IShareableConfigType;
+use OCA\OpenRegister\Service\ConfigurationService;
+use Throwable;
+use UnexpectedValueException;
+
+/**
+ * Serialises and installs a whole configuration set through the engine.
+ */
+class ConfigSetShareableConfigType implements IShareableConfigType
+{
+    /**
+     * Constructor.
+     *
+     * @param ConfigurationMapper  $configurationMapper Loads the configuration set to share.
+     * @param ConfigurationService $configService       Exports and imports the set.
+     */
+    public function __construct(
+        private readonly ConfigurationMapper $configurationMapper,
+        private readonly ConfigurationService $configService
+    ) {
+
+    }//end __construct()
+
+    /**
+     * The type id.
+     *
+     * @return string The id.
+     */
+    public function getId(): string
+    {
+        return 'openregister.configset';
+
+    }//end getId()
+
+    /**
+     * The display name.
+     *
+     * @return string The name.
+     */
+    public function getDisplayName(): string
+    {
+        return 'Configuration set';
+
+    }//end getDisplayName()
+
+    /**
+     * The discovery topic.
+     *
+     * @return string The topic.
+     */
+    public function getTopic(): string
+    {
+        return 'openregister-configset';
+
+    }//end getTopic()
+
+    /**
+     * Package a whole configuration set into a portable bundle.
+     *
+     * `$selection` is `{configuration: id}` (a Configuration id) or `{app: appId}`
+     * (the configuration an app owns), plus optional `{includeObjects?: bool}`.
+     *
+     * @param array $selection `{configuration|app, includeObjects?}`.
+     *
+     * @return array The exported multi-entity configuration bundle.
+     *
+     * @throws UnexpectedValueException When no set is named or found.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function serialise(array $selection): array
+    {
+        $configuration = $this->resolve(selection: $selection);
+
+        return $this->configService->exportConfig(
+            input: $configuration,
+            includeObjects: (bool) ($selection['includeObjects'] ?? false)
+        );
+
+    }//end serialise()
+
+    /**
+     * Install a configuration set into this instance.
+     *
+     * Uses the generic JSON import (idempotent, slug-matched) so a set spanning
+     * several registers/schemas/objects/views installs as one unit.
+     *
+     * @param array $bundle A configuration bundle produced by this type.
+     *
+     * @return array The import result.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function deserialise(array $bundle): array
+    {
+        return $this->configService->importFromJson(
+            data: $bundle,
+            version: (string) ($bundle['info']['version'] ?? '1.0.0'),
+            force: false
+        );
+
+    }//end deserialise()
+
+    /**
+     * Resolve the Configuration a selection points at.
+     *
+     * @param array $selection `{configuration|app}`.
+     *
+     * @return \OCA\OpenRegister\Db\Configuration The configuration set.
+     *
+     * @throws UnexpectedValueException When nothing is named or found.
+     */
+    private function resolve(array $selection)
+    {
+        $id = trim((string) ($selection['configuration'] ?? ''));
+        if ($id !== '' && ctype_digit($id) === true) {
+            try {
+                return $this->configurationMapper->find(id: (int) $id);
+            } catch (Throwable $e) {
+                throw new UnexpectedValueException(sprintf('No configuration set "%s".', $id));
+            }
+        }
+
+        $app = trim((string) ($selection['app'] ?? ''));
+        if ($app !== '') {
+            $found = $this->configurationMapper->findByApp(app: $app);
+            if ($found !== []) {
+                return $found[0];
+            }
+
+            throw new UnexpectedValueException(sprintf('No configuration set for app "%s".', $app));
+        }
+
+        throw new UnexpectedValueException('Sharing a configuration set needs a configuration id or an app.');
+
+    }//end resolve()
+}//end class

--- a/tests/Unit/Service/Config/ConfigSetShareableConfigTypeTest.php
+++ b/tests/Unit/Service/Config/ConfigSetShareableConfigTypeTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Config;
+
+use OCA\OpenRegister\Db\Configuration;
+use OCA\OpenRegister\Db\ConfigurationMapper;
+use OCA\OpenRegister\Service\Config\Types\ConfigSetShareableConfigType;
+use OCA\OpenRegister\Service\ConfigurationService;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
+
+class ConfigSetShareableConfigTypeTest extends TestCase
+{
+    private ConfigurationMapper $mapper;
+
+    private ConfigurationService $configService;
+
+    private ConfigSetShareableConfigType $type;
+
+    protected function setUp(): void
+    {
+        $this->mapper        = $this->createMock(ConfigurationMapper::class);
+        $this->configService = $this->createMock(ConfigurationService::class);
+        $this->type          = new ConfigSetShareableConfigType($this->mapper, $this->configService);
+    }
+
+    public function testIdentity(): void
+    {
+        $this->assertSame('openregister.configset', $this->type->getId());
+        $this->assertSame('openregister-configset', $this->type->getTopic());
+        $this->assertSame('Configuration set', $this->type->getDisplayName());
+    }
+
+    public function testSerialiseByConfigurationIdExportsTheSet(): void
+    {
+        $config = $this->createMock(Configuration::class);
+        $this->mapper->expects($this->once())->method('find')->with(5)->willReturn($config);
+        $this->configService->expects($this->once())->method('exportConfig')
+            ->with($config, false)
+            ->willReturn(['openapi' => '3.0.0', 'components' => ['registers' => ['a' => []]]]);
+
+        $bundle = $this->type->serialise(['configuration' => '5']);
+        $this->assertSame('3.0.0', $bundle['openapi']);
+    }
+
+    public function testSerialiseByAppUsesTheFirstMatch(): void
+    {
+        $config = $this->createMock(Configuration::class);
+        $this->mapper->expects($this->once())->method('findByApp')->with('openbuild')->willReturn([$config]);
+        $this->configService->expects($this->once())->method('exportConfig')
+            ->with($config, true)
+            ->willReturn(['openapi' => '3.0.0']);
+
+        $bundle = $this->type->serialise(['app' => 'openbuild', 'includeObjects' => true]);
+        $this->assertSame('3.0.0', $bundle['openapi']);
+    }
+
+    public function testSerialiseWithoutASelectionThrows(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->type->serialise([]);
+    }
+
+    public function testSerialiseForAnUnknownAppThrows(): void
+    {
+        $this->mapper->method('findByApp')->willReturn([]);
+        $this->expectException(UnexpectedValueException::class);
+        $this->type->serialise(['app' => 'nope']);
+    }
+
+    public function testDeserialiseImportsTheSet(): void
+    {
+        $bundle = ['info' => ['version' => '2.1.0'], 'components' => ['registers' => []]];
+        $this->configService->expects($this->once())->method('importFromJson')
+            ->with($bundle, null, null, null, '2.1.0', false)
+            ->willReturn(['registers' => 1, 'schemas' => 3]);
+
+        $result = $this->type->deserialise($bundle);
+        $this->assertSame(3, $result['schemas']);
+    }
+}

--- a/tests/Unit/Service/Config/FederatedConfigServiceTest.php
+++ b/tests/Unit/Service/Config/FederatedConfigServiceTest.php
@@ -181,4 +181,44 @@ class FederatedConfigServiceTest extends TestCase
         $result = $service->install('demo.type', [], 'ConductionNL/pack');
         $this->assertSame(['x'], $result['installed']);
     }
+
+    public function testPublishEnsuresRepoSetsTopicAndReturnsMetadata(): void
+    {
+        $this->registry->method('get')->willReturn($this->type());
+
+        $broker = $this->createMock(CredentialBrokerService::class);
+        // Repo missing (404) → created → topics set → contents written; every
+        // broker call returns a 2xx so publish completes and reports metadata.
+        $calls = [];
+        $broker->method('request')->willReturnCallback(
+            function (string $credentialId, string $appId, string $method, string $path) use (&$calls) {
+                $calls[] = $method.' '.$path;
+                // The initial repo existence check is a miss so ensureRepo creates it.
+                if ($method === 'GET' && str_starts_with($path, '/repos/') === true) {
+                    return ['status' => 404, 'body' => ''];
+                }
+                return ['status' => 201, 'body' => '{}'];
+            }
+        );
+
+        $signer = $this->createMock(\OCA\OpenRegister\Service\Config\BundleSigner::class);
+        $signer->method('sign')->willReturnArgument(0);
+        $service = new FederatedConfigService(
+            $this->registry,
+            $broker,
+            $signer,
+            $this->createMock(\OCP\Http\Client\IClientService::class),
+            $this->config,
+            $this->createMock(\Psr\Log\LoggerInterface::class)
+        );
+
+        $result = $service->publish('demo.type', ['x' => 1], 'ConductionNL/pack', 'set.json', 'cred-1');
+
+        $this->assertTrue($result['published']);
+        $this->assertSame('ConductionNL/pack', $result['repo']);
+        $this->assertSame('demo-topic', $result['topic']);
+        // The topic was set and the bundle written.
+        $this->assertContains('PUT /repos/ConductionNL/pack/topics', $calls);
+        $this->assertContains('PUT /repos/ConductionNL/pack/contents/set.json', $calls);
+    }
 }


### PR DESCRIPTION
## What

Two capabilities so a whole app's configuration can be published as one **discoverable** repo (the foundation both the hermiq cutover and the OpenBuild convergence build on).

### `ConfigSetShareableConfigType` (`openregister.configset`)
Shares a whole configuration **set** at once — registers + schemas + objects + views + flows + sources + mappings — not just one register. It wraps the proven `ConfigurationService::exportConfig(Configuration)` / `importFromJson`, so a set travels through the federated engine (signed, broker-published, discoverable) the same way a flow or a marked schema does. Selection is `{configuration: id}` or `{app: appId}`. A repo may hold **many** such files (a config-set repo); the type only reads/writes the configuration document, never surrounding app scaffolding.

### `publish()` now ensures repo + sets topic
Before writing the signed bundle, `publish()` now: GETs the repo, **creates it when absent** (org namespace, then the authenticated user's), and `PUT /repos/{owner}/{repo}/topics` with the type's discovery topic. Without the topic nothing published is findable via `discover()`; without repo-creation a per-set repo couldn't be published to. Both best-effort (a real write failure still surfaces). Returns `{published, repo, path, topic, status}`.

## Tests

7 unit (config-set serialise by id/app, unknown-app + no-selection throw, deserialise→importFromJson; publish ensures-repo + sets-topic + writes + returns metadata). All 46 Config-suite tests green.

**Live-verified on 8080**: `openregister.configset` appears in `/api/federated-config/types`, and bundling Configuration #4394 produces a full multi-entity OpenAPI doc (registers `merge-operation`+`flows`, schemas, mappings, sources, rules, …).

> The broker→GitHub repo-create / topic / contents PUT itself needs a real credential+repo to exercise end-to-end; the assembly, signing, type resolution and the call sequencing are unit-verified.

@spec `openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md`