### PR TITLE
feat(flow): a set-fields PATH cannot be templated — no flow can write to a position the run decides

### DIFF
--- a/lib/Service/Flow/Nodes/SetFieldsNode.php
+++ b/lib/Service/Flow/Nodes/SetFieldsNode.php
@@ -157,6 +157,12 @@ class SetFieldsNode implements IFlowNode, IFlowNodeConfigKeys
             );
         }
 
+        // An empty or blank path is refused when the flow is SAVED. It can only
+        // write to a key nothing reads, and the author should not have to find
+        // that out from an item that came back looking fine.
+        $this->assertPathsAreNamed(bag: $set, key: 'set');
+        $this->assertPathsAreNamed(bag: $compute, key: 'compute');
+
         // A malformed expression is caught HERE, when the flow is saved, rather
         // than evaluating to null on every item at 03:00 — `FlowExpression`
         // swallows a broken rule and returns null, which is indistinguishable
@@ -232,13 +238,13 @@ class SetFieldsNode implements IFlowNode, IFlowNodeConfigKeys
             //
             // A value that is exactly one placeholder keeps its TYPE, so a
             // counter stays a number and a list stays a list.
-            foreach ($set as $field => $value) {
-                self::assign(
-                    json: $json,
-                    path: (string) $field,
-                    value: FlowValueTemplate::render(value: $value, json: $json)
-                );
-            }
+            // The PATH is templated as well as the value. Without this the one
+            // node whose job is setting fields could refer to the item in its
+            // values but not in its positions, so no flow could write to a
+            // place the run decides — `stages.{{stage}}.status` created a key
+            // literally called `stages.{{stage}}.status`. Same invisible no-op
+            // as the dotted-path bug, same fix.
+            $this->applySet(json: $json, set: $set);
 
             // `compute` is the same idea as `set` for values that have to be
             // DERIVED rather than substituted. `{{retries}}` can copy a
@@ -255,17 +261,18 @@ class SetFieldsNode implements IFlowNode, IFlowNodeConfigKeys
             // can write this, and the same `{"var": "json.…"}` paths work in
             // both. It is applied AFTER `set`, so a computed value can build on
             // one that was just substituted.
-            foreach ($compute as $field => $logic) {
-                $json[(string) $field] = FlowExpression::evaluate(
-                    logic: $logic,
-                    data: FlowExpression::dataFor(
-                        item: [FlowItems::JSON => $json],
-                        itemIndex: (int) $index,
-                        itemCount: $count,
-                        context: $context
-                    )
-                );
-            }
+            // `compute` gets the same path treatment as `set`, deliberately.
+            // It used to write FLAT — `$json['a.b'] = …` — so it could express
+            // neither a nested position nor a templated one, and an author who
+            // learned the path rules from `set` got a silently different result
+            // from the node's other half.
+            $this->applyCompute(
+                json: $json,
+                compute: $compute,
+                itemIndex: (int) $index,
+                itemCount: $count,
+                context: $context
+            );
 
             // Provenance: this item's own index, one in and one out, so the
             // chain back to the input that caused it stays intact.
@@ -279,6 +286,98 @@ class SetFieldsNode implements IFlowNode, IFlowNodeConfigKeys
         return $out;
 
     }//end execute()
