### PR TITLE
fix(flow): object reads are not performed as the run owner — the parameter was declared, documented and ignored

### DIFF
--- a/lib/Service/Flow/Nodes/ObjectReadNode.php
+++ b/lib/Service/Flow/Nodes/ObjectReadNode.php
@@ -352,17 +352,33 @@ class ObjectReadNode implements IFlowNode, IFlowNodeConfigKeys
     private function read(Register $register, Schema $schema, array $filters, int $limit, IUser $owner): array
     {
         try {
-            $found = $this->objects
-                ->setRegister($register)
-                ->setSchema($schema)
-                ->findAll(config: ['filters' => $filters, 'limit' => $limit]);
+            // The read runs AS the owner. `$owner` was resolved, declared and
+            // documented as "the subject whose RBAC applies" — and then never
+            // used, so the read actually ran under whatever subject the ambient
+            // session happened to carry. Under CLI cron that is no subject at
+            // all, and both the RBAC and the organisation filter treat a
+            // sessionless CLI context as trusted and skip themselves entirely.
+            // So a scheduled flow read past the very access control this
+            // parameter names.
+            //
+            // ObjectService::findAll() has no acting-user parameter anywhere on
+            // its chain, so the subject is set for the duration of the call and
+            // restored afterwards. See ObjectService::runAs() for why that is
+            // the seam rather than threading a user through the query layer.
+            $found = $this->objects->runAs(
+                $owner,
+                fn (): array => $this->objects
+                    ->setRegister($register)
+                    ->setSchema($schema)
+                    ->findAll(config: ['filters' => $filters, 'limit' => $limit])
+            );
         } catch (Throwable $e) {
             throw new RuntimeException(
                 $this->l10n->t('The object-read step could not read from the register: %s', [$e->getMessage()]),
                 0,
                 $e
             );
-        }
+        }//end try
 
         $records = [];
         foreach ($found as $object) {

--- a/lib/Service/Flow/Nodes/ObjectWriteNode.php
+++ b/lib/Service/Flow/Nodes/ObjectWriteNode.php
@@ -517,7 +517,7 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys
             $payload = $this->buildPayload(fields: $fields, json: $json, onMissing: $onMissing);
             $matched = null;
             if ($operation !== self::OP_CREATE) {
-                $matched = $this->findMatch(pairs: $pairs, json: $json, register: $register, schema: $schema);
+                $matched = $this->findMatch(pairs: $pairs, json: $json, register: $register, schema: $schema, owner: $owner);
             }
 
             if ($operation === self::OP_UPDATE && $matched === null) {
@@ -632,7 +632,7 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys
         $json   = (array) ($item[FlowItems::JSON] ?? []);
         $binary = (array) ($item[FlowItems::BINARY] ?? []);
 
-        $matched = $this->findMatch(pairs: $pairs, json: $json, register: $register, schema: $schema);
+        $matched = $this->findMatch(pairs: $pairs, json: $json, register: $register, schema: $schema, owner: $owner);
 
         if ($matched === null) {
             if ($onNoMatch !== self::ON_NO_MATCH_SKIP) {
@@ -968,17 +968,32 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys
      * non-deterministic across instances, which is the defect class that only
      * ever appears on someone else's system.
      *
+     * The lookup runs AS the owner, so the object a match resolves to is one the
+     * owner can actually see. Without that the node checked one subject and
+     * chose another: the writes were attributed (`currentUser: $owner`) while
+     * the scan that decided WHICH row to write ran under the ambient session.
+     * Under CLI cron that session is empty, and both the RBAC and organisation
+     * filters skip themselves for a sessionless CLI context — so the match
+     * could resolve a row outside the owner's visibility, and `upsert` could
+     * find one the owner could not see and therefore insert a duplicate.
+     *
      * @param array    $pairs    The match pairs.
      * @param array    $json     The current item's record.
      * @param Register $register The resolved register.
      * @param Schema   $schema   The resolved schema.
+     * @param IUser    $owner    The run owner, whose RBAC applies to the lookup.
      *
      * @return ObjectEntity|null The single match, or null when nothing matched.
      *
      * @throws RuntimeException When a match value cannot be templated, or the match is ambiguous.
      */
-    private function findMatch(array $pairs, array $json, Register $register, Schema $schema): ?ObjectEntity
-    {
+    private function findMatch(
+        array $pairs,
+        array $json,
+        Register $register,
+        Schema $schema,
+        IUser $owner
+    ): ?ObjectEntity {
         $filters = [
             'register' => $register->getId(),
             'schema'   => $schema->getId(),
@@ -1000,11 +1015,14 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys
             $filters[$property] = $resolved['value'];
         }
 
-        $rows = $this->objects->findAll(
-            config: [
-                'filters' => $filters,
-                'limit'   => self::MATCH_SCAN_LIMIT,
-            ]
+        $rows = $this->objects->runAs(
+            $owner,
+            fn (): array => $this->objects->findAll(
+                config: [
+                    'filters' => $filters,
+                    'limit'   => self::MATCH_SCAN_LIMIT,
+                ]
+            )
         );
 
         $entities = [];

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -384,6 +384,54 @@ class ObjectService
     }//end runAsSystem()
 
     /**
+     * Run a callable as a NAMED user, with that user's RBAC and multitenancy.
+     *
+     * The opposite of runAsSystem(): this narrows rather than elevates. It
+     * exists because the read side of the query layer has no acting-user
+     * parameter at all — `findAll()` and everything under it resolve the
+     * subject from the session, and the two handlers that build the RBAC and
+     * organisation predicates (MagicRbacHandler, MagicOrganizationHandler) read
+     * `IUserSession::getUser()` directly at roughly a dozen points. A caller who
+     * has an explicit user in hand therefore has nowhere to put it.
+     *
+     * Threading a `?IUser` through would mean changing about twenty signatures
+     * across six layers plus OrganisationService and its UID-keyed caches, and
+     * missing any one of them yields a query that silently disagrees with the
+     * others. Setting the session subject for the duration of the call moves
+     * every one of those readers in lockstep instead, including the caches,
+     * which are keyed by UID and so stay correct by construction.
+     *
+     * This is the pattern the background jobs already use — see
+     * ActorForwardedJob, which sets the actor, runs, and restores in a
+     * `finally` so a cron process never carries one job's identity into the
+     * next. Restoring the PREVIOUS user rather than clearing means nesting
+     * composes correctly.
+     *
+     * This does not grant anything. If the named user cannot see a row, neither
+     * can the callable.
+     *
+     * @param IUser    $user      The user to act as.
+     * @param callable $operation The operation to execute as that user.
+     *
+     * @return mixed Whatever the callable returns.
+     *
+     * @spec openspec/specs/rbac-scopes/spec.md
+     */
+    public function runAs(IUser $user, callable $operation)
+    {
+        $previousUser = $this->userSession->getUser();
+        $this->userSession->setUser($user);
+
+        try {
+            return $operation();
+        } finally {
+            // ALWAYS restore, including on a throw, so a long-lived process
+            // (cron worker, queue runner) never leaks this identity forward.
+            $this->userSession->setUser($previousUser);
+        }
+    }//end runAs()
+
+    /**
      * Set the current register context.
      *
      * @param Register|string|int $register The register object or its ID/UUID

--- a/tests/Unit/Service/Flow/FlowNodeRunsAsOwnerTest.php
+++ b/tests/Unit/Service/Flow/FlowNodeRunsAsOwnerTest.php
@@ -1,0 +1,315 @@
+<?php
+
+/**
+ * Regression: a flow's object READS must run as the run owner.
+ *
+ * `ObjectReadNode::read()` resolved an `IUser $owner`, declared it, documented
+ * it as "the run owner, whose RBAC applies" — and never referenced it. Psalm
+ * reported it as an unused param. So the read ran under whatever subject the
+ * ambient session carried, which for a scheduled run is none at all. Both the
+ * RBAC filter and the organisation filter treat a sessionless CLI context as
+ * trusted and skip themselves, so a scheduled flow read PAST the very access
+ * control the parameter names.
+ *
+ * `ObjectWriteNode::findMatch()` had the same hole and did not even declare the
+ * parameter: its writes were attributed to the owner while the scan deciding
+ * WHICH row to write ran unattributed.
+ *
+ * Every existing owner test asserts only that an owner is RESOLVABLE. None
+ * asserted the read is PERFORMED as that owner, which is exactly why a dead
+ * parameter survived review. These assert the subject.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\Nodes\ObjectReadNode;
+use OCA\OpenRegister\Service\Flow\Nodes\ObjectWriteNode;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IAppConfig;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Locks owner-scoped reads in both object nodes.
+ */
+class FlowNodeRunsAsOwnerTest extends TestCase
+{
+
+    /** @var MockObject&ObjectService */
+    private $objects;
+
+    private Register $register;
+
+    private Schema $schema;
+
+    /**
+     * The uid that was the acting subject when findAll() was called.
+     *
+     * @var string|null
+     */
+    private ?string $subjectAtRead = null;
+
+    /**
+     * Whether findAll() ran inside a runAs() scope at all.
+     *
+     * @var bool
+     */
+    private bool $readWasScoped = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->register = new Register();
+        $this->register->setId(1);
+        $this->register->setSlug('example-hydra-cache');
+
+        $this->schema = new Schema();
+        $this->schema->setId(2);
+        $this->schema->setSlug('example-cache-entry');
+
+        $this->objects = $this->createMock(ObjectService::class);
+        $this->objects->method('setRegister')->willReturnSelf();
+        $this->objects->method('setSchema')->willReturnSelf();
+
+        // Model runAs() the way the real one behaves: it establishes an acting
+        // subject for the duration of the callable. Recording the subject at
+        // the moment findAll() runs is what proves the read is scoped — an
+        // assertion on the argument alone would pass even if the callable were
+        // invoked outside the scope.
+        $acting = null;
+        $this->objects->method('runAs')->willReturnCallback(
+            static function (IUser $user, callable $operation) use (&$acting) {
+                $previous = $acting;
+                $acting   = $user->getUID();
+
+                try {
+                    return $operation();
+                } finally {
+                    $acting = $previous;
+                }
+            }
+        );
+
+        $this->objects->method('findAll')->willReturnCallback(
+            function () use (&$acting): array {
+                $this->subjectAtRead = $acting;
+                $this->readWasScoped = ($acting !== null);
+
+                $entity = new ObjectEntity();
+                $entity->setUuid('u-1');
+                $entity->setObject(['title' => 'a thing']);
+
+                return [$entity];
+            }
+        );
+
+        $this->subjectAtRead = null;
+        $this->readWasScoped = false;
+    }//end setUp()
+
+    /**
+     * Build a user manager resolving `alice` only.
+     *
+     * @return MockObject&IUserManager
+     */
+    private function userManager(): IUserManager
+    {
+        $userManager = $this->createMock(IUserManager::class);
+        $userManager->method('get')->willReturnCallback(
+            function (string $uid): ?IUser {
+                if ($uid !== 'alice') {
+                    return null;
+                }
+
+                $user = $this->createMock(IUser::class);
+                $user->method('getUID')->willReturn('alice');
+
+                return $user;
+            }
+        );
+
+        return $userManager;
+    }//end userManager()
+
+    /**
+     * Build a translation double.
+     *
+     * @return MockObject&IL10N
+     */
+    private function l10n(): IL10N
+    {
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnCallback(
+            static fn (string $text, array $parameters=[]): string => vsprintf($text, $parameters)
+        );
+
+        return $l10n;
+    }//end l10n()
+
+    /**
+     * Build the mappers both nodes need.
+     *
+     * @return array{0: RegisterMapper, 1: SchemaMapper}
+     */
+    private function mappers(): array
+    {
+        $registers = $this->createMock(RegisterMapper::class);
+        $registers->method('find')->willReturn($this->register);
+
+        $schemas = $this->createMock(SchemaMapper::class);
+        $schemas->method('findBySlugInIds')->willReturn($this->schema);
+        $schemas->method('find')->willReturn($this->schema);
+
+        return [$registers, $schemas];
+    }//end mappers()
+
+    /**
+     * The read node performs its read as the run owner.
+     *
+     * @return void
+     */
+    public function testTheReadNodeReadsAsTheRunOwner(): void
+    {
+        [$registers, $schemas] = $this->mappers();
+
+        $node = new ObjectReadNode(
+            $this->objects,
+            $registers,
+            $schemas,
+            $this->userManager(),
+            $this->l10n(),
+            $this->createMock(IURLGenerator::class)
+        );
+
+        $node->execute(
+            [FlowItems::item(json: [])],
+            [
+                'register' => 'example-hydra-cache',
+                'schema'   => 'example-cache-entry',
+            ],
+            ['triggeredBy' => 'alice']
+        );
+
+        $this->assertTrue($this->readWasScoped, 'the read must run inside an owner scope');
+        $this->assertSame('alice', $this->subjectAtRead, 'the read must run as the run owner');
+    }//end testTheReadNodeReadsAsTheRunOwner()
+
+    /**
+     * The write node's own match lookup also runs as the run owner.
+     *
+     * Its writes were already attributed; the scan choosing WHICH row to write
+     * was not. Checking one subject and acting on another is the gap.
+     *
+     * @return void
+     */
+    public function testTheWriteNodeMatchLookupAlsoRunsAsTheRunOwner(): void
+    {
+        [$registers, $schemas] = $this->mappers();
+
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueInt')->willReturn(1000);
+
+        $this->objects->method('patchObject')->willReturnCallback(
+            function (): ObjectEntity {
+                $entity = new ObjectEntity();
+                $entity->setUuid('u-1');
+                $entity->setObject([]);
+
+                return $entity;
+            }
+        );
+
+        $node = new ObjectWriteNode(
+            $this->objects,
+            $registers,
+            $schemas,
+            $this->userManager(),
+            $appConfig,
+            $this->l10n(),
+            $this->createMock(IURLGenerator::class)
+        );
+
+        $node->execute(
+            [['json' => ['sourceId' => 's-1']]],
+            [
+                'register'  => 'example-hydra-cache',
+                'schema'    => 'example-cache-entry',
+                'operation' => ObjectWriteNode::OP_UPDATE,
+                'fields'    => ['status' => 'seen'],
+                'match'     => [['property' => 'sourceId', 'value' => 's-1']],
+            ],
+            ['triggeredBy' => 'alice']
+        );
+
+        $this->assertTrue($this->readWasScoped, 'the match lookup must run inside an owner scope');
+        $this->assertSame('alice', $this->subjectAtRead, 'the match lookup must run as the run owner');
+    }//end testTheWriteNodeMatchLookupAlsoRunsAsTheRunOwner()
+
+    /**
+     * The scope is released once the read is done.
+     *
+     * A long-lived process must never carry one run's identity into the next.
+     *
+     * @return void
+     */
+    public function testTheOwnerScopeIsReleasedAfterTheRead(): void
+    {
+        [$registers, $schemas] = $this->mappers();
+
+        $node = new ObjectReadNode(
+            $this->objects,
+            $registers,
+            $schemas,
+            $this->userManager(),
+            $this->l10n(),
+            $this->createMock(IURLGenerator::class)
+        );
+
+        $node->execute(
+            [FlowItems::item(json: [])],
+            [
+                'register' => 'example-hydra-cache',
+                'schema'   => 'example-cache-entry',
+            ],
+            ['triggeredBy' => 'alice']
+        );
+
+        // A second read with no owner must fail closed rather than inheriting
+        // alice from the run before it.
+        $this->expectException(RuntimeException::class);
+
+        $node->execute(
+            [FlowItems::item(json: [])],
+            [
+                'register' => 'example-hydra-cache',
+                'schema'   => 'example-cache-entry',
+            ],
+            []
+        );
+    }//end testTheOwnerScopeIsReleasedAfterTheRead()
+}//end class

--- a/tests/Unit/Service/Flow/ObjectReadNodeTest.php
+++ b/tests/Unit/Service/Flow/ObjectReadNodeTest.php
@@ -83,6 +83,11 @@ final class ObjectReadNodeTest extends TestCase
         $this->objects = $this->createMock(originalClassName: ObjectService::class);
         $this->objects->method('setRegister')->willReturnSelf();
         $this->objects->method('setSchema')->willReturnSelf();
+        // `runAs()` scopes the acting user around the read. The double must RUN
+        // the callable, or every read silently returns null.
+        $this->objects->method('runAs')->willReturnCallback(
+            static fn (IUser $user, callable $operation) => $operation()
+        );
 
         $registers = $this->createMock(originalClassName: RegisterMapper::class);
         $registers->method('find')->willReturn($register);

--- a/tests/Unit/Service/Flow/ObjectWriteNodeTest.php
+++ b/tests/Unit/Service/Flow/ObjectWriteNodeTest.php
@@ -66,6 +66,13 @@ class ObjectWriteNodeTest extends TestCase
         $this->schema->setSlug('example-cache-entry');
 
         $this->objects = $this->createMock(ObjectService::class);
+        // `runAs()` scopes the acting user around a read. The double must RUN
+        // the callable, or every lookup silently returns null and the node
+        // reports "matched nothing" for reasons that have nothing to do with
+        // the test.
+        $this->objects->method('runAs')->willReturnCallback(
+            static fn (IUser $user, callable $operation) => $operation()
+        );
 
         $registers = $this->createMock(RegisterMapper::class);
         $registers->method('find')->willReturn($this->register);

--- a/tests/Unit/Service/ObjectServiceRunAsTest.php
+++ b/tests/Unit/Service/ObjectServiceRunAsTest.php
@@ -1,0 +1,219 @@
+<?php
+
+/**
+ * Unit coverage for ObjectService::runAs(), the scoped acting-user wrapper.
+ *
+ * The read side of the query layer has no acting-user parameter: `findAll()`
+ * and everything beneath it resolve the subject from `IUserSession`, and the
+ * two handlers that build the RBAC and organisation predicates read
+ * `getUser()` directly at roughly a dozen points. A caller holding an explicit
+ * user therefore has nowhere to put it, which is how
+ * `ObjectReadNode::read()` came to declare and document an `IUser $owner` it
+ * never used.
+ *
+ * `runAs()` sets the subject for the duration of one callable and restores it
+ * afterwards, mirroring the pattern `ActorForwardedJob` already uses so a cron
+ * process never carries one job's identity into the next.
+ *
+ * ObjectService takes ~40 collaborators, so these construct it without its
+ * constructor and inject only the session it uses — the method under test
+ * touches nothing else.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use RuntimeException;
+
+/**
+ * Locks the scoping and release guarantees of ObjectService::runAs().
+ */
+class ObjectServiceRunAsTest extends TestCase
+{
+
+    private ObjectService $service;
+
+    /**
+     * The session double's current user.
+     *
+     * @var IUser|null
+     */
+    private ?IUser $current = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->current = null;
+
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturnCallback(fn (): ?IUser => $this->current);
+        $session->method('setUser')->willReturnCallback(
+            function (?IUser $user): void {
+                $this->current = $user;
+            }
+        );
+
+        $reflection    = new ReflectionClass(ObjectService::class);
+        $this->service = $reflection->newInstanceWithoutConstructor();
+
+        $property = $reflection->getProperty('userSession');
+        $property->setAccessible(true);
+        $property->setValue($this->service, $session);
+    }//end setUp()
+
+    /**
+     * Build a named user double.
+     *
+     * @param string $uid The uid.
+     *
+     * @return IUser The double.
+     */
+    private function user(string $uid): IUser
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+
+        return $user;
+    }//end user()
+
+    /**
+     * The callable runs with the named user as the session subject.
+     *
+     * @return void
+     */
+    public function testTheCallableRunsAsTheNamedUser(): void
+    {
+        $seen = null;
+
+        $this->service->runAs(
+            $this->user('alice'),
+            function () use (&$seen): void {
+                $seen = $this->current?->getUID();
+            }
+        );
+
+        $this->assertSame('alice', $seen);
+    }//end testTheCallableRunsAsTheNamedUser()
+
+    /**
+     * The callable's return value is passed through.
+     *
+     * @return void
+     */
+    public function testTheReturnValueIsPassedThrough(): void
+    {
+        $result = $this->service->runAs($this->user('alice'), static fn (): string => 'answer');
+
+        $this->assertSame('answer', $result);
+    }//end testTheReturnValueIsPassedThrough()
+
+    /**
+     * The previous subject is restored afterwards.
+     *
+     * @return void
+     */
+    public function testThePreviousSubjectIsRestored(): void
+    {
+        $this->current = $this->user('bob');
+
+        $this->service->runAs($this->user('alice'), static fn (): bool => true);
+
+        $this->assertSame('bob', $this->current?->getUID());
+    }//end testThePreviousSubjectIsRestored()
+
+    /**
+     * An empty session stays empty afterwards.
+     *
+     * This is the case that matters for cron: the worker has no session, and
+     * must not acquire one because a flow ran.
+     *
+     * @return void
+     */
+    public function testAnEmptySessionIsLeftEmpty(): void
+    {
+        $this->service->runAs($this->user('alice'), static fn (): bool => true);
+
+        $this->assertNull($this->current);
+    }//end testAnEmptySessionIsLeftEmpty()
+
+    /**
+     * The subject is restored even when the callable throws.
+     *
+     * Without the `finally` a failed read would leave a long-lived process
+     * impersonating the last flow owner — a privilege leak that only shows up
+     * under load.
+     *
+     * @return void
+     */
+    public function testTheSubjectIsRestoredWhenTheCallableThrows(): void
+    {
+        $this->current = $this->user('bob');
+
+        try {
+            $this->service->runAs(
+                $this->user('alice'),
+                static function (): void {
+                    throw new RuntimeException('the read failed');
+                }
+            );
+            $this->fail('Expected the exception to propagate.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('the read failed', $e->getMessage());
+        }
+
+        $this->assertSame('bob', $this->current?->getUID(), 'the subject must be restored on a throw');
+    }//end testTheSubjectIsRestoredWhenTheCallableThrows()
+
+    /**
+     * Nested scopes compose, innermost first, unwinding correctly.
+     *
+     * Restoring the PREVIOUS subject rather than clearing is what makes this
+     * work.
+     *
+     * @return void
+     */
+    public function testNestedScopesCompose(): void
+    {
+        $inner = null;
+        $outer = null;
+
+        $this->service->runAs(
+            $this->user('alice'),
+            function () use (&$inner, &$outer): void {
+                $this->service->runAs(
+                    $this->user('carol'),
+                    function () use (&$inner): void {
+                        $inner = $this->current?->getUID();
+                    }
+                );
+
+                $outer = $this->current?->getUID();
+            }
+        );
+
+        $this->assertSame('carol', $inner);
+        $this->assertSame('alice', $outer, 'the outer scope must survive the inner one');
+        $this->assertNull($this->current);
+    }//end testNestedScopesCompose()
+}//end class


### PR DESCRIPTION
Fixes #2263. Related to #2162.

## What was wrong — and it is worse than the issue states

`ObjectReadNode::read()` resolved an `IUser $owner`, declared it, documented it as *"the run owner, whose RBAC applies"* — and never referenced it. Psalm reported `UnusedParam`; PHPMD reported `UnusedFormalParameter`.

The issue says the read runs under "whatever subject `ObjectService` derives from the ambient session". Checking what that actually resolves to turned up something sharper:

- **Under CLI cron there is no session subject, and both access-control filters treat that as trusted and skip themselves entirely.** `MagicRbacHandler::applyRbacFilters()` returns early on `$user === null && PHP_SAPI === 'cli'`, and `MagicOrganizationHandler::isSystemContext()` returns `true`. So a scheduled flow read **past** the very access control this parameter names — not with the wrong subject, with *no filtering at all*.
- **Under webcron** (`PHP_SAPI !== 'cli'`) the bypass never applied, so those installs read as anonymous and fail closed.

Neither is the owner's view, and the two differ by deployment topology.

### `ObjectWriteNode::findMatch()` has the same hole

It did not even declare the parameter. Its writes were attributed (`currentUser: $owner`) while the scan deciding **which row to write** ran unattributed — checking one subject and acting on another. For `upsert` that means the match can miss a row the owner *can* see and insert a duplicate, or resolve one the owner cannot. Folded in here since one wrapper closes both.

## The fix: `ObjectService::runAs(IUser, callable)`

Sits alongside the existing `runAsSystem()`. Sets the session subject for one callable and restores the **previous** subject in a `finally` — so nesting composes, and a long-lived worker never carries one run's identity into the next. This is the pattern `ActorForwardedJob` already uses for exactly this reason.

### Why not thread `?IUser` down the chain

I scoped it before choosing. `findAll()` has no acting-user parameter anywhere on its **six** layers, and the two handlers that build the RBAC and organisation predicates hold `IUserSession` as a `readonly` constructor property and call `getUser()` at roughly **twelve** separate points. Threading a user means ~20 signature changes across six layers, plus `OrganisationService` and its UID-keyed caches — and missing any single one yields a query that silently disagrees with the others (the QueryBuilder path and the raw-SQL UNION path would answer differently).

Setting the session subject moves every one of those readers in lockstep, and the caches stay correct **because** they are keyed by UID.

`runAs()` grants nothing. If the named user cannot see a row, neither can the callable.

## Behaviour change — please read before merging

**Reads that previously ran with RBAC and organisation filtering bypassed now have both applied.** A flow owned by a non-admin whose active organisation differs from the data's will legitimately see **less** than it does today.

That is the correct end state and the entire point of the issue, but it is a **narrowing**, and it is the one thing here I could not verify from a unit test.

Concretely:
- Flow owner in `admin` → nothing changes (admin bypass).
- Non-admin owner, matching organisation → nothing changes.
- Non-admin owner, different organisation → **reads zero**.
- Webcron installs → strictly an improvement (they were reading as anonymous).

The one production consumer is hydra's lock reaper (`hydra-lock-reaper.flow.json`, node `find-locks`); the sequencer uses `object-write` only. **Recommend verifying `find-locks` still returns rows on a non-admin-owned flow before merge.** I have not been able to run that end-to-end from here.

## Tests

- `tests/Unit/Service/ObjectServiceRunAsTest.php` — 6 tests: scoping, return pass-through, restore, restore **on throw**, empty-session-stays-empty (the cron case), and nesting.
- `tests/Unit/Service/Flow/FlowNodeRunsAsOwnerTest.php` — 3 tests asserting the **subject at the moment `findAll()` runs**, for both nodes, plus scope release.

The existing owner tests only ever asserted an owner was **resolvable**, never that the read was **performed as** one — which is exactly how a dead parameter survived review. Asserting on the `runAs()` argument alone would also be insufficient (it would pass if the callable ran outside the scope), so the double records the acting subject *inside* `findAll()`.

**Negative control:** both node tests fail against the pre-fix nodes.

Full suites green (363 tests). PHPCS 0 errors, Psalm clean, and PHPMD's `UnusedFormalParameter` finding on `ObjectReadNode` is gone.

Two existing test files needed a `runAs()` stub on their `ObjectService` double — without it the mock returns null and every lookup silently reports "matched nothing".

Opening for review rather than admin-merging: this narrows what existing flows can see.