### PR TITLE
perf(objects): stop rebuilding the whole schema catalogue on every delete

### DIFF
--- a/lib/Db/SchemaMapper.php
+++ b/lib/Db/SchemaMapper.php
@@ -263,6 +263,10 @@ class SchemaMapper extends QBMapper
      *
      * @return void
      *
+     * @SuppressWarnings(PHPMD.ErrorControlOperator) The trace file is a
+     * best-effort diagnostic written from a shutdown function; a failure to
+     * write it must never surface as a warning on a real request.
+     *
      * @spec openspec/changes/object-write-sub-500ms/specs/object-write-performance/spec.md
      */
     private function traceRead(string $method): void
@@ -1791,6 +1795,27 @@ class SchemaMapper extends QBMapper
 
         // **PERFORMANCE OPTIMIZATION**: Generate facet configuration from schema properties.
         $this->generateFacetConfiguration(schema: $entity);
+
+        /*
+         * **MODIFICATION STAMP**: `updated` was never written on an edit. The
+         * column defaulted to CURRENT_TIMESTAMP at insert and then stayed at
+         * the creation time for the rest of the schema's life, so every
+         * consumer that keys on it was reading a value that could not move:
+         *
+         *  - ContextsController::buildEtag() served a stale JSON-LD context
+         *    ETag after a schema edit, and honoured If-None-Match with a 304.
+         *  - JsonLdContextService::cacheKey() reused a stale context.
+         *  - ReferentialIntegrityService's cross-request relation index treated
+         *    an unchanged stamp as "no schema changed" and could therefore keep
+         *    an index that predates a newly added onDelete relation.
+         *
+         * This is the single mapper choke point every runtime edit passes
+         * through (updateFromArray, the controllers, the tool providers), and
+         * it is set after hydrate() so a client-supplied `updated` cannot
+         * suppress it — the modification time is the server's to state.
+         */
+
+        $entity->setUpdated(new DateTime());
 
         $entity = parent::update(entity: $entity);
 

--- a/lib/Service/Object/DeleteObject.php
+++ b/lib/Service/Object/DeleteObject.php
@@ -318,6 +318,8 @@ class DeleteObject
             }
         }
 
+        \OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.org');
+
         $deletionData = [
             'deletedBy'    => $userId,
             'deletedAt'    => (new DateTime())->format(DateTime::ATOM),
@@ -346,6 +348,8 @@ class DeleteObject
             schema: $schemaEntity,
             oldEntity: $preDeleteState
         ) !== null;
+
+        \OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.update');
 
         // **CACHE INVALIDATION**: Clear collection and facet caches so soft-deleted objects disappear from regular queries.
         if ($result === true) {
@@ -383,6 +387,8 @@ class DeleteObject
             }
         }//end if
 
+        \OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.cache');
+
         // Create audit trail for delete if audit trails are enabled.
         if ($this->isAuditTrailsEnabled() === true) {
             // Determine the audit action based on cascade context.
@@ -402,6 +408,8 @@ class DeleteObject
                 cascadeContext: $cascadeContext
             );
         }//end if
+
+        \OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.audit');
 
         return $result;
     }//end delete()
@@ -550,6 +558,8 @@ class DeleteObject
             );
         }
 
+        \OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.handler.in');
+
         // Reset cascade count for root deletions.
         if ($originalObjectId === null) {
             $this->lastCascadeCount = 0;
@@ -572,6 +582,8 @@ class DeleteObject
 
         $object = $context['object'];
 
+        \OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.ctx');
+
         // Root deletions: check referential integrity and handle cascade.
         if ($originalObjectId === null) {
             $integrityResult = $this->handleIntegrityDeletion(
@@ -583,6 +595,8 @@ class DeleteObject
                 return $integrityResult;
             }
         }
+
+        \OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.integrity');
 
         try {
             // Pass the already-resolved scope so delete() skips its own re-find.
@@ -760,9 +774,12 @@ class DeleteObject
         $hasIntegrityAction = $schemaId !== null
             && $this->integrityService->hasIncomingOnDeleteReferences($schemaId) === true;
 
+        \OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.relindex');
+
         // Run legacy cascade regardless of integrity actions.
         if ($hasIntegrityAction === false) {
             $this->runLegacyCascade(context: $context, object: $object, uuid: $uuid);
+            \OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.legacycascade');
             return null;
         }
 

--- a/lib/Service/Object/ReferentialIntegrityService.php
+++ b/lib/Service/Object/ReferentialIntegrityService.php
@@ -40,6 +40,7 @@ use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Dto\DeletionAnalysis;
+use OCP\ICacheFactory;
 use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Uid\Uuid;
@@ -66,6 +67,29 @@ class ReferentialIntegrityService
      * @var int
      */
     private const MAX_DEPTH = 10;
+
+    /**
+     * Distributed-cache namespace for the relation index.
+     *
+     * @var string
+     */
+    private const CACHE_PREFIX = 'openregister_refintegrity';
+
+    /**
+     * Cache key holding the versioned relation index.
+     *
+     * @var string
+     */
+    private const CACHE_KEY_INDEX = 'relation_index';
+
+    /**
+     * Lifetime of a cached relation index, in seconds.
+     *
+     * A backstop only: correctness comes from the version token, not expiry.
+     *
+     * @var int
+     */
+    private const CACHE_TTL = 3600;
 
     /**
      * Valid onDelete action values.
@@ -111,6 +135,7 @@ class ReferentialIntegrityService
      * @param AuditTrailMapper $auditTrailMapper   Audit trail mapper for integrity action logging.
      * @param LoggerInterface  $logger             Logger for debugging.
      * @param IDBConnection    $db                 Database connection for raw SQL queries.
+     * @param ICacheFactory    $cacheFactory       Distributed cache for the relation index.
      *
      * @spec openspec/specs/object-lifecycle/spec.md
      */
@@ -120,7 +145,8 @@ class ReferentialIntegrityService
         private readonly MagicMapper $objectEntityMapper,
         private readonly AuditTrailMapper $auditTrailMapper,
         private readonly LoggerInterface $logger,
-        private readonly IDBConnection $db
+        private readonly IDBConnection $db,
+        private readonly ICacheFactory $cacheFactory
     ) {
     }//end __construct()
 
@@ -325,9 +351,27 @@ class ReferentialIntegrityService
             return;
         }
 
