### PR TITLE
fix(flow): fail runs abandoned in `running` instead of leaving them there

### DIFF
--- a/lib/Cron/FlowRunWorker.php
+++ b/lib/Cron/FlowRunWorker.php
@@ -37,11 +37,13 @@ use DateTime;
 use OCA\OpenRegister\Db\FlowRun;
 use OCA\OpenRegister\Db\FlowRunMapper;
 use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowResolverRegistry;
 use OCA\OpenRegister\Service\Flow\FlowRunService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
+use stdClass;
 use Throwable;
 
 /**
@@ -68,6 +70,18 @@ class FlowRunWorker extends TimedJob
     private const DEFAULT_RETENTION_DAYS = 30;
 
     /**
+     * How long a run may sit in `running` before it counts as abandoned.
+     *
+     * A run executes synchronously inside ONE worker pass, so a pass that is
+     * still going has touched its row far more recently than this. Fifteen
+     * minutes is therefore generous rather than tight — it exists to be
+     * unambiguous, not to be quick.
+     *
+     * @var int
+     */
+    private const DEFAULT_STALE_MINUTES = 15;
+
+    /**
      * Constructor.
      *
      * @param ITimeFactory         $time      Job scheduling clock.
@@ -81,7 +95,7 @@ class FlowRunWorker extends TimedJob
         ITimeFactory $time,
         private readonly FlowRunMapper $mapper,
         private readonly FlowRunService $runner,
-        private readonly \OCA\OpenRegister\Service\Flow\FlowResolverRegistry $resolvers,
+        private readonly FlowResolverRegistry $resolvers,
         private readonly IAppConfig $appConfig,
         private readonly LoggerInterface $logger
     ) {
@@ -107,6 +121,8 @@ class FlowRunWorker extends TimedJob
     {
         $now = new DateTime();
 
+        $this->reapStale(now: $now);
+
         foreach ($this->mapper->findQueued(limit: self::BATCH) as $run) {
             $this->advance(run: $run);
         }
@@ -120,11 +136,76 @@ class FlowRunWorker extends TimedJob
     }//end run()
 
     /**
+     * Fail runs abandoned in `running` by a pass that never came back.
+     *
+     * FAILED, not requeued. A run that died mid-walk may already have written
+     * an object, sent a mail, or called a webhook; restarting it would repeat
+     * those silently. The existing retry endpoint turns it back into a run when
+     * a person decides that is right — which is exactly the kind of decision
+     * that should not be made by a cron job.
+     *
+     * Left alone, such a row is unreachable: the worker reads only `queued` and
+     * due `suspended` runs, so nothing ever touches it again, and every surface
+     * that shows live runs shows it as running forever.
+     *
+     * @param DateTime $now The current time.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/or-flow-stale-runs/specs/flow-stale-runs/spec.md
+     */
+    private function reapStale(DateTime $now): void
+    {
+        $minutes = (int) $this->appConfig->getValueString(
+            'openregister',
+            'flow_run_stale_minutes',
+            (string) self::DEFAULT_STALE_MINUTES
+        );
+
+        if ($minutes <= 0) {
+            // An operator who runs very long single steps can switch the reaper
+            // off rather than have it fail work that is still going.
+            return;
+        }
+
+        $cutoff = (clone $now)->modify('-'.$minutes.' minutes');
+
+        foreach ($this->mapper->findStale(before: $cutoff, limit: self::BATCH) as $run) {
+            $run->setStatus(FlowRun::STATUS_FAILED);
+            $run->setError(
+                sprintf(
+                    'Abandoned: no worker pass has touched this run for over %d minutes, '
+                    .'so the pass that started it did not finish (a fatal, a timeout or a restart). '
+                    .'Retry it to run it again from the start.',
+                    $minutes
+                )
+            );
+            $run->setUpdated($now);
+            $this->mapper->update($run);
+
+            $this->logger->warning(
+                message: '[FlowRunWorker] Failed a run abandoned in `running`',
+                context: [
+                    'file' => __FILE__,
+                    'line' => __LINE__,
+                    'run'  => $run->getUuid(),
+                    'flow' => $run->getFlowId(),
+                ]
+            );
+        }//end foreach
+
+    }//end reapStale()
+
+    /**
      * Advance one run, never letting its failure stop the batch.
      *
      * @param FlowRun $run The run.
      *
      * @return void
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess) FlowItems::item is a pure value
+     * constructor with no state to inject; a factory collaborator would add a
+     * dependency to say the same thing.
      *
      * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
      */
