### PR TITLE
docs(openspec): change proposal for the object read visibility gate

### DIFF
--- a/openspec/changes/fix-object-read-visibility-gate/proposal.md
+++ b/openspec/changes/fix-object-read-visibility-gate/proposal.md
@@ -1,0 +1,77 @@
+# Fix object read visibility gated on the CREATE permission
+
+## Why
+
+`PermissionHandler::filterObjectsForPermissions()` is the object-level visibility
+filter on the **read** path. It gates visibility on the **create** permission:
+
+```php
+// Property-level RBAC ... this loop only decides object-level visibility.
+if ($this->hasPermission(
+        schema: $schema,
+        action: 'create',   // <-- gating READ visibility on CREATE
+        userId: $userId,
+        objectOwner: $objectOwner,
+        _rbac: $_rbac
+    ) === false
+) {
+    continue;   // object hidden
+}
+```
+
+`lib/Service/Object/PermissionHandler.php` ~line 911. The comment directly above
+states the loop decides visibility, and it asks for `create`.
+
+### Consequence
+
+On **any** register, a user who may not *create* a schema's objects cannot *see*
+them either. Read-only consumers are the normal case, so this is broad.
+
+Observed on openbuild (Conduction/openbuild#76): the `openbuild/application`
+schema authorises `create: ["admin"]`, so every non-admin fails the check and the
+object is skipped:
+
+| Caller | Raw OR objects | openbuild app list |
+|---|---|---|
+| admin | 21 | all |
+| `rbac-editor` (granted editor on an app) | **0** | none |
+
+The app-level permission model is therefore unreachable for exactly the users it
+exists to serve: an owner can grant a team editor/viewer on an app and those
+users still see nothing. The affordance exists and does not work.
+
+### Second gap: no way to express "any authenticated user"
+
+`resolveReadGroupIds()` treats `public` and `admin` as broadcast sentinels.
+`public` means **anonymous** (`isPublicReadable()` explicitly replaced the
+published/depublished gate). There is no value meaning "any logged-in caller but
+not anonymous", so that intent currently cannot be expressed at all — the only
+way to approximate it publishes the data.
+
+## What changes
+
+1. The read path gates on `read`, not `create`.
+2. A new `users` sentinel means "any authenticated caller, never anonymous".
+
+## Open question — resolve BEFORE implementing
+
+Adding `read: ['rbac-editors']` flipped `rbac-editor` from 0 to 21 objects, even
+though the gate above asks for `create`. Something on that path consults read
+rules and it is not yet known what. Until that is explained, a fix here is a
+guess that happens to work, and the verification matrix below cannot be trusted
+to mean what it says.
+
+## Blast radius
+
+OpenRegister is the foundation every Conduction app builds on. A wrong read gate
+either hides data everywhere or exposes it everywhere, silently — which is
+exactly what the `create` gate has been doing undetected. This change is not
+shippable without the full matrix in `tasks.md`.
+
+## Impact
+
+- Unblocks Conduction/openbuild#76 and four quarantined e2e scenarios
+  (`versionRouting` 9.2, `schema-access-scopes-rbac` ×3, plus the viewer-gating
+  assertion omitted from `save-as-template`).
+- Likely unblocks equivalent read-only-consumer cases in other apps on shared
+  registers; worth checking before and after.

--- a/openspec/changes/fix-object-read-visibility-gate/tasks.md
+++ b/openspec/changes/fix-object-read-visibility-gate/tasks.md
@@ -1,0 +1,71 @@
+# Tasks — fix object read visibility gate
+
+Phases 0 and 3 are the work. Phases 1–2 are ~15 lines and must not be written
+before Phase 0 is answered.
+
+## 0. Ground truth (blocking — do first)
+
+- [ ] 0.1 Trace `PermissionHandler::hasPermission()` end to end: which actions
+      exist, how owner / group / `public` are resolved, and whether `read` is
+      honoured the same way `create` is.
+- [ ] 0.2 **Explain the anomaly.** Setting `read: ['rbac-editors']` on schema 18
+      flipped `rbac-editor` from 0 to 21 visible objects, even though the
+      visibility gate asks for `create`. Identify what consults read rules on
+      that path. Do not proceed until this is understood — the whole diagnosis
+      rests on it.
+- [ ] 0.3 Record the answer in this change's `design.md`.
+
+## 1. Correctness fix
+
+- [ ] 1.1 `lib/Service/Object/PermissionHandler.php`,
+      `filterObjectsForPermissions()` (~line 911): `action: 'create'` →
+      `action: 'read'`.
+- [ ] 1.2 Audit the sibling call sites for the same mistake before touching
+      them: `filterUuidsForPermissions()`, the single-object read path (see the
+      isolation comment in `MagicMapper` ~5265), `RenderObject` ~1766.
+- [ ] 1.3 Preserve fail-closed behaviour: an unresolvable authorization must
+      still hide the object (`resolveReadGroupIds()` logs "fail-closed" ~1565).
+
+## 2. `users` sentinel
+
+- [ ] 2.1 `resolveReadGroupIds()` and `extractGroupIdsFromReadEntries()`:
+      recognise `users` alongside the existing `public` / `admin` broadcast
+      values.
+- [ ] 2.2 `users` means **any authenticated caller, never anonymous**. The
+      anonymous path (`groupId: 'public'`, ~516/538/647) must NOT match it —
+      that distinction is the entire point of the value.
+- [ ] 2.3 Document the three read values (`public`, `users`, named group) where
+      the authorization block is described.
+
+## 3. Verification matrix (shippability gate)
+
+Each row asserted, not reasoned about:
+
+- [ ] 3.1 anonymous + `read: ['public']` → visible
+- [ ] 3.2 anonymous + `read: ['users']` → **not** visible
+- [ ] 3.3 authenticated non-member + `read: ['users']` → visible at the OR layer,
+      filtered to nothing by the consuming app's own permission check
+- [ ] 3.4 authenticated + named group → visible only when in that group
+- [ ] 3.5 admin → unchanged (bypass)
+- [ ] 3.6 owner-only object → unchanged
+- [ ] 3.7 openbuild e2e suite stays green (30+ tests currently passing)
+- [ ] 3.8 at least one other app on a shared register re-run — OR is the
+      foundation, so regressions surface elsewhere first
+
+## 4. openbuild follow-through (separate PR, after 1–3 land)
+
+- [ ] 4.1 Set `read: ['users']` on the `application` schema in
+      `openbuild/lib/Settings/openbuild_register.json`.
+      ⚠️ Register schema changes need a FORCED import to apply — a normal import
+      advances the version WITHOUT applying the change.
+- [ ] 4.2 Un-skip `versionRouting` 9.2 and `schema-access-scopes-rbac` (3), and
+      add the viewer-gating assertion to `save-as-template`. Fixture groundwork
+      is already in `openbuild/tests/e2e/support/appRoles.ts`; RBAC users and
+      per-role sessions come from `globalSetup`.
+- [ ] 4.3 Revert the experimental `read: ['rbac-editors']` left on schema 18 of
+      the `ob-vue3-e2e` (:8099) instance during investigation.
+
+## Evidence
+
+Full measurement trail, including the raw numbers and the code references, is in
+Conduction/openbuild#76.


### PR DESCRIPTION
Proposal only — **no code changes**. Records a defect found while driving openbuild's quarantined permission suites (Conduction/openbuild#76), so the diagnosis and plan survive outside a chat session.

## The defect

`PermissionHandler::filterObjectsForPermissions()` — the object-level visibility filter on the **read** path — gates visibility on the **create** permission (`lib/Service/Object/PermissionHandler.php` ~911). The comment directly above it says the loop decides visibility; it asks for `create`.

On **any** register, a user who may not *create* a schema's objects cannot *see* them either. Read-only consumers are the normal case.

Measured on openbuild, whose `application` schema authorises `create: ["admin"]`:

| Caller | Raw OR objects | app list |
|---|---|---|
| admin | 21 | all |
| granted editor | **0** | none |

So an owner can grant a team editor/viewer on an app and those users still see nothing — the affordance exists and doesn't work.

## Second gap

`public` means **anonymous**; `admin` is also treated as broadcast. There is no value meaning *any authenticated caller*, so that intent can't be expressed without publishing the data. The proposal adds a `users` sentinel.

## Why proposal-only

`tasks.md` front-loads the two things that make this shippable:

- **Phase 0** — an unexplained observation that must be resolved first: adding `read: ['rbac-editors']` changed visibility even though the gate asks for `create`. Something consults read rules on that path. Any fix before that is a guess that happens to work.
- **Phase 3** — a six-row verification matrix (anonymous vs `public` vs `users`, member vs non-member, admin, owner-only) plus dependent-app suites.

The code change itself is ~15 lines. OpenRegister is the foundation every Conduction app builds on: a wrong read gate hides data everywhere or exposes it everywhere, silently — precisely what the `create` gate has been doing undetected. Not something to land unverified.

Full measurement trail in Conduction/openbuild#76.