### PR TITLE
fix(jobs): reconcile declared background jobs Nextcloud never registered (24 of 31 were missing)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -40,7 +40,7 @@ Open Register drijft apps zoals OpenCatalogi, Procest, Pipelinq en Software Cata
 
 Vrij en open source onder de EUPL-licentie.
     ]]></description>
-    <version>0.2.17-unstable.17</version>
+    <version>0.2.17-unstable.18</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>OpenRegister</namespace>
@@ -71,6 +71,7 @@ Vrij en open source onder de EUPL-licentie.
 
 	<repair-steps>
 		<post-migration>
+			<step>OCA\OpenRegister\Repair\ReconcileDeclaredBackgroundJobs</step>
 			<step>OCA\OpenRegister\Repair\RegisterRiskLevelMetadata</step>
 			<step>OCA\OpenRegister\Repair\LogDanglingLinkedTypes</step>
 			<step>OCA\OpenRegister\Repair\MigrateNotificationSubscriptionsToUserConfig</step>
@@ -87,6 +88,7 @@ Vrij en open source onder de EUPL-licentie.
 			<step>OCA\OpenRegister\Repair\SeedZgwZakenMigrationPack</step>
 		</post-migration>
 		<install>
+			<step>OCA\OpenRegister\Repair\ReconcileDeclaredBackgroundJobs</step>
 			<step>OCA\OpenRegister\Repair\RegisterRiskLevelMetadata</step>
 			<step>OCA\OpenRegister\Repair\LogDanglingLinkedTypes</step>
 			<step>OCA\OpenRegister\Repair\SeedDirectoryVirtualSchemas</step>

--- a/lib/Repair/ReconcileDeclaredBackgroundJobs.php
+++ b/lib/Repair/ReconcileDeclaredBackgroundJobs.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Repair step: register declared background jobs that Nextcloud never added.
+ *
+ * @category Repair
+ * @package  OCA\OpenRegister\Repair
+ *
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @copyright 2026 Conduction B.V.
+ *
+ * @link https://github.com/ConductionNL/openregister
+ */
+
+namespace OCA\OpenRegister\Repair;
+
+use OCP\BackgroundJob\IJob;
+use OCP\BackgroundJob\IJobList;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Reconciles `<job>` declarations in appinfo/info.xml against the job list.
+ *
+ * Nextcloud adds `<job>` entries to `oc_jobs` only when an app is INSTALLED or
+ * UPGRADED. Add a job to info.xml without bumping the app version and it is
+ * silently never registered — no error, no warning, and there is no
+ * `occ background-job:add` to correct it by hand.
+ *
+ * The failure is invisible in the worst way: the job's synchronous
+ * counterparts keep working, so the feature looks healthy while every
+ * asynchronous path queues into a void. Observed 2026-07-27 on a live
+ * instance where 24 of 31 declared jobs were absent, including
+ * `FlowRunWorker` — 59 flow runs sat `queued` and could never execute, while
+ * the synchronous `/api/flow-runs/test` route ran flows perfectly. See
+ * or#2170.
+ *
+ * Running as a repair step means `occ maintenance:repair` fixes an instance
+ * without anyone having to invent a version bump.
+ */
+class ReconcileDeclaredBackgroundJobs implements IRepairStep
+{
+    /**
+     * Constructor.
+     *
+     * @param IJobList           $jobList   The Nextcloud job list.
+     * @param ContainerInterface $container DI container, used to resolve job
+     *                                      classes lazily — a job whose own
+     *                                      dependencies cannot be built must
+     *                                      not take the whole repair run down.
+     * @param LoggerInterface    $logger    Logger.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly IJobList $jobList,
+        private readonly ContainerInterface $container,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Human-readable step name surfaced in occ + the admin UI.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Register OpenRegister background jobs declared in info.xml but missing from the job list';
+    }//end getName()
+
+    /**
+     * Add every declared job that is not already registered.
+     *
+     * Idempotent: `IJobList::has()` is checked first, and `add()` is itself a
+     * no-op for an already-present job/argument pair.
+     *
+     * @param IOutput $output Migration output handle.
+     *
+     * @return void
+     */
+    public function run(IOutput $output): void
+    {
+        $declared = $this->declaredJobs();
+        if ($declared === []) {
+            $output->info('[OpenRegister] No <job> declarations found — nothing to reconcile.');
+            return;
+        }
+
+        $added   = 0;
+        $skipped = 0;
+
+        foreach ($declared as $class) {
+            try {
+                if ($this->jobList->has($class, null) === true) {
+                    continue;
+                }
+
+                // Resolve through the container so a job with unbuildable
+                // dependencies fails here, named, rather than at cron time.
+                $job = $this->container->get($class);
+                if (($job instanceof IJob) === false) {
+                    $output->warning('[OpenRegister] '.$class.' is declared as a job but is not an IJob — skipped.');
+                    $skipped++;
+                    continue;
+                }
+
+                $this->jobList->add($class);
+                $output->info('[OpenRegister] Registered missing background job: '.$class);
+                $added++;
+            } catch (Throwable $e) {
+                // One unresolvable job must not abort the repair run: the
+                // whole point of this step is to recover an instance.
+                $output->warning('[OpenRegister] Could not register '.$class.': '.$e->getMessage());
+                $this->logger->warning(
+                    '[OpenRegister] Background-job reconciliation skipped '.$class,
+                    ['exception' => $e]
+                );
+                $skipped++;
+            }//end try
+        }//end foreach
+
+        if ($added === 0 && $skipped === 0) {
+            $output->info('[OpenRegister] All '.count($declared).' declared background jobs are already registered.');
+            return;
+        }
+
+        $output->info(
+            '[OpenRegister] Background jobs reconciled: '.$added.' added, '
+            .$skipped.' skipped, '.count($declared).' declared.'
+        );
+    }//end run()
+
+    /**
+     * Read the `<job>` class names out of appinfo/info.xml.
+     *
+     * Parsed from the manifest rather than hard-coded so the list cannot drift
+     * from the declaration this step exists to honour.
+     *
+     * @return array<int,string> Fully-qualified job class names.
+     */
+    private function declaredJobs(): array
+    {
+        $path = dirname(__DIR__, 2).'/appinfo/info.xml';
+        if (file_exists($path) === false) {
+            return [];
+        }
+
+        // Read the file ourselves and parse a STRING. simplexml_load_file()
+        // routes file access through libxml's external-entity loader, and
+        // Nextcloud installs a restrictive loader at boot — so loading by path
+        // silently returns false inside the NC runtime while working perfectly
+        // in a bare PHP process. That mismatch made this step report
+        // "no <job> declarations found" against an info.xml holding 31 of them.
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            return [];
+        }
+
+        $previous = libxml_use_internal_errors(true);
+        $xml      = simplexml_load_string($contents);
+        libxml_use_internal_errors($previous);
+
+        // NOTE: the element is `background-jobs` with a HYPHEN, so it cannot be
+        // reached as `$xml->background_jobs` — SimpleXML would silently return
+        // nothing and this step would cheerfully report "nothing to reconcile"
+        // while every job stayed unregistered. Braced access is required.
+        if ($xml === false || isset($xml->{'background-jobs'}) === false) {
+            return [];
+        }
+
+        $classes = [];
+        foreach ($xml->{'background-jobs'}->job as $job) {
+            $class = trim((string) $job);
+            if ($class !== '') {
+                $classes[] = $class;
+            }
+        }
+
+        return $classes;
+    }//end declaredJobs()
+}//end class


