### PR TITLE
fix(tests): green the Unit suite — 51 errors + 2 failures to zero

### DIFF
--- a/lib/Controller/RelationsController.php
+++ b/lib/Controller/RelationsController.php
@@ -376,8 +376,30 @@ class RelationsController extends Controller
                 continue;
             }
 
+            // Resolving the owning app's service is NOT part of the lookup, and
+            // failing to resolve it is not an error to report. An app that is
+            // absent or disabled makes Server::get() throw, and folding that
+            // into $errors put an `_errors` key on a response where every
+            // requested lookup actually succeeded — the opposite of the
+            // "silently skipped, never breaks the core response" contract above,
+            // and visible to every consumer that walks the envelope's top-level
+            // keys. Only a failure of an AVAILABLE service's own call is an
+            // error worth surfacing.
             try {
                 $service = \OCP\Server::get($spec['class']);
+            } catch (\Throwable $e) {
+                continue;
+            }
+
+            // Server::get() does not always THROW when it cannot supply a
+            // service — it can hand back null. Calling the availability probe on
+            // that produced "Call to a member function isXAvailable() on null"
+            // for every leaf, which then landed in $errors.
+            if (is_object($service) === false) {
+                continue;
+            }
+
+            try {
                 if ($spec['available'] !== null && $service->{$spec['available']}() !== true) {
                     continue;
                 }

--- a/tests/Unit/AppInfo/AttributeMcpDiscoveryTest.php
+++ b/tests/Unit/AppInfo/AttributeMcpDiscoveryTest.php
@@ -106,6 +106,52 @@ class RecordingApplication extends Application
 class AttributeMcpDiscoveryTest extends TestCase
 {
 
+    /**
+     * `\OC::$server` as it was before a test swapped it.
+     *
+     * @var object|null
+     */
+    private ?object $originalServer = null;
+
+
+    /**
+     * Remember the real service locator before any test replaces it.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalServer = (\OC::$server ?? null);
+
+    }//end setUp()
+
+
+    /**
+     * Put `\OC::$server` back.
+     *
+     * `invokeRealSeam()` installs a bare OC_FakeServer subclass that overrides
+     * one method and registers NO services. Leaving it in place made every
+     * later test in the run see a locator whose `get()` returns null — and
+     * `OCP\AppFramework\Http\Response::getHeaders()` calls
+     * `\OC::$server->get(IRequest::class)->getId()` unconditionally. That is
+     * what produced 21 "Call to a member function getId() on null" errors, plus
+     * the getSystemValueBool()/findLanguage() ones, in tests that pass perfectly
+     * well on their own. Restoring in tearDown (not at the end of the test)
+     * means a failing test cannot leak the fake either.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        if ($this->originalServer !== null) {
+            \OC::$server = $this->originalServer;
+        }
+
+        parent::tearDown();
+
+    }//end tearDown()
+
 
     /**
      * Reflect-invoke `collectAttributeMcpProviders()` on a RecordingApplication

--- a/tests/Unit/Controller/FlowRunControllerTest.php
+++ b/tests/Unit/Controller/FlowRunControllerTest.php
@@ -16,6 +16,7 @@ use OCA\OpenRegister\Service\Flow\FlowResolverRegistry;
 use OCA\OpenRegister\Service\Flow\FlowRunService;
 use OCP\AppFramework\Http;
 use OCP\IRequest;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -39,12 +40,17 @@ class FlowRunControllerTest extends TestCase
         $this->runner    = $this->createMock(FlowRunService::class);
         $this->resolvers = $this->createMock(FlowResolverRegistry::class);
 
+        // FlowRunController gained an IUserSession dependency (it attributes a
+        // test/retry run to the caller); the constructor call here was never
+        // updated, so every test in this class died with an ArgumentCountError
+        // before reaching its assertions.
         $this->controller = new FlowRunController(
             'openregister',
             $this->request,
             $this->mapper,
             $this->runner,
-            $this->resolvers
+            $this->resolvers,
+            $this->createMock(IUserSession::class)
         );
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -134,6 +134,18 @@ if ($skipNc === false && !defined('OC_CONSOLE')) {
             "[openregister/tests/bootstrap] Nextcloud root not found; running with composer autoload only.\n"
             . "  Set OPENREGISTER_TEST_NC_ROOT to the NC server source root if you need integration/DB tests.\n"
         );
+
+        // Say it once, then silence any child process.
+        //
+        // A `@runInSeparateProcess` test re-runs this bootstrap in a forked
+        // PHPUnit worker, and ANY output from that worker corrupts the channel
+        // PHPUnit uses to read the child's result back — the test then fails
+        // with this very notice as its error message rather than on its own
+        // merits (BootstrapTest::testRegistrationIsLazyAndDoesNotAutoloadGenerics).
+        // The child inherits this process's environment, so setting the
+        // harness's existing skip switch here keeps the diagnostic for the human
+        // running the suite while making every forked worker quiet.
+        putenv('OPENREGISTER_TEST_SKIP_NC=1');
     }
 }
 
@@ -182,3 +194,10 @@ if (interface_exists(\OCP\IUser::class) === false) {
 // Load the Doriath contract stubs + test fixtures for the credential-broker
 // Doriath custody leaf (class_exists-guarded — a real Doriath install wins).
 require_once __DIR__ . '/stubs/DoriathStubs.php';
+
+// Load the ContextChat contract stubs. `OCP\ContextChat\*` ships with the
+// context_chat app, which is an OPTIONAL seam here (ContentProvider implements
+// its interface, ContextChatService resolves the manager lazily) and therefore
+// absent from a bare composer install — same situation as Doriath above.
+// Guarded, so a real context_chat install always wins.
+require_once __DIR__ . '/stubs/ContextChatStubs.php';

--- a/tests/stubs/ContextChatStubs.php
+++ b/tests/stubs/ContextChatStubs.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * ContextChat contract stubs for PHPUnit runs without the context_chat app.
+ *
+ * `OCP\ContextChat\*` ships with Nextcloud's context_chat app, which is NOT a
+ * composer dependency of OpenRegister — `ContentProvider` implements the
+ * interface and `ContextChatService` resolves the manager lazily, exactly the
+ * same optional-app seam the Doriath stubs cover. Without the app installed the
+ * symbols simply do not exist, so `ContentProviderTest` died with
+ * `Interface "OCP\ContextChat\IContentProvider" not found` and every
+ * `createMock(IContentManager::class)` raised `UnknownTypeException` — 19 of the
+ * suite's errors, none of them a defect in OpenRegister.
+ *
+ * Every declaration is `class_exists`/`interface_exists`-guarded, so the moment
+ * the real app IS installed these are skipped and the genuine contract wins.
+ *
+ * The surface mirrors what OpenRegister actually consumes, taken from the call
+ * sites rather than guessed:
+ *
+ *   - IContentManager::isContextChatAvailable(): bool
+ *   - IContentManager::submitContent(string $appId, array $items): void
+ *   - IContentManager::deleteContent(string $appId, string $providerId, array $ids): void
+ *   - IContentProvider::getId/getAppId/getItemUrl/triggerInitialImport
+ *   - ContentItem — the value object handed to submitContent()
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCP\ContextChat {
+
+    if (interface_exists('OCP\ContextChat\IContentProvider') === false) {
+        /**
+         * Registers a source of indexable content with context_chat.
+         */
+        interface IContentProvider
+        {
+            /**
+             * The provider's own id, unique within its app.
+             *
+             * @return string The id.
+             */
+            public function getId(): string;
+
+            /**
+             * The app the provider belongs to.
+             *
+             * @return string The app id.
+             */
+            public function getAppId(): string;
+
+            /**
+             * A user-facing URL for one indexed item.
+             *
+             * @param string $id The item id.
+             *
+             * @return string The URL.
+             */
+            public function getItemUrl(string $id): string;
+
+            /**
+             * Called when context_chat wants the provider's whole corpus.
+             *
+             * @return void
+             */
+            public function triggerInitialImport(): void;
+        }
+    }
+
+    if (interface_exists('OCP\ContextChat\IContentManager') === false) {
+        /**
+         * The context_chat side: accepts and removes indexed content.
+         */
+        interface IContentManager
+        {
+            /**
+             * Whether context_chat is installed and ready to accept content.
+             *
+             * @return boolean Whether it is available.
+             */
+            public function isContextChatAvailable(): bool;
+
+            /**
+             * Hand content to context_chat for indexing.
+             *
+             * @param string             $appId The submitting app.
+             * @param array<int, object> $items The content items.
+             *
+             * @return void
+             */
+            public function submitContent(string $appId, array $items): void;
+
+            /**
+             * Remove previously-submitted content.
+             *
+             * @param string            $appId      The submitting app.
+             * @param string            $providerId The provider that owns it.
+             * @param array<int,string> $itemIds    The item ids to drop.
+             *
+             * @return void
+             */
+            public function deleteContent(string $appId, string $providerId, array $itemIds): void;
+
+            /**
+             * Announce a provider so context_chat will ask it for content.
+             *
+             * @param string $appId        The owning app.
+             * @param string $providerId   The provider's id.
+             * @param string $providerClass The provider's FQCN.
+             *
+             * @return void
+             */
+            public function registerContentProvider(string $appId, string $providerId, string $providerClass): void;
+        }
+    }
+
+    if (class_exists('OCP\ContextChat\ContentItem') === false) {
+        /**
+         * One indexable item handed to {@see IContentManager::submitContent()}.
+         */
+        class ContentItem
+        {
+            /**
+             * Build a content item.
+             *
+             * @param string             $itemId       The item's id within its provider.
+             * @param string             $providerId   The provider that owns it.
+             * @param string             $title        Human-readable title.
+             * @param string             $content      The indexable text.
+             * @param string             $documentType A coarse type label.
+             * @param \DateTime          $lastModified When it last changed.
+             * @param array<int, string> $users        The users allowed to see it.
+             */
+            public function __construct(
+                public string $itemId,
+                public string $providerId,
+                public string $title,
+                public string $content,
+                public string $documentType,
+                public \DateTime $lastModified,
+                public array $users
+            ) {
+
+            }//end __construct()
+        }
+    }
+}
+
+namespace OCP\ContextChat\Events {
+
+    if (class_exists('OCP\ContextChat\Events\ContentProviderRegisterEvent') === false) {
+        /**
+         * Dispatched so apps can announce their content providers.
+         *
+         * The real event carries the manager and forwards `registerContentProvider`
+         * to it, which is exactly what `ContentProviderRegistrationListener` relies
+         * on — so the stub forwards too rather than merely recording the call.
+         */
+        class ContentProviderRegisterEvent extends \OCP\EventDispatcher\Event
+        {
+            /**
+             * Build the event over the manager that will receive registrations.
+             *
+             * @param \OCP\ContextChat\IContentManager $contentManager The manager.
+             */
+            public function __construct(private \OCP\ContextChat\IContentManager $contentManager)
+            {
+                parent::__construct();
+
+            }//end __construct()
+
+            /**
+             * Announce a provider.
+             *
+             * @param string $appId         The owning app.
+             * @param string $providerId    The provider's id.
+             * @param string $providerClass The provider's FQCN.
+             *
+             * @return void
+             */
+            public function registerContentProvider(string $appId, string $providerId, string $providerClass): void
+            {
+                $this->contentManager->registerContentProvider($appId, $providerId, $providerClass);
+
+            }//end registerContentProvider()
+        }
+    }
+}

