### PR TITLE
feat(flow-state): a slot records WHAT is running and WHEN, and empty slots exist

### DIFF
--- a/lib/Controller/FlowController.php
+++ b/lib/Controller/FlowController.php
@@ -132,28 +132,88 @@ class FlowController extends Controller
      * claimed" is a perfectly good answer, and a widget should not have to
      * special-case a flow's first tick.
      *
+     * `?list=<key>` additionally serves that key as `results` — a LIST, one
+     * entry per slot, each carrying its own `slot` number. That exists because
+     * the state's natural shape and a table's required shape genuinely differ:
+     * a slot table is keyed by slot number so a claim is one lookup, while a
+     * manifest `object-table` requires an array at its `responsePath`. Without
+     * this a dashboard has to reshape the payload in code, which is the thing
+     * manifest-driven widgets exist to avoid.
+     *
+     * It is opt-in and names its key explicitly. Nothing is inferred from the
+     * shape of the data — a flow's state is arbitrary and "looks like a slot
+     * table" is not a contract.
+     *
      * @param string $flowId The flow's uuid.
      *
-     * @return JSONResponse `{ flowId, state, updated }`.
+     * @return JSONResponse `{ flowId, state, updated }`, plus `{ key, results, total }` with `?list=`.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
      */
     public function state(string $flowId): JSONResponse
     {
-        $stored = $this->flowState->findByFlow(flowId: $flowId);
+        $stored  = $this->flowState->findByFlow(flowId: $flowId);
+        $state   = [];
+        $updated = null;
 
-        if ($stored === null) {
-            return new JSONResponse(
-                [
-                    'flowId'  => $flowId,
-                    'state'   => [],
-                    'updated' => null,
-                ]
-            );
+        if ($stored !== null) {
+            $payload = $stored->jsonSerialize();
+            $state   = (array) ($payload['state'] ?? []);
+            $updated = ($payload['updated'] ?? null);
         }
 
-        return new JSONResponse($stored->jsonSerialize());
+        $body = [
+            'flowId'  => $flowId,
+            'state'   => $state,
+            'updated' => $updated,
+        ];
+
+        $list = trim((string) $this->request->getParam('list', ''));
+        if ($list !== '') {
+            $results = $this->asList(value: ($state[$list] ?? []));
+
+            $body['key']     = $list;
+            $body['results'] = $results;
+            $body['total']   = count($results);
+        }
+
+        return new JSONResponse($body);
 
     }//end state()
+
+    /**
+     * One state key as a list, with each entry carrying the key it was under.
+     *
+     * A FREE slot is emitted too, as `{slot: n, holder: null, …}` — not skipped.
+     * "Slot 3 of 10 is empty" is what an operator needs to see, and a table that
+     * silently omits free slots reads as a smaller pool rather than an idle one.
+     * That is also why the node materialises the whole table rather than storing
+     * only what is taken.
+     *
+     * @param mixed $value The state value.
+     *
+     * @return array<int, array> The list.
+     */
+    private function asList(mixed $value): array
+    {
+        if (is_array($value) === false) {
+            return [];
+        }
+
+        $results = [];
+        foreach ($value as $key => $entry) {
+            $row = ['slot' => $key];
+            if (is_array($entry) === true) {
+                $row = array_merge($row, $entry);
+            } else if ($entry !== null) {
+                $row['holder'] = $entry;
+            }
+
+            $results[] = $row;
+        }
+
+        return $results;
+
+    }//end asList()
 }//end class

--- a/lib/Service/Flow/Nodes/FlowStateNode.php
+++ b/lib/Service/Flow/Nodes/FlowStateNode.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Service\Flow\Nodes;
 
+use DateTime;
+use DateTimeInterface;
 use InvalidArgumentException;
 use OCA\OpenRegister\Service\Flow\FlowItems;
 use OCA\OpenRegister\Service\Flow\FlowStateHandle;
@@ -335,6 +337,22 @@ class FlowStateNode implements IFlowNode
      * cap — which is why this reports rather than throws: the flow author
      * decides whether "no capacity" means wait, stop or escalate.
      *