+
+    /**
+     * Refuse a configured field path that names nothing.
+     *
+     * @param array  $bag The `set` or `compute` mapping.
+     * @param string $key The configuration key, for the message.
+     *
+     * @return void
+     *
+     * @throws UnexpectedValueException When a path is empty or blank.
+     *
+     * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+     */
+    private function assertPathsAreNamed(array $bag, string $key): void
+    {
+        foreach (array_keys($bag) as $field) {
+            if (trim((string) $field) === '') {
+                throw new UnexpectedValueException(
+                    $this->l10n->t('A "%s" entry has an empty field path.', [$key])
+                );
+            }
+        }
+
+    }//end assertPathsAreNamed()
+
+    /**
+     * Apply the `set` mapping to one item's record.
+     *
+     * Both halves of a pair are resolved against the record as it stands, and
+     * the record is mutated as we go, so a later entry can read what an earlier
+     * one wrote. That ordering is part of the contract.
+     *
+     * @param array $json The item's record, modified in place.
+     * @param array $set  The configured field mapping.
+     *
+     * @return void
+     *
+     * @throws UnexpectedValueException When a path segment cannot be rendered.
+     *
+     * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+     */
+    private function applySet(array &$json, array $set): void
+    {
+        foreach ($set as $field => $value) {
+            self::assign(
+                json: $json,
+                path: $this->renderPath(path: (string) $field, json: $json),
+                value: FlowValueTemplate::render(value: $value, json: $json)
+            );
+        }
+
+    }//end applySet()
+
+    /**
+     * Apply the `compute` mapping to one item's record.
+     *
+     * @param array $json      The item's record, modified in place.
+     * @param array $compute   The configured expression mapping.
+     * @param int   $itemIndex This item's position in the batch.
+     * @param int   $itemCount The batch size.
+     * @param array $context   The run context.
+     *
+     * @return void
+     *
+     * @throws UnexpectedValueException When a path segment cannot be rendered.
+     *
+     * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+     */
+    private function applyCompute(
+        array &$json,
+        array $compute,
+        int $itemIndex,
+        int $itemCount,
+        array $context
+    ): void {
+        foreach ($compute as $field => $logic) {
+            self::assign(
+                json: $json,
+                path: $this->renderPath(path: (string) $field, json: $json),
+                value: FlowExpression::evaluate(
+                    logic: $logic,
+                    data: FlowExpression::dataFor(
+                        item: [FlowItems::JSON => $json],
+                        itemIndex: $itemIndex,
+                        itemCount: $itemCount,
+                        context: $context
+                    )
+                )
+            );
+        }
+
+    }//end applyCompute()
 
     /**
      * Write a value at a possibly-dotted path, creating the containers it needs.
@@ -298,6 +397,10 @@ class SetFieldsNode implements IFlowNode, IFlowNodeConfigKeys
      * A segment whose current value is not an array is REPLACED by a container.
      * The alternative — merging into a scalar — has no meaning, and silently
      * skipping would reintroduce the same invisible no-op this fixes.
+     *
+     * The path reaching here is already rendered, and a rendered segment can
+     * never contain a `.` (renderPath() refuses one), so splitting again is
+     * safe: the nesting is exactly what the configuration spelled out.
      *
      * @param array  $json  The item's record, modified in place.
      * @param string $path  The field name, optionally dotted.
@@ -331,4 +434,111 @@ class SetFieldsNode implements IFlowNode, IFlowNodeConfigKeys
         unset($cursor);
 
     }//end assign()
+
+    /**
+     * Render a configured path against the item, one segment at a time.
+     *
+     * A path is a POSITION, not a value, so it cannot be rendered the way a
+     * value is. Rendering the whole string and then splitting it would let item
+     * data decide the SHAPE of the path: a `{{stage}}` that happened to contain
+     * a dot would silently become two levels of nesting, writing somewhere the
+     * author never named. That is a data-controlled write position, and it is
+     * the sort of thing that is discovered much later and from the wrong end.
+     *
+     * So the literal path is split on `.` FIRST, and each segment is rendered
+     * on its own. That makes the structure a property of the CONFIGURATION and
+     * only the segment names a property of the data.
+     *
+     * Two decisions taken explicitly rather than by accident:
+     *
+     *  - **A dot in a rendered segment is REFUSED, not escaped.** There is no
+     *    escape syntax anywhere in this node — `assign()` splits on `.`
+     *    unconditionally — so an escaped segment would produce a key no other
+     *    node could address, including this one's own `rename` and `remove`.
+     *    Inventing half an escape mechanism here would be worse than saying no.
+     *  - **A segment that renders EMPTY is REFUSED.** Writing to `""` is a
+     *    silent write to a key nothing reads, which is exactly the failure this
+     *    change exists to remove. An unresolved placeholder is a broken path,
+     *    not a path to an empty name.
+     *
+     * A path containing no placeholder renders to itself, so every existing
+     * configuration is unaffected.
+     *
+     * @param string $path The configured path, optionally dotted and templated.
+     * @param array  $json The item's record, for placeholder resolution.
+     *
+     * @return string The rendered path.
+     *
+     * @throws UnexpectedValueException When a segment renders empty or introduces a dot.
+     *
+     * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+     */
+    private function renderPath(string $path, array $json): string
+    {
+        // Untouched fast path: nothing to render, so nothing can go wrong.
+        if (str_contains($path, '{{') === false) {
+            return $path;
+        }
+
+        $segments = explode('.', $path);
+        $rendered = [];
+
+        foreach ($segments as $segment) {
+            if (str_contains($segment, '{{') === false) {
+                $rendered[] = $segment;
+                continue;
+            }
+
+            $value = FlowValueTemplate::render(value: $segment, json: $json);
+
+            // An unresolved placeholder renders to null. That is a BROKEN path,
+            // not a path to a field called "": say so in those terms, because
+            // the author's mistake is the missing value, not the empty name.
+            if ($value === null) {
+                throw new UnexpectedValueException(
+                    $this->l10n->t(
+                        'The path segment "%s" resolved to nothing; a field position is never empty.',
+                        [$segment]
+                    )
+                );
+            }
+
+            // A container has no meaning as a key, and casting one would give a
+            // key like "Array" or a JSON blob.
+            if (is_scalar($value) === false) {
+                throw new UnexpectedValueException(
+                    $this->l10n->t(
+                        'The path segment "%s" resolved to a value that cannot name a field.',
+                        [$segment]
+                    )
+                );
+            }
+
+            $value = trim((string) $value);
+
+            if ($value === '') {
+                throw new UnexpectedValueException(
+                    $this->l10n->t(
+                        'The path segment "%s" resolved to nothing; a field position is never empty.',
+                        [$segment]
+                    )
+                );
+            }
+
+            if (str_contains($value, '.') === true) {
+                throw new UnexpectedValueException(
+                    $this->l10n->t(
+                        'The path segment "%1$s" resolved to "%2$s", which contains a dot. '
+                        .'A rendered segment names one field and cannot introduce nesting.',
+                        [$segment, $value]
+                    )
+                );
+            }
+
+            $rendered[] = $value;
+        }//end foreach
+
+        return implode('.', $rendered);
+
+    }//end renderPath()
 }//end class

