### PR TITLE
feat(flow): expose the node catalog so a builder can discover step types

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -479,6 +479,7 @@ return [
         // is pinned to OR object Y" so the sidebar tab can show it.
         // Visual flow builder — trigger event catalog (read-only, all users).
         ['name' => 'flow#eventCatalog', 'url' => '/api/flow/event-catalog', 'verb' => 'GET'],
+        ['name' => 'flow#nodeCatalog',  'url' => '/api/flow/node-catalog',  'verb' => 'GET'],
 
         ['name' => 'flowLinks#available', 'url' => '/api/integrations/flow/operations',                       'verb' => 'GET'],
         ['name' => 'flowLinks#index',     'url' => '/api/objects/{register}/{schema}/{id}/flow',              'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],

--- a/lib/Controller/FlowController.php
+++ b/lib/Controller/FlowController.php
@@ -28,9 +28,11 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Controller;
 
 use OCA\OpenRegister\Service\Flow\EventCatalogService;
+use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use OCP\WorkflowEngine\IManager;
 
 /**
  * Read endpoints backing the visual flow builder.
@@ -43,11 +45,13 @@ class FlowController extends Controller
      * @param string              $appName      App id.
      * @param IRequest            $request      HTTP request.
      * @param EventCatalogService $eventCatalog The flow trigger catalog.
+     * @param FlowNodeRegistry    $nodes        The registered flow-step types.
      */
     public function __construct(
         string $appName,
         IRequest $request,
         private readonly EventCatalogService $eventCatalog,
+        private readonly FlowNodeRegistry $nodes,
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
@@ -73,4 +77,43 @@ class FlowController extends Controller
             ]
         );
     }//end eventCatalog()
+
+    /**
+     * Return the flow NODE catalog — the step types a flow may use.
+     *
+     * The trigger catalog above answers "what can start a flow"; this answers
+     * "what can a flow do", which had no HTTP surface at all. A flow is authored
+     * as an object whose `edges[].type` names a registered node, so without this
+     * a builder has to hardcode the list — and that list goes stale silently the
+     * moment an app contributes a leaf, because an unknown type only surfaces
+     * when the flow RUNS (FlowNodeRegistry::get() throws). Apps really do
+     * contribute: openconnector ships source-call and synchronization-run,
+     * hermiq ships agent-step.
+     *
+     * Scope-filtered, so a non-administrator is never offered a step they could
+     * not run. Every node implements `isAvailableForScope()` already.
+     *
+     * @return JSONResponse `{ results: [{id,displayName,description,icon}], total }`.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @spec openspec/changes/visual-flow-builder/specs/flow-builder/spec.md
+     */
+    public function nodeCatalog(): JSONResponse
+    {
+        $scope = IManager::SCOPE_ADMIN;
+        if ($this->request->getParam('scope') === 'user') {
+            $scope = IManager::SCOPE_USER;
+        }
+
+        $results = $this->nodes->palette(scope: $scope);
+
+        return new JSONResponse(
+            [
+                'results' => $results,
+                'total'   => count($results),
+            ]
+        );
+    }//end nodeCatalog()
 }//end class

