### PR TITLE
feat(flow): set-fields can reference the item, and compute from it

### DIFF
--- a/lib/Service/Flow/FlowValueTemplate.php
+++ b/lib/Service/Flow/FlowValueTemplate.php
@@ -56,7 +56,6 @@ final class FlowValueTemplate
      */
     private const WHOLE = '/^\{\{\s*([A-Za-z0-9_@.]+)\s*\}\}$/';
 
-
     /**
      * Render a value — scalar, list or map — against an item's record.
      *
@@ -99,7 +98,6 @@ final class FlowValueTemplate
         );
 
     }//end render()
-
 
     /**
      * The value at a dotted path, or null when the path is absent.

--- a/lib/Service/Flow/FlowValueTemplate.php
+++ b/lib/Service/Flow/FlowValueTemplate.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * Substitutes `{{dotted.path}}` placeholders in a step's configured values.
+ *
+ * Every node that takes authored values resolves them against the item —
+ * `openconnector.source-call` its endpoint, body and query, `hermiq.agent-step`
+ * its prompt, `openregister.object-write` its fields. This is that rule, in one
+ * place, for OpenRegister's own nodes.
+ *
+ * It is deliberately NOT OpenConnector's `FlowTemplate`. That class belongs to
+ * an app which may not be installed, and OpenRegister's built-in nodes must not
+ * depend on one that isn't.
+ *
+ * A value that is EXACTLY one placeholder keeps the resolved value's TYPE, so a
+ * number stays a number and a list stays a list. That matters wherever the
+ * value is compared rather than printed: `"7"` and `7` are not the same filter.
+ * Anything else is substituted inline and stringified.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+/**
+ * Renders authored values against an item's record.
+ */
+final class FlowValueTemplate
+{
+
+    /**
+     * The placeholder shape: `{{ dotted.path }}`.
+     *
+     * @var string
+     */
+    private const PLACEHOLDER = '/\{\{\s*([A-Za-z0-9_@.]+)\s*\}\}/';
+
+    /**
+     * The same shape, anchored — a value that is ONLY a placeholder.
+     *
+     * @var string
+     */
+    private const WHOLE = '/^\{\{\s*([A-Za-z0-9_@.]+)\s*\}\}$/';
+
+
+    /**
+     * Render a value — scalar, list or map — against an item's record.
+     *
+     * @param mixed $value The authored value.
+     * @param array $json  The item's record.
+     *
+     * @return mixed The rendered value.
+     */
+    public static function render(mixed $value, array $json): mixed
+    {
+        if (is_array($value) === true) {
+            $rendered = [];
+            foreach ($value as $key => $entry) {
+                $rendered[$key] = self::render(value: $entry, json: $json);
+            }
+
+            return $rendered;
+        }
+
+        if (is_string($value) === false) {
+            return $value;
+        }
+
+        $whole = [];
+        if (preg_match(self::WHOLE, $value, $whole) === 1) {
+            return self::valueAt(path: $whole[1], json: $json);
+        }
+
+        return (string) preg_replace_callback(
+            self::PLACEHOLDER,
+            static function (array $matches) use ($json): string {
+                $resolved = self::valueAt(path: $matches[1], json: $json);
+                if (is_array($resolved) === true) {
+                    return (string) json_encode($resolved);
+                }
+
+                return (string) $resolved;
+            },
+            $value
+        );
+
+    }//end render()
+
+
+    /**
+     * The value at a dotted path, or null when the path is absent.
+     *
+     * @param string $path The dotted path.
+     * @param array  $json The item's record.
+     *
+     * @return mixed The value, or null.
+     */
+    private static function valueAt(string $path, array $json): mixed
+    {
+        $cursor = $json;
+        foreach (explode('.', $path) as $segment) {
+            if (is_array($cursor) === false || array_key_exists($segment, $cursor) === false) {
+                return null;
+            }
+
+            $cursor = $cursor[$segment];
+        }
+
+        return $cursor;
+
+    }//end valueAt()
+}//end class

