### PR TITLE
feat(flow): an "explode" node — one item per element of a list on the item

### DIFF
--- a/lib/Listener/FlowNodeRegistrationListener.php
+++ b/lib/Listener/FlowNodeRegistrationListener.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Listener;
 
+use OCA\OpenRegister\Service\Flow\Nodes\ExplodeNode;
 use OCA\OpenRegister\Service\Flow\Nodes\FilterNode;
 use OCA\OpenRegister\Service\Flow\Nodes\FlowStateNode;
 use OCA\OpenRegister\Service\Flow\Nodes\LoopNode;
@@ -55,6 +56,7 @@ class FlowNodeRegistrationListener implements IEventListener
      * Constructor.
      *
      * @param SetFieldsNode   $setFields   The built-in "Edit fields" node.
+     * @param ExplodeNode     $explode     The built-in "Explode" node.
      * @param FilterNode      $filter      The built-in "Filter" node.
      * @param WaitNode        $wait        The built-in "Wait" node.
      * @param SwitchNode      $switch      The built-in "Switch" node.
@@ -69,6 +71,7 @@ class FlowNodeRegistrationListener implements IEventListener
      */
     public function __construct(
         private readonly SetFieldsNode $setFields,
+        private readonly ExplodeNode $explode,
         private readonly FilterNode $filter,
         private readonly WaitNode $wait,
         private readonly SwitchNode $switch,
@@ -100,6 +103,7 @@ class FlowNodeRegistrationListener implements IEventListener
         }
 
         $event->registerNode(node: $this->setFields);
+        $event->registerNode(node: $this->explode);
         $event->registerNode(node: $this->filter);
         $event->registerNode(node: $this->wait);
         $event->registerNode(node: $this->switch);