--- a/tests/Unit/Controller/FlowControllerTest.php
+++ b/tests/Unit/Controller/FlowControllerTest.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * The read endpoints backing the visual flow builder.
+ *
+ * `eventCatalog()` answers "what can start a flow"; `nodeCatalog()` answers
+ * "what can a flow do". The second had no HTTP surface at all, so anything
+ * building a flow UI had to hardcode the step list — which goes stale silently
+ * the moment an app contributes a leaf, because an unknown `edges[].type` only
+ * fails when the flow RUNS.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use OCA\OpenRegister\Controller\FlowController;
+use OCA\OpenRegister\Service\Flow\EventCatalogService;
+use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
+use OCP\IRequest;
+use OCP\WorkflowEngine\IManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OCA\OpenRegister\Controller\FlowController
+ */
+class FlowControllerTest extends TestCase
+{
+
+    /**
+     * The mocked request.
+     *
+     * @var IRequest
+     */
+    private IRequest $request;
+
+    /**
+     * The mocked node registry.
+     *
+     * @var FlowNodeRegistry
+     */
+    private FlowNodeRegistry $nodes;
+
+    /**
+     * The controller under test.
+     *
+     * @var FlowController
+     */
+    private FlowController $controller;
+
+
+    /**
+     * Build the controller over mocked collaborators.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request = $this->createMock(IRequest::class);
+        $this->nodes   = $this->createMock(FlowNodeRegistry::class);
+
+        $this->controller = new FlowController(
+            'openregister',
+            $this->request,
+            $this->createMock(EventCatalogService::class),
+            $this->nodes
+        );
+
+    }//end setUp()
+
+
+    /**
+     * The catalog surfaces the registry's palette in the documented envelope.
+     *
+     * @return void
+     */
+    public function testNodeCatalogReturnsThePaletteWithATotal(): void
+    {
+        $palette = [
+            ['id' => 'openregister.set-fields', 'displayName' => 'Edit fields', 'description' => '', 'icon' => '/i.svg'],
+            ['id' => 'openconnector.source-call', 'displayName' => 'Call a source', 'description' => '', 'icon' => '/j.svg'],
+        ];
+        $this->nodes->method('palette')->willReturn($palette);
+
+        $response = $this->controller->nodeCatalog();
+        $data     = $response->getData();
+
+        $this->assertSame($palette, $data['results']);
+        $this->assertSame(2, $data['total'], 'the envelope matches eventCatalog()');
+
+    }//end testNodeCatalogReturnsThePaletteWithATotal()
+
+
+    /**
+     * An app-contributed leaf is visible — the whole point of the endpoint.
+     *
+     * @return void
+     */
+    public function testNodeCatalogSurfacesAppContributedLeaves(): void
+    {
+        $this->nodes->method('palette')->willReturn(
+            [['id' => 'hermiq.agent-step', 'displayName' => 'Agent step', 'description' => '', 'icon' => '']]
+        );
+
+        $ids = array_column($this->controller->nodeCatalog()->getData()['results'], 'id');
+
+        $this->assertContains('hermiq.agent-step', $ids);
+
+    }//end testNodeCatalogSurfacesAppContributedLeaves()
+
+
+    /**
+     * Admin scope is the default, so a builder never has to ask for it.
+     *
+     * @return void
+     */
+    public function testNodeCatalogDefaultsToAdminScope(): void
+    {
+        $this->request->method('getParam')->willReturn(null);
+        $this->nodes->expects($this->once())
+            ->method('palette')
+            ->with(IManager::SCOPE_ADMIN)
+            ->willReturn([]);
+
+        $this->controller->nodeCatalog();
+
+    }//end testNodeCatalogDefaultsToAdminScope()
+
+
+    /**
+     * `?scope=user` filters to what a non-administrator may actually run —
+     * offering an admin-only step to a user would produce a flow that only
+     * fails once it runs.
+     *
+     * @return void
+     */
+    public function testNodeCatalogHonoursTheUserScope(): void
+    {
+        $this->request->method('getParam')->willReturn('user');
+        $this->nodes->expects($this->once())
+            ->method('palette')
+            ->with(IManager::SCOPE_USER)
+            ->willReturn([]);
+
+        $this->controller->nodeCatalog();
+
+    }//end testNodeCatalogHonoursTheUserScope()
+
+
+    /**
+     * An empty registry is a legal answer, not an error.
+     *
+     * @return void
+     */
+    public function testNodeCatalogHandlesAnEmptyRegistry(): void
+    {
+        $this->request->method('getParam')->willReturn(null);
+        $this->nodes->method('palette')->willReturn([]);
+
+        $data = $this->controller->nodeCatalog()->getData();
+
+        $this->assertSame([], $data['results']);
+        $this->assertSame(0, $data['total']);
+
+    }//end testNodeCatalogHandlesAnEmptyRegistry()
+}//end class


### PR DESCRIPTION
Closes #2176.

`FlowNodeRegistry::palette()` already returns exactly what a flow builder needs — the registered step types, filtered by scope — and **nothing exposed it over HTTP**. `FlowController` shipped only `eventCatalog()`, so a client could discover what *starts* a flow but not what a flow can *do*.

That matters because a flow is authored as an object whose `edges[].type` names a registered node. With no palette endpoint a builder has to hardcode the list, and the list goes stale **silently**: an unknown type surfaces only when the flow *runs*, via `FlowNodeRegistry::get()` throwing. Apps genuinely contribute — openconnector ships `source-call` and `synchronization-run`, hermiq ships `agent-step` — and those were invisible to every HTTP client.

## What this adds

`GET /api/flow/node-catalog`, mirroring the trigger catalog's envelope (`{results, total}`) and reusing `palette()` unchanged.

Scope-filtered: `?scope=user` returns only what a non-administrator may actually run, because offering an admin-only step to a user just produces a flow that fails at run time. Every node already implements `isAvailableForScope()`, so the filtering is free.

## How it surfaced

Writing e2e coverage for the cross-app leaf contract. The natural assertion — *"both leaves are registered in the shared registry"* — had nothing to assert against, so the spec skips it with the reason stated inline rather than papering over it.

## Verification

- **5 unit tests**: envelope shape, an app-contributed leaf is visible, admin is the default scope, `?scope=user` is honoured, an empty registry is a legal answer rather than an error
- phpcs clean
- **15460 Unit tests, 0 errors, 0 failures**