### PR TITLE
fix(schema,objects): make slug resolution deterministic and stop losing fields in silence

### DIFF
--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -3838,8 +3838,91 @@ class MagicMapper extends AbstractObjectMapper
             }//end foreach
         }//end if
 
+        $this->reportDroppedProperties(data: $data, schemaProperties: $schemaProperties, schema: $schema);
+
         return $preparedData;
     }//end prepareObjectDataForTable()
+
+    /**
+     * Say so when a property the caller sent is about to be thrown away.
+     *
+     * The loop above is a whitelist BY OMISSION: it walks the schema's declared
+     * properties and copies those out of `$data`. Anything the caller sent that
+     * the schema does not declare is simply never read — and there is no `object`
+     * JSON blob column to fall back on, so it is gone. No error, no warning, no
+     * trace: the write succeeds and the field is missing.
+     *
+     * Measured 2026-08-02: the hydra flow documents carry `description`, the
+     * agentflow schema had no such property, and every flow's description was
+     * discarded on save. The graphs table then showed "—" for all ten, which
+     * reads exactly like ten flows that were never given a description.
+     *
+     * This does not reject — rejecting at the DB write boundary is far too late
+     * for a clean 400 (the entity is built, folders may exist, cascades have
+     * run) and would break every caller that harmlessly posts an extra key. It
+     * makes the loss VISIBLE, which is the whole difference between a schema
+     * that needs a property added and a field that quietly evaporates.
+     *
+     * @param array<string, mixed> $data             The caller's data, minus `@self`.
+     * @param mixed                $schemaProperties The schema's declared properties.
+     * @param Schema               $schema           The schema being written to.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/or-silent-field-loss/specs/silent-field-loss/spec.md
+     */
+    private function reportDroppedProperties(array $data, mixed $schemaProperties, Schema $schema): void
+    {
+        if (is_array($schemaProperties) === false) {
+            return;
+        }
+
+        $dropped = [];
+        foreach (array_keys($data) as $key) {
+            $name = (string) $key;
+            if (array_key_exists($name, $schemaProperties) === true) {
+                continue;
+            }
+
+            // `@`-prefixed keys are envelope/metadata (`@self` is already gone),
+            // `_`-prefixed keys are OpenRegister's own metadata columns, and `id`
+            // is the caller echoing back an identifier. None of these are user
+            // data the schema was ever supposed to declare, so warning about them
+            // would drown the signal in noise on literally every save.
+            if ($name === '' || $name === 'id' || $name[0] === '@' || $name[0] === '_') {
+                continue;
+            }
+
+            $dropped[] = $name;
+        }
+
+        if ($dropped === []) {
+            return;
+        }
+
+        $plural = 'ies';
+        if (count($dropped) === 1) {
+            $plural = 'y';
+        }
+
+        $this->logger->warning(
+            message: sprintf(
+                '[MagicMapper] Discarding %d propert%s the schema "%s" does not declare: %s. '
+                .'They are NOT stored anywhere — add them to the schema or stop sending them.',
+                count($dropped),
+                $plural,
+                (string) ($schema->getTitle() ?? $schema->getSlug() ?? (string) $schema->getId()),
+                implode(', ', $dropped)
+            ),
+            context: [
+                'file'       => __FILE__,
+                'line'       => __LINE__,
+                'schema'     => $schema->getId(),
+                'schemaSlug' => $schema->getSlug(),
+                'dropped'    => $dropped,
+            ]
+        );
+    }//end reportDroppedProperties()
 
     /**
      * Convert database row to ObjectEntity.

--- a/lib/Db/SchemaMapper.php
+++ b/lib/Db/SchemaMapper.php
@@ -404,6 +404,41 @@ class SchemaMapper extends QBMapper
             );
         }
 
+        // A bare slug can legitimately match SEVERAL rows. Since
+        // Version1Date20260723000000 widened the unique key from
+        // (organisation, slug) to (organisation, application, slug), two apps
+        // may each own a schema with the same generic slug — that widening was
+        // deliberate, and reverting it would put back the collision it fixed.
+        //
+        // What did NOT land with it is the determinism its own docblock promised
+        // ("resolution is scoped by app (import) and by register (runtime) in
+        // the accompanying code change"). The scoped resolvers exist, but every
+        // one of them falls back HERE when it misses, and here there was no
+        // ORDER BY and no row cap at all: which same-slug schema won was decided
+        // by the storage engine.
+        //
+        // Measured 2026-08-02: schemas 5012 "AgentFlow" (application '') and
+        // 5020 "Agent flow" (application 'hermiq') both carry slug `agentflow`
+        // in one organisation. 5012 holds 1 object, 5020 holds 46. Every
+        // slug-based resolution was a coin flip that happened to keep landing on
+        // the populated one.
+        //
+        // The tie-break, in order. First: a row an app OWNS beats an
+        // unattributed one. The widened key exists precisely to express
+        // ownership, so a leftover row that no app claims must never shadow an
+        // app's real schema. Second: the lowest id, matching
+        // RegisterMapper::find() and the `openregister:schemas:dedup` command's
+        // keep-the-lowest rule.
+        //
+        // Ownership has to come first, and not only for tidiness: on the live
+        // duplicate the unordered query returns the UNATTRIBUTED row first, and
+        // so would a bare `ORDER BY id ASC`.
+        $qb->addOrderBy(
+            $qb->createFunction("CASE WHEN application IS NULL OR application = '' THEN 1 ELSE 0 END"),
+            'ASC'
+        );
+        $qb->addOrderBy('id', 'ASC');
+
         // Apply organisation filter.
         // Set $_multitenancy=false to bypass organization filter (e.g., when expanding schemas for registers).
         $this->applyOrganisationFilter(
@@ -413,9 +448,44 @@ class SchemaMapper extends QBMapper
             multiTenancyEnabled: $_multitenancy
         );
 
+        // Two rows, not one: enough to KNOW the identifier was ambiguous, which
+        // a capped single-row fetch can never tell you. Silence is what let the
+        // agentflow collision run for as long as it did.
+        $qb->setMaxResults(2);
+
         $result = $qb->executeQuery();
-        $row    = $result->fetch();
+        $rows   = $result->fetchAll();
         $result->closeCursor();
+
+        $row = ($rows[0] ?? false);
+        if (count($rows) > 1) {
+            $this->logger->warning(
+                message: sprintf(
+                    '[SchemaMapper] Identifier "%s" matches more than one schema; resolving to #%s ("%s", application "%s"). '
+                    .'Fix the duplicate with `occ openregister:schemas:dedup`.',
+                    (string) $id,
+                    (string) ($rows[0]['id'] ?? '?'),
+                    (string) ($rows[0]['title'] ?? '?'),
+                    (string) ($rows[0]['application'] ?? '')
+                ),
+                context: [
+                    'file'       => __FILE__,
+                    'line'       => __LINE__,
+                    'identifier' => (string) $id,
+                    'candidates' => array_map(
+                        static function (array $candidate): array {
+                            return [
+                                'id'          => ($candidate['id'] ?? null),
+                                'title'       => ($candidate['title'] ?? null),
+                                'slug'        => ($candidate['slug'] ?? null),
+                                'application' => ($candidate['application'] ?? null),
+                            ];
+                        },
+                        $rows
+                    ),
+                ]
+            );
+        }//end if
 
         if ($row === false) {
             // Include diagnostic info in exception message for debugging.

--- a/lib/Exception/DatabaseConstraintException.php
+++ b/lib/Exception/DatabaseConstraintException.php
@@ -140,15 +140,29 @@ class DatabaseConstraintException extends Exception
         // MySQL/MariaDB format: "Duplicate entry 'value' for key 'constraint_name'".
         if (str_contains($dbMessage, 'Duplicate entry') === true && str_contains($dbMessage, 'for key') === true) {
             // Check for specific constraint names to provide more detailed messages.
+            //
+            // BOTH index names are matched, old and new. Version1Date20260723000000
+            // renamed `schemas_organisation_slug_unique` ->
+            // `schemas_org_app_slug_unique` (and the register equivalent) when it
+            // widened the key to (organisation, application, slug), and this
+            // parser was not updated with it — so on every post-migration
+            // instance these friendly messages had been dead since 2026-07-23,
+            // silently degrading to the generic "This schema already exists".
+            // The old names stay so an instance that has not yet migrated keeps
+            // its message too.
             // Schema slug uniqueness violation.
-            if (str_contains($dbMessage, 'schemas_organisation_slug_unique') === true) {
-                $msg = 'A schema with this slug already exists in your organization. ';
+            $isSchemaSlugViol = str_contains($dbMessage, 'schemas_organisation_slug_unique') === true
+                || str_contains($dbMessage, 'schemas_org_app_slug_unique') === true;
+            if ($isSchemaSlugViol === true) {
+                $msg = 'A schema with this slug already exists for this application in your organization. ';
                 return $msg.'Please choose a different slug or title.';
             }
 
             // Register slug uniqueness violation.
-            if (str_contains($dbMessage, 'registers_organisation_slug_unique') === true) {
-                $msg = 'A register with this slug already exists in your organization. ';
+            $isRegisterSlugViol = str_contains($dbMessage, 'registers_organisation_slug_unique') === true
+                || str_contains($dbMessage, 'registers_org_app_slug_unique') === true;
+            if ($isRegisterSlugViol === true) {
+                $msg = 'A register with this slug already exists for this application in your organization. ';
                 return $msg.'Please choose a different slug or title.';
             }
 

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -686,6 +686,10 @@ class ImportService
                 'updated'   => [],
                 'unchanged' => [],
                 'errors'    => [],
+                // Non-fatal findings the caller still needs to see. A dropped
+                // undeclared property is the first of these: the row imports
+                // fine and is quietly missing a field.
+                'warnings'  => [],
             ];
 
             // Phase 1: resolve every row to an (uuid, body) pair. When a pack is
@@ -732,6 +736,44 @@ class ImportService
 
                     // Body = schema properties only; empty strings → null.
                     $body = array_intersect_key($raw, $propertyKeys);
+
+                    // Report what that intersection just threw away. An import
+                    // drops undeclared keys BEFORE the save, so the warning at
+                    // the DB write boundary never sees them — an imported field
+                    // the schema does not declare would vanish with nothing
+                    // anywhere saying so. `@`/`_`/`id` are envelope and metadata,
+                    // never user data, so they are not losses.
+                    $importDropped = [];
+                    foreach (array_keys($raw) as $rawKey) {
+                        $rawName = (string) $rawKey;
+                        if (array_key_exists($rawName, $propertyKeys) === true) {
+                            continue;
+                        }
+
+                        if ($rawName === '' || $rawName === 'id' || $rawName === 'uuid'
+                            || $rawName[0] === '@' || $rawName[0] === '_'
+                        ) {
+                            continue;
+                        }
+
+                        $importDropped[] = $rawName;
+                    }
+
+                    if ($importDropped !== []) {
+                        $droppedPlural = 'ies';
+                        if (count($importDropped) === 1) {
+                            $droppedPlural = 'y';
+                        }
+
+                        $summary['warnings'][] = sprintf(
+                            'Row %d: dropped %d propert%s the schema does not declare: %s.',
+                            $rowNumber,
+                            count($importDropped),
+                            $droppedPlural,
+                            implode(', ', $importDropped)
+                        );
+                    }
+
                     foreach ($body as $key => $value) {
                         if ($value === '') {
                             $body[$key] = null;

--- a/openspec/changes/or-silent-field-loss/.openspec.yaml
+++ b/openspec/changes/or-silent-field-loss/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: silent-field-loss

--- a/openspec/changes/or-silent-field-loss/proposal.md
+++ b/openspec/changes/or-silent-field-loss/proposal.md
@@ -1,0 +1,69 @@
+# Proposal: or-silent-field-loss
+
+## Summary
+
+Two silences that turn out to be one story: a slug that resolves to whichever
+same-slug schema the storage engine hands back first, and a property the schema
+does not declare being discarded with no signal at all.
+
+## Why
+
+Measured on the live instance, 2026-08-02.
+
+**The duplicate.** Schemas 5012 "AgentFlow" (`application=''`, v0.0.1) and 5020
+"Agent flow" (`application='hermiq'`, v0.1.2) both carry slug `agentflow` in one
+organisation. `SchemaMapper::find()` — the resolver every scoped lookup falls back
+to — had no `ORDER BY` and no row cap, so which one won was the storage engine's
+choice. Run the query as the code ran it and Postgres returns **5012 first**: the
+stale, unowned copy, which is missing `description`, `notes`, `owner` and
+`triggerRegister`. The 64 live objects are all in **5020**.
+
+So a naive fix is worse than none: `ORDER BY id ASC` — the pattern
+`RegisterMapper::find()` already uses — would also pick 5012.
+
+**The drop.** `prepareObjectDataForTable()` is a whitelist by omission: it walks
+the schema's declared properties and copies those out of the payload. Everything
+else is never read, and there is no `object` blob column, so it is gone. No error,
+no warning, no trace. On the live agentflow table there is no `$bindings` and no
+`$comment` column, while every `hydra/flows/*.flow.json` carries both — they have
+been evaporating on every save.
+
+And the two connect: a save that resolved the schema to 5012 would prepare its
+row against 5012's property list, which has no `description`, and drop the field
+on the way to 5020's table. Field loss caused by ambiguous resolution, invisible
+at both ends.
+
+## What Changes
+
+- **`SchemaMapper::find()`** orders candidates — owned before unattributed, then
+  lowest id — reads two rows so ambiguity is *knowable*, and warns naming every
+  candidate when there is more than one.
+- **`DatabaseConstraintException`** recognises the post-migration index names.
+  `Version1Date20260723000000` renamed them on 2026-07-23 and this parser was not
+  updated, so the friendly slug-collision message had been silently dead on every
+  migrated instance ever since.
+- **`MagicMapper::prepareObjectDataForTable()`** warns, naming every discarded
+  property and the schema.
+- **`ImportService`** adds a `warnings` entry per row, because it filters
+  undeclared keys *before* the save where the mapper's warning cannot see them.
+
+## What this deliberately does NOT do
+
+**It does not add a uniqueness constraint on schema slugs.** Cross-application
+slug sharing is a deliberate, documented design:
+`Version1Date20260723000000` widened the key from `(organisation, slug)` to
+`(organisation, application, slug)` precisely because the narrow key made a
+generic slug shipped by app B (`conversation`, `order`, `task`) a hard collision
+with app A's, so the importer silently bound B to — or overwrote — A's schema.
+Re-narrowing it would put that back. What did not land with that migration is the
+determinism its own docblock promised; that is what this supplies.
+
+**It does not reject an undeclared property.** The DB write boundary is far too
+late for a clean 400 (the entity is built, folders may exist, cascades have run),
+and rejecting would break every caller that harmlessly posts an extra key. The
+requirement is visibility. Somebody has to be able to tell "this schema needs a
+property added" from "this field evaporated"; today those look identical.
+
+**It does not repair the live duplicate.** Two schemas exist on a shared instance
+and `occ openregister:schemas:dedup` is the operator tool for that. The code
+change makes the resolution correct and the ambiguity loud in the meantime.

--- a/openspec/changes/or-silent-field-loss/specs/silent-field-loss/spec.md
+++ b/openspec/changes/or-silent-field-loss/specs/silent-field-loss/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: A slug that matches several schemas resolves deterministically (REQ-SL-001)
+
+`SchemaMapper::find()` SHALL order its candidate rows before taking one, and
+SHALL cap the read so the choice is explicit rather than left to the storage
+engine. The order SHALL be:
+
+1. an exact primary-key match, when the identifier is numeric (existing);
+2. a row whose `application` is set, ahead of a row whose `application` is empty
+   or null;
+3. then the lowest `id`.
+
+Rule 2 exists because the unique key is `(organisation, application, slug)`: the
+key expresses OWNERSHIP, so a leftover row that no app claims SHALL NOT shadow an
+app's real schema. Rule 3 matches `RegisterMapper::find()` and the
+`openregister:schemas:dedup` keep-the-lowest rule.
+
+Cross-application slug sharing SHALL remain permitted. Migration
+`Version1Date20260723000000` widened the key deliberately so two apps can each own
+a schema with a generic slug; reverting that would restore the collision it fixed.
+
+When the identifier matches more than one schema, `SchemaMapper` SHALL log a
+warning naming every candidate and the one it resolved to.
+
+#### Scenario: An owned schema beats an unattributed one
+
+- **GIVEN** two schemas share a slug, one with `application` set and one without
+- **WHEN** the slug is resolved
+- **THEN** the one with `application` set is returned
+
+#### Scenario: An ambiguous identifier is reported
+
+- **GIVEN** a slug matching more than one schema
+- **WHEN** it is resolved
+- **THEN** a warning names every candidate and the resolved row
+
+@e2e exclude data-layer resolution — proven against the live duplicate
+(schemas 5012 `application=''` and 5020 `application='hermiq'`, both slug
+`agentflow`): the unordered query returns 5012 first, and so would a naive
+`ORDER BY id ASC`; the new tie-break returns 5020, which is the schema the 64
+live objects are in and the only one of the two that declares `description`
+
+### Requirement: The slug-collision message survives the index rename (REQ-SL-002)
+
+`DatabaseConstraintException` SHALL recognise both the pre-migration index names
+(`schemas_organisation_slug_unique`, `registers_organisation_slug_unique`) and
+the post-migration ones (`schemas_org_app_slug_unique`,
+`registers_org_app_slug_unique`).
+
+#### Scenario: The current index name produces the specific message
+
+- **GIVEN** a duplicate-key error naming `schemas_org_app_slug_unique`
+- **WHEN** it is translated
+- **THEN** the message says a schema with this slug already exists
+
+#### Scenario: An unrelated unique index keeps the generic message
+
+- **GIVEN** a duplicate-key error naming some other unique index
+- **WHEN** it is translated
+- **THEN** the generic message is returned
+
+@e2e exclude pure message mapping — covered by DatabaseConstraintExceptionSlugTest
+
+### Requirement: A property the schema does not declare is never dropped silently (REQ-SL-003)
+
+`MagicMapper::prepareObjectDataForTable()` copies only the schema's declared
+properties into the row, and there is no JSON blob column to fall back on, so an
+undeclared property is discarded permanently. It SHALL log a warning naming every
+discarded property and the schema, so the loss is visible.
+
+`ImportService` filters undeclared keys BEFORE the save, so that warning can never
+see them; the import summary SHALL therefore carry a `warnings` entry naming the
+row and the dropped properties.
+
+Neither SHALL reject the write. The DB write boundary is far too late for a clean
+400 — the entity is built, folders may exist and cascades have run — and rejecting
+would break every caller that harmlessly posts an extra key. The requirement is
+VISIBILITY, not refusal.
+
+Envelope and metadata keys (`@`-prefixed, `_`-prefixed, `id`, `uuid`) SHALL NOT be
+reported: they are not user data the schema was meant to declare, and reporting
+them would fire on every save.
+
+#### Scenario: An undeclared property is reported
+
+- **GIVEN** a payload carrying `$bindings`, which the schema does not declare
+- **WHEN** the object is saved
+- **THEN** the property is still not stored, and a warning names it
+
+#### Scenario: A fully declared payload reports nothing
+
+- **GIVEN** a payload whose every key the schema declares
+- **WHEN** the object is saved
+- **THEN** no drop warning is logged
+
+@e2e exclude data-layer write boundary — covered by MagicMapperTest with a
+positive control; verified against live data (the agentflow table has no
+`$bindings` / `$comment` column while every hydra flow document carries both)

--- a/openspec/changes/or-silent-field-loss/tasks.md
+++ b/openspec/changes/or-silent-field-loss/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: or-silent-field-loss
+
+- [x] `SchemaMapper::find()` — deterministic tie-break (owned before unattributed,
+      then lowest id), 2-row read, ambiguity warning naming every candidate.
+- [x] `DatabaseConstraintException` — recognise both the pre- and post-2026-07-23
+      slug index names.
+- [x] `MagicMapper::prepareObjectDataForTable()` — report every discarded
+      undeclared property; skip envelope/metadata keys.
+- [x] `ImportService` — per-row `warnings` for keys the pre-save filter drops.
+- [x] Tests, each with a positive control.
+- [ ] Operator: run `occ openregister:schemas:dedup` against the live `agentflow`
+      duplicate (5012 / 5020). Data repair, not a code change.

--- a/tests/Unit/Exception/DatabaseConstraintExceptionSlugTest.php
+++ b/tests/Unit/Exception/DatabaseConstraintExceptionSlugTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * The friendly slug-collision message had been dead since 2026-07-23.
+ *
+ * `Version1Date20260723000000` renamed the unique indexes when it widened the
+ * key from (organisation, slug) to (organisation, application, slug), and this
+ * parser was not renamed with it. On every migrated instance the specific
+ * message silently degraded to the generic "This schema already exists" — a
+ * control that still existed, was still referenced, and no longer fired.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Exception
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Exception;
+
+use Exception;
+use OCA\OpenRegister\Exception\DatabaseConstraintException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OCA\OpenRegister\Exception\DatabaseConstraintException
+ */
+class DatabaseConstraintExceptionSlugTest extends TestCase
+{
+
+    /**
+     * The index names in use since 2026-07-23 produce the specific message.
+     *
+     * @dataProvider currentIndexProvider
+     *
+     * @param string $index    The index name in the DB error.
+     * @param string $entity   The entity type.
+     * @param string $expected A phrase the message must contain.
+     *
+     * @return void
+     */
+    public function testCurrentIndexNamesAreRecognised(string $index, string $entity, string $expected): void
+    {
+        $message = DatabaseConstraintException::fromDatabaseException(
+            new Exception(sprintf("Duplicate entry 'agentflow' for key '%s'", $index)),
+            $entity
+        )->getMessage();
+
+        $this->assertStringContainsString($expected, $message);
+    }
+
+    /**
+     * The post-migration index names.
+     *
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public static function currentIndexProvider(): array
+    {
+        return [
+            'schema (new)'   => ['schemas_org_app_slug_unique', 'schema', 'A schema with this slug already exists'],
+            'register (new)' => ['registers_org_app_slug_unique', 'register', 'A register with this slug already exists'],
+        ];
+    }
+
+    /**
+     * The pre-migration names still work — an unmigrated instance keeps its message.
+     *
+     * @dataProvider legacyIndexProvider
+     *
+     * @param string $index    The legacy index name.
+     * @param string $entity   The entity type.
+     * @param string $expected A phrase the message must contain.
+     *
+     * @return void
+     */
+    public function testLegacyIndexNamesStillRecognised(string $index, string $entity, string $expected): void
+    {
+        $message = DatabaseConstraintException::fromDatabaseException(
+            new Exception(sprintf("Duplicate entry 'agentflow' for key '%s'", $index)),
+            $entity
+        )->getMessage();
+
+        $this->assertStringContainsString($expected, $message);
+    }
+
+    /**
+     * The pre-migration index names.
+     *
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public static function legacyIndexProvider(): array
+    {
+        return [
+            'schema (old)'   => ['schemas_organisation_slug_unique', 'schema', 'A schema with this slug already exists'],
+            'register (old)' => ['registers_organisation_slug_unique', 'register', 'A register with this slug already exists'],
+        ];
+    }
+
+    /**
+     * POSITIVE CONTROL: an unrelated unique index still gets the generic message.
+     *
+     * Without this the tests above pass for a parser that returns the schema
+     * message unconditionally.
+     *
+     * @return void
+     */
+    public function testAnUnrelatedUniqueIndexKeepsTheGenericMessage(): void
+    {
+        $message = DatabaseConstraintException::fromDatabaseException(
+            new Exception("Duplicate entry 'x' for key 'some_other_unique_idx'"),
+            'schema'
+        )->getMessage();
+
+        $this->assertStringNotContainsString('with this slug', $message);
+        $this->assertStringContainsString('already exists', $message);
+    }
+}