@@ -169,7 +250,7 @@ class FlowRunWorker extends TimedJob
             // user's id exactly as it would an object's fields.
             $seed = null;
             if ($subject === null) {
-                $subject = new \stdClass();
+                $subject = new stdClass();
                 $payload = (array) (($run->getContext() ?? [])['payload'] ?? []);
                 if ($payload !== []) {
                     $seed = [FlowItems::item(json: $payload)];

--- a/lib/Db/FlowRunMapper.php
+++ b/lib/Db/FlowRunMapper.php
@@ -218,6 +218,47 @@ class FlowRunMapper extends QBMapper
     }//end findDue()
 
     /**
+     * Runs left in `running` by a worker pass that never came back.
+     *
+     * `execute()` sets `running` and clears it when the walk returns. A pass
+     * that dies instead — a fatal, a PHP timeout, an OOM, a container
+     * restart — never clears it, and no `catch` can help because the process
+     * is gone. The row then sits in `running` forever: the worker will not
+     * pick it up (it only reads `queued` and due `suspended` runs), so it is
+     * not just stale, it is unreachable.
+     *
+     * That was invisible while nothing read `running`. It stops being
+     * invisible the moment a dashboard widget shows live runs — 68 such rows
+     * existed on one dev instance, the oldest two days old, and every one of
+     * them would have read as "running right now".
+     *
+     * @param DateTime $before Runs not touched since this moment are stale.
+     * @param integer  $limit  Maximum runs to reap in one pass.
+     *
+     * @return array<int, FlowRun> The abandoned runs.
+     *
+     * @spec openspec/changes/or-flow-stale-runs/specs/flow-stale-runs/spec.md
+     */
+    public function findStale(DateTime $before, int $limit=25): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('status', $qb->createNamedParameter(FlowRun::STATUS_RUNNING)))
+            ->andWhere(
+                $qb->expr()->lt(
+                    'updated',
+                    $qb->createNamedParameter($before, IQueryBuilder::PARAM_DATETIME_MUTABLE)
+                )
+            )
+            ->orderBy('updated', 'ASC')
+            ->setMaxResults($limit);
+
+        return $this->findEntities(query: $qb);
+
+    }//end findStale()
+
+    /**
      * Runs waiting in the queue to start.
      *
      * @param integer $limit Maximum runs to claim in one pass.

--- a/openspec/changes/or-flow-stale-runs/.openspec.yaml
+++ b/openspec/changes/or-flow-stale-runs/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-stale-runs

--- a/openspec/changes/or-flow-stale-runs/proposal.md
+++ b/openspec/changes/or-flow-stale-runs/proposal.md
@@ -1,0 +1,46 @@
+# Proposal: or-flow-stale-runs
+
+## Summary
+
+Fail runs abandoned in `running`, so a live-runs surface tells the truth.
+
+## Why
+
+`FlowRunService::execute()` sets `running` before the walk and clears it when
+the walk returns. A pass that dies instead — a fatal, a PHP timeout, an OOM, a
+container restart — never clears it, and the `catch (Throwable)` in the worker
+cannot help, because the process is gone.
+
+The row is then not merely stale, it is **unreachable**: the worker reads only
+`queued` runs and due `suspended` ones, so nothing ever looks at it again.
+
+This cost nothing while nothing read `running`. It stops being free the moment a
+dashboard widget shows live runs (`or-flow-active-runs`): 68 such rows existed on
+one dev instance, the oldest two days old, and every one of them would have read
+as "running right now" — forever.
+
+## What Changes
+
+- `FlowRunMapper::findStale()` — runs in `running` whose `updated` predates a
+  cut-off, oldest first.
+- `FlowRunWorker::reapStale()` — runs first in each pass, before any new work,
+  and marks each abandoned run `failed` with an error that says what happened
+  and what to do about it.
+- `flow_run_stale_minutes` app config, default 15, `0` to disable.
+
+## Design decisions
+
+**Failed, not requeued.** A run that died mid-walk may already have written an
+object, sent a mail, or called a webhook. Restarting it would repeat those
+silently. The retry endpoint already turns a terminal run back into a fresh run
+when a person decides that is right — which is exactly the kind of decision a
+cron job should not make.
+
+**Fifteen minutes, and configurable.** A run executes synchronously inside ONE
+pass, so a pass that is still going has touched its row far more recently than
+that; the window exists to be unambiguous, not tight. An operator running very
+long single steps can set `0` and opt out rather than have the reaper fail work
+that is still in flight.
+
+**Reaped before new work.** A pass that starts by cleaning up cannot mistake its
+own fresh `running` rows for abandoned ones.

--- a/openspec/changes/or-flow-stale-runs/specs/flow-stale-runs/spec.md
+++ b/openspec/changes/or-flow-stale-runs/specs/flow-stale-runs/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: A run abandoned in `running` is failed, not left running
+
+A run whose status is `running` and which has not been updated for longer than a
+configured window SHALL be marked `failed`, with an error stating that the pass
+which started it did not finish and that retrying will run it again.
+
+Such a run SHALL NOT be left as-is. It is unreachable: the worker reads only
+`queued` runs and due `suspended` ones, so nothing else will ever touch it, and
+every surface that shows live runs shows it as running indefinitely.
+
+#### Scenario: An abandoned run is failed with a readable reason
+
+- **GIVEN** a run in `running` last updated two days ago
+- **WHEN** the worker makes a pass
+- **THEN** the run's status is `failed`
+- **AND** its error says it was abandoned and can be retried
+
+### Requirement: An abandoned run is never restarted automatically
+
+Reaping SHALL NOT requeue or re-execute the run.
+
+A run that died mid-walk may already have written an object, sent a mail or
+called a webhook; restarting it would repeat those side effects silently. Turning
+a terminal run back into a fresh run is what the retry surface is for, and it is
+a decision for a person.
+
+#### Scenario: Reaping does not run anything
+
+- **GIVEN** an abandoned run
+- **WHEN** the worker reaps it
+- **THEN** no run is queued and no flow is executed
+
+### Requirement: The abandonment window is configurable and can be switched off
+
+The window SHALL be read from configuration with a default of 15 minutes, and a
+value of `0` or less SHALL disable reaping entirely.
+
+A run executes synchronously inside ONE worker pass, so a pass still in flight
+has touched its row far more recently than the default; the window exists to be
+unambiguous rather than tight. An operator whose single steps genuinely run
+longer SHALL be able to opt out rather than have live work failed.
+
+#### Scenario: The configured window reaches the query
+
+- **GIVEN** a configured window of 90 minutes
+- **WHEN** the worker makes a pass
+- **THEN** the stale query is asked for runs untouched since ~90 minutes ago
+
+#### Scenario: Zero disables the reaper
+
+- **GIVEN** a configured window of `0`
+- **WHEN** the worker makes a pass
+- **THEN** no stale query is issued and no run is updated
+
+### Requirement: Reaping happens before new work in the same pass
+
+The reap SHALL run before the pass starts or resumes any run, so a pass cannot
+mistake the `running` rows it has just created for abandoned ones.
+
+#### Scenario: A pass does not reap its own work
+
+- **GIVEN** a pass that starts a queued run
+- **WHEN** that same pass reaps
+- **THEN** the run it just started is not failed

--- a/openspec/changes/or-flow-stale-runs/tasks.md
+++ b/openspec/changes/or-flow-stale-runs/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: or-flow-stale-runs
+
+- [x] `FlowRunMapper::findStale()` — `running` runs older than a cut-off, oldest first.
+- [x] `FlowRunWorker::reapStale()` — first step of each pass; marks abandoned runs
+      `failed` with a reason naming the window and pointing at retry.
+- [x] `flow_run_stale_minutes` app config (default 15, `0` disables).
+- [x] Tests: an abandoned run is failed with a readable reason; it is NEVER
+      requeued or re-executed; the window is configurable and reaches the query
+      as a cut-off; `0` switches the reaper off entirely.
+- [x] Fixed pre-existing findings in the touched file while here: the
+      fully-qualified `FlowResolverRegistry` and `\stdClass` now have imports,
+      and `FlowItems::item` carries a reasoned StaticAccess suppression.
+- [ ] Backfill the 68 rows already stuck on the dev instance — deliberately NOT
+      a migration: the reaper fails them on its next pass, which is the same
+      outcome with none of the risk of a data migration over live rows.

--- a/tests/Unit/Cron/FlowRunWorkerStaleTest.php
+++ b/tests/Unit/Cron/FlowRunWorkerStaleTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * The worker fails runs abandoned in `running`.
+ *
+ * `execute()` sets `running` and clears it when the walk returns. A pass that
+ * dies instead — a fatal, a PHP timeout, an OOM, a container restart — never
+ * clears it, and no `catch` can help because the process is gone. Nothing then
+ * touches the row again: the worker reads only `queued` and due `suspended`
+ * runs. That was invisible while nothing read `running`; it stops being
+ * invisible the moment a dashboard widget shows live runs.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Cron;
+
+use DateTime;
+use OCA\OpenRegister\Cron\FlowRunWorker;
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Service\Flow\FlowResolverRegistry;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IAppConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class FlowRunWorkerStaleTest extends TestCase
+{
+    private FlowRunMapper&MockObject $mapper;
+
+    private FlowRunService&MockObject $runner;
+
+    private IAppConfig&MockObject $appConfig;
+
+    private FlowRunWorker $worker;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mapper    = $this->createMock(FlowRunMapper::class);
+        $this->runner    = $this->createMock(FlowRunService::class);
+        $this->appConfig = $this->createMock(IAppConfig::class);
+
+        // Nothing queued, nothing due, and pruning off — this suite is only
+        // about the reaper.
+        $this->mapper->method('findQueued')->willReturn([]);
+        $this->mapper->method('findDue')->willReturn([]);
+
+        $this->worker = new FlowRunWorker(
+            $this->createMock(ITimeFactory::class),
+            $this->mapper,
+            $this->runner,
+            $this->createMock(FlowResolverRegistry::class),
+            $this->appConfig,
+            new NullLogger()
+        );
+    }
+
+    /** Answer getValueString() from a map, falling back to the caller's default. */
+    private function config(array $values): void
+    {
+        $this->appConfig->method('getValueString')->willReturnCallback(
+            static fn (string $app, string $key, string $default = '') => ($values[$key] ?? $default)
+        );
+    }
+
+    /** Run one pass of the worker. */
+    private function pass(): void
+    {
+        $method = new \ReflectionMethod(FlowRunWorker::class, 'run');
+        $method->invoke($this->worker, null);
+    }
+
+    private function runningRun(string $uuid = 'zombie-1'): FlowRun
+    {
+        $run = new FlowRun();
+        $run->setUuid($uuid);
+        $run->setFlowId('f1');
+        $run->setStatus(FlowRun::STATUS_RUNNING);
+        $run->setUpdated(new DateTime('-2 days'));
+
+        return $run;
+    }
+
+    public function testAnAbandonedRunIsFailedWithAReadableReason(): void
+    {
+        // Pruning off so the pass does nothing else.
+        $this->config(['flow_run_retention_days' => '0']);
+
+        $run = $this->runningRun();
+        $this->mapper->method('findStale')->willReturn([$run]);
+
+        $saved = null;
+        $this->mapper->expects($this->once())->method('update')
+            ->willReturnCallback(function (FlowRun $r) use (&$saved) {
+                $saved = $r;
+                return $r;
+            });
+
+        $this->pass();
+
+        $this->assertSame(FlowRun::STATUS_FAILED, $saved->getStatus());
+        $this->assertStringContainsString('Abandoned', (string) $saved->getError());
+        $this->assertStringContainsString('Retry', (string) $saved->getError());
+    }
+
+    public function testAnAbandonedRunIsNeverRequeued(): void
+    {
+        // Requeuing would repeat every side effect the dead pass already
+        // performed — an object write, a mail, a webhook. Retry is a person's
+        // decision, not a cron job's.
+        $this->config(['flow_run_retention_days' => '0']);
+        $this->mapper->method('findStale')->willReturn([$this->runningRun()]);
+        $this->mapper->method('update')->willReturnArgument(0);
+
+        $this->runner->expects($this->never())->method('retry');
+        $this->runner->expects($this->never())->method('execute');
+
+        $this->pass();
+    }
+
+    public function testTheStaleWindowIsConfigurableAndPassedAsACutoff(): void
+    {
+        $this->config(['flow_run_retention_days' => '0', 'flow_run_stale_minutes' => '90']);
+
+        $this->mapper->expects($this->once())->method('findStale')
+            ->with(
+                $this->callback(static function (DateTime $before): bool {
+                    $minutesAgo = ((time() - $before->getTimestamp()) / 60);
+                    // ~90 minutes ago, with room for the test's own runtime.
+                    return $minutesAgo > 89 && $minutesAgo < 92;
+                }),
+                $this->anything()
+            )
+            ->willReturn([]);
+
+        $this->pass();
+    }
+
+    public function testAZeroWindowSwitchesTheReaperOff(): void
+    {
+        // An operator running very long single steps must be able to opt out
+        // rather than have the reaper fail work that is still going.
+        $this->config(['flow_run_retention_days' => '0', 'flow_run_stale_minutes' => '0']);
+
+        $this->mapper->expects($this->never())->method('findStale');
+        $this->mapper->expects($this->never())->method('update');
+
+        $this->pass();
+    }
+}


