### PR TITLE
fix(flow): scheduled runs were ownerless — 4th instance of the attribution defect

### DIFF
--- a/lib/Service/Flow/FlowScheduleService.php
+++ b/lib/Service/Flow/FlowScheduleService.php
@@ -125,7 +125,7 @@ class FlowScheduleService
                 continue;
             }
 
-            $this->fire(uuid: $uuid, now: $now);
+            $this->fire(uuid: $uuid, now: $now, owner: $flow->getOwner());
             $fired[] = $uuid;
         }//end foreach
 
@@ -202,13 +202,22 @@ class FlowScheduleService
      *
      * @return void
      */
-    private function fire(string $uuid, DateTimeInterface $now): void
+    private function fire(string $uuid, DateTimeInterface $now, ?string $owner=null): void
     {
+        // A scheduled run has no session, so the owner comes from the flow
+        // object itself — the person who created and enabled it. Without this
+        // the run is ownerless, context['triggeredBy'] is null, and every
+        // attribution-requiring node refuses: ObjectWriteNode returns "this
+        // flow run has no owner". That made every natively-scheduled flow
+        // silently incapable of writing anything. Fourth instance of the
+        // or#2158 defect class, after FlowMcpToolProvider::runFlow(),
+        // FlowRunService::execute() and FlowRunController::test().
         $this->runs->queue(
             flowId: $uuid,
             subject: [],
             trigger: 'schedule',
-            context: ['payload' => ['flowId' => $uuid, 'scheduledAt' => $now->format(DATE_ATOM)]]
+            context: ['payload' => ['flowId' => $uuid, 'scheduledAt' => $now->format(DATE_ATOM)]],
+            user: $owner
         );
 
         // Remember the fire time so the next occurrence is measured from here,

--- a/tests/Unit/Service/Flow/FlowScheduleServiceTest.php
+++ b/tests/Unit/Service/Flow/FlowScheduleServiceTest.php
@@ -63,9 +63,14 @@ class FlowScheduleServiceTest extends TestCase
         return $o;
     }
 
-    private function schedule(string $uuid, string $cron): ObjectEntity
+    private function schedule(string $uuid, string $cron, ?string $owner=null): ObjectEntity
     {
-        return $this->flow($uuid, ['enabled' => true, 'trigger' => 'schedule', 'cron' => $cron]);
+        $flow = $this->flow($uuid, ['enabled' => true, 'trigger' => 'schedule', 'cron' => $cron]);
+        if ($owner !== null) {
+            $flow->setOwner($owner);
+        }
+
+        return $flow;
     }
 
     public function testADueScheduledFlowFiresAndRecordsTheFire(): void
@@ -81,6 +86,25 @@ class FlowScheduleServiceTest extends TestCase
         $this->assertSame(['f1'], $fired);
         // A last-fire was recorded, so the next tick will not re-fire immediately.
         $this->assertArrayHasKey('flow_sched_last_f1', $this->store);
+    }
+
+    /**
+     * FAILING PATH (or#2158, fourth instance): a scheduled run has no session,
+     * so its owner must come from the flow object — the person who created and
+     * enabled it. Queued without one, `context['triggeredBy']` is null and every
+     * attribution-requiring node refuses; ObjectWriteNode returns "this flow run
+     * has no owner". Every natively-scheduled flow was silently unable to write.
+     *
+     * @return void
+     */
+    public function testAScheduledRunIsAttributedToTheFlowsOwner(): void
+    {
+        $this->objects->method('findAll')->willReturn([$this->schedule('f1', '*/5 * * * *', 'alice')]);
+
+        $this->runs->expects($this->once())->method('queue')
+            ->with('f1', $this->anything(), 'schedule', $this->anything(), 'alice');
+
+        $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00'));
     }
 
     public function testAFlowThatFiredRecentlyIsNotDueAgain(): void


### PR DESCRIPTION
**Fourth** instance of the or#2158 defect class, after `FlowMcpToolProvider::runFlow()`, `FlowRunService::execute()` and `FlowRunController::test()`.

## The defect

`FlowScheduleService::fire()` queued with no user, so **every natively-scheduled flow ran ownerless**: `context['triggeredBy']` was null and every attribution-requiring node refused. `ObjectWriteNode` returns *"This flow run has no owner (triggeredBy); an object write must be attributable."* A scheduled flow could therefore never write anything.

## Why this one is urgent rather than theoretical

`FlowRunWorker` and `FlowScheduleWorker` were registered **for the first time** in #2172 — before that, 24 of 31 declared jobs were never in `oc_jobs`, so scheduled flows silently never ran at all. Now they do run. Without this fix they would run and refuse, producing a steady stream of failed runs on every instance that picks up that change.

## The fix

A scheduled run has no session, so the owner comes from the flow object itself — the person who created and enabled it. That matches the standing decision that a dispatch is owned by whoever made and activated the flow.

## Verification

New test asserts `queue()` receives the owner; `FlowScheduleServiceTest` 7/7 green.

Found while writing the `apphost-schedule-flow-action` spec — the spec work looked at the adjacent scheduler and found the same hole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
