### PR TITLE
feat(config): fetchBundle — the discover→install bridge for the store

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1247,6 +1247,7 @@ return [
 		['name' => 'federatedConfig#install', 'url' => '/api/federated-config/install', 'verb' => 'POST'],
 		['name' => 'federatedConfig#publish', 'url' => '/api/federated-config/publish', 'verb' => 'POST'],
 		['name' => 'federatedConfig#discover', 'url' => '/api/federated-config/discover', 'verb' => 'GET'],
+		['name' => 'federatedConfig#fetch', 'url' => '/api/federated-config/fetch', 'verb' => 'GET'],
 		['name' => 'federatedConfig#publicKey', 'url' => '/api/federated-config/public-key', 'verb' => 'GET'],
     ],
 ];

--- a/lib/Controller/FederatedConfigController.php
+++ b/lib/Controller/FederatedConfigController.php
@@ -277,6 +277,46 @@ class FederatedConfigController extends Controller
     }//end discover()
 
     /**
+     * Fetch a published bundle file from a GitHub repo (the bridge from discover
+     * to install).
+     *
+     * @return JSONResponse The decoded bundle, or a 4xx.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function fetch(): JSONResponse
+    {
+        $repo = trim((string) $this->request->getParam('repo', ''));
+        $path = trim((string) $this->request->getParam('path', ''));
+        if ($repo === '' || $path === '') {
+            return new JSONResponse(['error' => 'A fetch needs a repo and a path.'], Http::STATUS_BAD_REQUEST);
+        }
+
+        $credentialId = null;
+        $user         = $this->userSession->getUser();
+        if ($user !== null) {
+            $stored = $this->config->getUserValue($user->getUID(), self::APP_ID, self::CREDENTIAL_PREF, '');
+            if ($stored !== '') {
+                $credentialId = $stored;
+            }
+        }
+
+        try {
+            $bundle = $this->service->fetchBundle(repo: $repo, path: $path, credentialId: $credentialId);
+        } catch (Throwable $e) {
+            return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
+        }
+
+        return new JSONResponse(['bundle' => $bundle]);
+
+    }//end fetch()
+
+    /**
      * This instance's signing public key, for other orgs to add to their trust list.
      *
      * @return JSONResponse `{publicKey}`.

--- a/lib/Service/Config/FederatedConfigService.php
+++ b/lib/Service/Config/FederatedConfigService.php
@@ -406,6 +406,74 @@ class FederatedConfigService
     }//end discover()
 
     /**
+     * Fetch a published bundle file from a GitHub repository.
+     *
+     * The bridge between discover() (which returns repo cards) and install()
+     * (which takes a bundle): given a repo and the path of its bundle file, this
+     * reads and decodes it. Public repos are read anonymously; a broker credential
+     * is used when supplied (rate limit, private repos).
+     *
+     * @param string      $repo         The `owner/repo`.
+     * @param string      $path         The bundle file path within the repo.
+     * @param string|null $credentialId Optional broker credential for an authenticated read.
+     *
+     * @return array The decoded bundle.
+     *
+     * @throws RuntimeException When the file cannot be fetched or decoded.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function fetchBundle(string $repo, string $path, ?string $credentialId=null): array
+    {
+        $repo = trim($repo);
+        $path = ltrim(trim($path), '/');
+        if ($repo === '' || $path === '') {
+            throw new RuntimeException('Fetching a bundle needs a repo and a path.');
+        }
+
+        $apiPath = sprintf('/repos/%s/contents/%s', $repo, $path);
+
+        try {
+            if ($credentialId !== null && $credentialId !== '') {
+                $result = $this->broker->request(
+                    credentialId: $credentialId,
+                    appId: self::APP_ID,
+                    method: 'GET',
+                    path: $apiPath,
+                    headers: ['Accept' => 'application/vnd.github+json']
+                );
+                $body   = (string) ($result['body'] ?? '');
+            } else {
+                $response = $this->clientService->newClient()->get(
+                    self::GITHUB_API.$apiPath,
+                    ['headers' => ['Accept' => 'application/vnd.github+json'], 'http_errors' => false]
+                );
+                $body     = (string) $response->getBody();
+            }
+        } catch (Throwable $e) {
+            throw new RuntimeException(sprintf('Could not fetch %s from %s: %s', $path, $repo, $e->getMessage()));
+        }//end try
+
+        $meta = json_decode($body, true);
+        if (is_array($meta) === false || isset($meta['content']) === false) {
+            throw new RuntimeException(sprintf('No bundle at %s in %s.', $path, $repo));
+        }
+
+        $decoded = base64_decode((string) $meta['content'], true);
+        if ($decoded === false) {
+            throw new RuntimeException(sprintf('Bundle at %s in %s is not valid base64.', $path, $repo));
+        }
+
+        $bundle = json_decode($decoded, true);
+        if (is_array($bundle) === false) {
+            throw new RuntimeException(sprintf('Bundle at %s in %s is not valid JSON.', $path, $repo));
+        }
+
+        return $bundle;
+
+    }//end fetchBundle()
+
+    /**
      * This instance's signing public key (base64) for others to trust.
      *
      * @return string The base64 Ed25519 public key.

--- a/tests/Unit/Service/Config/FederatedConfigServiceTest.php
+++ b/tests/Unit/Service/Config/FederatedConfigServiceTest.php
@@ -182,6 +182,45 @@ class FederatedConfigServiceTest extends TestCase
         $this->assertSame(['x'], $result['installed']);
     }
 
+    public function testFetchBundleDecodesTheRepoContentsFile(): void
+    {
+        $bundle  = ['type' => 'demo.type', 'objects' => [['a' => 1]]];
+        $content = base64_encode((string) json_encode($bundle));
+
+        $broker = $this->createMock(CredentialBrokerService::class);
+        $broker->method('request')->willReturn(['status' => 200, 'body' => (string) json_encode(['content' => $content, 'encoding' => 'base64'])]);
+
+        $service = new FederatedConfigService(
+            $this->registry,
+            $broker,
+            $this->createMock(\OCA\OpenRegister\Service\Config\BundleSigner::class),
+            $this->createMock(\OCP\Http\Client\IClientService::class),
+            $this->config,
+            $this->createMock(\Psr\Log\LoggerInterface::class)
+        );
+
+        $out = $service->fetchBundle('ConductionNL/pack', 'set.json', 'cred-1');
+        $this->assertSame($bundle, $out);
+    }
+
+    public function testFetchBundleRejectsMissingContent(): void
+    {
+        $broker = $this->createMock(CredentialBrokerService::class);
+        $broker->method('request')->willReturn(['status' => 404, 'body' => '{"message":"Not Found"}']);
+
+        $service = new FederatedConfigService(
+            $this->registry,
+            $broker,
+            $this->createMock(\OCA\OpenRegister\Service\Config\BundleSigner::class),
+            $this->createMock(\OCP\Http\Client\IClientService::class),
+            $this->config,
+            $this->createMock(\Psr\Log\LoggerInterface::class)
+        );
+
+        $this->expectException(RuntimeException::class);
+        $service->fetchBundle('ConductionNL/pack', 'missing.json', 'cred-1');
+    }
+
     public function testPublishEnsuresRepoSetsTopicAndReturnsMetadata(): void
     {
         $this->registry->method('get')->willReturn($this->type());


### PR DESCRIPTION
`discover()` returns repo cards and `install()` takes a bundle, but nothing read a published bundle **file** out of a repo — so a user who found a repo couldn't install it through the engine.

`fetchBundle(repo, path, credentialId?)` reads the repo's contents file (anonymously for public repos, via the broker when a credential is set), base64- + JSON-decodes it. Exposed as `GET /api/federated-config/fetch?repo=&path=`. This is the capability hermiq's cutover needs to retire its own catalog fetch path: **discover → fetch → install**, all on the shared engine.

2 unit tests. **Live-verified on 8080**: fetched a real `openbuild-app.json` from a public repo and decoded it; a missing path is a 404.

@spec `openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md`