### PR TITLE
test(unit): fix ~88 drifted unit tests exposed by the now-running phpunit hard gate

### DIFF
--- a/tests/Fixtures/vocabulary/sample-values.csv
+++ b/tests/Fixtures/vocabulary/sample-values.csv
@@ -1,0 +1,3 @@
+uri,notation,prefLabel_nl,definition,broaderUri
+https://example.org/vocab/csv-scheme/x,X,Waarde X,Definition of X,
+https://example.org/vocab/csv-scheme/y,Y,Waarde Y,Definition of Y,https://example.org/vocab/csv-scheme/x

--- a/tests/Unit/AppHost/BootstrapFactoryChainTest.php
+++ b/tests/Unit/AppHost/BootstrapFactoryChainTest.php
@@ -90,6 +90,13 @@ class BootstrapFactoryChainTest extends TestCase
         $map['OCA\\OpenRegister\\Service\\Credential\\CredentialAppTokenService']
             = $this->createMock(\OCA\OpenRegister\Service\Credential\CredentialAppTokenService::class);
 
+        // The InitializeActions factory injects the Doriath application
+        // registrar for the D-G manifest auto-onboarding hook
+        // (credential-doriath-leaf); a mock is enough — the repair step only
+        // calls it at run() time, never at construction.
+        $map['OCA\\OpenRegister\\Service\\Credential\\DoriathApplicationRegistrar']
+            = $this->createMock(\OCA\OpenRegister\Service\Credential\DoriathApplicationRegistrar::class);
+
         $container = $this->createMock(ContainerInterface::class);
         $container->method('get')->willReturnCallback(
             function (string $id) use (&$map, $container) {

--- a/tests/Unit/AppInfo/AttributeMcpDiscoveryTest.php
+++ b/tests/Unit/AppInfo/AttributeMcpDiscoveryTest.php
@@ -55,6 +55,7 @@ use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use ReflectionMethod;
+use ReflectionProperty;
 use RuntimeException;
 
 require_once __DIR__.'/../Mcp/Fixtures/AttributeFixtureService.php';
@@ -408,6 +409,25 @@ class AttributeMcpDiscoveryTest extends TestCase
      * Reflect-invoke the REAL getRegisteredAppContainer() seam (not the
      * RecordingApplication override) with a controlled `\OC::$server`.
      *
+     * These tests swap `\OC::$server` for a lightweight object extending
+     * `\OC_FakeServer` — which only works when `\OC::$server` is declared
+     * with that (narrow, stub-only) type. That is true in the pure-unit /
+     * no-NC-root bootstrap (tests/stubs/NextcloudInternalStubs.php declares
+     * `class OC { public static OC_FakeServer $server; }`). Under a booted
+     * real Nextcloud (OPENREGISTER_TEST_NC_ROOT — the CI hard-gate mode),
+     * `\OC` is core's real class and `\OC::$server` is strictly typed
+     * `\OC\Server`; PHP enforces that declared type on every assignment,
+     * including this one, so a fake extending `\OC_FakeServer` (unrelated to
+     * `\OC\Server`) cannot be assigned — TypeError. Building a
+     * type-compatible fake would mean subclassing the real, heavyweight
+     * `\OC\Server` (non-trivial constructor, full service wiring) purely to
+     * dodge a property-type check, which is worse than just skipping: this
+     * seam is exercised for real by every OTHER test in this file via the
+     * `RecordingApplication` override (see `invokeCollect()` above), so
+     * skipping here loses no coverage of `Application`'s own logic — only of
+     * the raw `\OC::$server` plumbing, which is itself stubbed to be a no-op
+     * fail-soft path in real NC.
+     *
      * @param object          $server The fake server to install on \OC::$server.
      * @param string          $appId  The app id to resolve.
      * @param LoggerInterface $logger PSR logger.
@@ -416,6 +436,18 @@ class AttributeMcpDiscoveryTest extends TestCase
      */
     private function invokeRealSeam(object $server, string $appId, LoggerInterface $logger): ?ContainerInterface
     {
+        $declaredType = (new ReflectionProperty(\OC::class, 'server'))->getType()?->getName();
+        if ($declaredType !== \OC_FakeServer::class) {
+            self::markTestSkipped(
+                sprintf(
+                    '\OC::$server is declared as %s in this bootstrap (real Nextcloud is loaded), not '
+                    .'OC_FakeServer — a fake extending OC_FakeServer cannot be assigned without a TypeError. '
+                    .'See the docblock on invokeRealSeam() for why this is skipped rather than worked around.',
+                    ($declaredType ?? 'unknown')
+                )
+            );
+        }
+
         \OC::$server = $server;
         $app         = (new ReflectionClass(Application::class))->newInstanceWithoutConstructor();
         $method      = new ReflectionMethod(Application::class, 'getRegisteredAppContainer');

--- a/tests/Unit/BackgroundJob/BlobMigrationJobTest.php
+++ b/tests/Unit/BackgroundJob/BlobMigrationJobTest.php
@@ -46,9 +46,52 @@ class BlobMigrationJobTest extends TestCase
     private SchemaMapper&MockObject $schemaMapper;
     private MagicMapper&MockObject $magicMapper;
 
+    /**
+     * The real, container-resolved instances for every service id this test
+     * overrides in \OC::$server, captured once (before this class's first
+     * override) so tearDown() can restore them.
+     *
+     * BlobMigrationJob is instantiated by Nextcloud's background-job runner
+     * with a fixed `ITimeFactory`-only constructor, so — unlike most services
+     * in this suite — its other dependencies cannot be handed in via the
+     * constructor; the job resolves them itself via `\OCP\Server::get()`.
+     * That forces this test to fake resolution by registering mocks directly
+     * on the process-wide `\OC::$server` container. Without a matching
+     * restore, those mocks leak into every LATER test in the same PHPUnit
+     * process that resolves the same service id (e.g.
+     * RelationsControllerTest's pluggable leaf integrations, which construct
+     * MapLinkService/PollLinkService/etc. through the real container and
+     * transitively need a real IDBConnection) — the leaked mock has no
+     * configured expectations by then and throws, which
+     * RelationsController::gatherRelations() catches and surfaces as a
+     * spurious `_errors` entry.
+     *
+     * @var array<class-string, object>
+     */
+    private static array $originalServices = [];
+
+    /**
+     * Whether {@see self::$originalServices} has been captured yet.
+     *
+     * @var bool
+     */
+    private static bool $originalsCaptured = false;
+
     protected function setUp(): void
     {
         parent::setUp();
+
+        if (self::$originalsCaptured === false) {
+            self::$originalServices = [
+                LoggerInterface::class => \OC::$server->get(LoggerInterface::class),
+                IDBConnection::class   => \OC::$server->get(IDBConnection::class),
+                IAppConfig::class      => \OC::$server->get(IAppConfig::class),
+                RegisterMapper::class  => \OC::$server->get(RegisterMapper::class),
+                SchemaMapper::class    => \OC::$server->get(SchemaMapper::class),
+                MagicMapper::class     => \OC::$server->get(MagicMapper::class),
+            ];
+            self::$originalsCaptured = true;
+        }
 
         $this->timeFactory    = $this->createMock(ITimeFactory::class);
         $this->logger         = $this->createMock(LoggerInterface::class);
@@ -57,6 +100,19 @@ class BlobMigrationJobTest extends TestCase
         $this->registerMapper = $this->createMock(RegisterMapper::class);
         $this->schemaMapper   = $this->createMock(SchemaMapper::class);
         $this->magicMapper    = $this->createMock(MagicMapper::class);
+    }
+
+    /**
+     * Restore the real \OC::$server bindings captured in setUp() so this
+     * test's mocks never leak into a later test's container resolution.
+     */
+    protected function tearDown(): void
+    {
+        foreach (self::$originalServices as $id => $instance) {
+            \OC::$server->registerService($id, static fn () => $instance);
+        }
+
+        parent::tearDown();
     }
 
     /**

--- a/tests/Unit/Capabilities/IntegrationsCapabilityTest.php
+++ b/tests/Unit/Capabilities/IntegrationsCapabilityTest.php
@@ -31,6 +31,7 @@ namespace OCA\OpenRegister\Tests\Unit\Capabilities;
 use OCA\OpenRegister\Capabilities\IntegrationsCapability;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCA\OpenRegister\Service\Integration\IntegrationRegistry;
+use OCA\OpenRegister\Service\Integration\LeafRegistry;
 use OCP\App\IAppManager;
 use OCP\IGroupManager;
 use OCP\IUser;
@@ -160,6 +161,16 @@ class IntegrationsCapabilityTest extends TestCase
     }//end appManager()
 
     /**
+     * Build a leaf registry mock with an empty leaf catalogue.
+     *
+     * @return LeafRegistry
+     */
+    private function leafRegistry(): LeafRegistry
+    {
+        return $this->createMock(LeafRegistry::class);
+    }//end leafRegistry()
+
+    /**
      * The capability publishes the ADR-019 discovery shape.
      *
      * @return void
@@ -170,7 +181,8 @@ class IntegrationsCapabilityTest extends TestCase
             registry: $this->registryWith([new _CapStubProvider(id: 'files')]),
             userSession: $this->userSession(uid: 'alice'),
             groupManager: $this->groupManager(isAdmin: false),
-            appManager: $this->appManager(enabledApps: [])
+            appManager: $this->appManager(enabledApps: []),
+            leafRegistry: $this->leafRegistry()
         );
 
         $payload = $cap->getCapabilities();
@@ -194,7 +206,8 @@ class IntegrationsCapabilityTest extends TestCase
             registry: $this->registryWith([new _CapStubProvider(id: 'tags', requiredApp: null)]),
             userSession: $this->userSession(uid: 'alice'),
             groupManager: $this->groupManager(isAdmin: false),
-            appManager: $this->appManager(enabledApps: [])
+            appManager: $this->appManager(enabledApps: []),
+            leafRegistry: $this->leafRegistry()
         );
 
         $row = $cap->getCapabilities()['openregister']['integrations']['providers'][0];
@@ -222,7 +235,8 @@ class IntegrationsCapabilityTest extends TestCase
             userSession: $this->userSession(uid: 'alice'),
             groupManager: $this->groupManager(isAdmin: false),
             // Only `calendar` is installed; `deck` is not.
-            appManager: $this->appManager(enabledApps: ['calendar'])
+            appManager: $this->appManager(enabledApps: ['calendar']),
+            leafRegistry: $this->leafRegistry()
         );
 
         $rows = $cap->getCapabilities()['openregister']['integrations']['providers'];
@@ -248,7 +262,8 @@ class IntegrationsCapabilityTest extends TestCase
             registry: $this->registryWith([new _CapStubProvider(id: 'files')]),
             userSession: $this->userSession(uid: 'bob'),
             groupManager: $this->groupManager(isAdmin: false),
-            appManager: $this->appManager(enabledApps: [])
+            appManager: $this->appManager(enabledApps: []),
+            leafRegistry: $this->leafRegistry()
         );
 
         $row = $cap->getCapabilities()['openregister']['integrations']['providers'][0];
@@ -271,7 +286,8 @@ class IntegrationsCapabilityTest extends TestCase
             registry: $this->registryWith([new _CapStubProvider(id: 'files')]),
             userSession: $this->userSession(uid: 'admin'),
             groupManager: $this->groupManager(isAdmin: true),
-            appManager: $this->appManager(enabledApps: [])
+            appManager: $this->appManager(enabledApps: []),
+            leafRegistry: $this->leafRegistry()
         );
 
         $row = $cap->getCapabilities()['openregister']['integrations']['providers'][0];

--- a/tests/Unit/Controller/AgentsControllerTest.php
+++ b/tests/Unit/Controller/AgentsControllerTest.php
@@ -12,7 +12,6 @@ use OCA\OpenRegister\Service\OrganisationService;
 use OCA\OpenRegister\Service\ToolRegistry;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -48,12 +47,10 @@ class AgentsControllerTest extends TestCase
         );
     }
 
-    public function testPage(): void
-    {
-        $result = $this->controller->page();
-
-        $this->assertInstanceOf(TemplateResponse::class, $result);
-    }
+    // NOTE: testPage() (AgentsController::page()) removed — the Agents SPA
+    // page moved to hermiq (or-chat-engine-decommission); the method no
+    // longer exists on AgentsController (see appinfo/routes.php comment at
+    // the former agents#page route).
 
     public function testIndexSuccess(): void
     {

--- a/tests/Unit/Controller/ObjectIntegrationsControllerTest.php
+++ b/tests/Unit/Controller/ObjectIntegrationsControllerTest.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Tests\Unit\Controller;
 
 use OCA\OpenRegister\Controller\ObjectIntegrationsController;
+use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Exception\NotImplementedException;
 use OCA\OpenRegister\Exception\ProviderUnavailableException;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
@@ -141,7 +142,8 @@ class ObjectIntegrationsControllerTest extends TestCase
             request: $request,
             registry: $registry,
             logger: new NullLogger(),
-            objectService: $objectService ?? $this->accessibleObjectService()
+            objectService: $objectService ?? $this->accessibleObjectService(),
+            schemaMapper: $this->createMock(SchemaMapper::class)
         );
     }//end buildController()
 

--- a/tests/Unit/Controller/Settings/FileSettingsControllerBranchTest.php
+++ b/tests/Unit/Controller/Settings/FileSettingsControllerBranchTest.php
@@ -8,37 +8,11 @@ use OCA\OpenRegister\Controller\Settings\FileSettingsController;
 use OCA\OpenRegister\Service\Anonymisation\AnonymisationBackendService;
 use OCA\OpenRegister\Service\Anonymisation\ProbeResult;
 use OCA\OpenRegister\Service\SettingsService;
-use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
-
-/**
- * Minimal test-double that restores the legacy empty-endpoint guard on
- * testOpenAnonymiserConnection (removed from production code when the method
- * was refactored to use AnonymisationBackendService via AppAPI).
- *
- * @internal
- */
-class LegacyGuardFileSettingsController extends FileSettingsController
-{
-    public function testOpenAnonymiserConnection(string $apiEndpoint=''): JSONResponse
-    {
-        if (empty($apiEndpoint) === true) {
-            return new JSONResponse(
-                data: [
-                    'success' => false,
-                    'error'   => 'API endpoint is required',
-                ],
-                statusCode: 400
-            );
-        }
-
-        return parent::testOpenAnonymiserConnection(apiEndpoint: $apiEndpoint);
-    }
-}
 
 /**
  * Branch coverage tests for FileSettingsController — targets uncovered branches in
@@ -61,7 +35,16 @@ class FileSettingsControllerBranchTest extends TestCase
         $this->settingsService = $this->createMock(SettingsService::class);
         $this->logger         = $this->createMock(LoggerInterface::class);
 
-        $this->controller = new LegacyGuardFileSettingsController(
+        // NOTE: this used to construct a LegacyGuardFileSettingsController
+        // test-double that re-added a "400 when $apiEndpoint is empty" guard
+        // on testOpenAnonymiserConnection(). That guard was removed from
+        // production when the method was refactored to detect OpenAnonymiser
+        // via AnonymisationBackendService (AppAPI ExApp detection) instead of
+        // a caller-supplied endpoint — see testTestOpenAnonymiserConnectionEmptyEndpoint()
+        // below, which now asserts the CURRENT behavior (200 + success=false)
+        // and therefore must run against the real controller, not the legacy
+        // double.
+        $this->controller = new FileSettingsController(
             'openregister',
             $this->request,
             $this->container,

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -1545,6 +1545,14 @@ class SettingsControllerTest extends TestCase
             private array $rows;
 
             /**
+             * Cursor position for fetch() — mirrors a real IResult, which
+             * hands back rows one at a time and `false` once exhausted.
+             *
+             * @var int
+             */
+            private int $cursor = 0;
+
+            /**
              * Constructor.
              *
              * @param array $rows Rows to return.
@@ -1565,15 +1573,24 @@ class SettingsControllerTest extends TestCase
             }
 
             /**
-             * Fetch one row.
+             * Fetch one row, advancing the internal cursor.
+             *
+             * The controller iterates results via `fetch()` in a while loop
+             * (NC 32 compat — fetchAllAssociative() is not on every
+             * supported server's IResult), so this stub must behave like a
+             * real cursor: return the next row, or `false` once exhausted.
              *
              * @param int $fetchMode Fetch mode.
              *
-             * @return mixed False (no rows).
+             * @return mixed The next row, or false when exhausted.
              */
             public function fetch(int $fetchMode = \PDO::FETCH_ASSOC)
             {
-                return false;
+                if ($this->cursor >= count($this->rows)) {
+                    return false;
+                }
+
+                return $this->rows[$this->cursor++];
             }
 
             /**

--- a/tests/Unit/Controller/UiControllerTest.php
+++ b/tests/Unit/Controller/UiControllerTest.php
@@ -52,7 +52,9 @@ class UiControllerTest extends TestCase
             'organisation'     => ['organisation'],
             'objects'          => ['objects'],
             'tables'           => ['tables'],
-            'chat'             => ['chat'],
+            // NOTE: 'chat' removed — UiController never had a chat() SPA
+            // route; `chat#*` in appinfo/routes.php are API-only endpoints
+            // (ChatController), not a TemplateResponse page.
             'configurations'   => ['configurations'],
             'deleted'          => ['deleted'],
             'auditTrail'       => ['auditTrail'],

--- a/tests/Unit/Db/SchemaLinkedTypesCleanupTest.php
+++ b/tests/Unit/Db/SchemaLinkedTypesCleanupTest.php
@@ -96,9 +96,17 @@ class SchemaLinkedTypesCleanupTest extends TestCase
     }//end testLinkedTypesNullIsAccepted()
 
     /**
-     * setConfiguration throws when linkedTypes is not an array.
+     * validateLinkedTypesValue() (invoked directly — see NOTE) throws when
+     * linkedTypes is not an array.
      *
-     * @covers \OCA\OpenRegister\Db\Schema::setConfiguration
+     * NOTE: as of the #419 per-key configuration isolation fix,
+     * `setConfiguration()` no longer lets this exception escape — it catches
+     * it, drops just the `linkedTypes` key, and keeps the rest of the
+     * configuration (see `testLinkedTypesNotArrayDroppedNotThrown()`). This
+     * test exercises the validator directly via reflection so the rejection
+     * itself stays covered.
+     *
+     * @covers \OCA\OpenRegister\Db\Schema::validateLinkedTypesValue
      *
      * @spec openspec/changes/cleanup-linked-entity-type-map/tasks.md#task-3
      */
@@ -107,13 +115,40 @@ class SchemaLinkedTypesCleanupTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessageMatches("/linkedTypes.*must be an array/");
 
-        $this->schema->setConfiguration(['linkedTypes' => 'not-an-array']);
+        $method = new \ReflectionMethod(Schema::class, 'validateLinkedTypesValue');
+        $method->setAccessible(true);
+        $method->invoke($this->schema, 'not-an-array');
     }//end testLinkedTypesThrowsWhenNotArray()
 
     /**
-     * setConfiguration throws when linkedTypes contains non-string value.
+     * setConfiguration() drops (rather than throws for) a non-array
+     * linkedTypes value — public-surface counterpart to
+     * {@see testLinkedTypesThrowsWhenNotArray()}.
      *
      * @covers \OCA\OpenRegister\Db\Schema::setConfiguration
+     *
+     * @spec openspec/changes/cleanup-linked-entity-type-map/tasks.md#task-3
+     */
+    public function testLinkedTypesNotArrayDroppedNotThrown(): void
+    {
+        $this->schema->setConfiguration(['linkedTypes' => 'not-an-array', 'objectNameField' => 'name']);
+        $config = $this->schema->getConfiguration();
+
+        $this->assertIsArray($config);
+        $this->assertArrayNotHasKey('linkedTypes', $config);
+        $this->assertSame('name', $config['objectNameField']);
+        $this->assertContains('linkedTypes', $this->schema->consumeDroppedAnnotationKeys());
+    }//end testLinkedTypesNotArrayDroppedNotThrown()
+
+    /**
+     * validateLinkedTypesValue() (invoked directly — see NOTE) throws when
+     * linkedTypes contains a non-string value.
+     *
+     * NOTE: as of the #419 per-key configuration isolation fix,
+     * `setConfiguration()` no longer lets this exception escape — see
+     * {@see testLinkedTypesThrowsWhenNotArray()} for the rationale.
+     *
+     * @covers \OCA\OpenRegister\Db\Schema::validateLinkedTypesValue
      *
      * @spec openspec/changes/cleanup-linked-entity-type-map/tasks.md#task-3
      */
@@ -122,7 +157,9 @@ class SchemaLinkedTypesCleanupTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessageMatches("/linkedTypes.*must be strings/");
 
-        $this->schema->setConfiguration(['linkedTypes' => ['files', 42]]);
+        $method = new \ReflectionMethod(Schema::class, 'validateLinkedTypesValue');
+        $method->setAccessible(true);
+        $method->invoke($this->schema, ['files', 42]);
     }//end testLinkedTypesThrowsWhenContainsNonString()
 
     /**

--- a/tests/Unit/Db/SchemaLinkedTypesTest.php
+++ b/tests/Unit/Db/SchemaLinkedTypesTest.php
@@ -103,8 +103,37 @@ class SchemaLinkedTypesTest extends TestCase
     }//end testSingleLegacyLinkedTypeAccepted()
 
     /**
-     * An unknown id (no legacy + no registry registration) is rejected
-     * with a clear error message that lists the accepted vocabulary.
+     * Invoke the private validateLinkedTypesValue() directly via reflection.
+     *
+     * `setConfiguration()` no longer lets a bad `linkedTypes` value escape as
+     * a thrown exception (see the class-level note below) — this seam exists
+     * so the validator's own rejection logic and message wording stay
+     * directly covered per the `@covers` annotation above.
+     *
+     * @param mixed $value The raw linkedTypes value to validate.
+     *
+     * @throws InvalidArgumentException Propagated from the validator.
+     *
+     * @return void
+     */
+    private function invokeValidateLinkedTypesValue(mixed $value): void
+    {
+        $method = new \ReflectionMethod(Schema::class, 'validateLinkedTypesValue');
+        $method->setAccessible(true);
+        $method->invoke($this->schema, $value);
+    }//end invokeValidateLinkedTypesValue()
+
+    /**
+     * An unknown id (no legacy + no registry registration) is rejected by
+     * the validator with a clear error message that lists the accepted
+     * vocabulary.
+     *
+     * NOTE: as of the #419 per-key configuration isolation fix,
+     * `setConfiguration()` itself no longer lets this exception escape — it
+     * catches it, drops just the `linkedTypes` key, and keeps the rest of
+     * the configuration (see `testUnknownLinkedTypeDroppedNotThrown()` for
+     * that public-surface behaviour). This test exercises the validator
+     * directly via reflection so the rejection message itself stays covered.
      *
      * @return void
      */
@@ -113,7 +142,7 @@ class SchemaLinkedTypesTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("Invalid linked type 'totally-not-a-real-thing'");
 
-        $this->schema->setConfiguration(['linkedTypes' => ['totally-not-a-real-thing']]);
+        $this->invokeValidateLinkedTypesValue(['totally-not-a-real-thing']);
     }//end testUnknownLinkedTypeRejected()
 
     /**
@@ -126,7 +155,7 @@ class SchemaLinkedTypesTest extends TestCase
     public function testUnknownLinkedTypeErrorListsValidValues(): void
     {
         try {
-            $this->schema->setConfiguration(['linkedTypes' => ['bogus']]);
+            $this->invokeValidateLinkedTypesValue(['bogus']);
             $this->fail('Expected InvalidArgumentException');
         } catch (InvalidArgumentException $e) {
             $message = $e->getMessage();
@@ -142,8 +171,36 @@ class SchemaLinkedTypesTest extends TestCase
     }//end testUnknownLinkedTypeErrorListsValidValues()
 
     /**
+     * Public-surface behaviour (#419): an unknown `linkedTypes` id no longer
+     * fails the whole `setConfiguration()` call — it is silently dropped
+     * (per-key isolation, so one bad key never loses the rest of the
+     * configuration on app import) and recorded for
+     * `consumeDroppedAnnotationKeys()` so the caller can log it.
+     *
+     * @return void
+     */
+    public function testUnknownLinkedTypeDroppedNotThrown(): void
+    {
+        $this->schema->setConfiguration(
+            [
+                'linkedTypes'     => ['totally-not-a-real-thing'],
+                'objectNameField' => 'name',
+            ]
+        );
+
+        $config = $this->schema->getConfiguration();
+        $this->assertIsArray($config);
+        $this->assertArrayNotHasKey('linkedTypes', $config, 'Invalid linkedTypes must be dropped, not persisted.');
+        $this->assertSame('name', $config['objectNameField'], 'Other keys must survive per-key isolation.');
+        $this->assertContains('linkedTypes', $this->schema->consumeDroppedAnnotationKeys());
+    }//end testUnknownLinkedTypeDroppedNotThrown()
+
+    /**
      * `linkedTypes` MUST be an array — strings and other scalars are
      * rejected at the configuration-validator layer.
+     *
+     * See {@see testUnknownLinkedTypeRejected()} for why this goes through
+     * the validator directly rather than `setConfiguration()`.
      *
      * @return void
      */
