### PR TITLE
feat(flow): object-write can put its result BESIDE the record instead of over it

### DIFF
--- a/lib/Service/Flow/Nodes/ObjectWriteNode.php
+++ b/lib/Service/Flow/Nodes/ObjectWriteNode.php
@@ -495,7 +495,11 @@ class ObjectWriteNode implements IFlowNode
             $writes++;
 
             $out[] = FlowItems::item(
-                json: $this->writtenJson(saved: $saved, register: $register, schema: $schema),
+                json: $this->outputJson(
+                    incoming: (array) ($item[FlowItems::JSON] ?? []),
+                    written: $this->writtenJson(saved: $saved, register: $register, schema: $schema),
+                    config: $config
+                ),
                 binary: $binary,
                 fromItemIndex: (int) $index
             );
@@ -504,6 +508,43 @@ class ObjectWriteNode implements IFlowNode
         return $out;
 
     }//end execute()
+
+    /**
+     * The json a written item carries onward.
+     *
+     * With `output` set, the incoming record is PRESERVED and the written object
+     * is added under that key — the convention every other node already follows
+     * (`hermiq.agent-step`, `openconnector.source-call`,
+     * `openregister.flow-state` all do this). Without it, the written object
+     * REPLACES the record, which is the historical behaviour and stays the
+     * default because changing it silently would rewrite what existing flows
+     * see.
+     *
+     * Replacing is fine for a write that ends a branch and wrong for one in the
+     * middle of a chain, because it discards everything the run was carrying. A
+     * per-issue lock is exactly the second shape: hydra's sequencer claims a
+     * lock and then still needs the repo, the issue and its slot number to do
+     * the work the lock protects. Measured while building it — after the lock
+     * write, `{{repo}}` rendered empty and the next call went to `/repos//issues`.
+     *
+     * @param array $incoming The item's json as it arrived.
+     * @param array $written  The written object's json.
+     * @param array $config   The step configuration.
+     *
+     * @return array The outgoing json.
+     */
+    private function outputJson(array $incoming, array $written, array $config): array
+    {
+        $key = trim((string) ($config['output'] ?? ''));
+        if ($key === '') {
+            return $written;
+        }
+
+        $incoming[$key] = $written;
+
+        return $incoming;
+
+    }//end outputJson()
 
     /**
      * Perform one guarded delete and build its output item.

--- a/tests/Unit/Service/Flow/ObjectWriteNodeTest.php
+++ b/tests/Unit/Service/Flow/ObjectWriteNodeTest.php
@@ -1056,4 +1056,67 @@ class ObjectWriteNodeTest extends TestCase
         $this->assertSame(1000, $seenDefault, 'the shipped default cap is 1000 writes per step execution');
 
     }//end testTheInstanceDefaultAppliesWhenNoCapIsConfigured()
+
+
+    /**
+     * With `output` set, the item's record SURVIVES and the write lands beside it.
+     *
+     * Replacing the record is fine for a write that ends a branch and wrong for
+     * one in the middle of a chain — a per-issue lock is exactly the second
+     * shape, because the run still needs the repo and the issue to do the work
+     * the lock protects. Measured while building hydra's sequencer: after the
+     * lock write, `{{repo}}` rendered empty and the next call went to
+     * `/repos//issues`.
+     *
+     * @return void
+     */
+    public function testAnOutputKeyPreservesTheIncomingRecord(): void
+    {
+        $this->objects->method('saveObject')->willReturnCallback(
+            function (mixed $object, ?array $extend=[], mixed $register=null, mixed $schema=null, ?string $uuid=null, bool $_rbac=true, bool $_multitenancy=true, bool $silent=false, ?array $uploadedFiles=null, ?IUser $currentUser=null): ObjectEntity {
+                return $this->entity('uuid-1', $object);
+            }
+        );
+
+        $out = $this->node->execute(
+            $this->items([['repo' => 'ConductionNL/hydra', 'issue' => 410]]),
+            $this->config(['output' => 'lock', 'fields' => ['title' => '{{repo}}']]),
+            $this->registerContext
+        );
+
+        // What the run was carrying is still there.
+        $this->assertSame('ConductionNL/hydra', $out[0]['json']['repo']);
+        $this->assertSame(410, $out[0]['json']['issue']);
+
+        // And the written object is beside it, under the named key.
+        $this->assertSame('uuid-1', $out[0]['json']['lock']['uuid']);
+        $this->assertSame('ConductionNL/hydra', $out[0]['json']['lock']['title']);
+    }
+
+    /**
+     * WITHOUT `output`, the written object still replaces the record.
+     *
+     * The historical behaviour stays the default: changing it silently would
+     * rewrite what every existing flow sees downstream of a write.
+     *
+     * @return void
+     */
+    public function testWithoutAnOutputKeyTheWrittenObjectStillReplacesTheRecord(): void
+    {
+        $this->objects->method('saveObject')->willReturnCallback(
+            function (mixed $object, ?array $extend=[], mixed $register=null, mixed $schema=null, ?string $uuid=null, bool $_rbac=true, bool $_multitenancy=true, bool $silent=false, ?array $uploadedFiles=null, ?IUser $currentUser=null): ObjectEntity {
+                return $this->entity('uuid-1', $object);
+            }
+        );
+
+        $out = $this->node->execute(
+            $this->items([['repo' => 'ConductionNL/hydra']]),
+            $this->config(['fields' => ['title' => 'literal']]),
+            $this->registerContext
+        );
+
+        $this->assertArrayNotHasKey('repo', $out[0]['json']);
+        $this->assertSame('uuid-1', $out[0]['json']['uuid']);
+    }
+
 }//end class


### PR DESCRIPTION
`ObjectWriteNode` replaced the item's json with the written object. Every other node preserves the record and writes its result under an `output` key — `hermiq.agent-step`, `openconnector.source-call` and `openregister.flow-state` all do. This one was the outlier.

## Why the difference is not cosmetic

Replacing is fine for a write that **ends** a branch, and wrong for one in the **middle of a chain**: it discards everything the run was carrying.

A per-issue lock is exactly the second shape. hydra's sequencer claims a lock and then still needs the repo, the issue and its slot number to do the work the lock protects. Measured while building it — after the lock write, `{{repo}}` rendered empty and the next call went to `/repos//issues`.

⚠️ The step already **accepted** an `output` key and silently ignored it, so an author could write one, see no error, and get the replace behaviour anyway.

## The change

With `output` set, the record survives and the write lands beside it. Without it, the historical replace behaviour is unchanged — pinned by its own test, because changing that silently would rewrite what every existing flow sees downstream of a write.

## Verification

15,558 unit tests green (2 new); phpcs (full tree, CI settings) and phpstan clean.