### PR TITLE
fix(schema): x-openregister-agent-context was dropped at save — every agent leaf resolved an empty context

### DIFF
--- a/lib/Db/Schema.php
+++ b/lib/Db/Schema.php
@@ -2333,6 +2333,16 @@ class Schema extends Entity implements JsonSerializable
         // trap the vocabulary exists to catch. Read by
         // SchemaShareableConfigScanner.
         'x-openregister-shareable',
+        // Declarative bound on what object data may reach an LLM: the
+        // per-schema allowlist Hermiq's AgentContextBuilder (and its JS twin
+        // src/utils/agentContext.js) reads to build an agent's context.
+        // Absent from this list, setConfiguration() silently DROPPED it, so
+        // every agent leaf on every schema fleet-wide resolved an EMPTY
+        // context — fail-closed, so never a leak, but the capability was
+        // wholly inert while schemas saved with HTTP 200 and no error. Same
+        // or#460/#462-class trap as `x-openregister-processing` and
+        // `x-openregister-contextchat` above. See or#2164.
+        'x-openregister-agent-context',
     ];
 
     /**

--- a/tests/Unit/Db/SchemaAnnotationVocabularyTest.php
+++ b/tests/Unit/Db/SchemaAnnotationVocabularyTest.php
@@ -228,4 +228,64 @@ class SchemaAnnotationVocabularyTest extends TestCase
         // Valid vocabulary key should survive.
         $this->assertArrayHasKey('x-openregister-archival', $config);
     }//end testActualTypoIsDropped()
+
+    /**
+     * FAILING PATH (or#2164): `x-openregister-agent-context` MUST survive the
+     * round-trip.
+     *
+     * This is the FOURTH recurrence of the same defect class in this
+     * vocabulary (`x-openregister-processing`, `x-openregister-contextchat`,
+     * `x-openregister-shareable`, now this one). The key is READ by Hermiq's
+     * AgentContextBuilder — and by its JS twin `src/utils/agentContext.js` —
+     * to bound what object data may reach an LLM. While it was absent from
+     * ANNOTATION_VOCABULARY, setConfiguration() silently dropped it, so EVERY
+     * agent leaf on EVERY schema fleet-wide resolved an EMPTY context.
+     *
+     * The failure was invisible by construction: the schema saved with HTTP
+     * 200, the only signal was a log line, and because an absent allowlist
+     * means "expose nothing" the behaviour was fail-closed — no leak, just a
+     * capability that could never do anything.
+     *
+     * @return void
+     */
+    public function testAgentContextAnnotationSurvivesRoundTrip(): void
+    {
+        $allowlist = ['findingId', 'severity', 'gate', 'rule', 'status'];
+
+        $this->schema->setConfiguration(['x-openregister-agent-context' => $allowlist]);
+
+        $config = $this->schema->getConfiguration();
+
+        $this->assertNotNull($config);
+        $this->assertArrayHasKey('x-openregister-agent-context', $config);
+        $this->assertSame($allowlist, $config['x-openregister-agent-context']);
+
+        // Not merely present — not reported as dropped either, since the drop
+        // list is the only runtime signal this failure ever produced.
+        $this->assertNotContains(
+            'x-openregister-agent-context',
+            $this->schema->consumeDroppedAnnotationKeys()
+        );
+
+    }//end testAgentContextAnnotationSurvivesRoundTrip()
+
+    /**
+     * The refinement form (per-property constraints) must survive too — the
+     * allowlist accepts either a flat list of property names or a map carrying
+     * per-property bounds such as `maxLength`.
+     *
+     * @return void
+     */
+    public function testAgentContextRefinementFormSurvivesRoundTrip(): void
+    {
+        $refined = ['description' => ['maxLength' => 500]];
+
+        $this->schema->setConfiguration(['x-openregister-agent-context' => $refined]);
+
+        $config = $this->schema->getConfiguration();
+
+        $this->assertArrayHasKey('x-openregister-agent-context', $config);
+        $this->assertSame($refined, $config['x-openregister-agent-context']);
+
+    }//end testAgentContextRefinementFormSurvivesRoundTrip()
 }//end class


### PR DESCRIPTION
Fixes #2164.

## The defect

`x-openregister-agent-context` was absent from `Schema::ANNOTATION_VOCABULARY`, so `validateConfigurationEntry()` silently dropped it on save. Hermiq's `AgentContextBuilder` (and its JS twin `src/utils/agentContext.js`) read exactly that key to bound what object data reaches an LLM — so **every agent leaf on every schema fleet-wide resolved an empty context**.

Fail-closed, so never a leak: an absent allowlist means "expose nothing". But the capability was wholly inert, and invisible by construction — the schema saved with HTTP 200, no validation error reached the caller, and the only signal was a log line.

## This is the fourth recurrence

The list already carries explanatory comments for `x-openregister-processing`, `x-openregister-contextchat` and `x-openregister-shareable` — each added after the same bug. That pattern is worth a structural fix (a test asserting every key READ anywhere in the fleet is present in the vocabulary), which I have deliberately **not** bundled here; this PR stays a one-key fix plus its regression tests.

## Verification

Live, against the running dev instance — a PUT of an allowlist onto the `hydra-cache` `finding` schema:

```
BEFORE agent-context: ABSENT — dropped
AFTER  agent-context: ['findingId','severity','gate','rule','status','stageName']
```

Unit: `SchemaAnnotationVocabularyTest` 8/8 green (2 new — flat allowlist and the per-property refinement form, each asserting the key survives the round-trip AND is not reported as dropped).

Note: `tests/Unit/Db/` has 7 pre-existing failures, all in `SchemaLinkedTypes*` (linkedTypes validation) — a different code path, untouched by this change, which adds one string to a const array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