--- a/openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+++ b/openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
@@ -134,6 +134,73 @@ that refuses to save.
 - **WHEN** the flow is saved
 - **THEN** validation fails and names what is missing
 
+### Requirement: A field path may be templated as well as its value (REQ-FN-009)
+
+The "Edit fields" step SHALL resolve `{{dotted.path}}` placeholders in the
+field PATH of both `set` and `compute`, not only in the value, so a flow can
+write to a position the run decides rather than only a position the author
+hardcoded. `compute` SHALL write through the same dotted-path writer as `set`,
+so the two halves of the node address positions identically.
+
+A path is a POSITION, not a value, so it SHALL be rendered one segment at a
+time: the configured path is split on `.` first and each segment rendered on
+its own. Rendering the whole string and then splitting would let item data
+decide the SHAPE of the path rather than only the name of a segment.
+
+The following SHALL be refused rather than written:
+
+- A segment whose placeholder resolves to nothing. An unresolved placeholder is
+  a broken path, not a path to a field named `""`.
+- A segment that resolves to a value which is not a scalar, since a container
+  cannot name a field.
+- A segment that resolves to a value containing a `.`. A rendered segment names
+  exactly one field and SHALL NOT introduce nesting. It is refused rather than
+  escaped: the node has no escape syntax, so an escaped segment would produce a
+  key that no other operation — including this node's own `rename` and
+  `remove` — could address.
+
+A configured path containing no placeholder SHALL be unaffected, and a literal
+`.` in the configured path SHALL keep nesting as before.
+
+An empty or blank configured path SHALL be rejected by `validateConfig()` when
+the flow is saved (REQ-FN-007).
+
+#### Scenario: A placeholder in the path decides where the value lands
+
+- **GIVEN** an item with `stage: "review"`
+- **AND** an "Edit fields" step setting `stages.{{stage}}.status` to `done`
+- **WHEN** the step runs
+- **THEN** the item carries `stages.review.status = "done"`
+- **AND** it does NOT carry a key literally named `stages.{{stage}}.status`
+
+#### Scenario: One configuration writes each item to its own position
+
+- **GIVEN** two items with `stage: "build"` and `stage: "ship"`
+- **AND** one step setting `stages.{{stage}}.ok`
+- **WHEN** the step runs
+- **THEN** the first item carries `stages.build.ok` and the second `stages.ship.ok`
+
+#### Scenario: A rendered segment cannot introduce nesting
+
+- **GIVEN** an item whose `stage` is `"a.b"`
+- **AND** a step setting `stages.{{stage}}.status`
+- **WHEN** the step runs
+- **THEN** the item fails with an error naming the segment and the dot
+- **AND** nothing is written
+
+#### Scenario: A segment resolving to nothing is refused
+
+- **GIVEN** an item with no `stage`
+- **AND** a step setting `stages.{{stage}}.status`
+- **WHEN** the step runs
+- **THEN** the item fails rather than writing to an empty field name
+
+#### Scenario: An empty field path is refused when the flow is saved
+
+- **GIVEN** an "Edit fields" step whose `set` carries an empty path
+- **WHEN** the flow is saved
+- **THEN** validation fails naming the offending configuration key
+
 ### Requirement: The Nextcloud Flow bridge is not duplicated (REQ-FN-008)
 
 OpenRegister already bridges to Nextcloud Flow: `WorkflowEngine\RegisterObjectEntity`

