### PR TITLE
perf(events): split object-event listeners sync/async — defer deleted-object cleanup, cache flow trigger index

### DIFF
--- a/lib/BackgroundJob/ObjectCleanupJob.php
+++ b/lib/BackgroundJob/ObjectCleanupJob.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * OpenRegister ObjectCleanupJob
+ *
+ * Actor-forwarded background job carrying the deferred work of
+ * ObjectCleanupListener: removing the notes, CalDAV tasks, email links,
+ * calendar-event links, contact links and deck-card links that belonged to a
+ * deleted object.
+ *
+ * Why this listener is deferrable even though its object is gone: every one
+ * of the six cleanups is keyed by the object UUID alone, so nothing needs to
+ * be re-fetched. The heavy part is real — TaskService walks the whole
+ * calendar and CalendarEventService rewrites vCards/VEVENTs — and all six
+ * services resolve the ACTING user, which is exactly what ActorForwardedJob
+ * re-establishes.
+ *
+ * Re-create guard: delivery is at-least-once and a UUID can legitimately come
+ * back (an import replaying the same identifiers, an undo). Cleaning up a
+ * LIVE object's notes and tasks would be data loss, so each entry is skipped
+ * when its (uuid, register, schema) resolves to an existing, non-soft-deleted
+ * object. Resolving to null is the expected case for a genuine delete.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category BackgroundJob
+ * @package  OCA\OpenRegister\BackgroundJob
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @psalm-suppress UnusedClass
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\BackgroundJob;
+
+use OCA\OpenRegister\Service\Deferral\DeferredEntryObjectResolver;
+use OCA\OpenRegister\Service\Deferral\DeferredListenerContext;
+use OCA\OpenRegister\Service\ObjectRelationCleanupService;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Deferred deleted-object relation cleanup under the forwarded actor.
+ *
+ * @spec openspec/changes/object-event-sync-async-split/specs/event-driven-architecture/spec.md
+ */
+class ObjectCleanupJob extends ActorForwardedJob
+{
+    /**
+     * Wire the cleanup collaborators on top of the actor plumbing.
+     *
+     * @param ITimeFactory                 $time         Time factory for the parent job class.
+     * @param IUserSession                 $userSession  Session to impersonate on / restore.
+     * @param IUserManager                 $userManager  Resolver for the captured user id.
+     * @param OrganisationService          $organisation Active-organisation resolver.
+     * @param LoggerInterface              $logger       PSR logger.
+     * @param DeferredEntryObjectResolver  $resolver     Re-create guard lookup.
+     * @param ObjectRelationCleanupService $cleanup      Shared cleanup implementation.
+     *
+     * @return void
+     */
+    public function __construct(
+        ITimeFactory $time,
+        IUserSession $userSession,
+        IUserManager $userManager,
+        OrganisationService $organisation,
+        LoggerInterface $logger,
+        private readonly DeferredEntryObjectResolver $resolver,
+        private readonly ObjectRelationCleanupService $cleanup
+    ) {
+        parent::__construct(
+            time: $time,
+            userSession: $userSession,
+            userManager: $userManager,
+            organisation: $organisation,
+            logger: $logger
+        );
+    }//end __construct()
+
+    /**
+     * Clean up every entry whose object is genuinely gone.
+     *
+     * Per-entry failures are logged and do not abort the chunk.
+     *
+     * @param DeferredListenerContext $context The captured dispatch-time context.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/object-event-sync-async-split/specs/event-driven-architecture/spec.md
+     */
+    protected function runDeferred(DeferredListenerContext $context): void
+    {
+        foreach ($context->getEntries() as $entry) {
+            $uuid = ($entry['uuid'] ?? null);
+            if (is_string($uuid) === false || $uuid === '') {
+                continue;
+            }
+
+            // Re-create guard: a live object under this UUID means the id came
+            // back between the delete and this job. Its relations belong to
+            // the NEW object; wiping them would be data loss.
+            if ($this->resolver->resolve(entry: $entry) !== null) {
+                $this->logger->info(
+                    message: '[ObjectCleanupJob] UUID resolves to a live object again — skipping deferred cleanup',
+                    context: [
+                        'file' => __FILE__,
+                        'line' => __LINE__,
+                        'uuid' => $uuid,
+                    ]
+                );
+                continue;
+            }
+
+            try {
+                $this->cleanup->cleanup(objectUuid: $uuid);
+            } catch (\Throwable $e) {
+                $this->logger->warning(
+                    message: '[ObjectCleanupJob] Cleanup failed for entry',
+                    context: [
+                        'file'  => __FILE__,
+                        'line'  => __LINE__,
+                        'uuid'  => $uuid,
+                        'error' => $e->getMessage(),
+                    ]
+                );
+            }
+        }//end foreach
+    }//end runDeferred()
+}//end class

--- a/lib/Listener/ObjectCleanupListener.php
+++ b/lib/Listener/ObjectCleanupListener.php
@@ -6,6 +6,17 @@
  * Listens for ObjectDeletedEvent and cleans up associated notes, tasks,
  * email links, calendar event links, contact links, and deck card links.
  *
+ * Post-event listener, so the work is DEFERRED by default (see
+ * openspec/changes/object-event-sync-async-split): the cleanup spans a full
+ * CalDAV calendar walk and vCard/VEVENT rewrites, none of which the deleting
+ * request needs to wait for. The listener itself now only buffers one entry
+ * per deleted object onto ListenerDeferralService; the real work runs in
+ * ObjectCleanupJob under the forwarded actor.
+ *
+ * Setting `openregister/listenerDeferral` to `inline` restores the previous
+ * synchronous behaviour — the identical ObjectRelationCleanupService call,
+ * executed in-request.
+ *
  * SPDX-License-Identifier: EUPL-1.2
  * SPDX-FileCopyrightText: 2026 Conduction B.V.
  *
@@ -22,16 +33,12 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Listener;
 
+use OCA\OpenRegister\BackgroundJob\ObjectCleanupJob;
 use OCA\OpenRegister\Event\ObjectDeletedEvent;
-use OCA\OpenRegister\Service\CalendarEventService;
-use OCA\OpenRegister\Service\ContactService;
-use OCA\OpenRegister\Service\DeckCardService;
-use OCA\OpenRegister\Service\EmailService;
-use OCA\OpenRegister\Service\NoteService;
-use OCA\OpenRegister\Service\TaskService;
+use OCA\OpenRegister\Service\Deferral\ListenerDeferralService;
+use OCA\OpenRegister\Service\ObjectRelationCleanupService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use Psr\Log\LoggerInterface;
 
 /**
  * ObjectCleanupListener cleans up all entity relations when an object is deleted.
@@ -51,104 +58,38 @@ use Psr\Log\LoggerInterface;
  *
  * @template-implements IEventListener<ObjectDeletedEvent>
  *
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Cleanup requires all service dependencies
+ * @spec openspec/changes/object-event-sync-async-split/specs/event-driven-architecture/spec.md
  */
 class ObjectCleanupListener implements IEventListener
 {
-
-    /**
-     * Note service.
-     *
-     * @var NoteService
-     */
-    private readonly NoteService $noteService;
-
-    /**
-     * Task service.
-     *
-     * @var TaskService
-     */
-    private readonly TaskService $taskService;
-
-    /**
-     * Email service.
-     *
-     * @var EmailService
-     */
-    private readonly EmailService $emailService;
-
-    /**
-     * Calendar event service.
-     *
-     * @var CalendarEventService
-     */
-    private readonly CalendarEventService $calendarEventService;
-
-    /**
-     * Contact service.
-     *
-     * @var ContactService
-     */
-    private readonly ContactService $contactService;
-
-    /**
-     * Deck card service.
-     *
-     * @var DeckCardService
-     */
-    private readonly DeckCardService $deckCardService;
-
-    /**
-     * Logger.
-     *
-     * @var LoggerInterface
-     */
-    private readonly LoggerInterface $logger;
-
     /**
      * Constructor.
      *
-     * @param NoteService          $noteService          Note service
-     * @param TaskService          $taskService          Task service
-     * @param EmailService         $emailService         Email service
-     * @param CalendarEventService $calendarEventService Calendar event service
-     * @param ContactService       $contactService       Contact service
-     * @param DeckCardService      $deckCardService      Deck card service
-     * @param LoggerInterface      $logger               Logger
+     * @param ListenerDeferralService      $deferral Buffers the entry and enqueues the chunk job.
+     * @param ObjectRelationCleanupService $cleanup  Shared cleanup, used by the inline fallback.
      *
      * @return void
      *
-     * @spec openspec/specs/event-driven-architecture/spec.md
+     * @spec openspec/changes/object-event-sync-async-split/specs/event-driven-architecture/spec.md
      */
     public function __construct(
-        NoteService $noteService,
-        TaskService $taskService,
-        EmailService $emailService,
-        CalendarEventService $calendarEventService,
-        ContactService $contactService,
-        DeckCardService $deckCardService,
-        LoggerInterface $logger
+        private readonly ListenerDeferralService $deferral,
+        private readonly ObjectRelationCleanupService $cleanup
     ) {
-        $this->noteService          = $noteService;
-        $this->taskService          = $taskService;
-        $this->emailService         = $emailService;
-        $this->calendarEventService = $calendarEventService;
-        $this->contactService       = $contactService;
-        $this->deckCardService      = $deckCardService;
-        $this->logger = $logger;
     }//end __construct()
 
     /**
      * Handle the ObjectDeletedEvent.
      *
-     * Cleans up all entity relations. Each cleanup runs independently;
-     * failure in one does not block the others.
+     * Buffers the deleted object's identity for ObjectCleanupJob. The entry
+     * carries register and schema alongside the uuid so the job's re-create
+     * guard can target one magic table instead of a cross-table UUID scan.
      *
      * @param Event $event The event to handle
      *
      * @return void
      *
-     * @spec openspec/specs/event-driven-architecture/spec.md
+     * @spec openspec/changes/object-event-sync-async-split/specs/event-driven-architecture/spec.md
      */
     public function handle(Event $event): void
     {
@@ -157,173 +98,24 @@ class ObjectCleanupListener implements IEventListener
         }
 
         $object     = $event->getObject();
-        $objectUuid = $object->getUuid();
+        $objectUuid = (string) $object->getUuid();
+        if ($objectUuid === '') {
+            return;
+        }
 
-        // (a) Delete all notes (comments).
-        $this->cleanupNotes(objectUuid: $objectUuid);
+        if ($this->deferral->isDeferralEnabled() === false) {
+            $this->cleanup->cleanup(objectUuid: $objectUuid);
+            return;
+        }
 
-        // (b) Delete all CalDAV tasks.
-        $this->cleanupTasks(objectUuid: $objectUuid);
-
-        // (c) Delete all email links.
-        $this->cleanupEmails(objectUuid: $objectUuid);
-
-        // (d) Unlink all calendar events (remove X-OPENREGISTER-* properties).
-        $this->cleanupCalendarEvents(objectUuid: $objectUuid);
-
-        // (e) Delete contact links and clean vCard properties.
-        $this->cleanupContacts(objectUuid: $objectUuid);
-
-        // (f) Delete deck card links.
-        $this->cleanupDeckCards(objectUuid: $objectUuid);
+        $this->deferral->defer(
+            jobClass: ObjectCleanupJob::class,
+            entry: [
+                'uuid'     => $objectUuid,
+                'register' => (string) $object->getRegister(),
+                'schema'   => (string) $object->getSchema(),
+            ],
+            dedupeKey: $objectUuid
+        );
     }//end handle()
