### PR TITLE
fix(flow): an object-read whose filter renders empty must fail, not read zero

### DIFF
--- a/lib/Service/Flow/FlowValueTemplate.php
+++ b/lib/Service/Flow/FlowValueTemplate.php
@@ -57,6 +57,118 @@ final class FlowValueTemplate
     private const WHOLE = '/^\{\{\s*([A-Za-z0-9_@.]+)\s*\}\}$/';
 
     /**
+     * Render a value and REPORT the placeholders that came out empty.
+     *
+     * {@see render()} cannot fail. A path the item does not carry resolves to
+     * null and is substituted as the empty string, so `"ZZ issue-lock {{repo}}"`
+     * silently becomes `"ZZ issue-lock "` and a caller that meant to constrain
+     * something ends up constraining something else. That is invisible wherever
+     * the rendered value is a QUESTION rather than a payload: an empty filter
+     * value matches nothing, the step returns zero rows, and the run reports
+     * success having done nothing.
+     *
+     * This variant renders exactly as `render()` does and additionally returns
+     * every placeholder path that could not be filled, so a caller for whom an
+     * empty value is meaningless can refuse rather than proceed. It does not
+     * decide that itself: `render()` stays the default, because omitting a
+     * FIELD legitimately narrows what is written.
+     *
+     * A path counts as unfilled when the item does not carry it, when it
+     * carries null, or when it carries the empty string. All three produce the
+     * same empty rendering, so telling them apart would only let one of them
+     * through.
+     *
+     * @param mixed $value The authored value.
+     * @param array $json  The item's record.
+     *
+     * @return array{value: mixed, unresolved: array<int, string>} The rendered
+     *               value, and the placeholder paths that rendered empty.
+     *
+     * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+     */
+    public static function renderTracked(mixed $value, array $json): array
+    {
+        $unresolved = [];
+        $rendered   = self::renderCollecting(value: $value, json: $json, unresolved: $unresolved);
+
+        return [
+            'value'      => $rendered,
+            'unresolved' => array_values(array_unique($unresolved)),
+        ];
+
+    }//end renderTracked()
+
+    /**
+     * Render recursively, collecting the paths that came out empty.
+     *
+     * @param mixed              $value      The authored value.
+     * @param array              $json       The item's record.
+     * @param array<int, string> $unresolved Collects the empty placeholder paths.
+     *
+     * @return mixed The rendered value.
+     */
+    private static function renderCollecting(mixed $value, array $json, array &$unresolved): mixed
+    {
+        if (is_array($value) === true) {
+            $rendered = [];
+            foreach ($value as $key => $entry) {
+                $rendered[$key] = self::renderCollecting(value: $entry, json: $json, unresolved: $unresolved);
+            }
+
+            return $rendered;
+        }
+
+        if (is_string($value) === false) {
+            return $value;
+        }
+
+        $whole = [];
+        if (preg_match(self::WHOLE, $value, $whole) === 1) {
+            $resolved = self::valueAt(path: $whole[1], json: $json);
+            if (self::isEmptyValue(value: $resolved) === true) {
+                $unresolved[] = $whole[1];
+            }
+
+            return $resolved;
+        }
+
+        return (string) preg_replace_callback(
+            self::PLACEHOLDER,
+            static function (array $matches) use ($json, &$unresolved): string {
+                $resolved = self::valueAt(path: $matches[1], json: $json);
+                if (self::isEmptyValue(value: $resolved) === true) {
+                    $unresolved[] = $matches[1];
+                }
+
+                if (is_array($resolved) === true) {
+                    return (string) json_encode($resolved);
+                }
+
+                return (string) $resolved;
+            },
+            $value
+        );
+
+    }//end renderCollecting()
+
+    /**
+     * Whether a resolved value renders as nothing at all.
+     *
+     * `false`, `0` and `[]` are deliberately NOT empty: they are answers, and a
+     * whole-value placeholder keeps their type, so `{"enabled": "{{wanted}}"}`
+     * resolving to `false` is a real constraint rather than a missing one.
+     *
+     * @param mixed $value The resolved value.
+     *
+     * @return boolean Whether it renders as nothing.
+     */
+    private static function isEmptyValue(mixed $value): bool
+    {
+        return ($value === null || $value === '');
+
+    }//end isEmptyValue()
+
+    /**
      * Render a value — scalar, list or map — against an item's record.
      *
      * @param mixed $value The authored value.

--- a/lib/Service/Flow/Nodes/ObjectReadNode.php
+++ b/lib/Service/Flow/Nodes/ObjectReadNode.php
@@ -29,6 +29,11 @@
  * and "the read did not happen" are different answers, and a reaper that reads
  * the second as the first quietly stops reaping.
  *
+ * The same distinction applies BEFORE the read: a filter whose placeholder
+ * renders empty asked a different question from the one it was authored to
+ * ask, so it throws too. See {@see renderFilters()} — that is the shape hydra's
+ * lock reaper was dormant in for weeks while every run reported `completed`.
+ *
  * TWO OUTPUT SHAPES, AND THE DEFAULT IS THE NARROWER ONE
  * ------------------------------------------------------
  * By default the matches land as a LIST under `output`, which is right for
@@ -273,7 +278,7 @@ class ObjectReadNode implements IFlowNode, IFlowNodeConfigKeys
         $out = [];
         foreach ($items as $index => $item) {
             $json    = (array) ($item[FlowItems::JSON] ?? []);
-            $filters = (array) FlowValueTemplate::render(value: (array) ($config['filters'] ?? []), json: $json);
+            $filters = $this->renderFilters(config: $config, json: $json);
 
             $records = $this->read(
                 register: $register,
@@ -330,6 +335,65 @@ class ObjectReadNode implements IFlowNode, IFlowNodeConfigKeys
         return $out;
 
     }//end execute()
+
+    /**
+     * Render the step's filters, refusing any placeholder that comes out empty.
+     *
+     * A FILTER IS A QUESTION, AND AN EMPTY ONE IS STILL A QUESTION.
+     * ------------------------------------------------------------
+     * `FlowValueTemplate::render()` cannot fail: a path the item does not carry
+     * resolves to null and substitutes as the empty string. For a written FIELD
+     * that is a deliberate narrowing, governed by `onMissing`. For a filter it
+     * is a silent change of meaning — `"ZZ issue-lock {{repo}}"` becomes
+     * `"ZZ issue-lock "`, which matches nothing, and the step then returns zero
+     * rows and reports success.
+     *
+     * That is not hypothetical. hydra's lock reaper is a scheduled flow whose
+     * filter interpolated `{{repo}}`, and a schedule tick's payload is only
+     * `{flowId, scheduledAt}` — so under its own trigger the filter always
+     * rendered empty and the reaper swept nothing, every run `completed`. It
+     * reaped correctly whenever a human passed `repo` in a test payload, which
+     * is exactly what kept it hidden.
+     *
+     * So an unfilled placeholder throws here, the same way
+     * `ObjectWriteNode::findMatch()` refuses an unfilled MATCH key: a guard
+     * that gets weaker when its input is missing is not a guard. `null` and the
+     * empty string count as unfilled alongside an absent path, because all
+     * three render identically — a computed field whose expression returned
+     * null is present in the record and just as empty.
+     *
+     * A step that genuinely wants "everything" says so by authoring no filter,
+     * which is a different sentence from one whose filter did not render.
+     *
+     * @param array $config The step configuration.
+     * @param array $json   The current item's record.
+     *
+     * @return array The rendered filters.
+     *
+     * @throws RuntimeException When a filter placeholder renders empty.
+     *
+     * @spec openspec/changes/or-flow-nodes/specs/flow-nodes/spec.md
+     */
+    private function renderFilters(array $config, array $json): array
+    {
+        $rendered = FlowValueTemplate::renderTracked(
+            value: (array) ($config['filters'] ?? []),
+            json: $json
+        );
+
+        if ($rendered['unresolved'] !== []) {
+            throw new RuntimeException(
+                $this->l10n->t(
+                    'The object-read step\'s filter could not be rendered: %s resolved to nothing on this item. '
+                    .'A filter that renders empty matches nothing, so the step would report success having read no objects.',
+                    [implode(', ', $rendered['unresolved'])]
+                )
+            );
+        }
+
+        return (array) $rendered['value'];
+
+    }//end renderFilters()
 
     /**
      * Perform one read as the run owner.

--- a/tests/Unit/Service/Flow/FlowValueTemplateTest.php
+++ b/tests/Unit/Service/Flow/FlowValueTemplateTest.php
@@ -109,4 +109,80 @@ final class FlowValueTemplateTest extends TestCase
         $this->assertSame('hydra-410', $out['nested']['deep']);
 
     }//end testStructuresAreRenderedRecursively()
+
+
+    /**
+     * `renderTracked()` renders identically AND names what came out empty.
+     *
+     * `render()` cannot fail, which is right for a written field and wrong for
+     * a question: an empty filter value matches nothing and the step reports
+     * success. So the tracked variant reports the paths, and leaves the
+     * decision to the caller.
+     *
+     * @return void
+     */
+    public function testRenderTrackedNamesTheEmptyPlaceholders(): void
+    {
+        $out = FlowValueTemplate::renderTracked(
+            ['name' => 'ZZ issue-lock {{repo}}', 'cutoff' => '{{cutoff}}'],
+            ['flowId' => 'f-1', 'scheduledAt' => '2026-08-02T15:00:00+00:00']
+        );
+
+        $this->assertSame('ZZ issue-lock ', $out['value']['name']);
+        $this->assertNull($out['value']['cutoff']);
+        $this->assertSame(['repo', 'cutoff'], $out['unresolved']);
+
+    }//end testRenderTrackedNamesTheEmptyPlaceholders()
+
+
+    /**
+     * Null and the empty string count as empty; `false`, `0` and `[]` do not.
+     *
+     * A computed field whose expression failed is PRESENT and null, and renders
+     * exactly as an absent path does — so treating them differently would only
+     * let one of them through. `false` and `0` are answers, and a whole-value
+     * placeholder keeps their type, so they are real values.
+     *
+     * @return void
+     */
+    public function testOnlyValuesThatRenderAsNothingCountAsEmpty(): void
+    {
+        $out = FlowValueTemplate::renderTracked(
+            [
+                'computedNull' => '{{cutoff}}',
+                'blank'        => '{{empty}}',
+                'flag'         => '{{off}}',
+                'count'        => '{{zero}}',
+                'list'         => '{{none}}',
+            ],
+            ['cutoff' => null, 'empty' => '', 'off' => false, 'zero' => 0, 'none' => []]
+        );
+
+        $this->assertSame(['cutoff', 'empty'], $out['unresolved']);
+        $this->assertFalse($out['value']['flag']);
+        $this->assertSame(0, $out['value']['count']);
+        $this->assertSame([], $out['value']['list']);
+
+    }//end testOnlyValuesThatRenderAsNothingCountAsEmpty()
+
+
+    /**
+     * A fully resolvable structure reports nothing unresolved.
+     *
+     * The positive control for the two above: a tracker that flagged everything
+     * would satisfy them both and refuse every real read.
+     *
+     * @return void
+     */
+    public function testRenderTrackedReportsNothingWhenEverythingResolves(): void
+    {
+        $out = FlowValueTemplate::renderTracked(
+            ['name' => 'ZZ issue-lock', '@self' => ['created' => ['lt' => '{{cutoff}}']]],
+            ['cutoff' => '2026-08-02 14:30:00']
+        );
+
+        $this->assertSame([], $out['unresolved']);
+        $this->assertSame('2026-08-02 14:30:00', $out['value']['@self']['created']['lt']);
+
+    }//end testRenderTrackedReportsNothingWhenEverythingResolves()
 }//end class