@@ -152,12 +209,15 @@ class SchemaLinkedTypesTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("'linkedTypes' must be an array");
 
-        $this->schema->setConfiguration(['linkedTypes' => 'files']);
+        $this->invokeValidateLinkedTypesValue('files');
     }//end testLinkedTypesMustBeAnArray()
 
     /**
      * Each entry in the array MUST be a string. Numeric / boolean
      * payloads are rejected.
+     *
+     * See {@see testUnknownLinkedTypeRejected()} for why this goes through
+     * the validator directly rather than `setConfiguration()`.
      *
      * @return void
      */
@@ -166,7 +226,7 @@ class SchemaLinkedTypesTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("All values in 'linkedTypes' must be strings");
 
-        $this->schema->setConfiguration(['linkedTypes' => ['files', 42]]);
+        $this->invokeValidateLinkedTypesValue(['files', 42]);
     }//end testLinkedTypeEntriesMustBeStrings()
 
     /**
@@ -205,9 +265,13 @@ class SchemaLinkedTypesTest extends TestCase
     }//end testEmptyLinkedTypesArrayAccepted()
 
     /**
-     * Mixing legacy ids with one unknown id rejects the whole payload —
-     * partial-acceptance would let bogus values slip into stored
-     * configuration. Defence in depth.
+     * Mixing legacy ids with one unknown id rejects the whole `linkedTypes`
+     * array from the validator — partial-acceptance would let bogus values
+     * slip into stored configuration. Defence in depth.
+     *
+     * See {@see testUnknownLinkedTypeRejected()} for why this goes through
+     * the validator directly rather than `setConfiguration()` — the public
+     * surface drops the offending key instead of throwing (#419).
      *
      * @return void
      */
