### PR TITLE
fix(flow): a stop only ends the run on the branch that was actually taken

### DIFF
--- a/lib/Service/Flow/Nodes/StopNode.php
+++ b/lib/Service/Flow/Nodes/StopNode.php
@@ -123,16 +123,45 @@ class StopNode implements IFlowNode
     /**
      * End the run.
      *
-     * @param array $items   The input items (unused — the run ends).
+     * Ends the run when it receives items. An EMPTY item list means this
+     * branch was not taken, and the node passes through instead — see the
+     * comment in the body for why that distinction is load-bearing.
+     *
+     * @param array $items   The input items — empty means "this branch was not taken".
      * @param array $config  The step configuration.
      * @param array $context Run-level metadata.
      *
-     * @return array Never returns normally.
+     * @return array The empty item list, when there was nothing to stop for.
      *
-     * @throws FlowStop Always — this is how the node ends the run.
+     * @throws FlowStop When items reached it — this is how the node ends the run.
      */
     public function execute(array $items, array $config, array $context): array
     {
+        // A stop that received NOTHING is a branch that was not taken.
+        //
+        // `FlowEngine::advanceItems()` marks every place on a firing
+        // transition's `to` list and then distributes items to them by output
+        // tag — so after a route, the branch the router did NOT choose is
+        // marked and holds zero items. Its steps still fire. For an item-driven
+        // node that is harmless (zero items, zero work; `SourceCallNode` even
+        // short-circuits explicitly). For a stop it was not: the node threw
+        // regardless, so a graph with a refusal stop on each guard branch ended
+        // its run on a guard that had not tripped.
+        //
+        // Measured on hydra's commit-by-API flow: every step through
+        // `move-ref` completed, the branch ref genuinely moved on GitHub — and
+        // the run reported `failed` with "the branch tip moved while the commit
+        // was being built". The opposite of what happened, and the failure the
+        // rail exists to report is exactly the one it falsely claimed. A caller
+        // reading the run status would roll back a commit that was correct.
+        //
+        // Refusing on an empty branch also cannot be what an author meant: they
+        // wrote the stop to describe a condition, and no items reaching it means
+        // the condition did not select anything.
+        if ($items === []) {
+            return [];
+        }
+
         $isError = (($config['error'] ?? false) === true);
         $message = trim((string) ($config['message'] ?? ''));
         if ($message === '') {

--- a/tests/Unit/Service/Flow/StopNodeTest.php
+++ b/tests/Unit/Service/Flow/StopNodeTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * A stop only stops the branch that was actually taken.
+ *
+ * These tests exist because the distinction is invisible in the graph. After a
+ * route, `FlowEngine::advanceItems()` marks EVERY place on the transition's
+ * `to` list and distributes items to them by output tag — so the branch the
+ * router did not choose is marked and holds zero items, and its steps still
+ * fire. Item-driven nodes shrug that off; a stop did not, and ended the run on
+ * a guard that had not tripped.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author  Conduction Development Team <dev@conduction.nl>
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowStop;
+use OCA\OpenRegister\Service\Flow\Nodes\StopNode;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Flow\Nodes\StopNode
+ */
+final class StopNodeTest extends TestCase
+{
+
+    /**
+     * The node under test.
+     *
+     * @var StopNode
+     */
+    private StopNode $node;
+
+
+    /**
+     * Build the node with stub collaborators.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $l10n = $this->createMock(originalClassName: IL10N::class);
+        $l10n->method('t')->willReturnArgument(0);
+
+        $this->node = new StopNode($l10n, $this->createMock(originalClassName: IURLGenerator::class));
+
+    }//end setUp()
+
+
+    /**
+     * A stop that received items ends the run, as an error when configured so.
+     *
+     * The guard test below is only meaningful next to this one: a node that
+     * stopped stopping would pass that test and be useless.
+     *
+     * @return void
+     */
+    public function testAStopWithItemsEndsTheRun(): void
+    {
+        $this->expectException(FlowStop::class);
+        $this->expectExceptionMessage('the tip moved');
+
+        $this->node->execute([['json' => ['a' => 1]]], ['error' => true, 'message' => 'the tip moved'], []);
+
+    }//end testAStopWithItemsEndsTheRun()
+
+
+    /**
+     * A stop on a branch the router did NOT choose passes through.
+     *
+     * Measured on hydra's commit-by-API flow before this: every step through
+     * `move-ref` completed and the branch ref genuinely moved on GitHub, while
+     * the run reported `failed` with "the branch tip moved while the commit was
+     * being built" — the opposite of what happened, and precisely the failure
+     * the rail exists to report. A caller reading the run status would roll back
+     * a commit that was correct.
+     *
+     * @return void
+     */
+    public function testAStopOnAnUntakenBranchDoesNotEndTheRun(): void
+    {
+        $out = $this->node->execute([], ['error' => true, 'message' => 'the tip moved'], []);
+
+        $this->assertSame([], $out);
+
+    }//end testAStopOnAnUntakenBranchDoesNotEndTheRun()
+
+
+    /**
+     * The same holds for a clean (non-error) stop.
+     *
+     * A clean stop on an untaken branch is quieter but no less wrong: it ends
+     * the run early, so every step after the router never runs.
+     *
+     * @return void
+     */
+    public function testACleanStopOnAnUntakenBranchAlsoPassesThrough(): void
+    {
+        $out = $this->node->execute([], ['error' => false, 'message' => 'nothing to do'], []);
+
+        $this->assertSame([], $out);
+
+    }//end testACleanStopOnAnUntakenBranchAlsoPassesThrough()
+}//end class


### PR DESCRIPTION
## What was wrong

`FlowEngine::advanceItems()` marks **every** place on a firing transition's `to` list and then distributes items to them by output tag. So after a route, the branch the router did **not** choose is marked and holds **zero items** — and its steps still fire.

Item-driven nodes shrug that off (zero items, zero work; `SourceCallNode` even short-circuits explicitly). `StopNode` did not: it threw regardless. A graph with a refusal stop on each guard branch therefore ended its run on a guard that had not tripped.

## How it showed up

On hydra's commit-by-API flow, which is what surfaced it. Every step through `move-ref` completed and the branch ref **genuinely moved on GitHub** — and the run reported:

```
failed — "The branch tip moved while the commit was being built.
          Refusing to base a tree on a stale parent."
```

The opposite of what happened, and precisely the failure the safety rail exists to report.

That is the dangerous shape: a caller reading the run status would roll back a commit that was correct, or — worse — come to trust a rail that had in fact never fired.

## The fix

A stop that received nothing passes through. An empty branch cannot be what an author meant: they wrote the stop to describe a condition, and no items reaching it means the condition selected nothing.

The success path is pinned alongside the two guard tests, because a node that stopped stopping would pass the guards and be useless.

## Verification

15,552 unit tests green (3 new); phpcs (full tree, CI settings) clean.
