### PR TITLE
fix(lifecycle): a throwing post-event listener must not fail a committed transition

### DIFF
--- a/lib/Service/Lifecycle/TransitionEngine.php
+++ b/lib/Service/Lifecycle/TransitionEngine.php
@@ -39,7 +39,9 @@ use OCA\OpenRegister\Service\Object\PermissionHandler;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
+use Throwable;
 
 /**
  * Apply named lifecycle transitions and report which actions are
@@ -71,6 +73,7 @@ class TransitionEngine
      * @param PermissionHandler $permissionHandler RBAC verdict on the object's `update`/`read` actions (F03).
      * @param RegisterMapper    $registerMapper    Mapper used to resolve the register slug.
      * @param IAppConfig        $appConfig         App config, for the slug-contract opt-in.
+     * @param LoggerInterface   $logger            Logger for post-commit listener failures.
      *
      * @spec openspec/specs/object-lifecycle/spec.md
      */
@@ -81,9 +84,85 @@ class TransitionEngine
         private readonly IUserSession $userSession,
         private readonly PermissionHandler $permissionHandler,
         private readonly RegisterMapper $registerMapper,
-        private readonly IAppConfig $appConfig
+        private readonly IAppConfig $appConfig,
+        private readonly LoggerInterface $logger
     ) {
     }//end __construct()