--- a/lib/Service/Flow/Nodes/ObjectReadNode.php
+++ b/lib/Service/Flow/Nodes/ObjectReadNode.php
@@ -65,6 +65,7 @@ use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowValueTemplate;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\IL10N;
@@ -258,7 +259,7 @@ class ObjectReadNode implements IFlowNode
         $out = [];
         foreach ($items as $index => $item) {
             $json    = (array) ($item[FlowItems::JSON] ?? []);
-            $filters = $this->renderFilters(filters: (array) ($config['filters'] ?? []), json: $json);
+            $filters = (array) FlowValueTemplate::render(value: (array) ($config['filters'] ?? []), json: $json);
 
             $records = $this->read(
                 register: $register,
@@ -315,87 +316,6 @@ class ObjectReadNode implements IFlowNode
         return $out;
 
     }//end execute()
-
-    /**
-     * Substitute `{{dotted.path}}` placeholders in the filter values.
-     *
-     * Deliberately its own small renderer rather than a shared one: OpenConnector
-     * owns `FlowTemplate`, and reaching across an app boundary for it would make
-     * OpenRegister's own node depend on an app that may not be installed.
-     * `ObjectWriteNode` resolves its `fields` with a private renderer for the
-     * same reason.
-     *
-     * A value that is EXACTLY one placeholder keeps the resolved value's type,
-     * so a numeric id stays a number and a list stays a list — a filter is
-     * compared, and `"7"` and `7` are not the same comparison. Anything else is
-     * substituted inline and stringified. A non-string passes through untouched,
-     * so a literal filter can be authored directly.
-     *
-     * @param array $filters The configured filters.
-     * @param array $json    The item's record.
-     *
-     * @return array The rendered filters.
-     */
-    private function renderFilters(array $filters, array $json): array
-    {
-        $rendered = [];
-        foreach ($filters as $key => $value) {
-            if (is_array($value) === true) {
-                $rendered[(string) $key] = $this->renderFilters(filters: $value, json: $json);
-                continue;
-            }
-
-            if (is_string($value) === false) {
-                $rendered[(string) $key] = $value;
-                continue;
-            }
-
-            $whole = [];
-            if (preg_match('/^\{\{\s*([A-Za-z0-9_@.]+)\s*\}\}$/', $value, $whole) === 1) {
-                $rendered[(string) $key] = $this->valueAt(path: $whole[1], json: $json);
-                continue;
-            }
-
-            $rendered[(string) $key] = (string) preg_replace_callback(
-                '/\{\{\s*([A-Za-z0-9_@.]+)\s*\}\}/',
-                function (array $matches) use ($json): string {
-                    $resolved = $this->valueAt(path: $matches[1], json: $json);
-                    if (is_array($resolved) === true) {
-                        return (string) json_encode($resolved);
-                    }
-
-                    return (string) $resolved;
-                },
-                $value
-            );
-        }//end foreach
-
-        return $rendered;
-
-    }//end renderFilters()
-
-    /**
-     * The value at a dotted path in the item's record, or null.
-     *
-     * @param string $path The dotted path.
-     * @param array  $json The item's record.
-     *
-     * @return mixed The value, or null when the path is absent.
-     */
-    private function valueAt(string $path, array $json): mixed
-    {
-        $cursor = $json;
-        foreach (explode('.', $path) as $segment) {
-            if (is_array($cursor) === false || array_key_exists($segment, $cursor) === false) {
-                return null;
-            }
-
-            $cursor = $cursor[$segment];
-        }
-
-        return $cursor;
-
-    }//end valueAt()
 
     /**
      * Perform one read as the run owner.

--- a/lib/Service/Flow/Nodes/SetFieldsNode.php
+++ b/lib/Service/Flow/Nodes/SetFieldsNode.php
@@ -31,6 +31,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Service\Flow\Nodes;
 
 use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowValueTemplate;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -184,8 +185,20 @@ class SetFieldsNode implements IFlowNode
                 $json = [];
             }
 
+            // Values are rendered against the item, the way every other node
+            // resolves its authored config — `source-call` its endpoint and
+            // body, `agent-step` its prompt, `object-write` its fields.
+            //
+            // This node could previously only write CONSTANTS: `{{retries}}`
+            // was stored as the literal seven characters. That makes the one
+            // node whose entire job is setting fields the only one that cannot
+            // refer to the item it is setting them on — and it is also the
+            // reference implementation other node authors copy.
+            //
+            // A value that is exactly one placeholder keeps its TYPE, so a
+            // counter stays a number and a list stays a list.
             foreach ($set as $field => $value) {
-                $json[(string) $field] = $value;
+                $json[(string) $field] = FlowValueTemplate::render(value: $value, json: $json);
             }
 
             // Provenance: this item's own index, one in and one out, so the

--- a/lib/Service/Flow/Nodes/SetFieldsNode.php
+++ b/lib/Service/Flow/Nodes/SetFieldsNode.php
@@ -30,6 +30,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Service\Flow\Nodes;
 
+use OCA\OpenRegister\Service\Flow\FlowExpression;
 use OCA\OpenRegister\Service\Flow\FlowItems;
 use OCA\OpenRegister\Service\Flow\FlowValueTemplate;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
@@ -127,14 +128,27 @@ class SetFieldsNode implements IFlowNode
      */
     public function validateConfig(array $config): void
     {
-        $set    = (array) ($config['set'] ?? []);
-        $rename = (array) ($config['rename'] ?? []);
-        $remove = (array) ($config['remove'] ?? []);
+        $set     = (array) ($config['set'] ?? []);
+        $compute = (array) ($config['compute'] ?? []);
+        $rename  = (array) ($config['rename'] ?? []);
+        $remove  = (array) ($config['remove'] ?? []);
 
-        if ($set === [] && $rename === [] && $remove === []) {
+        if ($set === [] && $compute === [] && $rename === [] && $remove === []) {
             throw new UnexpectedValueException(
-                $this->l10n->t('Choose at least one field to set, rename or remove.')
+                $this->l10n->t('Choose at least one field to set, compute, rename or remove.')
             );
+        }
+
+        // A malformed expression is caught HERE, when the flow is saved, rather
+        // than evaluating to null on every item at 03:00 — `FlowExpression`
+        // swallows a broken rule and returns null, which is indistinguishable
+        // from a field that legitimately resolved to nothing.
+        foreach ($compute as $field => $logic) {
+            if (FlowExpression::isValid(logic: $logic) === false) {
+                throw new UnexpectedValueException(
+                    $this->l10n->t('The expression for computed field "%s" is not valid.', [(string) $field])
+                );
+            }
         }
 
     }//end validateConfig()
@@ -142,9 +156,10 @@ class SetFieldsNode implements IFlowNode
     /**
      * Apply the configured reshaping to every item.
      *
-     * Order is remove, then rename, then set. Rename before set so setting a
-     * field the author also renamed away is not silently undone, and remove
-     * first so a rename can legitimately reuse a removed name.
+     * Order is remove, then rename, then set, then compute. Rename before set
+     * so setting a field the author also renamed away is not silently undone,
+     * and remove first so a rename can legitimately reuse a removed name.
+     * Compute last so a derived value can build on one just substituted.
      *
      * `keepOnlySet` mirrors n8n's option of the same name: drop everything the
      * step did not explicitly set, for building a clean payload.
@@ -158,9 +173,11 @@ class SetFieldsNode implements IFlowNode
     public function execute(array $items, array $config, array $context): array
     {
         $set         = (array) ($config['set'] ?? []);
+        $compute     = (array) ($config['compute'] ?? []);
         $rename      = (array) ($config['rename'] ?? []);
         $remove      = (array) ($config['remove'] ?? []);
         $keepOnlySet = (($config['keepOnlySet'] ?? false) === true);
+        $count       = count($items);
 
         $out = [];
         foreach ($items as $index => $item) {
@@ -199,6 +216,33 @@ class SetFieldsNode implements IFlowNode
             // counter stays a number and a list stays a list.
             foreach ($set as $field => $value) {
                 $json[(string) $field] = FlowValueTemplate::render(value: $value, json: $json);
+            }
+
+            // `compute` is the same idea as `set` for values that have to be
+            // DERIVED rather than substituted. `{{retries}}` can copy a
+            // counter; nothing could add one to it, because a template
+            // substitutes and does not calculate.
+            //
+            // That gap was not academic — it is what stopped hydra's
+            // retry/escalation flow: read the count, increment, store. The
+            // read and the store were expressible and the `+ 1` was not, so
+            // the counter sat at 0 and a run "retried" forever.
+            //
+            // The expression language is the one the routers already use
+            // (`FlowExpression`), so an author who can write a branch condition
+            // can write this, and the same `{"var": "json.…"}` paths work in
+            // both. It is applied AFTER `set`, so a computed value can build on
+            // one that was just substituted.
+            foreach ($compute as $field => $logic) {
+                $json[(string) $field] = FlowExpression::evaluate(
+                    logic: $logic,
+                    data: FlowExpression::dataFor(
+                        item: [FlowItems::JSON => $json],
+                        itemIndex: (int) $index,
+                        itemCount: $count,
+                        context: $context
+                    )
+                );
             }
 
             // Provenance: this item's own index, one in and one out, so the

--- a/tests/Unit/Service/Flow/FlowValueTemplateTest.php
+++ b/tests/Unit/Service/Flow/FlowValueTemplateTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Unit tests for FlowValueTemplate.
+ *
+ * The rule every node relies on to turn authored config into values from the
+ * item. Its sharp edge is TYPE: a filter or a counter is compared, not printed,
+ * and `"7"` is not `7`.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author  Conduction Development Team <dev@conduction.nl>
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowValueTemplate;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Flow\FlowValueTemplate
+ */
+final class FlowValueTemplateTest extends TestCase
+{
+
+    /**
+     * A value that is EXACTLY one placeholder keeps the resolved type.
+     *
+     * This is the property that matters wherever the value is compared rather
+     * than printed — a filter, a counter, a capacity. Stringifying a number
+     * here turns `retries < 3` into a string comparison.
+     *
+     * @return void
+     */
+    public function testAWholePlaceholderKeepsItsType(): void
+    {
+        $json = ['count' => 7, 'tags' => ['a', 'b'], 'ok' => true];
+
+        $this->assertSame(7, FlowValueTemplate::render('{{count}}', $json));
+        $this->assertSame(['a', 'b'], FlowValueTemplate::render('{{tags}}', $json));
+        $this->assertTrue(FlowValueTemplate::render('{{ok}}', $json));
+
+    }//end testAWholePlaceholderKeepsItsType()
+
+
+    /**
+     * An inline placeholder is substituted and stringified.
+     *
+     * @return void
+     */
+    public function testAnInlinePlaceholderIsStringified(): void
+    {
+        $out = FlowValueTemplate::render('retry {{count}} of {{max}}', ['count' => 2, 'max' => 3]);
+
+        $this->assertSame('retry 2 of 3', $out);
+
+    }//end testAnInlinePlaceholderIsStringified()
+
+
+    /**
+     * Dotted paths walk nested records, including numeric list indices.
+     *
+     * @return void
+     */
+    public function testDottedPathsWalkNestedRecords(): void
+    {
+        $json = ['queue' => ['body' => [['number' => 410]]]];
+
+        $this->assertSame(410, FlowValueTemplate::render('{{queue.body.0.number}}', $json));
+
+    }//end testDottedPathsWalkNestedRecords()
+
+
+    /**
+     * An absent path resolves to null, not to the literal placeholder.
+     *
+     * Returning the placeholder text would put `{{missing}}` into a filter or a
+     * URL, where it reads as a value rather than as an absence — which is how
+     * `/repos//issues` happens.
+     *
+     * @return void
+     */
+    public function testAnAbsentPathResolvesToNull(): void
+    {
+        $this->assertNull(FlowValueTemplate::render('{{missing}}', ['a' => 1]));
+        $this->assertSame('x=', FlowValueTemplate::render('x={{missing}}', ['a' => 1]));
+
+    }//end testAnAbsentPathResolvesToNull()
+
+
+    /**
+     * Maps and lists are rendered recursively; non-strings pass through.
+     *
+     * @return void
+     */
+    public function testStructuresAreRenderedRecursively(): void
+    {
+        $out = FlowValueTemplate::render(
+            ['holder' => '{{ref}}', 'limit' => 50, 'nested' => ['deep' => '{{ref}}']],
+            ['ref' => 'hydra-410']
+        );
+
+        $this->assertSame('hydra-410', $out['holder']);
+        $this->assertSame(50, $out['limit']);
+        $this->assertSame('hydra-410', $out['nested']['deep']);
+
+    }//end testStructuresAreRenderedRecursively()
+}//end class

--- a/tests/Unit/Service/Flow/SetFieldsNodeTest.php
+++ b/tests/Unit/Service/Flow/SetFieldsNodeTest.php
@@ -168,4 +168,75 @@ class SetFieldsNodeTest extends TestCase
         $this->assertSame(3, $out[0]['json']['max']);
     }
 
+
+
+    /**
+     * `compute` DERIVES a value, which a template cannot do.
+     *
+     * `{{retries}}` can copy a counter; nothing could add one to it, because a
+     * template substitutes and does not calculate. That is what stopped hydra's
+     * retry/escalation flow — read the count, increment, store: the read and the
+     * store were expressible and the `+ 1` was not, so the counter sat at 0 and
+     * a run "retried" forever.
+     *
+     * @return void
+     */
+    public function testComputeDerivesAValue(): void
+    {
+        $out = $this->node->execute(
+            [FlowItems::item(json: ['retries' => 2])],
+            ['compute' => ['next' => ['+' => [['var' => 'json.retries'], 1]]]],
+            []
+        );
+
+        $this->assertSame(3, $out[0]['json']['next']);
+    }
+
+    /**
+     * `compute` runs AFTER `set`, so it can build on a value just substituted.
+     *
+     * @return void
+     */
+    public function testComputeSeesWhatSetJustWrote(): void
+    {
+        $out = $this->node->execute(
+            [FlowItems::item(json: ['retries' => 1])],
+            [
+                'set'     => ['base' => '{{retries}}'],
+                'compute' => ['next' => ['+' => [['var' => 'json.base'], 10]]],
+            ],
+            []
+        );
+
+        $this->assertSame(11, $out[0]['json']['next']);
+    }
+
+    /**
+     * A malformed expression is refused when the flow is SAVED.
+     *
+     * `FlowExpression` swallows a broken rule and returns null, which is
+     * indistinguishable from a field that legitimately resolved to nothing. So
+     * the only place it can be caught honestly is at save time.
+     *
+     * @return void
+     */
+    public function testAMalformedExpressionIsRefusedAtSaveTime(): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+
+        $this->node->validateConfig(['compute' => ['next' => ['nosuchoperator' => [1, 2]]]]);
+    }
+
+    /**
+     * A step that only computes is a legitimate step.
+     *
+     * @return void
+     */
+    public function testAComputeOnlyStepValidates(): void
+    {
+        $this->node->validateConfig(['compute' => ['next' => ['+' => [1, 1]]]]);
+
+        $this->addToAssertionCount(1);
+    }
+
 }