-        $this->relationIndex     = [];
-        $this->schemaCache       = [];
-        $this->schemaRegisterMap = [];
+        // Fast path: the index is a small pure-array derivative of the schema
+        // definitions, which change rarely, so it survives across requests in
+        // the distributed cache. Every delete used to rebuild it, and that
+        // rebuild hydrates EVERY schema on the instance purely to discover
+        // which ones declare an onDelete relation — measured at ~270 ms of an
+        // ~800 ms delete against 1,935 schemas, of which only 121 can
+        // contribute. The version token below makes a stale index impossible.
+        $version = $this->schemaCatalogueVersion();
+        $cache   = $this->cacheFactory->createDistributed(self::CACHE_PREFIX);
+        if ($version !== null) {
+            $cached = $cache->get(self::CACHE_KEY_INDEX);
+            if (is_array($cached) === true
+                && ($cached['version'] ?? null) === $version
+                && is_array($cached['index'] ?? null) === true
+            ) {
+                $this->relationIndex = $cached['index'];
+                return;
+            }
+        }
+
+        $this->relationIndex = [];
 
         try {
             $allSchemas = $this->schemaMapper->findAll(
@@ -342,14 +386,104 @@ class ReferentialIntegrityService
             return;
         }
 
+        foreach ($allSchemas as $schema) {
+            $this->indexRelationsForSchema(schema: $schema, allSchemas: $allSchemas);
+        }
+
+        if ($version !== null) {
+            $cache->set(
+                self::CACHE_KEY_INDEX,
+                [
+                    'version' => $version,
+                    'index'   => $this->relationIndex,
+                ],
+                self::CACHE_TTL
+            );
+        }
+
+    }//end ensureRelationIndex()
+
+    /**
+     * Compute a token that changes whenever any schema definition changes.
+     *
+     * One cheap aggregate against the schema table stands in for hydrating the
+     * whole catalogue. Any insert or delete moves the count; any update moves
+     * `MAX(updated)`. Returning null on failure disables caching for this call
+     * rather than risking a stale referential-integrity index — a missed
+     * RESTRICT would delete data that should have been protected, so this fails
+     * towards the slow-but-correct path.
+     *
+     * @return string|null The version token, or null when it cannot be computed.
+     *
+     * @spec openspec/specs/object-lifecycle/spec.md
+     */
+    private function schemaCatalogueVersion(): ?string
+    {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->selectAlias($qb->createFunction('COUNT(*)'), 'cnt')
+                ->selectAlias($qb->createFunction('MAX(updated)'), 'mx')
+                ->from('openregister_schemas');
+            $result = $qb->executeQuery();
+            $row    = $result->fetch();
+            $result->closeCursor();
+            if (is_array($row) === false) {
+                return null;
+            }
+
+            return ((string) ($row['cnt'] ?? '')).'|'.((string) ($row['mx'] ?? ''));
+        } catch (\Throwable $e) {
+            $this->logger->debug(
+                message: '[ReferentialIntegrity] Could not compute schema catalogue version',
+                context: ['file' => __FILE__, 'line' => __LINE__, 'error' => $e->getMessage()]
+            );
+            return null;
+        }//end try
+
+    }//end schemaCatalogueVersion()
+
+    /**
+     * Hydrate the schema entities and schema-to-register map on demand.
+     *
+     * Split out of {@see ensureRelationIndex()} because these two structures are
+     * only read while APPLYING an integrity action (cascade / set-null /
+     * required-property checks). The overwhelmingly common delete has no
+     * incoming onDelete references at all and answers from the relation index
+     * alone, so it must not pay for hydrating the schema catalogue.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/object-lifecycle/spec.md
+     */
+    private function ensureSchemaDetail(): void
+    {
+        if ($this->schemaCache !== null) {
+            return;
+        }
+
+        $this->schemaCache       = [];
+        $this->schemaRegisterMap = [];
+
+        try {
+            $allSchemas = $this->schemaMapper->findAll(
+                _rbac: false,
+                _multitenancy: false
+            );
+        } catch (\Exception $e) {
+            $this->logger->warning(
+                message: '[ReferentialIntegrity] Failed to load schemas for detail cache',
+                context: ['file' => __FILE__, 'line' => __LINE__, 'error' => $e->getMessage()]
+            );
+            return;
+        }
+
         $this->buildSchemaRegisterMap();
 
         foreach ($allSchemas as $schema) {
             $this->schemaCache[(string) $schema->getId()] = $schema;
-            $this->indexRelationsForSchema(schema: $schema, allSchemas: $allSchemas);
         }
 
-    }//end ensureRelationIndex()
+    }//end ensureSchemaDetail()
 
     /**
      * Build a map from schema ID to register by scanning magic table names.
@@ -768,6 +902,8 @@ class ReferentialIntegrityService
     ): array {
         $candidates = [];
 
+        $this->ensureSchemaDetail();
+
         // Optimized path: search directly in the specific magic table using the property column.
         $register = $this->schemaRegisterMap[$sourceSchemaId] ?? null;
         $schema   = $this->schemaCache[$sourceSchemaId] ?? null;
@@ -975,6 +1111,8 @@ class ReferentialIntegrityService
      */
     private function isRequiredProperty(string $schemaId, string $propertyName): bool
     {
+        $this->ensureSchemaDetail();
+
         $schema = $this->schemaCache[$schemaId] ?? null;
         if ($schema === null) {
             return false;
@@ -995,6 +1133,8 @@ class ReferentialIntegrityService
      */
     private function getDefaultValue(string $schemaId, string $propertyName): mixed
     {
+        $this->ensureSchemaDetail();
+
         $schema = $this->schemaCache[$schemaId] ?? null;
         if ($schema === null) {
             return null;

--- a/lib/Service/Object/ReferentialIntegrityService.php
+++ b/lib/Service/Object/ReferentialIntegrityService.php
@@ -92,6 +92,19 @@ class ReferentialIntegrityService
     private const CACHE_TTL = 3600;
 
     /**
+     * How long a schema edit must have aged before the version token is trusted.
+     *
+     * `openregister_schemas.updated` is `timestamp(0)`, so two edits within the
+     * same clock second collapse onto one value and a token computed between
+     * them would wrongly compare equal. Two seconds clears the truncation
+     * boundary with a full second of slack for jitter between the PHP clock
+     * that writes the stamp and the one that reads it back.
+     *
+     * @var int
+     */
+    private const VERSION_SETTLE_SECONDS = 2;
+
+    /**
      * Valid onDelete action values.
      *
      * @var string[]
@@ -357,7 +370,15 @@ class ReferentialIntegrityService
         // rebuild hydrates EVERY schema on the instance purely to discover
         // which ones declare an onDelete relation — measured at ~270 ms of an
         // ~800 ms delete against 1,935 schemas, of which only 121 can
-        // contribute. The version token below makes a stale index impossible.
+        // contribute.
+        //
+        // Correctness rests entirely on the version token, and the token is
+        // trusted only when it can be shown to have settled — see
+        // {@see schemaCatalogueVersion()}, which returns null whenever that
+        // cannot be established. A null token bypasses the cache in BOTH
+        // directions: nothing is read, and nothing is written back. This gate
+        // is deliberately asymmetric. A missed cache hit costs milliseconds; a
+        // missed RESTRICT destroys data the user asked the system to protect.
         $version = $this->schemaCatalogueVersion();
         $cache   = $this->cacheFactory->createDistributed(self::CACHE_PREFIX);
         if ($version !== null) {
@@ -406,14 +427,37 @@ class ReferentialIntegrityService
     /**
      * Compute a token that changes whenever any schema definition changes.
      *
-     * One cheap aggregate against the schema table stands in for hydrating the
-     * whole catalogue. Any insert or delete moves the count; any update moves
-     * `MAX(updated)`. Returning null on failure disables caching for this call
-     * rather than risking a stale referential-integrity index — a missed
-     * RESTRICT would delete data that should have been protected, so this fails
-     * towards the slow-but-correct path.
+     * A narrow projection — `id`, `version`, `updated` — over the schema table
+     * stands in for hydrating the whole catalogue. It reads three small columns
+     * instead of decoding 1,935 JSON property blobs, and it is folded into one
+     * digest in PHP rather than in SQL so no database-specific aggregate
+     * (`string_agg` / `group_concat`) is required.
      *
-     * @return string|null The version token, or null when it cannot be computed.
+     * Three independent signals make it move:
+     *
+     *  1. The row set itself — an inserted or deleted schema changes the digest
+     *     regardless of any timestamp.
+     *  2. `version`, which {@see \OCA\OpenRegister\Db\SchemaMapper::updateFromArray()}
+     *     bumps on every edit that does not name a version explicitly.
+     *  3. `updated`, which SchemaMapper::update() now stamps on every edit. It
+     *     previously never moved at all, which is precisely how an edit that
+     *     added an incoming RESTRICT relation could leave this index stale and
+     *     let a protected parent be deleted.
+     *
+     * **The whole-second window.** `updated` is `timestamp(0)`, so two edits in
+     * the same clock second are indistinguishable, and an index built between
+     * them would carry a token that still matches. Signal 2 usually covers
+     * this, but a caller that supplies its own `version` defeats it, so the
+     * window is closed structurally instead: a token whose newest `updated` has
+     * not yet aged past the truncation boundary is refused outright. For the
+     * couple of seconds after any schema edit, deletes take the slow path and
+     * are correct by construction; after that the token is provably settled.
+     *
+     * Returning null on any failure — unreadable table, unparseable timestamp,
+     * a stamp in the future — disables caching for this call rather than
+     * risking a stale referential-integrity index.
+     *
+     * @return string|null The version token, or null when it cannot be trusted.
      *
      * @spec openspec/specs/object-lifecycle/spec.md
      */
@@ -421,17 +465,46 @@ class ReferentialIntegrityService
     {
         try {
             $qb = $this->db->getQueryBuilder();
-            $qb->selectAlias($qb->createFunction('COUNT(*)'), 'cnt')
-                ->selectAlias($qb->createFunction('MAX(updated)'), 'mx')
+            $qb->select('id', 'version', 'updated')
                 ->from('openregister_schemas');
             $result = $qb->executeQuery();
-            $row    = $result->fetch();
+            $rows   = $result->fetchAll();
             $result->closeCursor();
-            if (is_array($row) === false) {
+
+            $parts  = [];
+            $newest = null;
+            foreach ($rows as $row) {
+                $stamp   = (string) ($row['updated'] ?? '');
+                $parts[] = ((string) ($row['id'] ?? '')).':'
+                    .((string) ($row['version'] ?? '')).':'.$stamp;
+
+                if ($stamp === '') {
+                    continue;
+                }
+
+                $epoch = strtotime($stamp);
+                if ($epoch === false) {
+                    // An unparseable stamp means the freshness of this row
+                    // cannot be established, so the token cannot be trusted.
+                    return null;
+                }
+
+                if ($newest === null || $epoch > $newest) {
+                    $newest = $epoch;
+                }
+            }
+
+            // Refuse a token that has not settled past the timestamp(0)
+            // truncation boundary. A stamp in the future (clock skew, or a
+            // caller-supplied value) yields a negative age and is refused by
+            // the same comparison.
+            if ($newest !== null && (time() - $newest) < self::VERSION_SETTLE_SECONDS) {
                 return null;
             }
 
-            return ((string) ($row['cnt'] ?? '')).'|'.((string) ($row['mx'] ?? ''));
+            sort($parts);
+
+            return count($parts).'|'.md5(implode("\n", $parts));
         } catch (\Throwable $e) {
             $this->logger->debug(
                 message: '[ReferentialIntegrity] Could not compute schema catalogue version',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5479,7 +5479,7 @@ parameters:
 
 		-
 			message: "#^Unknown parameter \\$_multitenancy in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
-			count: 1
+			count: 2
 			path: lib/Service/Object/ReferentialIntegrityService.php
 
 		-
@@ -5489,7 +5489,7 @@ parameters:
 
 		-
 			message: "#^Unknown parameter \\$_rbac in call to method OCA\\\\OpenRegister\\\\Db\\\\SchemaMapper\\:\\:findAll\\(\\)\\.$#"
-			count: 1
+			count: 2
 			path: lib/Service/Object/ReferentialIntegrityService.php
 
 		-

--- a/tests/Unit/Service/Object/ReferentialIntegrityBatchCascadeTest.php
+++ b/tests/Unit/Service/Object/ReferentialIntegrityBatchCascadeTest.php
@@ -118,9 +118,26 @@ class ReferentialIntegrityBatchCascadeTest extends TestCase
             $this->objectMapper,
             $this->auditTrailMapper,
             $this->logger,
-            $this->createMock(IDBConnection::class)
+            $this->createMock(IDBConnection::class),
+            $this->createNullCacheFactory()
         );
     }//end setUp()
+
+
+    /**
+     * Build a cache factory whose cache never reports a hit.
+     *
+     * @return \OCP\ICacheFactory
+     */
+    private function createNullCacheFactory(): \OCP\ICacheFactory
+    {
+        $factory = $this->createMock(\OCP\ICacheFactory::class);
+        $factory->method('createDistributed')
+            ->willReturn($this->createMock(\OCP\ICache::class));
+
+        return $factory;
+
+    }//end createNullCacheFactory()
 
     /**
      * Create an ObjectEntity cascade target.

--- a/tests/Unit/Service/Object/ReferentialIntegrityIndexCacheTest.php
+++ b/tests/Unit/Service/Object/ReferentialIntegrityIndexCacheTest.php
@@ -1,0 +1,470 @@
+<?php
+/**
+ * Cross-request relation-index cache tests for ReferentialIntegrityService.
+ *
+ * The relation index answers "does this schema have incoming onDelete
+ * references?". A wrong "no" silently skips a RESTRICT and deletes protected
+ * data with no error, so the cache's invalidation is safety-critical and is
+ * asserted here by SIDE EFFECT — what the service answers and whether it
+ * re-read the schema catalogue — never by inspecting the cache payload.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ *
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright Conduction b.v.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://github.com/ConductionNL/openregister
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Object;
+
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Object\ReferentialIntegrityService;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Object\ReferentialIntegrityService
+ */
+class ReferentialIntegrityIndexCacheTest extends TestCase
+{
+
+    /**
+     * Shared in-memory cache standing in for the distributed cache.
+     *
+     * @var ICache
+     */
+    private ICache $cache;
+
+    /**
+     * Cache factory handing out the shared cache.
+     *
+     * @var ICacheFactory&MockObject
+     */
+    private ICacheFactory&MockObject $cacheFactory;
+
+
+    /**
+     * Set up a shared in-memory cache that survives across service instances.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cache = new class implements ICache {
+            /**
+             * @var array<string, mixed>
+             */
+            public array $store = [];
+
+            /**
+             * @var int
+             */
+            public int $setCalls = 0;
+
+            public function get($key)
+            {
+                return ($this->store[$key] ?? null);
+            }
+
+            public function set($key, $value, $ttl = 0)
+            {
+                $this->store[$key] = $value;
+                $this->setCalls++;
+                return true;
+            }
+
+            public function hasKey($key)
+            {
+                return isset($this->store[$key]);
+            }
+
+            public function remove($key)
+            {
+                unset($this->store[$key]);
+                return true;
+            }
+
+            public function clear($prefix = '')
+            {
+                $this->store = [];
+                return true;
+            }
+
+            public static function isAvailable(): bool
+            {
+                return true;
+            }
+        };
+
+        $this->cacheFactory = $this->createMock(ICacheFactory::class);
+        $this->cacheFactory->method('createDistributed')->willReturn($this->cache);
+
+    }//end setUp()
+
+
+    /**
+     * Build a schema entity carrying a single onDelete relation property.
+     *
+     * @param int    $id       Schema ID.
+     * @param string $slug     Schema slug.
+     * @param array  $props    Property definitions.
+     *
+     * @return Schema
+     */
+    private function schema(int $id, string $slug, array $props=[]): Schema
+    {
+        $schema = new Schema();
+        $schema->setId($id);
+        $schema->setSlug($slug);
+        $schema->setUuid('uuid-'.$id);
+        $schema->setProperties($props);
+
+        return $schema;
+
+    }//end schema()
+
+
+    /**
+     * A property that declares an onDelete relation to a target slug.
+     *
+     * @param string $targetSlug Target schema slug.
+     * @param string $onDelete   The onDelete action.
+     *
+     * @return array
+     */
+    private function relation(string $targetSlug, string $onDelete='RESTRICT'): array
+    {
+        return [
+            'type'     => 'string',
+            '$ref'     => $targetSlug,
+            'onDelete' => $onDelete,
+        ];
+
+    }//end relation()
+
+
+    /**
+     * Build a DB connection whose catalogue-version query yields the given row.
+     *
+     * Passing null for $row makes the query throw, standing in for a version
+     * token that cannot be computed.
+     *
+     * @param array|null $row The row returned by the aggregate query.
+     *
+     * @return IDBConnection&MockObject
+     */
+    private function dbReturning(?array $row): IDBConnection&MockObject
+    {
+        $db = $this->createMock(IDBConnection::class);
+
+        if ($row === null) {
+            $db->method('getQueryBuilder')->willThrowException(new \RuntimeException('no db'));
+            return $db;
+        }
+
+        $result = $this->createMock(IResult::class);
+        $result->method('fetch')->willReturn($row);
+
+        $qb = $this->createMock(IQueryBuilder::class);
+        $qb->method('selectAlias')->willReturnSelf();
+        $qb->method('createFunction')->willReturnArgument(0);
+        $qb->method('from')->willReturnSelf();
+        $qb->method('executeQuery')->willReturn($result);
+
+        $db->method('getQueryBuilder')->willReturn($qb);
+
+        return $db;
+
+    }//end dbReturning()
+
+
+    /**
+     * Construct a service over a given schema catalogue and version row.
+     *
+     * @param array      $schemas     Schemas returned by SchemaMapper::findAll.
+     * @param array|null $versionRow  Row for the catalogue-version query.
+     * @param int|null   $expectFinds Expected number of findAll calls, or null to not assert.
+     *
+     * @return ReferentialIntegrityService
+     */
+    private function service(array $schemas, ?array $versionRow, ?int $expectFinds=null): ReferentialIntegrityService
+    {
+        $schemaMapper = $this->createMock(SchemaMapper::class);
+
+        if ($expectFinds === null) {
+            $schemaMapper->method('findAll')->willReturn($schemas);
+        } else {
+            $schemaMapper->expects($this->exactly($expectFinds))
+                ->method('findAll')
+                ->willReturn($schemas);
+        }
+
+        return new ReferentialIntegrityService(
+            $schemaMapper,
+            $this->createMock(RegisterMapper::class),
+            $this->createMock(MagicMapper::class),
+            $this->createMock(AuditTrailMapper::class),
+            $this->createMock(LoggerInterface::class),
+            $this->dbReturning($versionRow),
+            $this->cacheFactory
+        );
+
+    }//end service()
+
+
+    /**
+     * An unchanged catalogue reuses the cached index without re-reading schemas.
+     *
+     * Asserted by side effect: the second service instance must answer
+     * correctly while SchemaMapper::findAll is never called on it.
+     *
+     * @return void
+     */
+    public function testUnchangedVersionReusesCachedIndex(): void
+    {
+        $catalogue = [
+            $this->schema(1, 'parent'),
+            $this->schema(2, 'child', ['parent' => $this->relation('parent')]),
+        ];
+        $row       = [
+            'cnt' => '2',
+            'mx'  => '2026-01-01 00:00:00',
+        ];
+
+        // First instance populates the cache (one findAll).
+        $first = $this->service($catalogue, $row, 1);
+        $this->assertTrue($first->hasIncomingOnDeleteReferences('1'));
+
+        // Second instance, same version token: must NOT touch the schema mapper.
+        $second = $this->service($catalogue, $row, 0);
+        $this->assertTrue(
+            $second->hasIncomingOnDeleteReferences('1'),
+            'Cached index must still report the incoming RESTRICT reference'
+        );
+
+    }//end testUnchangedVersionReusesCachedIndex()
+
+
+    /**
+     * A changed catalogue version busts the cache and rebuilds the index.
+     *
+     * The second instance sees a different version token and a catalogue in
+     * which the relation is gone, so it must answer false — proving it did not
+     * serve the cached "true".
+     *
+     * @return void
+     */
+    public function testChangedVersionBustsCache(): void
+    {
+        $withRelation = [
+            $this->schema(1, 'parent'),
+            $this->schema(2, 'child', ['parent' => $this->relation('parent')]),
+        ];
+
+        $first = $this->service(
+            $withRelation,
+            [
+                'cnt' => '2',
+                'mx'  => '2026-01-01 00:00:00',
+            ],
+            1
+        );
+        $this->assertTrue($first->hasIncomingOnDeleteReferences('1'));
+
+        // Catalogue changed: relation removed AND the version token moved.
+        $second = $this->service(
+            [$this->schema(1, 'parent')],
+            [
+                'cnt' => '1',
+                'mx'  => '2026-01-02 00:00:00',
+            ],
+            1
+        );
+        $this->assertFalse(
+            $second->hasIncomingOnDeleteReferences('1'),
+            'A moved version token must rebuild the index, not serve the stale one'
+        );
+
+    }//end testChangedVersionBustsCache()
+
+
+    /**
+     * A newly ADDED incoming RESTRICT must be seen once the token moves.
+     *
+     * This is the direction that loses data when it goes wrong: the cache says
+     * "no incoming references", so the RESTRICT is skipped and the parent is
+     * deleted even though a child still points at it.
+     *
+     * @return void
+     */
+    public function testNewlyAddedRestrictIsSeenAfterVersionMoves(): void
+    {
+        // Cache is primed while nothing references schema 1.
+        $before = $this->service(
+            [$this->schema(1, 'parent')],
+            [
+                'cnt' => '1',
+                'mx'  => '2026-01-01 00:00:00',
+            ],
+            1
+        );
+        $this->assertFalse($before->hasIncomingOnDeleteReferences('1'));
+
+        // A referencing schema is added; the token moves because COUNT(*) moved.
+        $after = $this->service(
+            [
+                $this->schema(1, 'parent'),
+                $this->schema(2, 'child', ['parent' => $this->relation('parent')]),
+            ],
+            [
+                'cnt' => '2',
+                'mx'  => '2026-01-02 00:00:00',
+            ],
+            1
+        );
+        $this->assertTrue(
+            $after->hasIncomingOnDeleteReferences('1'),
+            'A newly added incoming RESTRICT must be visible, not masked by the cached "no references"'
+        );
+
+    }//end testNewlyAddedRestrictIsSeenAfterVersionMoves()
+
+
+    /**
+     * An uncomputable version token bypasses the cache entirely.
+     *
+     * Failing safe means rebuilding from the catalogue rather than trusting an
+     * index that cannot be proven current.
+     *
+     * @return void
+     */
+    public function testUncomputableVersionBypassesCache(): void
+    {
+        $catalogue = [
+            $this->schema(1, 'parent'),
+            $this->schema(2, 'child', ['parent' => $this->relation('parent')]),
+        ];
+
+        // Prime the cache with a healthy token.
+        $primed = $this->service(
+            $catalogue,
+            [
+                'cnt' => '2',
+                'mx'  => '2026-01-01 00:00:00',
+            ],
+            1
+        );
+        $this->assertTrue($primed->hasIncomingOnDeleteReferences('1'));
+        $this->assertNotSame([], $this->cache->store, 'cache should be primed');
+
+        $setCallsBefore = $this->cache->setCalls;
+
+        // Token cannot be computed: must rebuild rather than read the cache.
+        $degraded = $this->service($catalogue, null, 1);
+        $this->assertTrue($degraded->hasIncomingOnDeleteReferences('1'));
+
+        $this->assertSame(
+            $setCallsBefore,
+            $this->cache->setCalls,
+            'An unverifiable index must not be written back to the cache'
+        );
+
+    }//end testUncomputableVersionBypassesCache()
+
+
+    /**
+     * A cache entry whose stored version does not match is not trusted.
+     *
+     * Guards the entry-shape check: a payload from an older deploy, or one
+     * without a version, must be discarded rather than used.
+     *
+     * @return void
+     */
+    public function testForeignCachePayloadIsIgnored(): void
+    {
+        // Plant an index claiming schema 1 has NO incoming references, under a
+        // version token that will not match.
+        $this->cache->set(
+            'relation_index',
+            [
+                'version' => 'stale-token',
+                'index'   => [],
+            ]
+        );
+
+        $service = $this->service(
+            [
+                $this->schema(1, 'parent'),
+                $this->schema(2, 'child', ['parent' => $this->relation('parent')]),
+            ],
+            [
+                'cnt' => '2',
+                'mx'  => '2026-01-01 00:00:00',
+            ],
+            1
+        );
+
+        $this->assertTrue(
+            $service->hasIncomingOnDeleteReferences('1'),
+            'A cache entry under a different version token must never be trusted'
+        );
+
+    }//end testForeignCachePayloadIsIgnored()
+
+
+    /**
+     * A malformed cache payload must not be trusted either.
+     *
+     * @return void
+     */
+    public function testMalformedCachePayloadIsIgnored(): void
+    {
+        $row = [
+            'cnt' => '2',
+            'mx'  => '2026-01-01 00:00:00',
+        ];
+
+        // Correct version token, but the index is not an array.
+        $this->cache->set(
+            'relation_index',
+            [
+                'version' => '2|2026-01-01 00:00:00',
+                'index'   => 'not-an-array',
+            ]
+        );
+
+        $service = $this->service(
+            [
+                $this->schema(1, 'parent'),
+                $this->schema(2, 'child', ['parent' => $this->relation('parent')]),
+            ],
+            $row,
+            1
+        );
+
+        $this->assertTrue(
+            $service->hasIncomingOnDeleteReferences('1'),
+            'A malformed cache payload must trigger a rebuild'
+        );
+
+    }//end testMalformedCachePayloadIsIgnored()
+
+
+}//end class

--- a/tests/Unit/Service/Object/ReferentialIntegrityIndexCacheTest.php
+++ b/tests/Unit/Service/Object/ReferentialIntegrityIndexCacheTest.php
@@ -161,30 +161,52 @@ class ReferentialIntegrityIndexCacheTest extends TestCase
 
 
     /**
-     * Build a DB connection whose catalogue-version query yields the given row.
+     * A settled catalogue row: an id/version pair stamped safely in the past.
      *
-     * Passing null for $row makes the query throw, standing in for a version
-     * token that cannot be computed.
+     * Every row the token reads must have aged past the timestamp(0) settle
+     * window, otherwise the service refuses the token by design.
      *
-     * @param array|null $row The row returned by the aggregate query.
+     * @param int    $id      Schema ID.
+     * @param string $version Schema version string.
+     * @param string $updated Modification stamp.
+     *
+     * @return array<string, string>
+     */
+    private function row(int $id, string $version='0.0.1', string $updated='2026-01-01 00:00:00'): array
+    {
+        return [
+            'id'      => (string) $id,
+            'version' => $version,
+            'updated' => $updated,
+        ];
+
+    }//end row()
+
+
+    /**
+     * Build a DB connection whose catalogue-version query yields the given rows.
+     *
+     * Passing null makes the query throw, standing in for a version token that
+     * cannot be computed at all.
+     *
+     * @param array|null $rows Rows returned by the catalogue-version query.
      *
      * @return IDBConnection&MockObject
      */
-    private function dbReturning(?array $row): IDBConnection&MockObject
+    private function dbReturning(?array $rows): IDBConnection&MockObject
     {
         $db = $this->createMock(IDBConnection::class);
 
-        if ($row === null) {
+        if ($rows === null) {
             $db->method('getQueryBuilder')->willThrowException(new \RuntimeException('no db'));
             return $db;
         }
 
         $result = $this->createMock(IResult::class);
-        $result->method('fetch')->willReturn($row);
+        $result->method('fetchAll')->willReturn($rows);
 
         $qb = $this->createMock(IQueryBuilder::class);
-        $qb->method('selectAlias')->willReturnSelf();
-        $qb->method('createFunction')->willReturnArgument(0);
+        $qb->method('select')->willReturnSelf();
         $qb->method('from')->willReturnSelf();
         $qb->method('executeQuery')->willReturn($result);
 
@@ -196,15 +218,15 @@ class ReferentialIntegrityIndexCacheTest extends TestCase
 
 
     /**
-     * Construct a service over a given schema catalogue and version row.
+     * Construct a service over a given schema catalogue and version rows.
      *
      * @param array      $schemas     Schemas returned by SchemaMapper::findAll.
-     * @param array|null $versionRow  Row for the catalogue-version query.
+     * @param array|null $versionRows Rows for the catalogue-version query.
      * @param int|null   $expectFinds Expected number of findAll calls, or null to not assert.
      *
      * @return ReferentialIntegrityService
      */
-    private function service(array $schemas, ?array $versionRow, ?int $expectFinds=null): ReferentialIntegrityService
+    private function service(array $schemas, ?array $versionRows, ?int $expectFinds=null): ReferentialIntegrityService
     {
         $schemaMapper = $this->createMock(SchemaMapper::class);
 
@@ -222,7 +244,7 @@ class ReferentialIntegrityIndexCacheTest extends TestCase
             $this->createMock(MagicMapper::class),
             $this->createMock(AuditTrailMapper::class),
             $this->createMock(LoggerInterface::class),
-            $this->dbReturning($versionRow),
+            $this->dbReturning($versionRows),
             $this->cacheFactory
         );
 
@@ -243,17 +265,14 @@ class ReferentialIntegrityIndexCacheTest extends TestCase
             $this->schema(1, 'parent'),
             $this->schema(2, 'child', ['parent' => $this->relation('parent')]),
         ];
-        $row       = [
-            'cnt' => '2',
-            'mx'  => '2026-01-01 00:00:00',
-        ];
+        $rows      = [$this->row(1), $this->row(2)];
 
         // First instance populates the cache (one findAll).
-        $first = $this->service($catalogue, $row, 1);
+        $first = $this->service($catalogue, $rows, 1);
         $this->assertTrue($first->hasIncomingOnDeleteReferences('1'));
 
         // Second instance, same version token: must NOT touch the schema mapper.
-        $second = $this->service($catalogue, $row, 0);
+        $second = $this->service($catalogue, $rows, 0);
         $this->assertTrue(
             $second->hasIncomingOnDeleteReferences('1'),
             'Cached index must still report the incoming RESTRICT reference'
@@ -280,10 +299,7 @@ class ReferentialIntegrityIndexCacheTest extends TestCase
 
         $first = $this->service(
             $withRelation,
-            [
-                'cnt' => '2',
-                'mx'  => '2026-01-01 00:00:00',
-            ],
+            [$this->row(1), $this->row(2)],
             1
         );
         $this->assertTrue($first->hasIncomingOnDeleteReferences('1'));
@@ -291,10 +307,7 @@ class ReferentialIntegrityIndexCacheTest extends TestCase
         // Catalogue changed: relation removed AND the version token moved.
         $second = $this->service(
             [$this->schema(1, 'parent')],
-            [
-                'cnt' => '1',
-                'mx'  => '2026-01-02 00:00:00',
-            ],
+            [$this->row(1)],
             1
         );
         $this->assertFalse(
@@ -319,24 +332,18 @@ class ReferentialIntegrityIndexCacheTest extends TestCase
         // Cache is primed while nothing references schema 1.
         $before = $this->service(
             [$this->schema(1, 'parent')],
-            [
-                'cnt' => '1',
-                'mx'  => '2026-01-01 00:00:00',
-            ],
+            [$this->row(1)],
             1
         );
         $this->assertFalse($before->hasIncomingOnDeleteReferences('1'));
 
-        // A referencing schema is added; the token moves because COUNT(*) moved.
+        // A referencing schema is added; the token moves because the row set did.
         $after = $this->service(
             [
                 $this->schema(1, 'parent'),
                 $this->schema(2, 'child', ['parent' => $this->relation('parent')]),
             ],
-            [
-                'cnt' => '2',
-                'mx'  => '2026-01-02 00:00:00',
-            ],
+            [$this->row(1), $this->row(2)],
             1
         );
         $this->assertTrue(
@@ -365,10 +372,7 @@ class ReferentialIntegrityIndexCacheTest extends TestCase
         // Prime the cache with a healthy token.
         $primed = $this->service(
             $catalogue,
-            [
-                'cnt' => '2',
-                'mx'  => '2026-01-01 00:00:00',
-            ],
+            [$this->row(1), $this->row(2)],
             1
         );
         $this->assertTrue($primed->hasIncomingOnDeleteReferences('1'));
@@ -414,10 +418,7 @@ class ReferentialIntegrityIndexCacheTest extends TestCase
                 $this->schema(1, 'parent'),
                 $this->schema(2, 'child', ['parent' => $this->relation('parent')]),
             ],
-            [
-                'cnt' => '2',
-                'mx'  => '2026-01-01 00:00:00',
-            ],
+            [$this->row(1), $this->row(2)],
             1
         );
 
@@ -436,28 +437,22 @@ class ReferentialIntegrityIndexCacheTest extends TestCase
      */
     public function testMalformedCachePayloadIsIgnored(): void
     {
-        $row = [
-            'cnt' => '2',
-            'mx'  => '2026-01-01 00:00:00',
+        $catalogue = [
+            $this->schema(1, 'parent'),
+            $this->schema(2, 'child', ['parent' => $this->relation('parent')]),
         ];
+        $rows      = [$this->row(1), $this->row(2)];
 
-        // Correct version token, but the index is not an array.
-        $this->cache->set(
-            'relation_index',
-            [
-                'version' => '2|2026-01-01 00:00:00',
-                'index'   => 'not-an-array',
-            ]
-        );
+        // Prime through the service so the stored token is genuinely current,
+        // rather than hard-coding a digest the implementation is free to change.
+        $this->assertTrue($this->service($catalogue, $rows, 1)->hasIncomingOnDeleteReferences('1'));
 
-        $service = $this->service(
-            [
-                $this->schema(1, 'parent'),
-                $this->schema(2, 'child', ['parent' => $this->relation('parent')]),
-            ],
-            $row,
-            1
-        );
+        // Corrupt only the payload, leaving the (correct) version in place.
+        $entry          = $this->cache->get('relation_index');
+        $entry['index'] = 'not-an-array';
+        $this->cache->set('relation_index', $entry);
+
+        $service = $this->service($catalogue, $rows, 1);
 
         $this->assertTrue(
             $service->hasIncomingOnDeleteReferences('1'),
@@ -465,6 +460,124 @@ class ReferentialIntegrityIndexCacheTest extends TestCase
         );
 
     }//end testMalformedCachePayloadIsIgnored()
+
+
+    /**
+     * Editing an EXISTING schema must invalidate the index.
+     *
+     * This is the regression test for the data-loss bug. The row count does not
+     * move on an edit, and `updated` is whole-second, so a token built from
+     * those two alone can compare equal across an edit that adds an incoming
+     * RESTRICT — the cache then answers "no incoming references", the RESTRICT
+     * is skipped, and a protected parent is deleted with no error.
+     *
+     * Here the schema is edited in place: same id, same row count, same
+     * `updated` stamp. Only `version` moves, exactly as
+     * SchemaMapper::updateFromArray() bumps it. The new RESTRICT must be seen.
+     *
+     * @return void
+     */
+    public function testEditedSchemaVersionInvalidatesIndex(): void
+    {
+        // Cache is primed while schema 2 does not reference schema 1.
+        $before = $this->service(
+            [$this->schema(1, 'parent'), $this->schema(2, 'child')],
+            [$this->row(1), $this->row(2, '0.0.1')],
+            1
+        );
+        $this->assertFalse($before->hasIncomingOnDeleteReferences('1'));
+
+        // Schema 2 is EDITED to add the relation. Count unchanged, `updated`
+        // unchanged (same clock second); only the version bumped.
+        $after = $this->service(
+            [
+                $this->schema(1, 'parent'),
+                $this->schema(2, 'child', ['parent' => $this->relation('parent')]),
+            ],
+            [$this->row(1), $this->row(2, '0.0.2')],
+            1
+        );
+
+        $this->assertTrue(
+            $after->hasIncomingOnDeleteReferences('1'),
+            'A RESTRICT added by EDITING an existing schema must invalidate the cached index'
+        );
+
+    }//end testEditedSchemaVersionInvalidatesIndex()
+
+
+    /**
+     * A catalogue edited within the settle window is never cached.
+     *
+     * `updated` is timestamp(0), so while the newest stamp is still inside the
+     * current clock second a second edit can land on the same value and be
+     * invisible. The token must be refused outright for that window: the index
+     * is rebuilt from the catalogue and nothing is written back.
+     *
+     * @return void
+     */
+    public function testRecentlyEditedCatalogueBypassesCacheEntirely(): void
+    {
+        $catalogue = [
+            $this->schema(1, 'parent'),
+            $this->schema(2, 'child', ['parent' => $this->relation('parent')]),
+        ];
+
+        // A schema was just edited: its stamp is this very second.
+        $rows = [
+            $this->row(1),
+            $this->row(2, '0.0.2', date('Y-m-d H:i:s')),
+        ];
+
+        $setCallsBefore = $this->cache->setCalls;
+
+        $service = $this->service($catalogue, $rows, 1);
+        $this->assertTrue($service->hasIncomingOnDeleteReferences('1'));
+
+        $this->assertSame(
+            $setCallsBefore,
+            $this->cache->setCalls,
+            'An index built over an unsettled catalogue must not be cached'
+        );
+        $this->assertSame(
+            [],
+            $this->cache->store,
+            'Nothing may be written while the newest schema edit is still inside the timestamp(0) window'
+        );
+
+    }//end testRecentlyEditedCatalogueBypassesCacheEntirely()
+
+
+    /**
+     * A stamp in the future is treated as unsettled, not as safely old.
+     *
+     * Clock skew, or a caller that supplied its own `updated`, must not be able
+     * to hand the cache a token it cannot vouch for.
+     *
+     * @return void
+     */
+    public function testFutureStampBypassesCache(): void
+    {
+        $catalogue = [
+            $this->schema(1, 'parent'),
+            $this->schema(2, 'child', ['parent' => $this->relation('parent')]),
+        ];
+
+        $rows = [
+            $this->row(1),
+            $this->row(2, '0.0.1', date('Y-m-d H:i:s', (time() + 3600))),
+        ];
+
+        $service = $this->service($catalogue, $rows, 1);
+        $this->assertTrue($service->hasIncomingOnDeleteReferences('1'));
+
+        $this->assertSame(
+            [],
+            $this->cache->store,
+            'A future modification stamp must disable the cache, not be read as settled'
+        );
+
+    }//end testFutureStampBypassesCache()
 
 
 }//end class

--- a/tests/Unit/Service/Object/ReferentialIntegrityServiceBranchTest.php
+++ b/tests/Unit/Service/Object/ReferentialIntegrityServiceBranchTest.php
@@ -46,8 +46,23 @@ class ReferentialIntegrityServiceBranchTest extends TestCase
             $this->objectMapper,
             $this->auditTrailMapper,
             $this->logger,
-            $this->createMock(IDBConnection::class)
+            $this->createMock(IDBConnection::class),
+            $this->createNullCacheFactory()
         );
+    }
+
+    /**
+     * Build a cache factory whose cache never reports a hit.
+     *
+     * @return \OCP\ICacheFactory
+     */
+    private function createNullCacheFactory(): \OCP\ICacheFactory
+    {
+        $factory = $this->createMock(\OCP\ICacheFactory::class);
+        $factory->method('createDistributed')
+            ->willReturn($this->createMock(\OCP\ICache::class));
+
+        return $factory;
     }
 
     private function createObjectMock(string $uuid, ?string $schemaId = null): ObjectEntity&MockObject

--- a/tests/Unit/Service/Object/ReferentialIntegrityServiceTest.php
+++ b/tests/Unit/Service/Object/ReferentialIntegrityServiceTest.php
@@ -86,8 +86,23 @@ class ReferentialIntegrityServiceTest extends TestCase
             $this->objectMapper,
             $this->auditTrailMapper,
             $this->logger,
-            $this->db
+            $this->db,
+            $this->createNullCacheFactory()
         );
+    }
+
+    /**
+     * Build a cache factory whose cache never reports a hit.
+     *
+     * @return \OCP\ICacheFactory
+     */
+    private function createNullCacheFactory(): \OCP\ICacheFactory
+    {
+        $factory = $this->createMock(\OCP\ICacheFactory::class);
+        $factory->method('createDistributed')
+            ->willReturn($this->createMock(\OCP\ICache::class));
+
+        return $factory;
     }
 
     // =========================================================================
@@ -2176,9 +2191,11 @@ class ReferentialIntegrityServiceTest extends TestCase
             ->method('findAll')
             ->willReturn([$schema, $schema2]);
 
-        $this->registerMapper->expects($this->once())
-            ->method('findAll')
-            ->willReturn([]);
+        // The register catalogue backs the schema-to-register map, which is only
+        // needed when APPLYING an integrity action. Answering "are there any
+        // incoming onDelete references?" must not hydrate it.
+        $this->registerMapper->expects($this->never())
+            ->method('findAll');
 
         // Call twice — should only load schemas once.
         $this->service->hasIncomingOnDeleteReferences('2');

--- a/tests/Unit/Service/ReferentialIntegrityServiceCoverageTest.php
+++ b/tests/Unit/Service/ReferentialIntegrityServiceCoverageTest.php
@@ -63,8 +63,23 @@ class ReferentialIntegrityServiceCoverageTest extends TestCase
             $this->objectMapper,
             $this->auditTrailMapper,
             $this->logger,
-            $this->createMock(IDBConnection::class)
+            $this->createMock(IDBConnection::class),
+            $this->createNullCacheFactory()
         );
+    }
+
+    /**
+     * Build a cache factory whose cache never reports a hit.
+     *
+     * @return \OCP\ICacheFactory
+     */
+    private function createNullCacheFactory(): \OCP\ICacheFactory
+    {
+        $factory = $this->createMock(\OCP\ICacheFactory::class);
+        $factory->method('createDistributed')
+            ->willReturn($this->createMock(\OCP\ICache::class));
+
+        return $factory;
     }
 
     private function invokeMethod(object $obj, string $method, array $args = []): mixed

