### PR TITLE
feat(flow): object-read can fan out one item per object

### DIFF
--- a/lib/Service/Flow/Nodes/ObjectReadNode.php
+++ b/lib/Service/Flow/Nodes/ObjectReadNode.php
@@ -29,6 +29,17 @@
  * and "the read did not happen" are different answers, and a reaper that reads
  * the second as the first quietly stops reaping.
  *
+ * TWO OUTPUT SHAPES, AND THE DEFAULT IS THE NARROWER ONE
+ * ------------------------------------------------------
+ * By default the matches land as a LIST under `output`, which is right for
+ * "how many are there" and "is there any" — questions that are one decision.
+ * With `fanOut: true` the step emits ONE ITEM PER OBJECT instead, which is what
+ * lets the rest of the engine act on them: every other node works per item, and
+ * nothing expands a list inside an item's json back into items
+ * (`openregister.loop` batches the items on the walk, not the entries of a
+ * field). A reaper needs the second shape, and with the first its delete step
+ * fails with "the match value for uuid could not be resolved from the item".
+ *
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  * SPDX-License-Identifier: EUPL-1.2
  *
@@ -249,7 +260,7 @@ class ObjectReadNode implements IFlowNode
             $json    = (array) ($item[FlowItems::JSON] ?? []);
             $filters = $this->renderFilters(filters: (array) ($config['filters'] ?? []), json: $json);
 
-            $json[$outKey] = $this->read(
+            $records = $this->read(
                 register: $register,
                 schema: $schema,
                 filters: $filters,
@@ -257,9 +268,46 @@ class ObjectReadNode implements IFlowNode
                 owner: $owner
             );
 
+            $binary = (array) ($item[FlowItems::BINARY] ?? []);
+
+            // FAN-OUT: one item per object, rather than one item holding a list.
+            //
+            // This exists because the list form does not COMPOSE. Every other
+            // node in the engine acts per item, and nothing expands a list
+            // inside an item's json back into items — `openregister.loop`
+            // batches the items on the walk, not the entries of a field. So a
+            // read that returns `{objects: [...]}` can be counted and branched
+            // on, and cannot be acted on one row at a time.
+            //
+            // Which is the motivating case. A reaper reads stale locks and then
+            // DELETES each one; with the list form its delete step sees one item
+            // whose `uuid` is not a field, and fails with "the match value for
+            // uuid could not be resolved from the item". Measured while building
+            // it.
+            //
+            // The list stays the DEFAULT because it is the right shape for the
+            // other half of the uses — "how many are there", "is there any" —
+            // where fanning out would turn one decision into N.
+            if (($config['fanOut'] ?? false) === true) {
+                foreach ($records as $record) {
+                    $out[] = FlowItems::item(
+                        json: array_merge($json, $record),
+                        binary: $binary,
+                        fromItemIndex: (int) $index
+                    );
+                }
+
+                // No matches means no items, which ends the branch — the same
+                // contract `openregister.loop` has for an empty input. It is
+                // not an error: "nothing to reap" is the ordinary case.
+                continue;
+            }
+
+            $json[$outKey] = $records;
+
             $out[] = FlowItems::item(
                 json: $json,
-                binary: (array) ($item[FlowItems::BINARY] ?? []),
+                binary: $binary,
                 fromItemIndex: (int) $index
             );
         }//end foreach

--- a/tests/Unit/Service/Flow/ObjectReadNodeTest.php
+++ b/tests/Unit/Service/Flow/ObjectReadNodeTest.php
@@ -358,4 +358,83 @@ final class ObjectReadNodeTest extends TestCase
         $this->node->validateConfig($this->config(['filters' => 'holder=me']));
 
     }//end testMalformedFiltersAreRefused()
