### PR TITLE
docs(federated-config): bring the openspec change up to the shipped standard

### DIFF
--- a/openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+++ b/openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
@@ -93,6 +93,100 @@ owner of a configuration SHALL scope who may share and install it.
 - **WHEN** they publish or install a configuration
 - **THEN** the action succeeds within the org's governance
 
+### Requirement: A schema marks its objects shareable with data, not code (REQ-FCS-006)
+
+A schema SHALL be able to opt its objects into the store with a single marker on
+its configuration — `x-openregister-shareable` (either `true` for derived
+defaults, or an `{id, topic, name}` object refining them) — rather than each app
+shipping a near-identical `IShareableConfigType`. OpenRegister SHALL scan marked schemas
+and auto-register one shareable type per register+schema pair. The marker key
+SHALL be a declared entry in the schema configuration vocabulary, so it survives
+`setConfiguration()` rather than being silently dropped.
+
+#### Scenario: A marked schema auto-surfaces as a type
+
+- **GIVEN** a schema whose configuration carries `x-openregister-shareable`
+- **WHEN** the shareable-type catalogue is read
+- **THEN** a type appears for that schema's objects with no per-app code
+- **AND** a pinned `{id, topic}` in the marker is honoured (preserving an existing published corpus)
+
+### Requirement: Published bundles are signed and verified (REQ-FCS-007)
+
+Publishing SHALL sign the canonical (key-sorted, provenance-excluded) bundle with
+the instance's Ed25519 key, minted and stored once, attaching an
+`{alg, publicKey, signature}` provenance block. Installing SHALL verify it: a
+tampered signature SHALL always be refused; an unsigned or untrusted-key bundle
+SHALL be refused once the organisation populates a trusted-keys allowlist (empty =
+not yet enforced). The instance SHALL expose its public key so other
+organisations can add it to their trust list.
+
+#### Scenario: A tampered bundle is refused
+
+- **GIVEN** a published, signed bundle whose contents are altered after signing
+- **WHEN** a user installs it
+- **THEN** the install is refused for a bad signature
+
+#### Scenario: Signing enforcement pins publishers
+
+- **GIVEN** an organisation with a non-empty trusted-keys allowlist
+- **WHEN** a bundle signed by a key not on the list (or unsigned) is installed
+- **THEN** the install is refused as untrusted
+
+### Requirement: Per-organisation role gating for publish and install (REQ-FCS-008)
+
+Beyond "any admin", an organisation SHALL be able to nominate the groups permitted
+to publish and to install via configuration (`federated_config_publish_groups` /
+`federated_config_install_groups`). An empty list means not-yet-enforced (any
+signed-in user may act); admins are always allowed.
+
+#### Scenario: A non-member is denied publish
+
+- **GIVEN** an org whose publish-groups list is set and does not include the user's groups
+- **WHEN** the non-admin user publishes
+- **THEN** the action is refused
+
+### Requirement: A whole configuration set is shareable as one type (REQ-FCS-009)
+
+OpenRegister SHALL make a whole configuration set — an app's worth of registers,
+schemas, objects, views, flows, sources and mappings — shareable as one type
+(`openregister.configset`), wrapping the existing multi-entity export/import. A
+repository MAY hold many such files (a config-set repository).
+
+#### Scenario: A configuration set round-trips
+
+- **GIVEN** an OpenRegister configuration spanning several registers and schemas
+- **WHEN** it is bundled as a configuration set and installed elsewhere
+- **THEN** every entity is installed as one unit
+
+### Requirement: Publish creates the repository, tags it, and can be fetched back (REQ-FCS-010)
+
+Publishing SHALL ensure the target repository exists (creating it when absent) and
+carry the type's discovery topic, so a freshly published configuration is findable
+via topic discovery. A published bundle file SHALL be fetchable from a repository
+(the bridge from discovery to install), read anonymously for public repositories
+or through the broker when a credential is supplied.
+
+#### Scenario: A published config is discoverable and installable
+
+- **GIVEN** a configuration published to a new repository
+- **WHEN** another instance discovers it by topic, fetches the bundle, and installs it
+- **THEN** the repository was created, topic-tagged, and the bundle installs
+
+### Requirement: A config-set repository can also be an installable standalone app (REQ-FCS-011)
+
+The store SHALL support a published config-set repository that additionally
+carries the files making it an app-store-installable, standalone Nextcloud app —
+an `info.xml` declaring OpenRegister its data-layer dependency, a build that
+packages the shared Vue component library, and a runtime that renders the set's
+manifest without the generating app present. The app-generating app (e.g.
+OpenBuild) emits the scaffolding; OpenRegister owns the configuration + federation.
+
+#### Scenario: A published app repository is installable
+
+- **GIVEN** an app published to a repository through the store
+- **WHEN** the repository is inspected
+- **THEN** it carries both the configuration set and the installable app scaffold (info.xml with OpenRegister required, the packaged Vue runtime)
+
 @e2e exclude backend service + fleet contract — covered by unit tests
 (IShareableConfigType registry, allowlist enforcement, secret exclusion) and
 Playwright e2e on the first two consumers (OpenBuild apps + Flows: publish →

--- a/openspec/changes/federated-config-sharing/tasks.md
+++ b/openspec/changes/federated-config-sharing/tasks.md
@@ -1,36 +1,67 @@
 # Tasks: federated-config-sharing
 
-## Phase 1 — design + trust (this change, then a design PR)
+## Phase 1 — design + trust
 - [x] `IShareableConfigType` contract (select / serialise / deserialise / exclude
       secrets / topic), storage-agnostic. Canonical repo layout. Trust model:
-      org allowlist + version pinning + secret exclusion (signing deferred).
+      org allowlist + version pinning + secret exclusion.
 
 ## Phase 2 — the engine
-- [x] `FederatedConfigService` in OpenRegister: extract OpenBuild's serialiser +
-      broker-routed push + topic discovery; back it with ConfigurationService's
-      bundle / version / preview-diff.
-- [x] `RegisterShareableConfigTypesEvent` + registry (mirror flow nodes).
+- [x] `FederatedConfigService` in OpenRegister (types / bundle / install / publish),
+      backed by ConfigurationService; broker-routed publish. (#2134)
+- [x] `RegisterShareableConfigTypesEvent` + registry (mirror flow nodes). (#2134)
 - [x] GitHub credentials via the credential broker's **Doriath** leaf per user/org
-      (NC-vault fallback); retire the shared-token assumption for user publish.
-- [x] Org source allowlist enforcement (per-org RBAC beyond admin: follow-up) enforcement.
+      (NC-vault fallback); no shared-token assumption for user publish. (#2134)
+- [x] Org source allowlist enforcement. (#2134)
+- [x] **Schema-marker mechanism** — `x-openregister-shareable` on a schema's
+      configuration auto-registers a `GenericObjectShareableConfigType`; vocabulary
+      entry so it survives `setConfiguration()`. 15 unit + 3 e2e. (#2140)
 
-## Phase 3 — prove on two types (with Playwright e2e)
-- [ ] OpenBuild apps onto the shared service (reference type).
-- [x] Flows as a shareable type — the reframed #2065 "integration network".
-- [x] e2e (Flows): bundle → install → run; allowlist denial; unknown-type 404. + unit.
+## Phase 3 — consumers (with Playwright e2e)
+- [x] Flows as a shareable type — reframed #2065. e2e: bundle→install→run;
+      allowlist denial; unknown-type 404. (#2134)
+- [x] Registers & schemas as a shareable type (adapter over ConfigurationService). (#2135)
+- [x] **Config set** (`openregister.configset`) — a whole app's multi-entity bundle. (#2148)
 
-## Phase 4 — fold in hermiq
-- [ ] Migrate hermiq's duplicated GitHub sync (agent templates + skills) onto the
-      shared service.
+## Phase 4 — store foundation
+- [x] **Publish endpoint** using the user-selected credential; repo-creation +
+      **topic-tagging** on publish. (#2147, #2148)
+- [x] **Discovery** endpoint (GitHub topic search) + **fetchBundle** (discover→install bridge). (#2147, #2149)
+- [x] **Ed25519 signing / verification** (`BundleSigner`): tamper always refused;
+      trusted-keys allowlist enforcement; instance public-key endpoint. (#2147)
+- [x] **Per-org RBAC** (`FederatedConfigAccess`): publish/install group allowlists. (#2147)
 
-## Phase 5 — roll out declared types (parallel)
-- [ ] nldesign: NL Design theme token sets as a type wrapping `ConfigBundleService`.
-- [ ] procest case types / workflow templates (redirect OTAP export).
-- [ ] shillinq payroll/tax packs (redirect OTAP export).
-- [ ] opencatalogi publication types + DCAT/TOOI waardelijsten.
-- [ ] docudesk templates; softwarecatalog GEMMA/AMEF; pipelinq; larpingapp.
+## Phase 5 — fold in hermiq
+- [x] Agent templates → schema marker (pinned topic). Skills → per-app
+      `HermiqSkillShareableConfigType` (agentskills.io markdown, quarantine install). (hermiq #126)
+- [x] Retire `GitHubTemplatePushService`/`CatalogService` (~1,390 lines); rewire the
+      three GitHub controllers onto the shared engine (`FederatedStoreService`).
+      Live-verified end-to-end against real GitHub. (hermiq #127)
 
-## Phase 6 — governance + index
-- [ ] Org source allowlist admin UI; optional curated discovery index over topics.
-- [ ] "How to share a config" docs — publish without a PR to a Conduction repo.
-- [ ] (Later) cryptographic signing / verification.
+## Phase 6 — roll out declared types (markers on shipped schemas)
+- [x] nldesign: NL Design theme token sets (wraps `ConfigBundleService`). (nldesign #192)
+- [x] procest case types (#244) · shillinq tax config (#516) · opencatalogi catalog (#148)
+      · softwarecatalog GEMMA element (#98) · larpingapp skill (#70) · docudesk template (#190)
+      · decidesk ProcessTemplate (#143) · pipelinq pipeline (#409).
+
+## Phase 7 — installable config-set repos (OpenBuild convergence)
+- [x] `ExportService::buildScaffoldMap` + fold the installable scaffold into the
+      `openbuild-app` publish; OpenRegister declared a hard dependency; standalone
+      nc-vue runtime renders the set's manifest. (openbuild #181)
+
+## Phase 8 — UI + governance
+- [x] nc-vue `CnConfigurationStore` — user settings pane: pick which GitHub
+      credential the store uses + instance signing key + browse-by-type discovery. (nc-vue #242)
+- [ ] Org source-allowlist / trusted-keys **admin** UI (config keys exist; no UI yet).
+- [ ] "How to share a config" end-user docs.
+
+## Verified against REAL GitHub (2026-07-26)
+- [x] publish → repo created + topic set + Ed25519-signed bundle (201) → fetch (with
+      provenance) → install (verified) → discover (topic search found the repo).
+- [x] hermiq skill round-trip through the rewired endpoints (publish → discover →
+      install → `state: quarantined, source: hub`).
+
+## Known follow-ups (external to the code)
+- [ ] Two test repos (`fedtest-store-*`, `hermiq-skill-test-*`) need manual deletion
+      — the broker correctly refuses `DELETE /repos/*` (token-custody safety).
+- [ ] OpenBuild full generate→install→run e2e (a CI/build step; live push is gated by
+      OpenBuild's per-app owners-role RBAC, orthogonal to the convergence).


### PR DESCRIPTION
The `federated-config-sharing` openspec change captured only the initial design. This updates it to what actually shipped and merged: **6 new requirements** (schema-marker, Ed25519 signing, per-org RBAC, config sets, repo-creation/topics/fetch, installable config-set repos) each with scenarios, and a `tasks.md` that reflects the shipped reality with PR references + the real-GitHub end-to-end verification. `openspec validate --strict` passes.