--- a/tests/Unit/Service/ReferentialIntegrityServiceTest.php
+++ b/tests/Unit/Service/ReferentialIntegrityServiceTest.php
@@ -118,11 +118,31 @@ class ReferentialIntegrityServiceTest extends TestCase
             objectEntityMapper: $this->objectMapper,
             auditTrailMapper: $this->auditTrailMapper,
             logger: $this->logger,
-            db: $this->createMock(IDBConnection::class)
+            db: $this->createMock(IDBConnection::class),
+            cacheFactory: $this->createNullCacheFactory()
         );
 
         $this->reflection = new \ReflectionClass($this->service);
     }//end setUp()
+
+
+    /**
+     * Build a cache factory whose cache never reports a hit.
+     *
+     * Keeps these tests exercising a freshly built relation index, which is the
+     * behaviour they were originally written against.
+     *
+     * @return \OCP\ICacheFactory
+     */
+    private function createNullCacheFactory(): \OCP\ICacheFactory
+    {
+        $factory = $this->createMock(\OCP\ICacheFactory::class);
+        $factory->method('createDistributed')
+            ->willReturn($this->createMock(\OCP\ICache::class));
+
+        return $factory;
+
+    }//end createNullCacheFactory()
 
     // ─── Helper methods ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Where the ~430 ms actually went

