### PR TITLE
feat(flow): a scheduled flow never overlaps itself

### DIFF
--- a/lib/Db/FlowRunMapper.php
+++ b/lib/Db/FlowRunMapper.php
@@ -147,6 +147,54 @@ class FlowRunMapper extends QBMapper
     }//end findActive()
 
     /**
+     * Whether one flow already has a run that has not finished.
+     *
+     * A SCHEDULED flow can be slower than its own interval — a hydra-shaped
+     * pipeline poll easily outlives five minutes — and `fireDueFlows()` has no
+     * overlap guard of its own, so tick N+1 would start while tick N is still
+     * going. Two runs of the same flow then race on whatever that flow is
+     * bookkeeping.
+     *
+     * This is the query that lets the scheduler refuse to do that. It is
+     * deliberately the same NON-terminal definition {@see findActive} uses:
+     * `queued`, `running` and `suspended` all mean "still going". A guard that
+     * only looked at `running` would let a suspended run be overlapped, which
+     * is precisely the long-lived state a slow flow spends its time in.
+     *
+     * Cheap on purpose — a count with a limit, not a fetch. The scheduler asks
+     * this once per due flow on every cron tick.
+     *
+     * @param string $flowId The flow's uuid.
+     *
+     * @return boolean True when a non-terminal run exists for this flow.
+     */
+    public function hasActiveRun(string $flowId): bool
+    {
+        if (trim($flowId) === '') {
+            return false;
+        }
+
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('id')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('flow_id', $qb->createNamedParameter($flowId)))
+            ->andWhere(
+                $qb->expr()->in(
+                    'status',
+                    $qb->createNamedParameter(FlowRun::ACTIVE, IQueryBuilder::PARAM_STR_ARRAY)
+                )
+            )
+            ->setMaxResults(1);
+
+        $result = $qb->executeQuery();
+        $row    = $result->fetch();
+        $result->closeCursor();
+
+        return $row !== false;
+
+    }//end hasActiveRun()
+
+    /**
      * How many runs are still going, for one organisation.
      *
      * Separate from {@see findActive} because a widget shows a bounded list but

--- a/lib/Service/Flow/FlowRunService.php
+++ b/lib/Service/Flow/FlowRunService.php
@@ -151,6 +151,25 @@ class FlowRunService
     }//end queue()
 
     /**
+     * Whether a flow already has a run that has not finished.
+     *
+     * Exposed for the SCHEDULER, which must not start tick N+1 of a flow while
+     * tick N is still going: a scheduled flow can outlive its own interval, and
+     * two concurrent runs of one flow race on whatever that flow is
+     * bookkeeping. See FlowRunMapper::hasActiveRun() for why "not finished"
+     * includes `suspended` and `queued`, not just `running`.
+     *
+     * @param string $flowId The flow's uuid.
+     *
+     * @return boolean True when a non-terminal run exists for this flow.
+     */
+    public function hasActiveRun(string $flowId): bool
+    {
+        return $this->mapper->hasActiveRun(flowId: $flowId);
+
+    }//end hasActiveRun()
+
+    /**
      * Queue a fresh run that repeats a finished one.
      *
      * Retry NEVER re-executes the old run — that would repeat every side effect
@@ -167,6 +186,7 @@ class FlowRunService
      *
      * @spec openspec/changes/or-flow-tooling/specs/flow-tooling/spec.md
      */
+
     public function retry(FlowRun $run): ?FlowRun
     {
         if ($run->isTerminal() === false) {

--- a/lib/Service/Flow/FlowScheduleService.php
+++ b/lib/Service/Flow/FlowScheduleService.php
@@ -125,6 +125,36 @@ class FlowScheduleService
                 continue;
             }
 
+            // SINGLETON: never overlap a flow with itself.
+            //
+            // A scheduled flow can be slower than its own interval — a pipeline
+            // poll on a five-minute cron easily is — and without this guard
+            // tick N+1 starts while tick N is still going. Two runs of one flow
+            // then race on whatever that flow is bookkeeping, which is exactly
+            // the failure openregister#2212 documented at the object layer.
+            //
+            // This is the property that makes the shell orchestrator being
+            // replaced safe today: `hydra-supervisor.sh` holds an exclusive
+            // flock, so exactly one supervisor exists and its check-then-write
+            // slot bookkeeping never races because nothing runs beside it. A
+            // scheduled flow gets the same guarantee here, and with it most
+            // flow state needs no locking at all.
+            //
+            // The last-fire marker is deliberately NOT advanced when we skip:
+            // the flow stays due, so it starts on the first tick after the
+            // previous run finishes rather than waiting a whole extra interval.
+            if ($this->runs->hasActiveRun(flowId: $uuid) === true) {
+                $this->logger->info(
+                    message: '[FlowSchedule] Skipping due flow — previous run has not finished',
+                    context: [
+                        'file' => __FILE__,
+                        'line' => __LINE__,
+                        'flow' => $uuid,
+                    ]
+                );
+                continue;
+            }
+
             $this->fire(uuid: $uuid, now: $now, owner: $flow->getOwner());
             $fired[] = $uuid;
         }//end foreach

