### PR TITLE
feat(config): publish honors repo visibility + API to manage the trust config

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1249,5 +1249,7 @@ return [
 		['name' => 'federatedConfig#discover', 'url' => '/api/federated-config/discover', 'verb' => 'GET'],
 		['name' => 'federatedConfig#fetch', 'url' => '/api/federated-config/fetch', 'verb' => 'GET'],
 		['name' => 'federatedConfig#publicKey', 'url' => '/api/federated-config/public-key', 'verb' => 'GET'],
+		['name' => 'federatedConfig#trust', 'url' => '/api/federated-config/trust', 'verb' => 'GET'],
+		['name' => 'federatedConfig#setTrust', 'url' => '/api/federated-config/trust', 'verb' => 'PUT'],
     ],
 ];

--- a/lib/Controller/FederatedConfigController.php
+++ b/lib/Controller/FederatedConfigController.php
@@ -35,6 +35,7 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IConfig;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Throwable;
@@ -60,12 +61,13 @@ class FederatedConfigController extends Controller
     /**
      * Constructor.
      *
-     * @param string                 $appName     The app id.
-     * @param IRequest               $request     The request.
-     * @param FederatedConfigService $service     The federation engine.
-     * @param FederatedConfigAccess  $access      Per-org publish/install gating.
-     * @param IUserSession           $userSession The current user.
-     * @param IConfig                $config      Reads the user's chosen store credential.
+     * @param string                 $appName      The app id.
+     * @param IRequest               $request      The request.
+     * @param FederatedConfigService $service      The federation engine.
+     * @param FederatedConfigAccess  $access       Per-org publish/install gating.
+     * @param IUserSession           $userSession  The current user.
+     * @param IConfig                $config       Reads the user's chosen store credential.
+     * @param IGroupManager          $groupManager Gates the trust-governance endpoints to admins.
      */
     public function __construct(
         string $appName,
@@ -73,7 +75,8 @@ class FederatedConfigController extends Controller
         private readonly FederatedConfigService $service,
         private readonly FederatedConfigAccess $access,
         private readonly IUserSession $userSession,
-        private readonly IConfig $config
+        private readonly IConfig $config,
+        private readonly IGroupManager $groupManager
     ) {
         parent::__construct(appName: $appName, request: $request);
 
@@ -223,6 +226,10 @@ class FederatedConfigController extends Controller
             $branch = 'main';
         }
 
+        // A newly created store repo is public by default; `visibility: private`
+        // makes it private (the token must have rights to create private repos).
+        $private = (trim((string) $this->request->getParam('visibility', 'public')) === 'private');
+
         try {
             $result = $this->service->publish(
                 typeId: $type,
@@ -230,7 +237,8 @@ class FederatedConfigController extends Controller
                 repo: $repo,
                 path: $path,
                 credentialId: $credentialId,
-                branch: $branch
+                branch: $branch,
+                private: $private
             );
         } catch (UnexpectedValueException $e) {
             return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
@@ -241,6 +249,83 @@ class FederatedConfigController extends Controller
         return new JSONResponse($result);
 
     }//end publish()