@@ -215,6 +279,6 @@ class SchemaLinkedTypesTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $this->schema->setConfiguration(['linkedTypes' => ['files', 'bogus']]);
+        $this->invokeValidateLinkedTypesValue(['files', 'bogus']);
     }//end testMixedValidAndInvalidLinkedTypesRejected()
 }//end class

--- a/tests/Unit/Service/Dbal/SqlTypeMapperTest.php
+++ b/tests/Unit/Service/Dbal/SqlTypeMapperTest.php
@@ -80,8 +80,12 @@ class SqlTypeMapperTest extends TestCase
             'datetimetz'           => [Types::DATETIMETZ_MUTABLE, 'string', 'date-time'],
             'datetimetz_immutable' => [Types::DATETIMETZ_IMMUTABLE, 'string', 'date-time'],
             'json'                 => [Types::JSON, 'object', null],
-            'binary'               => [Types::BINARY, 'string', 'binary'],
-            'blob'                 => [Types::BLOB, 'string', 'binary'],
+            // BINARY/BLOB map to plain string with NO format: 'binary' is not
+            // a JSON-Schema format OR's PropertyValidatorHandler accepts, so
+            // SqlTypeMapper deliberately omits it (bytea columns would
+            // otherwise fail their own generated schema's validation).
+            'binary'               => [Types::BINARY, 'string', null],
+            'blob'                 => [Types::BLOB, 'string', null],
             'simple_array'         => [Types::SIMPLE_ARRAY, 'array', null],
             'array'                => [Types::ARRAY, 'array', null],
         ];

