### PR TITLE
feat(flow): an object-read node — a flow can finally ask a question about objects

### DIFF
--- a/lib/Listener/FlowNodeRegistrationListener.php
+++ b/lib/Listener/FlowNodeRegistrationListener.php
@@ -32,6 +32,7 @@ use OCA\OpenRegister\Service\Flow\Nodes\FilterNode;
 use OCA\OpenRegister\Service\Flow\Nodes\FlowStateNode;
 use OCA\OpenRegister\Service\Flow\Nodes\LoopNode;
 use OCA\OpenRegister\Service\Flow\Nodes\MergeNode;
+use OCA\OpenRegister\Service\Flow\Nodes\ObjectReadNode;
 use OCA\OpenRegister\Service\Flow\Nodes\ObjectWriteNode;
 use OCA\OpenRegister\Service\Flow\Nodes\RouterNode;
 use OCA\OpenRegister\Service\Flow\Nodes\SetFieldsNode;
@@ -63,6 +64,7 @@ class FlowNodeRegistrationListener implements IEventListener
      * @param SubFlowNode     $subFlow     The built-in "Run a flow" node.
      * @param RouterNode      $router      The built-in "Route items" node.
      * @param ObjectWriteNode $objectWrite The built-in "Write an object" node.
+     * @param ObjectReadNode  $objectRead  The built-in "Read objects" node.
      * @param FlowStateNode   $flowState   The built-in "Flow state" node.
      */
     public function __construct(
@@ -76,6 +78,7 @@ class FlowNodeRegistrationListener implements IEventListener
         private readonly SubFlowNode $subFlow,
         private readonly RouterNode $router,
         private readonly ObjectWriteNode $objectWrite,
+        private readonly ObjectReadNode $objectRead,
         private readonly FlowStateNode $flowState
     ) {
 
@@ -106,6 +109,7 @@ class FlowNodeRegistrationListener implements IEventListener
         $event->registerNode(node: $this->subFlow);
         $event->registerNode(node: $this->router);
         $event->registerNode(node: $this->objectWrite);
+        $event->registerNode(node: $this->objectRead);
         $event->registerNode(node: $this->flowState);
 
     }//end handle()