+
+    /**
+     * Dispatch `ObjectTransitionedEvent` without letting a listener undo the write.
+     *
+     * `ObjectTransitionedEvent` is a POST event: by the time it is dispatched the
+     * lifecycle mutation has already been saved and committed. Propagating a
+     * listener's exception out of here therefore reports failure for work that
+     * succeeded — the caller sees a 500 (or a 422 "transition refused", when the
+     * listener happens to throw a `RuntimeException` that
+     * {@see \OCA\OpenRegister\Controller\TransitionController::transition()}
+     * maps to that status) while the object sits in its NEW state. Retrying then
+     * fails a second time with "not allowed from the current state", because the
+     * transition it is being asked to repeat has in fact already happened.
+     *
+     * So a post-event listener MUST NOT be able to fail a committed transition.
+     * That is deliberately NOT extended to the pre-event (`*ing`) family: those
+     * exist precisely so a listener can veto, they are dispatched before the
+     * save, and their exceptions must keep propagating. Nothing here touches
+     * them — the veto path for a transition is `HookStoppedException` raised
+     * inside `saveObject()`, which is upstream of this method and unaffected.
+     *
+     * Swallowing silently would trade a loud wrong answer for a quiet one, so
+     * the failure is logged at ERROR with the exception attached: a listener
+     * that throws here is a real bug, and the side effect it owns (a legal hold,
+     * a ledger posting, an outbound notification) did not happen.
+     *
+     * @param ObjectEntity $object The saved object, in its post-transition state.
+     * @param string       $action The transition action that was applied.
+     * @param string       $from   The lifecycle value before the transition.
+     * @param string       $to     The lifecycle value after the transition.
+     * @param string|null  $userId The acting user, when there is a session.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/object-lifecycle/spec.md
+     */
+    private function dispatchTransitioned(
+        ObjectEntity $object,
+        string $action,
+        string $from,
+        string $to,
+        ?string $userId
+    ): void {
+        $scope = $this->transitionEventScope(object: $object);
+
+        try {
+            $this->eventDispatcher->dispatchTyped(
+                new ObjectTransitionedEvent(
+                    object: $object,
+                    action: $action,
+                    from: $from,
+                    to: $to,
+                    userId: $userId,
+                    register: $scope['register'],
+                    schema: $scope['schema']
+                )
+            );
+        } catch (Throwable $e) {
+            $this->logger->error(
+                '[TransitionEngine] A listener threw on ObjectTransitionedEvent. '
+                .'The transition itself is COMMITTED; the listener\'s side effect did not run.',
+                [
+                    'app'       => 'openregister',
+                    'uuid'      => $object->getUuid(),
+                    'register'  => $scope['register'],
+                    'schema'    => $scope['schema'],
+                    'action'    => $action,
+                    'from'      => $from,
+                    'to'        => $to,
+                    'exception' => $e,
+                ]
+            );
+        }//end try
+
+    }//end dispatchTransitioned()
 
     /**
      * Resolve the register/schema pair to advertise on ObjectTransitionedEvent.
@@ -274,18 +353,12 @@ class TransitionEngine
 
         $userId = $actingUser?->getUID();
 
-        $scope = $this->transitionEventScope(object: $object);
-
-        $this->eventDispatcher->dispatchTyped(
-            new ObjectTransitionedEvent(
-                object: $saved,
-                action: $action,
-                from: $currentValue,
-                to: $targetState,
-                userId: $userId,
-                register: $scope['register'],
-                schema: $scope['schema']
-            )
+        $this->dispatchTransitioned(
+            object: $saved,
+            action: $action,
+            from: $currentValue,
+            to: $targetState,
+            userId: $userId
         );
 
         return $saved;
@@ -642,18 +715,12 @@ class TransitionEngine
             currentUser: $actingUser
         );
 
-        $scope = $this->transitionEventScope(object: $object);
-
-        $this->eventDispatcher->dispatchTyped(
-            new ObjectTransitionedEvent(
-                object: $saved,
-                action: $action,
-                from: $from,
-                to: $targetState,
-                userId: $actingUser?->getUID(),
-                register: $scope['register'],
-                schema: $scope['schema']
-            )
+        $this->dispatchTransitioned(
+            object: $saved,
+            action: $action,
+            from: $from,
+            to: $targetState,
+            userId: $actingUser?->getUID()
         );
 
         return $saved;

--- a/tests/Unit/Service/Lifecycle/TransitionEngineGraphTest.php
+++ b/tests/Unit/Service/Lifecycle/TransitionEngineGraphTest.php
@@ -39,6 +39,7 @@ use OCP\IAppConfig;
 use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 /**
@@ -70,6 +71,8 @@ class TransitionEngineGraphTest extends TestCase
 
     private IAppConfig&MockObject $appConfig;
 
+    private LoggerInterface&MockObject $logger;
+
     private TransitionEngine $engine;
 
     protected function setUp(): void
@@ -82,6 +85,7 @@ class TransitionEngineGraphTest extends TestCase
         $this->permission->method('hasPermission')->willReturn(true);
         $this->registerMapper = $this->createMock(RegisterMapper::class);
         $this->appConfig      = $this->createMock(IAppConfig::class);
+        $this->logger         = $this->createMock(LoggerInterface::class);
 
         // The slug contract ships DEFAULT OFF; these graph tests assert the
         // unchanged id-based event scope, so pin the flag to its default.
@@ -99,7 +103,8 @@ class TransitionEngineGraphTest extends TestCase
             $this->userSession,
             $this->permission,
             $this->registerMapper,
-            $this->appConfig
+            $this->appConfig,
+            $this->logger
         );
     }//end setUp()
 
@@ -325,4 +330,71 @@ class TransitionEngineGraphTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->engine->transition(self::CASE, 'move-to-'.self::S3);
     }//end testApplyRejectsNonCandidateAndDoesNotSave()
+
+    /**
+     * A throwing post-event listener must not fail an already-committed
+     * transition. `ObjectTransitionedEvent` is dispatched after `saveObject()`
+     * has returned, so propagating the listener's exception would report
+     * failure for a write that succeeded.
+     *
+     * @return void
+     */
+    public function testThrowingPostEventListenerDoesNotFailACommittedTransition(): void
+    {
+        $case = $this->caseObject(status: self::S1);
+        $this->wire(
+            case: $case,
+            annotation: $this->graphAnnotation(allowedMoves: 'forward'),
+            siblings: $this->siblings()
+        );
+
+        $saved = $this->caseObject(status: self::S2);
+        $this->objectService->expects($this->once())
+            ->method('saveObject')
+            ->willReturn($saved);
+
+        $this->dispatcher->method('dispatchTyped')
+            ->willThrowException(new \LogicException('listener exploded'));
+
+        $result = $this->engine->transition(objectId: self::CASE, action: 'move-to-'.self::S2);
+
+        // The commit stands and the caller gets the saved object back.
+        $this->assertSame(expected: $saved, actual: $result);
+    }//end testThrowingPostEventListenerDoesNotFailACommittedTransition()
+
+    /**
+     * Swallowing silently would hide a real bug, so the listener failure is
+     * logged at ERROR with the exception attached.
+     *
+     * @return void
+     */
+    public function testThrowingPostEventListenerIsLoggedAtError(): void
+    {
+        $case = $this->caseObject(status: self::S1);
+        $this->wire(
+            case: $case,
+            annotation: $this->graphAnnotation(allowedMoves: 'forward'),
+            siblings: $this->siblings()
+        );
+
+        $this->objectService->method('saveObject')
+            ->willReturn($this->caseObject(status: self::S2));
+
+        $boom = new \LogicException('listener exploded');
+        $this->dispatcher->method('dispatchTyped')->willThrowException($boom);
+
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->stringContains(string: 'ObjectTransitionedEvent'),
+                $this->callback(
+                    callback: static function (array $context) use ($boom): bool {
+                        return ($context['exception'] ?? null) === $boom
+                            && ($context['action'] ?? null) !== null;
+                    }
+                )
+            );
+
+        $this->engine->transition(objectId: self::CASE, action: 'move-to-'.self::S2);
+    }//end testThrowingPostEventListenerIsLoggedAtError()
 }//end class