### PR DESCRIPTION
Fixes #2170.

## The problem

Nextcloud writes `oc_jobs` **only** when an app is installed or upgraded. Add a `<job>` to `info.xml` without bumping the app version and it is silently never registered — no error, no warning, and there is no `occ background-job:add` to correct it by hand.

Measured on a live instance: **24 of 31 declared jobs were absent**. Not only flows — scheduled workflows, schedule reconciliation, sync, webhook retries, notification flushing, archival retention and DBAL introspection were all inert, with 59 flow runs sitting `queued` that could never execute.

It hides well, because the **synchronous** counterparts keep working. `POST /api/flow-runs/test` calls `FlowRunService::execute()` directly, so interactive flow testing was green while every asynchronous trigger queued into a void — staying `queued` forever rather than failing.

## The fix

A repair step that parses the `<job>` declarations out of `info.xml` and adds any `IJobList` does not already have. Being a repair step, it runs on `occ maintenance:repair`, so an instance can be corrected **without inventing a version bump**. Idempotent; one unresolvable job is logged and skipped rather than aborting the run, since the whole point is to recover an instance.

## Verified by controlled experiment

Deleted a registered job, ran the step, watched it come back:

```
INFO: [OpenRegister] Registered missing background job: OCA\OpenRegister\Cron\FlowScheduleWorker
INFO: [OpenRegister] Background jobs reconciled: 1 added, 0 skipped, 31 declared.
```

Separately, a version bump plus `occ upgrade` took the instance from **9 to 34** distinct registered job classes.

## Two traps hit while writing this, both worth knowing

**1.** SimpleXML cannot reach a hyphenated element as `$xml->background_jobs` — it needs `$xml->{'background-jobs'}`. The mismatch returns nothing rather than erroring.

**2. `simplexml_load_file()` silently returns false inside the Nextcloud runtime.** NC installs a restrictive libxml external-entity loader at boot, and PHP 8 routes file access through it. The identical parse works in a bare `php -r` process and fails under `require lib/base.php` — so the step reported *"no <job> declarations found"* against an info.xml holding 31 of them. Fixed by reading the file and parsing a string.

That second one generalises: **any app code parsing XML by path is suspect for the same reason.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