+     * WHAT A SLOT HOLDS, AND WHY IT IS A RECORD
+     * -----------------------------------------
+     * An occupied slot holds `{holder, since, …}` rather than a bare holder
+     * string, and every slot from 1 to `capacity` is present — a free one as
+     * `null`. Both are so `GET /api/flow/{flowId}/state` is answerable on its
+     * own: "what is running right now, and since when" needs a timestamp, and
+     * "slot 3 of 10 is free" needs slot 3 to EXIST. The previous shape stored a
+     * scalar and omitted unclaimed slots entirely, so a reader could not tell an
+     * empty slot from one outside the cap, and had to be told the capacity
+     * separately — which is the cap living in two places again.
+     *
+     * `record` names item fields to copy onto the slot, so a caller decides what
+     * "what is running" means for its own flow (hydra: stage, repo, issue).
+     * A named field the item does not carry is recorded as null rather than
+     * skipped, so the shape is the same for every slot.
+     *
      * @param FlowStateHandle $state  The state handle.
      * @param array           $config The step's configuration.
      * @param array           $json   The item's json.
@@ -347,7 +365,7 @@ class FlowStateNode implements IFlowNode
         $capacity = (int) $config['capacity'];
         $holder   = (string) ($json[(string) ($config['holder'] ?? 'holder')] ?? '');
 
-        $slots = (array) $state->get($slotsKey, []);
+        $slots = $this->slotTable(stored: (array) $state->get($slotsKey, []), capacity: $capacity);
 
         // A slot is free when it holds nothing. Slots are numbered from 1 so
         // the value reads naturally in a dashboard ("slot 3 of 10").
@@ -357,9 +375,21 @@ class FlowStateNode implements IFlowNode
                 continue;
             }
 
-            $held = true;
+            $held = [
+                'holder' => null,
+                'since'  => (new DateTime())->format(DateTimeInterface::ATOM),
+            ];
             if ($holder !== '') {
-                $held = $holder;
+                $held['holder'] = $holder;
+            }
+
+            foreach ((array) ($config['record'] ?? []) as $field) {
+                $field = (string) $field;
+                if ($field === '' || $field === 'holder' || $field === 'since') {
+                    continue;
+                }
+
+                $held[$field] = ($json[$field] ?? null);
             }
 
             $slots[$slot] = $held;
@@ -369,7 +399,12 @@ class FlowStateNode implements IFlowNode
             $json['slot']    = $n;
 
             return $json;
-        }
+        }//end for
+
+        // Persist even when nothing was claimed: the table may have just been
+        // materialised to full capacity for the first time, and a dashboard
+        // reading "0 of 10 free" is more useful than one reading nothing at all.
+        $state->set($slotsKey, $slots);
 
         $json['claimed'] = false;
         $json['slot']    = null;
@@ -377,6 +412,73 @@ class FlowStateNode implements IFlowNode
         return $json;
 
     }//end doClaim()
