### PR TITLE
fix(flow): validateConfig() cannot see a key it does not look for — so a node now states the ones it reads

### DIFF
--- a/lib/Service/Flow/FlowNodePreflight.php
+++ b/lib/Service/Flow/FlowNodePreflight.php
@@ -40,6 +40,33 @@
  * - The owning app **is not enabled**. Installing it is exactly the fix, and the
  *   document is not wrong. WARNED, loudly and structurally, and saved.
  *
+ * ## The type resolving is only half the question
+ *
+ * A resolved type says the app provides the step. It says nothing about whether
+ * the node can READ the config the edge hands it, and that second half produced
+ * its own set of measured failures (hydra#489, four inert flows). The check has
+ * two parts, and it needs both:
+ *
+ * - `validateConfig()` — the node's own opinion. Catches a REQUIRED key that is
+ *   missing or malformed. It cannot catch anything else, because a node only
+ *   examines the keys it looks for; a key it does not look for is invisible to
+ *   it by construction. Where the required set is empty the method is a no-op no
+ *   matter how carefully it is written — `StopNode::validateConfig()` is empty
+ *   for exactly that reason, and it is not wrong to be.
+ * - The node's declared vocabulary ({@see IFlowNodeConfigKeys}) — catches a key
+ *   the node will silently ignore. `StopNode` accepting `status`/`reason` while
+ *   reading `error`/`message`, `SubFlowNode` accepting `input`/`output` while
+ *   implementing neither: both satisfied every required key and both were inert.
+ *
+ * Keys beginning with `$` are authoring annotations (`$why`, `$comment`), used
+ * throughout the fleet's flow documents and read by nothing. They are exempt by
+ * contract — a check that refused them would refuse nearly every real flow,
+ * which is worse than no check.
+ *
+ * A node that does not declare a vocabulary is not vocabulary-checked. That is
+ * today's behaviour preserved for out-of-tree nodes, not an oversight; see
+ * {@see IFlowNodeConfigKeys} for why the contract is opt-in.
+ *
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  * SPDX-License-Identifier: EUPL-1.2
  *
@@ -66,6 +93,12 @@ use UnexpectedValueException;
 
 /**
  * Resolves every step type in a flow document before the flow can run.
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) The complexity is a count of
+ *   the distinct ways a flow document can be wrong, spread across ten short
+ *   single-purpose methods (the longest branches four ways). Splitting it would
+ *   move the branching, not remove it, and would put "what makes a step
+ *   unrunnable" in two places — which is the drift this class exists to end.
  *
  * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
  */
@@ -101,6 +134,51 @@ class FlowNodePreflight
      * COMPLETED, which is the failure this whole class exists to remove.
      */
     public const REASON_CONFIG_REJECTED = 'node-config-rejected';
+
+    /**
+     * The config carries a key the node never reads.
+     *
+     * Blocking, and it is the half `validateConfig()` structurally cannot see.
+     * That method answers "is anything REQUIRED missing"; a step written in
+     * another node's dialect can satisfy every required key and still be inert,
+     * because the keys carrying the actual intent are ones the node ignores.
+     * `StopNode` requires nothing at all, so it accepted `status`/`reason`
+     * (it reads `error`/`message`) and stopped runs with the generic "Flow
+     * stopped" and `isError=false`. `SubFlowNode` requires only `flow`, so it
+     * accepted `input`/`output` and passed the child nothing. Neither was
+     * catchable until a node could name its whole vocabulary.
+     */
+    public const REASON_CONFIG_UNKNOWN_KEY = 'node-config-unknown-key';
+
+    /**
+     * `onError` was put in `config` instead of on the edge.
+     *
+     * `FlowEngine::policyFor()` reads `$step['onError']` — the EDGE, one level
+     * up from `config`. A policy inside `config` is read by nothing.
+     *
+     * Blocking only when the buried policy differs from the engine default
+     * (`stop`), because that is exactly when it changes what the run does: the
+     * author asked for `continue` or `dead_letter` and silently got `stop`.
+     * A buried `"stop"` is still wrong, but it is wrong in the direction the
+     * engine was already going, so it warns instead of refusing a fleet's worth
+     * of live flow documents over a no-op key. Same rule, same threshold, as
+     * `hydra/scripts/test-flow-definitions.sh` — deliberately, so the two
+     * guards cannot disagree about the same document.
+     */
+    public const REASON_CONFIG_ONERROR_MISPLACED = 'node-config-onerror-misplaced';
+
+    /**
+     * The key the engine reads from the EDGE and never from `config`.
+     */
+    private const EDGE_LEVEL_ONERROR = 'onError';
+
+    /**
+     * The `onError` policy the engine applies when an edge declares none.
+     *
+     * Mirrors `FlowEngine::ON_ERROR_STOP`, not imported from it: this class
+     * must not gain a dependency on the engine to know one default string.
+     */
+    private const DEFAULT_ONERROR = 'stop';
 
     /**
      * Constructor.
@@ -147,12 +225,45 @@ class FlowNodePreflight
             return false;
         }
 
+        return ($this->nodesLookRight(nodes: $nodes) === true && $this->edgesLookRight(edges: $edges) === true);
+
+    }//end looksLikeFlow()
+
+    /**
+     * Whether every entry in a `nodes` list is a record carrying an id.
+     *
+     * @param array $nodes The candidate node list.
+     *
+     * @return boolean True when they all are.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    private function nodesLookRight(array $nodes): bool
+    {
         foreach ($nodes as $node) {
             if (is_array($node) === false || isset($node['id']) === false) {
                 return false;
             }
         }
 
+        return true;
+
+    }//end nodesLookRight()
+
+    /**
+     * Whether every entry in an `edges` list carries both endpoints.
+     *
+     * Either spelling is accepted — `from`/`to` is this engine's, `source`/
+     * `target` is what most graph editors emit.
+     *
+     * @param array $edges The candidate edge list.
+     *
+     * @return boolean True when they all do.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    private function edgesLookRight(array $edges): bool
+    {
         foreach ($edges as $edge) {
             if (is_array($edge) === false) {
                 return false;
@@ -167,7 +278,7 @@ class FlowNodePreflight
 
         return true;
 
-    }//end looksLikeFlow()
+    }//end edgesLookRight()
 
     /**
      * Resolve every step type the document names.
@@ -239,6 +350,15 @@ class FlowNodePreflight
                     ];
                 }//end if
 
+                // ...and the half a required-key check cannot reach. A node
+                // only sees the keys it looks for; the ones it does not look
+                // for are invisible to it BY CONSTRUCTION, however careful its
+                // validateConfig() is. Only the node's declared vocabulary
+                // ({@see IFlowNodeConfigKeys}) can expose those.
+                $dialect  = $this->dialectFindings(node: $node, edge: $edge, type: $type, edgeId: $edgeId);
+                $blocking = array_merge($blocking, $dialect['blocking']);
+                $warnings = array_merge($warnings, $dialect['warnings']);
+
                 continue;
             }//end if
 
@@ -276,6 +396,29 @@ class FlowNodePreflight
         $name   = ($label ?? (string) ($flow['name'] ?? 'flow'));
 
         foreach ($report['warnings'] as $warning) {
+            if ($warning['reason'] === self::REASON_CONFIG_ONERROR_MISPLACED) {
+                $this->logger->warning(
+                    message: sprintf(
+                        '[FlowNodePreflight] Flow "%s", edge "%s" (%s) sets config.onError="%s". '
+                        .'Nothing reads that: the engine takes the policy from the EDGE, beside "type". '
+                        .'It happens to match the default, so the run behaves the same — move it up one level.',
+                        $name,
+                        $warning['edge'],
+                        $warning['type'],
+                        ($warning['detail'] ?? '')
+                    ),
+                    context: [
+                        'file'   => __FILE__,
+                        'line'   => __LINE__,
+                        'flow'   => $name,
+                        'type'   => $warning['type'],
+                        'edge'   => $warning['edge'],
+                        'reason' => $warning['reason'],
+                    ]
+                );
+                continue;
+            }//end if
+
             // Loud on purpose. The measured failure was not that a step was
             // missing, it was that nothing said so — the run reported success.
             $this->logger->warning(
@@ -323,6 +466,38 @@ class FlowNodePreflight
     {
         $lines = [];
         foreach ($blocking as $finding) {
+            if ($finding['reason'] === self::REASON_CONFIG_UNKNOWN_KEY) {
+                // A node with an empty vocabulary needs saying in words:
+                // "it reads " followed by nothing reads like a truncated
+                // message, not like the deliberate answer it is.
+                $reads = (string) ($finding['reads'] ?? '');
+                if ($reads === '') {
+                    $reads = 'no config at all';
+                }
+
+                $lines[] = sprintf(
+                    '"%s" (edge %s) — config key(s) %s, which that node never reads; '
+                    .'it reads %s. Ignored keys make the step a pass-through that reports success',
+                    $finding['type'],
+                    $finding['edge'],
+                    ($finding['detail'] ?? '?'),
+                    $reads
+                );
+                continue;
+            }
+
+            if ($finding['reason'] === self::REASON_CONFIG_ONERROR_MISPLACED) {
+                $lines[] = sprintf(
+                    '"%s" (edge %s) — config.onError="%s" is read by nothing; the engine takes the policy '
+                    .'from the EDGE, beside "type". As written this step gets "%s"',
+                    $finding['type'],
+                    $finding['edge'],
+                    ($finding['detail'] ?? '?'),
+                    self::DEFAULT_ONERROR
+                );
+                continue;
+            }
+
             if ($finding['reason'] === self::REASON_CONFIG_REJECTED) {
                 $lines[] = sprintf(
                     '"%s" (edge %s) — the node exists but refuses this step\'s config: %s. '
@@ -354,9 +529,10 @@ class FlowNodePreflight
         }//end foreach
 
         return sprintf(
-            'Flow "%s" names %d step type(s) this instance cannot run: %s. '
-            .'Refusing the save: an unrunnable flow only fails once it is already halfway through, '
-            .'after earlier steps have made changes that do not roll back.',
+            'Flow "%s" has %d step(s) this instance cannot run as written: %s. '
+            .'Refusing the save: a step that cannot run only fails once the flow is already halfway through, '
+            .'after earlier steps have made changes that do not roll back — and a step whose config is ignored '
+            .'does not fail at all, it reports success having done nothing.',
             $flow,
             count($blocking),
             implode('; ', $lines)
@@ -401,6 +577,182 @@ class FlowNodePreflight
         return null;
 
     }//end configRejection()
+
+    /**
+     * Every config key on this edge that the node will never read.
+     *
+     * Only asked of a node that declares its vocabulary. A node that does not
+     * implement {@see IFlowNodeConfigKeys} is skipped entirely and silently:
+     * OpenRegister cannot know what `openconnector.source-call` or
+     * `hermiq.agent-step` read, and guessing would refuse correct flows from
+     * apps that shipped before this contract existed. That is today's behaviour
+     * preserved exactly — no node gets WORSE, some get better.
+     *
+     * Two exemptions, both deliberate and both documented on the interface:
+     *
+     * - A key beginning with `$` is an authoring annotation. `$why` and
+     *   `$comment` appear throughout the fleet's flow documents, explaining to
+     *   the next reader why a step exists. The engine has never read them. A
+     *   check without this exemption would refuse nearly every real flow, which
+     *   is a worse outcome than no check at all.
+     * - `onError` gets its own diagnosis rather than a generic "unknown key",
+     *   because the author did not invent it — they put a real engine option
+     *   one level too deep, and telling them so is worth more than telling them
+     *   the key is unrecognised.
+     *
+     * @param IFlowNode $node   The resolved node.
+     * @param array     $edge   The edge declaring the step.
+     * @param string    $type   The step type.
+     * @param string    $edgeId The edge's identifier, for the message.
+     *
+     * @return array{blocking: array<int, array<string, string>>, warnings: array<int, array<string, string>>}
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    private function dialectFindings(IFlowNode $node, array $edge, string $type, string $edgeId): array
+    {
+        $report = [
+            'blocking' => [],
+            'warnings' => [],
+        ];
+
+        $config = ($edge['config'] ?? []);
+        $known  = $this->declaredKeys(node: $node);
+        if ($known === null || is_array($config) === false || $config === []) {
+            return $report;
+        }
+
+        $app    = $this->ownerOf(type: $type);
+        $strays = $this->strayKeys(config: $config, known: $known);
+
+        if ($strays['onError'] === true) {
+            $finding  = $this->onErrorFinding(config: $config, type: $type, app: $app, edgeId: $edgeId);
+            $severity = 'blocking';
+            if ($finding['detail'] === self::DEFAULT_ONERROR) {
+                $severity = 'warnings';
+            }
+
+            $report[$severity][] = $finding;
+        }
+
+        if ($strays['unknown'] === []) {
+            return $report;
+        }
+
+        // One finding per EDGE, not per key. An edge authored in the wrong
+        // dialect is wrong once — listing its four stray keys as four separate
+        // refusals reads like four separate mistakes.
+        $report['blocking'][] = [
+            'type'   => $type,
+            'app'    => $app,
+            'edge'   => $edgeId,
+            'reason' => self::REASON_CONFIG_UNKNOWN_KEY,
+            'detail' => implode(', ', $strays['unknown']),
+            'reads'  => implode(', ', $known),
+        ];
+
+        return $report;
+
+    }//end dialectFindings()
+
+    /**
+     * A node's declared config vocabulary, or null when it declares none.
+     *
+     * Null and `[]` are different answers and the caller must be able to tell
+     * them apart: `[]` is `openregister.switch` saying it reads no config at
+     * all, null is a node that never joined the contract and must therefore not
+     * be judged by it.
+     *
+     * @param IFlowNode $node The resolved node.
+     *
+     * @return array<int, string>|null The keys, or null when unchecked.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    private function declaredKeys(IFlowNode $node): ?array
+    {
+        if (($node instanceof IFlowNodeConfigKeys) === false) {
+            return null;
+        }
+
+        try {
+            $known = $node->configKeys();
+        } catch (Throwable $e) {
+            // A node whose own vocabulary lookup throws must not block the save
+            // — same reasoning as configRejection(): one broken node cannot be
+            // allowed to make the instance unsavable.
+            $this->logger->warning(
+                message: '[FlowNodePreflight] A node\'s configKeys() failed, skipping the dialect check: '.$e->getMessage(),
+                context: ['file' => __FILE__, 'line' => __LINE__, 'node' => get_class($node)]
+            );
+            return null;
+        }
+
+        return array_map(static fn ($key): string => (string) $key, (array) $known);
+
+    }//end declaredKeys()
+
+    /**
+     * Split a step's config keys into the ones nothing will read.
+     *
+     * @param array              $config The step configuration.
+     * @param array<int, string> $known  The node's declared vocabulary.
+     *
+     * @return array{unknown: array<int, string>, onError: bool}
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    private function strayKeys(array $config, array $known): array
+    {
+        $unknown = [];
+        $onError = false;
+
+        foreach (array_keys($config) as $key) {
+            $key = (string) $key;
+            if (str_starts_with($key, IFlowNodeConfigKeys::ANNOTATION_PREFIX) === true) {
+                continue;
+            }
+
+            if ($key === self::EDGE_LEVEL_ONERROR) {
+                $onError = true;
+                continue;
+            }
+
+            if (in_array($key, $known, true) === false) {
+                $unknown[] = $key;
+            }
+        }//end foreach
+
+        return [
+            'unknown' => $unknown,
+            'onError' => $onError,
+        ];
+
+    }//end strayKeys()
+
+    /**
+     * Describe an `onError` policy that was written one level too deep.
+     *
+     * @param array  $config The step configuration.
+     * @param string $type   The step type.
+     * @param string $app    The app that owns the type.
+     * @param string $edgeId The edge's identifier.
+     *
+     * @return array<string, string> The finding; its severity is the caller's call.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    private function onErrorFinding(array $config, string $type, string $app, string $edgeId): array
+    {
+        return [
+            'type'   => $type,
+            'app'    => $app,
+            'edge'   => $edgeId,
+            'reason' => self::REASON_CONFIG_ONERROR_MISPLACED,
+            'detail' => (string) ($config[self::EDGE_LEVEL_ONERROR] ?? ''),
+        ];
+
+    }//end onErrorFinding()
 
     /**
      * The app a namespaced type belongs to.

--- a/lib/Service/Flow/FlowNodeRegistry.php
+++ b/lib/Service/Flow/FlowNodeRegistry.php
@@ -140,9 +140,14 @@ class FlowNodeRegistry
     /**
      * The palette an editor renders, as plain data.
      *
+     * Each entry additionally carries `configKeys` when the node declares its
+     * config vocabulary ({@see IFlowNodeConfigKeys}), which makes this endpoint
+     * the fleet's single machine-readable source of truth for what a step may
+     * be configured with — for the editor, and for any repository's flow lint.
+     *
      * @param int $scope The scope to build the palette for.
      *
-     * @return array<int, array<string, string>> One entry per available node.
+     * @return array<int, array<string, mixed>> One entry per available node.
      *
      * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
      */
@@ -151,12 +156,30 @@ class FlowNodeRegistry
         $palette = [];
         foreach ($this->all(scope: $scope) as $id => $node) {
             try {
-                $palette[] = [
+                $entry = [
                     'id'          => $id,
                     'displayName' => $node->getDisplayName(),
                     'description' => $node->getDescription(),
                     'icon'        => $node->getIcon(),
                 ];
+
+                // The node's config vocabulary, when it declares one. This is
+                // what stops a second, hand-maintained table of accepted keys
+                // from existing somewhere else and drifting: hydra's
+                // `scripts/test-flow-definitions.sh` keeps exactly such a table
+                // today, and a table maintained in another repository is only
+                // ever correct until the next node ships a key.
+                //
+                // ABSENT rather than empty when the node declares nothing, so a
+                // consumer can tell "reads no config" (`[]`, which
+                // openregister.switch really means) from "did not say", which
+                // is every node predating IFlowNodeConfigKeys and must not be
+                // read as a licence to reject its keys.
+                if (($node instanceof IFlowNodeConfigKeys) === true) {
+                    $entry['configKeys'] = array_values($node->configKeys());
+                }
+
+                $palette[] = $entry;
             } catch (\Throwable $e) {
                 // One node whose metadata throws (a missing icon, a broken
                 // translation) must not blank the whole palette — the author
@@ -166,7 +189,7 @@ class FlowNodeRegistry
                     context: ['file' => __FILE__, 'line' => __LINE__, 'type' => $id]
                 );
             }//end try
-        }
+        }//end foreach
 
         return $palette;
 

