### PR TITLE
fix(broker): log WHY a credential lookup failed instead of calling it "not found"

### DIFF
--- a/lib/Service/Credential/CredentialBrokerService.php
+++ b/lib/Service/Credential/CredentialBrokerService.php
@@ -520,8 +520,32 @@ class CredentialBrokerService
                 _rbac: false
             );
         } catch (Throwable $e) {
+            // Log the REASON. A credential that is genuinely absent and a lookup
+            // that THREW are entirely different problems, and collapsing both
+            // into `$credential = null` makes them indistinguishable — the
+            // operator is told "credential not found" about a credential that
+            // demonstrably exists.
+            //
+            // Measured 2026-08-01: a brokered call that returns 200 outside a
+            // flow run is denied inside one with `credential not found`, and the
+            // reason it is really failing was sitting in this swallowed
+            // exception. Diagnosing it without this meant guessing at guards
+            // that were never reached.
+            //
+            // Not re-thrown: a missing credential must still deny rather than
+            // 500, and the caller's contract is unchanged. Only the diagnosis
+            // improves.
+            $this->logger->warning(
+                '[CredentialBrokerService] the credential lookup threw; treating as not found',
+                [
+                    'credential' => $credentialId,
+                    'reason'     => $e->getMessage(),
+                    'class'      => get_class($e),
+                ]
+            );
+
             $credential = null;
-        }
+        }//end try
 
         if ($credential === null) {
             $this->deny(reason: 'credential not found', credentialId: $credentialId);


### PR DESCRIPTION
`loadAdmittedCredential()` wraps the object lookup in `catch (Throwable) { $credential = null; }` and then denies with `credential not found`.

So a credential that is **genuinely absent** and a lookup that **threw** are reported identically — and the operator is told "not found" about a credential that demonstrably exists.

## How this surfaced

Running hydra's assembled sequencer: a brokered call that returns **200 with 5.8 MB outside** a flow run is denied **inside** one, with `credential not found` — for a credential that resolves fine a second later from the same process.

The reason it was really failing was sitting in this swallowed exception. Diagnosing it without this meant guessing at guards that were never reached: **the lookup fails before guard 1**, so every scope, ownership and `allowedApps` hypothesis was chasing code that had not run.

## What changes

The exception is logged with its class and message, secret-free, the way every other denial in this class already is.

**Not re-thrown, deliberately:** a missing credential must still *deny* rather than 500, and the caller's contract is unchanged. Only the diagnosis improves — which is the point, because a broker that fails closed *and silently* is indistinguishable from one that is misconfigured.

## Verification

phpcs / phpstan clean, credential suite **116 green**. The phpmd coupling note on this class is pre-existing and untouched — this adds no dependency, only a call to the logger the class already holds.