### PR TITLE
test(events): cover the deferral path that shipped with live-only evidence

### DIFF
--- a/tests/Unit/BackgroundJob/ObjectCleanupJobTest.php
+++ b/tests/Unit/BackgroundJob/ObjectCleanupJobTest.php
@@ -1,0 +1,517 @@
+<?php
+
+/**
+ * ObjectCleanupJobTest
+ *
+ * Unit tests for the deferred half of the deleted-object relation cleanup.
+ *
+ * Every test asserts an observable side effect — which UUID reaches
+ * ObjectRelationCleanupService, and which identity the session carries at the
+ * exact moment that cleanup runs. A job that throws nothing while cleaning
+ * nothing, or that cleans up under the wrong (or no) actor, fails here.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category  Test
+ * @package   OCA\OpenRegister\Tests\Unit\BackgroundJob
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git-id>
+ * @link      https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\BackgroundJob;
+
+use OCA\OpenRegister\BackgroundJob\ObjectCleanupJob;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Deferral\DeferredEntryObjectResolver;
+use OCA\OpenRegister\Service\Deferral\DeferredListenerContext;
+use OCA\OpenRegister\Service\Deferral\ListenerDeferralService;
+use OCA\OpenRegister\Service\ObjectRelationCleanupService;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJobList;
+use OCP\IAppConfig;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Deferred cleanup: the right UUIDs, under the forwarded actor, never on a
+ * UUID that came back to life.
+ */
+class ObjectCleanupJobTest extends TestCase
+{
+
+    /**
+     * Stateful session double: remembers the last impersonated user.
+     *
+     * @var IUserSession&MockObject
+     */
+    private IUserSession&MockObject $userSession;
+
+    /**
+     * Resolver for the captured actor id.
+     *
+     * @var IUserManager&MockObject
+     */
+    private IUserManager&MockObject $userManager;
+
+    /**
+     * Re-create guard lookup.
+     *
+     * @var DeferredEntryObjectResolver&MockObject
+     */
+    private DeferredEntryObjectResolver&MockObject $resolver;
+
+    /**
+     * The collaborator that performs the actual deletions.
+     *
+     * @var ObjectRelationCleanupService&MockObject
+     */
+    private ObjectRelationCleanupService&MockObject $cleanup;
+
+    /**
+     * PSR logger double.
+     *
+     * @var LoggerInterface&MockObject
+     */
+    private LoggerInterface&MockObject $logger;
+
+    /**
+     * System under test.
+     *
+     * @var ObjectCleanupJob
+     */
+    private ObjectCleanupJob $job;
+
+    /**
+     * The user currently "logged in" on the session double.
+     *
+     * @var IUser|null
+     */
+    private ?IUser $sessionUser = null;
+
+    /**
+     * Every value handed to IUserSession::setUser(), in order.
+     *
+     * @var array<int, IUser|null>
+     */
+    private array $setUserCalls = [];
+
+    /**
+     * Build the job with a session double that actually holds a user.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userSession = $this->createMock(originalClassName: IUserSession::class);
+        $this->userManager = $this->createMock(originalClassName: IUserManager::class);
+        $this->resolver    = $this->createMock(originalClassName: DeferredEntryObjectResolver::class);
+        $this->cleanup     = $this->createMock(originalClassName: ObjectRelationCleanupService::class);
+        $this->logger      = $this->createMock(originalClassName: LoggerInterface::class);
+
+        $this->sessionUser  = null;
+        $this->setUserCalls = [];
+
+        // A plain return-value stub cannot show WHO the cleanup ran as, so the
+        // session double is stateful: setUser() stores, getUser() reads back.
+        $this->userSession->method('getUser')->willReturnCallback(
+            function (): ?IUser {
+                return $this->sessionUser;
+            }
+        );
+        $this->userSession->method('setUser')->willReturnCallback(
+            function ($user): void {
+                $this->sessionUser    = $user;
+                $this->setUserCalls[] = $user;
+            }
+        );
+
+        $this->job = new ObjectCleanupJob(
+            time: $this->createMock(originalClassName: ITimeFactory::class),
+            userSession: $this->userSession,
+            userManager: $this->userManager,
+            organisation: $this->createMock(originalClassName: OrganisationService::class),
+            logger: $this->logger,
+            resolver: $this->resolver,
+            cleanup: $this->cleanup
+        );
+
+    }//end setUp()
+
+    /**
+     * Make a user id resolvable by the job's IUserManager.
+     *
+     * @param string $userId The user id to resolve.
+     *
+     * @return IUser&MockObject The user the job will impersonate.
+     */
+    private function resolvableUser(string $userId): IUser&MockObject
+    {
+        $user = $this->createMock(originalClassName: IUser::class);
+        $user->method('getUID')->willReturn($userId);
+        $this->userManager->method('get')->with($userId)->willReturn($user);
+
+        return $user;
+
+    }//end resolvableUser()
+
+    /**
+     * Invoke the protected QueuedJob::run() with a serialized context.
+     *
+     * @param array<string, mixed> $argument The job argument payload.
+     *
+     * @return void
+     */
+    private function invokeRun(array $argument): void
+    {
+        // No setAccessible() call: protected members have been reflection
+        // invocable without it since PHP 8.1, and the method is deprecated.
+        $method = (new \ReflectionClass(objectOrClass: $this->job))->getMethod('run');
+        $method->invoke($this->job, $argument);
+
+    }//end invokeRun()
+
+    /**
+     * Run the job over the given entries as the given actor.
+     *
+     * @param array<int, array<string, mixed>> $entries The deferred entries.
+     * @param string|null                      $userId  The captured actor id.
+     *
+     * @return void
+     */
+    private function runJob(array $entries, ?string $userId='alice'): void
+    {
+        $argument = (new DeferredListenerContext(
+            userId: $userId,
+            orgUuid: null,
+            entries: $entries
+        ))->toJobArguments();
+
+        $this->invokeRun(argument: $argument);
+
+    }//end runJob()
+
+    /**
+     * POSITIVE CONTROL — every gone object is cleaned up, as the actor.
+     *
+     * Asserts both halves at once: the UUIDs that reach the cleanup service,
+     * and the session identity in force while each call happens.
+     *
+     * @return void
+     */
+    public function testCleansUpEveryGoneEntryUnderTheForwardedActor(): void
+    {
+        $alice = $this->resolvableUser(userId: 'alice');
+        $this->resolver->method('resolve')->willReturn(null);
+
+        $cleaned = [];
+        $this->cleanup->expects($this->exactly(count: 2))->method('cleanup')
+            ->willReturnCallback(
+                function (string $objectUuid) use (&$cleaned): void {
+                    $cleaned[] = [$objectUuid, $this->userSession->getUser()?->getUID()];
+                }
+            );
+
+        $this->runJob(
+            entries: [
+                ['uuid' => 'gone-a', 'register' => 'r', 'schema' => 's'],
+                ['uuid' => 'gone-b', 'register' => 'r', 'schema' => 's'],
+            ]
+        );
+
+        // The cleanup really ran, on the right UUIDs, as the captured actor.
+        $this->assertSame(
+            expected: [['gone-a', 'alice'], ['gone-b', 'alice']],
+            actual: $cleaned
+        );
+
+        // And the borrowed identity was handed back afterwards.
+        $this->assertSame(expected: [$alice, null], actual: $this->setUserCalls);
+
+    }//end testCleansUpEveryGoneEntryUnderTheForwardedActor()
+
+    /**
+     * The actor captured at defer time is the actor the job cleans up as.
+     *
+     * Drives the real ListenerDeferralService to build the job argument, so
+     * the assertion covers the whole capture -> serialize -> restore seam
+     * rather than a hand-written payload.
+     *
+     * @return void
+     */
+    public function testActorCapturedAtDeferTimeIsTheActorTheJobRunsAs(): void
+    {
+        $deferringSession = $this->createMock(originalClassName: IUserSession::class);
+        $deferringUser    = $this->createMock(originalClassName: IUser::class);
+        $deferringUser->method('getUID')->willReturn('bob');
+        $deferringSession->method('getUser')->willReturn($deferringUser);
+
+        $argument = null;
+        $jobList  = $this->createMock(originalClassName: IJobList::class);
+        $jobList->expects($this->once())->method('add')
+            ->willReturnCallback(
+                function (string $jobClass, $jobArgument) use (&$argument): void {
+                    $argument = $jobArgument;
+                }
+            );
+
+        $deferral = new ListenerDeferralService(
+            userSession: $deferringSession,
+            organisation: $this->createMock(originalClassName: OrganisationService::class),
+            jobList: $jobList,
+            appConfig: $this->createMock(originalClassName: IAppConfig::class),
+            logger: $this->createMock(originalClassName: LoggerInterface::class)
+        );
+
+        $deferral->defer(
+            jobClass: ObjectCleanupJob::class,
+            entry: ['uuid' => 'gone', 'register' => 'r', 'schema' => 's'],
+            dedupeKey: 'gone'
+        );
+        $deferral->flushAll();
+
+        $this->assertSame(expected: 'bob', actual: $argument['userId']);
+
+        // Only 'bob' resolves — asking for anything else yields no user and
+        // ActorForwardedJob would skip the work entirely.
+        $bob = $this->createMock(originalClassName: IUser::class);
+        $bob->method('getUID')->willReturn('bob');
+        $this->userManager->expects($this->once())->method('get')->with('bob')->willReturn($bob);
+        $this->resolver->method('resolve')->willReturn(null);
+
+        $actorDuringCleanup = null;
+        $this->cleanup->expects($this->once())->method('cleanup')->with('gone')
+            ->willReturnCallback(
+                function () use (&$actorDuringCleanup): void {
+                    $actorDuringCleanup = $this->userSession->getUser()?->getUID();
+                }
+            );
+
+        $this->invokeRun(argument: $argument);
+
+        $this->assertSame(expected: 'bob', actual: $actorDuringCleanup);
+
+    }//end testActorCapturedAtDeferTimeIsTheActorTheJobRunsAs()
+
+    /**
+     * The whole entry — not just the uuid — reaches the re-create guard.
+     *
+     * Register and schema must survive the job-argument round trip, otherwise
+     * the guard degrades to a cross-table UUID scan.
+     *
+     * @return void
+     */
+    public function testResolverReceivesTheFullEntryIdentifiers(): void
+    {
+        $this->resolvableUser(userId: 'alice');
+
+        $seen = [];
+        $this->resolver->expects($this->once())->method('resolve')
+            ->willReturnCallback(
+                static function (array $entry) use (&$seen): ?ObjectEntity {
+                    $seen = $entry;
+                    return null;
+                }
+            );
+        $this->cleanup->expects($this->once())->method('cleanup')->with('gone-a');
+
+        $this->runJob(entries: [['uuid' => 'gone-a', 'register' => 'reg-1', 'schema' => 'sch-1']]);
+
+        $this->assertSame(
+            expected: ['uuid' => 'gone-a', 'register' => 'reg-1', 'schema' => 'sch-1'],
+            actual: $seen
+        );
+
+    }//end testResolverReceivesTheFullEntryIdentifiers()
+
+    /**
+     * NEGATIVE CONTROL — a UUID that came back to life is never cleaned.
+     *
+     * Paired with testCleansUpEveryGoneEntryUnderTheForwardedActor(), which
+     * proves the same collaborator IS called in the ordinary case.
+     *
+     * @return void
+     */
+    public function testUuidThatResolvesToALiveObjectIsNotCleanedUp(): void
+    {
+        $this->resolvableUser(userId: 'alice');
+
+        $live = new ObjectEntity();
+        $live->setUuid('reborn');
+        $this->resolver->method('resolve')->willReturn($live);
+
+        $this->cleanup->expects($this->never())->method('cleanup');
+        $this->logger->expects($this->once())->method('info')
+            ->with($this->stringContains(string: 'live object'), $this->anything());
+
+        $this->runJob(entries: [['uuid' => 'reborn', 'register' => 'r', 'schema' => 's']]);
+
+    }//end testUuidThatResolvesToALiveObjectIsNotCleanedUp()
+
+    /**
+     * A mixed chunk cleans exactly the entry whose object is gone.
+     *
+     * Positive and negative control inside one run: dead code cleaning
+     * nothing fails the assertion, an unguarded loop cleaning everything
+     * fails the once() expectation.
+     *
+     * @return void
+     */
+    public function testMixedChunkCleansOnlyTheEntryThatIsReallyGone(): void
+    {
+        $this->resolvableUser(userId: 'alice');
+
+        $live = new ObjectEntity();
+        $live->setUuid('reborn');
+        $this->resolver->method('resolve')->willReturnCallback(
+            static function (array $entry) use ($live): ?ObjectEntity {
+                if ($entry['uuid'] === 'reborn') {
+                    return $live;
+                }
+
+                return null;
+            }
+        );
+
+        $cleaned = [];
+        $this->cleanup->expects($this->once())->method('cleanup')
+            ->willReturnCallback(
+                static function (string $objectUuid) use (&$cleaned): void {
+                    $cleaned[] = $objectUuid;
+                }
+            );
+
+        $this->runJob(
+            entries: [
+                ['uuid' => 'reborn', 'register' => 'r', 'schema' => 's'],
+                ['uuid' => 'gone', 'register' => 'r', 'schema' => 's'],
+            ]
+        );
+
+        $this->assertSame(expected: ['gone'], actual: $cleaned);
+
+    }//end testMixedChunkCleansOnlyTheEntryThatIsReallyGone()
+
+    /**
+     * Entries without a usable uuid are skipped, the rest still runs.
+     *
+     * @return void
+     */
+    public function testEntryWithoutAUsableUuidIsSkippedWithoutStoppingTheChunk(): void
+    {
+        $this->resolvableUser(userId: 'alice');
+
+        $this->resolver->expects($this->once())->method('resolve')->willReturn(null);
+        $this->cleanup->expects($this->once())->method('cleanup')->with('gone');
+
+        $this->runJob(
+            entries: [
+                ['register' => 'r', 'schema' => 's'],
+                ['uuid' => '', 'register' => 'r', 'schema' => 's'],
+                ['uuid' => 42, 'register' => 'r', 'schema' => 's'],
+                ['uuid' => 'gone', 'register' => 'r', 'schema' => 's'],
+            ]
+        );
+
+    }//end testEntryWithoutAUsableUuidIsSkippedWithoutStoppingTheChunk()
+
+    /**
+     * A failing cleanup is logged and the remaining entries still run.
+     *
+     * @return void
+     */
+    public function testCleanupFailureIsLoggedAndTheChunkContinues(): void
+    {
+        $this->resolvableUser(userId: 'alice');
+        $this->resolver->method('resolve')->willReturn(null);
+
+        $cleaned = [];
+        $this->cleanup->expects($this->exactly(count: 2))->method('cleanup')
+            ->willReturnCallback(
+                static function (string $objectUuid) use (&$cleaned): void {
+                    if ($objectUuid === 'boom') {
+                        throw new \RuntimeException('cleanup blew up');
+                    }
+
+                    $cleaned[] = $objectUuid;
+                }
+            );
+        $this->logger->expects($this->once())->method('warning');
+
+        $this->runJob(
+            entries: [
+                ['uuid' => 'boom', 'register' => 'r', 'schema' => 's'],
+                ['uuid' => 'gone', 'register' => 'r', 'schema' => 's'],
+            ]
+        );
+
+        $this->assertSame(expected: ['gone'], actual: $cleaned);
+
+    }//end testCleanupFailureIsLoggedAndTheChunkContinues()
+
+    /**
+     * NEGATIVE CONTROL — an actor that no longer exists cleans up nothing.
+     *
+     * Running anyway would delete another tenant's notes and tasks under
+     * whatever identity the cron worker happens to carry.
+     *
+     * @return void
+     */
+    public function testVanishedActorSkipsTheCleanupEntirely(): void
+    {
+        $this->userManager->method('get')->with('ghost')->willReturn(null);
+
+        $this->resolver->expects($this->never())->method('resolve');
+        $this->cleanup->expects($this->never())->method('cleanup');
+        $this->logger->expects($this->once())->method('warning');
+
+        $this->runJob(
+            entries: [['uuid' => 'gone', 'register' => 'r', 'schema' => 's']],
+            userId: 'ghost'
+        );
+
+        // No identity was borrowed, so none had to be given back.
+        $this->assertSame(expected: [], actual: $this->setUserCalls);
+
+    }//end testVanishedActorSkipsTheCleanupEntirely()
+
+    /**
+     * A session-less origin (occ, cron) still cleans up, without impersonating.
+     *
+     * @return void
+     */
+    public function testSessionlessOriginCleansUpWithoutImpersonation(): void
+    {
+        $this->userManager->expects($this->never())->method('get');
+        $this->resolver->method('resolve')->willReturn(null);
+
+        $actorDuringCleanup = 'not-called';
+        $this->cleanup->expects($this->once())->method('cleanup')->with('gone')
+            ->willReturnCallback(
+                function () use (&$actorDuringCleanup): void {
+                    $actorDuringCleanup = $this->userSession->getUser();
+                }
+            );
+
+        $this->runJob(
+            entries: [['uuid' => 'gone', 'register' => 'r', 'schema' => 's']],
+            userId: null
+        );
+
+        $this->assertNull(actual: $actorDuringCleanup);
+        $this->assertSame(expected: [null], actual: $this->setUserCalls);
+
+    }//end testSessionlessOriginCleansUpWithoutImpersonation()
+}//end class