--- a/tests/Unit/Service/Flow/ObjectReadNodeTest.php
+++ b/tests/Unit/Service/Flow/ObjectReadNodeTest.php
@@ -111,7 +111,19 @@ final class ObjectReadNodeTest extends TestCase
         );
 
         $l10n = $this->createMock(originalClassName: IL10N::class);
-        $l10n->method('t')->willReturnArgument(0);
+        // The double SUBSTITUTES rather than returning the template, because a
+        // message assertion against an un-substituted `%s` proves nothing about
+        // what the caller would actually read — and worse, matches by accident:
+        // `/repo/` is satisfied by the word "reported" in the template itself.
+        $l10n->method('t')->willReturnCallback(
+            static function (string $text, array $parameters=[]): string {
+                if ($parameters === []) {
+                    return $text;
+                }
+
+                return vsprintf($text, $parameters);
+            }
+        );
 
         $this->node = new ObjectReadNode(
             $this->objects,
@@ -441,5 +453,106 @@ final class ObjectReadNodeTest extends TestCase
         $this->assertCount(1, $out);
         $this->assertCount(2, $out[0]['json']['objects']);
     }
+
+
+    /**
+     * A filter placeholder the item cannot fill FAILS the step.
+     *
+     * This is the defect hydra's lock reaper was dormant in. Its filter
+     * interpolated `{{repo}}`, and a schedule tick's payload is only
+     * `{flowId, scheduledAt}` — so under its own trigger `lockName` rendered as
+     * `"ZZ issue-lock "`, matched nothing, and the run reported `completed`. It
+     * reaped correctly whenever a caller supplied `repo` in a test payload,
+     * which is precisely what kept it hidden.
+     *
+     * The read must never happen: an empty constraint is a different question,
+     * not a looser one.
+     *
+     * @return void
+     */
+    public function testAFilterThatRendersEmptyFailsTheStep(): void
+    {
+        $this->objects->expects($this->never())->method('findAll');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/could not be rendered: repo resolved to nothing/');
+
+        $this->node->execute(
+            [FlowItems::item(json: ['flowId' => 'f-1', 'scheduledAt' => '2026-08-02T15:00:00+00:00'])],
+            $this->config(['filters' => ['name' => 'ZZ issue-lock {{repo}}']]),
+            $this->ownedContext
+        );
+
+    }//end testAFilterThatRendersEmptyFailsTheStep()
+
+
+    /**
+     * A placeholder that resolves to null is refused just like an absent one.
+     *
+     * `openregister.set-fields` assigns whatever its expression returns, so a
+     * `compute` whose expression failed leaves the key PRESENT and null. That
+     * renders to the empty string exactly as a missing path does, so telling
+     * the two apart would only let one of them through.
+     *
+     * @return void
+     */
+    public function testAFilterPlaceholderResolvingToNullIsAlsoRefused(): void
+    {
+        $this->objects->expects($this->never())->method('findAll');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/could not be rendered: cutoff resolved to nothing/');
+
+        $this->node->execute(
+            [FlowItems::item(json: ['cutoff' => null])],
+            $this->config(['filters' => ['@self' => ['created' => ['lt' => '{{cutoff}}']]]]),
+            $this->ownedContext
+        );
+
+    }//end testAFilterPlaceholderResolvingToNullIsAlsoRefused()
+
+
+    /**
+     * The positive control: a filter whose placeholders all resolve still reads.
+     *
+     * A guard only ever seen refusing is indistinguishable from a step that
+     * cannot read at all, so the happy path is asserted beside it — including
+     * the values a strict emptiness rule could plausibly have swallowed.
+     * `false` and `0` are ANSWERS: a whole-value placeholder keeps their type,
+     * so `enabled = false` is a real constraint rather than a missing one.
+     *
+     * @return void
+     */
+    public function testAFullyRenderedFilterStillReads(): void
+    {
+        $seen = [];
+        $this->objects->method('findAll')->willReturnCallback(
+            function (array $config=[], bool $_rbac=true, bool $_multitenancy=true) use (&$seen): array {
+                $seen[] = $config['filters'];
+                return [];
+            }
+        );
+
+        $this->node->execute(
+            [FlowItems::item(json: ['cutoff' => '2026-08-02 14:30:00', 'wanted' => false, 'attempts' => 0])],
+            $this->config(
+                [
+                    'filters' => [
+                        'name'     => 'ZZ issue-lock',
+                        'enabled'  => '{{wanted}}',
+                        'attempts' => '{{attempts}}',
+                        '@self'    => ['created' => ['lt' => '{{cutoff}}']],
+                    ],
+                ]
+            ),
+            $this->ownedContext
+        );
+
+        $this->assertSame('ZZ issue-lock', $seen[0]['name']);
+        $this->assertFalse($seen[0]['enabled']);
+        $this->assertSame(0, $seen[0]['attempts']);
+        $this->assertSame('2026-08-02 14:30:00', $seen[0]['@self']['created']['lt']);
+
+    }//end testAFullyRenderedFilterStillReads()
 
 }//end class

