### PR TITLE
feat(flow): read a flow's state over HTTP so a dashboard can render it

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -480,6 +480,9 @@ return [
         // Visual flow builder — trigger event catalog (read-only, all users).
         ['name' => 'flow#eventCatalog', 'url' => '/api/flow/event-catalog', 'verb' => 'GET'],
         ['name' => 'flow#nodeCatalog',  'url' => '/api/flow/node-catalog',  'verb' => 'GET'],
+        // What a flow is holding between runs — the read side of flow state,
+        // so a dashboard can render slot occupancy (or#2216).
+        ['name' => 'flow#state',        'url' => '/api/flow/{flowId}/state', 'verb' => 'GET', 'requirements' => ['flowId' => '[^/]+']],
 
         ['name' => 'flowLinks#available', 'url' => '/api/integrations/flow/operations',                       'verb' => 'GET'],
         ['name' => 'flowLinks#index',     'url' => '/api/objects/{register}/{schema}/{id}/flow',              'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],

--- a/lib/Controller/FlowController.php
+++ b/lib/Controller/FlowController.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Controller;
 
+use OCA\OpenRegister\Db\FlowStateMapper;
 use OCA\OpenRegister\Service\Flow\EventCatalogService;
 use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
 use OCP\AppFramework\Controller;
@@ -46,12 +47,14 @@ class FlowController extends Controller
      * @param IRequest            $request      HTTP request.
      * @param EventCatalogService $eventCatalog The flow trigger catalog.
      * @param FlowNodeRegistry    $nodes        The registered flow-step types.
+     * @param FlowStateMapper     $flowState    Reads state a flow keeps between runs.
      */
     public function __construct(
         string $appName,
         IRequest $request,
         private readonly EventCatalogService $eventCatalog,
         private readonly FlowNodeRegistry $nodes,
+        private readonly FlowStateMapper $flowState,
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
@@ -116,4 +119,41 @@ class FlowController extends Controller
             ]
         );
     }//end nodeCatalog()
+
+    /**
+     * What a flow is currently holding between its runs.
+     *
+     * The state itself has existed since #2219 and nodes can write it since
+     * #2221, but nothing could READ it from outside the engine — so a slot
+     * table was live data nobody could render. This is the surface a dashboard
+     * needs to answer "which slot is running what, and since when".
+     *
+     * A flow with no state yet returns an empty map rather than 404: "nothing
+     * claimed" is a perfectly good answer, and a widget should not have to
+     * special-case a flow's first tick.
+     *
+     * @param string $flowId The flow's uuid.
+     *
+     * @return JSONResponse `{ flowId, state, updated }`.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function state(string $flowId): JSONResponse
+    {
+        $stored = $this->flowState->findByFlow(flowId: $flowId);
+
+        if ($stored === null) {
+            return new JSONResponse(
+                [
+                    'flowId'  => $flowId,
+                    'state'   => [],
+                    'updated' => null,
+                ]
+            );
+        }
+
+        return new JSONResponse($stored->jsonSerialize());
+
+    }//end state()
 }//end class

--- a/tests/Unit/Controller/FlowControllerTest.php
+++ b/tests/Unit/Controller/FlowControllerTest.php
@@ -74,7 +74,8 @@ class FlowControllerTest extends TestCase
             'openregister',
             $this->request,
             $this->createMock(EventCatalogService::class),
-            $this->nodes
+            $this->nodes,
+            $this->createMock(originalClassName: \OCA\OpenRegister\Db\FlowStateMapper::class)
         );
 
     }//end setUp()


### PR DESCRIPTION
Flow state has existed since #2219 and nodes could write it from #2221 — but nothing outside the engine could **read** it, so a slot table was live data nobody could show. `GET /api/flow/{flowId}/state` closes that.

## Empty map, not 404

A flow with no state yet returns `{"state": []}`. "Nothing claimed" is a perfectly good answer, and a widget should not have to special-case a flow's first tick to avoid rendering an error.

## This is what makes the slot dashboard possible

With the claim node writing `{"slots": {"1": "issue-101", "2": null, "3": "issue-207"}}`, a widget can now show which slot is running what — **without shelling onto the host**, which is the only way the shell orchestrator's `SLOT_DIR` files could ever be inspected.

## Verified live

```
GET /api/flow/api-demo-flow/state
  {"id":16,"flowId":"api-demo-flow",
   "state":{"slots":{"1":"issue-101","2":null,"3":"issue-207"},"cursor":42},
   "updated":"2026-07-31T07:34:36+00:00"}

GET /api/flow/never-run-flow/state
  {"flowId":"never-run-flow","state":[],"updated":null}
```

## Gates

phpcs clean on the controller, phpstan OK, **15,539 unit tests green**

*Note on the test file:* `FlowControllerTest` carries 15 phpcs errors on `origin/development` and still carries exactly 15 here — the one my change added is fixed. The rest are pre-existing and unrelated to this endpoint.

Part of #2216.