--- a/tests/stubs/NextcloudInternalStubs.php
+++ b/tests/stubs/NextcloudInternalStubs.php
@@ -445,6 +445,11 @@ if (class_exists(\OCA\DAV\CardDAV\CardDavBackend::class) === false) {
         public function deleteCard(int $addressBookId, string $cardUri): void {}
         public function updateCard(int $addressBookId, string $cardUri, string $data): string { return ""; }
         public function getAddressBook(int $addressBookId): ?array { return null; }
+        // ContactService::getContactsForObject() calls this to resolve an
+        // addressbook uri for the deep link. It was missing from the stub, so
+        // the tests that mock it failed with MethodCannotBeConfiguredException
+        // rather than exercising the behaviour.
+        public function getAddressBookById(int $addressBookId): ?array { return null; }
         public function getAddressBooksForPrincipal(string $principal): array { return []; }
     }');
 }//end if


### PR DESCRIPTION
`tests/Unit/` reported **51 errors and 2 failures** on `development`. Exactly **one** was a production bug; the rest were harness faults — which is the real cost, because 53 permanent red results are noise that a genuine regression hides in.

```
before:  Tests: 15454, Errors: 51, Failures: 2
after:   Tests: 15454, Errors:  0, Failures: 0
```

## 25 errors — one test leaked a global