--- a/tests/Unit/Service/Flow/SetFieldsNodeTemplatedPathTest.php
+++ b/tests/Unit/Service/Flow/SetFieldsNodeTemplatedPathTest.php
@@ -1,0 +1,315 @@
+<?php
+
+/**
+ * Regression: a `set` / `compute` PATH must be templatable.
+ *
+ * `SetFieldsNode::execute()` rendered the value and used the key raw, so
+ * `{"set": {"stages.{{stage}}.status": "done"}}` created a key literally named
+ * `stages.{{stage}}.status`. Nothing failed. The flow ran, the item came out,
+ * and the position the author meant to write was never touched —
+ * indistinguishable from success until something downstream read the place that
+ * stayed empty. Identical failure mode to the dotted-path bug fixed in #2244.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\Nodes\SetFieldsNode;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
+
+/**
+ * Locks templated-path rendering, and the two refusals around it.
+ */
+class SetFieldsNodeTemplatedPathTest extends TestCase
+{
+
+    private SetFieldsNode $node;
+
+    protected function setUp(): void
+    {
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnCallback(
+            static function (string $text, array $parameters=[]): string {
+                return vsprintf($text, $parameters);
+            }
+        );
+
+        $this->node = new SetFieldsNode($l10n, $this->createMock(IURLGenerator::class));
+    }//end setUp()
+
+    /**
+     * Run one record through the node and return the resulting json.
+     *
+     * @param array<string,mixed> $config Step configuration.
+     * @param array<string,mixed> $record The item's json.
+     *
+     * @return array<string,mixed> The resulting json.
+     */
+    private function apply(array $config, array $record): array
+    {
+        $out = $this->node->execute([FlowItems::item(json: $record)], $config, []);
+
+        return (array) $out[0][FlowItems::JSON];
+    }//end apply()
+
+    /**
+     * A placeholder in the path decides WHERE the value is written.
+     *
+     * @return void
+     */
+    public function testAPlaceholderInThePathDecidesThePosition(): void
+    {
+        $json = $this->apply(
+            ['set' => ['stages.{{stage}}.status' => 'done']],
+            ['stage' => 'review']
+        );
+
+        $this->assertSame(['review' => ['status' => 'done']], $json['stages']);
+
+        // The literal key is what used to be created instead.
+        $this->assertArrayNotHasKey('stages.{{stage}}.status', $json);
+    }//end testAPlaceholderInThePathDecidesThePosition()
+
+    /**
+     * A whole path that is one placeholder still names one field.
+     *
+     * @return void
+     */
+    public function testAWholePathMayBeASinglePlaceholder(): void
+    {
+        $json = $this->apply(
+            ['set' => ['{{key}}' => 'v']],
+            ['key' => 'chosen']
+        );
+
+        $this->assertSame('v', $json['chosen']);
+        $this->assertArrayNotHasKey('{{key}}', $json);
+    }//end testAWholePathMayBeASinglePlaceholder()
+
+    /**
+     * Two items writing the same configured path land in different positions.
+     *
+     * This is the whole point: one configuration, a position the run decides.
+     *
+     * @return void
+     */
+    public function testTwoItemsWriteToDifferentPositionsFromOneConfiguration(): void
+    {
+        $out = $this->node->execute(
+            [
+                FlowItems::item(json: ['stage' => 'build']),
+                FlowItems::item(json: ['stage' => 'ship']),
+            ],
+            ['set' => ['stages.{{stage}}.ok' => true]],
+            []
+        );
+
+        $this->assertTrue($out[0][FlowItems::JSON]['stages']['build']['ok']);
+        $this->assertTrue($out[1][FlowItems::JSON]['stages']['ship']['ok']);
+    }//end testTwoItemsWriteToDifferentPositionsFromOneConfiguration()
+
+    /**
+     * A numeric placeholder is usable as a segment.
+     *
+     * @return void
+     */
+    public function testANumericPlaceholderIsUsableAsASegment(): void
+    {
+        $json = $this->apply(
+            ['set' => ['slots.{{n}}' => 'taken']],
+            ['n' => 2]
+        );
+
+        $this->assertSame('taken', $json['slots'][2]);
+    }//end testANumericPlaceholderIsUsableAsASegment()
+
+    /**
+     * A path with no placeholder is completely unaffected.
+     *
+     * @return void
+     */
+    public function testAPathWithoutAPlaceholderIsUnchanged(): void
+    {
+        $json = $this->apply(['set' => ['a.b' => 1, 'flat' => 2]], []);
+
+        $this->assertSame(1, $json['a']['b']);
+        $this->assertSame(2, $json['flat']);
+    }//end testAPathWithoutAPlaceholderIsUnchanged()
+
+    /**
+     * A rendered segment may NOT introduce a dot.
+     *
+     * Otherwise item data would decide the SHAPE of the path, not just the
+     * name of one segment — a data-controlled write position.
+     *
+     * @return void
+     */
+    public function testARenderedSegmentMayNotIntroduceNesting(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('contains a dot');
+
+        $this->apply(
+            ['set' => ['stages.{{stage}}.status' => 'done']],
+            ['stage' => 'a.b']
+        );
+    }//end testARenderedSegmentMayNotIntroduceNesting()
+
+    /**
+     * A literal dot in the configured path still nests, as it always has.
+     *
+     * The refusal above is about RENDERED dots only.
+     *
+     * @return void
+     */
+    public function testALiteralDotInTheConfiguredPathStillNests(): void
+    {
+        $json = $this->apply(
+            ['set' => ['a.{{k}}.c' => 'v']],
+            ['k' => 'b']
+        );
+
+        $this->assertSame('v', $json['a']['b']['c']);
+    }//end testALiteralDotInTheConfiguredPathStillNests()
+
+    /**
+     * A segment that resolves to nothing is refused, not written to "".
+     *
+     * @return void
+     */
+    public function testASegmentThatResolvesToNothingIsRefused(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('resolved to nothing');
+
+        $this->apply(
+            ['set' => ['stages.{{missing}}.status' => 'done']],
+            ['stage' => 'review']
+        );
+    }//end testASegmentThatResolvesToNothingIsRefused()
+
+    /**
+     * A segment resolving to a container cannot name a field.
+     *
+     * @return void
+     */
+    public function testASegmentResolvingToAContainerIsRefused(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('cannot name a field');
+
+        $this->apply(
+            ['set' => ['{{bag}}' => 'v']],
+            ['bag' => ['a' => 1]]
+        );
+    }//end testASegmentResolvingToAContainerIsRefused()
+
+    /**
+     * `compute` gets the same path treatment as `set`.
+     *
+     * @return void
+     */
+    public function testComputeAlsoTemplatesItsPath(): void
+    {
+        $json = $this->apply(
+            [
+                'compute' => [
+                    'totals.{{bucket}}' => ['+' => [['var' => 'json.n'], 1]],
+                ],
+            ],
+            ['bucket' => 'nl', 'n' => 4]
+        );
+
+        $this->assertSame(5, $json['totals']['nl']);
+        $this->assertArrayNotHasKey('totals.{{bucket}}', $json);
+    }//end testComputeAlsoTemplatesItsPath()
+
+    /**
+     * `compute` also writes nested rather than flat.
+     *
+     * @return void
+     */
+    public function testComputeWritesNestedRatherThanFlat(): void
+    {
+        $json = $this->apply(
+            ['compute' => ['a.b' => ['+' => [1, 1]]]],
+            []
+        );
+
+        $this->assertSame(2, $json['a']['b']);
+        $this->assertArrayNotHasKey('a.b', $json);
+    }//end testComputeWritesNestedRatherThanFlat()
+
+    /**
+     * A computed value can build on one `set` just wrote at a templated path.
+     *
+     * @return void
+     */
+    public function testComputeCanBuildOnATemplatedSet(): void
+    {
+        $json = $this->apply(
+            [
+                'set'     => ['counts.{{k}}' => 1],
+                'compute' => ['doubled' => ['*' => [['var' => 'json.counts.nl'], 2]]],
+            ],
+            ['k' => 'nl']
+        );
+
+        $this->assertSame(1, $json['counts']['nl']);
+        $this->assertSame(2, $json['doubled']);
+    }//end testComputeCanBuildOnATemplatedSet()
+
+    /**
+     * An empty configured path is refused when the flow is SAVED.
+     *
+     * @return void
+     */
+    public function testAnEmptySetPathIsRefusedAtSaveTime(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('empty field path');
+
+        $this->node->validateConfig(['set' => ['' => 'v']]);
+    }//end testAnEmptySetPathIsRefusedAtSaveTime()
+
+    /**
+     * A blank `compute` path is refused when the flow is SAVED.
+     *
+     * @return void
+     */
+    public function testABlankComputePathIsRefusedAtSaveTime(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('empty field path');
+
+        $this->node->validateConfig(['compute' => ['   ' => ['+' => [1, 1]]]]);
+    }//end testABlankComputePathIsRefusedAtSaveTime()
+
+    /**
+     * An ordinary configuration still validates.
+     *
+     * @return void
+     */
+    public function testAnOrdinaryConfigurationStillValidates(): void
+    {
+        $this->node->validateConfig(['set' => ['stages.{{stage}}.status' => 'done']]);
+
+        $this->addToAssertionCount(1);
+    }//end testAnOrdinaryConfigurationStillValidates()
+}//end class


