### PR TITLE
fix(flow): `config.output` was inert on an object-write delete — and a successful delete dropped the incoming record

### DIFF
--- a/lib/Service/Flow/Nodes/ObjectWriteNode.php
+++ b/lib/Service/Flow/Nodes/ObjectWriteNode.php
@@ -482,10 +482,12 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys
         $register  = $this->resolveRegister(config: $config);
         $schema    = $this->resolveSchema(config: $config, register: $register);
 
+        // `onNoMatch` is deliberately absent here: it is read inside
+        // executeDelete(), the only path that acts on it, rather than resolved
+        // here and passed down as an eleventh parameter.
         $pairs      = $this->matchPairs(config: $config);
         $fields     = (array) ($config['fields'] ?? []);
         $onMissing  = $this->optionFrom(config: $config, key: 'onMissing', allowed: self::ON_MISSING, default: self::ON_MISSING_OMIT);
-        $onNoMatch  = $this->optionFrom(config: $config, key: 'onNoMatch', allowed: self::ON_NO_MATCH, default: self::ON_NO_MATCH_ERROR);
         $onConflict = $this->optionFrom(config: $config, key: 'onConflict', allowed: self::ON_CONFLICT, default: self::ON_CONFLICT_OVERWRITE);
         $replace    = (($config['replace'] ?? false) === true);
         $cap        = $this->writeCap(config: $config);
@@ -505,8 +507,8 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys
                     register: $register,
                     schema: $schema,
                     owner: $owner,
-                    onNoMatch: $onNoMatch,
                     cap: $cap,
+                    config: $config,
                     writes: $writes
                 );
                 continue;
