### PR TITLE
test(newman): make crud + rbac collections pass in the combined run (real register-resolution fix)

### DIFF
--- a/lib/Service/Object/PermissionHandler.php
+++ b/lib/Service/Object/PermissionHandler.php
@@ -1958,6 +1958,22 @@ class PermissionHandler
      * Uses RegisterMapper::getFirstRegisterWithSchema() to find the register
      * that contains the given schema.
      *
+     * The register is loaded with multitenancy and RBAC scoping DISABLED. This
+     * is an authorization-policy lookup, not a tenant-scoped data read: we only
+     * need the register entity to read its authorization cascade so the caller
+     * can make a security decision. The sibling id lookup
+     * (getFirstRegisterWithSchema → getAllRegisterIdsWithSchema) is already
+     * unscoped and global by design, so re-applying the active-organisation
+     * filter here would make a legitimately-linked register unresolvable purely
+     * because the caller's active-organisation pointer differs from the
+     * register's organisation — throwing DoesNotExistException, which the catch
+     * below re-throws as AuthorizationUnresolvableException and FAIL-CLOSES,
+     * denying even open-schema access for a cross-org (or transient
+     * active-org-changed) session. Object-row multitenancy isolation is enforced
+     * separately on the data reads (organisation column filters + the RBAC
+     * handler's active-organisation condition), so resolving the register's
+     * policy unscoped here does NOT weaken tenant isolation.
+     *
      * @param Schema $schema The schema to find the register for.
      *
      * @return Register|null The parent register, or null if not found.
@@ -1973,7 +1989,7 @@ class PermissionHandler
                 return null;
             }
 
-            return $registerMapper->find($registerId);
+            return $registerMapper->find(id: $registerId, _rbac: false, _multitenancy: false);
         } catch (\Throwable $e) {
             // Fail-closed: this method logged but still returned null, and null here
             // means "schema belongs to no register" -> open. Logging a fail-open does
@@ -2027,8 +2043,14 @@ class PermissionHandler
 
         try {
             $registerMapper = $this->container->get(RegisterMapper::class);
-            $register       = $registerMapper->find($registerId);
-            $auth           = $register->getAuthorization();
+            // Multitenancy/RBAC scoping DISABLED: this loads the register purely to
+            // read its authorization + configuration policy for a security decision.
+            // Org-scoping this lookup would make a legitimate register unresolvable
+            // whenever the caller's active-organisation pointer differs from the
+            // register's organisation, fail-closing on legitimate access. Tenant
+            // isolation of object rows is enforced separately on the data reads.
+            $register = $registerMapper->find(id: $registerId, _rbac: false, _multitenancy: false);
+            $auth     = $register->getAuthorization();
 
             $this->cachedRegisterAuth[$registerId]   = $auth;
             $this->cachedRegisterConfig[$registerId] = $register->getConfiguration();


### PR DESCRIPTION
## Problem

The Code Quality **Integration Tests (Newman)** job runs all ~14 `tests/integration/*.postman_collection.json` collections **sequentially against one shared NC32 instance, alphabetical order, no DB reset** (quality.yml ~L962). `openregister-crud` and `rbac` pass in isolation (fresh DB) but fail in the combined run.

Reproduced faithfully on a disposable NC32 (all 14 collections, one instance, no reset). Baseline: **rbac failed** (`1e. e2euser creates OWN object → 200/201` returned no `@self`; `1f/1g/1h` then 404). NC log during the run:

```
[PermissionHandler] Failed to get register for schema; denying access (fail-closed)
   error: Did expect one result but found none ... openregister_registers WHERE (... ) AND ((organisation = :x) OR (organisation IS NULL))
[MagicRbacHandler] Authorization unresolvable; clamping query to deny-all (fail-closed)
```

## Root cause (combined run) — a real bug, exposed by pollution

- **Pollution (trigger):** `openregister-crud` enables RBAC + multitenancy **globally**, switches the admin's active organisation, then **deletes its test org without restoring active-org / disabling multitenancy**. State leaks into `rbac` (runs later, alphabetically).
- **Real bug (root cause):** `PermissionHandler::getRegisterForSchema()` and `getRegisterAuthorization()` loaded the register via `RegisterMapper::find($id)` with the **default org-scoped multitenancy filter**. Their sibling id lookup (`getAllRegisterIdsWithSchema`) is deliberately **global/unscoped**, so the entity fetch must be too — this is an authorization-**policy** read, not a tenant-scoped data read. Once the caller's active-org pointer differed from the register's organisation, `find()` threw `DoesNotExistException` → re-thrown as `AuthorizationUnresolvableException` → **fail-closed deny**, blocking even a non-admin creating/reading their **own** object in an **open** schema.

## Fix

Load the register with `_rbac:false, _multitenancy:false` in both resolvers (policy lookup). Does **not** weaken tenant isolation — object-row multitenancy is enforced separately on the data reads (organisation column filters + `MagicRbacHandler`'s active-organisation condition). The IDOR fail-closed stays intact for genuinely-unresolvable schemas (no register link → `null` → open baseline unchanged; real DB errors still throw).

## Verification

- **Full 14-collection sequential run, fresh NC32 = 0 failures** (crud 194/194, rbac 40/40, all others green). Baseline reproduced rbac failing first.
- **rbac cross-org isolation still enforced** (section 3: "admin org-Z object filtered out", "cross-org GET denied 404, no existence leak" — all pass), confirming multitenancy/IDOR not weakened.
- **Unit tests:** 114 PermissionHandler + RegisterMapper tests green on `nextcloud:34`. PHPCS: 0 errors on the changed file.

## Note (not fixed here)

`openregister-crud` remains non-hermetic (leaves multitenancy/RBAC enabled + active-org on a deleted org). It did not itself fail post-fix, but a follow-up to make it restore global settings at teardown would be good hygiene. Not done here to avoid masking the security-relevant resolution bug this PR fixes.