--- a/lib/Service/Flow/Nodes/ObjectReadNode.php
+++ b/lib/Service/Flow/Nodes/ObjectReadNode.php
@@ -1,0 +1,517 @@
+<?php
+
+/**
+ * Reads register objects into a flow.
+ *
+ * The counterpart to {@see ObjectWriteNode}, and until now the missing half: a
+ * flow could create, patch and delete objects and had no way to ask a QUESTION
+ * about them. The live catalogue carried fourteen node types and exactly one
+ * object-shaped step, the write (ConductionNL/openregister#2235).
+ *
+ * The motivating case is a reaper. hydra's sequencer takes a per-issue lock as
+ * an object write with `onConflict: fail`, which is a real mutual-exclusion
+ * primitive since #2215 — but a crashed run leaves its lock behind, and the
+ * scheduled flow that would clear stale ones has to begin by LISTING them.
+ * Without a read step that flow cannot be written at all, and the workarounds
+ * are worse than the gap: calling OpenRegister's own REST API back through
+ * `openconnector.source-call` leaves the process, re-authenticates and crosses
+ * an HTTP boundary to read a table it is already sitting on top of.
+ *
+ * SAME GUARDS AS THE WRITE, FOR THE SAME REASON
+ * ---------------------------------------------
+ * A flow is authored data. If a flow could READ past RBAC then authoring one
+ * would be a disclosure escalation, exactly as writing past it would be a
+ * privilege escalation. So the read runs as `context.triggeredBy` — no system
+ * user, no owner named in the step's own configuration — and a run with no
+ * resolvable owner reads nothing and says why.
+ *
+ * A failure throws rather than yielding an empty result. "No objects matched"
+ * and "the read did not happen" are different answers, and a reaper that reads
+ * the second as the first quietly stops reaping.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Nodes;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\WorkflowEngine\IManager;
+use RuntimeException;
+use Throwable;
+use UnexpectedValueException;
+
+/**
+ * Reads objects from a register into the run.
+ */
+class ObjectReadNode implements IFlowNode
+{
+
+    /**
+     * The step type.
+     *
+     * @var string
+     */
+    public const NODE_ID = 'openregister.object-read';
+
+    /**
+     * Where the results land when the step names no `output`.
+     *
+     * @var string
+     */
+    private const DEFAULT_OUTPUT_KEY = 'objects';
+
+    /**
+     * How many objects one read returns when the step names no `limit`.
+     *
+     * A default rather than "everything": a reaper over a runaway lock table
+     * should process a bounded batch and come back on the next tick, not build
+     * a million-item walk in memory and time the run out.
+     *
+     * @var int
+     */
+    private const DEFAULT_LIMIT = 100;
+
+    /**
+     * The ceiling on `limit`, whatever the step asks for.
+     *
+     * @var int
+     */
+    private const MAX_LIMIT = 1000;
+
+    /**
+     * Constructor.
+     *
+     * @param ObjectService  $objects     Object reads, RBAC-enforcing.
+     * @param RegisterMapper $registers   Resolves the configured register.
+     * @param SchemaMapper   $schemas     Resolves the configured schema.
+     * @param IUserManager   $userManager Resolves the run owner.
+     * @param IL10N          $l10n        Translations.
+     * @param IURLGenerator  $urls        For the palette icon.
+     */
+    public function __construct(
+        private readonly ObjectService $objects,
+        private readonly RegisterMapper $registers,
+        private readonly SchemaMapper $schemas,
+        private readonly IUserManager $userManager,
+        private readonly IL10N $l10n,
+        private readonly IURLGenerator $urls
+    ) {
+
+    }//end __construct()
+
+    /**
+     * The step type.
+     *
+     * @return string The id.
+     */
+    public function getId(): string
+    {
+        return self::NODE_ID;
+
+    }//end getId()
+
+    /**
+     * Palette name.
+     *
+     * @return string The display name.
+     */
+    public function getDisplayName(): string
+    {
+        return $this->l10n->t('Read objects');
+
+    }//end getDisplayName()
+
+    /**
+     * Palette description.
+     *
+     * @return string The description.
+     */
+    public function getDescription(): string
+    {
+        return $this->l10n->t('Find objects in a register and put them on the item.');
+
+    }//end getDescription()
+
+    /**
+     * Palette icon.
+     *
+     * @return string The icon URL.
+     */
+    public function getIcon(): string
+    {
+        return $this->urls->imagePath('core', 'actions/search.svg');
+
+    }//end getIcon()
+
+    /**
+     * Available in both scopes — the owner's RBAC is what bounds the read.
+     *
+     * @param int $scope The scope constant.
+     *
+     * @return boolean Whether it is available.
+     */
+    public function isAvailableForScope(int $scope): bool
+    {
+        return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
+
+    }//end isAvailableForScope()
+
+    /**
+     * Refuse a step that cannot name what it reads.
+     *
+     * @param array $config The step configuration.
+     *
+     * @return void
+     *
+     * @throws UnexpectedValueException When register or schema is missing, or filters are malformed.
+     */
+    public function validateConfig(array $config): void
+    {
+        if (trim((string) ($config['register'] ?? '')) === '') {
+            throw new UnexpectedValueException($this->l10n->t('An object-read step needs a register.'));
+        }
+
+        if (trim((string) ($config['schema'] ?? '')) === '') {
+            throw new UnexpectedValueException($this->l10n->t('An object-read step needs a schema.'));
+        }
+
+        if (array_key_exists('filters', $config) === true && is_array($config['filters']) === false) {
+            throw new UnexpectedValueException($this->l10n->t('An object-read step\'s filters must be an object.'));
+        }
+
+    }//end validateConfig()
+
+    /**
+     * Read once per item, putting the results on each.
+     *
+     * One read per item, not one for the whole batch, because the filters are
+     * templated from the item — two items asking different questions must get
+     * their own answers. It is the same contract every other item-driven node
+     * follows.
+     *
+     * @param array $items   The input items.
+     * @param array $config  The step configuration.
+     * @param array $context Run-level metadata (carries the triggering user).
+     *
+     * @return array The items, each with the read's results added.
+     *
+     * @throws RuntimeException        When the run has no resolvable owner.
+     * @throws UnexpectedValueException When the register or schema does not resolve.
+     */
+    public function execute(array $items, array $config, array $context): array
+    {
+        // An empty branch asks nothing. It short-circuits before the owner is
+        // resolved, because there is nothing to attribute — the same contract
+        // `openconnector.source-call` follows.
+        if ($items === []) {
+            return [];
+        }
+
+        $this->validateConfig(config: $config);
+
+        $owner    = $this->resolveOwner(context: $context);
+        $register = $this->resolveRegister(config: $config);
+        $schema   = $this->resolveSchema(config: $config, register: $register);
+        $outKey   = trim((string) ($config['output'] ?? ''));
+        if ($outKey === '') {
+            $outKey = self::DEFAULT_OUTPUT_KEY;
+        }
+
+        $limit = $this->limitFrom(config: $config);
+
+        $out = [];
+        foreach ($items as $index => $item) {
+            $json    = (array) ($item[FlowItems::JSON] ?? []);
+            $filters = $this->renderFilters(filters: (array) ($config['filters'] ?? []), json: $json);
+
+            $json[$outKey] = $this->read(
+                register: $register,
+                schema: $schema,
+                filters: $filters,
+                limit: $limit,
+                owner: $owner
+            );
+
+            $out[] = FlowItems::item(
+                json: $json,
+                binary: (array) ($item[FlowItems::BINARY] ?? []),
+                fromItemIndex: (int) $index
+            );
+        }//end foreach
+
+        return $out;
+
+    }//end execute()
+
+    /**
+     * Substitute `{{dotted.path}}` placeholders in the filter values.
+     *
+     * Deliberately its own small renderer rather than a shared one: OpenConnector
+     * owns `FlowTemplate`, and reaching across an app boundary for it would make
+     * OpenRegister's own node depend on an app that may not be installed.
+     * `ObjectWriteNode` resolves its `fields` with a private renderer for the
+     * same reason.
+     *
+     * A value that is EXACTLY one placeholder keeps the resolved value's type,
+     * so a numeric id stays a number and a list stays a list — a filter is
+     * compared, and `"7"` and `7` are not the same comparison. Anything else is
+     * substituted inline and stringified. A non-string passes through untouched,
+     * so a literal filter can be authored directly.
+     *
+     * @param array $filters The configured filters.
+     * @param array $json    The item's record.
+     *
+     * @return array The rendered filters.
+     */
+    private function renderFilters(array $filters, array $json): array
+    {
+        $rendered = [];
+        foreach ($filters as $key => $value) {
+            if (is_array($value) === true) {
+                $rendered[(string) $key] = $this->renderFilters(filters: $value, json: $json);
+                continue;
+            }
+
+            if (is_string($value) === false) {
+                $rendered[(string) $key] = $value;
+                continue;
+            }
+
+            $whole = [];
+            if (preg_match('/^\{\{\s*([A-Za-z0-9_@.]+)\s*\}\}$/', $value, $whole) === 1) {
+                $rendered[(string) $key] = $this->valueAt(path: $whole[1], json: $json);
+                continue;
+            }
+
+            $rendered[(string) $key] = (string) preg_replace_callback(
+                '/\{\{\s*([A-Za-z0-9_@.]+)\s*\}\}/',
+                function (array $matches) use ($json): string {
+                    $resolved = $this->valueAt(path: $matches[1], json: $json);
+                    if (is_array($resolved) === true) {
+                        return (string) json_encode($resolved);
+                    }
+
+                    return (string) $resolved;
+                },
+                $value
+            );
+        }//end foreach
+
+        return $rendered;
+
+    }//end renderFilters()
+
+    /**
+     * The value at a dotted path in the item's record, or null.
+     *
+     * @param string $path The dotted path.
+     * @param array  $json The item's record.
+     *
+     * @return mixed The value, or null when the path is absent.
+     */
+    private function valueAt(string $path, array $json): mixed
+    {
+        $cursor = $json;
+        foreach (explode('.', $path) as $segment) {
+            if (is_array($cursor) === false || array_key_exists($segment, $cursor) === false) {
+                return null;
+            }
+
+            $cursor = $cursor[$segment];
+        }
+
+        return $cursor;
+
+    }//end valueAt()
+
+    /**
+     * Perform one read as the run owner.
+     *
+     * A failure THROWS rather than returning an empty list. "No objects
+     * matched" and "the read did not happen" are different answers, and a
+     * caller that cannot tell them apart — a reaper, a guard, a count — will
+     * read the second as the first and quietly do nothing.
+     *
+     * @param Register $register The resolved register.
+     * @param Schema   $schema   The resolved schema.
+     * @param array    $filters  The rendered filters.
+     * @param int      $limit    The bounded result cap.
+     * @param IUser    $owner    The run owner, whose RBAC applies.
+     *
+     * @return array<int, array> The matched objects, as plain records.
+     *
+     * @throws RuntimeException When the read itself fails.
+     */
+    private function read(Register $register, Schema $schema, array $filters, int $limit, IUser $owner): array
+    {
+        try {
+            $found = $this->objects
+                ->setRegister($register)
+                ->setSchema($schema)
+                ->findAll(config: ['filters' => $filters, 'limit' => $limit]);
+        } catch (Throwable $e) {
+            throw new RuntimeException(
+                $this->l10n->t('The object-read step could not read from the register: %s', [$e->getMessage()]),
+                0,
+                $e
+            );
+        }
+
+        $records = [];
+        foreach ($found as $object) {
+            if (($object instanceof ObjectEntity) === false) {
+                continue;
+            }
+
+            $record = (array) $object->getObject();
+            // The uuid is what a follow-up write or delete needs to name this
+            // row, and it does not live in the record's own fields.
+            $record['uuid'] = $object->getUuid();
+
+            $records[] = $record;
+        }
+
+        return $records;
+
+    }//end read()
+
+    /**
+     * The bounded result cap for one read.
+     *
+     * @param array $config The step configuration.
+     *
+     * @return int The limit.
+     */
+    private function limitFrom(array $config): int
+    {
+        $limit = (int) ($config['limit'] ?? self::DEFAULT_LIMIT);
+        if ($limit < 1) {
+            return self::DEFAULT_LIMIT;
+        }
+
+        return min($limit, self::MAX_LIMIT);
+
+    }//end limitFrom()
+
+    /**
+     * The run's owner, whose RBAC bounds the read.
+     *
+     * @param array $context Run-level metadata.
+     *
+     * @return IUser The run owner.
+     *
+     * @throws RuntimeException When the run carries no resolvable owner.
+     */
+    private function resolveOwner(array $context): IUser
+    {
+        $uid = ($context['triggeredBy'] ?? null);
+        if (is_string($uid) === false || trim($uid) === '') {
+            throw new RuntimeException(
+                $this->l10n->t('This flow run has no owner (triggeredBy); an object read must be attributable.')
+            );
+        }
+
+        $user = $this->userManager->get(trim($uid));
+        if ($user === null) {
+            throw new RuntimeException(
+                $this->l10n->t(
+                    'This flow run\'s owner "%s" (triggeredBy) is not a user account; an object read must be attributable.',
+                    [trim($uid)]
+                )
+            );
+        }
+
+        return $user;
+
+    }//end resolveOwner()
+
+    /**
+     * Resolve the configured register from a slug, uuid or id.
+     *
+     * @param array $config The step configuration.
+     *
+     * @return Register The resolved register.
+     *
+     * @throws UnexpectedValueException When it does not resolve.
+     */
+    private function resolveRegister(array $config): Register
+    {
+        $identifier = trim((string) ($config['register'] ?? ''));
+
+        try {
+            return $this->registers->find(id: $identifier, _rbac: false, _multitenancy: false);
+        } catch (Throwable $e) {
+            throw new UnexpectedValueException(
+                $this->l10n->t('The register "%s" could not be resolved.', [$identifier]),
+                0,
+                $e
+            );
+        }
+
+    }//end resolveRegister()
+
+    /**
+     * Resolve the configured schema, preferring the register's own schemas.
+     *
+     * A bare slug is only unique WITHIN a register. Resolving it globally lets
+     * a generic slug (`order`, `task`, `lock`) land on another app's schema
+     * that happens to share it — the same reasoning as `ObjectWriteNode`.
+     *
+     * @param array    $config   The step configuration.
+     * @param Register $register The already-resolved register.
+     *
+     * @return Schema The resolved schema.
+     *
+     * @throws UnexpectedValueException When it does not resolve.
+     */
+    private function resolveSchema(array $config, Register $register): Schema
+    {
+        $identifier = trim((string) ($config['schema'] ?? ''));
+
+        if (is_numeric($identifier) === false) {
+            $scoped = $this->schemas->findBySlugInIds(
+                slug: $identifier,
+                schemaIds: (array) ($register->getSchemas() ?? [])
+            );
+            if ($scoped !== null) {
+                return $scoped;
+            }
+        }
+
+        try {
+            return $this->schemas->find(id: $identifier, _rbac: false, _multitenancy: false);
+        } catch (Throwable $e) {
+            throw new UnexpectedValueException(
+                $this->l10n->t('The schema "%s" could not be resolved.', [$identifier]),
+                0,
+                $e
+            );
+        }
+
+    }//end resolveSchema()
+}//end class