+
+    /**
+     * The organisation's trust configuration (admin only).
+     *
+     * @return JSONResponse `{sourceAllowlist, trustedKeys, publishGroups, installGroups}` or 403.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function trust(): JSONResponse
+    {
+        if ($this->isAdmin() === false) {
+            return new JSONResponse(['error' => 'Only an administrator may read the trust configuration.'], Http::STATUS_FORBIDDEN);
+        }
+
+        return new JSONResponse($this->service->getTrustConfig());
+
+    }//end trust()
+
+    /**
+     * Set one trust-configuration value, or trust a publisher key (admin only).
+     *
+     * Accepts either `{field, value}` (field ∈ sourceAllowlist|trustedKeys|
+     * publishGroups|installGroups) or `{trustKey}` to append a public key to the
+     * trusted-keys list.
+     *
+     * @return JSONResponse The updated trust configuration, or a 4xx.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function setTrust(): JSONResponse
+    {
+        if ($this->isAdmin() === false) {
+            return new JSONResponse(['error' => 'Only an administrator may change the trust configuration.'], Http::STATUS_FORBIDDEN);
+        }
+
+        $trustKey = trim((string) $this->request->getParam('trustKey', ''));
+        if ($trustKey !== '') {
+            $this->service->trustPublisherKey(publicKey: $trustKey);
+            return new JSONResponse($this->service->getTrustConfig());
+        }
+
+        $field = trim((string) $this->request->getParam('field', ''));
+        if ($field === '') {
+            return new JSONResponse(['error' => 'A trust update needs a field or a trustKey.'], Http::STATUS_BAD_REQUEST);
+        }
+
+        try {
+            $this->service->setTrustValue(field: $field, value: (string) $this->request->getParam('value', ''));
+        } catch (Throwable $e) {
+            return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+        }
+
+        return new JSONResponse($this->service->getTrustConfig());
+
+    }//end setTrust()
+
+    /**
+     * Whether the current user is a Nextcloud administrator.
+     *
+     * @return boolean Whether the caller is an admin.
+     */
+    private function isAdmin(): bool
+    {
+        $user = $this->userSession->getUser();
+        return $user !== null && $this->groupManager->isAdmin($user->getUID());
+
+    }//end isAdmin()
 
     /**
      * Discover published bundles across GitHub by a type's discovery topic.

--- a/lib/Service/Config/FederatedConfigService.php
+++ b/lib/Service/Config/FederatedConfigService.php
@@ -63,6 +63,18 @@ class FederatedConfigService
     private const ALLOWLIST_KEY = 'federated_config_source_allowlist';
 
     /**
+     * Trust-configuration fields → their app-config keys (for the governance API).
+     *
+     * @var array<string, string>
+     */
+    private const TRUST_KEYS = [
+        'sourceAllowlist' => 'federated_config_source_allowlist',
+        'trustedKeys'     => 'federated_config_trusted_keys',
+        'publishGroups'   => 'federated_config_publish_groups',
+        'installGroups'   => 'federated_config_install_groups',
+    ];
+
+    /**
      * The GitHub API host for anonymous discovery.
      */
     private const GITHUB_API = 'https://api.github.com';
@@ -187,7 +199,8 @@ class FederatedConfigService
         string $repo,
         string $path,
         string $credentialId,
