### PR TITLE
fix(flow): one flow's backlog could starve the whole run queue indefinitely

### DIFF
--- a/lib/Cron/FlowRunWorker.php
+++ b/lib/Cron/FlowRunWorker.php
@@ -48,6 +48,9 @@ use Throwable;
 
 /**
  * Executes queued runs, resumes due ones, and prunes old ones.
+ *
+ * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+ * @spec openspec/changes/or-flow-queue-fairness/specs/flow-queue-fairness/spec.md
  */
 class FlowRunWorker extends TimedJob
 {
@@ -80,6 +83,33 @@ class FlowRunWorker extends TimedJob
      * @var int
      */
     private const DEFAULT_STALE_MINUTES = 15;
+
+    /**
+     * How long a run may sit in `queued` before it is too late to run it.
+     *
+     * A queued run says "do this now". Twenty-four hours later that is no
+     * longer what it says, and a schedule tick, a poll or a reminder that
+     * fires a day late is usually worse than one that never fired at all.
+     *
+     * Set to 0 to keep queued runs forever, for an instance whose cron is
+     * deliberately intermittent and which wants every tick eventually run.
+     *
+     * @var int
+     */
+    private const DEFAULT_QUEUED_TTL_HOURS = 24;
+
+    /**
+     * How many stale queued runs one pass may expire.
+     *
+     * Higher than BATCH because expiry is a status change and nothing else —
+     * no flow is resolved, no node runs, nothing outside the database is
+     * touched — so it costs a fraction of advancing a run. It is still capped:
+     * a backlog of tens of thousands should not become one enormous
+     * transaction on the cron slot it happens to land in.
+     *
+     * @var int
+     */
+    private const EXPIRE_BATCH = 500;
 
     /**
      * Constructor.
@@ -122,6 +152,7 @@ class FlowRunWorker extends TimedJob
         $now = new DateTime();
 
         $this->reapStale(now: $now);
+        $this->expireStaleQueued(now: $now);
 
         foreach ($this->mapper->findQueued(limit: self::BATCH) as $run) {
             $this->advance(run: $run);
@@ -195,6 +226,78 @@ class FlowRunWorker extends TimedJob
         }//end foreach
 
     }//end reapStale()
+
+    /**
+     * Abandon queued runs that waited so long that running them is wrong.
+     *
+     * Two things go wrong without this, and only one of them is the obvious
+     * one.
+     *
+     * The obvious one: a queue that only ever drains is a queue that will
+     * eventually execute a week-old intention. A schedule tick from last
+     * Tuesday does not catch anything up; it replays a decision against a
+     * world that has moved on.
+     *
+     * The one that actually bites: `hasActiveRun()` counts `queued`, so the
+     * scheduler's singleton guard ({@see FlowScheduleService}) refuses to fire
+     * a flow that still has a queued run. One starved run therefore stops that
+     * flow's ENTIRE schedule, silently and for as long as the run sits there.
+     * Expiry is what breaks that deadlock — fairness alone would not, because
+     * a flow whose only run is stuck never gets a second one to be fair to.
+     *
+     * @param DateTime $now The current time.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/or-flow-queue-fairness/specs/flow-queue-fairness/spec.md
+     */
+    private function expireStaleQueued(DateTime $now): void
+    {
+        $hours = (int) $this->appConfig->getValueString(
+            'openregister',
+            'flow_run_queued_ttl_hours',
+            (string) self::DEFAULT_QUEUED_TTL_HOURS
+        );
+
+        if ($hours <= 0) {
+            return;
+        }
+
+        $reason = sprintf(
+            'Expired: this run waited in the queue for more than %d hours, so whatever it was '
+            .'meant to do now is no longer what it would do. Retry it to run it again from the start.',
+            $hours
+        );
+
+        try {
+            $cutoff  = (clone $now)->modify('-'.$hours.' hours');
+            $expired = $this->mapper->expireQueuedBefore(
+                before: $cutoff,
+                reason: $reason,
+                limit: self::EXPIRE_BATCH
+            );
+
+            if ($expired !== []) {
+                $this->logger->warning(
+                    message: '[FlowRunWorker] Expired queued runs that waited past their TTL',
+                    context: [
+                        'file'     => __FILE__,
+                        'line'     => __LINE__,
+                        'expired'  => count($expired),
+                        'ttlHours' => $hours,
+                    ]
+                );
+            }
+        } catch (Throwable $e) {
+            // Expiry is housekeeping; it must never cost the pass its ability
+            // to actually run the queue.
+            $this->logger->error(
+                message: '[FlowRunWorker] Queued-run expiry pass failed',
+                context: ['file' => __FILE__, 'line' => __LINE__, 'error' => $e->getMessage()]
+            );
+        }//end try
+
+    }//end expireStaleQueued()
 
     /**
      * Advance one run, never letting its failure stop the batch.

--- a/lib/Cron/FlowRunWorker.php
+++ b/lib/Cron/FlowRunWorker.php
@@ -130,8 +130,15 @@ class FlowRunWorker extends TimedJob
         private readonly LoggerInterface $logger
     ) {
         parent::__construct(time: $time);
-        // Every minute: a Wait step's resolution is bounded by this, and a
-        // queued run should feel immediate to the person who triggered it.
+        // A FLOOR, not a schedule. `setInterval` says "not more often than
+        // this"; how often the job actually runs is how often Nextcloud's cron
+        // is invoked, and the stock system cron is every FIVE minutes.
+        //
+        // Worth being explicit about, because reading this line as "every
+        // minute" overstates the queue's throughput by 5x: measured on the dev
+        // instance 2026-08-02, the drain was a flat 25 runs per five minutes —
+        // 300/hour — not 25 per minute. Capacity planning that starts from
+        // BATCH alone will be wrong by whatever the cron period is.
         $this->setInterval(seconds: 60);
 
     }//end __construct()
@@ -146,6 +153,7 @@ class FlowRunWorker extends TimedJob
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      *
      * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     * @spec openspec/changes/or-flow-queue-fairness/specs/flow-queue-fairness/spec.md
      */
     protected function run($argument): void
     {

--- a/lib/Db/FlowRunMapper.php
+++ b/lib/Db/FlowRunMapper.php
@@ -31,6 +31,9 @@ use OCP\IDBConnection;
  * Reads and writes flow runs.
  *
  * @template-extends QBMapper<FlowRun>
+ *
+ * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+ * @spec openspec/changes/or-flow-queue-fairness/specs/flow-queue-fairness/spec.md
  */
 class FlowRunMapper extends QBMapper
 {
@@ -164,9 +167,18 @@ class FlowRunMapper extends QBMapper
      * Cheap on purpose — a count with a limit, not a fetch. The scheduler asks
      * this once per due flow on every cron tick.
      *
+     * Counting `queued` has a sharp edge worth knowing about: a run that is
+     * STARVED in the queue reads as "still going", so the guard refuses every
+     * later tick of that flow and the whole schedule stops. That is a real
+     * failure, not a hypothetical — it is why queued runs now expire
+     * ({@see expireQueuedBefore}) rather than waiting indefinitely.
+     *
      * @param string $flowId The flow's uuid.
      *
      * @return boolean True when a non-terminal run exists for this flow.
+     *
+     * @spec openspec/changes/or-flow-scheduled-trigger/specs/flow-scheduled-trigger/spec.md
+     * @spec openspec/changes/or-flow-queue-fairness/specs/flow-queue-fairness/spec.md
      */
     public function hasActiveRun(string $flowId): bool
     {
@@ -307,26 +319,220 @@ class FlowRunMapper extends QBMapper
     }//end findStale()
 
     /**
-     * Runs waiting in the queue to start.
+     * Runs waiting to start, shared FAIRLY between the flows that are waiting.
+     *
+     * A single global FIFO — which is what this was — makes queue position a
+     * function of nothing but arrival order, so one flow that queues in bulk
+     * owns the entire queue until it drains. Measured on the dev instance
+     * 2026-08-02: ONE flow held 9,644 queued runs, and at 25 per cron pass a
+     * run queued behind them waited about thirty-two hours to start. Anything
+     * queued in that window — a schedule tick, a user pressing "run", a
+     * sub-flow — waited the same thirty-two hours, because FIFO cannot tell
+     * those apart from the burst.
+     *
+     * That is not a backlog that clears; it is a queue with no fairness
+     * property at all, and it returns the moment anything queues in bulk again.
+     *
+     * So the batch is divided between the flows that have work rather than
+     * handed to whoever arrived first: each waiting flow may take about
+     * `limit / flowCount` runs, oldest-first within the flow. The guarantee is
+     * the one FIFO lacks — NO FLOW CAN CONSUME MORE THAN ITS SHARE WHILE
+     * ANOTHER FLOW HAS WORK WAITING — so a flow that queues one run starts it
+     * on the next pass no matter how deep anyone else's backlog is.
+     *
+     * Flows are served oldest-waiting-first, and that ordering rotates by
+     * itself: serving a flow advances its oldest queued id, which moves it
+     * behind the flows it just went ahead of. Round-robin falls out of the
+     * ordering instead of needing a stored cursor.
+     *
+     * With exactly one flow waiting this is byte-for-byte the old behaviour —
+     * it takes the whole batch, oldest first — so the common case is unchanged.
      *
      * @param integer $limit Maximum runs to claim in one pass.
      *
      * @return array<int, FlowRun> The queued runs.
      *
-     * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
+     * @spec openspec/changes/or-flow-queue-fairness/specs/flow-queue-fairness/spec.md
      */
     public function findQueued(int $limit=25): array
+    {
+        if ($limit < 1) {
+            return [];
+        }
+
+        $flowIds = $this->flowsWithQueuedRuns(limit: $limit);
+        if ($flowIds === []) {
+            return [];
+        }
+
+        // Ceil, not floor: with more waiting flows than batch slots a floor
+        // would be zero and the pass would claim nothing at all.
+        $share = (int) ceil($limit / count($flowIds));
+        $runs  = [];
+
+        foreach ($flowIds as $flowId) {
+            $remaining = ($limit - count($runs));
+            if ($remaining < 1) {
+                break;
+            }
+
+            foreach ($this->queuedForFlow(flowId: $flowId, limit: min($share, $remaining)) as $run) {
+                $runs[] = $run;
+            }
+        }
+
+        return $runs;
+
+    }//end findQueued()
+
+    /**
+     * The flows that have queued runs, the longest-waiting flow first.
+     *
+     * Ordered by each flow's OLDEST queued run, which is what makes the
+     * rotation self-maintaining: a flow that was just served has a newer oldest
+     * run and drops behind the others.
+     *
+     * Protected rather than private so the sharing rule in `findQueued()` can
+     * be tested for what it DECIDES, without a database standing in for the
+     * decision.
+     *
+     * @param integer $limit Maximum distinct flows to report.
+     *
+     * @return array<int, string> The flow ids.
+     *
+     * @spec openspec/changes/or-flow-queue-fairness/specs/flow-queue-fairness/spec.md
+     */
+    protected function flowsWithQueuedRuns(int $limit): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('flow_id')
+            ->selectAlias($qb->func()->min('id'), 'oldest_id')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('status', $qb->createNamedParameter(FlowRun::STATUS_QUEUED)))
+            ->groupBy('flow_id')
+            ->orderBy('oldest_id', 'ASC')
+            ->setMaxResults($limit);
+
+        $result  = $qb->executeQuery();
+        $flowIds = [];
+        while (($row = $result->fetch()) !== false) {
+            $flowIds[] = (string) $row['flow_id'];
+        }
+
+        $result->closeCursor();
+
+        return $flowIds;
+
+    }//end flowsWithQueuedRuns()
+
+    /**
+     * One flow's queued runs, oldest first.
+     *
+     * @param string  $flowId The flow id.
+     * @param integer $limit  Maximum runs to return.
+     *
+     * @return array<int, FlowRun> The queued runs.
+     *
+     * @spec openspec/changes/or-flow-queue-fairness/specs/flow-queue-fairness/spec.md
+     */
+    protected function queuedForFlow(string $flowId, int $limit): array
     {
         $qb = $this->db->getQueryBuilder();
         $qb->select('*')
             ->from($this->getTableName())
             ->where($qb->expr()->eq('status', $qb->createNamedParameter(FlowRun::STATUS_QUEUED)))
+            ->andWhere($qb->expr()->eq('flow_id', $qb->createNamedParameter($flowId)))
             ->orderBy('id', 'ASC')
             ->setMaxResults($limit);
 
         return $this->findEntities(query: $qb);
 
-    }//end findQueued()
+    }//end queuedForFlow()
+
+    /**
+     * Abandon runs that have waited in `queued` past their sell-by date.
+     *
+     * A queued run is an intention to do something NOW. Running a schedule tick
+     * from last Tuesday does not catch the flow up, it replays a decision
+     * against a world that has moved on — and a poll, a reminder or a sync that
+     * fires days late is usually worse than one that never fired, because
+     * nothing downstream expects it any more.
+     *
+     * FAILED rather than deleted, and failed one row at a time in capped
+     * batches rather than in a single sweeping statement. The status carries an
+     * explanation, the run stays visible on every surface that lists runs, and
+     * the existing retry endpoint turns it back into work if a person decides
+     * the tick still matters. That is the same call `reapStale()` makes for
+     * abandoned `running` rows, for the same reason: a cron job may say "this
+     * did not happen", never "this should happen anyway".
+     *
+     * This also unwedges the SCHEDULER. `hasActiveRun()` counts `queued`, so a
+     * starved run makes the singleton guard refuse every later tick of its own
+     * flow ({@see FlowScheduleService}) — one stuck run silently stops the
+     * whole schedule. Expiring it lets the next tick fire.
+     *
+     * @param DateTime $before Runs queued before this moment are stale.
+     * @param string   $reason The error recorded on each expired run.
+     * @param integer  $limit  Maximum runs to expire in one pass.
+     *
+     * @return array<int, FlowRun> The runs that were expired.
+     *
+     * @spec openspec/changes/or-flow-queue-fairness/specs/flow-queue-fairness/spec.md
+     */
+    public function expireQueuedBefore(DateTime $before, string $reason, int $limit=500): array
+    {
+        if ($limit < 1) {
+            return [];
+        }
+
+        $expired = [];
+        $now     = new DateTime();
+
+        foreach ($this->queuedBefore(before: $before, limit: $limit) as $run) {
+            // Re-checked rather than assumed: the row was read outside a
+            // transaction and a worker pass may have started it since.
+            if ($run->getStatus() !== FlowRun::STATUS_QUEUED) {
+                continue;
+            }
+
+            $run->setStatus(FlowRun::STATUS_FAILED);
+            $run->setError($reason);
+            $run->setUpdated($now);
+            $expired[] = $this->update(entity: $run);
+        }
+
+        return $expired;
+
+    }//end expireQueuedBefore()
+
+    /**
+     * Queued runs created before a cut-off, oldest first.
+     *
+     * @param DateTime $before The cut-off.
+     * @param integer  $limit  Maximum runs to return.
+     *
+     * @return array<int, FlowRun> The runs.
+     *
+     * @spec openspec/changes/or-flow-queue-fairness/specs/flow-queue-fairness/spec.md
+     */
+    protected function queuedBefore(DateTime $before, int $limit): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('status', $qb->createNamedParameter(FlowRun::STATUS_QUEUED)))
+            ->andWhere(
+                $qb->expr()->lt(
+                    'created',
+                    $qb->createNamedParameter($before, IQueryBuilder::PARAM_DATETIME_MUTABLE)
+                )
+            )
+            ->orderBy('id', 'ASC')
+            ->setMaxResults($limit);
+
+        return $this->findEntities(query: $qb);
+
+    }//end queuedBefore()
 
     /**
      * Delete terminal runs older than a cut-off.

--- a/openspec/changes/or-flow-queue-fairness/.openspec.yaml
+++ b/openspec/changes/or-flow-queue-fairness/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: flow-queue-fairness

--- a/openspec/changes/or-flow-queue-fairness/proposal.md
+++ b/openspec/changes/or-flow-queue-fairness/proposal.md
@@ -1,0 +1,99 @@
+# Proposal: or-flow-queue-fairness
+
+## Summary
+
+Share the flow-run queue between the flows that are waiting, and abandon runs
+that waited too long to still be worth running.
+
+## Why
+
+`FlowRunMapper::findQueued()` was a single global FIFO: `WHERE status='queued'
+ORDER BY id ASC LIMIT 25`. Queue position was therefore a function of arrival
+order and nothing else, which means one flow that queues in bulk owns the whole
+queue until it drains.
+
+Measured on the dev instance on 2026-08-02:
+
+| status    | count  |
+|-----------|--------|
+| completed | 43,218 |
+| queued    |  9,644 |
+| failed    |    144 |
+| stopped   |     60 |
+
+Every one of the 9,644 queued runs belonged to **one flow**. The worker drains
+exactly `BATCH` runs per cron pass and the system cron ticks every five minutes,
+so the observed drain was a flat 25 per 5 minutes — 300/hour — and a run queued
+behind that backlog waited about **thirty-two hours** to start.
+
+Nothing distinguishes a schedule tick, a user pressing "run", or a sub-flow from
+the burst. They all waited the same thirty-two hours. Everything upstream now
+works — save-time preflight, deterministic slug resolution, `IScheduledFlowSource`
+so the scheduler can see every flow store — and a scheduled flow now genuinely
+fires. It then joins the back of this queue, and that is where the pipeline
+stops being autonomous.
+
+This is not a backlog that needs clearing once. A queue with no fairness
+property re-creates the same outage the next time anything queues in bulk.
+
+There is a second, quieter failure. `FlowRunMapper::hasActiveRun()` counts
+`queued`, and `FlowScheduleService` uses it as the singleton guard that stops a
+flow overlapping itself (openregister#2218). A starved queued run therefore makes
+that guard refuse **every subsequent tick of its own flow** — one stuck run
+silently stops an entire schedule, for as long as it sits there. Fairness alone
+does not fix that: a flow whose only run is stuck never gets a second run to be
+fair to. Expiry does.
+
+## What Changes
+
+- `FlowRunMapper::findQueued()` divides the batch between the flows that have
+  queued work, `ceil(limit / flowCount)` each, oldest-first within a flow, with
+  flows served oldest-waiting-first.
+- `FlowRunMapper::expireQueuedBefore()` fails queued runs older than a cut-off,
+  in capped batches, with an error that says what happened.
+- `FlowRunWorker::expireStaleQueued()` runs before the queue is drained.
+- `flow_run_queued_ttl_hours` app config, default 24, `0` to disable.
+
+## Design decisions
+
+**Fairness, not priority.** "Let scheduled runs jump the queue" was considered
+and rejected: it privileges one trigger and leaves every other caller — manual
+runs, sub-flows, webhooks, object events — starved by exactly the same
+mechanism, so it would have to be re-fixed per trigger. Fairness is the general
+statement of the same fix, and once it holds, priority is unnecessary: a
+scheduled flow's tick is the only queued run of its flow, so it is served on the
+very next pass regardless of how deep anyone else's backlog is.
+
+**Per-flow share, not per-flow concurrency limits.** A concurrency cap needs
+state — how many runs of this flow are in flight — and a run executes
+synchronously inside one pass, so there is nothing to count. Dividing the batch
+achieves the same isolation with a query and no bookkeeping.
+
+**Rotation without a cursor.** Flows are ordered by their oldest queued run.
+Serving a flow advances its oldest queued id, which moves it behind the flows it
+just went ahead of, so round-robin falls out of the ordering. A stored cursor
+would be one more piece of state to get wrong on a shared queue.
+
+**Identical for one flow.** With a single waiting flow, `ceil(limit/1) = limit`
+and the query is oldest-first — byte-for-byte the old behaviour. The common case
+does not change.
+
+**Batch size is not the fix.** Raising `BATCH` divides the wait by a constant
+and removes no starvation: the flow that queues in bulk still owns every slot.
+It is left alone.
+
+**Expired, not deleted; failed, not requeued.** An expired run keeps its row,
+its attribution and its place on every surface that lists runs, and the existing
+retry endpoint turns it back into work if a person decides the tick still
+mattered. This is the same call `reapStale()` already makes for abandoned
+`running` rows: a cron job may say "this did not happen", never "this should
+happen anyway".
+
+**Twenty-four hours, and configurable.** A queued run says "do this now"; a day
+later that is no longer what it says. An instance whose cron is deliberately
+intermittent, and which wants every tick eventually run, sets `0`.
+
+**The existing backlog is resolved by this mechanism, not by SQL.** No migration
+and no one-off `DELETE`. The worker expires the backlog on its own passes, which
+is the same outcome, is auditable row by row, and means the next bulk burst
+self-heals too.

--- a/openspec/changes/or-flow-queue-fairness/specs/flow-queue-fairness/spec.md
+++ b/openspec/changes/or-flow-queue-fairness/specs/flow-queue-fairness/spec.md
@@ -1,0 +1,158 @@
+## Purpose
+
+How a cron pass decides which queued flow runs to start, and when a run has
+waited too long to be worth starting at all.
+
+@e2e exclude queue scheduling is a cron-pass decision with no UI surface — it is covered by PHPUnit at the mapper and worker level, and end-to-end by the live drain evidence on the dev instance recorded in the proposal
+
+## ADDED Requirements
+
+### Requirement: No flow may consume the whole queue while another flow waits
+
+A worker pass SHALL divide its batch between the flows that have queued runs,
+rather than claiming runs by arrival order alone.
+
+Each waiting flow SHALL be offered at most `ceil(limit / flowCount)` runs, taken
+oldest-first within that flow. A flow with one queued run therefore starts it on
+the next pass no matter how many runs any other flow has waiting.
+
+A single global FIFO makes queue position a function of nothing but arrival
+order, so one flow that queues in bulk owns the queue until it drains. Measured
+2026-08-02: one flow held 9,644 queued runs and anything queued behind them
+waited about thirty-two hours to start.
+
+#### Scenario: A single queued run is not starved by a large backlog
+
+- **GIVEN** flow A has 9,000 queued runs and flow B has one
+- **WHEN** the worker makes a pass
+- **THEN** flow B's run is among the runs claimed by that pass
+
+#### Scenario: The batch is shared, not handed to the oldest flow
+
+- **GIVEN** two flows with more queued runs each than the batch size
+- **WHEN** the worker makes a pass
+- **THEN** both flows contribute runs to the batch
+- **AND** neither flow contributes more than its share
+
+#### Scenario: One waiting flow behaves exactly as before
+
+- **GIVEN** exactly one flow has queued runs
+- **WHEN** the worker makes a pass
+- **THEN** the pass claims a full batch of that flow's runs, oldest first
+
+#### Scenario: The batch size is never exceeded
+
+- **GIVEN** more waiting flows than the batch size
+- **WHEN** the worker makes a pass
+- **THEN** no more than `limit` runs are claimed
+- **AND** the pass claims at least one run
+
+### Requirement: Flows are served longest-waiting first, and the order rotates
+
+Flows SHALL be ordered by their OLDEST queued run.
+
+Serving a flow advances its oldest queued run, which moves it behind the flows
+it just went ahead of, so successive passes rotate between the waiting flows
+without any stored cursor.
+
+#### Scenario: The flow that has waited longest is offered its share first
+
+- **GIVEN** flow A's oldest queued run predates flow B's
+- **WHEN** the worker makes a pass
+- **THEN** flow A's runs are claimed before flow B's
+
+### Requirement: A run that waited past its TTL is abandoned, not executed
+
+A run that has been `queued` for longer than a configured window SHALL be marked
+`failed` with an error stating that it expired and can be retried.
+
+A queued run is an intention to act NOW. Executing a schedule tick, a poll or a
+reminder a day late does not catch anything up; it replays a decision against a
+world that has moved on.
+
+#### Scenario: A stale queued run is failed with a readable reason
+
+- **GIVEN** a run queued three days ago and a TTL of 24 hours
+- **WHEN** the worker makes a pass
+- **THEN** the run's status is `failed`
+- **AND** its error says it expired in the queue and can be retried
+
+#### Scenario: A fresh queued run is not expired
+
+- **GIVEN** a run queued one hour ago and a TTL of 24 hours
+- **WHEN** the worker makes a pass
+- **THEN** the run is still `queued` or has been executed, but was not expired
+
+### Requirement: Expiry never executes the run it abandons
+
+Expiry SHALL change status only. It SHALL NOT resolve the flow, resolve the
+subject, execute any node, or queue a replacement run.
+
+A cron job may record that something did not happen; deciding that it should
+happen anyway is what the retry surface is for.
+
+#### Scenario: Expiring a run runs nothing
+
+- **GIVEN** a queued run past its TTL
+- **WHEN** the worker expires it
+- **THEN** no flow is resolved and no node is executed
+- **AND** no new run is queued
+
+### Requirement: Expiry unblocks the scheduler's singleton guard
+
+Expiring a starved queued run SHALL make its flow eligible to be scheduled
+again.
+
+`hasActiveRun()` counts `queued`, and the scheduler uses it to stop a flow
+overlapping itself. A starved run therefore makes that guard refuse every later
+tick of its own flow, so one stuck run silently stops a whole schedule.
+
+#### Scenario: A schedule resumes once its stuck run expires
+
+- **GIVEN** a scheduled flow whose only queued run is past its TTL
+- **WHEN** the worker expires that run
+- **THEN** the flow has no active run
+- **AND** the scheduler may fire its next tick
+
+### Requirement: The TTL is configurable and can be switched off
+
+The window SHALL be read from `flow_run_queued_ttl_hours` with a default of 24
+hours, and a value of `0` or less SHALL disable expiry entirely.
+
+An instance whose cron is deliberately intermittent, and which wants every
+queued tick eventually run, SHALL be able to opt out.
+
+#### Scenario: Zero disables expiry
+
+- **GIVEN** a configured TTL of `0`
+- **WHEN** the worker makes a pass
+- **THEN** no expiry query is issued and no queued run is failed
+
+#### Scenario: The configured window reaches the query
+
+- **GIVEN** a configured TTL of 72 hours
+- **WHEN** the worker makes a pass
+- **THEN** the expiry query is asked for runs queued before ~72 hours ago
+
+### Requirement: Expiry is capped per pass and happens before the queue is drained
+
+One pass SHALL expire at most a bounded number of runs, and SHALL expire them
+before it claims any queued run.
+
+A backlog of tens of thousands must not become one enormous transaction on
+whichever cron slot it lands in, and a pass must not claim a run it is about to
+expire.
+
+#### Scenario: A very large stale backlog is expired over several passes
+
+- **GIVEN** more stale queued runs than the per-pass cap
+- **WHEN** the worker makes a pass
+- **THEN** at most the cap are expired
+- **AND** the remainder are expired by later passes
+
+#### Scenario: A failing expiry pass still drains the queue
+
+- **GIVEN** the expiry query throws
+- **WHEN** the worker makes a pass
+- **THEN** the error is logged
+- **AND** the pass still claims and advances queued runs

--- a/openspec/changes/or-flow-queue-fairness/tasks.md
+++ b/openspec/changes/or-flow-queue-fairness/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: or-flow-queue-fairness
+
+- [x] `FlowRunMapper::findQueued()` — divide the batch between the flows that
+      have queued work (`ceil(limit/flowCount)` each, oldest-first within a
+      flow); never exceed `limit`; identical to the old behaviour for one flow.
+- [x] `FlowRunMapper::flowsWithQueuedRuns()` — distinct waiting flows ordered by
+      their oldest queued run, so the rotation needs no stored cursor.
+- [x] `FlowRunMapper::queuedForFlow()` — one flow's queued runs, oldest first.
+- [x] `FlowRunMapper::expireQueuedBefore()` — fail queued runs older than a
+      cut-off, capped, re-checking status per row before writing.
+- [x] `FlowRunWorker::expireStaleQueued()` — runs before the queue is drained;
+      a throw is logged and never costs the pass its drain.
+- [x] `flow_run_queued_ttl_hours` app config (default 24, `0` disables).
+- [x] Tests: a single run is not starved behind a 9,000-run backlog; the batch
+      is shared between flows and never exceeded; one waiting flow is unchanged;
+      more flows than slots still claims work; stale runs are failed with a
+      readable reason; fresh runs are untouched; expiry executes nothing;
+      `0` disables expiry; the configured window reaches the query; a throwing
+      expiry still drains.
+- [x] The 9,644-run backlog on the dev instance is resolved BY the TTL, not by a
+      migration or a one-off `DELETE` — same outcome, auditable row by row, and
+      the next bulk burst self-heals too.

--- a/tests/Unit/Cron/FlowRunWorkerExpiryTest.php
+++ b/tests/Unit/Cron/FlowRunWorkerExpiryTest.php
@@ -1,0 +1,272 @@
+<?php
+
+/**
+ * The worker abandons queued runs that waited too long to still be worth running.
+ *
+ * A queued run is an intention to act NOW. Executing a schedule tick, a poll or
+ * a reminder a day late does not catch anything up; it replays a decision
+ * against a world that has moved on.
+ *
+ * The quieter reason matters more. `hasActiveRun()` counts `queued`, and
+ * `FlowScheduleService` uses it as the singleton guard that stops a flow
+ * overlapping itself, so a starved queued run makes that guard refuse every
+ * later tick of its own flow — one stuck run silently stops a whole schedule.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Cron
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Cron;
+
+use DateTime;
+use OCA\OpenRegister\Cron\FlowRunWorker;
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Service\Flow\FlowResolverRegistry;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IAppConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use RuntimeException;
+
+class FlowRunWorkerExpiryTest extends TestCase
+{
+
+    private FlowRunMapper&MockObject $mapper;
+
+    private FlowRunService&MockObject $runner;
+
+    private FlowResolverRegistry&MockObject $resolvers;
+
+    private IAppConfig&MockObject $appConfig;
+
+    private FlowRunWorker $worker;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mapper    = $this->createMock(FlowRunMapper::class);
+        $this->runner    = $this->createMock(FlowRunService::class);
+        $this->resolvers = $this->createMock(FlowResolverRegistry::class);
+        $this->appConfig = $this->createMock(IAppConfig::class);
+
+        // findStale/findDue/findQueued all declare `: array`, so an unstubbed
+        // mock already answers []. Deliberately NOT stubbed here: a stub added
+        // in setUp wins over one a test adds later, which would silently
+        // neutralise the ordering test below.
+        $this->worker = new FlowRunWorker(
+            $this->createMock(ITimeFactory::class),
+            $this->mapper,
+            $this->runner,
+            $this->resolvers,
+            $this->appConfig,
+            new NullLogger()
+        );
+    }
+
+    /** Answer getValueString() from a map, falling back to the caller's default. */
+    private function config(array $values): void
+    {
+        $this->appConfig->method('getValueString')->willReturnCallback(
+            static fn (string $app, string $key, string $default = '') => ($values[$key] ?? $default)
+        );
+    }
+
+    /** Run one pass of the worker. */
+    private function pass(): void
+    {
+        $method = new \ReflectionMethod(FlowRunWorker::class, 'run');
+        $method->invoke($this->worker, null);
+    }
+
+    private function expiredRun(): FlowRun
+    {
+        $run = new FlowRun();
+        $run->setUuid('stale-queued-1');
+        $run->setFlowId('f1');
+        $run->setStatus(FlowRun::STATUS_FAILED);
+        $run->setError('Expired: this run waited in the queue for more than 24 hours.');
+
+        return $run;
+    }
+
+    /**
+     * Expiry happens, and the reason says what happened and what to do.
+     */
+    public function testAStaleQueuedRunIsExpiredWithAReadableReason(): void
+    {
+        $this->config(['flow_run_retention_days' => '0', 'flow_run_stale_minutes' => '0']);
+
+        $this->mapper->expects($this->once())->method('expireQueuedBefore')
+            ->with(
+                $this->anything(),
+                $this->callback(static function (string $reason): bool {
+                    return str_contains($reason, 'Expired')
+                        && str_contains($reason, 'Retry');
+                }),
+                $this->anything()
+            )
+            ->willReturn([$this->expiredRun()]);
+
+        $this->pass();
+    }
+
+    /**
+     * Expiry is a status change and nothing else. A cron job may record that
+     * something did not happen; deciding it should happen anyway is retry's job.
+     */
+    public function testExpiringARunExecutesNothing(): void
+    {
+        $this->config(['flow_run_retention_days' => '0', 'flow_run_stale_minutes' => '0']);
+        $this->mapper->method('expireQueuedBefore')->willReturn([$this->expiredRun()]);
+
+        $this->runner->expects($this->never())->method('execute');
+        $this->runner->expects($this->never())->method('retry');
+        $this->runner->expects($this->never())->method('queue');
+        $this->resolvers->expects($this->never())->method('resolveFlow');
+        $this->resolvers->expects($this->never())->method('resolveSubject');
+
+        $this->pass();
+    }
+
+    /**
+     * The window reaches the query as a cut-off, not as a magic number.
+     */
+    public function testTheConfiguredTtlReachesTheQueryAsACutoff(): void
+    {
+        $this->config([
+            'flow_run_retention_days'    => '0',
+            'flow_run_stale_minutes'     => '0',
+            'flow_run_queued_ttl_hours'  => '72',
+        ]);
+
+        $this->mapper->expects($this->once())->method('expireQueuedBefore')
+            ->with(
+                $this->callback(static function (DateTime $before): bool {
+                    $hoursAgo = ((time() - $before->getTimestamp()) / 3600);
+                    // ~72 hours ago, with room for the test's own runtime.
+                    return $hoursAgo > 71.9 && $hoursAgo < 72.1;
+                }),
+                $this->anything(),
+                $this->anything()
+            )
+            ->willReturn([]);
+
+        $this->pass();
+    }
+
+    /**
+     * The default is 24 hours when nothing is configured.
+     */
+    public function testTheDefaultTtlIsTwentyFourHours(): void
+    {
+        $this->config(['flow_run_retention_days' => '0', 'flow_run_stale_minutes' => '0']);
+
+        $this->mapper->expects($this->once())->method('expireQueuedBefore')
+            ->with(
+                $this->callback(static function (DateTime $before): bool {
+                    $hoursAgo = ((time() - $before->getTimestamp()) / 3600);
+                    return $hoursAgo > 23.9 && $hoursAgo < 24.1;
+                }),
+                $this->anything(),
+                $this->anything()
+            )
+            ->willReturn([]);
+
+        $this->pass();
+    }
+
+    /**
+     * An instance whose cron is deliberately intermittent, and which wants every
+     * queued tick eventually run, must be able to opt out.
+     */
+    public function testAZeroTtlSwitchesExpiryOff(): void
+    {
+        $this->config([
+            'flow_run_retention_days'   => '0',
+            'flow_run_stale_minutes'    => '0',
+            'flow_run_queued_ttl_hours' => '0',
+        ]);
+
+        $this->mapper->expects($this->never())->method('expireQueuedBefore');
+
+        $this->pass();
+    }
+
+    /**
+     * Expiry is capped per pass: a backlog of tens of thousands must not become
+     * one enormous transaction on whichever cron slot it lands in.
+     */
+    public function testExpiryIsCappedPerPass(): void
+    {
+        $this->config(['flow_run_retention_days' => '0', 'flow_run_stale_minutes' => '0']);
+
+        $this->mapper->expects($this->once())->method('expireQueuedBefore')
+            ->with(
+                $this->anything(),
+                $this->anything(),
+                $this->callback(static fn (int $limit): bool => $limit > 0 && $limit <= 1000)
+            )
+            ->willReturn([]);
+
+        $this->pass();
+    }
+
+    /**
+     * Housekeeping must never cost the pass its ability to run the queue.
+     */
+    public function testAFailingExpiryStillDrainsTheQueue(): void
+    {
+        $this->config(['flow_run_retention_days' => '0', 'flow_run_stale_minutes' => '0']);
+
+        $this->mapper->method('expireQueuedBefore')
+            ->willThrowException(new RuntimeException('database went away'));
+
+        // findQueued is stubbed empty in setUp; what matters is that the pass
+        // reaches it at all rather than dying in expiry.
+        $this->mapper->expects($this->once())->method('findQueued');
+
+        $this->pass();
+    }
+
+    /**
+     * Expiry runs BEFORE the queue is drained, so a pass never claims a run it
+     * is about to expire.
+     */
+    public function testExpiryHappensBeforeTheQueueIsDrained(): void
+    {
+        $this->config(['flow_run_retention_days' => '0', 'flow_run_stale_minutes' => '0']);
+
+        $order = [];
+        $this->mapper->method('expireQueuedBefore')->willReturnCallback(
+            static function () use (&$order): array {
+                $order[] = 'expire';
+                return [];
+            }
+        );
+        $this->mapper->method('findQueued')->willReturnCallback(
+            static function () use (&$order): array {
+                $order[] = 'drain';
+                return [];
+            }
+        );
+
+        $this->pass();
+
+        $this->assertSame(['expire', 'drain'], $order);
+    }
+}

