### PR TITLE
feat(objects): insert-only saves — opt-in create that fails instead of overwriting

### DIFF
--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -2681,6 +2681,18 @@ class ObjectsController extends Controller
         // Extract uploaded files from multipart/form-data using Request object.
         $uploadedFiles = $this->extractAllUploadedFiles();
 
+        // INSERT-ONLY opt-in (openregister#2210). `_failIfExists=true` turns this
+        // create from an upsert into a strict insert: an identifier that is
+        // already taken returns 409 instead of silently overwriting.
+        //
+        // Read from the raw request, not from $object — the body filter above
+        // strips `_`-prefixed keys, which is exactly the convention for control
+        // parameters that must not be persisted onto the object itself.
+        $failIfExists = filter_var(
+            $this->request->getParam('_failIfExists', false),
+            FILTER_VALIDATE_BOOLEAN
+        );
+
         // Determine RBAC and multitenancy settings based on admin status.
         $isAdmin = $this->isCurrentUserAdmin();
         $rbac    = !$isAdmin;
@@ -2707,7 +2719,8 @@ class ObjectsController extends Controller
                 _rbac: $rbac,
                 _multitenancy: true,
                 uuid: null,
-                uploadedFiles: $uploadedFilesValue
+                uploadedFiles: $uploadedFilesValue,
+                failIfExists: $failIfExists
             );
 
             // TODO: Unlock the object after saving using LockingHandler through ObjectService.
@@ -2736,6 +2749,19 @@ class ObjectsController extends Controller
             // MUST be caught before generic \Exception to avoid being absorbed as a 403 with
             // a non-structured body. See the `self-folder-access-control` capability spec.
             return $this->folderAccessDeniedResponse(exception: $exception);
+        } catch (\OCA\OpenRegister\Exception\ObjectExistsException $exception) {
+            // MUST be caught before the generic \Exception below, which flattens
+            // everything to 403. A losing claim reported as "forbidden" is
+            // indistinguishable from a permissions problem, and the caller cannot
+            // tell it simply lost a race — which is the entire point of asking
+            // for insert-only semantics.
+            return new JSONResponse(
+                data: [
+                    'error' => $exception->getMessage(),
+                    'uuid'  => $exception->getUuid(),
+                ],
+                statusCode: 409
+            );
         } catch (\Exception $exception) {
             // Handle all other exceptions (including RBAC permission errors).
             // Sanitized external-write failures carry their own 4xx status

--- a/lib/Exception/ObjectExistsException.php
+++ b/lib/Exception/ObjectExistsException.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * OpenRegister ObjectExistsException
+ *
+ * This file contains the exception class for insert-only save conflicts.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Exception
+ * @package  OCA\OpenRegister\Exception
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+namespace OCA\OpenRegister\Exception;
+
+use Exception;
+use Throwable;
+
+/**
+ * Exception thrown when an insert-only save finds the object already present
+ *
+ * `saveObject()` is an upsert by default: given a uuid that already exists it
+ * updates, silently and successfully. That is the right behaviour for most
+ * callers and is unchanged.
+ *
+ * It is the wrong behaviour for a caller that is claiming something — a lock, a
+ * slot, a lease, a ticket number, a queue position. There, "it already existed"
+ * is the whole answer, and losing it means two callers both believe they won.
+ * Such a caller passes `$failIfExists: true` and receives this exception
+ * instead of a silent overwrite.
+ *
+ * Uses HTTP 409 Conflict: the request could not be completed because of a
+ * conflict with the current state of the resource (RFC 9110 §15.5.10).
+ *
+ * @category Exception
+ * @package  OCA\OpenRegister\Exception
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+class ObjectExistsException extends Exception
+{
+
+    /**
+     * The identifier of the object that already existed.
+     *
+     * @var string|null
+     */
+    private ?string $uuid = null;
+
+    /**
+     * Constructor for ObjectExistsException
+     *
+     * @param string         $message  The error message describing the conflict
+     * @param string|null    $uuid     The identifier that already existed
+     * @param int            $code     The error code (default: 409 Conflict)
+     * @param Throwable|null $previous The previous exception that caused this one
+     *
+     * @return void
+     */
+    public function __construct(
+        string $message='An object with this identifier already exists',
+        ?string $uuid=null,
+        int $code=409,
+        ?Throwable $previous=null
+    ) {
+        $this->uuid = $uuid;
+
+        // HTTP 409 Conflict — the caller asked to create, and creating would
+        // have overwritten something that was already there.
+        parent::__construct(message: $message, code: $code, previous: $previous);
+
+    }//end __construct()
+
+    /**
+     * Get the identifier of the object that already existed.
+     *
+     * Lets a caller distinguish "my claim lost" from "something else went
+     * wrong" without parsing the message.
+     *
+     * @return string|null The conflicting identifier, when known.
+     */
+    public function getUuid(): ?string
+    {
+        return $this->uuid;
+
+    }//end getUuid()
+}//end class