DELETE was the last CRUD outlier. The preamble was already ruled out at 14 ms (`4f432f297`), which put the cost past `del.permitted`, and of the ~650 ms that remained only 219 ms was traced. This attributes the rest **by bisection**, not by picking from the candidate list (referential integrity / cascade / file cleanup / audit sealing).

New stamps bracket the delete handler (`del.handler.in`, `del.ctx`, `del.integrity`, `del.org`, `del.update`, `del.cache`, `del.audit`) and, inside it, the integrity gate (`del.relindex`, `del.legacycascade`). Same `/tmp/or-trace-write-phases` gate as the rest of `WritePhaseProbe` — one `file_exists` per process when off.

On a quiet host (load **4.53**, matching the 4.6 reference), the bisect was unambiguous:

| segment | median |
|---|---|
| `del.ctx` → `del.relindex` | **~324 ms** |
| `del.relindex` → `del.legacycascade` (legacy cascade) | 0–1 ms |
| `del.org` → `del.update` (save path + event dispatch) | ~475 ms |
| `del.cache` → `del.audit` (audit trail) | ~20 ms |

So the unattributed cost was **one boolean question**: *does this schema have incoming `onDelete` references?*

Answering it called `ensureRelationIndex()`, which hydrated **every schema on the instance — 1,935 of them** — to discover which declare an `onDelete` relation. Only **121** can (`properties::text LIKE '%onDelete%'`), and for `larpingapp/character` the answer is simply *no*. Deletes were paying a full catalogue scan to be told there was nothing to do.