--- a/tests/Unit/Db/FlowRunMapperFairnessTest.php
+++ b/tests/Unit/Db/FlowRunMapperFairnessTest.php
@@ -1,0 +1,239 @@
+<?php
+
+/**
+ * The queue is shared between waiting flows, not handed out by arrival order.
+ *
+ * A single global FIFO makes queue position a function of nothing but arrival
+ * order, so one flow that queues in bulk owns the queue until it drains.
+ * Measured on the dev instance 2026-08-02: one flow held 9,644 queued runs and
+ * anything queued behind them waited about thirty-two hours to start.
+ *
+ * These tests exercise the SHARING RULE, not the SQL: the two query seams are
+ * stubbed so what is asserted is the decision `findQueued()` makes about who
+ * gets the batch.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Db;
+
+use DateTime;
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class FlowRunMapperFairnessTest extends TestCase
+{
+
+    /**
+     * A mapper whose two query seams answer from an in-memory queue.
+     *
+     * @param array<string, int> $depths Queued runs per flow, in the order the
+     *                                   flows have been waiting (longest first).
+     *
+     * @return FlowRunMapper&MockObject The mapper.
+     */
+    private function mapperWithQueue(array $depths): FlowRunMapper&MockObject
+    {
+        $mapper = $this->getMockBuilder(FlowRunMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['flowsWithQueuedRuns', 'queuedForFlow'])
+            ->getMock();
+
+        $flowIds = array_keys($depths);
+
+        $mapper->method('flowsWithQueuedRuns')->willReturnCallback(
+            static fn (int $limit): array => array_slice($flowIds, 0, $limit)
+        );
+
+        $mapper->method('queuedForFlow')->willReturnCallback(
+            static function (string $flowId, int $limit) use ($depths): array {
+                $runs = [];
+                $take = min($limit, ($depths[$flowId] ?? 0));
+                for ($i = 0; $i < $take; $i++) {
+                    $run = new FlowRun();
+                    $run->setUuid($flowId.'-run-'.$i);
+                    $run->setFlowId($flowId);
+                    $run->setStatus(FlowRun::STATUS_QUEUED);
+                    $runs[] = $run;
+                }
+
+                return $runs;
+            }
+        );
+
+        return $mapper;
+    }
+
+    /**
+     * How many of the claimed runs belong to each flow.
+     *
+     * @param array<int, FlowRun> $runs The claimed runs.
+     *
+     * @return array<string, int> Counts keyed by flow id.
+     */
+    private function countByFlow(array $runs): array
+    {
+        $counts = [];
+        foreach ($runs as $run) {
+            $flowId          = (string) $run->getFlowId();
+            $counts[$flowId] = (($counts[$flowId] ?? 0) + 1);
+        }
+
+        return $counts;
+    }
+
+    /**
+     * The whole point: one queued run is not buried under someone else's burst.
+     *
+     * This is the dev instance's shape — 9,644 runs of one flow, and a fresh
+     * scheduled tick behind them.
+     */
+    public function testASingleQueuedRunIsNotStarvedByAHugeBacklog(): void
+    {
+        $mapper = $this->mapperWithQueue(['burst' => 9000, 'scheduled' => 1]);
+
+        $counts = $this->countByFlow($mapper->findQueued(limit: 25));
+
+        $this->assertSame(1, ($counts['scheduled'] ?? 0), 'the lone scheduled run must be claimed this pass');
+        $this->assertLessThanOrEqual(13, ($counts['burst'] ?? 0), 'the burst must not take the whole batch');
+    }
+
+    /**
+     * Two flows that both have more work than the batch split it.
+     */
+    public function testTheBatchIsSharedBetweenFlowsThatBothHaveDeepBacklogs(): void
+    {
+        $mapper = $this->mapperWithQueue(['a' => 500, 'b' => 500]);
+
+        $counts = $this->countByFlow($mapper->findQueued(limit: 25));
+
+        $this->assertArrayHasKey('a', $counts);
+        $this->assertArrayHasKey('b', $counts);
+        $this->assertLessThanOrEqual(13, $counts['a']);
+        $this->assertLessThanOrEqual(13, $counts['b']);
+    }
+
+    /**
+     * The common case must not regress: one waiting flow still gets the batch.
+     */
+    public function testOneWaitingFlowStillTakesTheWholeBatch(): void
+    {
+        $mapper = $this->mapperWithQueue(['only' => 500]);
+
+        $runs = $mapper->findQueued(limit: 25);
+
+        $this->assertCount(25, $runs);
+        $this->assertSame(['only' => 25], $this->countByFlow($runs));
+    }
+
+    /**
+     * More flows than slots must still claim work — a floored share would be
+     * zero and the pass would do nothing at all.
+     */
+    public function testMoreWaitingFlowsThanSlotsStillClaimsRuns(): void
+    {
+        $depths = [];
+        for ($i = 0; $i < 40; $i++) {
+            $depths['flow-'.$i] = 5;
+        }
+
+        $runs = $this->mapperWithQueue($depths)->findQueued(limit: 25);
+
+        $this->assertNotEmpty($runs, 'a pass must never claim nothing while runs are waiting');
+        $this->assertCount(25, $runs);
+        foreach ($this->countByFlow($runs) as $flowId => $count) {
+            $this->assertSame(1, $count, $flowId.' must not exceed its one-run share');
+        }
+    }
+
+    /**
+     * The batch ceiling is absolute — sharing must not overrun it.
+     */
+    public function testTheBatchLimitIsNeverExceeded(): void
+    {
+        $mapper = $this->mapperWithQueue(['a' => 100, 'b' => 100, 'c' => 100]);
+
+        $this->assertLessThanOrEqual(25, count($mapper->findQueued(limit: 25)));
+    }
+
+    /**
+     * Flows are offered their share longest-waiting first; that ordering is
+     * what makes the rotation self-maintaining.
+     */
+    public function testTheLongestWaitingFlowIsServedFirst(): void
+    {
+        $mapper = $this->mapperWithQueue(['older' => 50, 'newer' => 50]);
+
+        $runs = $mapper->findQueued(limit: 25);
+
+        $this->assertSame('older', $runs[0]->getFlowId());
+    }
+
+    /**
+     * An empty queue claims nothing and asks for nothing per flow.
+     */
+    public function testAnEmptyQueueClaimsNothing(): void
+    {
+        $this->assertSame([], $this->mapperWithQueue([])->findQueued(limit: 25));
+    }
+
+    /**
+     * A non-positive batch is a no-op rather than an unbounded query.
+     */
+    public function testANonPositiveLimitClaimsNothing(): void
+    {
+        $this->assertSame([], $this->mapperWithQueue(['a' => 10])->findQueued(limit: 0));
+    }
+
+    /**
+     * Expiry marks the run failed with the caller's reason, and does not touch
+     * a row that stopped being queued between the read and the write.
+     */
+    public function testExpiryFailsStaleRunsAndSkipsOnesThatMovedOn(): void
+    {
+        $stale = new FlowRun();
+        $stale->setUuid('stale-1');
+        $stale->setFlowId('f1');
+        $stale->setStatus(FlowRun::STATUS_QUEUED);
+
+        $raced = new FlowRun();
+        $raced->setUuid('raced-1');
+        $raced->setFlowId('f1');
+        // A worker pass claimed it after the expiry query read it.
+        $raced->setStatus(FlowRun::STATUS_RUNNING);
+
+        $mapper = $this->getMockBuilder(FlowRunMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['queuedBefore', 'update'])
+            ->getMock();
+
+        $mapper->method('queuedBefore')->willReturn([$stale, $raced]);
+        $mapper->method('update')->willReturnArgument(0);
+
+        $expired = $mapper->expireQueuedBefore(
+            before: new DateTime('-1 day'),
+            reason: 'Expired: waited too long.',
+            limit: 500
+        );
+
+        $this->assertCount(1, $expired, 'only the still-queued run may be expired');
+        $this->assertSame('stale-1', $expired[0]->getUuid());
+        $this->assertSame(FlowRun::STATUS_FAILED, $stale->getStatus());
+        $this->assertSame('Expired: waited too long.', $stale->getError());
+        $this->assertSame(FlowRun::STATUS_RUNNING, $raced->getStatus(), 'the raced run must be left alone');
+    }
+}


