### PR TITLE
ci: run Code Quality on every push to an open PR, not only when it opens

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -4,7 +4,26 @@ on:
   push:
     branches: [main, beta, development, feature/**, bugfix/**, hotfix/**]
   pull_request:
-    types: [opened, reopened]
+    # `synchronize` — a push to an open PR — is what was missing. Without it the
+    # quality suite runs ONCE, when the PR is opened, and every commit after
+    # that is merged unchecked while the PR still shows the first run's green.
+    #
+    # Observed on this repo 2026-07-31: #2227 was opened, failed phpcs on
+    # pre-existing debt, was fixed by a follow-up push, and the fix was never
+    # verified by CI. #2228's only Code Quality run stayed pinned to its first
+    # commit across a merge from development and two further commits, so its
+    # checks were describing code that no longer existed.
+    #
+    # The branch list on `push:` does not cover the gap: it names `feature/**`
+    # while the convention in practice is `feat/**` and `fix/**`, so most
+    # branches get nothing there either.
+    #
+    # Cost is bounded by the `concurrency` block below — a new push cancels the
+    # in-flight run for the same head ref rather than queueing beside it.
+    #
+    # hermiq's copy of this workflow omits `types:` entirely, which defaults to
+    # [opened, synchronize, reopened]. This repo is the outlier.
+    types: [opened, reopened, synchronize]
     branches: [main, beta, development]
   workflow_dispatch:
 


### PR DESCRIPTION
## The gap

`pull_request.types` was `[opened, reopened]`. So the quality suite runs **once**, when the PR is opened, and every commit after that merges unchecked — while the PR still shows the first run's green.

Two examples from today, in this repo:

- **#2227** was opened, failed phpcs on pre-existing debt, and was fixed by a follow-up push. The fix was never verified by CI.
- **#2228**'s only Code Quality run stayed pinned to its **first commit**, across a merge from `development` and two further commits. Its checks were describing code that no longer existed, and it took a manual `workflow_dispatch` to find out whether the branch was actually green.

The `push:` branch list does not cover the gap either — it names `feature/**`, while the convention in practice is `feat/**` and `fix/**`, so most branches get nothing there.

## Why this is the bad kind of gap

A PR that has never been checked shows no checks, and someone notices. A PR checked once, three commits ago, shows **green** — and looks more trustworthy than it is. That is the same failure shape as the defects this suite exists to catch.

## Cost

Bounded by the `concurrency` block already in the file: a new push cancels the in-flight run for the same head ref rather than queueing beside it. So a burst of pushes costs roughly one full run, not one per commit.

For reference, hermiq's copy of this workflow omits `types:` entirely, which defaults to `[opened, synchronize, reopened]`. This repo is the outlier.