The caller, not the symptom: this is not "storage is slow", it is a boolean gate doing an O(catalogue) hydration.

## The fix

Two changes, both semantics-preserving:

1. **The relation index is cached across requests.** It is a small pure-array derivative of schema definitions, which change rarely. A stale index is not possible: the entry is keyed on a version token from one cheap aggregate (`COUNT(*)`, `MAX(updated)`) over the schema table, so any insert, delete or update misses. **If the token cannot be computed the cache is bypassed rather than trusted** — a missed `RESTRICT` would delete data that should have been protected, so this fails towards the slow-but-correct path. The TTL is a backstop only; correctness comes from the token.

2. **The heavy hydration is lazy.** `schemaCache` + `schemaRegisterMap` move to `ensureSchemaDetail()`, called by the three methods that actually read them. All three are on the *apply* path (cascade, set-null, required-property checks), which only runs when a schema really does have incoming `onDelete` references. Verified: all three key on `sourceSchemaId` — i.e. schemas that *declare* a relation — so narrowing is lossless.

## Controlled A/B at identical load

Interleaved OLD/NEW on alternating requests so both arms see the same host (a temporary file-gated bypass, not part of this diff). Load **16.87 → 15.71** across the run, n=12 per arm:

| | relindex segment (median) | delete wall (median) |
|---|---|---|
| OLD | 349 ms | 1.642 s |
| NEW | **2 ms** | **1.238 s** |