--- a/tests/Unit/Service/DeckCardServiceTest.php
+++ b/tests/Unit/Service/DeckCardServiceTest.php
@@ -245,6 +245,7 @@ class DeckCardServiceTest extends TestCase
                 $this->appManager,
                 $this->userSession,
                 $this->logger,
+                $this->urlGenerator,
             ])
             ->onlyMethods(['userCanAccessBoard'])
             ->getMock();

--- a/tests/Unit/Service/MapLinkServiceTest.php
+++ b/tests/Unit/Service/MapLinkServiceTest.php
@@ -234,7 +234,9 @@ class MapLinkServiceTest extends TestCase
         $this->assertSame(42, $rows[0]['favoriteId']);
         $this->assertSame('Office', $rows[0]['name']);
         $this->assertSame('Work', $rows[0]['category']);
-        $this->assertStringContainsString('m=42', $rows[0]['url']);
+        // poiDeepLink() deep-links to the map coordinates (#map=16/lat/lng),
+        // not a marker-specific fragment — see MapLinkService::poiDeepLink().
+        $this->assertStringContainsString('#map=16/52.37/4.89', $rows[0]['url']);
     }//end testGetLinkedPoisReturnsRowsWithDeepLink()
 
     public function testGetLinkedPoisEmpty(): void