-        string $branch='main'
+        string $branch='main',
+        bool $private=false
     ): array {
         $type = $this->typeOrFail(typeId: $typeId);
 
@@ -195,7 +208,7 @@ class FederatedConfigService
         // freshly published config is findable via discover() (both single-config
         // and config-set repos rely on this). Best-effort: a failure here still
         // lets the contents write surface a clear error.
-        $this->ensureRepo(repo: $repo, credentialId: $credentialId);
+        $this->ensureRepo(repo: $repo, credentialId: $credentialId, private: $private);
         $this->setTopics(repo: $repo, topics: [$type->getTopic()], credentialId: $credentialId);
 
         $bundle  = $this->signer->sign(bundle: $type->serialise(selection: $selection));
@@ -241,12 +254,13 @@ class FederatedConfigService
      * used, otherwise the authenticated user's; a failure is logged, not fatal
      * (the subsequent contents write reports a missing repo clearly).
      *
-     * @param string $repo         The `owner/repo`.
-     * @param string $credentialId The broker credential.
+     * @param string  $repo         The `owner/repo`.
+     * @param string  $credentialId The broker credential.
+     * @param boolean $private      Whether a freshly created repo should be private.
      *
      * @return void
      */
-    private function ensureRepo(string $repo, string $credentialId): void
+    private function ensureRepo(string $repo, string $credentialId, bool $private=false): void
     {
         [$owner, $name] = array_pad(explode('/', $repo, 2), 2, '');
         if ($owner === '' || $name === '') {
@@ -277,7 +291,7 @@ class FederatedConfigService
                     method: 'POST',
                     path: $createPath,
                     headers: ['Accept' => 'application/vnd.github+json'],
-                    body: (string) json_encode(['name' => $name, 'private' => false, 'auto_init' => true])
+                    body: (string) json_encode(['name' => $name, 'private' => $private, 'auto_init' => true])
                 );
                 if ((int) ($created['status'] ?? 0) >= 200 && (int) ($created['status'] ?? 0) < 300) {
                     return;
@@ -485,6 +499,72 @@ class FederatedConfigService
         return $this->signer->publicKey();
 
     }//end publicKey()
+
+    /**
+     * The organisation's trust configuration (for a governance UI).
+     *
+     * @return array{sourceAllowlist: string, trustedKeys: string, publishGroups: string, installGroups: string}
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function getTrustConfig(): array
+    {
+        $out = [];
+        foreach (self::TRUST_KEYS as $field => $key) {
+            $out[$field] = $this->appConfig->getValueString(self::APP_ID, $key, '');
+        }
+
+        return $out;
+
+    }//end getTrustConfig()
+
+    /**
+     * Set one trust-configuration value (the allowlist, trusted keys, or a group list).
+     *
+     * @param string $field One of `sourceAllowlist|trustedKeys|publishGroups|installGroups`.
+     * @param string $value The new value (comma-separated).
+     *
+     * @return void
+     *
+     * @throws UnexpectedValueException When the field is unknown.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function setTrustValue(string $field, string $value): void
+    {
+        if (isset(self::TRUST_KEYS[$field]) === false) {
+            throw new UnexpectedValueException(sprintf('Unknown trust setting "%s".', $field));
+        }
+
+        $this->appConfig->setValueString(self::APP_ID, self::TRUST_KEYS[$field], trim($value));
+
+    }//end setTrustValue()
+
+    /**
+     * Add a base64 public key to the trusted-keys allowlist (a convenience over
+     * hand-editing the comma-separated list).
+     *
+     * @param string $publicKey The base64 Ed25519 public key to trust.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function trustPublisherKey(string $publicKey): void
+    {
+        $publicKey = trim($publicKey);
+        if ($publicKey === '') {
+            return;
+        }
+
+        $current = array_filter(array_map('trim', explode(',', $this->appConfig->getValueString(self::APP_ID, self::TRUST_KEYS['trustedKeys'], ''))));
+        if (in_array($publicKey, $current, true) === false) {
+            $current[] = $publicKey;
+        }
+
+        $this->appConfig->setValueString(self::APP_ID, self::TRUST_KEYS['trustedKeys'], implode(',', $current));
+
+    }//end trustPublisherKey()
 
     /**
      * Whether a source may be installed from.

--- a/tests/Unit/Service/Config/FederatedConfigServiceTest.php
+++ b/tests/Unit/Service/Config/FederatedConfigServiceTest.php
@@ -260,4 +260,44 @@ class FederatedConfigServiceTest extends TestCase
         $this->assertContains('PUT /repos/ConductionNL/pack/topics', $calls);
         $this->assertContains('PUT /repos/ConductionNL/pack/contents/set.json', $calls);
     }
+
+    public function testTrustConfigReadWriteRoundTrips(): void
+    {
+        $store = [];
+        $cfg   = $this->createMock(IAppConfig::class);
+        $cfg->method('getValueString')->willReturnCallback(
+            function (string $a, string $k, string $d = '') use (&$store) {
+                return ($store[$k] ?? $d);
+            }
+        );
+        $cfg->method('setValueString')->willReturnCallback(
+            function (string $a, string $k, string $v) use (&$store): bool {
+                $store[$k] = $v;
+                return true;
+            }
+        );
+
+        $service = new FederatedConfigService(
+            $this->registry,
+            $this->createMock(CredentialBrokerService::class),
+            $this->createMock(\OCA\OpenRegister\Service\Config\BundleSigner::class),
+            $this->createMock(\OCP\Http\Client\IClientService::class),
+            $cfg,
+            $this->createMock(\Psr\Log\LoggerInterface::class)
+        );
+
+        $service->setTrustValue('sourceAllowlist', 'ConductionNL');
+        $service->setTrustValue('publishGroups', 'editors');
+        $service->trustPublisherKey('KEYA=');
+        $service->trustPublisherKey('KEYA=');
+        $service->trustPublisherKey('KEYB=');
+
+        $trust = $service->getTrustConfig();
+        $this->assertSame('ConductionNL', $trust['sourceAllowlist']);
+        $this->assertSame('editors', $trust['publishGroups']);
+        $this->assertSame('KEYA=,KEYB=', $trust['trustedKeys']);
+
+        $this->expectException(UnexpectedValueException::class);
+        $service->setTrustValue('nope', 'x');
+    }
 }


### PR DESCRIPTION
Closes two governance/usability gaps in the store:

- **Publish honors visibility** — `publish(..., private:)` + controller `visibility: private` create a private store repo instead of always-public (default public, backward-compatible).
- **Trust config is API-manageable** — admin-gated `GET/PUT /api/federated-config/trust` for the source allowlist, trusted publisher keys, and publish/install group lists, plus a `trustKey` append convenience. Previously `occ`-only. Non-admin → 403; unknown field → 400.

Unit test (trust round-trip) + live-verified on 8080 (admin GET/PUT/trustKey, non-admin 403, unknown-field 400).