### PR TITLE
feat(sharing): share links and email invitations, redeemed on a public endpoint

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -81,6 +81,14 @@ return [
         ['name' => 'objectSharing#shares',       'url' => '/api/objects/{register}/{schema}/{id}/shares',           'verb' => 'GET',    'requirements' => ['register' => '[^/]+', 'schema' => '[^/]+', 'id' => '[^/]+']],
         ['name' => 'objectSharing#createShare',  'url' => '/api/objects/{register}/{schema}/{id}/shares',           'verb' => 'POST',   'requirements' => ['register' => '[^/]+', 'schema' => '[^/]+', 'id' => '[^/]+']],
         ['name' => 'objectSharing#destroyShare', 'url' => '/api/objects/{register}/{schema}/{id}/shares/{shareId}', 'verb' => 'DELETE', 'requirements' => ['register' => '[^/]+', 'schema' => '[^/]+', 'id' => '[^/]+', 'shareId' => '[^/]+']],
+        ['name' => 'objectSharing#createLink',   'url' => '/api/objects/{register}/{schema}/{id}/links',            'verb' => 'POST',   'requirements' => ['register' => '[^/]+', 'schema' => '[^/]+', 'id' => '[^/]+']],
+        ['name' => 'objectSharing#inviteByEmail','url' => '/api/objects/{register}/{schema}/{id}/invitations',      'verb' => 'POST',   'requirements' => ['register' => '[^/]+', 'schema' => '[^/]+', 'id' => '[^/]+']],
+
+        // PUBLIC. A share token is a bearer capability: nobody is logged in, so
+        // there is no principal for RBAC to resolve and core's validation of the
+        // token IS the authorization. Read-only, addresses exactly one object,
+        // and deliberately offers no listing — see ObjectShareLinkController.
+        ['name' => 'objectShareLink#show', 'url' => '/api/shared/{token}', 'verb' => 'GET', 'requirements' => ['token' => '[^/]+']],
 
         // PATCH routes for resources (partial updates).
         ['name' => 'registers#patch', 'url' => '/api/registers/{id}', 'verb' => 'PATCH', 'requirements' => ['id' => '[^/]+']],

--- a/lib/Controller/ObjectShareLinkController.php
+++ b/lib/Controller/ObjectShareLinkController.php
@@ -1,0 +1,256 @@
+<?php
+
+/**
+ * Public entry point for an object share LINK or EMAIL invitation.
+ *
+ * A link is a CAPABILITY, not a principal grant. Nobody is logged in, so there
+ * is no principal for RBAC to resolve — the TOKEN is the authorization, and core
+ * is what validates it. That is exactly why link and email types are absent from
+ * {@see \OCA\OpenRegister\Service\Rbac\ObjectGrantResolver}'s principal list:
+ * they are decided here instead of in the RBAC filter.
+ *
+ * WHAT MAKES THIS SAFE. Every check below is core's, not a reimplementation:
+ *
+ *  1. `getShareByToken()` resolves ONLY a live share. A revoked one is gone and
+ *     an expired one is refused, so revocation and expiry take effect on the
+ *     next request with nothing for OpenRegister to invalidate.
+ *  2. A password-protected share is refused until core says the supplied
+ *     password matches — we never compare it ourselves.
+ *  3. The share must be a LINK or EMAIL type on a FOLDER whose name is the
+ *     object's UUID. A share of anything else grants no object.
+ *  4. The object is then loaded with RBAC OFF, because there is no principal to
+ *     check it against and the token has already answered the question. This is
+ *     the one place in this capability that bypasses the filter, and it is
+ *     reachable only with a live token that core just validated.
+ *
+ * WHAT IT DELIBERATELY DOES NOT DO. It does not write, and it does not enumerate:
+ * a token addresses exactly one object, and there is no listing endpoint here. A
+ * link that carries write permission still cannot write through this controller.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/object-level-sharing-and-private-scope/specs/share-links-and-email-invites/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Resolves an object share token to the one object it addresses.
+ */
+class ObjectShareLinkController extends Controller
+{
+
+    /**
+     * Share types this endpoint will honour.
+     *
+     * Only the two bearer-capability types. A USER or GROUP share names a
+     * principal and is decided by the RBAC filter for a logged-in caller; it
+     * must not also be redeemable as an anonymous token.
+     *
+     * @var int[]
+     */
+    private const TOKEN_SHARE_TYPES = [
+        IShare::TYPE_LINK,
+        IShare::TYPE_EMAIL,
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param string          $appName       App name.
+     * @param IRequest        $request       Request.
+     * @param IManager        $shareManager  Core share manager — validates the token.
+     * @param ObjectService   $objectService Loads the addressed object.
+     * @param LoggerInterface $logger        Logger.
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly IManager $shareManager,
+        private readonly ObjectService $objectService,
+        private readonly LoggerInterface $logger
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * Resolve a share token to its object.
+     *
+     * @param string $token The share token.
+     *
+     * @return JSONResponse The object, or a refusal.
+     */
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function show(string $token): JSONResponse
+    {
+        $share = $this->resolveLiveShare(token: $token);
+        if ($share === null) {
+            // One shape for every refusal — invalid, revoked, expired, wrong
+            // type, wrong password. Distinguishing them would turn this into an
+            // oracle for which tokens exist.
+            return $this->refused();
+        }
+
+        $uuid = $this->objectUuidOf(share: $share);
+        if ($uuid === null) {
+            return $this->refused();
+        }
+
+        try {
+            // RBAC off: there is no principal to evaluate, and the token that
+            // core just validated IS the authorization. Multitenancy off for the
+            // same reason — an anonymous caller belongs to no organisation.
+            $object = $this->objectService->find(
+                id: $uuid,
+                _rbac: false,
+                _multitenancy: false
+            );
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                message: '[ObjectShareLink] Could not load the object a live token addressed',
+                context: ['file' => __FILE__, 'line' => __LINE__, 'error' => $e->getMessage()]
+            );
+            return $this->refused();
+        }
+
+        if ($object === null) {
+            return $this->refused();
+        }
+
+        return new JSONResponse(
+            [
+                'object'      => $object->jsonSerialize(),
+                'permissions' => $share->getPermissions(),
+            ]
+        );
+    }//end show()
+
+    /**
+     * Resolve a token to a live, permitted share, or null.
+     *
+     * @param string $token The share token.
+     *
+     * @return IShare|null The share, or null when it must not be honoured.
+     */
+    private function resolveLiveShare(string $token): ?IShare
+    {
+        if (trim($token) === '') {
+            return null;
+        }
+
+        try {
+            // Throws for an unknown token, and for one whose share has expired
+            // or been revoked — so expiry and revocation need no handling here.
+            $share = $this->shareManager->getShareByToken($token);
+        } catch (Throwable $e) {
+            return null;
+        }
+
+        if (in_array($share->getShareType(), self::TOKEN_SHARE_TYPES, true) === false) {
+            return null;
+        }
+
+        if ($this->passwordSatisfied(share: $share) === false) {
+            return null;
+        }
+
+        return $share;
+    }//end resolveLiveShare()
+
+    /**
+     * Whether a password-protected share has been unlocked.
+     *
+     * The comparison is core's `checkPassword()`, never a local one — it is what
+     * knows the hashing scheme and applies the brute-force protection.
+     *
+     * @param IShare $share The share.
+     *
+     * @return bool True when the share needs no password, or the supplied one matches.
+     */
+    private function passwordSatisfied(IShare $share): bool
+    {
+        if ($share->getPassword() === null) {
+            return true;
+        }
+
+        $supplied = $this->request->getParam('password');
+        if (is_string($supplied) === false || $supplied === '') {
+            return false;
+        }
+
+        try {
+            return $this->shareManager->checkPassword($share, $supplied);
+        } catch (Throwable $e) {
+            return false;
+        }
+    }//end passwordSatisfied()
+
+    /**
+     * The object UUID a share addresses, or null when it addresses none.
+     *
+     * An object's folder is named after its UUID. A share of a FILE inside that
+     * folder is a file share and grants no object — the same rule the grant
+     * resolver applies, kept identical here on purpose.
+     *
+     * @param IShare $share The share.
+     *
+     * @return string|null The object UUID.
+     */
+    private function objectUuidOf(IShare $share): ?string
+    {
+        try {
+            if ($share->getNodeType() !== 'folder') {
+                return null;
+            }
+
+            $name = $share->getNode()->getName();
+        } catch (Throwable $e) {
+            return null;
+        }
+
+        $uuidPattern = '/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/';
+        if ($name === '' || preg_match($uuidPattern, $name) !== 1) {
+            return null;
+        }
+
+        return $name;
+    }//end objectUuidOf()
+
+    /**
+     * The single refusal shape.
+     *
+     * @return JSONResponse A 404.
+     */
+    private function refused(): JSONResponse
+    {
+        return new JSONResponse(
+            ['message' => 'No such share'],
+            Http::STATUS_NOT_FOUND
+        );
+    }//end refused()
+}//end class

--- a/lib/Controller/ObjectSharingController.php
+++ b/lib/Controller/ObjectSharingController.php
@@ -232,6 +232,116 @@ class ObjectSharingController extends Controller
     }//end createShare()
 
     /**
+     * Create a tokenised link to an object.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object uuid.
+     *
+     * @return JSONResponse The created link, or an error.
+     *
+     * @NoAdminRequired
+     */
+    #[NoAdminRequired]
+    public function createLink(string $register, string $schema, string $id): JSONResponse
+    {
+        $object = $this->resolveObject(register: $register, schema: $schema, id: $id);
+        if ($object instanceof JSONResponse) {
+            return $object;
+        }
+
+        try {
+            $link = $this->sharing->createLink(
+                object: $object,
+                permissions: $this->requestedPermissions(),
+                password: $this->optionalParam(name: 'password'),
+                expiration: $this->optionalParam(name: 'expiration')
+            );
+        } catch (NotAuthorizedException $e) {
+            return new JSONResponse(['message' => $e->getMessage()], Http::STATUS_FORBIDDEN);
+        } catch (\InvalidArgumentException $e) {
+            return new JSONResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+        } catch (\Throwable $e) {
+            return $this->unexpected(exception: $e, context: 'createLink');
+        }
+
+        return new JSONResponse($link, Http::STATUS_CREATED);
+    }//end createLink()
+
+    /**
+     * Invite an email address to an object.
+     *
+     * @param string $register Register slug or id.
+     * @param string $schema   Schema slug or id.
+     * @param string $id       Object uuid.
+     *
+     * @return JSONResponse The created invitation, or an error.
+     *
+     * @NoAdminRequired
+     */
+    #[NoAdminRequired]
+    public function inviteByEmail(string $register, string $schema, string $id): JSONResponse
+    {
+        $object = $this->resolveObject(register: $register, schema: $schema, id: $id);
+        if ($object instanceof JSONResponse) {
+            return $object;
+        }
+
+        try {
+            $invite = $this->sharing->inviteByEmail(
+                object: $object,
+                email: (string) ($this->request->getParam('email') ?? ''),
+                permissions: $this->requestedPermissions(),
+                password: $this->optionalParam(name: 'password'),
+                expiration: $this->optionalParam(name: 'expiration')
+            );
+        } catch (NotAuthorizedException $e) {
+            return new JSONResponse(['message' => $e->getMessage()], Http::STATUS_FORBIDDEN);
+        } catch (\InvalidArgumentException $e) {
+            return new JSONResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+        } catch (\Throwable $e) {
+            return $this->unexpected(exception: $e, context: 'inviteByEmail');
+        }
+
+        return new JSONResponse($invite, Http::STATUS_CREATED);
+    }//end inviteByEmail()
+
+    /**
+     * The requested permission bitmask, defaulting to READ.
+     *
+     * Defaulting to read is the safe direction: a link that silently carried
+     * write because the caller omitted a field would be the wrong surprise.
+     *
+     * @return integer The bitmask.
+     */
+    private function requestedPermissions(): int
+    {
+        $requested = $this->request->getParam('permissions');
+        if (is_numeric($requested) === true) {
+            return (int) $requested;
+        }
+
+        return 1;
+    }//end requestedPermissions()
+
+    /**
+     * A request parameter, or null when it is absent or blank.
+     *
+     * @param string $name The parameter name.
+     *
+     * @return string|null The value.
+     */
+    private function optionalParam(string $name): ?string
+    {
+        $value = $this->request->getParam($name);
+        if (is_string($value) === false || trim($value) === '') {
+            return null;
+        }
+
+        return $value;
+    }//end optionalParam()
+
+    /**
      * Revoke one grant.
      *
      * @param string $register Register slug or id.

--- a/lib/Service/Rbac/ObjectSharingService.php
+++ b/lib/Service/Rbac/ObjectSharingService.php
@@ -46,6 +46,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Service\Rbac;
 
+use DateTime;
 use InvalidArgumentException;
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
@@ -284,6 +285,192 @@ class ObjectSharingService
             'permissions' => $created->getPermissions(),
         ];
     }//end grant()
+
+    /**
+     * Create a tokenised LINK to an object, optionally expiring and passworded.
+     *
+     * A link is a CAPABILITY, not a principal grant: it admits whoever presents
+     * the token, so it is deliberately absent from
+     * {@see ObjectGrantResolver::PRINCIPAL_SHARE_TYPES} and is never resolved by
+     * the RBAC filter. It is decided on the public entry point instead, from the
+     * token itself.
+     *
+     * That distinction is what reconciles this with ADR-006 (design Q4): the ADR
+     * says publication is a schema-level RBAC change and not a per-object data
+     * flag, and a revocable, expiring, core-issued bearer token is neither of
+     * those things.
+     *
+     * Everything about the token's lifecycle — generation, expiry enforcement,
+     * password hashing, revocation — stays core's.
+     *
+     * @param ObjectEntity $object      The object to link.
+     * @param integer      $permissions Core permission bitmask; defaults to READ.
+     * @param string|null  $password    Optional password.
+     * @param string|null  $expiration  Optional expiry, any format DateTime parses.
+     *
+     * @throws NotAuthorizedException When the caller is neither owner nor admin.
+     * @throws InvalidArgumentException On an unresolvable folder or a bad expiry.
+     *
+     * @return array<string, mixed> The created link, including its token.
+     */
+    public function createLink(
+        ObjectEntity $object,
+        int $permissions=1,
+        ?string $password=null,
+        ?string $expiration=null
+    ): array {
+        $share = $this->newFolderShare(
+            object: $object,
+            shareType: IShare::TYPE_LINK,
+            shareWith: null,
+            permissions: $permissions
+        );
+
+        $this->applyLinkOptions(share: $share, password: $password, expiration: $expiration);
+
+        $created = $this->shareManager->createShare($share);
+
+        return [
+            'id'          => $created->getFullId(),
+            'type'        => 'link',
+            'token'       => $created->getToken(),
+            'permissions' => $created->getPermissions(),
+            'expiration'  => $created->getExpirationDate()?->format('c'),
+            'hasPassword' => ($created->getPassword() !== null),
+        ];
+    }//end createLink()
+
+    /**
+     * Invite an EMAIL ADDRESS to an object.
+     *
+     * `TYPE_EMAIL` is core's account-less link addressed to an address — the
+     * Files behaviour, chosen deliberately (design Q2), because requiring the
+     * recipient to already have an account defeats inviting a colleague who does
+     * not have one.
+     *
+     * The message carries no object data: the recipient follows the invitation to
+     * reach the object, so revoking it still works after the mail has been sent.
+     * Delivery is core's mailer, not ours.
+     *
+     * @param ObjectEntity $object      The object to share.
+     * @param string       $email       The address to invite.
+     * @param integer      $permissions Core permission bitmask; defaults to READ.
+     * @param string|null  $password    Optional password.
+     * @param string|null  $expiration  Optional expiry.
+     *
+     * @throws NotAuthorizedException When the caller is neither owner nor admin.
+     * @throws InvalidArgumentException On a missing address or unresolvable folder.
+     *
+     * @return array<string, mixed> The created invitation.
+     */
+    public function inviteByEmail(
+        ObjectEntity $object,
+        string $email,
+        int $permissions=1,
+        ?string $password=null,
+        ?string $expiration=null
+    ): array {
+        if (filter_var(trim($email), FILTER_VALIDATE_EMAIL) === false) {
+            throw new InvalidArgumentException('A valid email address is required');
+        }
+
+        $share = $this->newFolderShare(
+            object: $object,
+            shareType: IShare::TYPE_EMAIL,
+            shareWith: trim($email),
+            permissions: $permissions
+        );
+
+        $this->applyLinkOptions(share: $share, password: $password, expiration: $expiration);
+
+        $created = $this->shareManager->createShare($share);
+
+        return [
+            'id'          => $created->getFullId(),
+            'type'        => 'email',
+            'sharedWith'  => $created->getSharedWith(),
+            'token'       => $created->getToken(),
+            'permissions' => $created->getPermissions(),
+            'expiration'  => $created->getExpirationDate()?->format('c'),
+        ];
+    }//end inviteByEmail()
+
+    /**
+     * Build an owner-checked share on the object's folder.
+     *
+     * @param ObjectEntity $object      The object.
+     * @param integer      $shareType   Core share type.
+     * @param string|null  $shareWith   Principal or address, or null for a link.
+     * @param integer      $permissions Core permission bitmask.
+     *
+     * @throws NotAuthorizedException When the caller is neither owner nor admin.
+     * @throws InvalidArgumentException When the folder cannot be resolved.
+     *
+     * @return IShare The unsaved share.
+     */
+    private function newFolderShare(
+        ObjectEntity $object,
+        int $shareType,
+        ?string $shareWith,
+        int $permissions
+    ): IShare {
+        $this->requireOwnerOrAdmin(object: $object);
+
+        $folder = $this->resolveFolder(object: $object);
+        if ($folder === null) {
+            throw new InvalidArgumentException('Could not resolve the object folder to share');
+        }
+
+        $uid = $this->callerUid();
+        if ($uid === null) {
+            throw new NotAuthorizedException(message: 'No user session');
+        }
+
+        $share = $this->shareManager->newShare();
+        $share->setNode($folder);
+        $share->setShareType($shareType);
+        $share->setSharedBy($uid);
+
+        // A share must never exceed what the sharer holds. The owner-or-admin
+        // check above establishes the sharer can reach the object at all; core
+        // additionally clamps against the node's own permissions when the share
+        // is created, so a wider request cannot become a wider share.
+        $share->setPermissions($permissions);
+
+        if ($shareWith !== null) {
+            $share->setSharedWith($shareWith);
+        }
+
+        return $share;
+    }//end newFolderShare()
+
+    /**
+     * Apply the optional password and expiry to a link-style share.
+     *
+     * @param IShare      $share      The share being built.
+     * @param string|null $password   Optional password.
+     * @param string|null $expiration Optional expiry.
+     *
+     * @throws InvalidArgumentException When the expiry cannot be parsed.
+     *
+     * @return void
+     */
+    private function applyLinkOptions(IShare $share, ?string $password, ?string $expiration): void
+    {
+        if ($password !== null && trim($password) !== '') {
+            $share->setPassword($password);
+        }
+
+        if ($expiration === null || trim($expiration) === '') {
+            return;
+        }
+
+        try {
+            $share->setExpirationDate(new DateTime($expiration));
+        } catch (Throwable $e) {
+            throw new InvalidArgumentException('Could not read that expiry date');
+        }
+    }//end applyLinkOptions()
 
     /**
      * Revoke one grant.

--- a/openspec/changes/object-level-sharing-and-private-scope/tasks.md
+++ b/openspec/changes/object-level-sharing-and-private-scope/tasks.md
@@ -135,15 +135,21 @@
 
 ## 5. The share provider surface (core owns the record)
 
-- [ ] 5.1 Share the object's FOLDER through `OCP\Share\IManager` — no provider registration (Q1). Reuse `ShareLinkService`'s folder-resolve and six-type walk for the read half
-- [ ] 5.2 Read share records THROUGH at decision time; keep NO OpenRegister-side copy (design D2 — `ShareLinkService` documents why a snapshot desyncs)
-- [ ] 5.3 Resolve the caller's principal set once per REQUEST and pass it to the emitters, rather than per row
-- [ ] 5.4 Link shares: token, expiry, password, revocation — all core's mechanics
+- [x] 5.1 Share the object's FOLDER through `OCP\Share\IManager` — no provider registration (Q1)
+- [x] 5.2 Read share records THROUGH at decision time; keep NO OpenRegister-side copy (design D2)
+- [x] 5.3 Resolve the caller's principal set once per REQUEST and pass it to the emitters
+- [x] 5.4 Link shares: token, expiry, password, revocation — all core's mechanics, redeemed on a
+      PUBLIC endpoint because a link admits whoever holds the token and there is no principal
+      for RBAC to resolve
 - [ ] 5.8 Carry object verbs (`run`, `use`) in `IShare`'s `IAttributes`; core's bitmask has no such verbs
 - [ ] 5.9 Make the file coupling explicit in the UI: a grant on the folder also reaches the files in it
-- [ ] 5.5 Email invitations through core's mailer; the message carries no object data, so revocation still works after delivery
-- [ ] 5.6 A share never exceeds the sharer's own access
-- [ ] 5.7 Verify a share revoked or expired in core takes effect immediately in OpenRegister
+- [x] 5.5 Email invitations through core's mailer (`TYPE_EMAIL`); the message carries no object
+      data, so revocation still works after delivery
+- [x] 5.6 A share never exceeds the sharer's own access — owner-or-admin is required to create
+      one, and core clamps the permission against the node
+- [x] 5.7 A share revoked or expired in core takes effect on the NEXT request, with nothing for
+      OpenRegister to invalidate — both are checks inside `getShareByToken()`. Tested, with the
+      control: neutering the revoke makes the test fail
 
 ## 6. nc-vue: one component, two surfaces
 

--- a/tests/Db/ObjectShareLinkIntegrationTest.php
+++ b/tests/Db/ObjectShareLinkIntegrationTest.php
@@ -1,0 +1,467 @@
+<?php
+
+/**
+ * Live-database tests for the object share LINK and EMAIL surface.
+ *
+ * A link is a bearer CAPABILITY, so it is decided in a different place from
+ * every other part of this capability: not in the RBAC filter, but on a public
+ * endpoint, from the token. That makes three properties worth proving against a
+ * real database and a real share manager rather than a mock.
+ *
+ *  1. A live token resolves to its object even though the caller is ANONYMOUS
+ *     and the object is PRIVATE. That is the whole point, and it is also the one
+ *     path in this capability that bypasses the RBAC filter.
+ *  2. Revocation and expiry take effect on the NEXT request, with nothing for
+ *     OpenRegister to invalidate — because both are core's checks, inside
+ *     `getShareByToken()`.
+ *  3. A token must not be a general-purpose key: a USER share's token must not
+ *     be redeemable anonymously, and a link must not turn a private object into
+ *     a listable one for other logged-in users.
+ *
+ * The tests drive the SERVICE and the CONTROLLER, not hand-built shares, so a
+ * broken owner-check or a wrong share type cannot pass unnoticed.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/object-level-sharing-and-private-scope/specs/share-links-and-email-invites/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Db;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Rbac\ObjectSharingService;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\Share\IManager;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @group DB
+ */
+class ObjectShareLinkIntegrationTest extends TestCase
+{
+
+    private MagicMapper $mapper;
+
+    private RegisterMapper $registerMapper;
+
+    private SchemaMapper $schemaMapper;
+
+    private IUserSession $userSession;
+
+    private IUserManager $userManager;
+
+    private IDBConnection $db;
+
+    private ?IUser $ownerUser = null;
+
+    private string $ownerUid = '';
+
+    /**
+     * @var int[]
+     */
+    private array $createdSchemaIds = [];
+
+    /**
+     * @var int[]
+     */
+    private array $createdRegisterIds = [];
+
+    /**
+     * @var string[]
+     */
+    private array $createdTables = [];
+
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mapper         = \OC::$server->get(MagicMapper::class);
+        $this->registerMapper = \OC::$server->get(RegisterMapper::class);
+        $this->schemaMapper   = \OC::$server->get(SchemaMapper::class);
+        $this->userSession    = \OC::$server->get(IUserSession::class);
+        $this->userManager    = \OC::$server->get(IUserManager::class);
+        $this->db             = \OC::$server->get(IDBConnection::class);
+
+        $suffix         = substr((string) Uuid::v4(), 0, 8);
+        $this->ownerUid = 'link-owner-'.$suffix;
+
+        $this->ownerUser = $this->userManager->createUser($this->ownerUid, 'Link-Test-Pass-123');
+        if ($this->ownerUser === false || $this->ownerUser === null) {
+            $this->markTestSkipped('could not create the owner user');
+        }
+
+        $this->userSession->setUser($this->ownerUser);
+    }//end setUp()
+
+
+    protected function tearDown(): void
+    {
+        $this->userSession->setUser(null);
+
+        if ($this->ownerUser !== null) {
+            $this->ownerUser->delete();
+        }
+
+        foreach ($this->createdTables as $tableName) {
+            try {
+                $this->db->prepare("DROP TABLE IF EXISTS $tableName")->execute();
+            } catch (\Exception $e) {
+                // Already gone.
+            }
+        }
+
+        foreach ([['openregister_schemas', $this->createdSchemaIds], ['openregister_registers', $this->createdRegisterIds]] as [$table, $ids]) {
+            foreach ($ids as $id) {
+                try {
+                    $qb = $this->db->getQueryBuilder();
+                    $qb->delete($table)
+                        ->where($qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+                    $qb->executeStatement();
+                } catch (\Exception $e) {
+                    // Already gone.
+                }
+            }
+        }
+
+        parent::tearDown();
+    }//end tearDown()
+
+
+    /**
+     * A live link token resolves a PRIVATE object for an ANONYMOUS caller.
+     *
+     * This is the capability working: no session, no principal, and the object
+     * is invisible to every logged-in user who is not its owner — yet the token
+     * reaches it, because the token is the authorization.
+     */
+    public function testALiveTokenResolvesAPrivateObjectAnonymously(): void
+    {
+        [$register, $schema, $object] = $this->privateObject('linked');
+
+        $link = $this->sharing()->createLink(object: $object, permissions: 1);
+        $this->assertNotEmpty($link['token'], 'core issued no token');
+
+        // Anonymous: no session at all.
+        $this->userSession->setUser(null);
+
+        $resolved = $this->resolveToken($link['token']);
+        $this->assertNotNull($resolved, 'a live token must resolve its object');
+        $this->assertSame($object->getUuid(), $resolved['uuid']);
+    }//end testALiveTokenResolvesAPrivateObjectAnonymously()
+
+
+    /**
+     * A REVOKED link stops resolving on the next request.
+     *
+     * Nothing in OpenRegister is invalidated — `getShareByToken()` simply no
+     * longer finds it. That is the read-through design (D2) paying off.
+     */
+    public function testARevokedLinkStopsResolving(): void
+    {
+        [$register, $schema, $object] = $this->privateObject('revocable');
+
+        $link = $this->sharing()->createLink(object: $object, permissions: 1);
+        $this->userSession->setUser(null);
+        $this->assertNotNull($this->resolveToken($link['token']), 'granted first');
+
+        $this->userSession->setUser($this->ownerUser);
+        $this->sharing()->revoke(object: $object, shareId: (string) $link['id']);
+        $this->userSession->setUser(null);
+
+        $this->assertNull(
+            $this->resolveToken($link['token']),
+            'a revoked link must stop resolving immediately'
+        );
+    }//end testARevokedLinkStopsResolving()
+
+
+    /**
+     * An EXPIRED link stops resolving.
+     *
+     * The expiry is set in the past directly, because core refuses to create a
+     * share that is already expired — the point under test is what happens once
+     * the date has passed, not whether core validates the input.
+     */
+    public function testAnExpiredLinkStopsResolving(): void
+    {
+        [$register, $schema, $object] = $this->privateObject('expiring');
+
+        $link = $this->sharing()->createLink(
+            object: $object,
+            permissions: 1,
+            expiration: (new \DateTime('+7 days'))->format('Y-m-d')
+        );
+
+        $this->userSession->setUser(null);
+        $this->assertNotNull($this->resolveToken($link['token']), 'valid while unexpired');
+
+        $this->expireShare(token: $link['token']);
+
+        $this->assertNull(
+            $this->resolveToken($link['token']),
+            'an expired link must stop resolving'
+        );
+    }//end testAnExpiredLinkStopsResolving()
+
+
+    /**
+     * A principal grant carries NO token, and the endpoint would refuse one anyway.
+     *
+     * The first version of this test tried to redeem a USER share's token
+     * anonymously and "passed" — because a USER share has no token at all, so it
+     * hit an early return and counted an assertion that proved nothing. Measured
+     * on this instance: `share_type = 0` rows all have a null token, while
+     * `share_type = 3` (link) has one.
+     *
+     * So the honest statement is two-part: today a principal grant cannot be
+     * redeemed as a bearer token because it HAS none, and the endpoint's type
+     * guard is defence-in-depth for the day a principal type starts carrying
+     * one. Both halves are asserted rather than implied.
+     */
+    public function testAPrincipalGrantCarriesNoTokenAndTheTypeGuardExists(): void
+    {
+        [$register, $schema, $object] = $this->privateObject('principalonly');
+
+        $recipientUid = 'link-recipient-'.substr((string) Uuid::v4(), 0, 8);
+        $recipient    = $this->userManager->createUser($recipientUid, 'Link-Test-Pass-123');
+
+        try {
+            $grant = $this->sharing()->grant(
+                object: $object,
+                type: 'user',
+                shareWith: $recipientUid,
+                permissions: 1
+            );
+
+            $share = \OC::$server->get(IManager::class)->getShareById((string) $grant['id']);
+
+            $this->assertEmpty(
+                (string) $share->getToken(),
+                'a USER share is expected to carry no token; if this fails the type guard below is the only defence'
+            );
+
+            // The guard itself: the public endpoint honours ONLY the two bearer
+            // types, so a principal share could not be redeemed even with a token.
+            $this->assertNotContains(
+                $share->getShareType(),
+                [\OCP\Share\IShare::TYPE_LINK, \OCP\Share\IShare::TYPE_EMAIL],
+                'a USER share must not be one of the types the public endpoint honours'
+            );
+        } finally {
+            $this->userSession->setUser($this->ownerUser);
+            if ($recipient !== false && $recipient !== null) {
+                $recipient->delete();
+            }
+        }
+    }//end testAPrincipalGrantCarriesNoTokenAndTheTypeGuardExists()
+
+
+    /**
+     * A link does NOT make the object listable for other logged-in users.
+     *
+     * A link is a capability for whoever holds the token, not a change of the
+     * object's scope. If creating one also widened the RBAC verdict it would be
+     * per-object publication by the back door — exactly what ADR-006 guards
+     * against, and the distinction design Q4 turns on.
+     */
+    public function testALinkDoesNotMakeTheObjectListableForOthers(): void
+    {
+        [$register, $schema, $object] = $this->privateObject('stillprivate');
+
+        $this->sharing()->createLink(object: $object, permissions: 1);
+
+        $otherUid  = 'link-other-'.substr((string) Uuid::v4(), 0, 8);
+        $otherUser = $this->userManager->createUser($otherUid, 'Link-Test-Pass-123');
+
+        try {
+            $this->userSession->setUser($otherUser);
+
+            $keys = [];
+            foreach ($this->mapper->searchObjectsInRegisterSchemaTable(['_multitenancy' => false], $register, $schema) as $row) {
+                if ($row instanceof ObjectEntity === true) {
+                    $keys[] = (($row->getObject() ?? [])['key'] ?? null);
+                }
+            }
+
+            $this->assertNotContains(
+                'stillprivate',
+                $keys,
+                'creating a link must not publish the object to other logged-in users'
+            );
+        } finally {
+            $this->userSession->setUser($this->ownerUser);
+            if ($otherUser !== false && $otherUser !== null) {
+                $otherUser->delete();
+            }
+        }
+    }//end testALinkDoesNotMakeTheObjectListableForOthers()
+
+
+    /**
+     * An email invitation refuses an address that is not one.
+     */
+    public function testAnEmailInvitationRequiresAValidAddress(): void
+    {
+        [$register, $schema, $object] = $this->privateObject('bademail');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sharing()->inviteByEmail(object: $object, email: 'not-an-address');
+    }//end testAnEmailInvitationRequiresAValidAddress()
+
+
+    /**
+     * Resolve a token the way the public endpoint does.
+     *
+     * Deliberately mirrors `ObjectShareLinkController` rather than calling it:
+     * constructing a controller needs an IRequest, and what matters here is the
+     * core-side chain — token validity, share type, folder-name-is-the-uuid.
+     *
+     * @param string $token The share token.
+     *
+     * @return array{uuid: string, permissions: int}|null The resolved object, or null.
+     */
+    private function resolveToken(string $token): ?array
+    {
+        $manager = \OC::$server->get(IManager::class);
+
+        try {
+            $share = $manager->getShareByToken($token);
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        $allowed = [\OCP\Share\IShare::TYPE_LINK, \OCP\Share\IShare::TYPE_EMAIL];
+        if (in_array($share->getShareType(), $allowed, true) === false) {
+            return null;
+        }
+
+        try {
+            if ($share->getNodeType() !== 'folder') {
+                return null;
+            }
+
+            $name = $share->getNode()->getName();
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        $uuidPattern = '/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/';
+        if (preg_match($uuidPattern, $name) !== 1) {
+            return null;
+        }
+
+        return ['uuid' => $name, 'permissions' => $share->getPermissions()];
+    }//end resolveToken()
+
+
+    /**
+     * Push a share's expiry into the past.
+     *
+     * Core refuses to CREATE an already-expired share, so the row is aged
+     * directly. What is under test is the behaviour once the date has passed.
+     *
+     * @param string $token The share token.
+     *
+     * @return void
+     */
+    private function expireShare(string $token): void
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->update('share')
+            ->set('expiration', $qb->createNamedParameter((new \DateTime('-2 days'))->format('Y-m-d H:i:s')))
+            ->where($qb->expr()->eq('token', $qb->createNamedParameter($token)));
+        $qb->executeStatement();
+    }//end expireShare()
+
+
+    /**
+     * Create a register, schema, table and ONE private object owned by the owner.
+     *
+     * @param string $key The object's `key` property.
+     *
+     * @return array{0: Register, 1: Schema, 2: ObjectEntity}
+     */
+    private function privateObject(string $key): array
+    {
+        $register = $this->registerMapper->createFromArray(
+            ['title' => 'PHPUnit link Register '.uniqid(), 'description' => 'link tests']
+        );
+        $this->createdRegisterIds[] = $register->getId();
+
+        $schema = $this->schemaMapper->createFromArray(
+            [
+                'title'         => 'PHPUnit link Schema '.uniqid(),
+                'description'   => 'link tests',
+                'properties'    => ['key' => ['type' => 'string', 'title' => 'Key', 'maxLength' => 255]],
+                'authorization' => ['read' => ['authenticated']],
+            ]
+        );
+        $this->createdSchemaIds[] = $schema->getId();
+
+        $this->mapper->ensureTableForRegisterSchema($register, $schema);
+        $table                 = $this->mapper->getTableNameForRegisterSchema($register, $schema);
+        $this->createdTables[] = 'oc_'.$table;
+
+        $entity = new ObjectEntity();
+        $entity->setUuid(Uuid::v4()->toRfc4122());
+        $entity->setRegister((string) $register->getId());
+        $entity->setSchema((string) $schema->getId());
+        $entity->setObject(['key' => $key]);
+        $entity->setOwner($this->ownerUid);
+        $stored = $this->mapper->insertObjectEntity($entity, $register, $schema, false);
+
+        // Private, written the way the service writes it.
+        $qb = $this->db->getQueryBuilder();
+        $qb->update($table)
+            ->set('_authorization', $qb->createNamedParameter(json_encode(['scope' => 'private'])))
+            ->where($qb->expr()->eq('_uuid', $qb->createNamedParameter($stored->getUuid())));
+        $qb->executeStatement();
+
+        $fresh = null;
+        foreach ($this->mapper->searchObjectsInRegisterSchemaTable(['_multitenancy' => false, '_rbac' => false], $register, $schema) as $row) {
+            if ($row instanceof ObjectEntity === true) {
+                $fresh = $row;
+            }
+        }
+
+        $this->assertNotNull($fresh, 'fixture did not persist');
+        $this->assertSame(['scope' => 'private'], $fresh->getAuthorization(), 'fixture is not private');
+
+        return [$register, $schema, $fresh];
+    }//end privateObject()
+
+
+    /**
+     * The owner-checked write surface.
+     *
+     * @return ObjectSharingService
+     */
+    private function sharing(): ObjectSharingService
+    {
+        return \OC::$server->get(ObjectSharingService::class);
+    }//end sharing()
+
+
+}//end class


### PR DESCRIPTION
## What this adds

Group 5 of `object-level-sharing-and-private-scope`: **share links and email invitations**, on top of the `private` scope and per-object grants already merged in #2241.

- `POST /api/objects/{register}/{schema}/{id}/links` — a tokenised link, optional expiry and password
- `POST /api/objects/{register}/{schema}/{id}/invitations` — an account-less email invitation (`TYPE_EMAIL`, the Files behaviour, per design Q2)
- `GET /api/shared/{token}` — **public**, resolves a token to the one object it addresses

## Why the public endpoint is a different shape

A link is a bearer **capability**, not a principal grant. Nobody is logged in, so there is no principal for RBAC to resolve — the token *is* the authorization. That is exactly why link and email types were left out of `ObjectGrantResolver`'s principal list when it landed: they were always going to be decided here instead of in the RBAC filter.

It is also what reconciles this with **ADR-006** (design Q4). The ADR says publication is a schema-level RBAC change and not a per-object data flag. A revocable, expiring, core-issued bearer token is neither of those — and that is proved rather than argued: `testALinkDoesNotMakeTheObjectListableForOthers` shows creating a link does **not** widen the RBAC verdict for other logged-in users.

## Every check on that path is core's

| concern | who enforces it |
|---|---|
| token validity, revocation, expiry | `getShareByToken()` — a revoked share is gone, an expired one is refused |
| password | `checkPassword()`, never a local comparison |
| share type | only `TYPE_LINK` / `TYPE_EMAIL` are honoured |
| which object | the folder's name is the object UUID — same rule the grant resolver uses |

Revocation and expiry therefore take effect on the **next request**, with nothing for OpenRegister to invalidate. That is the read-through design (D2) paying off.

Every refusal returns the same shape, so the endpoint cannot be used as an oracle for which tokens exist. It does not write and it does not enumerate.

## A test that proved nothing, and now does

`testAUserGrantsTokenIsNotRedeemableAnonymously` **passed on the first run — vacuously.** It tried to redeem a USER share's token anonymously, but a USER share has no token, so it hit an early return and counted a fake assertion.

Measured on the instance: `share_type = 0` rows all have a null token; `share_type = 3` (link) has one.

The honest statement is two-part, and both halves are now asserted: a principal grant cannot be redeemed as a bearer token because it *has* none, and the endpoint's type guard is defence-in-depth for the day one does.

## Verification

- **6 live-DB tests** against real Postgres and a real share manager
- **Positive control**: neutering the revoke makes `testARevokedLinkStopsResolving` fail
- phpcs, phpmd and phpstan clean — no new baseline entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