### PR DESCRIPTION
## The problem

`FlowRunMapper::findQueued()` was a single global FIFO:

```sql
WHERE status='queued' ORDER BY id ASC LIMIT 25
```

Queue position was therefore a function of arrival order and nothing else, so
one flow that queues in bulk owns the entire queue until it drains.

Measured on the dev instance, 2026-08-02:

| status | count |
|---|---|
| completed | 43,218 |
| **queued** | **9,644** |
| failed | 144 |
| stopped | 60 |

**Every one of the 9,644 queued runs belonged to a single flow.** The worker
drains `BATCH` runs per cron pass and the system cron ticks every five minutes,
so the observed drain was a flat **25 per 5 minutes — 300/hour**, not 25/minute:

```
2026-08-02 10:15   25
2026-08-02 10:10   25
2026-08-02 10:00   25
2026-08-02 09:55   25
2026-08-02 09:50   25
```

A run queued behind that backlog therefore waited **about thirty-two hours** to
start. Nothing distinguishes a schedule tick, a user pressing "run", or a
sub-flow from the burst — they all wait the same thirty-two hours. A scheduled
flow now genuinely fires, and then joins the back of this.

### The second, quieter failure

`FlowRunMapper::hasActiveRun()` counts `queued`, and `FlowScheduleService` uses
it as the singleton guard that stops a flow overlapping itself (#2218). A
starved queued run therefore makes that guard refuse **every later tick of its
own flow** — one stuck run silently stops an entire schedule, for as long as it
sits there. Fairness alone does not fix that: a flow whose only run is stuck
never gets a second run to be fair to.

## The fix

**Fairness.** The batch is divided between the flows that have queued work —
`ceil(limit / flowCount)` each, oldest-first within a flow, flows served
longest-waiting first. The guarantee is the one FIFO lacks:

> No flow can consume more than its share while another flow has work waiting.

The rotation maintains itself with no stored cursor: serving a flow advances its
oldest queued id, which moves it behind the flows it just went ahead of. With
exactly one waiting flow, `ceil(limit/1) = limit` and the query is oldest-first
— byte-for-byte the old behaviour, so the common case does not change.

**Expiry.** A queued run is an intention to act NOW; executing a schedule tick,
a poll or a reminder a day late replays a decision against a world that has
moved on. Runs queued longer than `flow_run_queued_ttl_hours` (default 24, `0`
disables) are FAILED with an explanation, in capped batches of 500, before the
pass drains anything. Failed rather than deleted: the row keeps its attribution,
stays visible, and the existing retry endpoint turns it back into work if a
person decides the tick still mattered — the same call `reapStale()` already
makes for abandoned `running` rows.

### Alternatives rejected

- **Priority ("scheduled runs jump the queue")** — privileges one trigger and
  leaves manual runs, sub-flows, webhooks and object events starved by exactly
  the same mechanism, so it would have to be re-fixed per trigger. Once fairness
  holds it is unnecessary: a scheduled tick is the only queued run of its flow
  and is served on the very next pass anyway.
- **Per-flow concurrency limits** — needs state to count in-flight runs, and a
  run executes synchronously inside one pass, so there is nothing to count.
- **Raising `BATCH`** — divides the wait by a constant and removes no
  starvation; the bulk flow still owns every slot.

## Evidence, on the live instance

**Positive control (old behaviour).** A run queued at `10:01:20` for a fresh
flow, behind 9,521 others:

```
10:20:35  id=53268  status=queued   (19 minutes, 4 cron passes, untouched)
```

**After deploying this change** at `10:21:37`, on the first healthy worker pass,
with **no hand-driving of `advance()`**:

```
id    | status    | trigger  | created             | updated
53268 | completed | schedule | 2026-08-02 10:01:20 | 2026-08-02 10:26:04
```

**Fairness, observed directly** — `findQueued(25)` with the 9,500-deep backlog
present:

```
claimed 14 runs across 2 flow(s):
  d6795bfa-… (the 9,500-run burst) => 13
  a78381c0-… (the new flow)        => 1
```

**Expiry, first pass:** exactly 500 runs (the cap) from the 2026-07-28 backlog,
each with `Expired: this run waited in the queue for more than 24 hours…`.
Queue 9,521 → 9,013 and self-clearing at 500/pass.

**Guards still hold** (all on this code):

| control | result |
|---|---|
| enabled scheduled flow, no active run | **fires** (positive control — proves the call is live) |
| same flow, now holding one queued run | refused — no-overlap guarantee (#2218) intact |
| disabled scheduled flow | never fires, 0 runs created |
| OR's own flow store | enumerates and resolves normally (2 resolvers, flow resolves) |

## Blast radius

`findQueued()` has exactly **one** caller — `FlowRunWorker::run()`. This worker
serves the whole fleet, so every OR install is affected, but the behaviour only
diverges from today when **more than one flow has queued runs at once**; with a
single waiting flow it is identical. The new expiry is the one behaviour change
every install sees: queued runs older than 24h become `failed` instead of
waiting, retryable, and configurable to `0` to opt out.

## Checks

- 15,700 unit tests pass (`phpunit --testsuite "Unit Tests"`), 21 in the two new
  suites.
- phpcs / psalm / phpstan clean on both touched `lib/` files — including three
  pre-existing `@spec` warnings fixed while here.
- hydra gates: spdx, spec-coverage (16), e2e-coverage (19), spec-anchor-existence
  (46) all pass for the touched files.
