### PR TITLE
fix(rbac): correct the read-visibility diagnosis and delete the dead gate

### DIFF
--- a/docs/features/organisation-roles.md
+++ b/docs/features/organisation-roles.md
@@ -667,10 +667,15 @@ Request → PermissionHandler → SaveObject/RenderObject → Response
 | Operation | Schema RBAC | Property RBAC |
 |-----------|------------|---------------|
 | **Create** | `SaveObject` calls `PermissionHandler.checkPermission()` | `PropertyRbacHandler.getUnauthorizedProperties()` validates incoming data |
-| **Read** | `PermissionHandler.hasPermission()` filters the result set | `PropertyRbacHandler.filterReadableProperties()` strips unauthorized fields from response |
+| **Read** | `MagicRbacHandler.buildRbacConditionsSql(action: 'read')` filters in SQL, before rows are loaded | `PropertyRbacHandler.filterReadableProperties()` strips unauthorized fields from response |
 | **Update** | `SaveObject` calls `PermissionHandler.checkPermission()` | `PropertyRbacHandler.getUnauthorizedProperties()` validates incoming data |
 | **Delete** | `SaveObject` calls `PermissionHandler.checkPermission()` | N/A |
-| **List** | `PermissionHandler.filterObjectsForPermissions()` filters results | Property filtering applied per-object during rendering |
+| **List** | Same SQL gate as Read — `MagicRbacHandler.buildRbacConditionsSql(action: 'read')` via `MagicSearchHandler` | Property filtering applied per-object during rendering |
+
+> Read and List share one enforcement point, and it is in SQL. There is no
+> post-load object filter in `PermissionHandler` — see the note where one used
+> to be. `PermissionHandler` owns the single-object verdict (`hasPermission()` /
+> `checkPermission()`), which is what Create, Update and Delete call.
 
 ### Database-Level Enforcement
 

--- a/lib/Service/Object/PermissionHandler.php
+++ b/lib/Service/Object/PermissionHandler.php
@@ -73,6 +73,8 @@ use Psr\Container\ContainerInterface;
  * @SuppressWarnings(PHPMD.NPathComplexity)          RBAC rules handle user/group/owner/public/conditional combos - cartesian product drives NPath
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)   RBAC needs IUserSession, IUserManager, IGroupManager, ConditionMatcher, Register/Schema mappers
  * @SuppressWarnings(PHPMD.ExcessiveClassLength)     All RBAC logic is centralised per ADR-011; splitting would re-scatter the security policy
+ *
+ * @spec openspec/specs/rbac-scopes/spec.md
  */
 class PermissionHandler
 {
@@ -811,6 +813,8 @@ class PermissionHandler
      * @param int|null $schemaId Specific schema to evict, or null to clear all.
      *
      * @return void
+     *
+     * @spec openspec/specs/rbac-scopes/spec.md
      */
     public function clearInheritFromPublicCache(?int $schemaId=null): void
     {
@@ -874,82 +878,20 @@ class PermissionHandler
         }
     }//end checkPermission()
 
-    /**
-     * Filter objects array based on RBAC and multi-tenancy permissions
+    /*
+     * NOTE: there is deliberately no object-level read filter here.
      *
-     * Removes objects from the array that the current user doesn't have permission to access
-     * or that belong to a different organization in multi-tenant mode.
+     * Listing is filtered in SQL by MagicRbacHandler::buildRbacConditionsSql()
+     * (action: 'read'), called from MagicSearchHandler — unauthorised rows are
+     * never loaded, which also keeps pagination correct. A post-load filter in
+     * this class would duplicate that gate and silently disagree with it.
      *
-     * @param array<array<string, mixed>> $objects       Array of objects to filter.
-     * @param bool                        $_rbac         Whether to apply RBAC filtering.
-     * @param bool                        $_multitenancy Whether to apply multitenancy filtering.
-     *
-     * @return array[] Filtered array of objects
-     *
-     * @psalm-return list<array<string, mixed>>
-     *
-     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Permission filtering requires multiple conditional checks
-     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)  RBAC/multitenancy flags follow established API patterns
-     *
-     * @spec openspec/specs/rbac-scopes/spec.md
+     * A `filterObjectsForPermissions()` method used to live at this spot. It had
+     * no production caller and gated visibility on `create`, so it read as the
+     * live read gate while never running — which cost a full investigation to
+     * establish (openspec/changes/fix-object-read-visibility-gate/design.md).
+     * Please do not reintroduce it; extend the SQL gate instead.
      */