--- a/tests/Unit/Service/PhotoLinkServiceTest.php
+++ b/tests/Unit/Service/PhotoLinkServiceTest.php
@@ -233,7 +233,10 @@ class PhotoLinkServiceTest extends TestCase
         $this->assertCount(1, $rows);
         $this->assertSame(42, $rows[0]['albumId']);
         $this->assertSame('Holiday', $rows[0]['albumName']);
-        $this->assertStringContainsString('albums/42', $rows[0]['url']);
+        // NC Photos routes albums by NAME, not the numeric id — verified live
+        // (see PhotoLinkService::albumDeepLink()): `/albums/{id}` opens an
+        // empty placeholder album, `/albums/{name}` opens the real one.
+        $this->assertStringContainsString('albums/Holiday', $rows[0]['url']);
     }//end testGetLinkedAlbumsReturnsRowsWithDeepLink()
 
     public function testGetLinkedAlbumsEmpty(): void

--- a/tests/Unit/Service/PollLinkServiceTest.php
+++ b/tests/Unit/Service/PollLinkServiceTest.php
@@ -181,7 +181,10 @@ class PollLinkServiceTest extends TestCase
         $this->assertSame(99, $rows[0]['pollId']);
         $this->assertSame('Stub Poll', $rows[0]['pollTitle']);
         $this->assertSame('textPoll', $rows[0]['pollType']);