--- a/tests/Unit/Service/Flow/FlowScheduleServiceTest.php
+++ b/tests/Unit/Service/Flow/FlowScheduleServiceTest.php
@@ -20,13 +20,16 @@ use PHPUnit\Framework\TestCase;
 
 class FlowScheduleServiceTest extends TestCase
 {
+
     private ObjectService&MockObject $objects;
 
     private FlowRunService&MockObject $runs;
 
     private IAppConfig&MockObject $config;
 
-    /** last-fire values keyed by config key, mutated by setValueString. */
+    /**
+     * last-fire values keyed by config key, mutated by setValueString.
+     */
     private array $store = [];
 
     private FlowScheduleService $service;
@@ -38,7 +41,7 @@ class FlowScheduleServiceTest extends TestCase
         $this->config  = $this->createMock(IAppConfig::class);
 
         $this->config->method('getValueString')->willReturnCallback(
-            fn (string $app, string $key, string $default = '') => $this->store[$key] ?? $default
+            fn (string $app, string $key, string $default='') => $this->store[$key] ?? $default
         );
         $this->config->method('setValueString')->willReturnCallback(
             function (string $app, string $key, string $value): bool {
@@ -53,7 +56,7 @@ class FlowScheduleServiceTest extends TestCase
             $this->config,
             $this->createMock(\Psr\Log\LoggerInterface::class)
         );
-    }
+    }//end setUp()
 
     private function flow(string $uuid, array $data): ObjectEntity
     {
@@ -61,7 +64,7 @@ class FlowScheduleServiceTest extends TestCase
         $o->setUuid($uuid);
         $o->setObject($data);
         return $o;
-    }
+    }//end flow()
 
     private function schedule(string $uuid, string $cron, ?string $owner=null): ObjectEntity
     {
@@ -71,7 +74,52 @@ class FlowScheduleServiceTest extends TestCase
         }
 
         return $flow;