-    public function filterObjectsForPermissions(array $objects, bool $_rbac, bool $_multitenancy): array
-    {
-        $filteredObjects = [];
-        $currentUser     = $this->userSession->getUser();
-        $userId          = null;
-        if ($currentUser !== null) {
-            $userId = $currentUser->getUID();
-        }
-
-        $activeOrganisation = $this->getActiveOrganisationForContext();
-
-        foreach ($objects as $object) {
-            $self = $object['@self'] ?? [];
-
-            // Check RBAC permissions if enabled.
-            if ($_rbac === true && $userId !== null) {
-                $objectOwner  = $self['owner'] ?? null;
-                $objectSchema = $self['schema'] ?? null;
-
-                if ($objectSchema !== null) {
-                    try {
-                        $schema = $this->schemaMapper->find($objectSchema);
-                        // Property-level RBAC (per-property authorization + writeOnly
-                        // stripping) is enforced on the read path by PropertyRbacHandler
-                        // via RenderObject; this loop only decides object-level visibility.
-                        if ($this->hasPermission(
-                                schema: $schema,
-                                action: 'create',
-                                userId: $userId,
-                                objectOwner: $objectOwner,
-                                _rbac: $_rbac
-                            ) === false
-                        ) {
-                            continue;
-                            // Skip this object if user doesn't have permission.
-                        }
-                    } catch (Exception $e) {
-                        // Skip objects with invalid schemas.
-                        continue;
-                    }//end try
-                }//end if
-            }//end if
-
-            // Check multi-organization filtering if enabled.
-            if ($_multitenancy === true && $activeOrganisation !== null) {
-                $objectOrganisation = $self['organisation'] ?? null;
-                if ($objectOrganisation !== null && $objectOrganisation !== $activeOrganisation) {
-                    continue;
-                    // Skip objects from different organizations.
-                }
-            }
-
-            $filteredObjects[] = $object;
-        }//end foreach
-
-        return $filteredObjects;
-    }//end filterObjectsForPermissions()
 
     /**
      * Filter UUIDs based on RBAC and multi-tenancy permissions
@@ -1838,6 +1780,8 @@ class PermissionHandler
      * does not hard-deny every authenticated read.
      *
      * @return bool The configured tenant default (true when unconfigured/unreachable).
+     *
+     * @spec openspec/specs/rbac-scopes/spec.md
      */
     public function inheritFromPublicTenantDefault(): bool
     {

--- a/openspec/changes/fix-object-read-visibility-gate/design.md
+++ b/openspec/changes/fix-object-read-visibility-gate/design.md
@@ -1,0 +1,71 @@
+# Design note — how the first diagnosis went wrong
+
+Phase 0.3 of the original `tasks.md` asked for the anomaly to be recorded here.
+The anomaly turned out to be the load-bearing detail, so this note keeps both
+the answer and the reasoning error that made it necessary.
+
+## The anomaly, and its answer
+
+**Observed:** setting `read: ['rbac-editors']` on schema 18 flipped
+`rbac-editor` from 0 visible objects to 21 — even though the gate the first
+proposal blamed asks for `create`, which no `read` rule can satisfy.
+
+**Answer:** that gate never executed. Object listing is filtered in SQL by
+`MagicRbacHandler::buildRbacConditionsSql(schema, action: 'read')`. The `read`
+rule was consumed by the SQL gate, which is the only gate on that path. The
+result was not surprising; the model of the code was wrong.
+
+## Why the wrong conclusion looked well-evidenced
+
+The first proposal was not built on a guess. It had a code reference, a comment
+directly above the line stating the loop decides visibility, a measured
+21-vs-0 table, and a doc page naming that function as the List enforcement
+point. Every one of those was real. The conclusion was still wrong, because a
+step was assumed rather than checked:
+
+**Nobody asked whether the function had a caller.**
+
+One `grep -rn filterObjectsForPermissions` across `lib/` answers it in seconds
+and returns nothing but the definition. That check was never run, because the
+function *looked* live: it is public, documented, `@spec`-annotated, covered by
+a test, and described in the feature docs. Dead code that is well maintained is
+indistinguishable from live code at a glance.
+
+The 21-vs-0 measurement then reinforced the error. It was a true measurement of
+a real effect, and it was compatible with the wrong model only because the
+wrong model was never asked to predict it. When the proposal noticed the
+mismatch, it recorded it as an "open question" and carried on — the mismatch
+*was* the refutation.
+
+## The rule this yields
+
+> A code path is not established as live by reading it. Evidence that it is
+> reached — a caller, a log line, a breakpoint, a deliberate break — is a
+> separate fact and has to be gathered separately.
+
+Corollary, and the one that actually cost the time here: **when a measurement
+does not fit the model, that is the finding.** Filing it as an open question
+next to the conclusion it contradicts preserves the conclusion at the expense
+of the evidence.
+
+## Artefacts to correct
+
+- `docs/features/organisation-roles.md:670,673` — names `hasPermission()` and
+  `filterObjectsForPermissions()` as the Read/List enforcement points. The live
+  one is `MagicRbacHandler::buildRbacConditionsSql()`. This doc line is part of
+  why the wrong function looked live and should be fixed with the code.
+- Conduction/openbuild#76 — carries the superseded diagnosis in its comments;
+  needs the correction before anyone acts on it.
+
+## Cross-handler contract, as measured
+
+| Authorization block | List (`MagicRbacHandler`) | `resolveReadGroupIds()` |
+|---|---|---|
+| absent / empty | open to all (`:1024` bypass) | broadcast (`:1610`) |
+| non-empty, no `read` key | **owner-only** (`:1029`→`:1041`) | **broadcast** (`:1614`) |
+| `read: ['public']` | anonymous, plus authenticated when `inheritFromPublic` | broadcast (`:1625`) |
+| `read: ['authenticated']` | any logged-in caller (`:413`) | targeted list |
+| `read: ['<group>']` | members of that group | members of that group |
+
+Row 2 is the disagreement recorded as item 3 of the proposal. Rows 1, 3, 4 and
+5 agree across both paths.

--- a/openspec/changes/fix-object-read-visibility-gate/proposal.md
+++ b/openspec/changes/fix-object-read-visibility-gate/proposal.md
@@ -1,77 +1,93 @@
-# Fix object read visibility gated on the CREATE permission
+# Object read visibility — corrected diagnosis
 
-## Why
+> **This proposal replaces its own first version (#2251).** That version claimed
+> the read path gated on `create` and that OpenRegister could not express "any
+> authenticated user". Phase 0 disproved both. The original reasoning is
+> preserved in `design.md` alongside the evidence that overturned it, because
+> how the wrong conclusion was reached is the more useful artefact.
 
-`PermissionHandler::filterObjectsForPermissions()` is the object-level visibility
-filter on the **read** path. It gates visibility on the **create** permission:
+## What Phase 0 established
 
-```php
-// Property-level RBAC ... this loop only decides object-level visibility.
-if ($this->hasPermission(
-        schema: $schema,
-        action: 'create',   // <-- gating READ visibility on CREATE
-        userId: $userId,
-        objectOwner: $objectOwner,
-        _rbac: $_rbac
-    ) === false
-) {
-    continue;   // object hidden
-}
+### The list gate is correct
+
+Object listing is filtered in SQL by
+`MagicRbacHandler::buildRbacConditionsSql(schema, action: 'read')`
+(`lib/Db/MagicMapper/MagicRbacHandler.php:988`, called from
+`MagicSearchHandler.php:579`). It asks for `read`. There is no `create` gate on
+the live read path.
+
+### The `create` gate is real but dead
+
+`PermissionHandler::filterObjectsForPermissions()`
+(`lib/Service/Object/PermissionHandler.php:896`) does gate visibility on
+`action: 'create'` — and has **no production caller**. Repo-wide, the only
+reference is `tests/Service/ObjectHandlersIntegrationTest.php:1436`, which
+invokes it with `_rbac: false` and therefore never reaches the check.
+
+Its sibling `filterUuidsForPermissions()` gates on `action: 'delete'`, which
+looked like the same mistake and is not: its only caller is
+`ObjectService::deleteObjects()` (`ObjectService.php:3693`). `delete` is the
+correct action there. That concern is withdrawn.
+
+### The `authenticated` pseudo-group already exists
+
+`authenticated` is implemented in all three handlers
+(`MagicRbacHandler.php:413` and `:495`, `PermissionHandler.php:594`,
+`PropertyRbacHandler.php:786`) and is already specified in
+`openspec/specs/rbac-scopes/spec.md:178` and `:205`. The claimed gap does not
+exist; no new sentinel is needed.
+
+## The actual root cause of the openbuild blackout
+
+A **non-empty** authorization block that omits `read` deliberately fails closed.
+`buildRbacConditionsSql` returns `bypass => true` only for an *empty* block
+(`:1024`); a populated block with no `read` key produces `$rules = []` (`:1029`)
+and falls through to the owner condition alone (`:1041`), so a non-owner matches
+nothing and sees zero rows. The behaviour is intentional and commented as such
+at `:1031`.
+
+Every schema in `openbuild/lib/Settings/openbuild_register.json` carries
+
+```json
+"authorization": { "create": ["admin"], "update": ["admin"], "delete": ["admin"] }
 ```
 
-`lib/Service/Object/PermissionHandler.php` ~line 911. The comment directly above
-states the loop decides visibility, and it asks for `create`.
+— non-empty, no `read`. All six (Application, ApplicationVersion,
+ApplicationTemplate, BuiltAppRoute, HelloMessage, exportJob) are therefore
+owner-only for every non-admin caller. That is the whole of
+Conduction/openbuild#76.
 
-### Consequence
+**The fix is one key in openbuild, not a change to OpenRegister.** Adding
+`"read": ["authenticated"]` uses a facility OpenRegister already ships.
 
-On **any** register, a user who may not *create* a schema's objects cannot *see*
-them either. Read-only consumers are the normal case, so this is broad.
+This also explains the anomaly the first proposal could not: adding
+`read: ['rbac-editors']` flipped `rbac-editor` from 0 to 21 because it supplied
+the missing `read` rule to the SQL gate. Nothing consulted the `create` gate; it
+was never running.
 
-Observed on openbuild (Conduction/openbuild#76): the `openbuild/application`
-schema authorises `create: ["admin"]`, so every non-admin fails the check and the
-object is skipped:
+## What still changes in OpenRegister
 
-| Caller | Raw OR objects | openbuild app list |
-|---|---|---|
-| admin | 21 | all |
-| `rbac-editor` (granted editor on an app) | **0** | none |
+Only defects that survived verification, all minor:
 
-The app-level permission model is therefore unreachable for exactly the users it
-exists to serve: an owner can grant a team editor/viewer on an app and those
-users still see nothing. The affordance exists and does not work.
-
-### Second gap: no way to express "any authenticated user"
-
-`resolveReadGroupIds()` treats `public` and `admin` as broadcast sentinels.
-`public` means **anonymous** (`isPublicReadable()` explicitly replaced the
-published/depublished gate). There is no value meaning "any logged-in caller but
-not anonymous", so that intent currently cannot be expressed at all — the only
-way to approximate it publishes the data.
-
-## What changes
-
-1. The read path gates on `read`, not `create`.
-2. A new `users` sentinel means "any authenticated caller, never anonymous".
-
-## Open question — resolve BEFORE implementing
-
-Adding `read: ['rbac-editors']` flipped `rbac-editor` from 0 to 21 objects, even
-though the gate above asks for `create`. Something on that path consults read
-rules and it is not yet known what. Until that is explained, a fix here is a
-guess that happens to work, and the verification matrix below cannot be trusted
-to mean what it says.
-
-## Blast radius
-
-OpenRegister is the foundation every Conduction app builds on. A wrong read gate
-either hides data everywhere or exposes it everywhere, silently — which is
-exactly what the `create` gate has been doing undetected. This change is not
-shippable without the full matrix in `tasks.md`.
+1. **Dead code with a misleading action.** `filterObjectsForPermissions()` reads
+   as the object-level read filter and is not wired to anything. Left as is, the
+   next reader repeats this investigation — as this proposal did.
+2. **Documentation that points at it.** `docs/features/organisation-roles.md:673`
+   names `filterObjectsForPermissions()` as the List enforcement point, and
+   `:670` names `hasPermission()` as the Read result-set filter. Neither is what
+   runs; `MagicRbacHandler` is.
+3. **An inconsistency to investigate, not yet a confirmed bug.**
+   `PermissionHandler::resolveReadGroupIds()` (`:1608`) treats a missing `read`
+   key as broadcast, where the list path treats it as owner-only. It feeds
+   `getReadableByUsers()` (notification fan-out), so the two paths disagree about
+   what a schema without a `read` key means. Whether that produces a user-visible
+   wrong outcome has not been established, and must not be "fixed" on the
+   strength of the asymmetry alone.
 
 ## Impact
 
-- Unblocks Conduction/openbuild#76 and four quarantined e2e scenarios
-  (`versionRouting` 9.2, `schema-access-scopes-rbac` ×3, plus the viewer-gating
-  assertion omitted from `save-as-template`).
-- Likely unblocks equivalent read-only-consumer cases in other apps on shared
-  registers; worth checking before and after.
+- Conduction/openbuild#76 is unblocked by an openbuild-side change.
+- No behavioural change to OpenRegister. Items 1–2 are cleanup; item 3 is an
+  investigation.
+- Blast radius is correspondingly small — the earlier framing, that a wrong read
+  gate was silently mis-filtering every app on every register, was incorrect.

--- a/openspec/changes/fix-object-read-visibility-gate/tasks.md
+++ b/openspec/changes/fix-object-read-visibility-gate/tasks.md
@@ -1,71 +1,71 @@
-# Tasks — fix object read visibility gate
+# Tasks — object read visibility
 
-Phases 0 and 3 are the work. Phases 1–2 are ~15 lines and must not be written
-before Phase 0 is answered.
+Phase 0 is complete and changed the plan. Phases 1–3 of the original task list
+(swap `create`→`read`, add a `users` sentinel, prove a six-row matrix) are
+**withdrawn**: the first is a change to dead code, the second duplicates the
+existing `authenticated` pseudo-group, and the third was written to verify a
+behavioural change that is no longer being made.
 
-## 0. Ground truth (blocking — do first)
+## 0. Ground truth — DONE
 
-- [ ] 0.1 Trace `PermissionHandler::hasPermission()` end to end: which actions
-      exist, how owner / group / `public` are resolved, and whether `read` is
-      honoured the same way `create` is.
-- [ ] 0.2 **Explain the anomaly.** Setting `read: ['rbac-editors']` on schema 18
-      flipped `rbac-editor` from 0 to 21 visible objects, even though the
-      visibility gate asks for `create`. Identify what consults read rules on
-      that path. Do not proceed until this is understood — the whole diagnosis
-      rests on it.
-- [ ] 0.3 Record the answer in this change's `design.md`.
+- [x] 0.1 Trace the live read path. It is
+      `MagicSearchHandler:579` → `MagicRbacHandler::buildRbacConditionsSql(action: 'read')`.
+- [x] 0.2 Explain the anomaly. The `create` gate never ran —
+      `filterObjectsForPermissions()` has no production caller. The `read` rule
+      was consumed by the SQL gate. See `design.md`.
+- [x] 0.3 Record the answer in `design.md`, including the cross-handler contract
+      table and the reasoning error that made this phase necessary.
 
-## 1. Correctness fix
+## 1. openbuild fix (the actual unblock)
 
-- [ ] 1.1 `lib/Service/Object/PermissionHandler.php`,
-      `filterObjectsForPermissions()` (~line 911): `action: 'create'` →
-      `action: 'read'`.
-- [ ] 1.2 Audit the sibling call sites for the same mistake before touching
-      them: `filterUuidsForPermissions()`, the single-object read path (see the
-      isolation comment in `MagicMapper` ~5265), `RenderObject` ~1766.
-- [ ] 1.3 Preserve fail-closed behaviour: an unresolvable authorization must
-      still hide the object (`resolveReadGroupIds()` logs "fail-closed" ~1565).
+- [ ] 1.1 Add `"read": ["authenticated"]` to the authorization block of all six
+      schemas in `openbuild/lib/Settings/openbuild_register.json`.
+      Anonymous callers stay excluded — `authenticated` requires `$userId !== null`
+      (`MagicRbacHandler.php:414`).
+- [ ] 1.2 Re-import with **force**. A normal import advances the version WITHOUT
+      applying the change.
+- [ ] 1.3 Verify against the live instance, not by reading the JSON: a non-admin
+      session lists the applications, and an anonymous request still does not.
 
-## 2. `users` sentinel
+## 2. openbuild test follow-through
 
-- [ ] 2.1 `resolveReadGroupIds()` and `extractGroupIdsFromReadEntries()`:
-      recognise `users` alongside the existing `public` / `admin` broadcast
-      values.
-- [ ] 2.2 `users` means **any authenticated caller, never anonymous**. The
-      anonymous path (`groupId: 'public'`, ~516/538/647) must NOT match it —
-      that distinction is the entire point of the value.
-- [ ] 2.3 Document the three read values (`public`, `users`, named group) where
-      the authorization block is described.
-
-## 3. Verification matrix (shippability gate)
-
-Each row asserted, not reasoned about:
-
-- [ ] 3.1 anonymous + `read: ['public']` → visible
-- [ ] 3.2 anonymous + `read: ['users']` → **not** visible
-- [ ] 3.3 authenticated non-member + `read: ['users']` → visible at the OR layer,
-      filtered to nothing by the consuming app's own permission check
-- [ ] 3.4 authenticated + named group → visible only when in that group
-- [ ] 3.5 admin → unchanged (bypass)
-- [ ] 3.6 owner-only object → unchanged
-- [ ] 3.7 openbuild e2e suite stays green (30+ tests currently passing)
-- [ ] 3.8 at least one other app on a shared register re-run — OR is the
-      foundation, so regressions surface elsewhere first
-
-## 4. openbuild follow-through (separate PR, after 1–3 land)
-
-- [ ] 4.1 Set `read: ['users']` on the `application` schema in
-      `openbuild/lib/Settings/openbuild_register.json`.
-      ⚠️ Register schema changes need a FORCED import to apply — a normal import
-      advances the version WITHOUT applying the change.
-- [ ] 4.2 Un-skip `versionRouting` 9.2 and `schema-access-scopes-rbac` (3), and
-      add the viewer-gating assertion to `save-as-template`. Fixture groundwork
-      is already in `openbuild/tests/e2e/support/appRoles.ts`; RBAC users and
+- [ ] 2.1 Un-skip `versionRouting` 9.2 and the three `schema-access-scopes-rbac`
+      scenarios; add the viewer-gating assertion omitted from `save-as-template`.
+      Fixtures are already in `tests/e2e/support/appRoles.ts`; RBAC users and
       per-role sessions come from `globalSetup`.
-- [ ] 4.3 Revert the experimental `read: ['rbac-editors']` left on schema 18 of
-      the `ob-vue3-e2e` (:8099) instance during investigation.
+- [ ] 2.2 Full openbuild e2e suite green.
+
+## 3. OpenRegister cleanup (no behavioural change)
+
+- [ ] 3.1 `filterObjectsForPermissions()` — remove it, or wire it up. Removing is
+      preferred: the live gate is in SQL and a second, post-load object filter
+      would duplicate it. If removed, delete
+      `tests/Service/ObjectHandlersIntegrationTest.php:1429-1436` with it.
+- [ ] 3.2 `docs/features/organisation-roles.md:670,673` — point Read and List at
+      `MagicRbacHandler::buildRbacConditionsSql()`. This doc line is part of why
+      the dead function looked live.
+- [ ] 3.3 Post the correction to Conduction/openbuild#76, which currently carries
+      the superseded diagnosis.
+
+## 4. Deferred — investigate before touching
+
+- [ ] 4.1 `resolveReadGroupIds()` treats a missing `read` key as broadcast; the
+      list path treats it as owner-only. Establish whether `getReadableByUsers()`
+      produces a wrong user-visible outcome as a result. Do not change it on the
+      asymmetry alone — the same reasoning shortcut is what produced the first
+      version of this proposal.
+
+## Withdrawn
+
+- ~~`action: 'create'` → `'read'` in `filterObjectsForPermissions()`~~ — dead code;
+  superseded by 3.1.
+- ~~`filterUuidsForPermissions()` gates on `delete`~~ — correct; its only caller
+  is `deleteObjects()`.
+- ~~Add a `users` sentinel~~ — `authenticated` already exists and is specified in
+  `openspec/specs/rbac-scopes/spec.md:178`.
+- ~~Six-row verification matrix~~ — written to gate a behavioural change that is
+  no longer proposed. Task 1.3 carries the verification that is still owed.
 
 ## Evidence
 
-Full measurement trail, including the raw numbers and the code references, is in
-Conduction/openbuild#76.
+Measurement trail in Conduction/openbuild#76; corrected reasoning in `design.md`.

--- a/tests/Service/ObjectHandlersIntegrationTest.php
+++ b/tests/Service/ObjectHandlersIntegrationTest.php
@@ -1426,18 +1426,6 @@ class ObjectHandlersIntegrationTest extends TestCase
     }
 
     /**
-     * Test filterObjectsForPermissions with RBAC disabled.
-     */
-    public function testFilterObjectsForPermissionsRbacDisabled(): void
-    {
-        $objects = [
-            ['@self' => ['schema' => $this->testSchema->getId(), 'owner' => 'admin'], 'title' => 'Test'],
-        ];
-        $result = $this->permissionHandler->filterObjectsForPermissions($objects, false, false);
-        $this->assertCount(1, $result);
-    }
-
-    /**
      * Test getActiveOrganisationForContext.
      */
     public function testGetActiveOrganisationForContext(): void


### PR DESCRIPTION
Follow-up to #2251, which this corrects.

## The short version

#2251 claimed the object read path gates on `create`, and that OpenRegister had no way to express "any authenticated user". Phase 0 disproved both.

| Claim in #2251 | Reality |
|---|---|
| The read path gates on `create` | Listing is filtered in SQL by `MagicRbacHandler::buildRbacConditionsSql(action: 'read')`. Correct already. |
| `filterObjectsForPermissions()` is the list filter | It has **no production caller**. The only repo-wide reference invokes it with `_rbac: false`, so the check never ran. |
| `filterUuidsForPermissions()` has the same bug (`delete`) | Its only caller is `deleteObjects()`. `delete` is correct. Withdrawn. |
| No sentinel for "any authenticated user" | `authenticated` already exists in all three handlers and is specified in `openspec/specs/rbac-scopes/spec.md:178`. |

## What actually caused the openbuild blackout

A **non-empty** authorization block that omits `read` fails closed to owner-only rows — deliberately, and commented as such at `MagicRbacHandler:1031`. Every openbuild schema carries `{create,update,delete: ["admin"]}` with no `read`, so every non-admin saw zero.

That is an openbuild-side data fix (`read: ["authenticated"]`), not a change to OpenRegister.

It also explains the anomaly #2251 filed as an unresolved open question: adding `read: ['rbac-editors']` flipped 0 → 21 because it supplied the missing rule to the SQL gate. Nothing consulted the `create` gate.

## What this PR changes

No behavioural change.

- Deletes `filterObjectsForPermissions()` and its test, leaving a note at the site so it is not reintroduced.
- Repoints `docs/features/organisation-roles.md` Read + List at the SQL gate. That doc line is part of why the dead function looked live.
- Rewrites the OpenSpec change; adds `design.md` recording the anomaly's answer, the cross-handler contract table, and the reasoning error — a code path was assumed live because it was public, documented, `@spec`-annotated and unit-tested. One `grep` for callers would have caught it.
- Fixes 3 pre-existing `@spec` warnings in the touched file.

## Verification

- `phpcs` clean at gate settings.
- `phpmd` compared at identical paths: 3 findings → 2. The removal drops `TooManyMethods` (26 → 25); none added.
- Live measurement on the disposable instance after the openbuild-side fix — anonymous 0 rows, authenticated 21 at the OR layer, and openbuild's own endpoint filtering that to 1/1/0 by app role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)