### PR TITLE
feat(flow): resolve a flow's step types when it is SAVED, not mid-run

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -480,6 +480,11 @@ return [
         // Visual flow builder — trigger event catalog (read-only, all users).
         ['name' => 'flow#eventCatalog', 'url' => '/api/flow/event-catalog', 'verb' => 'GET'],
         ['name' => 'flow#nodeCatalog',  'url' => '/api/flow/node-catalog',  'verb' => 'GET'],
+        // Preflight a flow document against the live node registry WITHOUT
+        // saving it — the question a CI job or a deploy check needs to ask
+        // about a document it is not writing. Must stay above `{flowId}` so
+        // "validate" is never captured as a flow uuid.
+        ['name' => 'flow#validate',     'url' => '/api/flow/validate',      'verb' => 'POST'],
         // What a flow is holding between runs — the read side of flow state,
         // so a dashboard can render slot occupancy (or#2216).
         ['name' => 'flow#state',        'url' => '/api/flow/{flowId}/state', 'verb' => 'GET', 'requirements' => ['flowId' => '[^/]+']],

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -164,6 +164,7 @@ use OCA\OpenRegister\Listener\HandoffLifecycleListener;
 use OCA\OpenRegister\Listener\HandoffQueueDrainListener;
 use OCA\OpenRegister\Listener\LifecycleActionListener;
 use OCA\OpenRegister\Listener\LifecycleInitialStateListener;
+use OCA\OpenRegister\Listener\FlowNodePreflightListener;
 use OCA\OpenRegister\Listener\LifecycleValidationListener;
 use OCA\OpenRegister\Listener\ApprovalChainGateListener;
 use OCA\OpenRegister\Listener\ApprovalChainAdvanceListener;
@@ -2457,6 +2458,16 @@ class Application extends App implements IBootstrap
         if (class_exists('OCA\\Tables\\Event\\TableDeletedEvent') === true) {
             $context->registerEventListener('OCA\\Tables\\Event\\TableDeletedEvent', TablesTableDeletedListener::class);
         }
+
+        // Flow preflight — refuse a flow document naming a step type this
+        // instance cannot run. Registered FIRST on both events so an unrunnable
+        // flow is rejected before any other listener does work on the way in.
+        // The registry has always refused an unknown type, but only at dispatch,
+        // mid-run, after earlier steps had already made changes that do not roll
+        // back (or#2247: a flow named `openregister.explode` against an instance
+        // that predated it, and nothing noticed until someone checked by hand).
+        $context->registerEventListener(ObjectCreatingEvent::class, FlowNodePreflightListener::class);
+        $context->registerEventListener(ObjectUpdatingEvent::class, FlowNodePreflightListener::class);
 
         // Lifecycle annotation listeners — see x-openregister-lifecycle.
         // Order matters: initial state runs on creating; validation runs on updating.

--- a/lib/Controller/FlowController.php
+++ b/lib/Controller/FlowController.php
@@ -29,8 +29,10 @@ namespace OCA\OpenRegister\Controller;
 
 use OCA\OpenRegister\Db\FlowStateMapper;
 use OCA\OpenRegister\Service\Flow\EventCatalogService;
+use OCA\OpenRegister\Service\Flow\FlowNodePreflight;
 use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\WorkflowEngine\IManager;
@@ -48,6 +50,7 @@ class FlowController extends Controller
      * @param EventCatalogService $eventCatalog The flow trigger catalog.
      * @param FlowNodeRegistry    $nodes        The registered flow-step types.
      * @param FlowStateMapper     $flowState    Reads state a flow keeps between runs.
+     * @param FlowNodePreflight   $preflight    Resolves a document's step types.
      */
     public function __construct(
         string $appName,
@@ -55,6 +58,7 @@ class FlowController extends Controller
         private readonly EventCatalogService $eventCatalog,
         private readonly FlowNodeRegistry $nodes,
         private readonly FlowStateMapper $flowState,
+        private readonly FlowNodePreflight $preflight,
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
@@ -181,6 +185,62 @@ class FlowController extends Controller
         return new JSONResponse($body);
 
     }//end state()
+
+    /**
+     * Resolve a flow document's step types without saving it.
+     *
+     * The listener that guards the save path answers "may this be stored"; this
+     * answers "would it run", which a CI job, an editor and a deployment check
+     * all need to ask about a document they are not writing. It is the same
+     * FlowNodePreflight, so the two answers cannot drift.
+     *
+     * Always 200 with a verdict — a document that cannot run is a valid answer,
+     * not a failed request. `valid` is false only for findings no install can
+     * fix; a step type owned by an app this instance has not enabled comes back
+     * under `warnings` with `valid` still true, because installing that app is
+     * the fix and the document is not wrong.
+     *
+     * @return JSONResponse `{ valid, blocking, warnings, message? }`.
+     *
+     * @NoAdminRequired
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function validate(): JSONResponse
+    {
+        $flow = $this->request->getParam('flow');
+        if (is_array($flow) === false) {
+            $flow = $this->request->getParams();
+        }
+
+        if ($this->preflight->looksLikeFlow(data: $flow) === false) {
+            return new JSONResponse(
+                [
+                    'valid'    => false,
+                    'blocking' => [],
+                    'warnings' => [],
+                    'message'  => 'Body does not describe a flow graph: it needs a non-empty "nodes" list whose '
+                        .'entries carry an "id", and a non-empty "edges" list whose entries carry "from"/"to".',
+                ],
+                Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        $report = $this->preflight->inspect(flow: $flow);
+        $name   = (string) ($flow['name'] ?? 'flow');
+        $body   = [
+            'valid'    => ($report['blocking'] === []),
+            'blocking' => $report['blocking'],
+            'warnings' => $report['warnings'],
+        ];
+
+        if ($report['blocking'] !== []) {
+            $body['message'] = $this->preflight->describe(flow: $name, blocking: $report['blocking']);
+        }
+
+        return new JSONResponse($body);
+
+    }//end validate()
 
     /**
      * One state key as a list, with each entry carrying the key it was under.

--- a/lib/Listener/FlowNodePreflightListener.php
+++ b/lib/Listener/FlowNodePreflightListener.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * OpenRegister FlowNodePreflightListener
+ *
+ * Refuses to store a flow document whose step types this instance cannot run.
+ *
+ * The registry has always refused an unknown step type; it just did it too late
+ * — at dispatch, mid-run, after earlier steps had already written to the outside
+ * world with no way back. This listener moves the same refusal to the moment the
+ * document is written, which is the only moment at which refusing is free.
+ *
+ * It hangs off `ObjectCreatingEvent` / `ObjectUpdatingEvent` because those are
+ * dispatched by `MagicMapper` for every persisted object, which means the API
+ * save path, the configuration importer and any seeding code all pass through
+ * here. A validation that only guarded the HTTP controller would be bypassed by
+ * exactly the import path that carried the measured defect.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Listener
+ * @package  OCA\OpenRegister\Listener
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Listener;
+
+use OCA\OpenRegister\Event\ObjectCreatingEvent;
+use OCA\OpenRegister\Event\ObjectUpdatingEvent;
+use OCA\OpenRegister\Service\Flow\FlowNodePreflight;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use UnexpectedValueException;
+
+/**
+ * Validates a flow document's step types before it is persisted.
+ *
+ * @template-implements IEventListener<ObjectCreatingEvent|ObjectUpdatingEvent>
+ */
+class FlowNodePreflightListener implements IEventListener
+{
+    /**
+     * Constructor.
+     *
+     * @param FlowNodePreflight $preflight Resolves step types against the registry.
+     * @param LoggerInterface   $logger    The logger.
+     */
+    public function __construct(
+        private readonly FlowNodePreflight $preflight,
+        private readonly LoggerInterface $logger
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Reject a save whose flow document names an unrunnable step type.
+     *
+     * @param Event $event The inbound event.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function handle(Event $event): void
+    {
+        if ($event instanceof ObjectCreatingEvent) {
+            $object = $event->getObject();
+        } else if ($event instanceof ObjectUpdatingEvent) {
+            $object = $event->getNewObject();
+        } else {
+            return;
+        }
+
+        $data = $object->getObject();
+        if (is_array($data) === false || $data === []) {
+            return;
+        }
+
+        if ($this->preflight->looksLikeFlow(data: $data) === false) {
+            return;
+        }
+
+        try {
+            $this->preflight->assertRunnable(
+                flow: $data,
+                label: (string) ($data['name'] ?? $object->getUuid() ?? 'flow')
+            );
+        } catch (UnexpectedValueException $e) {
+            $event->setErrors(
+                [
+                    'code'    => 'flow-node-type-unavailable',
+                    'message' => $e->getMessage(),
+                ]
+            );
+            $event->stopPropagation();
+        } catch (Throwable $e) {
+            // Preflight is a guard, not a gate on unrelated saves. If it fails
+            // for a reason of its own the save proceeds — the run-time refusal
+            // in FlowNodeRegistry::get() is still there as the backstop, which
+            // is exactly the situation before this listener existed.
+            $this->logger->warning(
+                message: '[FlowNodePreflightListener] Preflight itself failed, allowing the save: '.$e->getMessage(),
+                context: ['file' => __FILE__, 'line' => __LINE__, 'exception' => get_class($e)]
+            );
+        }//end try
+
+    }//end handle()
+}//end class

--- a/lib/Service/Flow/FlowNodePreflight.php
+++ b/lib/Service/Flow/FlowNodePreflight.php
@@ -1,0 +1,394 @@
+<?php
+
+/**
+ * Checks a flow document's step types against the live node registry.
+ *
+ * `FlowNodeRegistry::get()` already refuses an unknown type, and refuses it for
+ * the right reason — a silently skipped step produces a run that reports success
+ * while never having done the work. The defect this class closes is *when* it
+ * refuses: at step-dispatch time, mid-run, after earlier steps have already
+ * written to the outside world. Labels have moved, commits have landed, issues
+ * have been filed, and none of it rolls back when step four turns out to name a
+ * node this instance does not have.
+ *
+ * The measured case: `openregister.explode` shipped in or#2247 and was named by
+ * a flow document while the running instance sat at or#2244. Nothing noticed
+ * until someone checked by hand. The flow saved cleanly, ran, did real work, and
+ * then died in the middle.
+ *
+ * So the check moves to save/import time, where refusing costs nothing.
+ *
+ * ## Why not simply refuse every unknown type
+ *
+ * Because a flow legitimately outlives the apps on one instance. A shared
+ * configuration export carries flows naming `openconnector.source-call` and
+ * `hermiq.agent-step`; importing it onto an instance that has not installed
+ * openconnector yet must not fail — the flow is not wrong, the instance is
+ * merely incomplete, and it will become correct the moment the app is enabled.
+ * The fleet treats optional apps that way everywhere else (see the `IAppManager`
+ * probes in `ExternalIntegrationRouter`, `TalkLinkService`, `AnalyticsProvider`).
+ *
+ * The distinction that makes a hard refusal safe is ownership. Node ids are
+ * namespaced with the owning app by contract ({@see IFlowNode::getId()}), so the
+ * owner of `openregister.explode` is `openregister`. That gives two genuinely
+ * different situations:
+ *
+ * - The owning app **is enabled** and still does not provide the type. No
+ *   install can fix this: the app is right here and does not have it. It is
+ *   version drift or a typo, always a defect, never a legitimate absence. This
+ *   is the or#2247 case, and it is REFUSED.
+ * - The owning app **is not enabled**. Installing it is exactly the fix, and the
+ *   document is not wrong. WARNED, loudly and structurally, and saved.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use OCP\App\IAppManager;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use UnexpectedValueException;
+
+/**
+ * Resolves every step type in a flow document before the flow can run.
+ *
+ * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+ */
+class FlowNodePreflight
+{
+
+    /**
+     * The owning app is enabled but does not provide the type.
+     *
+     * Unfixable by installing anything — a defect, and therefore blocking.
+     */
+    public const REASON_MISSING_FROM_OWNER = 'node-type-missing-from-enabled-app';
+
+    /**
+     * The type carries no `app.` namespace, so no app can ever own it.
+     *
+     * Blocking: there is no install that would make this resolve.
+     */
+    public const REASON_NOT_NAMESPACED = 'node-type-not-namespaced';
+
+    /**
+     * The owning app is not enabled on this instance.
+     *
+     * Installing it is the fix, so this warns rather than blocks.
+     */
+    public const REASON_OWNER_NOT_ENABLED = 'node-type-owner-app-not-enabled';
+
+    /**
+     * Constructor.
+     *
+     * @param FlowNodeRegistry $registry   The live catalogue of node types.
+     * @param IAppManager      $appManager Tells an absent app from a stale one.
+     * @param LoggerInterface  $logger     The logger.
+     */
+    public function __construct(
+        private readonly FlowNodeRegistry $registry,
+        private readonly IAppManager $appManager,
+        private readonly LoggerInterface $logger
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Whether a piece of object data is shaped like a flow document.
+     *
+     * Deliberately structural rather than register/schema based: flows live in
+     * hermiq's `agentflow` objects, in OpenRegister's own `flow` schema, and in
+     * whatever a future app nominates. Keying off the shape means the check
+     * follows the documents instead of a configured location that can drift.
+     *
+     * The signature is a graph: a list of nodes carrying ids, and a list of
+     * edges carrying endpoints. Anything looser would start judging objects
+     * that merely happen to own a `nodes` key.
+     *
+     * @param array $data The object's data.
+     *
+     * @return boolean True when the data describes a flow graph.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function looksLikeFlow(array $data): bool
+    {
+        $nodes = ($data['nodes'] ?? null);
+        $edges = ($data['edges'] ?? null);
+        if (is_array($nodes) === false || is_array($edges) === false) {
+            return false;
+        }
+
+        if ($nodes === [] || $edges === []) {
+            return false;
+        }
+
+        foreach ($nodes as $node) {
+            if (is_array($node) === false || isset($node['id']) === false) {
+                return false;
+            }
+        }
+
+        foreach ($edges as $edge) {
+            if (is_array($edge) === false) {
+                return false;
+            }
+
+            $hasFrom = (isset($edge['from']) === true || isset($edge['source']) === true);
+            $hasTo   = (isset($edge['to']) === true || isset($edge['target']) === true);
+            if ($hasFrom === false || $hasTo === false) {
+                return false;
+            }
+        }
+
+        return true;
+
+    }//end looksLikeFlow()
+
+    /**
+     * Resolve every step type the document names.
+     *
+     * Only `edges[].type` is inspected. The graph's *shape* is deliberately not
+     * validated here even though {@see FlowDefinitionBuilder} could: a flow being
+     * drawn is legitimately half-connected, and refusing to save a draft would
+     * make the editor unusable. A step type, by contrast, is never bogus on
+     * purpose — nobody drafts a node type they do not mean.
+     *
+     * An edge with no `type` is a pass-through and is skipped, matching
+     * `RegistryStepDispatcher`, which returns items untouched for such an edge.
+     *
+     * @param array $flow The flow document.
+     *
+     * @return array{blocking: array<int, array<string, string>>, warnings: array<int, array<string, string>>}
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function inspect(array $flow): array
+    {
+        $blocking = [];
+        $warnings = [];
+
+        foreach (($flow['edges'] ?? []) as $index => $edge) {
+            if (is_array($edge) === false) {
+                continue;
+            }
+
+            $type = trim((string) ($edge['type'] ?? ''));
+            if ($type === '') {
+                continue;
+            }
+
+            if ($this->isRegistered(type: $type) === true) {
+                continue;
+            }
+
+            $finding = $this->classify(type: $type, edge: (string) ($edge['id'] ?? $edge['name'] ?? $index));
+            if ($finding['reason'] === self::REASON_OWNER_NOT_ENABLED) {
+                $warnings[] = $finding;
+                continue;
+            }
+
+            $blocking[] = $finding;
+        }//end foreach
+
+        return [
+            'blocking' => $blocking,
+            'warnings' => $warnings,
+        ];
+
+    }//end inspect()
+
+    /**
+     * Refuse a document the instance cannot run, and log the rest.
+     *
+     * @param array       $flow  The flow document.
+     * @param string|null $label A human name for the flow, used in the message.
+     *
+     * @return void
+     *
+     * @throws UnexpectedValueException When a step type can never resolve here.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function assertRunnable(array $flow, ?string $label=null): void
+    {
+        $report = $this->inspect(flow: $flow);
+        $name   = ($label ?? (string) ($flow['name'] ?? 'flow'));
+
+        foreach ($report['warnings'] as $warning) {
+            // Loud on purpose. The measured failure was not that a step was
+            // missing, it was that nothing said so — the run reported success.
+            $this->logger->warning(
+                message: sprintf(
+                    '[FlowNodePreflight] Flow "%s" uses step type "%s", which app "%s" owns. '
+                    .'That app is not enabled here, so this flow cannot run until it is.',
+                    $name,
+                    $warning['type'],
+                    $warning['app']
+                ),
+                context: [
+                    'file'   => __FILE__,
+                    'line'   => __LINE__,
+                    'flow'   => $name,
+                    'type'   => $warning['type'],
+                    'app'    => $warning['app'],
+                    'edge'   => $warning['edge'],
+                    'reason' => $warning['reason'],
+                ]
+            );
+        }//end foreach
+
+        if ($report['blocking'] === []) {
+            return;
+        }
+
+        throw new UnexpectedValueException($this->describe(flow: $name, blocking: $report['blocking']));
+
+    }//end assertRunnable()
+
+    /**
+     * Build the refusal message.
+     *
+     * Names every offending type and the app that owns it, all of them at once.
+     * Reporting only the first would turn one fix into a fix-save-fix loop.
+     *
+     * @param string                            $flow     The flow's name.
+     * @param array<int, array<string, string>> $blocking The blocking findings.
+     *
+     * @return string The message.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function describe(string $flow, array $blocking): string
+    {
+        $lines = [];
+        foreach ($blocking as $finding) {
+            if ($finding['reason'] === self::REASON_NOT_NAMESPACED) {
+                $lines[] = sprintf(
+                    '"%s" (edge %s) — not namespaced, so no app can provide it; '
+                    .'step types are "<app>.<node>", e.g. "openregister.route"',
+                    $finding['type'],
+                    $finding['edge']
+                );
+                continue;
+            }
+
+            $lines[] = sprintf(
+                '"%s" (edge %s) — app "%s" would own it and IS enabled here, but does not provide it; '
+                .'that app is behind the flow',
+                $finding['type'],
+                $finding['edge'],
+                $finding['app']
+            );
+        }
+
+        return sprintf(
+            'Flow "%s" names %d step type(s) this instance cannot run: %s. '
+            .'Refusing the save: an unrunnable flow only fails once it is already halfway through, '
+            .'after earlier steps have made changes that do not roll back.',
+            $flow,
+            count($blocking),
+            implode('; ', $lines)
+        );
+
+    }//end describe()
+
+    /**
+     * Decide why a type failed to resolve.
+     *
+     * @param string $type The unresolved step type.
+     * @param string $edge The edge that names it.
+     *
+     * @return array<string, string> The finding.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    private function classify(string $type, string $edge): array
+    {
+        $separator = strpos($type, '.');
+        if ($separator === false || $separator === 0) {
+            return [
+                'type'   => $type,
+                'app'    => '',
+                'edge'   => $edge,
+                'reason' => self::REASON_NOT_NAMESPACED,
+            ];
+        }
+
+        $app    = substr($type, 0, $separator);
+        $reason = self::REASON_OWNER_NOT_ENABLED;
+        if ($this->isAppEnabled(appId: $app) === true) {
+            $reason = self::REASON_MISSING_FROM_OWNER;
+        }
+
+        return [
+            'type'   => $type,
+            'app'    => $app,
+            'edge'   => $edge,
+            'reason' => $reason,
+        ];
+
+    }//end classify()
+
+    /**
+     * Whether the registry provides a type.
+     *
+     * @param string $type The step type.
+     *
+     * @return boolean True when a node answers to it.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    private function isRegistered(string $type): bool
+    {
+        try {
+            $this->registry->get(type: $type);
+            return true;
+        } catch (UnexpectedValueException) {
+            return false;
+        }
+
+    }//end isRegistered()
+
+    /**
+     * Whether an app is enabled on this instance.
+     *
+     * A throwing app manager must not be read as "app absent": that would turn
+     * an infrastructure hiccup into a blocked save. Treat it as enabled=false,
+     * which downgrades the finding to a warning rather than a refusal.
+     *
+     * @param string $appId The app id.
+     *
+     * @return boolean True when the app is enabled.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    private function isAppEnabled(string $appId): bool
+    {
+        try {
+            return $this->appManager->isEnabledForUser($appId);
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                message: '[FlowNodePreflight] Could not determine whether app "'.$appId.'" is enabled: '.$e->getMessage(),
+                context: ['file' => __FILE__, 'line' => __LINE__, 'app' => $appId]
+            );
+            return false;
+        }
+
+    }//end isAppEnabled()
+}//end class

--- a/lib/Service/Flow/FlowNodePreflight.php
+++ b/lib/Service/Flow/FlowNodePreflight.php
@@ -94,6 +94,15 @@ class FlowNodePreflight
     public const REASON_OWNER_NOT_ENABLED = 'node-type-owner-app-not-enabled';
 
     /**
+     * The type resolves, but the node refuses the config it was given.
+     *
+     * Blocking. A step whose config the node cannot read is not a step that
+     * half-works — it is a step that returns its input untouched and reports
+     * COMPLETED, which is the failure this whole class exists to remove.
+     */
+    public const REASON_CONFIG_REJECTED = 'node-config-rejected';
+
+    /**
      * Constructor.
      *
      * @param FlowNodeRegistry $registry   The live catalogue of node types.
@@ -172,6 +181,11 @@ class FlowNodePreflight
      * An edge with no `type` is a pass-through and is skipped, matching
      * `RegistryStepDispatcher`, which returns items untouched for such an edge.
      *
+     * A resolved type is checked TWICE: once that it exists, and once that the
+     * node accepts the config the edge gives it. The second check is the one
+     * that catches an edge written in another node's dialect — the type is
+     * right, the step runs, and it does nothing.
+     *
      * @param array $flow The flow document.
      *
      * @return array{blocking: array<int, array<string, string>>, warnings: array<int, array<string, string>>}
@@ -193,11 +207,42 @@ class FlowNodePreflight
                 continue;
             }
 
-            if ($this->isRegistered(type: $type) === true) {
-                continue;
-            }
+            $edgeId = (string) ($edge['id'] ?? $edge['name'] ?? $index);
+            $node   = $this->resolve(type: $type);
+            if ($node !== null) {
+                // The type resolving is only half the question. A node reads the
+                // config keys IT implements, and silently ignores the rest — so
+                // an edge written in another node's dialect resolves fine, runs,
+                // and returns its input untouched while reporting COMPLETED.
+                //
+                // Measured across the ten hydra flows: four are inert this way.
+                // `hydra-analyze-verdicts` declares `routes[].when`/`routes[].to`
+                // where RouterNode reads `rules[].output`, and `config.fields`
+                // where SetFieldsNode reads `set`/`compute`. The flow cannot run
+                // at all, and `scripts/test-flow-definitions.sh` passes on it —
+                // that script checks graph STRUCTURE and is blind to dialect.
+                //
+                // Every node already implements `validateConfig()`; the contract
+                // is on IFlowNode. It was simply never called at save time.
+                // SetFieldsNode's own docblock says the check exists so a
+                // malformed expression is "caught HERE, when the flow is saved,
+                // rather than evaluating to null on every item at 03:00" — which
+                // is exactly what it did NOT do, because nothing called it.
+                $rejection = $this->configRejection(node: $node, edge: $edge);
+                if ($rejection !== null) {
+                    $blocking[] = [
+                        'type'   => $type,
+                        'app'    => $this->ownerOf(type: $type),
+                        'edge'   => $edgeId,
+                        'reason' => self::REASON_CONFIG_REJECTED,
+                        'detail' => $rejection,
+                    ];
+                }//end if
 
-            $finding = $this->classify(type: $type, edge: (string) ($edge['id'] ?? $edge['name'] ?? $index));
+                continue;
+            }//end if
+
+            $finding = $this->classify(type: $type, edge: $edgeId);
             if ($finding['reason'] === self::REASON_OWNER_NOT_ENABLED) {
                 $warnings[] = $finding;
                 continue;
@@ -278,6 +323,17 @@ class FlowNodePreflight
     {
         $lines = [];
         foreach ($blocking as $finding) {
+            if ($finding['reason'] === self::REASON_CONFIG_REJECTED) {
+                $lines[] = sprintf(
+                    '"%s" (edge %s) — the node exists but refuses this step\'s config: %s. '
+                    .'A config it cannot read makes the step a pass-through that reports success',
+                    $finding['type'],
+                    $finding['edge'],
+                    ($finding['detail'] ?? 'no detail')
+                );
+                continue;
+            }
+
             if ($finding['reason'] === self::REASON_NOT_NAMESPACED) {
                 $lines[] = sprintf(
                     '"%s" (edge %s) — not namespaced, so no app can provide it; '
@@ -295,7 +351,7 @@ class FlowNodePreflight
                 $finding['edge'],
                 $finding['app']
             );
-        }
+        }//end foreach
 
         return sprintf(
             'Flow "%s" names %d step type(s) this instance cannot run: %s. '
@@ -307,6 +363,64 @@ class FlowNodePreflight
         );
 
     }//end describe()
+
+    /**
+     * Ask the node whether it can read this edge's config.
+     *
+     * A node that throws for a reason of its own (a broken translation, a
+     * missing collaborator) must not block the save — that would turn one bad
+     * node into an unsavable instance. Only the node's own refusal counts, and
+     * `UnexpectedValueException` is what every implementation in-tree raises.
+     *
+     * @param IFlowNode $node The resolved node.
+     * @param array     $edge The edge declaring the step.
+     *
+     * @return string|null The node's message, or null when it accepts the config.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    private function configRejection(IFlowNode $node, array $edge): ?string
+    {
+        $config = ($edge['config'] ?? []);
+        if (is_array($config) === false) {
+            return 'Step config must be an object.';
+        }
+
+        try {
+            $node->validateConfig($config);
+        } catch (UnexpectedValueException $e) {
+            return $e->getMessage();
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                message: '[FlowNodePreflight] A node\'s validateConfig() failed for its own reasons, not blocking: '
+                    .$e->getMessage(),
+                context: ['file' => __FILE__, 'line' => __LINE__, 'node' => get_class($node)]
+            );
+        }//end try
+
+        return null;
+
+    }//end configRejection()
+
+    /**
+     * The app a namespaced type belongs to.
+     *
+     * @param string $type The step type.
+     *
+     * @return string The app id, or an empty string when the type is not namespaced.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    private function ownerOf(string $type): string
+    {
+        $separator = strpos($type, '.');
+        if ($separator === false || $separator === 0) {
+            return '';
+        }
+
+        return substr($type, 0, $separator);
+
+    }//end ownerOf()
 
     /**
      * Decide why a type failed to resolve.
@@ -346,24 +460,23 @@ class FlowNodePreflight
     }//end classify()
 
     /**
-     * Whether the registry provides a type.
+     * The node answering to a type, or null when nothing does.
      *
      * @param string $type The step type.
      *
-     * @return boolean True when a node answers to it.
+     * @return IFlowNode|null The node.
      *
      * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
      */
-    private function isRegistered(string $type): bool
+    private function resolve(string $type): ?IFlowNode
     {
         try {
-            $this->registry->get(type: $type);
-            return true;
+            return $this->registry->get(type: $type);
         } catch (UnexpectedValueException) {
-            return false;
+            return null;
         }
 
-    }//end isRegistered()
+    }//end resolve()
 
     /**
      * Whether an app is enabled on this instance.

--- a/openspec/changes/or-flow-preflight/.openspec.yaml
+++ b/openspec/changes/or-flow-preflight/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-preflight

--- a/openspec/changes/or-flow-preflight/proposal.md
+++ b/openspec/changes/or-flow-preflight/proposal.md
@@ -50,6 +50,28 @@ have it. That is always a defect. If the owning app is absent, installing it is
 the fix. So the first refuses and the second warns — loudly, structurally, and
 without blocking anyone's import.
 
+## Known gaps this does NOT close
+
+Recorded precisely rather than half-fixed.
+
+**Schedule-triggered flows in a leaf app's store cannot fire at all.**
+`FlowScheduleService` enumerates only the `flow_register`/`flow_schema` pair
+(defaulting to `flows`/`flow`); it never consults the resolver registry. So
+`hydra-sequencer`, `hydra-dispatch` and `hydra-lock-reaper`, which live as
+hermiq `agentflow` objects, are invisible to the scheduler. Verified in
+`FlowScheduleService` (`REGISTER_KEY` / `SCHEMA_KEY` are the only lookups).
+
+**And their `cron` is dropped on the way in.** The live `agentflow` schema (5020)
+has no `cron` property — verified: `properties ? 'cron'` is false — so the `cron`
+key in those flow documents is silently discarded at save. That is the same
+family as `or-silent-field-loss`, and the warning added there is what makes it
+visible; declaring the property and teaching the scheduler to ask the resolvers
+is a separate change.
+
+Preflight does not catch either: both are about a definition asking for
+something the *instance* does not provide, but neither is expressible as an edge
+type or an edge config.
+
 ## What is deliberately NOT validated
 
 The graph's shape. `FlowDefinitionBuilder` could check it and already refuses

--- a/openspec/changes/or-flow-preflight/proposal.md
+++ b/openspec/changes/or-flow-preflight/proposal.md
@@ -1,0 +1,59 @@
+# Proposal: or-flow-preflight
+
+## Summary
+
+Resolve a flow's step types when the flow is STORED instead of when it runs.
+`FlowNodeRegistry::get()` already refuses an unknown type for exactly the right
+reason — a silently skipped step produces a run that reports success while never
+having done the work. It just refuses at the wrong moment: at step dispatch,
+mid-run, after earlier steps have already written to the outside world.
+
+## Why
+
+Measured, or#2247. `flows/hydra-file-findings.flow.json` names
+`openregister.explode`, which shipped in or#2247, while the running instance sat
+at or#2244. The document saved cleanly. It ran. It called out to the forge. Then
+it hit the explode edge and died, with nothing rolled back — no label move, no
+commit, no filed issue is undone by a mid-run throw. Nothing noticed until
+someone checked by hand.
+
+The general shape: nothing validated that what a flow definition NEEDS is what
+the live instance actually PROVIDES. The registry was the authority all along;
+it was simply never consulted until it was too late for the answer to be useful.
+
+## What Changes
+
+- **`FlowNodePreflight`** resolves every `edges[].type` against the registry and
+  classifies each failure by the app that owns it (derivable from the
+  `<app>.<node>` contract on `IFlowNode::getId()`).
+- **`FlowNodePreflightListener`** on `ObjectCreatingEvent` / `ObjectUpdatingEvent`
+  refuses the write. Those events are dispatched by `MagicMapper`, so the API
+  save path, the configuration importer and any seeding code all pass through it
+  — a guard on the HTTP controller alone would be bypassed by the import path
+  that actually carried the defect.
+- **`POST /api/flow/validate`** answers the same question about a document
+  nobody is writing, for CI and for the editor.
+
+## Why not simply refuse every unknown type
+
+Because that would break a legitimate case the fleet depends on. A shared
+configuration export carries flows naming `openconnector.source-call` and
+`hermiq.agent-step`; importing it onto an instance that has not enabled those
+apps must land. The flow is not wrong — the instance is incomplete, and it
+becomes correct the moment the app is enabled. Every other optional-app probe in
+this codebase treats absence that way (`ExternalIntegrationRouter`,
+`TalkLinkService`, `AnalyticsProvider`).
+
+Ownership is what makes a hard refusal safe. If the owning app is ENABLED and
+still lacks the type, no install fixes it: the app is right here and does not
+have it. That is always a defect. If the owning app is absent, installing it is
+the fix. So the first refuses and the second warns — loudly, structurally, and
+without blocking anyone's import.
+
+## What is deliberately NOT validated
+
+The graph's shape. `FlowDefinitionBuilder` could check it and already refuses
+dangling edges, duplicate node ids and node-shaped authoring — but a flow being
+drawn on a canvas is legitimately half-connected, and refusing to save a draft
+would make the editor unusable. A step TYPE is never bogus on purpose; nobody
+drafts a node type they do not mean.

--- a/openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+++ b/openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
@@ -47,6 +47,44 @@ legitimately half-connected, and refusing a draft would make the editor unusable
 - **WHEN** it is saved
 - **THEN** preflight does not run and the save is unaffected
 
+### Requirement: A resolved node must also accept the config it is given (REQ-PF-003)
+
+For every edge whose `type` resolves, OpenRegister SHALL call the node's
+`validateConfig()` — already on the `IFlowNode` contract and already implemented
+by every node in tree — and SHALL REFUSE the save when the node rejects it.
+
+This is the harder half of the same defect. A node reads the config keys IT
+implements and silently ignores the rest, so an edge written in another node's
+dialect resolves, runs, returns its input untouched and reports COMPLETED.
+Measured across the ten hydra flows, four are inert exactly this way;
+`hydra-analyze-verdicts` declares `routes[].when`/`routes[].to` where RouterNode
+reads `rules[].output`, and `fields` where SetFieldsNode reads `set`/`compute`,
+so it cannot run at all. `scripts/test-flow-definitions.sh` passes on all four:
+it validates graph STRUCTURE and is blind to dialect.
+
+A node that throws for a reason of its own (a broken translation, a missing
+collaborator) SHALL NOT block the save — only `UnexpectedValueException`, which
+is what every in-tree implementation raises to refuse a config, counts.
+
+Config SHALL NOT be checked for a node the instance does not have; an absent
+optional app stays a warning.
+
+#### Scenario: The right type with the wrong dialect is refused
+
+- **GIVEN** an edge of type `openregister.route` whose config declares `routes[]`
+- **WHEN** the flow is saved
+- **THEN** the save is refused, naming the edge and the node's own message
+
+#### Scenario: The same edge in the correct dialect saves
+
+- **GIVEN** the same edge declaring `rules[].output`
+- **WHEN** the flow is saved
+- **THEN** nothing blocks and nothing warns
+
+@e2e exclude backend save-path guard — covered by FlowNodeConfigDialectTest,
+which uses the REAL RouterNode and SetFieldsNode with the config from
+hydra-analyze-verdicts verbatim, with a positive control in the corrected dialect
+
 @e2e exclude backend save-path guard — covered by FlowNodePreflightTest,
 FlowNodePreflightListenerTest and FlowNodePreflightRegressionTest, the last of
 which replays or#2247 (the `hydra-file-findings` graph verbatim against a registry

--- a/openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+++ b/openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: A flow's step types are resolved when it is stored, not when it runs (REQ-PF-001)
+
+When an object shaped like a flow graph is created or updated, OpenRegister SHALL
+resolve every `edges[].type` it declares against the live `FlowNodeRegistry`
+before the object is persisted. An edge with no `type` is a pass-through and
+SHALL be skipped, matching `RegistryStepDispatcher`.
+
+A type that does not resolve SHALL be classified by the app that owns it, which
+the `<app>.<node>` namespacing contract on `IFlowNode::getId()` makes derivable:
+
+- When the owning app IS enabled on this instance, the save SHALL be REFUSED. No
+  installation can supply the type — the app is present and does not have it — so
+  this is version drift or a typo, and never a legitimate absence.
+- When the owning app is NOT enabled, the save SHALL proceed and a structured
+  warning SHALL be logged naming the flow, the edge, the type and the app.
+- A type carrying no `<app>.` namespace SHALL be refused, since no app can ever
+  provide it.
+
+A refusal SHALL name every offending type in one message, not the first only.
+
+The graph's SHAPE SHALL NOT be validated at save time: a flow being drawn is
+legitimately half-connected, and refusing a draft would make the editor unusable.
+
+#### Scenario: A type missing from an app that is installed is refused
+
+- **GIVEN** openregister is enabled and does not provide `openregister.explode`
+- **WHEN** a flow naming that type on an edge is saved
+- **THEN** the save is refused and the message names the type, the edge and the app
+
+#### Scenario: A type owned by an app that is not installed is allowed
+
+- **GIVEN** openconnector is not enabled
+- **WHEN** a flow naming `openconnector.source-call` is imported
+- **THEN** the object is stored and a warning naming the app is logged
+
+#### Scenario: An unnamespaced type is refused
+
+- **GIVEN** a flow edge whose type is `explode`
+- **WHEN** the flow is saved
+- **THEN** the save is refused, because no app can own an unnamespaced type
+
+#### Scenario: An ordinary object is not treated as a flow
+
+- **GIVEN** an object with no `nodes`/`edges` graph
+- **WHEN** it is saved
+- **THEN** preflight does not run and the save is unaffected
+
+@e2e exclude backend save-path guard — covered by FlowNodePreflightTest,
+FlowNodePreflightListenerTest and FlowNodePreflightRegressionTest, the last of
+which replays or#2247 (the `hydra-file-findings` graph verbatim against a registry
+holding every node an or#2244 instance had) through the real FlowNodeRegistry,
+the real preflight and the real ObjectCreatingEvent, with a positive control
+proving the same document saves once the node exists
+
+### Requirement: A flow document can be preflighted without being saved (REQ-PF-002)
+
+OpenRegister SHALL expose `POST /api/flow/validate`, which resolves a submitted
+flow document's step types and returns `{valid, blocking, warnings}` plus a
+`message` when anything blocks. It SHALL answer 200 for a document that cannot
+run — an unrunnable flow is a valid answer, not a failed request — and 400 only
+when the body does not describe a flow graph at all. It SHALL use the same
+`FlowNodePreflight` as the save-path guard so the two answers cannot drift.
+
+#### Scenario: A blocked document reports its findings
+
+- **GIVEN** a flow naming a type its enabled owner does not provide
+- **WHEN** it is posted to the validate endpoint
+- **THEN** the response is 200 with `valid: false` and the finding listed
+
+#### Scenario: A body that is not a graph is rejected
+
+- **GIVEN** a body with no nodes or edges
+- **WHEN** it is posted to the validate endpoint
+- **THEN** the response is 400
+
+@e2e exclude read-only backend endpoint — covered by FlowControllerTest

--- a/openspec/changes/or-flow-preflight/tasks.md
+++ b/openspec/changes/or-flow-preflight/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: or-flow-preflight
+
+- [x] `FlowNodePreflight` — structural flow recognition, per-edge type resolution
+      against the live registry, ownership-based classification.
+- [x] `FlowNodePreflightListener` on `ObjectCreatingEvent` / `ObjectUpdatingEvent`,
+      registered ahead of the other object listeners in `Application.php`.
+- [x] `POST /api/flow/validate` on `FlowController` + route.
+- [x] Unit tests for the classifier, the recognition guard and the listener.
+- [x] Regression test replaying or#2247 through real collaborators, with a
+      positive control proving the same document saves once the node exists.
+- [ ] Frontend: surface `blocking` / `warnings` in the flow editor before save.
+      Out of scope here — the backend refusal is what stops a half-run.

--- a/tests/Unit/Controller/FlowControllerTest.php
+++ b/tests/Unit/Controller/FlowControllerTest.php
@@ -25,6 +25,7 @@ namespace Unit\Controller;
 
 use OCA\OpenRegister\Controller\FlowController;
 use OCA\OpenRegister\Service\Flow\EventCatalogService;
+use OCA\OpenRegister\Service\Flow\FlowNodePreflight;
 use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
 use OCP\IRequest;
 use OCP\WorkflowEngine\IManager;
@@ -51,6 +52,13 @@ class FlowControllerTest extends TestCase
     private FlowNodeRegistry $nodes;
 
     /**
+     * The mocked preflight.
+     *
+     * @var FlowNodePreflight
+     */
+    private FlowNodePreflight $preflight;
+
+    /**
      * The controller under test.
      *
      * @var FlowController
@@ -67,15 +75,17 @@ class FlowControllerTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = $this->createMock(IRequest::class);
-        $this->nodes   = $this->createMock(FlowNodeRegistry::class);
+        $this->request   = $this->createMock(IRequest::class);
+        $this->nodes     = $this->createMock(FlowNodeRegistry::class);
+        $this->preflight = $this->createMock(FlowNodePreflight::class);
 
         $this->controller = new FlowController(
             'openregister',
             $this->request,
             $this->createMock(EventCatalogService::class),
             $this->nodes,
-            $this->createMock(originalClassName: \OCA\OpenRegister\Db\FlowStateMapper::class)
+            $this->createMock(originalClassName: \OCA\OpenRegister\Db\FlowStateMapper::class),
+            $this->preflight
         );
 
     }//end setUp()
@@ -207,7 +217,8 @@ class FlowControllerTest extends TestCase
             $this->request,
             $this->createMock(EventCatalogService::class),
             $this->nodes,
-            $mapper
+            $mapper,
+            $this->preflight
         );
 
         $data = $controller->state(flowId: 'flow-1')->getData();
@@ -242,7 +253,8 @@ class FlowControllerTest extends TestCase
             $this->request,
             $this->createMock(EventCatalogService::class),
             $this->nodes,
-            $mapper
+            $mapper,
+            $this->preflight
         );
 
         $data = $controller->state(flowId: 'flow-1')->getData();
@@ -251,4 +263,100 @@ class FlowControllerTest extends TestCase
         $this->assertArrayNotHasKey('results', $data);
 
     }//end testStateWithoutListIsUnchanged()
+
+
+    /**
+     * Preflighting a document that cannot run answers 200 with a verdict.
+     *
+     * A flow that will not run is a valid ANSWER, not a failed request — a CI
+     * job asking the question needs the finding list, not an HTTP error it has
+     * to reverse-engineer.
+     *
+     * @return void
+     */
+    public function testValidateReportsBlockingFindings(): void
+    {
+        $flow = [
+            'name'  => 'hydra-file-findings',
+            'nodes' => [['id' => 'a'], ['id' => 'b']],
+            'edges' => [['id' => 'e1', 'from' => 'a', 'to' => 'b', 'type' => 'openregister.explode']],
+        ];
+
+        $this->request->method('getParam')->willReturn($flow);
+        $this->preflight->method('looksLikeFlow')->willReturn(true);
+        $this->preflight->method('inspect')->willReturn(
+            [
+                'blocking' => [
+                    [
+                        'type'   => 'openregister.explode',
+                        'app'    => 'openregister',
+                        'edge'   => 'e1',
+                        'reason' => FlowNodePreflight::REASON_MISSING_FROM_OWNER,
+                    ],
+                ],
+                'warnings' => [],
+            ]
+        );
+        $this->preflight->method('describe')->willReturn('Flow "hydra-file-findings" names 1 step type(s)');
+
+        $response = $this->controller->validate();
+
+        $this->assertSame(200, $response->getStatus());
+        $data = $response->getData();
+        $this->assertFalse($data['valid']);
+        $this->assertCount(1, $data['blocking']);
+        $this->assertSame('openregister.explode', $data['blocking'][0]['type']);
+        $this->assertArrayHasKey('message', $data);
+
+    }//end testValidateReportsBlockingFindings()
+
+
+    /**
+     * An absent optional app is a warning, and the document stays valid.
+     *
+     * @return void
+     */
+    public function testValidateTreatsAnAbsentAppAsAWarning(): void
+    {
+        $this->request->method('getParam')->willReturn(['nodes' => [], 'edges' => []]);
+        $this->preflight->method('looksLikeFlow')->willReturn(true);
+        $this->preflight->method('inspect')->willReturn(
+            [
+                'blocking' => [],
+                'warnings' => [
+                    [
+                        'type'   => 'openconnector.source-call',
+                        'app'    => 'openconnector',
+                        'edge'   => 'e1',
+                        'reason' => FlowNodePreflight::REASON_OWNER_NOT_ENABLED,
+                    ],
+                ],
+            ]
+        );
+
+        $data = $this->controller->validate()->getData();
+
+        $this->assertTrue($data['valid']);
+        $this->assertCount(1, $data['warnings']);
+        $this->assertArrayNotHasKey('message', $data);
+
+    }//end testValidateTreatsAnAbsentAppAsAWarning()
+
+
+    /**
+     * A body that is not a graph is a 400, not a silent pass.
+     *
+     * @return void
+     */
+    public function testValidateRejectsANonFlowBody(): void
+    {
+        $this->request->method('getParam')->willReturn(['title' => 'not a flow']);
+        $this->preflight->method('looksLikeFlow')->willReturn(false);
+
+        $response = $this->controller->validate();
+
+        $this->assertSame(400, $response->getStatus());
+        $this->assertFalse($response->getData()['valid']);
+
+    }//end testValidateRejectsANonFlowBody()
 }//end class

--- a/tests/Unit/Listener/FlowNodePreflightListenerTest.php
+++ b/tests/Unit/Listener/FlowNodePreflightListenerTest.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * The save path is the seam that matters.
+ *
+ * A validation that only guarded the HTTP controller would be bypassed by the
+ * configuration importer, which is exactly the path a flow arrives on. These
+ * tests pin the refusal to `ObjectCreatingEvent`/`ObjectUpdatingEvent`, which
+ * `MagicMapper` dispatches for every persisted object.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Listener
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Listener;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Event\ObjectCreatingEvent;
+use OCA\OpenRegister\Event\ObjectUpdatingEvent;
+use OCA\OpenRegister\Listener\FlowNodePreflightListener;
+use OCA\OpenRegister\Service\Flow\FlowNodePreflight;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use UnexpectedValueException;
+
+/**
+ * @covers \OCA\OpenRegister\Listener\FlowNodePreflightListener
+ */
+class FlowNodePreflightListenerTest extends TestCase
+{
+
+    /**
+     * An object entity carrying the given data.
+     *
+     * @param array $data The object data.
+     *
+     * @return ObjectEntity
+     */
+    private function entity(array $data): ObjectEntity
+    {
+        $entity = new ObjectEntity();
+        $entity->setUuid('11111111-1111-1111-1111-111111111111');
+        $entity->setObject($data);
+
+        return $entity;
+    }
+
+    /**
+     * A flow document naming a type this instance cannot run.
+     *
+     * @return array
+     */
+    private function badFlow(): array
+    {
+        return [
+            'name'  => 'hydra-file-findings',
+            'nodes' => [['id' => 'a'], ['id' => 'b']],
+            'edges' => [['id' => 'e1', 'from' => 'a', 'to' => 'b', 'type' => 'openregister.explode']],
+        ];
+    }
+
+    /**
+     * A preflight stub that refuses everything graph-shaped.
+     *
+     * @param boolean $refuse Whether assertRunnable throws.
+     *
+     * @return FlowNodePreflight
+     */
+    private function preflight(bool $refuse): FlowNodePreflight
+    {
+        $preflight = $this->createMock(FlowNodePreflight::class);
+        $preflight->method('looksLikeFlow')->willReturnCallback(
+            static fn (array $data): bool => (isset($data['nodes']) === true && isset($data['edges']) === true)
+        );
+
+        if ($refuse === true) {
+            $preflight->method('assertRunnable')->willThrowException(
+                new UnexpectedValueException('Flow "hydra-file-findings" names 1 step type(s) this instance cannot run')
+            );
+        }
+
+        return $preflight;
+    }
+
+    /**
+     * Creation is stopped and carries a message naming the problem.
+     */
+    public function testCreationIsRefused(): void
+    {
+        $listener = new FlowNodePreflightListener(
+            $this->preflight(refuse: true),
+            $this->createMock(LoggerInterface::class)
+        );
+
+        $event = new ObjectCreatingEvent($this->entity($this->badFlow()));
+        $listener->handle($event);
+
+        $this->assertTrue($event->isPropagationStopped());
+        $this->assertSame('flow-node-type-unavailable', $event->getErrors()['code']);
+        $this->assertStringContainsString('cannot run', $event->getErrors()['message']);
+    }
+
+    /**
+     * An update to an existing flow is refused the same way.
+     */
+    public function testUpdateIsRefused(): void
+    {
+        $listener = new FlowNodePreflightListener(
+            $this->preflight(refuse: true),
+            $this->createMock(LoggerInterface::class)
+        );
+
+        $event = new ObjectUpdatingEvent(
+            newObject: $this->entity($this->badFlow()),
+            oldObject: $this->entity([])
+        );
+        $listener->handle($event);
+
+        $this->assertTrue($event->isPropagationStopped());
+    }
+
+    /**
+     * An ordinary object is untouched — the listener must not gate every save.
+     */
+    public function testANonFlowObjectIsUntouched(): void
+    {
+        $listener = new FlowNodePreflightListener(
+            $this->preflight(refuse: true),
+            $this->createMock(LoggerInterface::class)
+        );
+
+        $event = new ObjectCreatingEvent($this->entity(['title' => 'a lead', 'status' => 'open']));
+        $listener->handle($event);
+
+        $this->assertFalse($event->isPropagationStopped());
+        $this->assertSame([], $event->getErrors());
+    }
+
+    /**
+     * A runnable flow saves.
+     */
+    public function testARunnableFlowIsAllowed(): void
+    {
+        $listener = new FlowNodePreflightListener(
+            $this->preflight(refuse: false),
+            $this->createMock(LoggerInterface::class)
+        );
+
+        $event = new ObjectCreatingEvent($this->entity($this->badFlow()));
+        $listener->handle($event);
+
+        $this->assertFalse($event->isPropagationStopped());
+    }
+
+    /**
+     * Preflight failing for a reason of its own must not block unrelated saves.
+     *
+     * The run-time refusal in FlowNodeRegistry::get() is still the backstop,
+     * which is precisely the situation that held before this listener existed.
+     */
+    public function testAnInternalFailureDoesNotBlockTheSave(): void
+    {
+        $preflight = $this->createMock(FlowNodePreflight::class);
+        $preflight->method('looksLikeFlow')->willReturn(true);
+        $preflight->method('assertRunnable')->willThrowException(new \RuntimeException('registry exploded'));
+
+        $listener = new FlowNodePreflightListener($preflight, $this->createMock(LoggerInterface::class));
+
+        $event = new ObjectCreatingEvent($this->entity($this->badFlow()));
+        $listener->handle($event);
+
+        $this->assertFalse($event->isPropagationStopped());
+    }
+}

--- a/tests/Unit/Service/Flow/FlowNodeConfigDialectTest.php
+++ b/tests/Unit/Service/Flow/FlowNodeConfigDialectTest.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * A step whose type is right and whose config dialect is wrong.
+ *
+ * This is the harder half of the same defect. Resolving `edges[].type` proves an
+ * app provides the step; it says nothing about whether the node can READ the
+ * config the edge hands it. A node reads the keys it implements and silently
+ * ignores the rest, so an edge written in another node's dialect resolves,
+ * runs, returns its input untouched, and reports COMPLETED.
+ *
+ * Measured across the ten hydra flows: four are inert exactly this way.
+ * `hydra-analyze-verdicts` declares `routes[].when` / `routes[].to` where
+ * RouterNode reads `rules[].output`, and `fields` where SetFieldsNode reads
+ * `set` / `compute`. That flow cannot run at all — and
+ * `scripts/test-flow-definitions.sh` passes on it, because it validates graph
+ * STRUCTURE and is blind to dialect.
+ *
+ * Every node already implements `validateConfig()`; the contract is on
+ * IFlowNode. It was simply never called when a flow was saved. SetFieldsNode's
+ * own docblock says the check exists so a malformed expression is "caught HERE,
+ * when the flow is saved, rather than evaluating to null on every item at
+ * 03:00" — which is precisely what it did not do.
+ *
+ * These tests use the REAL RouterNode and SetFieldsNode with the REAL config
+ * from hydra-analyze-verdicts.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowNodePreflight;
+use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
+use OCA\OpenRegister\Service\Flow\Nodes\RouterNode;
+use OCA\OpenRegister\Service\Flow\Nodes\SetFieldsNode;
+use OCA\OpenRegister\Service\Flow\RegisterFlowNodesEvent;
+use OCP\App\IAppManager;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use UnexpectedValueException;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Flow\FlowNodePreflight
+ */
+class FlowNodeConfigDialectTest extends TestCase
+{
+
+    /**
+     * A preflight over the REAL router and set-fields nodes.
+     *
+     * @return FlowNodePreflight
+     */
+    private function preflight(): FlowNodePreflight
+    {
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnCallback(
+            static fn (string $t, array $p=[]): string => vsprintf(str_replace('%s', '%s', $t), $p)
+        );
+        $urls = $this->createMock(IURLGenerator::class);
+
+        $dispatcher = $this->createMock(IEventDispatcher::class);
+        $dispatcher->method('dispatchTyped')->willReturnCallback(
+            static function (Event $event) use ($l10n, $urls): void {
+                if (($event instanceof RegisterFlowNodesEvent) === false) {
+                    return;
+                }
+
+                $event->registerNode(new RouterNode($l10n, $urls));
+                $event->registerNode(new SetFieldsNode($l10n, $urls));
+            }
+        );
+
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('isEnabledForUser')->willReturn(true);
+
+        return new FlowNodePreflight(
+            new FlowNodeRegistry($dispatcher, $this->createMock(LoggerInterface::class)),
+            $appManager,
+            $this->createMock(LoggerInterface::class)
+        );
+    }
+
+    /**
+     * THE REGRESSION — hydra-analyze-verdicts, verbatim.
+     *
+     * `routes[].when`/`.to` where RouterNode reads `rules[].output`, and
+     * `fields` where SetFieldsNode reads `set`/`compute`. Both types resolve.
+     *
+     * @return void
+     */
+    public function testTheWrongDialectIsRefusedEvenThoughTheTypeResolves(): void
+    {
+        $flow = [
+            'name'  => 'hydra-analyze-verdicts',
+            'nodes' => [['id' => 'a'], ['id' => 'b'], ['id' => 'c']],
+            'edges' => [
+                [
+                    'id'     => 'derive',
+                    'from'   => 'a',
+                    'to'     => 'b',
+                    'type'   => 'openregister.set-fields',
+                    'config' => [
+                        'fields' => ['codePass' => ['var' => 'labels']],
+                    ],
+                ],
+                [
+                    'id'     => 'code-contradiction',
+                    'from'   => 'b',
+                    'to'     => 'c',
+                    'type'   => 'openregister.route',
+                    'config' => [
+                        'routes'  => [
+                            ['when' => ['var' => 'codePass'], 'to' => 'drop-code-pass'],
+                        ],
+                        'default' => 'skip-code-drop',
+                    ],
+                ],
+            ],
+        ];
+
+        $report = $this->preflight()->inspect(flow: $flow);
+
+        $this->assertSame([], $report['warnings']);
+        $this->assertCount(2, $report['blocking'], 'Both dialect mismatches must be caught.');
+
+        foreach ($report['blocking'] as $finding) {
+            $this->assertSame(FlowNodePreflight::REASON_CONFIG_REJECTED, $finding['reason']);
+            $this->assertSame('openregister', $finding['app']);
+            $this->assertNotSame('', ($finding['detail'] ?? ''));
+        }
+
+        $edges = array_column($report['blocking'], 'edge');
+        sort($edges);
+        $this->assertSame(['code-contradiction', 'derive'], $edges);
+    }
+
+    /**
+     * ...and the save is refused, naming both edges.
+     *
+     * @return void
+     */
+    public function testTheSaveIsRefusedNamingBothEdges(): void
+    {
+        $flow = [
+            'name'  => 'hydra-analyze-verdicts',
+            'nodes' => [['id' => 'a'], ['id' => 'b']],
+            'edges' => [
+                [
+                    'id'     => 'derive',
+                    'from'   => 'a',
+                    'to'     => 'b',
+                    'type'   => 'openregister.set-fields',
+                    'config' => ['fields' => ['x' => 1]],
+                ],
+            ],
+        ];
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessageMatches('/derive/');
+        $this->preflight()->assertRunnable(flow: $flow);
+    }
+
+    /**
+     * POSITIVE CONTROL — the SAME edges in the dialect the nodes actually read.
+     *
+     * Without this, the tests above are satisfied by a preflight that refuses
+     * every config it is shown.
+     *
+     * @return void
+     */
+    public function testTheCorrectDialectPasses(): void
+    {
+        $flow = [
+            'name'  => 'hydra-analyze-verdicts (corrected)',
+            'nodes' => [['id' => 'a'], ['id' => 'b'], ['id' => 'c']],
+            'edges' => [
+                [
+                    'id'     => 'derive',
+                    'from'   => 'a',
+                    'to'     => 'b',
+                    'type'   => 'openregister.set-fields',
+                    'config' => [
+                        'compute' => ['codePass' => ['var' => 'labels']],
+                    ],
+                ],
+                [
+                    'id'     => 'code-contradiction',
+                    'from'   => 'b',
+                    'to'     => 'c',
+                    'type'   => 'openregister.route',
+                    'config' => [
+                        'rules'   => [
+                            ['condition' => ['var' => 'codePass'], 'output' => 'drop-code-pass'],
+                        ],
+                        'default' => 'skip-code-drop',
+                    ],
+                ],
+            ],
+        ];
+
+        $report = $this->preflight()->inspect(flow: $flow);
+
+        $this->assertSame(['blocking' => [], 'warnings' => []], $report);
+    }
+
+    /**
+     * A node whose app is absent is still only WARNED about.
+     *
+     * Config cannot be checked for a node that is not here, and an absent
+     * optional app must not block an import. This pins that the config check
+     * did not accidentally turn absence into a refusal.
+     *
+     * @return void
+     */
+    public function testAnAbsentAppIsStillOnlyAWarning(): void
+    {
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnArgument(0);
+        $urls = $this->createMock(IURLGenerator::class);
+
+        $dispatcher = $this->createMock(IEventDispatcher::class);
+        $dispatcher->method('dispatchTyped')->willReturnCallback(
+            static function (Event $event) use ($l10n, $urls): void {
+                if ($event instanceof RegisterFlowNodesEvent) {
+                    $event->registerNode(new RouterNode($l10n, $urls));
+                }
+            }
+        );
+
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('isEnabledForUser')->willReturnCallback(
+            static fn (string $app): bool => ($app === 'openregister')
+        );
+
+        $preflight = new FlowNodePreflight(
+            new FlowNodeRegistry($dispatcher, $this->createMock(LoggerInterface::class)),
+            $appManager,
+            $this->createMock(LoggerInterface::class)
+        );
+
+        $report = $preflight->inspect(
+            flow: [
+                'name'  => 'partial',
+                'nodes' => [['id' => 'a'], ['id' => 'b']],
+                'edges' => [
+                    [
+                        'id'     => 'call',
+                        'from'   => 'a',
+                        'to'     => 'b',
+                        'type'   => 'openconnector.source-call',
+                        'config' => ['method' => 'GET'],
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertSame([], $report['blocking']);
+        $this->assertCount(1, $report['warnings']);
+    }
+}

--- a/tests/Unit/Service/Flow/FlowNodePreflightRegressionTest.php
+++ b/tests/Unit/Service/Flow/FlowNodePreflightRegressionTest.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * The or#2247 regression, replayed against real collaborators.
+ *
+ * Everything here is the production wiring except the app manager and the event
+ * dispatcher: a real `FlowNodeRegistry` populated through the real
+ * `RegisterFlowNodesEvent`, the real `FlowNodePreflight`, the real
+ * `FlowNodePreflightListener`, and the real `ObjectCreatingEvent` the mapper
+ * dispatches. The document is the graph of `hydra/flows/hydra-file-findings.flow.json`
+ * verbatim, which is the flow that actually shipped naming a node the instance
+ * did not have.
+ *
+ * The point of using real objects is that a mocked registry would prove only
+ * that the test's own stub throws. This proves the refusal happens through the
+ * same `FlowNodeRegistry::get()` that the engine calls at dispatch — just at
+ * save time instead of mid-run.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Event\ObjectCreatingEvent;
+use OCA\OpenRegister\Listener\FlowNodePreflightListener;
+use OCA\OpenRegister\Service\Flow\FlowNodePreflight;
+use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\RegisterFlowNodesEvent;
+use OCP\App\IAppManager;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Flow\FlowNodePreflight
+ * @covers \OCA\OpenRegister\Listener\FlowNodePreflightListener
+ */
+class FlowNodePreflightRegressionTest extends TestCase
+{
+
+    /**
+     * The graph of hydra/flows/hydra-file-findings.flow.json, verbatim.
+     *
+     * @return array The flow document.
+     */
+    private function hydraFileFindings(): array
+    {
+        return [
+            'name'  => 'hydra-file-findings',
+            'nodes' => [
+                ['id' => 'in', 'name' => 'A completed review stage'],
+                ['id' => 'exploded', 'name' => 'One item per finding'],
+                ['id' => 'actionable', 'name' => 'Open WARNING / SUGGESTION only'],
+                ['id' => 'filed', 'name' => 'Issue filed'],
+            ],
+            'edges' => [
+                ['id' => 'explode-findings', 'from' => 'in', 'to' => 'exploded', 'type' => 'openregister.explode'],
+                ['id' => 'actionable-only', 'from' => 'exploded', 'to' => 'actionable', 'type' => 'openregister.filter'],
+                ['id' => 'file-issue', 'from' => 'actionable', 'to' => 'filed', 'type' => 'openconnector.source-call'],
+            ],
+        ];
+    }
+
+    /**
+     * A node type contributed the way an app contributes one.
+     *
+     * @param string $id The type id.
+     *
+     * @return IFlowNode
+     */
+    private function node(string $id): IFlowNode
+    {
+        $node = $this->createMock(IFlowNode::class);
+        $node->method('getId')->willReturn($id);
+
+        return $node;
+    }
+
+    /**
+     * A REAL registry populated through the REAL contribution event.
+     *
+     * @param array<int, string> $types The types apps contribute.
+     *
+     * @return FlowNodeRegistry
+     */
+    private function registry(array $types): FlowNodeRegistry
+    {
+        $dispatcher = $this->createMock(IEventDispatcher::class);
+        $dispatcher->method('dispatchTyped')->willReturnCallback(
+            function (Event $event) use ($types): void {
+                if (($event instanceof RegisterFlowNodesEvent) === false) {
+                    return;
+                }
+
+                foreach ($types as $type) {
+                    $event->registerNode($this->node($type));
+                }
+            }
+        );
+
+        return new FlowNodeRegistry($dispatcher, $this->createMock(LoggerInterface::class));
+    }
+
+    /**
+     * A REAL preflight over a REAL registry.
+     *
+     * @param array<int, string> $types   Contributed types.
+     * @param array<int, string> $enabled Enabled apps.
+     *
+     * @return FlowNodePreflight
+     */
+    private function preflight(array $types, array $enabled): FlowNodePreflight
+    {
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('isEnabledForUser')->willReturnCallback(
+            static fn (string $appId): bool => in_array($appId, $enabled, true)
+        );
+
+        return new FlowNodePreflight(
+            $this->registry($types),
+            $appManager,
+            $this->createMock(LoggerInterface::class)
+        );
+    }
+
+    /**
+     * Every node type openregister ships as of or#2247.
+     *
+     * @return array<int, string>
+     */
+    private function or2247Nodes(): array
+    {
+        return [
+            'openregister.route',
+            'openregister.switch',
+            'openregister.filter',
+            'openregister.merge',
+            'openregister.loop',
+            'openregister.wait',
+            'openregister.stop',
+            'openregister.set-fields',
+            'openregister.sub-flow',
+            'openregister.flow-state',
+            'openregister.object-read',
+            'openregister.object-write',
+            'openregister.explode',
+        ];
+    }
+
+    /**
+     * THE REGRESSION.
+     *
+     * An instance at or#2244 has every node except `openregister.explode`, which
+     * shipped in or#2247. Saving the hydra flow there used to succeed, run, file
+     * real issues, and only then die on the explode step with nothing rolled
+     * back. It must now be refused at the save.
+     *
+     * @return void
+     */
+    public function testTheHydraFlowIsRefusedOnAnInstanceThatPredatesExplode(): void
+    {
+        $or2244 = array_values(
+            array_filter(
+                $this->or2247Nodes(),
+                static fn (string $type): bool => $type !== 'openregister.explode'
+            )
+        );
+
+        $listener = new FlowNodePreflightListener(
+            $this->preflight(types: $or2244, enabled: ['openregister', 'openconnector']),
+            $this->createMock(LoggerInterface::class)
+        );
+
+        $entity = new ObjectEntity();
+        $entity->setUuid('11111111-1111-1111-1111-111111111111');
+        $entity->setObject($this->hydraFileFindings());
+
+        $event = new ObjectCreatingEvent($entity);
+        $listener->handle($event);
+
+        $this->assertTrue($event->isPropagationStopped(), 'The save must be refused.');
+        $errors = $event->getErrors();
+        $this->assertSame('flow-node-type-unavailable', $errors['code']);
+        $this->assertStringContainsString('openregister.explode', $errors['message']);
+        $this->assertStringContainsString('explode-findings', $errors['message']);
+        $this->assertStringContainsString('openregister', $errors['message']);
+    }
+
+    /**
+     * POSITIVE CONTROL — the same flow on an instance at or#2247 saves.
+     *
+     * Without this the test above proves only that the listener refuses things,
+     * which a listener that refused everything would also satisfy.
+     *
+     * @return void
+     */
+    public function testTheSameFlowSavesOnceExplodeExists(): void
+    {
+        $complete = array_merge($this->or2247Nodes(), ['openconnector.source-call']);
+
+        $listener = new FlowNodePreflightListener(
+            $this->preflight(types: $complete, enabled: ['openregister', 'openconnector']),
+            $this->createMock(LoggerInterface::class)
+        );
+
+        $entity = new ObjectEntity();
+        $entity->setUuid('11111111-1111-1111-1111-111111111111');
+        $entity->setObject($this->hydraFileFindings());
+
+        $event = new ObjectCreatingEvent($entity);
+        $listener->handle($event);
+
+        $this->assertFalse($event->isPropagationStopped());
+        $this->assertSame([], $event->getErrors());
+    }
+
+    /**
+     * The same flow on an instance WITHOUT openconnector still saves.
+     *
+     * `openconnector.source-call` is unresolvable there too, but installing
+     * openconnector is the fix and the document is not wrong. Refusing here
+     * would break every configuration import onto a partial instance.
+     *
+     * @return void
+     */
+    public function testAnInstanceWithoutOpenconnectorStillAcceptsTheFlow(): void
+    {
+        $listener = new FlowNodePreflightListener(
+            $this->preflight(types: $this->or2247Nodes(), enabled: ['openregister']),
+            $this->createMock(LoggerInterface::class)
+        );
+
+        $entity = new ObjectEntity();
+        $entity->setUuid('11111111-1111-1111-1111-111111111111');
+        $entity->setObject($this->hydraFileFindings());
+
+        $event = new ObjectCreatingEvent($entity);
+        $listener->handle($event);
+
+        $this->assertFalse($event->isPropagationStopped());
+    }
+
+    /**
+     * The registry really is the authority — no second list to drift from it.
+     *
+     * @return void
+     */
+    public function testTheRegistryIsWhatDecides(): void
+    {
+        $preflight = $this->preflight(types: ['openregister.explode'], enabled: ['openregister']);
+
+        $report = $preflight->inspect(flow: $this->hydraFileFindings());
+
+        // explode resolves; filter does not and openregister is enabled; and
+        // source-call is owned by an app that is not enabled.
+        $this->assertCount(1, $report['blocking']);
+        $this->assertSame('openregister.filter', $report['blocking'][0]['type']);
+        $this->assertCount(1, $report['warnings']);
+        $this->assertSame('openconnector.source-call', $report['warnings'][0]['type']);
+    }
+}

--- a/tests/Unit/Service/Flow/FlowNodePreflightTest.php
+++ b/tests/Unit/Service/Flow/FlowNodePreflightTest.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * The registry refused an unknown step type in the right way and at the wrong time.
+ *
+ * `FlowNodeRegistry::get()` throws at dispatch — mid-run, after earlier steps
+ * have already moved labels, pushed commits and filed issues, none of which roll
+ * back. These tests pin the same refusal to save/import time, and pin the one
+ * distinction that makes refusing safe: an owning app that is ENABLED and still
+ * has no such type is a defect no install can fix, while an app that is simply
+ * not enabled here is a legitimate absence that must not block a save.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowNodePreflight;
+use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCP\App\IAppManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use UnexpectedValueException;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Flow\FlowNodePreflight
+ */
+class FlowNodePreflightTest extends TestCase
+{
+
+    /**
+     * Build a preflight over a fixed set of known types and enabled apps.
+     *
+     * @param array<int, string> $known   Types the registry provides.
+     * @param array<int, string> $enabled Apps that are enabled.
+     *
+     * @return FlowNodePreflight
+     */
+    private function preflight(array $known, array $enabled): FlowNodePreflight
+    {
+        $registry = $this->createMock(FlowNodeRegistry::class);
+        $registry->method('get')->willReturnCallback(
+            function (string $type) use ($known): IFlowNode {
+                if (in_array($type, $known, true) === false) {
+                    throw new UnexpectedValueException(
+                        sprintf('No app provides the flow node type "%s".', $type)
+                    );
+                }
+
+                return $this->createMock(IFlowNode::class);
+            }
+        );
+
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('isEnabledForUser')->willReturnCallback(
+            static fn (string $appId): bool => in_array($appId, $enabled, true)
+        );
+
+        return new FlowNodePreflight($registry, $appManager, $this->createMock(LoggerInterface::class));
+    }
+
+    /**
+     * A minimal two-node graph whose single edge carries the given type.
+     *
+     * @param string $type The step type.
+     *
+     * @return array The flow document.
+     */
+    private function flowWith(string $type): array
+    {
+        return [
+            'name'  => 'test-flow',
+            'nodes' => [['id' => 'a'], ['id' => 'b']],
+            'edges' => [['id' => 'e1', 'from' => 'a', 'to' => 'b', 'type' => $type]],
+        ];
+    }
+
+    /**
+     * The measured case: openregister is right here and does not have the type.
+     *
+     * `openregister.explode` shipped in or#2247 while the instance sat at
+     * or#2244. No install fixes that, so it must not be storable.
+     */
+    public function testATypeMissingFromAnEnabledAppIsRefused(): void
+    {
+        $preflight = $this->preflight(known: ['openregister.route'], enabled: ['openregister']);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessageMatches('/openregister\.explode/');
+        $preflight->assertRunnable(flow: $this->flowWith('openregister.explode'));
+    }
+
+    /**
+     * A type owned by an app that is not enabled here is NOT refused.
+     *
+     * A shared configuration export names openconnector and hermiq steps. An
+     * instance that has not enabled them yet is incomplete, not wrong, and the
+     * import must land — this is the case a blanket refusal would break.
+     */
+    public function testATypeFromAnAbsentAppIsWarnedNotRefused(): void
+    {
+        $preflight = $this->preflight(known: ['openregister.route'], enabled: ['openregister']);
+
+        $preflight->assertRunnable(flow: $this->flowWith('openconnector.source-call'));
+
+        $report = $preflight->inspect(flow: $this->flowWith('openconnector.source-call'));
+        $this->assertSame([], $report['blocking']);
+        $this->assertCount(1, $report['warnings']);
+        $this->assertSame(FlowNodePreflight::REASON_OWNER_NOT_ENABLED, $report['warnings'][0]['reason']);
+        $this->assertSame('openconnector', $report['warnings'][0]['app']);
+    }
+
+    /**
+     * An unnamespaced type can never resolve, so it is refused too.
+     */
+    public function testAnUnnamespacedTypeIsRefused(): void
+    {
+        $preflight = $this->preflight(known: ['openregister.route'], enabled: ['openregister']);
+
+        $report = $preflight->inspect(flow: $this->flowWith('explode'));
+        $this->assertCount(1, $report['blocking']);
+        $this->assertSame(FlowNodePreflight::REASON_NOT_NAMESPACED, $report['blocking'][0]['reason']);
+    }
+
+    /**
+     * Every missing type is reported at once, not one per save attempt.
+     */
+    public function testAllMissingTypesAreNamedInOneMessage(): void
+    {
+        $preflight = $this->preflight(known: [], enabled: ['openregister']);
+        $flow      = [
+            'name'  => 'multi',
+            'nodes' => [['id' => 'a'], ['id' => 'b'], ['id' => 'c']],
+            'edges' => [
+                ['id' => 'e1', 'from' => 'a', 'to' => 'b', 'type' => 'openregister.explode'],
+                ['id' => 'e2', 'from' => 'b', 'to' => 'c', 'type' => 'openregister.teleport'],
+            ],
+        ];
+
+        try {
+            $preflight->assertRunnable(flow: $flow);
+            $this->fail('Expected the flow to be refused.');
+        } catch (UnexpectedValueException $e) {
+            $this->assertStringContainsString('openregister.explode', $e->getMessage());
+            $this->assertStringContainsString('openregister.teleport', $e->getMessage());
+            $this->assertStringContainsString('openregister', $e->getMessage());
+        }
+    }
+
+    /**
+     * A registered type passes, and a typeless edge is a pass-through.
+     */
+    public function testKnownAndTypelessEdgesPass(): void
+    {
+        $preflight = $this->preflight(known: ['openregister.route'], enabled: ['openregister']);
+        $flow      = [
+            'name'  => 'ok',
+            'nodes' => [['id' => 'a'], ['id' => 'b'], ['id' => 'c']],
+            'edges' => [
+                ['id' => 'e1', 'from' => 'a', 'to' => 'b', 'type' => 'openregister.route'],
+                ['id' => 'e2', 'from' => 'b', 'to' => 'c'],
+            ],
+        ];
+
+        $preflight->assertRunnable(flow: $flow);
+        $this->assertSame(['blocking' => [], 'warnings' => []], $preflight->inspect(flow: $flow));
+    }
+
+    /**
+     * Recognition is structural, so it must not claim ordinary objects.
+     *
+     * @dataProvider nonFlowProvider
+     *
+     * @param array $data The object data.
+     *
+     * @return void
+     */
+    public function testOnlyGraphShapedDataIsTreatedAsAFlow(array $data): void
+    {
+        $preflight = $this->preflight(known: [], enabled: []);
+        $this->assertFalse($preflight->looksLikeFlow(data: $data));
+    }
+
+    /**
+     * Data that must NOT be mistaken for a flow.
+     *
+     * @return array<string, array{0: array}>
+     */
+    public static function nonFlowProvider(): array
+    {
+        return [
+            'no graph keys at all'  => [['title' => 'a lead', 'status' => 'open']],
+            'nodes but no edges'    => [['nodes' => [['id' => 'a']]]],
+            'edges but no nodes'    => [['edges' => [['from' => 'a', 'to' => 'b']]]],
+            'empty lists'           => [['nodes' => [], 'edges' => []]],
+            'nodes without ids'     => [['nodes' => [['label' => 'a']], 'edges' => [['from' => 'a', 'to' => 'b']]]],
+            'edges without endpoints' => [['nodes' => [['id' => 'a']], 'edges' => [['type' => 'x']]]],
+            'scalar nodes'          => [['nodes' => 'a,b', 'edges' => 'c']],
+        ];
+    }
+
+    /**
+     * A real graph IS recognised — the positive control for the above.
+     */
+    public function testAGraphIsRecognised(): void
+    {
+        $preflight = $this->preflight(known: [], enabled: []);
+        $this->assertTrue($preflight->looksLikeFlow(data: $this->flowWith('openregister.route')));
+        // `source`/`target` is the other endpoint spelling the builder accepts.
+        $this->assertTrue(
+            $preflight->looksLikeFlow(
+                data: [
+                    'nodes' => [['id' => 'a'], ['id' => 'b']],
+                    'edges' => [['source' => 'a', 'target' => 'b', 'type' => 'openregister.route']],
+                ]
+            )
+        );
+    }
+}


### PR DESCRIPTION
## The defect is WHEN, not WHAT

`FlowNodeRegistry::get()` already refuses an unknown step type, and its docblock already explains why: *"a silently skipped step produces a run that reports success while never having done the work"*. It just refuses at **step-dispatch time, mid-run**, after earlier steps have already written to the outside world. A mid-run throw does not un-move a label, un-push a commit or un-file an issue.

**Measured (or#2247).** `flows/hydra-file-findings.flow.json` names `openregister.explode`, which shipped in or#2247, while the running instance sat at or#2244. The flow saved cleanly, ran, called out to the forge, and then died on the explode edge. Nothing noticed until it was checked by hand.

## What this adds

- **`FlowNodePreflight`** — walks every `edges[].type` and resolves it through the same registry the engine uses. An edge with no `type` is a pass-through and is skipped, matching `RegistryStepDispatcher`.
- **`FlowNodePreflightListener`** on `ObjectCreatingEvent` / `ObjectUpdatingEvent`. Those are dispatched by `MagicMapper`, so the API save path, the configuration importer and any seeding code all pass through it. A guard on the HTTP controller alone would have been bypassed by exactly the import path that carried the defect.
- **`POST /api/flow/validate`** — the same question about a document nobody is writing, for CI and the editor. Same service, so the two answers cannot drift.

## Why this is not a blanket refusal

A blanket refusal would break a case the fleet depends on: a shared configuration export names `openconnector.source-call` and `hermiq.agent-step`, and importing it onto an instance that has not enabled those apps **must land**. The flow is not wrong — the instance is incomplete, and it becomes correct the moment the app is enabled. Every other optional-app probe in this codebase treats absence that way (`ExternalIntegrationRouter`, `TalkLinkService`, `AnalyticsProvider`).

**Ownership** is what makes refusing safe. Node ids are namespaced with the owning app by contract (`IFlowNode::getId()`), so:

| situation | verdict | why |
|---|---|---|
| owner app **enabled**, type still missing | **REFUSE** | no install fixes this — the app is right here and does not have it. This is or#2247. |
| owner app **not enabled** | **WARN**, save proceeds | installing it *is* the fix; the document is not wrong |
| no `app.` namespace | **REFUSE** | no app can ever provide it |

Every offending type is named in one message, not the first only — reporting one at a time turns a fix into a fix-save-fix loop.

## What is deliberately NOT validated

The graph's **shape**. `FlowDefinitionBuilder` could check it and already refuses dangling edges and node-shaped authoring — but a flow being drawn on a canvas is legitimately half-connected, and refusing to save a draft would make the editor unusable. A step *type* is never bogus on purpose.

## Proof

`FlowNodePreflightRegressionTest` replays or#2247 through **real** collaborators — a real `FlowNodeRegistry` populated via the real `RegisterFlowNodesEvent`, the real preflight, the real listener, the real `ObjectCreatingEvent` — using the `hydra-file-findings` graph verbatim, against a registry holding every node an or#2244 instance had. A mocked registry would only have proven the stub throws.

- refused, message names the type (`openregister.explode`), the edge (`explode-findings`) and the app
- **positive control**: the same document saves once `openregister.explode` exists
- an instance without openconnector still accepts the flow

Ran locally in `nextcloud:34.0.0-apache` (host PHP 8.2 is too old): **568/568 green** across `tests/Unit/Service/Flow/`, `tests/Unit/Listener/`, `tests/Unit/Controller/FlowControllerTest.php`. `phpcs` and `phpstan` clean on every touched file (`appinfo/routes.php` and `lib/AppInfo/Application.php` carry 749 pre-existing phpcs errors on the untouched base — verified by stashing; reformatting them is a whole-file rewrite and out of scope).