### PR TITLE
fix(flow): the scheduler could only see ONE flow store, so hermiq's schedules never fired

### DIFF
--- a/lib/Service/Flow/FlowResolverRegistry.php
+++ b/lib/Service/Flow/FlowResolverRegistry.php
@@ -176,6 +176,66 @@ class FlowResolverRegistry
     }//end flowsForTrigger()
 
     /**
+     * The scheduled-flow candidates every contributing app owns.
+     *
+     * The scheduler used to read one hard-coded store, so a flow that declared
+     * `trigger: schedule` in a leaf app's own register was invisible to it and
+     * could never fire — the event triggers had gone through the resolvers
+     * since day one, the schedule never had. This closes that: any app whose
+     * resolver also implements {@see IScheduledFlowSource} contributes its
+     * scheduled flows, exactly as it already contributes its event-triggered
+     * ones.
+     *
+     * A resolver that does not implement the interface is skipped rather than
+     * asked, so an app that owns only event-triggered flows costs nothing and
+     * needs no change. A resolver that throws is logged and skipped, because
+     * one broken app must not stop the whole instance's schedule.
+     *
+     * Candidates are de-duplicated by flow id, first source winning — the same
+     * precedence `resolveFlow()` uses, so the app that would actually run the
+     * flow is the one whose cron and owner are used.
+     *
+     * @return array<int, array{id: string, enabled: bool, trigger: string, cron: string, owner: string|null}>
+     *         The candidate flows.
+     *
+     * @spec openspec/changes/or-flow-schedule-any-store/specs/flow-scheduled-trigger/spec.md
+     */
+    public function scheduledFlows(): array
+    {
+        $candidates = [];
+        foreach ($this->all() as $resolver) {
+            if (($resolver instanceof IScheduledFlowSource) === false) {
+                continue;
+            }
+
+            try {
+                foreach ($resolver->scheduledFlows() as $candidate) {
+                    $id = (string) ($candidate['id'] ?? '');
+                    if ($id === '' || array_key_exists($id, $candidates) === true) {
+                        continue;
+                    }
+
+                    $candidates[$id] = [
+                        'id'      => $id,
+                        'enabled' => (bool) ($candidate['enabled'] ?? false),
+                        'trigger' => (string) ($candidate['trigger'] ?? ''),
+                        'cron'    => (string) ($candidate['cron'] ?? ''),
+                        'owner'   => ($candidate['owner'] ?? null),
+                    ];
+                }
+            } catch (\Throwable $e) {
+                $this->logger->warning(
+                    message: '[FlowResolverRegistry] A resolver threw listing scheduled flows: '.$e->getMessage(),
+                    context: ['file' => __FILE__, 'line' => __LINE__]
+                );
+            }//end try
+        }//end foreach
+
+        return array_values($candidates);
+
+    }//end scheduledFlows()
+
+    /**
      * Collect the contributed resolvers once per request.
      *
      * @return array<int, IFlowResolver> The resolvers.

--- a/lib/Service/Flow/FlowScheduleService.php
+++ b/lib/Service/Flow/FlowScheduleService.php
@@ -8,12 +8,20 @@
  * for, so this is driven by a worker ({@see FlowScheduleWorker}) that ticks
  * periodically and asks this service which scheduled flows are now due.
  *
- * A scheduled flow is an OpenRegister flow (in the flow store) whose `trigger`
- * is `schedule` and which carries a `cron` expression. "Due" is decided per
- * flow: the last time it fired is remembered (in app config, keyed by the flow's
- * uuid — so the flow object itself is never rewritten), and a flow is due when a
- * cron occurrence has passed since then. A flow seen for the first time has no
- * last-fire, so it fires once on the next tick and then follows its cron.
+ * A scheduled flow is any flow whose `trigger` is `schedule` and which carries a
+ * `cron` expression. Which flows exist is not this service's business: it asks
+ * the resolver registry, the same way the event triggers do. It used to read one
+ * hard-coded store instead — the `flow_register`/`flow_schema` pair — so a flow
+ * owned by a leaf app (hermiq's agentflows) was invisible to the scheduler and
+ * could never fire, no matter how correct its cron was. An event-triggered flow
+ * in that same store fired fine, which made the gap look like a flow-authoring
+ * problem rather than a missing enumeration.
+ *
+ * "Due" is decided per flow: the last time it fired is remembered (in app
+ * config, keyed by the flow's id — so the flow object itself is never
+ * rewritten), and a flow is due when a cron occurrence has passed since then. A
+ * flow seen for the first time has no last-fire, so it fires once on the next
+ * tick and then follows its cron.
  *
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  * SPDX-License-Identifier: EUPL-1.2
@@ -37,8 +45,6 @@ namespace OCA\OpenRegister\Service\Flow;
 use Cron\CronExpression;
 use DateTimeImmutable;
 use DateTimeInterface;
-use OCA\OpenRegister\Db\ObjectEntity;
-use OCA\OpenRegister\Service\ObjectService;
 use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -60,26 +66,15 @@ class FlowScheduleService
     private const LAST_FIRE_KEY = 'flow_sched_last_';
 
     /**
-     * Config keys (and defaults) naming the register and schema flows live in.
-     */
-    private const REGISTER_KEY = 'flow_register';
-
-    private const REGISTER_DEFAULT = 'flows';
-
-    private const SCHEMA_KEY = 'flow_schema';
-
-    private const SCHEMA_DEFAULT = 'flow';
-
-    /**
      * Constructor.
      *
-     * @param ObjectService   $objectService Lists the scheduled flows.
-     * @param FlowRunService  $runs          Queues a run for a due flow.
-     * @param IAppConfig      $appConfig     Names the store; remembers last-fire.
-     * @param LoggerInterface $logger        The logger.
+     * @param FlowResolverRegistry $resolvers Lists the scheduled flows every app owns.
+     * @param FlowRunService       $runs      Queues a run for a due flow.
+     * @param IAppConfig           $appConfig Remembers last-fire.
+     * @param LoggerInterface      $logger    The logger.
      */
     public function __construct(
-        private readonly ObjectService $objectService,
+        private readonly FlowResolverRegistry $resolvers,
         private readonly FlowRunService $runs,
         private readonly IAppConfig $appConfig,
         private readonly LoggerInterface $logger
@@ -99,28 +94,22 @@ class FlowScheduleService
     public function fireDueFlows(DateTimeInterface $now): array
     {
         try {
-            $flows = $this->objectService->findAll(
-                config: ['filters' => ['register' => $this->flowRegister(), 'schema' => $this->flowSchema()]],
-                _rbac: false,
-                _multitenancy: false
-            );
+            $candidates = $this->resolvers->scheduledFlows();
         } catch (Throwable $e) {
-            // No flow store yet — nothing scheduled.
+            // No resolver could be asked — nothing scheduled.
             return [];
         }
 
         $fired = [];
-        foreach ($flows as $flow) {
-            if (($flow instanceof ObjectEntity) === false) {
-                continue;
-            }
-
-            $cron = $this->scheduleOf(flow: $flow);
+        foreach ($candidates as $candidate) {
+            $cron = $this->scheduleOf(candidate: $candidate);
             if ($cron === null) {
                 continue;
             }
 
-            $uuid = (string) $flow->getUuid();
+            // The registry guarantees a non-empty id — a candidate without one
+            // is dropped there, so every id here is one a resolver can load.
+            $uuid = $candidate['id'];
             if ($this->isDue(cron: $cron, uuid: $uuid, now: $now) === false) {
                 continue;
             }
@@ -155,7 +144,12 @@ class FlowScheduleService
                 continue;
             }
 
-            $this->fire(uuid: $uuid, now: $now, owner: $flow->getOwner());
+            $owner = $candidate['owner'] ?? null;
+            if ($owner !== null) {
+                $owner = (string) $owner;
+            }
+
+            $this->fire(uuid: $uuid, now: $now, owner: $owner);
             $fired[] = $uuid;
         }//end foreach
 
@@ -164,25 +158,31 @@ class FlowScheduleService
     }//end fireDueFlows()
 
     /**
-     * The cron expression of a flow that is an enabled schedule, or null.
+     * The cron expression of a candidate that is an enabled schedule, or null.
      *
-     * @param ObjectEntity $flow The flow object.
+     * Every gate a scheduled flow has to pass is here, in the scheduler, and
+     * NOT in the app that contributed the candidate. A source is trusted to say
+     * which flows it owns; it is not trusted to decide which of them may run.
+     * That matters most for `enabled`: a leaf app that got its own filtering
+     * wrong would otherwise be able to run a flow an admin had switched off.
      *
-     * @return string|null The cron expression, or null when the flow is not a
-     *                     valid enabled schedule.
+     * @param array $candidate The candidate flow reported by a source, shaped
+     *                         `{id, enabled, trigger, cron, owner}`.
+     *
+     * @return string|null The cron expression, or null when the candidate is not
+     *                     a valid enabled schedule.
      */
-    private function scheduleOf(ObjectEntity $flow): ?string
+    private function scheduleOf(array $candidate): ?string
     {
-        $data = $flow->getObject();
-        if (($data['enabled'] ?? false) !== true) {
+        if (($candidate['enabled'] ?? false) !== true) {
             return null;
         }
 
-        if ((string) ($data['trigger'] ?? '') !== 'schedule') {
+        if ((string) ($candidate['trigger'] ?? '') !== 'schedule') {
             return null;
         }
 
-        $cron = trim((string) ($data['cron'] ?? ''));
+        $cron = trim((string) ($candidate['cron'] ?? ''));
         if ($cron === '' || CronExpression::isValidExpression($cron) === false) {
             return null;
         }
@@ -256,26 +256,4 @@ class FlowScheduleService
         $this->appConfig->setValueString(self::APP_ID, self::LAST_FIRE_KEY.$uuid, $now->format(DATE_ATOM));
 
     }//end fire()
-
-    /**
-     * The register flows are stored in.
-     *
-     * @return string The register slug.
-     */
-    private function flowRegister(): string
-    {
-        return $this->appConfig->getValueString(self::APP_ID, self::REGISTER_KEY, self::REGISTER_DEFAULT);
-
-    }//end flowRegister()
-
-    /**
-     * The schema flows are stored under.
-     *
-     * @return string The schema slug.
-     */
-    private function flowSchema(): string
-    {
-        return $this->appConfig->getValueString(self::APP_ID, self::SCHEMA_KEY, self::SCHEMA_DEFAULT);
-
-    }//end flowSchema()
 }//end class

--- a/lib/Service/Flow/IScheduledFlowSource.php
+++ b/lib/Service/Flow/IScheduledFlowSource.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Lets an app that owns flows expose the ones that run on a schedule.
+ *
+ * The event triggers already work for any app: an object write asks every
+ * contributed {@see IFlowResolver} which of its flows are wired to the event, so
+ * a flow living in a leaf app's own store fires exactly like one living in
+ * OpenRegister's. A schedule had no such path. {@see FlowScheduleService} read
+ * one hard-coded store — the `flow_register`/`flow_schema` pair — so a flow that
+ * declared `trigger: schedule` anywhere else was simply invisible to the
+ * scheduler and could never fire. hermiq's agentflows were the first casualty:
+ * correct flows, a correct cron, and nothing to notice them.
+ *
+ * This is the missing half of the resolver contract. It is deliberately a
+ * SEPARATE interface rather than three more methods on `IFlowResolver`, so an
+ * existing resolver keeps compiling and an app that owns only event-triggered
+ * flows never has to answer a question it has no answer to.
+ *
+ * A source reports CANDIDATES, not decisions. It says "these are the flows I own
+ * that mention a schedule", and the scheduler decides which of them may run:
+ * `enabled` is re-checked centrally, the trigger is re-checked centrally, the
+ * cron is re-parsed centrally, and the no-overlap guarantee (openregister#2218)
+ * is applied centrally. A source that got its own filtering wrong therefore
+ * cannot make a disabled flow run.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-schedule-any-store/specs/flow-scheduled-trigger/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+/**
+ * Contract for listing the scheduled flows an app owns.
+ */
+interface IScheduledFlowSource
+{
+    /**
+     * The flows this app owns that declare a schedule.
+     *
+     * Implementations SHOULD narrow to flows whose `trigger` is `schedule`,
+     * because the scheduler ticks every five minutes and listing a whole flow
+     * store each time is wasted work. They MUST report `enabled` honestly
+     * rather than silently omitting disabled flows — the scheduler needs the
+     * flag to make the decision, and reporting it keeps the "a disabled flow
+     * never runs" rule in one place.
+     *
+     * The return is typed loosely on purpose. An implementation lives in
+     * ANOTHER app, so its shape is a contract rather than a guarantee, and the
+     * registry reads every key defensively. Each entry SHOULD carry:
+     *
+     * - `id`      — the flow id the engine runs (what `resolveFlow()` accepts)
+     * - `enabled` — boolean, reported rather than filtered on
+     * - `trigger` — the flow's trigger, normally `schedule`
+     * - `cron`    — the cron expression, or an empty string
+     * - `owner`   — the user the run is attributed to, or null
+     *
+     * @return array<int, array<string, mixed>> One entry per candidate flow.
+     *
+     * @spec openspec/changes/or-flow-schedule-any-store/specs/flow-scheduled-trigger/spec.md
+     */
+    public function scheduledFlows(): array;
+}//end interface

--- a/lib/Service/Flow/OpenRegisterFlowResolver.php
+++ b/lib/Service/Flow/OpenRegisterFlowResolver.php
@@ -48,7 +48,7 @@ use Throwable;
  *
  * @spec openspec/changes/or-flow-native-store/specs/flow-native-store/spec.md
  */
-class OpenRegisterFlowResolver implements IFlowResolver
+class OpenRegisterFlowResolver implements IFlowResolver, IScheduledFlowSource
 {
 
     /**
@@ -230,6 +230,77 @@ class OpenRegisterFlowResolver implements IFlowResolver
         return $ids;
 
     }//end flowsForTrigger()
+
+    /**
+     * The scheduled flows OpenRegister's own store holds.
+     *
+     * This is the enumeration {@see FlowScheduleService} used to do inline. It
+     * moves here so the scheduler has exactly one way to find a scheduled flow —
+     * ask the resolvers — instead of one path for its own store and none for
+     * anybody else's. Behaviour for this store is unchanged: the same register
+     * and schema, the same fields, the same central enabled/cron checks.
+     *
+     * Neither `enabled` nor `trigger` is filtered server-side. The narrowing to
+     * schedules happens in PHP on purpose: a property filter that does not
+     * match the store's dialect returns an EMPTY result, and an empty result is
+     * indistinguishable from "nothing is scheduled" — which is precisely the
+     * silent nothing-ever-fires failure this change exists to fix. Listing the
+     * flow store costs what the trigger index already pays, once per five-minute
+     * tick. And the scheduler is told about disabled schedules rather than
+     * having them filtered away, so "a disabled flow never runs" stays a
+     * property of one place instead of every store's query.
+     *
+     * @return array<int, array{id: string, enabled: bool, trigger: string, cron: string, owner: string|null}>
+     *         The candidate flows.
+     *
+     * @spec openspec/changes/or-flow-schedule-any-store/specs/flow-scheduled-trigger/spec.md
+     */
+    public function scheduledFlows(): array
+    {
+        try {
+            $flows = $this->objectService->findAll(
+                config: ['filters' => ['register' => $this->flowRegister(), 'schema' => $this->flowSchema()]],
+                _rbac: false,
+                _multitenancy: false
+            );
+        } catch (Throwable $e) {
+            // No flow store yet — nothing scheduled here.
+            return [];
+        }
+
+        $candidates = [];
+        foreach ($flows as $flow) {
+            if (($flow instanceof ObjectEntity) === false) {
+                continue;
+            }
+
+            $data = $flow->getObject();
+            if ((string) ($data['trigger'] ?? '') !== 'schedule') {
+                continue;
+            }
+
+            $owner = trim((string) ($flow->getOwner() ?? ''));
+            if ($owner === '') {
+                $owner = trim((string) ($data['owner'] ?? ''));
+            }
+
+            $ownerId = null;
+            if ($owner !== '') {
+                $ownerId = $owner;
+            }
+
+            $candidates[] = [
+                'id'      => (string) $flow->getUuid(),
+                'enabled' => (($data['enabled'] ?? false) === true),
+                'trigger' => (string) ($data['trigger'] ?? ''),
+                'cron'    => (string) ($data['cron'] ?? ''),
+                'owner'   => $ownerId,
+            ];
+        }//end foreach
+
+        return $candidates;
+
+    }//end scheduledFlows()
 
     /**
      * The compact (id, trigger, register, schema) index of ENABLED flows.

--- a/openspec/changes/or-flow-schedule-any-store/.openspec.yaml
+++ b/openspec/changes/or-flow-schedule-any-store/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-scheduled-trigger

--- a/openspec/changes/or-flow-schedule-any-store/proposal.md
+++ b/openspec/changes/or-flow-schedule-any-store/proposal.md
@@ -1,0 +1,62 @@
+# Proposal: or-flow-schedule-any-store
+
+## Summary
+
+Let the flow scheduler see the flows other apps own. It asked one hard-coded
+store; now it asks the resolver registry, the way every other trigger already
+did.
+
+## Why
+
+Every trigger family except the schedule went through `FlowResolverRegistry`.
+The schedule alone read the `flow_register`/`flow_schema` pair directly, so a
+flow contributed by an app — hermiq's `agentflow` objects — was invisible to it.
+Not refused, not logged: invisible. The flow could be enabled, carry a valid
+cron, and be walked correctly on a manual run, and still never fire, because
+nothing ever asked whether it existed.
+
+Measured on the dev instance before this change: **zero** runs with
+`trigger='schedule'`, out of 52,478 runs (`object.created` 52,364, `test` 96,
+`verify-harness` 7, `hydra-e2e-harness` 6, `sub-flow` 2, `mcp` 2, `retry` 1).
+The three flows in that state — `hydra-sequencer`, `hydra-dispatch`,
+`hydra-lock-reaper` — are the hydra pipeline's clock. The pipeline ran correctly
+whenever it was triggered and nothing could trigger it.
+
+## What Changes
+
+- **`IScheduledFlowSource`** (new) — an optional capability a flow resolver may
+  also implement, listing the flows it owns that declare a schedule. Separate
+  from `IFlowResolver` so every existing resolver keeps compiling and an app
+  that owns only event-triggered flows answers nothing.
+- **`FlowResolverRegistry::scheduledFlows()`** — gathers candidates from every
+  contributing app, de-duplicating by flow id (first source wins, matching
+  `resolveFlow()`), logging and skipping a source that throws.
+- **`OpenRegisterFlowResolver`** — becomes a source for OpenRegister's own flow
+  store. This is the enumeration `FlowScheduleService` used to do inline, moved
+  so there is one way to find a scheduled flow instead of one for this store and
+  none for anybody else's. Behaviour for this store is unchanged.
+- **`FlowScheduleService`** — takes the registry instead of `ObjectService`, and
+  keeps every decision: `enabled`, trigger, cron validity, due-ness, and the
+  no-overlap guard (#2218) are all still applied here, to candidates from every
+  source. A source is trusted to say which flows it owns, not which may run.
+
+## Blast radius
+
+The scheduler now enumerates through the resolvers on every instance in the
+fleet, so it can see more flows than before. Three things bound that:
+
+1. A source reports only flows whose `trigger` is `schedule`. An event-triggered
+   or manual flow never reaches the scheduler.
+2. `enabled` is re-checked centrally. A disabled flow is never fired regardless
+   of what a source reported — asserted for a source that reports disabled flows
+   without filtering them.
+3. A flow with no cron, or an invalid one, is skipped.
+
+Cost is one flow-store listing per contributing app per five-minute tick — the
+same listing the trigger index already performs, and the scheduler's own listing
+is not added on top of it, it is the same one moved.
+
+## Non-goals
+
+The `cron` property missing from hermiq's `agentflow` schema is the second,
+independent cause of the same symptom and is fixed in hermiq, not here.

--- a/openspec/changes/or-flow-schedule-any-store/specs/flow-scheduled-trigger/spec.md
+++ b/openspec/changes/or-flow-schedule-any-store/specs/flow-scheduled-trigger/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: The scheduler finds scheduled flows in every app's store (REQ-SCH-003)
+
+OpenRegister SHALL discover scheduled flows by asking the flow resolver
+registry, not by reading one hard-coded store. Any app whose flow resolver also
+implements `IScheduledFlowSource` SHALL contribute its scheduled flows, and a
+flow that app owns SHALL fire on its cron exactly as one in OpenRegister's own
+store does. A resolver that does not implement the interface SHALL be skipped,
+and a source that throws SHALL be logged and skipped without stopping the rest of
+the instance's schedule.
+
+(Regression guard: the scheduler enumerated only the `flow_register`/
+`flow_schema` pair. Flows contributed by an app — hermiq's `agentflow` objects,
+including `hydra-sequencer`, `hydra-dispatch` and `hydra-lock-reaper` — were
+invisible to it and could never fire. Event triggers had gone through the
+resolvers since day one, so the same flow store worked for events and was dead
+for schedules; the instance recorded zero runs with trigger `schedule` across
+52,478 runs.)
+
+#### Scenario: A scheduled flow owned by another app fires
+
+- **GIVEN** an app whose flow resolver is also a scheduled-flow source
+- **AND** that app owns an enabled flow with trigger `schedule` and a valid cron
+- **WHEN** the schedule worker ticks and the flow is due
+- **THEN** a run is queued for it with trigger `schedule`, attributed to the
+  flow's owner
+
+#### Scenario: A resolver that owns no scheduled flows is not asked
+
+- **GIVEN** a contributed resolver that does not implement the source interface
+- **WHEN** the scheduler enumerates
+- **THEN** it is skipped and contributes nothing
+
+#### Scenario: One broken source does not stop the schedule
+
+- **GIVEN** two sources, the first of which throws
+- **WHEN** the scheduler enumerates
+- **THEN** the failure is logged and the second source's flows are still returned
+
+### Requirement: The run/do-not-run decision stays in the scheduler (REQ-SCH-004)
+
+A scheduled-flow source SHALL report candidates — including disabled ones, with
+their `enabled` flag — and SHALL NOT decide which of them may run. OpenRegister
+SHALL re-check `enabled`, re-check that the trigger is `schedule`, and re-parse
+the cron before firing, so an app that filtered wrongly cannot cause a disabled
+flow to run.
+
+The same flow id reported by more than one source SHALL yield exactly one
+candidate, first source winning — matching `resolveFlow()`'s precedence, and
+preventing a duplicated id from firing the same flow twice in one tick, which the
+no-overlap guard (openregister#2218) cannot catch because both fires precede
+either run.
+
+#### Scenario: A disabled flow reported by a source is not fired
+
+- **GIVEN** a source that reports a flow with `enabled` false
+- **WHEN** the schedule worker ticks
+- **THEN** no run is queued for it
+
+#### Scenario: A flow claimed by two sources fires once
+
+- **GIVEN** two sources reporting the same flow id
+- **WHEN** the scheduler enumerates
+- **THEN** exactly one candidate is produced, from the first source
+
+#### Scenario: The no-overlap guarantee is unchanged
+
+- **GIVEN** a due flow, from any source, whose previous run is still active
+- **WHEN** the schedule worker ticks
+- **THEN** no run is queued and its last-fire marker is not advanced
+
+@e2e exclude covered by FlowScheduleServiceTest, FlowResolverRegistryScheduleTest
+and OpenRegisterFlowResolverTest, plus a live verification on the dev instance
+(an `agentflow`-stored flow with a one-minute cron fired via `occ`, producing the
+first `trigger='schedule'` run the instance has ever held, while a disabled
+sibling produced none)

--- a/openspec/changes/or-flow-schedule-any-store/tasks.md
+++ b/openspec/changes/or-flow-schedule-any-store/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: or-flow-schedule-any-store
+
+## 1. The capability
+
+- [x] 1.1 Add `IScheduledFlowSource` — an optional capability alongside
+      `IFlowResolver`, so existing resolvers are untouched.
+- [x] 1.2 Add `FlowResolverRegistry::scheduledFlows()` — gather from every
+      contributing app, de-duplicate by id (first source wins), log and skip a
+      source that throws.
+
+## 2. OpenRegister's own store becomes a source
+
+- [x] 2.1 `OpenRegisterFlowResolver` implements `IScheduledFlowSource`,
+      reporting the flows in `flow_register`/`flow_schema` whose trigger is
+      `schedule`, with cron, enabled flag and owner.
+- [x] 2.2 Report disabled schedules honestly rather than filtering them, so the
+      run/do-not-run decision has one home.
+
+## 3. The scheduler enumerates through the registry
+
+- [x] 3.1 `FlowScheduleService` takes `FlowResolverRegistry` instead of
+      `ObjectService`; drop the store-naming config it no longer needs.
+- [x] 3.2 Keep every gate in the scheduler: enabled, trigger, cron validity,
+      due-ness, and the no-overlap guard (#2218).
+
+## 4. Tests
+
+- [x] 4.1 A flow contributed by another app fires, attributed to its owner.
+- [x] 4.2 A disabled candidate from a source that did not filter is not fired.
+- [x] 4.3 A resolver without the capability is skipped; a throwing source does
+      not stop the rest.
+- [x] 4.4 A duplicated flow id yields one candidate.
+- [x] 4.5 The existing no-overlap and last-fire-marker guarantees still hold.
+
+## 5. Verify
+
+- [x] 5.1 Positive control: count `trigger='schedule'` runs before the change.
+- [x] 5.2 Live: an `agentflow`-stored flow with a short cron fires; a disabled
+      one does not; the count returns to baseline after the probe is removed.

--- a/tests/Unit/Service/Flow/FlowResolverRegistryScheduleTest.php
+++ b/tests/Unit/Service/Flow/FlowResolverRegistryScheduleTest.php
@@ -1,0 +1,230 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowResolverRegistry;
+use OCA\OpenRegister\Service\Flow\IFlowResolver;
+use OCA\OpenRegister\Service\Flow\IScheduledFlowSource;
+use OCA\OpenRegister\Service\Flow\RegisterFlowResolversEvent;
+use OCP\EventDispatcher\IEventDispatcher;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The registry gathers scheduled flows from every app that owns some.
+ *
+ * This is the enumeration the scheduler had never had. Event triggers went
+ * through the resolvers from day one; the schedule read one hard-coded store, so
+ * a flow owned by any other app could not fire — no error, no run, nothing.
+ */
+class FlowResolverRegistryScheduleTest extends TestCase
+{
+
+    /**
+     * A registry whose resolvers are exactly the given ones.
+     *
+     * @param array<int, IFlowResolver> $resolvers The resolvers to contribute.
+     *
+     * @return FlowResolverRegistry The registry.
+     */
+    private function registryWith(array $resolvers): FlowResolverRegistry
+    {
+        $dispatcher = $this->createMock(IEventDispatcher::class);
+        $dispatcher->method('dispatchTyped')->willReturnCallback(
+            static function (object $event) use ($resolvers): void {
+                if (($event instanceof RegisterFlowResolversEvent) === false) {
+                    return;
+                }
+
+                foreach ($resolvers as $resolver) {
+                    $event->registerResolver($resolver);
+                }
+            }
+        );
+
+        return new FlowResolverRegistry($dispatcher, $this->createMock(\Psr\Log\LoggerInterface::class));
+    }//end registryWith()
+
+    /**
+     * A resolver that also sources scheduled flows.
+     *
+     * @param array $candidates What it reports (or a Throwable to throw).
+     *
+     * @return IFlowResolver&IScheduledFlowSource The source.
+     */
+    private function source(array $candidates): object
+    {
+        return new class($candidates) implements IFlowResolver, IScheduledFlowSource {
+            public function __construct(private array $candidates)
+            {
+            }
+
+            public function resolveFlow(string $flowId): ?array
+            {
+                return null;
+            }
+
+            public function resolveSubject(string $uuid, string $register, string $schema): ?object
+            {
+                return null;
+            }
+
+            public function flowsForTrigger(string $event, string $register, string $schema): array
+            {
+                return [];
+            }
+
+            public function scheduledFlows(): array
+            {
+                return $this->candidates;
+            }
+        };
+    }//end source()
+
+    /**
+     * A resolver that owns only event-triggered flows.
+     *
+     * @return IFlowResolver The resolver.
+     */
+    private function plainResolver(): IFlowResolver
+    {
+        return new class implements IFlowResolver {
+            public function resolveFlow(string $flowId): ?array
+            {
+                return null;
+            }
+
+            public function resolveSubject(string $uuid, string $register, string $schema): ?object
+            {
+                return null;
+            }
+
+            public function flowsForTrigger(string $event, string $register, string $schema): array
+            {
+                return [];
+            }
+        };
+    }//end plainResolver()
+
+    /**
+     * Every app that owns scheduled flows contributes them.
+     *
+     * @return void
+     */
+    public function testItGathersScheduledFlowsFromEveryContributingApp(): void
+    {
+        $registry = $this->registryWith(
+            [
+                $this->source([['id' => 'or-flow', 'enabled' => true, 'trigger' => 'schedule', 'cron' => '* * * * *']]),
+                $this->source([['id' => 'leaf-flow', 'enabled' => true, 'trigger' => 'schedule', 'cron' => '*/5 * * * *']]),
+            ]
+        );
+
+        $ids = array_column($registry->scheduledFlows(), 'id');
+
+        $this->assertSame(['or-flow', 'leaf-flow'], $ids);
+    }//end testItGathersScheduledFlowsFromEveryContributingApp()
+
+    /**
+     * A resolver that owns no scheduled flows is not asked and costs nothing.
+     *
+     * The capability is a SEPARATE interface precisely so an existing resolver
+     * keeps working untouched.
+     *
+     * @return void
+     */
+    public function testAResolverWithoutTheCapabilityIsSkipped(): void
+    {
+        $registry = $this->registryWith([$this->plainResolver()]);
+
+        $this->assertSame([], $registry->scheduledFlows());
+    }//end testAResolverWithoutTheCapabilityIsSkipped()
+
+    /**
+     * One broken app must not stop the whole instance's schedule.
+     *
+     * @return void
+     */
+    public function testAThrowingSourceIsSkippedAndTheRestStillReport(): void
+    {
+        $broken = new class implements IFlowResolver, IScheduledFlowSource {
+            public function resolveFlow(string $flowId): ?array
+            {
+                return null;
+            }
+
+            public function resolveSubject(string $uuid, string $register, string $schema): ?object
+            {
+                return null;
+            }
+
+            public function flowsForTrigger(string $event, string $register, string $schema): array
+            {
+                return [];
+            }
+
+            public function scheduledFlows(): array
+            {
+                throw new \RuntimeException('store is gone');
+            }
+        };
+
+        $registry = $this->registryWith(
+            [
+                $broken,
+                $this->source([['id' => 'ok', 'enabled' => true, 'trigger' => 'schedule', 'cron' => '* * * * *']]),
+            ]
+        );
+
+        $this->assertSame(['ok'], array_column($registry->scheduledFlows(), 'id'));
+    }//end testAThrowingSourceIsSkippedAndTheRestStillReport()
+
+    /**
+     * Two apps claiming one flow id yield ONE candidate, not two runs.
+     *
+     * `resolveFlow()` takes the first non-null answer, so the first source is
+     * also the app that would actually run the flow. Reporting the id twice
+     * would fire it twice per tick — a way of breaking the no-overlap guarantee
+     * (openregister#2218) that the singleton check cannot catch, because both
+     * fires happen before either run starts.
+     *
+     * @return void
+     */
+    public function testADuplicatedFlowIdIsReportedOnce(): void
+    {
+        $registry = $this->registryWith(
+            [
+                $this->source([['id' => 'dup', 'enabled' => true, 'trigger' => 'schedule', 'cron' => '* * * * *']]),
+                $this->source([['id' => 'dup', 'enabled' => true, 'trigger' => 'schedule', 'cron' => '0 0 * * *']]),
+            ]
+        );
+
+        $candidates = $registry->scheduledFlows();
+
+        $this->assertCount(1, $candidates);
+        // First source wins, so the cron is the first one's.
+        $this->assertSame('* * * * *', $candidates[0]['cron']);
+    }//end testADuplicatedFlowIdIsReportedOnce()
+
+    /**
+     * A candidate with no id is dropped rather than normalised into one.
+     *
+     * @return void
+     */
+    public function testACandidateWithoutAnIdIsDropped(): void
+    {
+        $registry = $this->registryWith(
+            [
+                $this->source([['enabled' => true, 'trigger' => 'schedule', 'cron' => '* * * * *']]),
+            ]
+        );
+
+        $this->assertSame([], $registry->scheduledFlows());
+    }//end testACandidateWithoutAnIdIsDropped()
+}//end class

--- a/tests/Unit/Service/Flow/FlowScheduleServiceTest.php
+++ b/tests/Unit/Service/Flow/FlowScheduleServiceTest.php
@@ -10,10 +10,9 @@ declare(strict_types=1);
 namespace Unit\Service\Flow;
 
 use DateTimeImmutable;
-use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Flow\FlowResolverRegistry;
 use OCA\OpenRegister\Service\Flow\FlowRunService;
 use OCA\OpenRegister\Service\Flow\FlowScheduleService;
-use OCA\OpenRegister\Service\ObjectService;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -21,7 +20,7 @@ use PHPUnit\Framework\TestCase;
 class FlowScheduleServiceTest extends TestCase
 {
 
-    private ObjectService&MockObject $objects;
+    private FlowResolverRegistry&MockObject $registry;
 
     private FlowRunService&MockObject $runs;
 
@@ -36,9 +35,9 @@ class FlowScheduleServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->objects = $this->createMock(ObjectService::class);
-        $this->runs    = $this->createMock(FlowRunService::class);
-        $this->config  = $this->createMock(IAppConfig::class);
+        $this->registry = $this->createMock(FlowResolverRegistry::class);
+        $this->runs     = $this->createMock(FlowRunService::class);
+        $this->config   = $this->createMock(IAppConfig::class);
 
         $this->config->method('getValueString')->willReturnCallback(
             fn (string $app, string $key, string $default='') => $this->store[$key] ?? $default
@@ -51,29 +50,27 @@ class FlowScheduleServiceTest extends TestCase
         );
 
         $this->service = new FlowScheduleService(
-            $this->objects,
+            $this->registry,
             $this->runs,
             $this->config,
             $this->createMock(\Psr\Log\LoggerInterface::class)
         );
     }//end setUp()
 
-    private function flow(string $uuid, array $data): ObjectEntity
+    /**
+     * A candidate as a source reports it.
+     */
+    private function candidate(string $id, array $data): array
     {
-        $o = new ObjectEntity();
-        $o->setUuid($uuid);
-        $o->setObject($data);
-        return $o;
-    }//end flow()
+        return array_merge(
+            ['id' => $id, 'enabled' => false, 'trigger' => '', 'cron' => '', 'owner' => null],
+            $data
+        );
+    }//end candidate()
 
-    private function schedule(string $uuid, string $cron, ?string $owner=null): ObjectEntity
+    private function schedule(string $id, string $cron, ?string $owner=null): array
     {
-        $flow = $this->flow($uuid, ['enabled' => true, 'trigger' => 'schedule', 'cron' => $cron]);
-        if ($owner !== null) {
-            $flow->setOwner($owner);
-        }
-
-        return $flow;
+        return $this->candidate($id, ['enabled' => true, 'trigger' => 'schedule', 'cron' => $cron, 'owner' => $owner]);
     }//end schedule()
 
     /**
@@ -89,7 +86,7 @@ class FlowScheduleServiceTest extends TestCase
      */
     public function testADueFlowIsSkippedWhileItsPreviousRunIsStillGoing(): void
     {
-        $this->objects->method('findAll')->willReturn([$this->schedule('f1', '*/5 * * * *')]);
+        $this->registry->method('scheduledFlows')->willReturn([$this->schedule('f1', '*/5 * * * *')]);
         $this->runs->method('hasActiveRun')->with('f1')->willReturn(true);
 
         $this->runs->expects($this->never())->method('queue');
@@ -112,7 +109,7 @@ class FlowScheduleServiceTest extends TestCase
      */
     public function testSkippingDoesNotRecordAFireSoTheFlowStaysDue(): void
     {
-        $this->objects->method('findAll')->willReturn([$this->schedule('f1', '*/5 * * * *')]);
+        $this->registry->method('scheduledFlows')->willReturn([$this->schedule('f1', '*/5 * * * *')]);
         $this->runs->method('hasActiveRun')->with('f1')->willReturn(true);
 
         $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00'));
@@ -124,7 +121,7 @@ class FlowScheduleServiceTest extends TestCase
     public function testADueScheduledFlowFiresAndRecordsTheFire(): void
     {
         // No last-fire recorded -> due on first sight.
-        $this->objects->method('findAll')->willReturn([$this->schedule('f1', '*/5 * * * *')]);
+        $this->registry->method('scheduledFlows')->willReturn([$this->schedule('f1', '*/5 * * * *')]);
 
         $this->runs->expects($this->once())->method('queue')
             ->with('f1', $this->anything(), 'schedule', $this->anything());
@@ -137,6 +134,38 @@ class FlowScheduleServiceTest extends TestCase
     }//end testADueScheduledFlowFiresAndRecordsTheFire()
 
     /**
+     * FAILING PATH: a flow living in a LEAF APP's store must fire.
+     *
+     * The scheduler used to enumerate one hard-coded store — the
+     * `flow_register`/`flow_schema` pair — so a flow contributed by any other
+     * app was invisible to it and could never fire, however correct its cron.
+     * hermiq's agentflows were the casualty: `hydra-sequencer`,
+     * `hydra-dispatch` and `hydra-lock-reaper` all declared a schedule and the
+     * instance recorded ZERO runs with trigger `schedule`, ever. The scheduler
+     * now asks the resolver registry, so a source is a source wherever it lives.
+     *
+     * @return void
+     */
+    public function testAFlowContributedByAnotherAppFires(): void
+    {
+        // The registry's answer is deliberately not shaped like an OpenRegister
+        // object — it is whatever a contributing app reported.
+        $this->registry->method('scheduledFlows')->willReturn(
+            [
+                $this->schedule('agentflow-uuid', '*/5 * * * *', 'admin'),
+            ]
+        );
+
+        $this->runs->expects($this->once())->method('queue')
+            ->with('agentflow-uuid', $this->anything(), 'schedule', $this->anything(), 'admin');
+
+        $this->assertSame(
+            ['agentflow-uuid'],
+            $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00'))
+        );
+    }//end testAFlowContributedByAnotherAppFires()
+
+    /**
      * FAILING PATH (or#2158, fourth instance): a scheduled run has no session,
      * so its owner must come from the flow object — the person who created and
      * enabled it. Queued without one, `context['triggeredBy']` is null and every
@@ -147,7 +176,7 @@ class FlowScheduleServiceTest extends TestCase
      */
     public function testAScheduledRunIsAttributedToTheFlowsOwner(): void
     {
-        $this->objects->method('findAll')->willReturn([$this->schedule('f1', '*/5 * * * *', 'alice')]);
+        $this->registry->method('scheduledFlows')->willReturn([$this->schedule('f1', '*/5 * * * *', 'alice')]);
 
         $this->runs->expects($this->once())->method('queue')
             ->with('f1', $this->anything(), 'schedule', $this->anything(), 'alice');
@@ -160,50 +189,62 @@ class FlowScheduleServiceTest extends TestCase
         // Fired at 10:00; the next */5 occurrence is 10:05, so at 10:02 it is
         // not due yet.
         $this->store['flow_sched_last_f1'] = '2026-07-25T10:00:00+00:00';
-        $this->objects->method('findAll')->willReturn([$this->schedule('f1', '*/5 * * * *')]);
+        $this->registry->method('scheduledFlows')->willReturn([$this->schedule('f1', '*/5 * * * *')]);
 
         $this->runs->expects($this->never())->method('queue');
 
         $this->assertSame([], $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:02:00')));
     }//end testAFlowThatFiredRecentlyIsNotDueAgain()
 
+    /**
+     * A disabled flow never runs — and the check lives HERE, not in the source.
+     *
+     * Enumerating through the resolvers means the scheduler now sees flows from
+     * apps it does not control, so `enabled` cannot be something a contributing
+     * app is trusted to have filtered on. This candidate is reported by a source
+     * that did not filter; the scheduler must still decline it. Every hydra flow
+     * currently ships `enabled: false` on purpose, so this is the property that
+     * keeps widening the scheduler's reach from starting ten flows.
+     *
+     * @return void
+     */
     public function testADisabledScheduleDoesNotFire(): void
     {
-        $this->objects->method('findAll')->willReturn(
-                [
-                    $this->flow('f1', ['enabled' => false, 'trigger' => 'schedule', 'cron' => '*/5 * * * *']),
-                ]
-                );
+        $this->registry->method('scheduledFlows')->willReturn(
+            [
+                $this->candidate('f1', ['enabled' => false, 'trigger' => 'schedule', 'cron' => '*/5 * * * *']),
+            ]
+        );
         $this->runs->expects($this->never())->method('queue');
         $this->assertSame([], $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00')));
     }//end testADisabledScheduleDoesNotFire()
 
     public function testANonScheduleTriggerDoesNotFire(): void
     {
-        $this->objects->method('findAll')->willReturn(
-                [
-                    $this->flow('f1', ['enabled' => true, 'trigger' => 'object.created', 'cron' => '*/5 * * * *']),
-                ]
-                );
+        $this->registry->method('scheduledFlows')->willReturn(
+            [
+                $this->candidate('f1', ['enabled' => true, 'trigger' => 'object.created', 'cron' => '*/5 * * * *']),
+            ]
+        );
         $this->runs->expects($this->never())->method('queue');
         $this->assertSame([], $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00')));
     }//end testANonScheduleTriggerDoesNotFire()
 
     public function testAnInvalidOrMissingCronIsSkipped(): void
     {
-        $this->objects->method('findAll')->willReturn(
-                [
-                    $this->flow('bad', ['enabled' => true, 'trigger' => 'schedule', 'cron' => 'not a cron']),
-                    $this->flow('none', ['enabled' => true, 'trigger' => 'schedule']),
-                ]
-                );
+        $this->registry->method('scheduledFlows')->willReturn(
+            [
+                $this->candidate('bad', ['enabled' => true, 'trigger' => 'schedule', 'cron' => 'not a cron']),
+                $this->candidate('none', ['enabled' => true, 'trigger' => 'schedule']),
+            ]
+        );
         $this->runs->expects($this->never())->method('queue');
         $this->assertSame([], $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00')));
     }//end testAnInvalidOrMissingCronIsSkipped()
 
     public function testNoFlowStoreFiresNothing(): void
     {
-        $this->objects->method('findAll')->willThrowException(new \RuntimeException('no such register'));
+        $this->registry->method('scheduledFlows')->willThrowException(new \RuntimeException('no such register'));
         $this->assertSame([], $this->service->fireDueFlows(new DateTimeImmutable('2026-07-25 10:00:00')));
     }//end testNoFlowStoreFiresNothing()
 }//end class

--- a/tests/Unit/Service/Flow/OpenRegisterFlowResolverTest.php
+++ b/tests/Unit/Service/Flow/OpenRegisterFlowResolverTest.php
@@ -123,4 +123,84 @@ class OpenRegisterFlowResolverTest extends TestCase
         $this->objects->method('findAll')->willThrowException(new RuntimeException('no such register'));
         $this->assertSame([], $this->resolver->flowsForTrigger('object.created', 'reg', 'sch'));
     }
+
+    /**
+     * Only flows that actually declare a schedule are offered to the scheduler.
+     *
+     * Blast radius: the scheduler now enumerates through the resolvers on every
+     * instance in the fleet, so what a source hands it decides how much extra
+     * work every instance does. An event-triggered flow must not appear here.
+     *
+     * @return void
+     */
+    public function testScheduledFlowsReportsOnlyScheduleTriggeredFlows(): void
+    {
+        $scheduled = $this->flowObject(['enabled' => true, 'trigger' => 'schedule', 'cron' => '*/5 * * * *']);
+        $evented   = $this->flowObject(['enabled' => true, 'trigger' => 'object.created']);
+        $scheduled->setUuid('sched');
+        $evented->setUuid('evented');
+
+        $this->objects->method('findAll')->willReturn([$scheduled, $evented]);
+
+        $candidates = $this->resolver->scheduledFlows();
+
+        $this->assertCount(1, $candidates);
+        $this->assertSame('sched', $candidates[0]['id']);
+        $this->assertSame('*/5 * * * *', $candidates[0]['cron']);
+        $this->assertTrue($candidates[0]['enabled']);
+    }
+
+    /**
+     * A DISABLED schedule is reported, with `enabled` false — not omitted.
+     *
+     * The scheduler makes the run/do-not-run decision itself, in one place, for
+     * every app's flows. A source that quietly dropped disabled flows would move
+     * that decision into each app, where it can be got wrong once per app.
+     *
+     * @return void
+     */
+    public function testScheduledFlowsReportsDisabledSchedulesHonestly(): void
+    {
+        $off = $this->flowObject(['enabled' => false, 'trigger' => 'schedule', 'cron' => '*/5 * * * *']);
+        $off->setUuid('off');
+        $this->objects->method('findAll')->willReturn([$off]);
+
+        $candidates = $this->resolver->scheduledFlows();
+
+        $this->assertCount(1, $candidates);
+        $this->assertFalse($candidates[0]['enabled']);
+    }
+
+    /**
+     * The owner comes from the object's owner, falling back to the flow field.
+     *
+     * A scheduled run has no session, so without an owner every
+     * attribution-requiring node refuses (or#2158).
+     *
+     * @return void
+     */
+    public function testScheduledFlowsCarriesTheOwner(): void
+    {
+        $owned = $this->flowObject(['enabled' => true, 'trigger' => 'schedule', 'cron' => '* * * * *']);
+        $owned->setUuid('owned');
+        $owned->setOwner('alice');
+
+        $fieldOnly = $this->flowObject(
+            ['enabled' => true, 'trigger' => 'schedule', 'cron' => '* * * * *', 'owner' => 'bob']
+        );
+        $fieldOnly->setUuid('field-only');
+
+        $this->objects->method('findAll')->willReturn([$owned, $fieldOnly]);
+
+        $candidates = $this->resolver->scheduledFlows();
+
+        $this->assertSame('alice', $candidates[0]['owner']);
+        $this->assertSame('bob', $candidates[1]['owner']);
+    }
+
+    public function testNoFlowStoreYieldsNoScheduledFlows(): void
+    {
+        $this->objects->method('findAll')->willThrowException(new RuntimeException('no such register'));
+        $this->assertSame([], $this->resolver->scheduledFlows());
+    }
 }


### PR DESCRIPTION
`FlowScheduleService` enumerated the `flow_register`/`flow_schema` pair
directly instead of asking `FlowResolverRegistry`. Every other trigger family
had gone through the resolvers since day one; the schedule never did. A flow
owned by a leaf app was therefore invisible to it — not refused, not logged,
invisible. It could be enabled, carry a valid cron, and walk correctly on a
manual run, and still never fire, because nothing ever asked whether it existed.

Measured on the dev instance before this: **zero** runs with
`trigger='schedule'` out of 52,478 (object.created 52,364, test 96,
verify-harness 7, hydra-e2e-harness 6, sub-flow 2, mcp 2, retry 1). The three
flows in that state are `hydra-sequencer`, `hydra-dispatch` and
`hydra-lock-reaper` — the sequencer is the hydra pipeline's heartbeat, so this
was the difference between a pipeline that can run and one that does.

## What this adds

- `IScheduledFlowSource` — an OPTIONAL capability a resolver may also
  implement. Separate from `IFlowResolver` so every existing resolver keeps
  compiling and an app owning only event-triggered flows answers nothing.
- `FlowResolverRegistry::scheduledFlows()` — gathers candidates from every
  contributing app, de-duplicating by flow id (first source wins, matching
  `resolveFlow()`), logging and skipping a source that throws.
- `OpenRegisterFlowResolver` becomes the source for OpenRegister's own store —
  the enumeration the service used to do inline, moved so there is ONE way to
  find a scheduled flow rather than one for this store and none for anyone
  else's.

## A source reports candidates; it does not decide

`enabled`, the trigger, and cron validity are all re-checked in the scheduler,
for every app's flows. A leaf app that filtered wrongly cannot make a disabled
flow run — asserted with a source that reports disabled flows unfiltered. This
matters concretely: all ten hydra flows ship `enabled: false` on purpose.

The no-overlap guarantee (#2218) is untouched and now covers every source.
De-duplication is part of preserving it: one id reported twice would fire twice
in a tick, which `hasActiveRun()` cannot catch because both fires precede
either run.

## Blast radius

The scheduler now enumerates through the resolvers on every instance. Bounded
by: a source reports only `trigger: schedule` flows; `enabled` is re-checked
centrally; a missing or invalid cron is skipped. Cost is one flow-store listing
per contributing app per five-minute tick — the listing the scheduler already
did, moved rather than added.

## Verified live

Positive control first: 0 schedule runs. Then, on the dev instance with this
code loaded (confirmed by `ReflectionClass::getFileName()`):

- an `agentflow`-stored flow with a one-minute cron fired — the first
  `trigger='schedule'` run the instance has ever held — and the worker took it
  through to `completed`
- an A/B against the pre-change code: the SAME flow, unambiguously due, with no
  active run, fired NOTHING
- a disabled sibling with the identical cron did not fire
- a second tick two minutes later fired nothing (singleton) and did not advance
  the last-fire marker
- regression control: a flow in OpenRegister's OWN store is still seen and
  still fires

Gates: phpcs clean, phpstan/psalm/phpmd no new findings, 15,683 unit tests green.

Pairs with hermiq#115 — the two halves of one defect. Merge this one first: hermiq's resolver implements the interface introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)