### PR DESCRIPTION
## The defect

`FlowRunService::execute()` sets `running` before the walk and clears it when the walk returns. A pass that **dies** instead — a fatal, a PHP timeout, an OOM, a container restart — never clears it, and the worker's `catch (Throwable)` cannot help, because the process is gone.

The row is then not merely stale, it is **unreachable**: the worker reads only `queued` runs and due `suspended` ones, so nothing ever looks at it again.

That cost nothing while nothing read `running`. It stopped being free the moment a dashboard widget started showing live runs (#2204):

```
select count(*), min(updated), max(updated) from oc_openregister_flow_runs where status='running';
 68 | 2026-07-28 00:55:46 | 2026-07-30 13:15:03
```

68 rows on one dev instance, the oldest two days old — every one of which would have read as "running right now", forever.

## The fix

The worker reaps **first** in each pass (so it cannot mistake its own fresh `running` rows for abandoned ones) and marks each abandoned run `failed` with an error saying what happened and that retrying will run it again.

**Failed, not requeued.** A run that died mid-walk may already have written an object, sent a mail or called a webhook; restarting it would repeat those silently. Retry already turns a terminal run into a fresh one when a person decides that is right — exactly the kind of decision a cron job should not make.

**`flow_run_stale_minutes`, default 15, `0` disables.** A run executes synchronously inside *one* pass, so a pass still in flight has touched its row far more recently than that; the window exists to be unambiguous rather than tight, and an operator whose single steps genuinely run longer can opt out rather than have live work failed.

**No backfill migration** for the rows already stuck: the reaper fails them on its next pass — same outcome, none of the risk of a data migration over live rows.

## Verification

- **36 tests green**, 4 new: failed with a readable reason; never requeued *or* re-executed; the window reaches the query as a cut-off; `0` switches the reaper off entirely.
- **phpcs / phpmd / phpstan / psalm clean.** While in this file, the pre-existing fully-qualified `FlowResolverRegistry` and `\stdClass` gained imports and `FlowItems::item` gained a reasoned `StaticAccess` suppression — phpmd is now clean on it rather than carrying three findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)