-        $this->assertSame('/index.php/apps/polls/vote/99', $rows[0]['url']);
+        // NC Polls routes votes at /apps/polls/vote/{id} — the legacy
+        // /index.php prefix broke under the SPA's <base href> (doubled to
+        // /apps/polls/index.php/apps/polls/vote/… on navigation).
+        $this->assertSame('/apps/polls/vote/99', $rows[0]['url']);
     }
 
     public function testCreateAndLinkPollThrowsWhenNoUser(): void

--- a/tests/Unit/Service/RelationHandlerDeepTest.php
+++ b/tests/Unit/Service/RelationHandlerDeepTest.php
@@ -21,6 +21,7 @@ namespace OCA\OpenRegister\Tests\Unit\Service;
 use OCA\OpenRegister\Db\MagicMapper\MagicRbacHandler;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Object\PerformanceHandler;
@@ -47,6 +48,8 @@ class RelationHandlerDeepTest extends TestCase
 
     private MockObject|LoggerInterface $logger;
 
+    private MockObject|RegisterMapper $registerMapper;
+
 
     /**
      * Set up test fixtures
@@ -60,13 +63,15 @@ class RelationHandlerDeepTest extends TestCase
         $this->performanceHandler = $this->createMock(PerformanceHandler::class);
         $this->rbacHandler        = $this->createMock(MagicRbacHandler::class);
         $this->logger             = $this->createMock(LoggerInterface::class);
+        $this->registerMapper     = $this->createMock(RegisterMapper::class);
 
         $this->handler = new RelationHandler(
             $this->objectMapper,
             $this->schemaMapper,
             $this->performanceHandler,
             $this->rbacHandler,
-            $this->logger
+            $this->logger,
+            $this->registerMapper
         );
 
     }//end setUp()

--- a/tests/Unit/Service/RelationHandlerTest.php
+++ b/tests/Unit/Service/RelationHandlerTest.php
@@ -23,6 +23,7 @@ namespace OCA\OpenRegister\Tests\Unit\Service;
 use OCA\OpenRegister\Db\MagicMapper\MagicRbacHandler;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Object\PerformanceHandler;
@@ -62,6 +63,9 @@ class RelationHandlerTest extends TestCase
     /** @var MockObject|LoggerInterface */
     private $logger;
 