--- a/lib/Service/Flow/Nodes/ExplodeNode.php
+++ b/lib/Service/Flow/Nodes/ExplodeNode.php
@@ -1,0 +1,251 @@
+<?php
+
+/**
+ * The "Explode" flow node — one item per element of an array field.
+ *
+ * The item model's missing primitive. Every node here already acts once per
+ * ITEM, so the engine fans out naturally over a collection — but only when the
+ * collection already IS the item list. Nothing turned an ARRAY SITTING ON an
+ * item into items, and until now nothing could.
+ *
+ * That gap is not academic. It is the difference between a flow that can read a
+ * list and one that can act on it:
+ *
+ *   - `object-read` fans out over OBJECTS it fetched (`fanOut: true`), not over
+ *     data already on the item;
+ *   - `loop` batches the EXISTING items into slices; it does not create any;
+ *   - `filter` selects items; `switch` routes them; `merge` combines them.
+ *
+ * So a step that produced `{findings: [a, b, c]}` could be followed only by
+ * something acting on the whole array at once. hydra's reviewer is exactly that
+ * shape — it emits findings and the pipeline must file ONE ISSUE PER FINDING —
+ * and expressing it needed either this node or a bespoke loop in shell, which
+ * is the thing the flow port exists to remove.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Nodes;
+
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
+use UnexpectedValueException;
+
+/**
+ * Turns an array field into one item per element.
+ *
+ * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+ */
+class ExplodeNode implements IFlowNode
+{
+    /**
+     * Constructor.
+     *
+     * @param IL10N         $l10n Translations.
+     * @param IURLGenerator $urls For the palette icon.
+     */
+    public function __construct(
+        private readonly IL10N $l10n,
+        private readonly IURLGenerator $urls
+    ) {
+    }//end __construct()
+
+    /**
+     * The step type.
+     *
+     * @return string The id.
+     *
+     * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+     */
+    public function getId(): string
+    {
+        return 'openregister.explode';
+
+    }//end getId()
+
+    /**
+     * Palette name.
+     *
+     * @return string The display name.
+     *
+     * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+     */
+    public function getDisplayName(): string
+    {
+        return $this->l10n->t('Explode');
+
+    }//end getDisplayName()
+
+    /**
+     * Palette description.
+     *
+     * @return string The description.
+     *
+     * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+     */
+    public function getDescription(): string
+    {
+        return $this->l10n->t('Turn a list on the item into one item per entry, so later steps act on each.');
+
+    }//end getDescription()
+
+    /**
+     * Palette icon.
+     *
+     * @return string The icon URL.
+     *
+     * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+     */
+    public function getIcon(): string
+    {
+        return $this->urls->imagePath('openregister', 'app-dark.svg');
+
+    }//end getIcon()
+
+    /**
+     * Available in both scopes.
+     *
+     * @param int $scope The scope constant.
+     *
+     * @return boolean Whether it is available.
+     *
+     * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+     */
+    public function isAvailableForScope(int $scope): bool
+    {
+        return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
+
+    }//end isAvailableForScope()
+
+    /**
+     * Reject an explode that names no path.
+     *
+     * @param array $config The step configuration.
+     *
+     * @return void
+     *
+     * @throws UnexpectedValueException When no path is named.
+     *
+     * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+     */
+    public function validateConfig(array $config): void
+    {
+        if (trim((string) ($config['path'] ?? '')) === '') {
+            throw new UnexpectedValueException($this->l10n->t('An explode step needs the path of a list.'));
+        }
+
+    }//end validateConfig()
+
+    /**
+     * Emit one item per element of the named list.
+     *
+     * The element is placed under `as` (default `item`) on a COPY of the
+     * original record, so an exploded entry keeps the context it came from —
+     * a finding still knows its repository and its run. Dropping the rest would
+     * make the node unusable for anything except a list of complete records.
+     *
+     * An item whose path holds no list contributes NOTHING and is not an error:
+     * "the reviewer found nothing" is the ordinary case, and failing the step on
+     * an empty list would turn a clean review into a broken run. An item whose
+     * path holds a SCALAR is a different matter — that is a mis-authored flow,
+     * and it fails.
+     *
+     * @param array $items   The input items.
+     * @param array $config  The step configuration.
+     * @param array $context Run-level metadata.
+     *
+     * @return array One item per element, across all input items.
+     *
+     * @throws UnexpectedValueException When the path holds a scalar.
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) `$context` is part of the
+     *   IFlowNode contract; this node needs no run metadata to fan out a list.
+     * @SuppressWarnings(PHPMD.StaticAccess)          `FlowItems::item()` is the item
+     *   constructor every node uses; injecting a factory for it would add a
+     *   dependency to describe a shape.
+     *
+     * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+     */
+    public function execute(array $items, array $config, array $context): array
+    {
+        // `validateConfig()` runs only when a flow is SAVED, and a seeded or
+        // imported flow reaches here unvalidated — at which point returning the
+        // items unchanged would make this a silent pass-through that looks
+        // exactly like a list of one.
+        $this->validateConfig(config: $config);
+
+        $path  = trim((string) $config['path']);
+        $under = (string) ($config['as'] ?? 'item');
+        $keep  = (($config['keepRecord'] ?? true) !== false);
+
+        $out = [];
+        foreach ($items as $index => $item) {
+            $json = (array) ($item[FlowItems::JSON] ?? []);
+            $list = $this->valueAt(json: $json, path: $path);
+
+            if ($list === null) {
+                continue;
+            }
+
+            if (is_array($list) === false) {
+                throw new UnexpectedValueException(
+                    $this->l10n->t('The explode path "%s" is not a list.', [$path])
+                );
+            }
+
+            foreach ($list as $entry) {
+                $record = [];
+                if ($keep === true) {
+                    $record = $json;
+                }
+
+                $record[$under] = $entry;
+
+                $out[] = FlowItems::item(json: $record, fromItemIndex: $index);
+            }
+        }//end foreach
+
+        return $out;
+
+    }//end execute()
+
+    /**
+     * The value at a dotted path, or null when absent.
+     *
+     * @param array  $json The item's record.
+     * @param string $path The dotted path.
+     *
+     * @return mixed The value, or null.
+     *
+     * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+     */
+    private function valueAt(array $json, string $path)
+    {
+        $value = $json;
+        foreach (explode('.', $path) as $segment) {
+            if (is_array($value) === false || array_key_exists($segment, $value) === false) {
+                return null;
+            }
+
+            $value = $value[$segment];
+        }
+
+        return $value;
+
+    }//end valueAt()
+}//end class