--- a/tests/Unit/Service/ObjectRelationCleanupServiceTest.php
+++ b/tests/Unit/Service/ObjectRelationCleanupServiceTest.php
@@ -1,0 +1,298 @@
+<?php
+
+/**
+ * ObjectRelationCleanupServiceTest
+ *
+ * Unit tests for the one shared relation cleanup that both the inline
+ * (kill-switch) listener path and the deferred ObjectCleanupJob call.
+ *
+ * The tests assert the six entity services are really invoked, with the
+ * deleted object's UUID, and that a failure in one of them does not swallow
+ * the others — a silently fail-soft implementation that catches everything
+ * and does nothing would pass a "did not throw" test and fails these.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category  Test
+ * @package   OCA\OpenRegister\Tests\Unit\Service
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git-id>
+ * @link      https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Service\CalendarEventService;
+use OCA\OpenRegister\Service\ContactService;
+use OCA\OpenRegister\Service\DeckCardService;
+use OCA\OpenRegister\Service\EmailService;
+use OCA\OpenRegister\Service\NoteService;
+use OCA\OpenRegister\Service\ObjectRelationCleanupService;
+use OCA\OpenRegister\Service\TaskService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Six independent, fail-soft cleanups keyed by the deleted object's UUID.
+ */
+class ObjectRelationCleanupServiceTest extends TestCase
+{
+
+    /**
+     * Note (comment) cleanup double.
+     *
+     * @var NoteService&MockObject
+     */
+    private NoteService&MockObject $noteService;
+
+    /**
+     * CalDAV task cleanup double.
+     *
+     * @var TaskService&MockObject
+     */
+    private TaskService&MockObject $taskService;
+
+    /**
+     * Email-link cleanup double.
+     *
+     * @var EmailService&MockObject
+     */
+    private EmailService&MockObject $emailService;
+
+    /**
+     * Calendar-event unlinking double.
+     *
+     * @var CalendarEventService&MockObject
+     */
+    private CalendarEventService&MockObject $calendarEventService;
+
+    /**
+     * Contact-link cleanup double.
+     *
+     * @var ContactService&MockObject
+     */
+    private ContactService&MockObject $contactService;
+
+    /**
+     * Deck-card-link cleanup double.
+     *
+     * @var DeckCardService&MockObject
+     */
+    private DeckCardService&MockObject $deckCardService;
+
+    /**
+     * PSR logger double.
+     *
+     * @var LoggerInterface&MockObject
+     */
+    private LoggerInterface&MockObject $logger;
+
+    /**
+     * System under test.
+     *
+     * @var ObjectRelationCleanupService
+     */
+    private ObjectRelationCleanupService $service;
+
+    /**
+     * Wire the service with a double for each of the six entity services.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->noteService          = $this->createMock(originalClassName: NoteService::class);
+        $this->taskService          = $this->createMock(originalClassName: TaskService::class);
+        $this->emailService         = $this->createMock(originalClassName: EmailService::class);
+        $this->calendarEventService = $this->createMock(originalClassName: CalendarEventService::class);
+        $this->contactService       = $this->createMock(originalClassName: ContactService::class);
+        $this->deckCardService      = $this->createMock(originalClassName: DeckCardService::class);
+
+        $this->logger = $this->createMock(originalClassName: LoggerInterface::class);
+
+        $this->service = new ObjectRelationCleanupService(
+            noteService: $this->noteService,
+            taskService: $this->taskService,
+            emailService: $this->emailService,
+            calendarEventService: $this->calendarEventService,
+            contactService: $this->contactService,
+            deckCardService: $this->deckCardService,
+            logger: $this->logger
+        );
+
+    }//end setUp()
+
+    /**
+     * POSITIVE CONTROL — all six cleanups run, each with the object UUID.
+     *
+     * @return void
+     */
+    public function testCleanupInvokesAllSixEntityCleanupsWithTheObjectUuid(): void
+    {
+        $this->noteService->expects($this->once())->method('deleteNotesForObject')->with('obj-1');
+        $this->taskService->expects($this->once())->method('getTasksForObject')->with('obj-1')->willReturn([]);
+        $this->emailService->expects($this->once())->method('deleteLinksForObject')->with('obj-1')->willReturn(2);
+        $this->calendarEventService->expects($this->once())->method('unlinkEventsForObject')->with('obj-1');
+        $this->contactService->expects($this->once())->method('deleteLinksForObject')->with('obj-1');
+        $this->deckCardService->expects($this->once())->method('deleteLinksForObject')->with('obj-1')->willReturn(1);
+
+        $this->service->cleanup(objectUuid: 'obj-1');
+
+    }//end testCleanupInvokesAllSixEntityCleanupsWithTheObjectUuid()
+
+    /**
+     * POSITIVE CONTROL — every listed task is deleted on its own calendar.
+     *
+     * @return void
+     */
+    public function testEveryListedTaskIsDeletedOnItsOwnCalendar(): void
+    {
+        $this->taskService->method('getTasksForObject')->with('obj-1')->willReturn(
+            [
+                ['id' => 'task-1', 'calendarId' => 'cal-a'],
+                ['id' => 'task-2', 'calendarId' => 'cal-b'],
+            ]
+        );
+
+        $deleted = [];
+        $this->taskService->expects($this->exactly(count: 2))->method('deleteTask')
+            ->willReturnCallback(
+                static function (string $calendarId, string $taskUri) use (&$deleted): void {
+                    $deleted[] = [$calendarId, $taskUri];
+                }
+            );
+
+        $this->service->cleanup(objectUuid: 'obj-1');
+
+        $this->assertSame(
+            expected: [['cal-a', 'task-1'], ['cal-b', 'task-2']],
+            actual: $deleted
+        );
+
+    }//end testEveryListedTaskIsDeletedOnItsOwnCalendar()
+
+    /**
+     * NEGATIVE CONTROL — no tasks means no task deletion, rest still runs.
+     *
+     * Paired with testEveryListedTaskIsDeletedOnItsOwnCalendar(); the note
+     * cleanup expectation in the same test proves the run was not a no-op.
+     *
+     * @return void
+     */
+    public function testNoListedTasksMeansNoTaskIsDeleted(): void
+    {
+        $this->taskService->method('getTasksForObject')->willReturn([]);
+        $this->taskService->expects($this->never())->method('deleteTask');
+
+        // Positive control in the same test: the run really happened.
+        $this->noteService->expects($this->once())->method('deleteNotesForObject')->with('obj-1');
+
+        $this->service->cleanup(objectUuid: 'obj-1');
+
+    }//end testNoListedTasksMeansNoTaskIsDeleted()
+
+    /**
+     * One failing entity cleanup does not block the other five.
+     *
+     * @return void
+     */
+    public function testOneFailingCleanupDoesNotBlockTheOthers(): void
+    {
+        $this->noteService->method('deleteNotesForObject')
+            ->willThrowException(new \RuntimeException('notes table gone'));
+
+        $this->taskService->expects($this->once())->method('getTasksForObject')->with('obj-1')->willReturn([]);
+        $this->emailService->expects($this->once())->method('deleteLinksForObject')->with('obj-1')->willReturn(0);
+        $this->calendarEventService->expects($this->once())->method('unlinkEventsForObject')->with('obj-1');
+        $this->contactService->expects($this->once())->method('deleteLinksForObject')->with('obj-1');
+        $this->deckCardService->expects($this->once())->method('deleteLinksForObject')->with('obj-1')->willReturn(0);
+        $this->logger->expects($this->atLeastOnce())->method('warning');
+
+        $this->service->cleanup(objectUuid: 'obj-1');
+
+    }//end testOneFailingCleanupDoesNotBlockTheOthers()
+
+    /**
+     * A task that refuses to delete does not strand the remaining tasks.
+     *
+     * @return void
+     */
+    public function testFailingTaskDeletionDoesNotStrandTheRemainingTasks(): void
+    {
+        $this->taskService->method('getTasksForObject')->willReturn(
+            [
+                ['id' => 'task-1', 'calendarId' => 'cal-a'],
+                ['id' => 'task-2', 'calendarId' => 'cal-b'],
+            ]
+        );
+
+        $deleted = [];
+        $this->taskService->expects($this->exactly(count: 2))->method('deleteTask')
+            ->willReturnCallback(
+                static function (string $calendarId, string $taskUri) use (&$deleted): void {
+                    if ($taskUri === 'task-1') {
+                        throw new \RuntimeException('CalDAV said no');
+                    }
+
+                    $deleted[] = [$calendarId, $taskUri];
+                }
+            );
+        $this->logger->expects($this->atLeastOnce())->method('warning');
+
+        $this->service->cleanup(objectUuid: 'obj-1');
+
+        $this->assertSame(expected: [['cal-b', 'task-2']], actual: $deleted);
+
+    }//end testFailingTaskDeletionDoesNotStrandTheRemainingTasks()
+
+    /**
+     * A failing task LISTING does not cancel the four later cleanups.
+     *
+     * @return void
+     */
+    public function testFailingTaskListingDoesNotCancelTheLaterCleanups(): void
+    {
+        $this->taskService->method('getTasksForObject')
+            ->willThrowException(new \RuntimeException('calendar backend down'));
+        $this->taskService->expects($this->never())->method('deleteTask');
+
+        $this->emailService->expects($this->once())->method('deleteLinksForObject')->with('obj-1')->willReturn(0);
+        $this->calendarEventService->expects($this->once())->method('unlinkEventsForObject')->with('obj-1');
+        $this->contactService->expects($this->once())->method('deleteLinksForObject')->with('obj-1');
+        $this->deckCardService->expects($this->once())->method('deleteLinksForObject')->with('obj-1')->willReturn(0);
+
+        $this->service->cleanup(objectUuid: 'obj-1');
+
+    }//end testFailingTaskListingDoesNotCancelTheLaterCleanups()
+
+    /**
+     * At-least-once delivery: a repeat run repeats the same six calls.
+     *
+     * The deferred job may be delivered twice; the cleanup must stay a plain
+     * "delete rows matching this UUID" both times rather than short-circuit
+     * on some remembered state.
+     *
+     * @return void
+     */
+    public function testRepeatDeliveryRepeatsTheSameCleanupCalls(): void
+    {
+        $this->noteService->expects($this->exactly(count: 2))->method('deleteNotesForObject')->with('obj-1');
+        $this->taskService->expects($this->exactly(count: 2))->method('getTasksForObject')->with('obj-1')->willReturn([]);
+        $this->emailService->expects($this->exactly(count: 2))->method('deleteLinksForObject')->with('obj-1')->willReturn(0);
+        $this->calendarEventService->expects($this->exactly(count: 2))->method('unlinkEventsForObject')->with('obj-1');
+        $this->contactService->expects($this->exactly(count: 2))->method('deleteLinksForObject')->with('obj-1');
+        $this->deckCardService->expects($this->exactly(count: 2))->method('deleteLinksForObject')->with('obj-1')->willReturn(0);
+
+        $this->service->cleanup(objectUuid: 'obj-1');
+        $this->service->cleanup(objectUuid: 'obj-1');
+
+    }//end testRepeatDeliveryRepeatsTheSameCleanupCalls()
+}//end class


