### PR TITLE
fix(broker): traversal is a path SEGMENT of `..`, not the substring anywhere

### DIFF
--- a/lib/Service/Credential/CredentialBrokerService.php
+++ b/lib/Service/Credential/CredentialBrokerService.php
@@ -895,18 +895,41 @@ class CredentialBrokerService
             $this->deny(reason: 'path must be a single-slash-rooted relative path', credentialId: '');
         }
 
-        // Single-decode, then reject any traversal in the decoded form.
+        // Single-decode, then reject traversal in the decoded form.
         $decoded = rawurldecode($path);
-        if (str_contains($decoded, '..') === true) {
-            $this->deny(reason: 'path contains traversal', credentialId: '');
-        }
 
-        $queryPos = strpos($decoded, '?');
+        $queryPos  = strpos($decoded, '?');
+        $matchPath = $decoded;
         if ($queryPos !== false) {
-            return substr($decoded, 0, $queryPos);
+            $matchPath = substr($decoded, 0, $queryPos);
         }
 
-        return $decoded;
+        // Traversal is a path SEGMENT equal to `..`, not the substring `..`
+        // appearing anywhere.
+        //
+        // The substring test rejected legitimate paths whose segments merely
+        // contain dots — GitHub's diff endpoint is `/repos/{o}/{r}/compare/
+        // {base}...{head}`, so EVERY commit comparison was denied as traversal.
+        // That is not a cosmetic refusal: `hydra-flows-first-port` task 2.5
+        // makes "diff the produced tree against the base before moving the ref"
+        // a mandatory rail on the commit-by-API path, precisely because
+        // `base_tree` overwrites rather than merges and a tree built against a
+        // moved base silently reverts files while producing a clean-looking
+        // commit. The rail could not be built at all while this guard stood.
+        //
+        // The security property is unchanged, and is checked both ways in the
+        // tests: `/a/../b` and `/a/%2e%2e/b` are still denied, because a
+        // traversal always presents as a segment that IS `..` once decoded.
+        // A segment like `..b`, `a..b` or `...` is a literal name and never
+        // walks anywhere. Double-encoding is unaffected: `%252e%252e` single-
+        // decodes to `%2e%2e`, which is not `..`, exactly as before.
+        foreach (explode('/', $matchPath) as $segment) {
+            if ($segment === '..') {
+                $this->deny(reason: 'path contains traversal', credentialId: '');
+            }
+        }
+
+        return $matchPath;
     }//end normalisePath()
 
     /**

--- a/tests/Unit/Service/Credential/CredentialBrokerServiceTest.php
+++ b/tests/Unit/Service/Credential/CredentialBrokerServiceTest.php
@@ -313,4 +313,89 @@ class CredentialBrokerServiceTest extends TestCase
         $this->expectException(CredentialAccessDeniedException::class);
         $service->request('cred-1', 'openconnector', 'GET', '/anything');
     }
+
+    /**
+     * A commit COMPARISON is not traversal, and it is the path the safety rail needs.
+     *
+     * GitHub's diff endpoint is `/repos/{o}/{r}/compare/{base}...{head}`. The
+     * guard used to reject any `..` SUBSTRING, so every commit comparison was
+     * denied — which made `hydra-flows-first-port` task 2.5's mandatory rail
+     * ("diff the produced tree against the base before moving the ref")
+     * impossible to build over the brokered path.
+     */
+    public function testACommitComparisonIsNotTraversal(): void
+    {
+        $service = $this->makeService(
+            'alice',
+            'alice',
+            ['provider' => 'github', 'allowedApps' => ['hermiq']],
+            $this->githubProvider(),
+            'SECRET123'
+        );
+
+        $result = $service->request(
+            'cred-1',
+            'hermiq',
+            'GET',
+            '/repos/Conduction/openregister/compare/ba3ed4f4...4f75bc84'
+        );
+
+        $this->assertSame(200, $result['status']);
+    }
+
+    /**
+     * Real traversal is still denied — a segment that IS `..`.
+     */
+    public function testTraversalSegmentIsStillDenied(): void
+    {
+        $service = $this->makeService(
+            'alice',
+            'alice',
+            ['provider' => 'github', 'allowedApps' => ['hermiq']],
+            $this->githubProvider(),
+            'SECRET123'
+        );
+
+        $this->expectException(CredentialAccessDeniedException::class);
+        $service->request('cred-1', 'hermiq', 'GET', '/repos/Conduction/../../etc/passwd');
+    }
+
+    /**
+     * And still denied when the traversal segment arrives percent-encoded.
+     *
+     * The guard decodes ONCE before checking, so `%2e%2e` is caught. Pinned
+     * separately because a segment-based check would be trivially bypassable
+     * if it ran before the decode.
+     */
+    public function testEncodedTraversalSegmentIsStillDenied(): void
+    {
+        $service = $this->makeService(
+            'alice',
+            'alice',
+            ['provider' => 'github', 'allowedApps' => ['hermiq']],
+            $this->githubProvider(),
+            'SECRET123'
+        );
+
+        $this->expectException(CredentialAccessDeniedException::class);
+        $service->request('cred-1', 'hermiq', 'GET', '/repos/Conduction/%2e%2e/%2e%2e/etc/passwd');
+    }
+
+    /**
+     * A segment that merely CONTAINS dots is a literal name and is allowed.
+     */
+    public function testASegmentContainingDotsIsAllowed(): void
+    {
+        $service = $this->makeService(
+            'alice',
+            'alice',
+            ['provider' => 'github', 'allowedApps' => ['hermiq']],
+            $this->githubProvider(),
+            'SECRET123'
+        );
+
+        $result = $service->request('cred-1', 'hermiq', 'GET', '/repos/Conduction/some..name');
+
+        $this->assertSame(200, $result['status']);
+    }
 }//end class


