### PR TITLE
feat(flow): state that survives between runs

### DIFF
--- a/lib/Db/FlowState.php
+++ b/lib/Db/FlowState.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * OpenRegister FlowState entity.
+ *
+ * State a flow keeps BETWEEN runs, as opposed to `FlowRun`'s marking/items/
+ * context, which are per-run and discarded when the run ends. See OR#2216.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Database
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * One flow's persistent state.
+ *
+ * A scheduled flow starts blank on every tick — the flow object holds its
+ * definition, and a run's marking/items/context die with the run. This is where
+ * a counter, a cursor, a capacity table or a "what have I already processed"
+ * watermark lives so the next tick can read it.
+ *
+ * Keyed by flow uuid and stored BESIDE the flow, never on it: writing state
+ * onto the flow object would churn the definition's audit history and race with
+ * an operator editing it. `FlowScheduleService` already made that choice for
+ * the last-fire timestamp; this generalises it.
+ *
+ * @method string|null   getFlowId()
+ * @method void          setFlowId(?string $flowId)
+ * @method array|null    getState()
+ * @method void          setState(?array $state)
+ * @method DateTime|null getUpdated()
+ * @method void          setUpdated(?DateTime $updated)
+ *
+ * @category Database
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+class FlowState extends Entity implements JsonSerializable
+{
+
+    /**
+     * The uuid of the flow this state belongs to.
+     *
+     * @var string|null
+     */
+    protected ?string $flowId = null;
+
+    /**
+     * The state itself, as a free-form map.
+     *
+     * @var array|null
+     */
+    protected ?array $state = null;
+
+    /**
+     * When the state was last written.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $updated = null;
+
+    /**
+     * Register field types.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->addType(fieldName: 'flowId', type: 'string');
+        $this->addType(fieldName: 'state', type: 'json');
+        $this->addType(fieldName: 'updated', type: 'datetime');
+
+    }//end __construct()
+
+    /**
+     * Serialise for API output.
+     *
+     * @return array The serialised state.
+     */
+    public function jsonSerialize(): array
+    {
+        $updated = null;
+        if ($this->updated !== null) {
+            $updated = $this->updated->format('c');
+        }
+
+        return [
+            'id'      => $this->id,
+            'flowId'  => $this->flowId,
+            'state'   => ($this->state ?? []),
+            'updated' => $updated,
+        ];
+
+    }//end jsonSerialize()
+}//end class

--- a/lib/Db/FlowStateMapper.php
+++ b/lib/Db/FlowStateMapper.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * OpenRegister FlowStateMapper.
+ *
+ * Reads and writes the state a flow keeps between runs. See OR#2216.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Database
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\Exception as DbException;
+use OCP\IDBConnection;
+
+/**
+ * Persistence for per-flow state.
+ *
+ * @template-extends QBMapper<FlowState>
+ *
+ * @category Database
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+class FlowStateMapper extends QBMapper
+{
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $db The database connection.
+     *
+     * @return void
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(db: $db, tableName: 'openregister_flow_state', entityClass: FlowState::class);
+
+    }//end __construct()
+
+    /**
+     * The state of one flow, or null when it has none yet.
+     *
+     * @param string $flowId The flow's uuid.
+     *
+     * @return FlowState|null The stored state, or null.
+     */
+    public function findByFlow(string $flowId): ?FlowState
+    {
+        if (trim($flowId) === '') {
+            return null;
+        }
+
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('flow_id', $qb->createNamedParameter($flowId)))
+            ->setMaxResults(1);
+
+        try {
+            return $this->findEntity(query: $qb);
+        } catch (DoesNotExistException $e) {
+            return null;
+        }
+
+    }//end findByFlow()
+
+    /**
+     * Write a flow's state, creating the row on first use.
+     *
+     * The insert is attempted FIRST and its unique-constraint violation is
+     * caught, rather than checking for an existing row and then writing. That
+     * ordering is deliberate: check-then-write is a lost update waiting for two
+     * concurrent writers, which is exactly what OR#2212 documented at the object
+     * store. Here the `flow_id` unique index decides, so a loser learns it lost
+     * and retries as an update rather than silently overwriting.
+     *
+     * Caught by REASON rather than by emitting dialect-specific upsert SQL, so
+     * it behaves the same on MySQL and PostgreSQL — the pattern
+     * `NotificationDedupeStateMapper` already uses in this codebase.
+     *
+     * @param string $flowId The flow's uuid.
+     * @param array  $state  The state to store.
+     *
+     * @return FlowState The stored state.
+     *
+     * @throws DbException When the write fails for any reason other than a
+     *                     concurrent insert of the same flow.
+     */
+    public function put(string $flowId, array $state): FlowState
+    {
+        $entity = new FlowState();
+        $entity->setFlowId($flowId);
+        $entity->setState($state);
+        $entity->setUpdated(new DateTime());
+
+        try {
+            return $this->insert(entity: $entity);
+        } catch (DbException $e) {
+            if ($e->getReason() !== DbException::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+                throw $e;
+            }
+
+            // Another writer created this flow's state between our insert and
+            // theirs. Update the row that won.
+            $existing = $this->findByFlow(flowId: $flowId);
+            if ($existing === null) {
+                // Vanished between the violation and the re-read — the only way
+                // this happens is a concurrent delete, so rethrow rather than
+                // invent a row.
+                throw $e;
+            }
+
+            $existing->setState($state);
+            $existing->setUpdated(new DateTime());
+
+            return $this->update(entity: $existing);
+        }//end try
+
+    }//end put()
+
+    /**
+     * Drop a flow's state.
+     *
+     * Used when a flow is deleted, so its bookkeeping does not outlive it and
+     * get inherited by a future flow that reuses the uuid.
+     *
+     * @param string $flowId The flow's uuid.
+     *
+     * @return void
+     */
+    public function deleteByFlow(string $flowId): void
+    {
+        $existing = $this->findByFlow(flowId: $flowId);
+        if ($existing === null) {
+            return;
+        }
+
+        $this->delete(entity: $existing);
+
+    }//end deleteByFlow()
+}//end class

