### PR TITLE
feat(flow): a node that reads and writes flow state, with a capacity claim

### DIFF
--- a/lib/Listener/FlowNodeRegistrationListener.php
+++ b/lib/Listener/FlowNodeRegistrationListener.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Listener;
 
 use OCA\OpenRegister\Service\Flow\Nodes\FilterNode;
+use OCA\OpenRegister\Service\Flow\Nodes\FlowStateNode;
 use OCA\OpenRegister\Service\Flow\Nodes\LoopNode;
 use OCA\OpenRegister\Service\Flow\Nodes\MergeNode;
 use OCA\OpenRegister\Service\Flow\Nodes\ObjectWriteNode;
@@ -62,6 +63,7 @@ class FlowNodeRegistrationListener implements IEventListener
      * @param SubFlowNode     $subFlow     The built-in "Run a flow" node.
      * @param RouterNode      $router      The built-in "Route items" node.
      * @param ObjectWriteNode $objectWrite The built-in "Write an object" node.
+     * @param FlowStateNode   $flowState   The built-in "Flow state" node.
      */
     public function __construct(
         private readonly SetFieldsNode $setFields,
@@ -73,7 +75,8 @@ class FlowNodeRegistrationListener implements IEventListener
         private readonly LoopNode $loop,
         private readonly SubFlowNode $subFlow,
         private readonly RouterNode $router,
-        private readonly ObjectWriteNode $objectWrite
+        private readonly ObjectWriteNode $objectWrite,
+        private readonly FlowStateNode $flowState
     ) {
 
     }//end __construct()
@@ -103,6 +106,7 @@ class FlowNodeRegistrationListener implements IEventListener
         $event->registerNode(node: $this->subFlow);
         $event->registerNode(node: $this->router);
         $event->registerNode(node: $this->objectWrite);
+        $event->registerNode(node: $this->flowState);
 
     }//end handle()
 }//end class