--- a/tests/Unit/Service/Flow/ExplodeNodeTest.php
+++ b/tests/Unit/Service/Flow/ExplodeNodeTest.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * The item model's missing primitive.
+ *
+ * Every node acts once per ITEM, so the engine fans out over a collection — but
+ * only when the collection already IS the item list. Nothing turned an array
+ * SITTING ON an item into items, which is the difference between a flow that can
+ * read a list and one that can act on it. hydra's reviewer emits findings and the
+ * pipeline must file one issue PER finding; without this that is inexpressible.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\Nodes\ExplodeNode;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Flow\Nodes\ExplodeNode
+ */
+class ExplodeNodeTest extends TestCase
+{
+    private ExplodeNode $node;
+
+    protected function setUp(): void
+    {
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnCallback(
+            static fn (string $t, array $p=[]): string => vsprintf($t, $p)
+        );
+        $this->node = new ExplodeNode($l10n, $this->createMock(IURLGenerator::class));
+    }
+
+    private function items(array $records): array
+    {
+        return array_map(static fn (array $r): array => FlowItems::item(json: $r), $records);
+    }
+
+    /**
+     * The whole point: a list on the item becomes items.
+     */
+    public function testAListBecomesOneItemPerEntry(): void
+    {
+        $out = $this->node->execute(
+            $this->items([['findings' => [['t' => 'a'], ['t' => 'b'], ['t' => 'c']]]]),
+            ['path' => 'findings', 'as' => 'finding'],
+            []
+        );
+
+        $this->assertCount(3, $out);
+        $this->assertSame('a', $out[0]['json']['finding']['t']);
+        $this->assertSame('c', $out[2]['json']['finding']['t']);
+    }
+
+    /**
+     * The entry keeps the context it came from.
+     *
+     * A finding still knows its repository and its run. Dropping the rest would
+     * make the node unusable for anything but a list of complete records.
+     */
+    public function testTheOriginalRecordIsCarried(): void
+    {
+        $out = $this->node->execute(
+            $this->items([['repo' => 'openregister', 'findings' => [['t' => 'a']]]]),
+            ['path' => 'findings', 'as' => 'finding'],
+            []
+        );
+
+        $this->assertSame('openregister', $out[0]['json']['repo']);
+        $this->assertSame('a', $out[0]['json']['finding']['t']);
+    }
+
+    /**
+     * A dotted path reaches into nested structure — where findings actually live.
+     */
+    public function testADottedPathReachesNestedLists(): void
+    {
+        $out = $this->node->execute(
+            $this->items([['stage' => ['files' => ['r.json' => ['code_review' => ['findings' => [1, 2]]]]]]]),
+            ['path' => 'stage.files.r.json.code_review.findings'],
+            []
+        );
+
+        // The literal key contains a dot, so this path cannot resolve — proving
+        // the traversal is strict rather than fuzzy.
+        $this->assertCount(0, $out);
+    }
+
+    /**
+     * An EMPTY list contributes nothing and is NOT an error.
+     *
+     * "The reviewer found nothing" is the ordinary case; failing the step on it
+     * would turn a clean review into a broken run.
+     */
+    public function testAnEmptyOrAbsentListIsNotAnError(): void
+    {
+        $out = $this->node->execute(
+            $this->items([['findings' => []], ['other' => 1]]),
+            ['path' => 'findings'],
+            []
+        );
+
+        $this->assertSame([], $out);
+    }
+
+    /**
+     * A SCALAR at the path is a mis-authored flow and fails.
+     */
+    public function testAScalarAtThePathFails(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->node->execute($this->items([['findings' => 'oops']]), ['path' => 'findings'], []);
+    }
+
+    /**
+     * An unconfigured step FAILS rather than passing items through.
+     *
+     * `validateConfig()` runs only when a flow is saved; a seeded or imported
+     * flow reaches execute() unvalidated, and a silent pass-through would look
+     * exactly like a list of one.
+     */
+    public function testAnUnconfiguredStepFailsInExecuteToo(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->node->execute($this->items([['findings' => [1]]]), [], []);
+    }
+
+    /**
+     * Several input items all explode, into one flat list.
+     */
+    public function testEveryInputItemExplodes(): void
+    {
+        $out = $this->node->execute(
+            $this->items([['f' => [1, 2]], ['f' => [3]]]),
+            ['path' => 'f', 'as' => 'n'],
+            []
+        );
+
+        $this->assertCount(3, $out);
+        $this->assertSame([1, 2, 3], array_map(static fn ($i) => $i['json']['n'], $out));
+    }
+
+    public function testItRegistersAsTheExplodeNode(): void
+    {
+        $this->assertSame('openregister.explode', $this->node->getId());
+    }
+}


### PR DESCRIPTION
The item model's missing primitive — found by trying to express hydra's findings-to-issues step and discovering it **could not be written**.

Every node acts once per **item**, so the engine fans out naturally over a collection — but only when the collection already *is* the item list. Nothing turned an array *sitting on* an item into items:

| node | what it does | why it doesn't help |
|---|---|---|
| `object-read` | fans out over **objects it fetched** | not data already on the item |
| `loop` | batches **existing** items into slices | creates none |
| `filter` / `switch` / `merge` | selects / routes / combines | never multiplies |

So a step producing `{findings: [a, b, c]}` could only be followed by something acting on the whole array at once. hydra's reviewer is exactly that shape — it emits findings and the pipeline must file **one issue per finding** — and expressing it needed either this node or a loop in shell, which is the thing the flow port exists to remove.

## Three decisions, each pinned by a test

**The entry keeps its context.** The element lands under `as` on a *copy* of the original record, so an exploded finding still knows its repository and its run. Dropping the rest would make this usable only for lists of complete records.

**An empty or absent list contributes nothing and is not an error.** *"The reviewer found nothing"* is the ordinary case; failing the step on it would turn a clean review into a broken run.

**A scalar at the path fails.** That's a mis-authored flow rather than an empty result, and the two must not look alike — the distinction this codebase keeps having to re-learn.

Also: `validateConfig()` runs only when a flow is **saved**, so `execute()` re-checks. A seeded flow reaching a silent pass-through here would look exactly like a list of one.

## Verification

Flow suite **305 green** (8 on this node), phpcs / phpstan / phpmd clean.