### PR TITLE
fix(lifecycle): honour the documented slug contract on ObjectTransitionedEvent (flagged, default off)

### DIFF
--- a/docs/transition-event-slug-contract.md
+++ b/docs/transition-event-slug-contract.md
@@ -1,0 +1,82 @@
+# `ObjectTransitionedEvent` — the slug contract
+
+`ObjectTransitionedEvent` documents its `register` and `schema` constructor
+params as **slugs**. `TransitionEngine` has always passed
+`(string) $object->getRegister()` / `getSchema()`, which are **numeric ids**.
+
+Every listener that compares those values to a slug literal has therefore never
+matched, and has **never run** — not once, with no exception, no log line and no
+failing test.
+
+## Why the fix ships disabled
+
+Honouring the documented contract is a two-line change. It is also one of the
+largest behaviour changes available in this codebase, because **44 listeners
+across scholiq (34), shillinq (8) and openbuild (2) start running at once**,
+against data that was written while they were silent.
+
+What those 44 do:
+
+| Class of work | Count | Examples |
+|---|---|---|
+| General-ledger postings | 5 | COGS valuation, fixed-asset disposal journals, intercompany mirrored entries, GR/IR clearing, delivery dispatch (which cascades into stock-move valuation) |
+| Outbound I/O | 7 | HTTP to DUO / OSO / municipality data exchange, external timetable systems, Nextcloud Talk provisioning, Docudesk generation, pipelinq timeline, parent/guardian notifications |
+| Bulk / cascading writes | ~14 | academic-year rollover, application conversion, conference-slot generation, grade rollups, report-card composition, credential issuance |
+| Benign local rollups | remainder | flags, counters, small recomputes (these still write objects) |
+
+None of this is idempotent at the listener layer, and there is no backfill. An
+instance that enables the flag will emit ledger entries and outbound calls for
+transitions that already happened under the old, silent behaviour.
+
+There is also an **emergent fail-closed hazard**, which is observable today and
+is not caused by this flag: `TransitionEngine::transition()` does not wrap
+`dispatchTyped()` in a try/catch. A listener that throws turns the user's
+transition into a 500. This already happens on this instance — a
+`learning-plan-evaluation` transition returns 500 with
+`Failed to process event: Property 'eventId' should be type 'integer or null'`,
+thrown by a listener and propagated out of the dispatcher. 23 of the 34 scholiq
+wake-ups call `saveObject()` with no `catch` anywhere in the file, so enabling
+the flag widens an existing hazard rather than creating a new one.
+
+## Enabling it
+
+```
+occ config:app:set openregister transition_event_slug_contract --value=yes
+```
+
+Default is `no`. Before enabling on an instance, audit that instance's own
+`ObjectTransitionedEvent` listeners against the table above.
+
+⚠️ The app-config local cache is APCu and per-SAPI: a value written by `occ` is
+not immediately visible to web workers. Poll until the change is actually
+observed rather than assuming it took effect.
+
+## What the flag does not fix
+
+- **5 shillinq listeners stay dead.** `ACMReportSignTransitionListener`,
+  `OpdrachtUitvoeringTransitionListener`, `CommitmentMaterialisationListener`,
+  `TenderNedAwardDetectedListener` and `VerplichtingTransitionListener` compare
+  `$event->getObject()->getSchema()` — the **ObjectEntity's own** numeric id,
+  which this change does not touch. Enabling the flag therefore leaves
+  shillinq's ledger wiring *half* live, which may be worse than fully dead.
+- **`ActionListener` payload values shift.** `lib/Listener/ActionListener.php`
+  overwrites `$payload['registerUuid']` / `['schemaUuid']` with the event's
+  strings. Those keys are matched against Action rows that store **UUIDs**, so
+  `"116"` never matched and `"bezwaar"` will not either — no matching change.
+  But the payload is passed verbatim to `ActionExecutor`, so any action template
+  or filter condition referencing `{{registerUuid}}` / `{{schemaUuid}}` starts
+  seeing a slug. Audit action templates before enabling.
+- **Filtered event subscription is unaffected.** `ObjectEventProxyListener`
+  resolves declared interest against the written `ObjectEntity`'s ids, never
+  against `$event->getRegister()`, so slug and id declarations both keep working.
+
+## Verification
+
+Live positive control on the development instance, procest `bezwaar`
+(register 17 = `procest`, schema 116 = `bezwaar`), using a probe listener with
+the same guard shape as the 44:
+
+| flag | transition | event carried | slug guard | listener ran |
+|---|---|---|---|---|
+| `no` (default) | HTTP 200 | `reg=17:sch=116` | rejects | **no** |
+| `yes` | HTTP 200 | `reg=procest:sch=bezwaar` | passes | **yes** |