--- a/lib/Service/Flow/Nodes/ObjectWriteNode.php
+++ b/lib/Service/Flow/Nodes/ObjectWriteNode.php
@@ -174,6 +174,36 @@ class ObjectWriteNode implements IFlowNode
     private const ON_NO_MATCH = [self::ON_NO_MATCH_ERROR, self::ON_NO_MATCH_SKIP];
 
     /**
+     * A create whose identifier is already taken overwrites it (the default).
+     *
+     * This is `saveObject()`'s long-standing upsert behaviour and stays the
+     * default: it is silent, so there is no way to enumerate which existing
+     * flows depend on it.
+     *
+     * @var string
+     */
+    private const ON_CONFLICT_OVERWRITE = 'overwrite';
+
+    /**
+     * A create whose identifier is already taken FAILS the item.
+     *
+     * Opt in with `onConflict: fail` when the write is a CLAIM — a lock, a
+     * slot, a lease, a queue position. There, "it already existed" is the whole
+     * answer, and overwriting it means two flow runs both believe they won
+     * while the loser is never told. See openregister#2210.
+     *
+     * @var string
+     */
+    private const ON_CONFLICT_FAIL = 'fail';
+
+    /**
+     * Accepted `onConflict` values.
+     *
+     * @var string[]
+     */
+    private const ON_CONFLICT = [self::ON_CONFLICT_OVERWRITE, self::ON_CONFLICT_FAIL];
+
+    /**
      * Writes one step execution may perform when it declares no `maxWrites`.
      *
      * Matches `FlowEngine::MAX_TRANSITIONS`'s order of magnitude so the two
@@ -405,12 +435,13 @@ class ObjectWriteNode implements IFlowNode
         $register  = $this->resolveRegister(config: $config);
         $schema    = $this->resolveSchema(config: $config, register: $register);
 
-        $pairs     = $this->matchPairs(config: $config);
-        $fields    = (array) ($config['fields'] ?? []);
-        $onMissing = $this->optionFrom(config: $config, key: 'onMissing', allowed: self::ON_MISSING, default: self::ON_MISSING_OMIT);
-        $onNoMatch = $this->optionFrom(config: $config, key: 'onNoMatch', allowed: self::ON_NO_MATCH, default: self::ON_NO_MATCH_ERROR);
-        $replace   = (($config['replace'] ?? false) === true);
-        $cap       = $this->writeCap(config: $config);
+        $pairs      = $this->matchPairs(config: $config);
+        $fields     = (array) ($config['fields'] ?? []);
+        $onMissing  = $this->optionFrom(config: $config, key: 'onMissing', allowed: self::ON_MISSING, default: self::ON_MISSING_OMIT);
+        $onNoMatch  = $this->optionFrom(config: $config, key: 'onNoMatch', allowed: self::ON_NO_MATCH, default: self::ON_NO_MATCH_ERROR);
+        $onConflict = $this->optionFrom(config: $config, key: 'onConflict', allowed: self::ON_CONFLICT, default: self::ON_CONFLICT_OVERWRITE);
+        $replace    = (($config['replace'] ?? false) === true);
+        $cap        = $this->writeCap(config: $config);
 
         $writes = 0;
         $out    = [];
@@ -453,7 +484,8 @@ class ObjectWriteNode implements IFlowNode
                 register: $register,
                 schema: $schema,
                 owner: $owner,
-                replace: $replace
+                replace: $replace,
+                onConflict: $onConflict
             );
             $writes++;
 
@@ -551,12 +583,13 @@ class ObjectWriteNode implements IFlowNode
      * update-side write goes through `patchObject()` unless the author asked for
      * `replace: true`, which is the only way to reach PUT semantics from a flow.
      *
-     * @param array             $payload  The templated field payload.
-     * @param ObjectEntity|null $matched  The matched object, when there is one.
-     * @param Register          $register The resolved register.
-     * @param Schema            $schema   The resolved schema.
-     * @param IUser             $owner    The run owner, as the acting user.
-     * @param bool              $replace  Whether to replace rather than patch.
+     * @param array             $payload    The templated field payload.
+     * @param ObjectEntity|null $matched    The matched object, when there is one.
+     * @param Register          $register   The resolved register.
+     * @param Schema            $schema     The resolved schema.
+     * @param IUser             $owner      The run owner, as the acting user.
+     * @param bool              $replace    Whether to replace rather than patch.
+     * @param string            $onConflict What to do when a create's identifier is already taken.
      *
      * @return ObjectEntity The written object.
      */
