### PR TITLE
feat(flow): set-fields can write a NESTED field, not only a flat one

### DIFF
--- a/lib/Service/Flow/Nodes/SetFieldsNode.php
+++ b/lib/Service/Flow/Nodes/SetFieldsNode.php
@@ -215,7 +215,11 @@ class SetFieldsNode implements IFlowNode
             // A value that is exactly one placeholder keeps its TYPE, so a
             // counter stays a number and a list stays a list.
             foreach ($set as $field => $value) {
-                $json[(string) $field] = FlowValueTemplate::render(value: $value, json: $json);
+                self::assign(
+                    json: $json,
+                    path: (string) $field,
+                    value: FlowValueTemplate::render(value: $value, json: $json)
+                );
             }
 
             // `compute` is the same idea as `set` for values that have to be
@@ -257,4 +261,56 @@ class SetFieldsNode implements IFlowNode
         return $out;
 
     }//end execute()
+
+    /**
+     * Write a value at a possibly-dotted path, creating the containers it needs.
+     *
+     * `{{dotted.path}}` has always READ through nested structures; writing one
+     * did not, so `"entry.owner"` created a top-level key literally CALLED
+     * `entry.owner` beside any real `entry`. Nothing failed — the flow ran, the
+     * item came out, and the object the author meant to build was simply never
+     * there. That is indistinguishable from success until something downstream
+     * reads the shape and finds it empty.
+     *
+     * It matters because composing a NESTED record is the reason a flow sets
+     * fields at all: hydra's run record is `cycles[].stages[]`, and without this
+     * a flow can only ever produce a flat bag. `compute` is no help — JsonLogic
+     * evaluates expressions and cannot construct an object.
+     *
+     * A segment whose current value is not an array is REPLACED by a container.
+     * The alternative — merging into a scalar — has no meaning, and silently
+     * skipping would reintroduce the same invisible no-op this fixes.
+     *
+     * @param array  $json  The item's record, modified in place.
+     * @param string $path  The field name, optionally dotted.
+     * @param mixed  $value The value to write.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+     */
+    private static function assign(array &$json, string $path, mixed $value): void
+    {
+        if (str_contains($path, '.') === false) {
+            $json[$path] = $value;
+
+            return;
+        }
+
+        $segments = explode('.', $path);
+        $last     = array_pop($segments);
+        $cursor   = &$json;
+
+        foreach ($segments as $segment) {
+            if (isset($cursor[$segment]) === false || is_array($cursor[$segment]) === false) {
+                $cursor[$segment] = [];
+            }
+
+            $cursor = &$cursor[$segment];
+        }
+
+        $cursor[$last] = $value;
+        unset($cursor);
+
+    }//end assign()
 }//end class