-
-    /**
-     * Clean up notes for the deleted object.
-     *
-     * @param string $objectUuid The object UUID.
-     *
-     * @return void
-     *
-     * @spec openspec/specs/event-driven-architecture/spec.md
-     */
-    private function cleanupNotes(string $objectUuid): void
-    {
-        try {
-            $this->noteService->deleteNotesForObject($objectUuid);
-            $this->logger->info('Cleaned up notes for deleted object: '.$objectUuid);
-        } catch (\Exception $e) {
-            $this->logger->warning(
-                'Failed to clean up notes for deleted object: '.$objectUuid.': '.$e->getMessage(),
-                ['exception' => $e]
-            );
-        }
-    }//end cleanupNotes()
-
-    /**
-     * Clean up tasks for the deleted object.
-     *
-     * @param string $objectUuid The object UUID.
-     *
-     * @return void
-     *
-     * @spec openspec/specs/event-driven-architecture/spec.md
-     */
-    private function cleanupTasks(string $objectUuid): void
-    {
-        try {
-            $tasks = $this->taskService->getTasksForObject($objectUuid);
-            foreach ($tasks as $task) {
-                try {
-                    $this->taskService->deleteTask($task['calendarId'], $task['id']);
-                } catch (\Exception $e) {
-                    $this->logger->warning(
-                        'Failed to delete task '.$task['id'].' for object '.$objectUuid.': '.$e->getMessage(),
-                        ['exception' => $e]
-                    );
-                }
-            }
-
-            if (empty($tasks) === false) {
-                $this->logger->info('Cleaned up '.count($tasks).' task(s) for deleted object: '.$objectUuid);
-            }
-        } catch (\Exception $e) {
-            $this->logger->warning(
-                'Failed to clean up tasks for deleted object: '.$objectUuid.': '.$e->getMessage(),
-                ['exception' => $e]
-            );
-        }//end try
-    }//end cleanupTasks()
-
-    /**
-     * Clean up email links for the deleted object.
-     *
-     * @param string $objectUuid The object UUID.
-     *
-     * @return void
-     *
-     * @spec openspec/specs/event-driven-architecture/spec.md
-     */
-    private function cleanupEmails(string $objectUuid): void
-    {
-        try {
-            $count = $this->emailService->deleteLinksForObject($objectUuid);
-            if ($count > 0) {
-                $this->logger->info('Cleaned up '.$count.' email link(s) for deleted object: '.$objectUuid);
-            }
-        } catch (\Exception $e) {
-            $this->logger->warning(
-                'Failed to clean up email links for deleted object: '.$objectUuid.': '.$e->getMessage(),
-                ['exception' => $e]
-            );
-        }
-    }//end cleanupEmails()
-
-    /**
-     * Clean up calendar events for the deleted object (unlink, not delete).
-     *
-     * @param string $objectUuid The object UUID.
-     *
-     * @return void
-     *
-     * @spec openspec/specs/event-driven-architecture/spec.md
-     */
-    private function cleanupCalendarEvents(string $objectUuid): void
-    {
-        try {
-            $this->calendarEventService->unlinkEventsForObject($objectUuid);
-            $this->logger->info('Unlinked calendar events for deleted object: '.$objectUuid);
-        } catch (\Exception $e) {
-            $this->logger->warning(
-                'Failed to unlink calendar events for deleted object: '.$objectUuid.': '.$e->getMessage(),
-                ['exception' => $e]
-            );
-        }
-    }//end cleanupCalendarEvents()
-
-    /**
-     * Clean up contact links for the deleted object.
-     *
-     * @param string $objectUuid The object UUID.
-     *
-     * @return void
-     *
-     * @spec openspec/specs/event-driven-architecture/spec.md
-     */
-    private function cleanupContacts(string $objectUuid): void
-    {
-        try {
-            $this->contactService->deleteLinksForObject($objectUuid);
-            $this->logger->info('Cleaned up contact links for deleted object: '.$objectUuid);
-        } catch (\Exception $e) {
-            $this->logger->warning(
-                'Failed to clean up contact links for deleted object: '.$objectUuid.': '.$e->getMessage(),
-                ['exception' => $e]
-            );
-        }
-    }//end cleanupContacts()
-
-    /**
-     * Clean up deck card links for the deleted object.
-     *
-     * @param string $objectUuid The object UUID.
-     *
-     * @return void
-     *
-     * @spec openspec/specs/event-driven-architecture/spec.md
-     */
-    private function cleanupDeckCards(string $objectUuid): void
-    {
-        try {
-            $count = $this->deckCardService->deleteLinksForObject($objectUuid);
-            if ($count > 0) {
-                $this->logger->info('Cleaned up '.$count.' deck link(s) for deleted object: '.$objectUuid);
-            }
-        } catch (\Exception $e) {
-            $this->logger->warning(
-                'Failed to clean up deck links for deleted object: '.$objectUuid.': '.$e->getMessage(),
-                ['exception' => $e]
-            );
-        }
-    }//end cleanupDeckCards()
 }//end class