@@ -591,15 +593,15 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys
     /**
      * Perform one guarded delete and build its output item.
      *
-     * @param array    $item      The input item (`json` and `binary`).
-     * @param int      $index     The input item's index, for provenance.
-     * @param array    $pairs     The composite match pairs.
-     * @param Register $register  The resolved register.
-     * @param Schema   $schema    The resolved schema.
-     * @param IUser    $owner     The run owner, as the acting user.
-     * @param string   $onNoMatch What a zero-match delete means.
-     * @param int      $cap       The step's write cap.
-     * @param int      $writes    Writes performed so far; incremented by reference.
+     * @param array    $item     The input item (`json` and `binary`).
+     * @param int      $index    The input item's index, for provenance.
+     * @param array    $pairs    The composite match pairs.
+     * @param Register $register The resolved register.
+     * @param Schema   $schema   The resolved schema.
+     * @param IUser    $owner    The run owner, as the acting user.
+     * @param int      $cap      The step's write cap.
+     * @param array    $config   The step configuration; `onNoMatch` and `output` are read from it.
+     * @param int      $writes   Writes performed so far; incremented by reference.
      *
      * @return array The output item.
      *
@@ -612,10 +614,21 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys
         Register $register,
         Schema $schema,
         IUser $owner,
-        string $onNoMatch,
         int $cap,
+        array $config,
         int &$writes
     ): array {
+        // Read from the config rather than taken as an eleventh parameter. The
+        // caller resolves it exactly this way; passing both it and the config
+        // would be two spellings of one fact, and the parameter list is already
+        // at its limit.
+        $onNoMatch = $this->optionFrom(
+            config: $config,
+            key: 'onNoMatch',
+            allowed: self::ON_NO_MATCH,
+            default: self::ON_NO_MATCH_ERROR
+        );
+
         $json   = (array) ($item[FlowItems::JSON] ?? []);
         $binary = (array) ($item[FlowItems::BINARY] ?? []);
 
@@ -632,8 +645,21 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys
             // it is never indistinguishable from a removal in the run log.
             $json['deleted'] = false;
 
+            // ...and it gets the `output` key too, when one is set. A step
+            // whose output key exists only on the branch that deleted
+            // something makes `{{removed.deleted}}` resolve on some items and
+            // not others, which is a downstream null nobody can explain.
+            //
+            // NOT via outputJson() here: on this branch the record IS the
+            // output, so an empty key must leave `$json` alone rather than
+            // replace it with the two-field written record.
+            $outputKey = trim((string) ($config['output'] ?? ''));
+            if ($outputKey !== '') {
+                $json[$outputKey] = ['deleted' => false];
+            }
+
             return FlowItems::item(json: $json, binary: $binary, fromItemIndex: $index);
-        }
+        }//end if
 
         $uuid = (string) $matched->getUuid();
 
@@ -651,13 +677,25 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys
         );
         $writes++;
 
+        // Through `outputJson()`, exactly like every non-delete write. Without
+        // it a delete was the one operation that could not carry its incoming
+        // record forward: `config.output` never reached this method, so the
+        // key the author set did nothing and everything the item was carrying
+        // — the issue number, the repo, the run id — was dropped at the delete.
+        //
+        // With no `output` set the returned record is unchanged, so this is not
+        // a behaviour change for any flow that does not ask for one.
         return FlowItems::item(
-            json: [
-                'uuid'     => $uuid,
-                'register' => $this->identifierOf(register: $register),
-                'schema'   => $this->labelOf(schema: $schema),
-                'deleted'  => true,
-            ],
+            json: $this->outputJson(
+                incoming: $json,
+                written: [
+                    'uuid'     => $uuid,
+                    'register' => $this->identifierOf(register: $register),
+                    'schema'   => $this->labelOf(schema: $schema),
+                    'deleted'  => true,
+                ],
+                config: $config
+            ),
             binary: $binary,
             fromItemIndex: $index
         );

--- a/tests/Unit/Service/Flow/ObjectWriteNodeTest.php
+++ b/tests/Unit/Service/Flow/ObjectWriteNodeTest.php
@@ -890,6 +890,95 @@ class ObjectWriteNodeTest extends TestCase
     }//end testASkippedDeleteIsDistinguishableFromAPerformedOne()
 
 
+    /**
+     * `config.output` on a delete used to be read by nothing.
+     *
+     * `outputJson()` is what honours the key, and it was only ever called on the
+     * non-delete path — `executeDelete()` was never handed the config. So a
+     * delete was the one operation that could not carry its incoming record
+     * forward: everything the item was holding (the issue number, the repo, the
+     * run id) was dropped the moment something was removed.
+     *
+     * @return void
+     */
+    public function testADeleteHonoursTheOutputKeyAndKeepsTheIncomingRecord(): void
+    {
+        $this->tableOf([['uuid' => 'u-gone', 'data' => ['sourceId' => 'r1']]]);
+        $this->objects->method('deleteObject')->willReturn(true);
+
+        $out = $this->node->execute(
+            $this->items([['retiredId' => 'r1', 'issue' => 489]]),
+            $this->deleteConfig(['output' => 'removed']),
+            $this->registerContext
+        );
+
+        $json = $out[0]['json'];
+
+        $this->assertSame(489, $json['issue'], 'the incoming record survives the delete');
+        $this->assertSame('r1', $json['retiredId']);
+        $this->assertSame('u-gone', $json['removed']['uuid'], 'the delete record lands under the output key');
+        $this->assertTrue($json['removed']['deleted']);
+
+    }//end testADeleteHonoursTheOutputKeyAndKeepsTheIncomingRecord()
+
+
+    /**
+     * POSITIVE CONTROL — with no `output`, the shape is exactly what it was.
+     *
+     * The fix must not change any flow that does not ask for one.
+     *
+     * @return void
+     */
+    public function testADeleteWithoutAnOutputKeyIsUnchanged(): void
+    {
+        $this->tableOf([['uuid' => 'u-gone', 'data' => ['sourceId' => 'r1']]]);
+        $this->objects->method('deleteObject')->willReturn(true);
+
+        $out = $this->node->execute(
+            $this->items([['retiredId' => 'r1', 'issue' => 489]]),
+            $this->deleteConfig(),
+            $this->registerContext
+        );
+
+        $json = $out[0]['json'];
+
+        $this->assertSame('u-gone', $json['uuid']);
+        $this->assertTrue($json['deleted']);
+        $this->assertArrayNotHasKey('issue', $json, 'unchanged: without output, the delete record IS the item');
+        $this->assertArrayNotHasKey('removed', $json);
+
+    }//end testADeleteWithoutAnOutputKeyIsUnchanged()
+
+
+    /**
+     * A SKIPPED delete gets the output key too.
+     *
+     * An output key that exists only on the branch that removed something makes
+     * `{{removed.deleted}}` resolve on some items and not others — a downstream
+     * null with no visible cause.
+     *
+     * @return void
+     */
+    public function testASkippedDeleteAlsoCarriesTheOutputKey(): void
+    {
+        $this->tableOf([]);
+        $this->objects->expects($this->never())->method('deleteObject');
+
+        $out = $this->node->execute(
+            $this->items([['retiredId' => 'r1', 'issue' => 489]]),
+            $this->deleteConfig(['onNoMatch' => 'skip', 'output' => 'removed']),
+            $this->registerContext
+        );
+
+        $json = $out[0]['json'];
+
+        $this->assertFalse($json['deleted'], 'the top-level flag stays where it was');
+        $this->assertSame('r1', $json['retiredId']);
+        $this->assertFalse($json['removed']['deleted']);
+
+    }//end testASkippedDeleteAlsoCarriesTheOutputKey()
+
+
     public function testAnAmbiguousDeleteMatchFailsRatherThanChoosing(): void
     {
         $this->tableOf(


### PR DESCRIPTION
Closes #2261.

## The defect

`outputJson()` is the method that honours `config.output`. It was called on exactly one path — the non-delete write. `executeDelete()` was never handed `$config` at all, so the key an author set on a delete step was read by nothing.

The sharper half is the **second** consequence. Because the output key could not be reached, a successful delete discarded the incoming record entirely and emitted only:

```json
{"uuid": "…", "register": "…", "schema": "…", "deleted": true}
```

Whatever the item was carrying — the issue number, the repo, the run id — was gone from that point in the graph. Every other operation can preserve it via `output`.

The **skip** path was already inconsistent with this: it returns the input record with `deleted: false` merged in. So a delete that *succeeded* lost more context than one that found nothing.

## The fix

`executeDelete()` now receives the config and routes its return through `outputJson()`. **With no `output` set the returned record is byte-identical to before**, so no existing flow changes — there is a test asserting exactly that.

The skip branch gets the key too, but deliberately **not** through `outputJson()`: on that branch the incoming record *is* the output, so an empty key has to leave `$json` alone rather than replace it with the two-field written record. (I wrote it the naive way first and it silently discarded the record — hence the explicit branch and the comment saying why.)

An output key that exists only on the branch that removed something makes `{{removed.deleted}}` resolve on some items and not others, which is a downstream null with no visible cause.

`onNoMatch` is now read inside `executeDelete()` from the config it was already given, rather than passed alongside it — two spellings of one fact, and adding `$config` had pushed the parameter list to eleven.

## Tests

| test | asserts |
|---|---|
| `testADeleteHonoursTheOutputKeyAndKeepsTheIncomingRecord` | incoming record survives; delete record lands under `removed` |
| `testADeleteWithoutAnOutputKeyIsUnchanged` | **control** — shape is exactly what it was |
| `testASkippedDeleteAlsoCarriesTheOutputKey` | top-level flag stays put, nested key present |

Full unit suite: **15 701 tests, 0 failures**. PHPCS `lib/Service/Flow`: 0 errors. Psalm: no errors. PHPMD: no new findings (the `ExcessiveParameterList` the first draft introduced is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)