### PR TITLE
fix(db): resolve the SchemaMapper::findAll() phpstan finding — a @method docblock was shadowing four runtime fatals; phpmd is 2, not 312

### DIFF
--- a/lib/Db/ApplicationMapper.php
+++ b/lib/Db/ApplicationMapper.php
@@ -58,9 +58,7 @@ use OCP\IUserSession;
  * @method Application update(Entity $entity)
  * @method Application insertOrUpdate(Entity $entity)
  * @method Application delete(Entity $entity)
- * @method Application find(int|string $id)
  * @method Application findEntity(IQueryBuilder $query)
- * @method Application[] findAll(int|null $limit=null, int|null $offset=null)
  * @method list<Application> findEntities(IQueryBuilder $query)
  *
  * @template-extends QBMapper<Application>
@@ -280,7 +278,7 @@ class ApplicationMapper extends QBMapper
      *
      * @throws \Exception If user doesn't have read permission
      *
-     * @psalm-return list<OCA\OpenRegister\Db\Application>
+     * @psalm-return list<\OCA\OpenRegister\Db\Application>
      */
     public function findAll(
         ?int $limit=null,

--- a/lib/Db/AuditTrailMapper.php
+++ b/lib/Db/AuditTrailMapper.php
@@ -49,9 +49,7 @@ use Symfony\Component\Uid\Uuid;
  * @method AuditTrail update(Entity $entity)
  * @method AuditTrail insertOrUpdate(Entity $entity)
  * @method AuditTrail delete(Entity $entity)
- * @method AuditTrail find(int|string $id)
  * @method AuditTrail findEntity(IQueryBuilder $query)
- * @method AuditTrail[] findAll(int|null $limit=null, int|null $offset=null)
  * @method list<AuditTrail> findEntities(IQueryBuilder $query)
  *
  * @template-extends QBMapper<AuditTrail>
@@ -231,7 +229,7 @@ class AuditTrailMapper extends QBMapper
      *
      * @return AuditTrail[]
      *
-     * @psalm-return list<OCA\OpenRegister\Db\AuditTrail>
+     * @psalm-return list<\OCA\OpenRegister\Db\AuditTrail>
      *
      * @SuppressWarnings(PHPMD.NPathComplexity)       Complex query building requires many conditional paths
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)

--- a/lib/Db/ConfigurationMapper.php
+++ b/lib/Db/ConfigurationMapper.php
@@ -50,9 +50,7 @@ use OCP\IUserSession;
  * @method           Configuration update(Entity $entity)
  * @method           Configuration insertOrUpdate(Entity $entity)
  * @method           Configuration delete(Entity $entity)
- * @method           Configuration find(int|string $id)
  * @method           Configuration findEntity(IQueryBuilder $query)
- * @method           Configuration[] findAll(int|null $limit=null, int|null $offset=null)
  * @method           list<Configuration> findEntities(IQueryBuilder $query)
  *
  * @extends QBMapper<Configuration>
@@ -495,7 +493,7 @@ class ConfigurationMapper extends QBMapper
      *
      * @throws \Exception If user doesn't have read permission
      *
-     * @psalm-return list<OCA\OpenRegister\Db\Configuration>
+     * @psalm-return list<\OCA\OpenRegister\Db\Configuration>
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Multitenancy toggle is intentional
      */

--- a/lib/Db/DestructionListMapper.php
+++ b/lib/Db/DestructionListMapper.php
@@ -171,6 +171,6 @@ class DestructionListMapper extends QBMapper
     {
         $entity->setUpdated(new DateTime());
 
-        return $this->update(objectId: $entity);
+        return $this->update(entity: $entity);
     }//end updateEntry()
 }//end class

--- a/lib/Db/OrganisationMapper.php
+++ b/lib/Db/OrganisationMapper.php
@@ -56,7 +56,6 @@ use Symfony\Component\Uid\Uuid;
  * @method Organisation delete(Entity $entity)
  * @method Organisation find(int|string $id)
  * @method Organisation findEntity(IQueryBuilder $query)
- * @method Organisation[] findAll(int|null $limit=null, int|null $offset=null)
  * @method list<Organisation> findEntities(IQueryBuilder $query)
  *
  * @template-extends QBMapper<Organisation>
@@ -448,16 +447,25 @@ class OrganisationMapper extends QBMapper
      */
 
     /**
-     * Find all organisations with pagination
+     * Find all organisations with pagination and optional column filters
      *
-     * @param int $limit  Maximum number of results to return (default 50)
-     * @param int $offset Number of results to skip (default 0)
+     * The `$filters` parameter is NOT optional sugar: three tenant-lifecycle
+     * background jobs (TenantDeprovisionJob, TenantPurgeJob, TenantUsageSyncJob)
+     * already call `findAll(filters: ['status' => ...])`. Until this parameter
+     * existed those calls raised `Error: Unknown named parameter $filters`, which
+     * is an `\Error` and therefore slipped straight past their `catch (\Exception)`
+     * — every run of all three jobs died uncaught. See openregister#2282.
+     *
+     * @param int   $limit   Maximum number of results to return (default 50)
+     * @param int   $offset  Number of results to skip (default 0)
+     * @param array $filters Column => value equality filters (also accepts the
+     *                       'IS NULL' / 'IS NOT NULL' sentinels used fleet-wide)
      *
      * @return Organisation[]
      *
-     * @psalm-return list<OCA\OpenRegister\Db\Organisation>
+     * @psalm-return list<\OCA\OpenRegister\Db\Organisation>
      */
