### PR TITLE
fix(flow): object-write cannot match on `uuid` — the one identifier object-read exists to hand it

### DIFF
--- a/lib/Service/Flow/Nodes/ObjectWriteNode.php
+++ b/lib/Service/Flow/Nodes/ObjectWriteNode.php
@@ -88,6 +88,7 @@ use UnexpectedValueException;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)   A write step needs the object service, both configuration mappers and the user manager.
  * @SuppressWarnings(PHPMD.ExcessiveClassLength)     Most of the length is reasoning and per-rule docblocks; the executable body is small and flat.
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) One branch per named configuration key and one per operation; collapsing it hides the guards.
+ * @SuppressWarnings(PHPMD.TooManyMethods)           One small, named method per guard and per operation; merging them would bury the delete guards.
  */
 class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys
 {
@@ -257,6 +258,36 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys
      * @var integer
      */
     private const MATCH_SCAN_LIMIT = 100;
+
+    /**
+     * Prefix that addresses a match pair to object metadata rather than a property.
+     *
+     * @var string
+     */
+    private const SELF_PREFIX = '@self.';
+
+    /**
+     * Metadata fields a match pair may name.
+     *
+     * Deliberately narrower than the full metadata column set: these are the
+     * fields that identify or scope a row and are stable enough to match on.
+     * `uuid` is the one that matters most — it is what `ObjectReadNode` puts on
+     * every item it emits so a follow-up write can name the row.
+     *
+     * @var string[]
+     */
+    private const MATCHABLE_METADATA_FIELDS = [
+        'uuid',
+        'slug',
+        'uri',
+        'version',
+        'owner',
+        'organisation',
+        'application',
+        'name',
+        'created',
+        'updated',
+    ];
 
     /**
      * Constructor.
@@ -984,6 +1015,8 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys
             'schema'   => $schema->getId(),
         ];
 
+        $properties = ($schema->getProperties() ?? []);
+
         foreach ($pairs as $pair) {
             $property = (string) $pair['property'];
             $resolved = $this->resolveTemplate(value: $pair['value'], json: $json);
@@ -997,7 +1030,12 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys
                 );
             }
 
-            $filters[$property] = $resolved['value'];
+            $this->assignMatchFilter(
+                filters: $filters,
+                property: $property,
+                value: $resolved['value'],
+                properties: $properties
+            );
         }
 
         $rows = $this->objects->findAll(
@@ -1033,6 +1071,94 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys
         return $entities[0];
 
     }//end findMatch()
+
+    /**
+     * Route one resolved match pair into the property bag or the `@self` bag.
+     *
+     * A schema property and an object's metadata live in different places: the
+     * property in the row's JSON document, the metadata in the magic table's
+     * underscore-prefixed columns. A filter therefore has to be addressed to the
+     * right one. Every match pair used to go into the property bag
+     * unconditionally, so `uuid` — which is metadata and never a document field —
+     * was looked up as a property that does not exist and hit the
+     * `WHERE 1 = 0` branch. Zero rows, no error: an update or delete matched
+     * nothing while the run reported success, and an upsert inserted a duplicate.
+     *
+     * That `uuid` in particular is what `ObjectReadNode` puts on every item it
+     * emits, expressly so a follow-up write or delete can name the row — so the
+     * most natural way to chain a read into a write was the one way that could
+     * not work.
+     *
+     * Routing rules, in order:
+     *   1. An explicit `@self.<field>` prefix always addresses metadata.
+     *   2. A name the schema declares as a property addresses the property. This
+     *      keeps precedence with the schema, so a schema that genuinely has a
+     *      `name` or `owner` property behaves exactly as before.
+     *   3. A name that is a known metadata field addresses metadata.
+     *   4. Anything else is refused, by name. It could only ever have produced
+     *      `1 = 0`, and a guard that silently matches nothing is not a guard.
+     *
+     * @param array               $filters    The filter bag being built (by reference).
+     * @param string              $property   The configured match property name.
+     * @param mixed               $value      The resolved match value.
+     * @param array<string,mixed> $properties The schema's declared properties.
+     *
+     * @return void
+     *
+     * @throws RuntimeException When the property is neither a schema property nor metadata.
+     *
+     * @spec openspec/changes/or-flow-object-write-node/specs/flow-object-write-node/spec.md
+     */
+    private function assignMatchFilter(array &$filters, string $property, mixed $value, array $properties): void
+    {
+        // 1. Explicit metadata addressing.
+        if (str_starts_with($property, self::SELF_PREFIX) === true) {
+            $field = substr($property, strlen(self::SELF_PREFIX));
+            if (in_array($field, self::MATCHABLE_METADATA_FIELDS, true) === false) {
+                throw new RuntimeException(
+                    $this->l10n->t(
+                        'The match names metadata field "%1$s", which does not exist. Matchable metadata fields are: %2$s.',
+                        [$field, implode(', ', self::MATCHABLE_METADATA_FIELDS)]
+                    )
+                );
+            }
+
+            $filters['@self'][$field] = $value;
+            return;
+        }
+
+        // 2. The schema wins for any name it declares.
+        if (array_key_exists($property, $properties) === true) {
+            $filters[$property] = $value;
+            return;
+        }
+
+        // 3. A metadata field the schema does not shadow.
+        if (in_array($property, self::MATCHABLE_METADATA_FIELDS, true) === true) {
+            $filters['@self'][$property] = $value;
+            return;
+        }
+
+        // 4. Neither a declared property nor metadata.
+        //
+        // Refuse only when the schema actually told us what it has. An empty
+        // property list cannot distinguish "this schema declares nothing" from
+        // "the declaration was not available here", and a guard that fires on
+        // missing information would break working flows rather than protect
+        // them. With no declaration to check against, keep the historical
+        // behaviour and let the query layer answer.
+        if ($properties !== []) {
+            throw new RuntimeException(
+                $this->l10n->t(
+                    'The match names "%1$s", which is neither a property of this schema nor a metadata field, '
+                    .'so it could never match anything. Matchable metadata fields are: %2$s.',
+                    [$property, implode(', ', self::MATCHABLE_METADATA_FIELDS)]
+                )
+            );
+        }
+
+        $filters[$property] = $value;
+    }//end assignMatchFilter()
 
     /**
      * Template the configured field mapping against one item.

--- a/openspec/changes/or-flow-object-write-node/specs/flow-object-write-node/spec.md
+++ b/openspec/changes/or-flow-object-write-node/specs/flow-object-write-node/spec.md
@@ -713,6 +713,54 @@ string, or anything else that could reach beyond equality on named properties.
 Composite equality is the whole widening; an expression language here would
 make the delete guard of REQ-OWN-012 unauditable.
 
+A match pair MAY name object METADATA as well as a schema property. Metadata
+does not live in the object's JSON document but in the magic table's
+underscore-prefixed columns, so the node SHALL address such a pair to the
+`@self` filter bag rather than the property bag. Routing SHALL follow this
+order:
+
+1. A name carrying an explicit `@self.` prefix SHALL always address metadata.
+   An unknown metadata field behind that prefix SHALL be refused.
+2. A name the schema declares as a property SHALL address that property, so a
+   schema that genuinely declares `name` or `owner` is unaffected.
+3. A name that is a matchable metadata field SHALL address metadata. The
+   matchable set is `uuid`, `slug`, `uri`, `version`, `owner`, `organisation`,
+   `application`, `name`, `created`, `updated`.
+4. A name that is neither SHALL be refused, naming the offending key, whenever
+   the schema declares any properties at all. Such a match could only ever
+   produce `WHERE 1 = 0`, and a guard that silently matches nothing is not a
+   guard. Where the schema declares no properties the node cannot distinguish
+   "declares nothing" from "declaration unavailable" and SHALL NOT refuse.
+
+`uuid` is the case that matters: `ObjectReadNode` puts it on every item it
+emits expressly so a following write or delete can name the row.
+
+#### Scenario: A match on uuid resolves the object a read emitted
+
+- **GIVEN** an `object-read` step whose items each carry `uuid`
+- **AND** a following `object-write` step with `operation: delete` matching on
+  `property: "uuid"`, `value: "{{uuid}}"`
+- **WHEN** the flow runs
+- **THEN** the lookup SHALL filter on `@self.uuid`
+- **AND** the delete SHALL remove exactly that object
+- **AND** it SHALL NOT silently match nothing while the run reports completed
+
+#### Scenario: A schema property shadows a metadata field of the same name
+
+- **GIVEN** a schema that declares a property `name`
+- **AND** a match naming `name`
+- **WHEN** the step executes
+- **THEN** the match SHALL address the schema property, not `@self.name`
+- **AND** an author needing the metadata field SHALL express it as `@self.name`
+
+#### Scenario: A match that could never resolve is refused
+
+- **GIVEN** a schema declaring properties, none of them `nonsense`
+- **AND** a match naming `nonsense`
+- **WHEN** the step executes
+- **THEN** the item SHALL fail with an error naming `nonsense`
+- **AND** the step SHALL NOT run a query that can only return zero rows
+
 #### Scenario: Two pairs narrow to one object
 
 - **GIVEN** two objects sharing `sourceId: "s1"` but differing on `tenant`

--- a/tests/Unit/Service/Flow/ObjectWriteNodeMetadataMatchTest.php
+++ b/tests/Unit/Service/Flow/ObjectWriteNodeMetadataMatchTest.php
@@ -1,0 +1,477 @@
+<?php
+
+/**
+ * Regression: `object-write` must be able to match on object metadata.
+ *
+ * `findMatch()` put every match pair into the schema-property bag, so `uuid` —
+ * which is metadata living in the magic table's `_uuid` column and never inside
+ * the JSON document — was looked up as a property that does not exist and hit
+ * `MagicSearchHandler::applyObjectFilters()`'s `WHERE 1 = 0` branch. Zero rows,
+ * no error. An update or delete matched nothing while the run reported
+ * `completed`, and an upsert silently inserted a duplicate.
+ *
+ * `ObjectReadNode` puts `uuid` on every item it emits expressly so a follow-up
+ * write or delete can name the row, so the most natural way to chain a read into
+ * a write was the one way that could not work.
+ *
+ * These tests assert the SHAPE of the filter array handed to `findAll()`. The
+ * table fake in ObjectWriteNodeTest matches filter keys only against a row's
+ * `data`, which models the bug — a test written against that fake would pass for
+ * the wrong reason.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\Nodes\ObjectWriteNode;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IAppConfig;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Locks metadata routing in ObjectWriteNode::findMatch().
+ */
+class ObjectWriteNodeMetadataMatchTest extends TestCase
+{
+
+    /** @var MockObject&ObjectService */
+    private $objects;
+
+    private ObjectWriteNode $node;
+
+    private Register $register;
+
+    private Schema $schema;
+
+    /** @var array<int, string> */
+    private array $runContext = ['triggeredBy' => 'alice'];
+
+    /**
+     * The filter bag the node last handed to findAll().
+     *
+     * @var array<string,mixed>|null
+     */
+    private ?array $seenFilters = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->register = new Register();
+        $this->register->setId(1);
+        $this->register->setSlug('example-hydra-cache');
+
+        $this->schema = new Schema();
+        $this->schema->setId(2);
+        $this->schema->setSlug('example-cache-entry');
+
+        $this->objects = $this->createMock(ObjectService::class);
+        $this->objects->method('setRegister')->willReturnSelf();
+        $this->objects->method('setSchema')->willReturnSelf();
+
+        $registers = $this->createMock(RegisterMapper::class);
+        $registers->method('find')->willReturn($this->register);
+
+        $schemas = $this->createMock(SchemaMapper::class);
+        $schemas->method('findBySlugInIds')->willReturn($this->schema);
+        $schemas->method('find')->willReturn($this->schema);
+
+        $userManager = $this->createMock(IUserManager::class);
+        $userManager->method('get')->willReturnCallback(
+            function (string $uid): ?IUser {
+                if ($uid !== 'alice') {
+                    return null;
+                }
+
+                $user = $this->createMock(IUser::class);
+                $user->method('getUID')->willReturn('alice');
+
+                return $user;
+            }
+        );
+
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnCallback(
+            static function (string $text, array $parameters=[]): string {
+                return vsprintf($text, $parameters);
+            }
+        );
+
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueInt')->willReturn(1000);
+
+        $this->node = new ObjectWriteNode(
+            $this->objects,
+            $registers,
+            $schemas,
+            $userManager,
+            $appConfig,
+            $l10n,
+            $this->createMock(IURLGenerator::class)
+        );
+
+        $this->seenFilters = null;
+    }//end setUp()
+
+    /**
+     * Give the schema a declared property set.
+     *
+     * @param array<string,mixed> $properties Declared properties.
+     *
+     * @return void
+     */
+    private function withProperties(array $properties): void
+    {
+        $this->schema->setProperties($properties);
+    }//end withProperties()
+
+    /**
+     * Capture the filters handed to findAll() and return the given matches.
+     *
+     * @param ObjectEntity[] $matches Entities the lookup should resolve to.
+     *
+     * @return void
+     */
+    private function captureFindAll(array $matches=[]): void
+    {
+        $this->objects->method('findAll')->willReturnCallback(
+            function (array $config=[]) use ($matches): array {
+                $this->seenFilters = (array) ($config['filters'] ?? []);
+
+                return $matches;
+            }
+        );
+    }//end captureFindAll()
+
+    /**
+     * Build an entity.
+     *
+     * @param string              $uuid Entity uuid.
+     * @param array<string,mixed> $data Entity document.
+     *
+     * @return ObjectEntity
+     */
+    private function entity(string $uuid, array $data=[]): ObjectEntity
+    {
+        $entity = new ObjectEntity();
+        $entity->setUuid($uuid);
+        $entity->setObject($data);
+
+        return $entity;
+    }//end entity()
+
+    /**
+     * Build a delete configuration matching on the given pairs.
+     *
+     * @param array<int,array{property:string,value:mixed}> $pairs Match pairs.
+     *
+     * @return array<string,mixed>
+     */
+    private function deleteConfig(array $pairs): array
+    {
+        return [
+            'register'      => 'example-hydra-cache',
+            'schema'        => 'example-cache-entry',
+            'operation'     => ObjectWriteNode::OP_DELETE,
+            'confirmDelete' => true,
+            'match'         => $pairs,
+        ];
+    }//end deleteConfig()
+
+    /**
+     * Run one item through the node.
+     *
+     * @param array<string,mixed> $config Step configuration.
+     * @param array<string,mixed> $record Item json.
+     *
+     * @return void
+     */
+    private function runNode(array $config, array $record): void
+    {
+        $this->node->execute([FlowItems::item(json: $record)], $config, $this->runContext);
+    }//end runNode()
+
+    /**
+     * A match on `uuid` addresses metadata, not a schema property.
+     *
+     * This is the defect: `uuid` used to land in the property bag, where it
+     * could only produce `WHERE 1 = 0`.
+     *
+     * @return void
+     */
+    public function testAMatchOnUuidIsRoutedToTheMetadataBag(): void
+    {
+        $this->withProperties(['title' => ['type' => 'string']]);
+        $this->captureFindAll([$this->entity('u-1')]);
+        $this->objects->method('deleteObject')->willReturn(true);
+
+        $this->runNode(
+            $this->deleteConfig([['property' => 'uuid', 'value' => '{{uuid}}']]),
+            ['uuid' => 'u-1']
+        );
+
+        $this->assertIsArray($this->seenFilters);
+        $this->assertSame(
+            ['uuid' => 'u-1'],
+            $this->seenFilters['@self'] ?? null,
+            'uuid must be addressed as metadata'
+        );
+        $this->assertArrayNotHasKey(
+            'uuid',
+            $this->seenFilters,
+            'uuid must NOT remain a top-level property filter — that is the 1 = 0 path'
+        );
+    }//end testAMatchOnUuidIsRoutedToTheMetadataBag()
+
+    /**
+     * The uuid a read node emits is usable verbatim by a following write.
+     *
+     * @return void
+     */
+    public function testTheUuidEmittedByAReadIsUsableByTheFollowingWrite(): void
+    {
+        $this->withProperties(['title' => ['type' => 'string']]);
+        $this->captureFindAll([$this->entity('read-emitted-uuid')]);
+
+        $deleted = null;
+        $this->objects->method('deleteObject')->willReturnCallback(
+            function (...$args) use (&$deleted): bool {
+                $deleted = ($args[0] ?? null);
+
+                return true;
+            }
+        );
+
+        // Exactly the item shape ObjectReadNode emits: the record's own fields
+        // plus the uuid it adds for this purpose.
+        $this->runNode(
+            $this->deleteConfig([['property' => 'uuid', 'value' => '{{uuid}}']]),
+            ['title' => 'a cached thing', 'uuid' => 'read-emitted-uuid']
+        );
+
+        $this->assertSame('read-emitted-uuid', $deleted);
+
+        // The lookup that produced it must have addressed metadata. Without this
+        // the assertion above passes on the pre-fix node too, because the double
+        // returns its row regardless of what was asked.
+        $this->assertSame(
+            ['uuid' => 'read-emitted-uuid'],
+            $this->seenFilters['@self'] ?? null
+        );
+    }//end testTheUuidEmittedByAReadIsUsableByTheFollowingWrite()
+
+    /**
+     * Register and schema stay top-level scoping keys, not metadata filters.
+     *
+     * @return void
+     */
+    public function testRegisterAndSchemaRemainTopLevelScopingKeys(): void
+    {
+        $this->withProperties(['title' => ['type' => 'string']]);
+        $this->captureFindAll([$this->entity('u-1')]);
+        $this->objects->method('deleteObject')->willReturn(true);
+
+        $this->runNode(
+            $this->deleteConfig([['property' => 'uuid', 'value' => 'u-1']]),
+            []
+        );
+
+        $this->assertSame(1, $this->seenFilters['register'] ?? null);
+        $this->assertSame(2, $this->seenFilters['schema'] ?? null);
+    }//end testRegisterAndSchemaRemainTopLevelScopingKeys()
+
+    /**
+     * A declared schema property still addresses the property bag.
+     *
+     * @return void
+     */
+    public function testADeclaredPropertyStillAddressesTheProperty(): void
+    {
+        $this->withProperties(['sourceId' => ['type' => 'string']]);
+        $this->captureFindAll([$this->entity('u-1')]);
+        $this->objects->method('deleteObject')->willReturn(true);
+
+        $this->runNode(
+            $this->deleteConfig([['property' => 'sourceId', 'value' => 's-1']]),
+            []
+        );
+
+        $this->assertSame('s-1', $this->seenFilters['sourceId'] ?? null);
+        $this->assertArrayNotHasKey('@self', $this->seenFilters);
+    }//end testADeclaredPropertyStillAddressesTheProperty()
+
+    /**
+     * The schema wins when a property shadows a metadata field name.
+     *
+     * A schema that genuinely declares `name` or `owner` must keep behaving
+     * exactly as before.
+     *
+     * @return void
+     */
+    public function testADeclaredPropertyShadowsTheMetadataFieldOfTheSameName(): void
+    {
+        $this->withProperties(['name' => ['type' => 'string']]);
+        $this->captureFindAll([$this->entity('u-1')]);
+        $this->objects->method('deleteObject')->willReturn(true);
+
+        $this->runNode(
+            $this->deleteConfig([['property' => 'name', 'value' => 'thing']]),
+            []
+        );
+
+        $this->assertSame('thing', $this->seenFilters['name'] ?? null);
+        $this->assertArrayNotHasKey('@self', $this->seenFilters);
+    }//end testADeclaredPropertyShadowsTheMetadataFieldOfTheSameName()
+
+    /**
+     * An explicit `@self.` prefix always addresses metadata.
+     *
+     * This is the escape hatch for a schema that shadows a metadata name.
+     *
+     * @return void
+     */
+    public function testAnExplicitSelfPrefixAlwaysAddressesMetadata(): void
+    {
+        $this->withProperties(['name' => ['type' => 'string']]);
+        $this->captureFindAll([$this->entity('u-1')]);
+        $this->objects->method('deleteObject')->willReturn(true);
+
+        $this->runNode(
+            $this->deleteConfig([['property' => '@self.name', 'value' => 'thing']]),
+            []
+        );
+
+        $this->assertSame(['name' => 'thing'], $this->seenFilters['@self'] ?? null);
+        $this->assertArrayNotHasKey('name', $this->seenFilters);
+    }//end testAnExplicitSelfPrefixAlwaysAddressesMetadata()
+
+    /**
+     * Metadata and property pairs combine in one match.
+     *
+     * @return void
+     */
+    public function testMetadataAndPropertyPairsCombine(): void
+    {
+        $this->withProperties(['tenant' => ['type' => 'string']]);
+        $this->captureFindAll([$this->entity('u-1')]);
+        $this->objects->method('deleteObject')->willReturn(true);
+
+        $this->runNode(
+            $this->deleteConfig(
+                [
+                    ['property' => 'uuid', 'value' => 'u-1'],
+                    ['property' => 'tenant', 'value' => 'nl'],
+                ]
+            ),
+            []
+        );
+
+        $this->assertSame(['uuid' => 'u-1'], $this->seenFilters['@self'] ?? null);
+        $this->assertSame('nl', $this->seenFilters['tenant'] ?? null);
+    }//end testMetadataAndPropertyPairsCombine()
+
+    /**
+     * A name that is neither a property nor metadata is refused, loudly.
+     *
+     * It could only ever have produced `1 = 0`. Refusing beats matching nothing
+     * while reporting success.
+     *
+     * @return void
+     */
+    public function testAMatchOnSomethingThatCannotExistIsRefused(): void
+    {
+        $this->withProperties(['title' => ['type' => 'string']]);
+        $this->captureFindAll([]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('nonsense');
+
+        $this->runNode(
+            $this->deleteConfig([['property' => 'nonsense', 'value' => 'x']]),
+            []
+        );
+    }//end testAMatchOnSomethingThatCannotExistIsRefused()
+
+    /**
+     * An unknown metadata field behind an explicit prefix is refused too.
+     *
+     * @return void
+     */
+    public function testAnUnknownExplicitMetadataFieldIsRefused(): void
+    {
+        $this->withProperties(['title' => ['type' => 'string']]);
+        $this->captureFindAll([]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('nonsense');
+
+        $this->runNode(
+            $this->deleteConfig([['property' => '@self.nonsense', 'value' => 'x']]),
+            []
+        );
+    }//end testAnUnknownExplicitMetadataFieldIsRefused()
+
+    /**
+     * With no declared properties the node keeps its historical behaviour.
+     *
+     * An empty property list cannot distinguish "declares nothing" from "the
+     * declaration was not available", so the refusal must not fire on it —
+     * otherwise a working flow breaks on missing information.
+     *
+     * @return void
+     */
+    public function testWithNoDeclaredPropertiesAnUnknownNameIsStillPassedThrough(): void
+    {
+        $this->captureFindAll([$this->entity('u-1')]);
+        $this->objects->method('deleteObject')->willReturn(true);
+
+        $this->runNode(
+            $this->deleteConfig([['property' => 'sourceId', 'value' => 's-1']]),
+            []
+        );
+
+        $this->assertSame('s-1', $this->seenFilters['sourceId'] ?? null);
+    }//end testWithNoDeclaredPropertiesAnUnknownNameIsStillPassedThrough()
+
+    /**
+     * Even with no declared properties, uuid is routed to metadata.
+     *
+     * @return void
+     */
+    public function testUuidIsRoutedToMetadataEvenWithoutDeclaredProperties(): void
+    {
+        $this->captureFindAll([$this->entity('u-1')]);
+        $this->objects->method('deleteObject')->willReturn(true);
+
+        $this->runNode(
+            $this->deleteConfig([['property' => 'uuid', 'value' => 'u-1']]),
+            []
+        );
+
+        $this->assertSame(['uuid' => 'u-1'], $this->seenFilters['@self'] ?? null);
+    }//end testUuidIsRoutedToMetadataEvenWithoutDeclaredProperties()
+}//end class


### PR DESCRIPTION
Fixes #2259.

## What was wrong

`ObjectWriteNode::findMatch()` put **every** match pair into the schema-property bag. `uuid` is metadata — it lives in the magic table's `_uuid` column and never inside the JSON document — so it was looked up as a property that does not exist and landed on `MagicSearchHandler::applyObjectFilters()`'s `WHERE 1 = 0` branch. Zero rows, no error.

The silence had a different cost per operation:

| operation | what actually happened |
|---|---|
| `update` | matched nothing, run reported `completed` |
| `delete` | matched nothing, run reported `completed` |
| `upsert` | **inserted a duplicate** |

`ObjectReadNode` puts `uuid` on every item it emits, with a comment saying it is "what a follow-up write or delete needs to name this row". So the read handed the write the one identifier the write could not use, and the most natural way to chain *read these rows, then act on each of them* was the one way that could not work.

The issue is accurate on every point. One thing it flagged as uncertain — "the `@self` route has its own defect, so verify against the live `MagicSearchHandler` path rather than assuming `@self` works" — I checked before relying on it: an exact `@self[uuid]=…` filter **already resolves correctly** on the running instance. This fix therefore does **not** depend on #2260 and can land independently.

## The fix

`findMatch()` now routes each pair, in order:

1. An explicit **`@self.` prefix** always addresses metadata. An unknown field behind it is refused.
2. A name the **schema declares as a property** addresses that property. The schema keeps precedence, so a schema that genuinely declares `name` or `owner` behaves exactly as before — and `@self.name` is the escape hatch.
3. A name that is a **matchable metadata field** addresses metadata: `uuid`, `slug`, `uri`, `version`, `owner`, `organisation`, `application`, `name`, `created`, `updated`.
4. Anything else is **refused, by name**. It could only ever have produced `1 = 0`, and a guard that silently matches nothing is not a guard.

### The one deliberately conservative decision

Rule 4 fires **only when the schema declares at least one property**. An empty property list cannot distinguish "this schema declares nothing" from "the declaration was not available here", and a refusal that triggers on missing information would break working flows rather than protect them. Flagging it explicitly because it is the kind of implicit condition that deserves review.

## Tests

11 new tests in `tests/Unit/Service/Flow/ObjectWriteNodeMetadataMatchTest.php`.

They assert the **shape of the filter array handed to `findAll()`**, not merely the entity returned. This matters: the existing `tableOf()` fake in `ObjectWriteNodeTest` matches filter keys only against a row's `data`, which **models the bug** — a `uuid` test written against that fake passes for the wrong reason. One of my own tests initially passed on the pre-fix node for exactly that reason and was strengthened until it did not.

**Negative control against the pre-fix node: 7 of 11 fail.** The 4 that pass are exactly the backwards-compatibility guards (declared property still addresses the property, schema shadows metadata, register/schema stay top-level scoping keys, no-declared-properties passthrough).

Full flow suite: **365 tests green**. PHPCS 0 errors, Psalm clean.

Also resolves a **pre-existing** PHPMD `TooManyMethods` failure on this class (26 methods, over the 25 limit, before my change).

## Risk

- A match naming something that is neither a property nor metadata now **fails loudly** instead of matching nothing. Any flow relying on that silence was already broken — for `upsert` it was actively inserting duplicates — but it is a behaviour change and a previously "green" flow may now report an error. That is the intent, and it is worth a reviewer's eye.
- Matching on `uuid`/`owner`/etc. now actually resolves. Flows that silently no-opped will start doing real work, including real deletes.

Opening for review rather than admin-merging.