### PR DESCRIPTION
## What was wrong

`CredentialBrokerService::normalisePath()` denied any path containing the **substring** `..`. That rejected legitimate paths whose segments merely contain dots — most importantly GitHub's diff endpoint:

```
/repos/{owner}/{repo}/compare/{base}...{head}
```

So **every commit comparison through the broker was refused as traversal.**

## Why it matters more than it looks

`hydra-flows-first-port` task 2.5 makes *"diff the produced tree against the base before moving the ref"* a **mandatory** rail on the commit-by-API path. The reason is specific: `base_tree` **overwrites rather than merges**, so a tree built against a base that has since moved silently reverts every file the caller did not send, and the resulting commit looks clean. That has happened for real (two files lost an import and a template gate during the nc-vue migration, caught only by running the full suite).

The rail could not be built at all over the brokered path while this guard stood.

Found by running the chain end to end: blob `201`, tree `201`, commit `201`, then compare **`403`**.

## The fix

Check for a **segment** that IS `..`, which is what traversal actually is. A segment like `..b`, `a..b` or `...` is a literal name and never walks anywhere.

Security property unchanged, pinned both ways:

| path | before | after |
|---|---|---|
| `/repos/Conduction/../../etc/passwd` | denied | **denied** |
| `/repos/Conduction/%2e%2e/%2e%2e/etc/passwd` | denied | **denied** |
| `/repos/Conduction/openregister/compare/A...B` | denied | allowed |
| `/repos/Conduction/some..name` | denied | allowed |

The encoded case is pinned separately on purpose: the guard decodes **once before** checking, so an encoded traversal segment is still caught — a segment check running *before* the decode would be trivially bypassable, and that is the mistake this test exists to prevent. Double-encoding is unaffected: `%252e%252e` single-decodes to `%2e%2e`, which is not `..`, exactly as before.

## Verification

15,553 unit tests green (4 new); phpcs (full tree, CI settings) and phpstan clean.