--- a/lib/Service/Flow/IFlowNodeConfigKeys.php
+++ b/lib/Service/Flow/IFlowNodeConfigKeys.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * A node that can name the config keys it reads.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `IFlowNode::validateConfig()` answers "is anything REQUIRED missing". It
+ * cannot answer "is anything here that I will silently ignore", and the second
+ * question is the one that produced the measured failures.
+ *
+ * `StopNode::validateConfig()` has an empty body: it requires nothing, so it
+ * accepts `{"status": "...", "reason": "..."}` — keys it never reads; it reads
+ * `error` / `message` — and then stops the run with the generic "Flow stopped"
+ * and `isError=false`. `SubFlowNode` requires only `flow`/`flowId`, so it
+ * accepts `input`/`output` alongside them and passes the child nothing. In both
+ * cases the type resolves, the step dispatches, the run reports COMPLETED, and
+ * the work never happened. A required-key check cannot see either one, because
+ * in both the required keys are present.
+ *
+ * So a node must be able to state its whole vocabulary, not just its mandatory
+ * part. That is this interface.
+ *
+ * WHY NOT ON `IFlowNode` ITSELF
+ * -----------------------------
+ * Adding a method to `IFlowNode` is a fatal error for every class implementing
+ * it that has not been updated — and implementations live in other repositories
+ * (openconnector ships `source-call` and `synchronization-run`, hermiq ships
+ * `agent-step` and `workload-step`). Publishing a release that fatals those apps
+ * on load is a worse outcome than the defect being closed.
+ *
+ * A separate, optional interface is also how Nextcloud itself adds capability to
+ * an operation contract: `ISpecificOperation` and `IComplexOperation` extend
+ * `IOperation` rather than widening it, and core probes with `instanceof`. This
+ * file follows that, deliberately, for the same reason `IFlowNode` was shaped
+ * after `IOperation` in the first place.
+ *
+ * The cost is honest and stated: a node that does not implement this interface
+ * is NOT unknown-key checked. That is exactly today's behaviour, so nothing
+ * regresses — but nothing improves for that node either, until its owner opts
+ * in. Every node OpenRegister itself ships implements it.
+ *
+ * THE ANNOTATION RULE
+ * -------------------
+ * A config key beginning with `$` is documentation, not configuration. Flow
+ * documents in the fleet carry `$why` and `$comment` throughout — they explain
+ * to the next reader why a step exists, and the engine has never read them.
+ * A check that refused them would refuse nearly every real flow, so `$`-prefixed
+ * keys are exempt by contract, not by accident. This is the same rule
+ * `hydra/scripts/test-flow-definitions.sh` applies, stated here so the two
+ * cannot drift apart on what counts as an annotation.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+/**
+ * Optional companion to {@see IFlowNode}: the node's full config vocabulary.
+ */
+interface IFlowNodeConfigKeys
+{
+    /**
+     * The prefix marking a config key as an authoring annotation.
+     *
+     * `$why`, `$comment` and anything else so prefixed is documentation the
+     * engine never reads and no author mistakes for behaviour. Exempt from the
+     * unknown-key check by contract.
+     */
+    public const ANNOTATION_PREFIX = '$';
+
+    /**
+     * Every config key this node reads, required and optional alike.
+     *
+     * The list is the node's whole vocabulary. A key on a step that is not in
+     * it, and is not an annotation ({@see self::ANNOTATION_PREFIX}), is one the
+     * node will silently ignore — which is a step that returns its input
+     * untouched and reports success.
+     *
+     * Only TOP-LEVEL keys. Nested shape (`rules[].condition`, `set.<field>`) is
+     * the node's own business and is checked in `validateConfig()`, where the
+     * node can say something specific about it.
+     *
+     * An empty list is meaningful and legal: it means the node reads NO config,
+     * so any key at all on that step is wrong. `openregister.switch` is exactly
+     * that — its conditions live on its outgoing edges, never in its config.
+     *
+     * @return array<int, string> The accepted top-level config keys.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function configKeys(): array;
+}//end interface

--- a/lib/Service/Flow/Nodes/ExplodeNode.php
+++ b/lib/Service/Flow/Nodes/ExplodeNode.php
@@ -41,6 +41,7 @@ namespace OCA\OpenRegister\Service\Flow\Nodes;
 
 use OCA\OpenRegister\Service\Flow\FlowItems;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\WorkflowEngine\IManager;
@@ -51,7 +52,7 @@ use UnexpectedValueException;
  *
  * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
  */
-class ExplodeNode implements IFlowNode
+class ExplodeNode implements IFlowNode, IFlowNodeConfigKeys
 {
     /**
      * Constructor.
@@ -131,6 +132,19 @@ class ExplodeNode implements IFlowNode
         return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
 
     }//end isAvailableForScope()
+
+    /**
+     * The config vocabulary of an explode step.
+     *
+     * @return array<int, string> The accepted config keys.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function configKeys(): array
+    {
+        return ['path', 'as', 'keepRecord'];
+
+    }//end configKeys()
 
     /**
      * Reject an explode that names no path.

--- a/lib/Service/Flow/Nodes/FilterNode.php
+++ b/lib/Service/Flow/Nodes/FilterNode.php
@@ -32,6 +32,7 @@ namespace OCA\OpenRegister\Service\Flow\Nodes;
 use OCA\OpenRegister\Service\Flow\FlowExpression;
 use OCA\OpenRegister\Service\Flow\FlowItems;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\WorkflowEngine\IManager;
@@ -40,7 +41,7 @@ use UnexpectedValueException;
 /**
  * Drops items that do not match.
  */
-class FilterNode implements IFlowNode
+class FilterNode implements IFlowNode, IFlowNodeConfigKeys
 {
     /**
      * Constructor.
@@ -111,6 +112,19 @@ class FilterNode implements IFlowNode
         return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
 
     }//end isAvailableForScope()
+
+    /**
+     * The config vocabulary of a filter step.
+     *
+     * @return array<int, string> The accepted config keys.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function configKeys(): array
+    {
+        return ['condition'];
+
+    }//end configKeys()
 
     /**
      * Reject a filter with no condition, or one that cannot be evaluated.

--- a/lib/Service/Flow/Nodes/FlowStateNode.php
+++ b/lib/Service/Flow/Nodes/FlowStateNode.php
@@ -26,6 +26,7 @@ use InvalidArgumentException;
 use OCA\OpenRegister\Service\Flow\FlowItems;
 use OCA\OpenRegister\Service\Flow\FlowStateHandle;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\WorkflowEngine\IManager;
@@ -61,7 +62,7 @@ use OCP\WorkflowEngine\IManager;
  *
  * @link https://OpenRegister.app
  */
-class FlowStateNode implements IFlowNode
+class FlowStateNode implements IFlowNode, IFlowNodeConfigKeys
 {
 
     /**
@@ -183,6 +184,36 @@ class FlowStateNode implements IFlowNode
         return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
 
     }//end isAvailableForScope()
+
+    /**
+     * The config vocabulary of a flow-state step, across all five operations.
+     *
+     * Deliberately the UNION rather than a per-operation set: which keys are
+     * required for which operation is `validateConfig()`'s question, and it
+     * answers it with a message naming the operation. This method answers only
+     * "could this node ever read that key".
+     *
+     * @return array<int, string> The accepted config keys.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function configKeys(): array
+    {
+        return [
+            'operation',
+            'key',
+            'as',
+            'default',
+            'value',
+            'from',
+            'record',
+            'slots',
+            'capacity',
+            'holder',
+            'slot',
+        ];
+
+    }//end configKeys()
 
     /**
      * Validate the authored configuration.

--- a/lib/Service/Flow/Nodes/LoopNode.php
+++ b/lib/Service/Flow/Nodes/LoopNode.php
@@ -31,6 +31,7 @@ namespace OCA\OpenRegister\Service\Flow\Nodes;
 
 use OCA\OpenRegister\Service\Flow\FlowItems;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\WorkflowEngine\IManager;
@@ -39,7 +40,7 @@ use UnexpectedValueException;
 /**
  * Batches an item list into slices of a configured size.
  */
-class LoopNode implements IFlowNode
+class LoopNode implements IFlowNode, IFlowNodeConfigKeys
 {
     /**
      * Constructor.
@@ -110,6 +111,19 @@ class LoopNode implements IFlowNode
         return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
 
     }//end isAvailableForScope()
+
+    /**
+     * The config vocabulary of a loop step.
+     *
+     * @return array<int, string> The accepted config keys.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function configKeys(): array
+    {
+        return ['batchSize'];
+
+    }//end configKeys()
 
     /**
      * Reject a non-positive batch size.

--- a/lib/Service/Flow/Nodes/MergeNode.php
+++ b/lib/Service/Flow/Nodes/MergeNode.php
@@ -40,6 +40,7 @@ namespace OCA\OpenRegister\Service\Flow\Nodes;
 
 use OCA\OpenRegister\Service\Flow\FlowItems;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\WorkflowEngine\IManager;
@@ -48,7 +49,7 @@ use UnexpectedValueException;
 /**
  * Merges branch item lists — append, merge-by-key, or unique.
  */
-class MergeNode implements IFlowNode
+class MergeNode implements IFlowNode, IFlowNodeConfigKeys
 {
 
     /**
@@ -127,6 +128,19 @@ class MergeNode implements IFlowNode
         return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
 
     }//end isAvailableForScope()
+
+    /**
+     * The config vocabulary of a merge step.
+     *
+     * @return array<int, string> The accepted config keys.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function configKeys(): array
+    {
+        return ['mode', 'key'];
+
+    }//end configKeys()
 
     /**
      * Reject an unknown mode, or a keyed mode with no key.

--- a/lib/Service/Flow/Nodes/ObjectReadNode.php
+++ b/lib/Service/Flow/Nodes/ObjectReadNode.php
@@ -67,6 +67,7 @@ use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Flow\FlowItems;
 use OCA\OpenRegister\Service\Flow\FlowValueTemplate;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -80,7 +81,7 @@ use UnexpectedValueException;
 /**
  * Reads objects from a register into the run.
  */
-class ObjectReadNode implements IFlowNode
+class ObjectReadNode implements IFlowNode, IFlowNodeConfigKeys
 {
 
     /**
@@ -192,6 +193,19 @@ class ObjectReadNode implements IFlowNode
         return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
 
     }//end isAvailableForScope()
+
+    /**
+     * The config vocabulary of an object-read step.
+     *
+     * @return array<int, string> The accepted config keys.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function configKeys(): array
+    {
+        return ['register', 'schema', 'filters', 'fanOut', 'limit', 'output'];
+
+    }//end configKeys()
 
     /**
      * Refuse a step that cannot name what it reads.

--- a/lib/Service/Flow/Nodes/ObjectWriteNode.php
+++ b/lib/Service/Flow/Nodes/ObjectWriteNode.php
@@ -70,6 +70,7 @@ use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Flow\FlowItems;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\IAppConfig;
 use OCP\IL10N;
@@ -88,7 +89,7 @@ use UnexpectedValueException;
  * @SuppressWarnings(PHPMD.ExcessiveClassLength)     Most of the length is reasoning and per-rule docblocks; the executable body is small and flat.
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) One branch per named configuration key and one per operation; collapsing it hides the guards.
  */
-class ObjectWriteNode implements IFlowNode
+class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys
 {
 
     /**
@@ -352,6 +353,37 @@ class ObjectWriteNode implements IFlowNode
         return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
 
     }//end isAvailableForScope()
+
+    /**
+     * The config vocabulary of an object-write step, across all four operations.
+     *
+     * The union, not a per-operation set. Which keys are FORBIDDEN for which
+     * operation is `validateOperationKeys()`'s question and it answers it far
+     * more usefully than a bare "unknown key" ever could — `"fields" has no
+     * meaning for a delete step` names the mistake, not just the symptom.
+     *
+     * @return array<int, string> The accepted config keys.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function configKeys(): array
+    {
+        return [
+            'register',
+            'schema',
+            'operation',
+            'fields',
+            'match',
+            'replace',
+            'output',
+            'confirmDelete',
+            'maxWrites',
+            'onConflict',
+            'onMissing',
+            'onNoMatch',
+        ];
+
+    }//end configKeys()
 
     /**
      * Refuse a configuration the author cannot have meant.

--- a/lib/Service/Flow/Nodes/RouterNode.php
+++ b/lib/Service/Flow/Nodes/RouterNode.php
@@ -36,6 +36,7 @@ namespace OCA\OpenRegister\Service\Flow\Nodes;
 use OCA\OpenRegister\Service\Flow\FlowExpression;
 use OCA\OpenRegister\Service\Flow\FlowItems;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\WorkflowEngine\IManager;
@@ -44,7 +45,7 @@ use UnexpectedValueException;
 /**
  * Tags each item with the output branch it should go to.
  */
-class RouterNode implements IFlowNode
+class RouterNode implements IFlowNode, IFlowNodeConfigKeys
 {
     /**
      * Constructor.
@@ -115,6 +116,25 @@ class RouterNode implements IFlowNode
         return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
 
     }//end isAvailableForScope()
+
+    /**
+     * The config vocabulary of a route step.
+     *
+     * `routes` is NOT here, deliberately. It is the single most common way to
+     * author this node wrong (hydra-analyze-verdicts shipped it), and it is
+     * wrong all the way down — the entries are `when`/`to` where this node
+     * reads `condition`/`output`. Accepting the outer key would leave the
+     * inner mismatch just as silent.
+     *
+     * @return array<int, string> The accepted config keys.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function configKeys(): array
+    {
+        return ['rules', 'default'];
+
+    }//end configKeys()
 
     /**
      * Reject a router with no rules — it would route nothing.

--- a/lib/Service/Flow/Nodes/SetFieldsNode.php
+++ b/lib/Service/Flow/Nodes/SetFieldsNode.php
@@ -34,6 +34,7 @@ use OCA\OpenRegister\Service\Flow\FlowExpression;
 use OCA\OpenRegister\Service\Flow\FlowItems;
 use OCA\OpenRegister\Service\Flow\FlowValueTemplate;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\WorkflowEngine\IManager;
@@ -42,7 +43,7 @@ use UnexpectedValueException;
 /**
  * Reshapes each item's record.
  */
-class SetFieldsNode implements IFlowNode
+class SetFieldsNode implements IFlowNode, IFlowNodeConfigKeys
 {
     /**
      * Constructor.
@@ -113,6 +114,23 @@ class SetFieldsNode implements IFlowNode
         return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
 
     }//end isAvailableForScope()
+
+    /**
+     * The config vocabulary of a set-fields step.
+     *
+     * `fields` is NOT here. It is the plausible-looking name an author reaches
+     * for, it is what `openregister.object-write` calls its payload, and
+     * hydra-analyze-verdicts shipped a step using it that set nothing at all.
+     *
+     * @return array<int, string> The accepted config keys.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function configKeys(): array
+    {
+        return ['set', 'compute', 'rename', 'remove', 'keepOnlySet'];
+
+    }//end configKeys()
 
     /**
      * Reject a configuration that would do nothing.

--- a/lib/Service/Flow/Nodes/StopNode.php
+++ b/lib/Service/Flow/Nodes/StopNode.php
@@ -29,6 +29,7 @@ namespace OCA\OpenRegister\Service\Flow\Nodes;
 
 use OCA\OpenRegister\Service\Flow\FlowStop;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\WorkflowEngine\IManager;
@@ -36,7 +37,7 @@ use OCP\WorkflowEngine\IManager;
 /**
  * Stops the run, optionally as an error.
  */
-class StopNode implements IFlowNode
+class StopNode implements IFlowNode, IFlowNodeConfigKeys
 {
     /**
      * Constructor.
@@ -109,7 +110,32 @@ class StopNode implements IFlowNode
     }//end isAvailableForScope()
 
     /**
-     * Nothing to validate — a stop with no message is a fine clean stop.
+     * The config vocabulary of a stop step.
+     *
+     * Both keys are OPTIONAL — a stop with no config is a perfectly good "end
+     * this branch here" — which is why `validateConfig()` below has nothing to
+     * require and why an empty body was, on its own terms, correct. It is also
+     * why this node was the one that let `{"status": "...", "reason": "..."}`
+     * through: a required-key check cannot object to a config with no required
+     * keys. Naming the vocabulary is the only thing that can.
+     *
+     * @return array<int, string> The accepted config keys.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function configKeys(): array
+    {
+        return ['error', 'message'];
+
+    }//end configKeys()
+
+    /**
+     * Nothing to REQUIRE — a stop with no message is a fine clean stop.
+     *
+     * Empty, and correct to be: this node has no mandatory key, so there is
+     * nothing here to miss. The check that catches a stop step written in
+     * another node's dialect is {@see self::configKeys()} above, which is a
+     * different question and needed a different method to ask it.
      *
      * @param array $config The step configuration.
      *

--- a/lib/Service/Flow/Nodes/SubFlowNode.php
+++ b/lib/Service/Flow/Nodes/SubFlowNode.php
@@ -46,6 +46,7 @@ use OCA\OpenRegister\Service\Flow\FlowResolverRegistry;
 use OCA\OpenRegister\Service\Flow\FlowRunService;
 use OCA\OpenRegister\Service\Flow\FlowToken;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\WorkflowEngine\IManager;
@@ -56,7 +57,7 @@ use UnexpectedValueException;
 /**
  * Executes a named flow as a step, optionally waiting for its result.
  */
-class SubFlowNode implements IFlowNode
+class SubFlowNode implements IFlowNode, IFlowNodeConfigKeys
 {
 
     /**
@@ -151,6 +152,25 @@ class SubFlowNode implements IFlowNode
         return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
 
     }//end isAvailableForScope()
+
+    /**
+     * The config vocabulary of a sub-flow step.
+     *
+     * `input` and `output` are NOT here, and their absence is the point. This
+     * node hands the child its items whole and returns the child's items
+     * whole; there is no mapping layer to configure. A step declaring them
+     * required only `flow`, so it saved, ran, and the author's intended
+     * mapping simply never happened — measured, in hydra#489.
+     *
+     * @return array<int, string> The accepted config keys.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function configKeys(): array
+    {
+        return ['flow', 'flowId', 'wait'];
+
+    }//end configKeys()
 
     /**
      * Reject a sub-flow step that names no flow.

--- a/lib/Service/Flow/Nodes/SwitchNode.php
+++ b/lib/Service/Flow/Nodes/SwitchNode.php
@@ -33,6 +33,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Service\Flow\Nodes;
 
 use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\WorkflowEngine\IManager;
@@ -40,7 +41,7 @@ use OCP\WorkflowEngine\IManager;
 /**
  * A pass-through node whose outgoing edges carry the routing conditions.
  */
-class SwitchNode implements IFlowNode
+class SwitchNode implements IFlowNode, IFlowNodeConfigKeys
 {
     /**
      * Constructor.
@@ -113,11 +114,31 @@ class SwitchNode implements IFlowNode
     }//end isAvailableForScope()
 
     /**
+     * A switch reads NO config — its conditions live on its outgoing edges.
+     *
+     * The empty list is a real statement, not a stub: any key at all on a
+     * switch step is one nothing will ever read. An author who writes
+     * `config.rules` here has written a route and drawn a switch, and the flow
+     * will pass every item down the first edge without complaint.
+     *
+     * @return array<int, string> The accepted config keys — none.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function configKeys(): array
+    {
+        return [];
+
+    }//end configKeys()
+
+    /**
      * Nothing to validate on the node — the conditions live on its edges.
      *
      * @param array $config The step configuration.
      *
      * @return void
+     *
+     * @spec openspec/changes/or-flow-logic/specs/flow-logic/spec.md
      */
     public function validateConfig(array $config): void
     {

--- a/lib/Service/Flow/Nodes/WaitNode.php
+++ b/lib/Service/Flow/Nodes/WaitNode.php
@@ -33,6 +33,7 @@ namespace OCA\OpenRegister\Service\Flow\Nodes;
 use DateTime;
 use OCA\OpenRegister\Service\Flow\FlowSuspension;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\WorkflowEngine\IManager;
@@ -41,7 +42,7 @@ use UnexpectedValueException;
 /**
  * Suspends the run for a duration or until a moment.
  */
-class WaitNode implements IFlowNode
+class WaitNode implements IFlowNode, IFlowNodeConfigKeys
 {
     /**
      * Constructor.
@@ -112,6 +113,19 @@ class WaitNode implements IFlowNode
         return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
 
     }//end isAvailableForScope()
+
+    /**
+     * The config vocabulary of a wait step.
+     *
+     * @return array<int, string> The accepted config keys.
+     *
+     * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+     */
+    public function configKeys(): array
+    {
+        return ['for', 'until'];
+
+    }//end configKeys()
 
     /**
      * Reject a wait that names no time.

--- a/openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+++ b/openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
@@ -92,6 +92,111 @@ holding every node an or#2244 instance had) through the real FlowNodeRegistry,
 the real preflight and the real ObjectCreatingEvent, with a positive control
 proving the same document saves once the node exists
 
+### Requirement: A node declares the config keys it reads, and stray keys are refused (REQ-PF-004)
+
+`validateConfig()` answers exactly one question — is anything REQUIRED missing —
+and cannot answer the other one. A node examines only the keys it looks for, so a
+key it does not look for is invisible to it by construction, and where a node
+requires nothing the method is a no-op however carefully it is written.
+
+Measured, in hydra#489, on flows that REQ-PF-003 passes:
+
+- `openregister.stop` accepted `config.status` / `config.reason` — it reads
+  `error` / `message` — and stopped runs with the generic "Flow stopped" and
+  `isError: false`. `StopNode::validateConfig()` has a literally empty body, and
+  on its own terms that is correct: a stop with no config is a clean stop.
+- `openregister.sub-flow` requires only `flow`/`flowId`, so it accepted
+  `config.input` / `config.output`, neither of which it implements, and the child
+  flow received nothing the author meant to hand it.
+
+Both satisfied every required key. Both resolved, dispatched and reported
+COMPLETED.
+
+OpenRegister SHALL therefore offer `IFlowNodeConfigKeys::configKeys()`, by which a
+node states its WHOLE top-level config vocabulary, required and optional alike;
+and the preflight SHALL REFUSE a save when an edge's `config` carries a key the
+resolved node's vocabulary does not contain.
+
+The contract SHALL be a SEPARATE, OPTIONAL interface rather than a new method on
+`IFlowNode`. Node implementations live in other repositories (openconnector ships
+`source-call` and `synchronization-run`, hermiq ships `agent-step` and
+`workload-step`); widening `IFlowNode` would make every un-updated implementation
+a fatal error on load. A node that does not implement the new interface SHALL NOT
+be vocabulary-checked, which is exactly the behaviour before this requirement.
+Every node OpenRegister itself ships SHALL implement it.
+
+Two exemptions SHALL apply:
+
+- A config key beginning with `$` is an authoring annotation. `$why` and
+  `$comment` appear throughout the fleet's flow documents and the engine has
+  never read them; a check without this exemption would refuse nearly every real
+  flow, which is worse than no check.
+- `onError` SHALL be reported as a MISPLACED engine option rather than an unknown
+  key, since `FlowEngine` reads the policy from the EDGE, one level above
+  `config`. It SHALL block only when the buried value differs from the engine
+  default `stop` — that is precisely when the run's behaviour differs from what
+  was asked for — and SHALL warn otherwise. This is the same threshold
+  `hydra/scripts/test-flow-definitions.sh` applies, so two guards cannot disagree
+  about one document.
+
+An edge SHALL yield at most one unknown-key finding, listing all its stray keys
+together: an edge written in the wrong dialect is one mistake, not four.
+
+The node catalogue (`GET /api/flow/node-catalog`) SHALL serve each node's
+`configKeys` when it declares them, and SHALL OMIT the field when it does not, so
+a consumer can distinguish "reads no config" (`[]`) from "did not say". This makes
+one machine-readable source of truth available to the editor and to any
+repository's flow lint, in place of a hand-maintained table per repository.
+
+#### Scenario: A stop step written in another node's dialect is refused
+
+- **GIVEN** an edge of type `openregister.stop` whose config declares `status` and `reason`
+- **WHEN** the flow is saved
+- **THEN** the save is refused, naming both keys and the keys the node does read
+
+#### Scenario: The same step in the node's own dialect saves
+
+- **GIVEN** the same edge declaring `error` and `message`
+- **WHEN** the flow is saved
+- **THEN** nothing blocks and nothing warns
+
+#### Scenario: A stop step with no config at all saves
+
+- **GIVEN** an edge of type `openregister.stop` with no config
+- **WHEN** the flow is saved
+- **THEN** nothing blocks, because both keys are optional
+
+#### Scenario: Authoring annotations are tolerated
+
+- **GIVEN** an edge whose config carries `$why` and `$comment` beside valid keys
+- **WHEN** the flow is saved
+- **THEN** nothing blocks and nothing warns
+
+#### Scenario: A node that declares no vocabulary is not checked
+
+- **GIVEN** a registered node that does not implement `IFlowNodeConfigKeys`
+- **WHEN** a flow gives one of its edges arbitrary config keys
+- **THEN** nothing blocks, because OpenRegister cannot know that node's vocabulary
+
+#### Scenario: A buried non-default onError policy is refused
+
+- **GIVEN** an edge whose config declares `onError: "continue"`
+- **WHEN** the flow is saved
+- **THEN** the save is refused, saying the policy belongs on the edge beside `type`
+
+#### Scenario: A buried default onError policy only warns
+
+- **GIVEN** an edge whose config declares `onError: "stop"`
+- **WHEN** the flow is saved
+- **THEN** the object is stored and a warning naming the edge is logged
+
+@e2e exclude backend save-path guard — covered by FlowNodeConfigVocabularyTest,
+which drives the REAL nodes through the REAL registry and preflight in both
+directions: the four bogus configs measured in hydra#489 are refused, and every
+one of the ten live hydra flow documents still saves. It additionally ratchets
+that every in-tree node declares a vocabulary and that every declared key appears
+in that node's own source
+
 ### Requirement: A flow document can be preflighted without being saved (REQ-PF-002)
 
 OpenRegister SHALL expose `POST /api/flow/validate`, which resolves a submitted

--- a/openspec/changes/or-flow-preflight/tasks.md
+++ b/openspec/changes/or-flow-preflight/tasks.md
@@ -8,5 +8,19 @@
 - [x] Unit tests for the classifier, the recognition guard and the listener.
 - [x] Regression test replaying or#2247 through real collaborators, with a
       positive control proving the same document saves once the node exists.
+- [x] `IFlowNodeConfigKeys` — the optional contract by which a node states its
+      whole config vocabulary, plus the unknown-key check in the preflight and
+      the `$`-prefixed annotation exemption. Separate interface, not a new method
+      on `IFlowNode`: openconnector and hermiq implement `IFlowNode` from their
+      own repositories and would fatal on load.
+- [x] `configKeys()` on all thirteen in-tree nodes, with a ratchet test that
+      every registered OpenRegister node declares one and that every declared key
+      appears in that node's own source.
+- [x] `configKeys` served on `GET /api/flow/node-catalog`, so hydra's
+      `scripts/test-flow-definitions.sh` can consume the vocabulary instead of
+      keeping a second hand-maintained table.
+- [ ] hydra: replace the `NODE_KEYS` table in `scripts/test-flow-definitions.sh`
+      with the node-catalog payload. Out of scope here — the OpenRegister side is
+      what makes it possible, and it is a change in another repository.
 - [ ] Frontend: surface `blocking` / `warnings` in the flow editor before save.
       Out of scope here — the backend refusal is what stops a half-run.

--- a/tests/Unit/Service/Flow/FlowNodeConfigDialectTest.php
+++ b/tests/Unit/Service/Flow/FlowNodeConfigDialectTest.php
@@ -137,17 +137,51 @@ class FlowNodeConfigDialectTest extends TestCase
         $report = $this->preflight()->inspect(flow: $flow);
 
         $this->assertSame([], $report['warnings']);
-        $this->assertCount(2, $report['blocking'], 'Both dialect mismatches must be caught.');
 
         foreach ($report['blocking'] as $finding) {
-            $this->assertSame(FlowNodePreflight::REASON_CONFIG_REJECTED, $finding['reason']);
             $this->assertSame('openregister', $finding['app']);
             $this->assertNotSame('', ($finding['detail'] ?? ''));
         }
 
-        $edges = array_column($report['blocking'], 'edge');
+        $edges = array_unique(array_column($report['blocking'], 'edge'));
         sort($edges);
-        $this->assertSame(['code-contradiction', 'derive'], $edges);
+        $this->assertSame(
+            ['code-contradiction', 'derive'],
+            $edges,
+            'Both dialect mismatches must be caught.'
+        );
+
+        // Each edge is caught TWICE, and the two catches are genuinely
+        // different questions about it:
+        //
+        //   REASON_CONFIG_REJECTED    the node's own validateConfig() — the
+        //                             REQUIRED key is missing (`rules`, `set`)
+        //   REASON_CONFIG_UNKNOWN_KEY the node's declared vocabulary — the keys
+        //                             that ARE there will never be read
+        //
+        // The second is what the whole document would have needed if the first
+        // had had nothing to say, which is exactly the StopNode / SubFlowNode
+        // case (see FlowNodeConfigVocabularyTest). Asserting both are present
+        // keeps either from silently regressing behind the other.
+        $reasons = array_unique(array_column($report['blocking'], 'reason'));
+        sort($reasons);
+        $this->assertSame(
+            [
+                FlowNodePreflight::REASON_CONFIG_REJECTED,
+                FlowNodePreflight::REASON_CONFIG_UNKNOWN_KEY,
+            ],
+            $reasons
+        );
+
+        foreach (['code-contradiction', 'derive'] as $edge) {
+            $forEdge = array_values(
+                array_filter(
+                    $report['blocking'],
+                    static fn (array $f): bool => ($f['edge'] === $edge)
+                )
+            );
+            $this->assertCount(2, $forEdge, sprintf('Edge "%s" must be caught by both halves.', $edge));
+        }
     }
 
     /**

--- a/tests/Unit/Service/Flow/FlowNodeConfigVocabularyTest.php
+++ b/tests/Unit/Service/Flow/FlowNodeConfigVocabularyTest.php
@@ -1,0 +1,671 @@
+<?php
+/**
+ * A step whose config carries keys the node will never read.
+ *
+ * This is the half `validateConfig()` structurally cannot reach, and it is the
+ * half that shipped four inert flows.
+ *
+ * `validateConfig()` answers ONE question: is anything REQUIRED missing. A node
+ * only examines the keys it looks for, so a key it does not look for is
+ * invisible to it by construction — however carefully the method is written.
+ * Where a node requires nothing the method is a no-op no matter what:
+ * `StopNode::validateConfig()` has a literally empty body, and on its own terms
+ * that is correct, because a stop with no config is a perfectly good "end this
+ * branch here".
+ *
+ * Which is exactly why StopNode was the node that let this through. Measured in
+ * hydra#489:
+ *
+ *   config.status / .reason   StopNode reads error / message    → run stopped
+ *                                                                 with the
+ *                                                                 generic
+ *                                                                 "Flow stopped"
+ *                                                                 and
+ *                                                                 isError=false
+ *   config.input / .output    SubFlowNode reads flow/flowId/wait → child got
+ *                                                                 nothing
+ *
+ * Both satisfied every required key. Both resolved, dispatched, and reported
+ * COMPLETED. or#2254's preflight passed both, because it delegates entirely to
+ * `validateConfig()` and neither step is missing anything required.
+ *
+ * The fix is {@see IFlowNodeConfigKeys}: a node states its WHOLE vocabulary, not
+ * just its mandatory part, and the preflight compares.
+ *
+ * BOTH DIRECTIONS ARE TESTED HERE, deliberately. A validator that refuses valid
+ * flows is worse than none, and the fleet's real flow documents carry `$why` and
+ * `$comment` annotations throughout — a check without the annotation exemption
+ * would refuse nearly every one of them.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowNodePreflight;
+use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
+use OCA\OpenRegister\Service\Flow\Nodes\ExplodeNode;
+use OCA\OpenRegister\Service\Flow\Nodes\FilterNode;
+use OCA\OpenRegister\Service\Flow\Nodes\LoopNode;
+use OCA\OpenRegister\Service\Flow\Nodes\MergeNode;
+use OCA\OpenRegister\Service\Flow\Nodes\ObjectReadNode;
+use OCA\OpenRegister\Service\Flow\Nodes\ObjectWriteNode;
+use OCA\OpenRegister\Service\Flow\Nodes\RouterNode;
+use OCA\OpenRegister\Service\Flow\Nodes\SetFieldsNode;
+use OCA\OpenRegister\Service\Flow\Nodes\StopNode;
+use OCA\OpenRegister\Service\Flow\Nodes\SubFlowNode;
+use OCA\OpenRegister\Service\Flow\Nodes\SwitchNode;
+use OCA\OpenRegister\Service\Flow\Nodes\WaitNode;
+use OCA\OpenRegister\Service\Flow\RegisterFlowNodesEvent;
+use OCP\App\IAppManager;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use UnexpectedValueException;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Flow\FlowNodePreflight
+ * @covers \OCA\OpenRegister\Service\Flow\FlowNodeRegistry
+ */
+class FlowNodeConfigVocabularyTest extends TestCase
+{
+
+    /**
+     * A preflight over the REAL nodes, with only openregister enabled.
+     *
+     * @return FlowNodePreflight
+     */
+    private function preflight(): FlowNodePreflight
+    {
+        return new FlowNodePreflight(
+            $this->registry(),
+            $this->appManager(),
+            $this->createMock(LoggerInterface::class)
+        );
+
+    }//end preflight()
+
+    /**
+     * A registry carrying every node OpenRegister itself ships.
+     *
+     * @return FlowNodeRegistry
+     */
+    private function registry(): FlowNodeRegistry
+    {
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnCallback(
+            static function (string $text, array $params=[]): string {
+                return vsprintf(str_replace(['%1$s', '%2$s'], ['%s', '%s'], $text), $params);
+            }
+        );
+        $urls = $this->createMock(IURLGenerator::class);
+
+        $dispatcher = $this->createMock(IEventDispatcher::class);
+        $dispatcher->method('dispatchTyped')->willReturnCallback(
+            function (Event $event) use ($l10n, $urls): void {
+                if (($event instanceof RegisterFlowNodesEvent) === false) {
+                    return;
+                }
+
+                $event->registerNode(new RouterNode($l10n, $urls));
+                $event->registerNode(new SwitchNode($l10n, $urls));
+                $event->registerNode(new SetFieldsNode($l10n, $urls));
+                $event->registerNode(new FilterNode($l10n, $urls));
+                $event->registerNode(new MergeNode($l10n, $urls));
+                $event->registerNode(new LoopNode($l10n, $urls));
+                $event->registerNode(new ExplodeNode($l10n, $urls));
+                $event->registerNode(new WaitNode($l10n, $urls));
+                $event->registerNode(new StopNode($l10n, $urls));
+
+                // These three take collaborators (mappers, object service) that
+                // nothing here exercises: only getId(), configKeys() and
+                // validateConfig() are reached. The REAL class is used, with its
+                // constructor bypassed, so the vocabulary under test is the
+                // shipped one and not a restatement of it.
+                foreach ([SubFlowNode::class, ObjectReadNode::class, ObjectWriteNode::class] as $class) {
+                    $event->registerNode(
+                        $this->getMockBuilder($class)
+                            ->disableOriginalConstructor()
+                            ->onlyMethods(['execute'])
+                            ->getMock()
+                    );
+                }
+            }
+        );
+
+        return new FlowNodeRegistry($dispatcher, $this->createMock(LoggerInterface::class));
+
+    }//end registry()
+
+    /**
+     * An app manager in which only openregister is enabled.
+     *
+     * @return IAppManager
+     */
+    private function appManager(): IAppManager
+    {
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('isEnabledForUser')->willReturnCallback(
+            static function (string $app): bool {
+                return ($app === 'openregister');
+            }
+        );
+
+        return $appManager;
+
+    }//end appManager()
+
+    /**
+     * Wrap one edge in the smallest document `looksLikeFlow()` accepts.
+     *
+     * @param array  $edge The edge under test.
+     * @param string $name The flow's name.
+     *
+     * @return array The flow document.
+     */
+    private function flowWith(array $edge, string $name='test-flow'): array
+    {
+        return [
+            'name'  => $name,
+            'nodes' => [['id' => 'a'], ['id' => 'b']],
+            'edges' => [(['from' => 'a', 'to' => 'b'] + $edge)],
+        ];
+
+    }//end flowWith()
+
+    /**
+     * THE REGRESSION — a stop step in another node's dialect.
+     *
+     * Verbatim from the hydra flow that shipped it. or#2254's preflight passes
+     * this document: `StopNode::validateConfig()` requires nothing, so there is
+     * nothing for it to object to.
+     *
+     * @return void
+     */
+    public function testAStopStepInTheWrongDialectIsRefused(): void
+    {
+        $flow = $this->flowWith(
+            [
+                'id'     => 'give-up',
+                'type'   => 'openregister.stop',
+                'config' => [
+                    'status' => 'failed',
+                    'reason' => 'no work left',
+                ],
+            ]
+        );
+
+        $report = $this->preflight()->inspect(flow: $flow);
+
+        $this->assertCount(1, $report['blocking'], 'One edge, one finding.');
+        $this->assertSame(
+            FlowNodePreflight::REASON_CONFIG_UNKNOWN_KEY,
+            $report['blocking'][0]['reason']
+        );
+        $this->assertSame('give-up', $report['blocking'][0]['edge']);
+        $this->assertStringContainsString('status', $report['blocking'][0]['detail']);
+        $this->assertStringContainsString('reason', $report['blocking'][0]['detail']);
+        // The message must say what the node DOES read, or the author is left
+        // to go and find the source.
+        $this->assertStringContainsString('error', $report['blocking'][0]['reads']);
+        $this->assertStringContainsString('message', $report['blocking'][0]['reads']);
+
+    }//end testAStopStepInTheWrongDialectIsRefused()
+
+    /**
+     * ...and the SAVE is refused, not merely reported.
+     *
+     * @return void
+     */
+    public function testTheSaveIsRefusedForABogusStopConfig(): void
+    {
+        $flow = $this->flowWith(
+            [
+                'id'     => 'give-up',
+                'type'   => 'openregister.stop',
+                'config' => ['status' => 'failed'],
+            ]
+        );
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessageMatches('/give-up/');
+        $this->preflight()->assertRunnable(flow: $flow);
+
+    }//end testTheSaveIsRefusedForABogusStopConfig()
+
+    /**
+     * POSITIVE CONTROL — the same step in the dialect StopNode reads.
+     *
+     * Without this the test above is satisfied by a preflight that refuses every
+     * stop step it is shown.
+     *
+     * @return void
+     */
+    public function testTheCorrectStopDialectPasses(): void
+    {
+        $flow = $this->flowWith(
+            [
+                'id'     => 'give-up',
+                'type'   => 'openregister.stop',
+                'config' => [
+                    'error'   => true,
+                    'message' => 'no work left',
+                ],
+            ]
+        );
+
+        $report = $this->preflight()->inspect(flow: $flow);
+
+        $this->assertSame([], $report['blocking']);
+        $this->assertSame([], $report['warnings']);
+
+    }//end testTheCorrectStopDialectPasses()
+
+    /**
+     * SECOND CONTROL — a stop step with NO config at all.
+     *
+     * "End this branch here" is the ordinary use of this node and must not
+     * become a validation error just because the node now has a vocabulary.
+     *
+     * @return void
+     */
+    public function testAStopStepWithNoConfigPasses(): void
+    {
+        $flow = $this->flowWith(['id' => 'done', 'type' => 'openregister.stop']);
+
+        $this->assertSame([], $this->preflight()->inspect(flow: $flow)['blocking']);
+
+    }//end testAStopStepWithNoConfigPasses()
+
+    /**
+     * THE SECOND REGRESSION — a sub-flow step declaring input/output.
+     *
+     * `SubFlowNode` requires only `flow`, so `validateConfig()` accepts this and
+     * the child receives nothing the author meant to hand it.
+     *
+     * @return void
+     */
+    public function testASubFlowStepDeclaringInputAndOutputIsRefused(): void
+    {
+        $flow = $this->flowWith(
+            [
+                'id'     => 'delegate',
+                'type'   => 'openregister.sub-flow',
+                'config' => [
+                    'flow'   => 'a1b2c3d4-0000-0000-0000-000000000000',
+                    'input'  => ['issue' => '{{issue}}'],
+                    'output' => 'result',
+                ],
+            ]
+        );
+
+        $report = $this->preflight()->inspect(flow: $flow);
+
+        $this->assertCount(1, $report['blocking']);
+        $this->assertSame(
+            FlowNodePreflight::REASON_CONFIG_UNKNOWN_KEY,
+            $report['blocking'][0]['reason']
+        );
+        $this->assertStringContainsString('input', $report['blocking'][0]['detail']);
+        $this->assertStringContainsString('output', $report['blocking'][0]['detail']);
+
+    }//end testASubFlowStepDeclaringInputAndOutputIsRefused()
+
+    /**
+     * POSITIVE CONTROL — the same sub-flow step without the invented keys.
+     *
+     * @return void
+     */
+    public function testACorrectSubFlowStepPasses(): void
+    {
+        $flow = $this->flowWith(
+            [
+                'id'     => 'delegate',
+                'type'   => 'openregister.sub-flow',
+                'config' => [
+                    'flow' => 'a1b2c3d4-0000-0000-0000-000000000000',
+                    'wait' => true,
+                ],
+            ]
+        );
+
+        $this->assertSame([], $this->preflight()->inspect(flow: $flow)['blocking']);
+
+    }//end testACorrectSubFlowStepPasses()
+
+    /**
+     * A switch declaring config is refused — it reads none.
+     *
+     * An empty vocabulary is a real statement, not a missing one. An author who
+     * writes `rules` here has drawn a switch and configured a route; the flow
+     * would send every item down the first edge without complaint.
+     *
+     * @return void
+     */
+    public function testASwitchDeclaringAnyConfigIsRefused(): void
+    {
+        $flow = $this->flowWith(
+            [
+                'id'     => 'branch',
+                'type'   => 'openregister.switch',
+                'config' => ['rules' => [['condition' => true, 'output' => 'x']]],
+            ]
+        );
+
+        $report = $this->preflight()->inspect(flow: $flow);
+
+        $this->assertCount(1, $report['blocking']);
+        $this->assertSame(
+            FlowNodePreflight::REASON_CONFIG_UNKNOWN_KEY,
+            $report['blocking'][0]['reason']
+        );
+        $this->assertSame('', $report['blocking'][0]['reads']);
+
+    }//end testASwitchDeclaringAnyConfigIsRefused()
+
+    /**
+     * ...and a switch with no config at all still passes.
+     *
+     * @return void
+     */
+    public function testABareSwitchPasses(): void
+    {
+        $flow = $this->flowWith(['id' => 'branch', 'type' => 'openregister.switch']);
+
+        $this->assertSame([], $this->preflight()->inspect(flow: $flow)['blocking']);
+
+    }//end testABareSwitchPasses()
+
+    /**
+     * THE RULE THAT KEEPS THE CHECK USABLE — `$`-prefixed keys are annotations.
+     *
+     * `$why` and `$comment` appear throughout the fleet's flow documents. The
+     * engine has never read them. Refusing them would refuse nearly every real
+     * flow, which is a worse outcome than no check at all.
+     *
+     * @return void
+     */
+    public function testAnnotationKeysAreTolerated(): void
+    {
+        $flow = $this->flowWith(
+            [
+                'id'     => 'derive',
+                'type'   => 'openregister.set-fields',
+                'config' => [
+                    '$why'     => 'the verdict labels are what the router reads',
+                    '$comment' => 'kept flat on purpose',
+                    'compute'  => ['codePass' => ['var' => 'labels']],
+                ],
+            ]
+        );
+
+        $report = $this->preflight()->inspect(flow: $flow);
+
+        $this->assertSame([], $report['blocking']);
+        $this->assertSame([], $report['warnings']);
+
+    }//end testAnnotationKeysAreTolerated()
+
+    /**
+     * A misplaced `onError` gets its own diagnosis, not "unknown key".
+     *
+     * `FlowEngine::policyFor()` reads `$step['onError']` — the EDGE, one level up
+     * from `config`. An author who buries it there did not invent a key; they
+     * put a real option in the wrong place, and saying so is worth more than
+     * saying the key is unrecognised.
+     *
+     * Blocking when the buried policy differs from the engine default, because
+     * that is when it changes what the run does.
+     *
+     * @return void
+     */
+    public function testABuriedNonDefaultOnErrorPolicyIsRefused(): void
+    {
+        $flow = $this->flowWith(
+            [
+                'id'     => 'read',
+                'type'   => 'openregister.object-read',
+                'config' => [
+                    'register' => 'hydra',
+                    'schema'   => 'lock',
+                    'onError'  => 'continue',
+                ],
+            ]
+        );
+
+        $report = $this->preflight()->inspect(flow: $flow);
+
+        $this->assertCount(1, $report['blocking']);
+        $this->assertSame(
+            FlowNodePreflight::REASON_CONFIG_ONERROR_MISPLACED,
+            $report['blocking'][0]['reason']
+        );
+        $this->assertStringContainsString(
+            'beside "type"',
+            $this->preflight()->describe(flow: 'test-flow', blocking: $report['blocking'])
+        );
+
+    }//end testABuriedNonDefaultOnErrorPolicyIsRefused()
+
+    /**
+     * ...and a buried `"stop"` WARNS rather than refusing.
+     *
+     * It is still wrong, but it is wrong in the direction the engine was already
+     * going — the run behaves identically. Three edges across the fleet's live
+     * flow documents are in exactly this state, and refusing a fleet's worth of
+     * working flows over a no-op key is the "worse than none" failure.
+     *
+     * The threshold is deliberately the same one
+     * `hydra/scripts/test-flow-definitions.sh` applies, so two guards cannot
+     * disagree about one document.
+     *
+     * @return void
+     */
+    public function testABuriedDefaultOnErrorPolicyOnlyWarns(): void
+    {
+        $flow = $this->flowWith(
+            [
+                'id'     => 'read',
+                'type'   => 'openregister.object-read',
+                'config' => [
+                    'register' => 'hydra',
+                    'schema'   => 'lock',
+                    'onError'  => 'stop',
+                ],
+            ]
+        );
+
+        $report = $this->preflight()->inspect(flow: $flow);
+
+        $this->assertSame([], $report['blocking']);
+        $this->assertCount(1, $report['warnings']);
+        $this->assertSame(
+            FlowNodePreflight::REASON_CONFIG_ONERROR_MISPLACED,
+            $report['warnings'][0]['reason']
+        );
+
+    }//end testABuriedDefaultOnErrorPolicyOnlyWarns()
+
+    /**
+     * A node that declares NO vocabulary is not vocabulary-checked.
+     *
+     * openconnector and hermiq contribute nodes from their own repositories and
+     * predate this contract. Guessing at their keys would refuse correct flows,
+     * so they are skipped — today's behaviour preserved exactly.
+     *
+     * @return void
+     */
+    public function testANodeThatDeclaresNoVocabularyIsSkipped(): void
+    {
+        $node = new class implements IFlowNode {
+            public function getId(): string
+            {
+                return 'openregister.legacy-thing';
+            }
+
+            public function getDisplayName(): string
+            {
+                return 'Legacy';
+            }
+
+            public function getDescription(): string
+            {
+                return 'Predates IFlowNodeConfigKeys.';
+            }
+
+            public function getIcon(): string
+            {
+                return '';
+            }
+
+            public function isAvailableForScope(int $scope): bool
+            {
+                return true;
+            }
+
+            public function validateConfig(array $config): void
+            {
+            }
+
+            public function execute(array $items, array $config, array $context): array
+            {
+                return $items;
+            }
+        };
+
+        $dispatcher = $this->createMock(IEventDispatcher::class);
+        $dispatcher->method('dispatchTyped')->willReturnCallback(
+            static function (Event $event) use ($node): void {
+                if ($event instanceof RegisterFlowNodesEvent) {
+                    $event->registerNode($node);
+                }
+            }
+        );
+
+        $preflight = new FlowNodePreflight(
+            new FlowNodeRegistry($dispatcher, $this->createMock(LoggerInterface::class)),
+            $this->appManager(),
+            $this->createMock(LoggerInterface::class)
+        );
+
+        $flow = $this->flowWith(
+            [
+                'id'     => 'legacy',
+                'type'   => 'openregister.legacy-thing',
+                'config' => ['anythingAtAll' => true, 'andThis' => 'too'],
+            ]
+        );
+
+        $this->assertSame([], $preflight->inspect(flow: $flow)['blocking']);
+
+    }//end testANodeThatDeclaresNoVocabularyIsSkipped()
+
+    /**
+     * Every node OpenRegister ships declares its vocabulary.
+     *
+     * The contract is opt-in so that out-of-tree nodes do not fatal on upgrade.
+     * That leniency must not become a quiet way for an OpenRegister node to
+     * escape the check — a ratchet, not a suggestion.
+     *
+     * @return void
+     */
+    public function testEveryInTreeNodeDeclaresItsVocabulary(): void
+    {
+        $missing = [];
+        foreach ($this->registry()->all() as $id => $node) {
+            if (($node instanceof IFlowNodeConfigKeys) === false) {
+                $missing[] = $id;
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $missing,
+            'These OpenRegister nodes do not declare configKeys(), so any config key at all passes on them.'
+        );
+
+    }//end testEveryInTreeNodeDeclaresItsVocabulary()
+
+    /**
+     * A declared key must be one the node's source actually reads.
+     *
+     * A vocabulary nobody checks is a second hand-maintained table, and the
+     * whole point of the contract is to have exactly one. This reads the node's
+     * own source and asserts every key it declares appears in it.
+     *
+     * @return void
+     */
+    public function testEveryDeclaredKeyAppearsInTheNodeSource(): void
+    {
+        $problems = [];
+        foreach ($this->registry()->all() as $id => $node) {
+            if (($node instanceof IFlowNodeConfigKeys) === false) {
+                continue;
+            }
+
+            // A mocked node's reflection points at the mock, so climb to the
+            // class it was built from.
+            $class = new \ReflectionClass($node);
+            while ($class->isAnonymous() === true || str_contains($class->getName(), 'MockObject') === true) {
+                $parent = $class->getParentClass();
+                if ($parent === false) {
+                    continue 2;
+                }
+
+                $class = $parent;
+            }
+
+            $source = (string) file_get_contents((string) $class->getFileName());
+            foreach ($node->configKeys() as $key) {
+                if (str_contains($source, "'".$key."'") === false) {
+                    $problems[] = $id.': '.$key;
+                }
+            }
+        }
+
+        $this->assertSame([], $problems, 'Declared config keys that the node source never mentions.');
+
+    }//end testEveryDeclaredKeyAppearsInTheNodeSource()
+
+    /**
+     * The node catalogue serves the vocabulary, so nothing has to restate it.
+     *
+     * `hydra/scripts/test-flow-definitions.sh` keeps its own table of accepted
+     * keys per node type. Two hand-maintained tables in two repositories drift;
+     * this is the surface that lets the second one be deleted.
+     *
+     * @return void
+     */
+    public function testThePaletteServesTheVocabulary(): void
+    {
+        $palette = $this->registry()->palette(scope: IManager::SCOPE_ADMIN);
+        $byId    = array_column($palette, null, 'id');
+
+        $this->assertArrayHasKey('openregister.stop', $byId);
+        $this->assertSame(['error', 'message'], $byId['openregister.stop']['configKeys']);
+
+        // An empty declaration must survive as `[]`, not vanish — "reads no
+        // config" and "did not say" are different answers.
+        $this->assertArrayHasKey('configKeys', $byId['openregister.switch']);
+        $this->assertSame([], $byId['openregister.switch']['configKeys']);
+
+    }//end testThePaletteServesTheVocabulary()
+}//end class


### PR DESCRIPTION
## The hole

or#2254 moved step-type resolution to save time, and for **config** it delegated entirely to `IFlowNode::validateConfig()`.

That method answers exactly one question — *is anything REQUIRED missing* — and it structurally cannot answer the other one. A node examines only the keys it looks for, so a key it does **not** look for is invisible to it by construction, however carefully the method is written. Where a node requires nothing, the method is a no-op no matter what.

Measured in hydra#489, on documents or#2254's preflight **passes**:

| step type | authored | node actually reads | result |
|---|---|---|---|
| `openregister.stop` | `status`, `reason` | `error`, `message` | run stopped with the generic "Flow stopped" and `isError: false` |
| `openregister.sub-flow` | `flow` + `input`, `output` | `flow`/`flowId`, `wait` | child flow got nothing the author meant to hand it |

Both satisfied every required key. Both resolved, dispatched, and reported `COMPLETED`.

`StopNode::validateConfig()` has a literally empty body — and **on its own terms that is correct**: a stop with no config is a perfectly good "end this branch here". There was nothing for it to require. `SwitchNode` was in the same state and would have accepted anything at all.

Of the four inert flows fixed in hydra#489, or#2254's preflight would have caught one.

## The fix, and why this shape

A node must be able to state its **whole** vocabulary, not just its mandatory part. `IFlowNodeConfigKeys::configKeys()` does that; the preflight refuses an edge carrying a key outside it.

**A separate, optional interface — not a method added to `IFlowNode`.** Implementations live in other repositories (openconnector ships `source-call` and `synchronization-run`, hermiq ships `agent-step` and `workload-step`). Widening `IFlowNode` makes every un-updated implementation a **fatal error on load** — a worse outcome than the defect being closed. Nextcloud adds capability to `IOperation` the same way (`ISpecificOperation`, `IComplexOperation`) rather than widening it, which is also how `IFlowNode` came to be shaped after `IOperation` in the first place.

The cost is stated rather than hidden: a node that does not implement it is **not** vocabulary-checked — exactly today's behaviour, so nothing regresses, but nothing improves for that node until its owner opts in. All thirteen in-tree nodes implement it, and a **ratchet test fails if a new OpenRegister node does not** — plus a second test asserting every declared key appears in that node's own source, so the declaration cannot quietly become a second table of its own.

## The rule for unknown keys

Two exemptions, both stated in the contract rather than discovered later:

- **`$`-prefixed keys are authoring annotations.** `\$why` and `\$comment` run throughout the fleet's flow documents, explaining to the next reader why a step exists; the engine has never read them. Without this exemption the check refuses nearly every real flow — worse than no check at all. This is the same rule `hydra/scripts/test-flow-definitions.sh` already applies.
- **`onError` is diagnosed as a MISPLACED engine option, not an unknown key.** `FlowEngine::policyFor()` reads `\$step['onError']` — the EDGE, one level above `config`. It **blocks** when the buried value differs from the engine default `stop`, which is precisely when the run does something other than what was asked; it **warns** otherwise. Same threshold as hydra's guard, deliberately, so two guards cannot disagree about one document. Three edges in the live fleet are in the tolerated state.

## Cross-repo: one source of truth

`GET /api/flow/node-catalog` now serves each node's `configKeys`, **omitting** the field when a node declares none so a consumer can tell `[]` ("reads no config", which `openregister.switch` really means) from "did not say".

`hydra/scripts/test-flow-definitions.sh` keeps a hand-maintained `NODE_KEYS` table, extended again in hydra#489. Two hand-maintained tables in two repositories drift. This is the surface that lets the second one be deleted; the hydra-side swap is listed as a follow-up task rather than done here, since it is a change in another repository.

## Evidence — both directions

Driven through the real `FlowNodeRegistry`, the real `FlowNodePreflight` and the real `ObjectCreatingEvent` save path (`FlowNodePreflightListener`), not through inspection alone.

**REFUSED at the save boundary:**
```
StopNode status/reason     REFUSED: "openregister.stop" (edge give-up) — config key(s) status, reason,
                                    which that node never reads; it reads error, message
SubFlowNode input/output   REFUSED: "openregister.sub-flow" (edge delegate) — config key(s) input, output
Switch with config         REFUSED: "openregister.switch" (edge branch) — config key(s) rules,
                                    which that node never reads; it reads no config at all
Buried onError=continue    REFUSED: config.onError="continue" is read by nothing; the engine takes the
                                    policy from the EDGE, beside "type". As written this step gets "stop"
CONTROL correct stop       SAVES
```

**STILL SAVES — all ten live hydra flow documents (`origin/development`, post-#489):**
```
SAVES  hydra-analyze-verdicts.flow.json   SAVES  hydra-lock-reaper.flow.json
SAVES  hydra-applier.flow.json            SAVES  hydra-record-stage.flow.json
SAVES  hydra-commit-by-api.flow.json      SAVES  hydra-retry-escalate.flow.json
SAVES  hydra-dispatch.flow.json           SAVES  hydra-sequencer.flow.json
SAVES  hydra-file-findings.flow.json      SAVES  hydra-label-transition.flow.json
===== 0 of 10 refused =====
```

A validator that refuses valid flows is worse than none, so that second block is the load-bearing half.

## Quality

- Full unit suite: **15 688 tests, 0 failures**
- PHPCS `lib/Service/Flow`: **0 errors**
- PHPMD: no new findings; `looksLikeFlow()`'s **pre-existing** cyclomatic/NPath findings fixed while here by extracting its two shape loops
- Psalm: no new errors

`FlowNodeConfigDialectTest` was updated, not weakened: the same document is still refused, and it now asserts that **each** bad edge is caught by **both** halves — `validateConfig()` for the missing required key and the vocabulary check for the keys that will never be read — so neither can silently regress behind the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)