-    public function findAll(int $limit=50, int $offset=0): array
+    public function findAll(int $limit=50, int $offset=0, ?array $filters=[]): array
     {
         $qb = $this->db->getQueryBuilder();
 
@@ -466,6 +474,20 @@ class OrganisationMapper extends QBMapper
             ->orderBy('name', 'ASC')
             ->setMaxResults($limit)
             ->setFirstResult($offset);
+
+        foreach ($filters ?? [] as $filter => $value) {
+            if ($value === 'IS NOT NULL') {
+                $qb->andWhere($qb->expr()->isNotNull($filter));
+                continue;
+            }
+
+            if ($value === 'IS NULL') {
+                $qb->andWhere($qb->expr()->isNull($filter));
+                continue;
+            }
+
+            $qb->andWhere($qb->expr()->eq($filter, $qb->createNamedParameter($value)));
+        }
 
         return $this->findEntities(query: $qb);
     }//end findAll()

--- a/lib/Db/SchemaMapper.php
+++ b/lib/Db/SchemaMapper.php
@@ -83,9 +83,7 @@ use OCA\OpenRegister\Service\Survivorship\SurvivorshipAnnotationValidator;
  * @method Schema update(Entity $entity)
  * @method Schema insertOrUpdate(Entity $entity)
  * @method Schema delete(Entity $entity, bool $force=false)
- * @method Schema find(int|string $id, ?array $_extend=[], bool $_rbac=true, bool $_multitenancy=true)
  * @method Schema findEntity(IQueryBuilder $query)
- * @method Schema[] findAll(int|null $limit=null, int|null $offset=null)
  * @method list<Schema> findEntities(IQueryBuilder $query)
  *
  * @template-extends QBMapper<Schema>
@@ -813,7 +811,7 @@ class SchemaMapper extends QBMapper
      *
      * @throws \Exception If user doesn't have read permission
      *
-     * @psalm-return                                  list<OCA\OpenRegister\Db\Schema>
+     * @psalm-return                                  list<\OCA\OpenRegister\Db\Schema>
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)   Flags control security filtering behavior
      */

--- a/lib/Db/SearchTrailMapper.php
+++ b/lib/Db/SearchTrailMapper.php
@@ -50,9 +50,7 @@ use Symfony\Component\Uid\Uuid;
  * @method SearchTrail update(Entity $entity)
  * @method SearchTrail insertOrUpdate(Entity $entity)
  * @method SearchTrail delete(Entity $entity)
- * @method SearchTrail find(int|string $id)
  * @method SearchTrail findEntity(IQueryBuilder $query)
- * @method SearchTrail[] findAll(int|null $limit=null, int|null $offset=null)
  * @method list<SearchTrail> findEntities(IQueryBuilder $query)
  *
  * @template-extends QBMapper<SearchTrail>
@@ -113,7 +111,7 @@ class SearchTrailMapper extends QBMapper
      *
      * @return SearchTrail[]
      *
-     * @psalm-return list<OCA\OpenRegister\Db\SearchTrail>
+     * @psalm-return list<\OCA\OpenRegister\Db\SearchTrail>
      */
     public function findAll(
         ?int $limit=null,

--- a/lib/Db/SelectionListMapper.php
+++ b/lib/Db/SelectionListMapper.php
@@ -166,6 +166,6 @@ class SelectionListMapper extends QBMapper
     {
         $entity->setUpdated(new DateTime());
 
-        return $this->update(objectId: $entity);
+        return $this->update(entity: $entity);
     }//end updateEntry()
 }//end class

--- a/lib/Db/ViewMapper.php
+++ b/lib/Db/ViewMapper.php
@@ -58,9 +58,7 @@ use Symfony\Component\Uid\Uuid;
  * @method View update(Entity $entity)
  * @method View insertOrUpdate(Entity $entity)
  * @method View delete(Entity $entity)
- * @method View find(int|string $id)
  * @method View findEntity(IQueryBuilder $query)
- * @method View[] findAll(int|null $limit=null, int|null $offset=null)
  * @method list<View> findEntities(IQueryBuilder $query)
  *
  * @template-extends QBMapper<View>
@@ -206,7 +204,7 @@ class ViewMapper extends QBMapper
      *
      * @throws \Exception If user doesn't have read permission
      *
