### PR TITLE
fix(search): @self metadata filters cannot express any comparison — no query can ask "created before X"

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -494,6 +494,13 @@ class Application extends App implements IBootstrap
         // clear HTTP 400 instead of a silent zero-row result or a bare 500.
         $context->registerMiddleware(\OCA\OpenRegister\Middleware\EncryptedFieldFilterMiddleware::class);
 
+        // Register the UnknownMetadataFieldMiddleware: maps
+        // UnknownMetadataFieldException — thrown when a `@self` filter names a
+        // field that no metadata column corresponds to — onto an HTTP 400 that
+        // names the field and lists the filterable ones, instead of the opaque
+        // driver-level 500 an unresolvable column name used to produce.
+        $context->registerMiddleware(\OCA\OpenRegister\Middleware\UnknownMetadataFieldMiddleware::class);
+
         // Bind the dormant Path B PDF anonymisation fallback bridge to its
         // null implementation. Tenants enabling Path B replace this binding
         // with a concrete NcOfficeConverterInterface implementation that

--- a/lib/Db/MagicMapper/MagicSearchHandler.php
+++ b/lib/Db/MagicMapper/MagicSearchHandler.php
@@ -46,6 +46,7 @@ use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\MagicMapper\MagicRbacHandler;
 use OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler;
 use OCA\OpenRegister\Exception\EncryptedFieldFilterException;
+use OCA\OpenRegister\Exception\UnknownMetadataFieldException;
 use OCA\OpenRegister\Service\DateTimeNormalizer;
 use OCA\OpenRegister\Service\Object\SchemaTypeConverter;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -70,6 +71,60 @@ use DateTime;
  */
 class MagicSearchHandler
 {
+
+    /**
+     * Comparison operators accepted inside a filter's value bag.
+     *
+     * Declared once and shared by the schema-property path and the `@self`
+     * metadata path so the two dialects cannot drift apart again. Bare keys,
+     * never `$`-prefixed — `$`-style belongs to OperatorEvaluator's policy
+     * language, which is a different subsystem.
+     *
+     * @var string[]
+     */
+    private const COMPARISON_OPERATORS = ['gte', 'lte', 'gt', 'lt', 'in', 'notIn', 'ne'];
+
+    /**
+     * Metadata columns every magic table carries.
+     *
+     * Mirrors MagicMapper::getMetadataColumns(); kept as a literal here so a
+     * `@self` filter can be rejected by name before it ever reaches SQL, rather
+     * than being interpolated into a query that fails as an opaque HTTP 500.
+     *
+     * @var string[]
+     */
+    private const METADATA_COLUMNS = [
+        '_id',
+        '_uuid',
+        '_slug',
+        '_uri',
+        '_version',
+        '_register',
+        '_schema',
+        '_schema_version',
+        '_owner',
+        '_organisation',
+        '_application',
+        '_name',
+        '_description',
+        '_summary',
+        '_image',
+        '_folder',
+        '_size',
+        '_created',
+        '_updated',
+        '_expires',
+        '_deleted',
+        '_locked',
+        '_files',
+        '_relations',
+        '_geo',
+        '_groups',
+        '_retention',
+        '_tmlo',
+        '_validation',
+        '_authorization',
+    ];
 
     /**
      * Tracks filter properties that don't exist in the schema during search.
@@ -495,6 +550,10 @@ class MagicSearchHandler
      * @param array|null $existingColumns Optional list of existing column names.
      *
      * @return string[] Array of SQL WHERE conditions (without leading AND/WHERE).
+     *
+     * @throws UnknownMetadataFieldException When a `@self` key names no metadata column.
+     *
+     * @spec openspec/specs/zoeken-filteren/spec.md#requirement-self-metadata-filters-support-comparison-operators
      */
     public function buildWhereConditionsSql(array $query, Schema $schema, ?array $existingColumns=null): array
     {
@@ -525,6 +584,19 @@ class MagicSearchHandler
                 $conditions[] = $rbacCondition;
             }
         }
