### PR TITLE
docs(objects): failIfExists is NOT a lock — say so where it is read

### DIFF
--- a/lib/Exception/ObjectExistsException.php
+++ b/lib/Exception/ObjectExistsException.php
@@ -41,6 +41,15 @@ use Throwable;
  * Uses HTTP 409 Conflict: the request could not be completed because of a
  * conflict with the current state of the resource (RFC 9110 §15.5.10).
  *
+ * ⚠️ NOT A LOCK — see openregister#2212. The guard that raises this sits
+ * between the existence lookup and the write, which are two separate
+ * operations. Under CONCURRENT claims several callers can all pass the lookup
+ * before any of them writes, and several receive 201. A sequential second
+ * create is correctly refused; simultaneous ones are not serialised. Do not
+ * rely on this for mutual exclusion until the arbitration moves into the
+ * database (a real INSERT against the `_uuid` unique constraint, or a
+ * transaction around check-and-write).
+ *
  * @category Exception
  * @package  OCA\OpenRegister\Exception
  *

--- a/lib/Service/Flow/Nodes/ObjectWriteNode.php
+++ b/lib/Service/Flow/Nodes/ObjectWriteNode.php
@@ -192,6 +192,11 @@ class ObjectWriteNode implements IFlowNode
      * answer, and overwriting it means two flow runs both believe they won
      * while the loser is never told. See openregister#2210.
      *
+     * ⚠️ NOT YET SAFE FOR MUTUAL EXCLUSION — openregister#2212. The underlying
+     * guard is a check followed by a write, so concurrent flow runs can all
+     * pass the check and several succeed. It refuses a sequential duplicate
+     * correctly; it does not serialise simultaneous ones.
+     *
      * @var string
      */
     private const ON_CONFLICT_FAIL = 'fail';

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -2916,6 +2916,15 @@ class SaveObject
                 // upsert is silent, so there is no way to discover from the code
                 // which callers depend on it. Flipping the default would change
                 // behaviour fleet-wide with no way to enumerate the blast radius.
+                //
+                // ⚠️ THIS IS NOT A LOCK — openregister#2212. This check and the
+                // write below are two separate operations, so N concurrent
+                // callers can all reach here having found nothing and all
+                // proceed. Measured: 10 simultaneous claims on one identifier
+                // returned 201 six times. It narrows the window; it does not
+                // close it. Closing it means letting the database arbitrate — a
+                // real INSERT against the `_uuid` unique constraint, translated
+                // into this exception.
                 if ($failIfExists === true) {
                     $this->logger->debug(
                         message: '[SaveObject] Existing object found and failIfExists is set, refusing the write',


### PR DESCRIPTION
Follow-up to #2211, which I merged with a guarantee stronger than it delivers.

## The concurrent test fails

10 simultaneous `POST …?_failIfExists=true` on one identifier, three runs:

```
run1: 201=6  409=2  rows=1
run2: 201=4  409=6  rows=1
run3: 201=2  409=8  rows=1
```

**Multiple callers receive 201.** One row survives, so the extra 201s are lost updates that reported success. The guard sits between the existence lookup and the write — two separate operations — so N callers can all pass the lookup before any writes.

My sequential test (`claim1 → 201`, `claim2 → 409`) passes precisely *because* it serialises the calls. That was the wrong test, and it is the one that convinced me.

## What still holds

- The **default path is untouched** — no existing caller is affected.
- A **sequential** duplicate is correctly refused.

## What does not

`_failIfExists` / `onConflict: fail` **must not be relied on for mutual exclusion.** Closing it means letting the database arbitrate: a real `INSERT` against the existing `_uuid` unique constraint, translated into `ObjectExistsException`. Tracked in #2212.

## This PR

Puts that warning in all three places someone reads before trusting it — the exception docblock, the guard in `SaveObject`, and the node's `onConflict` constant. Docs only; no behaviour change.

---

The acceptance criterion in hydra task 3.5 said *"prove this with two flows started simultaneously, not last"*. I wrote that criterion, then verified sequentially anyway.