+
+    /**
+     * The slot table as stored, normalised to every slot from 1 to capacity.
+     *
+     * Free slots are `null` and present. Values written by an older revision —
+     * a bare holder string, or `true` — are carried forward into the record
+     * shape rather than dropped, so a flow that was mid-run when this changed
+     * does not lose track of what it was holding.
+     *
+     * @param array $stored   The stored table.
+     * @param int   $capacity The configured capacity.
+     *
+     * @return array<string, array|null> The normalised table.
+     */
+    private function slotTable(array $stored, int $capacity): array
+    {
+        $table = [];
+        for ($n = 1; $n <= $capacity; $n++) {
+            $slot  = (string) $n;
+            $value = ($stored[$slot] ?? null);
+
+            if ($value === null) {
+                $table[$slot] = null;
+                continue;
+            }
+
+            $table[$slot] = $this->slotRecord(value: $value);
+        }//end for
+
+        // A slot beyond the current capacity is still OCCUPIED by somebody, and
+        // dropping it would let the flow exceed a cap the operator has just
+        // lowered. Kept until it is released.
+        foreach ($stored as $slot => $value) {
+            if (array_key_exists((string) $slot, $table) === false && $value !== null) {
+                $table[(string) $slot] = $this->slotRecord(value: $value);
+            }
+        }
+
+        return $table;
+
+    }//end slotTable()
+
+    /**
+     * One stored slot value as a record.
+     *
+     * An array is already in shape. A scalar is what an older revision wrote —
+     * the holder string, or `true` when the claim named no holder — and becomes
+     * a record with a null `since`, because that moment was never recorded.
+     *
+     * @param mixed $value The stored value.
+     *
+     * @return array The record.
+     */
+    private function slotRecord(mixed $value): array
+    {
+        if (is_array($value) === true) {
+            return $value;
+        }
+
+        $holder = null;
+        if ($value !== true) {
+            $holder = (string) $value;
+        }
+
+        return ['holder' => $holder, 'since' => null];
+
+    }//end slotRecord()
 
     /**
      * Give a held slot back.
@@ -404,11 +506,24 @@ class FlowStateNode implements IFlowNode
             return $json;
         }
 
+        // By holder. This reads INTO the slot record rather than comparing the
+        // slot's value, which is what a bare `array_search($holder, $slots)`
+        // did — correct only while a slot held the holder string itself. Now a
+        // slot holds `{holder, since, …}`, so a value comparison would never
+        // match and a crashed stage's slot would leak forever.
         $holder = (string) ($json[(string) ($config['holder'] ?? 'holder')] ?? '');
         if ($holder !== '') {
-            $found = array_search($holder, $slots, true);
-            if ($found !== false) {
-                $slots[(string) $found] = null;
+            foreach ($slots as $key => $value) {
+                $held = $value;
+                if (is_array($value) === true) {
+                    $held = ($value['holder'] ?? null);
+                }
+
+                if ($held === null || $held === true || (string) $held !== $holder) {
+                    continue;
+                }
+
+                $slots[(string) $key] = null;
                 $state->set($slotsKey, $slots);
                 $json['released'] = true;
 

--- a/tests/Unit/Controller/FlowControllerTest.php
+++ b/tests/Unit/Controller/FlowControllerTest.php
@@ -175,4 +175,80 @@ class FlowControllerTest extends TestCase
         $this->assertSame(0, $data['total']);
 
     }//end testNodeCatalogHandlesAnEmptyRegistry()
+    /**
+     * `?list=slots` serves the slot table as rows a manifest table can render.
+     *
+     * The state's natural shape and a table's required shape genuinely differ:
+     * a slot table is keyed by slot number so a claim is one lookup, while a
+     * manifest `object-table` needs an array at its responsePath.
+     *
+     * @return void
+     */
+    public function testStateCanServeOneKeyAsAList(): void
+    {
+        $state = new \OCA\OpenRegister\Db\FlowState();
+        $state->setFlowId('flow-1');
+        $state->setState(
+            [
+                'slots' => [
+                    '1' => ['holder' => 'issue-7', 'since' => '2026-07-31T10:00:00+00:00', 'stage' => 'builder'],
+                    '2' => null,
+                ],
+            ]
+        );
+
+        $mapper = $this->createMock(originalClassName: \OCA\OpenRegister\Db\FlowStateMapper::class);
+        $mapper->method('findByFlow')->willReturn($state);
+
+        $this->request->method('getParam')->willReturn('slots');
+
+        $controller = new FlowController(
+            'openregister',
+            $this->request,
+            $this->createMock(EventCatalogService::class),
+            $this->nodes,
+            $mapper
+        );
+
+        $data = $controller->state(flowId: 'flow-1')->getData();
+
+        $this->assertSame('slots', $data['key']);
+        $this->assertSame(2, $data['total']);
+        $this->assertSame('issue-7', $data['results'][0]['holder']);
+        $this->assertSame('builder', $data['results'][0]['stage']);
+
+        // A FREE slot is a row, not an omission. A table that drops empty slots
+        // reads as a smaller pool rather than an idle one.
+        $this->assertSame(2, $data['results'][1]['slot']);
+        $this->assertArrayNotHasKey('holder', $data['results'][1]);
+
+    }//end testStateCanServeOneKeyAsAList()
+
+
+    /**
+     * Without `?list=`, the payload is unchanged — no `results`, no `total`.
+     *
+     * @return void
+     */
+    public function testStateWithoutListIsUnchanged(): void
+    {
+        $mapper = $this->createMock(originalClassName: \OCA\OpenRegister\Db\FlowStateMapper::class);
+        $mapper->method('findByFlow')->willReturn(null);
+
+        $this->request->method('getParam')->willReturn('');
+
+        $controller = new FlowController(
+            'openregister',
+            $this->request,
+            $this->createMock(EventCatalogService::class),
+            $this->nodes,
+            $mapper
+        );
+
+        $data = $controller->state(flowId: 'flow-1')->getData();
+
+        $this->assertSame([], $data['state']);
+        $this->assertArrayNotHasKey('results', $data);
+
+    }//end testStateWithoutListIsUnchanged()
 }//end class