--- a/lib/Service/Lifecycle/TransitionEngine.php
+++ b/lib/Service/Lifecycle/TransitionEngine.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Service\Lifecycle;
 
 use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
@@ -36,6 +37,7 @@ use OCA\OpenRegister\Exception\NotAuthorizedException;
 use OCA\OpenRegister\Service\ObjectService;
 use OCA\OpenRegister\Service\Object\PermissionHandler;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
 use OCP\IUserSession;
 use RuntimeException;
 
@@ -50,6 +52,16 @@ use RuntimeException;
 class TransitionEngine
 {
     /**
+     * App-config key opting an instance into the documented slug contract.
+     *
+     * Default 'no' — see {@see transitionEventScope()} for why a contract fix
+     * ships disabled.
+     *
+     * @var string
+     */
+    public const SLUG_CONTRACT_FLAG = 'transition_event_slug_contract';
+
+    /**
      * Constructor.
      *
      * @param ObjectService     $objectService     Object CRUD service used to load + save the entity.
@@ -57,6 +69,8 @@ class TransitionEngine
      * @param IEventDispatcher  $eventDispatcher   Dispatcher used to fire ObjectTransitionedEvent.
      * @param IUserSession      $userSession       Current user session, for actor attribution.
      * @param PermissionHandler $permissionHandler RBAC verdict on the object's `update`/`read` actions (F03).
+     * @param RegisterMapper    $registerMapper    Mapper used to resolve the register slug.
+     * @param IAppConfig        $appConfig         App config, for the slug-contract opt-in.
      *
      * @spec openspec/specs/object-lifecycle/spec.md
      */
@@ -65,9 +79,75 @@ class TransitionEngine
         private readonly SchemaMapper $schemaMapper,
         private readonly IEventDispatcher $eventDispatcher,
         private readonly IUserSession $userSession,
-        private readonly PermissionHandler $permissionHandler
+        private readonly PermissionHandler $permissionHandler,
+        private readonly RegisterMapper $registerMapper,
+        private readonly IAppConfig $appConfig
     ) {
     }//end __construct()