--- a/tests/Unit/Service/Flow/SetFieldsNodeTest.php
+++ b/tests/Unit/Service/Flow/SetFieldsNodeTest.php
@@ -124,4 +124,48 @@ class SetFieldsNodeTest extends TestCase
         $this->node->validateConfig(['set' => ['a' => 1]]);
         $this->addToAssertionCount(1);
     }
+
+
+    /**
+     * `set` values are rendered against the item, not stored verbatim.
+     *
+     * Before this, the one node whose entire job is setting fields was the only
+     * one that could not refer to the item it was setting them on: `{{retries}}`
+     * was stored as the literal seven characters. It is also the reference
+     * implementation other node authors copy, so the gap propagated.
+     *
+     * @return void
+     */
+    public function testSetValuesAreRenderedFromTheItem(): void
+    {
+        $out = $this->node->execute(
+            [FlowItems::item(json: ['repo' => 'ConductionNL/hydra', 'retries' => 2])],
+            ['set' => ['label' => 'retry {{retries}} on {{repo}}', 'count' => '{{retries}}']],
+            []
+        );
+
+        $this->assertSame('retry 2 on ConductionNL/hydra', $out[0]['json']['label']);
+
+        // A whole placeholder keeps its type — a counter must stay a number,
+        // or every downstream `<` comparison becomes a string comparison.
+        $this->assertSame(2, $out[0]['json']['count']);
+    }
+
+    /**
+     * A literal with no placeholder is untouched.
+     *
+     * @return void
+     */
+    public function testALiteralValueIsUnchanged(): void
+    {
+        $out = $this->node->execute(
+            [FlowItems::item(json: [])],
+            ['set' => ['stage' => 'builder', 'max' => 3]],
+            []
+        );
+
+        $this->assertSame('builder', $out[0]['json']['stage']);
+        $this->assertSame(3, $out[0]['json']['max']);
+    }
+
 }