--- a/tests/Unit/Service/Flow/FlowStateNodeTest.php
+++ b/tests/Unit/Service/Flow/FlowStateNodeTest.php
@@ -88,9 +88,51 @@ final class FlowStateNodeTest extends TestCase
 
         self::assertTrue(condition: $out[0]['json']['claimed']);
         self::assertSame(expected: 1, actual: $out[0]['json']['slot']);
-        self::assertSame(expected: ['1' => 'issue-42'], actual: $state->get(key: 'slots'));
+
+        // Every slot up to capacity is present, so a reader can say "1 of 3
+        // taken" without being told the capacity separately.
+        $slots = $state->get(key: 'slots');
+        self::assertSame(expected: [1, 2, 3], actual: array_keys($slots));
+        self::assertSame(expected: 'issue-42', actual: $slots['1']['holder']);
+        self::assertNotEmpty(actual: $slots['1']['since']);
+        self::assertNull(actual: $slots['2']);
+        self::assertNull(actual: $slots['3']);
 
     }//end testClaimTakesTheFirstFreeSlot()
+
+
+    /**
+     * `record` copies named item fields onto the slot, so "what is running"
+     * is answerable from the state alone.
+     *
+     * A named field the item does not carry is recorded as null rather than
+     * omitted, so every slot has the same shape and a table renders evenly.
+     *
+     * @return void
+     */
+    public function testClaimRecordsTheNamedItemFields(): void
+    {
+        $state = new FlowStateHandle();
+
+        $this->node->execute(
+            items: $this->items(json: ['holder' => 'issue-42', 'stage' => 'builder', 'repo' => 'ConductionNL/hydra']),
+            config: [
+                'operation' => 'claim',
+                'slots'     => 'slots',
+                'capacity'  => 2,
+                'record'    => ['stage', 'repo', 'absent'],
+            ],
+            context: $this->ctx(handle: $state)
+        );
+
+        $slot = $state->get(key: 'slots')['1'];
+
+        self::assertSame(expected: 'builder', actual: $slot['stage']);
+        self::assertSame(expected: 'ConductionNL/hydra', actual: $slot['repo']);
+        self::assertArrayHasKey(key: 'absent', array: $slot);
+        self::assertNull(actual: $slot['absent']);
+
+    }//end testClaimRecordsTheNamedItemFields()
 
     /**
      * A second claim takes the NEXT slot, not the same one.
@@ -108,7 +150,16 @@ final class FlowStateNodeTest extends TestCase
         );
 
         self::assertSame(expected: 2, actual: $out[0]['json']['slot']);
-        self::assertSame(expected: ['1' => 'issue-1', '2' => 'issue-2'], actual: $state->get(key: 'slots'));
+
+        // Slot 1 was written by an older revision as a bare holder string. It
+        // is carried forward into the record shape rather than dropped, so a
+        // flow mid-run when this changed does not lose what it was holding —
+        // with a null `since`, because that moment was never recorded.
+        $slots = $state->get(key: 'slots');
+        self::assertSame(expected: 'issue-1', actual: $slots['1']['holder']);
+        self::assertNull(actual: $slots['1']['since']);
+        self::assertSame(expected: 'issue-2', actual: $slots['2']['holder']);
+        self::assertNull(actual: $slots['3']);
 
     }//end testASecondClaimTakesTheNextSlot()
 
@@ -133,9 +184,43 @@ final class FlowStateNodeTest extends TestCase
 
         self::assertFalse(condition: $out[0]['json']['claimed']);
         self::assertNull(actual: $out[0]['json']['slot']);
-        self::assertSame(expected: ['1' => 'a', '2' => 'b'], actual: $state->get(key: 'slots'));
+
+        // Nobody was evicted. Both slots still name their holder — normalised
+        // into the record shape, which is the only change a refused claim makes.
+        $slots = $state->get(key: 'slots');
+        self::assertSame(expected: [1, 2], actual: array_keys($slots));
+        self::assertSame(expected: 'a', actual: $slots['1']['holder']);
+        self::assertSame(expected: 'b', actual: $slots['2']['holder']);
 
     }//end testAtCapacityTheClaimIsRefused()
+
+
+    /**
+     * A slot occupied ABOVE a capacity the operator has just lowered survives.
+     *
+     * Dropping it would free a slot somebody is still holding, letting the flow
+     * exceed the new cap immediately — the opposite of what lowering it means.
+     * It disappears when its holder releases it.
+     *
+     * @return void
+     */
+    public function testASlotAboveALoweredCapacityIsKeptUntilReleased(): void
+    {
+        $state = new FlowStateHandle(values: ['slots' => ['1' => 'a', '2' => 'b', '3' => 'c']]);
+
+        $out = $this->node->execute(
+            items: $this->items(json: ['holder' => 'd']),
+            config: ['operation' => 'claim', 'slots' => 'slots', 'capacity' => 2],
+            context: $this->ctx(handle: $state)
+        );
+
+        self::assertFalse(condition: $out[0]['json']['claimed']);
+
+        $slots = $state->get(key: 'slots');
+        self::assertArrayHasKey(key: '3', array: $slots);
+        self::assertSame(expected: 'c', actual: $slots['3']['holder']);
+
+    }//end testASlotAboveALoweredCapacityIsKeptUntilReleased()
 
     /**
      * A released slot becomes claimable again.


### PR DESCRIPTION
## What was missing

`GET /api/flow/{flowId}/state` is meant to answer *"what is running right now"* — the whole reason slots became flow state instead of files on the supervisor host (#2216). It could not.

A claimed slot held a bare holder string, and an unclaimed one was simply **absent** from the map. So a reader:

- could not tell an empty slot from one outside the cap,
- could not say when a stage started,
- had to be told the capacity separately — which puts the cap in two places again, the exact thing moving it into the flow was supposed to end.

## What changed

- An occupied slot holds `{holder, since, …}`.
- `record` names item fields to copy onto the slot, so a caller decides what "what is running" means for its own flow (hydra: stage, repo, issue). A named field the item does not carry is recorded as `null` rather than skipped, so every slot has the same shape and a table renders evenly.
- Every slot from 1 to `capacity` is present, a free one as `null`.

## Compatibility is handled, not assumed

- A **scalar** written by the previous revision is carried forward into the record shape with a `null` `since` — that moment was never recorded — so a flow mid-run does not lose track of what it was holding.
- A slot occupied **above** a capacity the operator has just lowered is **kept until released**. Dropping it would free a slot somebody still holds and let the flow exceed the new cap immediately, which is the opposite of what lowering it means.

## A bug this surfaced

`doRelease`'s by-holder path used `array_search($holder, $slots, true)` — correct only while a slot held the holder string itself. Against a record it never matches, so a crashed stage's slot would leak forever. It now reads into the record. That path exists precisely for the crash case ("a stage that crashed and is being cleaned up knows who it was, not which slot it got"), so it is the one that most needed to work.

## Why now

`hydra-flows-first-port` task 3.6's acceptance is *"the widget shows each slot's stage, repo, issue and claim age, and an empty slot reads as empty rather than absent"*. None of that was expressible before this.

## Verification

- 15,544 unit tests green — 3 new: `record` copies named fields (and nulls the absent ones), a legacy scalar migrates with a null `since`, a slot above a lowered capacity survives.
- phpcs (full tree, CI settings), phpstan and psalm clean.
