### PR TITLE
fix(flow): attribute interactive test runs to the caller (3rd instance of the ownerless-run defect)

### DIFF
--- a/lib/Controller/FlowRunController.php
+++ b/lib/Controller/FlowRunController.php
@@ -40,6 +40,7 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use OCP\IUserSession;
 use stdClass;
 
 /**
@@ -61,7 +62,8 @@ class FlowRunController extends Controller
         IRequest $request,
         private readonly FlowRunMapper $mapper,
         private readonly FlowRunService $runner,
-        private readonly FlowResolverRegistry $resolvers
+        private readonly FlowResolverRegistry $resolvers,
+        private readonly IUserSession $userSession
     ) {
         parent::__construct(appName: $appName, request: $request);
 
@@ -222,11 +224,19 @@ class FlowRunController extends Controller
             $seed = FlowItems::normalise(value: $seedParam);
         }
 
+        // Attribute the test run to the caller. Without this the run is
+        // ownerless, so `context['triggeredBy']` is null and every
+        // attribution-requiring node refuses — ObjectWriteNode returns "this
+        // flow run has no owner". An interactive test run has a session by
+        // definition, so there is no reason for it to be the one dispatch path
+        // that discards its actor. Same defect class as or#2158 in
+        // FlowMcpToolProvider::runFlow().
         $run = $this->runner->queue(
             flowId: $flowId,
             subject: [],
             trigger: 'test',
-            context: ['pins' => $pins]
+            context: ['pins' => $pins],
+            user: $this->userSession->getUser()?->getUID()
         );
 
         $run = $this->runner->execute(


### PR DESCRIPTION
Follow-up to #2169, same defect class, third instance.

## Problem

`FlowRunController::test()` queued its run **without the acting user** — in the one dispatch path that has a session by definition.

Consequence: the run was ownerless, `context['triggeredBy']` was null, and every attribution-requiring node refused. `ObjectWriteNode` returned *"This flow run has no owner (triggeredBy); an object write must be attributable."* So the interactive "run this flow now" button could **never** exercise a write node — the only runs that appeared to work were harness runs carrying a hand-injected context.

## Why this mattered for verification

This is what made the earlier "object-write is proven" claim overstated. The node had 387 passing unit tests and a green live run, but that run's context was injected by the harness. On every real path the node refused.

## Live proof, after the fix

A naturally triggered run, nothing injected:

```
run status : completed
triggeredBy: admin                     <- resolved from IUserSession
log        : [{"transition":"write1","status":"completed","itemsIn":1,"itemsOut":1}]
```

And the object actually landed, read back through the API:

```
findings BEFORE: 7
findings AFTER : 8
  -> rule 'written by openregister.object-write' | created 2026-07-27T17:58:13+00:00 | owner admin
```

## Related

While proving this, two other things surfaced and are filed separately: the live instance was 57 commits behind `origin/development` so the #2169 fix was not deployed (environment, not code), and #2170 — `FlowRunWorker` is never registered in `oc_jobs`, so **asynchronous** runs still cannot execute regardless of attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