+
+    /**
+     * Resolve the register/schema pair to advertise on ObjectTransitionedEvent.
+     *
+     * ObjectTransitionedEvent documents both params as SLUGS, but this engine has
+     * always passed `(string) $object->getRegister()` / `getSchema()`, which are
+     * numeric ids. Every listener comparing them to a slug literal has therefore
+     * never matched and never run — 44 of them across scholiq, shillinq and
+     * openbuild.
+     *
+     * Honouring the documented contract is a one-line change and a very large
+     * behaviour change: it simultaneously activates dormant general-ledger
+     * posting, outbound HTTP to external parties, and bulk-write handlers that
+     * have never executed against this data. So the corrected contract ships
+     * DISABLED and is opted into per instance, after that instance has assessed
+     * its own listeners. See `docs/transition-event-slug-contract.md`.
+     *
+     * Resolution failures fall back to the id rather than throwing: a lifecycle
+     * transition must not start failing because a slug lookup missed.
+     *
+     * @param ObjectEntity $object The object being transitioned.
+     *
+     * @return array{register: string, schema: string} Values for the event.
+     *
+     * @spec openspec/specs/object-lifecycle/spec.md
+     */
+    private function transitionEventScope(ObjectEntity $object): array
+    {
+        $registerRef = (string) $object->getRegister();
+        $schemaRef   = (string) $object->getSchema();
+
+        if ($this->appConfig->getValueString('openregister', self::SLUG_CONTRACT_FLAG, 'no') !== 'yes') {
+            return [
+                'register' => $registerRef,
+                'schema'   => $schemaRef,
+            ];
+        }
+
+        try {
+            $register = $this->registerMapper->find($registerRef);
+            $slug     = $register->getSlug();
+            if ($slug !== null && $slug !== '') {
+                $registerRef = $slug;
+            }
+        } catch (\Throwable $e) {
+            // Keep the id; a missing slug must not break the transition.
+        }
+
+        try {
+            $schema = $this->schemaMapper->find($schemaRef, _multitenancy: false);
+            $slug   = $schema->getSlug();
+            if ($slug !== null && $slug !== '') {
+                $schemaRef = $slug;
+            }
+        } catch (\Throwable $e) {
+            // Keep the id; a missing slug must not break the transition.
+        }
+
+        return [
+            'register' => $registerRef,
+            'schema'   => $schemaRef,
+        ];
+
+    }//end transitionEventScope()
 
     /**
      * Apply a named transition to an object.
@@ -194,6 +274,8 @@ class TransitionEngine
 
         $userId = $actingUser?->getUID();
 
+        $scope = $this->transitionEventScope(object: $object);
+
         $this->eventDispatcher->dispatchTyped(
             new ObjectTransitionedEvent(
                 object: $saved,
@@ -201,8 +283,8 @@ class TransitionEngine
                 from: $currentValue,
                 to: $targetState,
                 userId: $userId,
-                register: (string) $object->getRegister(),
-                schema: (string) $object->getSchema()
+                register: $scope['register'],
+                schema: $scope['schema']
             )
         );
 
@@ -560,6 +642,8 @@ class TransitionEngine
             currentUser: $actingUser
         );
 
+        $scope = $this->transitionEventScope(object: $object);
+
         $this->eventDispatcher->dispatchTyped(
             new ObjectTransitionedEvent(
                 object: $saved,
@@ -567,8 +651,8 @@ class TransitionEngine
                 from: $from,
                 to: $targetState,
                 userId: $actingUser?->getUID(),
-                register: (string) $object->getRegister(),
-                schema: (string) $object->getSchema()
+                register: $scope['register'],
+                schema: $scope['schema']
             )
         );
 

--- a/tests/Unit/Service/Lifecycle/TransitionEngineGraphTest.php
+++ b/tests/Unit/Service/Lifecycle/TransitionEngineGraphTest.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace Unit\Service\Lifecycle;
 
 use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
@@ -34,6 +35,7 @@ use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
 use OCA\OpenRegister\Service\Object\PermissionHandler;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
 use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -64,6 +66,10 @@ class TransitionEngineGraphTest extends TestCase
 
     private PermissionHandler&MockObject $permission;
 
+    private RegisterMapper&MockObject $registerMapper;
+
+    private IAppConfig&MockObject $appConfig;
+
     private TransitionEngine $engine;
 
     protected function setUp(): void
@@ -74,13 +80,26 @@ class TransitionEngineGraphTest extends TestCase
         $this->userSession    = $this->createMock(IUserSession::class);
         $this->permission     = $this->createMock(PermissionHandler::class);
         $this->permission->method('hasPermission')->willReturn(true);
+        $this->registerMapper = $this->createMock(RegisterMapper::class);
+        $this->appConfig      = $this->createMock(IAppConfig::class);
+
+        // The slug contract ships DEFAULT OFF; these graph tests assert the
+        // unchanged id-based event scope, so pin the flag to its default.
+        $this->appConfig->method('getValueString')
+            ->willReturnCallback(
+                static function (string $app, string $key, string $default = '') {
+                    return $default;
+                }
+            );
 
         $this->engine = new TransitionEngine(
             $this->objectService,
             $this->schemaMapper,
             $this->dispatcher,
             $this->userSession,
-            $this->permission
+            $this->permission,
+            $this->registerMapper,
+            $this->appConfig
         );
     }//end setUp()
 

--- a/tests/Unit/Service/Lifecycle/TransitionEngineSlugContractTest.php
+++ b/tests/Unit/Service/Lifecycle/TransitionEngineSlugContractTest.php
@@ -1,0 +1,259 @@
+<?php
+
+/**
+ * OpenRegister TransitionEngine slug-contract tests
+ *
+ * ObjectTransitionedEvent documents `register` and `schema` as SLUGS, but the
+ * engine has always advertised the numeric ids carried by the entity. Correcting
+ * that wakes dormant listeners fleet-wide, so the corrected contract ships behind
+ * the `transition_event_slug_contract` app-config flag, DEFAULT OFF.
+ *
+ * These tests pin all three branches: default-off is byte-identical to the old
+ * behaviour, opt-in resolves slugs, and a resolution failure falls back to the id
+ * rather than breaking the transition.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Lifecycle
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Lifecycle;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Event\ObjectTransitionedEvent;
+use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * @coversDefaultClass \OCA\OpenRegister\Service\Lifecycle\TransitionEngine
+ */
+class TransitionEngineSlugContractTest extends TestCase
+{
+    /**
+     * The object under test carries IDS, exactly as MagicMapper writes them.
+     */
+    private const REGISTER_ID = '17';
+
+    private const SCHEMA_ID = '116';
+
+    private const REGISTER_SLUG = 'zaken';
+
+    private const SCHEMA_SLUG = 'zaak';
+
+    private const CASE = '00000000-0000-0000-0000-0000000000aa';
+
+    private ObjectService&MockObject $objectService;
+
+    private SchemaMapper&MockObject $schemaMapper;
+
+    private IEventDispatcher&MockObject $dispatcher;
+
+    private IUserSession&MockObject $userSession;
+
+    private PermissionHandler&MockObject $permission;
+
+    private RegisterMapper&MockObject $registerMapper;
+
+    private IAppConfig&MockObject $appConfig;
+
+    protected function setUp(): void
+    {
+        $this->objectService  = $this->createMock(ObjectService::class);
+        $this->schemaMapper   = $this->createMock(SchemaMapper::class);
+        $this->dispatcher     = $this->createMock(IEventDispatcher::class);
+        $this->userSession    = $this->createMock(IUserSession::class);
+        $this->permission     = $this->createMock(PermissionHandler::class);
+        $this->permission->method('hasPermission')->willReturn(true);
+        $this->registerMapper = $this->createMock(RegisterMapper::class);
+        $this->appConfig      = $this->createMock(IAppConfig::class);
+
+    }//end setUp()
+
+    /**
+     * Build the engine, with the slug-contract flag set to the given value.
+     *
+     * @param string $flag Value the app config reports for the opt-in flag.
+     */
+    private function engine(string $flag): TransitionEngine
+    {
+        $this->appConfig->method('getValueString')
+            ->willReturnCallback(
+                static function (string $app, string $key, string $default = '') use ($flag) {
+                    if ($app === 'openregister' && $key === TransitionEngine::SLUG_CONTRACT_FLAG) {
+                        return $flag;
+                    }
+
+                    return $default;
+                }
+            );
+
+        return new TransitionEngine(
+            $this->objectService,
+            $this->schemaMapper,
+            $this->dispatcher,
+            $this->userSession,
+            $this->permission,
+            $this->registerMapper,
+            $this->appConfig
+        );
+
+    }//end engine()
+
+    /**
+     * A case object whose register/schema are numeric IDS, as stored.
+     */
+    private function caseObject(): ObjectEntity
+    {
+        $case = new ObjectEntity();
+        $case->setUuid(self::CASE);
+        $case->setRegister(self::REGISTER_ID);
+        $case->setSchema(self::SCHEMA_ID);
+        $case->setObject(['status' => 'ontvangen']);
+        return $case;
+
+    }//end caseObject()
+
+    /**
+     * Wire a minimal static-transition lifecycle so `transition()` succeeds.
+     *
+     * @param string|null $schemaSlug Slug the resolved schema reports, or null.
+     */
+    private function wire(?string $schemaSlug): void
+    {
+        $annotation = [
+            'field'       => 'status',
+            'transitions' => [
+                'approve' => [
+                    'from' => ['ontvangen'],
+                    'to'   => 'behandeld',
+                ],
+            ],
+        ];
+
+        // Real entities, not mocks: `getSlug()` is a magic `@method` on Entity
+        // and therefore cannot be configured on a PHPUnit double.
+        $schema = new Schema();
+        $schema->setConfiguration(['x-openregister-lifecycle' => $annotation]);
+        $schema->setSlug($schemaSlug);
+
+        $this->objectService->method('find')->willReturn($this->caseObject());
+        $this->schemaMapper->method('find')->willReturn($schema);
+        $this->objectService->method('saveObject')->willReturn($this->caseObject());
+
+    }//end wire()
+
+    /**
+     * Capture the register/schema advertised on the dispatched event.
+     *
+     * @return array{0: string, 1: string} Register then schema, as dispatched.
+     */
+    private function dispatchedScope(TransitionEngine $engine): array
+    {
+        $seen = [];
+        $this->dispatcher->expects($this->once())
+            ->method('dispatchTyped')
+            ->willReturnCallback(
+                function ($event) use (&$seen): void {
+                    $this->assertInstanceOf(ObjectTransitionedEvent::class, $event);
+                    $seen = [$event->getRegister(), $event->getSchema()];
+                }
+            );
+
+        $engine->transition(self::CASE, 'approve');
+
+        return $seen;
+
+    }//end dispatchedScope()
+
+    /**
+     * DEFAULT OFF: the event must carry the ids, byte-identical to today.
+     *
+     * This is the merge-safety assertion — if this ever changes, 44 dormant
+     * listeners wake at once on instances that never opted in.
+     */
+    public function testDefaultOffAdvertisesIdsUnchanged(): void
+    {
+        $this->wire(self::SCHEMA_SLUG);
+        $this->registerMapper->expects($this->never())->method('find');
+
+        $scope = $this->dispatchedScope($this->engine('no'));
+
+        $this->assertSame([self::REGISTER_ID, self::SCHEMA_ID], $scope);
+
+    }//end testDefaultOffAdvertisesIdsUnchanged()
+
+    /**
+     * Opt-in: the event carries the documented slugs. Positive control for the
+     * feature actually doing something — without it, the "off" test above passes
+     * against a resolver that never resolves anything.
+     */
+    public function testOptInAdvertisesSlugs(): void
+    {
+        $register = new Register();
+        $register->setSlug(self::REGISTER_SLUG);
+        $this->registerMapper->method('find')->willReturn($register);
+
+        $this->wire(self::SCHEMA_SLUG);
+
+        $scope = $this->dispatchedScope($this->engine('yes'));
+
+        $this->assertSame([self::REGISTER_SLUG, self::SCHEMA_SLUG], $scope);
+
+    }//end testOptInAdvertisesSlugs()
+
+    /**
+     * Opt-in with a failing register lookup: keep the id, do not throw. A
+     * lifecycle transition must not start failing because a slug lookup missed.
+     */
+    public function testOptInFallsBackToIdWhenResolutionFails(): void
+    {
+        $this->registerMapper->method('find')
+            ->willThrowException(new RuntimeException('gone'));
+
+        $this->wire(self::SCHEMA_SLUG);
+
+        $scope = $this->dispatchedScope($this->engine('yes'));
+
+        $this->assertSame([self::REGISTER_ID, self::SCHEMA_SLUG], $scope);
+
+    }//end testOptInFallsBackToIdWhenResolutionFails()
+
+    /**
+     * Opt-in where the entity simply has no slug: keep the id rather than
+     * advertising an empty string.
+     */
+    public function testOptInKeepsIdWhenSlugIsEmpty(): void
+    {
+        $register = new Register();
+        $register->setSlug('');
+        $this->registerMapper->method('find')->willReturn($register);
+
+        $this->wire(null);
+
+        $scope = $this->dispatchedScope($this->engine('yes'));
+
+        $this->assertSame([self::REGISTER_ID, self::SCHEMA_ID], $scope);
+
+    }//end testOptInKeepsIdWhenSlugIsEmpty()
+}//end class