`AttributeMcpDiscoveryTest::invokeRealSeam()` did `\OC::$server = $server` and never put it back. The replacement is a bare `OC_FakeServer` subclass that overrides one method and registers **no services**, so every later test saw a locator whose `get()` returns `null` — and `OCP\AppFramework\Http\Response::getHeaders()` calls `\OC::$server->get(IRequest::class)->getId()` unconditionally.

That produced 21 × `Call to a member function getId() on null`, plus the `getSystemValueBool()` and `findLanguage()` variants. **Every one of those tests passed in isolation**, which is exactly what made this read as 21 broken tests rather than one leak.

Restored in `tearDown()` rather than at the end of the test, so a *failing* test cannot leak it either.

## 19 errors — no ContextChat stubs

`OCP\ContextChat\*` ships with the context_chat app, which is an optional seam here (`ContentProvider` implements its interface; `ContextChatService` resolves the manager lazily). Absent from a bare composer install, so the interface did not exist and every `createMock(IContentManager::class)` raised `UnknownTypeException`.

Added guarded stubs next to the existing Doriath ones, with the surface taken **from the call sites** rather than guessed: `isContextChatAvailable` / `submitContent` / `deleteContent` / `registerContentProvider`, `IContentProvider`, `ContentItem`, and the `ContentProviderRegisterEvent` that forwards to the manager.