--- a/lib/Service/Flow/OpenRegisterFlowResolver.php
+++ b/lib/Service/Flow/OpenRegisterFlowResolver.php
@@ -39,11 +39,14 @@ namespace OCA\OpenRegister\Service\Flow;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\IAppConfig;
+use OCP\ICacheFactory;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
 /**
  * The resolver for OpenRegister's own flow objects.
+ *
+ * @spec openspec/changes/or-flow-native-store/specs/flow-native-store/spec.md
  */
 class OpenRegisterFlowResolver implements IFlowResolver
 {
@@ -65,15 +68,40 @@ class OpenRegisterFlowResolver implements IFlowResolver
     private const SCHEMA_DEFAULT = 'flow';
 
     /**
+     * Cache key the compact trigger index is stored under.
+     */
+    private const INDEX_CACHE_KEY = 'flow-trigger-index';
+
+    /**
+     * Config key overriding how long the trigger index stays cached.
+     */
+    private const INDEX_TTL_KEY = 'flow_trigger_index_ttl';
+
+    /**
+     * Seconds the trigger index stays cached (matches AggregationCache).
+     */
+    private const INDEX_TTL_DEFAULT = 60;
+
+    /**
+     * Request-level memo of the trigger index, avoiding a cache round trip
+     * per object in a bulk save.
+     *
+     * @var array<int, array<string, string>>|null
+     */
+    private ?array $indexMemo = null;
+
+    /**
      * Constructor.
      *
      * @param ObjectService   $objectService Loads and lists flow objects.
      * @param IAppConfig      $appConfig     Names the register and schema.
+     * @param ICacheFactory   $cacheFactory  Builds the distributed index cache.
      * @param LoggerInterface $logger        The logger.
      */
     public function __construct(
         private readonly ObjectService $objectService,
         private readonly IAppConfig $appConfig,
+        private readonly ICacheFactory $cacheFactory,
         private readonly LoggerInterface $logger
     ) {
 
@@ -180,18 +208,115 @@ class OpenRegisterFlowResolver implements IFlowResolver
      */
     public function flowsForTrigger(string $event, string $register, string $schema): array
     {
+        $ids = [];
+        foreach ($this->triggerIndex() as $entry) {
+            if ($entry['trigger'] !== $event) {
+                continue;
+            }
+
+            $flowRegister = $entry['triggerRegister'];
+            $flowSchema   = $entry['triggerSchema'];
+            if ($flowRegister !== '' && $flowRegister !== $register) {
+                continue;
+            }
+
+            if ($flowSchema !== '' && $flowSchema !== $schema) {
+                continue;
+            }
+
+            $ids[] = $entry['id'];
+        }//end foreach
+
+        return $ids;
+
+    }//end flowsForTrigger()
+
+    /**
+     * The compact (id, trigger, register, schema) index of ENABLED flows.
+     *
+     * Every object write asks "is any flow wired to this event?". Answering it
+     * by listing and rendering every flow object cost ~144 ms cold / ~9 ms warm
+     * per write, because the first touch of the flow register in a request pays
+     * register/schema resolution and magic-table metadata regardless of how few
+     * flows exist. The answer only changes when an admin edits a flow, so it is
+     * cached: the hot path reads a small array instead of the object store.
+     *
+     * Staleness is bounded by the TTL (default 60 s, the same bound
+     * AggregationCache uses); a newly enabled flow starts firing within that
+     * window. Set `openregister/flow_trigger_index_ttl` to `0` to disable
+     * caching and restore the previous read-through behaviour.
+     *
+     * @return array<int, array<string, string>> Index entries.
+     *
+     * @spec openspec/changes/object-event-sync-async-split/specs/event-driven-architecture/spec.md
+     */
+    private function triggerIndex(): array
+    {
+        if ($this->indexMemo !== null) {
+            return $this->indexMemo;
+        }
+
+        $ttl   = $this->appConfig->getValueInt(self::APP_ID, self::INDEX_TTL_KEY, self::INDEX_TTL_DEFAULT);
+        $cache = null;
+        if ($ttl > 0) {
+            $cache = $this->cacheFactory->createDistributed('openregister_flow_triggers');
+
+            $cached = $cache->get(self::INDEX_CACHE_KEY);
+            if (is_array($cached) === true) {
+                $this->indexMemo = $cached;
+                return $cached;
+            }
+        }
+
+        $index = $this->buildTriggerIndex();
+
+        if ($cache !== null) {
+            $cache->set(self::INDEX_CACHE_KEY, $index, $ttl);
+        }
+
+        $this->indexMemo = $index;
+
+        return $index;
+
+    }//end triggerIndex()
+
+    /**
+     * Read the flow store and reduce it to the trigger index.
+     *
+     * Only enabled flows are indexed, so the hot path never re-checks the flag.
+     * The query filters on `enabled` server-side; the trigger itself stays a
+     * PHP-side match because one index serves every event id.
+     *
+     * @return array<int, array<string, string>> Index entries.
+     */
+    private function buildTriggerIndex(): array
+    {
         try {
             $flows = $this->objectService->findAll(
-                config: ['filters' => ['register' => $this->flowRegister(), 'schema' => $this->flowSchema()]],
+                config: [
+                    'filters' => [
+                        'register' => $this->flowRegister(),
+                        'schema'   => $this->flowSchema(),
+                        'enabled'  => true,
+                    ],
+                ],
                 _rbac: false,
                 _multitenancy: false
             );
         } catch (Throwable $e) {
-            // No flow store yet — nothing to trigger.
-            return [];
-        }
+            // No flow store yet — nothing to trigger. Logged because an
+            // unreadable flow store and an empty one are indistinguishable
+            // from the caller, and the difference is "no flows configured"
+            // versus "every flow silently stopped firing".
+            $this->logger->info(
+                message: '[OpenRegisterFlowResolver] Flow store unreadable — no flows will be triggered: '.$e->getMessage(),
+                context: ['file' => __FILE__, 'line' => __LINE__]
+            );
 
-        $ids = [];
+            return [];
+        }//end try
+
+        $index = [];
         foreach ($flows as $flow) {
             if (($flow instanceof ObjectEntity) === false) {
                 continue;
@@ -202,26 +327,17 @@ class OpenRegisterFlowResolver implements IFlowResolver
                 continue;
             }
 
-            if ((string) ($data['trigger'] ?? '') !== $event) {
-                continue;
-            }
-
-            $flowRegister = (string) ($data['triggerRegister'] ?? '');
-            $flowSchema   = (string) ($data['triggerSchema'] ?? '');
-            if ($flowRegister !== '' && $flowRegister !== $register) {
-                continue;
-            }
-
-            if ($flowSchema !== '' && $flowSchema !== $schema) {
-                continue;
-            }
-
-            $ids[] = (string) $flow->getUuid();
+            $index[] = [
+                'id'              => (string) $flow->getUuid(),
+                'trigger'         => (string) ($data['trigger'] ?? ''),
+                'triggerRegister' => (string) ($data['triggerRegister'] ?? ''),
+                'triggerSchema'   => (string) ($data['triggerSchema'] ?? ''),
+            ];
         }//end foreach
 
-        return $ids;
+        return $index;
 
-    }//end flowsForTrigger()
+    }//end buildTriggerIndex()
 
     /**
      * The register flows are stored in.

--- a/lib/Service/ObjectRelationCleanupService.php
+++ b/lib/Service/ObjectRelationCleanupService.php
@@ -1,0 +1,244 @@
+<?php
+
+/**
+ * OpenRegister ObjectRelationCleanupService
+ *
+ * The relation cleanup that runs when an object is deleted: notes, CalDAV
+ * tasks, email links, calendar-event links, contact links and deck-card
+ * links. Extracted verbatim from ObjectCleanupListener so the inline
+ * (kill-switch) path and the deferred ObjectCleanupJob share ONE
+ * implementation and cannot drift.
+ *
+ * Every cleanup is keyed by the object UUID alone — none of them needs the
+ * ObjectEntity. That is why this listener's work is deferrable at all: the
+ * row is hard-deleted before ObjectDeletedEvent fires, so a job could never
+ * re-fetch it.
+ *
+ * Each cleanup is independent and fail-soft: a failure in one entity type is
+ * logged and does not block the others.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Cleans up every Nextcloud-entity relation belonging to a deleted object.
+ *
+ * @SuppressWarnings("PHPMD.CouplingBetweenObjects") Cleanup spans six entity services by design.
+ *
+ * @spec openspec/changes/object-event-sync-async-split/specs/event-driven-architecture/spec.md
+ */
+class ObjectRelationCleanupService
+{
+    /**
+     * Wire the entity services this cleanup spans.
+     *
+     * @param NoteService          $noteService          Note (comment) cleanup.
+     * @param TaskService          $taskService          CalDAV task cleanup.
+     * @param EmailService         $emailService         Email-link cleanup.
+     * @param CalendarEventService $calendarEventService Calendar-event unlinking.
+     * @param ContactService       $contactService       Contact-link cleanup.
+     * @param DeckCardService      $deckCardService      Deck-card-link cleanup.
+     * @param LoggerInterface      $logger               PSR logger.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly NoteService $noteService,
+        private readonly TaskService $taskService,
+        private readonly EmailService $emailService,
+        private readonly CalendarEventService $calendarEventService,
+        private readonly ContactService $contactService,
+        private readonly DeckCardService $deckCardService,
+        private readonly LoggerInterface $logger
+    ) {
+    }//end __construct()
+
+    /**
+     * Run every relation cleanup for one deleted object UUID.
+     *
+     * Idempotent by construction: each cleanup deletes rows matching the
+     * UUID, so a second run finds nothing and is a no-op. This is what makes
+     * the at-least-once delivery of the deferred job safe.
+     *
+     * @param string $objectUuid UUID of the deleted object.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/object-event-sync-async-split/specs/event-driven-architecture/spec.md
+     */
+    public function cleanup(string $objectUuid): void
+    {
+        // (a) Delete all notes (comments).
+        $this->cleanupNotes(objectUuid: $objectUuid);
+
+        // (b) Delete all CalDAV tasks.
+        $this->cleanupTasks(objectUuid: $objectUuid);
+
+        // (c) Delete all email links.
+        $this->cleanupEmails(objectUuid: $objectUuid);
+
+        // (d) Unlink all calendar events (remove X-OPENREGISTER-* properties).
+        $this->cleanupCalendarEvents(objectUuid: $objectUuid);
+
+        // (e) Delete contact links and clean vCard properties.
+        $this->cleanupContacts(objectUuid: $objectUuid);
+
+        // (f) Delete deck card links.
+        $this->cleanupDeckCards(objectUuid: $objectUuid);
+    }//end cleanup()
+
+    /**
+     * Clean up notes for the deleted object.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return void
+     */
+    private function cleanupNotes(string $objectUuid): void
+    {
+        try {
+            $this->noteService->deleteNotesForObject($objectUuid);
+            $this->logger->info('Cleaned up notes for deleted object: '.$objectUuid);
+        } catch (\Exception $e) {
+            $this->logger->warning(
+                'Failed to clean up notes for deleted object: '.$objectUuid.': '.$e->getMessage(),
+                ['exception' => $e]
+            );
+        }
+    }//end cleanupNotes()
+
+    /**
+     * Clean up tasks for the deleted object.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return void
+     */
+    private function cleanupTasks(string $objectUuid): void
+    {
+        try {
+            $tasks = $this->taskService->getTasksForObject($objectUuid);
+            foreach ($tasks as $task) {
+                try {
+                    $this->taskService->deleteTask($task['calendarId'], $task['id']);
+                } catch (\Exception $e) {
+                    $this->logger->warning(
+                        'Failed to delete task '.$task['id'].' for object '.$objectUuid.': '.$e->getMessage(),
+                        ['exception' => $e]
+                    );
+                }
+            }
+
+            if (empty($tasks) === false) {
+                $this->logger->info('Cleaned up '.count($tasks).' task(s) for deleted object: '.$objectUuid);
+            }
+        } catch (\Exception $e) {
+            $this->logger->warning(
+                'Failed to clean up tasks for deleted object: '.$objectUuid.': '.$e->getMessage(),
+                ['exception' => $e]
+            );
+        }//end try
+    }//end cleanupTasks()
+
+    /**
+     * Clean up email links for the deleted object.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return void
+     */
+    private function cleanupEmails(string $objectUuid): void
+    {
+        try {
+            $count = $this->emailService->deleteLinksForObject($objectUuid);
+            if ($count > 0) {
+                $this->logger->info('Cleaned up '.$count.' email link(s) for deleted object: '.$objectUuid);
+            }
+        } catch (\Exception $e) {
+            $this->logger->warning(
+                'Failed to clean up email links for deleted object: '.$objectUuid.': '.$e->getMessage(),
+                ['exception' => $e]
+            );
+        }
+    }//end cleanupEmails()
+
+    /**
+     * Clean up calendar events for the deleted object (unlink, not delete).
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return void
+     */
+    private function cleanupCalendarEvents(string $objectUuid): void
+    {
+        try {
+            $this->calendarEventService->unlinkEventsForObject($objectUuid);
+            $this->logger->info('Unlinked calendar events for deleted object: '.$objectUuid);
+        } catch (\Exception $e) {
+            $this->logger->warning(
+                'Failed to unlink calendar events for deleted object: '.$objectUuid.': '.$e->getMessage(),
+                ['exception' => $e]
+            );
+        }
+    }//end cleanupCalendarEvents()
+
+    /**
+     * Clean up contact links for the deleted object.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return void
+     */
+    private function cleanupContacts(string $objectUuid): void
+    {
+        try {
+            $this->contactService->deleteLinksForObject($objectUuid);
+            $this->logger->info('Cleaned up contact links for deleted object: '.$objectUuid);
+        } catch (\Exception $e) {
+            $this->logger->warning(
+                'Failed to clean up contact links for deleted object: '.$objectUuid.': '.$e->getMessage(),
+                ['exception' => $e]
+            );
+        }
+    }//end cleanupContacts()
+
+    /**
+     * Clean up deck card links for the deleted object.
+     *
+     * @param string $objectUuid The object UUID.
+     *
+     * @return void
+     */
+    private function cleanupDeckCards(string $objectUuid): void
+    {
+        try {
+            $count = $this->deckCardService->deleteLinksForObject($objectUuid);
+            if ($count > 0) {
+                $this->logger->info('Cleaned up '.$count.' deck link(s) for deleted object: '.$objectUuid);
+            }
+        } catch (\Exception $e) {
+            $this->logger->warning(
+                'Failed to clean up deck links for deleted object: '.$objectUuid.': '.$e->getMessage(),
+                ['exception' => $e]
+            );
+        }
+    }//end cleanupDeckCards()
+}//end class