### PR DESCRIPTION
## The bug

`ObjectTransitionedEvent` documents its `register` and `schema` params as **slugs** (`lib/Event/ObjectTransitionedEvent.php:79,86`). `TransitionEngine` has always passed `(string) $object->getRegister()` / `getSchema()` — **numeric ids**.

The event violates its own contract, so every listener comparing those values to a slug literal never matches. **44 listeners have never run.** No exception, no log line, no failing test.

Verified live before changing anything — a real transition on procest `bezwaar`:

```
TRANS-EVENT:reg=17:sch=116
```

Register 17 is `procest`; schema 116 is `bezwaar`.

## Why this ships behind a flag, default OFF

The correction is two lines. Two lines is not the size of the change.

| Class of work | Count | Examples |
|---|---|---|
| 🔴 General-ledger postings | **5** | COGS valuation, fixed-asset disposal journals, intercompany mirrored entries, GR/IR clearing, delivery dispatch (cascades into stock-move valuation, doubling the ledger effect) |
| 🔴 Outbound I/O | **7** | HTTP to DUO / OSO / municipality data exchange, external timetable systems, Talk provisioning, Docudesk generation, pipelinq timeline, parent/guardian notifications |
| 🟠 Bulk / cascading writes | **~14** | academic-year rollover, application conversion, conference-slot generation, grade rollups, report-card composition, credential issuance |
| 🟢 Benign local rollups | remainder | flags, counters, small recomputes — these still write objects |

