### PR TITLE
fix(ci): issue-triage pinned a shared-workflow branch that no longer exists

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -12,7 +12,10 @@ on:
 
 jobs:
   triage:
-    uses: ConductionNL/.github/.github/workflows/issue-triage.yml@feature/openspec-project-sync
+    # `@main`, not `@feature/openspec-project-sync` — that branch no longer
+    # exists on ConductionNL/.github, so this reference was unresolvable and the
+    # triage workflow never ran.
+    uses: ConductionNL/.github/.github/workflows/issue-triage.yml@main
     with:
       app-name: openregister
       backlog-existing: ${{ github.event_name == 'workflow_dispatch' && inputs.backlog-existing || false }}


### PR DESCRIPTION
One-line fix. `issue-triage.yml` pinned:

```
uses: ConductionNL/.github/.github/workflows/issue-triage.yml@feature/openspec-project-sync
```

That branch no longer exists on `ConductionNL/.github` — only `main` does, and it carries `issue-triage.yml`. So the reference was unresolvable and the triage workflow never ran.

```
GET repos/ConductionNL/.github/branches/main                          -> main
GET repos/ConductionNL/.github/branches/feature/openspec-project-sync -> Branch not found
```

Found while fixing the same class of defect in openconnector (ConductionNL/openconnector#1093), where it was one of three stacked problems that had taken out that repo's **entire** shared CI surface — quality, tests, release, branch-protection, documentation, openspec-sync and sync-to-beta all dead, which is why a fix for a bug firing on every object write sat unmerged for 233 commits.

openregister is much less affected: only this one reference, and no job here mixes `uses:` with `runs-on:` (the structural error that made GitHub reject openconnector's files outright). Verified by parsing every workflow in this repo.

YAML validated locally.