+    /**
+     * `fanOut` emits ONE ITEM PER OBJECT, carrying the incoming record with it.
+     *
+     * This is what lets the rest of the engine act on the results. Every other
+     * node works per item, and nothing expands a list inside an item's json back
+     * into items — `openregister.loop` batches the items on the walk, not the
+     * entries of a field. With the list shape a reaper's delete step sees one
+     * item whose `uuid` is not a field, and fails with "the match value for
+     * uuid could not be resolved from the item".
+     *
+     * @return void
+     */
+    public function testFanOutEmitsOneItemPerObject(): void
+    {
+        $this->objects->method('findAll')->willReturn(
+            [$this->entity('uuid-1', ['holder' => 'a']), $this->entity('uuid-2', ['holder' => 'b'])]
+        );
+
+        $out = $this->node->execute(
+            [FlowItems::item(json: ['repo' => 'ConductionNL/hydra'])],
+            $this->config(['fanOut' => true]),
+            $this->ownedContext
+        );
+
+        $this->assertCount(2, $out);
+        $this->assertSame(['uuid-1', 'uuid-2'], array_column(array_column($out, 'json'), 'uuid'));
+        $this->assertSame(['a', 'b'], array_column(array_column($out, 'json'), 'holder'));
+
+        // What the run was carrying comes along on every fanned-out item.
+        $this->assertSame('ConductionNL/hydra', $out[0]['json']['repo']);
+        $this->assertSame('ConductionNL/hydra', $out[1]['json']['repo']);
+    }
+
+    /**
+     * Fanning out over NO matches ends the branch rather than erroring.
+     *
+     * "Nothing to reap" is the ordinary case, and it is the same contract
+     * `openregister.loop` has for an empty input.
+     *
+     * @return void
+     */
+    public function testFanOutOverNoMatchesEndsTheBranch(): void
+    {
+        $this->objects->method('findAll')->willReturn([]);
+
+        $out = $this->node->execute(
+            [FlowItems::item(json: ['repo' => 'ConductionNL/hydra'])],
+            $this->config(['fanOut' => true]),
+            $this->ownedContext
+        );
+
+        $this->assertSame([], $out);
+    }
+
+    /**
+     * WITHOUT `fanOut`, the list shape is unchanged.
+     *
+     * It stays the default because it is right for the other half of the uses —
+     * "how many are there", "is there any" — where fanning out would turn one
+     * decision into N.
+     *
+     * @return void
+     */
+    public function testWithoutFanOutTheListShapeIsUnchanged(): void
+    {
+        $this->objects->method('findAll')->willReturn(
+            [$this->entity('uuid-1', ['holder' => 'a']), $this->entity('uuid-2', ['holder' => 'b'])]
+        );
+
+        $out = $this->node->execute(
+            [FlowItems::item(json: ['repo' => 'ConductionNL/hydra'])],
+            $this->config(),
+            $this->ownedContext
+        );
+
+        $this->assertCount(1, $out);
+        $this->assertCount(2, $out[0]['json']['objects']);
+    }
+
 }//end class


### PR DESCRIPTION
Follows #2236, which I shipped returning a **list** under `output` — then tried to build the reaper it exists for, and it did not compose.

## Why the list shape does not work for the motivating case

Every other node in the engine acts **per item**, and nothing expands a list inside an item's json back into items — `openregister.loop` batches the items on the *walk*, not the entries of a field.

So a read returning `{objects: [...]}` can be counted and branched on, and **cannot be acted on one row at a time**.

That is exactly what a reaper does: read stale locks, then delete each one. With the list shape its delete step sees a single item whose `uuid` is not a field, and fails with:

```
The match value for "uuid" could not be resolved from the item
```

Measured while building it, not predicted.

## The change

`fanOut: true` emits one item per object, carrying the incoming record onto each so the run keeps what it was holding. No matches means no items, which ends the branch — the same contract `openregister.loop` has for an empty input, and not an error, because *"nothing to reap"* is the ordinary case.

The **list stays the default**. It is the right shape for the other half of the uses — "how many are there", "is there any" — where fanning out turns one decision into N. Both shapes are pinned by tests.

I flagged this exact trade-off in #2235 and picked the side that did not serve the case the node was built for.

## Verification

15,571 unit tests green (3 new); phpcs (full tree, CI settings) and phpstan clean.