Per app: scholiq 34, shillinq 8, openbuild 2.

None are idempotent at the listener layer, and there is no backfill. An instance that flips this **emits ledger entries and outbound calls for transitions that already happened while the listeners were silent.** That is a migration, and it belongs to the operator of each instance — not to a merge.

## Emergent fail-closed hazard (widened, not created, by this flag)

`transition()` does not wrap `dispatchTyped()` in a try/catch, so a throwing listener turns the user's transition into a 500.

**This is observable on the development instance today, with the flag OFF.** A `learning-plan-evaluation` transition returns 500:

```
Failed to process event: Property 'eventId' should be type 'integer or null' but is 'string'
OCA\OpenRegister\Exception\ValidationException
```

thrown by a listener and propagated out of the dispatcher. 23 of the 34 scholiq wake-ups call `saveObject()` with **no `catch` anywhere in the file**.

I have **not** guarded the dispatch in this PR — that is a separate behaviour change affecting listeners that already fire, and it deserves its own review. Filed separately.

## Positive control

This is the control nobody could construct before, which is why the bug was known but never shipped. A probe listener with the same guard shape as the 44 (`$event->getRegister() !== 'procest'` / `$event->getSchema() !== 'bezwaar'`), on a real live transition:

| flag | transition | event carried | slug guard | listener ran |
|---|---|---|---|---|
| `no` (default) | HTTP 200 | `reg=17:sch=116` | rejects | **no** |
| `yes` | HTTP 200 | `reg=procest:sch=bezwaar` | passes | **YES** |