--- a/lib/Service/Flow/Nodes/FlowStateNode.php
+++ b/lib/Service/Flow/Nodes/FlowStateNode.php
@@ -1,0 +1,424 @@
+<?php
+
+/**
+ * Reads and writes the state a flow keeps between runs.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Nodes;
+
+use InvalidArgumentException;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowStateHandle;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
+
+/**
+ * The node that makes flow state usable from a graph.
+ *
+ * A scheduled flow starts blank on every tick. `FlowStateHandle` gives it
+ * somewhere to remember things; this node is how a graph reaches that without
+ * writing PHP.
+ *
+ * The interesting operation is `claim`. A capacity cap — hydra's "at most ten
+ * pipelines at once", a booking, a lease — is a map of named slots where a free
+ * one must be taken by exactly one holder. Expressed with `get` and `set` that
+ * is a read-modify-write, and two runs doing it concurrently lose one of the
+ * claims. `claim` does the whole thing in one step, inside a single run, and
+ * emits `claimed: false` rather than pretending it succeeded.
+ *
+ * ⚠️ What makes that SAFE is that a scheduled flow never overlaps itself
+ * (`FlowScheduleService::fireDueFlows()` skips a tick whose previous run is
+ * still going). That is the same property the shell orchestrator this replaces
+ * relies on — one supervisor holding a flock, whose own slot bookkeeping is a
+ * plain check-then-write and is safe only because nothing runs beside it.
+ * This node is NOT a cross-flow lock: for that, write an object with
+ * `onConflict: fail`, where the database arbitrates.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+class FlowStateNode implements IFlowNode
+{
+
+    /**
+     * Read one key into the item.
+     *
+     * @var string
+     */
+    private const OP_GET = 'get';
+
+    /**
+     * Write one key.
+     *
+     * @var string
+     */
+    private const OP_SET = 'set';
+
+    /**
+     * Remove one key.
+     *
+     * @var string
+     */
+    private const OP_FORGET = 'forget';
+
+    /**
+     * Take a free slot from a map, or report that none was free.
+     *
+     * @var string
+     */
+    private const OP_CLAIM = 'claim';
+
+    /**
+     * Give a held slot back.
+     *
+     * @var string
+     */
+    private const OP_RELEASE = 'release';
+
+    /**
+     * Accepted operations.
+     *
+     * @var string[]
+     */
+    private const OPERATIONS = [
+        self::OP_GET,
+        self::OP_SET,
+        self::OP_FORGET,
+        self::OP_CLAIM,
+        self::OP_RELEASE,
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param IL10N         $l10n Translations.
+     * @param IURLGenerator $urls Icon paths.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly IL10N $l10n,
+        private readonly IURLGenerator $urls
+    ) {
+
+    }//end __construct()
+
+    /**
+     * The type identifier.
+     *
+     * @return string The id.
+     */
+    public function getId(): string
+    {
+        return 'openregister.flow-state';
+
+    }//end getId()
+
+    /**
+     * The display name.
+     *
+     * @return string The display name.
+     */
+    public function getDisplayName(): string
+    {
+        return $this->l10n->t('Flow state');
+
+    }//end getDisplayName()
+
+    /**
+     * The description.
+     *
+     * @return string The description.
+     */
+    public function getDescription(): string
+    {
+        return $this->l10n->t('Remember something between runs of this flow — a counter, a cursor, or a table of slots.');
+
+    }//end getDescription()
+
+    /**
+     * The icon.
+     *
+     * @return string The icon URL.
+     */
+    public function getIcon(): string
+    {
+        return $this->urls->imagePath('core', 'actions/history.svg');
+
+    }//end getIcon()
+
+    /**
+     * Availability.
+     *
+     * @param integer $scope The scope constant.
+     *
+     * @return boolean Whether it is available.
+     */
+    public function isAvailableForScope(int $scope): bool
+    {
+        return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
+
+    }//end isAvailableForScope()
+
+    /**
+     * Validate the authored configuration.
+     *
+     * @param array $config The step's configuration.
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException When the configuration cannot run.
+     */
+    public function validateConfig(array $config): void
+    {
+        $operation = (string) ($config['operation'] ?? '');
+        if (in_array($operation, self::OPERATIONS, true) === false) {
+            throw new InvalidArgumentException(
+                sprintf('operation must be one of: %s', implode(', ', self::OPERATIONS))
+            );
+        }
+
+        if ($operation === self::OP_CLAIM || $operation === self::OP_RELEASE) {
+            if (trim((string) ($config['slots'] ?? '')) === '') {
+                throw new InvalidArgumentException('slots is required for claim and release');
+            }
+
+            if ($operation === self::OP_CLAIM && (int) ($config['capacity'] ?? 0) < 1) {
+                throw new InvalidArgumentException('capacity must be at least 1 for claim');
+            }
+
+            return;
+        }
+
+        if (trim((string) ($config['key'] ?? '')) === '') {
+            throw new InvalidArgumentException('key is required');
+        }
+
+    }//end validateConfig()
+
+    /**
+     * Run the step.
+     *
+     * @param array $items   The input items.
+     * @param array $config  The step's configuration.
+     * @param array $context Run-level metadata.
+     *
+     * @return array The output items.
+     *
+     * @throws InvalidArgumentException When flow state is unavailable.
+     */
+    public function execute(array $items, array $config, array $context): array
+    {
+        $state = ($context[FlowStateHandle::CONTEXT_KEY] ?? null);
+        if (($state instanceof FlowStateHandle) === false) {
+            // A run with no flow id has no state to keep. Failing loudly beats
+            // silently behaving as though every key were empty, which would
+            // make a capacity cap wave everything through.
+            throw new InvalidArgumentException('This run has no flow state — flow state needs a flow-scoped run.');
+        }
+
+        $operation = (string) ($config['operation'] ?? '');
+        $output    = [];
+
+        foreach ($items as $index => $item) {
+            $json = (array) ($item['json'] ?? []);
+
+            $json = match ($operation) {
+                self::OP_GET => $this->doGet(state: $state, config: $config, json: $json),
+                self::OP_SET => $this->doSet(state: $state, config: $config, json: $json),
+                self::OP_FORGET => $this->doForget(state: $state, config: $config, json: $json),
+                self::OP_CLAIM => $this->doClaim(state: $state, config: $config, json: $json),
+                self::OP_RELEASE => $this->doRelease(state: $state, config: $config, json: $json),
+                default => $json,
+            };
+
+            $output[] = FlowItems::item(
+                json: $json,
+                binary: (array) ($item['binary'] ?? []),
+                fromItemIndex: (int) $index
+            );
+        }//end foreach
+
+        return $output;
+
+    }//end execute()
+
+    /**
+     * Read one key into the item.
+     *
+     * @param FlowStateHandle $state  The state handle.
+     * @param array           $config The step's configuration.
+     * @param array           $json   The item's json.
+     *
+     * @return array The item's json.
+     */
+    private function doGet(FlowStateHandle $state, array $config, array $json): array
+    {
+        $key       = (string) $config['key'];
+        $as        = (string) ($config['as'] ?? $key);
+        $json[$as] = $state->get($key, ($config['default'] ?? null));
+
+        return $json;
+
+    }//end doGet()
+
+    /**
+     * Write one key.
+     *
+     * @param FlowStateHandle $state  The state handle.
+     * @param array           $config The step's configuration.
+     * @param array           $json   The item's json.
+     *
+     * @return array The item's json.
+     */
+    private function doSet(FlowStateHandle $state, array $config, array $json): array
+    {
+        $key = (string) $config['key'];
+
+        // `from` reads the value off the item, so a step can store something it
+        // just computed; `value` is a literal for authored constants.
+        $value = ($config['value'] ?? null);
+        if (isset($config['from']) === true) {
+            $value = ($json[(string) $config['from']] ?? null);
+        }
+
+        $state->set($key, $value);
+
+        return $json;
+
+    }//end doSet()
+
+    /**
+     * Remove one key.
+     *
+     * @param FlowStateHandle $state  The state handle.
+     * @param array           $config The step's configuration.
+     * @param array           $json   The item's json.
+     *
+     * @return array The item's json.
+     */
+    private function doForget(FlowStateHandle $state, array $config, array $json): array
+    {
+        $state->forget((string) $config['key']);
+
+        return $json;
+
+    }//end doForget()
+
+    /**
+     * Take a free slot, or report that none was free.
+     *
+     * Emits `claimed` and `slot` onto the item so a router can branch on them.
+     * A caller that ignores `claimed` and proceeds anyway has overrun its own
+     * cap — which is why this reports rather than throws: the flow author
+     * decides whether "no capacity" means wait, stop or escalate.
+     *
+     * @param FlowStateHandle $state  The state handle.
+     * @param array           $config The step's configuration.
+     * @param array           $json   The item's json.
+     *
+     * @return array The item's json.
+     */
+    private function doClaim(FlowStateHandle $state, array $config, array $json): array
+    {
+        $slotsKey = (string) $config['slots'];
+        $capacity = (int) $config['capacity'];
+        $holder   = (string) ($json[(string) ($config['holder'] ?? 'holder')] ?? '');
+
+        $slots = (array) $state->get($slotsKey, []);
+
+        // A slot is free when it holds nothing. Slots are numbered from 1 so
+        // the value reads naturally in a dashboard ("slot 3 of 10").
+        for ($n = 1; $n <= $capacity; $n++) {
+            $slot = (string) $n;
+            if (($slots[$slot] ?? null) !== null) {
+                continue;
+            }
+
+            $held = true;
+            if ($holder !== '') {
+                $held = $holder;
+            }
+
+            $slots[$slot] = $held;
+            $state->set($slotsKey, $slots);
+
+            $json['claimed'] = true;
+            $json['slot']    = $n;
+
+            return $json;
+        }
+
+        $json['claimed'] = false;
+        $json['slot']    = null;
+
+        return $json;
+
+    }//end doClaim()
+
+    /**
+     * Give a held slot back.
+     *
+     * @param FlowStateHandle $state  The state handle.
+     * @param array           $config The step's configuration.
+     * @param array           $json   The item's json.
+     *
+     * @return array The item's json.
+     */
+    private function doRelease(FlowStateHandle $state, array $config, array $json): array
+    {
+        $slotsKey = (string) $config['slots'];
+        $slots    = (array) $state->get($slotsKey, []);
+
+        // Release by slot number when the caller knows it, otherwise by holder
+        // — a stage that crashed and is being cleaned up knows who it was, not
+        // which slot it got.
+        $slot = ($json[(string) ($config['slot'] ?? 'slot')] ?? null);
+        if ($slot !== null && array_key_exists((string) $slot, $slots) === true) {
+            $slots[(string) $slot] = null;
+            $state->set($slotsKey, $slots);
+            $json['released'] = true;
+
+            return $json;
+        }
+
+        $holder = (string) ($json[(string) ($config['holder'] ?? 'holder')] ?? '');
+        if ($holder !== '') {
+            $found = array_search($holder, $slots, true);
+            if ($found !== false) {
+                $slots[(string) $found] = null;
+                $state->set($slotsKey, $slots);
+                $json['released'] = true;
+
+                return $json;
+            }
+        }
+
+        $json['released'] = false;
+
+        return $json;
+
+    }//end doRelease()
+}//end class