--- a/tests/Unit/Service/Flow/ObjectReadNodeTest.php
+++ b/tests/Unit/Service/Flow/ObjectReadNodeTest.php
@@ -1,0 +1,361 @@
+<?php
+
+/**
+ * Unit tests for ObjectReadNode.
+ *
+ * The read is the half the engine was missing: a flow could write objects and
+ * never ask a question about them (#2235). These tests pin the properties that
+ * make it usable AND safe — it reads as the run owner, it bounds what it
+ * returns, and a failed read is never mistaken for an empty one.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author  Conduction Development Team <dev@conduction.nl>
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\Nodes\ObjectReadNode;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use UnexpectedValueException;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Flow\Nodes\ObjectReadNode
+ */
+final class ObjectReadNodeTest extends TestCase
+{
+
+    /**
+     * The mocked object service.
+     *
+     * @var ObjectService
+     */
+    private ObjectService $objects;
+
+    /**
+     * The node under test.
+     *
+     * @var ObjectReadNode
+     */
+    private ObjectReadNode $node;
+
+    /**
+     * A run context naming a real owner.
+     *
+     * @var array<string, mixed>
+     */
+    private array $ownedContext = ['triggeredBy' => 'alice'];
+
+
+    /**
+     * Wire the node over mocked collaborators.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $register = new Register();
+        $register->setId(1);
+        $register->setSlug('example-hydra-cache');
+
+        $schema = new Schema();
+        $schema->setId(2);
+        $schema->setSlug('example-lock');
+
+        $this->objects = $this->createMock(originalClassName: ObjectService::class);
+        $this->objects->method('setRegister')->willReturnSelf();
+        $this->objects->method('setSchema')->willReturnSelf();
+
+        $registers = $this->createMock(originalClassName: RegisterMapper::class);
+        $registers->method('find')->willReturn($register);
+
+        $schemas = $this->createMock(originalClassName: SchemaMapper::class);
+        $schemas->method('findBySlugInIds')->willReturn($schema);
+        $schemas->method('find')->willReturn($schema);
+
+        $users = $this->createMock(originalClassName: IUserManager::class);
+        $users->method('get')->willReturnCallback(
+            function (string $uid): ?IUser {
+                if ($uid !== 'alice') {
+                    return null;
+                }
+
+                $user = $this->createMock(originalClassName: IUser::class);
+                $user->method('getUID')->willReturn('alice');
+
+                return $user;
+            }
+        );
+
+        $l10n = $this->createMock(originalClassName: IL10N::class);
+        $l10n->method('t')->willReturnArgument(0);
+
+        $this->node = new ObjectReadNode(
+            $this->objects,
+            $registers,
+            $schemas,
+            $users,
+            $l10n,
+            $this->createMock(originalClassName: IURLGenerator::class)
+        );
+
+    }//end setUp()
+
+
+    /**
+     * A stored object, as the mapper would return it.
+     *
+     * @param string $uuid   The object uuid.
+     * @param array  $record The object's own fields.
+     *
+     * @return ObjectEntity The entity.
+     */
+    private function entity(string $uuid, array $record): ObjectEntity
+    {
+        $object = new ObjectEntity();
+        $object->setUuid($uuid);
+        $object->setObject($record);
+
+        return $object;
+
+    }//end entity()
+
+
+    /**
+     * The step's baseline configuration.
+     *
+     * @param array $overrides Config overrides.
+     *
+     * @return array The configuration.
+     */
+    private function config(array $overrides=[]): array
+    {
+        return array_merge(
+            ['register' => 'example-hydra-cache', 'schema' => 'example-lock'],
+            $overrides
+        );
+
+    }//end config()
+
+
+    /**
+     * Results land under `output`, beside the record the item was carrying.
+     *
+     * @return void
+     */
+    public function testResultsLandBesideTheIncomingRecord(): void
+    {
+        $this->objects->method('findAll')->willReturn(
+            [$this->entity('uuid-1', ['holder' => 'issue-7'])]
+        );
+
+        $out = $this->node->execute(
+            [FlowItems::item(json: ['repo' => 'ConductionNL/hydra'])],
+            $this->config(['output' => 'locks']),
+            $this->ownedContext
+        );
+
+        $this->assertSame('ConductionNL/hydra', $out[0]['json']['repo']);
+        $this->assertCount(1, $out[0]['json']['locks']);
+        $this->assertSame('issue-7', $out[0]['json']['locks'][0]['holder']);
+
+    }//end testResultsLandBesideTheIncomingRecord()
+
+
+    /**
+     * Every result carries its uuid, because that is what a follow-up names it by.
+     *
+     * A reaper reads locks and then DELETES them. The uuid does not live in the
+     * record's own fields, so without this the read would be unusable for the
+     * case it exists to serve.
+     *
+     * @return void
+     */
+    public function testEveryResultCarriesItsUuid(): void
+    {
+        $this->objects->method('findAll')->willReturn(
+            [$this->entity('uuid-1', ['holder' => 'a']), $this->entity('uuid-2', ['holder' => 'b'])]
+        );
+
+        $out = $this->node->execute(
+            [FlowItems::item(json: [])],
+            $this->config(),
+            $this->ownedContext
+        );
+
+        $this->assertSame(['uuid-1', 'uuid-2'], array_column($out[0]['json']['objects'], 'uuid'));
+
+    }//end testEveryResultCarriesItsUuid()
+
+
+    /**
+     * Filters are templated from the item, so two items ask their own questions.
+     *
+     * @return void
+     */
+    public function testFiltersAreRenderedFromTheItem(): void
+    {
+        $seen = [];
+        $this->objects->method('findAll')->willReturnCallback(
+            function (array $config=[], bool $_rbac=true, bool $_multitenancy=true) use (&$seen): array {
+                $seen[] = $config;
+                return [];
+            }
+        );
+
+        $this->node->execute(
+            [FlowItems::item(json: ['ref' => 'hydra-410']), FlowItems::item(json: ['ref' => 'hydra-411'])],
+            $this->config(['filters' => ['holder' => '{{ref}}']]),
+            $this->ownedContext
+        );
+
+        $this->assertSame('hydra-410', $seen[0]['filters']['holder']);
+        $this->assertSame('hydra-411', $seen[1]['filters']['holder']);
+
+    }//end testFiltersAreRenderedFromTheItem()
+
+
+    /**
+     * The result set is bounded, and an absurd `limit` is capped rather than honoured.
+     *
+     * A reaper over a runaway lock table should take a batch and come back next
+     * tick, not build a million-item walk in memory and time the run out.
+     *
+     * @return void
+     */
+    public function testTheResultSetIsBounded(): void
+    {
+        $seen = [];
+        $this->objects->method('findAll')->willReturnCallback(
+            function (array $config=[], bool $_rbac=true, bool $_multitenancy=true) use (&$seen): array {
+                $seen[] = $config['limit'];
+                return [];
+            }
+        );
+
+        $this->node->execute([FlowItems::item(json: [])], $this->config(), $this->ownedContext);
+        $this->node->execute([FlowItems::item(json: [])], $this->config(['limit' => 5]), $this->ownedContext);
+        $this->node->execute([FlowItems::item(json: [])], $this->config(['limit' => 999999]), $this->ownedContext);
+        $this->node->execute([FlowItems::item(json: [])], $this->config(['limit' => 0]), $this->ownedContext);
+
+        $this->assertSame([100, 5, 1000, 100], $seen);
+
+    }//end testTheResultSetIsBounded()
+
+
+    /**
+     * A run with no owner reads NOTHING, and says why.
+     *
+     * A flow is authored data. If a flow could read past RBAC then authoring
+     * one would be a disclosure escalation, exactly as writing past it would be
+     * a privilege escalation.
+     *
+     * @return void
+     */
+    public function testARunWithNoOwnerReadsNothing(): void
+    {
+        $this->objects->expects($this->never())->method('findAll');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/triggeredBy/');
+
+        $this->node->execute([FlowItems::item(json: [])], $this->config(), ['triggeredBy' => null]);
+
+    }//end testARunWithNoOwnerReadsNothing()
+
+
+    /**
+     * An owner that is not a real account also fails closed.
+     *
+     * @return void
+     */
+    public function testAnUnknownOwnerAlsoFailsClosed(): void
+    {
+        $this->objects->expects($this->never())->method('findAll');
+
+        $this->expectException(RuntimeException::class);
+
+        $this->node->execute([FlowItems::item(json: [])], $this->config(), ['triggeredBy' => 'mallory']);
+
+    }//end testAnUnknownOwnerAlsoFailsClosed()
+
+
+    /**
+     * A FAILED read throws rather than looking like an empty one.
+     *
+     * "No objects matched" and "the read did not happen" are different answers.
+     * A reaper that reads the second as the first quietly stops reaping, and
+     * nothing about the run says so.
+     *
+     * @return void
+     */
+    public function testAFailedReadIsNotAnEmptyResult(): void
+    {
+        $this->objects->method('findAll')->willThrowException(new \Exception('table is gone'));
+
+        $this->expectException(RuntimeException::class);
+
+        $this->node->execute([FlowItems::item(json: [])], $this->config(), $this->ownedContext);
+
+    }//end testAFailedReadIsNotAnEmptyResult()
+
+
+    /**
+     * An empty branch asks nothing and is not an error.
+     *
+     * The owner is not even resolved: there is nothing to attribute.
+     *
+     * @return void
+     */
+    public function testAnEmptyBranchReadsNothing(): void
+    {
+        $this->objects->expects($this->never())->method('findAll');
+
+        $this->assertSame([], $this->node->execute([], $this->config(), []));
+
+    }//end testAnEmptyBranchReadsNothing()
+
+
+    /**
+     * A step that cannot name what it reads is refused when the flow is saved.
+     *
+     * @return void
+     */
+    public function testAStepMustNameARegisterAndSchema(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->node->validateConfig(['schema' => 'example-lock']);
+
+    }//end testAStepMustNameARegisterAndSchema()
+
+
+    /**
+     * Malformed filters are refused at save time too.
+     *
+     * @return void
+     */
+    public function testMalformedFiltersAreRefused(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->node->validateConfig($this->config(['filters' => 'holder=me']));
+
+    }//end testMalformedFiltersAreRefused()
+}//end class