The probe listener was temporary and is **not** part of this diff.

Default-off behaviour is byte-identical to today — the flag-off run above carries exactly the ids it always did.

## What this does NOT fix

- **5 shillinq listeners stay dead.** `ACMReportSignTransitionListener`, `OpdrachtUitvoeringTransitionListener`, `CommitmentMaterialisationListener`, `TenderNedAwardDetectedListener`, `VerplichtingTransitionListener` compare `$event->getObject()->getSchema()` — the **ObjectEntity's own** numeric id, untouched here. Enabling the flag leaves shillinq's ledger wiring *half* live, which may be worse than fully dead.
- **`ActionListener` payload shift.** It overwrites `$payload['registerUuid']`/`['schemaUuid']` with the event's strings. Those are matched against Action rows storing **UUIDs**, so `"116"` never matched and `"bezwaar"` won't either — **no matching change**. But the payload goes verbatim to `ActionExecutor`, so any template or filter referencing `{{registerUuid}}`/`{{schemaUuid}}` starts seeing a slug. Audit templates before enabling. **Unverified:** whether any live Action row stores a numeric id, or any template references those keys.
- **Filtered event subscription is unaffected** — `ObjectEventProxyListener` resolves declared interest against the written `ObjectEntity`'s ids, never `$event->getRegister()`. Slug and id declarations both keep working.

## Checks

`phpcs` 0 errors on the touched file (1 pre-existing class-level `@spec` warning left alone — I am not inventing `@spec` values).

Refs procest#690