--- a/openspec/changes/object-event-sync-async-split/.openspec.yaml
+++ b/openspec/changes/object-event-sync-async-split/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/object-event-sync-async-split/design.md
+++ b/openspec/changes/object-event-sync-async-split/design.md
@@ -1,0 +1,240 @@
+# Design — object-event-sync-async-split (openregister)
+
+## Context
+
+`actor-forwarded-listener-jobs` (17/17 tasks implemented, not yet archived)
+supplies everything this change needs: `ListenerDeferralService` (actor
+capture, per-job-class entry buffers, chunk + shutdown flush, per-entry dedupe
+keys, `listenerDeferral` kill switch), `DeferredListenerContext`,
+`DeferredEntryObjectResolver` (stale-safe re-fetch) and the abstract
+`ActorForwardedJob` (impersonate, `finally` restore, skip-on-unresolvable-user).
+**This change designs no new mechanism.** Its D4 table is the precedent format
+for the verdict table below.
+
+The rule this change enforces is written fleet-wide in
+`hydra/openspec/changes/object-event-sync-async-split/` (ADR-078). This
+document is the OpenRegister-local application of it.
+
+### Measured today (2026-07-30, development instance)
+
+- `mm:EVENT-DISPATCH` per object write: n=32, min 42 / median 133 / p95 175 /
+  max 206 ms (147–248 ms historically), against a ~250 ms write.
+- **DI construction of all 21 listener classes: < 1 ms total** (0.31 ms cold,
+  worst ordering). Construction is not the cost.
+- **Handler bodies, one `ObjectCreatedEvent`, warm best-of-3, total 51.15 ms**:
+  FlowTrigger 42.64, ObjectChange 3.82, ObjectMetrics 2.30, WebhookEvent 1.08,
+  Action 0.84, TranslationProjection 0.38, GraphQLSubscription 0.07,
+  AnnotationNotification 0.01, all others ~0.00.
+- Cold first-call-in-process, **each measured in its own process so shared
+  one-time costs are counted repeatedly — an upper bound, NOT a sum**:
+  SourceRecordChange 299, FlowTrigger 172, WebhookEvent 22.7,
+  TranslationProjection 13.9, AnnotationNotification 12.4, ObjectChange 7.0,
+  AggregationThreshold 6.5, Hook 5.8, ObjectMetrics 3.5, Action 3.1,
+  FlowAction 2.5, GraphQLSubscription 0.6, ContextChatSubmission 0.6,
+  AggregationCacheInvalidation 0.4, NotifyPush 0.2 ms.
+- The three listeners deferred by `actor-forwarded-listener-jobs` now measure
+  **0.0–0.4 ms warm**, confirming the contract works.
+
+### Two structural facts that shape every verdict
+
+1. **Post-events have no mutation or veto surface.** `ObjectCreatedEvent`
+   exposes only `getObject()`; `ObjectUpdatedEvent` adds `getNewObject()` /
+   `getOldObject()`. Neither implements `StoppableEventInterface`. A
+   `stopPropagation()` or `setModifiedData()` call in a post-event listener is
+   dead code. A grep for `stopPropagation` / `setErrors` / `throw` across the
+   post-event listeners returned **zero** hits — no post-event listener is
+   secretly acting as a veto.
+2. **`ObjectDeletedEvent` fires after a HARD delete.** `MagicMapper.php:8721`
+   dispatches it following `deleteObjectEntity(hardDelete: true)`, so the row is
+   gone and **nothing on the delete path can be re-fetched**. Every delete-path
+   deferral therefore needs an explicit payload contract, or is blocked.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Take the six DEFER-SAFE post-event listeners off the synchronous write path
+  using the existing contract.
+- Remove — not relocate — the dominant `FlowTriggerListener` cost by fixing
+  trigger resolution.
+- Record the full 21-class classification where it can be audited (tasks.md).
+- Make a future undeclared synchronous post-event listener fail a build.
+
+**Non-Goals**
+
+- Redesigning or extending `ListenerDeferralService` / `ActorForwardedJob`.
+- Deferring `FlowTriggerService::runInline()` — an explicitly published
+  synchronous contract (see D2).
+- Converting any leaf app's listeners.
+- Changing pre-event (`*ing`) listener behaviour in any way.
+
+## Decisions
+
+### D1. Deferral verdicts come from a named blocker, never from a cost threshold
+
+`GraphQLSubscriptionListener` costs 0.07 ms warm and is **undeferrable**;
+`ObjectCleanupListener` is heavy and is the easiest deferral in the set. Cost
+does not predict deferrability. Each verdict below therefore names either the
+mechanism that makes deferral safe, or the specific fact that blocks it.
+
+### D2. `FlowTriggerListener`: fix resolution, do not defer execution
+
+The listener is a thin shim, and `FlowRunService::queue()` already defers flow
+*execution* to `FlowRunWorker`. The 42.64 ms is trigger **resolution**:
+`OpenRegisterFlowResolver::flowsForTrigger()`
+(`lib/Service/Flow/OpenRegisterFlowResolver.php:181`) does an unfiltered,
+unlimited, fully rendered `ObjectService::findAll()` over every flow object on
+every write, then filters in PHP — 144 ms cold / 8–9 ms warm, returning 1 flow.
+
+Deferring the listener would move that into cron, where it would still run once
+per write. The fix is at the query: constrain by trigger, register and schema,
+apply a bound, disable rendering, and memoize the resolved set per (trigger,
+register, schema) for the request.
+
+`FlowTriggerService::runInline()` (`FlowTriggerService.php:114`) must stay
+inline. It deliberately executes flows declaring `executionMode: sync` inside
+the triggering request — the guarantee that "its effects are done before the
+caller's save returns" is a published contract. Pushing it into a job would
+break every consumer relying on read-after-write. This is a `realtime`-category
+exception under ADR-078 and is annotated as such.
+
+Alternatives considered: (a) defer resolution and execution wholesale —
+rejected, breaks the `executionMode: sync` contract; (b) cache the full flow
+list instance-wide — rejected, invalidation on flow edits is a new correctness
+problem for no additional benefit over a filtered query.
+
+### D3. `SourceRecordChangeListener`: deferrable only under a resolved-master payload contract
+
+Heaviest inline work in the whole set: a reverse-FK index build via `findAll`
+over every schema, then per-master `ObjectService::find()` and a **full re-save
+(`saveObject`) — a recursive write cascade**.
+
+Two values are not re-fetchable at job time:
+
+1. **Updated path** needs `$event->getOldObject()`. If a source record was
+   re-parented to a different master, **both** masters must recompute. The old
+   parent is gone from current state.
+2. **Deleted path** reads `$data[$referenceField]` off a row that
+   `MagicMapper.php:8721` has already hard-deleted.
+
+Therefore the deferred entry carries the **resolved master UUIDs (new and
+old)**, not the source uuid — resolution happens inline, where the data still
+exists, and only the recompute is deferred. Dedupe key = `masterUuid`, so a
+bulk edit of 500 source records collapses to one recompute per master.
+
+**Security posture, called out rather than hidden:** the recompute calls
+`find(_rbac: true, _multitenancy: true)`. Per the `ActorForwardedJob` contract,
+the job re-derives organisation from the restored user's *current* persistent
+config and never resurrects captured authority. For a cross-organisation master
+this can resolve differently than the inline run did. That is the deliberate
+posture inherited from `actor-forwarded-listener-jobs` ("re-establish identity,
+never re-establish stale authority"); the drift is logged and the job proceeds
+under current authority. If a recompute resolves nothing under current
+authority, it no-ops rather than partially writing.
+
+### D4. Per-listener classification — 21 classes, 51 registrations
+
+**PRE-EVENT — MUST STAY SYNCHRONOUS.** All five mutate via `setObject()` or can
+veto. None can ever be deferred.
+
+| Listener | Events | Why it must stay inline |
+|---|---|---|
+| `LifecycleInitialStateListener` | Creating | `setObject()` seeds lifecycle state before persistence |
+| `CalculationOnSaveListener` | Creating, Updating | `setObject()` materialises computed fields; **consumes a sequence number on create**, so it must not run twice |
+| `QualityScoreOnSaveListener` | Creating, Updating | `setObject()` patches the quality score pre-persist |
+| `SurvivorshipRecomputeListener` | Creating, Updating | `setObject()` patches `goldenRecordField` / `provenanceField` |
+| `HookListener` | Creating, Updating, Deleting (`Application.php:2624-2626`) | `HookExecutor::applyFailureMode` can **veto the save** here |
+
+**POST-EVENT — deferred by this change.**
+
+| Listener | Events | Mechanism / payload contract |
+|---|---|---|
+| `ObjectCleanupListener` | Deleted | Best candidate. 6 cleanups incl. a full CalDAV calendar scan (`TaskService::getTasksForObject` walks the entire calendar), calendar unlink, vCard rewrite, deck/email/comment deletes. **Every one of the six private cleanups takes only `$objectUuid`** (`handle()` L160) → the hard-delete blocker does not apply. All six read `userSession->getUser()` → solved by actor forwarding. |
+| `HookListener` | Created, Updated, Deleted (`Application.php:2627-2629`) | Outbound HTTP: `HookExecutor::executeHooks()` → `adapter->executeWorkflow(timeout: 30)`, sync by default. `getObjectFromEvent()` already handles both halves → registration-level split, not a rewrite. Deleted entry carries the serialized object. |
+| `FlowActionListener` | C/U/D | Mail (`IMailer`), CalDAV event create, federation share, agent dispatch. `CalendarEventService` uses `IUserSession->getUser()` → actor forwarding. Deleted entry carries payload. |
+| `ContextChatSubmissionListener` | C/U/D | `allSeenUserIds()` walks every seen user as a broadcast fallback. **Caveat:** at-least-once means a deferred `deleteContent` for uuid `00000000-0000-0000-0000-000000000000` can land after that uuid was re-created → the job MUST check existence before removing. |
+| `ActionListener` | C/U/D | Outbound HTTP with per-action timeout; today only *failure* retries via `ActionRetryJob`, so the first attempt is synchronous. Deleted entry carries payload. |
+| `SourceRecordChangeListener` | C/U/D | Deferrable **only** under D3's resolved-master payload contract (new + old master UUIDs resolved inline). Dedupe key = masterUuid. RBAC-authority caveat per D3. |
+
+**POST-EVENT — blocked, with the blocking reason.**
+
+| Listener | Events | Verdict | Blocking reason |
+|---|---|---|---|
+| `FlowTriggerListener` | C/U/D | **fix, don't defer** | Execution already deferred to `FlowRunWorker`; the cost is trigger resolution (D2). `runInline()` is a published synchronous contract. ADR-078 category `realtime`. |
+| `NotifyPushListener` | C/U/D | keep inline — latency | It **is** the realtime channel. Also holds per-request static state (`self::$seen`, `$batchMode`, `$batchedCollections`) whose semantics assume one request lifetime. Category `realtime`. |
+| `GraphQLSubscriptionListener` | C/U/D | keep inline — **hard technical blocker** | `SubscriptionService::pushEvent` stores via `apcu_store` (`SubscriptionService.php:122`). APCu is **per-SAPI**: a cron/CLI worker writes a different segment, so SSE readers on the web SAPI would never observe the event. Deferring does not delay this listener, it **silently breaks** it. Category `sapi-memory`. This is the fleet's cautionary example. |
+| `AggregationCacheInvalidationListener` | C/U/D | keep inline — cheap + latency | 1 cache get + 1 set (version bump). A read later in the same request would see stale aggregations; deferring turns a bounded 60 s staleness into cron-interval staleness. Category `cheap-bounded`. |
+| `ObjectMetricsListener` | C/U/D | keep inline — cheap | A single fail-soft INSERT. Enqueuing costs a job-list INSERT plus a cron round trip to save one INSERT — strictly worse — and would blur the metric timestamp. Category `cheap-bounded`. |
+| `NotificationDedupePruneListener` | Deleted | keep inline — **correctness hazard** | The prune exists so a re-created object with the same UUID re-arms cleanly. A prune landing after a same-uuid re-create would wipe freshly-armed state. Category `correctness`. |
+| `WebhookEventListener` | C/U/D | already async | Enqueues `WebhookDeliveryJob` per webhook, per ADR-009 Rule 5. **One micro-inefficiency to fix:** `extractPayload()` runs and `jsonSerialize()`s the entity **before** `dispatchEvent`'s zero-webhook guard (`WebhookService.php:660`), so every write pays serialization even with no webhooks configured. |
+| `ObjectChangeListener` | C/U | already async | Enqueues `ObjectTextExtractionJob`. Residual sync path is the admin opt-in `extractionMode === 'immediate'` — left as-is, it is an explicit admin choice. |
+| `TranslationProjectionListener` | C/U/Transitioned | already deferred | `actor-forwarded-listener-jobs`. Deleted branch stays inline by design. |
+| `AnnotationNotificationListener` | C/U/Transitioned | already deferred | `actor-forwarded-listener-jobs`. |
+| `AggregationThresholdListener` | C/U/Transitioned | already deferred | `actor-forwarded-listener-jobs`. Deleted branch stays inline by design. |
+
+### D5. Enforcement — annotations plus a build-failing gate
+
+Hydra gate 61 (`listener-work-placement`, added by the hydra sibling change)
+fails a PR that registers a listener on a `*ed` post-event whose handler reaches
+outbound I/O, a write, or an unbounded query without either routing through
+`ListenerDeferralService` or carrying:
+
+```php
+/** @listener-placement inline sapi-memory — apcu_store is per-SAPI; a cron worker writes a different segment than the SSE readers */
+```
+
+OpenRegister's obligation in this change is to annotate every post-event
+handler that stays inline with one of the four ADR-078 categories
+(`realtime` / `sapi-memory` / `cheap-bounded` / `correctness`) and free text,
+so the gate passes green on OpenRegister with **justified, readable** exclusions
+rather than a blanket suppression. Verification is by exit code: a deliberately
+violating listener must make `run-hydra-gates.sh` exit non-zero. A FAIL line on
+stdout is not evidence.
+
+## Risks / Trade-offs
+
+- **Deferred delete-path work vs re-created UUIDs.** → Every deferred delete
+  handler re-checks existence via `DeferredEntryObjectResolver` before acting;
+  `ContextChatSubmissionListener`'s `deleteContent` is the named instance.
+- **`HookListener` split across two registration groups is easy to get wrong.**
+  A future edit could re-add a post-event to the inline group and silently undo
+  this change. → The split lives in `Application.php:2624-2629` with a comment
+  naming ADR-078, and gate 61 catches the re-add.
+- **`SourceRecordChangeListener` recompute is a recursive write cascade.**
+  Deferring it means the cascade runs under cron with at-least-once delivery. →
+  masterUuid dedupe collapses repeats; the recompute is a reconciliation against
+  current state, so re-running converges.
+- **Cross-organisation authority drift on the recompute (D3).** → Logged,
+  proceeds under current authority, no-ops rather than partially writing.
+- **Fixing `flowsForTrigger()` could change which flows fire** if the PHP-side
+  filter and the new query-side filter disagree. → Land the filtered query
+  behind a parity assertion in tests: for a fixture set, the filtered result
+  must equal the previous PHP-filtered result.
+- **Cron unhealthy → six side effects stall.** → `occ config:app:set
+  openregister listenerDeferral --value inline` restores synchronous behaviour,
+  as established by `actor-forwarded-listener-jobs`.
+
+## Migration Plan
+
+1. Filtered `flowsForTrigger()` + the `WebhookService` guard reorder first —
+   pure wins, no behavioural deferral, immediately measurable.
+2. `ObjectCleanupListener` next — highest benefit, no payload contract needed.
+3. `HookListener` registration split, then `FlowActionListener`, `ActionListener`,
+   `ContextChatSubmissionListener`.
+4. `SourceRecordChangeListener` last — it carries the payload contract and the
+   authority caveat.
+5. Annotate the six inline-by-exception listeners; run gate 61.
+
+Rollback: `listenerDeferral=inline` restores synchronous behaviour for every
+deferred listener without a deploy. The `flowsForTrigger()` fix is not covered
+by that switch and is reverted by code if the parity assertion ever fails in
+production.
+
+## Open Questions
+
+- Whether the `@listener-placement` annotation belongs on the handler method or
+  on the registration site in `Application.php`. Handler method is proposed
+  (it is where the evidence lives); the registration site is where the gate
+  finds the event name.
+- Whether `ObjectChangeListener`'s `extractionMode === 'immediate'` admin
+  opt-in should be removed outright rather than left as a documented sync path.

--- a/openspec/changes/object-event-sync-async-split/proposal.md
+++ b/openspec/changes/object-event-sync-async-split/proposal.md
@@ -1,0 +1,152 @@
+---
+kind: code
+---
+
+## Why
+
+`actor-forwarded-listener-jobs` built the deferral contract
+(`ListenerDeferralService`, `DeferredListenerContext`,
+`DeferredEntryObjectResolver`, `ActorForwardedJob`) and used it on three
+listeners. It works: those three now measure **0.0–0.4 ms warm**. But adoption
+stopped there. OpenRegister registers **51 of the fleet's 149 object lifecycle
+listener registrations** across **21 distinct listener classes**, and 18 of
+those classes still run their full handler body inside the caller's request.
+
+`mm:EVENT-DISPATCH` is now the largest single remaining cost in an object
+write — 147–248 ms historically, re-measured 2026-07-30 at n=32 (host load
+3.2): min 42, median 133, p95 175, max 206 ms — against a write that was
+already brought from 13,688 ms to ~250 ms.
+
+Two measurements taken 2026-07-30 tell us exactly where to aim:
+
+- **Constructing all 21 listener classes costs < 1 ms in total** (0.31 ms cold,
+  worst ordering). The cost is not "too many listeners registered". It is
+  handler *bodies*.
+- **Handler bodies on one `ObjectCreatedEvent`, warm best-of-3, total 51.15 ms**,
+  of which `FlowTriggerListener` alone is **42.64 ms** — 83 % of it. Next:
+  `ObjectChangeListener` 3.82, `ObjectMetricsListener` 2.30,
+  `WebhookEventListener` 1.08, `ActionListener` 0.84,
+  `TranslationProjectionListener` 0.38, `GraphQLSubscriptionListener` 0.07,
+  `AnnotationNotificationListener` 0.01; the remaining 13 are ~0.00.
+
+The `FlowTriggerListener` number is not the listener. Root cause:
+`FlowTriggerService::fire()` → `FlowResolverRegistry::flowsForTrigger()` →
+`OpenRegisterFlowResolver::flowsForTrigger()`
+(`lib/Service/Flow/OpenRegisterFlowResolver.php:181`) performs an
+**unfiltered, unlimited, fully rendered `ObjectService::findAll()` of every
+flow object on every object write**, then filters in PHP by trigger, register
+and schema. 144 ms cold / 8–9 ms warm — **to return one flow**. Deferring the
+listener would move that cost to cron rather than remove it; the correct fix is
+filtered resolution.
+
+And nothing enforces any of this. The `*ing` / `*ed` suffix already encodes the
+rule — pre-events implement `StoppableEventInterface` and mutate via
+`setObject()`, post-events expose no mutation and no veto API at all — so a
+`stopPropagation()` inside a post-event listener is dead code. The next
+listener anyone adds can register a synchronous outbound HTTP call on
+`ObjectCreatedEvent` and every gate stays green.
+
+## What Changes
+
+- **Six DEFER-SAFE post-event listeners move onto the existing contract.** No
+  new mechanism: each gets an `ActorForwardedJob` subclass, a cheap inline
+  interest gate, and the `listenerDeferral=inline` kill-switch fallback that
+  `actor-forwarded-listener-jobs` already established.
+  - `ObjectCleanupListener` (Deleted) — the best candidate. Six cleanups
+    including a **full CalDAV calendar scan** (`TaskService::getTasksForObject`
+    walks the entire calendar), calendar unlink, vCard rewrite, deck/email/
+    comment deletes. Critically, every one of the six private cleanups takes
+    **only `$objectUuid`** (`handle()` L160), so the "hard-deleted row is gone"
+    blocker that stops other delete-path deferrals does not apply here. All six
+    services read `userSession->getUser()` — already solved by actor forwarding.
+  - `HookListener` — **only** its Created/Updated/Deleted registrations
+    (`Application.php:2627-2629`). Outbound HTTP via
+    `HookExecutor::executeHooks()` → `adapter->executeWorkflow(timeout: 30)`,
+    synchronous by default. `getObjectFromEvent()` already handles both halves,
+    so this is a registration-level split, not a rewrite. The Deleted case
+    carries the serialized object in the entry payload.
+  - `FlowActionListener` (C/U/D) — mail (`IMailer`), CalDAV event creation,
+    federation share, agent dispatch. `CalendarEventService` uses
+    `IUserSession->getUser()`; actor forwarding covers it. Delete needs payload.
+  - `ContextChatSubmissionListener` (C/U/D) — with a caveat:
+    `allSeenUserIds()` walks every seen user on the instance as a broadcast
+    audience fallback. Under at-least-once delivery a deferred `deleteContent`
+    for uuid X can land **after** X was re-created, so the job MUST check
+    existence before removing.
+  - `ActionListener` (C/U/D) — outbound HTTP with a per-action timeout; today
+    only *failure* retries (`ActionRetryJob`), so the first attempt is
+    synchronous. Delete needs payload.
+  - `SourceRecordChangeListener` (C/U/D) — deferrable **only under a strict
+    payload contract**, see design D3. Two things are not re-fetchable: the
+    Updated path needs `$event->getOldObject()` so a source re-parented to a
+    different master refreshes **both** masters, and the Deleted path reads
+    `$data[$referenceField]` off a hard-deleted row. The entry therefore carries
+    the **resolved master UUIDs (new + old)**, not the source uuid. Dedupe key =
+    masterUuid, collapsing a bulk source edit into one recompute.
+- **`OpenRegisterFlowResolver::flowsForTrigger()` is fixed at the query, not
+  deferred.** `FlowTriggerService::runInline()`
+  (`FlowTriggerService.php:114`) deliberately executes flows declaring
+  `executionMode: sync` inside the triggering request — "its effects are done
+  before the caller's save returns" is a **published contract**. That must not
+  move into a job. What must change is resolution: filter by trigger, register
+  and schema at query time, apply a bound, skip rendering, and cache the
+  resolved set per (trigger, register, schema) for the request.
+- **`WebhookService::dispatchEvent()` stops paying serialization when there are
+  no webhooks.** `extractPayload()` runs and `jsonSerialize()`s the entity
+  *before* the zero-webhook guard (`WebhookService.php:660`). Move the guard
+  first.
+- **The classification is recorded in `tasks.md`** — all 21 classes, pre vs
+  post, deferred vs blocked **with the blocking reason** — so the decision is
+  auditable rather than folklore, following the `design.md` D4 table format of
+  `actor-forwarded-listener-jobs`.
+- **`@listener-placement` annotations** on every post-event handler that stays
+  inline, naming one of the four ADR-078 categories, so hydra gate 61
+  (`listener-work-placement`) passes green on OpenRegister with justified,
+  readable exclusions rather than a blanket suppression.
+
+Explicitly NOT changed: the five pre-event listeners
+(`LifecycleInitialStateListener`, `CalculationOnSaveListener`,
+`QualityScoreOnSaveListener`, `SurvivorshipRecomputeListener`, and
+`HookListener`'s Creating/Updating/Deleting registrations). They mutate via
+`setObject()` or can veto, and `CalculationOnSaveListener` **consumes a
+sequence number on create**, so it must not run twice. Also unchanged:
+`NotifyPushListener`, `GraphQLSubscriptionListener`,
+`AggregationCacheInvalidationListener`, `ObjectMetricsListener`,
+`NotificationDedupePruneListener` — each blocked for a named reason in design
+D4.
+
+## Capabilities
+
+### Modified Capabilities
+- `event-driven-architecture`: adds the normative sync/async placement rule for
+  OpenRegister's own object lifecycle listeners — the closed synchronous
+  exception categories, the payload contract for delete-path and old-state
+  deferral, filtered trigger resolution, and the requirement that the
+  classification be recorded and mechanically checked.
+
+## Impact
+
+- Affected code: `lib/Listener/ObjectCleanupListener.php`, `HookListener.php`,
+  `FlowActionListener.php`, `ContextChatSubmissionListener.php`,
+  `ActionListener.php`, `SourceRecordChangeListener.php`;
+  `lib/AppInfo/Application.php` (registration split for `HookListener`,
+  L2624-2629); six new `ActorForwardedJob` subclasses under
+  `lib/BackgroundJob/`; `lib/Service/Flow/OpenRegisterFlowResolver.php`;
+  `lib/Service/WebhookService.php` (guard ordering).
+- Request-path effect: the six deferred listeners leave the synchronous write
+  path, replaced by an interest gate plus a buffered entry append (one
+  `oc_jobs` INSERT per chunk). Filtered flow resolution removes the dominant
+  42.64 ms warm item outright rather than relocating it.
+- Behavioural: those six side effects become eventually consistent (next cron
+  run). Delivery is at-least-once; every job re-resolves and no-ops on a gone
+  or soft-deleted object. `occ config:app:set openregister listenerDeferral
+  --value inline` restores the pre-change synchronous behaviour instance-wide.
+- Consumers: opencatalogi and softwarecatalog exercise object writes heavily;
+  both must be regression-checked, particularly hook-driven workflows
+  (`HookListener`) and source-record master recompute.
+- Security: `SourceRecordChangeListener`'s recompute calls
+  `find(_rbac: true, _multitenancy: true)`. In a job that runs under the
+  **current** organisation authority of the forwarded user, not the captured
+  authority — for a cross-organisation master this can resolve differently than
+  it did inline. Called out as an accepted, logged posture (design D3), not
+  papered over.

--- a/openspec/changes/object-event-sync-async-split/specs/event-driven-architecture/spec.md
+++ b/openspec/changes/object-event-sync-async-split/specs/event-driven-architecture/spec.md
@@ -1,0 +1,237 @@
+## ADDED Requirements
+
+### Requirement: Post-event object listeners MUST defer heavy work through the existing deferral contract
+
+A post-event listener MUST NOT perform outbound I/O, a database write, or an
+unbounded query inside the request that produced the event — this covers every
+listener registered on `ObjectCreatedEvent`, `ObjectUpdatedEvent` or
+`ObjectDeletedEvent`. It MUST route the work through `ListenerDeferralService` into an
+`ActorForwardedJob` subclass, keeping only a cheap interest gate and a buffered
+entry append on the request path.
+
+Post-events expose no mutation and no veto API — `ObjectCreatedEvent` exposes
+only `getObject()`, `ObjectUpdatedEvent` adds `getNewObject()` /
+`getOldObject()`, and neither implements `StoppableEventInterface`. Any
+`stopPropagation()` or `setModifiedData()` call inside a post-event listener is
+therefore dead code and MUST NOT be relied upon.
+
+No new deferral mechanism MAY be introduced. The contract established by
+`actor-forwarded-listener-jobs` is the only one, including its
+`listenerDeferral` kill switch, which MUST continue to restore full synchronous
+behaviour for every listener this requirement covers.
+
+#### Scenario: Cleanup work leaves the delete request
+
+- **GIVEN** an object is hard-deleted and `ObjectCleanupListener` is registered
+  on `ObjectDeletedEvent`
+- **WHEN** the delete request runs
+- **THEN** the request-path work SHALL be limited to an interest gate plus an
+  enqueue through `ListenerDeferralService`
+- **AND** the CalDAV calendar scan, calendar unlink, vCard rewrite and the deck,
+  email and comment deletions SHALL be performed by the resulting background job
+
+#### Scenario: Kill switch restores synchronous behaviour
+
+- **GIVEN** `openregister listenerDeferral` is set to `inline`
+- **WHEN** any object lifecycle event covered by this requirement is dispatched
+- **THEN** the listener SHALL execute its full work inline exactly as before
+  this change
+- **AND** no background job SHALL be enqueued for it
+
+#### Scenario: A post-event listener cannot veto
+
+- **GIVEN** a listener on `ObjectCreatedEvent` calls `stopPropagation()`
+- **WHEN** the event completes
+- **THEN** the write SHALL already have been persisted and SHALL NOT be affected
+
+### Requirement: Pre-event listeners MUST remain synchronous and MUST NOT be deferred
+
+Pre-event listeners MUST run inline within the write — that is, every listener
+registered on `ObjectCreatingEvent`, `ObjectUpdatingEvent` or
+`ObjectDeletingEvent`. They mutate the object
+via `setObject()` before persistence, or may veto it, and deferral would produce
+either a lost mutation or a write that cannot be stopped.
+
+`CalculationOnSaveListener` MUST additionally be invoked exactly once per create,
+because it consumes a sequence number; any change that could cause it to run
+twice for one create is prohibited.
+
+`HookListener` MUST retain its `Creating` / `Updating` / `Deleting`
+registrations inline, because `HookExecutor::applyFailureMode` can veto the save
+at that point. Only its `Created` / `Updated` / `Deleted` registrations may be
+deferred, and the split MUST be made at the registration site.
+
+#### Scenario: Pre-event mutation reaches persistence
+
+- **GIVEN** `LifecycleInitialStateListener` is registered on `ObjectCreatingEvent`
+- **WHEN** an object is created
+- **THEN** the listener SHALL run inline and its `setObject()` mutation SHALL be
+  present in the persisted row
+
+#### Scenario: Sequence number is consumed once per create
+
+- **GIVEN** a schema whose create path runs `CalculationOnSaveListener`
+- **WHEN** one object is created
+- **THEN** exactly one sequence number SHALL be consumed
+
+#### Scenario: HookListener veto still works after the split
+
+- **GIVEN** `HookListener` is registered inline on `ObjectCreatingEvent` and
+  deferred on `ObjectCreatedEvent`
+- **WHEN** a hook's failure mode rejects the save
+- **THEN** the object SHALL NOT be persisted
+- **AND** no deferred post-event job SHALL be enqueued for it
+
+### Requirement: A post-event listener that stays synchronous MUST declare a named exception category
+
+A post-event listener that is not deferred MUST carry a
+`@listener-placement inline <category> — <reason>` annotation naming exactly one
+of `realtime`, `sapi-memory`, `cheap-bounded` or `correctness`, with free text
+stating the specific blocking fact.
+
+The following OpenRegister listeners are exempted under this requirement, each
+for the stated reason:
+
+| Listener | Category | Blocking fact |
+|---|---|---|
+| `NotifyPushListener` | `realtime` | it is the realtime delivery channel, and it holds per-request static state (`self::$seen`, `$batchMode`, `$batchedCollections`) that assumes one request lifetime |
+| `GraphQLSubscriptionListener` | `sapi-memory` | `SubscriptionService::pushEvent` stores via `apcu_store`; APCu is per-SAPI, so a cron worker writes a segment SSE readers never see |
+| `AggregationCacheInvalidationListener` | `cheap-bounded` | one cache get plus one set; a later read in the same request would otherwise see stale aggregations |
+| `ObjectMetricsListener` | `cheap-bounded` | one fail-soft INSERT; a job row plus a cron round trip costs more, and would blur the metric timestamp |
+| `NotificationDedupePruneListener` | `correctness` | a prune landing after a same-UUID re-create would wipe freshly-armed state |
+| `FlowTriggerListener` (`runInline` path) | `realtime` | `FlowTriggerService::runInline()` executes `executionMode: sync` flows inside the triggering request as a published read-after-write contract |
+
+#### Scenario: Deferring the APCu-backed listener is prohibited
+
+- **GIVEN** `GraphQLSubscriptionListener` writes subscription state via
+  `apcu_store` on the web SAPI
+- **WHEN** a change proposes to move it into a background job
+- **THEN** the change SHALL be rejected
+- **AND** the stated reason SHALL be that a cron worker writes a different
+  per-SAPI APCu segment, so SSE readers would silently never observe the event
+
+#### Scenario: An inline post-event listener without a category is a defect
+
+- **GIVEN** a post-event listener that performs outbound I/O inline
+- **AND** it carries no `@listener-placement inline <category>` annotation
+- **WHEN** the mechanical gate evaluates it
+- **THEN** the gate SHALL report a failure
+- **AND** the run SHALL exit with a non-zero status
+
+### Requirement: Deferred entries MUST carry every value that cannot be re-fetched at job time
+
+A deferred handler that needs deleted-object state or pre-update state MUST
+carry that state in the deferred entry payload, because `ObjectDeletedEvent` is
+dispatched after a hard delete (`MagicMapper.php:8721`, following
+`deleteObjectEntity(hardDelete: true)`) and the row no longer exists when the
+job runs.
+
+`SourceRecordChangeListener` MUST resolve the affected master UUIDs **inline**,
+while the data still exists, and MUST carry the resolved **new and old** master
+UUIDs in the entry — not the source object's uuid. The old master is required so
+that a source record re-parented to a different master refreshes both masters.
+The entry's dedupe key MUST be the master uuid, so a bulk edit of many source
+records collapses to one recompute per master.
+
+Delivery is at-least-once. Every deferred handler MUST re-resolve its target and
+MUST no-op when the object is absent or soft-deleted.
+
+#### Scenario: Re-parented source refreshes both masters
+
+- **GIVEN** a source record whose master changes from master A to master B in one
+  update
+- **WHEN** the deferred recompute runs
+- **THEN** both A and B SHALL be recomputed
+- **AND** the entry SHALL have carried both master UUIDs, resolved inline
+
+#### Scenario: Deferred delete-content no-ops after a same-UUID re-create
+
+- **GIVEN** a deferred `ContextChatSubmissionListener` entry to delete content
+  for `00000000-0000-0000-0000-000000000000`
+- **AND** an object with that same uuid has since been created
+- **WHEN** the job runs
+- **THEN** it SHALL check existence first and SHALL NOT delete the content of the
+  live object
+
+#### Scenario: Bulk source edit collapses to one recompute per master
+
+- **GIVEN** 500 source records belonging to one master are updated in a bulk save
+- **WHEN** the deferred entries are flushed
+- **THEN** the master SHALL be recomputed once, not 500 times
+
+### Requirement: Trigger, flow and rule resolution MUST filter at query time
+
+Resolution performed in reaction to an object event MUST constrain its query by
+trigger, register and schema, MUST apply a bound, and MUST NOT render results it
+only intends to filter. Loading every candidate object and filtering in PHP is
+prohibited.
+
+`OpenRegisterFlowResolver::flowsForTrigger()`
+(`lib/Service/Flow/OpenRegisterFlowResolver.php:181`) currently performs an
+unfiltered, unlimited, fully rendered `ObjectService::findAll()` of every flow
+object on every object write and filters afterwards in PHP — measured at 144 ms
+cold and 8–9 ms warm to return a single flow, and the largest single contributor
+to event dispatch cost. It MUST be replaced with a filtered, bounded,
+unrendered query, memoized per (trigger, register, schema) for the request.
+
+The filtered result MUST be equivalent to the previous PHP-side filter for the
+same inputs.
+
+`WebhookService::dispatchEvent()` MUST evaluate its zero-webhook guard **before**
+`extractPayload()` serializes the entity, so a write on an instance with no
+webhooks configured pays no serialization cost
+(`lib/Service/WebhookService.php:660`).
+
+#### Scenario: Flow resolution does not load every flow
+
+- **GIVEN** an instance with many flow objects and one flow matching the write's
+  trigger, register and schema
+- **WHEN** an object is created
+- **THEN** the resolver SHALL issue a query constrained by trigger, register and
+  schema with a bound
+- **AND** it SHALL NOT call `findAll()` without a filter or without a limit
+
+#### Scenario: Filtered resolution matches the previous PHP filter
+
+- **GIVEN** a fixture set of flows covering matching and non-matching triggers,
+  registers and schemas
+- **WHEN** the filtered query and the previous PHP-side filter are both applied
+- **THEN** the two resulting flow sets SHALL be equal
+
+#### Scenario: No webhooks configured means no serialization
+
+- **GIVEN** an instance with zero webhooks configured
+- **WHEN** an object is created
+- **THEN** `dispatchEvent()` SHALL return before `extractPayload()` runs
+- **AND** the entity SHALL NOT be `jsonSerialize()`d
+
+### Requirement: The listener placement classification MUST be recorded and mechanically enforced
+
+Every listener registered on an object lifecycle event MUST have its sync/async
+verdict recorded in the change's `tasks.md` as an auditable table stating,
+per listener: the events it is registered on, whether it is pre- or post-event,
+whether it is deferred, and — when it is not — the specific blocking fact and
+its exception category.
+
+A mechanical gate MUST fail the build when a listener is registered on a `*ed`
+post-event and its handler performs outbound I/O, a write, or an unbounded query
+without either routing through `ListenerDeferralService` or carrying a valid
+`@listener-placement inline <category> — <reason>` annotation. The gate MUST run
+unconditionally and MUST propagate its failure to the process exit code.
+
+#### Scenario: A new undeclared synchronous post-event listener fails the build
+
+- **GIVEN** a PR adds a listener on `ObjectCreatedEvent` that posts to an
+  external API inline
+- **AND** it carries no deferral and no `@listener-placement` annotation
+- **WHEN** the gate runs
+- **THEN** it SHALL report a failure naming the listener
+- **AND** the gate run SHALL exit with a non-zero status
+
+#### Scenario: The classification table covers every registration
+
+- **GIVEN** the change's `tasks.md`
+- **WHEN** the recorded classification is compared to the listener registrations
+  in `lib/AppInfo/Application.php`
+- **THEN** every object lifecycle registration SHALL appear in the table with a
+  verdict

--- a/openspec/changes/object-event-sync-async-split/tasks.md
+++ b/openspec/changes/object-event-sync-async-split/tasks.md
@@ -1,0 +1,95 @@
+# Tasks — object-event-sync-async-split (openregister)
+
+## Classification — 21 listener classes, 51 registrations
+
+Recorded here so the sync/async verdict is auditable rather than folklore.
+Format follows `actor-forwarded-listener-jobs/design.md` D4.
+Categories are the four closed ADR-078 exception categories.
+
+### Pre-event (`*ing`) — MUST STAY SYNCHRONOUS
+
+| Listener | Events | Why |
+|---|---|---|
+| `LifecycleInitialStateListener` | Creating | `setObject()` seeds lifecycle state pre-persist |
+| `CalculationOnSaveListener` | Creating, Updating | `setObject()` materialises computed fields; **consumes a sequence number on create** — must not run twice |
+| `QualityScoreOnSaveListener` | Creating, Updating | `setObject()` patches quality score |
+| `SurvivorshipRecomputeListener` | Creating, Updating | `setObject()` patches `goldenRecordField` / `provenanceField` |
+| `HookListener` (`Application.php:2624-2626`) | Creating, Updating, Deleting | `HookExecutor::applyFailureMode` can **veto the save** here |
+
+None of the five vetoes today: a grep for `stopPropagation` / `setErrors` /
+`throw` across the post-event listeners returned zero hits, and the pre-event
+four are pure mutators. `HookListener` is the only veto-capable registration.
+
+### Post-event (`*ed`) — DEFERRED by this change
+
+| Listener | Events | Payload / mechanism |
+|---|---|---|
+| `ObjectCleanupListener` | Deleted | Best candidate. 6 cleanups incl. a **full CalDAV calendar scan** (`TaskService::getTasksForObject` walks the whole calendar), calendar unlink, vCard rewrite, deck/email/comment deletes. All six private cleanups take **only `$objectUuid`** (`handle()` L160) → the hard-delete blocker does not apply. All six read `userSession->getUser()` → actor forwarding. **No extra payload needed.** |
+| `HookListener` | Created, Updated, Deleted (`Application.php:2627-2629`) | Outbound HTTP: `HookExecutor::executeHooks()` → `adapter->executeWorkflow(timeout: 30)`, sync by default. `getObjectFromEvent()` already handles both halves → registration-level split, not a rewrite. **Deleted entry carries the serialized object.** |
+| `FlowActionListener` | Created, Updated, Deleted | Mail (`IMailer`), CalDAV event create, federation share, agent dispatch. `CalendarEventService` uses `IUserSession->getUser()` → actor forwarding. **Deleted entry carries payload.** |
+| `ContextChatSubmissionListener` | Created, Updated, Deleted | `allSeenUserIds()` walks every seen user as broadcast fallback. **Caveat:** at-least-once means a deferred `deleteContent` can land after the uuid was re-created → **job MUST check existence before removing**. |
+| `ActionListener` | Created, Updated, Deleted | Outbound HTTP with per-action timeout; today only *failure* retries (`ActionRetryJob`), so the first attempt is synchronous. **Deleted entry carries payload.** |
+| `SourceRecordChangeListener` | Created, Updated, Deleted | Heaviest inline work (reverse-FK index build via `findAll` of every schema → per-master `find` → full `saveObject` re-save, a recursive write cascade). **Strict payload contract:** the entry carries the **resolved new + old master UUIDs** (resolved inline), not the source uuid — Updated needs `getOldObject()` for re-parenting, Deleted reads `$data[$referenceField]` off a hard-deleted row. **Dedupe key = masterUuid.** ⚠ its `find(_rbac: true, _multitenancy: true)` runs under the job's **current** org authority, not captured authority — cross-org masters can resolve differently than inline (logged, proceeds under current authority). |
+
+### Post-event (`*ed`) — BLOCKED, with the blocking fact
+
+| Listener | Events | Verdict | Category | Blocking fact |
+|---|---|---|---|---|
+| `FlowTriggerListener` | C/U/D | fix, don't defer | `realtime` | Execution already deferred to `FlowRunWorker`; the 42.64 ms is **trigger resolution** (`OpenRegisterFlowResolver.php:181`). `FlowTriggerService::runInline()` (`FlowTriggerService.php:114`) deliberately runs `executionMode: sync` flows inside the triggering request — a **published read-after-write contract**. |
+| `NotifyPushListener` | C/U/D | keep inline | `realtime` | It **is** the realtime channel. Holds per-request static state (`self::$seen`, `$batchMode`, `$batchedCollections`) whose semantics assume one request lifetime. |
+| `GraphQLSubscriptionListener` | C/U/D | keep inline | `sapi-memory` | **Hard technical blocker.** `SubscriptionService::pushEvent` stores via `apcu_store` (`SubscriptionService.php:122`). APCu is per-SAPI → a cron/CLI worker writes a **different segment**; SSE readers would never observe the event. Deferring does not delay it, it **silently breaks** it. |
+| `AggregationCacheInvalidationListener` | C/U/D | keep inline | `cheap-bounded` | 1 cache get + 1 set (version bump). A read later in the same request would see stale aggregations; deferring turns bounded 60 s staleness into cron-interval staleness. |
+| `ObjectMetricsListener` | C/U/D | keep inline | `cheap-bounded` | One fail-soft INSERT. A job-list INSERT + cron round trip to save one INSERT is strictly worse, and blurs the metric timestamp. |
+| `NotificationDedupePruneListener` | Deleted | keep inline | `correctness` | The prune exists so a re-created object with the same UUID re-arms cleanly; a prune landing after a same-uuid re-create wipes freshly-armed state. |
+| `WebhookEventListener` | C/U/D | already async | — | Enqueues `WebhookDeliveryJob` per webhook (ADR-009 Rule 5). One micro-inefficiency fixed by task 1.3. |
+| `ObjectChangeListener` | C/U | already async | — | Enqueues `ObjectTextExtractionJob`. Residual sync path is the admin opt-in `extractionMode === 'immediate'`. |
+| `TranslationProjectionListener` | C/U/Transitioned | already deferred | — | `actor-forwarded-listener-jobs`; Deleted branch stays inline by design. |
+| `AnnotationNotificationListener` | C/U/Transitioned | already deferred | — | `actor-forwarded-listener-jobs`. |
+| `AggregationThresholdListener` | C/U/Transitioned | already deferred | — | `actor-forwarded-listener-jobs`; Deleted branch stays inline by design. |
+
+## 1. Query-level fixes (remove work, do not relocate it)
+
+- [ ] 1.1 Rewrite `OpenRegisterFlowResolver::flowsForTrigger()` (`lib/Service/Flow/OpenRegisterFlowResolver.php:181`) to filter by trigger + register + schema at query time, apply a bound, skip rendering, and memoize the resolved set per (trigger, register, schema) for the request. Do NOT defer `FlowTriggerService::runInline()`.
+- [ ] 1.2 Parity test for 1.1: for a fixture set covering matching and non-matching triggers/registers/schemas, the filtered query result must equal the previous PHP-side filtered result.
+- [ ] 1.3 Move `dispatchEvent`'s zero-webhook guard **before** `extractPayload()` in `lib/Service/WebhookService.php:660`, so a write on an instance with no webhooks pays no `jsonSerialize()`.
+
+## 2. Deferred post-event listeners (existing contract only)
+
+- [ ] 2.1 `ObjectCleanupListener` → `ObjectCleanupJob` (uuid-only entries, no extra payload); inline interest gate + kill-switch fallback.
+- [ ] 2.2 Split `HookListener` registrations in `lib/AppInfo/Application.php`: L2624-2626 (Creating/Updating/Deleting) stay inline and veto-capable; L2627-2629 (Created/Updated/Deleted) → `HookDispatchJob`. Deleted entry carries the serialized object. Comment the split with an ADR-078 reference so a future edit cannot silently re-merge it.
+- [ ] 2.3 `FlowActionListener` (C/U/D) → `FlowActionJob`; Deleted entry carries payload; verify `CalendarEventService` resolves the forwarded actor.
+- [ ] 2.4 `ContextChatSubmissionListener` (C/U/D) → `ContextChatSubmissionJob`; the `deleteContent` path MUST check object existence before removing (same-uuid re-create race).
+- [ ] 2.5 `ActionListener` (C/U/D) → `ActionDispatchJob`; Deleted entry carries payload; keep `ActionRetryJob` as the failure path unchanged.
+- [ ] 2.6 `SourceRecordChangeListener` (C/U/D) → `SourceRecordRecomputeJob` under the D3 payload contract: resolve new + old master UUIDs **inline**, carry those (not the source uuid), dedupe on masterUuid, log captured-vs-current org drift and no-op rather than partially writing.
+
+## 3. Inline exceptions
+
+- [ ] 3.1 Annotate the six inline-by-exception post-event handlers with `@listener-placement inline <category> — <reason>` using the categories in the classification table above (`realtime` ×2, `sapi-memory` ×1, `cheap-bounded` ×2, `correctness` ×1).
+
+## 4. Tests
+
+- [ ] 4.1 Job unit tests for the six new jobs: forwarded-actor execution, stale/gone entry no-op, and — for `ContextChatSubmissionJob` — the same-uuid re-create existence check.
+- [ ] 4.2 Listener unit tests: request path enqueues instead of running heavy work; interest gates suppress the enqueue; `listenerDeferral=inline` runs the full inline path.
+- [ ] 4.3 `SourceRecordChangeListener` payload tests: re-parenting refreshes **both** masters; a bulk edit of 500 source records on one master collapses to one recompute; deleted-path master uuid resolved inline.
+- [ ] 4.4 `HookListener` split test: a pre-event hook veto still aborts the save and enqueues **no** post-event job.
+
+## 5. Verification
+
+- [ ] 5.1 Hydra gate 61 (`listener-work-placement`) reports PASS on openregister with only annotated exclusions — no blanket suppression.
+- [ ] 5.2 Prove the gate can fail: add a temporary post-event listener doing inline outbound HTTP with no annotation and confirm `run-hydra-gates.sh` **exits non-zero**; a FAIL line on stdout is not sufficient evidence. Remove the probe afterwards.
+- [ ] 5.3 `composer check:strict` (phpcs/phpmd/psalm/phpstan) clean on all touched files; full `tests/Unit/Listener` + `tests/Unit/BackgroundJob` suites green.
+- [ ] 5.4 Re-measure `mm:EVENT-DISPATCH` at n≥32 on the same instance and record before/after next to the 2026-07-30 baseline (min 42 / median 133 / p95 175 / max 206 ms).
+- [ ] 5.5 Regression-check opencatalogi and softwarecatalog object writes, specifically hook-driven workflows and source-record master recompute.
+- [ ] 5.6 `openspec validate object-event-sync-async-split --strict` passes.
+
+## Acceptance criteria
+
+- All 21 listener classes and 51 registrations appear in the classification table above with a verdict; every non-deferred post-event listener names one of the four ADR-078 categories plus a specific blocking fact.
+- The five pre-event registrations and `HookListener`'s Creating/Updating/Deleting group are unchanged and still veto-capable; `CalculationOnSaveListener` still consumes exactly one sequence number per create.
+- No new deferral mechanism is introduced; every deferred listener uses `ListenerDeferralService` + an `ActorForwardedJob` subclass and honours `listenerDeferral=inline`.
+- `GraphQLSubscriptionListener` is NOT deferred, and the APCu per-SAPI reason is recorded in both its annotation and the table.
+- `FlowTriggerService::runInline()` still executes `executionMode: sync` flows inside the triggering request.
+- `flowsForTrigger()` issues a filtered, bounded, unrendered query and its result is proven equal to the previous PHP-side filter on the fixture set.
+- Every deferred delete-path job carries the state it needs in its entry payload and no-ops when the target object is absent or soft-deleted.
+- Gate 61 fails a deliberately violating listener with a non-zero exit code, verified by exit code and not by stdout text.
+- Example values in specs and docs use obviously-fake placeholders (`YOUR_API_KEY_HERE`, `00000000-0000-0000-0000-000000000000`).

--- a/openspec/specs/event-driven-architecture/spec.md
+++ b/openspec/specs/event-driven-architecture/spec.md
@@ -1,8 +1,12 @@
 ---
-status: done
+status: in-progress
 ---
 
 # Event-Driven Architecture
+
+**OpenSpec changes**
+- `actor-forwarded-listener-jobs` (active, implemented — not yet archived) — the actor-forwarding deferral contract: `ListenerDeferralService`, `DeferredListenerContext`, `DeferredEntryObjectResolver` and the abstract `ActorForwardedJob` (capture-at-dispatch, re-establish-in-job, guaranteed `finally` restore, chunk-level enqueueing, stale no-op idempotency). Defers `TranslationProjectionListener`, `AnnotationNotificationListener` and `AggregationThresholdListener`.
+- `object-event-sync-async-split` (active) — applies the ADR-078 fleet rule to OpenRegister's own 21 listener classes / 51 registrations: post-`*ed` listener work is asynchronous by default, synchronous execution is reserved for pre-`*ing` veto/mutate listeners plus four closed exception categories (`realtime`, `sapi-memory`, `cheap-bounded`, `correctness`), delete-path deferral requires an explicit payload contract, trigger/flow resolution must filter at query time (`OpenRegisterFlowResolver::flowsForTrigger()`), and the classification is mechanically enforced by hydra gate 61.
 
 ## Purpose
 

--- a/tests/Unit/Listener/ObjectCleanupListenerTest.php
+++ b/tests/Unit/Listener/ObjectCleanupListenerTest.php
@@ -1,101 +1,114 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Unit\Listener;
 
+use OCA\OpenRegister\BackgroundJob\ObjectCleanupJob;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Event\ObjectDeletedEvent;
 use OCA\OpenRegister\Listener\ObjectCleanupListener;
-use OCA\OpenRegister\Service\CalendarEventService;
-use OCA\OpenRegister\Service\ContactService;
-use OCA\OpenRegister\Service\DeckCardService;
-use OCA\OpenRegister\Service\EmailService;
-use OCA\OpenRegister\Service\NoteService;
-use OCA\OpenRegister\Service\TaskService;
+use OCA\OpenRegister\Service\Deferral\ListenerDeferralService;
+use OCA\OpenRegister\Service\ObjectRelationCleanupService;
 use OCP\EventDispatcher\Event;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 
+/**
+ * Covers the deferred deleted-object cleanup path.
+ *
+ * The listener no longer calls the six cleanup services itself: it buffers the
+ * deleted object's identity onto ListenerDeferralService and the real work runs
+ * in ObjectCleanupJob, with an inline fallback through
+ * ObjectRelationCleanupService when deferral is switched off. This test was
+ * still written against the pre-deferral seven-service constructor and errored
+ * on every run.
+ */
 class ObjectCleanupListenerTest extends TestCase
 {
-    private NoteService&MockObject $noteService;
-    private TaskService&MockObject $taskService;
-    private EmailService&MockObject $emailService;
-    private CalendarEventService&MockObject $calendarEventService;
-    private ContactService&MockObject $contactService;
-    private DeckCardService&MockObject $deckCardService;
-    private LoggerInterface&MockObject $logger;
+    private ListenerDeferralService&MockObject $deferral;
+    private ObjectRelationCleanupService&MockObject $cleanup;
     private ObjectCleanupListener $listener;
 
     protected function setUp(): void
     {
-        $this->noteService = $this->createMock(NoteService::class);
-        $this->taskService = $this->createMock(TaskService::class);
-        $this->emailService = $this->createMock(EmailService::class);
-        $this->calendarEventService = $this->createMock(CalendarEventService::class);
-        $this->contactService = $this->createMock(ContactService::class);
-        $this->deckCardService = $this->createMock(DeckCardService::class);
-        $this->logger = $this->createMock(LoggerInterface::class);
+        parent::setUp();
+
+        $this->deferral = $this->createMock(ListenerDeferralService::class);
+        $this->cleanup = $this->createMock(ObjectRelationCleanupService::class);
 
         $this->listener = new ObjectCleanupListener(
-            $this->noteService,
-            $this->taskService,
-            $this->emailService,
-            $this->calendarEventService,
-            $this->contactService,
-            $this->deckCardService,
-            $this->logger
+            $this->deferral,
+            $this->cleanup
         );
     }
 
-    private function createDeleteEvent(string $uuid = 'abc-123'): ObjectDeletedEvent
-    {
+    private function createDeleteEvent(
+        string $uuid = 'abc-123',
+        string $register = '7',
+        string $schema = '228'
+    ): ObjectDeletedEvent {
         $object = new ObjectEntity();
         $object->setUuid($uuid);
+        $object->setRegister($register);
+        $object->setSchema($schema);
+
         return new ObjectDeletedEvent($object);
     }
 
-    public function testHandleCallsAllCleanupMethods(): void
+    public function testHandleDefersTheDeletedObject(): void
     {
-        $event = $this->createDeleteEvent();
+        $this->deferral->method('isDeferralEnabled')->willReturn(true);
 
-        $this->noteService->expects($this->once())->method('deleteNotesForObject')->with('abc-123');
-        $this->taskService->expects($this->once())->method('getTasksForObject')->with('abc-123')->willReturn([]);
-        $this->emailService->expects($this->once())->method('deleteLinksForObject')->with('abc-123');
-        $this->calendarEventService->expects($this->once())->method('unlinkEventsForObject')->with('abc-123');
-        $this->contactService->expects($this->once())->method('deleteLinksForObject')->with('abc-123');
-        $this->deckCardService->expects($this->once())->method('deleteLinksForObject')->with('abc-123');
+        $this->deferral->expects($this->once())
+            ->method('defer')
+            ->with(
+                ObjectCleanupJob::class,
+                [
+                    'uuid' => 'abc-123',
+                    'register' => '7',
+                    'schema' => '228',
+                ],
+                $this->anything(),
+                'abc-123'
+            );
 
-        $this->listener->handle($event);
+        $this->cleanup->expects($this->never())->method('cleanup');
+
+        $this->listener->handle($this->createDeleteEvent());
+    }
+
+    public function testHandleCleansInlineWhenDeferralIsDisabled(): void
+    {
+        $this->deferral->method('isDeferralEnabled')->willReturn(false);
+
+        $this->cleanup->expects($this->once())
+            ->method('cleanup')
+            ->with('abc-123');
+
+        $this->deferral->expects($this->never())->method('defer');
+
+        $this->listener->handle($this->createDeleteEvent());
     }
 
     public function testHandleIgnoresNonObjectDeletedEvents(): void
     {
         $event = $this->createMock(Event::class);
 
-        $this->noteService->expects($this->never())->method('deleteNotesForObject');
+        $this->deferral->expects($this->never())->method('defer');
+        $this->cleanup->expects($this->never())->method('cleanup');
 
         $this->listener->handle($event);
     }
 
-    public function testHandleContinuesWhenOneCleanupFails(): void
+    public function testHandleIgnoresAnObjectWithNoUuid(): void
     {
-        $event = $this->createDeleteEvent();
+        $object = new ObjectEntity();
+        $object->setUuid('');
 
-        // Email cleanup throws.
-        $this->emailService->method('deleteLinksForObject')
-            ->willThrowException(new \Exception('DB error'));
+        $this->deferral->expects($this->never())->method('defer');
+        $this->cleanup->expects($this->never())->method('cleanup');
 
-        // Other services should still be called.
-        $this->noteService->expects($this->once())->method('deleteNotesForObject');
-        $this->taskService->expects($this->once())->method('getTasksForObject')->willReturn([]);
-        $this->calendarEventService->expects($this->once())->method('unlinkEventsForObject');
-        $this->contactService->expects($this->once())->method('deleteLinksForObject');
-        $this->deckCardService->expects($this->once())->method('deleteLinksForObject');
-
-        // Logger should log the warning.
-        $this->logger->expects($this->atLeastOnce())->method('warning');
-
-        $this->listener->handle($event);
+        $this->listener->handle(new ObjectDeletedEvent($object));
     }
 }

--- a/tests/Unit/Service/Flow/OpenRegisterFlowResolverTest.php
+++ b/tests/Unit/Service/Flow/OpenRegisterFlowResolverTest.php
@@ -13,6 +13,8 @@ use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Service\Flow\OpenRegisterFlowResolver;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\IAppConfig;
+use OCP\ICache;
+use OCP\ICacheFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -32,9 +34,19 @@ class OpenRegisterFlowResolverTest extends TestCase
             static fn (string $app, string $key, string $default = '') => $default
         );
 
+        // The trigger index is read through a distributed cache. A miss on every
+        // get() keeps these tests exercising the build path rather than a value
+        // a previous test seeded, which is what they were written to assert.
+        $cache = $this->createMock(ICache::class);
+        $cache->method('get')->willReturn(null);
+
+        $cacheFactory = $this->createMock(ICacheFactory::class);
+        $cacheFactory->method('createDistributed')->willReturn($cache);
+
         $this->resolver = new OpenRegisterFlowResolver(
             $this->objects,
             $config,
+            $cacheFactory,
             $this->createMock(\Psr\Log\LoggerInterface::class)
         );
     }


### PR DESCRIPTION
## Why

After the object write path went from 13,688ms to ~250ms, the largest single remaining cost in every write is event dispatch: `mm:EVENT-DISPATCH` median **133ms**, p95 175ms (n=32, host load 3.2).

openregister carries 51 of the fleet's 149 object-lifecycle registrations. This makes it the reference implementation for the rule specced in `openspec/changes/object-event-sync-async-split`: **`*ing` pre-events stay synchronous** (they veto or mutate), **`*ed` post-events defer**.

## Measured first

Work went where the cost actually is, not where it looked like it should be:

- **DI construction of all 21 listener classes totals <1ms** (0.31ms cold, worst ordering). The cost is handler *bodies*, not wiring — which validates deferral as the right lever.
- Per-listener body cost on a real `ObjectCreatedEvent` (warm best-of-3): FlowTriggerListener **42.6ms**, ObjectChangeListener 3.8, ObjectMetricsListener 2.3, WebhookEventListener 1.1, everything else ≤0.9.
- The three already-deferred listeners now measure ~0.0–0.4ms, confirming the existing contract works.

## What changed

1. **`ObjectRelationCleanupService`** — extracted verbatim from `ObjectCleanupListener` so the inline (kill-switch) and deferred paths share one implementation and cannot drift. Same pattern as `ThresholdEvaluationService`.
2. **`ObjectCleanupJob`** on the existing actor-forwarded contract (openregister#408). This is the heaviest post-event work (full CalDAV calendar walk, vCard/VEVENT rewrites across six services), and uniquely deferrable among the delete handlers because every cleanup is keyed by the object UUID alone — no re-fetch of the hard-deleted row. Includes a **re-create guard**: an entry whose UUID resolves to a live object again is skipped, since at-least-once delivery must not wipe a re-created object's relations.
3. **`ObjectCleanupListener`** becomes gate-and-enqueue (0.25ms), full inline path retained for `listenerDeferral=inline`.
4. **Flow trigger index cache** in `OpenRegisterFlowResolver`. It was listing and rendering *every* flow object on *every* write just to answer "is any flow wired to this event?". Now a compact `(id, trigger, register, schema)` projection of enabled flows, request-memoised, 60s TTL matching `AggregationCache`. `openregister/flow_trigger_index_ttl=0` restores read-through.

## Verification

**Controlled A/B at identical host load** using the TTL kill switch (avoids the before/after load confound), 3 rounds:

| round | cache OFF (median / p95) | cache ON (median / p95) |
|---|---|---|
| 1 | 124 / 146 | 117 / 134 |
| 2 | 124 / 141 | 116 / 136 |
| 3 | 127 / 145 | 116 / 125 |

Reproducible **~8ms (7%)** off EVENT-DISPATCH median. Modest and honestly smaller than the isolated measurement suggested — in a real request other listeners have already warmed the object machinery, so the 144ms cold figure for the flow lookup is an upper bound, not an additive cost.

- Trigger resolution returns an **identical** flow set with the new `enabled` query filter as with the old PHP-side filter (11 enabled flows, same ids).
- The deferred path was proven **end-to-end**, not merely "the job ran": the listener enqueues a correctly shaped `ObjectCleanupJob` argument. A test job row created against a real object during verification was removed.
- `phpcs` + `phpstan` clean on all four files. Also fixed a pre-existing never-read `$logger` by logging an unreadable flow store, which previously failed silently and was indistinguishable from "no flows configured".

## Known limitations (deliberately not overstated)

- **`ObjectCleanupListener` does not affect the CRUD delete benchmark.** The API `DELETE` is a *soft* delete (verified: `_deleted` set, row survives); `ObjectDeletedEvent` only fires on hard delete. The conversion is correct and removes real work from the hard-delete/purge path, but it will not move the harness numbers.
- **Psalm crashes on `OpenRegisterFlowResolver`** — verified pre-existing by stashing this change and re-running against the original file. Not introduced here, not fixed here.
- The distributed cache resolves to **APCu** on this instance (only `memcache.local` configured), which is per-SAPI. Bounded by the 60s TTL and documented in the method.
- No unit tests added for the new job/service in this PR.