--- a/tests/Unit/Service/Lifecycle/TransitionEngineSlugContractTest.php
+++ b/tests/Unit/Service/Lifecycle/TransitionEngineSlugContractTest.php
@@ -115,7 +115,8 @@ class TransitionEngineSlugContractTest extends TestCase
             $this->userSession,
             $this->permission,
             $this->registerMapper,
-            $this->appConfig
+            $this->appConfig,
+            $this->createMock(\Psr\Log\LoggerInterface::class)
         );
 
     }//end engine()


### PR DESCRIPTION
Closes #2249.

## The defect

`TransitionEngine` dispatched `ObjectTransitionedEvent` **unguarded**, at both call sites (`transition()` static-map mode, `applyGraphTransition()` graph mode). The event is a **post** event: by the time it fires, `saveObject()` has returned and the lifecycle mutation is committed. A listener that throws therefore reported failure for work that had already succeeded.

## Reproduced live, before the fix

Probe listener registered on `ObjectTransitionedEvent`, transitioning procest `bezwaar` objects (register 17, schema 116, action `intrekken`) on the dev instance:

| probe throws | HTTP | DB before | DB after |
|---|---|---|---|
| `\LogicException` | **500** | `Ontvankelijkheidstoets` | **`Ingetrokken`** |
| `\RuntimeException` | **422** `{"error":"PROBE-P01..."}` | `Ontvankelijkheidstoets` | **`Ingetrokken`** |

Both committed. The 422 case is the nastier one: `TransitionController::transition()` maps `RuntimeException` to 422 "transition refused", so the caller is told the transition did **not** happen — and a retry then fails with *"not allowed from the current state"*, because the transition it is being asked to repeat has in fact already happened.

> Note: the repro recorded in `docs/transition-event-slug-contract.md` (a `learning-plan-evaluation` transition) is **stale** — that schema is now append-only, so it 500s with `AppendOnlyException` from `saveObject()` *before* any dispatch, and nothing commits. That is a legitimate failure, not this bug.

## The fix

Both sites now go through one private `dispatchTransitioned()` that catches `\Throwable` and logs at **ERROR** with the exception attached.

Design points:

- **A post-event listener must not be able to fail an already-committed write.** That is the whole defect.
- **Not silent.** Swallowing everything would trade a loud wrong answer for a quiet one. ERROR (not WARNING) because a listener throwing here is a real bug *and* the side effect it owns — a legal hold, a ledger posting, an outbound notification — did not run.
- **Pre-events are untouched.** The `*ing` family exists precisely so a listener can veto; those dispatch *before* the save and must keep propagating. The veto path for a transition is `HookStoppedException` raised inside `saveObject()`, which is upstream of this guard.
- **No existing helper to reuse.** I checked: OpenRegister has no shared guarded-dispatch helper. It does have an established *idiom* — `SaveObject::dispatchReferenceValidatedEvent()` and `SaveObjects::emitChunkSideEffects()` both wrap post-event dispatch in `try/catch` + logger inline. This follows that idiom, factored to one helper because there are two call sites.

## Positive control, after the fix

Same probe still throwing `\LogicException`, same transition:

- **HTTP 200**, response body is the transitioned object
- DB: `Ontvankelijkheidstoets` → **`Ingetrokken`** (commit stands)
- `nextcloud.log`, level 3, app `openregister`:
  `[TransitionEngine] A listener threw on ObjectTransitionedEvent. The transition itself is COMMITTED; the listener's side effect did not run.` with `LogicException` attached

All three legs proven: no 500, transition commits, failure visible.

## Tests

- `testThrowingPostEventListenerDoesNotFailACommittedTransition` — saved object still returned
- `testThrowingPostEventListenerIsLoggedAtError` — asserts ERROR + the exception in context

`tests/Unit/Service/Lifecycle/` **47/47 green**; `TransitionControllerTest` 6/6 green.

`LoggerInterface` is a new (trailing) constructor param; the two tests that construct the engine positionally were updated.

## Quality

`phpcs` on `TransitionEngine.php`: **0 errors** (1 pre-existing warning — class-level `@spec`, present before this change). `TransitionEngineGraphTest.php` went 122 → **111** errors: my additions are clean and I removed the 11 I had introduced; the remaining 111 are pre-existing file-wide `RequireNamedParameters` debt, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