@@ -566,14 +599,20 @@ class ObjectWriteNode implements IFlowNode
         Register $register,
         Schema $schema,
         IUser $owner,
-        bool $replace
+        bool $replace,
+        string $onConflict=self::ON_CONFLICT_OVERWRITE
     ): ObjectEntity {
         if ($matched === null) {
+            // `matched === null` means the node's own lookup found nothing —
+            // but that lookup and this write are two separate calls, so another
+            // flow run can land in between. Passing failIfExists through is what
+            // closes that window: the database, not the node, arbitrates.
             return $this->objects->saveObject(
                 object: $payload,
                 register: $register,
                 schema: $schema,
-                currentUser: $owner
+                currentUser: $owner,
+                failIfExists: ($onConflict === self::ON_CONFLICT_FAIL)
             );
         }
 

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -61,6 +61,7 @@ use OCA\OpenRegister\Event\ReferenceValidatedEvent;
 use OCA\OpenRegister\Event\ReferenceValidationFailedEvent;
 use OCA\OpenRegister\Service\SettingsService;
 use OCA\OpenRegister\Exception\CircularReferenceException;
+use OCA\OpenRegister\Exception\ObjectExistsException;
 use OCA\OpenRegister\Exception\ReferenceValidationException;
 use OCA\OpenRegister\Exception\ValidationException;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -2759,10 +2760,12 @@ class SaveObject
      * @param bool                     $_validation   Whether to validate the object (default: true).
      * @param array|null               $uploadedFiles Uploaded files array (optional).
      * @param IUser|null               $currentUser   Explicit acting user for `@self.folder` access checks; falls back to the session user when null.
+     * @param bool                     $failIfExists  Insert-only: throw ObjectExistsException rather than update when taken (default: false).
      *
      * @return ObjectEntity The saved object entity.
      *
      * @throws Exception If there is an error during save.
+     * @throws ObjectExistsException When $failIfExists is true and the identifier is already taken.
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList) Required for flexible save options
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)    Boolean flags needed for flexible save behavior
@@ -2781,7 +2784,8 @@ class SaveObject
         bool $silent=false,
         bool $_validation=true,
         ?array $uploadedFiles=null,