## 4 errors — a constructor grew, its test did not

`FlowRunController` gained an `IUserSession` parameter; the test still passed five arguments, so every test in the class died with `ArgumentCountError` before reaching an assertion.

## 2 errors — a stub missing a method the code calls

`ContactService` calls `CardDavBackend::getAddressBookById()`; the stub never declared it, so mocking it raised `MethodCannotBeConfiguredException`.

## 1 error — bootstrap output corrupted an isolated worker

A `@runInSeparateProcess` test re-runs the bootstrap in a forked PHPUnit worker, and **any** output from that worker corrupts the channel PHPUnit reads the result back through — so the test failed with the bootstrap's own notice as its error message. The notice is now emitted once and the harness's existing `OPENREGISTER_TEST_SKIP_NC` switch is set for inherited children: humans still see the diagnostic, workers stay quiet.

## 1 failure — a real production bug

`RelationsController`'s leaf-integration loop carries this comment:

> …so a missing/disabled app is **silently skipped and never breaks the core relations response**.

It did not do that. `\OCP\Server::get()` can hand back **null** rather than throw, and calling the availability probe on null was caught and recorded in `$errors` — so a response where *every requested lookup succeeded* still carried an `_errors` key, for all 13 leaf integrations, visible to every consumer that walks the envelope's top-level keys.

Resolution is now separated from the call: failing to resolve a service is not an error to report; only a failure of an **available** service's own call is.

## Verification

- **15454 tests, 0 errors, 0 failures**
- phpcs clean on the one changed `lib/` file
- each fix verified in isolation before the full run, so the counts above are attributable rather than incidental