--- a/tests/Unit/Service/Flow/ObjectWriteNodeMetadataMatchTest.php
+++ b/tests/Unit/Service/Flow/ObjectWriteNodeMetadataMatchTest.php
@@ -90,6 +90,17 @@ class ObjectWriteNodeMetadataMatchTest extends TestCase
         $this->schema->setSlug('example-cache-entry');
 
         $this->objects = $this->createMock(ObjectService::class);
+        // `runAs()` scopes the acting user around the lookup. The double must
+        // RUN the callable: an unstubbed mock method returns null, so
+        // `findMatch()` sees no rows and every delete here reported "A delete
+        // matched no object" — nine errors that had nothing to do with the
+        // behaviour under test. `ObjectWriteNodeTest` and `ObjectReadNodeTest`
+        // were both updated when the read moved inside `runAs()`
+        // (openregister#2272); this file was not, so it has been failing on
+        // `development` ever since.
+        $this->objects->method('runAs')->willReturnCallback(
+            static fn (IUser $user, callable $operation) => $operation()
+        );
         $this->objects->method('setRegister')->willReturnSelf();
         $this->objects->method('setSchema')->willReturnSelf();
 


### PR DESCRIPTION
## The defect

A filter is a **question**, and `FlowValueTemplate::render()` cannot fail: a path the item does not carry resolves to `null` and substitutes as the empty string. For a written FIELD that is a deliberate narrowing, governed by `onMissing`. For a filter it silently changes the question — the step matches nothing and the run reports `completed`.