+    /** @var MockObject|RegisterMapper */
+    private $registerMapper;
+
     /**
      * Set up test dependencies
      *
@@ -74,13 +78,15 @@ class RelationHandlerTest extends TestCase
         $this->performanceHandler = $this->createMock(PerformanceHandler::class);
         $this->rbacHandler        = $this->createMock(MagicRbacHandler::class);
         $this->logger             = $this->createMock(LoggerInterface::class);
+        $this->registerMapper     = $this->createMock(RegisterMapper::class);
 
         $this->handler = new RelationHandler(
             $this->objectMapper,
             $this->schemaMapper,
             $this->performanceHandler,
             $this->rbacHandler,
-            $this->logger
+            $this->logger,
+            $this->registerMapper
         );
     }
 

--- a/tests/stubs/NextcloudInternalStubs.php
+++ b/tests/stubs/NextcloudInternalStubs.php
@@ -67,7 +67,16 @@ if (class_exists('OC_FakeConfig') === false) {
 // registerService() can be retrieved via get().  Unknown services return null
 // so tests that just guard against an error don't blow up.
 // -----------------------------------------------------------------
-if (class_exists(\OC::class) === false) {
+// OC_FakeServer is declared in its OWN class_exists()-guarded block,
+// independent of whether the real `\OC` class is already loaded (e.g. when
+// OPENREGISTER_TEST_NC_ROOT bootstraps a real Nextcloud root). Tests that
+// reflect-invoke seams like Application::getRegisteredAppContainer() build
+// fakes that `extends \OC_FakeServer` regardless of which server topology is
+// in play, so this stub must stay available even when the "real \OC" branch
+// below is skipped. Nesting it inside the `class_exists(\OC::class)` guard
+// (the pre-fix layout) meant a real NC bootstrap satisfied that guard and
+// silently left `OC_FakeServer` undefined — "Class OC_FakeServer not found".
+if (class_exists('OC_FakeServer') === false) {
     // We have to declare this in the global namespace without a namespace block.
     // eval() makes that possible even when this file is parsed under strict_types.
     eval('
@@ -110,7 +119,13 @@ if (class_exists(\OC::class) === false) {
         /** @return mixed */
         public function getAppInfo(string $appName): mixed { return []; }
     }
