### PR TITLE
fix(quality): triage the findings the repaired check:strict exposed (phpstan 115 → 87)

### DIFF
--- a/lib/Command/DedupeConfigurationsCommand.php
+++ b/lib/Command/DedupeConfigurationsCommand.php
@@ -127,6 +127,14 @@ class DedupeConfigurationsCommand extends Command
             );
         }
 
+        // $dupeRows was read below but never assigned. PHP 8 yields null for an
+        // undefined variable, and `null === 0` is false, so the "nothing to do"
+        // early-return could never fire: on a clean database the command fell
+        // through and reported "0 app(s), 0 duplicate row(s) would be deleted"
+        // instead of "No duplicate configuration rows found.". It is the total
+        // number of rows queued for deletion across every app in the plan.
+        $dupeRows = count($deleteIds);
+
         if ($dupeRows === 0) {
             $output->writeln('<info>No duplicate configuration rows found.</info>');
             return 0;

--- a/lib/Mcp/IMcpToolProvider.php
+++ b/lib/Mcp/IMcpToolProvider.php
@@ -63,11 +63,31 @@ interface IMcpToolProvider
      * fail this check are silently dropped with a warning-level log entry and
      * MUST NOT be passed to the LLM.
      *
+     * `scope` and the annotation hint keys are OPTIONAL and were missing from
+     * this contract, which described a closed four-key shape. Real providers
+     * have always emitted them — FlowMcpToolProvider sets `scope` to
+     * 'create'/'read', AttributeToolScanner copies it off the #[McpTool]
+     * attribute, and AttributeToolProvider copies every
+     * McpAnnotationValidator::HINT_KEYS entry — and consumers have always read
+     * them back (McpProviderBridge::getFunctions()). Because the declared shape
+     * omitted them, PHPStan resolved those reads against a shape that could not
+     * contain the key and reported the live `scope` forwarding as dead code
+     * ("array_key_exists() with 'scope' and array{...} will always evaluate to
+     * false"). The code was right and the contract was wrong.
+     *
+     * These keys are ADVISORY metadata only. ObjectService RBAC remains the
+     * sole authoritative invoke-time gate (ADR-063), so `scope` never widens
+     * access on its own.
+     *
      * @return list<array{
      *   id: string,
      *   name: string,
      *   description: string,
-     *   inputSchema: array
+     *   inputSchema: array,
+     *   scope?: string,
+     *   readOnlyHint?: bool,
+     *   destructiveHint?: bool,
+     *   idempotentHint?: bool
      * }> Tool descriptors
      */
     public function getTools(): array;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -52,7 +52,14 @@ parameters:
         - '#has unknown class OCP\\ContextChat\\#'
         - '#has invalid type OCP\\ContextChat\\#'
         - '#Instantiated class OCP\\ContextChat\\#'
-        - '#implements unknown interface OCP\\ContextChat\\#'
+        # NOT ignorable: "Class ContentProvider implements unknown interface
+        # OCP\ContextChat\IContentProvider" is a class-level structural error
+        # that phpstan refuses to suppress via ignoreErrors — adding a pattern
+        # for it does not remove the error, it ADDS a second one
+        # ("... cannot be ignored, use excludePaths instead"). Excluding the
+        # whole file would hide real findings in it, so this single diagnostic
+        # is left visible until the nextcloud/ocp bump in #2273 resolves the
+        # interface for real.
         # Note the lower-case 'a' in TagUnassignedEvent — the two event class
         # names are NOT symmetrical (TagAssignedEvent / TagUnassignedEvent), so
         # a `Tag(Un)?AssignedEvent` alternation silently misses the Unassigned

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -30,6 +30,41 @@ parameters:
         # OCA\DAV is server-internal and not in nextcloud/ocp stubs
         - '#unknown class OCA\\DAV\\#'
         - '#Class OCA\\DAV\\#'
+        # OCP\ContextChat\* and OCP\SystemTag\Tag(Un)AssignedEvent exist on the
+        # servers this app supports, but NOT in the `nextcloud/ocp` stub package,
+        # which composer.lock pins at v31.0.9 while the app targets NC 32-34.
+        # Verified on the NC 34 container backing this checkout:
+        #   /var/www/html/lib/public/SystemTag/TagAssignedEvent.php   PRESENT
+        #   /var/www/html/lib/public/ContextChat/IContentManager.php  PRESENT
+        # and both are ABSENT from vendor/nextcloud/ocp. So these 33 diagnostics
+        # describe a stale analysis path, not defective code — the listeners and
+        # the ContextChat content provider are correct as written.
+        #
+        # The real fix is to bump nextcloud/ocp to a stub matching the supported
+        # server range; that is a fleet-wide dependency change with its own
+        # fallout (it will move many other diagnostics at once), so it is tracked
+        # separately rather than smuggled in behind a static-analysis triage.
+        # These patterns are deliberately narrow — they name the two namespaces
+        # involved and nothing else.
+        - '#unknown class OCP\\ContextChat\\#'
+        - '#OCP\\ContextChat\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class OCP\\ContextChat\\#'
+        - '#has unknown class OCP\\ContextChat\\#'
+        - '#has invalid type OCP\\ContextChat\\#'
+        - '#Instantiated class OCP\\ContextChat\\#'
+        - '#implements unknown interface OCP\\ContextChat\\#'
+        # Note the lower-case 'a' in TagUnassignedEvent — the two event class
+        # names are NOT symmetrical (TagAssignedEvent / TagUnassignedEvent), so
+        # a `Tag(Un)?AssignedEvent` alternation silently misses the Unassigned
+        # half. Matching the namespace avoids re-introducing that trap.
+        - '#unknown class OCP\\SystemTag\\Tag(A|Una)ssignedEvent#'
+        - '#Class OCP\\SystemTag\\Tag(A|Una)ssignedEvent not found#'
+        - '#has invalid type OCP\\SystemTag\\Tag(A|Una)ssignedEvent#'
+        - '#@implements has invalid type OCP\\SystemTag\\Tag(A|Una)ssignedEvent#'
+        # The listener implements IEventListener over a union that includes the
+        # two absent SystemTag events, so the whole @implements union fails the
+        # subtype check for the same stub-gap reason.
+        - '#in generic type OCP\\EventDispatcher\\IEventListener<.*OCP\\SystemTag\\Tag.*> in PHPDoc tag @implements is not subtype of template type#'
         # OCA\Bookmarks is an optional peer app (lazy-resolved via
         # \OCP\Server::get() behind a class_exists guard) — not a
         # composer dependency, so its classes are absent during analysis.

--- a/psalm.xml
+++ b/psalm.xml
@@ -76,6 +76,30 @@
                 <referencedClass name="OCA\OpenRegister\Service\FileService"/>
                 <referencedClass name="OCA\OpenRegister\Service\CalendarEventService"/>
                 <referencedClass name="OCA\OpenRegister\Mcp\IMcpToolProvider"/>
+                <!--
+                    Present on the supported servers (NC 32-34) but absent from
+                    the `nextcloud/ocp` stub, which composer.lock pins at
+                    v31.0.9. Verified on the NC 34 container backing this
+                    checkout: lib/public/SystemTag/TagAssignedEvent.php and
+                    lib/public/ContextChat/IContentManager.php both exist there
+                    and neither exists under vendor/nextcloud/ocp. Stale
+                    analysis path, not defective code. Bumping the stub is
+                    tracked separately — it moves many diagnostics at once.
+                -->
+                <referencedClass name="OCP\ContextChat\IContentManager"/>
+                <referencedClass name="OCP\ContextChat\IContentProvider"/>
+                <referencedClass name="OCP\ContextChat\ContentItem"/>
+                <referencedClass name="OCP\ContextChat\Events\ContentProviderRegisterEvent"/>
+                <referencedClass name="OCP\SystemTag\TagAssignedEvent"/>
+                <referencedClass name="OCP\SystemTag\TagUnassignedEvent"/>
+                <!--
+                    OCA\DAV is Nextcloud server-internal and is never shipped in
+                    the OCP stubs. phpstan.neon already ignores this namespace
+                    for the same reason; psalm.xml simply never gained the
+                    matching entries.
+                -->
+                <referencedClass name="OCA\DAV\CalDAV\CalDavBackend"/>
+                <referencedClass name="OCA\DAV\CardDAV\CardDavBackend"/>
                 <!-- OCA\Bookmarks optional peer app (lazy-resolved at runtime) -->
                 <referencedClass name="OCA\Bookmarks\QueryParameters"/>
                 <referencedClass name="OCA\Bookmarks\Db\Bookmark"/>


### PR DESCRIPTION
fix(quality): triage the findings the repaired check:strict exposed

openregister#2256 made `composer check:strict` able to fail. This triages what
it exposed, rather than baselining it green.

Re-measured on a clean worktree at origin/development, PHP 8.3.32, tools exactly
as locked (psalm 5.26.1 / phpstan 1.12.33 / phpmd 2.15.0):
phpstan 115, psalm 55 (CI-equivalent), phpmd 312 over baseline.

TWO REAL DEFECTS FIXED

1. DedupeConfigurationsCommand read $dupeRows without ever assigning it. PHP 8
   yields null for an undefined variable and `null === 0` is false, so the
   "No duplicate configuration rows found." early-return could NEVER fire: on a
   clean database the command fell through and reported
   "0 app(s), 0 duplicate row(s) would be deleted". Assigned from the plan.
   Control: null === 0 -> early-return SKIPPED; 0 === 0 -> early-return FIRES.

2. IMcpToolProvider::getTools() declared a CLOSED four-key descriptor shape.
   Real providers have always emitted more — FlowMcpToolProvider sets `scope`,
   AttributeToolScanner copies it off #[McpTool], AttributeToolProvider copies
   every McpAnnotationValidator::HINT_KEYS entry — and McpProviderBridge has
   always read them back. Because the contract omitted them, PHPStan resolved
   those reads against a shape that could not contain the key and called the
   live `scope` forwarding dead code. The code was right; the contract was
   wrong. Documented the optional keys (verified against HINT_KEYS, which has
   exactly three entries).

ONE FALSE-POSITIVE CLUSTER SUPPRESSED, NARROWLY AND WITH EVIDENCE

`nextcloud/ocp` is pinned at v31.0.9 while this app targets NC 32-34.
OCP\ContextChat\* and OCP\SystemTag\Tag(Un)assignedEvent are absent from the
stub but PRESENT on the NC 34 container backing this checkout — 33 phpstan and
13 psalm findings describing correct code. Suppressed per-namespace with the
evidence inline; nothing blanket-baselined. The dependency bump is the real fix
and is tracked in #2273.

NET EFFECT, RECONCILED HONESTLY

phpstan 115 -> 87: -32 stub cluster, -1 dupeRows, -2 dead-code reports that the
contract fix retired, +7 NEWLY SURFACED. The +7 are redundant `??` defaults in
McpToolsService and McpProviderBridge that were previously hidden behind
unreachable-code analysis — correcting the contract made that code reachable and
therefore analysable. They are pre-existing style debt, now visible rather than
masked, and are left visible deliberately.

Five stub-cluster findings remain unsuppressed (they are not name-scoped to the
two namespaces) and are left red on purpose.

---

### Classification of everything else (not fixed here)

| cluster | n | verdict |
|---|---|---|
| OCP stub stale (ContextChat / SystemTag) | 33 | (b) false positive — suppressed w/ evidence, bump tracked in #2273 |
| redundant `??` / offset always exists | 26→33 | (c) real but cosmetic — left visible |
| always-true/false dead branches | 19 | (c) needs per-site review, several look like genuine dead guards |
| param/return type mismatches | 11 | (c) |
| `Unknown parameter $_rbac/$_multitenancy` on mapper calls | 2 live, 247 already baselined | **unexplained** — the named params DO exist on `SchemaMapper::findAll()` (lines 827-828) and there is no duplicate class. Not resolved; NOT suppressed. |
| `AuditHandler::extractSchemaId()/extractSchemaSlug()` unused | 2 | (c) dead code, candidate for deletion |
| `AggregationRunner` empty-array foreach / `Offset *NEVER*` | 3 | (c) looks like genuine dead aggregation paths — worth a real look |
| `MultiTenancyTrait` calling get/setOrganisation on `Entity` | 3 | (b) trait/concrete-class limitation |
| `ContentProvider.php:261` unknown named params | 2 | see the unexplained row above |

**phpmd: 312 over baseline — NOT triaged.** Out of budget. Untouched, still red.

### Why psalm reads 55 in CI and 68 locally

Resolved, and it is not a real difference. The 13-finding gap is exactly
`Imagick` (9) + `ImagickPixel` (4) `UndefinedClass`, and no PHP 8.3 image on this
host carries the `imagick` extension while CI's `shivammathur/setup-php` does.
Control: re-running psalm with an `Imagick`/`ImagickPixel` stub gave 58 = 55 + 3,
where the 3 extra are `UndefinedConstant` artefacts of my minimal stub declaring
only one constant (`FILTER_LANCZOS` and `ALPHACHANNEL_EXTRACT` were the misses).
**55 is the true number; 68 is local environment noise.** Anyone measuring psalm
on this repo locally must either install imagick or subtract that cluster.