hydra's lock reaper is the safety net that stops a wedged per-issue lock blocking the whole pipeline. Its filter interpolated `{{repo}}`, and `FlowScheduleService::fire()` puts only `{flowId, scheduledAt}` in a schedule tick's payload — so under its own trigger the filter always rendered `"ZZ issue-lock "`, matched nothing, and reported success. It reaped correctly whenever a caller supplied `repo` in a test payload, which is exactly what kept it hidden.

## The change

- `FlowValueTemplate::renderTracked()` — renders exactly as `render()` does, and additionally returns every placeholder path that came out empty. `render()` is untouched and stays the default.
- `ObjectReadNode` refuses a filter whose placeholder resolved to nothing, mirroring `ObjectWriteNode::findMatch()`'s existing "a match key is never omitted" rule.
- `null` and `''` count as unfilled alongside an absent path — all three render identically, and `openregister.set-fields` assigns whatever its expression returns, so a failed `compute` leaves the key present and null. `false`, `0` and `[]` are answers and stay answers.

**What it deliberately does not do:** reading zero objects is still an ordinary result. "Nothing matched" and "I could not ask the question" are different answers and only the second is an error — a reaper on a quiet instance must not go red.

## Proved live, three flows on ONE scheduled tick

Fired by `FlowScheduleWorker` → `FlowRunWorker` via `occ background-job:execute`, with **no caller-supplied input**:

| flow | status | `find-locks` |
|---|---|---|
| filter with `{{repo}}` (the old shape) | **stopped** | **failed** — *"filter could not be rendered: repo resolved to nothing on this item"* |
| filter pre-rendered `"ZZ issue-lock "` (the query the old flow actually issued) | completed | 1 item in / **0 out** |
| the fixed reaper | completed | 1 in / 1 out → stale lock `_deleted` set, fresh lock untouched |

Asserted in the database on `_deleted`, not on run status. A tick with nothing stale still reports `completed` with 0 out.

## Drive-by: a pre-existing red suite

`tests/Unit/Service/Flow/ObjectWriteNodeMetadataMatchTest.php` has been failing on `development` since #2272 moved the match lookup inside `ObjectService::runAs()`. Its `ObjectService` double never stubbed `runAs`, so the mock returned `null`, the callable never ran, and all nine delete cases errored with *"A delete matched no object"* — a stale test double failing a correct caller. `ObjectWriteNodeTest` and `ObjectReadNodeTest` were both updated at the time; this file was missed.

## Checks

- `phpunit` full suite: **15778 tests, 0 failures** (baseline on `development`: 9 errors)
- new tests fail without the production change (verified by disabling the guard)
- `phpcs` clean on `lib/Service/Flow/`; `psalm` and `phpstan` clean on both changed files
- `phpmd` unchanged in rule classes for the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)