+    ');
+}//end if
 
+if (class_exists(\OC::class) === false) {
+    // We have to declare this in the global namespace without a namespace block.
+    // eval() makes that possible even when this file is parsed under strict_types.
+    eval('
     class OC {
         public static OC_FakeServer $server;
         /** @var bool CLI mode flag (false in unit tests) */


### PR DESCRIPTION
### test(unit): fix ~88 drifted unit tests exposed by the now-running phpunit hard gate

Categories fixed:
- ArgumentCountError (constructor drift): IntegrationsCapabilityTest,
  ObjectIntegrationsControllerTest, RelationHandlerTest,
  RelationHandlerDeepTest, DeckCardServiceTest, BootstrapFactoryChainTest
  — add the missing mocked constructor args (LeafRegistry, SchemaMapper,
  RegisterMapper, IURLGenerator, DoriathApplicationRegistrar) to match
  current production constructors.
- Removed/renamed methods: AgentsControllerTest::testPage() removed
  (AgentsController::page() genuinely gone — Agents SPA moved to hermiq
  per or-chat-engine-decommission) and UiControllerTest's 'chat' SPA-route
  data set removed (UiController never had a chat() route; chat#* routes
  are API-only ChatController endpoints).
- OC_FakeServer bootstrap bug: tests/stubs/NextcloudInternalStubs.php only
  declared OC_FakeServer inside the class_exists(\OC::class) guard, so a
  real-NC-bootstrapped run (OPENREGISTER_TEST_NC_ROOT, as the CI hard gate
  uses) skipped it entirely. Split OC_FakeServer into its own independently
  guarded block.
- AttributeMcpDiscoveryTest real-seam tests: under a booted real Nextcloud,
  \OC:: is strictly typed \OC\Server, so a fake extending
  OC_FakeServer can no longer be assigned (TypeError). These 3 tests now
  detect that case and skip with a documented reason; the seam they'd cover
  is otherwise exercised via the RecordingApplication override used by
  every other test in the file.
- Missing CSV fixture: tests/Fixtures/vocabulary/sample-values.csv was
  never committed — a blanket  .gitignore rule silently excluded it.
  Added (force-added past the ignore rule).
- SqlTypeMapperTest binary/blob format: production intentionally dropped
  format:'binary' (not a valid JSON-Schema format OR's
  PropertyValidatorHandler accepts) — updated expectations to match.
- MapLinkServiceTest/PhotoLinkServiceTest/PollLinkServiceTest deep-link
  assertions: production deep-link generation intentionally changed
  (marker param dropped for maps, albums now keyed by name not id for
  photos, /index.php prefix dropped for polls — all verified-live fixes
  per git history) — updated expectations to match current behaviour.
- SchemaLinkedTypesTest/SchemaLinkedTypesCleanupTest: setConfiguration()
  no longer throws on an invalid linkedTypes value (per-key configuration
  isolation, #419) — it now drops just that key and keeps the rest of the
  configuration. Updated the throw-expecting tests to invoke the private
  validator directly via reflection (preserving message-content coverage)
  and added new tests asserting the drop-not-throw public-surface behaviour.
- SettingsControllerTest debug-filtering: the test's own createDoctrineResult()
  IResult stub had fetch() hardcoded to always return false, so the
  production code's fetch()-based row iteration (NC 32 compat) never saw
  rows. Fixed the stub to actually iterate.
- FileSettingsControllerBranchTest: removed a dead LegacyGuardFileSettingsController
  test-double that re-added a 400-on-empty-endpoint guard removed from
  production; the sole test exercising it was rewritten to test current
  behaviour (200 + success=false) but was still going through the legacy
  double.
- Test-isolation leak (root cause of an undocumented extra failure):
  BlobMigrationJobTest registered mocks directly into the process-wide
  \OC::$server container with no teardown, leaking stale mocks into any
  LATER test resolving the same service ids via \OCP\Server::get() —
  concretely, RelationsControllerTest's pluggable leaf-integration lookups
  (MapLinkService/PollLinkService/etc., resolved through the real
  container) intermittently surfaced a spurious _errors key. Added
  setUp()/tearDown() capture-and-restore of the real container bindings.

Verified via the exact CI hard-gate command against a disposable
NC 34 + Postgres container: 0 errors, 0 failures (15271 tests,
34109 assertions; only pre-existing warnings/deprecations remain).

---
**Sweep metadata**

- Verified to merge **cleanly** into `development` as of `e9a65e722` (tested by an actual merge, not a heuristic)
- Contribution: 20 files changed, 322 insertions(+), 67 deletions(-)
- Last commit: 4 days ago

Opened as part of a sweep of unmerged branches. Authored by an earlier session — the body above is that branch's own commit message, unedited. **I have not reviewed the content**; this PR exists so the work is visible and reviewable rather than sitting on an unmerged branch. Merge on its own merits.