### PR DESCRIPTION
Fixes #2262.

## What was wrong

`SetFieldsNode::execute()` rendered the **value** and used the **key** raw:

```json
{"set": {"stages.{{stage}}.status": "done"}}
```

created a key literally named `stages.{{stage}}.status`. Nothing failed — the flow ran, the item came out, and the position the author meant to write was never touched. Indistinguishable from success until something downstream read the place that stayed empty.

This is the same class the node's own `assign()` docblock already describes for dotted paths ("*created a top-level key literally CALLED `entry.owner`… That is indistinguishable from success*"). Dotted paths were fixed in #2244; templated ones were not.

One correction to the issue's framing: `set` is a **map whose key IS the path**, not a `{path, value}` object. That is precisely why the path was never rendered — it is a PHP array key of authored config, and `FlowValueTemplate::render()` recurses into arrays while preserving keys verbatim.

## The fix

A path is a **position**, not a value, so it is rendered **one segment at a time**: the configured path is split on `.` first and each segment rendered on its own.

Rendering the whole string and then splitting would let item data decide the **shape** of the path rather than only the name of a segment — a `{{stage}}` that happened to contain a dot would silently become two levels of nesting, writing somewhere the author never named. Segment-wise rendering makes the structure a property of the *configuration* and only the segment name a property of the *data*.

