### PR TITLE
feat(flow): nodes can read and write flow state; bump version so the migration runs

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -40,7 +40,7 @@ Open Register drijft apps zoals OpenCatalogi, Procest, Pipelinq en Software Cata
 
 Vrij en open source onder de EUPL-licentie.
     ]]></description>
-    <version>0.2.17-unstable.19</version>
+    <version>0.2.17-unstable.20</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>OpenRegister</namespace>

--- a/lib/Exception/ObjectExistsException.php
+++ b/lib/Exception/ObjectExistsException.php
@@ -41,14 +41,19 @@ use Throwable;
  * Uses HTTP 409 Conflict: the request could not be completed because of a
  * conflict with the current state of the resource (RFC 9110 §15.5.10).
  *
- * ⚠️ NOT A LOCK — see openregister#2212. The guard that raises this sits
- * between the existence lookup and the write, which are two separate
- * operations. Under CONCURRENT claims several callers can all pass the lookup
- * before any of them writes, and several receive 201. A sequential second
- * create is correctly refused; simultaneous ones are not serialised. Do not
- * rely on this for mutual exclusion until the arbitration moves into the
- * database (a real INSERT against the `_uuid` unique constraint, or a
- * transaction around check-and-write).
+ * This IS safe under concurrency as of openregister#2215. An earlier version of
+ * this note said the opposite, and it was true when written: the only guard
+ * then sat between the existence lookup and the write, so several simultaneous
+ * callers could all pass it and all receive 201. The arbitration now lives in
+ * MagicMapper, which refuses both the update branch and a losing INSERT when
+ * insert-only is asked for. Verified 6/6 races at 12 concurrent claimants on
+ * one identifier: 1x201, 11x409, one row.
+ *
+ * The mechanism is worth knowing before changing that code: the losing writer
+ * usually never reaches an INSERT at all. It passes the service-level lookup,
+ * so the audit trail records `create`, and then the mapper's own lookup finds
+ * the winner's row and takes the UPDATE branch. Guarding only the constraint
+ * violation therefore fixes almost nothing.
  *
  * @category Exception
  * @package  OCA\OpenRegister\Exception

--- a/lib/Service/Flow/FlowRunService.php
+++ b/lib/Service/Flow/FlowRunService.php
@@ -35,6 +35,7 @@ namespace OCA\OpenRegister\Service\Flow;
 use DateTime;
 use OCA\OpenRegister\Db\FlowRun;
 use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Db\FlowStateMapper;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -47,14 +48,16 @@ class FlowRunService
     /**
      * Constructor.
      *
-     * @param FlowRunMapper      $mapper    Persists runs.
-     * @param FlowEngine         $engine    Walks the graph.
-     * @param FlowNodeRegistry   $registry  Resolves step types.
-     * @param LoggerInterface    $logger    The logger.
-     * @param ContainerInterface $container Lazily resolves OrganisationService.
+     * @param FlowRunMapper      $mapper      Persists runs.
+     * @param FlowStateMapper    $stateMapper Persists state that outlives a run.
+     * @param FlowEngine         $engine      Walks the graph.
+     * @param FlowNodeRegistry   $registry    Resolves step types.
+     * @param LoggerInterface    $logger      The logger.
+     * @param ContainerInterface $container   Lazily resolves OrganisationService.
      */
     public function __construct(
         private readonly FlowRunMapper $mapper,
+        private readonly FlowStateMapper $stateMapper,
         private readonly FlowEngine $engine,
         private readonly FlowNodeRegistry $registry,
         private readonly LoggerInterface $logger,
@@ -170,6 +173,52 @@ class FlowRunService
     }//end hasActiveRun()
 
     /**
+     * Write a run's flow state back to its own table, when a node changed it.
+     *
+     * @param FlowRun $run     The run that just finished a pass.
+     * @param array   $context The context the engine returned.
+     *
+     * @return void
+     */
+    private function persistFlowState(FlowRun $run, array $context): void
+    {
+        $handle = ($context[FlowStateHandle::CONTEXT_KEY] ?? null);
+        if (($handle instanceof FlowStateHandle) === false) {
+            return;
+        }
+
+        if ($handle->isDirty() === false) {
+            return;
+        }
+
+        $flowId = trim((string) $run->getFlowId());
+        if ($flowId === '') {
+            return;
+        }
+
+        try {
+            $this->stateMapper->put(flowId: $flowId, state: $handle->all());
+        } catch (Throwable $e) {
+            // Deliberately non-fatal, and deliberately LOUD. A run that did its
+            // work should not be recorded as failed because its bookkeeping
+            // could not be saved — but a silently dropped state write would let
+            // a flow repeat work forever while looking healthy, so this must be
+            // visible rather than swallowed.
+            $this->logger->error(
+                message: '[FlowRunService] Could not persist flow state',
+                context: [
+                    'file'  => __FILE__,
+                    'line'  => __LINE__,
+                    'flow'  => $flowId,
+                    'run'   => $run->getUuid(),
+                    'error' => $e->getMessage(),
+                ]
+            );
+        }//end try
+
+    }//end persistFlowState()
+
+    /**
      * Queue a fresh run that repeats a finished one.
      *
      * Retry NEVER re-executes the old run — that would repeat every side effect
@@ -186,7 +235,6 @@ class FlowRunService
      *
      * @spec openspec/changes/or-flow-tooling/specs/flow-tooling/spec.md
      */