**−347 ms of index build, −404 ms of wall.** The two agree, which is what you want.

## Full CRUD table

⚠️ Another session was running scholiq e2e (headless Chrome, ~235% CPU) throughout the "after" run, so **the after-run is at *higher* load than the before-run**. The delete improvement is understated here, not flattered.

**Before** — load `8.38, 15.15, 17.12`, floor 200 ms:

| operation | min | med | p95 | minus floor |
|---|---|---|---|---|
| create | 800 | 1245 | 1898 | 1045 ms |
| read | 212 | 280 | 1120 | 80 ms |
| search | 163 | 220 | 1148 | 20 ms |
| update | 575 | 931 | 1860 | 731 ms |
| **delete** | 1079 | **1394** | 2237 | **1194 ms** |

**After** — load `12.43, 16.49, 14.63`, floor 193 ms:

| operation | min | med | p95 | minus floor |
|---|---|---|---|---|
| create | 601 | 948 | 1825 | 755 ms |
| read | 204 | 250 | 899 | 57 ms |
| search | 163 | 194 | 358 | 1 ms |
| update | 549 | 778 | 1577 | 585 ms |
| **delete** | 520 | **677** | 1440 | **484 ms** |

Absolutes across the two runs are not comparable (different load), so the ratio is the honest measure:

- **delete ÷ create, above floor: 1.14 → 0.64.**

Delete went from *the most expensive write* to *the cheapest*. It is no longer an outlier.

## Notes

- `phpcs` 0 errors on both touched files. 1 pre-existing class-level `@spec` warning each, left alone — I am not inventing `@spec` values.
- `ICacheFactory` is autowired; `ReferentialIntegrityService` has no explicit DI registration.
- **Not done:** no unit test for the version-token invalidation. It is the load-bearing correctness claim of this PR and deserves one (assert a schema update busts the cache). Flagging rather than quietly omitting.
