### PR TITLE
fix(flow): refuse a node that carries step config instead of running it as a no-op

### DIFF
--- a/lib/Service/Flow/FlowDefinitionBuilder.php
+++ b/lib/Service/Flow/FlowDefinitionBuilder.php
@@ -115,8 +115,38 @@ class FlowDefinitionBuilder
                 );
             }
 
+            // A node is a PLACE and carries no behaviour. The step is the EDGE:
+            // `FlowEngine::stepFor()` resolves a transition to the matching entry
+            // in `edges[]` and `RegistryStepDispatcher::dispatch()` reads `type`
+            // and `config` off that edge.
+            //
+            // So `type` on a node is not merely redundant — it is the entire
+            // behaviour of the flow, put where nothing looks. Accepting it means
+            // every transition becomes a pass-through (dispatch() returns items
+            // untouched when `type` is empty) and the run reports COMPLETED: no
+            // error, no warning, nothing in the trace, and an output key that is
+            // simply absent. That is indistinguishable from a flow whose steps
+            // all genuinely had nothing to do.
+            //
+            // Three graphs in the fleet were authored this way and none of them
+            // failed anywhere — one had shipped as a completed task, and one had
+            // unit tests that asserted on `nodes[].type` and therefore passed
+            // (or#2226). Node-shaped authoring is the natural mistake, because
+            // that is how a graph editor presents a flow. Refusing here is what
+            // turns "runs and does nothing" into a message naming the node.
+            if (array_key_exists('type', $node) === true || array_key_exists('config', $node) === true) {
+                throw new InvalidArgumentException(
+                    message: sprintf(
+                        'Flow node "%s" carries "type"/"config", which the engine never reads — a node is a '
+                        .'place. Move the step onto the edge that leaves it: an edge takes "type" and "config" '
+                        .'and is what actually runs.',
+                        $id
+                    )
+                );
+            }
+
             $places[] = $id;
-        }
+        }//end foreach
 
         return $places;
 

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -3298,8 +3298,7 @@ class SaveObject
      * @param bool        $silent        Whether to skip audit trail
      * @param bool        $_multitenancy Whether to apply multitenancy
      * @param IUser|null  $currentUser   Explicit acting user for `@self.folder` access checks (forwarded to setSelfMetadata)
-     *
-     * @param bool         $failIfExists  Insert-only: refuse instead of updating when the identifier is taken.
+     * @param bool        $failIfExists  Insert-only: refuse instead of updating when the identifier is taken.
      *
      * @return ObjectEntity Created object
      *

--- a/tests/Unit/Service/Flow/FlowDefinitionBuilderTest.php
+++ b/tests/Unit/Service/Flow/FlowDefinitionBuilderTest.php
@@ -132,6 +132,51 @@ class FlowDefinitionBuilderTest extends TestCase
         ]);
     }
 
+    public function testANodeCarryingStepConfigIsRejected(): void
+    {
+        // The step is the EDGE. A `type` on a node is never read, so accepting
+        // this yields a graph where every transition is a pass-through and the
+        // run reports COMPLETED having done nothing — silently. Three graphs in
+        // the fleet were authored this way and none of them failed anywhere
+        // (or#2226).
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Flow node "a" carries "type"/"config", which the engine never reads');
+
+        $this->builder->build([
+            'nodes' => [['id' => 'a', 'type' => 'openregister.stop'], ['id' => 'b']],
+            'edges' => [['id' => 'go', 'from' => 'a', 'to' => 'b']],
+        ]);
+    }
+
+    public function testANodeCarryingOnlyConfigIsAlsoRejected(): void
+    {
+        // `config` without `type` is the same authoring mistake half-made, and
+        // it is just as invisible at run time.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Flow node "a" carries "type"/"config"');
+
+        $this->builder->build([
+            'nodes' => [['id' => 'a', 'config' => ['error' => false]], ['id' => 'b']],
+            'edges' => [['id' => 'go', 'from' => 'a', 'to' => 'b']],
+        ]);
+    }
+
+    public function testANodeMayCarryPresentationalKeys(): void
+    {
+        // The rejection is about EXECUTABLE config only. A canvas legitimately
+        // stores position, label and styling on a node, and refusing those
+        // would make every drawn graph unbuildable.
+        $definition = $this->builder->build([
+            'nodes' => [
+                ['id' => 'a', 'position' => ['x' => 0, 'y' => 0], 'label' => 'Start', 'colour' => '#21468B'],
+                ['id' => 'b', 'position' => ['x' => 100, 'y' => 0]],
+            ],
+            'edges' => [['id' => 'go', 'from' => 'a', 'to' => 'b', 'type' => 'openregister.stop']],
+        ]);
+
+        $this->assertNotNull($definition);
+    }
+
     public function testANodeWithoutAnIdIsRejected(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
Fixes #2226.

## The problem

The step is the **edge**. `FlowEngine::stepFor()` resolves a transition to the matching entry in `edges[]`, and `RegistryStepDispatcher::dispatch()` reads `type` and `config` off that edge. A node is a Petri-net place and carries no behaviour.

So a `type` on a node is not merely redundant — it is the whole behaviour of the flow, put where nothing looks. The engine accepted it: every transition became a pass-through (`dispatch()` returns items untouched when `type` is empty) and the run reported **`completed`**. No error, no warning, nothing in the trace, and an output key simply absent — indistinguishable from a flow whose steps genuinely had nothing to do.

Measured on a live instance, the same four-step graph both ways:

| where `type`/`config` sat | result |
|---|---|
| on `nodes[]` | `status: completed`, items untouched, the agent's sidecar never contacted |
| on `edges[]` | the agent step ran, and its parsed answer landed on the item |

## Why it is worth an error rather than documentation

Three graphs in the fleet were authored this way and none of them failed anywhere:

- `hydra/flows/hydra-dispatch.flow.json` — shipped as a **completed task**. Claimed nothing, dispatched nothing, released nothing.
- `hydra/flows/hydra-applier.flow.json` — same, caught only by running it.
- `hermiq`'s seeded `Hydra Triage` flow — whose unit tests asserted on `nodes[].type` and therefore all passed.

Node-shaped authoring is the natural mistake: it is how a graph editor presents a flow, and this class's own docblock calls itself "the translation layer between what users author (a graph of nodes and edges) and what executes (a Petri net)", which reads as though node config would be translated.

## The change

`extractPlaces()` already refuses a duplicate node id, for a closely related reason — *"the graph would run but not be the graph the user drew"*. This is the same kind of authoring error with a larger blast radius, so it is refused in the same place, with a message that names the node and says where the step belongs.

Presentational keys are untouched. `position`, `label` and styling are what a canvas legitimately stores on a node, and a test pins that such a graph still builds.

## Blast radius

All three affected graphs are `enabled: false`, so nothing in flight breaks by this becoming an error. They are corrected in ConductionNL/hydra#435 and ConductionNL/hermiq#91.

## Verification

- **15,542** unit tests green (3 new: `type` rejected, `config`-only rejected, presentational keys still build).
- phpcs, phpstan and psalm clean on the changed file.
