### PR TITLE
test(newman): fix crud file-path + rbac 500 in CI (host-CWD reproduction)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ phpqa_output.log
 # Newman job checks out the app fresh (no dev-container state), so the
 # fixture must be tracked, not generated.
 !tests/integration/magic-mapper-data/*.csv
+# Exception: committed CSV fixture consumed by the file-upload requests in
+# tests/integration/openregister-crud.postman_collection.json (referenced by a
+# path relative to the collection, so it resolves on the CI host runner too).
+!tests/integration/test-import.csv
 
 # Files with unusual names (trailing space, no extension) that are likely mistakes.
 # Patterns listed here must NOT match legitimate PHP source filenames.

--- a/composer.json
+++ b/composer.json
@@ -136,6 +136,7 @@
 		"phpunit/phpunit": "^10.5.62",
 		"roave/security-advisories": "dev-latest",
 		"sabre/vobject": "^4.5",
+		"sabre/xml": "^2.2",
 		"squizlabs/php_codesniffer": "^3.9",
 		"vimeo/psalm": "^5.26"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "55f2a9133d8b9e31346d27035e35bf7a",
+    "content-hash": "1ffcd5da6eb2511608c8efc07f3f1be2",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -11632,29 +11632,28 @@
         },
         {
             "name": "sabre/uri",
-            "version": "3.1.0",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/uri.git",
-                "reference": "a926c749dddfb289b8a9b5218d16ac06affdc631"
+                "reference": "b76524c22de90d80ca73143680a8e77b1266c291"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/uri/zipball/a926c749dddfb289b8a9b5218d16ac06affdc631",
-                "reference": "a926c749dddfb289b8a9b5218d16ac06affdc631",
+                "url": "https://api.github.com/repos/sabre-io/uri/zipball/b76524c22de90d80ca73143680a8e77b1266c291",
+                "reference": "b76524c22de90d80ca73143680a8e77b1266c291",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.2"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.95",
+                "friendsofphp/php-cs-fixer": "^3.63",
                 "phpstan/extension-installer": "^1.4",
-                "phpstan/phpstan": "^2.1",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^10.5",
-                "rector/rector": "^2.4"
+                "phpstan/phpstan": "^1.12",
+                "phpstan/phpstan-phpunit": "^1.4",
+                "phpstan/phpstan-strict-rules": "^1.6",
+                "phpunit/phpunit": "^9.6"
             },
             "type": "library",
             "autoload": {
@@ -11689,7 +11688,7 @@
                 "issues": "https://github.com/sabre-io/uri/issues",
                 "source": "https://github.com/fruux/sabre-uri"
             },
-            "time": "2026-04-26T04:19:03+00:00"
+            "time": "2024-08-27T12:18:16+00:00"
         },
         {
             "name": "sabre/vobject",
@@ -11797,16 +11796,16 @@
         },
         {
             "name": "sabre/xml",
-            "version": "4.1.0",
+            "version": "2.2.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/xml.git",
-                "reference": "bec83cbe2f4e1e1ca4254ed8d7caa7e32cc74b05"
+                "reference": "01a7927842abf3e10df3d9c2d9b0cc9d813a3fcc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/xml/zipball/bec83cbe2f4e1e1ca4254ed8d7caa7e32cc74b05",
-                "reference": "bec83cbe2f4e1e1ca4254ed8d7caa7e32cc74b05",
+                "url": "https://api.github.com/repos/sabre-io/xml/zipball/01a7927842abf3e10df3d9c2d9b0cc9d813a3fcc",
+                "reference": "01a7927842abf3e10df3d9c2d9b0cc9d813a3fcc",
                 "shasum": ""
             },
             "require": {
@@ -11814,17 +11813,13 @@
                 "ext-xmlreader": "*",
                 "ext-xmlwriter": "*",
                 "lib-libxml": ">=2.6.20",
-                "php": "^8.2",
-                "sabre/uri": ">=2.0,<4.0.0"
+                "php": "^7.1 || ^8.0",
+                "sabre/uri": ">=1.0,<3.0.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.95",
-                "phpstan/extension-installer": "^1.4",
-                "phpstan/phpstan": "^2.1",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^10.5",
-                "rector/rector": "^2.4"
+                "friendsofphp/php-cs-fixer": "~2.17.1||3.63.2",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
             },
             "type": "library",
             "autoload": {
@@ -11866,7 +11861,7 @@
                 "issues": "https://github.com/sabre-io/xml/issues",
                 "source": "https://github.com/fruux/sabre-xml"
             },
-            "time": "2026-04-27T10:56:01+00:00"
+            "time": "2024-09-06T07:37:46+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -13354,9 +13349,9 @@
     "platform": {
         "php": "^8.3"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -575,10 +575,18 @@ class UserService
 
             $query = $this->db->getQueryBuilder();
 
-            $query->select('s.size')
-                ->from('storages', 's')
-                ->join('s', 'mounts', 'm', $query->expr()->eq('s.id', 'm.storage_id'))
+            // Used space lives in oc_filecache.size for the storage root (path = ''),
+            // NOT in oc_storages (which has no size column). Join the file cache to the
+            // user's home mount on the numeric storage id: oc_filecache.storage and
+            // oc_mounts.storage_id are both BIGINT, so this avoids the
+            // "operator does not exist: character varying = bigint" error that a
+            // storages.id (varchar) = mounts.storage_id (bigint) join throws on PostgreSQL.
+            $query->select('f.size')
+                ->from('filecache', 'f')
+                ->innerJoin('f', 'mounts', 'm', $query->expr()->eq('f.storage', 'm.storage_id'))
                 ->where($query->expr()->eq('m.user_id', $query->createNamedParameter($userId)))
+                ->andWhere($query->expr()->eq('f.path', $query->createNamedParameter('')))
+                ->andWhere($query->expr()->eq('m.mount_point', $query->createNamedParameter('/'.$userId.'/')))
                 ->setMaxResults(1);
 
             $result = $query->execute();
@@ -594,7 +602,12 @@ class UserService
                 context: ['file' => __FILE__, 'line' => __LINE__]
             );
             return 0;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
+            // This is a best-effort, memory-safe helper: any failure (a DB error, a
+            // driver-level Error, or a misconfigured query builder) must degrade to 0
+            // rather than propagate — the contract is "the used space, or 0 if it cannot
+            // be determined safely". Catching \Throwable (not just \Exception) keeps a
+            // stray \Error from escaping into the caller and turning a quota lookup into a 500.
             $this->logger->warning(
                 message: '[UserService] Memory-safe quota calculation failed for user: '.$userId,
                 context: [

--- a/tests/integration/openregister-crud.postman_collection.json
+++ b/tests/integration/openregister-crud.postman_collection.json
@@ -4167,7 +4167,7 @@
                 {
                   "key": "file",
                   "type": "file",
-                  "src": "/var/www/html/custom_apps/openregister/tests/integration/test-import.csv"
+                  "src": "test-import.csv"
                 },
                 {
                   "key": "schema",
@@ -4230,7 +4230,7 @@
                 {
                   "key": "file",
                   "type": "file",
-                  "src": "/var/www/html/custom_apps/openregister/tests/integration/test-import.csv"
+                  "src": "test-import.csv"
                 },
                 {
                   "key": "schema",

--- a/tests/integration/rbac.postman_collection.json
+++ b/tests/integration/rbac.postman_collection.json
@@ -170,6 +170,73 @@
           ]
         },
         {
+          "name": "S0b. Warm e2euser session (initialise home before RBAC asserts)",
+          "protocolProfileBehavior": {
+            "disableCookies": true
+          },
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "OCS-APIRequest",
+                "value": "true"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/ocs/v1.php/cloud/user",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "ocs",
+                "v1.php",
+                "cloud",
+                "user"
+              ]
+            },
+            "auth": {
+              "type": "basic",
+              "basic": [
+                {
+                  "key": "username",
+                  "value": "{{e2e_user}}",
+                  "type": "string"
+                },
+                {
+                  "key": "password",
+                  "value": "{{e2e_password}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// e2euser's FIRST authenticated request triggers Nextcloud core's one-time",
+                  "// skeleton copy (completeLogin -> copySkeleton). Under the DB locking provider",
+                  "// (CI has no Redis) that copy can raise a LockedException on '/<uid>/files/Documents',",
+                  "// surfacing as a 500 on whatever endpoint happens to be first. This warm-up absorbs",
+                  "// that one-time initialisation so the later RBAC assertions see a settled home.",
+                  "// Any status is acceptable here; we only care that the home is initialised afterwards.",
+                  "pm.test('e2euser session warmed (home initialised)', () => {",
+                  "    pm.expect(pm.response.code).to.be.a('number');",
+                  "});",
+                  "console.log('e2euser warm-up statuscode', pm.response.code);"
+                ]
+              }
+            }
+          ]
+        },
+        {
           "name": "S1. Create RBAC test register",
           "protocolProfileBehavior": {
             "disableCookies": true

--- a/tests/integration/test-import.csv
+++ b/tests/integration/test-import.csv
@@ -1,0 +1,4 @@
+name,age
+Alice Example,30
+Bob Example,42
+Carol Example,27


### PR DESCRIPTION
## Summary

The **openregister-crud** and **rbac** Newman collections failed in the Code Quality *Integration Tests (Newman)* job (they pass in warm dev-container repros but fail on the CI host runner). Reproduced **exactly as CI** — newman on the host, CWD = `tests/integration`, one fresh NC32 + Postgres container, no reset, `composer install` vendor (sabre/xml 4.1.0) — which surfaced the real root causes.

## Root causes & fixes

### 1. `sabre/xml` vendor-shadowing — the real cause of BOTH failures
`composer.lock` pinned **sabre/xml 4.1.0** (pulled transitively by the `sabre/vobject` dev-dep). 4.1.0's `XmlSerializable` declares `xmlSerialize(): void`; core Nextcloud ships **sabre/xml 2.2.11** (no return type). OR's `include vendor/autoload.php` registers 4.1.0 first, so core CalDAV classes fail the signature check with a **PHP fatal** the moment a calendar is provisioned:
```
Declaration of Sabre\CalDAV\Xml\Property\SupportedCalendarComponentSet::xmlSerialize(Sabre\Xml\Writer $writer)
must be compatible with Sabre\Xml\XmlSerializable::xmlSerialize(Sabre\Xml\Writer $writer): void
```
- **rbac**: `POST /ocs/v1.php/cloud/users` (create `e2euser`) → calendar-home provisioning → CalDAV → fatal → **HTTP 500** (assertion S0).
- **crud**: `File 1: Create File on Object` is the first file op on a fresh install, so OR creates its `openregister` **system user** on the fly → same calendar fatal → **500**, and File 3–6 then **404**.

**Fix:** pin `sabre/xml` to `^2.2` in `composer.json` and regenerate the lock (sabre/xml 2.2.11, sabre/uri 2.3.4). `sabre/vobject 4.5.8` is unaffected (allows sabre/xml `^2.1`). Matches the documented durable fix for this class-load trap.

### 2. rbac `1a`: core first-login skeleton-copy lock race
`e2euser`'s first authenticated request triggers Nextcloud core's one-time skeleton copy (`completeLogin → copySkeleton`), which under the **DB locking provider** (CI has no Redis) raises `LockedException` on `/<uid>/files/Documents` → 500 on whatever endpoint is first (in CI, `1a`). Added an **S0b warm-up** request in the rbac Setup folder that logs `e2euser` in once (tolerant of any status). **No RBAC behaviour weakened** — `1a` still asserts 403/404 and passes.

### 3. crud file-upload fixture path (hygiene)
The Import requests referenced an absolute container path (`/var/www/html/custom_apps/...`) that never resolves on the CI host runner, so the file silently failed to load and Import tested nothing. Committed `tests/integration/test-import.csv` (with a `.gitignore` exception) and switched the form-data `src` to a **collection-relative path**; Import now returns 200.

### 4. `UserService` quota query — real bug, fired in CI on every `/user/me`
`getUsedSpaceMemorySafe` selected a non-existent `oc_storages.size` and joined `oc_storages.id` (varchar) = `oc_mounts.storage_id` (bigint) → PostgreSQL `SQLSTATE[42883] operator does not exist: character varying = bigint`. Rewrote it to read `oc_filecache.size` for the user's home-mount storage root (bigint join, works on Postgres/MySQL/SQLite) and hardened the catch to `\Throwable`. Fixes **36 pre-existing `UserServiceTest` errors**. (This was caught and returned 0, so it was not itself the rbac 500 — but is a genuine bug worth fixing.)

## Verification (CI-faithful, host CWD, one container)
- **crud** 194/194 ✅ · **rbac** 41/41 ✅ (both from a fresh install)
- Full **14-collection** sequence: **0 failures** (no regression)
- Unit: `UserServiceTest` 73/73, `UserServiceCoverageTest` 26/26, `UserServiceBranchCoverageTest` 8/8, `UserControllerTest` 39/39 ✅
- PHPCS on `UserService.php`: 0 errors

## Follow-up (not in this PR)
`[MetricsService] Failed to record metric — "Only strings, Literals and Parameters are allowed"` (MetricsService.php:211) logs on nearly every object create/update in CI. Caught and non-fatal, but a real query-builder bug worth a separate issue.