-
     public function retry(FlowRun $run): ?FlowRun
     {
         if ($run->isTerminal() === false) {
@@ -271,6 +319,22 @@ class FlowRunService
         // gets back exactly what it held when it stopped.
         $context[FlowToken::CONTEXT_KEY] = FlowToken::fromArray(($context[FlowToken::CONTEXT_KEY] ?? null));
 
+        // Flow state is the token's long-lived sibling: the token belongs to
+        // THIS run and dies with it, this belongs to the FLOW and outlives every
+        // run of it. Loaded from its own table rather than from the run's
+        // context, because a scheduled flow's next tick is a different run and
+        // would otherwise start blank — which is the whole gap OR#2216 exists
+        // to close.
+        //
+        // Handed over as an object for the same reason as the token: nodes take
+        // $context by value, so only a handle gives them write access.
+        $flowState = null;
+        if (trim((string) $run->getFlowId()) !== '') {
+            $stored    = $this->stateMapper->findByFlow(flowId: (string) $run->getFlowId());
+            $flowState = new FlowStateHandle(values: ($stored?->getState() ?? []));
+            $context[FlowStateHandle::CONTEXT_KEY] = $flowState;
+        }
+
         try {
             $result = $this->engine->run(
                 flow: $flow,
@@ -327,6 +391,22 @@ class FlowRunService
         if (isset($context[FlowToken::CONTEXT_KEY]) === true && $context[FlowToken::CONTEXT_KEY] instanceof FlowToken === true) {
             $context[FlowToken::CONTEXT_KEY] = $context[FlowToken::CONTEXT_KEY]->jsonSerialize();
         }
+
+        // Flow state persists to its OWN table and is then removed from the
+        // run's context. Two reasons it must not be written into the context
+        // JSON alongside the token:
+        //
+        // - it would be a per-run COPY of flow-level state, and a resumed run
+        // would restore a stale snapshot over whatever later runs had
+        // written
+        // - a slot table or a cursor would be duplicated into every run row
+        // the flow ever produces
+        //
+        // Only written when a node actually changed something: a flow that
+        // merely READS its state should not touch the row on every tick, and a
+        // five-minute schedule makes that difference thousands of writes a week.
+        $this->persistFlowState(run: $run, context: $context);
+        unset($context[FlowStateHandle::CONTEXT_KEY]);
 
         $run->setStatus($status);
         $run->setItems((array) ($result['items'] ?? []));

--- a/lib/Service/Flow/FlowStateHandle.php
+++ b/lib/Service/Flow/FlowStateHandle.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * The state a flow carries BETWEEN runs, as a writable handle.
+ *
+ * `FlowToken` is the value that belongs to one RUN — a correlation id, a
+ * reference resolved once, an envelope threaded through a pipeline — and it
+ * dies when that run ends. This is its long-lived sibling: the value that
+ * belongs to the FLOW and outlives every run of it.
+ *
+ * A scheduled flow starts blank on every tick, so anything it needs to
+ * remember — a capacity table, a cursor, "what did I already process" — has
+ * nowhere to live. Before this, every such value had to become a separate
+ * register object, which is how hydra's concurrency cap became object writes
+ * and walked into the lost update in OR#2212.
+ *
+ * A node reaches it at `$context['flowState']` and may WRITE to it, for the
+ * same reason `FlowToken` is a class and not an array: `IFlowNode::execute()`
+ * takes `$context` by value, so a plain array could only ever be read. An
+ * object is a handle, and the handle survives the copy — which buys write
+ * access for every node without changing the signature any node implements.
+ *
+ * WHAT IT IS NOT: a lock. Two runs of one flow reading, mutating and writing
+ * this back would race exactly as OR#2212 described. Safety comes from the
+ * scheduler refusing to overlap a flow with itself (see
+ * `FlowScheduleService::fireDueFlows()`), which is the same property that makes
+ * the shell orchestrator this replaces safe today — one process holding a
+ * flock, not an atomic claim. Do not reach for this to coordinate ACROSS
+ * flows; use an object write with `onConflict: fail` for that.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use JsonSerializable;
+
+/**
+ * A mutable view of one flow's persistent state.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+class FlowStateHandle implements JsonSerializable
+{
+
+    /**
+     * Where a node finds this in the step context.
+     *
+     * @var string
+     */
+    public const CONTEXT_KEY = 'flowState';
+
+    /**
+     * The stored values.
+     *
+     * @var array
+     */
+    private array $values = [];
+
+    /**
+     * Whether anything was written since the handle was built.
+     *
+     * Tracked so a run that only READS state does not rewrite the row. A flow
+     * polling every five minutes would otherwise touch its state table on every
+     * tick forever, for nothing.
+     *
+     * @var boolean
+     */
+    private bool $dirty = false;
+
+    /**
+     * Build a handle over stored values.
+     *
+     * @param array|null $values The values already stored for this flow.
+     *
+     * @return void
+     */
+    public function __construct(?array $values=null)
+    {
+        $this->values = ($values ?? []);
+
+    }//end __construct()
+
+    /**
+     * Read one value.
+     *
+     * @param string $key     The key to read.
+     * @param mixed  $default Returned when the key was never written.
+     *
+     * @return mixed The stored value, or the default.
+     */
+    public function get(string $key, mixed $default=null): mixed
+    {
+        return ($this->values[$key] ?? $default);
+
+    }//end get()
+
+    /**
+     * Write one value.
+     *
+     * @param string $key   The key to write.
+     * @param mixed  $value The value to store.
+     *
+     * @return void
+     */
+    public function set(string $key, mixed $value): void
+    {
+        $this->values[$key] = $value;
+        $this->dirty        = true;
+
+    }//end set()
+
+    /**
+     * Remove one value.
+     *
+     * @param string $key The key to remove.
+     *
+     * @return void
+     */
+    public function forget(string $key): void
+    {
+        if (array_key_exists($key, $this->values) === false) {
+            return;
+        }
+
+        unset($this->values[$key]);
+        $this->dirty = true;
+
+    }//end forget()
+
+    /**
+     * Whether this flow has ever stored the key.
+     *
+     * Distinct from `get() === null`: a flow may deliberately store null.
+     *
+     * @param string $key The key to test.
+     *
+     * @return boolean True when the key exists.
+     */
+    public function has(string $key): bool
+    {
+        return array_key_exists($key, $this->values);
+
+    }//end has()
+
+    /**
+     * Whether anything was written since this handle was built.
+     *
+     * @return boolean True when the state needs persisting.
+     */
+    public function isDirty(): bool
+    {
+        return $this->dirty;
+
+    }//end isDirty()
+
+    /**
+     * All stored values.
+     *
+     * @return array The values.
+     */
+    public function all(): array
+    {
+        return $this->values;
+
+    }//end all()
+
+    /**
+     * Serialise for storage.
+     *
+     * @return array The values.
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->values;
+
+    }//end jsonSerialize()
+}//end class

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -2917,14 +2917,16 @@ class SaveObject
                 // which callers depend on it. Flipping the default would change
                 // behaviour fleet-wide with no way to enumerate the blast radius.
                 //
-                // ⚠️ THIS IS NOT A LOCK — openregister#2212. This check and the
-                // write below are two separate operations, so N concurrent
-                // callers can all reach here having found nothing and all
-                // proceed. Measured: 10 simultaneous claims on one identifier
-                // returned 201 six times. It narrows the window; it does not
-                // close it. Closing it means letting the database arbitrate — a
-                // real INSERT against the `_uuid` unique constraint, translated
-                // into this exception.
+                // This guard alone is NOT what makes the claim safe — it is a
+                // fast path. It and the write below are two separate
+                // operations, so under concurrency N callers can all reach here
+                // having found nothing. The arbitration that actually closes
+                // the race lives one layer down in
+                // MagicMapper::saveObjectToRegisterSchemaTable(), which refuses
+                // both the update branch and a losing INSERT when this flag is
+                // set (openregister#2215). Verified 6/6 races at 12 concurrent
+                // claimants: 1x201, 11x409. Do not remove that guard on the
+                // assumption that this one covers it.
                 if ($failIfExists === true) {
                     $this->logger->debug(
                         message: '[SaveObject] Existing object found and failIfExists is set, refusing the write',

--- a/tests/Unit/Service/Flow/FlowRunRetryTest.php
+++ b/tests/Unit/Service/Flow/FlowRunRetryTest.php
@@ -31,6 +31,7 @@ class FlowRunRetryTest extends TestCase
 
         $this->service = new FlowRunService(
             $this->mapper,
+            $this->createMock(\OCA\OpenRegister\Db\FlowStateMapper::class),
             $this->createMock(FlowEngine::class),
             $this->createMock(FlowNodeRegistry::class),
             new NullLogger(),

--- a/tests/Unit/Service/Flow/FlowRunServiceTest.php
+++ b/tests/Unit/Service/Flow/FlowRunServiceTest.php
@@ -164,6 +164,7 @@ class FlowRunServiceTest extends TestCase
 
         $this->service = new FlowRunService(
             $this->mapper,
+            $this->createMock(\OCA\OpenRegister\Db\FlowStateMapper::class),
             $engine,
             $registry,
             $this->createMock(LoggerInterface::class),

--- a/tests/Unit/Service/Flow/FlowStateHandleTest.php
+++ b/tests/Unit/Service/Flow/FlowStateHandleTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * Unit tests for FlowStateHandle.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author  Conduction Development Team <dev@conduction.nl>
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowStateHandle;
+use PHPUnit\Framework\TestCase;
+
+final class FlowStateHandleTest extends TestCase
+{
+    /**
+     * A handle built from stored values reads them back.
+     *
+     * This is the property that makes a scheduled flow's next tick useful: the
+     * fifth run sees what the fourth wrote.
+     *
+     * @return void
+     */
+    public function testStoredValuesAreReadable(): void
+    {
+        $handle = new FlowStateHandle(values: ['cursor' => 12, 'slots' => ['1' => 'job-7']]);
+
+        self::assertSame(expected: 12, actual: $handle->get('cursor'));
+        self::assertSame(expected: ['1' => 'job-7'], actual: $handle->get('slots'));
+
+    }//end testStoredValuesAreReadable()
+
+    /**
+     * An unknown key returns the caller's default.
+     *
+     * A flow's FIRST tick has nothing stored, and that must not be a special
+     * case the flow author has to handle.
+     *
+     * @return void
+     */
+    public function testUnknownKeyReturnsTheDefault(): void
+    {
+        $handle = new FlowStateHandle();
+
+        self::assertSame(expected: 'none', actual: $handle->get('cursor', 'none'));
+        self::assertNull(actual: $handle->get('cursor'));
+
+    }//end testUnknownKeyReturnsTheDefault()
+
+    /**
+     * A fresh handle is clean; writing marks it dirty.
+     *
+     * This is what stops a flow that merely READS its state from rewriting the
+     * row on every tick. On a five-minute schedule that difference is thousands
+     * of pointless writes a week.
+     *
+     * @return void
+     */
+    public function testOnlyWritingMarksTheHandleDirty(): void
+    {
+        $handle = new FlowStateHandle(values: ['cursor' => 1]);
+        self::assertFalse(condition: $handle->isDirty());
+
+        $handle->get('cursor');
+        self::assertFalse(condition: $handle->isDirty());
+
+        $handle->set('cursor', 2);
+        self::assertTrue(condition: $handle->isDirty());
+
+    }//end testOnlyWritingMarksTheHandleDirty()
+
+    /**
+     * Forgetting a key removes it and marks the handle dirty.
+     *
+     * Releasing a slot is a delete, not a write of null — `has()` must go false
+     * so a later claim sees the slot as free.
+     *
+     * @return void
+     */
+    public function testForgettingRemovesTheKeyAndDirties(): void
+    {
+        $handle = new FlowStateHandle(values: ['slot1' => 'job-7']);
+
+        $handle->forget('slot1');
+
+        self::assertFalse(condition: $handle->has('slot1'));
+        self::assertTrue(condition: $handle->isDirty());
+
+    }//end testForgettingRemovesTheKeyAndDirties()
+
+    /**
+     * Forgetting an absent key does not dirty the handle.
+     *
+     * Otherwise a flow that releases an already-free slot would rewrite the row
+     * for nothing on every tick.
+     *
+     * @return void
+     */
+    public function testForgettingAnAbsentKeyDoesNotDirty(): void
+    {
+        $handle = new FlowStateHandle();
+
+        $handle->forget('slot1');
+
+        self::assertFalse(condition: $handle->isDirty());
+
+    }//end testForgettingAnAbsentKeyDoesNotDirty()
+
+    /**
+     * `has()` distinguishes a stored null from an absent key.
+     *
+     * A flow may deliberately store null — an empty slot, say — and that is not
+     * the same as never having written the key.
+     *
+     * @return void
+     */
+    public function testHasDistinguishesStoredNullFromAbsent(): void
+    {
+        $handle = new FlowStateHandle(values: ['slot1' => null]);
+
+        self::assertTrue(condition: $handle->has('slot1'));
+        self::assertFalse(condition: $handle->has('slot2'));
+        self::assertNull(actual: $handle->get('slot1'));
+
+    }//end testHasDistinguishesStoredNullFromAbsent()
+
+    /**
+     * The handle serialises to exactly what was stored.
+     *
+     * @return void
+     */
+    public function testSerialisesToItsValues(): void
+    {
+        $handle = new FlowStateHandle(values: ['cursor' => 1]);
+        $handle->set('slot1', 'job-7');
+
+        self::assertSame(
+            expected: ['cursor' => 1, 'slot1' => 'job-7'],
+            actual: $handle->jsonSerialize()
+        );
+
+    }//end testSerialisesToItsValues()
+}//end class

--- a/tests/Unit/Service/Flow/FlowTriggerServiceTest.php
+++ b/tests/Unit/Service/Flow/FlowTriggerServiceTest.php
@@ -91,6 +91,7 @@ class FlowTriggerServiceTest extends TestCase
 
         $runner = new FlowRunService(
             $mapper,
+            $this->createMock(\OCA\OpenRegister\Db\FlowStateMapper::class),
             $this->createMock(\OCA\OpenRegister\Service\Flow\FlowEngine::class),
             $this->createMock(\OCA\OpenRegister\Service\Flow\FlowNodeRegistry::class),
             new \Psr\Log\NullLogger(),


### PR DESCRIPTION
Completes the storage layer from #2219.

`FlowStateHandle` is `FlowToken`'s long-lived sibling: the token belongs to one **run** and dies with it; this belongs to the **flow** and outlives every run of it. Nodes reach it at `$context['flowState']`.

It is a class rather than an array for exactly the reason `FlowToken` is: `IFlowNode::execute()` takes `$context` **by value**, so a plain array could only ever be read. An object is a handle, and the handle survives the copy — write access for every node without changing the signature any node implements.

## Loaded at run start, persisted at run end, removed from the run context

Writing it into the context JSON would:

- leave a **per-run copy of flow-level state**, so a resumed run would restore a stale snapshot over whatever later runs had written
- duplicate a slot table into every run row the flow ever produces

Only persisted when a node actually changed something. A flow that merely *reads* its state should not touch the row — on a five-minute schedule that is thousands of writes a week avoided.

## Also in here, and why this is not purely additive

**Version bump.** #2219 shipped a migration **without** bumping `appinfo/info.xml`, so it would never have executed on any deployment. 3 of the 4 most recent migration commits bump it; mine didn't. Found because a host reboot wiped the dev container and the table had to be recreated — the migration's absence became visible only then.

**Two stale comments corrected.** `SaveObject` and `ObjectExistsException` still carried *"THIS IS NOT A LOCK — openregister#2212"* warnings I added before #2215 fixed it. True when written, false now — and a false warning on a hot write path is worse than none: it invites someone to add a redundant second guard, or to avoid a mechanism that works.

## Verified live — four separate handles against one flow

```
run1  sees []                                    dirty=false
run2  sees {"slots":{"1":"job-A","2":null},...}  <- run1's writes survived
run3  read-only                                  dirty=false, row untouched
run4  forget("slots")                            dirty=true, has()=false
```

## Gates

phpcs clean, phpstan OK, **15,528 unit tests green** (7 new for the handle)

Part of #2216. Unblocks hydra#425 task 3.5 — a slot table now has somewhere to live between ticks.