+
+        // 3. `@self` metadata filters.
+        // This step was missing entirely: the comment numbering jumped 2 → 4 and
+        // buildObjectFilterConditionsSql() skips every `@`-prefixed key, so a
+        // metadata filter was silently DROPPED on the UNION path. A dropped
+        // filter returns too MANY rows, which is the dangerous direction — the
+        // single-table path returned too few for the same query.
+        $metadataConditions = $this->buildMetadataFilterConditionsSql(
+            query: $query,
+            connection: $connection,
+            isPostgres: $isPostgres
+        );
+        $conditions         = array_merge($conditions, $metadataConditions);
 
         // 4. Full-text search filter with optional fuzzy matching.
         if ($search !== null && trim($search) !== '') {
@@ -734,7 +806,7 @@ class MagicSearchHandler
             // Handle array filter values: comparison operators
             // (gte/lte/gt/lt/in/notIn/ne) or a bare IN clause.
             if (is_array($value) === true) {
-                $comparisonOperators = ['gte', 'lte', 'gt', 'lt', 'in', 'notIn', 'ne'];
+                $comparisonOperators = self::COMPARISON_OPERATORS;
                 if (empty(array_intersect(array_keys($value), $comparisonOperators)) === false) {
                     if (isset($value['gte']) === true) {
                         $colRef       = $this->buildFilterColumnRef(
@@ -889,6 +961,142 @@ class MagicSearchHandler
 
         return '('.implode(' OR ', $orParts).')';
     }//end buildArrayPropertyConditionSql()
+
+    /**
+     * Build SQL conditions for `@self` metadata filters on the UNION path
+     *
+     * The raw-SQL multi-table path had no metadata step at all, so a `@self`
+     * filter was silently discarded and the query returned rows the caller had
+     * explicitly excluded. This mirrors applyMetadataFilters() one-for-one —
+     * same operator vocabulary, same null sentinels, same unknown-field
+     * rejection — so the two paths cannot answer the same question differently.
+     *
+     * Columns are unqualified here (each UNION arm selects from one table) and
+     * quoted through quoteIdentifier(), matching the object-filter builder.
+     *
+     * @param array  $query      The full query array
+     * @param object $connection Database connection for value quoting
+     * @param bool   $isPostgres Whether the active platform is PostgreSQL (selects "" vs ``)
+     *
+     * @return string[] Array of SQL conditions
+     *
+     * @throws UnknownMetadataFieldException When a `@self` key names no metadata column.
+     *
+     * @spec openspec/specs/zoeken-filteren/spec.md#requirement-self-metadata-filters-support-comparison-operators
+     */
+    private function buildMetadataFilterConditionsSql(
+        array $query,
+        object $connection,
+        bool $isPostgres
+    ): array {
+        $metadataFilters = ($query['@self'] ?? []);
+        if (is_array($metadataFilters) === false || empty($metadataFilters) === true) {
+            return [];
+        }
+
+        $conditions = [];
+
+        foreach ($metadataFilters as $field => $value) {
+            $column = $this->quoteIdentifier(
+                name: $this->resolveMetadataColumn(field: (string) $field),
+                isPostgres: $isPostgres
+            );
+
+            if ($value === 'IS NOT NULL') {
+                $conditions[] = "{$column} IS NOT NULL";
+                continue;
+            }
+
+            if ($value === 'IS NULL') {
+                $conditions[] = "{$column} IS NULL";
+                continue;
+            }
+
+            if (is_array($value) === true) {
+                $conditions = array_merge(
+                    $conditions,
+                    $this->buildMetadataOperatorConditionsSql(
+                        column: $column,
+                        value: $value,
+                        connection: $connection
+                    )
+                );
+                continue;
+            }
+
+            $conditions[] = "{$column} = ".$connection->quote((string) $value);
+        }//end foreach
+
+        return $conditions;
+    }//end buildMetadataFilterConditionsSql()
+
+    /**
+     * Build the SQL for one metadata column's operator bag (or bare IN list)
+     *
+     * @param string $column     Quoted column identifier
+     * @param array  $value      Operator bag or bare list of values
+     * @param object $connection Database connection for value quoting
+     *
+     * @return string[] Array of SQL conditions
+     */
+    private function buildMetadataOperatorConditionsSql(string $column, array $value, object $connection): array
+    {
+        $quoteList = static function (mixed $values) use ($connection): array {
+            if (is_array($values) === false) {
+                $values = [$values];
+            }
+
+            return array_map(
+                static fn (mixed $item): string => $connection->quote((string) $item),
+                $values
+            );
+        };
+
+        // No operator key at all: a bare list keeps its historical IN(...) meaning.
+        if (empty(array_intersect(array_keys($value), self::COMPARISON_OPERATORS)) === true) {
+            $quoted = $quoteList($value);
+            if (empty($quoted) === true) {
+                // An empty IN () is a syntax error and matches nothing by definition.
+                return ['1 = 0'];
+            }
+
+            return [$column.' IN ('.implode(', ', $quoted).')'];
+        }
+
+        $conditions = [];
+        $simple     = [
+            'gte' => '>=',
+            'lte' => '<=',
+            'gt'  => '>',
+            'lt'  => '<',
+            'ne'  => '<>',
+        ];
+
+        foreach ($simple as $operator => $sqlOperator) {
+            if (isset($value[$operator]) === true) {
+                $conditions[] = "{$column} {$sqlOperator} ".$connection->quote((string) $value[$operator]);
+            }
+        }
+
+        if (isset($value['in']) === true) {
+            $quoted = $quoteList($value['in']);
+            if (empty($quoted) === true) {
+                $conditions[] = '1 = 0';
+            } else {
+                $conditions[] = $column.' IN ('.implode(', ', $quoted).')';
+            }
+        }
+
+        if (isset($value['notIn']) === true) {
+            $quoted = $quoteList($value['notIn']);
+            // An empty NOT IN () is a syntax error and means "exclude nothing".
+            if (empty($quoted) === false) {
+                $conditions[] = $column.' NOT IN ('.implode(', ', $quoted).')';
+            }
+        }
+
+        return $conditions;
+    }//end buildMetadataOperatorConditionsSql()
 
     /**
      * Build SQL conditions for TMLO metadata JSON field filters.
@@ -1149,33 +1357,157 @@ class MagicSearchHandler
     /**
      * Apply metadata filters to the query
      *
+     * Metadata lives in the magic table's underscore-prefixed columns (`_created`,
+     * `_uuid`, …), so a `@self` filter is resolved against a column rather than
+     * against the JSON document.
+     *
+     * The comparison vocabulary is deliberately IDENTICAL to the one
+     * applyObjectFilters() accepts — bare `gte|lte|gt|lt|in|notIn|ne` keys, never
+     * `$`-prefixed. `@self.created` and a schema property must not need different
+     * syntax to express the same comparison; that asymmetry is what made
+     * "created before X" inexpressible.
+     *
+     * A bare list with no operator key keeps its historical meaning (`IN (…)`),
+     * so `{"@self":{"register":[1,2]}}` is unaffected.
+     *
      * @param IQueryBuilder $qb      Query builder to modify
      * @param array         $filters Metadata filters to apply
      *
      * @return void
+     *
+     * @throws UnknownMetadataFieldException When a `@self` key names no metadata column.
+     *
+     * @spec openspec/specs/zoeken-filteren/spec.md#requirement-self-metadata-filters-support-comparison-operators
      */
     private function applyMetadataFilters(IQueryBuilder $qb, array $filters): void
     {
         foreach ($filters as $field => $value) {
-            $columnName = '_'.$field;
-            // Metadata columns are prefixed with _.
+            $columnName = $this->resolveMetadataColumn(field: (string) $field);
+            $columnRef  = "t.{$columnName}";
+
+            // A null check is terminal: without the `continue` the sentinel string
+            // ALSO reached the equality below, so `IS NOT NULL` emitted
+            // `_owner IS NOT NULL AND _owner = 'IS NOT NULL'` — zero rows on a text
+            // column and a cast error on a timestamp one.
             if ($value === 'IS NOT NULL') {
-                $qb->andWhere($qb->expr()->isNotNull("t.{$columnName}"));
-            } else if ($value === 'IS NULL') {
-                $qb->andWhere($qb->expr()->isNull("t.{$columnName}"));
-            } else if (is_array($value) === true) {
-                $qb->andWhere(
-                    $qb->expr()->in(
-                        "t.{$columnName}",
-                        $qb->createNamedParameter($value, IQueryBuilder::PARAM_STR_ARRAY)
-                    )
-                );
+                $qb->andWhere($qb->expr()->isNotNull($columnRef));
                 continue;
             }
 
-            $qb->andWhere($qb->expr()->eq("t.{$columnName}", $qb->createNamedParameter($value)));
-        }
+            if ($value === 'IS NULL') {
+                $qb->andWhere($qb->expr()->isNull($columnRef));
+                continue;
+            }
+
+            if (is_array($value) === true) {
+                $this->applyMetadataOperators(qb: $qb, columnRef: $columnRef, value: $value);
+                continue;
+            }
+
+            $qb->andWhere($qb->expr()->eq($columnRef, $qb->createNamedParameter($value)));
+        }//end foreach
     }//end applyMetadataFilters()
+
+    /**
+     * Apply an operator bag (or a bare IN list) to one metadata column
+     *
+     * @param IQueryBuilder $qb        Query builder to modify
+     * @param string        $columnRef Fully qualified column reference
+     * @param array         $value     Operator bag or bare list of values
+     *
+     * @return void
+     *
+     * @SuppressWarnings(PHPMD.NPathComplexity) A flat sequence of independent, ANDed operator checks
+     */
+    private function applyMetadataOperators(IQueryBuilder $qb, string $columnRef, array $value): void
+    {
+        // No operator key at all: a bare list keeps its historical IN(...) meaning.
+        if (empty(array_intersect(array_keys($value), self::COMPARISON_OPERATORS)) === true) {
+            $qb->andWhere(
+                $qb->expr()->in($columnRef, $qb->createNamedParameter($value, IQueryBuilder::PARAM_STR_ARRAY))
+            );
+
+            return;
+        }
+
+        // Multiple operators AND together, so {"gte":a,"lte":b} is a range.
+        if (isset($value['gte']) === true) {
+            $qb->andWhere($qb->expr()->gte($columnRef, $qb->createNamedParameter($value['gte'])));
+        }
+
+        if (isset($value['lte']) === true) {
+            $qb->andWhere($qb->expr()->lte($columnRef, $qb->createNamedParameter($value['lte'])));
+        }
+
+        if (isset($value['gt']) === true) {
+            $qb->andWhere($qb->expr()->gt($columnRef, $qb->createNamedParameter($value['gt'])));
+        }
+
+        if (isset($value['lt']) === true) {
+            $qb->andWhere($qb->expr()->lt($columnRef, $qb->createNamedParameter($value['lt'])));
+        }
+
+        if (isset($value['ne']) === true) {
+            $qb->andWhere($qb->expr()->neq($columnRef, $qb->createNamedParameter($value['ne'])));
+        }
+
+        if (isset($value['in']) === true) {
+            $inValues = $value['in'];
+            if (is_array($inValues) === false) {
+                $inValues = [$inValues];
+            }
+
+            $qb->andWhere(
+                $qb->expr()->in($columnRef, $qb->createNamedParameter($inValues, IQueryBuilder::PARAM_STR_ARRAY))
+            );
+        }
+
+        if (isset($value['notIn']) === true) {
+            $notInValues = $value['notIn'];
+            if (is_array($notInValues) === false) {
+                $notInValues = [$notInValues];
+            }
+
+            // An empty NOT IN () is a SQL syntax error and means "exclude nothing".
+            if (empty($notInValues) === false) {
+                $qb->andWhere(
+                    $qb->expr()->notIn(
+                        $columnRef,
+                        $qb->createNamedParameter($notInValues, IQueryBuilder::PARAM_STR_ARRAY)
+                    )
+                );
+            }
+        }
+    }//end applyMetadataOperators()
+
+    /**
+     * Resolve a `@self` field name to its magic-table metadata column
+     *
+     * Two things went wrong without this. The name was concatenated raw, so the
+     * camelCase `schemaVersion` addressed a `_schemaVersion` column that does not
+     * exist (the real one is `_schema_version`) and the request died as an opaque
+     * HTTP 500. And any typo was interpolated straight into SQL rather than being
+     * named back to the caller.
+     *
+     * @param string $field Metadata field name as written in `@self`
+     *
+     * @return string The underscore-prefixed column name
+     *
+     * @throws UnknownMetadataFieldException When the field names no metadata column.
+     */
+    private function resolveMetadataColumn(string $field): string
+    {
+        $columnName = '_'.$this->sanitizeColumnName(name: $field);
+
+        if (in_array($columnName, self::METADATA_COLUMNS, true) === false) {
+            throw new UnknownMetadataFieldException(
+                field: $field,
+                known: self::METADATA_COLUMNS
+            );
+        }
+
+        return $columnName;
+    }//end resolveMetadataColumn()
 
     /**
      * Apply object field filters based on schema properties
@@ -1253,7 +1585,7 @@ class MagicSearchHandler
             }
 
             if (is_array($value) === true) {
-                $comparisonOperators = ['gte', 'lte', 'gt', 'lt', 'in', 'notIn', 'ne'];
+                $comparisonOperators = self::COMPARISON_OPERATORS;
                 if (empty(array_intersect(array_keys($value), $comparisonOperators)) === true) {
                     // Cast numeric columns to text when filtered by non-numeric
                     // (e.g. UUID) values so PostgreSQL does not abort with 22P02.

--- a/lib/Exception/UnknownMetadataFieldException.php
+++ b/lib/Exception/UnknownMetadataFieldException.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * OpenRegister UnknownMetadataFieldException
+ *
+ * This file contains the exception class raised when a `@self` filter names a
+ * metadata field that no magic-table metadata column corresponds to.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Exception
+ * @package  OCA\OpenRegister\Exception
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+namespace OCA\OpenRegister\Exception;
+
+use Exception;
+use Throwable;
+
+/**
+ * Exception thrown when a `@self` filter names an unknown metadata field.
+ *
+ * Metadata filters resolve to an underscore-prefixed magic-table column, so a
+ * name with no matching column cannot be answered. Before this exception the
+ * name was concatenated straight into the SQL, which surfaced either as an
+ * opaque HTTP 500 from the database driver or — worse, on some column types —
+ * as an empty result set indistinguishable from "nothing matched".
+ *
+ * Failing here names the offending field and lists what is filterable, so the
+ * caller can correct the query instead of interpreting a silent zero.
+ *
+ * @category Exception
+ * @package  OCA\OpenRegister\Exception
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/zoeken-filteren/spec.md#requirement-self-metadata-filters-support-comparison-operators
+ */
+class UnknownMetadataFieldException extends Exception
+{
+    /**
+     * Constructor for UnknownMetadataFieldException.
+     *
+     * @param string         $field    The `@self` field name that could not be resolved.
+     * @param string[]       $known    The metadata column names that are filterable.
+     * @param int            $code     The error code (default: 400).
+     * @param Throwable|null $previous The previous exception that caused this one.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly string $field,
+        private readonly array $known=[],
+        int $code=400,
+        ?Throwable $previous=null
+    ) {
+        // Report the caller-facing names (no leading underscore), sorted, so the
+        // message is a usable correction rather than an internal column dump.
+        $names = array_map(
+            static fn (string $column): string => ltrim($column, '_'),
+            $known
+        );
+        sort($names);
+
+        parent::__construct(
+            message: sprintf(
+                'Unknown "@self" metadata field "%s". Filterable metadata fields are: %s.',
+                $field,
+                implode(', ', $names)
+            ),
+            code: $code,
+            previous: $previous
+        );
+    }//end __construct()
+
+    /**
+     * The `@self` field name that triggered this exception.
+     *
+     * @return string The field name.
+     *
+     * @spec openspec/specs/zoeken-filteren/spec.md#requirement-self-metadata-filters-support-comparison-operators
+     */
+    public function getField(): string
+    {
+        return $this->field;
+    }//end getField()
+
+    /**
+     * The metadata column names that are filterable.
+     *
+     * @return string[] The known metadata column names.
+     *
+     * @spec openspec/specs/zoeken-filteren/spec.md#requirement-self-metadata-filters-support-comparison-operators
+     */
+    public function getKnown(): array
+    {
+        return $this->known;
+    }//end getKnown()
+}//end class

--- a/lib/Middleware/UnknownMetadataFieldMiddleware.php
+++ b/lib/Middleware/UnknownMetadataFieldMiddleware.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * OpenRegister UnknownMetadataFieldMiddleware
+ *
+ * Translates an unresolvable `@self` metadata filter into a 400 response.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Middleware
+ * @package  OCA\OpenRegister\Middleware
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/zoeken-filteren/spec.md#requirement-self-metadata-filters-support-comparison-operators
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Middleware;
+
+use Exception;
+use OCA\OpenRegister\Exception\UnknownMetadataFieldException;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\Response;
+use OCP\AppFramework\Middleware;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Middleware translating unknown `@self` metadata filters into 400 responses.
+ *
+ * Without this the field name reached the database driver and came back as an
+ * opaque HTTP 500, which reads like a server fault rather than a correctable
+ * query mistake.
+ *
+ * @package OCA\OpenRegister\Middleware
+ *
+ * @spec openspec/specs/zoeken-filteren/spec.md#requirement-self-metadata-filters-support-comparison-operators
+ */
+class UnknownMetadataFieldMiddleware extends Middleware
+{
+    /**
+     * Constructor.
+     *
+     * @param LoggerInterface $logger The app logger.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly LoggerInterface $logger
+    ) {
+    }//end __construct()
+
+    /**
+     * Map UnknownMetadataFieldException onto a 400 Bad Request response.
+     *
+     * @param Controller $controller The controller that was executing.
+     * @param string     $methodName The controller method that was executing.
+     * @param Exception  $exception  The exception that was thrown.
+     *
+     * @return Response The 400 response naming the unknown metadata field.
+     *
+     * @throws Exception Rethrows every exception that is not an UnknownMetadataFieldException.
+     *
+     * @spec openspec/specs/zoeken-filteren/spec.md#requirement-self-metadata-filters-support-comparison-operators
+     */
+    public function afterException(Controller $controller, string $methodName, Exception $exception): Response
+    {
+        if ($exception instanceof UnknownMetadataFieldException === false) {
+            throw $exception;
+        }
+
+        $this->logger->info(
+            sprintf(
+                '[UnknownMetadataFieldMiddleware] rejected unknown @self field "%s" in %s::%s',
+                $exception->getField(),
+                $controller::class,
+                $methodName
+            ),
+            ['file' => __FILE__, 'line' => __LINE__]
+        );
+
+        return new JSONResponse(
+            data: [
+                'error'   => 'unknown-metadata-field',
+                'field'   => $exception->getField(),
+                'message' => $exception->getMessage(),
+            ],
+            statusCode: 400
+        );
+    }//end afterException()
+}//end class

--- a/openspec/specs/zoeken-filteren/spec.md
+++ b/openspec/specs/zoeken-filteren/spec.md
@@ -123,6 +123,52 @@ The system MUST support filtering on object metadata fields (register, schema, u
 - **THEN** `query['@self']['register']` MUST be `[1, 2, 3]`
 - **AND** `MagicSearchHandler.applyMetadataFilters()` MUST use `WHERE t._register IN (1, 2, 3)`
 
+### Requirement: @self metadata filters support comparison operators
+A `@self` metadata filter MUST accept the same comparison-operator vocabulary as a schema-property filter — the bare keys `gte`, `lte`, `gt`, `lt`, `in`, `notIn`, `ne` — so that the same comparison does not need different syntax depending on whether the field is metadata or a property. An array value carrying none of those keys MUST retain its IN-list meaning. Multiple operators on one field MUST combine with AND.
+
+This vocabulary MUST be applied identically on both query paths: the single-table `IQueryBuilder` path (`MagicSearchHandler.applyMetadataFilters()`) and the raw-SQL multi-table UNION path (`MagicSearchHandler.buildWhereConditionsSql()`). Neither path may silently ignore a `@self` filter.
+
+#### Scenario: Date cutoff selects objects created before a moment
+- **GIVEN** a schema whose objects were created between 2026-05-21 and 2026-08-02
+- **WHEN** the caller filters with `@self[created][lte]=2026-06-01T00:00:00Z`
+- **THEN** `MagicSearchHandler.applyMetadataFilters()` MUST emit `WHERE t._created <= '2026-06-01T00:00:00Z'`
+- **AND** only objects created at or before that moment MUST be returned
+
+#### Scenario: A cutoff in the future selects every object
+- **GIVEN** the same schema
+- **WHEN** the caller filters with `@self[created][lte]=2030-01-01T00:00:00Z`
+- **THEN** every non-deleted object MUST be returned
+- **AND** the result MUST NOT be empty — an empty result here indicates the operator key was discarded and the value compared for equality
+
+#### Scenario: Two operators bound a range
+- **GIVEN** objects with varying `_updated` timestamps
+- **WHEN** the caller filters with `@self[updated][gte]=2026-01-01&@self[updated][lte]=2026-02-01`
+- **THEN** the system MUST emit both `t._updated >= '2026-01-01'` and `t._updated <= '2026-02-01'`
+
+#### Scenario: A metadata filter is honoured on the multi-table UNION path
+- **GIVEN** a search spanning more than one register/schema table
+- **WHEN** the caller supplies a `@self` metadata filter
+- **THEN** `MagicSearchHandler.buildWhereConditionsSql()` MUST include a condition for that filter in every UNION arm
+- **AND** the filter MUST NOT be dropped — dropping it would return objects the caller explicitly excluded
+
+#### Scenario: A null-check does not also compare against the sentinel
+- **GIVEN** objects that all have an `_owner` value
+- **WHEN** the caller filters with `@self[owner]=IS NOT NULL`
+- **THEN** the system MUST emit only `t._owner IS NOT NULL`
+- **AND** it MUST NOT additionally emit `t._owner = 'IS NOT NULL'`, which would match nothing on a text column and raise a cast error on a timestamp column
+
+#### Scenario: A camelCase metadata field resolves to its snake_case column
+- **GIVEN** the metadata column `_schema_version`
+- **WHEN** the caller filters with `@self[schemaVersion]=1.0`
+- **THEN** the system MUST compare against `t._schema_version`
+
+#### Scenario: An unknown metadata field is refused by name
+- **GIVEN** a caller filtering with `@self[creatd]=…` (a misspelling)
+- **WHEN** the query is built
+- **THEN** the system MUST raise `UnknownMetadataFieldException` and respond HTTP 400
+- **AND** the message MUST name the offending field and list the filterable metadata fields
+- **AND** the system MUST NOT interpolate the name into SQL, which previously surfaced as an opaque HTTP 500
+
 ### Requirement: Fuzzy search with pg_trgm integration
 The system MUST support optional fuzzy (typo-tolerant) search when the `_fuzzy=true` parameter is explicitly set AND the PostgreSQL `pg_trgm` extension is available. Fuzzy search MUST use the `similarity()` function on the `_name` column with a threshold of `0.1`. When fuzzy search is active, a `_relevance` score column MUST be available for sorting.
 

--- a/tests/Unit/Db/MagicSearchHandlerMetadataOperatorTest.php
+++ b/tests/Unit/Db/MagicSearchHandlerMetadataOperatorTest.php
@@ -1,0 +1,429 @@
+<?php
+/**
+ * Regression: `@self` metadata filters must support comparison operators.
+ *
+ * Before this fix no query could express "created before X". On the single-table
+ * path `applyMetadataFilters()` had no operator inspection at all, so
+ * `{"@self":{"created":{"lte":"…"}}}` became `_created IN ('…')` — a disguised
+ * equality against a timestamp column that matched nothing. On the raw-SQL UNION
+ * path the metadata step was missing entirely, so the same filter was dropped and
+ * the query returned rows the caller had explicitly excluded.
+ *
+ * The positive control that distinguishes the two failure modes: a cutoff far in
+ * the FUTURE must return everything. Under the old single-table code it returned
+ * nothing (mistranslated), and under the old UNION code an impossible cutoff
+ * returned everything (dropped). A test that only ever asserts "zero rows" cannot
+ * tell a working filter from a broken one.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Db;
+
+use OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler;
+use OCA\OpenRegister\Db\MagicMapper\MagicRbacHandler;
+use OCA\OpenRegister\Db\MagicMapper\MagicSearchHandler;
+use OCA\OpenRegister\Exception\UnknownMetadataFieldException;
+use OCA\OpenRegister\Service\DateTimeNormalizer;
+use OCA\OpenRegister\Service\Object\SchemaTypeConverter;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+
+/**
+ * Locks comparison-operator support on `@self` metadata filters, on both the
+ * QueryBuilder path and the raw-SQL UNION path.
+ */
+class MagicSearchHandlerMetadataOperatorTest extends TestCase
+{
+
+    private IDBConnection&MockObject $db;
+
+    private LoggerInterface&MockObject $logger;
+
+    private MagicSearchHandler $handler;
+
+    /**
+     * WHERE fragments captured from the QueryBuilder path.
+     *
+     * @var string[]
+     */
+    private array $captured = [];
+
+    protected function setUp(): void
+    {
+        $this->db     = $this->createMock(IDBConnection::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->handler = new MagicSearchHandler(
+            db: $this->db,
+            logger: $this->logger,
+            rbacHandler: $this->createMock(MagicRbacHandler::class),
+            organizationHandler: $this->createMock(MagicOrganizationHandler::class),
+            schemaTypeConverter: new SchemaTypeConverter(),
+            dateTimeNormalizer: new DateTimeNormalizer($this->logger)
+        );
+
+        $this->captured = [];
+    }//end setUp()
+
+    /**
+     * Build a connection mock whose quote() wraps values in single quotes.
+     *
+     * @return object The connection double.
+     */
+    private function makeConnection(): object
+    {
+        $conn = $this->createMock(IDBConnection::class);
+        $conn->method('quote')->willReturnCallback(static fn ($v) => "'{$v}'");
+        return $conn;
+    }//end makeConnection()
+
+    /**
+     * Run applyMetadataFilters() against a QueryBuilder double and return the
+     * WHERE fragments it produced, rendered as readable `op(column,value)` text.
+     *
+     * @param array<string,mixed> $filters The `@self` bag.
+     *
+     * @return string[] Captured WHERE fragments.
+     */
+    private function invokeApply(array $filters): array
+    {
+        $expr = $this->createMock(IExpressionBuilder::class);
+        foreach (['eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'in', 'notIn'] as $operator) {
+            $expr->method($operator)->willReturnCallback(
+                static function (string $column, $value) use ($operator): string {
+                    if (is_array($value) === true) {
+                        $value = implode('|', $value);
+                    }
+
+                    return "{$operator}({$column},{$value})";
+                }
+            );
+        }
+
+        $expr->method('isNull')->willReturnCallback(static fn (string $c): string => "isNull({$c})");
+        $expr->method('isNotNull')->willReturnCallback(static fn (string $c): string => "isNotNull({$c})");
+
+        $qb = $this->createMock(IQueryBuilder::class);
+        $qb->method('expr')->willReturn($expr);
+        // Return the bound value itself so the rendered fragment shows what was bound.
+        $qb->method('createNamedParameter')->willReturnCallback(static fn ($value) => $value);
+        $qb->method('andWhere')->willReturnCallback(
+            function (...$predicates) use ($qb) {
+                foreach ($predicates as $predicate) {
+                    $this->captured[] = (string) $predicate;
+                }
+
+                return $qb;
+            }
+        );
+
+        $method = new ReflectionMethod(MagicSearchHandler::class, 'applyMetadataFilters');
+        $method->setAccessible(true);
+        $method->invoke($this->handler, $qb, $filters);
+
+        return $this->captured;
+    }//end invokeApply()
+
+    /**
+     * Run the raw-SQL UNION metadata builder and return its conditions.
+     *
+     * @param array<string,mixed> $query Full query array (must carry `@self`).
+     *
+     * @return string[] Generated SQL conditions.
+     */
+    private function invokeUnion(array $query): array
+    {
+        $method = new ReflectionMethod(MagicSearchHandler::class, 'buildMetadataFilterConditionsSql');
+        $method->setAccessible(true);
+        return $method->invoke($this->handler, $query, $this->makeConnection(), true);
+    }//end invokeUnion()
+
+    /**
+     * `created` with an `lte` operator must emit a `<=` comparison.
+     *
+     * This is the exact query that returned zero rows for every cutoff before the
+     * fix, including cutoffs far in the future.
+     *
+     * @return void
+     */
+    public function testCreatedLteEmitsALessThanOrEqualComparison(): void
+    {
+        $captured = $this->invokeApply(['created' => ['lte' => '2026-01-01T00:00:00Z']]);
+
+        $this->assertContains('lte(t._created,2026-01-01T00:00:00Z)', $captured);
+
+        // The mistranslation this replaces: an IN() list built from the operator
+        // bag's VALUES, which discarded the `lte` key entirely.
+        foreach ($captured as $fragment) {
+            $this->assertStringNotContainsString('in(t._created', $fragment);
+        }
+    }//end testCreatedLteEmitsALessThanOrEqualComparison()
+
+    /**
+     * A cutoff far in the future is still a `<=` comparison, not a no-op.
+     *
+     * The positive control in test form: the generated predicate must be the same
+     * SHAPE regardless of the value, so a future cutoff selects everything rather
+     * than matching a literal timestamp string.
+     *
+     * @return void
+     */
+    public function testAFutureCutoffProducesTheSameComparisonShape(): void
+    {
+        $captured = $this->invokeApply(['created' => ['lte' => '2030-01-01T00:00:00Z']]);
+
+        $this->assertContains('lte(t._created,2030-01-01T00:00:00Z)', $captured);
+    }//end testAFutureCutoffProducesTheSameComparisonShape()
+
+    /**
+     * Every comparison operator in the shared vocabulary reaches SQL.
+     *
+     * @return void
+     */
+    public function testEveryComparisonOperatorIsTranslated(): void
+    {
+        $captured = $this->invokeApply(
+            [
+                'created' => [
+                    'gte' => 'a',
+                    'lte' => 'b',
+                    'gt'  => 'c',
+                    'lt'  => 'd',
+                    'ne'  => 'e',
+                ],
+            ]
+        );
+
+        $this->assertContains('gte(t._created,a)', $captured);
+        $this->assertContains('lte(t._created,b)', $captured);
+        $this->assertContains('gt(t._created,c)', $captured);
+        $this->assertContains('lt(t._created,d)', $captured);
+        $this->assertContains('neq(t._created,e)', $captured);
+    }//end testEveryComparisonOperatorIsTranslated()
+
+    /**
+     * `gte` plus `lte` AND together into a bounded range.
+     *
+     * @return void
+     */
+    public function testGteAndLteCombineIntoARange(): void
+    {
+        $captured = $this->invokeApply(['updated' => ['gte' => '2026-01-01', 'lte' => '2026-02-01']]);
+
+        $this->assertContains('gte(t._updated,2026-01-01)', $captured);
+        $this->assertContains('lte(t._updated,2026-02-01)', $captured);
+    }//end testGteAndLteCombineIntoARange()
+
+    /**
+     * A bare list with no operator key keeps its historical IN() meaning.
+     *
+     * Guards against the fix breaking `{"@self":{"register":[1,2]}}`.
+     *
+     * @return void
+     */
+    public function testABareListStillMeansIn(): void
+    {
+        $captured = $this->invokeApply(['register' => [1, 2]]);
+
+        $this->assertContains('in(t._register,1|2)', $captured);
+    }//end testABareListStillMeansIn()
+
+    /**
+     * A plain scalar still means equality.
+     *
+     * @return void
+     */
+    public function testAScalarStillMeansEquality(): void
+    {
+        $captured = $this->invokeApply(['uuid' => 'abc']);
+
+        $this->assertContains('eq(t._uuid,abc)', $captured);
+    }//end testAScalarStillMeansEquality()
+
+    /**
+     * A null check must not ALSO emit an equality against the sentinel string.
+     *
+     * The branch had no `continue`, so `IS NOT NULL` produced
+     * `_owner IS NOT NULL AND _owner = 'IS NOT NULL'` — zero rows on a text column
+     * and a cast error on a timestamp one.
+     *
+     * @return void
+     */
+    public function testANullCheckDoesNotAlsoCompareAgainstTheSentinel(): void
+    {
+        $captured = $this->invokeApply(['owner' => 'IS NOT NULL']);
+
+        $this->assertSame(['isNotNull(t._owner)'], $captured);
+    }//end testANullCheckDoesNotAlsoCompareAgainstTheSentinel()
+
+    /**
+     * The IS NULL sentinel gets the same treatment.
+     *
+     * @return void
+     */
+    public function testIsNullDoesNotAlsoCompareAgainstTheSentinel(): void
+    {
+        $captured = $this->invokeApply(['deleted' => 'IS NULL']);
+
+        $this->assertSame(['isNull(t._deleted)'], $captured);
+    }//end testIsNullDoesNotAlsoCompareAgainstTheSentinel()
+
+    /**
+     * A camelCase metadata field resolves to its snake_case column.
+     *
+     * `schemaVersion` addressed a `_schemaVersion` column that does not exist and
+     * died as an opaque HTTP 500; the real column is `_schema_version`.
+     *
+     * @return void
+     */
+    public function testACamelCaseFieldResolvesToItsSnakeCaseColumn(): void
+    {
+        $captured = $this->invokeApply(['schemaVersion' => '1.0']);
+
+        $this->assertContains('eq(t._schema_version,1.0)', $captured);
+    }//end testACamelCaseFieldResolvesToItsSnakeCaseColumn()
+
+    /**
+     * An unknown metadata field fails loud instead of reaching SQL.
+     *
+     * @return void
+     */
+    public function testAnUnknownMetadataFieldIsRefusedByName(): void
+    {
+        $this->expectException(UnknownMetadataFieldException::class);
+        $this->expectExceptionMessage('nonsense');
+
+        $this->invokeApply(['nonsense' => 'x']);
+    }//end testAnUnknownMetadataFieldIsRefusedByName()
+
+    /**
+     * The rejection message lists what IS filterable, so it is correctable.
+     *
+     * @return void
+     */
+    public function testTheRejectionNamesTheFilterableFields(): void
+    {
+        try {
+            $this->invokeApply(['creatd' => 'x']);
+            $this->fail('Expected UnknownMetadataFieldException.');
+        } catch (UnknownMetadataFieldException $e) {
+            $this->assertSame('creatd', $e->getField());
+            $this->assertStringContainsString('created', $e->getMessage());
+            $this->assertStringContainsString('uuid', $e->getMessage());
+        }
+    }//end testTheRejectionNamesTheFilterableFields()
+
+    // ---------------------------------------------------------------------
+    // UNION path — the metadata step that did not exist at all.
+    // ---------------------------------------------------------------------
+
+    /**
+     * The UNION path emits a metadata condition rather than dropping the filter.
+     *
+     * Dropping returned too MANY rows, which is the dangerous direction: the
+     * caller's explicit exclusion silently did nothing.
+     *
+     * @return void
+     */
+    public function testTheUnionPathNoLongerDropsMetadataFilters(): void
+    {
+        $conditions = $this->invokeUnion(['@self' => ['created' => ['lte' => '2026-01-01']]]);
+
+        $this->assertNotEmpty($conditions, 'A @self filter must produce at least one UNION condition.');
+        $this->assertContains('"_created" <= \'2026-01-01\'', $conditions);
+    }//end testTheUnionPathNoLongerDropsMetadataFilters()
+
+    /**
+     * The UNION path speaks the same operator vocabulary as the QueryBuilder path.
+     *
+     * @return void
+     */
+    public function testTheUnionPathTranslatesEveryComparisonOperator(): void
+    {
+        $conditions = $this->invokeUnion(
+            [
+                '@self' => [
+                    'created' => [
+                        'gte' => 'a',
+                        'lte' => 'b',
+                        'gt'  => 'c',
+                        'lt'  => 'd',
+                        'ne'  => 'e',
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertContains('"_created" >= \'a\'', $conditions);
+        $this->assertContains('"_created" <= \'b\'', $conditions);
+        $this->assertContains('"_created" > \'c\'', $conditions);
+        $this->assertContains('"_created" < \'d\'', $conditions);
+        $this->assertContains('"_created" <> \'e\'', $conditions);
+    }//end testTheUnionPathTranslatesEveryComparisonOperator()
+
+    /**
+     * The UNION path handles the null sentinels and bare IN lists too.
+     *
+     * @return void
+     */
+    public function testTheUnionPathHandlesSentinelsAndBareLists(): void
+    {
+        $this->assertContains('"_owner" IS NOT NULL', $this->invokeUnion(['@self' => ['owner' => 'IS NOT NULL']]));
+        $this->assertContains('"_deleted" IS NULL', $this->invokeUnion(['@self' => ['deleted' => 'IS NULL']]));
+        $this->assertContains(
+            '"_register" IN (\'1\', \'2\')',
+            $this->invokeUnion(['@self' => ['register' => [1, 2]]])
+        );
+    }//end testTheUnionPathHandlesSentinelsAndBareLists()
+
+    /**
+     * An empty `notIn` excludes nothing rather than emitting invalid SQL.
+     *
+     * @return void
+     */
+    public function testAnEmptyNotInExcludesNothing(): void
+    {
+        $conditions = $this->invokeUnion(['@self' => ['owner' => ['notIn' => []]]]);
+
+        $this->assertSame([], $conditions);
+    }//end testAnEmptyNotInExcludesNothing()
+
+    /**
+     * A query with no `@self` bag produces no metadata conditions.
+     *
+     * @return void
+     */
+    public function testAQueryWithoutSelfProducesNoConditions(): void
+    {
+        $this->assertSame([], $this->invokeUnion(['name' => 'x']));
+    }//end testAQueryWithoutSelfProducesNoConditions()
+
+    /**
+     * The UNION path refuses an unknown metadata field just as loudly.
+     *
+     * @return void
+     */
+    public function testTheUnionPathAlsoRefusesUnknownFields(): void
+    {
+        $this->expectException(UnknownMetadataFieldException::class);
+
+        $this->invokeUnion(['@self' => ['nonsense' => 'x']]);
+    }//end testTheUnionPathAlsoRefusesUnknownFields()
+}//end class


### PR DESCRIPTION
Fixes #2260.

## What was actually wrong

Two distinct defects that fail in **opposite directions**, both silent.

**1. Single-table path — MISTRANSLATION (returns ~0).**
`MagicSearchHandler::applyMetadataFilters()` had no operator inspection at all. Any array value became `IN (…)` built from the bag's *values*, discarding the keys. So:

```json
{"@self": {"created": {"lte": "2026-01-01T00:00:00Z"}}}
```

emitted `t._created IN ('2026-01-01T00:00:00Z')` — a disguised equality against a timestamp column.

**2. UNION path — DROP (returns too many).**
`buildWhereConditionsSql()` had no metadata step whatsoever. Its own numbered comments run `1, 2, 4, 5, 6, 7` — step 3 was never written — and `buildObjectFilterConditionsSql()` skips every `@`-prefixed key. A `@self` filter was silently discarded, returning rows the caller had explicitly excluded. This is the more dangerous direction and was not previously measured.

## Corrections to the issue's suggested fix

The issue proposed reusing `lib/Db/ObjectHandlers/MariaDbSearchHandler.php`, whose operator handling is correct. **It is not reusable.** It addresses `o.created` — unprefixed columns on the retired `openregister_objects` monolith — not the magic tables' `t._created`. It is dead code alongside `MariaDbFacetHandler`, `MetaDataFacetHandler`, `HyperFacetHandler` and `OptimizedFacetHandler`, all of which still query the monolith. Wiring it up would have targeted the wrong table.

The right move was to give the metadata path the vocabulary `applyObjectFilters()` already speaks.

## Two further defects found while in here

- **`IS NULL` / `IS NOT NULL` fall-through.** Neither branch had a `continue`, so the sentinel string *also* reached the equality below. `@self[owner]=IS NOT NULL` produced `_owner IS NOT NULL AND _owner = 'IS NOT NULL'` — **measured 0 rows against a ground truth of 51,209** — and an HTTP 500 cast error on a timestamp column.
- **No column-name sanitisation.** `'_'.$field` meant the camelCase `schemaVersion` addressed a `_schemaVersion` column that does not exist (real name `_schema_version`), dying as an opaque HTTP 500.

## The fix

- `@self` accepts the same bare-key vocabulary as schema properties: `gte`, `lte`, `gt`, `lt`, `in`, `notIn`, `ne`. Extracted into one shared constant used by all three call sites so the dialects cannot drift apart again.
- The missing metadata step added to the UNION path, mirroring the QueryBuilder path one-for-one.
- Both null-check branches now terminate.
- Field names route through `sanitizeColumnName()`.
- An unknown `@self` field is **refused by name** with the filterable fields listed — `UnknownMetadataFieldException` → HTTP 400 via a new middleware — instead of being interpolated into SQL. Loud beats empty.

Backwards compatibility is preserved: a bare list keeps its `IN()` meaning and a scalar keeps equality.

## Positive-control evidence

Live, against a real 51,238-row magic table (register 65 / schema 25, objects spanning 2026-05-21 → 2026-08-02).

First, via the HTTP API on unmodified `development`:

| query | rows |
|---|---|
| no filter | 51,200 |
| `@self[created][lte]=2030-01-01` (far **future**) | **0** |
| `@self[created][lte]=2000-01-01` (far past) | 0 |

Zero in **both** directions is the control that matters: it proves the predicate was applied and wrong, not skipped. A dropped filter would have returned everything for the future cutoff.

After the fix, the generated SQL against the same live data:

| variant | rows |
|---|---|
| baseline (no filter) | 51,209 |
| `_created <= '2030-01-01'` | **51,209** — everything, as it must |
| `_created <= '2000-01-01'` | 0 |
| `_created <= '2026-06-01'` | **1** — a strict, discriminating subset |
| `_owner IS NOT NULL` (old, with fall-through) | 0 |
| `_owner IS NOT NULL` (fixed) | **51,209** |

## Tests

17 new regression tests in `tests/Unit/Db/MagicSearchHandlerMetadataOperatorTest.php` covering both paths.

**Negative control — run against the pre-fix handler, 15 of 17 fail.** The 2 that pass are exactly the backwards-compatibility guards (bare list → `IN`, scalar → equality), which must pass on both. A test that only ever passes is indistinguishable from one that is not wired up.

Full `tests/Unit/Db/` suite: 1333 tests, 4231 assertions, green (3 pre-existing warnings). PHPCS 0 errors, PHPMD clean, Psalm clean on the changed files.

## Risk

Query-layer change on a production app, so flagging explicitly rather than merging:

- The UNION path now **applies** filters it previously ignored. Any caller that (unknowingly) depended on `@self` being dropped there will see fewer rows. That is the correct behaviour, but it is a real behaviour change.
- Unknown `@self` field names now 400 instead of 500. No previously-working query is affected — an unresolvable column could never succeed.

Opening for review rather than admin-merging.