-        ?IUser $currentUser=null
+        ?IUser $currentUser=null,
+        bool $failIfExists=false
     ): ObjectEntity {
         // Extract UUID and @self metadata from data.
         [$uuid, $selfData, $data] = $this->extractUuidAndSelfData(
@@ -2896,6 +2900,39 @@ class SaveObject
             );
 
             if ($existingObject !== null) {
+                // INSERT-ONLY GUARD (openregister#2210).
+                //
+                // The default below is an upsert: an existing identifier is
+                // updated, silently and successfully. That is correct for the
+                // overwhelming majority of callers and is untouched.
+                //
+                // It is wrong for a caller that is CLAIMING something — a lock,
+                // a slot, a lease, a queue position. There "it already existed"
+                // is the entire answer, and swallowing it means two callers both
+                // believe they won and the loser is never told. Such a caller
+                // opts in with $failIfExists and gets a 409 instead.
+                //
+                // Deliberately opt-in rather than the default: the current
+                // upsert is silent, so there is no way to discover from the code
+                // which callers depend on it. Flipping the default would change
+                // behaviour fleet-wide with no way to enumerate the blast radius.
+                if ($failIfExists === true) {
+                    $this->logger->debug(
+                        message: '[SaveObject] Existing object found and failIfExists is set, refusing the write',
+                        context: [
+                            'file'     => __FILE__,
+                            'line'     => __LINE__,
+                            'uuid'     => $uuid,
+                            'objectId' => $existingObject->getId(),
+                        ]
+                    );
+
+                    throw new ObjectExistsException(
+                        message: sprintf('An object with identifier "%s" already exists.', (string) $uuid),
+                        uuid: (string) $uuid
+                    );
+                }
+
                 $this->logger->debug(
                     message: '[SaveObject] Existing object found, proceeding with UPDATE',
                     context: [

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -1084,7 +1084,8 @@ class ObjectService
      *
      * @return ObjectEntity The saved object.
      *
-     * @throws Exception If there is an error during save.
+     * @throws Exception If there is an error during save
+     * @throws \OCA\OpenRegister\Exception\ObjectExistsException When $failIfExists is true and the identifier is already taken.
      */
 
     /**
@@ -1118,6 +1119,7 @@ class ObjectService
      * @param bool                     $silent        Whether to skip audit trail creation and events (default: false)
      * @param array|null               $uploadedFiles Uploaded files from multipart/form-data (optional)
      * @param IUser|null               $currentUser   Explicit acting user for `@self.folder` access checks
+     * @param bool                     $failIfExists  Insert-only: throw ObjectExistsException rather than update when taken (default: false = upsert)
      *                                                (forwarded to `ensureObjectFolder` → `assertObjectFolderAccessible`).
      *                                                Defaults to null → `IUserSession::getUser()` resolution.
      *                                                Non-HTTP callers (cron, import pipelines, event listeners)
@@ -1146,7 +1148,8 @@ class ObjectService
         bool $_multitenancy=true,
         bool $silent=false,
         ?array $uploadedFiles=null,
-        ?IUser $currentUser=null
+        ?IUser $currentUser=null,
+        bool $failIfExists=false
     ): ObjectEntity {
         // Bound the folder-access revalidation cache to this single save call
         // (not the whole FileService/request lifetime), so a cascade save that
@@ -1300,7 +1303,8 @@ class ObjectService
             silent: $silent,
             _validation: true,
             uploadedFiles: $uploadedFiles,
-            currentUser: $currentUser
+            currentUser: $currentUser,
+            failIfExists: $failIfExists
         );
 
         // Invalidate contact matching cache for objects with email properties.

--- a/tests/Unit/Exception/ObjectExistsExceptionTest.php
+++ b/tests/Unit/Exception/ObjectExistsExceptionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Unit tests for ObjectExistsException.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Exception
+ *
+ * @author  Conduction Development Team <dev@conduction.nl>
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @spec openspec/specs/object-crud/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Exception;
+
+use OCA\OpenRegister\Exception\ObjectExistsException;
+use PHPUnit\Framework\TestCase;
+
+final class ObjectExistsExceptionTest extends TestCase
+{
+    /**
+     * 409 Conflict, not 403.
+     *
+     * A losing claim reported as "forbidden" is indistinguishable from a
+     * permissions problem, and the caller cannot tell it simply lost a race —
+     * which is the entire reason for asking for insert-only semantics.
+     *
+     * @return void
+     */
+    public function testExceptionCarriesStatus409(): void
+    {
+        $exception = new ObjectExistsException();
+        self::assertSame(expected: 409, actual: $exception->getCode());
+
+    }//end testExceptionCarriesStatus409()
+
+    /**
+     * The conflicting identifier is retrievable without parsing the message.
+     *
+     * @return void
+     */
+    public function testExceptionExposesUuid(): void
+    {
+        $exception = new ObjectExistsException(
+            message: 'An object with identifier "abc" already exists.',
+            uuid: 'abc'
+        );
+
+        self::assertSame(expected: 'abc', actual: $exception->getUuid());
+
+    }//end testExceptionExposesUuid()
+
+    /**
+     * The uuid is optional — a caller may raise it without one.
+     *
+     * @return void
+     */
+    public function testUuidIsNullWhenNotSupplied(): void
+    {
+        $exception = new ObjectExistsException();
+        self::assertNull(actual: $exception->getUuid());
+
+    }//end testUuidIsNullWhenNotSupplied()
+}//end class


### PR DESCRIPTION
Closes #2210.

## The problem, measured

`saveObject()` is an upsert. Given an identifier that already exists it updates — silently and successfully:

```
POST /api/objects/13/213 {"id":"a1b2…0001","name":"probe-1"}  -> created
POST /api/objects/13/213 {"id":"a1b2…0001","name":"probe-2"}  -> 200, same id
SELECT count(*), string_agg(_name,'|')                        ->  1 | probe-2
```

That is right for almost every caller. It is wrong for a caller **claiming** something — a lock, a slot, a lease, a queue position. There "it already existed" is the entire answer, and swallowing it means two callers both believe they won while the loser is never told. The `_uuid` unique constraint exists on the table, but nothing surfaces it: the collision resolves into an update before it can fail.

## What this adds — all opt-in

| | |
|---|---|
| `ObjectExistsException` | 409 Conflict, carries the uuid so a caller can tell "my claim lost" from other errors |
| `SaveObject::saveObject()` | `$failIfExists` (default **false**) + a guard on the existing-object branch |
| `ObjectService::saveObject()` | pass-through |
| `ObjectsController::create()` | `_failIfExists=true` → 409, caught **before** the generic `\Exception` handler that flattens to 403 |
| `ObjectWriteNode` | `onConflict: fail` for flows |

**Defaulting to `false` is the load-bearing choice.** Making create strictly-insert by default would change behaviour for every caller relying on today's upsert — and because that upsert is *silent*, there is no way to enumerate from the code who depends on it.

The controller catch placement matters too: a losing claim reported as "forbidden" is indistinguishable from a permissions problem, which defeats the purpose of asking for insert-only semantics.

## Verified on a live instance, both directions

```
default (no flag):    create=201, create=201  -> 1 row, last write wins   (unchanged)
_failIfExists=true:   create=201, create=409  -> 1 row, FIRST claimant kept it

409 body: {"error":"An object with identifier \"…\" already exists.","uuid":"…"}
```

Re-run after the final `phpcbf` reformat, not just before it.

## Gates

- `phpcs` clean on all changed files
- `phpstan` OK
- **15,516 unit tests green**, plus 3 new tests for the exception

## Consumer

hydra's flows-first port (hydra#425, decision D7): a concurrency cap expressed as slot objects, where `ObjectWriteNode`'s `findMatch` + `saveObject` pair could not claim a slot without a lost update. That task stayed deliberately blocked rather than shipping a lock that silently loses.

⚠️ Worth a reviewer's eye on the `SaveObject` guard placement specifically — it sits on the hottest write path in the fleet.