### PR DESCRIPTION
## What

Unit tests for the deferral path that shipped in #2214 with **live-only evidence**.

`ObjectCleanupJob` and `ObjectRelationCleanupService` landed with no unit tests at
all — the evidence for both was a run against a live instance. These 16 tests
close that gap.

| File | Tests | Covers |
|---|---|---|
| `tests/Unit/BackgroundJob/ObjectCleanupJobTest.php` | 9 | actor impersonation, vanished actor, sessionless origin, unusable UUID, per-entry failure isolation |
| `tests/Unit/Service/ObjectRelationCleanupServiceTest.php` | 7 | the six cleanup collaborators, fail-soft behaviour |

## Why these assert side effects, not absence-of-throw

The failure mode this path actually has is a **flawless no-op**. A background job
has no session, so a deferred cleanup that loses its acting user performs a
permission-scoped read, finds nothing, cleans nothing, and reports success —
no exception, no log line, nothing for a naive test to catch.

So every test here asserts an *observable* effect: which UUID reaches
`ObjectRelationCleanupService`, and which identity the session carries at the
exact moment cleanup runs. A job that throws nothing while cleaning nothing
fails here.

This is ADR-078 Rule 6 (any deferred path MUST carry the acting user) and
ADR-060 (a green signal from a component that cannot produce the observable
effect is not evidence).

## Verification

Run in the `nextcloud:34.0.0-apache` container against `development` with this
branch's tests:

```
php vendor/bin/phpunit -c phpunit.xml --no-coverage tests/Unit
→ OK. Tests: 15599, Assertions: 34868, 0 errors, 0 failures
```

The two new files in isolation: `OK (16 tests, 58 assertions)`.

## Scope note

An earlier local copy of this work also carried "repairs" to
`ObjectCleanupListenerTest.php` and `OpenRegisterFlowResolverTest.php`. Those
were checked against `development` after #2214 merged and are **already fixed
there** — the `ICacheFactory` constructor argument is present, and the remaining
delta was docblock/whitespace only. They are deliberately **not** included here,
to avoid re-litigating files #2214 already settled.
