### PR TITLE
fix(metrics): un-nest values() — no metric was ever recorded

### DIFF
--- a/lib/Service/MetricsService.php
+++ b/lib/Service/MetricsService.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Service;
 
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
 
@@ -37,6 +38,8 @@ use Psr\Log\LoggerInterface;
  * @author   Conduction <info@conduction.nl>
  * @license  EUPL-1.2 https://opensource.org/licenses/EUPL-1.2
  * @link     https://www.conduction.nl
+ *
+ * @spec openspec/specs/production-observability/spec.md#metrics-storage-strategy
  */
 
 class MetricsService
@@ -182,20 +185,27 @@ class MetricsService
 
             // Build INSERT query for metrics table.
             // Create named parameters for all values to prevent SQL injection.
+            //
+            // 🔴 `values()` takes a FLAT column => parameter map. Wrapping it in
+            // an extra array (`[[ ... ]]`, as this did) makes each value an array
+            // rather than a parameter, so Doctrine rejected every insert with
+            // "Only strings, Literals and Parameters are allowed" — silently,
+            // because the catch below is fail-soft by design. The result was that
+            // NO metric was ever recorded while an error was logged on every
+            // object write. Every other `->values()` call in this app uses the
+            // flat form; this was the only nested one.
             $qb->insert('openregister_metrics')
                 ->values(
                     values: [
-                        [
-                            'metric_type'   => $qb->createNamedParameter($metricType),
-                            'entity_type'   => $qb->createNamedParameter($entityType),
-                            'entity_id'     => $qb->createNamedParameter($entityId),
-                            'user_id'       => $qb->createNamedParameter($userId),
-                            'status'        => $qb->createNamedParameter($status),
-                            'duration_ms'   => $qb->createNamedParameter($durationMs),
-                            'metadata'      => $qb->createNamedParameter($this->encodeMetadata(metadata: $metadata)),
-                            'error_message' => $qb->createNamedParameter($errorMessage),
-                            'created_at'    => $qb->createNamedParameter(time()),
-                        ],
+                        'metric_type'   => $qb->createNamedParameter($metricType),
+                        'entity_type'   => $qb->createNamedParameter($entityType),
+                        'entity_id'     => $qb->createNamedParameter($entityId),
+                        'user_id'       => $qb->createNamedParameter($userId),
+                        'status'        => $qb->createNamedParameter($status),
+                        'duration_ms'   => $qb->createNamedParameter($durationMs, IQueryBuilder::PARAM_INT),
+                        'metadata'      => $qb->createNamedParameter($this->encodeMetadata(metadata: $metadata)),
+                        'error_message' => $qb->createNamedParameter($errorMessage),
+                        'created_at'    => $qb->createNamedParameter(time(), IQueryBuilder::PARAM_INT),
                     ]
                 );
 

--- a/tests/Unit/Listener/ObjectMetricsListenerTest.php
+++ b/tests/Unit/Listener/ObjectMetricsListenerTest.php
@@ -76,8 +76,17 @@ class ObjectMetricsListenerTest extends TestCase
         );
         $qb->method('values')->willReturnCallback(
             function (array $values) use ($qb): IQueryBuilder {
-                // MetricsService passes a list containing one row map.
-                $this->insertedValues = $values[0];
+                // MetricsService passes a FLAT column => parameter map, which is
+                // what IQueryBuilder::values() actually accepts.
+                //
+                // 🔴 This previously read `$values[0]`, matching a nested
+                // `[[ … ]]` shape the service used to pass. That shape is invalid:
+                // the real Doctrine builder rejects it with "Only strings,
+                // Literals and Parameters are allowed", so every insert failed in
+                // production while this mock happily accepted it and the suite
+                // stayed green. Assert the shape the DB actually takes, or the
+                // mock certifies a call that can never succeed.
+                $this->insertedValues = $values;
                 return $qb;
             }
         );


### PR DESCRIPTION
## The bug

`MetricsService::recordMetric()` passed its column map to `$qb->values()` wrapped in an extra array:

```php
->values(values: [[ 'metric_type' => $qb->createNamedParameter(...), … ]])   // wrong
->values(values: [  'metric_type' => $qb->createNamedParameter(...), … ] )   // right
```

Doctrine's `values()` takes a **flat** `column => parameter` map. Nested, each value arrives as an array rather than a parameter, so every insert was rejected with:

```
Only strings, Literals and Parameters are allowed
```

## Why nobody noticed

The `catch` in `recordMetric()` is fail-soft **by design** — *"metrics recording failures should not break application functionality"*. So the only symptom was one log line per object write, which read as noise.

It wasn't noise. It was a **100% failure rate**: `oc_openregister_metrics` had never been written to at all. The operational-metrics feature has never once worked.

## Verification (live instance)

- `[MetricsService] Failed to record metric` per chat turn: **10 → 0**
- `oc_openregister_metrics` began accumulating rows immediately (30 rows, fresh timestamps) — for the first time

## Scope

Every other `->values()` call in this app already uses the flat form; this was the only nested one, which is what made it the outlier rather than an API quirk.

Also in this PR:
- `duration_ms` and `created_at` typed `PARAM_INT` to match the `integer`/`bigint` columns
- class-level `@spec` tag added — PHPCS was warning about it (pre-existing)

Gates: PHP lint, PHPCS, PHPMD clean.

Found while profiling a hermiq chat turn; the bug is OpenRegister's and fires on every object write fleet-wide.