-    }
+    }//end schedule()
+
+    /**
+     * SINGLETON: a due flow whose previous run has not finished is skipped.
+     *
+     * A scheduled flow can outlive its own interval — a pipeline poll on a
+     * five-minute cron easily does — and without this guard tick N+1 starts
+     * while tick N is still going. Two runs of one flow then race on whatever
+     * that flow is bookkeeping, which is the failure openregister#2212
+     * documented one layer down at the object store.
+     *
+     * @return void
+     */
+    public function testADueFlowIsSkippedWhileItsPreviousRunIsStillGoing(): void
+    {
+        $this->objects->method('findAll')->willReturn([$this->schedule('f1', '*/5 * * * *')]);
+        $this->runs->method('hasActiveRun')->with('f1')->willReturn(true);
+
+        $this->runs->expects($this->never())->method('queue');
+
+        $fired = $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00'));
+
+        $this->assertSame([], $fired);
+
+    }//end testADueFlowIsSkippedWhileItsPreviousRunIsStillGoing()
+
+    /**
+     * Skipping must NOT advance the last-fire marker.
+     *
+     * If it did, a flow skipped at 10:00 would not be due again until 10:05
+     * even though its previous run finished at 10:01 — the pipeline would idle
+     * a whole interval for no reason. Leaving the marker alone means the flow
+     * starts on the first tick after its run completes.
+     *
+     * @return void
+     */
+    public function testSkippingDoesNotRecordAFireSoTheFlowStaysDue(): void
+    {
+        $this->objects->method('findAll')->willReturn([$this->schedule('f1', '*/5 * * * *')]);
+        $this->runs->method('hasActiveRun')->with('f1')->willReturn(true);
+
+        $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00'));
+
+        $this->assertArrayNotHasKey('flow_sched_last_f1', $this->store);
+
+    }//end testSkippingDoesNotRecordAFireSoTheFlowStaysDue()
 
     public function testADueScheduledFlowFiresAndRecordsTheFire(): void
     {
@@ -86,7 +134,7 @@ class FlowScheduleServiceTest extends TestCase
         $this->assertSame(['f1'], $fired);
         // A last-fire was recorded, so the next tick will not re-fire immediately.
         $this->assertArrayHasKey('flow_sched_last_f1', $this->store);
-    }
+    }//end testADueScheduledFlowFiresAndRecordsTheFire()
 
     /**
      * FAILING PATH (or#2158, fourth instance): a scheduled run has no session,
@@ -105,7 +153,7 @@ class FlowScheduleServiceTest extends TestCase
             ->with('f1', $this->anything(), 'schedule', $this->anything(), 'alice');
 
         $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00'));
-    }
+    }//end testAScheduledRunIsAttributedToTheFlowsOwner()
 
     public function testAFlowThatFiredRecentlyIsNotDueAgain(): void
     {
@@ -117,39 +165,45 @@ class FlowScheduleServiceTest extends TestCase
         $this->runs->expects($this->never())->method('queue');
 
         $this->assertSame([], $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:02:00')));
-    }
+    }//end testAFlowThatFiredRecentlyIsNotDueAgain()
 
     public function testADisabledScheduleDoesNotFire(): void
     {
-        $this->objects->method('findAll')->willReturn([
-            $this->flow('f1', ['enabled' => false, 'trigger' => 'schedule', 'cron' => '*/5 * * * *']),
-        ]);
+        $this->objects->method('findAll')->willReturn(
+                [
+                    $this->flow('f1', ['enabled' => false, 'trigger' => 'schedule', 'cron' => '*/5 * * * *']),
+                ]
+                );
         $this->runs->expects($this->never())->method('queue');
         $this->assertSame([], $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00')));
-    }
+    }//end testADisabledScheduleDoesNotFire()
 
     public function testANonScheduleTriggerDoesNotFire(): void
     {
-        $this->objects->method('findAll')->willReturn([
-            $this->flow('f1', ['enabled' => true, 'trigger' => 'object.created', 'cron' => '*/5 * * * *']),
-        ]);
+        $this->objects->method('findAll')->willReturn(
+                [
+                    $this->flow('f1', ['enabled' => true, 'trigger' => 'object.created', 'cron' => '*/5 * * * *']),
+                ]
+                );
         $this->runs->expects($this->never())->method('queue');
         $this->assertSame([], $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00')));
-    }
+    }//end testANonScheduleTriggerDoesNotFire()
 
     public function testAnInvalidOrMissingCronIsSkipped(): void
     {
-        $this->objects->method('findAll')->willReturn([
-            $this->flow('bad', ['enabled' => true, 'trigger' => 'schedule', 'cron' => 'not a cron']),
-            $this->flow('none', ['enabled' => true, 'trigger' => 'schedule']),
-        ]);
+        $this->objects->method('findAll')->willReturn(
+                [
+                    $this->flow('bad', ['enabled' => true, 'trigger' => 'schedule', 'cron' => 'not a cron']),
+                    $this->flow('none', ['enabled' => true, 'trigger' => 'schedule']),
+                ]
+                );
         $this->runs->expects($this->never())->method('queue');
         $this->assertSame([], $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00')));
-    }
+    }//end testAnInvalidOrMissingCronIsSkipped()
 
     public function testNoFlowStoreFiresNothing(): void
     {
         $this->objects->method('findAll')->willThrowException(new \RuntimeException('no such register'));
         $this->assertSame([], $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00')));
-    }
-}
+    }//end testNoFlowStoreFiresNothing()
+}//end class


### PR DESCRIPTION
`fireDueFlows()` had no overlap guard. A scheduled flow can be slower than its own interval — a pipeline poll on a five-minute cron easily is — so tick N+1 started while tick N was still going, and **two runs of one flow raced on whatever that flow was bookkeeping**. Same failure as #2212, arriving from the scheduler instead of the object store.

## What this adds

`FlowRunMapper::hasActiveRun()`, using the same **non-terminal** definition `findActive()` already uses: `queued`, `running` and `suspended` all mean "still going". A guard that only looked at `running` would let a *suspended* run be overlapped — precisely the long-lived state a slow flow spends its time in. It is a count with a limit rather than a fetch, since the scheduler asks once per due flow per tick.

## The last-fire marker is deliberately not advanced on a skip

If it were, a flow skipped at 10:00 would not be due again until 10:05 even though its run finished at 10:01 — idling a whole interval for nothing. Left alone, the flow starts on the first tick after its previous run completes.

## Why this matters beyond one guard

It is the property that makes the shell orchestrator being replaced safe **today**. `hydra-supervisor.sh` holds an exclusive `flock`, so exactly one supervisor exists and its check-then-write slot bookkeeping never races — not because the claim is atomic, but because **nothing runs beside it**.

A scheduled flow now gets the same guarantee. With it, most flow state needs no locking at all — which is the prerequisite for giving flows state that survives between runs (#2216).

## Verified

Two tests, both confirmed **RED against `origin/development`** (2 failures) before this change:

- a due flow is skipped while its previous run is still going
- skipping does not record a fire, so the flow stays due

Gates: phpcs clean, phpstan OK, **15,518 unit tests green**.

Part of #2216. Consumed by hydra#425 tasks 3.5 and 3.7.