### PR DESCRIPTION
Closes #2235.

## The gap

The live catalogue carried fourteen node types and exactly **one** object-shaped step: the write. A flow could create, patch and delete register objects and had **no way to read them**.

## What it blocked

A **reaper**. hydra's sequencer takes a per-issue lock as an object write with `onConflict: fail` — a real mutual-exclusion primitive since #2215 (measured: 12 simultaneous claimants → 1 winner, 11 told `already exists`, one row). But a crashed run leaves its lock behind, and the scheduled flow that would clear stale ones has to begin by *listing* them. Without a read step, that flow cannot be written at all.

The workarounds were worse than the gap: calling OpenRegister's own REST API back through `openconnector.source-call` leaves the process, re-authenticates and crosses an HTTP boundary to read a table it is already sitting on top of — and puts OR's API surface into a Source object, where an unrelated URL or permission change breaks the flow silently.

## Same guards as the write, for the same reason

A flow is authored data. If a flow could **read** past RBAC then authoring one would be a disclosure escalation, exactly as writing past it would be a privilege escalation. The read runs as `context.triggeredBy`; a run with no resolvable owner reads nothing and says why.

## Three properties worth naming

- **A failed read throws** rather than returning an empty list. *"No objects matched"* and *"the read did not happen"* are different answers, and a reaper that reads the second as the first quietly stops reaping — with nothing in the run saying so.
- **Every result carries its `uuid`.** That is what a follow-up write or delete names it by, and it is not in the record's own fields. Without it the read would be unusable for the case it exists to serve.
- **The result set is bounded** — default 100, ceiling 1000. A reaper over a runaway lock table should take a batch and come back next tick, not build a million-item walk and time the run out.

Filters are templated per item, so two items ask their own questions. The renderer is deliberately **local** rather than shared: `FlowTemplate` belongs to OpenConnector, and OpenRegister's own node must not depend on an app that may not be installed. `ObjectWriteNode` resolves its `fields` privately for the same reason.

## Verification

15,568 unit tests green (10 new, covering the owner guard both ways, the failed-vs-empty distinction, uuid presence, bounding, and per-item filter rendering); phpcs (full tree, CI settings) and phpstan clean.