--- a/tests/Unit/Service/Flow/SetFieldsNodeTest.php
+++ b/tests/Unit/Service/Flow/SetFieldsNodeTest.php
@@ -239,4 +239,97 @@ class SetFieldsNodeTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    /**
+     * A dotted key WRITES a nested structure rather than a literal key.
+     *
+     * Reads have always gone through `{{dotted.path}}`; writes did not, so
+     * `"entry.owner"` produced a top-level key literally CALLED `entry.owner`
+     * beside any real `entry`. Nothing failed — the flow ran, the item came out,
+     * and the object the author meant to build was simply never there. That is
+     * indistinguishable from success until something downstream reads the shape
+     * and finds it empty.
+     */
+    public function testADottedKeyWritesANestedStructure(): void
+    {
+        $out = $this->node->execute(
+            $this->items([['who' => 'ruben', 'code' => 0]]),
+            ['set' => ['entry.owner' => '{{who}}', 'entry.exit_code' => '{{code}}']],
+            []
+        );
+
+        $this->assertSame('ruben', $out[0]['json']['entry']['owner']);
+        // The whole-placeholder type rule still holds through a nested write.
+        $this->assertSame(0, $out[0]['json']['entry']['exit_code']);
+        $this->assertArrayNotHasKey('entry.owner', $out[0]['json']);
+    }
+
+    /**
+     * Several dotted keys build ONE object rather than clobbering each other.
+     */
+    public function testSiblingDottedKeysShareTheirContainer(): void
+    {
+        $out = $this->node->execute(
+            $this->items([[]]),
+            ['set' => ['e.a' => '1', 'e.b' => '2', 'e.c' => '3']],
+            []
+        );
+
+        $this->assertSame(['a' => '1', 'b' => '2', 'c' => '3'], $out[0]['json']['e']);
+    }
+
+    /**
+     * A dotted write MERGES into an existing container instead of replacing it.
+     *
+     * A record composer appends a stage to a cycle that already has fields; a
+     * write that replaced the container would silently drop them.
+     */
+    public function testADottedWriteMergesIntoAnExistingObject(): void
+    {
+        $out = $this->node->execute(
+            $this->items([['entry' => ['kept' => 'yes']]]),
+            ['set' => ['entry.added' => 'also']],
+            []
+        );
+
+        $this->assertSame('yes', $out[0]['json']['entry']['kept']);
+        $this->assertSame('also', $out[0]['json']['entry']['added']);
+    }
+
+    /**
+     * Deep paths create every level they need.
+     */
+    public function testADeepPathCreatesEveryLevel(): void
+    {
+        $out = $this->node->execute($this->items([[]]), ['set' => ['a.b.c.d' => 'deep']], []);
+
+        $this->assertSame('deep', $out[0]['json']['a']['b']['c']['d']);
+    }
+
+    /**
+     * A scalar in the path is REPLACED by a container, not merged into.
+     *
+     * Merging into a scalar has no meaning, and silently skipping would
+     * reintroduce the invisible no-op this fixes.
+     */
+    public function testAScalarInThePathBecomesAContainer(): void
+    {
+        $out = $this->node->execute(
+            $this->items([['entry' => 'i am a string']]),
+            ['set' => ['entry.owner' => 'ruben']],
+            []
+        );
+
+        $this->assertSame(['owner' => 'ruben'], $out[0]['json']['entry']);
+    }
+
+    /**
+     * An undotted key is untouched by any of this.
+     */
+    public function testAnUndottedKeyStillWritesFlat(): void
+    {
+        $out = $this->node->execute($this->items([[]]), ['set' => ['plain' => 'value']], []);
+
+        $this->assertSame('value', $out[0]['json']['plain']);
+    }
+
 }


### PR DESCRIPTION
`{{dotted.path}}` has always **read** through nested structures. Writing one did not: `"entry.owner"` created a top-level key literally *called* `entry.owner`, sitting beside any real `entry`.

**Nothing failed.** The flow ran, the item came out, and the object the author meant to build was simply never there — indistinguishable from success until something downstream reads the shape and finds it empty. Reading and writing the same notation with different meanings is the kind of asymmetry nobody checks for, because the read side proves the notation works.

## Why it matters

Composing a **nested record** is the reason a flow sets fields at all. hydra's run record is `cycles[].stages[]`, and its composer (`hydra-flows-first-port` task 5.2) has to assemble one object per stage. Without this a flow can only ever produce a flat bag — and `compute` is no help, because JsonLogic evaluates expressions and cannot construct an object.

## Behaviour, all pinned by tests

| | |
|---|---|
| dotted key | writes through, creating every level it needs |
| sibling dotted keys | share their container rather than clobbering each other |
| existing object | **merged into**, so a composer can append a stage to a cycle without dropping its fields |
| scalar in the path | **replaced** by a container — merging into a scalar has no meaning, and silently skipping would reintroduce the invisible no-op this fixes |
| whole-placeholder typing | still holds through a nested write, so an exit code stays a number |
| undotted key | untouched |

## Verification

Flow suite **297 green** (21 on this node), phpcs / psalm / phpstan clean.