### PR DESCRIPTION
Two changes to the same node, which together make it able to do its job.

## 1. `set` values are rendered against the item

`SetFieldsNode` wrote its `set` values **verbatim**. So the one node whose entire job is setting fields was the only one that could not refer to the item it was setting them on — `{{retries}}` was stored as the literal seven characters.

Every other node resolves its authored config against the item: `openconnector.source-call` its endpoint, body and query, `hermiq.agent-step` its prompt, `openregister.object-write` its fields, `openregister.object-read` its filters. It is also, per its own docblock, *"the reference implementation of `IFlowNode`… an app contributing a node type has this to copy"* — so the gap propagated.

### One renderer instead of a fourth copy

The rule now lives in `FlowValueTemplate`. `ObjectReadNode`'s own private renderer is **deleted** and it uses the shared one, so this reduces the number of copies rather than adding one.

Deliberately **not** OpenConnector's `FlowTemplate`: that belongs to an app which may not be installed, and OpenRegister's built-in nodes must not depend on one that isn't.

The sharp edge is **type**, and it is pinned: a value that is exactly one placeholder keeps the resolved value's type, so a counter stays a number and a list stays a list — stringifying turns `retries < 3` into a string comparison. An absent path resolves to `null`, not to the literal placeholder, because returning the text is how `/repos//issues` happens.

