### PR TITLE
feat(broker): allow GET /search/issues so a scheduled flow can find work org-wide

### DIFF
--- a/lib/Settings/credential-providers.json
+++ b/lib/Settings/credential-providers.json
@@ -229,6 +229,7 @@
         { "method": "PUT", "pathPattern": "/repos/*/contents/*" },
         { "method": "POST", "pathPattern": "/repos/*/git/*" },
         { "method": "GET", "pathPattern": "/search/repositories" },
+        { "$why": "Finding queued work across an organisation in ONE call. hydra's sequencer runs on a schedule, and a schedule tick carries no repository — so it searches the org for the queue label and reads the repository back off whatever it finds. The alternative is enumerating the org and querying each repo in turn, which hydra's retired supervisor already tried: 41 repos x 5 label queries = 205 calls per tick, and the forge's abuse governor started 403'ing every request from that IP for ~15 minutes. This is read-only, host-locked to api.github.com like every rule here, and returns strictly less per issue than the GET /repos/* grant already present above. It is the issues counterpart of /search/repositories on the line above, which is already allowed.", "method": "GET", "pathPattern": "/search/issues" },
         { "method": "GET", "pathPattern": "/user" },
         { "method": "POST", "pathPattern": "/user/repos" },
         { "method": "POST", "pathPattern": "/orgs/*/repos" },

--- a/tests/Unit/Service/Credential/DoffinProviderTest.php
+++ b/tests/Unit/Service/Credential/DoffinProviderTest.php
@@ -163,7 +163,32 @@ class DoffinProviderTest extends TestCase
         // arbitrary code in the repository. This one lets it file a bug report.
         // Bounded to /issues, it writes issue metadata and never a byte of code,
         // and is reversible through the PATCH rule beside it.
-        $this->assertCount(17, $github['allowRules']);
+        //
+        // 18 since 2026-08-02: `GET /search/issues`. hydra's sequencer runs on a
+        // SCHEDULE, and a schedule tick's payload is only
+        // `{flowId, scheduledAt}` — it carries no repository. So it searches the
+        // organisation for its queue label and reads the repository back off
+        // whatever it finds. The alternative is enumerating the org and querying
+        // each repository in turn, which hydra already tried and abandoned:
+        // 41 repos x 5 label queries = 205 calls per tick, and the forge's abuse
+        // governor 403'd everything from that IP for ~15 minutes.
+        // Read-only, host-locked like every rule here, and the issues
+        // counterpart of `GET /search/repositories` which rule 5 already allows.
+        // Narrower per issue than `GET /repos/*` at rule 1: a search result
+        // omits fields a direct issue read returns.
+        $this->assertCount(18, $github['allowRules']);
+
+        // The search grant is READ-only and must stay so: a search rule that
+        // grew a write method would be a write to every repository the token can
+        // see, in one call.
+        $issueSearch = array_values(
+            array_filter(
+                $github['allowRules'],
+                static fn (array $rule): bool => ($rule['pathPattern'] ?? '') === '/search/issues'
+            )
+        );
+        $this->assertCount(1, $issueSearch);
+        $this->assertSame('GET', $issueSearch[0]['method']);
 
         // The grant is CREATE-only and must stay that way: nothing here may
         // reach a repository, a release or file content.


### PR DESCRIPTION
## What

One rule added to the `github` provider's `allowRules`:

```json
{ "method": "GET", "pathPattern": "/search/issues" }
```

## Why

hydra's sequencer polls for queued issues **on a schedule**. A schedule tick's payload is only `{flowId, scheduledAt}` (`FlowScheduleService::fire()`), so it carries no repository — the sequencer therefore searches the **organisation** for its queue label and reads the repository back off whatever it finds, out of the result's `repository_url`.

That call is `GET /search/issues`, and the broker refused it:

```
403 Credential broker refused the request (Request not permitted).
```

## Why not enumerate instead

Because hydra already tried that and abandoned it. The retired `hydra-supervisor.sh` moved from per-repo enumeration to a single org-wide search after **41 repos x 5 label queries = 205 calls per tick** got its IP flagged by the forge's abuse governor, which then 403'd everything for ~15 minutes. One search call replaces that fan-out.

## Why this is a small widening

- **Read-only**, and host-locked to `api.github.com` like every rule here.
- `GET /search/repositories` is **already allowed** — search-class reads on this host are already accepted, and this is its issues counterpart.
- It returns **strictly less per issue** than the `GET /repos/*` grant already present two lines above; search results omit fields a direct issue read returns.

The catalogue is a security control that is never writable through any API, so a rule can only arrive in a reviewed release — hence this PR rather than configuration. Recorded with a `$why`, as the `/repos/*/pulls` rule below already is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