-     * @psalm-return list<OCA\OpenRegister\Db\View>
+     * @psalm-return list<\OCA\OpenRegister\Db\View>
      */
     public function findAll(?string $owner=null): array
     {

--- a/lib/Service/Flow/Nodes/ObjectWriteNode.php
+++ b/lib/Service/Flow/Nodes/ObjectWriteNode.php
@@ -523,9 +523,6 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys
         $replace    = (($config['replace'] ?? false) === true);
         $cap        = $this->writeCap(config: $config);
 
-        $writes = 0;
-        $out    = [];
-
         // THE WRITES RUN AS THE OWNER, rather than merely naming one.
         //
         // `$owner` was resolved, passed down every path as `currentUser:` and

--- a/phpstan-baseline-jsonresponse-invariance.neon
+++ b/phpstan-baseline-jsonresponse-invariance.neon
@@ -1,0 +1,57 @@
+# Five controller list-endpoints whose declared JSONResponse generic no longer
+# matches, now that the stale `@method ... findAll(...)` docblocks have been
+# removed from lib/Db (see openregister#2283 and the PR that introduced this file).
+#
+# WHY THESE ARE BASELINED RATHER THAN FIXED — read the reported pairs closely:
+#
+#   ConfigurationsController::index() should return
+#     JSONResponse<200, array{results: array<int, Configuration>}, array>
+#   but returns
+#     JSONResponse<200, array{results: array<int, Configuration>}, array{}>
+#
+# The two types are textually IDENTICAL apart from the third template parameter:
+# `array` (from the docblock's `array<never, never>`) versus `array{}` (what the
+# JSONResponse constructor actually produces for default headers). JSONResponse's
+# template parameters are INVARIANT, so phpstan rejects the pair on the headers
+# alone. This is a pre-existing docblock-vs-constructor mismatch across the
+# controller layer; the removed `@method` shadow had simply been changing the
+# results type enough that phpstan never got as far as comparing headers.
+#
+# Attempting the obvious fix (widening `array<X>` to `array<int, X>` in the five
+# @psalm-return docblocks) was measured and made it WORSE — 5 errors became 8,
+# because it also exposed the 500-branch returns (`array{error: string}` against
+# a declared literal `'Failed to retrieve…'`). Doing this properly means auditing
+# the JSONResponse generic docblocks across the whole controller layer, which is
+# a change of its own with its own review — not a rider on a Db-layer fix.
+#
+# This is category (c): real, out of scope, baselined WITH a reason and an issue.
+# It is deliberately a separate file rather than 5 more lines buried in the
+# 338 KB phpstan-baseline.neon, so the reason cannot get detached from the entries.
+#
+# Tracked in: openregister#2288
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\ApplicationsController\\:\\:index\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|500, array\\{error\\?\\: 'Failed to retrieve…', results\\?\\: array\\<OCA\\\\OpenRegister\\\\Db\\\\Application\\>\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, array\\{results\\: array\\<int, OCA\\\\OpenRegister\\\\Db\\\\Application\\>\\}, array\\{\\}\\>\\.$#"
+			count: 1
+			path: lib/Controller/ApplicationsController.php
+
+		-
+			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\ConfigurationController\\:\\:index\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|500, array\\<'Failed to fetch…'\\|OCA\\\\OpenRegister\\\\Db\\\\Configuration\\>, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, array\\<int, OCA\\\\OpenRegister\\\\Db\\\\Configuration\\>, array\\{\\}\\>\\.$#"
+			count: 1
+			path: lib/Controller/ConfigurationController.php
+
+		-
+			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\ConfigurationsController\\:\\:index\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, array\\{results\\: array\\<OCA\\\\OpenRegister\\\\Db\\\\Configuration\\>\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, array\\{results\\: array\\<int, OCA\\\\OpenRegister\\\\Db\\\\Configuration\\>\\}, array\\{\\}\\>\\.$#"
+			count: 1
+			path: lib/Controller/ConfigurationsController.php
+
+		-
+			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\OrganisationController\\:\\:search\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200\\|500, array\\{error\\?\\: 'Search failed', organisations\\?\\: array\\<array\\{id\\: int, uuid\\: string\\|null, slug\\: string\\|null, name\\: string\\|null, description\\: string\\|null, groups\\: array\\|null, active\\: bool\\|null, parent\\: string\\|null, \\.\\.\\.\\}\\>, limit\\?\\: int\\<1, 100\\>, offset\\?\\: int\\<0, max\\>, count\\?\\: int\\<0, max\\>\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, array\\{organisations\\: array\\<int, array\\{id\\: int, uuid\\: string\\|null, slug\\: string\\|null, name\\: string\\|null, description\\: string\\|null, groups\\: array\\|null, active\\: bool\\|null, parent\\: string\\|null, \\.\\.\\.\\}\\>, limit\\: int, offset\\: int, count\\: int\\}, array\\{\\}\\>\\.$#"
+			count: 1
+			path: lib/Controller/OrganisationController.php
+
+		-
+			message: "#^Method OCA\\\\OpenRegister\\\\Controller\\\\SchemasController\\:\\:index\\(\\) should return OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, array\\{results\\: array\\<array\\{id\\: int, uuid\\: string\\|null, uri\\: string\\|null, slug\\: string\\|null, title\\: string\\|null, description\\: string\\|null, version\\: string\\|null, summary\\: string\\|null, \\.\\.\\.\\}\\>\\}, array\\> but returns OCP\\\\AppFramework\\\\Http\\\\JSONResponse\\<200, array\\{results\\: array\\<int, array\\{id\\: int, uuid\\: string\\|null, uri\\: string\\|null, slug\\: string\\|null, title\\: string\\|null, description\\: string\\|null, version\\: string\\|null, summary\\: string\\|null, \\.\\.\\.\\}\\>\\}, array\\{\\}\\>\\.$#"
+			count: 1
+			path: lib/Controller/SchemasController.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,11 @@ includes:
     # Apps without debt ship an empty baseline file; canonical includes are otherwise byte-identical
     # across the fleet.
     - phpstan-baseline.neon
+    # Five JSONResponse generic-invariance mismatches surfaced by removing the
+    # stale `@method` shadows from lib/Db. Kept in their own file so the reason
+    # (written at the top of it) cannot get detached from the entries.
+    # openregister#2288
+    - phpstan-baseline-jsonresponse-invariance.neon
 
 parameters:
     level: 5

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -49,21 +49,6 @@
       <code><![CDATA[_rbac]]></code>
     </InvalidNamedArgument>
   </file>
-  <file src="lib/BackgroundJob/TenantDeprovisionJob.php">
-    <InvalidNamedArgument>
-      <code><![CDATA[filters]]></code>
-    </InvalidNamedArgument>
-  </file>
-  <file src="lib/BackgroundJob/TenantPurgeJob.php">
-    <InvalidNamedArgument>
-      <code><![CDATA[filters]]></code>
-    </InvalidNamedArgument>
-  </file>
-  <file src="lib/BackgroundJob/TenantUsageSyncJob.php">
-    <InvalidNamedArgument>
-      <code><![CDATA[filters]]></code>
-    </InvalidNamedArgument>
-  </file>
   <file src="lib/Calendar/RegisterCalendarProvider.php">
     <LessSpecificImplementedReturnType>
       <code><![CDATA[array]]></code>
@@ -122,11 +107,6 @@
       <code><![CDATA[Uuid::v4()]]></code>
     </ImplicitToStringCast>
   </file>
-  <file src="lib/Db/DestructionListMapper.php">
-    <InvalidNamedArgument>
-      <code><![CDATA[objectId]]></code>
-    </InvalidNamedArgument>
-  </file>
   <file src="lib/Db/Mapping.php">
     <RedundantPropertyInitializationCheck>
       <code><![CDATA[isset($this->id) === true]]></code>
@@ -171,11 +151,6 @@
       <code><![CDATA[$this->id]]></code>
       <code><![CDATA['unknown']]></code>
     </RedundantPropertyInitializationCheck>
-  </file>
-  <file src="lib/Db/SelectionListMapper.php">
-    <InvalidNamedArgument>
-      <code><![CDATA[objectId]]></code>
-    </InvalidNamedArgument>
   </file>
   <file src="lib/Listener/FlowTriggerListener.php">
     <UndefinedMethod>

--- a/tests/Unit/Db/MapperNamedArgumentContractTest.php
+++ b/tests/Unit/Db/MapperNamedArgumentContractTest.php
@@ -58,7 +58,7 @@ class MapperNamedArgumentContractTest extends TestCase
         }
 
         return $names;
-    }
+    }//end parameterNames()
 
     /**
      * TenantDeprovisionJob, TenantPurgeJob and TenantUsageSyncJob all call
@@ -74,9 +74,9 @@ class MapperNamedArgumentContractTest extends TestCase
             'filters',
             $this->parameterNames(OrganisationMapper::class, 'findAll'),
             'OrganisationMapper::findAll() must accept a $filters named argument; '
-            . 'three tenant-lifecycle background jobs already pass one.'
+            .'three tenant-lifecycle background jobs already pass one.'
         );
-    }
+    }//end testOrganisationMapperFindAllAcceptsFilters()
 
     /**
      * The three tenant jobs pass `filters:` as a named argument, so the
@@ -97,13 +97,13 @@ class MapperNamedArgumentContractTest extends TestCase
                 $parameter->isDefaultValueAvailable(),
                 sprintf(
                     'OrganisationMapper::findAll($%s) has no default, so '
-                    . 'findAll(filters: ...) — which three background jobs make — '
-                    . 'would raise ArgumentCountError.',
+                    .'findAll(filters: ...) — which three background jobs make — '
+                    .'would raise ArgumentCountError.',
                     $parameter->getName()
                 )
             );
         }
-    }
+    }//end testOrganisationMapperFindAllIsCallableWithOnlyFilters()
 
     /**
      * `SelectionListMapper::updateEntry()` forwarded to the inherited
@@ -132,7 +132,7 @@ class MapperNamedArgumentContractTest extends TestCase
             ->willReturn($entity);
 
         $this->assertSame($entity, $mapper->updateEntry($entity));
-    }
+    }//end testSelectionListMapperUpdateEntryForwardsWithAValidArgumentName()
 
     /**
      * Identical defect, identical shape, in DestructionListMapper.
@@ -154,7 +154,7 @@ class MapperNamedArgumentContractTest extends TestCase
             ->willReturn($entity);
 
         $this->assertSame($entity, $mapper->updateEntry($entity));
-    }
+    }//end testDestructionListMapperUpdateEntryForwardsWithAValidArgumentName()
 
     /**
      * The mechanical guard for the whole defect class.
@@ -191,11 +191,11 @@ class MapperNamedArgumentContractTest extends TestCase
         ];
 
         foreach ($cleaned as $shortName) {
-            $file = dirname(__DIR__, 3) . '/lib/Db/' . $shortName . '.php';
+            $file = dirname(__DIR__, 3).'/lib/Db/'.$shortName.'.php';
             $this->assertFileExists($file);
 
             $source = (string) file_get_contents($file);
-            $class  = 'OCA\\OpenRegister\\Db\\' . $shortName;
+            $class  = 'OCA\\OpenRegister\\Db\\'.$shortName;
 
             preg_match_all('/^ \* @method\s+\S+\s+(\w+)\(/m', $source, $annotated);
 
@@ -216,14 +216,14 @@ class MapperNamedArgumentContractTest extends TestCase
                     $native,
                     sprintf(
                         '%s carries "@method ... %s(...)" while also declaring %s() '
-                        . 'natively. The docblock silently overrides the real signature '
-                        . 'for phpstan and psalm — see openregister#2283.',
+                        .'natively. The docblock silently overrides the real signature '
+                        .'for phpstan and psalm — see openregister#2283.',
                         $shortName,
                         $name,
                         $name
                     )
                 );
             }
-        }
-    }
-}
+        }//end foreach
+    }//end testCleanedMappersDeclareNoShadowingMethodAnnotation()
+}//end class

--- a/tests/Unit/Db/MapperNamedArgumentContractTest.php
+++ b/tests/Unit/Db/MapperNamedArgumentContractTest.php
@@ -1,0 +1,229 @@
+<?php
+
+/**
+ * Regression tests for named-argument contracts on lib/Db mappers.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Db;
+
+use OCA\OpenRegister\Db\DestructionList;
+use OCA\OpenRegister\Db\DestructionListMapper;
+use OCA\OpenRegister\Db\OrganisationMapper;
+use OCA\OpenRegister\Db\SelectionList;
+use OCA\OpenRegister\Db\SelectionListMapper;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * A named argument that does not exist on the callee is a PHP 8 fatal
+ * (`Error: Unknown named parameter $x`) — and `\Error` is NOT an `\Exception`,
+ * so a `catch (\Exception)` around the call does not contain it.
+ *
+ * Four such calls shipped because phpstan's reports about them had been
+ * baselined alongside ~62 phantom reports of an identical shape, caused by
+ * stale class-level `@method` docblocks shadowing the real signature
+ * (see openregister#2283). These tests assert the CONSEQUENCE — that the call
+ * a caller actually makes is accepted by the callee — rather than any
+ * particular docblock text.
+ */
+class MapperNamedArgumentContractTest extends TestCase
+{
+    /**
+     * Return the parameter names of a method, in declaration order.
+     *
+     * @param string $class  Fully-qualified class name.
+     * @param string $method Method name.
+     *
+     * @return string[]
+     */
+    private function parameterNames(string $class, string $method): array
+    {
+        $names = [];
+        foreach ((new ReflectionMethod($class, $method))->getParameters() as $parameter) {
+            $names[] = $parameter->getName();
+        }
+
+        return $names;
+    }
+
+    /**
+     * TenantDeprovisionJob, TenantPurgeJob and TenantUsageSyncJob all call
+     * `organisationMapper->findAll(filters: ['status' => ...])`. Until the
+     * parameter existed, every run of all three jobs died on an uncaught
+     * `\Error` — their `catch (\Exception)` could not see it.
+     *
+     * @return void
+     */
+    public function testOrganisationMapperFindAllAcceptsFilters(): void
+    {
+        $this->assertContains(
+            'filters',
+            $this->parameterNames(OrganisationMapper::class, 'findAll'),
+            'OrganisationMapper::findAll() must accept a $filters named argument; '
+            . 'three tenant-lifecycle background jobs already pass one.'
+        );
+    }
+
+    /**
+     * The three tenant jobs pass `filters:` as a named argument, so the
+     * parameter must not merely exist — it must be reachable by that name
+     * without positionally supplying $limit/$offset first.
+     *
+     * @return void
+     */
+    public function testOrganisationMapperFindAllIsCallableWithOnlyFilters(): void
+    {
+        $reflection = new ReflectionMethod(OrganisationMapper::class, 'findAll');
+        foreach ($reflection->getParameters() as $parameter) {
+            if ($parameter->getName() === 'filters') {
+                continue;
+            }
+
+            $this->assertTrue(
+                $parameter->isDefaultValueAvailable(),
+                sprintf(
+                    'OrganisationMapper::findAll($%s) has no default, so '
+                    . 'findAll(filters: ...) — which three background jobs make — '
+                    . 'would raise ArgumentCountError.',
+                    $parameter->getName()
+                )
+            );
+        }
+    }
+
+    /**
+     * `SelectionListMapper::updateEntry()` forwarded to the inherited
+     * `QBMapper::update()` as `update(objectId: $entity)`. `QBMapper::update()`
+     * takes `$entity`, so the first ever call to `updateEntry()` would have
+     * raised `Error: Unknown named parameter $objectId`.
+     *
+     * This drives the real method body against a stub of `update()` whose
+     * signature PHPUnit copies from QBMapper — so the named argument is
+     * resolved for real. Before the fix this test fails with \Error.
+     *
+     * @return void
+     */
+    public function testSelectionListMapperUpdateEntryForwardsWithAValidArgumentName(): void
+    {
+        $entity = new SelectionList();
+
+        $mapper = $this->getMockBuilder(SelectionListMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['update'])
+            ->getMock();
+
+        $mapper->expects($this->once())
+            ->method('update')
+            ->with($this->identicalTo($entity))
+            ->willReturn($entity);
+
+        $this->assertSame($entity, $mapper->updateEntry($entity));
+    }
+
+    /**
+     * Identical defect, identical shape, in DestructionListMapper.
+     *
+     * @return void
+     */
+    public function testDestructionListMapperUpdateEntryForwardsWithAValidArgumentName(): void
+    {
+        $entity = new DestructionList();
+
+        $mapper = $this->getMockBuilder(DestructionListMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['update'])
+            ->getMock();
+
+        $mapper->expects($this->once())
+            ->method('update')
+            ->with($this->identicalTo($entity))
+            ->willReturn($entity);
+
+        $this->assertSame($entity, $mapper->updateEntry($entity));
+    }
+
+    /**
+     * The mechanical guard for the whole defect class.
+     *
+     * A class-level `@method` line that names a method the class ALSO declares
+     * natively overrides the real signature for phpstan and psalm, turning
+     * correct calls into phantom errors — and, worse, making a genuine
+     * unknown-named-argument fatal indistinguishable from that noise.
+     *
+     * Narrowing an INHERITED QBMapper method (insert/update/delete/findEntity/
+     * findEntities) is legitimate and is deliberately not caught here: those
+     * methods are not declared by the class itself.
+     *
+     * SCOPE: only the `find`/`findAll` shadows have been removed so far — those
+     * are the ones producing live findings. The same seven classes still shadow
+     * `insert`/`update`/`delete`, and 14 further mappers still shadow `findAll`.
+     * Both remainders are tracked in openregister#2283; widening the method list
+     * below is how that issue gets closed.
+     *
+     * @return void
+     */
+    public function testCleanedMappersDeclareNoShadowingMethodAnnotation(): void
+    {
+        $guarded = ['find', 'findAll'];
+
+        $cleaned = [
+            'ApplicationMapper',
+            'AuditTrailMapper',
+            'ConfigurationMapper',
+            'OrganisationMapper',
+            'SchemaMapper',
+            'SearchTrailMapper',
+            'ViewMapper',
+        ];
+
+        foreach ($cleaned as $shortName) {
+            $file = dirname(__DIR__, 3) . '/lib/Db/' . $shortName . '.php';
+            $this->assertFileExists($file);
+
+            $source = (string) file_get_contents($file);
+            $class  = 'OCA\\OpenRegister\\Db\\' . $shortName;
+
+            preg_match_all('/^ \* @method\s+\S+\s+(\w+)\(/m', $source, $annotated);
+
+            $native = [];
+            foreach ((new ReflectionClass($class))->getMethods() as $method) {
+                if ($method->getDeclaringClass()->getName() === $class) {
+                    $native[$method->getName()] = true;
+                }
+            }
+
+            foreach (array_unique($annotated[1]) as $name) {
+                if (in_array($name, $guarded, true) === false) {
+                    continue;
+                }
+
+                $this->assertArrayNotHasKey(
+                    $name,
+                    $native,
+                    sprintf(
+                        '%s carries "@method ... %s(...)" while also declaring %s() '
+                        . 'natively. The docblock silently overrides the real signature '
+                        . 'for phpstan and psalm — see openregister#2283.',
+                        $shortName,
+                        $name,
+                        $name
+                    )
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What this is

The tail of the `composer check:strict` measurement programme for openregister:
triage the phpmd block, and resolve the unexplained `SchemaMapper::findAll()`
phpstan finding.

Everything below was measured on `origin/development` @ `410da3dbd`, inside
**`nextcloud:32-apache` (PHP 8.3.32)** — which matches what CI pins
(`.github/workflows/code-quality.yml` → `php-version: "8.3"`). Host PHP is 8.2 and
too old; `nextcloud:34` is PHP 8.5, on which Psalm 5.26.1 crashes inside its own
`MethodCallAnalyzer`.

**Analysis-path verification** (an unverified count is worthless — a sibling repo
once measured 2672 phpstan errors of which 97.6% were an `unknown class OCP\*`
cascade from an empty stub directory):

```
string(6) "8.3.32"
bool(true)      # interface_exists('OCP\IRequest')
bool(true)      # class_exists('OCP\AppFramework\Db\QBMapper')
```
`vendor/nextcloud/ocp/OCP/` is populated (63 top-level stub files + subdirs, no
`OCP.bak/`). `php -m` includes **imagick** — its absence alone once shifted a psalm
count from 55 to 68.

---

## 1. phpmd — the brief said "312 over baseline, untriaged". It is **2**.

That premise is stale relative to `origin/development`. Commit `410da3dbd`
("honest baselines", #2276) is already merged and **added 187 phpmd baseline
entries**; the baseline now carries 517. A full run on today's `development`:

```
$ ./vendor/bin/phpmd lib text phpmd.xml --baseline-file phpmd.baseline.xml
lib/Service/Flow/Nodes/ObjectWriteNode.php:526  UnusedLocalVariable  Avoid unused local variables such as '$writes'.
lib/Service/Flow/Nodes/ObjectWriteNode.php:527  UnusedLocalVariable  Avoid unused local variables such as '$out'.
exit 2
```

That non-empty, exit-2 result is itself the positive control that phpmd parsed
`lib/` and *can* fail — it reached a file five directories deep.

**Contamination control.** That 16-minute run overlapped edits I was making to nine
`lib/Db` files, so it could in principle have read some of them post-edit. Re-running
phpmd over those nine files at their pristine `410da3dbd` content (`git archive` into a
clean tree) returns **exit 0, no findings** — the overlap masked nothing, and the count
of 2 stands.

**Triage: 2/2 = category (a) REAL, but they are dead code, not behaviour bugs.**
Said plainly rather than dressed up. `execute()` initialises `$writes`/`$out` and
then hands the entire loop to `writeItems()` inside `runAs()`; `writeItems()`
declares its own pair at lines 622-623. The originals were never read — leftovers
from the `runAs()` refactor. Removed.

- Nothing baselined. Nothing suppressed. **0 new baseline entries in this PR.**
- Control for "behaviour-neutral": phpmd on that file goes 2 → 0 (exit 0), and the
  91 existing ObjectWriteNode unit tests pass unchanged.

For the record on the 517 already-baselined entries: they are overwhelmingly
complexity/style — `CyclomaticComplexity` 97, `NpathComplexity` 62, `StaticAccess`
59, `ElseExpression` 56, `LongMethod` 33, `WeightedMethodCount` 32,
`CouplingBetweenObjects` 27. That is category (c) and it is the right outcome for
legacy code; this PR does not add to it.

---

## 1b. psalm — the brief said "55 (21 UnusedBaselineEntry, 6 UnusedParam)". Also stale.

A full psalm run on this branch reports **5 errors, all `UnusedBaselineEntry`** — and
they are exactly the five sites fixed in section 2, nothing else. There are **no**
`UnusedParam` errors and no other `UnusedBaselineEntry`. (`3744 other issues` are
INFO-level, below `errorLevel="4"`, as before.)

Since my changes can only *create* unused baseline entries, never remove them, and I
touched none of the files the brief's 21+6 would live in, `origin/development` itself
must already be at **0 psalm errors** — commit `410da3dbd` took the psalm baseline
287 → 215 and closed that block. *(Deduction, not a separate pristine run.)*

**This is the useful part:** psalm flagging those five entries as unused is
**independent, cross-tool confirmation that the four defects in section 2 were real
and are now gone.** phpstan is not the only tool that saw them.

`psalm --update-baseline` (tool-driven, not a hand edit) removed exactly those five
and no others. Pruning a stale entry makes the gate **stricter** — it can no longer
absorb a future regression at that site silently. The two remaining
`InvalidNamedArgument` entries (`ReportRenderJob`, `_rbac`/`_multitenancy` on
`MagicMapper::findAll`) still match, correctly: that defect is real and unfixed (#2282).

Final state of this branch: **psalm exit 0 · phpmd exit 0, zero findings on full `lib/`**.

---

## 2. The `SchemaMapper::findAll()` finding — resolved, and it was hiding four fatals

**Cause: a class-level `@method` docblock shadows the real signature.**

`lib/Db/SchemaMapper.php:88` declared

```
 * @method Schema[] findAll(int|null $limit=null, int|null $offset=null)
```

while the class declares `findAll()` with eight parameters at line 820. PHPStan and
Psalm both resolve **named arguments against the annotation, not the declaration**.
The earlier investigation looked for a `@method` override near line 827 and reported
"none found" — it is 740 lines above, in the class docblock.

**Positive control.** Deleting that one line, changing nothing else:

```
before: BackfillSystemOwnerCommand.php:237  Unknown parameter $_multitenancy ...
        BackfillSystemOwnerCommand.php:237  Unknown parameter $_rbac ...
after:  (both gone)
```

**Natural control in the same file.** Line 219 makes an identically-shaped call —
`registerMapper->findAll(_rbac: false, _multitenancy: false)` — and is *not* flagged.
`RegisterMapper` has no `@method findAll` line.

**Cross-tool corroboration.** Psalm reports the same calls as `InvalidNamedArgument`
(7 in `psalm-baseline.xml`), so this is not a phpstan quirk.

**Scale.** 123 `@method` lines across 34 files in `lib/Db/` name a method the same
class also declares natively. Note the correction to the brief: there are **80**
`Unknown parameter` entries in `phpstan-baseline.neon`, not 247.

### The part that matters

Exact split of the 80, since the whole point of this exercise is honest counting:

| | entries |
|---|---|
| on `OCA\OpenRegister\Db\*` mappers | **62** |
| &nbsp;&nbsp;— of which **phantom** (native signature *does* have the parameter) | **55** |
| &nbsp;&nbsp;— of which **real** (native signature does *not*) | **7**, across 4 defect sites |
| on `stdClass` | 14 — not classified here |
| on `OCA\OpenRegister\Service\ObjectService` | 4 — not classified here |

Those **4 defect sites are genuine PHP 8 fatals** — and because they looked exactly like the
55 phantoms, they were baselined alongside them. An unknown named
argument raises `\Error`, and `\Error` is **not** an `\Exception` (verified on PHP 8.3.32):

```
$ php -r 'function f(int $limit=50){} try { f(filters:[1]); } catch (\Exception $e) { echo "Exception\n"; } catch (\Throwable $t) { echo get_class($t),": ",$t->getMessage(),"\n"; }'
Error: Unknown named parameter $filters
```

| # | call site | callee | effect | this PR |
|---|---|---|---|---|
| 1 | `TenantDeprovisionJob:79`, `TenantPurgeJob:97`, `TenantUsageSyncJob:87` — `findAll(filters: ['status' => …])` | `OrganisationMapper::findAll(int $limit=50, int $offset=0)` — no `$filters` | uncaught `\Error`; their `catch (\Exception)` cannot see it. **All three tenant-lifecycle jobs died on every run.** | **fixed** — `findAll()` gains `$filters` with the fleet-standard filter loop |
| 2 | `SelectionListMapper:169` — `$this->update(objectId: $entity)` | inherited `QBMapper::update(Entity $entity)` | `updateEntry()` fatals on first call | **fixed** |
| 3 | `DestructionListMapper:174` — same | same | same | **fixed** |
| 4 | `ReportRenderJob:372` — `findAll(_rbac: false, _multitenancy: false)` | `MagicMapper::findAll(...)` — has neither | caught by `catch (\Throwable)` → `return []`. **Every scheduled report renders zero dashboards, silently.** Independently, no `register`/`schema` is passed and `MagicMapper::findAll()` early-returns `[]` without them. | **not fixed — #2282.** Needs a decision on the RBAC contract of the central object mapper; the job is not even constructed with a `SchemaMapper`. |

The discriminator between phantom and real is one question — *does the **native**
signature have the parameter?* Nothing in the baseline recorded that answer, which is
precisely why 80 entries of two very different kinds sat together.

### Also in this PR

- Removes the `find`/`findAll` shadows from the seven mappers with live findings
  (`SchemaMapper`, `AuditTrailMapper`, `SearchTrailMapper`, `ViewMapper`,
  `ConfigurationMapper`, `ApplicationMapper`, `OrganisationMapper`).
- Fixes the seven `@psalm-return list<OCA\OpenRegister\Db\X>` FQCNs those shadows were
  hiding: written without a leading backslash inside namespace `OCA\OpenRegister\Db`,
  they resolve to `OCA\OpenRegister\Db\OCA\OpenRegister\Db\X`. The correct form is
  already used a few lines away (`OrganisationMapper::findByName`).

### Tests

`tests/Unit/Db/MapperNamedArgumentContractTest.php` — 5 tests, 15 assertions, green.
They assert the **consequence** (the call a caller actually makes is accepted by the
callee), not any docblock text. The two `updateEntry()` tests drive the real method
body against a signature-preserving stub.

**Negative control, run for real:** reverting the `SelectionListMapper` fix makes that
test fail with `Error: Unknown named parameter $objectId` at
`lib/Db/SelectionListMapper.php:169`. It is not a test that passes either way.

The fifth test is the mechanical guard for the whole defect class, scoped to
`find`/`findAll` on the seven cleaned mappers.

### Whole-branch verification (not just the files I touched)

| check | result |
|---|---|
| `phpunit --testsuite="Unit Tests"` | **15785 tests, 35444 assertions — 0 failures, 0 errors** |
| `phpmd lib --baseline-file phpmd.baseline.xml` | **exit 0, zero findings** (was exit 2, two findings) |
| `psalm --threads=1 --no-cache` | **exit 0** |
| `phpstan analyse` | **exit 0, "No errors"** |
| `phpcs --standard=phpcs.xml` on all 10 changed `lib/` files | **0 errors** |

`phpcs.xml` scopes to `<file>lib</file>`, so `tests/` sits outside the gate; the new test
was still run through `phpcbf` for house style (17 auto-fixes). The 11 remaining are the
repo's custom `NamedParametersSniff` asking for named arguments on PHPUnit assertion
calls — out of gate scope, and left alone deliberately.

---

## What is NOT done

- **#2282** — `ReportRenderJob`. Real, live, silent. Needs an RBAC decision, not a patch.
- **#2283** — 14 mappers still carry a latent `@method … findAll(…)` shadow, the seven
  cleaned here still shadow `insert`/`update`/`delete`, and five malformed
  `@psalm-return` remain. Widening the guarded-method list in the new test is how that
  issue closes.
- `phpstan-baseline.neon` still contains the ~62 phantom entries this PR makes
  unmatched. `reportUnmatchedIgnoredErrors: false` tolerates them, so nothing breaks,
  but they should be regenerated. Deliberately left to a separate change so this PR's
  diff stays readable — a 338 KB baseline regeneration would bury everything above.
- Removing the shadows surfaces **5** new phpstan findings (I first reported 2 — CI
  corrected me). All five are the same thing, and it is *not* the results type: the
  controllers declare `JSONResponse<…, array<never, never>>` headers while the constructor
  produces `array{}`, and those template parameters are **invariant**, so phpstan rejects
  pairs that are textually identical apart from `array` vs `array{}`.
  I tried the obvious fix and **measured that it made things worse** — widening
  `array<X>` → `array<int, X>` in the five docblocks took it from 5 errors to 8, by also
  exposing the 500-branch returns. Reverted.
  Baselined in a **dedicated file**, `phpstan-baseline-jsonresponse-invariance.neon`, with
  the full reasoning at the top of it, and filed as **#2288**. Category (c).
  **Verified narrow rather than assumed narrow:** inserting a call to a nonexistent method
  into `ApplicationsController::index()` — one of the five baselined methods — still yields
  `Call to an undefined method …thisMethodDoesNotExistAtAll()`. Probe reverted, file
  byte-identical.

## Not merged

Opened only. A concurrent agent is merging across the fleet; do not batch this one in
without reading section 2.

Refs #2282, #2283