## 2. `compute` derives a value

A template substitutes; it does not calculate. And no other node does arithmetic either.

That gap is what stopped hydra's retry/escalation flow: read the count, increment, store. The read and the store were expressible and the **`+ 1` was not**, so the counter sat at 0 and a run "retried" forever without ever exhausting its budget.

`compute` takes the **same expression language the routers already use** (`FlowExpression`), so an author who can write a branch condition can write this, and the same `{"var": "json.…"}` paths work in both. It runs after `set`, so a derived value can build on one just substituted.

A malformed expression is refused when the flow is **saved** — `FlowExpression` swallows a broken rule and returns `null`, which is indistinguishable from a field that legitimately resolved to nothing, so save time is the only place it can be caught honestly.

### Proved live, end to end

With `maxRetries = 2`:

```
fail -> retries 1     (retry)
fail -> retries 2     (retry)
fail -> retries 2     (budget exhausted; escalate, no bump)
pass -> counter gone  (cleared)
```

## Compatibility

A `set` value containing `{{…}}` that was previously stored literally will now be substituted. That is the same contract every other node already has, and consistency is the point — but it is a behaviour change worth naming rather than burying.

## Verification

15,582 unit tests green (11 new — 5 on the renderer, 6 on the node); phpcs (full tree, CI settings) and phpstan clean.