--- a/tests/Unit/Service/Flow/FlowStateNodeTest.php
+++ b/tests/Unit/Service/Flow/FlowStateNodeTest.php
@@ -1,0 +1,302 @@
+<?php
+
+/**
+ * Unit tests for FlowStateNode.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author  Conduction Development Team <dev@conduction.nl>
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use InvalidArgumentException;
+use OCA\OpenRegister\Service\Flow\FlowStateHandle;
+use OCA\OpenRegister\Service\Flow\Nodes\FlowStateNode;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+
+final class FlowStateNodeTest extends TestCase
+{
+
+    /**
+     * The node under test.
+     *
+     * @var FlowStateNode
+     */
+    private FlowStateNode $node;
+
+    /**
+     * Build the node with stub collaborators.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $l10n = $this->createMock(originalClassName: IL10N::class);
+        $l10n->method('t')->willReturnArgument(0);
+
+        $this->node = new FlowStateNode($l10n, $this->createMock(originalClassName: IURLGenerator::class));
+
+    }//end setUp()
+
+    /**
+     * Wrap a handle in the context shape the engine passes.
+     *
+     * @param FlowStateHandle $handle The handle.
+     *
+     * @return array The context.
+     */
+    private function ctx(FlowStateHandle $handle): array
+    {
+        return [FlowStateHandle::CONTEXT_KEY => $handle];
+
+    }//end ctx()
+
+    /**
+     * One item, with the given json.
+     *
+     * @param array $json The item's json.
+     *
+     * @return array The items array.
+     */
+    private function items(array $json=[]): array
+    {
+        return [['json' => $json]];
+
+    }//end items()
+
+    /**
+     * A claim takes the first free slot and reports which.
+     *
+     * @return void
+     */
+    public function testClaimTakesTheFirstFreeSlot(): void
+    {
+        $state = new FlowStateHandle();
+
+        $out = $this->node->execute(
+            items: $this->items(json: ['holder' => 'issue-42']),
+            config: ['operation' => 'claim', 'slots' => 'slots', 'capacity' => 3],
+            context: $this->ctx(handle: $state)
+        );
+
+        self::assertTrue(condition: $out[0]['json']['claimed']);
+        self::assertSame(expected: 1, actual: $out[0]['json']['slot']);
+        self::assertSame(expected: ['1' => 'issue-42'], actual: $state->get(key: 'slots'));
+
+    }//end testClaimTakesTheFirstFreeSlot()
+
+    /**
+     * A second claim takes the NEXT slot, not the same one.
+     *
+     * @return void
+     */
+    public function testASecondClaimTakesTheNextSlot(): void
+    {
+        $state = new FlowStateHandle(values: ['slots' => ['1' => 'issue-1']]);
+
+        $out = $this->node->execute(
+            items: $this->items(json: ['holder' => 'issue-2']),
+            config: ['operation' => 'claim', 'slots' => 'slots', 'capacity' => 3],
+            context: $this->ctx(handle: $state)
+        );
+
+        self::assertSame(expected: 2, actual: $out[0]['json']['slot']);
+        self::assertSame(expected: ['1' => 'issue-1', '2' => 'issue-2'], actual: $state->get(key: 'slots'));
+
+    }//end testASecondClaimTakesTheNextSlot()
+
+    /**
+     * AT CAPACITY, a claim reports failure rather than overrunning.
+     *
+     * This is the whole point of the cap. A node that silently handed out an
+     * eleventh slot would make "at most ten pipelines" a comment rather than a
+     * limit.
+     *
+     * @return void
+     */
+    public function testAtCapacityTheClaimIsRefused(): void
+    {
+        $state = new FlowStateHandle(values: ['slots' => ['1' => 'a', '2' => 'b']]);
+
+        $out = $this->node->execute(
+            items: $this->items(json: ['holder' => 'c']),
+            config: ['operation' => 'claim', 'slots' => 'slots', 'capacity' => 2],
+            context: $this->ctx(handle: $state)
+        );
+
+        self::assertFalse(condition: $out[0]['json']['claimed']);
+        self::assertNull(actual: $out[0]['json']['slot']);
+        self::assertSame(expected: ['1' => 'a', '2' => 'b'], actual: $state->get(key: 'slots'));
+
+    }//end testAtCapacityTheClaimIsRefused()
+
+    /**
+     * A released slot becomes claimable again.
+     *
+     * @return void
+     */
+    public function testReleaseFreesTheSlotForTheNextClaim(): void
+    {
+        $state = new FlowStateHandle(values: ['slots' => ['1' => 'a', '2' => 'b']]);
+
+        $this->node->execute(
+            items: $this->items(json: ['slot' => 1]),
+            config: ['operation' => 'release', 'slots' => 'slots'],
+            context: $this->ctx(handle: $state)
+        );
+
+        self::assertSame(expected: ['1' => null, '2' => 'b'], actual: $state->get(key: 'slots'));
+
+        $out = $this->node->execute(
+            items: $this->items(json: ['holder' => 'c']),
+            config: ['operation' => 'claim', 'slots' => 'slots', 'capacity' => 2],
+            context: $this->ctx(handle: $state)
+        );
+
+        self::assertSame(expected: 1, actual: $out[0]['json']['slot']);
+
+    }//end testReleaseFreesTheSlotForTheNextClaim()
+
+    /**
+     * A slot can be released by holder when the number is unknown.
+     *
+     * A stage that crashed knows who it was, not which slot it got.
+     *
+     * @return void
+     */
+    public function testReleaseByHolderWhenTheSlotNumberIsUnknown(): void
+    {
+        $state = new FlowStateHandle(values: ['slots' => ['1' => 'a', '2' => 'b']]);
+
+        $out = $this->node->execute(
+            items: $this->items(json: ['holder' => 'b']),
+            config: ['operation' => 'release', 'slots' => 'slots'],
+            context: $this->ctx(handle: $state)
+        );
+
+        self::assertTrue(condition: $out[0]['json']['released']);
+        self::assertSame(expected: ['1' => 'a', '2' => null], actual: $state->get(key: 'slots'));
+
+    }//end testReleaseByHolderWhenTheSlotNumberIsUnknown()
+
+    /**
+     * Releasing something nobody holds reports false and changes nothing.
+     *
+     * @return void
+     */
+    public function testReleasingAnUnheldSlotReportsFalse(): void
+    {
+        $state = new FlowStateHandle(values: ['slots' => ['1' => 'a']]);
+
+        $out = $this->node->execute(
+            items: $this->items(json: ['holder' => 'zzz']),
+            config: ['operation' => 'release', 'slots' => 'slots'],
+            context: $this->ctx(handle: $state)
+        );
+
+        self::assertFalse(condition: $out[0]['json']['released']);
+        self::assertFalse(condition: $state->isDirty());
+
+    }//end testReleasingAnUnheldSlotReportsFalse()
+
+    /**
+     * Get reads a key onto the item, with a default on the first tick.
+     *
+     * @return void
+     */
+    public function testGetReadsAKeyWithADefault(): void
+    {
+        $state = new FlowStateHandle(values: ['cursor' => 7]);
+
+        $out = $this->node->execute(
+            items: $this->items(json: []),
+            config: ['operation' => 'get', 'key' => 'cursor'],
+            context: $this->ctx(handle: $state)
+        );
+        self::assertSame(expected: 7, actual: $out[0]['json']['cursor']);
+
+        $fresh = $this->node->execute(
+            items: $this->items(json: []),
+            config: ['operation' => 'get', 'key' => 'cursor', 'default' => 0],
+            context: $this->ctx(handle: new FlowStateHandle())
+        );
+        self::assertSame(expected: 0, actual: $fresh[0]['json']['cursor']);
+
+    }//end testGetReadsAKeyWithADefault()
+
+    /**
+     * Set can store a literal or a value read off the item.
+     *
+     * @return void
+     */
+    public function testSetStoresALiteralOrAValueFromTheItem(): void
+    {
+        $state = new FlowStateHandle();
+
+        $this->node->execute(
+            items: $this->items(json: []),
+            config: ['operation' => 'set', 'key' => 'cursor', 'value' => 3],
+            context: $this->ctx(handle: $state)
+        );
+        self::assertSame(expected: 3, actual: $state->get(key: 'cursor'));
+
+        $this->node->execute(
+            items: $this->items(json: ['lastId' => 99]),
+            config: ['operation' => 'set', 'key' => 'cursor', 'from' => 'lastId'],
+            context: $this->ctx(handle: $state)
+        );
+        self::assertSame(expected: 99, actual: $state->get(key: 'cursor'));
+
+    }//end testSetStoresALiteralOrAValueFromTheItem()
+
+    /**
+     * A run with no flow state fails loudly rather than waving work through.
+     *
+     * Treating absent state as "everything is empty" would make a capacity cap
+     * pass every claim.
+     *
+     * @return void
+     */
+    public function testARunWithoutFlowStateRefuses(): void
+    {
+        $this->expectException(exception: InvalidArgumentException::class);
+
+        $this->node->execute(
+            items: $this->items(json: []),
+            config: ['operation' => 'get', 'key' => 'cursor'],
+            context: []
+        );
+
+    }//end testARunWithoutFlowStateRefuses()
+
+    /**
+     * Configuration is validated before a flow can be saved with it.
+     *
+     * @return void
+     */
+    public function testInvalidConfigurationIsRejected(): void
+    {
+        $this->expectException(exception: InvalidArgumentException::class);
+        $this->node->validateConfig(config: ['operation' => 'nonsense']);
+
+    }//end testInvalidConfigurationIsRejected()
+
+    /**
+     * A claim without a capacity cannot cap anything.
+     *
+     * @return void
+     */
+    public function testClaimWithoutCapacityIsRejected(): void
+    {
+        $this->expectException(exception: InvalidArgumentException::class);
+        $this->node->validateConfig(config: ['operation' => 'claim', 'slots' => 'slots']);
+
+    }//end testClaimWithoutCapacityIsRejected()
+}//end class


