### PR TITLE
fix(magic-mapper): a write that did not land must not report success, and the audit must say what happened

### DIFF
--- a/lib/Db/AuditTrailMapper.php
+++ b/lib/Db/AuditTrailMapper.php
@@ -366,7 +366,11 @@ class AuditTrailMapper extends QBMapper
      *
      * @param ObjectEntity|null $old            The old state of the object
      * @param ObjectEntity|null $new            The new state of the object
-     * @param string|null       $action         The action to create the audit trail for
+     * @param string|null       $action         The action to record. NULL (the default) infers it from which
+     *                                          entities are present: no `new` is a delete, no `old` is a create,
+     *                                          otherwise an update. A NAMED action is used verbatim — the
+     *                                          inference used to overwrite an explicit 'update' because it was
+     *                                          indistinguishable from the old default (#2217).
      * @param array|null        $cascadeContext Optional referential-integrity cascade context. When
      *                                          non-null, the context is folded into the `changed`
      *                                          column of the initial INSERT (previously this required
@@ -383,7 +387,7 @@ class AuditTrailMapper extends QBMapper
     public function createAuditTrail(
         ?ObjectEntity $old=null,
         ?ObjectEntity $new=null,
-        ?string $action='update',
+        ?string $action=null,
         ?array $cascadeContext=null
     ): AuditTrail {
         $auditTrail = $this->buildAuditTrail(old: $old, new: $new, action: $action, cascadeContext: $cascadeContext);
@@ -401,7 +405,11 @@ class AuditTrailMapper extends QBMapper
      *
      * @param ObjectEntity|null $old            The old state of the object
      * @param ObjectEntity|null $new            The new state of the object
-     * @param string|null       $action         The action to create the audit trail for
+     * @param string|null       $action         The action to record. NULL (the default) infers it from which
+     *                                          entities are present: no `new` is a delete, no `old` is a create,
+     *                                          otherwise an update. A NAMED action is used verbatim — the
+     *                                          inference used to overwrite an explicit 'update' because it was
+     *                                          indistinguishable from the old default (#2217).
      * @param array|null        $cascadeContext Optional referential-integrity cascade context to fold
      *                                          into the `changed` column (keys: triggerObject,
      *                                          triggerSchema, action_type, property).
@@ -416,17 +424,36 @@ class AuditTrailMapper extends QBMapper
     public function buildAuditTrail(
         ?ObjectEntity $old=null,
         ?ObjectEntity $new=null,
-        ?string $action='update',
+        ?string $action=null,
         ?array $cascadeContext=null
     ): AuditTrail {
+        // Infer the action from which entities are present — but ONLY when the
+        // caller did not name one.
+        //
+        // These two rules used to fire on `$action === 'update'`, which is both
+        // the default AND a legitimate explicit value, so a caller who KNEW the
+        // write was an update could not say so: `old: null, action: 'update'`
+        // was rewritten to `create` before it reached the row. That is not
+        // hypothetical — it is why MagicMapper taking its UPDATE branch on a
+        // service-labelled create still produced a `create` entry (#2217), and
+        // it is the reason a fix passing an explicit action would have looked
+        // applied while changing nothing.
+        //
+        // The inference is unchanged for every caller that omits `action`; only
+        // an explicitly-named one now survives.
+        $inferring = ($action === null);
+        if ($inferring === true) {
+            $action = 'update';
+        }
+
         // Determine the action based on the presence of old and new objects.
         $objectEntity = $new;
-        if ($new === null && $action === 'update') {
+        if ($inferring === true && $new === null) {
             $action       = 'delete';
             $objectEntity = $old;
         }
 
-        if ($old === null && $action === 'update') {
+        if ($inferring === true && $old === null && $new !== null) {
             $action       = 'create';
             $objectEntity = $new;
         }

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -174,6 +174,29 @@ class MagicMapper extends AbstractObjectMapper
     private const METADATA_PREFIX = '_';
 
     /**
+     * Whether the last single-object write INSERTED or UPDATED.
+     *
+     * The mapper is the only layer that knows. `SaveObject` performs its own
+     * existence lookup and labels the operation from that — but the mapper then
+     * looks again, and between the two lookups a concurrent writer can land the
+     * row, so the mapper takes the UPDATE branch on an operation the service
+     * has already called a create. The audit trail then records `create` for a
+     * write that updated somebody else's row.
+     *
+     * Measured while debugging #2212: three audit `create` entries against a
+     * single `_id` that was inserted once. The audit trail said three objects
+     * were created; one was.
+     *
+     * Read it with {@see getLastWriteAction()} immediately after the write.
+     * Per-request state on a per-request service, in the same spirit as the
+     * `lastRun*` fields elsewhere in the fleet — it is a report of what just
+     * happened, not a cache.
+     *
+     * @var string One of `create` or `update`; empty before any write.
+     */
+    private string $lastWriteAction = '';
+
+    /**
      * Number of magic tables probed per UNION ALL query in the locate phase.
      *
      * `findAcrossAllMagicTables` used to issue one `SELECT *` per magic table,
@@ -3451,6 +3474,7 @@ class MagicMapper extends AbstractObjectMapper
                         ]
                     );
                     $this->updateObjectInRegisterSchemaTable(uuid: $uuid, data: $preparedData, tableName: $tableName);
+                    $this->lastWriteAction = 'update';
                     return $uuid;
                 }//end try
 
@@ -3463,6 +3487,7 @@ class MagicMapper extends AbstractObjectMapper
                         'tableName' => $tableName,
                     ]
                 );
+                $this->lastWriteAction = 'create';
                 return $uuid;
             }//end if
 
@@ -3492,6 +3517,7 @@ class MagicMapper extends AbstractObjectMapper
 
             // Update existing object.
             $this->updateObjectInRegisterSchemaTable(uuid: $uuid, data: $preparedData, tableName: $tableName);
+            $this->lastWriteAction = 'update';
             $this->logger->debug(
                 message: '[MagicMapper] Updated object in register+schema table',
                 context: [
@@ -3517,6 +3543,25 @@ class MagicMapper extends AbstractObjectMapper
             throw $e;
         }//end try
     }//end saveObjectToRegisterSchemaTable()
+
+    /**
+     * What the last single-object write actually did.
+     *
+     * `create` or `update` — as decided by THIS layer's lookup, which is the
+     * one that ran last and therefore the one that matches the row. A caller
+     * that labelled the operation from its own earlier lookup should prefer
+     * this for anything it records, because between the two lookups a
+     * concurrent writer can turn a create into an update.
+     *
+     * Empty before any write in this request.
+     *
+     * @return string `create`, `update`, or ''.
+     */
+    public function getLastWriteAction(): string
+    {
+        return $this->lastWriteAction;
+
+    }//end getLastWriteAction()
 
     /**
      * Prepare object data for storage in register+schema table
@@ -6636,16 +6681,43 @@ class MagicMapper extends AbstractObjectMapper
                 _multitenancy: false
             );
         } catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
-            // Fallback: manually set ID if re-fetch fails.
-            $this->logger->warning(
-                message: '[MagicMapper] Failed to re-fetch inserted entity, using fallback',
-                context: ['file' => __FILE__, 'line' => __LINE__]
-            );
+            // The filtered read could not see the row. That has two very
+            // different causes and they must not share an outcome.
+            //
+            // The row IS there, and only the hydrating read could not reach it
+            // (scoping, an org/owner context still being established). Degraded
+            // but honest: the write landed, so return the in-memory entity with
+            // the id the row actually has.
+            //
+            // The row is NOT there. The write did not land, and returning the
+            // in-memory entity says it did — with a null id, to a caller that
+            // has no way to tell. That is the shape of a lost write reported as
+            // a success, which is exactly what #2212 turned out to be. It now
+            // throws.
             $row = $this->findObjectInRegisterSchemaTable(uuid: $uuid, tableName: $tableName);
-            if ($row !== null) {
-                $entity->setId((int) $row[self::METADATA_PREFIX.'id']);
+            if ($row === null) {
+                $this->logger->error(
+                    message: '[MagicMapper] Inserted object is not in the table afterwards — refusing to report success',
+                    context: [
+                        'file'      => __FILE__,
+                        'line'      => __LINE__,
+                        'uuid'      => $uuid,
+                        'tableName' => $tableName,
+                    ]
+                );
+
+                throw new Exception(
+                    sprintf('Object "%s" was written to %s but is not there afterwards.', $uuid, $tableName)
+                );
             }
 
+            $this->logger->warning(
+                message: '[MagicMapper] Could not re-fetch the inserted entity through the filtered read; '
+                    .'the row exists, so the raw id is used',
+                context: ['file' => __FILE__, 'line' => __LINE__, 'uuid' => $uuid]
+            );
+
+            $entity->setId((int) $row[self::METADATA_PREFIX.'id']);
             $insertedEntity = $entity;
         }//end try
 

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -3393,8 +3393,32 @@ class SaveObject
         \OCA\OpenRegister\Service\WritePhaseProbe::mark('sv:FILEPROPS');
 
         // Create audit trail if not in silent mode.
+        //
+        // The ACTION comes from the mapper, not from this method's name. We got
+        // here because the service-level existence lookup found nothing — but
+        // the mapper looks again, and between the two lookups a concurrent
+        // writer can land the row, so the mapper may have taken its UPDATE
+        // branch on what we are calling a create.
+        //
+        // Recording `create` regardless is how three audit `create` entries
+        // ended up against a single `_id` that was inserted once (#2212/#2217):
+        // the audit trail said three objects were created, and one was. The
+        // mapper's lookup ran last and therefore matches the row, so it is the
+        // one to believe. `old: null` is kept for a genuine create — there is
+        // no previous version to diff against — while an update is recorded as
+        // an update rather than as a second birth.
         if ($silent === false && $this->isAuditTrailsEnabled() === true) {
-            $log = $this->auditTrailMapper->createAuditTrail(old: null, new: $savedEntity);
+            $action = $this->unifiedObjectMapper->getLastWriteAction();
+            if ($action === 'update') {
+                $log = $this->auditTrailMapper->createAuditTrail(
+                    old: null,
+                    new: $savedEntity,
+                    action: 'update'
+                );
+            } else {
+                $log = $this->auditTrailMapper->createAuditTrail(old: null, new: $savedEntity);
+            }
+
             $savedEntity->setLastLog($log->jsonSerialize());
             \OCA\OpenRegister\Service\WritePhaseProbe::mark('sv:AUDIT');
         }

--- a/tests/Unit/Db/AuditTrailMapperBulkTest.php
+++ b/tests/Unit/Db/AuditTrailMapperBulkTest.php
@@ -316,4 +316,55 @@ class AuditTrailMapperBulkTest extends TestCase
         $qb->method('getTableName')->willReturn('*PREFIX*openregister_audit_trails');
         $this->db->method('getQueryBuilder')->willReturn($qb);
     }//end mockQueryBuilderTableName()
+    /**
+     * An explicitly-named `update` survives, even with no `old` entity.
+     *
+     * The inference used to fire on `$action === 'update'`, which is both the
+     * default AND a legitimate explicit value — so a caller that KNEW the write
+     * was an update could not say so, and got `create` in the row. That is
+     * exactly the case MagicMapper hits when its own lookup takes the UPDATE
+     * branch on an operation the service labelled a create (#2217), and it is
+     * why a fix passing an explicit action would have looked applied while
+     * changing nothing.
+     *
+     * @return void
+     */
+    public function testAnExplicitUpdateSurvivesWithNoOldEntity(): void
+    {
+        $trail = $this->mapper->buildAuditTrail(
+            old: null,
+            new: $this->makeObject('obj-upd'),
+            action: 'update'
+        );
+
+        $this->assertSame('update', $trail->getAction());
+    }//end testAnExplicitUpdateSurvivesWithNoOldEntity()
+
+    /**
+     * With no action named, a missing `old` still infers a create.
+     *
+     * The guard tests above are only meaningful next to this one: a change that
+     * simply stopped inferring would pass them and break every caller that
+     * relies on the inference — which is most of them.
+     *
+     * @return void
+     */
+    public function testAnOmittedActionStillInfersCreate(): void
+    {
+        $trail = $this->mapper->buildAuditTrail(old: null, new: $this->makeObject('obj-new'));
+
+        $this->assertSame('create', $trail->getAction());
+    }//end testAnOmittedActionStillInfersCreate()
+
+    /**
+     * With no action named, a missing `new` still infers a delete.
+     *
+     * @return void
+     */
+    public function testAnOmittedActionStillInfersDelete(): void
+    {
+        $trail = $this->mapper->buildAuditTrail(old: $this->makeObject('obj-gone'), new: null);
+
+        $this->assertSame('delete', $trail->getAction());
+    }//end testAnOmittedActionStillInfersDelete()
 }//end class


### PR DESCRIPTION
Answers two of the four questions in #2217 by fixing them. The other two are answered in a comment on the issue.

## 1. A re-fetch that finds nothing is a lost write, not a fallback

`insertObjectEntity()` re-reads the row it just wrote and, on `DoesNotExistException`, logged a warning and returned the **in-memory entity** as though persisted. Two very different causes shared that outcome:

- **the row IS there** and only the filtered read could not reach it (scoping, an org/owner context still being established) — degraded but honest, and it now uses the raw row's id;
- **the row is NOT there.** The write did not land, the returned entity has a null id, and the caller has no way to tell.

The second now throws. That is the shape of a lost write reported as a success, which is what #2212 turned out to be.

## 2. The audit action now comes from the layer that knows

`SaveObject` labels the operation from its **own** existence lookup. The mapper then looks again, and between the two lookups a concurrent writer can land the row — so the mapper takes its UPDATE branch on what the service already called a create, and the audit records `create`.

Measured while debugging #2212: **three audit `create` entries against a single `_id` that was inserted once.** The audit trail said three objects were created; one was.

`MagicMapper::getLastWriteAction()` now reports what it actually did, set at all three write branches, and `SaveObject` records that instead of its own prediction.

## ⚠️ The fix that would have looked applied and changed nothing

`buildAuditTrail()` inferred the action from `$action === 'update'` — which is both the **default** and a legitimate **explicit** value. So `old: null, action: 'update'` was rewritten to `create` before it reached the row, and a caller who *knew* the write was an update could not say so.

I wrote the `SaveObject` half first, and it was a silent no-op. Worth flagging, because it is the same shape as the defect being fixed: a change that reads as applied and isn't.

The default is now `null` = "infer"; a named action is used verbatim. Behaviour is unchanged for every caller that omits it — which is most of them, and is pinned by two tests alongside the guard, because a change that simply *stopped* inferring would pass the guard and break everyone else.

## Verification

- 15,545 unit tests green — 3 new: an explicit `update` survives with no `old`; an omitted action still infers `create`; an omitted action still infers `delete`.
- phpcs (full tree, CI settings) and phpstan clean.

## Not in this PR

- **Collapsing the two insert-or-update decisions into one** — a structural change with a different risk profile, discussed on the issue.
- **The p50/p95 cost of the second lookup** — needs instrumentation on a live instance; the CRUD-budget work already owns that harness. Left open rather than guessed at.