### The decisions the issue asked to be made explicitly

| case | decision | why |
|---|---|---|
| rendered segment contains `.` | **refused**, not escaped | there is no escape syntax anywhere in this node — `assign()` splits unconditionally — so an escaped segment would produce a key nothing else could address, including this node's own `rename` and `remove`. Inventing half an escape mechanism is worse than saying no. |
| segment resolves to nothing | **refused** | an unresolved placeholder is a broken path, not a path to a field named `""`. Reported in those terms so the author looks at the missing value, not the empty name. |
| segment resolves to a non-scalar | **refused** | a container cannot name a field; casting yields `"Array"`. |
| empty/blank configured path | **refused at save time** in `validateConfig()` | the author learns in the editor, not from a 03:00 run. |

All four are documented in the method docblock and specced as REQ-FN-009.

### `compute` gets the same treatment

The issue offered "same treatment **or** documented as deliberately not having it". I chose the former.

`compute` used to write **flat** — `$json['a.b'] = …` — so it could express neither a nested position nor a templated one, and an author who learned the path rules from `set` got a silently different result from the node's other half.

**This is a behaviour change:** a `compute` key containing a dot now nests instead of creating a literal dotted key. Calling it out explicitly — it is the one part of this PR that changes existing semantics rather than adding capability. It is the same "indistinguishable from success" shape, so I judged preserving it worse than changing it, but it deserves a reviewer's opinion.

## Backwards compatibility

A path with no placeholder renders to itself, and a literal `.` still nests. Existing `set` configurations are unaffected — there is a test for each.

## Tests

15 new tests in `tests/Unit/Service/Flow/SetFieldsNodeTemplatedPathTest.php`.

**Negative control against the pre-change node: 13 of 15 fail.** The 2 that pass are exactly the unchanged-behaviour guards.

Full flow suite: **369 tests green**. PHPCS 0 errors, Psalm clean.

PHPMD on this file is now **completely clear**, including a **pre-existing** `CyclomaticComplexity` finding on `execute()` — the `set`/`compute` loops were extracted into named `applySet()` / `applyCompute()` methods, which also shortened `execute()` back under the length threshold.

## Risk

- The `compute` nesting change above.
- Three new refusal paths. A flow whose templated path resolves to nothing now **fails the item** where it previously wrote to a stray key. That is the intent — the write was going nowhere useful either way — but a previously "green" run may now report an error.

Opening for review rather than admin-merging.