### PR DESCRIPTION
#2219 gave a flow somewhere to remember things and #2220 let nodes reach it — but nothing could **write** it from a graph, so a flow author still had to drop into PHP. This closes that.

`get` / `set` / `forget` are the obvious three. **`claim` is the one worth having.**

## Why `claim` is a single operation

A capacity cap — hydra's "at most ten pipelines at once", a booking, a lease — is a map of named slots where a free one must be taken by exactly one holder. Expressed with `get` and `set` that is a **read-modify-write across two steps**, which is precisely the shape that lost writes in #2212.

`claim` does the whole thing in one step and emits `claimed: false` rather than pretending it succeeded, so a router can branch on it and the flow author decides whether "no capacity" means wait, stop or escalate.

`release` takes a slot number when the caller has one and falls back to the holder when it doesn't — a stage that crashed knows who it was, not which slot it got.

## A run with no flow state throws

Absent state read as "nothing claimed" would make a capacity cap wave everything through — the worst possible failure for this node. It fails loudly instead.

## ⚠️ Not a cross-flow lock

Documented in the class, because it will be the first question. What makes it safe is that a scheduled flow **never overlaps itself** (#2218) — the same property the shell orchestrator being replaced relies on, where one supervisor holds a `flock` and its own slot bookkeeping is a plain check-then-write, safe only because nothing runs beside it.

For coordination **across** flows, write an object with `onConflict: fail` and let the database arbitrate.

## Verified live — node resolved from the registry, not constructed by hand

```
flow-state registered: true
claim job-1 -> slot 1    claim job-2 -> slot 2    claim job-3 -> slot 3
claim job-4 -> claimed=false, slot=NULL      <- the cap holds
release slot 2, then job-5 -> slot 2         <- the freed slot is reused
```

## Gates

phpcs clean, phpstan OK, **15,539 unit tests green** (11 new)

Part of #2216. This is the primitive hydra#425 task 3.5 is built on.
