### PR TITLE
docs(openspec): schedulable flows + app-declared credential providers

### DIFF
--- a/openspec/changes/app-declared-credential-providers/.openspec.yaml
+++ b/openspec/changes/app-declared-credential-providers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/app-declared-credential-providers/design.md
+++ b/openspec/changes/app-declared-credential-providers/design.md
@@ -1,0 +1,332 @@
+# Design: App-declared credential providers
+
+## Context
+
+The credential broker's provider catalogue (`lib/Settings/credential-providers.json`,
+loaded by `ProviderCatalogue`) is deliberately **runtime-immutable** — ADR-004
+Rule 3. It is what turns a stored secret into a *bounded* capability:
+
+- `baseUrl` is the **host-lock** — `resolveAndLockUrl()` rebuilds the URL from
+  `baseUrl . path` and denies unless the resolved host equals the base host.
+- `allowRules[]` is the **path/method bound** — `assertRuleAllowed()` denies
+  unless one `{method, pathPattern}` matches via `fnmatch()`.
+- `inject_only: true` marks a provider the broker *cannot* bound (an unbounded
+  self-hosted host, or a non-HTTP consumer like the `claude` CLI). Those carry
+  no `baseUrl` and no `allowRules`; `request()` refuses them outright and their
+  secret is reachable only through `resolveInjectable()`, which runs Guards 1+2
+  and hands the plaintext to the trusted same-instance caller.
+
+`CredentialBrokerService::request()` runs four fail-closed guards in order:
+owner/organisation (IDOR) → `allowedApps` → allow-rule → host-lock. Every denial
+funnels through one static 403 with a secret-free reason. `CredentialController::create()`
+rejects any `provider` that `ProviderCatalogue::get()` does not resolve.
+
+The cost of that immutability is documented in ADR-004's own consequences:
+*"apps cannot self-serve new hosts."* Observed twice while building
+hydra-console — no `codeberg`/`forgejo` entry (forcing a `generic-bearer`
+`inject_only` fallback with **no** host-lock and **no** rules), and `github`
+allow-rules with no issue-label write (openregister#2165). The second was
+fixable only because we own this repo. An external app author's real options
+today are "wait for an OpenRegister release" or "keep custody of the secret" —
+and the second is precisely the failure ADR-004 exists to prevent, so the
+immutability is currently *pushing secrets out of the vault*.
+
+Stakeholders: OpenRegister (custody boundary owner), consuming app authors
+(hydra-console first, then openconnector's arbitrary Sources), and the
+instance administrator who carries the risk of any egress this instance makes.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- An app can **declare**, as shipped config, the credential providers it needs —
+  host, auth scheme, and the exact methods and paths it will call.
+- No app can grant itself a host or a path the reviewed catalogue does not
+  already permit **without an explicit human approval step**.
+- The audit trail records **who** approved, **when**, and **exactly what** they
+  approved (a digest), so an approval cannot be silently re-pointed later.
+- A declared provider is usable **only by the app that declared it**.
+- The `inject_only` vs proxied distinction survives untouched, along with
+  `request()`'s refusal to proxy `inject_only` and `resolveInjectable()`'s
+  refusal to serve proxy credentials.
+- The shipped catalogue file remains runtime-immutable — no API writes it.
+
+**Non-Goals:**
+
+- Broker *capability* work: OAuth2 token exchange, mTLS, request signing, SMTP.
+  A declaration expresses exactly what `injectAuth()` can already do — one
+  request header carrying one secret. Anything else is out of scope.
+- Letting an app declare an `inject_only` provider (see D5).
+- Federating or syncing approvals between instances. Approval is per-instance.
+- Changing any existing catalogue entry, credential, or guard order.
+- A UI for authoring declarations. A declaration is shipped code, reviewed in
+  the app's own repo; OpenRegister only renders it for the approver.
+
+## Decisions
+
+### D1 — Where a declaration lives: a shipped JSON file in the declaring app
+
+An app ships `lib/Settings/credential-providers.json` in **its own** app
+directory, in the same shape as OpenRegister's catalogue plus the declaration
+fields in D3. A `DeclaredProviderLoader` walks `IAppManager::getInstalledApps()`
+and reads `IAppManager::getAppPath($appId).'/lib/Settings/credential-providers.json'`,
+caching the parsed result in-memory per request — mirroring `ProviderCatalogue`
+and `AppHost\Scheduling\ScheduleManifestLoader`. Read errors, malformed JSON and
+schema violations fail **soft to empty** (log a warning, contribute nothing), so
+a broken declaration denies rather than half-admits.
+
+*Alternatives rejected:* a `POST /api/credentials/providers` registration API —
+it makes the catalogue runtime-writable, which is exactly the property ADR-004
+Rule 3 protects, and it puts the declaration in mutable state where a compromised
+app can rewrite it between approval and use. A `<credential-provider>` block in
+`appinfo/info.xml` — Nextcloud's app metadata is not a place other apps parse,
+and the JSON shape must match the catalogue byte-for-byte so the broker's guards
+operate on one entry shape.
+
+### D2 — Declarative, not imperative (ADR-031)
+
+ADR-031's rule is: when the platform can express behaviour as declared metadata,
+prefer that over a service class. This change is that rule applied to egress. An
+app does **not** call a `registerProvider()` service method at boot; it ships a
+static, reviewable, diffable JSON file, and OpenRegister reads it. Consequences
+that matter here and are the reason the declarative form is not merely stylistic:
+
+- **It is reviewable in the app's own PR.** The exact host and rule set appear
+  in a code diff, so the app's own reviewers see the egress request before the
+  administrator ever does.
+- **It is digestible.** A file has a stable content digest, which is what makes
+  D4's approval-pinning possible at all. An imperative registration call has no
+  artefact to pin.
+- **It cannot execute.** There is no app code path that runs inside
+  OpenRegister's credential layer — the loader only parses data.
+- **It is inert without approval.** A declaration is *a request*, never an
+  effect. Nothing in the file changes broker behaviour until D4's admission
+  decision resolves, which is precisely the property an imperative registration
+  cannot offer (a call that "registers" has already registered).
+
+The one imperative surface added is the administrator's approve/reject/revoke
+action, which is a human decision and therefore correctly a command, not config.
+
+### D3 — Namespacing and app-scoping: a declared provider cannot be shadowed or borrowed
+
+A declared provider's effective identifier is `<appId>:<localId>` (for example
+`hydra_console:codeberg`). Base-catalogue identifiers contain no colon, so:
+
+- A declaration **cannot shadow** a reviewed provider — the identifier space is
+  disjoint. The resolver consults `ProviderCatalogue` first regardless; a base
+  hit wins and the declaration layer is never reached for that id.
+- A credential minted against `<appId>:<localId>` has `allowedApps` **forced** to
+  `[<appId>]` at mint time, and Guard 2 (`assertAppAllowed()`) then enforces it on
+  every call unchanged. A second app cannot borrow the credential even if it
+  learns the UUID; and an owner cannot widen `allowedApps` on a declared-provider
+  credential through `PUT /api/credentials/{id}`.
+
+*Alternative rejected:* flat identifiers with a first-writer-wins registry —
+two apps declaring `codeberg` would then race, and an app could take the name a
+future reviewed entry wants. Namespacing removes the whole class.
+
+### D4 — Two admission lanes, and why only one needs a human
+
+This is the core of the security model, and the part the PO should confirm.
+
+**Lane A — narrowing (admitted on discovery, no approval).** A declaration may
+carry `extends: <base provider id>`. It then MUST use the base's `baseUrl` and
+`authScheme` verbatim, and its `allowRules[]` MUST be a **subset** of the base's
+rules — each declared rule must have the same `method` and a `pathPattern` that
+is equal to, or strictly narrower than, a base rule (a base pattern that
+`fnmatch()`-matches every path the declared pattern can produce). Such a
+declaration grants **nothing** the reviewed catalogue does not already permit —
+it can only *reduce* an app's reach below what it would get by using the base
+provider directly. Requiring an approval click for a strictly-safer configuration
+would train administrators to click through approvals, which is itself a security
+regression. Any `extends` declaration that fails the subset test is **rejected
+outright** — it is a bug in the app, not an escalation request, and is never
+silently promoted to Lane B.
+
+**Lane B — novel (unusable until an administrator approves).** Any declaration
+without `extends`, or one naming a host or path the reviewed catalogue does not
+already permit, is `pending`. `resolveProvider()` denies it, so a credential
+minted against it fails closed with a distinct, secret-free reason. An
+administrator reviews the rendered host + full rule set in OpenRegister's
+credential settings and approves, rejects, or later revokes. This is the lane
+that resolves both observed costs: `hydra_console:codeberg` at a Forgejo host
+(cost 1), and a GitHub declaration carrying issue-label rules the base lacks
+(cost 2) — an app author can now ask for those without an OpenRegister release,
+and a human still decides.
+
+**Approval is pinned to a content digest.** The approval record stores a digest
+over the canonical serialisation of the exact declaration entry approved. On
+every resolution the loader recomputes the digest; on mismatch the approval is
+**invalid** and the provider returns to `pending`. This closes the
+time-of-check/time-of-use hole that would otherwise make the whole approval
+theatre: ship a benign declaration, get approved, widen it in the next app
+update. Re-approval requires a human to look at the new rule set.
+
+*Alternatives rejected:*
+- **Unrestricted app-declared providers** (a runtime-writable catalogue). Any
+  app could point another user's secret at a host of its choosing. This deletes
+  ADR-004 Rule 3 and the entire value of the broker.
+- **Narrowing-only, no approval lane.** Safe, and it is Lane A — but it cannot
+  express a host absent from the catalogue, so Codeberg (cost 1) stays
+  unsolved and the `generic-bearer` fallback remains the only option. Rejecting
+  Lane B would mean shipping a change that does not fix the reported problem.
+- **App-scoping (`allowedApps`) as the sole control.** Scoping stops *borrowing*,
+  not the declaring app itself aiming a user's token at an attacker-controlled
+  host. Necessary, not sufficient — kept as D3, on top of D4.
+- **Keep the catalogue immutable; add only a declaration *schema* for reviewed
+  inclusion** (declarations as machine-checkable PR material). It removes no
+  release from the loop and cannot express a **per-install** host at all — a
+  municipality's own Forgejo domain can never appear in a file shipped to every
+  instance. This is the option ADR-004's `$fleetComment` already named as
+  needing "a per-install, admin-approved provider registration", which is D4.
+
+### D5 — A declaration MUST be a host-locked proxy entry; `inject_only` is rejected
+
+A declared entry MUST carry `baseUrl` and a non-empty `allowRules[]`.
+`"inject_only": true` in a declaration is a validation error.
+
+The reasoning is the inverse of what it first looks like. `inject_only` needs no
+host and no rules, so it looks like the *easy* thing to allow — but it is the
+path where the raw secret **leaves OpenRegister** into the calling app, bounded
+by nothing except Guards 1+2. An app-declared `inject_only` entry would therefore
+be a secret-egress path with no bound at all, created by the app that receives
+the secret. Meanwhile it would add nothing: the reviewed `generic-apikey`,
+`generic-bearer`, `generic-basic`, `generic-oauth2` and `generic-jwt` entries
+already serve exactly that case for any app, today, unchanged.
+
+So the distinction is preserved and sharpened: `inject_only` remains a
+**reviewed-catalogue-only** concept; declarations exist to move apps *up* to a
+host-locked proxy entry, which is what hydra-console wanted and could not have.
+`request()` still refuses `inject_only`; `resolveInjectable()` still returns
+`null` for proxy providers, and therefore returns `null` for **every** declared
+provider — a declared credential is always a `request()` credential.
+
+### D6 — Resolution order and the guard chain stay identical
+
+`resolveProvider()` becomes: base catalogue → admitted declaration → deny. An
+admitted declaration returns the **same entry array shape** the base catalogue
+returns, so `isInjectOnly()`, `assertRuleAllowed()`, `resolveAndLockUrl()`,
+`injectAuth()`, `performCall()` and both guard chains are untouched. No new guard
+is introduced and no existing guard is bypassed; admission is a *resolution*
+concern that happens strictly before Guard 3. That is deliberate — the smaller
+the diff inside the guard chain, the smaller the review surface on a custody
+boundary.
+
+### D7 — Approval state is an auditable object, not an app-config flag
+
+Approvals are recorded as `credentialProviderApproval` objects in the existing
+credential-broker register, written through `ObjectService` like any other
+OpenRegister object. This buys ADR-003's immutable hash-chained audit trail for
+free: who approved, when, from what previous state, with the digest they saw.
+Properties: `providerIdentifier`, `declaringApp`, `declarationDigest`, `status`
+(`pending` / `approved` / `rejected` / `revoked`), `decidedBy`, `decidedAt`,
+`decisionNote`, `baseUrl`, `allowRulesSnapshot`. Storing the rule snapshot means
+the trail shows what was approved even after the app changes or is uninstalled.
+
+*Alternative rejected:* `IAppConfig` key/values. Cheaper to read, but it has no
+history — "who approved this" would be unanswerable, which is a hard requirement.
+Resolution cost is handled by caching the approval map in-memory per request, the
+same way `ProviderCatalogue` caches the file.
+
+### D8 — Fail-closed lifecycle
+
+Disabling or uninstalling the declaring app removes its declarations from
+discovery, so its declared providers stop resolving and every credential minted
+against them denies — never silently proxies. Approval records are **kept** (the
+audit trail is immutable); re-enabling the app re-admits the provider only if the
+digest still matches the kept approval. Revocation by an administrator takes
+effect on the next resolution, with no cache TTL beyond the current request.
+
+## Seed Data (ADR-001)
+
+This change introduces one schema (`credentialProviderApproval`), so seed data is
+required. It ships in `lib/Settings/credential_broker_register.json` under
+`components.objects[]` and is imported by the existing credential-broker Repair
+step.
+
+**Safety rule specific to this schema:** an approval object is an *admission
+decision*. A seed row that reads as `approved` would admit a provider on a fresh
+install with no human ever deciding — the exact failure this change exists to
+prevent. Therefore **every seed row MUST carry `status: "revoked"`** and a
+digest that matches nothing (`sha256:0000…0000`), so that even if a real app
+later declared the same identifier, the row could never admit it.
+
+Seed rows (all ADR-001 `example-` prefixed and self-identifying):
+
+- `example-approval-pending-forge` — `providerIdentifier:
+  "example_app:example-forge"`, `declaringApp: "example_app"`, `baseUrl:
+  "https://forge.example.org/api/v1"`, `allowRulesSnapshot: [{ "method": "GET",
+  "pathPattern": "/repos/*" }]`, `status: "revoked"`, `decidedBy:
+  "example-admin"`, `decisionNote: "Example seed row — demonstrates the pending
+  Lane B shape. Ships revoked so it can never admit anything."`,
+  `declarationDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"`.
+- `example-approval-revoked-forge` — same declaring app, `providerIdentifier:
+  "example_app:example-forge-legacy"`, `status: "revoked"`, `decisionNote:
+  "Example seed row — demonstrates a revoked decision and its audit fields."`,
+  same nil digest.
+
+Related items: none. An approval object has no files, notes, tasks or contacts —
+it is a decision record whose only relation is the immutable audit trail
+ADR-003 generates for it, which needs no seeding. No `@self.seedExemption` marker
+is used: both rows carry the `example-` prefix.
+
+## Risks / Trade-offs
+
+- **An administrator approves a declaration they do not understand** (rule sets
+  are dense; approval fatigue is real) → the admin view renders the resolved
+  host and every method+path in full, states plainly which lane the declaration
+  is in, and Lane A never asks for a click — so the only approvals an
+  administrator ever sees are the ones that actually widen reach.
+- **Digest drift on every innocent app update** — an app adding an unrelated
+  provider changes the file, and if the digest covered the whole file every
+  approval would break → the digest is computed **per declaration entry**, over
+  a canonical serialisation, not over the file. Only the changed entry
+  re-enters `pending`.
+- **Subset checking for `allowRules` is where Lane A can go wrong.** A wrong
+  "narrower than" test silently widens reach with no human in the loop → the
+  test is conservative: same `method`, and the base pattern must
+  `fnmatch()`-match the declared pattern with any `*` in the declared pattern
+  treated as "could be anything". Anything not provably narrower is **rejected**,
+  never escalated. This path carries dedicated tests including the adversarial
+  cases (`/repos/*` vs `/repos/*/../../admin`, `*` at the pattern head).
+- **A declared host is per-install and unreviewed by Conduction** — an approved
+  Forgejo host is trusted by that instance's administrator only → accepted
+  deliberately; that is the whole point of a per-install approval, and the
+  approval record names the human who took it.
+- **Path traversal through a declared `pathPattern`** → unchanged from today:
+  `normalisePath()` runs before matching and `resolveAndLockUrl()` re-derives
+  and re-checks the host. Declarations add no new URL construction.
+- **A compromised app re-declares with a widened rule set** → digest pinning
+  (D4) returns it to `pending` and it denies until a human re-approves.
+- **Cost: more moving parts on a custody boundary** → mitigated by D6 — the
+  guard chain itself does not change, only provider *resolution* does.
+
+## Migration Plan
+
+Additive; no data migration. Order:
+
+1. Ship the `credentialProviderApproval` schema + seed rows via the existing
+   credential-broker Repair step (register version bump).
+2. Ship the loader, validator, resolver and admin surface. With no app shipping
+   a declaration, behaviour is byte-identical to today.
+3. hydra-console ships the first declaration (`codeberg`) and its administrator
+   approves it; its `generic-bearer` fallback credential is retired.
+
+Rollback: disabling the feature is removing the declaration layer from
+`resolveProvider()` — declared credentials then deny (fail closed) and no base
+provider is affected. Approval objects remain as an audit record.
+
+## Open Questions
+
+- **Should Lane A really skip approval?** The design argues a strict subset
+  grants nothing new and that click-fatigue is the larger risk, but an
+  administrator may reasonably want to see *every* provider any app can use,
+  even the narrower ones. A middle option is: Lane A is admitted without
+  approval but is always **listed** in the admin view as "auto-admitted
+  (narrowing)". This design assumes that middle option; PO to confirm.
+- **Should a Lane B approval expire?** A host approved in 2026 may not deserve
+  trust in 2028. Not specified here; re-approval is currently triggered only by
+  digest drift.
+- **Does an organisation-scoped credential need an organisation-level approval**
+  distinct from the instance administrator's? Assumed no for now — the host-lock
+  is an instance-wide egress decision.

--- a/openspec/changes/app-declared-credential-providers/proposal.md
+++ b/openspec/changes/app-declared-credential-providers/proposal.md
@@ -1,0 +1,129 @@
+---
+kind: code
+depends_on: []
+---
+
+# Proposal: App-declared credential providers
+
+## Why
+
+`lib/Settings/credential-providers.json` is a **runtime-immutable** catalogue
+(ADR-004 Rule 3): the host-lock, the auth-header scheme, and the `allowRules[]`
+that bound what a brokered secret can ever do are read from disk and are not
+writable through any API. That immutability is the security control, and it is
+also the bottleneck — *"apps cannot self-serve new hosts"* is already listed as
+a known consequence in ADR-004. Two concrete costs were paid while building the
+hydra-console app:
+
+1. **No `codeberg`/`forgejo` provider exists** (only `github`/`gitlab`). A
+   Codeberg-hosted forge had to fall back to a `generic-bearer` `inject_only`
+   credential — which means the raw token leaves OpenRegister into the calling
+   app and there is *no* host-lock and *no* per-path allow-rule at all. The
+   fallback is strictly weaker than the first-class provider we could not have.
+2. **The `github` provider's `allowRules` permitted no issue-label write**, so
+   the broker refused label-driven forge automation even with a valid PAT
+   (ConductionNL/openregister#2165). It was only fixable because we own
+   OpenRegister. An app author outside this repo had no route at all: their
+   options were "open a PR against OpenRegister and wait for a release" or
+   "keep custody of the secret yourself" — and the second is what actually
+   happens, which is exactly what ADR-004 exists to prevent.
+
+The immutability must survive; the bottleneck must not. An app should be able to
+**declare** the credentials and the bounded egress it needs, and an
+administrator — not the app — decides whether that declaration becomes usable.
+
+## What Changes
+
+- **A declaration file, shipped by the consuming app.** An app may ship
+  `lib/Settings/credential-providers.json` in **its own** app directory, in the
+  same shape as OpenRegister's catalogue. OpenRegister discovers declarations by
+  walking `IAppManager::getInstalledApps()` + `getAppPath($appId)` — the same
+  read-only, declarative-config pattern as `AppHost\Scheduling\ScheduleManifestLoader`
+  (ADR-031: declare it, do not code it).
+- **Declared identifiers are namespaced and app-scoped.** A declared provider is
+  addressed as `<appId>:<localId>`. Base-catalogue identifiers contain no colon,
+  so a declaration can **never shadow or override** a reviewed provider, and the
+  base catalogue always wins on any collision. A credential minted against a
+  declared provider is forced to `allowedApps == [<declaringApp>]` — it cannot
+  be borrowed by a second app.
+- **Two admission lanes, one boundary.**
+  - **Narrowing lane (no approval needed).** A declaration carrying
+    `extends: <base provider id>` may only *intersect* the base: identical host,
+    and an `allowRules[]` subset of the base's rules. It grants nothing the
+    reviewed catalogue does not already permit, so it is admitted on discovery.
+    Anything that would widen host or rules is rejected outright, not escalated.
+  - **Approval lane (explicit human step).** A declaration that names a host or
+    a path the reviewed catalogue does not already permit — a Codeberg or
+    self-hosted Forgejo base URL, GitHub issue-label rules the base lacks — is
+    **`pending` and unusable** until an administrator approves it. The broker
+    fails closed on a pending, rejected, or revoked declaration.
+- **Approval is bound to a digest of the exact declaration.** The approval
+  record stores a content digest; if the app later edits its declaration, the
+  digest no longer matches, the approval is invalidated automatically, and the
+  provider returns to `pending`. An app cannot ship a benign declaration, obtain
+  approval, and then widen it in an update.
+- **The approval record is an auditable object, not a config flag.** A
+  `credentialProviderApproval` schema is added to the existing credential-broker
+  register, so every approve / reject / revoke is carried by OpenRegister's
+  immutable hash-chained audit trail (ADR-003) and records **who** decided,
+  **when**, and **what digest** they saw.
+- **`inject_only` declarations are rejected.** An app-declared provider MUST be
+  a host-locked proxy declaration (`baseUrl` + `allowRules` required). The
+  reviewed `generic-apikey`/`generic-bearer`/`generic-basic`/`generic-oauth2`/
+  `generic-jwt` entries already cover the app-injected case and are unchanged;
+  a *declared* `inject_only` entry would add a secret-egress path with no bound
+  at all, which is the one thing this change must not create. The existing
+  `inject_only` vs proxied distinction, and `resolveInjectable()`'s refusal to
+  serve proxy credentials, are preserved exactly.
+- **Lifecycle is fail-closed.** Disabling or uninstalling the declaring app
+  makes its declared providers unresolvable and any credential minted against
+  them denied — never silently proxied.
+- **Admin surface.** OpenRegister's credential settings gain a "Declared
+  providers" view: pending declarations with the full host + rule set rendered
+  for review, and approve / reject / revoke actions. `GET /api/credentials/providers`
+  keeps exposing only `identifier` + `title` (never allow-rules), plus the
+  declaration's `origin` and `status` so a picker can hide unusable providers.
+
+Not breaking: every existing catalogue provider, every existing credential, and
+both broker paths behave identically. The change is additive.
+
+## Capabilities
+
+### New Capabilities
+- `app-declared-credential-providers`: how an app declares a credential provider,
+  how OpenRegister discovers and validates that declaration, the narrowing lane
+  vs the admin-approval lane, digest-bound approval and automatic invalidation,
+  app-scoping of declared providers and their credentials, and the fail-closed
+  lifecycle on app disable/uninstall.
+
+### Modified Capabilities
+- `credential-broker`: provider resolution is no longer "the shipped catalogue
+  only" — it becomes "the shipped catalogue, then an *admitted* declaration",
+  with the base catalogue winning every collision and every non-admitted
+  declaration denying. Credential mint validation accepts a namespaced declared
+  identifier and forces `allowedApps` for it. ADR-004 Rule 3 is amended: the
+  shipped catalogue stays runtime-immutable, and the only runtime addition is an
+  administrator-approved, digest-pinned, app-scoped declaration.
+
+## Impact
+
+- **Code**: `lib/Service/Credential/ProviderCatalogue.php` (base loader, unchanged
+  semantics) gains a sibling declaration loader and a resolver that layers the
+  two; `CredentialBrokerService::resolveProvider()` consults the resolver;
+  `assertRuleAllowed()`, `resolveAndLockUrl()`, `injectAuth()`, `isInjectOnly()`
+  and both guard chains are untouched — a declared provider produces the same
+  entry shape, so it is guarded by exactly the same four guards.
+  `CredentialController::create()`/`providers()` gain declared-provider handling.
+- **Config/registers**: `lib/Settings/credential_broker_register.json` gains the
+  `credentialProviderApproval` schema; the shipped
+  `lib/Settings/credential-providers.json` is unchanged by this proposal.
+- **ADRs**: ADR-004 (credential-broker custody) Rule 3 amended; ADR-003 (audit
+  trail) consumed as-is; ADR-031 (declarative over imperative) is the reason the
+  declaration is a shipped JSON file rather than a registration API call;
+  ADR-001 seed data applies to the new schema.
+- **Dependent apps**: additive for opencatalogi/softwarecatalog/openconnector —
+  no existing provider or credential changes. hydra-console is the first
+  consumer (a `codeberg` declaration replacing its `generic-bearer` fallback).
+- **Security review**: this change touches the credential custody boundary and
+  MUST carry tests for every deny path (unapproved, digest-drift, widening
+  attempt, cross-app borrow, shadowing attempt, disabled declaring app).

--- a/openspec/changes/app-declared-credential-providers/specs/app-declared-credential-providers/spec.md
+++ b/openspec/changes/app-declared-credential-providers/specs/app-declared-credential-providers/spec.md
@@ -1,0 +1,286 @@
+## ADDED Requirements
+
+### Requirement: Declarations are discovered from shipped app config only
+
+OpenRegister SHALL discover app credential-provider declarations by reading
+`lib/Settings/credential-providers.json` from each installed app's own directory
+(resolved via `IAppManager::getInstalledApps()` and `IAppManager::getAppPath()`),
+and MUST NOT expose any API that creates, updates, or deletes a declaration. The
+shipped catalogue at `openregister/lib/Settings/credential-providers.json`
+remains runtime-immutable and is never written by this capability.
+
+#### Scenario: An app's declaration file is discovered
+
+- **WHEN** an installed, enabled app ships `lib/Settings/credential-providers.json`
+- **THEN** OpenRegister reads that file and offers its entries for admission
+- **AND** the file is read only, never written
+
+#### Scenario: No write API exists for declarations
+
+- **WHEN** any HTTP client attempts to create or modify a provider declaration
+  through the OpenRegister API
+- **THEN** no such route exists and the request cannot succeed
+
+#### Scenario: A malformed declaration file contributes nothing
+
+- **WHEN** an app's declaration file is unreadable, is not valid JSON, or fails
+  declaration validation
+- **THEN** OpenRegister logs a secret-free warning and admits no entry from that file
+- **AND** provider resolution for that app's declared identifiers denies
+
+### Requirement: Declared identifiers are namespaced and cannot shadow the reviewed catalogue
+
+A declared provider's effective identifier SHALL be `<appId>:<localId>`, and
+OpenRegister MUST resolve the shipped catalogue first, so a declaration can never
+shadow, override, or replace a reviewed provider entry.
+
+#### Scenario: A declaration cannot take a reviewed identifier
+
+- **WHEN** an app declares an entry whose effective identifier would be `github`
+  (no `<appId>:` prefix)
+- **THEN** the declaration is rejected as invalid and admits nothing
+
+#### Scenario: The base catalogue wins on resolution
+
+- **WHEN** a credential names the provider `github`
+- **THEN** the broker resolves the shipped catalogue entry
+- **AND** no declaration layer is consulted for that identifier
+
+#### Scenario: Two apps may declare the same local name
+
+- **WHEN** app `alpha` and app `beta` each declare a local id `codeberg`
+- **THEN** they resolve as `alpha:codeberg` and `beta:codeberg` independently
+
+### Requirement: A narrowing declaration is admitted without administrator approval
+
+A declaration carrying `extends: <base provider id>` SHALL be admitted on
+discovery without an approval step if and only if it uses the base entry's
+`baseUrl` and `authScheme` verbatim and every declared allow-rule is provably
+narrower than or equal to a base allow-rule (same `method`, and a `pathPattern`
+that matches no path the base rule does not already match). Such a declaration
+grants no host and no path the reviewed catalogue does not already permit.
+
+#### Scenario: A strict subset is admitted immediately
+
+- **WHEN** an app declares `extends: github` with the single rule
+  `GET /repos/*` and GitHub's base rules include `GET /repos/*`
+- **THEN** the provider is usable without any administrator action
+- **AND** it is listed in the admin view as auto-admitted (narrowing)
+
+#### Scenario: An identical-to-base declaration is admitted
+
+- **WHEN** an app declares `extends: gitlab` reproducing GitLab's rule set exactly
+- **THEN** the provider is admitted, granting nothing beyond the base
+
+### Requirement: A declaration that widens beyond its base is rejected, never escalated
+
+A declaration carrying `extends` MUST be rejected as invalid when its host,
+`authScheme`, or allow-rules exceed the base entry, and MUST NOT be converted
+into a pending approval request. Anything not provably narrower than the base
+SHALL be treated as widening.
+
+#### Scenario: A wider path pattern is rejected
+
+- **WHEN** an app declares `extends: github` with the rule `PUT /repos/*` while
+  the base permits only `PUT /repos/*/contents/*`
+- **THEN** the declaration is rejected as invalid
+- **AND** no pending approval is created for it
+
+#### Scenario: A different host under extends is rejected
+
+- **WHEN** an app declares `extends: github` with a `baseUrl` other than the
+  base entry's `baseUrl`
+- **THEN** the declaration is rejected as invalid
+
+#### Scenario: An unprovable pattern relationship is rejected
+
+- **WHEN** a declared `pathPattern` cannot be shown to match only paths the base
+  rule already matches
+- **THEN** the declaration is rejected as invalid rather than admitted
+
+### Requirement: A novel declaration is unusable until an administrator approves it
+
+A declaration SHALL be recorded with status `pending` and MUST NOT resolve when
+it names a host or a path the reviewed catalogue does not already permit. The broker
+MUST deny every call and every secret resolution for a `pending`, `rejected`, or
+`revoked` declaration, with a static 403 and a secret-free reason.
+
+#### Scenario: A pending declaration denies
+
+- **WHEN** an app declares a provider at a host absent from the reviewed
+  catalogue and a credential is minted against it
+- **THEN** every brokered call for that credential is denied with HTTP 403
+- **AND** no outbound request is made
+
+#### Scenario: An approved declaration resolves
+
+- **WHEN** an administrator approves a pending declaration
+- **THEN** the provider resolves and brokered calls proceed subject to the
+  broker's existing guards
+
+#### Scenario: A rejected declaration stays unusable
+
+- **WHEN** an administrator rejects a pending declaration
+- **THEN** the provider does not resolve and re-discovery does not re-open it as
+  pending while the same digest is on record as rejected
+
+### Requirement: Approval is pinned to a digest of the approved declaration
+
+An approval record SHALL store a content digest computed over a canonical
+serialisation of the individual declaration entry approved, and OpenRegister MUST
+recompute that digest on every resolution. A digest mismatch MUST invalidate the
+approval and return the provider to `pending`.
+
+#### Scenario: Editing an approved declaration revokes its admission
+
+- **WHEN** an approved app ships an app update that adds an allow-rule to that
+  declaration
+- **THEN** the recomputed digest no longer matches the approval
+- **AND** the provider returns to `pending` and denies until re-approved
+
+#### Scenario: An unrelated entry change does not disturb an approval
+
+- **WHEN** an app adds a second, different declared provider to its file
+- **THEN** the first provider's digest is unchanged and its approval stands
+
+### Requirement: Approval decisions are recorded in the audit trail with the deciding user
+
+Every approve, reject, and revoke decision SHALL be persisted as a
+`credentialProviderApproval` object carrying `providerIdentifier`,
+`declaringApp`, `declarationDigest`, `status`, `decidedBy`, `decidedAt`,
+`decisionNote`, `baseUrl` and `allowRulesSnapshot`, so OpenRegister's immutable
+hash-chained audit trail records who decided, when, and exactly what they saw.
+Approval records MUST NOT be deleted when the declaring app is disabled or
+uninstalled.
+
+#### Scenario: An approval names its approver
+
+- **WHEN** an administrator approves a declaration
+- **THEN** an approval object is written with `decidedBy` set to that
+  administrator's user id and `decidedAt` set to the decision time
+- **AND** the audit trail carries the state transition
+
+#### Scenario: The approved rule set is preserved
+
+- **WHEN** the declaring app is later uninstalled
+- **THEN** the approval record still shows the `baseUrl` and
+  `allowRulesSnapshot` that were approved
+
+#### Scenario: Only an administrator may decide
+
+- **WHEN** a non-administrator invokes the approve, reject, or revoke endpoint
+- **THEN** the request is refused and no approval object is written
+
+### Requirement: A declared provider is usable only by the app that declared it
+
+A credential minted against a declared provider SHALL have `allowedApps` forced
+to exactly the declaring app, and OpenRegister MUST refuse any request that would
+add another app to that credential's `allowedApps`.
+
+#### Scenario: A second app cannot borrow the credential
+
+- **WHEN** app `beta` calls the broker with a credential minted against
+  `alpha:codeberg`
+- **THEN** the existing allowed-app guard denies the call with HTTP 403
+
+#### Scenario: allowedApps cannot be widened after mint
+
+- **WHEN** the credential owner submits an update adding `beta` to the
+  `allowedApps` of a credential minted against `alpha:codeberg`
+- **THEN** the update is refused and `allowedApps` remains `["alpha"]`
+
+### Requirement: A declaration MUST be a host-locked proxy entry
+
+A declared provider entry SHALL carry a `baseUrl` and a non-empty `allowRules[]`,
+and MUST NOT set `inject_only`. The reviewed catalogue remains the only source of
+`inject_only` providers, so `resolveInjectable()` MUST return `null` for every
+declared provider and `request()` remains the only path for a declared credential.
+
+#### Scenario: An inject_only declaration is rejected
+
+- **WHEN** an app declares an entry with `"inject_only": true`
+- **THEN** the declaration is rejected as invalid and admits nothing
+
+#### Scenario: A declaration without allow-rules is rejected
+
+- **WHEN** an app declares an entry with no `baseUrl` or with an empty
+  `allowRules[]`
+- **THEN** the declaration is rejected as invalid
+
+#### Scenario: resolveInjectable refuses a declared credential
+
+- **WHEN** an app calls `resolveInjectable()` with a credential minted against an
+  approved declared provider
+- **THEN** `null` is returned and no secret leaves OpenRegister
+
+#### Scenario: The reviewed generic inject_only entries are unchanged
+
+- **WHEN** an app uses the reviewed `generic-bearer` provider
+- **THEN** its behaviour is exactly as before this change
+
+### Requirement: Declared providers fail closed on disable, uninstall, and revocation
+
+Disabling or uninstalling the declaring app SHALL make its declared providers
+unresolvable, and an administrator revocation MUST take effect on the next
+resolution. In every case the broker MUST deny rather than fall back to any other
+provider or make an unbounded call.
+
+#### Scenario: Disabling the app denies its declared credentials
+
+- **WHEN** the declaring app is disabled
+- **THEN** brokered calls for credentials minted against its declared providers
+  are denied with HTTP 403
+
+#### Scenario: Revocation takes effect without a restart
+
+- **WHEN** an administrator revokes an approved declaration
+- **THEN** the next brokered call for that provider is denied
+
+#### Scenario: Re-enabling requires a matching digest
+
+- **WHEN** the declaring app is re-enabled with its declaration unchanged
+- **THEN** the kept approval applies again and the provider resolves
+- **AND** if the declaration changed, the provider is `pending` instead
+
+### Requirement: The provider listing exposes origin and status but never allow-rules
+
+`GET /api/credentials/providers` SHALL return, for every reviewed and every
+discovered provider, only the `identifier`, `title`, `origin` (`catalogue` or the
+declaring app id) and `status` (`admitted`, `pending`, `rejected`, `revoked`).
+Allow-rules MUST NOT be returned by this endpoint.
+
+#### Scenario: A picker can hide unusable providers
+
+- **WHEN** a client requests the provider list
+- **THEN** each entry carries its origin and status
+- **AND** no `allowRules` or `baseUrl` field is present in the response
+
+#### Scenario: The admin review view may show the full rule set
+
+- **WHEN** an administrator opens the declared-providers admin view
+- **THEN** the host and every method and path pattern are rendered for review
+
+### Requirement: The approval schema ships with the credential-broker register migration
+
+The `credentialProviderApproval` schema SHALL be added to
+`lib/Settings/credential_broker_register.json` with a register version bump and
+imported by the existing credential-broker Repair step. Seed rows MUST carry the
+`example-` prefix, a `status` of `revoked`, and a digest that matches no real
+declaration, so no seed row can ever admit a provider.
+
+#### Scenario: A fresh install materialises the schema
+
+- **WHEN** the credential-broker Repair step runs on a fresh install
+- **THEN** the `credentialProviderApproval` schema exists in the credential-broker
+  register with its seed rows
+
+#### Scenario: Seed rows cannot admit anything
+
+- **WHEN** an app declares a provider whose identifier matches a seed row
+- **THEN** the seed row's `revoked` status and non-matching digest admit nothing
+- **AND** the declaration is treated as `pending`
+
+#### Scenario: An existing install upgrades without touching credentials
+
+- **WHEN** the Repair step runs on an install that already has credentials
+- **THEN** the schema is added and no existing credential or provider changes

--- a/openspec/changes/app-declared-credential-providers/specs/credential-broker/spec.md
+++ b/openspec/changes/app-declared-credential-providers/specs/credential-broker/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+<!--
+  These are ADDED, not MODIFIED: the canonical openspec/specs/credential-broker/spec.md
+  carries no requirement text for provider resolution or mint validation today
+  (that behaviour is described in ADR-004 Rule 3 and in unarchived changes), so
+  there is no existing requirement block to copy forward. These requirements state
+  the amended behaviour in full.
+-->
+
+### Requirement: Provider resolution consults the shipped catalogue first, then an admitted declaration
+
+`CredentialBrokerService` SHALL resolve a credential's provider by looking up the
+shipped, runtime-immutable catalogue first and, only when that yields nothing, an
+app declaration that is currently admitted. Any other outcome MUST deny. A
+pending, rejected, revoked, invalid, or digest-drifted declaration MUST NOT
+resolve, and the shipped catalogue MUST remain unwritable at runtime.
+
+#### Scenario: A reviewed provider resolves from the catalogue
+
+- **WHEN** a credential names `mollie`
+- **THEN** the shipped catalogue entry is used and no declaration is consulted
+
+#### Scenario: An admitted declaration resolves
+
+- **WHEN** a credential names `alpha:codeberg` and that declaration is admitted
+- **THEN** the declared entry is used
+
+#### Scenario: An unknown or non-admitted provider denies
+
+- **WHEN** a credential names a provider that is neither in the catalogue nor an
+  admitted declaration
+- **THEN** the broker denies with HTTP 403 and a secret-free reason
+
+### Requirement: A declared provider is guarded by the same four guards as a reviewed provider
+
+A resolved declaration SHALL yield the same provider entry shape as a catalogue
+entry, so the owner/organisation guard, the allowed-app guard, the allow-rule
+guard, and the host-lock guard MUST run unchanged and in the same order for a
+declared provider. No guard may be skipped, reordered, or weakened for a declared
+provider.
+
+#### Scenario: The host-lock applies to a declared baseUrl
+
+- **WHEN** a caller supplies a path that would resolve to a host other than the
+  declared `baseUrl` host
+- **THEN** the host-lock guard denies with HTTP 403
+
+#### Scenario: The allow-rule guard applies to declared rules
+
+- **WHEN** a caller requests a method and path not matched by any declared
+  allow-rule
+- **THEN** the allow-rule guard denies with HTTP 403
+
+#### Scenario: Denials remain secret-free
+
+- **WHEN** any guard denies a declared-provider call
+- **THEN** the logged reason carries only the credential UUID and a static reason
+  and never any part of the secret
+
+### Requirement: Minting against a declared provider validates admission and forces app scope
+
+`CredentialController::create()` SHALL accept a namespaced declared provider
+identifier only when that declaration is currently admitted, and MUST set the new
+credential's `allowedApps` to exactly the declaring app. Minting against a
+pending, rejected, revoked, or unknown declaration MUST be refused.
+
+#### Scenario: Minting against a pending declaration is refused
+
+- **WHEN** a user creates a credential for a declared provider awaiting approval
+- **THEN** the request is refused and no vault secret is written
+
+#### Scenario: Minting forces the declaring app as the only allowed app
+
+- **WHEN** a user creates a credential for the admitted provider `alpha:codeberg`
+  and supplies `allowedApps: ["alpha", "beta"]`
+- **THEN** the stored credential has `allowedApps` equal to `["alpha"]`
+
+#### Scenario: Reviewed providers keep their existing mint behaviour
+
+- **WHEN** a user creates a credential for `github`
+- **THEN** provider validation and `allowedApps` handling are exactly as before
+  this change

--- a/openspec/changes/app-declared-credential-providers/tasks.md
+++ b/openspec/changes/app-declared-credential-providers/tasks.md
@@ -1,0 +1,49 @@
+# Tasks: App-declared credential providers
+
+## 1. Declaration model and register
+
+- [ ] 1.1 Add the `credentialProviderApproval` schema to `lib/Settings/credential_broker_register.json` (properties per design D7, register version bump) and add the two `example-` prefixed, `status: revoked`, nil-digest seed rows under `components.objects[]` per the Seed Data section.
+- [ ] 1.2 Document the app declaration file format (path, entry shape, `extends`, the `inject_only` prohibition, namespacing) in `docs/Features/credential-broker.md`, with the hydra-console `codeberg` entry as the worked example.
+
+## 2. Discovery, validation and admission
+
+- [ ] 2.1 Add `lib/Service/Credential/DeclaredProviderLoader.php` walking `IAppManager::getInstalledApps()` + `getAppPath()`, reading each app's `lib/Settings/credential-providers.json`, caching per request and failing soft to empty on read/parse error.
+- [ ] 2.2 Add `lib/Service/Credential/DeclarationValidator.php` rejecting: a colon-free (unnamespaced) identifier, `inject_only: true`, a missing `baseUrl`, an empty `allowRules[]`, and any unknown/extra field.
+- [ ] 2.3 Implement the narrowing test in the validator — same `method`, and the base `pathPattern` must match every path the declared pattern can produce; anything not provably narrower is rejected, never escalated to pending.
+- [ ] 2.4 Compute the per-entry `declarationDigest` over a canonical serialisation of the single entry (not the whole file), so an unrelated entry change never invalidates a standing approval.
+- [ ] 2.5 Add `lib/Service/Credential/DeclaredProviderResolver.php` returning the admission state (`admitted` via narrowing, `admitted` via matching approval, `pending`, `rejected`, `revoked`, `invalid`) and a catalogue-shaped entry array only when admitted.
+
+## 3. Approval plane
+
+- [ ] 3.1 Add an approval service writing `credentialProviderApproval` objects through `ObjectService::saveObject()` (entity/array first arg) recording `decidedBy`, `decidedAt`, `declarationDigest`, `baseUrl` and `allowRulesSnapshot`.
+- [ ] 3.2 Add admin-only approve / reject / revoke routes on `CredentialController` (or a dedicated controller) with the correct Nextcloud auth attributes and registered entries in `appinfo/routes.php`.
+- [ ] 3.3 Keep approval records on app disable/uninstall and re-apply a kept approval on re-enable only when the digest still matches.
+
+## 4. Broker and controller wiring
+
+- [ ] 4.1 Change `CredentialBrokerService::resolveProvider()` to try `ProviderCatalogue` first and the declared resolver second, denying on anything not admitted — leaving `isInjectOnly()`, `assertRuleAllowed()`, `resolveAndLockUrl()`, `injectAuth()` and the guard order untouched.
+- [ ] 4.2 Make `resolveInjectable()` return `null` for every declared provider, so a declared credential is always a `request()` credential.
+- [ ] 4.3 Extend `CredentialController::create()` to accept an admitted namespaced identifier, refuse a non-admitted one, and force `allowedApps` to the declaring app; block widening `allowedApps` for such credentials in the update path.
+- [ ] 4.4 Extend `GET /api/credentials/providers` to return `origin` and `status` alongside `identifier` and `title`, and verify no `allowRules` or `baseUrl` leaks into that response.
+
+## 5. Admin UI
+
+- [ ] 5.1 Add a "Declared providers" section to the credential admin settings listing declared providers with origin, status, resolved host and the full method+path rule set, plus approve / reject / revoke actions and an auto-admitted (narrowing) label.
+
+## 6. Tests and verification
+
+- [ ] 6.1 Unit-test the validator and the narrowing test, including the adversarial cases (`*` at the pattern head, `/repos/*` vs `/repos/*/../../admin`, method mismatch, wider host).
+- [ ] 6.2 Unit-test every deny path on the broker: pending, rejected, revoked, digest drift, disabled declaring app, cross-app borrow, shadowing attempt, `inject_only` declaration, mint against a non-admitted declaration.
+- [ ] 6.3 Assert no regression for reviewed providers — existing `CredentialBrokerServiceTest`, `ProviderCatalogueTest`, `DoffinProviderTest` and the organisation-scope tests stay green, and `generic-*` inject_only behaviour is unchanged.
+- [ ] 6.4 Live-verify end to end on the dev instance with a real declaration: pending denies, approval admits, an edited declaration re-pends; confirm opencatalogi and softwarecatalog show no regression and run `composer check:strict`.
+
+## Acceptance criteria
+
+- No app can reach a host or a path the reviewed catalogue does not already permit without an administrator approval recorded against a named user.
+- A narrowing declaration grants strictly less than its base provider and is admitted without a click; anything not provably narrower is rejected outright.
+- Editing an approved declaration returns it to `pending` and denies until re-approved.
+- A declared provider is usable only by the app that declared it, and cannot shadow or override any reviewed catalogue entry.
+- `inject_only` remains reviewed-catalogue-only; `request()` still refuses `inject_only` and `resolveInjectable()` returns `null` for every declared provider.
+- The four broker guards run unchanged, in the same order, for declared and reviewed providers alike, and every denial is a static 403 with a secret-free reason.
+- Every approve, reject and revoke is retrievable from the audit trail with the deciding user, the time, and the rule set that was approved.
+- With no app shipping a declaration, broker behaviour is byte-identical to today.

--- a/openspec/changes/apphost-schedule-flow-action/.openspec.yaml
+++ b/openspec/changes/apphost-schedule-flow-action/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/apphost-schedule-flow-action/design.md
+++ b/openspec/changes/apphost-schedule-flow-action/design.md
@@ -1,0 +1,281 @@
+# Design — `openregister:flow-run` schedule action
+
+## Context
+
+`apphost-manifest-schedules` shipped the AppHost scheduling engine: a manifest
+declares `schedules[]`, `ScheduleReconciler` idempotently upserts one
+OpenConnector `job` per `applicationId + scheduleId`, and OpenConnector's
+`JobService` executes it. That change's D-4 deliberately made the action space a
+CLOSED, server-owned map so an app can never name an arbitrary FQCN — and seeded
+it with exactly one entry.
+
+Verified against the code as it stands today:
+
+- `ScheduleActionAllowList::MAP` has one key,
+  `openconnector:synchronization` → `OCA\OpenConnector\Action\SynchronizationAction`
+  (`lib/AppHost/Scheduling/ScheduleActionAllowList.php:48-50`). `resolve()`
+  returns null for anything else and the reconciler skips + logs
+  (`ScheduleReconciler::reconcile()`, the `$jobClass === null` branch).
+- `ScheduleDescriptor` already carries `id`, exactly one of
+  `intervalSeconds`/`cron`, `action`, `arguments` and `enabled`, and carries **no**
+  execution identity by construction.
+- Owner resolution is already fail-closed: `resolveOwner()` returns null unless
+  `IUserManager::get()` finds a live user, and a null owner skips the schedule
+  with a warning rather than writing an ownerless job.
+- The reconciled `job` carries `userId`; OpenConnector's
+  `JobService::executeJob()` reads it, sets the session user, skips the job with
+  a WARNING when the user no longer exists, and restores the prior session user
+  in a `finally` (`openconnector/lib/Service/JobService.php:363-421`). The job
+  class itself is instantiated via `$this->containerInterface->get($jobData['jobClass'])`
+  and invoked as `$action->run($arguments)`.
+- On the flow side, `FlowRunService::queue()` takes an explicit
+  `?string $user` and stores it as the run's `triggeredBy`;
+  `FlowRunService::execute()` then carries it into
+  `context['triggeredBy']` (the or#2158 fix,
+  `lib/Service/Flow/FlowRunService.php:186-194`). `ObjectWriteNode` refuses to
+  write when that key is null or does not resolve to a user account
+  (`lib/Service/Flow/Nodes/ObjectWriteNode.php:698-712`).
+- The flow engine can now do real recurring work: `openregister.object-write`
+  exists in-tree, and `openconnector.source-call` /
+  `openconnector:synchronization-run` landed in ConductionNL/openconnector#1067.
+
+The gap is therefore narrow and specific: the allow-list has no flow entry, so a
+virtual app's only schedulable action is an OpenConnector synchronisation.
+
+**Adjacent defect found while verifying.** `FlowScheduleService::fire()`
+(`lib/Service/Flow/FlowScheduleService.php`) — the native `trigger: schedule`
+path, driven by `FlowScheduleWorker` — calls `queue()` with `flowId`, `subject`,
+`trigger` and `context` but **no `user:` argument**. Every natively-scheduled
+flow run therefore has a null `triggeredBy` and every object-write inside it
+refuses. This is the same defect class as or#2158 / `FlowRunController::test`,
+sitting in the code most adjacent to this change, so it is fixed here rather
+than left to be rediscovered.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One new server-owned allow-list entry, `openregister:flow-run`, so a manifest
+  schedule can name a flow.
+- A vetted action class that resolves the flow and queues exactly one run per
+  fire, with `trigger: 'schedule'`.
+- Attribution that is mandatory and fail-closed: no owner → no run queued, and
+  never a run with a null `triggeredBy`.
+- The same defect closed on the native scheduled-flow path.
+
+**Non-Goals:**
+
+- No arbitrary FQCN execution. The allow-list stays closed; nothing in
+  `manifest.schedules[]` becomes a class name.
+- No new scheduling engine, no second clock. Cadence, enable/disable, per-app
+  scoping, upsert, reference keying and GC are consumed from
+  `ScheduleReconciler` unchanged.
+- No manifest-schema change. `schedules[].action` is already a free string
+  validated against the allow-list; `arguments` is already an open object.
+- No inline execution. The action queues; `FlowRunWorker` executes.
+- No webhook/push action in this pass (see D-5).
+
+## Decisions
+
+### D-1 — One new allow-list entry, closed map preserved
+
+`ScheduleActionAllowList::MAP` gains `'openregister:flow-run' => 'OCA\\OpenRegister\\AppHost\\Scheduling\\Action\\FlowRunAction'`.
+Everything that made D-4 safe is untouched: the value is a constant in
+OpenRegister's own source, not manifest data; `resolve()` still returns null for
+anything unknown; the reconciler still skips-and-logs a non-allow-listed action.
+
+*Alternative considered — a `flow:<uuid>` action-type pattern* (parse the flow
+id out of the action string). Rejected: it turns the closed enum into a parsed
+grammar, and the flow id belongs in `arguments` where every other action's
+parameters already live (`arguments.synchronizationId` is the precedent).
+
+*Alternative considered — let the manifest name the node/step directly.*
+Rejected: that is a flow author's job, expressed in the flow document. A
+schedule says *when*, the flow says *what*.
+
+### D-2 — The action queues, it never executes
+
+`FlowRunAction::run(array $argument): array` resolves
+`argument['flowId']` through `FlowResolverRegistry::resolveFlow()`, then calls
+`FlowRunService::queue(flowId, subject: [], trigger: 'schedule', context: [...], user: <owner>)`
+and returns a stack-trace-shaped array like `SynchronizationAction` does.
+`FlowRunWorker` picks the queued run up on its own cadence and executes it.
+
+Rationale: a cron pass must not sit on an arbitrary graph — that is exactly the
+argument in `FlowRunService::queue()`'s own docblock, and it applies at least as
+strongly to a background sweep that also has to run every other job in the pass.
+Queuing also means a scheduled run gets the same retry, suspension, logging and
+retention behaviour as every other run, for free.
+
+*Alternative considered — call `execute()` inline* so the OC job log records the
+run's outcome directly. Rejected: an unbounded graph inside `JobService`'s
+try/finally would let one slow flow starve the whole cron pass, and would create
+a second execution path with its own failure semantics.
+
+### D-3 — Attribution: mandatory, derived from the schedule's owner, fail-closed
+
+The chain, end to end, has exactly one identity source and no fallback to the
+session:
+
+1. `ScheduleReconciler` resolves the owner from the owning application
+   (`@self.owner` for a virtual app, the matching `openbuild` application object
+   for an on-disk app), verifies it against `IUserManager`, and refuses to write
+   a job at all when it is unresolvable.
+2. That owner is persisted as the job's `userId`.
+3. `JobService::executeJob()` skips the job with a WARNING when that user no
+   longer exists, and otherwise sets it as the session user for the duration of
+   `run()`.
+4. `FlowRunAction` reads the acting user from `IUserSession` and re-verifies it
+   against `IUserManager`. **If it is null or does not resolve, the action
+   queues nothing and returns an ERROR result.** It never passes `user: null`
+   to `queue()`.
+
+Step 4 is deliberately redundant with steps 1-3. Three dispatch paths have
+already been caught dropping the actor between queue and node (or#2158,
+`FlowRunController::test`, and the `execute()` context-carry itself); the
+cheapest defence is that the last hop before `queue()` refuses rather than
+degrades. A scheduled run has no session of its own, so "whoever is logged in"
+is not an available fallback and must not be invented as one.
+
+`arguments.runAs` / `arguments.owner` are **ignored** if present, matching the
+reconciler's existing treatment of author-supplied identity.
+
+*Alternative considered — carry the owner in `arguments` at reconcile time.*
+Rejected: it duplicates identity into manifest-derived data, which is precisely
+where an author could later try to influence it. `userId` on the job is the one
+server-owned identity field, and `JobService` already enforces it.
+
+### D-4 — Flow resolution by uuid or slug, refuse on miss
+
+`argument['flowId']` is resolved through `FlowResolverRegistry::resolveFlow()`,
+which asks every contributed resolver in turn; OpenRegister's own resolver looks
+the flow up in the configured flow register/schema
+(`flow_register`/`flow_schema`, defaulting to `flows`/`flow`) and returns null
+for an object that is not shaped like a flow.
+
+Two failure modes are explicitly non-silent: a missing/blank `flowId` and a
+`flowId` no resolver owns both produce an ERROR result and **no** queued run.
+Queuing a run for a flow that cannot be resolved would only create a run the
+worker is guaranteed to fail.
+
+**Known hazard, called out for implementation:** `ObjectService::find(id, register:, schema:)`
+does not actually scope the lookup by register/schema — a bare slug such as
+`flow` resolves against the first matching object anywhere (or#2161). The action
+MUST therefore treat resolution as "the resolver returned a flow-shaped
+document", and the tasks include a live check that a slug belonging to a
+different register is not silently accepted.
+
+### D-5 — Webhook/push action: recommended as a follow-up, NOT in this pass
+
+A `openregister:webhook-call` action is tempting to add in the same edit — the
+allow-list is a map, and one more entry is one more line. The recommendation is
+still **no, not here**, for two reasons:
+
+- A flow can already do it. With `openconnector.source-call` merged, "on a
+  schedule, POST to an endpoint" is a one-node flow scheduled through
+  `openregister:flow-run`. A dedicated webhook action would be a second, weaker
+  way to express something the first entry already covers — and it would arrive
+  without the flow engine's run log, retry and suspension.
+- Egress is a security surface with its own unresolved control. OR already has
+  SSRF hardening on the object-write file path
+  (`lib/Service/Object/SaveObject/FilePropertyHandler.php`), and the hydra
+  console work recorded that the egress allowlist is not enforced at the network
+  layer. Adding a *scheduled, unattended, owner-privileged* outbound call is a
+  materially different risk from an interactive one, and deserves its own change
+  with its own destination allow-list — not a line in this map.
+
+If a direct webhook action is wanted later, it should reuse
+`lib/Service/WebhookService.php` and land with a destination allow-list, not as
+a bare URL argument.
+
+### D-6 — Fix `FlowScheduleService::fire()` in the same pass
+
+`fire()` gains an owner-bearing `queue()` call: the acting user is the flow
+object's owner (`@self.owner`), verified against `IUserManager`; when it does not
+resolve, the flow is **skipped** for that tick (logged) rather than fired
+ownerless. The last-fire timestamp is only recorded when a run was actually
+queued, so a flow blocked on attribution is not silently marked as having run.
+
+Scoped in here rather than split out because it is the same one-line defect
+class in the immediately adjacent scheduler, and shipping the manifest path
+correct while the native path stays broken would be the more confusing outcome.
+
+### Declarative-vs-imperative (ADR-031)
+
+**Declaration side: declarative. Execution side: an existing imperative engine,
+reused — nothing new is written imperatively.**
+
+The *what to run and when* stays entirely in data: `manifest.schedules[]` (an
+app declares its schedule) plus the flow document itself (a flow declares its
+nodes and edges, and the flow engine walks it). Neither the app author nor this
+change writes procedural per-app PHP.
+
+The imperative surface this change adds is one thin adapter class whose whole
+body is "resolve a flow id, check the owner, call `queue()`". It sits in the
+same seam `apphost-manifest-schedules` D-1 already justified: a clock-driven
+sweep is not derivable from object state, so it lives in a `TimedJob`-shaped
+engine rather than an `x-openregister-*` extension. This change does not widen
+that seam — it adds a value to a map and an adapter into an engine that already
+exists. Critically, it *reduces* the imperative surface for app authors: work
+that previously required either an OpenConnector synchronisation or shipped PHP
+can now be expressed as a declared flow.
+
+### Seed data (ADR-001)
+
+**None.** This change introduces no register or schema JSON and therefore no
+seed objects, and it ships no schema migration.
+
+- The allow-list is a PHP constant in OpenRegister's own source, not seeded
+  data — that is what makes it server-owned and closed (D-1).
+- Flows are ordinary OR objects in the configured flow register/schema, created
+  by users; this change reads them and never seeds one.
+- Flow runs are rows created at execution time by `FlowRunService`, not seed
+  data.
+- Reconciled OpenConnector `job` objects are created at runtime by
+  `ScheduleReconciler` against the pre-existing `openconnector`/`job` schema.
+
+## Risks / Trade-offs
+
+- **[Ownerless scheduled run writes nothing, silently]** A schedule whose owner
+  was deleted would previously have produced a run that failed deep inside
+  `ObjectWriteNode`. → Refuse at the action, before queuing, and log an ERROR
+  result that lands in the OC job log where an admin will see it (D-3).
+- **[Privilege of a scheduled flow]** A flow scheduled by an app runs as the
+  app owner, unattended, on a clock. → Identity comes only from the
+  server-resolved job `userId`; `arguments.runAs`/`owner` are ignored; the
+  reconciler already refuses to create the job without a live owner.
+- **[Flow id resolves to the wrong object]** `find()` does not scope by
+  register/schema (or#2161), so a bare slug can match elsewhere. → Resolve only
+  through `FlowResolverRegistry`, require a flow-shaped document, and verify with
+  a live check that a foreign slug is refused (D-4).
+- **[Run pile-up]** A cadence shorter than the flow's runtime queues runs faster
+  than `FlowRunWorker` drains them. → The action queues exactly one run per
+  fire and the existing OC cadence bounds fire rate; overlapping-run suppression
+  is explicitly out of scope and noted as an open question.
+- **[Cross-app instantiation]** The vetted class is an OpenRegister class
+  instantiated by OpenConnector's container. → Nextcloud's autoloader resolves
+  `OCA\OpenRegister\*` for any enabled app, and this is the same seam the
+  existing entry uses in the opposite direction; covered by a live check rather
+  than assumed.
+- **[Scope creep into egress]** → Webhook/push action explicitly deferred with a
+  reason (D-5).
+
+## Migration Plan
+
+1. Land the allow-list entry + `FlowRunAction` + the `FlowScheduleService` fix.
+   All three are additive; instances with no `openregister:flow-run` schedule are
+   unaffected.
+2. No migration, no seed, no schema change. Rollback is reverting the commit —
+   an existing schedule using the new action simply reverts to being logged as
+   non-allow-listed and skipped, which is the pre-change behaviour.
+
+## Open Questions
+
+- Should a scheduled flow suppress a new run while a previous run for the same
+  schedule is still `queued`/`running`? Provisionally **no** (out of scope, and
+  the flow engine has no per-flow concurrency notion today), but it is the most
+  likely first follow-up.
+- Should `arguments` be passed into the run's `context` as a payload so a flow
+  can be parameterised per schedule? Provisionally **yes**, under a `payload`
+  key, mirroring `FlowScheduleService::fire()`'s existing
+  `context: ['payload' => ...]` shape.

--- a/openspec/changes/apphost-schedule-flow-action/proposal.md
+++ b/openspec/changes/apphost-schedule-flow-action/proposal.md
@@ -1,0 +1,95 @@
+---
+kind: code
+---
+
+## Why
+
+An OpenBuild app declares its background work in `manifest.schedules[]`, and
+OpenRegister's AppHost `ScheduleReconciler` turns each declaration into an
+OpenConnector `job` row. Which work a declaration may name is deliberately not
+the app author's choice: `ScheduleActionAllowList::MAP`
+(`lib/AppHost/Scheduling/ScheduleActionAllowList.php:48-50`) is a CLOSED,
+server-owned map, and a manifest-supplied FQCN is never used as a `jobClass`
+(design D-4, ADR-005). That is the right shape — an app must not be able to
+schedule arbitrary code as its owner.
+
+The problem is that the map has exactly **one** entry today,
+`openconnector:synchronization`. So a virtual app can schedule an OpenConnector
+synchronisation and *nothing else*. In particular it cannot schedule a **flow**,
+even though the OpenRegister flow engine is now the fleet's one flow engine
+(ADR-065) and a flow is already able to do the two things recurring work needs:
+call an external API (`openconnector.source-call`, merged with
+`openconnector:synchronization-run` in ConductionNL/openconnector#1067) and write
+objects (`openregister.object-write`,
+`lib/Service/Flow/Nodes/ObjectWriteNode.php`). An app author who wants
+"every night, fetch X and update Y" has to model it as a synchronisation or ship
+PHP — which is exactly what the virtual-app programme exists to avoid.
+
+Attribution is the sharp edge, not the plumbing. Three separate dispatch paths
+were just found dropping the acting user, leaving `context['triggeredBy']` null
+so `ObjectWriteNode` refused every write (or#2158 in
+`FlowMcpToolProvider::runFlow()`, plus `FlowRunController::test`, plus the
+`FlowRunService::execute` context-carry itself,
+`lib/Service/Flow/FlowRunService.php:186-194`). A scheduled run has no session at
+all, so it cannot fall back to "whoever is logged in": the owner must come from
+the schedule's own declaration, and the action must refuse to run rather than run
+ownerless.
+
+## What Changes
+
+- Add a second, server-owned entry to `ScheduleActionAllowList`:
+  `openregister:flow-run` → a vetted OpenRegister action class. The allow-list
+  stays CLOSED; no manifest-supplied FQCN becomes executable, and no new
+  manifest key is introduced (`schedules[].action` already carries a type
+  string).
+- Add `OCA\OpenRegister\AppHost\Scheduling\Action\FlowRunAction` — the vetted
+  class the new entry points at. Its `run(array $argument)` resolves the flow
+  named by `argument.flowId` (uuid or slug) through `FlowResolverRegistry`,
+  refuses when it does not resolve, and otherwise queues one run through
+  `FlowRunService::queue()` with `trigger: 'schedule'`.
+- **Attribution is mandatory and fail-closed.** The action derives the acting
+  user from the executing job's `userId` — which the reconciler already resolves
+  from the owning application's owner and refuses to write without
+  (`ScheduleReconciler::reconcile()`, the `$ownerUid === null` branch, and
+  `resolveOwner()`). When no live user is resolvable at execution time the
+  action performs **no** queue and returns an ERROR result. It never queues a
+  run with a null `triggeredBy`.
+- Fix the same defect class in the adjacent native path: `FlowScheduleService::fire()`
+  (`lib/Service/Flow/FlowScheduleService.php`) queues every `trigger: schedule`
+  flow with **no** `user:` argument, so every natively-scheduled flow is
+  ownerless today and every object-write inside it refuses. A scheduled native
+  flow is attributed to its flow object's owner, fail-closed the same way.
+- No new scheduling engine. Cadence (`interval` / `cron`), `enabled`,
+  per-application scoping, idempotent upsert, reference keying and
+  garbage-collection all stay exactly as `ScheduleReconciler` implements them;
+  the flow action is only a new value in the existing allow-list.
+- **Not in this change:** a webhook/push action. See Design — recommended as a
+  follow-up, not folded in here.
+
+## Capabilities
+
+### New Capabilities
+- `apphost-schedule-flow-action`: the `openregister:flow-run` schedule action —
+  its allow-list entry, argument contract, flow resolution, fail-closed
+  attribution, and its non-goals (no arbitrary FQCN, no second scheduler).
+
+### Modified Capabilities
+<!-- The `apphost-scheduling` capability (openspec/changes/apphost-manifest-schedules)
+     is not yet archived into openspec/specs/, and none of its requirements change:
+     the reconciler contract is consumed as-is, not amended. No delta spec. -->
+
+## Impact
+
+- `lib/AppHost/Scheduling/ScheduleActionAllowList.php` — one added map entry.
+- `lib/AppHost/Scheduling/Action/FlowRunAction.php` — new.
+- `lib/Service/Flow/FlowScheduleService.php` — owner-bearing `queue()` call.
+- Depends on `FlowResolverRegistry::resolveFlow()`, `FlowRunService::queue()`,
+  `IUserSession`/`IUserManager`, and `FlowRunWorker` (which executes the queued
+  run — this change queues, it never executes inline).
+- Cross-app: OpenConnector's `JobService::executeJob()` instantiates the vetted
+  `jobClass` through its container and sets the session user from the job's
+  `userId` before calling `run()`
+  (`openconnector/lib/Service/JobService.php:363-397`). OpenRegister ships no
+  change to OpenConnector.
+- Tests: `tests/Unit/AppHost/Scheduling/ScheduleActionAllowListTest.php` gains
+  the new entry; a new unit test covers the action's fail-closed attribution.

--- a/openspec/changes/apphost-schedule-flow-action/specs/apphost-schedule-flow-action/spec.md
+++ b/openspec/changes/apphost-schedule-flow-action/specs/apphost-schedule-flow-action/spec.md
@@ -1,0 +1,130 @@
+## ADDED Requirements
+
+### Requirement: Manifest schedule can name the flow-run action
+
+A manifest `schedules[]` entry SHALL be able to declare `action: "openregister:flow-run"`, and the AppHost schedule action allow-list SHALL resolve that action type to a single server-owned OpenRegister action class. The allow-list SHALL remain a CLOSED, server-owned map: a manifest-supplied fully-qualified class name SHALL NEVER be used as the executed `jobClass`, and an action type that is not in the map SHALL be skipped and logged rather than executed. Adding the flow-run action SHALL NOT change the `schedules[]` declaration shape — the flow is named in `arguments`, not in the `action` string.
+
+#### Scenario: Flow-run action is allow-listed
+
+- **WHEN** the allow-list is asked to resolve the action type `openregister:flow-run`
+- **THEN** it returns the server-owned OpenRegister flow-run action class, and reports the action type as allowed
+
+#### Scenario: Existing synchronization action is unaffected
+
+- **WHEN** the allow-list is asked to resolve `openconnector:synchronization`
+- **THEN** it still returns the OpenConnector synchronization action class, unchanged
+
+#### Scenario: Manifest-supplied class name is never executed
+
+- **WHEN** a manifest declares `action: "OCA\\Evil\\Payload"` (or any other value not present in the allow-list)
+- **THEN** the allow-list resolves it to nothing, no job is reconciled for that schedule, and the rejection is logged with the application id, schedule id and action type
+
+#### Scenario: Virtual app schedules a flow on a cron cadence
+
+- **WHEN** a virtual app declares `schedules: [{ id: "nightly-intake", cron: "0 2 * * *", action: "openregister:flow-run", arguments: { flowId: "00000000-0000-0000-0000-000000000000" }, enabled: true }]`
+- **THEN** the reconciler upserts one job for that schedule whose `jobClass` is the server-owned flow-run action class and whose arguments carry the declared `flowId`
+
+### Requirement: Flow-run action queues exactly one run and never executes inline
+
+The flow-run action SHALL, when executed, queue exactly one flow run through the flow run service with trigger `schedule`, and SHALL NOT walk the flow graph itself. Execution of the queued run SHALL be left to the existing flow run worker, so a scheduled run receives the same logging, retry, suspension and retention behaviour as every other run. The action SHALL return a result describing what it did, so that the outcome is recorded in the executing job's log.
+
+#### Scenario: Due schedule queues one run
+
+- **WHEN** the flow-run action executes for a schedule naming a resolvable flow, with a resolvable owner
+- **THEN** exactly one flow run is created with status `queued`, trigger `schedule` and the declared flow's id, and the flow graph is not walked during the action
+
+#### Scenario: Queued run is executed by the existing worker
+
+- **WHEN** the flow run worker next ticks after a scheduled run has been queued
+- **THEN** the worker advances that run exactly as it advances any other queued run, with no scheduling-specific execution path
+
+#### Scenario: Two fires queue two independent runs
+
+- **WHEN** the same schedule fires twice
+- **THEN** two separate runs exist, each with its own identity and log, and neither replaces or resumes the other
+
+### Requirement: Attribution is mandatory and fail-closed
+
+Every run queued by the flow-run action SHALL carry a non-null acting user, resolved from the schedule's owning application rather than from any session or from manifest data. The action SHALL verify that the acting user resolves to a live user account, and when it does not, the action SHALL queue no run at all and SHALL return an error result. The action SHALL NEVER queue a run with a null acting user, and SHALL ignore any author-supplied `runAs` or `owner` value in the schedule's arguments.
+
+#### Scenario: Run carries the application owner as its acting user
+
+- **WHEN** the flow-run action executes for a schedule owned by a live user
+- **THEN** the queued run's `triggeredBy` is that user, and when the run is executed the flow node context carries the same user as `triggeredBy`
+
+#### Scenario: No resolvable owner queues nothing
+
+- **WHEN** the flow-run action executes with no acting user available, or with an acting user that does not resolve to a live account
+- **THEN** no run is queued, the action returns an error result naming missing attribution as the reason, and nothing is written
+
+#### Scenario: Author-supplied identity is ignored
+
+- **WHEN** a schedule declares `arguments: { flowId: "…", runAs: "admin" }`
+- **THEN** the queued run is attributed to the application owner resolved server-side, and the declared `runAs` value has no effect on the run's acting user
+
+#### Scenario: Attributed run may write objects
+
+- **WHEN** a scheduled run whose flow contains an object-write step is executed
+- **THEN** the write is performed as the run's acting user rather than refused for missing attribution
+
+### Requirement: Flow resolution refuses rather than queues a doomed run
+
+The flow-run action SHALL resolve the flow named by its `flowId` argument through the flow resolver registry, accepting either a uuid or a slug, and SHALL confirm that the resolved document is flow-shaped. When `flowId` is missing or blank, or when no resolver owns it, or when the resolved object is not a flow, the action SHALL queue no run and SHALL return an error result naming the unresolvable flow. Resolution SHALL NOT rely on register/schema arguments to scope the lookup, because those arguments do not scope object lookup by id.
+
+#### Scenario: Flow resolves by uuid
+
+- **WHEN** the action executes with `arguments: { flowId: "00000000-0000-0000-0000-000000000000" }` naming an existing flow
+- **THEN** the flow is resolved and a run is queued for it
+
+#### Scenario: Missing flow id queues nothing
+
+- **WHEN** the action executes with no `flowId` argument, or with a blank one
+- **THEN** no run is queued and the action returns an error result
+
+#### Scenario: Unknown flow id queues nothing
+
+- **WHEN** the action executes with a `flowId` no resolver owns
+- **THEN** no run is queued and the action returns an error result naming the flow id
+
+#### Scenario: Object that is not a flow is refused
+
+- **WHEN** `flowId` resolves to an object that carries neither nodes nor edges — for example a slug that matches an object in a different register
+- **THEN** the action treats the flow as unresolvable, queues no run, and returns an error result
+
+### Requirement: Existing schedule contract is consumed unchanged
+
+The flow-run action SHALL be scheduled entirely through the existing AppHost scheduling engine, and this capability SHALL NOT introduce a second scheduler, a second cadence source or a new manifest key. Interval and cron cadences, the `enabled` flag, per-application scoping, the deterministic application-plus-schedule reference key, idempotent upsert and garbage-collection of removed schedules SHALL apply to a flow-run schedule exactly as they apply to any other allow-listed action.
+
+#### Scenario: Disabled schedule does not fire
+
+- **WHEN** a flow-run schedule declares `enabled: false`
+- **THEN** the reconciled job is disabled and no flow run is queued for it
+
+#### Scenario: Removed schedule is garbage-collected
+
+- **WHEN** a flow-run schedule is removed from its application's manifest
+- **THEN** the reconciler disables the corresponding job on its next sweep, preserving its run history, and no further flow runs are queued
+
+#### Scenario: Unchanged schedule is a no-op
+
+- **WHEN** the reconciler sweeps and a flow-run schedule's declaration is unchanged
+- **THEN** no write is performed for that schedule
+
+#### Scenario: Schedules of two applications stay separate
+
+- **WHEN** two applications each declare a flow-run schedule with the same schedule id
+- **THEN** each is reconciled into its own job under its own application-scoped reference, and each run is attributed to its own application's owner
+
+### Requirement: Natively scheduled flows are attributed the same way
+
+A flow whose own trigger is `schedule` SHALL be queued with a non-null acting user resolved from the flow object's owner, verified against a live user account. When that owner does not resolve, the flow SHALL be skipped for that tick with a logged warning and its last-fire marker SHALL NOT be advanced, so a flow blocked on attribution is never recorded as having run.
+
+#### Scenario: Natively scheduled flow carries its owner
+
+- **WHEN** a flow with trigger `schedule` becomes due and its owner is a live user
+- **THEN** the queued run's `triggeredBy` is that owner, and an object-write step inside that run is performed rather than refused
+
+#### Scenario: Ownerless scheduled flow is skipped, not fired
+
+- **WHEN** a due flow with trigger `schedule` has no owner that resolves to a live account
+- **THEN** no run is queued, a warning is logged naming the flow, and the flow's last-fire marker is left unchanged so it is re-evaluated on the next tick

--- a/openspec/changes/apphost-schedule-flow-action/tasks.md
+++ b/openspec/changes/apphost-schedule-flow-action/tasks.md
@@ -1,0 +1,57 @@
+# Tasks — `openregister:flow-run` schedule action
+
+## 1. Allow-list entry
+
+- [ ] 1.1 Add `openregister:flow-run` to `ScheduleActionAllowList::MAP`, pointing at `OCA\OpenRegister\AppHost\Scheduling\Action\FlowRunAction`, keeping the value a plain string constant and the map closed.
+  - `resolve('openregister:flow-run')` returns the action FQCN and `isAllowed()` is true.
+  - `resolve('openconnector:synchronization')` is unchanged.
+  - Any other action type still resolves to null.
+- [ ] 1.2 Extend `tests/Unit/AppHost/Scheduling/ScheduleActionAllowListTest.php` to cover both entries and the closed-map behaviour.
+  - A manifest-shaped FQCN string (e.g. `OCA\Evil\Payload`) resolves to null.
+  - The test asserts the exact map size, so a future entry cannot be added silently.
+
+## 2. The flow-run action
+
+- [ ] 2.1 Create `lib/AppHost/Scheduling/Action/FlowRunAction.php` with an SPDX docblock, `declare(strict_types=1)`, a `@spec` tag pointing at this change's spec, and a `run(array $argument=[]): array` method returning a stack-trace-shaped result like `SynchronizationAction`.
+  - Constructor injects `FlowResolverRegistry`, `FlowRunService`, `IUserSession`, `IUserManager` and `LoggerInterface` only.
+  - The class contains no graph walking and no direct `ObjectService` use.
+- [ ] 2.2 Resolve the acting user first: read the UID from `IUserSession`, re-verify it with `IUserManager::get()`, and return an ERROR result with no side effect when it is null or unresolvable.
+  - No call to `queue()` happens on this path.
+  - The error message names missing attribution as the reason and carries no secrets.
+- [ ] 2.3 Ignore any `runAs` / `owner` key present in `$argument`; never read identity from arguments.
+  - A schedule declaring `runAs` produces a run attributed to the session-resolved owner.
+- [ ] 2.4 Resolve `argument['flowId']` through `FlowResolverRegistry::resolveFlow()`, returning an ERROR result with no queued run when the id is missing, blank, unowned, or resolves to a non-flow-shaped document.
+  - Resolution never passes register/schema as scoping arguments (or#2161: they do not scope).
+  - A slug matching an object in a different register is refused, not queued.
+- [ ] 2.5 Queue exactly one run via `FlowRunService::queue()` with `trigger: 'schedule'`, the non-null `user`, and the schedule's `arguments` carried under `context['payload']`.
+  - The returned run has status `queued` and a non-null `triggeredBy`.
+  - The action returns an OK result naming the flow id and the run uuid.
+- [ ] 2.6 Add `tests/Unit/AppHost/Scheduling/Action/FlowRunActionTest.php` covering: happy path, no acting user, deleted acting user, missing `flowId`, unresolvable `flowId`, non-flow-shaped object, and `runAs` being ignored.
+  - Each failure case asserts `queue()` was never called.
+
+## 3. Native scheduled-flow attribution
+
+- [ ] 3.1 Fix `FlowScheduleService::fire()` to pass the flow object's owner as `user:`, verified against `IUserManager`, and to skip the flow with a logged warning when it does not resolve.
+  - The last-fire marker is only written when a run was actually queued.
+  - A due flow with a live owner queues a run whose `triggeredBy` is that owner.
+- [ ] 3.2 Add unit coverage for both branches of 3.1 in the flow-schedule service tests.
+  - Ownerless due flow: no run queued, marker unchanged, warning logged.
+
+## 4. Quality gates
+
+- [ ] 4.1 Run `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) and fix every finding, including any pre-existing one in the files touched.
+- [ ] 4.2 Run the hydra mechanical gates (SPDX, forbidden-patterns, stub-scan, spec-coverage, spec-anchor-existence, orphaned-write-capability) and clear all failures.
+  - `FlowRunAction` is reachable from the allow-list, so the orphaned-write-capability gate must pass on its real seam.
+- [ ] 4.3 Run the PHP unit suite in the `nextcloud:34` container (host PHP is too old) and confirm no regression.
+
+## 5. Live verification
+
+- [ ] 5.1 On the dev instance, create a flow containing an `openregister.object-write` step, owned by a live user.
+- [ ] 5.2 Declare a `schedules[]` entry with `action: "openregister:flow-run"` and a short `interval` on a virtual app owned by that user, then let the reconciler sweep.
+  - A single OpenConnector `job` exists for the schedule with the vetted `jobClass` and the owner's `userId`.
+  - A second sweep with an unchanged declaration performs no write.
+- [ ] 5.3 Let the job execute and confirm through the UI that a run appears with a non-null `triggeredBy` and that the object-write actually wrote an object.
+  - The written object's owner is the application owner, not a system or null user.
+- [ ] 5.4 Delete or disable the schedule's owner and confirm fail-closed behaviour end to end: no ownerless run is queued and the refusal is visible in the job log.
+- [ ] 5.5 Confirm the negative paths live: a non-allow-listed action is skipped and logged, and a `flowId` naming an object in another register queues nothing.
+- [ ] 5.6 Confirm a natively scheduled flow (`trigger: schedule`) now runs attributed, and that an ownerless one is skipped without advancing its last-fire marker.


### PR DESCRIPTION
Two follow-up specs named by the hydra-console chain.

## `apphost-schedule-flow-action`

`manifest.schedules[]` can only ever run **one thing** — `ScheduleActionAllowList::MAP` has a single entry, `openconnector:synchronization`. So a virtual app cannot schedule a flow, even though the flow engine can now both call external APIs (#1067) and write objects (#2160).

Adds a flow-run action while **keeping the closed allow-list** — the point of that design is that an app cannot name an arbitrary class. Attribution is mandatory and fail-closed: a scheduled run has no session, so the owner comes from the schedule declaration and the action refuses rather than running ownerless.

Writing this spec found the same defect a **fourth** time in the adjacent scheduler (`FlowScheduleService::fire()` queued with no user) — fixed separately in #2173.

## `app-declared-credential-providers`

The provider catalogue is runtime-immutable, so an app author cannot register the credentials their app needs. Two costs observed while building hydra-console: no `codeberg`/`forgejo` provider exists, and the `github` provider permitted no issue-label write — fixed in #2165 only because we could edit OpenRegister itself.

The design keeps the security boundary rather than removing it:

- **Narrowing lane** — same host and auth scheme, provably-subset allow-rules → auto-admitted, because it grants strictly less than the base provider the app could already use. Anything not provably narrower is rejected outright, never escalated.
- **Novel lane** — new host or path → `pending`, denied until an administrator approves. This is the lane that actually fixes Codeberg.
- **Approval pinned to a content digest**, so an app that ships benign, gets approved, then widens is returned to pending. Without this the approval is theatre.
- **Always app-scoped and namespaced**, so a declaration can neither shadow a reviewed entry nor be borrowed.
- **`inject_only` declarations rejected** — a declared one would be unbounded secret egress authored by the app receiving the secret.

### ⚠️ Needs a PO decision

Whether the **narrowing lane should really skip approval**. Argument for: a strict subset grants less than the app already had, and click-fatigue on no-op approvals is itself a security regression. Argument against: it is the one path where something becomes usable with no human in the loop. Recorded as the first deferred question rather than buried in the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