--- a/tests/Unit/Service/MagicMapperTest.php
+++ b/tests/Unit/Service/MagicMapperTest.php
@@ -662,6 +662,114 @@ class MagicMapperTest extends TestCase
 
 
     /**
+     * A property the schema does not declare is dropped — and now SAYS SO.
+     *
+     * The loop in prepareObjectDataForTable is a whitelist by omission: it walks
+     * the schema's declared properties and copies those out of the payload.
+     * Anything else is never read, and there is no `object` JSON blob column to
+     * fall back on, so it is gone. Until now that happened with no error, no
+     * warning and no trace — the write succeeded and the field was simply
+     * missing.
+     *
+     * Measured 2026-08-02 on the live agentflow schema: the hydra flow documents
+     * carry `$bindings` and `$comment`, the schema declares neither, and the
+     * table has no column for either. Both were being discarded on every save
+     * with nothing anywhere recording it.
+     *
+     * @return void
+     */
+    public function testUndeclaredPropertiesAreDroppedButReported(): void
+    {
+        $schema = new TestableSchema();
+        $schema->setId(42);
+        $schema->setTitle('Agent flow');
+        $schema->testProperties = [
+            'name'  => ['type' => 'string'],
+            'nodes' => ['type' => 'array'],
+        ];
+
+        $dropped = [];
+        $this->mockLogger->method('warning')->willReturnCallback(
+            static function (string $message, array $context=[]) use (&$dropped): void {
+                if (str_contains($message, 'does not declare') === true) {
+                    $dropped = ($context['dropped'] ?? []);
+                }
+            }
+        );
+
+        $objectData = [
+            '@self'     => ['uuid' => 'flow-uuid-1'],
+            'name'      => 'hydra-file-findings',
+            'nodes'     => [['id' => 'in']],
+            // Undeclared, and load-bearing-looking. These are the real ones.
+            '$bindings' => ['forgeCredential' => 'abc'],
+            '$comment'  => 'why this flow exists',
+            // Envelope/metadata keys must NOT be reported — they are not user
+            // data the schema was ever meant to declare, and warning about them
+            // would fire on literally every save.
+            'id'        => 'flow-uuid-1',
+            '_version'  => 3,
+        ];
+
+        $reflection = new \ReflectionClass($this->magicMapper);
+        $method     = $reflection->getMethod('prepareObjectDataForTable');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->magicMapper, $objectData, $this->mockRegister, $schema);
+
+        // Still dropped — this change makes the loss visible, it does not store
+        // the field. Rejecting at the DB write boundary would be far too late.
+        $this->assertArrayNotHasKey('$bindings', $result);
+        $this->assertArrayNotHasKey('$comment', $result);
+        $this->assertSame('hydra-file-findings', $result['name']);
+
+        // ...and now it is reported, naming exactly the user-data keys.
+        sort($dropped);
+        $this->assertSame(['$bindings', '$comment'], $dropped);
+
+    }//end testUndeclaredPropertiesAreDroppedButReported()
+
+
+    /**
+     * POSITIVE CONTROL: a payload the schema fully declares warns about nothing.
+     *
+     * Without this, the test above is satisfied by a warning that fires always.
+     *
+     * @return void
+     */
+    public function testAFullyDeclaredPayloadReportsNoDrop(): void
+    {
+        $schema = new TestableSchema();
+        $schema->setId(42);
+        $schema->setTitle('Agent flow');
+        $schema->testProperties = ['name' => ['type' => 'string']];
+
+        $warned = false;
+        $this->mockLogger->method('warning')->willReturnCallback(
+            static function (string $message) use (&$warned): void {
+                if (str_contains($message, 'does not declare') === true) {
+                    $warned = true;
+                }
+            }
+        );
+
+        $reflection = new \ReflectionClass($this->magicMapper);
+        $method     = $reflection->getMethod('prepareObjectDataForTable');
+        $method->setAccessible(true);
+
+        $method->invoke(
+            $this->magicMapper,
+            ['@self' => ['uuid' => 'u'], 'name' => 'ok', 'id' => 'u'],
+            $this->mockRegister,
+            $schema
+        );
+
+        $this->assertFalse($warned, 'A fully declared payload must not warn.');
+
+    }//end testAFullyDeclaredPayloadReportsNoDrop()
+
+
+    /**
      * Test clear cache functionality
      *
      * @return void


### PR DESCRIPTION
Two silences that turn out to be one story.

## 1. The duplicate — and why the obvious fix is worse than none

Schemas **5012** "AgentFlow" (`application=''`, v0.0.1) and **5020** "Agent flow" (`application='hermiq'`, v0.1.2) both carry slug `agentflow` in one organisation. `SchemaMapper::find()` — the resolver every scoped lookup falls back to when it misses — had **no `ORDER BY` and no row cap**, so which one won was the storage engine's choice.

Run the query as the code ran it:

```
$ SELECT id,title,application FROM oc_openregister_schemas WHERE LOWER(slug)='agentflow';
5012|AgentFlow|
5020|Agent flow|hermiq
```

Postgres returns **5012 first** — the stale, unowned copy, which is missing `description`, `notes`, `owner` and `triggerRegister`. All **64** live objects are in 5020.

So `ORDER BY id ASC` — the pattern `RegisterMapper::find()` already uses, and the obvious thing to copy — would *also* pick 5012. Determinism alone is not the fix; the right one has to be **ownership first, then lowest id**:

```
$ ... ORDER BY (CASE WHEN application IS NULL OR application = '' THEN 1 ELSE 0 END), id LIMIT 2;
5020|Agent flow|hermiq
5012|AgentFlow|
```

The unique key has been `(organisation, application, slug)` since `Version1Date20260723000000`, and it exists precisely to express ownership — so a leftover row no app claims must never shadow an app's real schema. `find()` now reads **two** rows, so ambiguity is knowable at all, and warns naming every candidate.

**Deliberately not a uniqueness constraint.** Cross-app slug sharing is a documented design: the narrow key made a generic slug shipped by app B (`conversation`, `order`, `task`) a hard collision with app A's, so the importer silently bound B to — or overwrote — A's schema. Re-narrowing puts that back. What did *not* land with that migration is the determinism its own docblock promised ("resolution is scoped by app (import) and by register (runtime) in the accompanying code change"). That is what this supplies.

**Bonus, found on the way:** `DatabaseConstraintException` still matched only the *pre*-rename index names, so the friendly slug-collision message had been silently dead on every migrated instance since 2026-07-23, degrading to the generic "already exists". Both name pairs now match.

## 2. The drop

`prepareObjectDataForTable()` is a whitelist by omission: it walks the schema's declared properties and copies those out of the payload. Everything else is never read, and there is no JSON blob column, so it is gone — no error, no warning, no trace.

On the live agentflow table there is **no `$bindings` and no `$comment` column**, while every `hydra/flows/*.flow.json` carries both. They have been evaporating on every save.

**And the two connect.** A save that resolved the schema to 5012 prepares its row against 5012's property list, which has no `description`, and drops the field on the way to 5020's table. Field loss caused by ambiguous resolution, invisible at both ends.

It **warns rather than rejects**. The DB write boundary is far too late for a clean 400 — the entity is built, folders may exist, cascades have run — and rejecting would break every caller that harmlessly posts an extra key. Envelope/metadata keys (`@`-, `_`-prefixed, `id`, `uuid`) are excluded or it would fire on every save. `ImportService` filters undeclared keys *before* the save, where that warning can never see them, so it reports per row into a new summary `warnings` list.

## Contradicting the brief

The brief said the agentflow schema "has no `description` property". Not for the schema the objects live in: **5020 declares it**, and 14 of 63 rows have one, including 8 created today. The two `hydra-*` rows are empty because the seeding call did not send it — not because OR dropped it. The real silent drop on these documents is `$bindings` / `$comment`. Separately: nothing in either repo reads `$bindings`, so it is an authoring convention no code consumes — worth knowing before anyone adds a column for it.

## Proof

- Tie-break run against the live duplicate (above)
- `MagicMapperTest` — drop reported, naming exactly the user-data keys, **plus a positive control** that a fully declared payload warns about nothing
- `DatabaseConstraintExceptionSlugTest` — new and legacy index names, **plus a positive control** that an unrelated unique index keeps the generic message
- **Full unit suite: 15,644 tests, 0 failures.** phpcs clean on every touched file; the 3 phpstan findings in `SchemaMapper` are pre-existing on the untouched base (verified by stashing).