--- a/lib/Migration/Version1Date20260731080000.php
+++ b/lib/Migration/Version1Date20260731080000.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Creates `openregister_flow_state` — state a flow keeps BETWEEN runs.
+ *
+ * OR#2216. A scheduled flow starts blank on every tick. The flow object carries
+ * only its definition (`nodes`, `edges`, `cron`, …) and `openregister_flow_runs`
+ * carries `marking` / `items` / `context`, which are PER-RUN resumption state
+ * discarded when the run ends.
+ *
+ * So a flow that polls every five minutes has nowhere to keep a counter, a
+ * cursor, a capacity table or "what did I already process". Every such value
+ * had to become a separate register object, which is how hydra's concurrency
+ * cap ended up as object writes and walked into the lost-update documented in
+ * OR#2212.
+ *
+ * WHY A TABLE RATHER THAN A COLUMN ON THE FLOW. `FlowScheduleService` already
+ * keeps one piece of per-flow state — the last-fire timestamp — beside the flow
+ * rather than on it, and says why: "so the flow object itself is never
+ * rewritten". Writing state onto the flow object each tick would churn the
+ * definition's version and audit history with machine noise, race with an
+ * operator editing that flow in the UI (last-write-wins is fine for data and
+ * wrong for a definition), and merge "what this flow does" with "what this flow
+ * is currently holding". This generalises the scheduler's existing choice
+ * instead of contradicting it.
+ *
+ * `flow_id` is UNIQUE: exactly one state row per flow. That is what lets a
+ * writer claim it atomically rather than read-then-write, which is the mistake
+ * this whole line of work exists to stop repeating.
+ *
+ * Strictly additive — a new table cannot fail on existing data. Idempotent:
+ * created only when absent.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adds the `openregister_flow_state` table.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+class Version1Date20260731080000 extends SimpleMigrationStep
+{
+
+    /**
+     * The table holding per-flow state that survives between runs.
+     *
+     * @var string
+     */
+    private const TABLE = 'openregister_flow_state';
+
+    /**
+     * Create the table when it does not exist yet.
+     *
+     * @param IOutput                   $output        Migration output.
+     * @param Closure(): ISchemaWrapper $schemaClosure Schema accessor.
+     * @param array                     $options       Migration options.
+     *
+     * @return null|ISchemaWrapper The modified schema, or null when unchanged.
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+            @var ISchemaWrapper $schema
+        */
+
+        $schema = $schemaClosure();
+
+        if ($schema->hasTable(self::TABLE) === true) {
+            return null;
+        }
+
+        $table = $schema->createTable(self::TABLE);
+
+        $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true]);
+        $table->addColumn('flow_id', Types::STRING, ['notnull' => true, 'length' => 64]);
+        // The state itself. TEXT rather than a typed column set: what a flow
+        // needs to remember is the flow author's business, and a schema here
+        // would have to be migrated every time one of them needed a new field.
+        $table->addColumn('state', Types::TEXT, ['notnull' => false]);
+        $table->addColumn('updated', Types::DATETIME, ['notnull' => false]);
+
+        $table->setPrimaryKey(['id']);
+
+        // UNIQUE, not just indexed. One state row per flow is what allows a
+        // claim to be settled by the database instead of by a read-then-write
+        // in PHP — see OR#2212 for what the latter costs.
+        $table->addUniqueIndex(['flow_id'], 'or_flowstate_flow_uq');
+
+        return $schema;
+
+    }//end changeSchema()
+}//end class

--- a/tests/Unit/Db/FlowStateTest.php
+++ b/tests/Unit/Db/FlowStateTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * Unit tests for the FlowState entity.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ *
+ * @author  Conduction Development Team <dev@conduction.nl>
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Db;
+
+use DateTime;
+use OCA\OpenRegister\Db\FlowState;
+use PHPUnit\Framework\TestCase;
+
+final class FlowStateTest extends TestCase
+{
+    /**
+     * State round-trips as an array.
+     *
+     * The `json` field type is what lets a flow keep a structured value — a
+     * slot table, a cursor, a counter — rather than a string it has to parse
+     * itself on every tick.
+     *
+     * @return void
+     */
+    public function testStateRoundTripsAsAnArray(): void
+    {
+        $entity = new FlowState();
+        $entity->setFlowId('flow-1');
+        $entity->setState(['slots' => ['1' => 'job-7'], 'cursor' => 12]);
+
+        self::assertSame(expected: 'flow-1', actual: $entity->getFlowId());
+        self::assertSame(expected: ['slots' => ['1' => 'job-7'], 'cursor' => 12], actual: $entity->getState());
+
+    }//end testStateRoundTripsAsAnArray()
+
+    /**
+     * A flow with no state yet serialises as an empty map, not null.
+     *
+     * A consumer reading `state` should be able to index into it without a null
+     * check on the very first tick, which is exactly when a scheduled flow has
+     * nothing stored.
+     *
+     * @return void
+     */
+    public function testAbsentStateSerialisesAsAnEmptyMap(): void
+    {
+        $entity = new FlowState();
+        $entity->setFlowId('flow-1');
+
+        $json = $entity->jsonSerialize();
+
+        self::assertSame(expected: [], actual: $json['state']);
+
+    }//end testAbsentStateSerialisesAsAnEmptyMap()
+
+    /**
+     * `updated` serialises as ISO-8601, or null when never written.
+     *
+     * @return void
+     */
+    public function testUpdatedSerialisesAsIso8601OrNull(): void
+    {
+        $entity = new FlowState();
+        self::assertNull(actual: $entity->jsonSerialize()['updated']);
+
+        $entity->setUpdated(new DateTime('2026-07-31 08:00:00+00:00'));
+        self::assertStringStartsWith(prefix: '2026-07-31T08:00:00', string: $entity->jsonSerialize()['updated']);
+
+    }//end testUpdatedSerialisesAsIso8601OrNull()
+}//end class


### PR DESCRIPTION
A scheduled flow **starts blank on every tick**. The flow object carries only its definition (`nodes`, `edges`, `cron`); `openregister_flow_runs` carries `marking`/`items`/`context`, which are **per-run** resumption state discarded when the run ends.

So a flow polling every five minutes had nowhere to keep a counter, a cursor, a capacity table, or "what did I already process". Every such value had to become a separate register object — which is how hydra's concurrency cap became object writes and walked into the lost update in #2212.

## Why a table, not a column on the flow

`FlowScheduleService` already keeps one piece of per-flow state — the last-fire timestamp — beside the flow rather than on it, and says why:

> so the flow object itself is never rewritten

Writing state onto the flow object each tick would churn the definition's version and audit history with machine noise, race with an operator editing that flow in the UI, and merge "what this flow does" with "what it is currently holding". This **generalises the scheduler's existing choice** rather than contradicting it.

## `flow_id` is UNIQUE, and `put()` inserts first

One state row per flow. `put()` attempts the INSERT **first** and catches the unique-constraint violation **by reason**, rather than checking for a row and then writing. Check-then-write is a lost update waiting for two concurrent writers — the mistake this whole line of work exists to stop repeating. Caught by reason rather than dialect-specific upsert SQL, so MySQL and PostgreSQL behave identically (the pattern `NotificationDedupeStateMapper` already uses).

## Verified on the live instance, not only in unit tests

```
create -> update -> readback -> delete     round-trips correctly
10 CONCURRENT put() on a fresh flow id     10 OK, 1 row, 1 id, no errors
```

Migration executed for real via `occ upgrade` (instance left out of maintenance mode), and the table verified to carry `or_flowstate_flow_uq` UNIQUE on `flow_id`. Live checks re-run **after** the final `phpcbf` reformat.

## Gates

phpcs clean, phpstan OK, **15,521 unit tests green**

## Scope, stated plainly

This is the **storage layer**. Nodes cannot read or write it yet — exposing it in the run context and persisting changes at run end is the next step, deliberately separate so this lands verifiable rather than half-wired.

Part of #2216. Consumed by hydra#425 tasks 3.5 and 3.7.
